### PR TITLE
Improve ownership detection for multi-user setups

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/PkgOps.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/PkgOps.kt
@@ -125,6 +125,15 @@ class PkgOps @Inject constructor(
         }
     }
 
+    suspend fun isInstalleMaybe(pkg: Pkg.Id, userHandle: UserHandle2): Boolean = try {
+        ipcFunnel.use {
+            packageManager.getPackageUid(pkg.name, 0)
+        }
+        true
+    } catch (e: NameNotFoundException) {
+        false
+    }
+
     suspend fun queryAppInfos(
         pkg: Pkg.Id,
         flags: Int = GET_UNINSTALLED_PACKAGES

--- a/app/src/main/java/eu/darken/sdmse/common/areas/modules/pub/SdcardsModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/areas/modules/pub/SdcardsModule.kt
@@ -49,13 +49,14 @@ class SdcardsModule @Inject constructor(
             }
             ?.run { sdcards.add(this) }
 
+        // Secondary storage is not user specific, e.g. /storage/3135-3132/Android/data
         storageEnvironment.getPublicSecondaryStorage(userManager2.currentUser().handle)
             .mapNotNull { determineAreaAccessPath(it) }
             .map {
                 DataArea(
                     path = it,
                     type = DataArea.Type.SDCARD,
-                    userHandle = userManager2.currentUser().handle,
+                    userHandle = userManager2.systemUser().handle,
                     flags = emptySet(),
                 )
             }


### PR DESCRIPTION
For multi-user devices perform an additional check on corpses that reside in data areas where they are potentially shared between user profiles.

Fixes #156