### PR TITLE
AppCleaner: If the lock screen becomes active, hide the overlay until the lockscreen is dismissed

### DIFF
--- a/app-common/src/main/java/eu/darken/sdmse/common/AndroidModule.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/AndroidModule.kt
@@ -2,6 +2,7 @@ package eu.darken.sdmse.common
 
 import android.app.AlarmManager
 import android.app.Application
+import android.app.KeyguardManager
 import android.app.NotificationManager
 import android.app.admin.DevicePolicyManager
 import android.app.usage.StorageStatsManager
@@ -92,4 +93,9 @@ class AndroidModule {
     @Singleton
     fun usageStatsManager(@ApplicationContext context: Context): UsageStatsManager =
         context.getSystemService(Context.USAGE_STATS_SERVICE) as UsageStatsManager
+
+    @Provides
+    @Singleton
+    fun keyguardManager(@ApplicationContext context: Context): KeyguardManager =
+        context.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
 }

--- a/app/src/main/java/eu/darken/sdmse/automation/core/ScreenState.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/ScreenState.kt
@@ -1,0 +1,91 @@
+package eu.darken.sdmse.automation.core
+
+import android.app.KeyguardManager
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.PowerManager
+import androidx.core.content.ContextCompat
+import dagger.Reusable
+import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.flow.setupCommonEventHandlers
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.channels.trySendBlocking
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.runBlocking
+import javax.inject.Inject
+
+@Reusable
+class ScreenState @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val powerManager: PowerManager,
+    private val keyguardManager: KeyguardManager,
+) {
+
+    suspend fun isScreenOn(): Boolean = powerManager.isInteractive
+
+    suspend fun isUnlocked(): Boolean = !keyguardManager.isKeyguardLocked
+
+    val state: Flow<State> = callbackFlow {
+        trySendBlocking(State(isScreenOn = isScreenOn(), isUnlocked = isUnlocked()))
+
+        val receiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context, intent: Intent) {
+                log(TAG) { "onReceive(context=$context, intent=$intent)" }
+
+                when (intent.action) {
+                    Intent.ACTION_SCREEN_ON -> {
+                        runBlocking {
+                            trySend(State(isScreenOn = true, isUnlocked = isUnlocked()))
+                        }
+                    }
+
+                    Intent.ACTION_SCREEN_OFF -> {
+                        runBlocking {
+                            trySend(State(isScreenOn = false, isUnlocked = false))
+                        }
+                    }
+
+                    Intent.ACTION_USER_PRESENT -> {
+                        runBlocking {
+                            trySend(State(isScreenOn = false, isUnlocked = true))
+                        }
+                    }
+
+                    else -> log(ERROR) { "Unknown intent: $intent" }
+                }
+            }
+        }
+
+        val intentFilter = IntentFilter().apply {
+            addAction(Intent.ACTION_SCREEN_ON)
+            addAction(Intent.ACTION_SCREEN_OFF)
+            addAction(Intent.ACTION_USER_PRESENT)
+        }
+
+        ContextCompat.registerReceiver(context, receiver, intentFilter, ContextCompat.RECEIVER_NOT_EXPORTED)
+
+        awaitClose {
+            log(TAG) { "unregisterReceiver($receiver)" }
+            context.unregisterReceiver(receiver)
+        }
+    }
+        .setupCommonEventHandlers(TAG) { "state" }
+
+    data class State(
+        val isScreenOn: Boolean,
+        val isUnlocked: Boolean,
+    ) {
+        val isScreenAvailable: Boolean
+            get() = isScreenOn && isUnlocked
+    }
+
+    companion object {
+        private val TAG = logTag("Automation", "ScreenState")
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/automation/core/ScreenState.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/ScreenState.kt
@@ -53,7 +53,7 @@ class ScreenState @Inject constructor(
 
                     Intent.ACTION_USER_PRESENT -> {
                         runBlocking {
-                            trySend(State(isScreenOn = false, isUnlocked = true))
+                            trySend(State(isScreenOn = isScreenOn(), isUnlocked = true))
                         }
                     }
 
@@ -68,7 +68,8 @@ class ScreenState @Inject constructor(
             addAction(Intent.ACTION_USER_PRESENT)
         }
 
-        ContextCompat.registerReceiver(context, receiver, intentFilter, ContextCompat.RECEIVER_NOT_EXPORTED)
+        // ACTION_USER_PRESENT is not being send without RECEIVER_EXPORTED, seems like a bug?
+        ContextCompat.registerReceiver(context, receiver, intentFilter, ContextCompat.RECEIVER_EXPORTED)
 
         awaitClose {
             log(TAG) { "unregisterReceiver($receiver)" }


### PR DESCRIPTION
This fixes the issue that some users were not able to dismiss their lockscreen while the overlay was active, but they were also not able to dismiss the overlay.