### PR TITLE
AppCleaner: Improve scan, include more types of folders.

### DIFF
--- a/app/src/main/assets/clutter/db_clutter_markers.json
+++ b/app/src/main/assets/clutter/db_clutter_markers.json
@@ -5717,8 +5717,14 @@
 	{"loc": "PUBLIC_DATA", "path": "com.android.gallery3d"},
 	{"loc": "PUBLIC_DATA", "path": "com.cooliris.media"},
 	{"loc": "SDCARD", "path": "Gallery", "flags": ["common", "keeper"]},
-	{"loc": "SDCARD", "path": "Pictures", "flags": ["common", "keeper"]},
 	{"loc": "SDCARD", "path": ".face"}
+  ]
+}, {
+  "pkgs": ["com.android.providers.media"],
+  "mrks": [
+	{"loc": "SDCARD", "path": "Pictures", "flags": ["common", "keeper"]},
+	{"loc": "SDCARD", "path": "Movies", "flags": ["common", "keeper"]},
+	{"loc": "SDCARD", "path": "Music", "flags": ["common", "keeper"]}
   ]
 }, {
   "pkgs": ["com.diveboard.mobile"],

--- a/app/src/main/assets/expendables/db_hidden_caches_files.json
+++ b/app/src/main/assets/expendables/db_hidden_caches_files.json
@@ -94,15 +94,6 @@
 		}
 	  ]
 	}, {
-	  "packages": ["com.quickoffice.android"],
-	  "fileFilter": [
-		{
-		  "locations": ["PRIVATE_DATA"],
-		  "startsWith": ["com.quickoffice.android/files/"],
-		  "patterns": ["^(?:com\\.quickoffice\\.android\\/files\\/)([\\w\\W]+?\\.thumb\\.(?:home|panel))$"]
-		}
-	  ]
-	}, {
 	  "packages": ["com.google.android.apps.genie.geniewidget"],
 	  "fileFilter": [
 		{
@@ -237,19 +228,6 @@
 		}
 	  ]
 	}, {
-	  "packages": ["nextapp.fx"],
-	  "fileFilter": [
-		{
-		  "locations": ["SDCARD"],
-		  "startsWith": [".FX/CloudThumbnail/"],
-		  "patterns": ["^(?:\\.FX\\/CloudThumbnail\\/)([\\W\\w]+?)$"]
-		}, {
-		  "locations": ["SDCARD"],
-		  "startsWith": [".FX/ImageThumbnail/"],
-		  "patterns": ["^(?:\\.FX\\/ImageThumbnail\\/)([\\W\\w]+?)$"]
-		}
-	  ]
-	}, {
 	  "packages": [
 		"com.infraware.polarisoffice5tablet",
 		"com.infraware.polarisoffice.entbiz.gd",
@@ -350,24 +328,6 @@
 		}
 	  ]
 	}, {
-	  "packages": ["net.coollet.infzmreader"],
-	  "fileFilter": [
-		{
-		  "locations": ["SDCARD"],
-		  "startsWith": ["infzm/thumb_image/"],
-		  "patterns": ["^(?:infzm\\/thumb_image\\/)([\\W\\w]+)$"]
-		}
-	  ]
-	}, {
-	  "packages": ["com.kascend.video"],
-	  "fileFilter": [
-		{
-		  "locations": ["SDCARD"],
-		  "startsWith": ["kascend/videoshow/.thumbcache/"],
-		  "patterns": ["^(?:kascend\\/videoshow\\/\\.thumbcache\\/)([\\W\\w]+)$"]
-		}
-	  ]
-	}, {
 	  "packages": ["com.telenav.doudouyou.android.autonavi"],
 	  "fileFilter": [
 		{
@@ -439,15 +399,6 @@
 			"^(?:com\\.ninegag\\.android\\.app\\/files\\/avatar\\/)([\\W\\w]+)$",
 			"^(?:com\\.ninegag\\.android\\.app\\/files\\/covers\\/)([\\W\\w]+)$"
 		  ]
-		}
-	  ]
-	}, {
-	  "packages": ["com.hashcode.walloid", "com.hashcode.walloidpro"],
-	  "fileFilter": [
-		{
-		  "locations": ["SDCARD"],
-		  "startsWith": ["Walloid/.Thumbnail/"],
-		  "patterns": ["^(?:Walloid\\/\\.Thumbnail\\/)([\\W\\w]+)$"]
 		}
 	  ]
 	}, {
@@ -583,16 +534,6 @@
 		  "locations": ["PRIVATE_DATA"],
 		  "startsWith": ["com.sec.android.gallery3d/Temp/"],
 		  "patterns": ["^(?:com\\.sec\\.android\\.gallery3d\\/Temp\\/)([0-9]+?)$"]
-		}
-	  ]
-	}, {
-	  "packages": ["com.sec.android.app.videoplayer"],
-	  "fileFilter": [
-		{
-		  "locations": ["SDCARD"],
-		  "startsWith": [".thumbnails/"],
-		  "notContains": [".nomedia"],
-		  "patterns": ["^(?:\\.thumbnails\\/.+?\\/)([\\W\\w]+?)$"]
 		}
 	  ]
 	}, {
@@ -1157,24 +1098,6 @@
 		  "locations": ["SDCARD"],
 		  "startsWith": [".Android/.data/com.visky.gallery.data/.data/.secure/.cache"],
 		  "patterns": ["^(?:\\.Android/\\.data/com\\.visky\\.gallery\\.data/\\.data/\\.secure/\\.cache/)(.+?)$"]
-		}
-	  ]
-	}, {
-	  "packages": ["com.miui.player"],
-	  "fileFilter": [
-		{
-		  "locations": ["SDCARD"],
-		  "startsWith": ["MIUI/music/album/.player_thumb"],
-		  "patterns": ["^(?:MIUI/music/album/\\.player_thumb/)(.+?)$"]
-		}
-	  ]
-	}, {
-	  "packages": ["com.miui.videoplayer"],
-	  "fileFilter": [
-		{
-		  "locations": ["SDCARD"],
-		  "startsWith": ["MIUI/Video/thumb/"],
-		  "patterns": ["^(?:MIUI/Video/thumb/)(.+?)$"]
 		}
 	  ]
 	}, {

--- a/app/src/main/assets/expendables/db_thumbnail_files.json
+++ b/app/src/main/assets/expendables/db_thumbnail_files.json
@@ -1,0 +1,83 @@
+{
+  "schemaVersion": 1,
+  "appFilter": [
+	{
+	  "packages": ["com.quickoffice.android"],
+	  "fileFilter": [
+		{
+		  "locations": ["PRIVATE_DATA"],
+		  "startsWith": ["com.quickoffice.android/files/"],
+		  "patterns": ["^(?:com\\.quickoffice\\.android\\/files\\/)([\\w\\W]+?\\.thumb\\.(?:home|panel))$"]
+		}
+	  ]
+	}, {
+	  "packages": ["nextapp.fx"],
+	  "fileFilter": [
+		{
+		  "locations": ["SDCARD"],
+		  "startsWith": [".FX/CloudThumbnail/"],
+		  "patterns": ["^(?:\\.FX\\/CloudThumbnail\\/)([\\W\\w]+?)$"]
+		}, {
+		  "locations": ["SDCARD"],
+		  "startsWith": [".FX/ImageThumbnail/"],
+		  "patterns": ["^(?:\\.FX\\/ImageThumbnail\\/)([\\W\\w]+?)$"]
+		}
+	  ]
+	}, {
+	  "packages": ["net.coollet.infzmreader"],
+	  "fileFilter": [
+		{
+		  "locations": ["SDCARD"],
+		  "startsWith": ["infzm/thumb_image/"],
+		  "patterns": ["^(?:infzm\\/thumb_image\\/)([\\W\\w]+)$"]
+		}
+	  ]
+	}, {
+	  "packages": ["com.kascend.video"],
+	  "fileFilter": [
+		{
+		  "locations": ["SDCARD"],
+		  "startsWith": ["kascend/videoshow/.thumbcache/"],
+		  "patterns": ["^(?:kascend\\/videoshow\\/\\.thumbcache\\/)([\\W\\w]+)$"]
+		}
+	  ]
+	}, {
+	  "packages": ["com.hashcode.walloid", "com.hashcode.walloidpro"],
+	  "fileFilter": [
+		{
+		  "locations": ["SDCARD"],
+		  "startsWith": ["Walloid/.Thumbnail/"],
+		  "patterns": ["^(?:Walloid\\/\\.Thumbnail\\/)([\\W\\w]+)$"]
+		}
+	  ]
+	}, {
+	  "packages": ["com.sec.android.app.videoplayer"],
+	  "fileFilter": [
+		{
+		  "locations": ["SDCARD"],
+		  "startsWith": [".thumbnails/"],
+		  "notContains": [".nomedia"],
+		  "patterns": ["^(?:\\.thumbnails\\/.+?\\/)([\\W\\w]+?)$"]
+		}
+	  ]
+	}, {
+	  "packages": ["com.miui.player"],
+	  "fileFilter": [
+		{
+		  "locations": ["SDCARD"],
+		  "startsWith": ["MIUI/music/album/.player_thumb"],
+		  "patterns": ["^(?:MIUI/music/album/\\.player_thumb/)(.+?)$"]
+		}
+	  ]
+	}, {
+	  "packages": ["com.miui.videoplayer"],
+	  "fileFilter": [
+		{
+		  "locations": ["SDCARD"],
+		  "startsWith": ["MIUI/Video/thumb/"],
+		  "patterns": ["^(?:MIUI/Video/thumb/)(.+?)$"]
+		}
+	  ]
+	}
+  ]
+}

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleanerSettings.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleanerSettings.kt
@@ -43,6 +43,7 @@ class AppCleanerSettings @Inject constructor(
     val filterAnalyticsEnabled = dataStore.createValue("filter.analytics.enabled", true)
     val filterGameFilesEnabled = dataStore.createValue("filter.gamefiles.enabled", false)
     val filterHiddenCachesEnabled = dataStore.createValue("filter.hiddencaches.enabled", true)
+    val filterThumbnailsEnabled = dataStore.createValue("filter.thumbnails.enabled", true)
     val filterOfflineCachesEnabled = dataStore.createValue("filter.offlinecache.enabled", false)
     val filterRecycleBinsEnabled = dataStore.createValue("filter.recyclebins.enabled", false)
     val filterWebviewEnabled = dataStore.createValue("filter.webview.enabled", true)
@@ -75,6 +76,7 @@ class AppCleanerSettings @Inject constructor(
         filterAnalyticsEnabled,
         filterGameFilesEnabled,
         filterHiddenCachesEnabled,
+        filterThumbnailsEnabled,
         filterOfflineCachesEnabled,
         filterRecycleBinsEnabled,
         filterWebviewEnabled,

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/RecycleBinsFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/RecycleBinsFilter.kt
@@ -1,4 +1,4 @@
-package eu.darken.sdmse.appcleaner.core.forensics.generic
+package eu.darken.sdmse.appcleaner.core.forensics.filter
 
 import dagger.Binds
 import dagger.Module
@@ -41,6 +41,7 @@ class RecycleBinsFilter @Inject constructor(
         areaType: DataArea.Type,
         segments: Segments
     ): Boolean {
+        log(TAG) { "TARGET: ${target.path}" }
         val hierarchy = segments.lowercase()
 
         // package/trashfile

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/RecycleBinsFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/RecycleBinsFilter.kt
@@ -41,7 +41,6 @@ class RecycleBinsFilter @Inject constructor(
         areaType: DataArea.Type,
         segments: Segments
     ): Boolean {
-        log(TAG) { "TARGET: ${target.path}" }
         val hierarchy = segments.lowercase()
 
         // package/trashfile

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/ThumbnailsFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/ThumbnailsFilter.kt
@@ -25,7 +25,7 @@ import javax.inject.Provider
 
 
 @Reusable
-class HiddenFilter @Inject constructor(
+class ThumbnailsFilter @Inject constructor(
     private val jsonBasedSieveFactory: JsonBasedSieve.Factory,
     environment: StorageEnvironment,
 ) : ExpendablesFilter {
@@ -36,7 +36,7 @@ class HiddenFilter @Inject constructor(
 
     override suspend fun initialize() {
         log(TAG) { "initialize()" }
-        sieve = jsonBasedSieveFactory.create("expendables/db_hidden_caches_files.json")
+        sieve = jsonBasedSieveFactory.create("expendables/db_thumbnail_files.json")
     }
 
     override suspend fun isExpendable(
@@ -58,40 +58,32 @@ class HiddenFilter @Inject constructor(
 
         val lcsegments = segments.lowercase()
 
-        // package/cache.dat
-        if (lcsegments.size == 2 && HIDDEN_CACHE_FILES.contains(lcsegments[1])) {
+        // package/thumbs.dat
+        if (lcsegments.size == 2 && HIDDEN_FILES.contains(lcsegments[1])) {
             return true
         }
 
-        // package/files/cache.dat
-        if (lcsegments.size == 3 && HIDDEN_CACHE_FILES.contains(lcsegments[2])) {
+        // package/files/thumbs.dat
+        if (lcsegments.size == 3 && HIDDEN_FILES.contains(lcsegments[2])) {
             return true
         }
 
         //    0      1     2
-        // package/.cache/file
-        if (lcsegments.size >= 3 && HIDDEN_CACHE_FOLDERS.contains(lcsegments[1])) { // weird name cache folder
+        // package/.thumbnails/file
+        if (lcsegments.size >= 3 && HIDDEN_FODLERS.contains(lcsegments[1])) {
             return true
         }
         if (isException(segments)) return false
 
         //    0      1     2     3
-        // package/files/.cache/file
-        if (lcsegments.size >= 4
-            && "files" == lcsegments[1]
-            && (HIDDEN_CACHE_FOLDERS.contains(lcsegments[2]) || "cache" == lcsegments[2])
-        ) {
-            // cache hidden in files
+        // package/files/.thumbnails/file
+        if (lcsegments.size >= 4 && "files" == lcsegments[1] && HIDDEN_FODLERS.contains(lcsegments[2])) {
             return true
         }
 
         //    -1     0      1     2     3
         // sdcard/Huawei/Themes/.cache/file
-        if (lcsegments.size >= 4
-            && areaType == DataArea.Type.SDCARD
-            && HIDDEN_CACHE_FOLDERS.contains(lcsegments[2])
-        ) {
-            // cache hidden in files
+        if (lcsegments.size >= 4 && areaType == DataArea.Type.SDCARD && HIDDEN_FODLERS.contains(lcsegments[2])) {
             return true
         }
 
@@ -99,15 +91,15 @@ class HiddenFilter @Inject constructor(
     }
 
     private fun isException(dirs: Segments): Boolean {
-        return dirs.size >= 4 && dirs[2] == "Cache" && dirs[3].contains(".unity3d&")
+        return false
     }
 
     @Reusable
     class Factory @Inject constructor(
         private val settings: AppCleanerSettings,
-        private val filterProvider: Provider<HiddenFilter>
+        private val filterProvider: Provider<ThumbnailsFilter>
     ) : ExpendablesFilter.Factory {
-        override suspend fun isEnabled(): Boolean = settings.filterHiddenCachesEnabled.value()
+        override suspend fun isEnabled(): Boolean = settings.filterThumbnailsEnabled.value()
         override suspend fun create(): ExpendablesFilter = filterProvider.get()
     }
 
@@ -118,34 +110,18 @@ class HiddenFilter @Inject constructor(
     }
 
     companion object {
-        private val HIDDEN_CACHE_FOLDERS: Collection<String> = listOf(
-            ".cache",
-            "tmp", ".tmp",
-            "tmpdata", "tmp-data", "tmp_data",
-            ".tmpdata", ".tmp-data", ".tmp_data",
-            ".temp", "temp",
-            "tempdata", "temp-data", "temp_data",
-            ".tempdata", ".temp-data", ".temp_data",
-            "cache", "_cache", "-cache",
-            "imagecache", "image-cache", "image_cache",
-            ".imagecache", ".image-cache", ".image_cache",
-            "videocache", "video-cache", "video_cache",
-            ".videocache", ".video-cache", ".video_cache",
-            "mediacache", "media-cache", "media_cache",
-            ".mediacache", ".mediacache", ".media-cache",
-            "diskcache", "disk-cache", "disk_cache",
-            ".diskcache", ".disk-cache", ".disk_cache",
-            "filescache"
+        private val HIDDEN_FODLERS: Collection<String> = listOf(
+            ".thumbs",
+            "thumbs",
+            ".thumbnails",
+            "thumbnails",
         )
-        private val HIDDEN_CACHE_FILES: Collection<String> = listOf(
-            "cache.dat",
-            "tmp.dat",
-            "temp.dat",
-            ".temp.jpg"
+        private val HIDDEN_FILES: Collection<String> = listOf(
+
         )
         private val IGNORED_FILES: Collection<String> = listOf(
             ".nomedia"
         )
-        private val TAG = logTag("AppCleaner", "Scanner", "Filter", "HiddenCaches")
+        private val TAG = logTag("AppCleaner", "Scanner", "Filter", "Thumbnails")
     }
 }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/ui/AppJunkExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/ui/AppJunkExtensions.kt
@@ -14,6 +14,7 @@ val <T : ExpendablesFilter> KClass<T>.labelRes: Int
         DefaultCachesPublicFilter::class -> R.string.appcleaner_filter_defaultcachespublic_label
         DefaultCachesPrivateFilter::class -> R.string.appcleaner_filter_defaultcachesprivate_label
         HiddenFilter::class -> R.string.appcleaner_filter_hiddencaches_label
+        ThumbnailsFilter::class -> R.string.appcleaner_filter_thumbnails_label
         CodeCacheFilter::class -> R.string.appcleaner_filter_codecache_label
         AdvertisementFilter::class -> R.string.appcleaner_filter_advertisement_label
         BugReportingFilter::class -> R.string.appcleaner_filter_bugreporting_label
@@ -37,6 +38,7 @@ val <T : ExpendablesFilter> KClass<T>.descriptionRes: Int
         DefaultCachesPublicFilter::class -> R.string.appcleaner_filter_defaultcachespublic_summary
         DefaultCachesPrivateFilter::class -> R.string.appcleaner_filter_defaultcachesprivate_summary
         HiddenFilter::class -> R.string.appcleaner_filter_hiddencaches_summary
+        ThumbnailsFilter::class -> R.string.appcleaner_filter_thumbnails_summary
         CodeCacheFilter::class -> R.string.appcleaner_filter_codecache_summary
         AdvertisementFilter::class -> R.string.appcleaner_filter_advertisement_summary
         BugReportingFilter::class -> R.string.appcleaner_filter_bugreporting_summary
@@ -60,6 +62,7 @@ val <T : ExpendablesFilter> KClass<T>.iconsRes: Int
         DefaultCachesPublicFilter::class -> R.drawable.ic_baseline_format_list_bulleted_24
         DefaultCachesPrivateFilter::class -> R.drawable.ic_baseline_format_list_bulleted_24
         HiddenFilter::class -> R.drawable.ic_hidden_file_24
+        ThumbnailsFilter::class -> R.drawable.ic_multimedia_24
         CodeCacheFilter::class -> R.drawable.ic_baseline_format_list_bulleted_24
         AdvertisementFilter::class -> R.drawable.ic_baseline_ads_click_24
         BugReportingFilter::class -> R.drawable.ic_bug_report

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/ui/AppJunkExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/ui/AppJunkExtensions.kt
@@ -5,7 +5,7 @@ import androidx.annotation.StringRes
 import eu.darken.sdmse.R
 import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilter
 import eu.darken.sdmse.appcleaner.core.forensics.filter.*
-import eu.darken.sdmse.appcleaner.core.forensics.generic.RecycleBinsFilter
+import eu.darken.sdmse.appcleaner.core.forensics.filter.RecycleBinsFilter
 import kotlin.reflect.KClass
 
 @get:StringRes

--- a/app/src/main/java/eu/darken/sdmse/common/clutter/dynamic/NestedPackageV2Matcher.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/clutter/dynamic/NestedPackageV2Matcher.kt
@@ -107,7 +107,7 @@ open class NestedPackageV2Matcher(
         override fun match(otherAreaType: DataArea.Type, otherSegments: List<String>): Marker.Match? {
             if (this.areaType !== otherAreaType) return null
 
-            return if (otherSegments.matches(this.segments, ignoreCase)) Marker.Match(setOf(pkgId)) else null
+            return if (otherSegments.matches(this.segments, ignoreCase)) Marker.Match(setOf(pkgId), flags) else null
         }
     }
 }

--- a/app/src/main/java/eu/darken/sdmse/common/forensics/Owner.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/forensics/Owner.kt
@@ -3,6 +3,7 @@ package eu.darken.sdmse.common.forensics
 import android.os.Parcelable
 import eu.darken.sdmse.common.clutter.Marker
 import eu.darken.sdmse.common.pkgs.Pkg
+import eu.darken.sdmse.common.pkgs.features.Installed
 import eu.darken.sdmse.common.user.UserHandle2
 import kotlinx.parcelize.Parcelize
 
@@ -12,6 +13,9 @@ data class Owner(
     val userHandle: UserHandle2,
     val flags: Set<Marker.Flag> = emptySet(),
 ) : Parcelable {
+
+    val installId: Installed.InstallId
+        get() = Installed.InstallId(pkgId, userHandle)
 
     fun hasFlag(flag: Marker.Flag): Boolean = flags.contains(flag)
 

--- a/app/src/main/res/drawable/ic_multimedia_24.xml
+++ b/app/src/main/res/drawable/ic_multimedia_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M9 13V5C9 3.9 9.9 3 11 3H20C21.1 3 22 3.9 22 5V11H18.57L17.29 9.26C17.23 9.17 17.11 9.17 17.05 9.26L15.06 12C15 12.06 14.88 12.07 14.82 12L13.39 10.25C13.33 10.18 13.22 10.18 13.16 10.25L11.05 12.91C10.97 13 11.04 13.15 11.16 13.15H17.5V15H11C9.89 15 9 14.11 9 13M6 22V21H4V22H2V2H4V3H6V2H8.39C7.54 2.74 7 3.8 7 5V13C7 15.21 8.79 17 11 17H15.7C14.67 17.83 14 19.08 14 20.5C14 21.03 14.11 21.53 14.28 22H6M4 7H6V5H4V7M4 11H6V9H4V11M4 15H6V13H4V15M6 19V17H4V19H6M23 13V15H21V20.5C21 21.88 19.88 23 18.5 23S16 21.88 16 20.5 17.12 18 18.5 18C18.86 18 19.19 18.07 19.5 18.21V13H23Z" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -270,6 +270,8 @@
     <string name="appcleaner_filter_analytics_summary">Analytics related data, e.g. cached stats for what you click in an app.</string>
     <string name="appcleaner_filter_hiddencaches_label">Hidden caches</string>
     <string name="appcleaner_filter_hiddencaches_summary">General purpose caches stored outside of the systems reach.</string>
+    <string name="appcleaner_filter_thumbnails_label">Media thumbnails</string>
+    <string name="appcleaner_filter_thumbnails_summary">Image, video and audio preview thumbnail pictures.</string>
     <string name="appcleaner_filter_gamefiles_label">Game files</string>
     <string name="appcleaner_filter_gamefiles_summary">Game related resources that the game would reload on next launch if necessary.</string>
     <string name="appcleaner_filter_offlinecache_label">Offline cache</string>

--- a/app/src/main/res/xml/preferences_appcleaner.xml
+++ b/app/src/main/res/xml/preferences_appcleaner.xml
@@ -55,6 +55,11 @@
             app:summary="@string/appcleaner_filter_hiddencaches_summary"
             app:title="@string/appcleaner_filter_hiddencaches_label" />
         <CheckBoxPreference
+            app:icon="@drawable/ic_multimedia_24"
+            app:key="filter.thumbnails.enabled"
+            app:summary="@string/appcleaner_filter_thumbnails_summary"
+            app:title="@string/appcleaner_filter_thumbnails_label" />
+        <CheckBoxPreference
             app:icon="@drawable/ic_baseline_format_list_bulleted_24"
             app:key="filter.codecache.enabled"
             app:summary="@string/appcleaner_filter_codecache_summary"

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/HiddenFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/HiddenFilterTest.kt
@@ -166,22 +166,6 @@ class HiddenFilterTest : BaseFilterTest() {
                 .locs(SDCARD, PUBLIC_DATA, PRIVATE_DATA)
         )
         addCandidate(
-            neg().pkgs(testPkg).prefixFree("$testPkg/.thumbnails")
-                .locs(SDCARD, PUBLIC_DATA, PRIVATE_DATA)
-        )
-        addCandidate(
-            pos().pkgs(testPkg).prefixFree("$testPkg/.thumbnails/file")
-                .locs(SDCARD, PUBLIC_DATA, PRIVATE_DATA)
-        )
-        addCandidate(
-            neg().pkgs(testPkg).prefixFree("$testPkg/files/.thumbnails")
-                .locs(SDCARD, PUBLIC_DATA, PRIVATE_DATA)
-        )
-        addCandidate(
-            pos().pkgs(testPkg).prefixFree("$testPkg/files/.thumbnails/file")
-                .locs(SDCARD, PUBLIC_DATA, PRIVATE_DATA)
-        )
-        addCandidate(
             neg().pkgs(testPkg).prefixFree("$testPkg/TempData")
                 .locs(SDCARD, PUBLIC_DATA, PRIVATE_DATA)
         )
@@ -523,25 +507,6 @@ class HiddenFilterTest : BaseFilterTest() {
         confirm(create())
     }
 
-    @Test fun testFilterQuickOffice() = runTest {
-        addDefaultNegatives()
-        addCandidate(
-            neg().pkgs("com.quickoffice.android").locs(PRIVATE_DATA).prefixFree("com.quickoffice.android/files")
-        )
-        addCandidate(
-            neg().pkgs("com.quickoffice.android").locs(PRIVATE_DATA).prefixFree("com.quickoffice.android/files/asdasd")
-        )
-        addCandidate(
-            pos().pkgs("com.quickoffice.android").locs(PRIVATE_DATA)
-                .prefixFree("com.quickoffice.android/files/kljalskdjlkjasd.thumb.panel")
-        )
-        addCandidate(
-            pos().pkgs("com.quickoffice.android").locs(PRIVATE_DATA)
-                .prefixFree("com.quickoffice.android/files/kljalskdjlkjasd.thumb.home")
-        )
-        confirm(create())
-    }
-
     @Test fun testFilterGenieWidget() = runTest {
         addDefaultNegatives()
         addCandidate(
@@ -700,19 +665,6 @@ class HiddenFilterTest : BaseFilterTest() {
         confirm(create())
     }
 
-    @Test fun testFilterNextAppFx() = runTest {
-        addDefaultNegatives()
-        addCandidate(neg().pkgs("nextapp.fx").locs(SDCARD).prefixFree(".FX/CloudThumbnail"))
-        addCandidate(
-            pos().pkgs("nextapp.fx").locs(SDCARD).prefixFree(".FX/CloudThumbnail/$rngString")
-        )
-        addCandidate(neg().pkgs("nextapp.fx").locs(SDCARD).prefixFree(".FX/ImageThumbnail"))
-        addCandidate(
-            pos().pkgs("nextapp.fx").locs(SDCARD).prefixFree(".FX/ImageThumbnail/$rngString")
-        )
-        confirm(create())
-    }
-
     @Test fun testFilterPolarisOffice() = runTest {
         addDefaultNegatives()
         val pkgs = arrayOf(
@@ -815,26 +767,6 @@ class HiddenFilterTest : BaseFilterTest() {
         addCandidate(neg().pkgs("com.evernote.skitch").locs(SDCARD).prefixFree("Skitch/Temp"))
         addCandidate(
             pos().pkgs("com.evernote.skitch").locs(SDCARD).prefixFree("Skitch/Temp/$rngString")
-        )
-        confirm(create())
-    }
-
-    @Test fun testFilterInfzmReader() = runTest {
-        addDefaultNegatives()
-        addCandidate(neg().pkgs("net.coollet.infzmreader").locs(SDCARD).prefixFree("infzm/thumb_image"))
-        addCandidate(
-            pos().pkgs("net.coollet.infzmreader").locs(SDCARD)
-                .prefixFree("infzm/thumb_image/$rngString")
-        )
-        confirm(create())
-    }
-
-    @Test fun testFilterKascendVideo() = runTest {
-        addDefaultNegatives()
-        addCandidate(neg().pkgs("com.kascend.video").locs(SDCARD).prefixFree("kascend/videoshow/.thumbcache"))
-        addCandidate(
-            pos().pkgs("com.kascend.video").locs(SDCARD)
-                .prefixFree("kascend/videoshow/.thumbcache/$rngString")
         )
         confirm(create())
     }
@@ -1023,18 +955,6 @@ class HiddenFilterTest : BaseFilterTest() {
         addCandidate(
             pos().pkgs("com.ninegag.android.app").locs(PUBLIC_DATA)
                 .prefixFree("com.ninegag.android.app/files/covers/$rngString")
-        )
-        confirm(create())
-    }
-
-    @Test fun testFilterWalloid() = runTest {
-        addDefaultNegatives()
-        addCandidate(
-            neg().pkgs("com.hashcode.walloidpro", "com.hashcode.walloid").locs(SDCARD).prefixFree("Walloid/.Thumbnail")
-        )
-        addCandidate(
-            pos().pkgs("com.hashcode.walloidpro", "com.hashcode.walloid").locs(SDCARD)
-                .prefixFree("Walloid/.Thumbnail/$rngString")
         )
         confirm(create())
     }
@@ -1298,38 +1218,6 @@ class HiddenFilterTest : BaseFilterTest() {
             neg().pkgs("com.android.gallery3d", "com.google.android.gallery3d", "com.sec.android.gallery3d")
                 .locs(SDCARD).prefixFree(".face")
         )
-        confirm(create())
-    }
-
-    @Test fun testVideoPlayer() = runTest {
-        addCandidate(
-            pos().pkgs("com.sec.android.app.videoplayer").locs(SDCARD).prefixFree(".thumbnails/MAKO-6.0.1/movie_10326")
-        )
-        addCandidate(
-            pos().pkgs("com.sec.android.app.videoplayer").locs(SDCARD)
-                .prefixFree(".thumbnails/MAKO-6.0.1/movie_10326/camera.ListView.lvl")
-        )
-        addCandidate(
-            pos().pkgs("com.sec.android.app.videoplayer").locs(SDCARD)
-                .prefixFree(".thumbnails/MAKO-6.0.1/movie_156560/instaweather_vid_20141227_085331.ListView.lvl")
-        )
-        addCandidate(neg().pkgs("com.sec.android.app.videoplayer").locs(SDCARD).prefixFree(".thumbnails/MAKO-6.0.1"))
-        addCandidate(
-            pos().pkgs("com.sec.android.app.videoplayer").locs(SDCARD)
-                .prefixFree(".thumbnails/I9505XXUEMKF_4.3/movie_10326")
-        )
-        addCandidate(
-            pos().pkgs("com.sec.android.app.videoplayer").locs(SDCARD)
-                .prefixFree(".thumbnails/I9505XXUEMKF_4.3/movie_10326/camera.ListView.lvl")
-        )
-        addCandidate(
-            pos().pkgs("com.sec.android.app.videoplayer").locs(SDCARD)
-                .prefixFree(".thumbnails/I9505XXUEMKF_4.3/movie_156560/instaweather_vid_20141227_085331.ListView.lvl")
-        )
-        addCandidate(
-            neg().pkgs("com.sec.android.app.videoplayer").locs(SDCARD).prefixFree(".thumbnails/I9505XXUEMKF_4.3")
-        )
-        addCandidate(neg().pkgs("com.sec.android.app.videoplayer").locs(SDCARD).prefixFree(".thumbnails"))
         confirm(create())
     }
 
@@ -1944,12 +1832,6 @@ class HiddenFilterTest : BaseFilterTest() {
         confirm(create())
     }
 
-    @Test fun testSamsungMyFilesThumbnails() = runTest {
-        addCandidate(neg().pkgs("com.sec.android.app.myfiles").locs(SDCARD).prefixFree("Movies/.thumbnails"))
-        addCandidate(pos().pkgs("com.sec.android.app.myfiles").locs(SDCARD).prefixFree("Movies/.thumbnails/something"))
-        confirm(create())
-    }
-
     @Test fun testCutPasteFramesTemp() = runTest {
         addCandidate(
             neg().pkgs("com.zmobileapps.cutpasteframes").locs(SDCARD).prefixFree("DCIM/Cut Paste Frames/.temp")
@@ -2121,14 +2003,6 @@ class HiddenFilterTest : BaseFilterTest() {
         confirm(create())
     }
 
-    @Test fun testMovieFx() = runTest {
-        addCandidate(neg().pkgs("tv.waterston.movieridefx").locs(SDCARD).prefixFree("MovieRideFX/thumbs"))
-        addCandidate(pos().pkgs("tv.waterston.movieridefx").locs(SDCARD).prefixFree("MovieRideFX/thumbs/test"))
-        addCandidate(neg().pkgs("tv.waterston.movieridefx").locs(SDCARD).prefixFree("MovieRideFXtmp"))
-        addCandidate(pos().pkgs("tv.waterston.movieridefx").locs(SDCARD).prefixFree("MovieRideFXtmp.mp4"))
-        confirm(create())
-    }
-
     @Test fun testInstashot() = runTest {
         addCandidate(
             neg().pkgs("com.camerasideas.instashot").locs(PUBLIC_DATA)
@@ -2193,31 +2067,12 @@ class HiddenFilterTest : BaseFilterTest() {
         confirm(create())
     }
 
-    @Test fun testMiuiPlayer() = runTest {
-        addDefaultNegatives()
-        addCandidate(neg().pkgs("com.miui.player").locs(SDCARD).prefixFree("MIUI/music/album/.player_thumb"))
-        addCandidate(
-            pos().pkgs("com.miui.player").locs(SDCARD).prefixFree("MIUI/music/album/.player_thumb/file")
-        )
-        confirm(create())
-    }
-
     @Test fun testMIUIGallery() = runTest {
         addDefaultNegatives()
         neg("com.miui.gallery", SDCARD, "DCIM/Creative/temp")
         pos("com.miui.gallery", SDCARD, "DCIM/Creative/temp/file")
         neg("com.miui.gallery", SDCARD, "MIUI/Gallery/cloud/.cache")
         pos("com.miui.gallery", SDCARD, "MIUI/Gallery/cloud/.cache/$rngString")
-        confirm(create())
-    }
-
-    @Test fun testMIUIVideoThumbs() = runTest {
-        addDefaultNegatives()
-        addCandidate(neg().pkgs("com.miui.videoplayer").locs(SDCARD).prefixFree("MIUI/Video/thumb/"))
-        addCandidate(
-            pos().pkgs("com.miui.videoplayer").locs(SDCARD)
-                .prefixFree("MIUI/Video/thumb/6ba49cfe32916e890491ee101f97424d.thumb")
-        )
         confirm(create())
     }
 
@@ -2273,6 +2128,13 @@ class HiddenFilterTest : BaseFilterTest() {
         neg("com.xiaomi.bluetooth", SDCARD, "Download/MiuiFastConnect")
         pos("com.xiaomi.bluetooth", SDCARD, "Download/MiuiFastConnect/$rngString")
 
+        confirm(create())
+    }
+
+
+    @Test fun testMovieFx() = runTest {
+        addCandidate(neg().pkgs("tv.waterston.movieridefx").locs(SDCARD).prefixFree("MovieRideFXtmp"))
+        addCandidate(pos().pkgs("tv.waterston.movieridefx").locs(SDCARD).prefixFree("MovieRideFXtmp.mp4"))
         confirm(create())
     }
 }

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/RecycleBinsFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/RecycleBinsFilterTest.kt
@@ -1,7 +1,6 @@
 package eu.darken.sdmse.appcleaner.core.forensics.filter
 
 import eu.darken.sdmse.appcleaner.core.forensics.*
-import eu.darken.sdmse.appcleaner.core.forensics.generic.RecycleBinsFilter
 import eu.darken.sdmse.common.areas.DataArea.Type.*
 import eu.darken.sdmse.common.rngString
 import kotlinx.coroutines.test.runTest

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/ThumbnailsFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/ThumbnailsFilterTest.kt
@@ -1,0 +1,176 @@
+package eu.darken.sdmse.appcleaner.core.forensics.filter
+
+import eu.darken.sdmse.appcleaner.core.forensics.*
+import eu.darken.sdmse.common.areas.DataArea.Type.*
+import eu.darken.sdmse.common.rngString
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class ThumbnailsFilterTest : BaseFilterTest() {
+
+    @BeforeEach
+    override fun setup() {
+        super.setup()
+    }
+
+    @AfterEach
+    override fun teardown() {
+        super.teardown()
+    }
+
+    private fun create() = ThumbnailsFilter(
+        jsonBasedSieveFactory = createJsonSieveFactory(),
+        environment = storageEnvironment,
+    )
+
+    @Test fun testHiddenCacheDefaults() = runTest {
+        addDefaultNegatives()
+
+        addCandidate(
+            neg().pkgs(testPkg).prefixFree("$testPkg/.thumbnails")
+                .locs(SDCARD, PUBLIC_DATA, PRIVATE_DATA)
+        )
+        addCandidate(
+            pos().pkgs(testPkg).prefixFree("$testPkg/.thumbnails/file")
+                .locs(SDCARD, PUBLIC_DATA, PRIVATE_DATA)
+        )
+        addCandidate(
+            neg().pkgs(testPkg).prefixFree("$testPkg/files/.thumbnails")
+                .locs(SDCARD, PUBLIC_DATA, PRIVATE_DATA)
+        )
+        addCandidate(
+            pos().pkgs(testPkg).prefixFree("$testPkg/files/.thumbnails/file")
+                .locs(SDCARD, PUBLIC_DATA, PRIVATE_DATA)
+        )
+        confirm(create())
+    }
+
+    @Test fun testFilterQuickOffice() = runTest {
+        addDefaultNegatives()
+        addCandidate(
+            neg().pkgs("com.quickoffice.android").locs(PRIVATE_DATA).prefixFree("com.quickoffice.android/files")
+        )
+        addCandidate(
+            neg().pkgs("com.quickoffice.android").locs(PRIVATE_DATA).prefixFree("com.quickoffice.android/files/asdasd")
+        )
+        addCandidate(
+            pos().pkgs("com.quickoffice.android").locs(PRIVATE_DATA)
+                .prefixFree("com.quickoffice.android/files/kljalskdjlkjasd.thumb.panel")
+        )
+        addCandidate(
+            pos().pkgs("com.quickoffice.android").locs(PRIVATE_DATA)
+                .prefixFree("com.quickoffice.android/files/kljalskdjlkjasd.thumb.home")
+        )
+        confirm(create())
+    }
+
+    @Test fun testFilterNextAppFx() = runTest {
+        addDefaultNegatives()
+        addCandidate(neg().pkgs("nextapp.fx").locs(SDCARD).prefixFree(".FX/CloudThumbnail"))
+        addCandidate(
+            pos().pkgs("nextapp.fx").locs(SDCARD).prefixFree(".FX/CloudThumbnail/$rngString")
+        )
+        addCandidate(neg().pkgs("nextapp.fx").locs(SDCARD).prefixFree(".FX/ImageThumbnail"))
+        addCandidate(
+            pos().pkgs("nextapp.fx").locs(SDCARD).prefixFree(".FX/ImageThumbnail/$rngString")
+        )
+        confirm(create())
+    }
+
+    @Test fun testFilterInfzmReader() = runTest {
+        addDefaultNegatives()
+        addCandidate(neg().pkgs("net.coollet.infzmreader").locs(SDCARD).prefixFree("infzm/thumb_image"))
+        addCandidate(
+            pos().pkgs("net.coollet.infzmreader").locs(SDCARD)
+                .prefixFree("infzm/thumb_image/$rngString")
+        )
+        confirm(create())
+    }
+
+    @Test fun testFilterKascendVideo() = runTest {
+        addDefaultNegatives()
+        addCandidate(neg().pkgs("com.kascend.video").locs(SDCARD).prefixFree("kascend/videoshow/.thumbcache"))
+        addCandidate(
+            pos().pkgs("com.kascend.video").locs(SDCARD)
+                .prefixFree("kascend/videoshow/.thumbcache/$rngString")
+        )
+        confirm(create())
+    }
+
+    @Test fun testFilterWalloid() = runTest {
+        addDefaultNegatives()
+        addCandidate(
+            neg().pkgs("com.hashcode.walloidpro", "com.hashcode.walloid").locs(SDCARD).prefixFree("Walloid/.Thumbnail")
+        )
+        addCandidate(
+            pos().pkgs("com.hashcode.walloidpro", "com.hashcode.walloid").locs(SDCARD)
+                .prefixFree("Walloid/.Thumbnail/$rngString")
+        )
+        confirm(create())
+    }
+
+    @Test fun testVideoPlayer() = runTest {
+        addCandidate(
+            pos().pkgs("com.sec.android.app.videoplayer").locs(SDCARD).prefixFree(".thumbnails/MAKO-6.0.1/movie_10326")
+        )
+        addCandidate(
+            pos().pkgs("com.sec.android.app.videoplayer").locs(SDCARD)
+                .prefixFree(".thumbnails/MAKO-6.0.1/movie_10326/camera.ListView.lvl")
+        )
+        addCandidate(
+            pos().pkgs("com.sec.android.app.videoplayer").locs(SDCARD)
+                .prefixFree(".thumbnails/MAKO-6.0.1/movie_156560/instaweather_vid_20141227_085331.ListView.lvl")
+        )
+        addCandidate(neg().pkgs("com.sec.android.app.videoplayer").locs(SDCARD).prefixFree(".thumbnails/MAKO-6.0.1"))
+        addCandidate(
+            pos().pkgs("com.sec.android.app.videoplayer").locs(SDCARD)
+                .prefixFree(".thumbnails/I9505XXUEMKF_4.3/movie_10326")
+        )
+        addCandidate(
+            pos().pkgs("com.sec.android.app.videoplayer").locs(SDCARD)
+                .prefixFree(".thumbnails/I9505XXUEMKF_4.3/movie_10326/camera.ListView.lvl")
+        )
+        addCandidate(
+            pos().pkgs("com.sec.android.app.videoplayer").locs(SDCARD)
+                .prefixFree(".thumbnails/I9505XXUEMKF_4.3/movie_156560/instaweather_vid_20141227_085331.ListView.lvl")
+        )
+        addCandidate(
+            neg().pkgs("com.sec.android.app.videoplayer").locs(SDCARD).prefixFree(".thumbnails/I9505XXUEMKF_4.3")
+        )
+        addCandidate(neg().pkgs("com.sec.android.app.videoplayer").locs(SDCARD).prefixFree(".thumbnails"))
+        confirm(create())
+    }
+
+    @Test fun testSamsungMyFilesThumbnails() = runTest {
+        addCandidate(neg().pkgs("com.sec.android.app.myfiles").locs(SDCARD).prefixFree("Movies/.thumbnails"))
+        addCandidate(pos().pkgs("com.sec.android.app.myfiles").locs(SDCARD).prefixFree("Movies/.thumbnails/something"))
+        confirm(create())
+    }
+
+    @Test fun testMiuiPlayer() = runTest {
+        addDefaultNegatives()
+        addCandidate(neg().pkgs("com.miui.player").locs(SDCARD).prefixFree("MIUI/music/album/.player_thumb"))
+        addCandidate(
+            pos().pkgs("com.miui.player").locs(SDCARD).prefixFree("MIUI/music/album/.player_thumb/file")
+        )
+        confirm(create())
+    }
+
+    @Test fun testMIUIVideoThumbs() = runTest {
+        addDefaultNegatives()
+        addCandidate(neg().pkgs("com.miui.videoplayer").locs(SDCARD).prefixFree("MIUI/Video/thumb/"))
+        addCandidate(
+            pos().pkgs("com.miui.videoplayer").locs(SDCARD)
+                .prefixFree("MIUI/Video/thumb/6ba49cfe32916e890491ee101f97424d.thumb")
+        )
+        confirm(create())
+    }
+
+    @Test fun testMovieFx() = runTest {
+        addCandidate(neg().pkgs("tv.waterston.movieridefx").locs(SDCARD).prefixFree("MovieRideFX/thumbs"))
+        addCandidate(pos().pkgs("tv.waterston.movieridefx").locs(SDCARD).prefixFree("MovieRideFX/thumbs/test"))
+        confirm(create())
+    }
+}


### PR DESCRIPTION
* Include folders in scan where the owner was dynamically matched, i.e. `_some.pkg` 
* Create additional "Thumbnails" filter
* Some additional performance gains due to refactoring too.