### PR TITLE
Deduplicator: Fix crash when loading previews

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/deduplicator/ui/PreviewDeletionDialog.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/ui/PreviewDeletionDialog.kt
@@ -8,6 +8,7 @@ import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.GridLayoutManager
+import coil.transform.RoundedCornersTransformation
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.materialswitch.MaterialSwitch
 import eu.darken.sdmse.R
@@ -95,7 +96,9 @@ class PreviewDeletionDialog(private val context: Context) {
             }
             binding.deleteAllIcon.isVisible = binding.deleteAllToggle.isVisible
 
-            binding.previewImage.loadFilePreview(mode.previews.single())
+            binding.previewImage.loadFilePreview(mode.previews.single()) {
+                transformations(RoundedCornersTransformation(36F))
+            }
 
             binding.root
         } else {
@@ -224,7 +227,9 @@ class PreviewDeletionDialog(private val context: Context) {
                 item: Item,
                 payloads: List<Any>
             ) -> Unit = { item, _ ->
-                previewImage.loadFilePreview(item.lookup)
+                previewImage.loadFilePreview(item.lookup) {
+                    transformations(RoundedCornersTransformation(36F))
+                }
             }
 
         }

--- a/app/src/main/java/eu/darken/sdmse/deduplicator/ui/details/cluster/elements/PHashGroupFileVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/ui/details/cluster/elements/PHashGroupFileVH.kt
@@ -2,6 +2,7 @@ package eu.darken.sdmse.deduplicator.ui.details.cluster.elements
 
 import android.text.format.Formatter
 import android.view.ViewGroup
+import coil.transform.RoundedCornersTransformation
 import eu.darken.sdmse.R
 import eu.darken.sdmse.common.coil.loadFilePreview
 import eu.darken.sdmse.common.lists.binding
@@ -35,7 +36,9 @@ class PHashGroupFileVH(parent: ViewGroup) :
         lastItem = item
         val dupe = item.duplicate
 
-        previewImage.loadFilePreview(dupe.lookup)
+        previewImage.loadFilePreview(dupe.lookup) {
+            transformations(RoundedCornersTransformation(36F))
+        }
         primary.text = dupe.lookup.userReadablePath.get(context)
         secondary.text = String.format("%.2f%%", dupe.similarity * 100)
         sizeValue.text = Formatter.formatShortFileSize(context, dupe.size)

--- a/app/src/main/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListGridVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListGridVH.kt
@@ -1,5 +1,6 @@
 package eu.darken.sdmse.deduplicator.ui.list
 
+import android.graphics.Bitmap
 import android.text.format.Formatter
 import android.view.ViewGroup
 import androidx.core.view.isVisible
@@ -35,7 +36,10 @@ class DeduplicatorListGridVH(parent: ViewGroup) :
         lastItem = item
         val cluster = item.cluster
 
-        previewImage.loadFilePreview(cluster.previewFile)
+        previewImage.loadFilePreview(cluster.previewFile) {
+            // Exception java.lang.IllegalArgumentException: Software rendering doesn't support hardware bitmaps
+            bitmapConfig(Bitmap.Config.ARGB_8888)
+        }
 
         primary.text = Formatter.formatShortFileSize(context, cluster.totalSize)
         secondary.text = context.getQuantityString2(eu.darken.sdmse.common.R.plurals.result_x_items, cluster.count)

--- a/app/src/main/res/layout/deduplicator_cluster_element_phashgroup_file.xml
+++ b/app/src/main/res/layout/deduplicator_cluster_element_phashgroup_file.xml
@@ -6,7 +6,7 @@
     android:layout_height="wrap_content"
     android:background="@drawable/bg_listitem_selectable">
 
-    <com.google.android.material.imageview.ShapeableImageView
+    <ImageView
         android:id="@+id/preview_image"
         android:layout_width="32dp"
         android:layout_height="32dp"
@@ -16,7 +16,6 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:shapeAppearanceOverlay="@style/PreviewRoundedBox.Small"
         tools:src="?colorPrimary" />
 
     <com.google.android.material.textview.MaterialTextView

--- a/app/src/main/res/layout/view_delete_confirmation_preview_grid_item.xml
+++ b/app/src/main/res/layout/view_delete_confirmation_preview_grid_item.xml
@@ -1,17 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="64dp"
     android:layout_height="64dp">
 
-    <com.google.android.material.imageview.ShapeableImageView
+    <ImageView
         android:id="@+id/preview_image"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_margin="3dp"
         android:scaleType="centerCrop"
-        app:shapeAppearanceOverlay="@style/PreviewRoundedBox.Small"
         tools:src="@color/green" />
 
 </FrameLayout>

--- a/app/src/main/res/layout/view_delete_confirmation_preview_single.xml
+++ b/app/src/main/res/layout/view_delete_confirmation_preview_single.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
-    <com.google.android.material.imageview.ShapeableImageView
+    <ImageView
         android:id="@+id/preview_image"
         android:layout_width="148dp"
         android:layout_height="148dp"
@@ -15,7 +15,6 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:shapeAppearanceOverlay="@style/PreviewRoundedBox.Large"
         tools:src="@color/green" />
 
     <ImageView


### PR DESCRIPTION
Use Coil's transformations to get rounded corners. Using Coil to load hardware supported bitmaps into `ShapeableImageView` can lead to crashs.

```
Exception java.lang.IllegalArgumentException: Software rendering doesn't support hardware bitmaps
  at android.graphics.BaseCanvas.throwIfHwBitmapInSwMode (BaseCanvas.java:749)
  at android.graphics.BaseCanvas.throwIfCannotDraw (BaseCanvas.java:94)
  at android.graphics.BaseCanvas.drawBitmap (BaseCanvas.java:152)
  at android.graphics.Canvas.drawBitmap (Canvas.java:1604)
  at android.graphics.drawable.BitmapDrawable.draw (BitmapDrawable.java:560)
  at android.widget.ImageView.onDraw (ImageView.java:1446)
  at com.google.android.material.imageview.ShapeableImageView.onDraw (ShapeableImageView.java)
```

Seems to happen randomly, this was:

```
samsung b0q (Galaxy S22 Ultra)
Android 13 (SDK 33)

```