### PR TITLE
Scheduler: Support for running custom commands at the end of a schedule

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/scheduler/core/Schedule.kt
+++ b/app/src/main/java/eu/darken/sdmse/scheduler/core/Schedule.kt
@@ -20,6 +20,7 @@ data class Schedule(
     @Json(name = "corpsefinderEnabled") val useCorpseFinder: Boolean = false,
     @Json(name = "systemcleanerEnabled") val useSystemCleaner: Boolean = false,
     @Json(name = "appcleanerEnabled") val useAppCleaner: Boolean = false,
+    @Json(name = "commandsAfterSchedule") val commandsAfterSchedule: List<String> = emptyList(),
     @Json(name = "executedAt") val executedAt: Instant? = null,
 ) {
     val isEnabled: Boolean

--- a/app/src/main/java/eu/darken/sdmse/scheduler/ui/manager/SchedulerManagerEvents.kt
+++ b/app/src/main/java/eu/darken/sdmse/scheduler/ui/manager/SchedulerManagerEvents.kt
@@ -1,0 +1,7 @@
+package eu.darken.sdmse.scheduler.ui.manager
+
+import eu.darken.sdmse.scheduler.core.Schedule
+
+sealed interface SchedulerManagerEvents {
+    data class FinalCommandsEdit(val schedule: Schedule) : SchedulerManagerEvents
+}

--- a/app/src/main/java/eu/darken/sdmse/scheduler/ui/manager/SchedulerManagerFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/scheduler/ui/manager/SchedulerManagerFragment.kt
@@ -6,6 +6,7 @@ import androidx.core.view.isGone
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.ui.setupWithNavController
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
 import eu.darken.sdmse.R
 import eu.darken.sdmse.common.WebpageTool
@@ -14,6 +15,7 @@ import eu.darken.sdmse.common.lists.differ.update
 import eu.darken.sdmse.common.lists.setupDefaults
 import eu.darken.sdmse.common.uix.Fragment3
 import eu.darken.sdmse.common.viewbinding.viewBinding
+import eu.darken.sdmse.databinding.SchedulerCommandsEditDialogBinding
 import eu.darken.sdmse.databinding.SchedulerManagerFragmentBinding
 import javax.inject.Inject
 
@@ -54,6 +56,26 @@ class SchedulerManagerFragment : Fragment3(R.layout.scheduler_manager_fragment) 
             adapter.update(it.listItems)
             loadingOverlay.isGone = it.listItems != null
             list.isGone = it.listItems == null
+        }
+
+        vm.events.observe2(ui) { event ->
+            when (event) {
+                is SchedulerManagerEvents.FinalCommandsEdit -> {
+                    MaterialAlertDialogBuilder(requireContext()).apply {
+                        val binding = SchedulerCommandsEditDialogBinding.inflate(layoutInflater, null, false)
+                        binding.commandInput.setText(event.schedule.commandsAfterSchedule.joinToString("\n"))
+                        setView(binding.root)
+
+                        setTitle(R.string.scheduler_commands_after_schedule_label)
+                        setMessage(R.string.scheduler_commands_after_schedule_desc)
+                        setPositiveButton(eu.darken.sdmse.common.R.string.general_save_action) { _, _ ->
+                            val cmdsRaw = binding.commandInput.text?.toString() ?: ""
+                            vm.updateCommandsAfterSchedule(event.schedule.id, cmdsRaw)
+                        }
+                        setNegativeButton(eu.darken.sdmse.common.R.string.general_cancel_action) { _, _ -> }
+                    }.show()
+                }
+            }
         }
 
         super.onViewCreated(view, savedInstanceState)

--- a/app/src/main/java/eu/darken/sdmse/scheduler/ui/manager/items/ScheduleRowVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/scheduler/ui/manager/items/ScheduleRowVH.kt
@@ -96,17 +96,26 @@ class ScheduleRowVH(parent: ViewGroup) :
             setChecked2(schedule.useAppCleaner)
             setOnCheckedChangeListener { _, _ -> item.onToggleAppCleaner() }
         }
