### PR TITLE
AppCleaner: Fix abort on deletion error

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/deleter/AppJunkDeleter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/deleter/AppJunkDeleter.kt
@@ -21,7 +21,7 @@ import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.files.APathLookup
 import eu.darken.sdmse.common.files.GatewaySwitch
-import eu.darken.sdmse.common.files.WriteException
+import eu.darken.sdmse.common.files.PathException
 import eu.darken.sdmse.common.files.deleteAll
 import eu.darken.sdmse.common.files.filterDistinctRoots
 import eu.darken.sdmse.common.files.matches
@@ -125,7 +125,7 @@ class AppJunkDeleter @Inject constructor(
                     targetFile.deleteAll(gatewaySwitch)
                     log(TAG) { "Deleted $targetFile!" }
                     deleted.add(targetFile)
-                } catch (e: WriteException) {
+                } catch (e: PathException) {
                     log(TAG, WARN) { "Deletion failed for $targetFile" }
                 }
             }


### PR DESCRIPTION
If the exists/lookup check fails, this can also be a ReadException. WriteException only comes from actual deletion failures, but we still need to look up all the files we want to delete.