### PR TITLE
CorpseFinder: Remove impossible exclusion actions for corpse content items

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/PostProcessorModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/PostProcessorModule.kt
@@ -23,7 +23,6 @@ import eu.darken.sdmse.common.root.canUseRootNow
 import eu.darken.sdmse.exclusion.core.ExclusionManager
 import eu.darken.sdmse.exclusion.core.excludeNestedLookups
 import eu.darken.sdmse.exclusion.core.pathExclusions
-import eu.darken.sdmse.exclusion.core.types.match
 import eu.darken.sdmse.main.core.SDMTool
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -101,24 +100,14 @@ class PostProcessorModule @Inject constructor(
 
         var after = before.copy(
             expendables = before.expendables.mapValues { (type, paths) ->
-                paths.filterNot { path ->
-                    exclusions.any { it.match(path) }
-                }
-            }
-        )
-
-        after = after.copy(
-            expendables = after.expendables?.mapValues { (type, paths) ->
-                var temp = paths
-                exclusions.forEach { temp = it.excludeNestedLookups(temp) }
-                temp
+                exclusions.excludeNestedLookups(paths)
             }
         )
 
         after = after.copy(
             expendables = after.expendables?.mapValues { (type, paths) ->
                 val edges = edgeCaseMap[type] ?: emptySet()
-                if (edges.isNotEmpty()) log(TAG, VERBOSE) { "Readding edge cases: $edges" }
+                if (edges.isNotEmpty()) log(TAG, VERBOSE) { "Re-adding edge cases: $edges" }
                 paths.plus(edges)
             }
         )

--- a/app/src/main/java/eu/darken/sdmse/corpsefinder/ui/details/corpse/CorpseFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/corpsefinder/ui/details/corpse/CorpseFragment.kt
@@ -62,12 +62,6 @@ class CorpseFragment : Fragment3(R.layout.corpsefinder_corpse_fragment) {
                         true
                     }
 
-                    R.id.action_exclude_selected -> {
-                        vm.exclude(selected)
-                        tracker.clearSelection()
-                        true
-                    }
-
                     else -> false
                 }
             }

--- a/app/src/main/java/eu/darken/sdmse/corpsefinder/ui/details/corpse/CorpseViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/corpsefinder/ui/details/corpse/CorpseViewModel.kt
@@ -88,16 +88,8 @@ class CorpseViewModel @Inject constructor(
         log(TAG, INFO) { "exclude(): $items" }
         val corpse = corpseData.first()
 
-        val targets = items.mapNotNull {
-            when (it) {
-                is CorpseElementFileVH.Item -> it.lookup.lookedUp
-                else -> null
-            }
-        }.toSet()
-        if (targets.isEmpty()) {
+        if (items.singleOrNull() is CorpseElementHeaderVH.Item) {
             corpseFinder.exclude(setOf(corpse.identifier))
-        } else {
-            corpseFinder.exclude(corpse.identifier, targets)
         }
     }
 

--- a/app/src/main/java/eu/darken/sdmse/exclusion/core/ExclusionExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/exclusion/core/ExclusionExtensions.kt
@@ -1,5 +1,8 @@
 package eu.darken.sdmse.exclusion.core
 
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.files.APathLookup
 import eu.darken.sdmse.common.files.isAncestorOf
@@ -34,38 +37,51 @@ suspend fun ExclusionManager.pkgExclusions(tool: SDMTool.Type) = currentExclusio
         }
     }
 
