### PR TITLE
targetSdk: Int? is deprecated

### DIFF
--- a/buildSrc/src/main/java/ProjectConfig.kt
+++ b/buildSrc/src/main/java/ProjectConfig.kt
@@ -53,7 +53,6 @@ fun LibraryExtension.setupLibraryDefaults() {
 
     defaultConfig {
         minSdk = ProjectConfig.minSdk
-        targetSdk = ProjectConfig.targetSdk
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")


### PR DESCRIPTION
**Fix:** ``targetSdk: Int?' is deprecated. Will be removed from library DSL in v9.0``

**Reference:** https://stackoverflow.com/questions/75256272/kotlin-multiplatform-mobile-targetsdk-deprecated