### PR TITLE
Core: Retry failed File.canDelete() with root if available.

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/core/local/LocalGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/core/local/LocalGateway.kt
@@ -389,7 +389,14 @@ class LocalGateway @Inject constructor(
                     } else {
                         javaFile.delete()
                     }
-                    if (!success) throw IOException("delete() call returned false")
+                    if (!success) {
+                        if (mode == Mode.AUTO && hasRoot()) {
+                            delete(path, Mode.ROOT)
+                            return@runIO
+                        } else {
+                            throw IOException("delete() call returned false")
+                        }
+                    }
                 }
                 hasRoot() && (mode == Mode.ROOT || mode == Mode.AUTO && !canNormalWrite) -> {
                     rootOps {


### PR DESCRIPTION
File.canWrite() check is unreliable. File.delete() may still fail. If this happens, and we have root, retry with root.

Fixes #44