### PR TITLE
SystemCleaner: Refactor code to allow for other actions than deletion

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardEvents.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardEvents.kt
@@ -5,7 +5,7 @@ import eu.darken.sdmse.corpsefinder.core.tasks.CorpseFinderDeleteTask
 import eu.darken.sdmse.deduplicator.core.Duplicate
 import eu.darken.sdmse.deduplicator.core.tasks.DeduplicatorDeleteTask
 import eu.darken.sdmse.main.core.SDMTool
-import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerDeleteTask
+import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerProcessingTask
 
 sealed interface DashboardEvents {
 
@@ -17,7 +17,7 @@ sealed interface DashboardEvents {
     ) : DashboardEvents
 
     data class SystemCleanerDeleteConfirmation(
-        val task: SystemCleanerDeleteTask,
+        val task: SystemCleanerProcessingTask,
     ) : DashboardEvents
 
     data class AppCleanerDeleteConfirmation(

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModel.kt
@@ -55,7 +55,7 @@ import eu.darken.sdmse.scheduler.ui.SchedulerDashCardVH
 import eu.darken.sdmse.setup.SetupManager
 import eu.darken.sdmse.systemcleaner.core.SystemCleaner
 import eu.darken.sdmse.systemcleaner.core.hasData
-import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerDeleteTask
+import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerProcessingTask
 import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerScanTask
 import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerSchedulerTask
 import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerTask
@@ -171,7 +171,7 @@ class DashboardViewModel @Inject constructor(
                 launch { submitTask(SystemCleanerScanTask()) }
             },
             onDelete = {
-                val task = SystemCleanerDeleteTask()
+                val task = SystemCleanerProcessingTask()
                 events.postValue(DashboardEvents.SystemCleanerDeleteConfirmation(task))
             },
             onCancel = {
@@ -489,12 +489,12 @@ class DashboardViewModel @Inject constructor(
                 BottomBarState.Action.WORKING_CANCELABLE -> taskManager.cancel(SDMTool.Type.SYSTEMCLEANER)
                 BottomBarState.Action.WORKING -> {}
                 BottomBarState.Action.DELETE -> if (systemCleaner.state.first().data != null) {
-                    submitTask(SystemCleanerDeleteTask())
+                    submitTask(SystemCleanerProcessingTask())
                 }
 
                 BottomBarState.Action.ONECLICK -> {
                     submitTask(SystemCleanerScanTask())
-                    submitTask(SystemCleanerDeleteTask())
+                    submitTask(SystemCleanerProcessingTask())
                 }
             }
         }
@@ -560,7 +560,7 @@ class DashboardViewModel @Inject constructor(
 
     fun confirmFilterContentDeletion() = launch {
         log(TAG, INFO) { "confirmFilterContentDeletion()" }
-        submitTask(SystemCleanerDeleteTask())
+        submitTask(SystemCleanerProcessingTask())
     }
 
     fun showSystemCleanerDetails() {
@@ -618,7 +618,7 @@ class DashboardViewModel @Inject constructor(
             is SystemCleanerTask.Result -> when (result) {
                 is SystemCleanerScanTask.Success -> {}
                 is SystemCleanerSchedulerTask.Success -> {}
-                is SystemCleanerDeleteTask.Success -> events.postValue(DashboardEvents.TaskResult(result))
+                is SystemCleanerProcessingTask.Success -> events.postValue(DashboardEvents.TaskResult(result))
             }
 
             is AppCleanerTask.Result -> when (result) {

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/FilterContent.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/FilterContent.kt
@@ -2,16 +2,16 @@ package eu.darken.sdmse.systemcleaner.core
 
 import eu.darken.sdmse.common.ca.CaDrawable
 import eu.darken.sdmse.common.ca.CaString
-import eu.darken.sdmse.common.files.APathLookup
 import eu.darken.sdmse.systemcleaner.core.filter.FilterIdentifier
+import eu.darken.sdmse.systemcleaner.core.filter.SystemCleanerFilter
 
 data class FilterContent(
     val identifier: FilterIdentifier,
     val icon: CaDrawable,
     val label: CaString,
     val description: CaString,
-    val items: Collection<APathLookup<*>>
+    val items: Collection<SystemCleanerFilter.Match>
 ) {
     val size: Long
-        get() = items.sumOf { it.size }
+        get() = items.sumOf { it.lookup.size }
 }

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/BaseSystemCleanerFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/BaseSystemCleanerFilter.kt
@@ -1,0 +1,31 @@
+package eu.darken.sdmse.systemcleaner.core.filter
+
+import eu.darken.sdmse.common.files.GatewaySwitch
+import eu.darken.sdmse.common.files.deleteAll
+import eu.darken.sdmse.common.files.filterDistinctRoots
+import eu.darken.sdmse.common.flow.throttleLatest
+import eu.darken.sdmse.common.progress.Progress
+import eu.darken.sdmse.common.progress.updateProgressSecondary
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+
+abstract class BaseSystemCleanerFilter : SystemCleanerFilter {
+
+    private val progressPub = MutableStateFlow<Progress.Data?>(Progress.Data())
+    override val progress: Flow<Progress.Data?> = progressPub.throttleLatest(250)
+
+    override fun updateProgress(update: (Progress.Data?) -> Progress.Data?) {
+        progressPub.value = update(progressPub.value)
+    }
+
+    suspend fun Collection<SystemCleanerFilter.Match>.deleteAll(
+        gatewaySwitch: GatewaySwitch
+    ) = this
+        .map { it as SystemCleanerFilter.Match.Deletion }
+        .map { it.lookup }
+        .filterDistinctRoots()
+        .forEach { targetContent ->
+            updateProgressSecondary(targetContent.userReadablePath)
+            targetContent.deleteAll(gatewaySwitch)
+        }
+}

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/SystemCleanerFilterExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/SystemCleanerFilterExtensions.kt
@@ -1,0 +1,19 @@
+package eu.darken.sdmse.systemcleaner.core.filter
+
+import eu.darken.sdmse.exclusion.core.types.Exclusion
+import eu.darken.sdmse.exclusion.core.types.excludeNestedLookups
+import eu.darken.sdmse.systemcleaner.core.sieve.BaseSieve
+
+suspend fun BaseSieve.Result.toDeletion(): SystemCleanerFilter.Match.Deletion? {
+    return if (matches) SystemCleanerFilter.Match.Deletion(item) else null
+}
+
+suspend fun Collection<Exclusion.Path>.excludeNestedLookups(
+    matches: Collection<SystemCleanerFilter.Match>
+): Set<SystemCleanerFilter.Match> {
+    var temp = matches.map { it.lookup }.toSet()
+    this.forEach { temp = it.excludeNestedLookups(temp) }
+    return matches
+        .filter { temp.contains(it.lookup) }
+        .toSet()
+}

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/AnalyticsFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/AnalyticsFilter.kt
@@ -8,7 +8,6 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.R
 import eu.darken.sdmse.common.areas.DataArea
-import eu.darken.sdmse.common.areas.DataAreaManager
 import eu.darken.sdmse.common.ca.CaDrawable
 import eu.darken.sdmse.common.ca.CaString
 import eu.darken.sdmse.common.ca.toCaDrawable
@@ -17,9 +16,12 @@ import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.segs
 import eu.darken.sdmse.systemcleaner.core.SystemCleanerSettings
+import eu.darken.sdmse.systemcleaner.core.filter.BaseSystemCleanerFilter
 import eu.darken.sdmse.systemcleaner.core.filter.SystemCleanerFilter
+import eu.darken.sdmse.systemcleaner.core.filter.toDeletion
 import eu.darken.sdmse.systemcleaner.core.sieve.BaseSieve
 import eu.darken.sdmse.systemcleaner.core.sieve.BaseSieve.*
 import eu.darken.sdmse.systemcleaner.core.sieve.SegmentCriterium
@@ -29,8 +31,8 @@ import javax.inject.Provider
 
 class AnalyticsFilter @Inject constructor(
     private val baseSieveFactory: BaseSieve.Factory,
-    private val areaManager: DataAreaManager,
-) : SystemCleanerFilter {
+    private val gatewaySwitch: GatewaySwitch,
+) : BaseSystemCleanerFilter() {
 
     override suspend fun getIcon(): CaDrawable = R.drawable.ic_analytics_onsurface.toCaDrawable()
 
@@ -65,8 +67,12 @@ class AnalyticsFilter @Inject constructor(
     }
 
 
-    override suspend fun matches(item: APathLookup<*>): Boolean {
-        return sieve.match(item).matches
+    override suspend fun match(item: APathLookup<*>): SystemCleanerFilter.Match? {
+        return sieve.match(item).toDeletion()
+    }
+
+    override suspend fun process(matches: Collection<SystemCleanerFilter.Match>) {
+        matches.deleteAll(gatewaySwitch)
     }
 
     override fun toString(): String = "${this::class.simpleName}(${hashCode()})"

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/AnrFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/AnrFilter.kt
@@ -20,21 +20,24 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.segs
 import eu.darken.sdmse.common.root.RootManager
 import eu.darken.sdmse.common.root.canUseRootNow
 import eu.darken.sdmse.systemcleaner.core.SystemCleanerSettings
+import eu.darken.sdmse.systemcleaner.core.filter.BaseSystemCleanerFilter
 import eu.darken.sdmse.systemcleaner.core.filter.SystemCleanerFilter
+import eu.darken.sdmse.systemcleaner.core.filter.toDeletion
 import eu.darken.sdmse.systemcleaner.core.sieve.BaseSieve
 import eu.darken.sdmse.systemcleaner.core.sieve.SegmentCriterium
-import java.lang.String
 import javax.inject.Inject
 import javax.inject.Provider
 
 class AnrFilter @Inject constructor(
     private val baseSieveFactory: BaseSieve.Factory,
     private val areaManager: DataAreaManager,
-) : SystemCleanerFilter {
+    private val gatewaySwitch: GatewaySwitch,
+) : BaseSystemCleanerFilter() {
 
     override suspend fun getIcon(): CaDrawable = R.drawable.ic_baseline_running_with_errors_24.toCaDrawable()
 
@@ -78,11 +81,15 @@ class AnrFilter @Inject constructor(
     }
 
 
-    override suspend fun matches(item: APathLookup<*>): Boolean {
-        return sieve.match(item).matches
+    override suspend fun match(item: APathLookup<*>): SystemCleanerFilter.Match? {
+        return sieve.match(item).toDeletion()
     }
 
-    override fun toString(): kotlin.String = "${this::class.simpleName}(${hashCode()})"
+    override suspend fun process(matches: Collection<SystemCleanerFilter.Match>) {
+        matches.deleteAll(gatewaySwitch)
+    }
+
+    override fun toString(): String = "${this::class.simpleName}(${hashCode()})"
 
     @Reusable
     class Factory @Inject constructor(

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/DataLocalTmpFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/DataLocalTmpFilter.kt
@@ -8,7 +8,6 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.R
 import eu.darken.sdmse.common.areas.DataArea
-import eu.darken.sdmse.common.areas.DataAreaManager
 import eu.darken.sdmse.common.ca.CaDrawable
 import eu.darken.sdmse.common.ca.CaString
 import eu.darken.sdmse.common.ca.toCaDrawable
@@ -18,11 +17,14 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.segs
 import eu.darken.sdmse.common.root.RootManager
 import eu.darken.sdmse.common.root.canUseRootNow
 import eu.darken.sdmse.systemcleaner.core.SystemCleanerSettings
+import eu.darken.sdmse.systemcleaner.core.filter.BaseSystemCleanerFilter
 import eu.darken.sdmse.systemcleaner.core.filter.SystemCleanerFilter
+import eu.darken.sdmse.systemcleaner.core.filter.toDeletion
 import eu.darken.sdmse.systemcleaner.core.sieve.BaseSieve
 import eu.darken.sdmse.systemcleaner.core.sieve.SegmentCriterium
 import eu.darken.sdmse.systemcleaner.core.sieve.SegmentCriterium.*
@@ -31,8 +33,8 @@ import javax.inject.Provider
 
 class DataLocalTmpFilter @Inject constructor(
     private val baseSieveFactory: BaseSieve.Factory,
-    private val areaManager: DataAreaManager,
-) : SystemCleanerFilter {
+    private val gatewaySwitch: GatewaySwitch,
+) : BaseSystemCleanerFilter() {
 
     override suspend fun getIcon(): CaDrawable = R.drawable.ic_android_studio_24.toCaDrawable()
 
@@ -59,8 +61,12 @@ class DataLocalTmpFilter @Inject constructor(
     }
 
 
-    override suspend fun matches(item: APathLookup<*>): Boolean {
-        return sieve.match(item).matches
+    override suspend fun match(item: APathLookup<*>): SystemCleanerFilter.Match? {
+        return sieve.match(item).toDeletion()
+    }
+
+    override suspend fun process(matches: Collection<SystemCleanerFilter.Match>) {
+        matches.deleteAll(gatewaySwitch)
     }
 
     override fun toString(): String = "${this::class.simpleName}(${hashCode()})"

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/DataLoggerFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/DataLoggerFilter.kt
@@ -8,7 +8,6 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.R
 import eu.darken.sdmse.common.areas.DataArea
-import eu.darken.sdmse.common.areas.DataAreaManager
 import eu.darken.sdmse.common.ca.CaDrawable
 import eu.darken.sdmse.common.ca.CaString
 import eu.darken.sdmse.common.ca.toCaDrawable
@@ -18,11 +17,14 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.segs
 import eu.darken.sdmse.common.root.RootManager
 import eu.darken.sdmse.common.root.canUseRootNow
 import eu.darken.sdmse.systemcleaner.core.SystemCleanerSettings
+import eu.darken.sdmse.systemcleaner.core.filter.BaseSystemCleanerFilter
 import eu.darken.sdmse.systemcleaner.core.filter.SystemCleanerFilter
+import eu.darken.sdmse.systemcleaner.core.filter.toDeletion
 import eu.darken.sdmse.systemcleaner.core.sieve.BaseSieve
 import eu.darken.sdmse.systemcleaner.core.sieve.SegmentCriterium
 import eu.darken.sdmse.systemcleaner.core.sieve.SegmentCriterium.*
@@ -31,8 +33,8 @@ import javax.inject.Provider
 
 class DataLoggerFilter @Inject constructor(
     private val baseSieveFactory: BaseSieve.Factory,
-    private val areaManager: DataAreaManager,
-) : SystemCleanerFilter {
+    private val gatewaySwitch: GatewaySwitch,
+) : BaseSystemCleanerFilter() {
 
     override suspend fun getIcon(): CaDrawable = R.drawable.ic_baseline_format_list_bulleted_24.toCaDrawable()
 
@@ -62,8 +64,12 @@ class DataLoggerFilter @Inject constructor(
     }
 
 
-    override suspend fun matches(item: APathLookup<*>): Boolean {
-        return sieve.match(item).matches
+    override suspend fun match(item: APathLookup<*>): SystemCleanerFilter.Match? {
+        return sieve.match(item).toDeletion()
+    }
+
+    override suspend fun process(matches: Collection<SystemCleanerFilter.Match>) {
+        matches.deleteAll(gatewaySwitch)
     }
 
     override fun toString(): String = "${this::class.simpleName}(${hashCode()})"

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/DownloadCacheFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/DownloadCacheFilter.kt
@@ -8,7 +8,6 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.R
 import eu.darken.sdmse.common.areas.DataArea
-import eu.darken.sdmse.common.areas.DataAreaManager
 import eu.darken.sdmse.common.ca.CaDrawable
 import eu.darken.sdmse.common.ca.CaString
 import eu.darken.sdmse.common.ca.toCaDrawable
@@ -18,11 +17,14 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.segs
 import eu.darken.sdmse.common.root.RootManager
 import eu.darken.sdmse.common.root.canUseRootNow
 import eu.darken.sdmse.systemcleaner.core.SystemCleanerSettings
+import eu.darken.sdmse.systemcleaner.core.filter.BaseSystemCleanerFilter
 import eu.darken.sdmse.systemcleaner.core.filter.SystemCleanerFilter
+import eu.darken.sdmse.systemcleaner.core.filter.toDeletion
 import eu.darken.sdmse.systemcleaner.core.sieve.BaseSieve
 import eu.darken.sdmse.systemcleaner.core.sieve.SegmentCriterium
 import eu.darken.sdmse.systemcleaner.core.sieve.SegmentCriterium.*
@@ -31,8 +33,8 @@ import javax.inject.Provider
 
 class DownloadCacheFilter @Inject constructor(
     private val baseSieveFactory: BaseSieve.Factory,
-    private val areaManager: DataAreaManager,
-) : SystemCleanerFilter {
+    private val gatewaySwitch: GatewaySwitch,
+) : BaseSystemCleanerFilter() {
 
     override suspend fun getIcon(): CaDrawable = R.drawable.ic_android_studio_24.toCaDrawable()
 
@@ -66,8 +68,12 @@ class DownloadCacheFilter @Inject constructor(
     }
 
 
-    override suspend fun matches(item: APathLookup<*>): Boolean {
-        return sieve.match(item).matches
+    override suspend fun match(item: APathLookup<*>): SystemCleanerFilter.Match? {
+        return sieve.match(item).toDeletion()
+    }
+
+    override suspend fun process(matches: Collection<SystemCleanerFilter.Match>) {
+        matches.deleteAll(gatewaySwitch)
     }
 
     override fun toString(): String = "${this::class.simpleName}(${hashCode()})"

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/LinuxFilesFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/LinuxFilesFilter.kt
@@ -8,7 +8,6 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.R
 import eu.darken.sdmse.common.areas.DataArea
-import eu.darken.sdmse.common.areas.DataAreaManager
 import eu.darken.sdmse.common.ca.CaDrawable
 import eu.darken.sdmse.common.ca.CaString
 import eu.darken.sdmse.common.ca.toCaDrawable
@@ -17,8 +16,11 @@ import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.systemcleaner.core.SystemCleanerSettings
+import eu.darken.sdmse.systemcleaner.core.filter.BaseSystemCleanerFilter
 import eu.darken.sdmse.systemcleaner.core.filter.SystemCleanerFilter
+import eu.darken.sdmse.systemcleaner.core.filter.toDeletion
 import eu.darken.sdmse.systemcleaner.core.sieve.BaseSieve
 import java.io.File
 import javax.inject.Inject
@@ -26,8 +28,8 @@ import javax.inject.Provider
 
 class LinuxFilesFilter @Inject constructor(
     private val baseSieveFactory: BaseSieve.Factory,
-    private val areaManager: DataAreaManager,
-) : SystemCleanerFilter {
+    private val gatewaySwitch: GatewaySwitch,
+) : BaseSystemCleanerFilter() {
 
     override suspend fun getIcon(): CaDrawable = R.drawable.ic_os_linux.toCaDrawable()
 
@@ -56,8 +58,12 @@ class LinuxFilesFilter @Inject constructor(
     }
 
 
-    override suspend fun matches(item: APathLookup<*>): Boolean {
-        return sieve.match(item).matches
+    override suspend fun match(item: APathLookup<*>): SystemCleanerFilter.Match? {
+        return sieve.match(item).toDeletion()
+    }
+
+    override suspend fun process(matches: Collection<SystemCleanerFilter.Match>) {
+        matches.deleteAll(gatewaySwitch)
     }
 
     override fun toString(): String = "${this::class.simpleName}(${hashCode()})"

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/LogDropboxFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/LogDropboxFilter.kt
@@ -8,7 +8,6 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.R
 import eu.darken.sdmse.common.areas.DataArea
-import eu.darken.sdmse.common.areas.DataAreaManager
 import eu.darken.sdmse.common.ca.CaDrawable
 import eu.darken.sdmse.common.ca.CaString
 import eu.darken.sdmse.common.ca.toCaDrawable
@@ -18,11 +17,14 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.segs
 import eu.darken.sdmse.common.root.RootManager
 import eu.darken.sdmse.common.root.canUseRootNow
 import eu.darken.sdmse.systemcleaner.core.SystemCleanerSettings
+import eu.darken.sdmse.systemcleaner.core.filter.BaseSystemCleanerFilter
 import eu.darken.sdmse.systemcleaner.core.filter.SystemCleanerFilter
+import eu.darken.sdmse.systemcleaner.core.filter.toDeletion
 import eu.darken.sdmse.systemcleaner.core.sieve.BaseSieve
 import eu.darken.sdmse.systemcleaner.core.sieve.BaseSieve.*
 import eu.darken.sdmse.systemcleaner.core.sieve.SegmentCriterium
@@ -32,8 +34,8 @@ import javax.inject.Provider
 
 class LogDropboxFilter @Inject constructor(
     private val baseSieveFactory: BaseSieve.Factory,
-    private val areaManager: DataAreaManager,
-) : SystemCleanerFilter {
+    private val gatewaySwitch: GatewaySwitch,
+) : BaseSystemCleanerFilter() {
 
     override suspend fun getIcon(): CaDrawable = R.drawable.ic_baseline_format_list_bulleted_24.toCaDrawable()
 
@@ -60,8 +62,12 @@ class LogDropboxFilter @Inject constructor(
     }
 
 
-    override suspend fun matches(item: APathLookup<*>): Boolean {
-        return sieve.match(item).matches
+    override suspend fun match(item: APathLookup<*>): SystemCleanerFilter.Match? {
+        return sieve.match(item).toDeletion()
+    }
+
+    override suspend fun process(matches: Collection<SystemCleanerFilter.Match>) {
+        matches.deleteAll(gatewaySwitch)
     }
 
     override fun toString(): String = "${this::class.simpleName}(${hashCode()})"

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/LogFilesFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/LogFilesFilter.kt
@@ -19,9 +19,11 @@ import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.isAncestorOf
 import eu.darken.sdmse.common.files.segs
 import eu.darken.sdmse.systemcleaner.core.SystemCleanerSettings
+import eu.darken.sdmse.systemcleaner.core.filter.BaseSystemCleanerFilter
 import eu.darken.sdmse.systemcleaner.core.filter.SystemCleanerFilter
 import eu.darken.sdmse.systemcleaner.core.sieve.BaseSieve
 import eu.darken.sdmse.systemcleaner.core.sieve.NameCriterium
@@ -35,7 +37,8 @@ import javax.inject.Provider
 class LogFilesFilter @Inject constructor(
     private val baseSieveFactory: BaseSieve.Factory,
     private val areaManager: DataAreaManager,
-) : SystemCleanerFilter {
+    private val gatewaySwitch: GatewaySwitch,
+) : BaseSystemCleanerFilter() {
 
     override suspend fun getIcon(): CaDrawable = R.drawable.ic_baseline_format_list_bulleted_24.toCaDrawable()
 
@@ -79,9 +82,9 @@ class LogFilesFilter @Inject constructor(
     }
 
 
-    override suspend fun matches(item: APathLookup<*>): Boolean {
+    override suspend fun match(item: APathLookup<*>): SystemCleanerFilter.Match? {
         val sieveResult = sieve.match(item)
-        if (!sieveResult.matches) return false
+        if (!sieveResult.matches) return null
 
         // TODO Support SAF path matching?
         // https://github.com/d4rken/sdmaid-public/issues/2147
@@ -89,7 +92,13 @@ class LogFilesFilter @Inject constructor(
 
         // https://github.com/d4rken/sdmaid-public/issues/961
         val overlap = mediaLocations.any { it.isAncestorOf(item) }
-        return !overlap && !badTelegramMatch
+        if (overlap || badTelegramMatch) return null
+
+        return SystemCleanerFilter.Match.Deletion(item)
+    }
+
+    override suspend fun process(matches: Collection<SystemCleanerFilter.Match>) {
+        matches.deleteAll(gatewaySwitch)
     }
 
     override fun toString(): String = "${this::class.simpleName}(${hashCode()})"

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/LostDirFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/LostDirFilter.kt
@@ -8,7 +8,6 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.R
 import eu.darken.sdmse.common.areas.DataArea
-import eu.darken.sdmse.common.areas.DataAreaManager
 import eu.darken.sdmse.common.ca.CaDrawable
 import eu.darken.sdmse.common.ca.CaString
 import eu.darken.sdmse.common.ca.toCaDrawable
@@ -17,8 +16,11 @@ import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.systemcleaner.core.SystemCleanerSettings
+import eu.darken.sdmse.systemcleaner.core.filter.BaseSystemCleanerFilter
 import eu.darken.sdmse.systemcleaner.core.filter.SystemCleanerFilter
+import eu.darken.sdmse.systemcleaner.core.filter.toDeletion
 import eu.darken.sdmse.systemcleaner.core.sieve.BaseSieve
 import java.io.File
 import javax.inject.Inject
@@ -26,8 +28,8 @@ import javax.inject.Provider
 
 class LostDirFilter @Inject constructor(
     private val baseSieveFactory: BaseSieve.Factory,
-    private val areaManager: DataAreaManager,
-) : SystemCleanerFilter {
+    private val gatewaySwitch: GatewaySwitch,
+) : BaseSystemCleanerFilter() {
 
     override suspend fun getIcon(): CaDrawable = R.drawable.ic_baseline_usb_24.toCaDrawable()
 
@@ -56,8 +58,12 @@ class LostDirFilter @Inject constructor(
     }
 
 
-    override suspend fun matches(item: APathLookup<*>): Boolean {
-        return sieve.match(item).matches
+    override suspend fun match(item: APathLookup<*>): SystemCleanerFilter.Match? {
+        return sieve.match(item).toDeletion()
+    }
+
+    override suspend fun process(matches: Collection<SystemCleanerFilter.Match>) {
+        matches.deleteAll(gatewaySwitch)
     }
 
     override fun toString(): String = "${this::class.simpleName}(${hashCode()})"

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/MacFilesFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/MacFilesFilter.kt
@@ -8,7 +8,6 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.R
 import eu.darken.sdmse.common.areas.DataArea
-import eu.darken.sdmse.common.areas.DataAreaManager
 import eu.darken.sdmse.common.ca.CaDrawable
 import eu.darken.sdmse.common.ca.CaString
 import eu.darken.sdmse.common.ca.toCaDrawable
@@ -17,8 +16,11 @@ import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.systemcleaner.core.SystemCleanerSettings
+import eu.darken.sdmse.systemcleaner.core.filter.BaseSystemCleanerFilter
 import eu.darken.sdmse.systemcleaner.core.filter.SystemCleanerFilter
+import eu.darken.sdmse.systemcleaner.core.filter.toDeletion
 import eu.darken.sdmse.systemcleaner.core.sieve.BaseSieve
 import eu.darken.sdmse.systemcleaner.core.sieve.NameCriterium
 import javax.inject.Inject
@@ -26,8 +28,8 @@ import javax.inject.Provider
 
 class MacFilesFilter @Inject constructor(
     private val baseSieveFactory: BaseSieve.Factory,
-    private val areaManager: DataAreaManager,
-) : SystemCleanerFilter {
+    private val gatewaySwitch: GatewaySwitch,
+) : BaseSystemCleanerFilter() {
 
     override suspend fun getIcon(): CaDrawable = R.drawable.ic_os_mac.toCaDrawable()
 
@@ -62,8 +64,12 @@ class MacFilesFilter @Inject constructor(
     }
 
 
-    override suspend fun matches(item: APathLookup<*>): Boolean {
-        return sieve.match(item).matches
+    override suspend fun match(item: APathLookup<*>): SystemCleanerFilter.Match? {
+        return sieve.match(item).toDeletion()
+    }
+
+    override suspend fun process(matches: Collection<SystemCleanerFilter.Match>) {
+        matches.deleteAll(gatewaySwitch)
     }
 
     override fun toString(): String = "${this::class.simpleName}(${hashCode()})"

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/TombstonesFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/TombstonesFilter.kt
@@ -8,7 +8,6 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.R
 import eu.darken.sdmse.common.areas.DataArea
-import eu.darken.sdmse.common.areas.DataAreaManager
 import eu.darken.sdmse.common.ca.CaDrawable
 import eu.darken.sdmse.common.ca.CaString
 import eu.darken.sdmse.common.ca.toCaDrawable
@@ -18,11 +17,14 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.segs
 import eu.darken.sdmse.common.root.RootManager
 import eu.darken.sdmse.common.root.canUseRootNow
 import eu.darken.sdmse.systemcleaner.core.SystemCleanerSettings
+import eu.darken.sdmse.systemcleaner.core.filter.BaseSystemCleanerFilter
 import eu.darken.sdmse.systemcleaner.core.filter.SystemCleanerFilter
+import eu.darken.sdmse.systemcleaner.core.filter.toDeletion
 import eu.darken.sdmse.systemcleaner.core.sieve.BaseSieve
 import eu.darken.sdmse.systemcleaner.core.sieve.SegmentCriterium
 import javax.inject.Inject
@@ -30,8 +32,8 @@ import javax.inject.Provider
 
 class TombstonesFilter @Inject constructor(
     private val baseSieveFactory: BaseSieve.Factory,
-    private val areaManager: DataAreaManager,
-) : SystemCleanerFilter {
+    private val gatewaySwitch: GatewaySwitch,
+) : BaseSystemCleanerFilter() {
 
     override suspend fun getIcon(): CaDrawable = R.drawable.ic_tombstone.toCaDrawable()
 
@@ -58,8 +60,12 @@ class TombstonesFilter @Inject constructor(
     }
 
 
-    override suspend fun matches(item: APathLookup<*>): Boolean {
-        return sieve.match(item).matches
+    override suspend fun match(item: APathLookup<*>): SystemCleanerFilter.Match? {
+        return sieve.match(item).toDeletion()
+    }
+
+    override suspend fun process(matches: Collection<SystemCleanerFilter.Match>) {
+        matches.deleteAll(gatewaySwitch)
     }
 
     override fun toString(): String = "${this::class.simpleName}(${hashCode()})"

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/UsagestatsFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/UsagestatsFilter.kt
@@ -8,7 +8,6 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.R
 import eu.darken.sdmse.common.areas.DataArea
-import eu.darken.sdmse.common.areas.DataAreaManager
 import eu.darken.sdmse.common.ca.CaDrawable
 import eu.darken.sdmse.common.ca.CaString
 import eu.darken.sdmse.common.ca.toCaDrawable
@@ -18,11 +17,14 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.segs
 import eu.darken.sdmse.common.root.RootManager
 import eu.darken.sdmse.common.root.canUseRootNow
 import eu.darken.sdmse.systemcleaner.core.SystemCleanerSettings
+import eu.darken.sdmse.systemcleaner.core.filter.BaseSystemCleanerFilter
 import eu.darken.sdmse.systemcleaner.core.filter.SystemCleanerFilter
+import eu.darken.sdmse.systemcleaner.core.filter.toDeletion
 import eu.darken.sdmse.systemcleaner.core.sieve.BaseSieve
 import eu.darken.sdmse.systemcleaner.core.sieve.SegmentCriterium
 import javax.inject.Inject
@@ -30,8 +32,8 @@ import javax.inject.Provider
 
 class UsagestatsFilter @Inject constructor(
     private val baseSieveFactory: BaseSieve.Factory,
-    private val areaManager: DataAreaManager,
-) : SystemCleanerFilter {
+    private val gatewaySwitch: GatewaySwitch,
+) : BaseSystemCleanerFilter() {
 
     override suspend fun getIcon(): CaDrawable = R.drawable.ic_chart_bar_stacked_24.toCaDrawable()
 
@@ -61,8 +63,12 @@ class UsagestatsFilter @Inject constructor(
     }
 
 
-    override suspend fun matches(item: APathLookup<*>): Boolean {
-        return sieve.match(item).matches
+    override suspend fun match(item: APathLookup<*>): SystemCleanerFilter.Match? {
+        return sieve.match(item).toDeletion()
+    }
+
+    override suspend fun process(matches: Collection<SystemCleanerFilter.Match>) {
+        matches.deleteAll(gatewaySwitch)
     }
 
     override fun toString(): String = "${this::class.simpleName}(${hashCode()})"

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/WindowsFilesFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/WindowsFilesFilter.kt
@@ -8,7 +8,6 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.R
 import eu.darken.sdmse.common.areas.DataArea
-import eu.darken.sdmse.common.areas.DataAreaManager
 import eu.darken.sdmse.common.ca.CaDrawable
 import eu.darken.sdmse.common.ca.CaString
 import eu.darken.sdmse.common.ca.toCaDrawable
@@ -17,8 +16,11 @@ import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.systemcleaner.core.SystemCleanerSettings
+import eu.darken.sdmse.systemcleaner.core.filter.BaseSystemCleanerFilter
 import eu.darken.sdmse.systemcleaner.core.filter.SystemCleanerFilter
+import eu.darken.sdmse.systemcleaner.core.filter.toDeletion
 import eu.darken.sdmse.systemcleaner.core.sieve.BaseSieve
 import eu.darken.sdmse.systemcleaner.core.sieve.NameCriterium
 import javax.inject.Inject
@@ -26,8 +28,8 @@ import javax.inject.Provider
 
 class WindowsFilesFilter @Inject constructor(
     private val baseSieveFactory: BaseSieve.Factory,
-    private val areaManager: DataAreaManager,
-) : SystemCleanerFilter {
+    private val gatewaySwitch: GatewaySwitch,
+) : BaseSystemCleanerFilter() {
 
     override suspend fun getIcon(): CaDrawable = R.drawable.ic_os_windows.toCaDrawable()
 
@@ -58,8 +60,12 @@ class WindowsFilesFilter @Inject constructor(
         log(TAG) { "initialized()" }
     }
 
-    override suspend fun matches(item: APathLookup<*>): Boolean {
-        return sieve.match(item).matches
+    override suspend fun match(item: APathLookup<*>): SystemCleanerFilter.Match? {
+        return sieve.match(item).toDeletion()
+    }
+
+    override suspend fun process(matches: Collection<SystemCleanerFilter.Match>) {
+        matches.deleteAll(gatewaySwitch)
     }
 
     override fun toString(): String = "${this::class.simpleName}(${hashCode()})"

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/tasks/SystemCleanerProcessingTask.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/tasks/SystemCleanerProcessingTask.kt
@@ -8,7 +8,7 @@ import eu.darken.sdmse.systemcleaner.core.filter.FilterIdentifier
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-data class SystemCleanerDeleteTask(
+data class SystemCleanerProcessingTask(
     val targetFilters: Set<FilterIdentifier>? = null,
     val targetContent: Set<APath>? = null,
 ) : SystemCleanerTask {
@@ -17,7 +17,7 @@ data class SystemCleanerDeleteTask(
 
     @Parcelize
     data class Success(
-        private val deletedItems: Int,
+        private val processedItems: Int,
         private val recoveredSpace: Long
     ) : Result {
         override val primaryInfo: CaString

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/ui/details/filtercontent/FilterContentFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/ui/details/filtercontent/FilterContentFragment.kt
@@ -94,7 +94,7 @@ class FilterContentFragment : Fragment3(R.layout.systemcleaner_filtercontent_fra
                             event.items.singleOrNull() is FilterContentElementFileVH.Item -> getString(
                                 eu.darken.sdmse.common.R.string.general_delete_confirmation_message_x,
                                 (event.items.single() as FilterContentElementFileVH.Item)
-                                    .lookup.userReadablePath.get(context)
+                                    .match.lookup.userReadablePath.get(context)
                             )
 
                             else -> getString(

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/ui/details/filtercontent/elements/FilterContentElementFileVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/ui/details/filtercontent/elements/FilterContentElementFileVH.kt
@@ -4,13 +4,13 @@ import android.text.format.Formatter
 import android.view.ViewGroup
 import eu.darken.sdmse.R
 import eu.darken.sdmse.common.coil.loadFilePreview
-import eu.darken.sdmse.common.files.APathLookup
 import eu.darken.sdmse.common.files.FileType
 import eu.darken.sdmse.common.files.labelRes
 import eu.darken.sdmse.common.lists.binding
 import eu.darken.sdmse.common.lists.selection.SelectableVH
 import eu.darken.sdmse.databinding.SystemcleanerFiltercontentElementFileBinding
 import eu.darken.sdmse.systemcleaner.core.FilterContent
+import eu.darken.sdmse.systemcleaner.core.filter.SystemCleanerFilter
 import eu.darken.sdmse.systemcleaner.ui.details.filtercontent.FilterContentElementsAdapter
 
 
@@ -35,14 +35,14 @@ class FilterContentElementFileVH(parent: ViewGroup) :
         payloads: List<Any>
     ) -> Unit = binding { item ->
         lastItem = item
-        icon.loadFilePreview(item.lookup)
+        icon.loadFilePreview(item.match.lookup)
 
-        primary.text = item.lookup.userReadablePath.get(context)
+        primary.text = item.match.lookup.userReadablePath.get(context)
 
-        secondary.text = if (item.lookup.fileType == FileType.FILE) {
-            Formatter.formatFileSize(context, item.lookup.size)
+        secondary.text = if (item.match.lookup.fileType == FileType.FILE) {
+            Formatter.formatFileSize(context, item.match.expectedGain)
         } else {
-            getString(item.lookup.fileType.labelRes)
+            getString(item.match.lookup.fileType.labelRes)
         }
 
         root.setOnClickListener { item.onItemClick(item) }
@@ -50,14 +50,14 @@ class FilterContentElementFileVH(parent: ViewGroup) :
 
     data class Item(
         val filterContent: FilterContent,
-        val lookup: APathLookup<*>,
+        val match: SystemCleanerFilter.Match,
         val onItemClick: (Item) -> Unit,
     ) : FilterContentElementsAdapter.Item {
 
         override val itemSelectionKey: String
-            get() = lookup.lookedUp.path
+            get() = match.path.path
 
-        override val stableId: Long = lookup.hashCode().toLong()
+        override val stableId: Long = match.lookup.hashCode().toLong()
     }
 
 }

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/ui/list/SystemCleanerListViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/ui/list/SystemCleanerListViewModel.kt
@@ -11,7 +11,7 @@ import eu.darken.sdmse.common.uix.ViewModel3
 import eu.darken.sdmse.main.core.taskmanager.TaskManager
 import eu.darken.sdmse.systemcleaner.core.SystemCleaner
 import eu.darken.sdmse.systemcleaner.core.hasData
-import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerDeleteTask
+import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerProcessingTask
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
@@ -61,11 +61,11 @@ class SystemCleanerListViewModel @Inject constructor(
             events.postValue(SystemCleanerListEvents.ConfirmDeletion(items))
             return@launch
         }
-        val task = SystemCleanerDeleteTask(targetFilters = items.map { it.content.identifier }.toSet())
-        val result = taskManager.submit(task) as SystemCleanerDeleteTask.Result
+        val task = SystemCleanerProcessingTask(targetFilters = items.map { it.content.identifier }.toSet())
+        val result = taskManager.submit(task) as SystemCleanerProcessingTask.Result
         log(TAG) { "doDelete(): Result was $result" }
         when (result) {
-            is SystemCleanerDeleteTask.Success -> events.postValue(SystemCleanerListEvents.TaskResult(result))
+            is SystemCleanerProcessingTask.Success -> events.postValue(SystemCleanerListEvents.TaskResult(result))
         }
     }
 

--- a/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/SystemCleanerFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/SystemCleanerFilterTest.kt
@@ -25,6 +25,7 @@ import eu.darken.sdmse.common.user.UserHandle2
 import eu.darken.sdmse.systemcleaner.core.SystemCleanerSettings
 import io.kotest.assertions.withClue
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.every
@@ -315,7 +316,7 @@ abstract class SystemCleanerFilterTest : BaseTest() {
 
         withClue("No filter should just match a random file") {
             doMock(Type.SDCARD, UUID.randomUUID().toString(), null, Flag.File).forEach {
-                filter.matches(it) shouldBe false
+                filter.match(it) shouldBe null
             }
         }
 
@@ -327,7 +328,7 @@ abstract class SystemCleanerFilterTest : BaseTest() {
                 addAll(doMock(Type.SDCARD, "$randomFolder/$randomFile", null, Flag.File))
             }
 
-            randoms.forEach { filter.matches(it) shouldBe false }
+            randoms.forEach { filter.match(it) shouldBe null }
         }
 
         withClue("No filter should match the root of a data area") {
@@ -339,19 +340,19 @@ abstract class SystemCleanerFilterTest : BaseTest() {
                     modifiedAt = Instant.EPOCH,
                     target = null,
                 )
-                filter.matches(lookup) shouldBe false
+                filter.match(lookup) shouldBe null
             }
         }
 
         positives.forEach { canidate ->
             withClue("Should match ${canidate.path} (${canidate.fileType})") {
-                filter.matches(canidate) shouldBe true
+                filter.match(canidate) shouldNotBe null
             }
             log { "Matched: ${canidate.path}" }
         }
         negatives.forEach { canidate ->
             withClue("Should NOT match ${canidate.path} (${canidate.fileType})") {
-                filter.matches(canidate) shouldBe false
+                filter.match(canidate) shouldBe null
             }
             log { "Didn't match: ${canidate.path}" }
         }

--- a/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/ANRFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/ANRFilterTest.kt
@@ -33,6 +33,7 @@ class ANRFilterTest : SystemCleanerFilterTest() {
             override fun create(config: BaseSieve.Config): BaseSieve = BaseSieve(config, fileForensics)
         },
         areaManager = areaManager,
+        gatewaySwitch = gatewaySwitch,
     )
 
     @Test fun testFilter() = runTest {

--- a/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/AdvertisementFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/AdvertisementFilterTest.kt
@@ -25,6 +25,7 @@ class AdvertisementFilterTest : SystemCleanerFilterTest() {
             override fun create(config: BaseSieve.Config): BaseSieve = BaseSieve(config, fileForensics)
         },
         areaManager = areaManager,
+        gatewaySwitch = gatewaySwitch,
     )
 
     @Test fun testFilter() = runTest {

--- a/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/AnalyticsFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/AnalyticsFilterTest.kt
@@ -25,7 +25,7 @@ class AnalyticsFilterTest : SystemCleanerFilterTest() {
         baseSieveFactory = object : BaseSieve.Factory {
             override fun create(config: BaseSieve.Config): BaseSieve = BaseSieve(config, fileForensics)
         },
-        areaManager = areaManager,
+        gatewaySwitch = gatewaySwitch,
     )
 
     @Test fun testFilter() = runTest {

--- a/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/DataLocalTmpFilterFactoryTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/DataLocalTmpFilterFactoryTest.kt
@@ -33,7 +33,7 @@ class DataLocalTmpFilterFactoryTest : SystemCleanerFilterTest() {
         baseSieveFactory = object : BaseSieve.Factory {
             override fun create(config: BaseSieve.Config): BaseSieve = BaseSieve(config, fileForensics)
         },
-        areaManager = areaManager,
+        gatewaySwitch = gatewaySwitch,
     )
 
     @Test fun testFilter() = runTest {

--- a/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/DataLoggerFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/DataLoggerFilterTest.kt
@@ -33,7 +33,7 @@ class DataLoggerFilterTest : SystemCleanerFilterTest() {
         baseSieveFactory = object : BaseSieve.Factory {
             override fun create(config: BaseSieve.Config): BaseSieve = BaseSieve(config, fileForensics)
         },
-        areaManager = areaManager,
+        gatewaySwitch = gatewaySwitch,
     )
 
     @Test fun testFilter() = runTest {

--- a/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/DownloadCacheFiltertest.kt
+++ b/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/DownloadCacheFiltertest.kt
@@ -33,7 +33,7 @@ class DownloadCacheFiltertest : SystemCleanerFilterTest() {
         baseSieveFactory = object : BaseSieve.Factory {
             override fun create(config: BaseSieve.Config): BaseSieve = BaseSieve(config, fileForensics)
         },
-        areaManager = areaManager,
+        gatewaySwitch = gatewaySwitch,
     )
 
     @Test fun testFilter() = runTest {

--- a/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/EmptyDirectoryFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/EmptyDirectoryFilterTest.kt
@@ -25,7 +25,6 @@ class EmptyDirectoryFilterTest : SystemCleanerFilterTest() {
         baseSieveFactory = object : BaseSieve.Factory {
             override fun create(config: BaseSieve.Config): BaseSieve = BaseSieve(config, fileForensics)
         },
-        areaManager = areaManager,
         gatewaySwitch = gatewaySwitch,
     )
 

--- a/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/LinuxFoldersFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/LinuxFoldersFilterTest.kt
@@ -25,7 +25,7 @@ class LinuxFoldersFilterTest : SystemCleanerFilterTest() {
         baseSieveFactory = object : BaseSieve.Factory {
             override fun create(config: BaseSieve.Config): BaseSieve = BaseSieve(config, fileForensics)
         },
-        areaManager = areaManager,
+        gatewaySwitch = gatewaySwitch,
     )
 
     @Test fun testFilter() = runTest {

--- a/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/LogDropboxFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/LogDropboxFilterTest.kt
@@ -33,7 +33,7 @@ class LogDropboxFilterTest : SystemCleanerFilterTest() {
         baseSieveFactory = object : BaseSieve.Factory {
             override fun create(config: BaseSieve.Config): BaseSieve = BaseSieve(config, fileForensics)
         },
-        areaManager = areaManager,
+        gatewaySwitch = gatewaySwitch,
     )
 
     @Test fun testFilter() = runTest {

--- a/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/LogFilesFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/LogFilesFilterTest.kt
@@ -28,6 +28,7 @@ class LogFilesFilterTest : SystemCleanerFilterTest() {
             override fun create(config: BaseSieve.Config): BaseSieve = BaseSieve(config, fileForensics)
         },
         areaManager = areaManager,
+        gatewaySwitch = gatewaySwitch,
     )
 
     @Test fun testFilter() = runTest {

--- a/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/LostDirFilterFactoryTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/LostDirFilterFactoryTest.kt
@@ -25,7 +25,7 @@ class LostDirFilterFactoryTest : SystemCleanerFilterTest() {
         baseSieveFactory = object : BaseSieve.Factory {
             override fun create(config: BaseSieve.Config): BaseSieve = BaseSieve(config, fileForensics)
         },
-        areaManager = areaManager,
+        gatewaySwitch = gatewaySwitch,
     )
 
     @Test fun testFilter() = runTest {

--- a/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/MacFilesFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/MacFilesFilterTest.kt
@@ -25,7 +25,7 @@ class MacFilesFilterTest : SystemCleanerFilterTest() {
         baseSieveFactory = object : BaseSieve.Factory {
             override fun create(config: BaseSieve.Config): BaseSieve = BaseSieve(config, fileForensics)
         },
-        areaManager = areaManager,
+        gatewaySwitch = gatewaySwitch,
     )
 
     @Test fun testFilter() = runTest {

--- a/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/RecentTasksFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/RecentTasksFilterTest.kt
@@ -32,7 +32,7 @@ class RecentTasksFilterTest : SystemCleanerFilterTest() {
         baseSieveFactory = object : BaseSieve.Factory {
             override fun create(config: BaseSieve.Config): BaseSieve = BaseSieve(config, fileForensics)
         },
-        areaManager = areaManager,
+        gatewaySwitch = gatewaySwitch,
     )
 
     @Test fun testFilter() = runTest {

--- a/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/SuperfluousApksFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/SuperfluousApksFilterTest.kt
@@ -30,7 +30,7 @@ class SuperfluousApksFilterTest : SystemCleanerFilterTest() {
         },
         pkgOps = pkgOps,
         pkgRepo = pkgRepo,
-        areaManager = areaManager,
+        gatewaySwitch = gatewaySwitch,
     )
 
     @Test fun testFilter() = runTest {

--- a/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/TempFilesFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/TempFilesFilterTest.kt
@@ -25,7 +25,7 @@ class TempFilesFilterTest : SystemCleanerFilterTest() {
         baseSieveFactory = object : BaseSieve.Factory {
             override fun create(config: BaseSieve.Config): BaseSieve = BaseSieve(config, fileForensics)
         },
-        areaManager = areaManager,
+        gatewaySwitch = gatewaySwitch,
     )
 
     @Test fun testFilter() = runTest {

--- a/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/TombstonesFilterFactoryTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/TombstonesFilterFactoryTest.kt
@@ -33,7 +33,7 @@ class TombstonesFilterFactoryTest : SystemCleanerFilterTest() {
         baseSieveFactory = object : BaseSieve.Factory {
             override fun create(config: BaseSieve.Config): BaseSieve = BaseSieve(config, fileForensics)
         },
-        areaManager = areaManager,
+        gatewaySwitch = gatewaySwitch,
     )
 
     @Test fun testFilter() = runTest {

--- a/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/UsageStatsFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/UsageStatsFilterTest.kt
@@ -33,7 +33,7 @@ class UsageStatsFilterTest : SystemCleanerFilterTest() {
         baseSieveFactory = object : BaseSieve.Factory {
             override fun create(config: BaseSieve.Config): BaseSieve = BaseSieve(config, fileForensics)
         },
-        areaManager = areaManager,
+        gatewaySwitch = gatewaySwitch,
     )
 
     @Test fun testFilter() = runTest {

--- a/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/WindowsFilesFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/WindowsFilesFilterTest.kt
@@ -27,7 +27,7 @@ class WindowsFilesFilterTest : SystemCleanerFilterTest() {
         baseSieveFactory = object : BaseSieve.Factory {
             override fun create(config: BaseSieve.Config): BaseSieve = BaseSieve(config, fileForensics)
         },
-        areaManager = areaManager,
+        gatewaySwitch = gatewaySwitch,
     )
 
     @Test fun testFilter() = runTest {


### PR DESCRIPTION
Now we process a `SystemCleanerFilter.Match` and the action applied to matches does not have to be "deletion". This paves the way for filter that do other more than just delete files, e.g. a filter that compresses data.