### PR TITLE
CorpseFinder: Disable root based filters on unknown API levels

### DIFF
--- a/app-common/src/main/java/eu/darken/sdmse/common/BuildWrap.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/BuildWrap.kt
@@ -29,5 +29,7 @@ fun hasApiLevel(level: Int): Boolean = when {
     else -> false
 }
 
+const val UNTESTED_API = 35
+
 inline fun <reified R> ifApiLevel(level: Int, block: () -> R): R? = if (hasApiLevel(level)) block() else null
 

--- a/app/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/AppAsecFileCorpseFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/AppAsecFileCorpseFilter.kt
@@ -7,6 +7,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.R
+import eu.darken.sdmse.common.UNTESTED_API
 import eu.darken.sdmse.common.areas.DataArea
 import eu.darken.sdmse.common.areas.DataAreaManager
 import eu.darken.sdmse.common.areas.currentAreas
@@ -18,6 +19,7 @@ import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.*
 import eu.darken.sdmse.common.files.local.LocalGateway
 import eu.darken.sdmse.common.forensics.FileForensics
+import eu.darken.sdmse.common.hasApiLevel
 import eu.darken.sdmse.common.progress.*
 import eu.darken.sdmse.corpsefinder.core.Corpse
 import eu.darken.sdmse.corpsefinder.core.CorpseFinderSettings
