### PR TITLE
Automation: Cancel automation if the screen becomes unavailable

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
@@ -31,6 +31,7 @@ import eu.darken.sdmse.appcleaner.core.automation.specs.vivo.VivoSpecs
 import eu.darken.sdmse.automation.core.AutomationHost
 import eu.darken.sdmse.automation.core.AutomationModule
 import eu.darken.sdmse.automation.core.AutomationTask
+import eu.darken.sdmse.automation.core.common.ScreenUnavailableException
 import eu.darken.sdmse.automation.core.specs.AutomationExplorer
 import eu.darken.sdmse.automation.core.specs.AutomationSpec
 import eu.darken.sdmse.automation.core.specs.SpecGenerator
@@ -134,6 +135,10 @@ class ClearCacheModule @AssistedInject constructor(
                 processSpecForPkg(installed)
                 log(TAG, INFO) { "Successfully cleared cache for for $target" }
                 successful.add(target)
+            } catch (e: ScreenUnavailableException) {
+                log(TAG, WARN) { "Cancelled because screen become unavailable: ${e.asLog()}" }
+                // TODO We don't have to abort here, but this is not a normal state and should show an error?
+                throw e
             } catch (e: TimeoutCancellationException) {
                 log(TAG, WARN) { "Timeout while processing $installed" }
                 failed.add(target)

--- a/app/src/main/java/eu/darken/sdmse/automation/core/AutomationService.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/AutomationService.kt
@@ -132,12 +132,13 @@ class AutomationService : AccessibilityService(), AutomationHost, Progress.Host,
                     }
 
                     acv != null -> {
-                        log(
-                            TAG,
-                            VERBOSE
-                        ) { "Updating control view (isScreenAvailable=${screenState.isScreenAvailable})" }
-                        log(TAG, VERBOSE) { "Updating progress $progress" }
-                        acv.setProgress(if (screenState.isScreenAvailable) progressData else null)
+                        if (screenState.isScreenAvailable) {
+                            log(TAG, VERBOSE) { "Updating progress $progress" }
+                            acv.setProgress(progressData)
+                        } else {
+                            log(TAG, WARN) { "NULLing control view, screen is unavailable!" }
+                            acv.setProgress(null)
+                        }
                     }
 
                     else -> {

--- a/app/src/main/java/eu/darken/sdmse/automation/core/ScreenState.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/ScreenState.kt
@@ -27,9 +27,9 @@ class ScreenState @Inject constructor(
     private val keyguardManager: KeyguardManager,
 ) {
 
-    suspend fun isScreenOn(): Boolean = powerManager.isInteractive
+    private suspend fun isScreenOn(): Boolean = powerManager.isInteractive
 
-    suspend fun isUnlocked(): Boolean = !keyguardManager.isKeyguardLocked
+    private suspend fun isUnlocked(): Boolean = !keyguardManager.isKeyguardLocked
 
     val state: Flow<State> = callbackFlow {
         trySendBlocking(State(isScreenOn = isScreenOn(), isUnlocked = isUnlocked()))

--- a/app/src/main/java/eu/darken/sdmse/automation/core/common/PlanAbortException.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/common/PlanAbortException.kt
@@ -1,5 +1,5 @@
 package eu.darken.sdmse.automation.core.common
 
-class PlanAbortException(
+open class PlanAbortException(
     message: String,
 ) : AutomationException(message)

--- a/app/src/main/java/eu/darken/sdmse/automation/core/common/ScreenUnavailableException.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/common/ScreenUnavailableException.kt
@@ -1,0 +1,16 @@
+package eu.darken.sdmse.automation.core.common
+
+import eu.darken.sdmse.R
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.error.HasLocalizedError
+import eu.darken.sdmse.common.error.LocalizedError
+
+class ScreenUnavailableException(
+    message: String,
+) : PlanAbortException(message), HasLocalizedError {
+    override fun getLocalizedError() = LocalizedError(
+        throwable = this,
+        label = R.string.automation_error_screen_unavailable_title.toCaString(),
+        description = R.string.automation_error_screen_unavailable_body.toCaString()
+    )
+}

--- a/app/src/main/java/eu/darken/sdmse/automation/core/specs/AutomationExplorer.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/specs/AutomationExplorer.kt
@@ -40,7 +40,7 @@ class AutomationExplorer @AssistedInject constructor(
         progressPub.value = update(progressPub.value)
     }
 
-    suspend fun process(spec: AutomationSpec.Explorer): Unit {
+    suspend fun process(spec: AutomationSpec.Explorer) {
         log(TAG) { "process(): $spec" }
 
         var attempts = 0
@@ -61,22 +61,23 @@ class AutomationExplorer @AssistedInject constructor(
             override val stepper: StepProcessor = stepProcessorFactory.create(host)
         }
 
-        withTimeout(spec.executionTimeout.toMillis()) {
-            log(TAG, VERBOSE) { "Creating plan..." }
-            val plan = spec.createPlan()
-            log(TAG) { "Plan created: $plan" }
+        log(TAG, VERBOSE) { "Creating plan..." }
+        val plan = spec.createPlan()
+        log(TAG) { "Plan created: $plan" }
 
+        withTimeout(spec.executionTimeout.toMillis()) {
             while (currentCoroutineContext().isActive) {
                 try {
                     plan(context)
                     // Success :)
                     return@withTimeout
                 } catch (e: PlanAbortException) {
-                    log(TAG, WARN) { "ABORT Step due to ${e.asLog()}" }
+                    log(TAG, WARN) { "ABORT Plan due to ${e.asLog()}" }
                     throw e
                 } catch (e: Exception) {
                     log(TAG, WARN) { "Plan failed, retrying (attempts=$attempts):\n${e.asLog()}" }
                     delay(300)
+                    attempts++
                 }
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -504,6 +504,8 @@
     <string name="automation_error_not_enabled_body">Accessibility service is disabled. Turn it on again.</string>
     <string name="automation_error_not_running_title">Service isn\'t running</string>
     <string name="automation_error_not_running_body">Accessibility service is not running. Try rebooting the device.</string>
+    <string name="automation_error_screen_unavailable_title">Screen unavailable</string>
+    <string name="automation_error_screen_unavailable_body">The operation was aborted because the screen became unavailable (e.g. display off or lockscreen active).</string>
 
     <string name="history_label">History</string>
     <string name="history_description">A chronological list of recent actions and affected data.</string>


### PR DESCRIPTION
Operations that use the accessibility service may obstruct the user. In some cases the lockscreen prevented the user from canceling. So #685 disabled the overlay if the screen is unavailable, e.g. the lockscreen is active.

This change goes a step further.
The overlay is still hidden if the screen becomes unavailable, but we will also throw a special Exception that should propagate up the stack and cancel the whole operation.

So to stop the automation, turning off the screen is enough. The automation itself keeps the screen from timing-out, so this should only happen if the user manually presses the power button.

Also see #692.

Closes #686

A "pause" option would be inappropriate here, screen becoming unavailable is an exceptional state.