### PR TITLE
Setup: Improve root setup display and interaction

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/setup/SetupViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/SetupViewModel.kt
@@ -169,6 +169,8 @@ class SetupViewModel @Inject constructor(
                 .sortedBy { item ->
                     if (screenOptions.showCompleted && !item.state.isComplete) {
                         Int.MIN_VALUE
+                    } else if (item is RootSetupCardVH.Item && item.state.isInstalled && item.state.useRoot == null) {
+                        Int.MIN_VALUE
                     } else {
                         DISPLAY_ORDER.indexOfFirst { it.isInstance(item) }
                     }

--- a/app/src/main/java/eu/darken/sdmse/setup/root/RootSetupCardVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/root/RootSetupCardVH.kt
@@ -1,7 +1,9 @@
 package eu.darken.sdmse.setup.root
 
 import android.view.ViewGroup
+import androidx.core.view.isVisible
 import eu.darken.sdmse.R
+import eu.darken.sdmse.common.getColorForAttr
 import eu.darken.sdmse.common.lists.binding
 import eu.darken.sdmse.databinding.SetupRootItemBinding
 import eu.darken.sdmse.setup.SetupAdapter
@@ -16,6 +18,18 @@ class RootSetupCardVH(parent: ViewGroup) :
         item: Item,
         payloads: List<Any>
     ) -> Unit = binding { item ->
+
+        rootState.apply {
+            isVisible = item.state.useRoot == true && item.state.isInstalled
+            text = getString(
+                if (item.state.ourService) R.string.setup_root_state_ready_label
+                else R.string.setup_root_state_waiting_label
+            )
+            setTextColor(
+                if (item.state.ourService) context.getColorForAttr(android.R.attr.textColorSecondary)
+                else context.getColorForAttr(android.R.attr.colorError)
+            )
+        }
 
         allowRootOptions.apply {
             setOnCheckedChangeListener(null)

--- a/app/src/main/res/layout/setup_root_item.xml
+++ b/app/src/main/res/layout/setup_root_item.xml
@@ -41,18 +41,31 @@
             android:layout_marginHorizontal="16dp"
             android:layout_marginTop="8dp"
             android:text="@string/setup_root_card_body"
-            app:layout_constraintBottom_toTopOf="@id/allow_root_options"
+            app:layout_constraintBottom_toTopOf="@id/root_state"
             app:layout_constraintEnd_toEndOf="@id/title"
             app:layout_constraintStart_toStartOf="@id/title"
             app:layout_constraintTop_toBottomOf="@id/title" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/root_state"
+            style="@style/TextAppearance.Material3.LabelMedium"
+            android:layout_width="wrap_content"
+            android:layout_marginTop="16dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="16dp"
+            android:text="@string/setup_root_state_waiting_label"
+            app:layout_constraintBottom_toTopOf="@id/allow_root_options"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/body" />
 
         <RadioGroup
             android:id="@+id/allow_root_options"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="16dp"
-            android:layout_marginVertical="8dp"
-            app:layout_constraintTop_toBottomOf="@id/body">
+            android:layout_marginBottom="8dp"
+            app:layout_constraintTop_toBottomOf="@id/root_state">
 
             <com.google.android.material.radiobutton.MaterialRadioButton
                 android:id="@+id/allow_root_options_enable"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -120,6 +120,8 @@
 
     <string name="setup_root_card_title">Root access</string>
     <string name="setup_root_card_body">Should SD Maid use root access if it is available? Root access can be used to check additional system folders and private application data.</string>
+    <string name="setup_root_state_ready_label">Root access is ready.</string>
+    <string name="setup_root_state_waiting_label">Waiting for root access.</string>
     <string name="setup_root_enable_root_use_label">Use root access if available</string>
     <string name="setup_root_disable_root_use_label">Don\'t use root access</string>
     <string name="setup_root_card_body2">Only available on rooted devices. If you didn\'t make this modification, then your device is not rooted and this setting has no effect.</string>


### PR DESCRIPTION
* Display a "root link state" similar to what we have for Shizuku
* If Magisk is detected, and the user has not made a yes/no decision about root, put the root setup card at the top as granting root, will automatically finish most other setup steps.