### PR TITLE
Setup: Show Shizuku card even if Shizuku app is not detected

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/setup/SetupViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/SetupViewModel.kt
@@ -232,6 +232,7 @@ class SetupViewModel @Inject constructor(
             SAFSetupCardVH.Item::class,
             UsageStatsSetupCardVH.Item::class,
             AutomationSetupCardVH.Item::class,
+            ShizukuSetupCardVH.Item::class,
             RootSetupCardVH.Item::class,
         )
         private val TAG = logTag("Setup", "ViewModel")

--- a/app/src/main/java/eu/darken/sdmse/setup/shizuku/ShizukuSetupCardVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/shizuku/ShizukuSetupCardVH.kt
@@ -34,10 +34,9 @@ class ShizukuSetupCardVH(parent: ViewGroup) :
                 item.onToggleUseShizuku(selection)
             }
         }
-        allowShizukuOptionsEnable.isEnabled = item.state.isInstalled
 
         shizukuState.apply {
-            isVisible = item.state.isInstalled && item.state.isEnabled == true
+            isVisible = item.state.isEnabled == true
             text = getString(
                 if (item.state.ourService) R.string.setup_shizuku_state_ready_label
                 else R.string.setup_shizuku_state_waiting_label

--- a/app/src/main/java/eu/darken/sdmse/setup/shizuku/ShizukuSetupModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/shizuku/ShizukuSetupModule.kt
@@ -47,11 +47,10 @@ class ShizukuSetupModule @Inject constructor(
 
             val baseState = State(
                 isEnabled = isEnabled,
-                isInstalled = shizukuManager.isInstalled(),
                 isCompatible = shizukuManager.isCompatible(),
             )
 
-            if (isEnabled != true || !baseState.isInstalled) return@combine flowOf(baseState)
+            if (isEnabled != true) return@combine flowOf(baseState)
 
             combine(
                 shizukuManager.shizukuBinder.onStart { emit(null) },
@@ -100,14 +99,13 @@ class ShizukuSetupModule @Inject constructor(
 
     data class State(
         val isEnabled: Boolean?,
-        val isInstalled: Boolean,
         val isCompatible: Boolean = false,
         val basicService: Boolean = false,
         val ourService: Boolean = false,
     ) : SetupModule.State {
 
         override val isComplete: Boolean =
-            isEnabled == false || !isCompatible || !isInstalled || (ourService && isEnabled == true)
+            isEnabled == false || !isCompatible || (ourService && isEnabled == true)
     }
 
     @Module @InstallIn(SingletonComponent::class)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -127,7 +127,7 @@
     <string name="setup_shizuku_card_body2">This setting has no effect if the Shizuku app is not set up on your device.</string>
     <string name="setup_shizuku_state_ready_label">Shizuku link is ready.</string>
     <string name="setup_shizuku_state_waiting_label">Waiting for link with Shizuku.</string>
-    <string name="setup_shizuku_enable_shizuku_use_label">Use Shizuku</string>
+    <string name="setup_shizuku_enable_shizuku_use_label">Use Shizuku if available</string>
     <string name="setup_shizuku_disable_shizuku_use_label">Don\'t use Shizuku</string>
 
     <string name="setup_dismiss_hint">You can find the setup screen again via the settings menu.</string>


### PR DESCRIPTION
This makes the behavior analog to the root setup card and also makes users that are not yet using Shizuku, aware of the option being possible.

Closes #641