### PR TITLE
Scheduler: Improve time calculation

### DIFF
--- a/app-common/src/main/java/eu/darken/sdmse/common/TimeExtensions.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/TimeExtensions.kt
@@ -10,3 +10,6 @@ fun OffsetDateTime.toSystemTimezone(): ZonedDateTime = this
 
 fun Instant.toSystemTimezone(): ZonedDateTime = this
     .atZone(ZoneId.systemDefault())
+
+fun Instant.toUtcTimezone(): ZonedDateTime = this
+    .atZone(ZoneId.of("UTC"))

--- a/app/src/main/java/eu/darken/sdmse/scheduler/core/Schedule.kt
+++ b/app/src/main/java/eu/darken/sdmse/scheduler/core/Schedule.kt
@@ -2,6 +2,8 @@ package eu.darken.sdmse.scheduler.core
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.log
 import java.time.Duration
 import java.time.Instant
 import java.time.ZoneId
@@ -23,31 +25,53 @@ data class Schedule(
     val isEnabled: Boolean
         get() = scheduledAt != null
 
-    val firstExecution: Instant?
-        get() {
-            if (scheduledAt == null) return null
-            return scheduledAt
-                .atZone(ZoneId.systemDefault())
-                .withHour(hour)
-                .withMinute(minute)
-                .let {
-                    if (it.isAfter(scheduledAt.atZone(ZoneId.systemDefault()))) {
-                        it.plus(repeatInterval.minus(Duration.ofDays(1)))
-                    } else {
-                        it.plus(repeatInterval)
-                    }
+    internal fun calcFirstExecutionAt(
+        userZone: ZoneId = ZoneId.systemDefault()
+    ): Instant? {
+        if (scheduledAt == null) return null
+
+        val scheduledAtZoned = scheduledAt.atZone(userZone)
+        return scheduledAtZoned
+            .withHour(hour)
+            .withMinute(minute)
+            .let {
+                if (it.isAfter(scheduledAtZoned)) {
+                    it.plus(repeatInterval.minus(Duration.ofDays(1)))
+                } else {
+                    it.plus(repeatInterval)
                 }
-                .toInstant()
-        }
+            }
+            .toInstant()
+    }
 
-    val nextExecution: Instant?
-        get() {
-            if (scheduledAt == null) return null
+    fun calcExecutionEta(
+        now: Instant,
+        reschedule: Boolean,
+        userZone: ZoneId = ZoneId.systemDefault(),
+    ): Duration? {
+        if (scheduledAt == null) return null
 
-            var nextTrigger = firstExecution!!
-            while (nextTrigger.isBefore(Instant.now())) {
+        fun calcNextTrigger(present: Instant): Instant {
+            var nextTrigger = calcFirstExecutionAt(userZone)!!
+            while (nextTrigger.isBefore(present)) {
                 nextTrigger = nextTrigger.plus(repeatInterval)
             }
             return nextTrigger
         }
+
+        return Duration
+            .between(now, calcNextTrigger(now))
+            .let { eta ->
+                if (reschedule && eta < Duration.ofHours(12)) {
+                    // `setInitialDelay` could have variance, e.g. due to system power management
+                    // Our minimal repeat interval is 1d+, so let's prevent accidental immediate rescheduling
+                    log(SchedulerManager.TAG, WARN) { "schedule($label): Premature rescheduling! ETA is only $eta" }
+                    val futureNow = now.plus(eta).plus(Duration.ofMinutes(3))
+                    Duration.between(now, calcNextTrigger(futureNow))
+                } else {
+                    eta
+                }
+            }
+    }
+
 }

--- a/app/src/main/java/eu/darken/sdmse/scheduler/ui/SchedulerDashCardVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/scheduler/ui/SchedulerDashCardVH.kt
@@ -9,6 +9,7 @@ import eu.darken.sdmse.databinding.SchedulerDashboardItemBinding
 import eu.darken.sdmse.main.core.taskmanager.TaskManager
 import eu.darken.sdmse.main.ui.dashboard.DashboardAdapter
 import eu.darken.sdmse.scheduler.core.SchedulerManager
+import java.time.Instant
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 
@@ -29,15 +30,18 @@ class SchedulerDashCardVH(parent: ViewGroup) :
         val formatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT)
 
         subtitle.isVisible = item.schedulerState.schedules.none { it.isEnabled }
-
+        val now = Instant.now()
         val nextSchedule = item.schedulerState.schedules
             .filter { it.isEnabled }
-            .maxByOrNull { it.nextExecution!! }
+            .minByOrNull { it.calcExecutionEta(now, false)!! }
         executionNextLabel.isVisible = nextSchedule != null
         executionNextValue.apply {
             isVisible = nextSchedule != null
             text = nextSchedule?.let {
-                "${it.nextExecution?.toSystemTimezone()?.format(formatter)} (${it.label})"
+                val nextAt = now
+                    .plus(it.calcExecutionEta(now, false))
+                    .toSystemTimezone().format(formatter)
+                "$nextAt (${it.label})"
             }
         }
 

--- a/app/src/main/java/eu/darken/sdmse/scheduler/ui/manager/items/ScheduleRowVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/scheduler/ui/manager/items/ScheduleRowVH.kt
@@ -10,6 +10,7 @@ import eu.darken.sdmse.common.toSystemTimezone
 import eu.darken.sdmse.databinding.SchedulerManagerListScheduleItemBinding
 import eu.darken.sdmse.scheduler.core.Schedule
 import eu.darken.sdmse.scheduler.ui.manager.SchedulerAdapter
+import java.time.Instant
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
@@ -45,13 +46,12 @@ class ScheduleRowVH(parent: ViewGroup) :
         }
 
         val formatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT)
