### PR TITLE
Setup: Automatic ACS restart if extra permissions are available (via ADB)

### DIFF
--- a/app-common/src/main/java/eu/darken/sdmse/common/permissions/Permission.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/permissions/Permission.kt
@@ -88,6 +88,9 @@ sealed class Permission(
             }
         }
     }
+
+    object WRITE_SECURE_SETTINGS
+        : Permission("android.permission.WRITE_SECURE_SETTINGS")
 }
 
 interface RuntimePermission

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,13 +34,17 @@
         android:name="android.permission.QUERY_ALL_PACKAGES"
         tools:ignore="QueryAllPackagesPermission" />
 
+    <uses-permission
+        android:name="android.permission.WRITE_SECURE_SETTINGS"
+        tools:ignore="ProtectedPermissions" />
+
     <application
         android:name="eu.darken.sdmse.App"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
-        android:roundIcon="@mipmap/ic_launcher_round"
         android:largeHeap="true"
+        android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity

--- a/app/src/main/java/eu/darken/sdmse/automation/core/AutomationService.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/AutomationService.kt
@@ -10,6 +10,7 @@ import android.view.Gravity
 import android.view.WindowManager
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
+import androidx.annotation.Keep
 import androidx.appcompat.view.ContextThemeWrapper
 import dagger.hilt.android.AndroidEntryPoint
 import eu.darken.sdmse.R
@@ -50,6 +51,7 @@ import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
 import kotlin.coroutines.resume
 
