### PR TITLE
StorageAnalyzer: Remove category percentages

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/analyzer/ui/storage/storage/categories/AppCategoryVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/analyzer/ui/storage/storage/categories/AppCategoryVH.kt
@@ -27,7 +27,7 @@ class AppCategoryVH(parent: ViewGroup) :
 
         val usedText = Formatter.formatShortFileSize(context, content.spaceUsed)
         val totalPercent = ((content.spaceUsed / storage.spaceUsed.toDouble()) * 100).toInt()
-        usedSpace.text = getString(R.string.analyzer_storage_content_x_used_of_total_y, usedText, "$totalPercent%")
+        usedSpace.text = getString(R.string.analyzer_space_used, usedText)
         progress.progress = totalPercent
 
         root.setOnClickListener { item.onItemClicked(content) }

--- a/app/src/main/java/eu/darken/sdmse/analyzer/ui/storage/storage/categories/MediaCategoryVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/analyzer/ui/storage/storage/categories/MediaCategoryVH.kt
@@ -27,7 +27,7 @@ class MediaCategoryVH(parent: ViewGroup) :
 
         val usedText = Formatter.formatShortFileSize(context, content.spaceUsed)
         val totalPercent = ((content.spaceUsed / storage.spaceUsed.toDouble()) * 100).toInt()
-        usedSpace.text = getString(R.string.analyzer_storage_content_x_used_of_total_y, usedText, "$totalPercent%")
+        usedSpace.text = getString(R.string.analyzer_space_used, usedText)
         progress.progress = totalPercent
 
         root.setOnClickListener { item.onItemClicked(content) }

--- a/app/src/main/java/eu/darken/sdmse/analyzer/ui/storage/storage/categories/SystemCategoryVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/analyzer/ui/storage/storage/categories/SystemCategoryVH.kt
@@ -27,7 +27,7 @@ class SystemCategoryVH(parent: ViewGroup) :
 
         val usedText = Formatter.formatShortFileSize(context, content.spaceUsed)
         val totalPercent = ((content.spaceUsed / storage.spaceUsed.toDouble()) * 100).toInt()
-        usedSpace.text = getString(R.string.analyzer_storage_content_x_used_of_total_y, usedText, "$totalPercent%")
+        usedSpace.text = getString(R.string.analyzer_space_used, usedText)
         progress.progress = totalPercent
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -369,7 +369,6 @@
     <string name="analyzer_storage_content_type_media_description">Captured pictures, recorded videos or downloaded data. Any data that doesn\'t belong to a specific app.</string>
     <string name="analyzer_storage_content_type_system_label">System data</string>
     <string name="analyzer_storage_content_type_system_description">System data and system apps.</string>
-    <string name="analyzer_storage_content_x_used_of_total_y">%1$s used (%2$s of total)</string>
     <string name="analyzer_storage_content_app_code_label">App code</string>
     <string name="analyzer_storage_content_app_code_description">Install files, libraries and resources. This space can only be freed by uninstalling the app.</string>
     <string name="analyzer_storage_content_app_data_label">App data</string>


### PR DESCRIPTION
The rounding is confusing and does not deliver enough value. The progressbars deliver the same info and quicker.

Fixes #316