### PR TITLE
Leave a breadcrumb for debugging when package data has changed.

### DIFF
--- a/app-common-pkgs/src/main/java/eu/darken/sdmse/common/pkgs/PkgRepo.kt
+++ b/app-common-pkgs/src/main/java/eu/darken/sdmse/common/pkgs/PkgRepo.kt
@@ -63,6 +63,7 @@ class PkgRepo @Inject constructor(
         pkgEventListener.events
             .onEach {
                 log(TAG) { "Refreshing package cache due to event: $it" }
+                Bugs.leaveBreadCrumb("Installed package data has changed")
                 refresh()
             }
             .launchIn(appScope)


### PR DESCRIPTION
Trying to track a background crash, still can't figure out what triggers it.