### PR TITLE
Fix crash when json file is corrupted.

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/common/serialization/SerializedStorage.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/serialization/SerializedStorage.kt
@@ -1,0 +1,71 @@
+package eu.darken.sdmse.common.serialization
+
+import com.squareup.moshi.JsonAdapter
+import eu.darken.sdmse.common.coroutine.DispatcherProvider
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.sdmse.common.debug.logging.asLog
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.files.local.fromFile
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import java.io.EOFException
+import java.io.File
+import java.io.IOException
+
+abstract class SerializedStorage<T> constructor(
+    private val dispatcherProvider: DispatcherProvider,
+    private val logTag: String,
+) {
+    abstract val provideBackupPath: () -> File
+    abstract val provideBackupFileName: () -> String
+
+    private val saveCurrent by lazy {
+        File(provideBackupPath(), "${provideBackupFileName()}.json").also {
+            it.parentFile!!.mkdirs()
+        }
+    }
+    private val saveBackup by lazy {
+        File(provideBackupPath(), "${provideBackupFileName()}.json.backup").also {
+            it.parentFile!!.mkdirs()
+        }
+    }
+
+    abstract val provideAdapter: () -> JsonAdapter<T>
+    private val adapter by lazy { provideAdapter() }
+
+    private val lock = Mutex()
+
+    suspend fun save(data: T): Unit = lock.withLock {
+        log(logTag) { "save(): $data" }
+        withContext(NonCancellable + dispatcherProvider.IO) {
+            if (saveCurrent.exists()) {
+                saveCurrent.copyTo(saveBackup, overwrite = true)
+            }
+            try {
+                val rawJson = adapter.toJson(data)
+                saveCurrent.writeText(rawJson)
+            } catch (e: IOException) {
+                log(logTag, ERROR) { "Saving failed: ${e.asLog()}" }
+                saveBackup.copyTo(saveCurrent, overwrite = true)
+                saveBackup.delete()
+            }
+        }
+    }
+
+    suspend fun load(): T? = lock.withLock {
+        var data: T? = null
+        withContext(dispatcherProvider.IO) {
+            if (!saveCurrent.exists()) return@withContext
+            try {
+                data = adapter.fromFile(saveCurrent)
+            } catch (e: EOFException) {
+                log(logTag, ERROR) { "Empty data file: $saveCurrent" }
+                saveCurrent.delete()
+            }
+        }
+        log(logTag) { "load(): $data" }
+        return data
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/exclusion/core/ExclusionManager.kt
+++ b/app/src/main/java/eu/darken/sdmse/exclusion/core/ExclusionManager.kt
@@ -22,7 +22,7 @@ class ExclusionManager @Inject constructor(
 ) {
 
     private val _exclusions = DynamicStateFlow(parentScope = appScope + dispatcherProvider.IO) {
-        exclusionStorage.load()
+        exclusionStorage.load() ?: emptySet()
     }
     val exclusions: Flow<Collection<Exclusion>> = _exclusions.flow
 

--- a/app/src/main/java/eu/darken/sdmse/exclusion/core/ExclusionStorage.kt
+++ b/app/src/main/java/eu/darken/sdmse/exclusion/core/ExclusionStorage.kt
@@ -1,65 +1,30 @@
 package eu.darken.sdmse.exclusion.core
 
 import android.content.Context
+import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapter
 import dagger.hilt.android.qualifiers.ApplicationContext
-import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
-import eu.darken.sdmse.common.debug.logging.asLog
-import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.debug.logging.logTag
-import eu.darken.sdmse.common.files.local.fromFile
+import eu.darken.sdmse.common.serialization.SerializedStorage
 import eu.darken.sdmse.exclusion.core.types.Exclusion
-import kotlinx.coroutines.NonCancellable
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.withContext
-import okio.IOException
 import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class ExclusionStorage @Inject constructor(
+    dispatcherProvider: DispatcherProvider,
     @ApplicationContext private val context: Context,
     private val moshi: Moshi,
-) {
-    private val saveDir by lazy {
-        File(context.filesDir, "exclusions").apply { mkdirs() }
-    }
-    private val saveCurrent by lazy { File(saveDir, "exclusions-v1.json") }
-    private val saveBackup by lazy { File(saveDir, "exclusions-v1.json.backup") }
+) : SerializedStorage<Set<Exclusion>>(dispatcherProvider, TAG) {
 
-    private val adapter by lazy { moshi.adapter<Set<Exclusion>>() }
+    override val provideBackupPath: () -> File = { File(context.filesDir, "exclusions") }
 
-    private val lock = Mutex()
+    override val provideBackupFileName: () -> String = { "exclusions-v1" }
 
-    suspend fun save(exclusions: Set<Exclusion>): Unit = lock.withLock {
-        log(TAG) { "save(): ${exclusions.size}" }
-        withContext(NonCancellable) {
-            if (saveCurrent.exists()) {
-                saveCurrent.copyTo(saveBackup, overwrite = true)
-            }
-            try {
-                val rawJson = adapter.toJson(exclusions)
-                saveCurrent.writeText(rawJson)
-            } catch (e: IOException) {
-                log(TAG, ERROR) { "Saving exclusions failed: ${e.asLog()}" }
-                saveBackup.copyTo(saveCurrent, overwrite = true)
-                saveBackup.delete()
-            }
-        }
-    }
-
-    suspend fun load(): Set<Exclusion> = lock.withLock {
-        val exclusions = if (saveCurrent.exists()) {
-            adapter.fromFile(saveCurrent)
-        } else {
-            emptySet()
-        }
-        log(TAG) { "load(): ${exclusions.size}" }
-        return exclusions
-    }
+    override val provideAdapter: () -> JsonAdapter<Set<Exclusion>> = { moshi.adapter() }
 
     companion object {
         private val TAG = logTag("Exclusion", "Storage")

--- a/app/src/main/java/eu/darken/sdmse/scheduler/core/ScheduleStorage.kt
+++ b/app/src/main/java/eu/darken/sdmse/scheduler/core/ScheduleStorage.kt
@@ -1,70 +1,32 @@
 package eu.darken.sdmse.scheduler.core
 
 import android.content.Context
+import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapter
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
-import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
-import eu.darken.sdmse.common.debug.logging.asLog
-import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
-import eu.darken.sdmse.common.files.local.fromFile
-import kotlinx.coroutines.NonCancellable
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.withContext
-import okio.IOException
+import eu.darken.sdmse.common.serialization.SerializedStorage
 import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class ScheduleStorage @Inject constructor(
-    private val dispatcherProvider: DispatcherProvider,
+    dispatcherProvider: DispatcherProvider,
     @ApplicationContext private val context: Context,
     private val moshi: Moshi,
-) {
+) : SerializedStorage<Set<Schedule>>(dispatcherProvider, TAG) {
 
-    private val saveDir by lazy {
+    override val provideBackupPath: () -> File = {
         val baseDir = File(context.filesDir, "scheduler")
-        File(baseDir, "schedules").apply { mkdirs() }
-    }
-    private val saveCurrent by lazy { File(saveDir, "schedules-v1.json") }
-    private val saveBackup by lazy { File(saveDir, "schedules-v1.json.backup") }
-
-    private val adapter by lazy { moshi.adapter<Set<Schedule>>() }
-
-    private val lock = Mutex()
-
-    suspend fun save(schedules: Set<Schedule>): Unit = lock.withLock {
-        log(TAG) { "save(): ${schedules.size}" }
-        withContext(NonCancellable + dispatcherProvider.IO) {
-            if (saveCurrent.exists()) {
-                saveCurrent.copyTo(saveBackup, overwrite = true)
-            }
-            try {
-                val rawJson = adapter.toJson(schedules)
-                saveCurrent.writeText(rawJson)
-            } catch (e: IOException) {
-                log(TAG, ERROR) { "Saving schedules failed: ${e.asLog()}" }
-                saveBackup.copyTo(saveCurrent, overwrite = true)
-                saveBackup.delete()
-            }
-        }
+        File(baseDir, "schedules")
     }
 
-    suspend fun load(): Set<Schedule> = lock.withLock {
-        val schedules = withContext(dispatcherProvider.IO) {
-            if (saveCurrent.exists()) {
-                adapter.fromFile(saveCurrent)
-            } else {
-                emptySet()
-            }
-        }
-        log(TAG) { "load(): ${schedules.size}" }
-        return schedules
-    }
+    override val provideBackupFileName: () -> String = { "schedules-v1" }
+
+    override val provideAdapter: () -> JsonAdapter<Set<Schedule>> = { moshi.adapter<Set<Schedule>>() }
 
     companion object {
         private val TAG = logTag("Scheduler", "Storage")

--- a/app/src/main/java/eu/darken/sdmse/scheduler/core/SchedulerManager.kt
+++ b/app/src/main/java/eu/darken/sdmse/scheduler/core/SchedulerManager.kt
@@ -34,7 +34,7 @@ class SchedulerManager @Inject constructor(
 ) {
 
     private val internalState = DynamicStateFlow(parentScope = appScope + dispatcherProvider.IO) {
-        State(schedules = storage.load())
+        State(schedules = storage.load() ?: emptySet())
     }
     val state: Flow<State> = internalState.flow
 

--- a/app/src/main/java/eu/darken/sdmse/scheduler/core/SchedulerRestoreReceiver.kt
+++ b/app/src/main/java/eu/darken/sdmse/scheduler/core/SchedulerRestoreReceiver.kt
@@ -31,7 +31,7 @@ class SchedulerRestoreReceiver : BroadcastReceiver() {
             return
         }
 
-        log(TAG, INFO) { "Rechecking scheduler states (${intent.data}" }
+        log(TAG, INFO) { "Rechecking scheduler states (${intent.data})" }
 
         val asyncPi = goAsync()
 

--- a/app/src/test/java/eu/darken/sdmse/common/exclusion/core/ExclusionStorageTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/common/exclusion/core/ExclusionStorageTest.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
 import testhelpers.json.toComparableJson
 import java.io.File
 
@@ -30,7 +31,11 @@ class ExclusionStorageTest : BaseTest() {
         testFolder.deleteAll()
     }
 
-    fun create() = ExclusionStorage(context, moshi)
+    fun create() = ExclusionStorage(
+        dispatcherProvider = TestDispatcherProvider(),
+        context = context,
+        moshi = moshi
+    )
 
     @Test
     fun `combined serialization`() = runTest {

--- a/app/src/test/java/eu/darken/sdmse/scheduler/core/ScheduleStorageTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/scheduler/core/ScheduleStorageTest.kt
@@ -1,0 +1,70 @@
+package eu.darken.sdmse.scheduler.core
+
+import android.content.Context
+import eu.darken.sdmse.common.files.local.deleteAll
+import eu.darken.sdmse.common.serialization.SerializationAppModule
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import testhelpers.json.toComparableJson
+import java.io.File
+import java.time.Instant
+
+class ScheduleStorageTest : BaseTest() {
+    private val testDir = File(IO_TEST_BASEDIR)
+    private val context: Context = mockk<Context>().apply {
+        every { filesDir } returns testDir
+    }
+
+    @AfterEach
+    fun cleanup() {
+        testDir.deleteAll()
+    }
+
+    private fun create() = ScheduleStorage(
+        context = context,
+        dispatcherProvider = TestDispatcherProvider(),
+        moshi = SerializationAppModule().moshi()
+    )
+
+    @Test
+    fun `load empty`() = runTest {
+        create().load() shouldBe null
+    }
+
+    @Test
+    fun `load save clear`() = runTest {
+        val schedule = Schedule(
+            id = "1234id",
+            createdAt = Instant.EPOCH
+        )
+        create().apply {
+            load() shouldBe null
+            save(setOf(schedule))
+            load() shouldBe setOf(schedule)
+            val saveFile = provideBackupPath().listFiles()!!.single()
+            saveFile.readText().toComparableJson() shouldBe """
+                [
+                    {
+                        "id": "1234id",
+                        "createdAt": "1970-01-01T00:00:00Z",
+                        "hour": 22.0,
+                        "minute": 0.0,
+                        "label": "",
+                        "repeatInterval": "PT72H",
+                        "corpsefinderEnabled": false,
+                        "systemcleanerEnabled": false,
+                        "appcleanerEnabled": false
+                    }
+                ]
+            """.toComparableJson()
+            saveFile.delete()
+            load() shouldBe null
+        }
+    }
+}


### PR DESCRIPTION
Use common base class to handle json-based storage and align edge-case handling: If the save-file is empty delete it and return null.

```java
java.io.EOFException: End of input
        at com.squareup.moshi.JsonUtf8Reader.nextNonWhitespace(JsonUtf8Reader.java:1144)
        at com.squareup.moshi.JsonUtf8Reader.doPeek(JsonUtf8Reader.java:337)
        at com.squareup.moshi.JsonUtf8Reader.peek(JsonUtf8Reader.java:206)
        at com.squareup.moshi.internal.NullSafeJsonAdapter.fromJson(NullSafeJsonAdapter.java:38)
        at eu.darken.sdmse.common.files.local.JsonAdapterExtensionsKt.from(JsonAdapterExtensions.kt:33)
```

This does only seem to happen on boot restores 🤔 

```
1683447102661 D/SDMSE:Scheduler:Receiver:Restore: onReceive(android.app.ReceiverRestrictedContext@6fac6ca,Intent { act=android.intent.action.BOOT_COMPLETED flg=0x89000010 cmp=eu.darken.sdmse/.scheduler.core.SchedulerRestoreReceiver (has extras) })
1683447102661 I/SDMSE:Scheduler:Receiver:Restore: Rechecking scheduler states (null
1683447102661 D/SDMSE:Debug:CurriculumVitae: Launch count is 298
1683447102712 D/SDMSE:Debug:CurriculumVitae: Launch BETA count is 298
1683447102723 D/SDMSE:Debug:CurriculumVitae: Current version history is [0.7.2-rc0, 0.7.8-beta0]
1683447105831 W/SDMSE:JsonAdapterExtensions: from(source=source(java.io.FileInputStream@2615831)): java.io.EOFException: End of input
1683447105831 W/SDMSE:JsonAdapterExtensions: fromFile(file=/data/user/0/eu.darken.sdmse/files/scheduler/schedules/schedules-v1.json): java.io.EOFException: End of input
```
