### PR TITLE
Don't crash if we are not allowed to open the system details for an app

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/ui/details/appjunk/elements/AppJunkElementHeaderVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/ui/details/appjunk/elements/AppJunkElementHeaderVH.kt
@@ -8,6 +8,8 @@ import eu.darken.sdmse.R
 import eu.darken.sdmse.appcleaner.core.AppJunk
 import eu.darken.sdmse.appcleaner.ui.details.appjunk.AppJunkElementsAdapter
 import eu.darken.sdmse.common.coil.loadAppIcon
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.lists.binding
 import eu.darken.sdmse.common.pkgs.getSettingsIntent
 import eu.darken.sdmse.databinding.AppcleanerAppjunkElementHeaderBinding
@@ -31,7 +33,11 @@ class AppJunkElementHeaderVH(parent: ViewGroup) :
             loadAppIcon(junk.pkg)
             setOnLongClickListener {
                 val intent = junk.pkg.getSettingsIntent(context)
-                context.startActivity(intent)
+                try {
+                    context.startActivity(intent)
+                } catch (e: Exception) {
+                    log(WARN) { "Settings intent failed for ${junk.pkg}: $e" }
+                }
                 true
             }
         }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/ui/list/AppCleanerListRowVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/ui/list/AppCleanerListRowVH.kt
@@ -5,6 +5,8 @@ import android.view.ViewGroup
 import eu.darken.sdmse.R
 import eu.darken.sdmse.appcleaner.core.AppJunk
 import eu.darken.sdmse.common.coil.loadAppIcon
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.lists.binding
 import eu.darken.sdmse.common.pkgs.getSettingsIntent
 import eu.darken.sdmse.databinding.AppcleanerListItemBinding
@@ -27,7 +29,11 @@ class AppCleanerListRowVH(parent: ViewGroup) :
             loadAppIcon(junk.pkg)
             setOnLongClickListener {
                 val intent = junk.pkg.getSettingsIntent(context)
-                context.startActivity(intent)
+                try {
+                    context.startActivity(intent)
+                } catch (e: Exception) {
+                    log(WARN) { "Settings intent failed for ${junk.pkg}: $e" }
+                }
                 true
             }
         }

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/actions/AppActionDialogVM.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/actions/AppActionDialogVM.kt
@@ -13,9 +13,16 @@ import eu.darken.sdmse.appcontrol.core.createSystemSettingsIntent
 import eu.darken.sdmse.appcontrol.core.toggle.AppControlToggleTask
 import eu.darken.sdmse.appcontrol.core.uninstall.UninstallException
 import eu.darken.sdmse.appcontrol.core.uninstall.UninstallTask
-import eu.darken.sdmse.appcontrol.ui.list.actions.items.*
+import eu.darken.sdmse.appcontrol.ui.list.actions.items.AppStoreActionVH
+import eu.darken.sdmse.appcontrol.ui.list.actions.items.ExcludeActionVH
+import eu.darken.sdmse.appcontrol.ui.list.actions.items.LaunchActionVH
+import eu.darken.sdmse.appcontrol.ui.list.actions.items.SystemSettingsActionVH
+import eu.darken.sdmse.appcontrol.ui.list.actions.items.ToggleActionVH
+import eu.darken.sdmse.appcontrol.ui.list.actions.items.UninstallActionVH
 import eu.darken.sdmse.common.SingleLiveEvent
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.navigation.navArgs
@@ -29,7 +36,12 @@ import eu.darken.sdmse.exclusion.core.currentExclusions
 import eu.darken.sdmse.exclusion.core.types.Exclusion
 import eu.darken.sdmse.exclusion.core.types.PackageExclusion
 import eu.darken.sdmse.main.core.taskmanager.TaskManager
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.take
 import javax.inject.Inject
 
 
@@ -88,7 +100,12 @@ class AppActionDialogVM @Inject constructor(
             appInfo = appInfo,
             onSettings = {
                 val intent = it.createSystemSettingsIntent(context)
-                context.startActivity(intent)
+                try {
+                    context.startActivity(intent)
+                } catch (e: Exception) {
+                    log(TAG, ERROR) { "Launching system settings intent failed: ${e.asLog()}" }
+                    errorEvents.postValue(e)
+                }
             }
         )
 


### PR DESCRIPTION
realme narzo 30A (RMX3171) @ Android 11
```
java.lang.SecurityException: Not allowed to start activity Intent { act=android.settings.APPLICATION_DETAILS_SETTINGS dat=package:com.coloros.sauhelper flg=0x10000000 }
``