### PR TITLE
Fix accessibility service init crash.

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/automation/core/AutomationService.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/AutomationService.kt
@@ -169,12 +169,12 @@ class AutomationService : AccessibilityService(), AutomationHost, Progress.Host,
     }
 
     override fun onAccessibilityEvent(event: AccessibilityEvent) {
-        if (!automationProcessor.hasTask) return
-
         if (generalSettings.hasAcsConsent.valueBlocking != true) {
             log(TAG, WARN) { "Missing consent for accessibility service, skipping event." }
             return
         }
+
+        if (!automationProcessor.hasTask) return
 
         val copy = try {
             AccessibilityEvent.obtain(event)


### PR DESCRIPTION
If consent is not given, the service is not completely initialized, so the order here matters.