### PR TITLE
Fix AppCleaner item count being off by 1 when inaccessible caches are listed

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/InaccessibleCacheProvider.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/InaccessibleCacheProvider.kt
@@ -16,7 +16,7 @@ class InaccessibleCacheProvider @Inject constructor(
         val storageStats = storageStatsProvider.getStats(pkgId) ?: return null
         return InaccessibleCache(
             pkgId,
-            itemCount = 2,
+            itemCount = 1,
             cacheBytes = storageStats.cacheBytes,
             externalCacheBytes = if (hasApiLevel(31)) {
                 @Suppress("NewApi")


### PR DESCRIPTION
Fixes #117