### PR TITLE
AppCleaner: Launch accessibility service on demand if `WRITE_SECURE_SETTINGS` is available

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/automation/core/AutomationManager.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/AutomationManager.kt
@@ -3,63 +3,192 @@ package eu.darken.sdmse.automation.core
 import android.content.ComponentName
 import android.content.Context
 import android.provider.Settings
-import android.text.TextUtils
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.sdmse.automation.core.errors.AutomationNoConsentException
 import eu.darken.sdmse.automation.core.errors.AutomationNotEnabledException
 import eu.darken.sdmse.automation.core.errors.AutomationNotRunningException
+import eu.darken.sdmse.common.SystemSettingsProvider
 import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.datastore.value
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.flow.setupCommonEventHandlers
 import eu.darken.sdmse.common.flow.shareLatest
+import eu.darken.sdmse.common.sharedresource.SharedResource
+import eu.darken.sdmse.common.sharedresource.useRes
 import eu.darken.sdmse.main.core.GeneralSettings
+import eu.darken.sdmse.setup.SetupHelper
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class AutomationManager @Inject constructor(
     @ApplicationContext val context: Context,
-    private val generalSettings: GeneralSettings,
+    private val settings: GeneralSettings,
     @AppScope private val appScope: CoroutineScope,
+    private val setupHelper: SetupHelper,
+    private val settingsProvider: SystemSettingsProvider,
 ) {
 
-    val useAcs: Flow<Boolean> = generalSettings.hasAcsConsent.flow
+    val useAcs: Flow<Boolean> = settings.hasAcsConsent.flow
         .mapLatest { (it ?: false) && isServiceEnabled() && isServiceLaunched() }
         .shareLatest(appScope)
 
-    fun isServiceEnabled(): Boolean {
-        val comp = ComponentName(context, AutomationService::class.java)
-
-        val setting = Settings.Secure.getString(context.contentResolver, Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES)
-            ?: return false
-
-        val splitter = TextUtils.SimpleStringSplitter(':')
-        splitter.setString(setting)
-
-        while (splitter.hasNext()) {
-            val componentNameString = splitter.next()
-            val enabledService = ComponentName.unflattenFromString(componentNameString)
-            if (enabledService != null && enabledService == comp) return true
-        }
-
-        return false
+    private val ourServiceComp: ComponentName by lazy {
+        ComponentName(context, AutomationService::class.java)
     }
 
-    fun isServiceLaunched() = AutomationService.instance != null
+    private suspend fun getAutomationServices(): Set<ComponentName> {
+        val setting = settingsProvider.get<String>(
+            SystemSettingsProvider.Type.SECURE,
+            Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES
+        )
+
+        return setting
+            ?.split(":")
+            ?.filter { it.isNotBlank() }
+            ?.mapNotNull { ComponentName.unflattenFromString(it) }
+            ?.toSet()
+            ?: emptySet()
+    }
+
+    private suspend fun setAutomationServices(services: Set<ComponentName>) {
+        settingsProvider.put(
+            SystemSettingsProvider.Type.SECURE,
+            Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES,
+            services.joinToString(":") { it.flattenToString() }
+        )
+        val after = getAutomationServices()
+        log(TAG) { "setAutomationServices($services) -> $after" }
+    }
+
+    suspend fun isServiceEnabled(): Boolean = getAutomationServices().contains(ourServiceComp)
+
+    private fun currentService(): AutomationService? = AutomationService.instance
+
+    fun isServiceLaunched() = currentService() != null
 
     suspend fun submit(task: AutomationTask): AutomationTask.Result {
         log(TAG) { "submit(): $task" }
 
-        if (generalSettings.hasAcsConsent.value() != true) throw AutomationNoConsentException()
+        return serviceResource.useRes { it.submit(task) }
+    }
 
-        if (!isServiceEnabled()) throw AutomationNotEnabledException()
+    private suspend fun startService(): AutomationService {
+        log(TAG, VERBOSE) { "startService()" }
 
-        val service = AutomationService.instance ?: throw AutomationNotRunningException()
-        return service.submit(task)
+        if (settings.hasAcsConsent.value() != true) {
+            log(TAG, WARN) { "startService(): No user consent to enable ACS!" }
+            throw AutomationNoConsentException()
+        }
+
+        var service = currentService()
+
+        if (service != null) {
+            log(TAG) { "startService(): ACS is already running" }
+            return service
+        }
+
+        if (!setupHelper.checkSecureSettings()) {
+            log(TAG, WARN) { "startService(): Service is not running and we don't have secure settings access." }
+            throw AutomationNotEnabledException()
+        }
+
+        log(TAG) { "startService(): Starting service..." }
+
+        val currentServices = getAutomationServices()
+        log(TAG) { "startService(): Before writing ACS settings: $currentServices" }
+
+        if (currentServices.contains(ourServiceComp)) {
+            log(TAG, WARN) { "startService(): Service isn't running but we are already enabled? We can wait a bit..." }
+        } else {
+            val newAcsValue = currentServices.plus(ourServiceComp)
+            setAutomationServices(newAcsValue)
+        }
+
+        while (currentCoroutineContext().isActive) {
+            service = currentService()
+            if (service != null) break
+            log(TAG, VERBOSE) { "startService(): Waiting for service to start" }
+            delay(500)
+        }
+
+        log(TAG, INFO) { "startService(): Service started!" }
+        return service!!
+    }
+
+    private suspend fun stopService() {
+        log(TAG, VERBOSE) { "stopService()" }
+        if (!setupHelper.checkSecureSettings()) {
+            throw IllegalStateException("stopService(): Trying to stop service but secure settings permission isn't available")
+        }
+
+        val currentServices = getAutomationServices()
+
+        val newServices = currentServices - ourServiceComp
+        if (currentServices == newServices) {
+            log(TAG, WARN) { "stopService(): We were not part of the active service components: $currentServices" }
+        }
+
+        setAutomationServices(newServices)
+
+        while (currentCoroutineContext().isActive) {
+            if (currentService() == null) break
+            log(TAG, VERBOSE) { "stopService(): Waiting for service to stop" }
+            delay(500)
+        }
+        log(TAG, INFO) { "stopService(): Service stopped!" }
+    }
+
+    private val serviceLauncher = callbackFlow {
+        val serviceWasRunning = isServiceLaunched()
+        log(TAG) { "serviceLauncher: serviceWasRunning=$serviceWasRunning" }
+
+        val canToggle = setupHelper.checkSecureSettings()
+        log(TAG) { "serviceLauncher: canToggle=$canToggle" }
+
+        val service = if (canToggle) {
+            withTimeoutOrNull(10 * 1000L) { startService() }
+        } else {
+            currentService()
+        }
+
+        if (service == null) throw AutomationNotRunningException()
+
+        val wrapper = ServiceWrapper(service = service)
+
+        send(wrapper)
+
+        log(TAG) { "serviceLauncher: Service provided, waiting for close..." }
+        awaitClose {
+            log(TAG) { "serviceLauncher: Closing..." }
+            if (!serviceWasRunning) {
+                log(TAG) { "serviceLauncher: Service wasn't running, let's toggle it off again" }
+                runBlocking { stopService() }
+            }
+        }
+    }
+        .setupCommonEventHandlers(TAG) { "serviceLauncher" }
+
+    private val serviceResource = SharedResource(TAG, appScope, serviceLauncher)
+
+    data class ServiceWrapper(
+        private val service: AutomationService,
+    ) {
+        suspend fun <R> submit(task: AutomationTask): R = service.submit(task) as R
     }
 
     companion object {

--- a/app/src/main/java/eu/darken/sdmse/setup/SetupHealer.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/SetupHealer.kt
@@ -2,27 +2,18 @@ package eu.darken.sdmse.setup
 
 import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
-import eu.darken.sdmse.automation.core.AutomationService
-import eu.darken.sdmse.common.SystemSettingsProvider
 import eu.darken.sdmse.common.areas.DataAreaManager
 import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
-import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
-import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
-import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.flow.combine
-import eu.darken.sdmse.common.permissions.Permission
 import eu.darken.sdmse.common.pkgs.pkgops.PkgOps
 import eu.darken.sdmse.common.root.RootManager
-import eu.darken.sdmse.common.root.canUseRootNow
 import eu.darken.sdmse.common.shizuku.ShizukuManager
-import eu.darken.sdmse.common.shizuku.canUseShizukuNow
 import eu.darken.sdmse.common.user.UserManager2
 import eu.darken.sdmse.common.user.ourInstall
-import eu.darken.sdmse.setup.automation.AutomationSetupModule
 import eu.darken.sdmse.setup.notification.NotificationSetupModule
 import eu.darken.sdmse.setup.storage.StorageSetupModule
 import eu.darken.sdmse.setup.usagestats.UsageStatsSetupModule
@@ -38,12 +29,11 @@ import javax.inject.Singleton
 class SetupHealer @Inject constructor(
     @AppScope private val appScope: CoroutineScope,
     @ApplicationContext private val context: Context,
-    private val settingsProvider: SystemSettingsProvider,
     private val shizukuManager: ShizukuManager,
     private val rootManager: RootManager,
+    private val setupHelper: SetupHelper,
     private val pkgOps: PkgOps,
     private val userManager2: UserManager2,
-    private val automationSetupModule: AutomationSetupModule,
     private val usageStatsSetupModule: UsageStatsSetupModule,
     private val notificationSetupModule: NotificationSetupModule,
     private val storageSetupModule: StorageSetupModule,
@@ -57,17 +47,15 @@ class SetupHealer @Inject constructor(
         combine(
             rootManager.useRoot,
             shizukuManager.useShizuku,
-            automationSetupModule.state,
             usageStatsSetupModule.state,
             notificationSetupModule.state,
             storageSetupModule.state,
         ) { useRoot, useShizuku,
-            acsState, usageState, notifState, storageState ->
+            usageState, notifState, storageState ->
 
             val hasHealingPowers = useRoot || useShizuku
 
-            val hasIncomplete =
-                !acsState.isComplete || !usageState.isComplete || !notifState.isComplete || !storageState.isComplete
+            val hasIncomplete = !usageState.isComplete || !notifState.isComplete || !storageState.isComplete
 
             if (hasHealingPowers && hasIncomplete) {
                 internalState.value = internalState.value.copy(isWorking = true)
@@ -75,7 +63,6 @@ class SetupHealer @Inject constructor(
 
             var reloadDataAreas = false
             try {
-                if (acsState.tryHeal()) automationSetupModule.refresh()
                 if (usageState.tryHeal()) usageStatsSetupModule.refresh()
                 if (notifState.tryHeal()) notificationSetupModule.refresh()
                 if (storageState.tryHeal()) {
@@ -95,85 +82,12 @@ class SetupHealer @Inject constructor(
             .launchIn(appScope)
     }
 
-    private suspend fun ensureGrantPermission(): Boolean {
-        if (shizukuManager.canUseShizukuNow()) {
-            log(TAG, VERBOSE) { "ensureGrantPermission() available via Shizuku" }
-            return true
-        }
-
-        if (rootManager.canUseRootNow()) {
-            log(TAG, VERBOSE) { "ensureGrantPermission() available via Root" }
-            return true
-        }
-
-        log(TAG, VERBOSE) { "ensureGrantPermission() is not available" }
-        return false
-    }
-
-    private suspend fun ensureSecureSettings(): Boolean {
-        if (settingsProvider.hasSecureWriteAccess()) {
-            log(TAG, VERBOSE) { "ensureSecureSettings(): We already have secure settings access" }
-            return true
-        }
-
-        if (!ensureGrantPermission()) {
-            log(TAG) { "ensureSecureSettings(): Can't gain grant permissions" }
-            return false
-        }
-        pkgOps.grantPermission(userManager2.ourInstall(), Permission.WRITE_SECURE_SETTINGS)
-
-        return settingsProvider.hasSecureWriteAccess().also {
-            if (it) log(TAG, INFO) { "We were able to gain secure settings access :)" }
-            else log(TAG, INFO) { "We were not able to gain secure settings access :(" }
-        }
-    }
-
-    private suspend fun AutomationSetupModule.State.tryHeal(): Boolean {
-        if (isComplete || hasConsent != true || isServiceEnabled) {
-            return false
-        }
-
-        if (!ensureSecureSettings()) {
-            log(TAG, WARN) { "ACS: We don't have secure settings access." }
-            return false
-        }
-
-        log(TAG) { "ACS: Setting up..." }
-
-        val beforeAcs: String? = settingsProvider.get(
-            SystemSettingsProvider.Type.SECURE,
-            SETTINGS_KEY_ACS
-        )
-        log(TAG) { "ACS: Before writing ACS settings: $beforeAcs" }
-
-        val splitAcs = beforeAcs
-            ?.split(":")
-            ?.filter { it.isNotBlank() }
-            ?: emptySet()
-        if (splitAcs.contains(SETTINGS_VALUE_OUR_ACS)) {
-            log(TAG, ERROR) { "ACS: Service isn't running but we are already enabled?" }
-        } else {
-            val newAcsValue = splitAcs.plus(SETTINGS_VALUE_OUR_ACS).joinToString(":")
-            settingsProvider.put(
-                SystemSettingsProvider.Type.SECURE,
-                SETTINGS_KEY_ACS, newAcsValue
-            )
-            val afterAcs: String? = settingsProvider.get(
-                SystemSettingsProvider.Type.SECURE,
-                SETTINGS_KEY_ACS
-            )
-            log(TAG) { "ACS: After writings ACS settings: $afterAcs" }
-        }
-
-        return true
-    }
-
     private suspend fun UsageStatsSetupModule.State.tryHeal(): Boolean {
         if (isComplete || missingPermission.isEmpty()) {
             return false
         }
 
-        if (!ensureGrantPermission()) {
+        if (!setupHelper.checkGrantPermissions()) {
             log(TAG) { "USAGE_STATS: We don't have grant access permission" }
             return false
         }
@@ -194,7 +108,7 @@ class SetupHealer @Inject constructor(
             return false
         }
 
-        if (!ensureGrantPermission()) {
+        if (!setupHelper.checkGrantPermissions()) {
             log(TAG) { "STORAGE: We don't have grant access permission" }
             return false
         }
@@ -215,7 +129,7 @@ class SetupHealer @Inject constructor(
             return false
         }
 
-        if (!ensureGrantPermission()) {
+        if (!setupHelper.checkGrantPermissions()) {
             log(TAG) { "NOTIFICATIONS: We don't have grant access permission" }
             return false
         }
@@ -239,8 +153,6 @@ class SetupHealer @Inject constructor(
     )
 
     companion object {
-        private val SETTINGS_VALUE_OUR_ACS = "eu.darken.sdmse/${AutomationService::class.qualifiedName!!}"
-        private const val SETTINGS_KEY_ACS = "enabled_accessibility_services"
         private val TAG = logTag("Setup", "Healer")
     }
 }

--- a/app/src/main/java/eu/darken/sdmse/setup/SetupHelper.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/SetupHelper.kt
@@ -1,0 +1,64 @@
+package eu.darken.sdmse.setup
+
+import dagger.Reusable
+import eu.darken.sdmse.common.SystemSettingsProvider
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.permissions.Permission
+import eu.darken.sdmse.common.pkgs.pkgops.PkgOps
+import eu.darken.sdmse.common.root.RootManager
+import eu.darken.sdmse.common.root.canUseRootNow
+import eu.darken.sdmse.common.shizuku.ShizukuManager
+import eu.darken.sdmse.common.shizuku.canUseShizukuNow
+import eu.darken.sdmse.common.user.UserManager2
+import eu.darken.sdmse.common.user.ourInstall
+import javax.inject.Inject
+
+@Reusable
+class SetupHelper @Inject constructor(
+    private val shizukuManager: ShizukuManager,
+    private val rootManager: RootManager,
+    private val settingsProvider: SystemSettingsProvider,
+    private val pkgOps: PkgOps,
+    private val userManager2: UserManager2,
+) {
+
+    suspend fun checkGrantPermissions(): Boolean {
+        if (shizukuManager.canUseShizukuNow()) {
+            log(TAG, VERBOSE) { "ensureGrantPermission() available via Shizuku" }
+            return true
+        }
+
+        if (rootManager.canUseRootNow()) {
+            log(TAG, VERBOSE) { "ensureGrantPermission() available via Root" }
+            return true
+        }
+
+        log(TAG, VERBOSE) { "ensureGrantPermission() is not available" }
+        return false
+    }
+
+    suspend fun checkSecureSettings(): Boolean {
+        if (settingsProvider.hasSecureWriteAccess()) {
+            log(TAG, VERBOSE) { "ensureSecureSettings(): We already have secure settings access" }
+            return true
+        }
+
+        if (!checkGrantPermissions()) {
+            log(TAG) { "ensureSecureSettings(): Can't gain grant permissions" }
+            return false
+        }
+        pkgOps.grantPermission(userManager2.ourInstall(), Permission.WRITE_SECURE_SETTINGS)
+
+        return settingsProvider.hasSecureWriteAccess().also {
+            if (it) log(TAG, INFO) { "We were able to gain secure settings access :)" }
+            else log(TAG, INFO) { "We were not able to gain secure settings access :(" }
+        }
+    }
+
+    companion object {
+        private val TAG = logTag("Setup", "Healer", "Helper")
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/setup/SetupViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/SetupViewModel.kt
@@ -117,7 +117,9 @@ class SetupViewModel @Inject constructor(
                                 launch {
                                     automationSetupModule.setAllow(true)
                                     automationSetupModule.refresh()
-                                    events.postValue(SetupEvents.ConfigureAccessibilityService(state))
+                                    if (!state.canSelfEnable) {
+                                        events.postValue(SetupEvents.ConfigureAccessibilityService(state))
+                                    }
                                 }
                             },
                             onDismiss = {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -140,6 +140,7 @@
     <string name="setup_acs_state_enabled">Accessibility service is enabled</string>
     <string name="setup_acs_state_disabled">Accessibility service is disabled</string>
     <string name="setup_acs_state_running">Accessibility service is running</string>
+    <string name="setup_acs_state_ondemand">Service will be launched on demand</string>
     <string name="setup_acs_state_stopped">Accessibility service is stopped</string>
     <string name="setup_acs_state_stopped_hint">The service is enabled, but not running. Toggling it off/on or rebooting your device. Check that SD Maid is not being "optimized" by the system.</string>
     <string name="setup_acs_state_stopped_hint_miui">If the service keeps getting disabled after a while, try enabling the "Auto Start" option for SD Maid in the system settings.</string>


### PR DESCRIPTION
If SD Maid has access to Shizuku, or has been manually granted the `WRITE_SECURE_SETTINGS` permission, then SD Maid is able to self launch the accessibility service.

SD Maid will now detect this, and only launch the accessibility service for the duration of task. This is good for resource use, and also prevents the system from annoying the user with notifications about "SD Maid SE" being able to read the screen.

```
20:32:40.706 SDMSE:Automation:Manager             D  submit(): eu.darken.sdmse.appcleaner.core.automation.ClearCacheTask@df294a6
20:32:40.710 SDMSE:Automation:Manager:SR          D  Acquiring shared resource...
20:32:40.710 SDMSE:Automation:Manager             V  serviceLauncher.onStart()
20:32:40.710 SDMSE:Automation:Manager             D  serviceLauncher: serviceWasRunning=false
20:32:40.711 SDMSE:Automation:Manager             D  serviceLauncher: canToggle=true
20:32:40.711 SDMSE:Automation:Manager             V  startService()
20:32:40.712 SDMSE:Automation:Manager             D  startService(): Starting service...
20:32:40.714 SDMSE:Automation:Manager             D  startService(): Before writing ACS settings: []
20:32:40.728 SDMSE:Automation:Manager             D  setAutomationServices([ComponentInfo{eu.darken.sdmse/eu.darken.sdmse.automation.core.AutomationService}]) -> [ComponentInfo{eu.darken.sdmse/eu.darken.sdmse.automation.core.AutomationService}]
20:32:40.728 SDMSE:Automation:Manager             V  startService(): Waiting for service to start
20:32:41.229 SDMSE:Automation:Manager             I  startService(): Service started!
20:32:41.229 SDMSE:Automation:Manager             D  serviceLauncher: Service provided, waiting for close...
20:32:41.229 SDMSE:Automation:Manager             V  serviceLauncher.onEach(): ServiceWrapper(service=eu.darken.sdmse.automation.core.AutomationService@831dbad)
20:32:41.229 SDMSE:Automation:Manager:SR          V  Resource ready: Resource(resource=ServiceWrapper(service=eu.darken.sdmse.automation.core.AutomationService@831dbad))
20:32:43.740 SDMSE:Automation:Manager             D  serviceLauncher: Closing...
20:32:43.740 SDMSE:Automation:Manager             D  serviceLauncher: Service wasn't running, let's toggle it off again
20:32:43.740 SDMSE:Automation:Manager             V  stopService()
20:32:43.752 SDMSE:Automation:Manager             D  setAutomationServices([]) -> []
20:32:43.752 SDMSE:Automation:Manager             V  stopService(): Waiting for service to stop
20:32:44.252 SDMSE:Automation:Manager             I  stopService(): Service stopped!
20:32:44.253 SDMSE:Automation:Manager             V  serviceLauncher.onCompletion()
20:32:44.253 SDMSE:Automation:Manager:SR          V  Releasing shared resource...
20:32:44.253 SDMSE:Automation:Manager:SR          D  Shared resource flow completed.
``` 

![Screenshot from 2023-07-02 19-01-44](https://github.com/d4rken-org/sdmaid-se/assets/1439229/eac008af-e87e-433f-b65f-400a9da5663d)

