### PR TITLE
Fix regression: AppCleaner failing without root

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/common/pkgs/InstalledPathAreaMapping.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/pkgs/InstalledPathAreaMapping.kt
@@ -1,6 +1,8 @@
 package eu.darken.sdmse.common.pkgs
 
 import eu.darken.sdmse.common.areas.DataArea
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.pkgs.features.Installed
 
@@ -9,7 +11,7 @@ fun Installed.getPrivateDataDirs(areas: Collection<DataArea>): Collection<APath>
         .filter { it.type == DataArea.Type.PRIVATE_DATA }
         .filter { it.userHandle == userHandle }
 
-    if (privateAreas.isEmpty()) throw IllegalArgumentException("No PRIVATE_DATA areas provided")
+    if (privateAreas.isEmpty()) log(WARN) { "No PRIVATE_DATA areas provided" }
 
     return privateAreas.map { it.path.child(packageName) }
 }


### PR DESCRIPTION
Change `getPrivateDataDirs` to return empty instead of throwing an exception.