### PR TITLE
File previews in all tools

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -166,6 +166,7 @@ dependencies {
     implementation("com.airbnb.android:lottie:3.5.0")
 
     implementation("io.coil-kt:coil:2.0.0-rc02")
+    implementation("io.coil-kt:coil-video:2.0.0-rc02")
 
     implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
     implementation("com.github.reddit:IndicatorFastScroll:f9576c7") // 1.4.0

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -165,8 +165,8 @@ dependencies {
 
     implementation("com.airbnb.android:lottie:3.5.0")
 
-    implementation("io.coil-kt:coil:2.0.0-rc02")
-    implementation("io.coil-kt:coil-video:2.0.0-rc02")
+    implementation("io.coil-kt:coil:2.4.0")
+    implementation("io.coil-kt:coil-video:2.4.0")
 
     implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
     implementation("com.github.reddit:IndicatorFastScroll:f9576c7") // 1.4.0

--- a/app/src/main/java/eu/darken/sdmse/analyzer/core/content/ContentItem.kt
+++ b/app/src/main/java/eu/darken/sdmse/analyzer/core/content/ContentItem.kt
@@ -8,6 +8,7 @@ import eu.darken.sdmse.common.files.FileType
 
 data class ContentItem(
     val path: APath,
+    val lookup: APathLookup<*>?,
     val label: CaString = path.path.toCaString(),
     val itemSize: Long?,
     val type: FileType,
@@ -26,6 +27,7 @@ data class ContentItem(
     companion object {
         fun fromInaccessible(path: APath): ContentItem = ContentItem(
             path = path,
+            lookup = null,
             type = FileType.DIRECTORY,
             itemSize = null,
             children = null,
@@ -33,6 +35,7 @@ data class ContentItem(
 
         fun fromLookup(lookup: APathLookup<*>, children: Collection<ContentItem>? = null): ContentItem = ContentItem(
             path = lookup.lookedUp,
+            lookup = lookup,
             children = children,
             itemSize = when (lookup.fileType) {
                 FileType.FILE -> lookup.size

--- a/app/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentItemVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentItemVH.kt
@@ -3,9 +3,12 @@ package eu.darken.sdmse.analyzer.ui.storage.content
 import android.text.format.Formatter
 import android.view.ViewGroup
 import androidx.core.view.isGone
+import coil.dispose
 import eu.darken.sdmse.R
 import eu.darken.sdmse.analyzer.core.content.ContentItem
+import eu.darken.sdmse.common.coil.loadFilePreview
 import eu.darken.sdmse.common.files.FileType
+import eu.darken.sdmse.common.files.iconRes
 import eu.darken.sdmse.common.lists.binding
 import eu.darken.sdmse.databinding.AnalyzerContentItemVhBinding
 
@@ -24,15 +27,14 @@ class ContentItemVH(parent: ViewGroup) :
     ) -> Unit = binding { item ->
         val content = item.content
 
-        // TODO can we load previews for some files?
-        contentIcon.setImageResource(
-            when (content.type) {
-                FileType.DIRECTORY -> R.drawable.ic_folder
-                FileType.SYMBOLIC_LINK -> R.drawable.ic_file_link
-                FileType.FILE -> R.drawable.ic_file
-                FileType.UNKNOWN -> R.drawable.file_question
+        contentIcon.apply {
+            if (content.lookup != null) {
+                loadFilePreview(content.lookup)
+            } else {
+                dispose()
+                setImageResource(content.type.iconRes)
             }
-        )
+        }
 
         primary.text = if (item.parent != null) {
             content.path.segments.drop(item.parent.path.segments.size).single()

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/ui/details/appjunk/elements/AppJunkElementFileVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/ui/details/appjunk/elements/AppJunkElementFileVH.kt
@@ -6,9 +6,9 @@ import eu.darken.sdmse.R
 import eu.darken.sdmse.appcleaner.core.AppJunk
 import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilter
 import eu.darken.sdmse.appcleaner.ui.details.appjunk.AppJunkElementsAdapter
+import eu.darken.sdmse.common.coil.loadFilePreview
 import eu.darken.sdmse.common.files.APathLookup
 import eu.darken.sdmse.common.files.FileType
-import eu.darken.sdmse.common.files.iconRes
 import eu.darken.sdmse.common.files.labelRes
 import eu.darken.sdmse.common.lists.binding
 import eu.darken.sdmse.databinding.AppcleanerAppjunkElementFileBinding
@@ -28,7 +28,7 @@ class AppJunkElementFileVH(parent: ViewGroup) :
         payloads: List<Any>
     ) -> Unit = binding { item ->
 
-        icon.setImageResource(item.lookup.fileType.iconRes)
+        icon.loadFilePreview(item.lookup)
 
         primary.text = item.lookup.userReadablePath.get(context)
 

--- a/app/src/main/java/eu/darken/sdmse/common/coil/CoilExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/coil/CoilExtensions.kt
@@ -6,6 +6,8 @@ import androidx.core.view.isInvisible
 import coil.imageLoader
 import coil.request.Disposable
 import coil.request.ImageRequest
+import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.common.files.iconRes
 import eu.darken.sdmse.common.pkgs.Pkg
 
 fun ImageRequest.Builder.loadingView(
@@ -32,6 +34,22 @@ fun ImageView.loadAppIcon(pkg: Pkg): Disposable? {
     val request = ImageRequest.Builder(context).apply {
         data(pkg)
         target(this@loadAppIcon)
+    }.build()
+
+    return context.imageLoader.enqueue(request)
+}
+
+fun ImageView.loadFilePreview(lookup: APathLookup<*>): Disposable? {
+    val current = tag as? APathLookup<*>
+    if (current?.lookedUp == lookup.lookedUp) return null
+    tag = lookup
+
+    val request = ImageRequest.Builder(context).apply {
+        data(lookup)
+        val alt = lookup.fileType.iconRes
+        fallback(alt)
+        error(alt)
+        target(this@loadFilePreview)
     }.build()
 
     return context.imageLoader.enqueue(request)

--- a/app/src/main/java/eu/darken/sdmse/common/coil/CoilModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/coil/CoilModule.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.Log
 import coil.ImageLoader
 import coil.ImageLoaderFactory
+import coil.decode.VideoFrameDecoder
 import coil.util.Logger
 import dagger.Module
 import dagger.Provides
@@ -11,12 +12,12 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import eu.darken.sdmse.common.BuildConfigWrap
-import eu.darken.sdmse.common.coil.AppIconFetcher
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.debug.logging.Logging
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.main.core.GeneralSettings
 import javax.inject.Provider
 import javax.inject.Singleton
 
@@ -28,7 +29,9 @@ class CoilModule {
     @Provides
     fun imageLoader(
         @ApplicationContext context: Context,
+        generalSettings: GeneralSettings,
         appIconFetcherFactory: AppIconFetcher.Factory,
+        pathPreviewFetcher: PathPreviewFetcher.Factory,
         dispatcherProvider: DispatcherProvider,
     ): ImageLoader = ImageLoader.Builder(context).apply {
 
@@ -43,6 +46,8 @@ class CoilModule {
         }
         components {
             add(appIconFetcherFactory)
+            add(VideoFrameDecoder.Factory())
+            add(pathPreviewFetcher)
         }
         dispatcher(dispatcherProvider.Default)
     }.build()

--- a/app/src/main/java/eu/darken/sdmse/common/coil/PathPreviewFetcher.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/coil/PathPreviewFetcher.kt
@@ -1,0 +1,73 @@
+package eu.darken.sdmse.common.coil
+
+import android.content.Context
+import android.webkit.MimeTypeMap
+import androidx.core.content.ContextCompat
+import coil.ImageLoader
+import coil.decode.DataSource
+import coil.decode.ImageSource
+import coil.fetch.DrawableResult
+import coil.fetch.FetchResult
+import coil.fetch.Fetcher
+import coil.fetch.SourceResult
+import coil.request.Options
+import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.sdmse.common.datastore.value
+import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.common.files.FileType
+import eu.darken.sdmse.common.files.GatewaySwitch
+import eu.darken.sdmse.common.files.iconRes
+import eu.darken.sdmse.main.core.GeneralSettings
+import okio.buffer
+import javax.inject.Inject
+
+class PathPreviewFetcher @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val generalSettings: GeneralSettings,
+    private val gatewaySwitch: GatewaySwitch,
+    private val data: APathLookup<*>,
+    private val options: Options,
+) : Fetcher {
+
+    private val fallbackIcon by lazy {
+        DrawableResult(
+            drawable = ContextCompat.getDrawable(options.context, data.fileType.iconRes)!!,
+            isSampled = false,
+            dataSource = DataSource.MEMORY
+        )
+    }
+
+    override suspend fun fetch(): FetchResult {
+        if (data.fileType != FileType.FILE || data.size == 0L) return fallbackIcon
+
+        if (!generalSettings.usePreviews.value()) return fallbackIcon
+
+        val ext = MimeTypeMap.getFileExtensionFromUrl(data.name)
+        val mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(ext) ?: return fallbackIcon
+
+        val isValid = mimeType.startsWith("image") || mimeType.startsWith("video")
+        if (!isValid) return fallbackIcon
+
+        val buffer = gatewaySwitch.read(data.lookedUp).buffer()
+
+        return SourceResult(
+            ImageSource(buffer, context),
+            mimeType,
+            dataSource = DataSource.DISK
+        )
+    }
+
+    class Factory @Inject constructor(
+        @ApplicationContext private val context: Context,
+        private val generalSettings: GeneralSettings,
+        private val gatewaySwitch: GatewaySwitch,
+    ) : Fetcher.Factory<APathLookup<*>> {
+
+        override fun create(
+            data: APathLookup<*>,
+            options: Options,
+            imageLoader: ImageLoader
+        ): Fetcher = PathPreviewFetcher(context, generalSettings, gatewaySwitch, data, options)
+    }
+}
+

--- a/app/src/main/java/eu/darken/sdmse/corpsefinder/ui/details/corpse/elements/CorpseElementFileVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/corpsefinder/ui/details/corpse/elements/CorpseElementFileVH.kt
@@ -3,7 +3,12 @@ package eu.darken.sdmse.corpsefinder.ui.details.corpse.elements
 import android.text.format.Formatter
 import android.view.ViewGroup
 import eu.darken.sdmse.R
-import eu.darken.sdmse.common.files.*
+import eu.darken.sdmse.common.coil.loadFilePreview
+import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.common.files.FileType
+import eu.darken.sdmse.common.files.joinSegments
+import eu.darken.sdmse.common.files.labelRes
+import eu.darken.sdmse.common.files.removePrefix
 import eu.darken.sdmse.common.lists.binding
 import eu.darken.sdmse.corpsefinder.core.Corpse
 import eu.darken.sdmse.corpsefinder.ui.details.corpse.CorpseElementsAdapter
@@ -23,7 +28,7 @@ class CorpseElementFileVH(parent: ViewGroup) :
         payloads: List<Any>
     ) -> Unit = binding { item ->
 
-        icon.setImageResource(item.lookup.fileType.iconRes)
+        icon.loadFilePreview(item.lookup)
 
         val prefixFree = item.lookup.lookedUp.removePrefix(item.corpse.path)
         primary.text = prefixFree.joinSegments("/")

--- a/app/src/main/java/eu/darken/sdmse/main/core/GeneralSettings.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/core/GeneralSettings.kt
@@ -26,6 +26,7 @@ class GeneralSettings @Inject constructor(
         get() = context.dataStore
 
     val themeType = dataStore.createValue("core.ui.theme.type", ThemeType.SYSTEM.identifier)
+    val usePreviews = dataStore.createValue("core.ui.previews.enabled", true)
 
     val isOnboardingCompleted = dataStore.createValue("core.onboarding.completed", false)
 
@@ -46,6 +47,7 @@ class GeneralSettings @Inject constructor(
     override val mapper = PreferenceStoreMapper(
         debugSettings.isDebugMode,
         themeType,
+        usePreviews,
         isBugReporterEnabled,
         enableDashboardOneClick
     )

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/ui/details/filtercontent/elements/FilterContentElementFileVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/ui/details/filtercontent/elements/FilterContentElementFileVH.kt
@@ -3,9 +3,9 @@ package eu.darken.sdmse.systemcleaner.ui.details.filtercontent.elements
 import android.text.format.Formatter
 import android.view.ViewGroup
 import eu.darken.sdmse.R
+import eu.darken.sdmse.common.coil.loadFilePreview
 import eu.darken.sdmse.common.files.APathLookup
 import eu.darken.sdmse.common.files.FileType
-import eu.darken.sdmse.common.files.iconRes
 import eu.darken.sdmse.common.files.labelRes
 import eu.darken.sdmse.common.lists.binding
 import eu.darken.sdmse.databinding.SystemcleanerFiltercontentElementFileBinding
@@ -26,7 +26,7 @@ class FilterContentElementFileVH(parent: ViewGroup) :
         payloads: List<Any>
     ) -> Unit = binding { item ->
 
-        icon.setImageResource(item.lookup.fileType.iconRes)
+        icon.loadFilePreview(item.lookup)
 
         primary.text = item.lookup.userReadablePath.get(context)
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -71,6 +71,9 @@
     <string name="ui_theme_system_label">System</string>
     <string name="ui_theme_setting_explanation">Change the current app theme and override system settings.</string>
 
+    <string name="ui_previews_title">File previews</string>
+    <string name="ui_previews_summary">Display file previews in all tools (e.g. image and video thumbnails).</string>
+
     <string name="settings_support_label">Support</string>
     <string name="documentation_label">Documentation</string>
     <string name="issue_tracker_description">A public issue tracker for bug reports and feature requests.</string>

--- a/app/src/main/res/xml/preferences_general.xml
+++ b/app/src/main/res/xml/preferences_general.xml
@@ -18,6 +18,13 @@
             android:key="core.ui.theme.type"
             android:title="@string/ui_theme_setting_label"
             app:summary="@string/ui_theme_setting_explanation" />
+
+        <CheckBoxPreference
+            app:icon="@drawable/image_multiple"
+            app:key="core.ui.previews.enabled"
+            app:singleLineTitle="false"
+            app:summary="@string/ui_previews_summary"
+            app:title="@string/ui_previews_title" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/settings_category_other_label">


### PR DESCRIPTION
File previews in all tools.
Can be disabled in settings.
Works for video and image types.
Supports access via Root and SAF.

Also see #314