### PR TITLE
Move details screen for available data areas

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/main/ui/settings/SettingsIndexFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/settings/SettingsIndexFragment.kt
@@ -47,10 +47,6 @@ class SettingsIndexFragment : PreferenceFragment2() {
             SettingsFragmentDirections.actionSettingsContainerFragmentToSetupFragment(showCompleted = true).navigate()
             true
         }
-        findPreference<Preference>("areas.current.show")!!.setOnPreferenceClickListener {
-            SettingsFragmentDirections.actionSettingsContainerFragmentToDataAreasFragment().navigate()
-            true
-        }
 
         findPreference<Preference>("core.changelog")!!.summary = BuildConfigWrap.VERSION_DESCRIPTION
         findPreference<Preference>("core.privacy")!!.setOnPreferenceClickListener {

--- a/app/src/main/java/eu/darken/sdmse/setup/SetupFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/SetupFragment.kt
@@ -80,9 +80,16 @@ class SetupFragment : Fragment3(R.layout.setup_fragment) {
                         webpageTool.open("https://github.com/d4rken-org/sdmaid-se/wiki/Setup")
                         true
                     }
-                    else -> super.onOptionsItemSelected(it)
+
+                    R.id.action_show_areas -> {
+                        SetupFragmentDirections.actionSetupFragmentToDataAreasFragment().navigate()
+                        true
+                    }
+
+                    else -> false
                 }
             }
+            menu?.findItem(R.id.action_show_areas)?.isVisible = !vm.isOnboarding
         }
 
         ui.list.setupDefaults(setupAdapter, dividers = false)

--- a/app/src/main/res/menu/menu_setup.xml
+++ b/app/src/main/res/menu/menu_setup.xml
@@ -9,4 +9,13 @@
         android:title="@string/general_help_title"
         android:icon="@drawable/ic_help_outline"
         app:showAsAction="always" />
+
+    <item
+        android:id="@+id/action_show_areas"
+        android:orderInCategory="90"
+        android:title="@string/data_areas_label"
+        android:visible="false"
+        android:contentDescription="@string/data_areas_short_summary"
+        android:icon="@drawable/ic_baseline_format_list_bulleted_24"
+        app:showAsAction="never" />
 </menu>

--- a/app/src/main/res/navigation/main_nav.xml
+++ b/app/src/main/res/navigation/main_nav.xml
@@ -100,6 +100,9 @@
             app:destination="@id/dashboardFragment"
             app:popUpTo="@id/main"
             app:popUpToInclusive="true" />
+        <action
+            android:id="@+id/action_setupFragment_to_dataAreasFragment"
+            app:destination="@id/dataAreasFragment" />
     </fragment>
 
     <fragment
@@ -109,9 +112,6 @@
         <action
             android:id="@+id/action_settingsContainerFragment_to_setupFragment"
             app:destination="@id/setupFragment" />
-        <action
-            android:id="@+id/action_settingsContainerFragment_to_dataAreasFragment"
-            app:destination="@id/dataAreasFragment" />
         <action
             android:id="@+id/action_settingsContainerFragment_to_exclusionsListFragment"
             app:destination="@id/exclusionsListFragment" />

--- a/app/src/main/res/xml/preferences_index.xml
+++ b/app/src/main/res/xml/preferences_index.xml
@@ -51,11 +51,6 @@
             app:icon="@drawable/ic_cellphone_cog_24"
             app:summary="@string/setup_forcedshow_summary"
             app:title="@string/setup_title" />
-        <Preference
-            android:key="areas.current.show"
-            app:icon="@drawable/ic_baseline_format_list_bulleted_24"
-            app:summary="@string/data_areas_short_summary"
-            app:title="@string/data_areas_label" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/settings_category_other_label">


### PR DESCRIPTION
It's too niche to show it as main item in the first settings page. Can now be reached via context menu in the setup screen (but not on the very first onboarding).