-
+        val now = Instant.now()
         primary.apply {
             isVisible = schedule.scheduledAt != null
-            text = schedule.nextExecution?.let { startedAt ->
-                val next = startedAt.toSystemTimezone()
-                val formatted = next.format(formatter)
-                getString(R.string.scheduler_schedule_next_at_x, formatted)
+            text = schedule.calcExecutionEta(now, false)?.let { eta ->
+                val next = now.plus(eta).toSystemTimezone().format(formatter)
+                getString(R.string.scheduler_schedule_next_at_x, next)
             }
         }
 

--- a/app/src/test/java/eu/darken/sdmse/scheduler/core/ScheduleTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/scheduler/core/ScheduleTest.kt
@@ -1,0 +1,172 @@
+package eu.darken.sdmse.scheduler.core
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+
+class ScheduleTest : BaseTest() {
+
+    @Test fun `first execution calculation`() {
+        val schedule = Schedule(
+            id = "id",
+            hour = 22,
+            minute = 0,
+            repeatInterval = Duration.ofDays(1),
+            scheduledAt = Instant.parse("2022-01-01T12:00:00Z")
+        )
+
+        schedule.calcFirstExecutionAt(
+            userZone = ZoneId.of("UTC")
+        ) shouldBe Instant.parse("2022-01-01T22:00:00Z")
+        schedule.calcFirstExecutionAt(
+            userZone = ZoneId.of("GMT+1")
+        ) shouldBe Instant.parse("2022-01-01T21:00:00Z")
+        schedule.calcFirstExecutionAt(
+            userZone = ZoneId.of("GMT-1")
+        ) shouldBe Instant.parse("2022-01-01T23:00:00Z")
+    }
+
+    @Test fun `time calculation - initial schedule`() {
+        val schedule = Schedule(
+            id = "id",
+            hour = 22,
+            minute = 0,
+            repeatInterval = Duration.ofDays(1),
+            scheduledAt = Instant.parse("2022-01-01T12:00:00Z")
+        )
+
+        schedule.calcExecutionEta(
+            userZone = ZoneId.of("UTC"),
+            reschedule = false,
+            now = Instant.parse("2022-01-01T12:00:00Z")
+        ) shouldBe Duration.ofHours(10)
+    }
+
+    @Test fun `time calculation - initial schedule - timezone`() {
+        val schedule = Schedule(
+            id = "id",
+            hour = 22,
+            minute = 0,
+            repeatInterval = Duration.ofDays(1),
+            scheduledAt = Instant.parse("2022-01-01T12:00:00Z")
+        )
+
+        schedule.calcExecutionEta(
+            userZone = ZoneId.of("GMT+1"),
+            reschedule = false,
+            now = Instant.parse("2022-01-01T12:00:00Z")
+        ) shouldBe Duration.ofHours(9)
+    }
+
+    @Test fun `time calculation - initial schedule - close call`() {
+        val schedule = Schedule(
+            id = "id",
+            hour = 22,
+            minute = 2,
+            repeatInterval = Duration.ofDays(1),
+            scheduledAt = Instant.parse("2022-01-01T22:00:00Z")
+        )
+        schedule.calcExecutionEta(
+            userZone = ZoneId.of("UTC"),
+            reschedule = false,
+            now = Instant.parse("2022-01-01T22:00:00Z")
+        ) shouldBe Duration.ofMinutes(2)
+    }
+
+    @Test fun `time calculation - initial schedule - close call - timezone`() {
+        val schedule = Schedule(
+            id = "id",
+            hour = 22,
+            minute = 0,
+            repeatInterval = Duration.ofDays(1),
+            scheduledAt = Instant.parse("2022-01-01T22:00:00Z")
+        )
+        schedule.calcExecutionEta(
+            userZone = ZoneId.of("GMT-1"),
+            reschedule = false,
+            now = Instant.parse("2022-01-01T22:00:00Z")
+        ) shouldBe Duration.ofHours(1)
+    }
+
+    @Test fun `time calculation - initial schedule - collision`() {
+        val schedule = Schedule(
+            id = "id",
+            hour = 22,
+            minute = 0,
+            repeatInterval = Duration.ofDays(1),
+            scheduledAt = Instant.parse("2022-01-01T22:00:00Z")
+        )
+        schedule.calcExecutionEta(
+            userZone = ZoneId.of("UTC"),
+            reschedule = false,
+            now = Instant.parse("2022-01-01T22:00:00Z")
+        ) shouldBe Duration.ofDays(1)
+    }
+
+    @Test fun `time calculation - initial schedule - just too late`() {
+        val schedule = Schedule(
+            id = "id",
+            hour = 22,
+            minute = 0,
+            repeatInterval = Duration.ofDays(1),
+            scheduledAt = Instant.parse("2022-01-01T22:00:00Z")
+        )
+        schedule.calcExecutionEta(
+            userZone = ZoneId.of("UTC"),
+            reschedule = false,
+            now = Instant.parse("2022-01-01T22:01:00Z")
+        ) shouldBe Duration.ofDays(1).minus(Duration.ofMinutes(1))
+    }
+
+    @Test fun `time calculation - reschedule`() {
+        val schedule = Schedule(
+            id = "id",
+            hour = 14,
+            minute = 0,
+            repeatInterval = Duration.ofDays(1),
+            scheduledAt = Instant.parse("2022-01-01T12:00:00Z")
+        )
+
+        schedule.calcExecutionEta(
+            userZone = ZoneId.of("UTC"),
+            reschedule = true,
+            now = Instant.parse("2022-01-02T14:05:00Z")
+        ) shouldBe Duration.ofHours(24).minusMinutes(5)
+    }
+
+    @Test fun `time calculation - reschedule - premature`() {
+        val schedule = Schedule(
+            id = "id",
+            hour = 12,
+            minute = 0,
+            repeatInterval = Duration.ofDays(1),
+            scheduledAt = Instant.parse("2022-01-01T11:00:00Z")
+        )
+
+        schedule.calcExecutionEta(
+            userZone = ZoneId.of("UTC"),
+            reschedule = true,
+            now = Instant.parse("2022-01-02T11:55:00Z")
+        ) shouldBe Duration.ofHours(24).plusMinutes(5)
+    }
+
+    @Test fun `time calculation - reschedule - premature - timezone`() {
+        val schedule = Schedule(
+            id = "id",
+            hour = 12,
+            minute = 0,
+            repeatInterval = Duration.ofDays(1),
+            scheduledAt = Instant.parse("2022-01-01T11:00:00Z")
+        )
+
+        // 12 hour safety margin causes a reschedule to go to the next day
+        schedule.calcExecutionEta(
+            userZone = ZoneId.of("GMT-1"),
+            reschedule = true,
+            now = Instant.parse("2022-01-02T11:55:00Z")
+        ) shouldBe Duration.ofHours(25).plusMinutes(5)
+    }
+}


### PR DESCRIPTION
Check if the schedule has executed prematurely and prevent immediate re-execution. Also refactoring and some tests.

Possible fix for #692