### PR TITLE
Root/Shizuku: Fix not being able to bind the service interface after AGP updating AGP 8.0.2->8.1.2

### DIFF
--- a/app-common/src/main/java/eu/darken/sdmse/common/ipc/BinderExtensions.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/ipc/BinderExtensions.kt
@@ -15,7 +15,7 @@ import kotlin.reflect.KClass
 fun <T : Any> IBinder.getInterface(clazz: KClass<T>): T? = try {
     val fDescriptor = Class
         .forName(clazz.qualifiedName + "\$Stub")
-        .getDeclaredField("DESCRIPTOR")
+        .getField("DESCRIPTOR")
         .apply { isAccessible = true }
 
     val intf = queryLocalInterface(fDescriptor[this] as String)


### PR DESCRIPTION
Closes #689

Full stacktrace was:

```java
E  getInterfaceFromBinder() failed: java.lang.NoSuchFieldException: No field DESCRIPTOR in class Leu/darken/sdmse/common/root/service/RootServiceConnection$Stub; (declaration of 'eu.darken.sdmse.common.root.service.RootServiceConnection$Stub' appears in /data/app/~~EMtqW8brkim4xhEVD5O_QA==/eu.darken.sdmse-DoVHI6JXBh7_Q7fsel3LcA==/base.apk!classes12.dex)
	at java.lang.Class.getDeclaredField(Native Method)
	at eu.darken.sdmse.common.ipc.BinderExtensionsKt.getInterface(BinderExtensions.kt:18)
	at eu.darken.sdmse.common.root.service.internal.RootHostLauncher$createConnection$1$ipcReceiver$1.onConnect(RootHostLauncher.kt:57)
	at eu.darken.sdmse.common.root.service.internal.RootConnectionReceiver.doOnConnect(RootConnectionReceiver.kt:164)
	at eu.darken.sdmse.common.root.service.internal.RootConnectionReceiver.access$doOnConnect(RootConnectionReceiver.kt:28)
	at eu.darken.sdmse.common.root.service.internal.RootConnectionReceiver$receiver$1.onReceive$lambda$9$lambda$8$lambda$6(RootConnectionReceiver.kt:101)
	at eu.darken.sdmse.common.root.service.internal.RootConnectionReceiver$receiver$1.$r8$lambda$HKc6gPCzGFkriQwJNV28QLf_Xag(Unknown Source:0)
	at eu.darken.sdmse.common.root.service.internal.RootConnectionReceiver$receiver$1$$ExternalSyntheticLambda0.run(Unknown Source:2)
	at android.os.Handler.handleCallback(Handler.java:938)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loopOnce(Looper.java:226)
	at android.os.Looper.loop(Looper.java:313)
	at android.os.HandlerThread.run(HandlerThread.java:67)
E  FATAL EXCEPTION: javaroot:RootConnectionReceiver#7619a93c-df14-406d-82b3-cdf6f7238009
Process: eu.darken.sdmse, PID: 14319
eu.darken.sdmse.common.root.RootException: Failed to get user connection
	at eu.darken.sdmse.common.root.service.internal.RootHostLauncher$createConnection$1$ipcReceiver$1.onConnect(RootHostLauncher.kt:58)
	at eu.darken.sdmse.common.root.service.internal.RootConnectionReceiver.doOnConnect(RootConnectionReceiver.kt:164)
	at eu.darken.sdmse.common.root.service.internal.RootConnectionReceiver.access$doOnConnect(RootConnectionReceiver.kt:28)
	at eu.darken.sdmse.common.root.service.internal.RootConnectionReceiver$receiver$1.onReceive$lambda$9$lambda$8$lambda$6(RootConnectionReceiver.kt:101)
	at eu.darken.sdmse.common.root.service.internal.RootConnectionReceiver$receiver$1.$r8$lambda$HKc6gPCzGFkriQwJNV28QLf_Xag(Unknown Source:0)
	at eu.darken.sdmse.common.root.service.internal.RootConnectionReceiver$receiver$1$$ExternalSyntheticLambda0.run(Unknown Source:2)
	at android.os.Handler.handleCallback(Handler.java:938)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loopOnce(Looper.java:226)
	at android.os.Looper.loop(Looper.java:313)
	at android.os.HandlerThread.run(HandlerThread.java:67)
```