### PR TITLE
Fix debug log being incomplete after crashes

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/common/debug/DebugCardProvider.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/debug/DebugCardProvider.kt
@@ -8,8 +8,6 @@ import eu.darken.sdmse.common.datastore.valueBlocking
 import eu.darken.sdmse.common.debug.autoreport.DebugSettings
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.GatewaySwitch
-import eu.darken.sdmse.common.files.local.LocalPath
-import eu.darken.sdmse.common.files.lookup
 import eu.darken.sdmse.common.navigation.navVia
 import eu.darken.sdmse.common.pkgs.PkgRepo
 import eu.darken.sdmse.common.pkgs.pkgops.PkgOps
@@ -26,6 +24,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 import java.util.*
 import javax.inject.Inject
@@ -99,10 +98,13 @@ class DebugCardProvider @Inject constructor(
                 }
             },
             onRunTest = {
-                vm.launch {
-                    val local =
-                        LocalPath.build("/data_mirror/data_ce/null/0/com.google.android.trichromelibrary_428014133/lib")
-                    local.lookup(gatewaySwitch)
+//                vm.launch {
+//                    val local =
+//                        LocalPath.build("/data_mirror/data_ce/null/0/com.google.android.trichromelibrary_428014133/lib")
+//                    local.lookup(gatewaySwitch)
+//                }
+                appScope.launch {
+                    throw RuntimeException()
                 }
             }
         )

--- a/app/src/main/java/eu/darken/sdmse/common/debug/autoreport/DebugSettings.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/debug/autoreport/DebugSettings.kt
@@ -23,4 +23,6 @@ class DebugSettings @Inject constructor(
     val isTraceMode = dataStore.createValue("debug.trace.enabled", false)
     val isDryRunMode = dataStore.createValue("debug.dryrun.enabled", false)
 
+    val recorderPath = dataStore.createValue<String?>("recorder.log.path", null)
+
 }


### PR DESCRIPTION
Store current log path in debug settings so we can append to the previous log file after a crash.

See #245