### PR TITLE
AppCleaner: Don't run acs based actions when triggered via scheduler.

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
@@ -81,7 +81,7 @@ class AppCleaner @Inject constructor(
                     is AppCleanerDeleteTask -> performDelete(task)
                     is AppCleanerSchedulerTask -> {
                         performScan(AppCleanerScanTask())
-                        performDelete(AppCleanerDeleteTask())
+                        performDelete(AppCleanerDeleteTask(includeInaccessible = task.useAutomation))
                     }
                 }
             }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerSchedulerTask.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerSchedulerTask.kt
@@ -7,6 +7,7 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 data class AppCleanerSchedulerTask(
     val scheduleId: String,
+    val useAutomation: Boolean,
 ) : AppCleanerTask {
 
     sealed interface Result : AppCleanerTask.Result

--- a/app/src/main/java/eu/darken/sdmse/scheduler/core/SchedulerReceiver.kt
+++ b/app/src/main/java/eu/darken/sdmse/scheduler/core/SchedulerReceiver.kt
@@ -9,7 +9,9 @@ import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerSchedulerTask
 import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.Bugs
-import eu.darken.sdmse.common.debug.logging.Logging.Priority.*
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
@@ -67,7 +69,10 @@ class SchedulerReceiver : BroadcastReceiver() {
 
             if (schedule.useCorpseFinder) tasks.add(CorpseFinderSchedulerTask(schedule.id))
             if (schedule.useSystemCleaner) tasks.add(SystemCleanerSchedulerTask(schedule.id))
-            if (schedule.useAppCleaner) tasks.add(AppCleanerSchedulerTask(schedule.id))
+            if (schedule.useAppCleaner) {
+                val useAutomation = schedulerSettings.useAutomation.value()
+                tasks.add(AppCleanerSchedulerTask(schedule.id, useAutomation = useAutomation))
+            }
 
             tasks.forEach { task ->
                 appScope.launch {

--- a/app/src/main/java/eu/darken/sdmse/scheduler/core/SchedulerSettings.kt
+++ b/app/src/main/java/eu/darken/sdmse/scheduler/core/SchedulerSettings.kt
@@ -24,11 +24,13 @@ class SchedulerSettings @Inject constructor(
         get() = context.dataStore
 
     val skipWhenPowerSaving = dataStore.createValue("requirement.notpowersaving.enabled", true)
+    val useAutomation = dataStore.createValue("option.automation.enabled", false)
 
     val createdDefaultEntry = dataStore.createValue("default.entry.created", false)
 
     override val mapper = PreferenceStoreMapper(
-        skipWhenPowerSaving
+        skipWhenPowerSaving,
+        useAutomation
     )
 
     companion object {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -433,6 +433,8 @@
     <string name="scheduler_no_active_schedules_subtitle">No active schedules</string>
     <string name="scheduler_setting_nopowersaving_title">Skip on low battery</string>
     <string name="scheduler_setting_nopowersaving_summary">If the phone is in power-saving mode, the scheduled execution will be skipped.</string>
+    <string name="scheduler_setting_automation_title">Accessibility service</string>
+    <string name="scheduler_setting_automation_summary">Include actions that use an accessibility service. This requires that SD Maid can interact with your screen (i.e. it\'s unlocked) when the tasks are executed.</string>
 
     <string name="updates_dashcard_title">Update available</string>
     <string name="updates_dashcard_body">An update is available. You have %1$s and the latest version is %2$s.</string>

--- a/app/src/main/res/xml/preferences_scheduler.xml
+++ b/app/src/main/res/xml/preferences_scheduler.xml
@@ -7,4 +7,9 @@
         app:summary="@string/scheduler_setting_nopowersaving_summary"
         app:title="@string/scheduler_setting_nopowersaving_title" />
 
+    <CheckBoxPreference
+        app:icon="@drawable/ic_baseline_accessibility_new_24"
+        app:key="option.automation.enabled"
+        app:summary="@string/scheduler_setting_automation_summary"
+        app:title="@string/scheduler_setting_automation_title" />
 </PreferenceScreen>


### PR DESCRIPTION
Can be enabled again via settings.

See https://github.com/d4rken-org/sdmaid-se/issues/79#issuecomment-1546873735