### PR TITLE
Catch activity launch crash for appcontrol entries.

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/actions/AppActionDialogVM.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/actions/AppActionDialogVM.kt
@@ -1,5 +1,6 @@
 package eu.darken.sdmse.appcontrol.ui.list.actions
 
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import androidx.lifecycle.SavedStateHandle
@@ -66,7 +67,13 @@ class AppActionDialogVM @Inject constructor(
             ?.let { intent ->
                 LaunchActionVH.Item(
                     appInfo = appInfo,
-                    onItemClicked = { context.startActivity(intent) }
+                    onItemClicked = {
+                        try {
+                            context.startActivity(intent)
+                        } catch (e: ActivityNotFoundException) {
+                            errorEvents.postValue(e)
+                        }
+                    }
                 )
             }
 


### PR DESCRIPTION
We can still crash despite using `getLaunchIntentForPackage`

```
android.content.ActivityNotFoundException: Unable to find explicit activity class {com.google.android.apps.dynamite/com.google.android.apps.dynamite.startup.StartUpActivity}; have you declared this activity in your AndroidManifest.xml?
        at android.app.Instrumentation.checkStartActivityResult(Instrumentation.java:2179)
        at android.app.Instrumentation.execStartActivity(Instrumentation.java:1812)
        at android.app.ContextImpl.startActivity(ContextImpl.java:1091)
        at android.app.ContextImpl.startActivity(ContextImpl.java:1062)
        at android.content.ContextWrapper.startActivity(ContextWrapper.java:411)
        at eu.darken.sdmse.appcontrol.ui.list.actions.AppActionDialogVM$state$2$launchAction$2$1.invoke(AppActionDialogVM.kt:69)
```