### PR TITLE
SystemCleaner: Exclude `/cache/magisk/zygisk_lsposed` from DownloadCache filter

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/DownloadCacheFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/DownloadCacheFilter.kt
@@ -58,6 +58,7 @@ class DownloadCacheFilter @Inject constructor(
                 SegmentCriterium(segs("last_postrecovery"), mode = Mode.Contain()),
                 SegmentCriterium(segs("last_data_partition_info"), mode = Mode.Contain()),
                 SegmentCriterium(segs("last_dataresizing"), mode = Mode.Contain()),
+                SegmentCriterium(segs("magisk", "zygisk_lsposed"), mode = Mode.Ancestor()),
             )
         )
         sieve = baseSieveFactory.create(config)

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/DownloadCacheFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/DownloadCacheFilter.kt
@@ -58,7 +58,7 @@ class DownloadCacheFilter @Inject constructor(
                 SegmentCriterium(segs("last_postrecovery"), mode = Mode.Contain()),
                 SegmentCriterium(segs("last_data_partition_info"), mode = Mode.Contain()),
                 SegmentCriterium(segs("last_dataresizing"), mode = Mode.Contain()),
-                SegmentCriterium(segs("magisk", "zygisk_lsposed"), mode = Mode.Ancestor()),
+                SegmentCriterium(segs("magisk"), mode = Mode.Ancestor()),
             )
         )
         sieve = baseSieveFactory.create(config)

--- a/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/DownloadCacheFiltertest.kt
+++ b/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/DownloadCacheFiltertest.kt
@@ -54,8 +54,8 @@ class DownloadCacheFiltertest : SystemCleanerFilterTest() {
 
         neg(DataArea.Type.DOWNLOAD_CACHE, "magisk", Flag.Dir)
         neg(DataArea.Type.DOWNLOAD_CACHE, "magisk/test", Flag.Dir)
-        pos(DataArea.Type.DOWNLOAD_CACHE, "magisk/testfile", Flag.File)
-        pos(DataArea.Type.DOWNLOAD_CACHE, "magisk/test/file", Flag.File)
+        neg(DataArea.Type.DOWNLOAD_CACHE, "magisk/testfile", Flag.File)
+        neg(DataArea.Type.DOWNLOAD_CACHE, "magisk/test/file", Flag.File)
         neg(DataArea.Type.DOWNLOAD_CACHE, "magisk/zygisk_lsposed", Flag.Dir)
         neg(DataArea.Type.DOWNLOAD_CACHE, "magisk/zygisk_lsposed/sepolicy.rule", Flag.File)
         confirm(create())

--- a/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/DownloadCacheFiltertest.kt
+++ b/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/DownloadCacheFiltertest.kt
@@ -45,11 +45,19 @@ class DownloadCacheFiltertest : SystemCleanerFilterTest() {
         neg(DataArea.Type.DOWNLOAD_CACHE, "recovery/last_postrecovery", Flag.File)
         neg(DataArea.Type.DOWNLOAD_CACHE, "recovery/last_data_partition_info", Flag.File)
         neg(DataArea.Type.DOWNLOAD_CACHE, "recovery/last_dataresizing", Flag.File)
+
         neg(DataArea.Type.DOWNLOAD_CACHE, rngString, Flag.Dir)
         pos(DataArea.Type.DOWNLOAD_CACHE, rngString, Flag.File)
         pos(DataArea.Type.DOWNLOAD_CACHE, "recovery/$rngString", Flag.File)
         pos(DataArea.Type.DOWNLOAD_CACHE, "magisk.log", Flag.File)
         pos(DataArea.Type.DOWNLOAD_CACHE, "magisk.log.bak", Flag.File)
+
+        neg(DataArea.Type.DOWNLOAD_CACHE, "magisk", Flag.Dir)
+        neg(DataArea.Type.DOWNLOAD_CACHE, "magisk/test", Flag.Dir)
+        pos(DataArea.Type.DOWNLOAD_CACHE, "magisk/testfile", Flag.File)
+        pos(DataArea.Type.DOWNLOAD_CACHE, "magisk/test/file", Flag.File)
+        neg(DataArea.Type.DOWNLOAD_CACHE, "magisk/zygisk_lsposed", Flag.Dir)
+        neg(DataArea.Type.DOWNLOAD_CACHE, "magisk/zygisk_lsposed/sepolicy.rule", Flag.File)
         confirm(create())
     }
 


### PR DESCRIPTION
Specifically to prevent deletion of `/cache/magisk/zygisk_lsposed/sepolicy.rule` etc.

Fixes #669