### PR TITLE
Fix AppCleaner ACS based deletion failing on fast API30+ devices

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/automation/core/AutomationService.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/AutomationService.kt
@@ -205,7 +205,8 @@ class AutomationService : AccessibilityService(), AutomationHost, Progress.Host,
         if (!automationProcessor.hasTask) return
 
         val eventCopy = if (hasApiLevel(30)) {
-            event
+            @Suppress("NewApi")
+            AccessibilityEvent(event)
         } else {
             try {
                 @Suppress("DEPRECATION")
@@ -233,7 +234,7 @@ class AutomationService : AccessibilityService(), AutomationHost, Progress.Host,
                     }
                     .also { log(TAG, VERBOSE) { "Fallback root was $fallbackRoot, now is $it" } }
             } catch (e: Exception) {
-                log(TAG, ERROR) { "Failed to get fallbackRoot from $event" }
+                log(TAG, ERROR) { "Failed to get fallbackRoot from $event: $e" }
             }
         }
 

--- a/app/src/main/java/eu/darken/sdmse/automation/core/crawler/AccessibilityNodeExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/crawler/AccessibilityNodeExtensions.kt
@@ -136,4 +136,4 @@ fun AccessibilityNodeInfo.scrollNode(): Boolean {
     return performAction(AccessibilityNodeInfo.ACTION_SCROLL_FORWARD)
 }
 
-val AccessibilityEvent.pkgId: Pkg.Id get() = packageName.toString().toPkgId()
+val AccessibilityEvent.pkgId: Pkg.Id? get() = packageName.takeIf { !it.isNullOrBlank() }?.toString()?.toPkgId()

--- a/app/src/main/java/eu/darken/sdmse/automation/core/crawler/AutomationCrawler.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/crawler/AutomationCrawler.kt
@@ -81,7 +81,10 @@ class AutomationCrawler @AssistedInject constructor(
             // Condition for the right window, e.g. check title
             if (step.windowIntent != null && step.windowEventFilter != null) {
                 log(TAG, VERBOSE) { "Waiting for window event filter to pass..." }
-                host.events.filter { step.windowEventFilter.invoke(it) }.first()
+                host.events.filter {
+                    log(TAG, VERBOSE) { "Testing window event $it" }
+                    step.windowEventFilter.invoke(it)
+                }.first()
                 log(TAG, VERBOSE) { "Waiting for window event filter passed!" }
             }
 


### PR DESCRIPTION
The crawler's window test never passed due to events being "empty" and so the process never continues as SD Maid can't confirm the right window is visible.

While the ACS event handling changed in API30+ and AccessibilityEvent are not longer pooled and recycled, we still need to copy the event or we encounter:
```java
Cannot perform this action on a not sealed instance.
```
and empty events. So despite .recycle() being a NOOP, events are stilled null'ed?