### PR TITLE
Scheduler: Rounding up causes duplicate execution if the task took less than the rounded up time

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/scheduler/core/SchedulerManager.kt
+++ b/app/src/main/java/eu/darken/sdmse/scheduler/core/SchedulerManager.kt
@@ -130,8 +130,7 @@ class SchedulerManager @Inject constructor(
 
         val nextExecutionAt = nextExecution!!
 
-        // Let the schedules start at the even minutes for a better user experience
-        val timeTillnextExecution = Duration.ofMinutes(Duration.between(Instant.now(), nextExecutionAt).toMinutes())
+        val timeTillnextExecution = Duration.between(Instant.now(), nextExecutionAt)
 
         log(TAG) { "schedule($label): Next execution is in $timeTillnextExecution, at $nextExecutionAt" }
 


### PR DESCRIPTION
Could be the fix for #692