-    }
 
+        commandsContainer.isVisible = item.showCommands
+        commandsInfo.text = if (schedule.commandsAfterSchedule.isNotEmpty()) {
+            schedule.commandsAfterSchedule.mapIndexed { index, s -> "#$index: $s" }.joinToString("\n")
+        } else {
+            getString(R.string.scheduler_commands_after_schedule_desc)
+        }
+        commandsEditAction.setOnClickListener { item.onEditFinalCommands() }
+    }
 
     data class Item(
         val schedule: Schedule,
+        val showCommands: Boolean,
         val onEdit: () -> Unit,
         val onToggle: () -> Unit,
         val onRemove: () -> Unit,
         val onToggleCorpseFinder: () -> Unit,
         val onToggleSystemCleaner: () -> Unit,
         val onToggleAppCleaner: () -> Unit,
+        val onEditFinalCommands: () -> Unit,
     ) : SchedulerAdapter.Item {
 
         override val stableId: Long = schedule.id.hashCode().toLong()

--- a/app/src/main/res/layout/scheduler_commands_edit_dialog.xml
+++ b/app/src/main/res/layout/scheduler_commands_edit_dialog.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <com.google.android.material.textfield.TextInputEditText
+        android:id="@+id/command_input"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="32dp"
+        android:layout_marginVertical="16dp"
+        android:hint="reboot"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:ignore="HardcodedText" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/scheduler_manager_list_schedule_item.xml
+++ b/app/src/main/res/layout/scheduler_manager_list_schedule_item.xml
@@ -102,6 +102,50 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/appcleaner_tool_name" />
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/commands_container"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:visibility="gone"
+                tools:visibility="visible">
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/commands_label"
+                    style="@style/TextAppearance.Material3.BodyMedium"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="8dp"
+                    android:text="@string/scheduler_commands_after_schedule_label"
+                    app:layout_constraintBottom_toTopOf="@id/commands_info"
+                    app:layout_constraintEnd_toStartOf="@id/commands_edit_action"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/commands_info"
+                    style="@style/TextAppearance.Material3.LabelSmall"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="8dp"
+                    android:text="@string/scheduler_commands_after_schedule_desc"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toStartOf="@id/commands_edit_action"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/commands_label" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/commands_edit_action"
+                    style="@style/Widget.Material3.Button"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/general_edit_action"
+                    app:icon="@drawable/ic_mode_edit"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
         </LinearLayout>
 
         <com.google.android.material.button.MaterialButton

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -583,6 +583,8 @@
     <string name="scheduler_notification_result_title">Scheduler finished</string>
     <string name="scheduler_notification_result_success_message">All scheduled tasks ran successfully.</string>
     <string name="scheduler_notification_result_failure_message">Some scheduled tasks failed or encountered errors. Try running them manually.</string>
+    <string name="scheduler_commands_after_schedule_label">Post-schedule commands</string>
+    <string name="scheduler_commands_after_schedule_desc">Android shell commands that will be executed at the end of a schedule.</string>
 
     <string name="updates_dashcard_title">Update available</string>
     <string name="updates_dashcard_body">An update is available. You have %1$s and the latest version is %2$s.</string>


### PR DESCRIPTION
Closes #45

Supports multiple commands, one per line.

If root is available, the command will be run with root.
If root is not available, but Shizuku is, then Shizuku will be used.
Otherwise normal app shell priviledges are used.

![Screenshot from 2023-11-30 18-24-26](https://github.com/d4rken-org/sdmaid-se/assets/1439229/2e75570d-6de3-49cf-bc2c-e0b602776175)
![Screenshot from 2023-11-30 18-24-17](https://github.com/d4rken-org/sdmaid-se/assets/1439229/25ded2de-10d4-4647-883c-32bab7c61cf7)
