### PR TITLE
Attempt to recover malfunctioning ACS if permissions allow it.

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/automation/core/AutomationManager.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/AutomationManager.kt
@@ -113,7 +113,16 @@ class AutomationManager @Inject constructor(
         log(TAG) { "startService(): Before writing ACS settings: $currentServices" }
 
         if (currentServices.contains(ourServiceComp)) {
-            log(TAG, WARN) { "startService(): Service isn't running but we are already enabled? We can wait a bit..." }
+            log(TAG, WARN) { "startService(): Service isn't running but we are already enabled? Let's re-toggle" }
+            setAutomationServices(currentServices.minus(ourServiceComp))
+
+            // Give the system some time
+            delay(3000)
+
+            val afterToggleOff = getAutomationServices()
+            if (afterToggleOff.contains(ourServiceComp)) throw IllegalStateException("Failed to remove our ACS service")
+
+            setAutomationServices(afterToggleOff.plus(ourServiceComp))
         } else {
             val newAcsValue = currentServices.plus(ourServiceComp)
             setAutomationServices(newAcsValue)


### PR DESCRIPTION
If the service is already enabled, but not running, let's turn it off/on and see if that helps.

In response to a situation encountered in a log here: https://github.com/d4rken-org/sdmaid-se/issues/460#issuecomment-1637077942