### PR TITLE
CorpseFinder: Improve uninstall watcher notifications

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/PkgOps.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/PkgOps.kt
@@ -26,6 +26,7 @@ import eu.darken.sdmse.common.pkgs.container.ApkInfo
 import eu.darken.sdmse.common.pkgs.container.NormalPkg
 import eu.darken.sdmse.common.pkgs.features.Installed
 import eu.darken.sdmse.common.pkgs.features.getInstallerInfo
+import eu.darken.sdmse.common.pkgs.getLabel2
 import eu.darken.sdmse.common.pkgs.getSharedLibraries2
 import eu.darken.sdmse.common.pkgs.pkgops.ipc.PkgOpsClient
 import eu.darken.sdmse.common.pkgs.toPkgId
@@ -159,14 +160,13 @@ class PkgOps @Inject constructor(
         }
     }
 
-    suspend fun getLabel(packageName: String): String? = ipcFunnel.use {
+    suspend fun getLabel(pkgId: Pkg.Id): String? = ipcFunnel.use {
         try {
-            packageManager
-                .getApplicationInfo(packageName, GET_UNINSTALLED_PACKAGES)
-                .loadLabel(packageManager)
-                .toString()
+            ipcFunnel.use {
+                packageManager.getLabel2(pkgId)
+            }
         } catch (e: NameNotFoundException) {
-            log(TAG, WARN) { "getLabel(packageName=$packageName) packageName not found." }
+            log(TAG, WARN) { "getLabel(packageName=$pkgId) packageName not found." }
             null
         }
     }

--- a/app/src/main/java/eu/darken/sdmse/corpsefinder/core/CorpseFinder.kt
+++ b/app/src/main/java/eu/darken/sdmse/corpsefinder/core/CorpseFinder.kt
@@ -7,6 +7,7 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.common.ca.CaString
 import eu.darken.sdmse.common.ca.caString
+import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.*
@@ -91,6 +92,7 @@ class CorpseFinder @Inject constructor(
                         val internalDeleteResult = if (task.autoDelete) {
                             deleteCorpses(CorpseFinderDeleteTask(targetCorpses = targets)).also {
                                 val watcherResult = ExternalWatcherResult.Deletion(
+                                    appName = pkgOps.getLabel(task.target)?.toCaString(),
                                     pkgId = task.target,
                                     deletedItems = it.deletedItems,
                                     freedSpace = it.recoveredSpace,

--- a/app/src/main/java/eu/darken/sdmse/corpsefinder/core/watcher/ExternalWatcherResult.kt
+++ b/app/src/main/java/eu/darken/sdmse/corpsefinder/core/watcher/ExternalWatcherResult.kt
@@ -1,5 +1,6 @@
 package eu.darken.sdmse.corpsefinder.core.watcher
 
+import eu.darken.sdmse.common.ca.CaString
 import eu.darken.sdmse.common.pkgs.Pkg
 
 interface ExternalWatcherResult {
@@ -11,6 +12,7 @@ interface ExternalWatcherResult {
     ) : ExternalWatcherResult
 
     data class Deletion(
+        val appName: CaString?,
         override val pkgId: Pkg.Id,
         val deletedItems: Int,
         val freedSpace: Long,

--- a/app/src/main/java/eu/darken/sdmse/corpsefinder/core/watcher/UninstallWatcherNotifications.kt
+++ b/app/src/main/java/eu/darken/sdmse/corpsefinder/core/watcher/UninstallWatcherNotifications.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import android.content.Intent
 import android.text.format.Formatter
 import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationCompat.BigTextStyle
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.sdmse.R
 import eu.darken.sdmse.common.BuildConfigWrap
@@ -68,26 +69,26 @@ class UninstallWatcherNotifications @Inject constructor(
     }
 
     private fun forDeletionResult(result: ExternalWatcherResult.Deletion): Notification = getBuilder(result).apply {
-        setContentText(
-            context.getQuantityString2(
-                R.plurals.corpsefinder_watcher_notification_delete_result,
-                result.deletedItems,
-                result.pkgId.name,
-                Formatter.formatShortFileSize(context, result.freedSpace),
-                result.deletedItems
-            )
+        val resultText = context.getQuantityString2(
+            R.plurals.corpsefinder_watcher_notification_delete_result,
+            result.deletedItems,
+            result.appName?.get(context) ?: result.pkgId.name,
+            Formatter.formatShortFileSize(context, result.freedSpace),
+            result.deletedItems
         )
+        setContentText(resultText)
+        setStyle(BigTextStyle().bigText(resultText))
     }.build()
 
     private fun forScanResult(result: ExternalWatcherResult.Scan): Notification = getBuilder(result).apply {
-        setContentText(
-            context.getQuantityString2(
-                R.plurals.corpsefinder_watcher_notification_scan_result,
-                result.foundItems,
-                result.foundItems,
-                result.pkgId.name
-            )
+        val resultText = context.getQuantityString2(
+            R.plurals.corpsefinder_watcher_notification_scan_result,
+            result.foundItems,
+            result.foundItems,
+            result.pkgId.name
         )
+        setContentText(resultText)
+        setStyle(BigTextStyle().bigText(resultText))
 
         val deleteIntent = Intent(context, ExternalWatcherTaskReceiver::class.java).apply {
             action = ExternalWatcherTaskReceiver.TASK_INTENT


### PR DESCRIPTION
* Allow for more space to not cut off text.
* Display app name instead of packagename if available.

Closes #569