@@ -46,6 +48,11 @@ class AppAsecFileCorpseFilter @Inject constructor(
 
         if (!gateway.hasRoot()) {
             log(TAG) { "LocalGateway has no root, skipping." }
+            return emptySet()
+        }
+
+        if (hasApiLevel(UNTESTED_API)) {
+            log(TAG, WARN) { "Untested API level ($UNTESTED_API) skipping for safety." }
             return emptySet()
         }
 

--- a/app/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/AppLibCorpseFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/AppLibCorpseFilter.kt
@@ -7,6 +7,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.R
+import eu.darken.sdmse.common.UNTESTED_API
 import eu.darken.sdmse.common.areas.DataArea
 import eu.darken.sdmse.common.areas.DataAreaManager
 import eu.darken.sdmse.common.areas.currentAreas
@@ -18,6 +19,7 @@ import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.*
 import eu.darken.sdmse.common.files.local.LocalGateway
 import eu.darken.sdmse.common.forensics.FileForensics
+import eu.darken.sdmse.common.hasApiLevel
 import eu.darken.sdmse.common.progress.*
 import eu.darken.sdmse.corpsefinder.core.Corpse
 import eu.darken.sdmse.corpsefinder.core.CorpseFinderSettings
@@ -47,6 +49,11 @@ class AppLibCorpseFilter @Inject constructor(
 
         if (!gateway.hasRoot()) {
             log(TAG) { "LocalGateway has no root, skipping." }
+            return emptySet()
+        }
+
+        if (hasApiLevel(UNTESTED_API)) {
+            log(TAG, WARN) { "Untested API level ($UNTESTED_API) skipping for safety." }
             return emptySet()
         }
 

--- a/app/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/AppSourceCorpseFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/AppSourceCorpseFilter.kt
@@ -7,6 +7,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.R
+import eu.darken.sdmse.common.UNTESTED_API
 import eu.darken.sdmse.common.areas.DataArea
 import eu.darken.sdmse.common.areas.DataAreaManager
 import eu.darken.sdmse.common.areas.currentAreas
@@ -18,6 +19,7 @@ import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.*
 import eu.darken.sdmse.common.files.local.LocalGateway
 import eu.darken.sdmse.common.forensics.FileForensics
+import eu.darken.sdmse.common.hasApiLevel
 import eu.darken.sdmse.common.progress.*
 import eu.darken.sdmse.corpsefinder.core.Corpse
 import eu.darken.sdmse.corpsefinder.core.CorpseFinderSettings
@@ -46,6 +48,11 @@ class AppSourceCorpseFilter @Inject constructor(
 
         if (!gateway.hasRoot()) {
             log(TAG) { "LocalGateway has no root, skipping." }
+            return emptySet()
+        }
+
+        if (hasApiLevel(UNTESTED_API)) {
+            log(TAG, WARN) { "Untested API level ($UNTESTED_API) skipping for safety." }
             return emptySet()
         }
 

--- a/app/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/AppSourcePrivateCorpseFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/AppSourcePrivateCorpseFilter.kt
@@ -7,6 +7,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.R
+import eu.darken.sdmse.common.UNTESTED_API
 import eu.darken.sdmse.common.areas.DataArea
 import eu.darken.sdmse.common.areas.DataAreaManager
 import eu.darken.sdmse.common.areas.currentAreas
@@ -18,6 +19,7 @@ import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.*
 import eu.darken.sdmse.common.files.local.LocalGateway
 import eu.darken.sdmse.common.forensics.FileForensics
+import eu.darken.sdmse.common.hasApiLevel
 import eu.darken.sdmse.common.progress.*
 import eu.darken.sdmse.corpsefinder.core.Corpse
 import eu.darken.sdmse.corpsefinder.core.CorpseFinderSettings
@@ -47,6 +49,11 @@ class AppSourcePrivateCorpseFilter @Inject constructor(
 
         if (!gateway.hasRoot()) {
             log(TAG) { "LocalGateway has no root, skipping." }
+            return emptySet()
+        }
+
+        if (hasApiLevel(UNTESTED_API)) {
+            log(TAG, WARN) { "Untested API level ($UNTESTED_API) skipping for safety." }
             return emptySet()
         }
 

--- a/app/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/DalvikCorpseFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/DalvikCorpseFilter.kt
@@ -9,6 +9,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.R
+import eu.darken.sdmse.common.UNTESTED_API
 import eu.darken.sdmse.common.areas.DataArea
 import eu.darken.sdmse.common.areas.DataAreaManager
 import eu.darken.sdmse.common.areas.currentAreas
@@ -21,6 +22,7 @@ import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.*
 import eu.darken.sdmse.common.files.local.LocalGateway
 import eu.darken.sdmse.common.forensics.FileForensics
+import eu.darken.sdmse.common.hasApiLevel
 import eu.darken.sdmse.common.pkgs.getSharedLibraries2
 import eu.darken.sdmse.common.progress.*
 import eu.darken.sdmse.corpsefinder.core.Corpse
@@ -51,6 +53,11 @@ class DalvikCorpseFilter @Inject constructor(
 
         if (!gateway.hasRoot()) {
             log(TAG) { "LocalGateway has no root, skipping." }
+            return emptySet()
+        }
+
+        if (hasApiLevel(UNTESTED_API)) {
+            log(TAG, WARN) { "Untested API level ($UNTESTED_API) skipping for safety." }
             return emptySet()
         }
 

--- a/app/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/PrivateDataCorpseFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/PrivateDataCorpseFilter.kt
@@ -7,6 +7,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.R
+import eu.darken.sdmse.common.UNTESTED_API
 import eu.darken.sdmse.common.areas.DataArea
 import eu.darken.sdmse.common.areas.DataAreaManager
 import eu.darken.sdmse.common.areas.currentAreas
@@ -18,6 +19,7 @@ import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.*
 import eu.darken.sdmse.common.files.local.LocalGateway
 import eu.darken.sdmse.common.forensics.FileForensics
+import eu.darken.sdmse.common.hasApiLevel
 import eu.darken.sdmse.common.progress.*
 import eu.darken.sdmse.corpsefinder.core.Corpse
 import eu.darken.sdmse.corpsefinder.core.CorpseFinderSettings
@@ -47,6 +49,11 @@ class PrivateDataCorpseFilter @Inject constructor(
 
         if (!gateway.hasRoot()) {
             log(TAG) { "LocalGateway has no root, skipping." }
+            return emptySet()
+        }
+
+        if (hasApiLevel(UNTESTED_API)) {
+            log(TAG, WARN) { "Untested API level ($UNTESTED_API) skipping for safety." }
             return emptySet()
         }
 


### PR DESCRIPTION
i.e. before letting these loose on Android 15/16, we should test them. Theoretically this is an issue with all tools, but the CorpseFinder would have the most negative impact on unsuspecting users.