### PR TITLE
CorpseFinder: Fix uninstall watcher deletion not working correctly.

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/corpsefinder/core/watcher/UninstallWatcherNotifications.kt
+++ b/app/src/main/java/eu/darken/sdmse/corpsefinder/core/watcher/UninstallWatcherNotifications.kt
@@ -102,7 +102,7 @@ class UninstallWatcherNotifications @Inject constructor(
             context,
             0,
             deleteIntent,
-            PendingIntentCompat.FLAG_IMMUTABLE
+            PendingIntentCompat.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
         )
 
         val deleteAction = NotificationCompat.Action(


### PR DESCRIPTION
Fixes #585