### PR TITLE
SAF: Workarounds for missing ACTION_OPEN_DOCUMENT_TREE support

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/setup/saf/SAFSetupModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/saf/SAFSetupModule.kt
@@ -162,6 +162,9 @@ class SAFSetupModule @Inject constructor(
                 }
         }
 
+        // TODO provide some more elaborate lookups for TV boxes that struggle with this?
+        // See https://commonsware.com/blog/2017/12/27/storage-access-framework-missing-action.html
+
         log(TAG) { "Generated: $requestObjects" }
         return requestObjects
     }


### PR DESCRIPTION
i.e. no "Documents" app that consumes `ACTION_OPEN_DOCUMENT_TREE`