### PR TITLE
UI: Fix crash when going to setup from a settings "setup required" hint

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/setup/SetupModuleExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/SetupModuleExtensions.kt
@@ -10,24 +10,29 @@ import kotlinx.coroutines.flow.first
 
 suspend fun SetupModule.isComplete() = state.first()?.isComplete ?: false
 
-fun Collection<SetupModule.Type>.showFixSetupHint(fragment: Fragment) = Snackbar
-    .make(
-        fragment.requireView(),
-        fragment.getString(
-            R.string.setup_feature_requires_additional_setup_x,
-            this.joinToString(", ") { "\"${fragment.getString(it.labelRes)}\"" }
-        ),
-        Snackbar.LENGTH_LONG
-    )
-    .enableBigText()
-    .apply { duration = 5000 }
-    .setAction(eu.darken.sdmse.common.R.string.general_set_up_action) {
-        val direction = SettingsFragmentDirections.goToSetup(
-            options = SetupScreenOptions(
-                showCompleted = true,
-                typeFilter = this.toList()
-            )
+fun Collection<SetupModule.Type>.showFixSetupHint(fragment: Fragment) {
+    // If the user navigates back while the snackbar is still showing
+    // then we don't have access to the fragment anymore to get the navcontroller
+    val navController = fragment.findNavController()
+    Snackbar
+        .make(
+            fragment.requireView(),
+            fragment.getString(
+                R.string.setup_feature_requires_additional_setup_x,
+                this.joinToString(", ") { "\"${fragment.getString(it.labelRes)}\"" }
+            ),
+            Snackbar.LENGTH_LONG
         )
-        fragment.findNavController().navigate(direction)
-    }
-    .show()
+        .enableBigText()
+        .apply { duration = 5000 }
+        .setAction(eu.darken.sdmse.common.R.string.general_set_up_action) {
+            val direction = SettingsFragmentDirections.goToSetup(
+                options = SetupScreenOptions(
+                    showCompleted = true,
+                    typeFilter = this.toList()
+                )
+            )
+            navController.navigate(direction)
+        }
+        .show()
+}


### PR DESCRIPTION
If the user clicks a setting that requires further setup, and then navigates back one level before clicking "Set up", then we crash. Not sure how common this is IRL, but Google's monkey testing runs into this regularly.