### PR TITLE
Warm up the size caches for results in each tool to prevent ANRs

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
@@ -103,6 +103,10 @@ class AppCleaner @Inject constructor(
             scan()
         }
 
+        log(TAG) { "Warming up fields..." }
+        results.forEach { it.size }
+        log(TAG) { "Field warm up done." }
+
         internalData.value = Data(
             junks = results,
         )

--- a/app/src/main/java/eu/darken/sdmse/corpsefinder/core/CorpseFinder.kt
+++ b/app/src/main/java/eu/darken/sdmse/corpsefinder/core/CorpseFinder.kt
@@ -144,6 +144,10 @@ class CorpseFinder @Inject constructor(
 
         results.forEach { log(TAG, INFO) { "Result: $it" } }
 
+        log(TAG) { "Warming up fields..." }
+        results.forEach { it.size }
+        log(TAG) { "Field warm up done." }
+
         internalData.value = Data(
             corpses = results
         )

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/SystemCleaner.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/SystemCleaner.kt
@@ -99,6 +99,10 @@ class SystemCleaner @Inject constructor(
             crawl()
         }
 
+        log(TAG) { "Warming up fields..." }
+        results.forEach { it.size }
+        log(TAG) { "Field warm up done." }
+
         internalData.value = Data(
             filterContents = results
         )


### PR DESCRIPTION
Since switching to lazy data retrieval for SAF lookups, we can get ANRs if the UI accesses the item sizes.

```
ANR:  Input dispatching timed out (Waiting to send non-key event because the touched window has not finished processing certain input events that were delivered to it over 500.0ms ago. waitqueue length = 34, head.seq = 32642, Wait queue head age: 5867.8ms.)
        at kotlin.SynchronizedLazyImpl.getValue(LazyJVM.kt:69)
        at eu.darken.sdmse.common.files.core.saf.SAFPathLookup.getSize(SAFPathLookup.kt:18)
        at eu.darken.sdmse.systemcleaner.core.FilterContent.getSize(FilterContent.kt:11)
        at eu.darken.sdmse.systemcleaner.core.SystemCleaner$Data.getTotalSize(SystemCleaner:193)
        at eu.darken.sdmse.systemcleaner.ui.SystemCleanerDashCardVH$special$$inlined$binding$default$1.invoke(BindableVH.kt:57)
        at eu.darken.sdmse.systemcleaner.ui.SystemCleanerDashCardVH$special$$inlined$binding$default$1.invoke(BindableVH.kt:20)
        at eu.darken.sdmse.common.lists.BindableVH.bind(BindableVH.kt:12)
```