### PR TITLE
Google Play: Improve upgrade check reliability

### DIFF
--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplay.kt
@@ -56,10 +56,12 @@ class UpgradeRepoGplay @Inject constructor(
                     billingCache.lastProStateAt.value(now)
                     Info(billingData = data)
                 }
+
                 (now - lastProStateAt) < 7 * 24 * 60 * 1000L -> { // 7 days
                     log(TAG, VERBOSE) { "We are not pro, but were recently, did GPlay try annoy us again?" }
                     Info(gracePeriod = true, billingData = null)
                 }
+
                 else -> {
                     Info(billingData = data)
                 }
@@ -114,8 +116,10 @@ class UpgradeRepoGplay @Inject constructor(
                 purchase.products.mapNotNull { productId ->
                     val sku = OurSku.PRO_SKUS.singleOrNull { it.id == productId }
                     if (sku == null) {
-                        log(ERROR) { "Unknown product: $productId" }
+                        log(TAG, ERROR) { "Unknown product: $productId ($purchase)" }
                         return@mapNotNull null
+                    } else {
+                        log(TAG) { "Mapped $productId to $sku ($purchase)" }
                     }
                     PurchasedSku(sku, purchase)
                 }


### PR DESCRIPTION
Previously we used `orderId` to check for valid purchases but apparently this is not a reliable way to check state.

While [documentation](https://developer.android.com/reference/com/android/billingclient/api/Purchase#getOrderId()) says:

> The order ID will be null if the purchase is in the Purchase.PurchaseState.PENDING state and populated if the purchase has transitioned to the Purchase.PurchaseState.PURCHASED state.

in reality I could reproduce cases where the `orderId` field was `null` despite `getPurchaseState() == PURCHASED`. What up Google?

My best guess so far is that the cached data that `queryPurchasesAsync` sometimes returns, does not always contain all fields. Clearing Google Play cache can reset it and fix that, but it's unclear why and when the "half-cached" state returns.

A normal, fully cached purchase entry looks like this:

```json
{
    "orderId": "GPA.<id>",
    "packageName": "eu.darken.sdmse",
    "productId": "eu.darken.sdmse.iap.upgrade.pro",
    "purchaseTime": 1697351226769,
    "purchaseState": 0,
    "purchaseToken": "<token>",
    "quantity": 1,
    "acknowledged": true
}
```

A half-cached entry looks like this:

```json
{
    "packageName": "eu.darken.sdmse",
    "productId": "eu.darken.sdmse.iap.upgrade.pro",
    "purchaseTime": 1680023656958,
    "purchaseState": 0,
    "purchaseToken": "<token>"
}
```

While the json payload contains `purchaseState == UNSPECIFIED`, the actual `Purchase.getPurchaseState()` function still returns `PURCHASED` in the half-cached state. Due to fallback handling:

```java
    public int getPurchaseState() {
        switch (this.zzc.optInt("purchaseState", 1)) {
            case 4:
                return 2;
            default:
                return 1;
        }
    }
```

So this PR changes the check to `getPurchaseState`.