### PR TITLE
IO: Improve LocalPath scan performance

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalGateway.kt
@@ -237,7 +237,6 @@ class LocalGateway @Inject constructor(
                     log(TAG, VERBOSE) { "lookupFiles($mode->NORMAL): $path" }
                     if (nonRootList == null) throw ReadException(path)
                     nonRootList
-                        .filter { it.canRead() }
                         .map { it.toLocalPath() }
                         .map { it.performLookup(ipcFunnel, libcoreTool) }
                 }

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalPathExtensions.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalPathExtensions.kt
@@ -5,7 +5,11 @@ import android.system.StructStat
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
-import eu.darken.sdmse.common.files.*
+import eu.darken.sdmse.common.files.Ownership
+import eu.darken.sdmse.common.files.Permissions
+import eu.darken.sdmse.common.files.ReadException
+import eu.darken.sdmse.common.files.Segments
+import eu.darken.sdmse.common.files.asFile
 import eu.darken.sdmse.common.funnel.IPCFunnel
 import eu.darken.sdmse.common.pkgs.pkgops.LibcoreTool
 import java.io.File
@@ -36,7 +40,7 @@ fun LocalPath.performLookup(
     ipcFunnel: IPCFunnel,
     libcoreTool: LibcoreTool,
 ): LocalPathLookup {
-    val type = file.getAPathFileType() ?: throw ReadException(this, "Does not exist")
+    val type = file.getAPathFileType() ?: throw ReadException(this, "Does not exist or can't be read")
 
     val fstat: StructStat? = try {
         Os.lstat(file.path)


### PR DESCRIPTION
Remove extra canRead check. Doesn't seem necessary.
I don't see why this was necessary and it costs a lot of extra time when iterating files.
Theoretically we would abort early if we encounter a read error, but this does not seem to happen on real devices I tested with.