+@Keep
 @AndroidEntryPoint
 class AutomationService : AccessibilityService(), AutomationHost, Progress.Host, Progress.Client {
 

--- a/app/src/main/java/eu/darken/sdmse/common/SystemSettingsProvider.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/SystemSettingsProvider.kt
@@ -1,0 +1,39 @@
+package eu.darken.sdmse.common
+
+import android.content.ContentResolver
+import android.content.Context
+import android.provider.Settings
+import dagger.Reusable
+import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.permissions.Permission
+import javax.inject.Inject
+
+@Reusable
+class SystemSettingsProvider @Inject constructor(
+    @ApplicationContext private val context: Context,
+    val contentResolver: ContentResolver,
+) {
+
+    suspend fun hasSecureWriteAccess(): Boolean = Permission.WRITE_SECURE_SETTINGS.isGranted(context)
+
+    suspend inline fun <reified T : Any> get(type: Type, key: String): T? = when (val valueType = T::class) {
+        String::class -> Settings.Secure.getString(contentResolver, key) as T?
+        else -> throw UnsupportedOperationException("Type $valueType not supported")
+    }.also { log(TAG, VERBOSE) { "get($type,$key) -> $it" } }
+
+    suspend inline fun <reified T : Any> put(type: Type, key: String, value: T) = when (val valueType = T::class) {
+        String::class -> Settings.Secure.putString(contentResolver, key, value as String)
+        else -> throw UnsupportedOperationException("Type $valueType not supported")
+    }.also { log(TAG, VERBOSE) { "put($type,$key,$value) -> $it" } }
+
+    enum class Type(val value: String) {
+        SECURE("secure")
+    }
+
+    companion object {
+        val TAG = logTag("SystemSettings", "Provider")
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/setup/SetupFragmentVM.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/SetupFragmentVM.kt
@@ -184,6 +184,7 @@ class SetupFragmentVM @Inject constructor(
                 Permission.IGNORE_BATTERY_OPTIMIZATION -> {}
                 Permission.PACKAGE_USAGE_STATS -> {}
                 Permission.POST_NOTIFICATIONS -> {}
+                Permission.WRITE_SECURE_SETTINGS -> {}
                 null -> {}
             }
             setupManager.refresh()

--- a/app/src/main/java/eu/darken/sdmse/setup/accessibility/AccessibilitySetupModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/accessibility/AccessibilitySetupModule.kt
@@ -13,22 +13,35 @@ import dagger.multibindings.IntoSet
 import eu.darken.sdmse.automation.core.AutomationController
 import eu.darken.sdmse.automation.core.AutomationService
 import eu.darken.sdmse.common.DeviceDetective
+import eu.darken.sdmse.common.SystemSettingsProvider
+import eu.darken.sdmse.common.SystemSettingsProvider.*
+import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.datastore.value
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.rngString
 import eu.darken.sdmse.main.core.GeneralSettings
 import eu.darken.sdmse.setup.SetupModule
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 
 @Reusable
 class AccessibilitySetupModule @Inject constructor(
     @ApplicationContext private val context: Context,
+    @AppScope private val appScope: CoroutineScope,
     private val generalSettings: GeneralSettings,
     private val automationController: AutomationController,
     private val deviceDetective: DeviceDetective,
+    private val settingsProvider: SystemSettingsProvider,
 ) : SetupModule {
 
     private val refreshTrigger = MutableStateFlow(rngString)
@@ -66,6 +79,36 @@ class AccessibilitySetupModule @Inject constructor(
         )
     }
 
+    init {
+        state
+            .filter { !it.isComplete && it.hasConsent == true && !it.isServiceEnabled }
+            .onEach { currentState ->
+                log(TAG, VERBOSE) { "ACS should be enabled, but isn't: $currentState" }
+
+                val hasWriteSettings = settingsProvider.hasSecureWriteAccess()
+                if (!hasWriteSettings) return@onEach
+                else log(TAG, VERBOSE) { "We have secure settings access, let's troubleshoot" }
+
+                val beforeAcs: String? = settingsProvider.get(Type.SECURE, SETTINGS_KEY_ACS)
+                log(TAG) { "Before writing ACS settings: $beforeAcs" }
+
+                val splitAcs = beforeAcs
+                    ?.split(":")
+                    ?.filter { it.isNotBlank() }
+                    ?: emptySet()
+                if (splitAcs.contains(SETTINGS_VALUE_OUR_ACS)) {
+                    log(TAG, ERROR) { "Service isn't running but we are already enabled?" }
+                } else {
+                    val newAcsValue = splitAcs.plus(SETTINGS_VALUE_OUR_ACS).joinToString(":")
+                    settingsProvider.put(Type.SECURE, SETTINGS_KEY_ACS, newAcsValue)
+                    val afterAcs: String? = settingsProvider.get(Type.SECURE, SETTINGS_KEY_ACS)
+                    log(TAG) { "After writings ACS settings: $afterAcs" }
+                }
+            }
+            .catch { log(TAG) { "Automatic ACS recovery failed: ${it.asLog()}" } }
+            .launchIn(appScope)
+    }
+
     suspend fun setAllow(allowed: Boolean) {
         log(TAG) { "setAllow($allowed)" }
         if (!allowed) {
@@ -80,6 +123,7 @@ class AccessibilitySetupModule @Inject constructor(
 
     override suspend fun refresh() {
         log(TAG) { "refresh()" }
+
         refreshTrigger.value = rngString
     }
 
@@ -102,6 +146,8 @@ class AccessibilitySetupModule @Inject constructor(
     }
 
     companion object {
+        private val SETTINGS_VALUE_OUR_ACS = "eu.darken.sdmse/${AutomationService::class.qualifiedName!!}"
+        private const val SETTINGS_KEY_ACS = "enabled_accessibility_services"
         private val TAG = logTag("Setup", "Accessibility", "Module")
     }
 }


### PR DESCRIPTION
It can be pretty annoying if the system keeps killing the accessibility service and you are being asked on every other launch of SD Maid to enable it again (Chinese ROMs 👀).

This PR adds a hidden restart mechanism for power users:

If you grant SD Maid the `WRITE_SECURE_SETTINGS` permission via ADB, then SD Maid will use this to restart the service when necessary.

The documentation for this can be found here, in the ACS troubleshooting section:

https://github.com/d4rken-org/sdmaid-se/wiki/Setup#acs-automatic-service-restart