### PR TITLE
Leave breadcrumbs for Bugsnag to track down crash

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/main/ui/MainActivity.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/MainActivity.kt
@@ -6,6 +6,7 @@ import androidx.activity.viewModels
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import dagger.hilt.android.AndroidEntryPoint
 import eu.darken.sdmse.R
+import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.debug.recorder.core.RecorderModule
 import eu.darken.sdmse.common.navigation.findNavController
 import eu.darken.sdmse.common.uix.Activity2
@@ -48,6 +49,10 @@ class MainActivity : Activity2() {
             } else {
                 window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
             }
+        }
+
+        navController.addOnDestinationChangedListener { controller, destination, bundle ->
+            Bugs.leaveBreadCrumb("Navigated to $destination with args $bundle")
         }
     }
 

--- a/app/src/main/java/eu/darken/sdmse/main/ui/MainActivity.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/MainActivity.kt
@@ -51,7 +51,7 @@ class MainActivity : Activity2() {
             }
         }
 
-        navController.addOnDestinationChangedListener { controller, destination, bundle ->
+        navController.addOnDestinationChangedListener { _, destination, bundle ->
             Bugs.leaveBreadCrumb("Navigated to $destination with args $bundle")
         }
     }


### PR DESCRIPTION
Trying to track down where this error originates from:

```java
java.lang.IllegalAccessException: Trying to access closed resource! (SDMSE:Gateway:Switch{171831447}, ActiveLease(job=StandaloneCoroutine{Cancelled}@c371b38))
        at eu.darken.sdmse.common.sharedresource.Resource.getItem(Resource:12)
        at eu.darken.sdmse.common.sharedresource.SharedResourceExtensionsKt.useRes(SharedResourceExtensionsKt:5)
        at eu.darken.sdmse.common.sharedresource.HasSharedResource.useRes$suspendImpl(HasSharedResource:6)
        at eu.darken.sdmse.common.sharedresource.HasSharedResource.useRes(HasSharedResource:4)
        at eu.darken.sdmse.common.pkgs.PkgRepo.generatePkgcache(PkgRepo:81)
        at eu.darken.sdmse.common.pkgs.PkgRepo.load(PkgRepo:75)
        at eu.darken.sdmse.common.pkgs.PkgRepo.reload(PkgRepo:68)
 ```