### PR TITLE
AppCleaner: Fix single path/filter type deletion always triggering ACS based deletion for inaccessible caches

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerDeleteTask.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerDeleteTask.kt
@@ -18,6 +18,7 @@ data class AppCleanerDeleteTask(
     val targetPkgs: Set<Installed.InstallId>? = null,
     val targetFilters: Set<KClass<out ExpendablesFilter>>? = null,
     val targetContents: Set<APath>? = null,
+    val includeInaccessible: Boolean = true,
     val onlyInaccessible: Boolean = false,
 ) : AppCleanerTask {
 

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/ui/details/appjunk/AppJunkEvents.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/ui/details/appjunk/AppJunkEvents.kt
@@ -1,17 +1,13 @@
 package eu.darken.sdmse.appcleaner.ui.details.appjunk
 
 import eu.darken.sdmse.appcleaner.core.AppJunk
-import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilter
+import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerDeleteTask
 import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerTask
-import eu.darken.sdmse.common.files.APath
-import kotlin.reflect.KClass
 
 sealed class AppJunkEvents {
     data class ConfirmDeletion(
         val appJunk: AppJunk,
-        val filterType: KClass<out ExpendablesFilter>? = null,
-        val path: APath? = null,
-        val onlyInaccessible: Boolean = false,
+        val deletionTask: AppCleanerDeleteTask,
     ) : AppJunkEvents()
 
     data class TaskForParent(val task: AppCleanerTask) : AppJunkEvents()


### PR DESCRIPTION
Fixes #218 