-suspend fun <P : APath, PL : APathLookup<P>> Exclusion.Path.excludeNestedLookups(paths: Collection<PL>): Collection<PL> {
-    if (paths.isEmpty()) return emptySet()
 
-    val excluded = mutableSetOf<PL>()
+suspend fun <P : APath, PL : APathLookup<P>> Exclusion.Path.excludeNestedLookups(paths: Collection<PL>): Set<PL> {
+    val pathMap = paths.associateBy { it.lookedUp }
 
-    var temp = paths.filter { path ->
-        match(path.lookedUp).also {
-            if (it) excluded.add(path)
-        }
-    }
+    val result = this.excludeNested(pathMap.keys)
 
-    temp = temp.filter { path ->
-        excluded.none { path.isAncestorOf(it) }
-    }
+    return result.map { pathMap[it]!! }.toSet()
+}
 
+suspend fun <P : APath, PL : APathLookup<P>> Collection<Exclusion.Path>.excludeNestedLookups(paths: Collection<PL>): Set<PL> {
+    var temp = paths.toSet()
+    this.forEach { temp = it.excludeNestedLookups(temp) }
     return temp
 }
 
-suspend fun <T : APath> Exclusion.Path.excludeNested(paths: Collection<T>): Collection<T> {
+suspend fun <T : APath> Collection<Exclusion.Path>.excludeNested(paths: Collection<T>): Set<T> {
+    var temp = paths.toSet()
+    this.forEach { temp = it.excludeNested(temp) }
+    return temp
+}
+
+suspend fun <T : APath> Exclusion.Path.excludeNested(paths: Collection<T>): Set<T> {
     if (paths.isEmpty()) return emptySet()
 
     val excluded = mutableSetOf<T>()
 
-    var temp = paths.filter { path ->
-        match(path).also {
-            if (it) excluded.add(path)
-        }
+    // Files that are left after applying direct exclusions
+    val afterFirstPass = paths.filter { path ->
+        val isExcluded = match(path)
+        if (isExcluded) excluded.add(path)
+        !isExcluded
     }
 
-    temp = temp.filter { path ->
-        excluded.none { path.isAncestorOf(it) }
+    // Files that are left after also checking ancestors, i.e. if we have:
+    // dirA
+    // dirA/dirB/
+    // dirA/dirB/file
+    // and exclude "file", then we also need to exclude all "dirA" and "dirB", otherwise we delete the parent and thus "file"
+    val afterSecondPass = afterFirstPass.filterNot { path ->
+        val reason = excluded.firstOrNull { path.isAncestorOf(it) }
+        if (reason != null) log(TAG, VERBOSE) { "Nested exclusion match: $path <- $reason <- $this" }
+        reason != null
     }
 
-    return temp
+    return afterSecondPass.toSet()
 }
+
+private val TAG = logTag("Exclusion", "Extensions")

--- a/app/src/main/java/eu/darken/sdmse/exclusion/core/types/PathExclusion.kt
+++ b/app/src/main/java/eu/darken/sdmse/exclusion/core/types/PathExclusion.kt
@@ -3,6 +3,9 @@ package eu.darken.sdmse.exclusion.core.types
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import eu.darken.sdmse.common.ca.CaString
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.files.isAncestorOf
 import eu.darken.sdmse.common.files.matches
@@ -20,10 +23,14 @@ data class PathExclusion(
         get() = path.userReadablePath
 
     override suspend fun match(candidate: APath): Boolean {
-        return candidate.matches(path) || path.isAncestorOf(candidate)
+        val match = candidate.matches(path) || path.isAncestorOf(candidate)
+        if (match) log(TAG, VERBOSE) { "Exclusion match: $candidate <- $this " }
+        return match
     }
 
     companion object {
         fun createId(path: APath): ExclusionId = "${PathExclusion::class.simpleName}-${path.path}"
+        private val TAG = logTag("Exclusion", "Path")
+
     }
 }

--- a/app/src/main/java/eu/darken/sdmse/exclusion/core/types/PkgExclusion.kt
+++ b/app/src/main/java/eu/darken/sdmse/exclusion/core/types/PkgExclusion.kt
@@ -4,6 +4,9 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import eu.darken.sdmse.common.ca.CaString
 import eu.darken.sdmse.common.ca.caString
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.pkgs.Pkg
 import eu.darken.sdmse.common.pkgs.getLabel2
 
@@ -20,10 +23,13 @@ data class PkgExclusion(
         get() = caString { it.packageManager.getLabel2(pkgId) ?: pkgId.name }
 
     override suspend fun match(candidate: Pkg.Id): Boolean {
-        return pkgId == candidate
+        val match = pkgId == candidate
+        if (match) log(TAG, VERBOSE) { "Exclusion match: $candidate <- $this " }
+        return match
     }
 
     companion object {
         fun createId(pkgId: Pkg.Id): ExclusionId = "${PkgExclusion::class.simpleName}-${pkgId.name}"
+        private val TAG = logTag("Exclusion", "Pkg")
     }
 }

--- a/app/src/main/java/eu/darken/sdmse/exclusion/core/types/SegmentExclusion.kt
+++ b/app/src/main/java/eu/darken/sdmse/exclusion/core/types/SegmentExclusion.kt
@@ -4,6 +4,9 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import eu.darken.sdmse.common.ca.CaString
 import eu.darken.sdmse.common.ca.caString
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.files.Segments
 import eu.darken.sdmse.common.files.containsSegments
@@ -23,14 +26,20 @@ data class SegmentExclusion(
     override val label: CaString
         get() = caString { segments.joinSegments() }
 
-    override suspend fun match(candidate: APath): Boolean = candidate.segments.containsSegments(
-        other = this.segments,
-        allowPartial = allowPartial,
-        ignoreCase = ignoreCase,
-    )
+    override suspend fun match(candidate: APath): Boolean {
+        val match = candidate.segments.containsSegments(
+            other = this.segments,
+            allowPartial = allowPartial,
+            ignoreCase = ignoreCase,
+        )
+        if (match) log(TAG, VERBOSE) { "Exclusion match: $candidate <- $this " }
+        return match
+    }
 
     companion object {
         fun createId(segments: Segments): ExclusionId =
             "${SegmentExclusion::class.simpleName}-${segments.joinToString("/")}"
+
+        private val TAG = logTag("Exclusion", "Segment")
     }
 }

--- a/app/src/main/res/menu/menu_corpsefinder_corpse_cab.xml
+++ b/app/src/main/res/menu/menu_corpsefinder_corpse_cab.xml
@@ -9,12 +9,6 @@
         app:showAsAction="ifRoom" />
 
     <item
-        android:id="@+id/action_exclude_selected"
-        android:icon="@drawable/ic_shield_plus_24"
-        android:title="@string/general_exclude_selected_action"
-        app:showAsAction="ifRoom" />
-
-    <item
         android:id="@+id/action_select_all"
         android:icon="@drawable/baseline_select_all_24"
         android:title="@string/general_list_select_all_action"

--- a/app/src/test/java/eu/darken/sdmse/common/exclusion/core/ExclusionExtensionsTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/common/exclusion/core/ExclusionExtensionsTest.kt
@@ -1,0 +1,124 @@
+package eu.darken.sdmse.common.exclusion.core
+
+import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.files.segs
+import eu.darken.sdmse.common.serialization.SerializationAppModule
+import eu.darken.sdmse.exclusion.core.excludeNested
+import eu.darken.sdmse.exclusion.core.types.PathExclusion
+import eu.darken.sdmse.exclusion.core.types.SegmentExclusion
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.io.File
+
+class ExclusionExtensionsTest : BaseTest() {
+    private val testFile = File(IO_TEST_BASEDIR, "testfile")
+    private val moshi = SerializationAppModule().moshi()
+
+    @AfterEach
+    fun cleanup() {
+        testFile.delete()
+    }
+
+    @Test
+    fun `exclude nested - segment - local path`() = runTest {
+        val excl = SegmentExclusion(segs("path", "item"), allowPartial = false, ignoreCase = true)
+        val paths = setOf(
+            LocalPath.build("altroot"),
+            LocalPath.build("root"),
+            LocalPath.build("root", "test"),
+            LocalPath.build("root", "test", "path"),
+            LocalPath.build("root", "test", "path", "item", "subitem"),
+            LocalPath.build("root", "alt"),
+            LocalPath.build("root", "alt", "path"),
+            LocalPath.build("root", "alt", "path", "item"),
+            LocalPath.build("root", "alt", "path", "item", "subitem"),
+        )
+
+        excl.excludeNested(paths) shouldBe setOf(
+            LocalPath.build("altroot"),
+        )
+    }
+
+    @Test
+    fun `exclude nested - path - local path`() = runTest {
+        val excl = PathExclusion(LocalPath.build("root", "test", "path"))
+        val paths = setOf(
+            LocalPath.build("root"),
+            LocalPath.build("root", "test"),
+            LocalPath.build("root", "test", "path"),
+            LocalPath.build("root", "test", "path", "item"),
+            LocalPath.build("root", "test", "path", "item", "subitem"),
+            LocalPath.build("root", "alt"),
+            LocalPath.build("root", "alt", "path"),
+            LocalPath.build("root", "alt", "path", "item"),
+            LocalPath.build("root", "alt", "path", "item", "subitem"),
+        )
+
+        excl.excludeNested(paths) shouldBe setOf(
+            LocalPath.build("root", "alt"),
+            LocalPath.build("root", "alt", "path"),
+            LocalPath.build("root", "alt", "path", "item"),
+            LocalPath.build("root", "alt", "path", "item", "subitem"),
+        )
+    }
+
+    @Test
+    fun `exclude multiple nested - segment - local path`() = runTest {
+        val excls = setOf(
+            SegmentExclusion(segs("subitem1"), allowPartial = false, ignoreCase = true),
+            SegmentExclusion(segs("subitem2"), allowPartial = false, ignoreCase = true),
+        )
+        val paths = setOf(
+            LocalPath.build("altroot"),
+            LocalPath.build("root", "test"),
+            LocalPath.build("root", "test", "path"),
+            LocalPath.build("root", "test", "path", "item"),
+            LocalPath.build("root", "test", "path", "item", "subitem1"),
+            LocalPath.build("root", "test", "path", "item", "subitem2"),
+            LocalPath.build("root", "test", "path", "item", "subitem3"),
+            LocalPath.build("root", "alt"),
+            LocalPath.build("root", "alt", "path"),
+            LocalPath.build("root", "alt", "path", "item"),
+            LocalPath.build("root", "alt", "path", "item", "subitem1"),
+            LocalPath.build("root", "alt", "path", "item", "subitem2"),
+            LocalPath.build("root", "alt", "path", "item", "subitem3"),
+        )
+
+        excls.excludeNested(paths) shouldBe setOf(
+            LocalPath.build("altroot"),
+            LocalPath.build("root", "test", "path", "item", "subitem3"),
+            LocalPath.build("root", "alt", "path", "item", "subitem3"),
+        )
+    }
+
+    @Test
+    fun `exclude multiple nested - path - local path`() = runTest {
+        val excls = setOf(
+            PathExclusion(LocalPath.build("root", "test", "path", "item", "subitem1")),
+            PathExclusion(LocalPath.build("root", "alt", "path", "item", "subitem1")),
+        )
+        val paths = setOf(
+            LocalPath.build("altroot"),
+            LocalPath.build("root"),
+            LocalPath.build("root", "test"),
+            LocalPath.build("root", "test", "path"),
+            LocalPath.build("root", "test", "path", "item"),
+            LocalPath.build("root", "test", "path", "item", "subitem1"),
+            LocalPath.build("root", "test", "path", "item", "subitem2"),
+            LocalPath.build("root", "alt"),
+            LocalPath.build("root", "alt", "path"),
+            LocalPath.build("root", "alt", "path", "item"),
+            LocalPath.build("root", "alt", "path", "item", "subitem1"),
+            LocalPath.build("root", "alt", "path", "item", "subitem2"),
+        )
+
+        excls.excludeNested(paths) shouldBe setOf(
+            LocalPath.build("altroot"),
+            LocalPath.build("root", "test", "path", "item", "subitem2"),
+            LocalPath.build("root", "alt", "path", "item", "subitem2"),
+        )
+    }
+}


### PR DESCRIPTION
Corpses that have content items are always folders.
If we create exclusions for content items, we must always exclude the top level item, i.e. the root corpse itself -> removing the whole entry.

So excluding a content item is always the same as excluding the whole corpse.
So to reduce confusion here, I removed the exclusion context option for content items.