### PR TITLE
Fix native library linking crash

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -150,7 +150,7 @@ dependencies {
     addRetrofit()
 
     "gplayImplementation"("com.bugsnag:bugsnag-android:5.9.2")
-    "gplayImplementation"("com.getkeepsafe.relinker:relinker:1.4.3")
+    "gplayImplementation"("com.getkeepsafe.relinker:relinker:1.4.4")
 
     "gplayImplementation"("com.android.billingclient:billing:5.1.0")
     "gplayImplementation"("com.android.billingclient:billing-ktx:5.1.0")

--- a/app/src/gplay/java/eu/darken/sdmse/common/debug/autoreport/GooglePlayReporting.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/debug/autoreport/GooglePlayReporting.kt
@@ -38,11 +38,9 @@ class GooglePlayReporting @Inject constructor(
         val isEnabled = generalSettings.isBugReporterEnabled.valueBlocking
         log(TAG) { "setup(): isEnabled=$isEnabled" }
 
-        if (isEnabled) {
             ReLinker
                 .log { message -> log(App.TAG) { "ReLinker: $message" } }
                 .loadLibrary(application, "bugsnag-plugin-android-anr")
-        }
         try {
             val bugsnagConfig = Configuration.load(context).apply {
                 if (generalSettings.isBugReporterEnabled.valueBlocking) {


### PR DESCRIPTION
Even if bugsnag is disabled, use the relinker, otherwise setting bugsnag up for NOOP can still crash.