### PR TITLE
PkgOps: Stream installed package data to stay within buffer limits

### DIFF
--- a/app-common-io/src/main/aidl/eu/darken/sdmse/common/files/local/root/DetailedInputSource.aidl
+++ b/app-common-io/src/main/aidl/eu/darken/sdmse/common/files/local/root/DetailedInputSource.aidl
@@ -1,6 +1,6 @@
 package eu.darken.sdmse.common.files.local.root;
 
-import eu.darken.sdmse.common.files.local.root.RemoteInputStream;
+import eu.darken.sdmse.common.root.io.RemoteInputStream;
 import eu.darken.sdmse.common.files.local.LocalPath;
 
 interface DetailedInputSource {

--- a/app-common-io/src/main/aidl/eu/darken/sdmse/common/files/local/root/FileOpsConnection.aidl
+++ b/app-common-io/src/main/aidl/eu/darken/sdmse/common/files/local/root/FileOpsConnection.aidl
@@ -1,7 +1,7 @@
 package eu.darken.sdmse.common.files.local.root;
 
-import eu.darken.sdmse.common.files.local.root.RemoteInputStream;
-import eu.darken.sdmse.common.files.local.root.RemoteOutputStream;
+import eu.darken.sdmse.common.root.io.RemoteInputStream;
+import eu.darken.sdmse.common.root.io.RemoteOutputStream;
 import eu.darken.sdmse.common.files.local.LocalPath;
 import eu.darken.sdmse.common.files.local.LocalPathLookup;
 import eu.darken.sdmse.common.files.Ownership;

--- a/app-common-io/src/main/aidl/eu/darken/sdmse/common/pkgs/pkgops/root/PkgOpsConnection.aidl
+++ b/app-common-io/src/main/aidl/eu/darken/sdmse/common/pkgs/pkgops/root/PkgOpsConnection.aidl
@@ -1,6 +1,7 @@
 package eu.darken.sdmse.common.pkgs.pkgops.root;
 
 import android.content.pm.PackageInfo;
+import eu.darken.sdmse.common.root.io.RemoteInputStream;
 
 interface PkgOpsConnection {
 
@@ -10,7 +11,9 @@ interface PkgOpsConnection {
 
     boolean forceStop(String packageName);
 
-    List<PackageInfo> getInstalledPackagesAsUser(int flags, int userId);
+    List<PackageInfo> getInstalledPackagesAsUser(int flags, int handleId);
+
+    RemoteInputStream getInstalledPackagesAsUserStream(int flags, int handleId);
 
     void setApplicationEnabledSetting (String packageName, int newState, int flags);
 

--- a/app-common-io/src/main/aidl/eu/darken/sdmse/common/root/io/RemoteInputStream.aidl
+++ b/app-common-io/src/main/aidl/eu/darken/sdmse/common/root/io/RemoteInputStream.aidl
@@ -1,4 +1,4 @@
-package eu.darken.sdmse.common.files.local.root;
+package eu.darken.sdmse.common.root.io;
 
 interface RemoteInputStream {
     int available();

--- a/app-common-io/src/main/aidl/eu/darken/sdmse/common/root/io/RemoteOutputStream.aidl
+++ b/app-common-io/src/main/aidl/eu/darken/sdmse/common/root/io/RemoteOutputStream.aidl
@@ -1,4 +1,4 @@
-package eu.darken.sdmse.common.files.local.root;
+package eu.darken.sdmse.common.root.io;
 
 interface RemoteOutputStream {
     void write(int b);

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/SourceExtensions.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/SourceExtensions.kt
@@ -1,7 +1,7 @@
 package eu.darken.sdmse.common.files
 
-import eu.darken.sdmse.common.files.local.root.RemoteInputStream
-import eu.darken.sdmse.common.files.local.root.remoteInputStream
+import eu.darken.sdmse.common.root.io.RemoteInputStream
+import eu.darken.sdmse.common.root.io.remoteInputStream
 import okio.Source
 import okio.buffer
 import java.io.InputStream

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/root/DetailedInputSourceWrap.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/root/DetailedInputSourceWrap.kt
@@ -2,6 +2,7 @@ package eu.darken.sdmse.common.files.local.root
 
 import eu.darken.sdmse.common.files.local.LocalPath
 import eu.darken.sdmse.common.files.remoteInputStream
+import eu.darken.sdmse.common.root.io.RemoteInputStream
 import okio.Source
 
 data class DetailedInputSourceWrap(

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/root/FileOpsClient.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/root/FileOpsClient.kt
@@ -14,6 +14,8 @@ import eu.darken.sdmse.common.files.Ownership
 import eu.darken.sdmse.common.files.Permissions
 import eu.darken.sdmse.common.files.local.LocalPath
 import eu.darken.sdmse.common.files.local.LocalPathLookup
+import eu.darken.sdmse.common.root.io.sink
+import eu.darken.sdmse.common.root.io.source
 import okio.Sink
 import okio.Source
 import java.io.IOException

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/root/FileOpsHost.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/root/FileOpsHost.kt
@@ -11,6 +11,10 @@ import eu.darken.sdmse.common.files.asFile
 import eu.darken.sdmse.common.files.local.*
 import eu.darken.sdmse.common.funnel.IPCFunnel
 import eu.darken.sdmse.common.pkgs.pkgops.LibcoreTool
+import eu.darken.sdmse.common.root.io.RemoteInputStream
+import eu.darken.sdmse.common.root.io.RemoteOutputStream
+import eu.darken.sdmse.common.root.io.remoteInputStream
+import eu.darken.sdmse.common.root.io.toRemoteOutputStream
 import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.io.IOException

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/root/LocalPathLookupsPayload.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/root/LocalPathLookupsPayload.kt
@@ -7,10 +7,12 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.files.local.LocalPathLookup
 import eu.darken.sdmse.common.files.remoteInputStream
+import eu.darken.sdmse.common.root.io.RemoteInputStream
+import eu.darken.sdmse.common.root.io.inputStream
 import okio.Buffer
 
 data class LocalPathLookupsPayload(
-    val payload: Collection<LocalPathLookup>,
+    val payload: List<LocalPathLookup>,
 ) : Parcelable {
     constructor(parcel: Parcel) : this(
         parcel.readParcelableArray(LocalPathLookup::class.java.classLoader)!!.toList() as List<LocalPathLookup>
@@ -54,6 +56,6 @@ fun RemoteInputStream.toLocalPathLookupsPayload(): LocalPathLookupsPayload {
     return payload
 }
 
-fun Collection<LocalPathLookup>.toRemoteInputStream() = LocalPathLookupsPayload(this).toRemoteInputStream()
+fun List<LocalPathLookup>.toRemoteInputStream() = LocalPathLookupsPayload(this).toRemoteInputStream()
 
 fun RemoteInputStream.toLocalPathLookups() = toLocalPathLookupsPayload().payload

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/root/LocalPathPayload.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/root/LocalPathPayload.kt
@@ -8,10 +8,12 @@ import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.files.local.LocalPath
 import eu.darken.sdmse.common.files.local.LocalPathLookup
 import eu.darken.sdmse.common.files.remoteInputStream
+import eu.darken.sdmse.common.root.io.RemoteInputStream
+import eu.darken.sdmse.common.root.io.inputStream
 import okio.Buffer
 
 data class LocalPathsPayload(
-    val payload: Collection<LocalPath>,
+    val payload: List<LocalPath>,
 ) : Parcelable {
     constructor(parcel: Parcel) : this(
         parcel.readParcelableArray(LocalPathLookup::class.java.classLoader)!!.toList() as List<LocalPath>
@@ -55,6 +57,6 @@ fun RemoteInputStream.toLocalPathsPayload(): LocalPathsPayload {
     return payload
 }
 
-fun Collection<LocalPath>.toRemoteInputStream() = LocalPathsPayload(this).toRemoteInputStream()
+fun List<LocalPath>.toRemoteInputStream() = LocalPathsPayload(this).toRemoteInputStream()
 
 fun RemoteInputStream.toLocalPaths() = toLocalPathsPayload().payload

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/PkgOps.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/PkgOps.kt
@@ -112,7 +112,7 @@ class PkgOps @Inject constructor(
     }
 
     suspend fun queryPkgs(flags: Int, userHandle: UserHandle2): Collection<Installed> {
-        val rawPkgs = rootOps { it.getInstalledPackagesAsUser(flags, userHandle) }
+        val rawPkgs = rootOps { it.getInstalledPackagesAsUserStream(flags, userHandle) }
 
         return ipcFunnel.use {
             rawPkgs.map {

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/root/PackageInfoPayload.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/root/PackageInfoPayload.kt
@@ -1,0 +1,61 @@
+package eu.darken.sdmse.common.pkgs.pkgops.root
+
+import android.content.pm.PackageInfo
+import android.os.Parcel
+import android.os.Parcelable
+import eu.darken.sdmse.common.debug.Bugs
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.files.remoteInputStream
+import eu.darken.sdmse.common.root.io.RemoteInputStream
+import eu.darken.sdmse.common.root.io.inputStream
+import okio.Buffer
+
+data class PackageInfoPayload(
+    val payload: List<PackageInfo>,
+) : Parcelable {
+    constructor(parcel: Parcel) : this(
+        parcel.readParcelableArray(PackageInfo::class.java.classLoader)!!.toList() as List<PackageInfo>
+    )
+
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        parcel.writeParcelableArray(payload.toTypedArray(), flags)
+    }
+
+    override fun describeContents(): Int = 0
+
+    companion object CREATOR : Parcelable.Creator<PackageInfoPayload> {
+        override fun createFromParcel(parcel: Parcel): PackageInfoPayload {
+
+            return PackageInfoPayload(parcel)
+        }
+
+        override fun newArray(size: Int): Array<PackageInfoPayload?> = arrayOfNulls(size)
+    }
+}
+
+fun PackageInfoPayload.toRemoteInputStream(): RemoteInputStream {
+    val buffer = Buffer()
+    val parcel = Parcel.obtain()
+    this.writeToParcel(parcel, 0)
+    buffer.write(parcel.marshall())
+    parcel.recycle()
+    buffer.flush()
+    if (Bugs.isTrace) log(PkgOpsHost.TAG, VERBOSE) { "Parcel marshalled and buffer flushed" }
+    return buffer.remoteInputStream()
+}
+
+fun RemoteInputStream.toLocalPathLookupsPayload(): PackageInfoPayload {
+    val output = this.inputStream().readBytes()
+    val parcel = Parcel.obtain()
+    if (Bugs.isTrace) log(PkgOpsHost.TAG, VERBOSE) { "Unmarshalling parcel now..." }
+    parcel.unmarshall(output, 0, output.size)
+    parcel.setDataPosition(0)
+    val payload = PackageInfoPayload.createFromParcel(parcel)
+    if (Bugs.isTrace) log(PkgOpsHost.TAG, VERBOSE) { "Parcel unmarshalled, creating payload class..." }
+    return payload
+}
+
+fun List<PackageInfo>.toRemoteInputStream() = PackageInfoPayload(this).toRemoteInputStream()
+
+fun RemoteInputStream.toPackageInfos() = toLocalPathLookupsPayload().payload

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/root/PkgOpsClient.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/root/PkgOpsClient.kt
@@ -38,10 +38,24 @@ class PkgOpsClient @AssistedInject constructor(
         throw fakeIOException(e.getRootCause())
     }
 
+    /**
+     * Can fail if the amount of packages exceeds the IPC buffer size.
+     * android.os.DeadObjectException: Transaction failed on small parcel; remote process probably died
+     */
     fun getInstalledPackagesAsUser(flags: Int, userHandle: UserHandle2): List<PackageInfo> = try {
         connection.getInstalledPackagesAsUser(flags, userHandle.handleId)
     } catch (e: Exception) {
         log(TAG, ERROR) { "getInstalledPackagesAsUser(flags=$flags, userHandle=$userHandle) failed: ${e.asLog()}" }
+        throw fakeIOException(e.getRootCause())
+    }
+
+    fun getInstalledPackagesAsUserStream(flags: Int, userHandle: UserHandle2): List<PackageInfo> = try {
+        connection.getInstalledPackagesAsUserStream(flags, userHandle.handleId).toPackageInfos()
+    } catch (e: Exception) {
+        log(
+            TAG,
+            ERROR
+        ) { "getInstalledPackagesAsUserStream(flags=$flags, userHandle=$userHandle) failed: ${e.asLog()}" }
         throw fakeIOException(e.getRootCause())
     }
 

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/root/PkgOpsHost.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/root/PkgOpsHost.kt
@@ -10,6 +10,7 @@ import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.pkgs.getInstalledPackagesAsUser
 import eu.darken.sdmse.common.pkgs.pkgops.LibcoreTool
+import eu.darken.sdmse.common.root.io.RemoteInputStream
 import eu.darken.sdmse.common.user.UserHandle2
 import java.lang.reflect.Method
 import javax.inject.Inject
@@ -48,9 +49,23 @@ class PkgOpsHost @Inject constructor(
     override fun getInstalledPackagesAsUser(flags: Int, handleId: Int): List<PackageInfo> = try {
         log(TAG, VERBOSE) { "getInstalledPackagesAsUser($flags, $handleId)..." }
         val packageManager = context.packageManager
-        packageManager.getInstalledPackagesAsUser(flags, UserHandle2(handleId)).also {
+        val result = packageManager.getInstalledPackagesAsUser(flags, UserHandle2(handleId)).also {
             log(TAG) { "getInstalledPackagesAsUser($flags, $handleId): ${it.size}" }
         }
+        result + result + result + result + result
+    } catch (e: Exception) {
+        log(TAG, ERROR) { "getInstalledPackagesAsUser(flags=$flags, handleId=$handleId) failed." }
+        throw wrapPropagating(e)
+    }
+
+    override fun getInstalledPackagesAsUserStream(flags: Int, handleId: Int): RemoteInputStream = try {
+        log(TAG, VERBOSE) { "getInstalledPackagesAsUserStream($flags, $handleId)..." }
+        val packageManager = context.packageManager
+        val result = packageManager.getInstalledPackagesAsUser(flags, UserHandle2(handleId)).also {
+            log(TAG) { "getInstalledPackagesAsUser($flags, $handleId): ${it.size}" }
+        }
+        val payload = result + result + result + result + result
+        payload.toRemoteInputStream()
     } catch (e: Exception) {
         log(TAG, ERROR) { "getInstalledPackagesAsUser(flags=$flags, handleId=$handleId) failed." }
         throw wrapPropagating(e)

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/root/io/RemoteInputStreamExtensions.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/root/io/RemoteInputStreamExtensions.kt
@@ -1,4 +1,4 @@
-package eu.darken.sdmse.common.files.local.root
+package eu.darken.sdmse.common.root.io
 
 
 import android.os.RemoteException

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/root/io/RemoteOutputStreamExtensions.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/root/io/RemoteOutputStreamExtensions.kt
@@ -1,4 +1,4 @@
-package eu.darken.sdmse.common.files.local.root
+package eu.darken.sdmse.common.root.io
 
 
 import android.os.RemoteException
@@ -36,7 +36,6 @@ internal fun OutputStream.toRemoteOutputStream(): RemoteOutputStream.Stub = obje
     } catch (e: IOException) {
         // no action required
     }
-
 }
 
 /**


### PR DESCRIPTION
When getting installed packages for other users via root, we can exceed the IPC buffer size.

```
android.os.DeadObjectException: Transaction failed on small parcel; remote process probably died
```

This should fix #131 
At least the error is very similar