### PR TITLE
AppControl: Improve list filter interaction and behaviour

### DIFF
--- a/app-common/src/main/res/values/strings.xml
+++ b/app-common/src/main/res/values/strings.xml
@@ -77,6 +77,7 @@
     <string name="general_delete_action">Delete</string>
     <string name="general_delete_selected_action">Delete selected</string>
     <string name="general_show_details_action">Show details</string>
+    <string name="general_show_all_action">Show all</string>
 
     <string name="general_delete_confirmation_title">Confirm deletion</string>
     <string name="general_delete_confirmation_message_x">Delete \"%s\"?</string>

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListFragment.kt
@@ -202,7 +202,7 @@ class AppControlListFragment : Fragment3(R.layout.appcontrol_list_fragment) {
             fastscroller.isInvisible = state.progress != null || state.appInfos.isNullOrEmpty()
             refreshAction.isInvisible = state.progress != null
 
-            val checkedSortMode = when (state.listSort.mode) {
+            val checkedSortMode = when (state.options.listSort.mode) {
                 SortSettings.Mode.NAME -> R.id.sortmode_name
                 SortSettings.Mode.LAST_UPDATE -> R.id.sortmode_updated
                 SortSettings.Mode.INSTALLED_AT -> R.id.sortmode_installed
@@ -225,11 +225,11 @@ class AppControlListFragment : Fragment3(R.layout.appcontrol_list_fragment) {
             }
 
             sortmodeDirection.setIconResource(
-                if (state.listSort.reversed) R.drawable.ic_sort_descending_24 else R.drawable.ic_sort_ascending_24
+                if (state.options.listSort.reversed) R.drawable.ic_sort_descending_24 else R.drawable.ic_sort_ascending_24
             )
-            currentSortMode = state.listSort.mode
+            currentSortMode = state.options.listSort.mode
 
-            val listFilter = state.listFilter
+            val listFilter = state.options.listFilter
             tagFilterUserSwitch.setChecked2(listFilter.tags.contains(FilterSettings.Tag.USER), animate = false)
             tagFilterSystemSwitch.setChecked2(listFilter.tags.contains(FilterSettings.Tag.SYSTEM), animate = false)
             tagFilterEnabledSwitch.setChecked2(listFilter.tags.contains(FilterSettings.Tag.ENABLED), animate = false)
@@ -240,6 +240,8 @@ class AppControlListFragment : Fragment3(R.layout.appcontrol_list_fragment) {
                     eu.darken.sdmse.common.R.plurals.result_x_items, state.appInfos.size
                 )
                 adapter.update(state.appInfos)
+            } else if (state.progress != null) {
+                toolbar.subtitle = getString(eu.darken.sdmse.common.R.string.general_progress_loading)
             } else {
                 toolbar.subtitle = null
             }

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListFragment.kt
@@ -188,6 +188,7 @@ class AppControlListFragment : Fragment3(R.layout.appcontrol_list_fragment) {
         ui.sortmodeDirection.setOnClickListener { vm.toggleSortDirection() }
 
         ui.apply {
+            tagFilterClearAction.setOnClickListener { vm.clearTags() }
             tagFilterUserSwitch.setOnClickListener { vm.toggleTag(FilterSettings.Tag.USER) }
             tagFilterSystemSwitch.setOnClickListener { vm.toggleTag(FilterSettings.Tag.SYSTEM) }
             tagFilterEnabledSwitch.setOnClickListener { vm.toggleTag(FilterSettings.Tag.ENABLED) }

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListFragment.kt
@@ -92,7 +92,7 @@ class AppControlListFragment : Fragment3(R.layout.appcontrol_list_fragment) {
             setDrawerLockMode(DrawerLayout.LOCK_MODE_LOCKED_CLOSED)
             addDrawerListener(object : DrawerListener {
                 override fun onDrawerSlide(drawerView: View, slideOffset: Float) {
-
+                    ui.refreshAction.isInvisible = true
                 }
 
                 override fun onDrawerStateChanged(newState: Int) {
@@ -104,9 +104,8 @@ class AppControlListFragment : Fragment3(R.layout.appcontrol_list_fragment) {
                 }
 
                 override fun onDrawerClosed(drawerView: View) {
-
+                    ui.refreshAction.isInvisible = false
                 }
-
             })
         }
 

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListViewModel.kt
@@ -255,6 +255,11 @@ class AppControlListViewModel @Inject constructor(
         }
     }
 
+    fun clearTags() = launch {
+        log(TAG) { "clearTags()" }
+        settings.listFilter.update { old -> old.copy(tags = emptySet()) }
+    }
+
     fun refresh() = launch {
         log(TAG) { "refresh()" }
         appControl.submit(AppControlScanTask())

--- a/app/src/main/res/layout/appcontrol_list_fragment.xml
+++ b/app/src/main/res/layout/appcontrol_list_fragment.xml
@@ -90,8 +90,8 @@
             android:id="@+id/filterpane"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_gravity="end"
             android:background="?colorSurfaceVariant"
+            android:layout_gravity="end"
             android:clickable="true"
             android:focusable="true"
             android:focusableInTouchMode="true"
@@ -172,12 +172,28 @@
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/tag_filters_label"
                 style="@style/TextAppearance.Material3.BodyLarge"
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="16dp"
+                android:layout_marginTop="8dp"
+                android:paddingVertical="16dp"
                 android:text="@string/general_tag_filter_label"
+                app:layout_constraintEnd_toStartOf="@id/tag_filter_clear_action"
+                app:layout_constraintHorizontal_chainStyle="spread_inside"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/sortmode_group" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/tag_filter_clear_action"
+                style="@style/Widget.Material3.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:gravity="end|center_vertical"
+                android:paddingEnd="8dp"
+                android:layout_height="wrap_content"
+                android:text="@string/general_show_all_action"
+                app:layout_constraintBottom_toBottomOf="@id/tag_filters_label"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/tag_filters_label"
+                app:layout_constraintTop_toTopOf="@id/tag_filters_label" />
 
             <ImageView
                 android:id="@+id/tag_filter_user_icon"


### PR DESCRIPTION
* Restart filter operations (cancel previous ones) if filter options are changed rapidly.
* Add a "Clear filter" button.
* Hide refresh button is the filter pane is open.
* Add "inbetween" progress state for the UI operations

Closes #526