### PR TITLE
Setup: Improve SAF access handling on Android 11 and Android 12 after Google Play system update of the `Files` app

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/saf/SAFGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/saf/SAFGateway.kt
@@ -53,7 +53,7 @@ class SAFGateway @Inject constructor(
      * SAFDocFiles need require a treeUri that actually gives us access though, i.e. the closet SAF permission we have.
      */
     private fun findDocFile(file: SAFPath): SAFDocFile {
-        val match = file.matchPermission(contentResolver.persistedUriPermissions)
+        val match = file.findPermission(contentResolver.persistedUriPermissions)
 
         if (match == null) {
             log(TAG, VERBOSE) { "No UriPermission match for $file" }

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/saf/SAFPathExtensions.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/saf/SAFPathExtensions.kt
@@ -26,7 +26,7 @@ data class PermissionMatch(
     val missingSegments: List<String>,
 )
 
-fun SAFPath.matchPermission(permissions: Collection<UriPermission>): PermissionMatch? {
+fun SAFPath.findPermission(permissions: Collection<UriPermission>): PermissionMatch? {
     val targetSegments = mutableListOf<String>().apply {
         addAll(segments)
     }

--- a/app/src/main/java/eu/darken/sdmse/setup/saf/SAFSetupModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/saf/SAFSetupModule.kt
@@ -25,7 +25,7 @@ import eu.darken.sdmse.common.files.exists
 import eu.darken.sdmse.common.files.local.LocalPath
 import eu.darken.sdmse.common.files.local.toLocalPath
 import eu.darken.sdmse.common.files.saf.SAFPath
-import eu.darken.sdmse.common.files.saf.matchPermission
+import eu.darken.sdmse.common.files.saf.findPermission
 import eu.darken.sdmse.common.flow.replayingShare
 import eu.darken.sdmse.common.hasApiLevel
 import eu.darken.sdmse.common.pkgs.pkgops.PkgOps
@@ -96,7 +96,7 @@ class SAFSetupModule @Inject constructor(
                         return@mapNotNull null
                     }
 
-                    val matchedPermission = safPath.matchPermission(currentUriPerms)
+                    val matchedPermission = safPath.findPermission(currentUriPerms)
 
                     val label = when (volume.isRemovable) {
                         true -> R.string.data_area_sdcard_label.toCaString()
@@ -168,7 +168,7 @@ class SAFSetupModule @Inject constructor(
                         return@mapNotNull null
                     }
 
-                    val matchedPermission = safPath.matchPermission(currentUriPerms)
+                    val matchedPermission = safPath.findPermission(currentUriPerms)
 
                     val grantIntentSDMOg = Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).apply {
                         putExtra("android.content.extra.SHOW_ADVANCED", true)

--- a/app/src/main/java/eu/darken/sdmse/setup/saf/SAFSetupModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/saf/SAFSetupModule.kt
@@ -148,13 +148,14 @@ class SAFSetupModule @Inject constructor(
                     val viableTargets = mutableListOf<LocalPath>()
 
                     // The newer `Files` app if updates through Google Play system updates, no longer supports selecting this
+                    // https://cs.android.com/android/platform/superproject/main/+/main:packages/apps/DocumentsUI/src/com/android/documentsui/picker/ActionHandler.java;l=84;bpv=1;bpt=0;drc=901f1d6044aade190bb943ccc18d26244132648e;dlc=306a2b606a1f01498d2d83a1d8362962f114e6e8
                     if ((documentsPkg?.targetSdkVersion ?: 0) < 34) {
                         viableTargets.add(baseDir.child("Android", "data"))
+                        viableTargets.add(baseDir.child("Android", "obb"))
                     }
-                    viableTargets.add(baseDir.child("Android", "obb"))
 
                     // We don't need extra permission for this AFAIK
-//                    viableTargets.add(baseDir.child("Android", "media"))
+                    // viableTargets.add(baseDir.child("Android", "media"))
 
                     viableTargets
                 }
@@ -169,7 +170,6 @@ class SAFSetupModule @Inject constructor(
 
                     val matchedPermission = safPath.matchPermission(currentUriPerms)
 
-                    // https://cs.android.com/android/platform/superproject/main/+/main:packages/apps/DocumentsUI/src/com/android/documentsui/picker/ActionHandler.java;l=84;bpv=1;bpt=0;drc=901f1d6044aade190bb943ccc18d26244132648e;dlc=306a2b606a1f01498d2d83a1d8362962f114e6e8
                     val grantIntentSDMOg = Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).apply {
                         putExtra("android.content.extra.SHOW_ADVANCED", true)
 


### PR DESCRIPTION
Google seems to have backported some Android 14 changes with tighter restrictions on access to `Android/data` and `Android/obb` The previous `EXTRA_INITIAL_URI` argument trick is no longer working.

Also see:
https://cs.android.com/android/platform/superproject/main/+/main:packages/apps/DocumentsUI/src/com/android/documentsui/picker/ActionHandler.java;l=84;bpv=1;bpt=0;drc=901f1d6044aade190bb943ccc18d26244132648e;dlc=306a2b606a1f01498d2d83a1d8362962f114e6e8

There are now 3 states to this for Android 11 and Android 12 users:

* You have the original "Files" app (API-level 31, e.g. `aml_doc_310851020 (310851020)`) that came with your ROM, then you can just grant access as expected
* You have the latest "Files" app (API-level 34 or later, e.g. `14-10492947 (340916000)`), then you can't grant access
* You have a version in between those two, then you should be able to grant access after this code change. Though I couldn't confirm this myself, just based on user reports.

Updates not compiled for API-level 34 still work, if you [try some of the older versions](https://www.apkmirror.com/apk/google-inc/files-6/).

In any case, a possible workaround to this is uninstalling the application updates. You can uninstall the update of the `Files` app, then complete the setup in SD Maid. Updating the `Files` app again won't break the granted permission.

* Open device settings
* Go to "Apps & notifications" or "Application Manager"
* Find the `Files` system app
* Tap on the three-dot menu, usually on the top right corner
* Choose "Uninstall updates"

or

`adb uninstall com.google.android.documentsui`

I've updated the [Setup WIKI](https://github.com/d4rken-org/sdmaid-se/wiki/Setup/_edit#troubleshooting) with instructions:

https://github.com/d4rken-org/sdmaid-se/wiki/Setup#saf-androiddataobb-access

Closes #639