### PR TITLE
AppCleaner: Refactoring to allow for alternative space saving measures

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleanerExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleanerExtensions.kt
@@ -1,4 +1,19 @@
 package eu.darken.sdmse.appcleaner.core
 
+import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilter
+import eu.darken.sdmse.exclusion.core.types.Exclusion
+import eu.darken.sdmse.exclusion.core.types.excludeNestedLookups
+
 val AppCleaner.Data?.hasData: Boolean
     get() = this?.junks?.isNotEmpty() ?: false
+
+
+suspend fun Collection<Exclusion.Path>.excludeNestedLookups(
+    matches: Collection<ExpendablesFilter.Match>
+): Set<ExpendablesFilter.Match> {
+    var temp = matches.map { it.lookup }.toSet()
+    this.forEach { temp = it.excludeNestedLookups(temp) }
+    return matches
+        .filter { temp.contains(it.lookup) }
+        .toSet()
+}

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppJunk.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppJunk.kt
@@ -1,18 +1,17 @@
 package eu.darken.sdmse.appcleaner.core
 
 import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilter
+import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilterIdentifier
 import eu.darken.sdmse.appcleaner.core.scanner.InaccessibleCache
 import eu.darken.sdmse.common.ca.CaString
 import eu.darken.sdmse.common.ca.toCaString
-import eu.darken.sdmse.common.files.APathLookup
 import eu.darken.sdmse.common.pkgs.features.Installed
 import eu.darken.sdmse.common.user.UserProfile2
-import kotlin.reflect.KClass
 
 data class AppJunk(
     val pkg: Installed,
     val userProfile: UserProfile2?,
-    val expendables: Map<KClass<out ExpendablesFilter>, Collection<APathLookup<*>>>?,
+    val expendables: Map<ExpendablesFilterIdentifier, Collection<ExpendablesFilter.Match>>?,
     val inaccessibleCache: InaccessibleCache?,
 ) {
 
@@ -30,7 +29,7 @@ data class AppJunk(
     }
 
     val size by lazy {
-        val knownFiles = expendables?.values?.flatten()?.sumOf { it.size } ?: 0L
+        val knownFiles = expendables?.values?.flatten()?.sumOf { it.expectedGain } ?: 0L
         val inaccessible = inaccessibleCache?.cacheBytes ?: 0L
         // TODO If we read public storage caches, do we need to calculate the "internal inaccessible bytes"?
         knownFiles + inaccessible

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/ExpendablesFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/ExpendablesFilter.kt
@@ -5,20 +5,46 @@ import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.files.APathLookup
 import eu.darken.sdmse.common.files.Segments
 import eu.darken.sdmse.common.pkgs.Pkg
+import eu.darken.sdmse.common.progress.Progress
+import kotlin.reflect.KClass
 
-interface ExpendablesFilter {
+interface ExpendablesFilter : Progress.Host, Progress.Client {
+
+    val identifier: ExpendablesFilterIdentifier
+        get() = this.javaClass.kotlin
 
     suspend fun initialize()
 
-    suspend fun isExpendable(
+    suspend fun match(
         pkgId: Pkg.Id,
         target: APathLookup<APath>,
         areaType: DataArea.Type,
         segments: Segments
-    ): Boolean
+    ): Match?
+
+    suspend fun process(matches: Collection<Match>)
+
+    interface Match {
+        val identifier: ExpendablesFilterIdentifier
+        val lookup: APathLookup<*>
+        val path: APath
+            get() = lookup.lookedUp
+
+        val expectedGain: Long
+
+        data class Deletion(
+            override val identifier: ExpendablesFilterIdentifier,
+            override val lookup: APathLookup<*>,
+        ) : Match {
+            override val expectedGain: Long
+                get() = lookup.size
+        }
+    }
 
     interface Factory {
         suspend fun isEnabled(): Boolean
         suspend fun create(): ExpendablesFilter
     }
 }
+
+typealias ExpendablesFilterIdentifier = KClass<out ExpendablesFilter>

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/AnalyticsFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/AnalyticsFilter.kt
@@ -7,6 +7,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.appcleaner.core.AppCleanerSettings
+import eu.darken.sdmse.appcleaner.core.forensics.BaseExpendablesFilter
 import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilter
 import eu.darken.sdmse.appcleaner.core.forensics.sieves.json.JsonBasedSieve
 import eu.darken.sdmse.common.areas.DataArea
@@ -15,6 +16,7 @@ import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.Segments
 import eu.darken.sdmse.common.pkgs.Pkg
 import javax.inject.Inject
@@ -22,8 +24,9 @@ import javax.inject.Provider
 
 @Reusable
 class AnalyticsFilter @Inject constructor(
-    private val jsonBasedSieveFactory: JsonBasedSieve.Factory
-) : ExpendablesFilter {
+    private val jsonBasedSieveFactory: JsonBasedSieve.Factory,
+    private val gatewaySwitch: GatewaySwitch,
+) : BaseExpendablesFilter() {
 
     private lateinit var sieve: JsonBasedSieve
 
@@ -32,15 +35,23 @@ class AnalyticsFilter @Inject constructor(
         sieve = jsonBasedSieveFactory.create("expendables/db_analytics_files.json")
     }
 
-    override suspend fun isExpendable(
+    override suspend fun match(
         pkgId: Pkg.Id,
         target: APathLookup<APath>,
         areaType: DataArea.Type,
         segments: Segments
-    ): Boolean {
-        if (segments.isNotEmpty() && IGNORED_FILES.contains(segments[segments.size - 1])) return false
+    ): ExpendablesFilter.Match? {
+        if (segments.isNotEmpty() && IGNORED_FILES.contains(segments[segments.size - 1])) return null
 
-        return segments.isNotEmpty() && sieve.matches(pkgId, areaType, segments)
+        return if (segments.isNotEmpty() && sieve.matches(pkgId, areaType, segments)) {
+            target.toDeletionMatch()
+        } else {
+            null
+        }
+    }
+
+    override suspend fun process(matches: Collection<ExpendablesFilter.Match>) {
+        matches.deleteAll(gatewaySwitch)
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/DefaultCachesPublicFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/DefaultCachesPublicFilter.kt
@@ -7,6 +7,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.appcleaner.core.AppCleanerSettings
+import eu.darken.sdmse.appcleaner.core.forensics.BaseExpendablesFilter
 import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilter
 import eu.darken.sdmse.common.areas.DataArea
 import eu.darken.sdmse.common.areas.isPublic
@@ -15,6 +16,7 @@ import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.Segments
 import eu.darken.sdmse.common.pkgs.Pkg
 import eu.darken.sdmse.common.storage.StorageEnvironment
@@ -24,7 +26,8 @@ import javax.inject.Provider
 @Reusable
 class DefaultCachesPublicFilter @Inject constructor(
     environment: StorageEnvironment,
-) : ExpendablesFilter {
+    private val gatewaySwitch: GatewaySwitch,
+) : BaseExpendablesFilter() {
 
     private val cacheFolderPrefixes = environment.ourExternalCacheDirs.map { it.name }
 
@@ -32,17 +35,25 @@ class DefaultCachesPublicFilter @Inject constructor(
         log(TAG) { "initialize()" }
     }
 
-    override suspend fun isExpendable(
+    override suspend fun match(
         pkgId: Pkg.Id,
         target: APathLookup<APath>,
         areaType: DataArea.Type,
         segments: Segments
-    ): Boolean {
-        if (segments.isNotEmpty() && IGNORED_FILES.contains(segments[segments.size - 1])) return false
+    ): ExpendablesFilter.Match? {
+        if (segments.isNotEmpty() && IGNORED_FILES.contains(segments[segments.size - 1])) return null
 
-        if (!areaType.isPublic) return false
+        if (!areaType.isPublic) return null
 
-        return segments.size >= 3 && cacheFolderPrefixes.contains(segments[1])
+        return if (segments.size >= 3 && cacheFolderPrefixes.contains(segments[1])) {
+            target.toDeletionMatch()
+        } else {
+            null
+        }
+    }
+
+    override suspend fun process(matches: Collection<ExpendablesFilter.Match>) {
+        matches.deleteAll(gatewaySwitch)
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/HiddenFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/HiddenFilter.kt
@@ -7,6 +7,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.appcleaner.core.AppCleanerSettings
+import eu.darken.sdmse.appcleaner.core.forensics.BaseExpendablesFilter
 import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilter
 import eu.darken.sdmse.appcleaner.core.forensics.sieves.json.JsonBasedSieve
 import eu.darken.sdmse.common.areas.DataArea
@@ -15,6 +16,7 @@ import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.Segments
 import eu.darken.sdmse.common.files.lowercase
 import eu.darken.sdmse.common.pkgs.Pkg
@@ -28,7 +30,8 @@ import javax.inject.Provider
 class HiddenFilter @Inject constructor(
     private val jsonBasedSieveFactory: JsonBasedSieve.Factory,
     environment: StorageEnvironment,
-) : ExpendablesFilter {
+    private val gatewaySwitch: GatewaySwitch,
+) : BaseExpendablesFilter() {
 
     private val cacheFolderPrefixes = environment.ourCacheDirs.map { it.name }
 
@@ -39,41 +42,41 @@ class HiddenFilter @Inject constructor(
         sieve = jsonBasedSieveFactory.create("expendables/db_hidden_caches_files.json")
     }
 
-    override suspend fun isExpendable(
+    override suspend fun match(
         pkgId: Pkg.Id,
         target: APathLookup<APath>,
         areaType: DataArea.Type,
         segments: Segments
-    ): Boolean {
+    ): ExpendablesFilter.Match? {
         if (segments.isNotEmpty() && IGNORED_FILES.contains(segments[segments.size - 1])) {
-            return false
+            return null
         }
 
         // Default case, we don't handle that.
         // package/cache/file
         if (segments.size >= 2 && pkgId.name == segments[0] && cacheFolderPrefixes.contains(segments[1])) {
             // Case matching is important here as all paths that differ in casing are hidden caches (e.g. not system made)
-            return false
+            return null
         }
 
         val lcsegments = segments.lowercase()
 
         // package/cache.dat
         if (lcsegments.size == 2 && HIDDEN_CACHE_FILES.contains(lcsegments[1])) {
-            return true
+            return target.toDeletionMatch()
         }
 
         // package/files/cache.dat
         if (lcsegments.size == 3 && HIDDEN_CACHE_FILES.contains(lcsegments[2])) {
-            return true
+            return target.toDeletionMatch()
         }
 
         //    0      1     2
         // package/.cache/file
         if (lcsegments.size >= 3 && HIDDEN_CACHE_FOLDERS.contains(lcsegments[1])) { // weird name cache folder
-            return true
+            return target.toDeletionMatch()
         }
-        if (isException(segments)) return false
+        if (isException(segments)) return null
 
         //    0      1     2     3
         // package/files/.cache/file
@@ -82,7 +85,7 @@ class HiddenFilter @Inject constructor(
             && (HIDDEN_CACHE_FOLDERS.contains(lcsegments[2]) || "cache" == lcsegments[2])
         ) {
             // cache hidden in files
-            return true
+            return target.toDeletionMatch()
         }
 
         //    -1     0      1     2     3
@@ -92,14 +95,22 @@ class HiddenFilter @Inject constructor(
             && HIDDEN_CACHE_FOLDERS.contains(lcsegments[2])
         ) {
             // cache hidden in files
-            return true
+            return target.toDeletionMatch()
         }
 
-        return segments.isNotEmpty() && sieve.matches(pkgId, areaType, segments)
+        return if (segments.isNotEmpty() && sieve.matches(pkgId, areaType, segments)) {
+            target.toDeletionMatch()
+        } else {
+            null
+        }
     }
 
     private fun isException(dirs: Segments): Boolean {
         return dirs.size >= 4 && dirs[2] == "Cache" && dirs[3].contains(".unity3d&")
+    }
+
+    override suspend fun process(matches: Collection<ExpendablesFilter.Match>) {
+        matches.deleteAll(gatewaySwitch)
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/TelegramFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/TelegramFilter.kt
@@ -7,6 +7,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.appcleaner.core.AppCleanerSettings
+import eu.darken.sdmse.appcleaner.core.forensics.BaseExpendablesFilter
 import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilter
 import eu.darken.sdmse.appcleaner.core.forensics.sieves.dynamic.DynamicSieve
 import eu.darken.sdmse.common.areas.DataArea
@@ -15,6 +16,7 @@ import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.Segments
 import eu.darken.sdmse.common.pkgs.Pkg
 import eu.darken.sdmse.common.pkgs.toPkgId
@@ -24,7 +26,8 @@ import javax.inject.Provider
 @Reusable
 class TelegramFilter @Inject constructor(
     private val dynamicSieveFactory: DynamicSieve.Factory,
-) : ExpendablesFilter {
+    private val gatewaySwitch: GatewaySwitch,
+) : BaseExpendablesFilter() {
 
     private lateinit var sieve: DynamicSieve
 
@@ -114,15 +117,23 @@ class TelegramFilter @Inject constructor(
         sieve = dynamicSieveFactory.create(configs)
     }
 
-    override suspend fun isExpendable(
+    override suspend fun match(
         pkgId: Pkg.Id,
         target: APathLookup<APath>,
         areaType: DataArea.Type,
         segments: Segments
-    ): Boolean {
-        if (segments.isNotEmpty() && IGNORED_FILES.contains(segments[segments.size - 1])) return false
+    ): ExpendablesFilter.Match? {
+        if (segments.isNotEmpty() && IGNORED_FILES.contains(segments[segments.size - 1])) return null
 
-        return segments.isNotEmpty() && sieve.matches(pkgId, areaType, segments)
+        return if (segments.isNotEmpty() && sieve.matches(pkgId, areaType, segments)) {
+            target.toDeletionMatch()
+        } else {
+            null
+        }
+    }
+
+    override suspend fun process(matches: Collection<ExpendablesFilter.Match>) {
+        matches.deleteAll(gatewaySwitch)
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/ThumbnailsFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/ThumbnailsFilter.kt
@@ -7,6 +7,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.appcleaner.core.AppCleanerSettings
+import eu.darken.sdmse.appcleaner.core.forensics.BaseExpendablesFilter
 import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilter
 import eu.darken.sdmse.appcleaner.core.forensics.sieves.json.JsonBasedSieve
 import eu.darken.sdmse.common.areas.DataArea
@@ -15,6 +16,7 @@ import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.Segments
 import eu.darken.sdmse.common.files.lowercase
 import eu.darken.sdmse.common.pkgs.Pkg
@@ -28,7 +30,8 @@ import javax.inject.Provider
 class ThumbnailsFilter @Inject constructor(
     private val jsonBasedSieveFactory: JsonBasedSieve.Factory,
     environment: StorageEnvironment,
-) : ExpendablesFilter {
+    private val gatewaySwitch: GatewaySwitch,
+) : BaseExpendablesFilter() {
 
     private val cacheFolderPrefixes = environment.ourCacheDirs.map { it.name }
 
@@ -39,58 +42,66 @@ class ThumbnailsFilter @Inject constructor(
         sieve = jsonBasedSieveFactory.create("expendables/db_thumbnail_files.json")
     }
 
-    override suspend fun isExpendable(
+    override suspend fun match(
         pkgId: Pkg.Id,
         target: APathLookup<APath>,
         areaType: DataArea.Type,
         segments: Segments
-    ): Boolean {
+    ): ExpendablesFilter.Match? {
         if (segments.isNotEmpty() && IGNORED_FILES.contains(segments[segments.size - 1])) {
-            return false
+            return null
         }
 
         if (segments.size >= 2 && HIDDEN_FOLDERS.contains(segments[0])) {
-            return true
+            return target.toDeletionMatch()
         }
 
         // Default case, we don't handle that.
         // package/cache/file
         if (segments.size >= 2 && pkgId.name == segments[0] && cacheFolderPrefixes.contains(segments[1])) {
             // Case matching is important here as all paths that differ in casing are hidden caches (e.g. not system made)
-            return false
+            return null
         }
 
         val lcsegments = segments.lowercase()
 
         // package/thumbs.dat
         if (lcsegments.size == 2 && HIDDEN_FILES.contains(lcsegments[1])) {
-            return true
+            return target.toDeletionMatch()
         }
 
         // package/files/thumbs.dat
         if (lcsegments.size == 3 && HIDDEN_FILES.contains(lcsegments[2])) {
-            return true
+            return target.toDeletionMatch()
         }
 
         //    0      1     2
         // package/.thumbnails/file
         if (lcsegments.size >= 3 && HIDDEN_FOLDERS.contains(lcsegments[1])) {
-            return true
+            return target.toDeletionMatch()
         }
 
         //    0      1     2     3
         // package/files/.thumbnails/file
         if (lcsegments.size >= 4 && "files" == lcsegments[1] && HIDDEN_FOLDERS.contains(lcsegments[2])) {
-            return true
+            return target.toDeletionMatch()
         }
 
         //    -1     0      1     2     3
         // sdcard/Huawei/Themes/.cache/file
         if (lcsegments.size >= 4 && areaType == DataArea.Type.SDCARD && HIDDEN_FOLDERS.contains(lcsegments[2])) {
-            return true
+            return target.toDeletionMatch()
         }
 
-        return segments.isNotEmpty() && sieve.matches(pkgId, areaType, segments)
+        return if (segments.isNotEmpty() && sieve.matches(pkgId, areaType, segments)) {
+            target.toDeletionMatch()
+        } else {
+            null
+        }
+    }
+
+    override suspend fun process(matches: Collection<ExpendablesFilter.Match>) {
+        matches.deleteAll(gatewaySwitch)
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/ViberFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/ViberFilter.kt
@@ -7,6 +7,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.appcleaner.core.AppCleanerSettings
+import eu.darken.sdmse.appcleaner.core.forensics.BaseExpendablesFilter
 import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilter
 import eu.darken.sdmse.appcleaner.core.forensics.sieves.dynamic.DynamicSieve
 import eu.darken.sdmse.common.areas.DataArea
@@ -15,6 +16,7 @@ import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.Segments
 import eu.darken.sdmse.common.pkgs.Pkg
 import eu.darken.sdmse.common.pkgs.toPkgId
@@ -24,7 +26,8 @@ import javax.inject.Provider
 @Reusable
 class ViberFilter @Inject constructor(
     private val dynamicSieveFactory: DynamicSieve.Factory,
-) : ExpendablesFilter {
+    private val gatewaySwitch: GatewaySwitch,
+) : BaseExpendablesFilter() {
 
     private lateinit var sieve: DynamicSieve
 
@@ -49,15 +52,23 @@ class ViberFilter @Inject constructor(
         sieve = dynamicSieveFactory.create(setOf(config))
     }
 
-    override suspend fun isExpendable(
+    override suspend fun match(
         pkgId: Pkg.Id,
         target: APathLookup<APath>,
         areaType: DataArea.Type,
         segments: Segments
-    ): Boolean {
-        if (segments.isNotEmpty() && IGNORED_FILES.contains(segments[segments.size - 1])) return false
+    ): ExpendablesFilter.Match? {
+        if (segments.isNotEmpty() && IGNORED_FILES.contains(segments[segments.size - 1])) return null
 
-        return segments.isNotEmpty() && sieve.matches(pkgId, areaType, segments)
+        return if (segments.isNotEmpty() && sieve.matches(pkgId, areaType, segments)) {
+            target.toDeletionMatch()
+        } else {
+            null
+        }
+    }
+
+    override suspend fun process(matches: Collection<ExpendablesFilter.Match>) {
+        matches.deleteAll(gatewaySwitch)
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/WeChatFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/WeChatFilter.kt
@@ -7,6 +7,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.appcleaner.core.AppCleanerSettings
+import eu.darken.sdmse.appcleaner.core.forensics.BaseExpendablesFilter
 import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilter
 import eu.darken.sdmse.appcleaner.core.forensics.sieves.dynamic.DynamicSieve
 import eu.darken.sdmse.common.areas.DataArea
@@ -15,6 +16,7 @@ import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.Segments
 import eu.darken.sdmse.common.pkgs.Pkg
 import eu.darken.sdmse.common.pkgs.toPkgId
@@ -24,7 +26,8 @@ import javax.inject.Provider
 @Reusable
 class WeChatFilter @Inject constructor(
     private val dynamicSieveFactory: DynamicSieve.Factory,
-) : ExpendablesFilter {
+    private val gatewaySwitch: GatewaySwitch,
+) : BaseExpendablesFilter() {
 
     private lateinit var sieve: DynamicSieve
 
@@ -48,15 +51,23 @@ class WeChatFilter @Inject constructor(
         sieve = dynamicSieveFactory.create(setOf(config))
     }
 
-    override suspend fun isExpendable(
+    override suspend fun match(
         pkgId: Pkg.Id,
         target: APathLookup<APath>,
         areaType: DataArea.Type,
         segments: Segments
-    ): Boolean {
-        if (segments.isNotEmpty() && IGNORED_FILES.contains(segments[segments.size - 1])) return false
+    ): ExpendablesFilter.Match? {
+        if (segments.isNotEmpty() && IGNORED_FILES.contains(segments[segments.size - 1])) return null
 
-        return segments.isNotEmpty() && sieve.matches(pkgId, areaType, segments)
+        return if (segments.isNotEmpty() && sieve.matches(pkgId, areaType, segments)) {
+            target.toDeletionMatch()
+        } else {
+            null
+        }
+    }
+
+    override suspend fun process(matches: Collection<ExpendablesFilter.Match>) {
+        matches.deleteAll(gatewaySwitch)
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/WebViewCacheFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/WebViewCacheFilter.kt
@@ -7,6 +7,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.appcleaner.core.AppCleanerSettings
+import eu.darken.sdmse.appcleaner.core.forensics.BaseExpendablesFilter
 import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilter
 import eu.darken.sdmse.appcleaner.core.forensics.sieves.json.JsonBasedSieve
 import eu.darken.sdmse.common.areas.DataArea
@@ -22,8 +23,9 @@ import javax.inject.Provider
 
 @Reusable
 class WebViewCacheFilter @Inject constructor(
-    private val jsonBasedSieveFactory: JsonBasedSieve.Factory
-) : ExpendablesFilter {
+    private val jsonBasedSieveFactory: JsonBasedSieve.Factory,
+    private val gatewaySwitch: GatewaySwitch,
+) : BaseExpendablesFilter() {
 
     private lateinit var sieve: JsonBasedSieve
 
@@ -32,21 +34,29 @@ class WebViewCacheFilter @Inject constructor(
         sieve = jsonBasedSieveFactory.create("expendables/db_webcaches.json")
     }
 
-    override suspend fun isExpendable(
+    override suspend fun match(
         pkgId: Pkg.Id,
         target: APathLookup<APath>,
         areaType: DataArea.Type,
         segments: Segments
-    ): Boolean {
+    ): ExpendablesFilter.Match? {
         if (segments.isNotEmpty() && IGNORED_FILES.contains(segments[segments.size - 1])) {
-            return false
+            return null
         }
 
         if (WEBVIEW_CACHES.any { it.prepend(pkgId.name).isAncestorOf(segments) }) {
-            return true
+            return target.toDeletionMatch()
         }
 
-        return segments.isNotEmpty() && sieve.matches(pkgId, areaType, segments)
+        return if (segments.isNotEmpty() && sieve.matches(pkgId, areaType, segments)) {
+            target.toDeletionMatch()
+        } else {
+            null
+        }
+    }
+
+    override suspend fun process(matches: Collection<ExpendablesFilter.Match>) {
+        matches.deleteAll(gatewaySwitch)
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/WhatsAppReceivedFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/WhatsAppReceivedFilter.kt
@@ -7,6 +7,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.appcleaner.core.AppCleanerSettings
+import eu.darken.sdmse.appcleaner.core.forensics.BaseExpendablesFilter
 import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilter
 import eu.darken.sdmse.appcleaner.core.forensics.sieves.dynamic.DynamicSieve
 import eu.darken.sdmse.common.areas.DataArea
@@ -15,6 +16,7 @@ import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.Segments
 import eu.darken.sdmse.common.pkgs.Pkg
 import eu.darken.sdmse.common.pkgs.toPkgId
@@ -24,7 +26,8 @@ import javax.inject.Provider
 @Reusable
 class WhatsAppReceivedFilter @Inject constructor(
     private val dynamicSieveFactory: DynamicSieve.Factory,
-) : ExpendablesFilter {
+    private val gatewaySwitch: GatewaySwitch,
+) : BaseExpendablesFilter() {
 
     private lateinit var sieve: DynamicSieve
 
@@ -77,15 +80,23 @@ class WhatsAppReceivedFilter @Inject constructor(
         sieve = dynamicSieveFactory.create(configs)
     }
 
-    override suspend fun isExpendable(
+    override suspend fun match(
         pkgId: Pkg.Id,
         target: APathLookup<APath>,
         areaType: DataArea.Type,
         segments: Segments
-    ): Boolean {
-        if (segments.isNotEmpty() && IGNORED_FILES.contains(segments[segments.size - 1])) return false
+    ): ExpendablesFilter.Match? {
+        if (segments.isNotEmpty() && IGNORED_FILES.contains(segments[segments.size - 1])) return null
 
-        return segments.isNotEmpty() && sieve.matches(pkgId, areaType, segments)
+        return if (segments.isNotEmpty() && sieve.matches(pkgId, areaType, segments)) {
+            target.toDeletionMatch()
+        } else {
+            null
+        }
+    }
+
+    override suspend fun process(matches: Collection<ExpendablesFilter.Match>) {
+        matches.deleteAll(gatewaySwitch)
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/WhatsAppSentFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/WhatsAppSentFilter.kt
@@ -7,6 +7,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.appcleaner.core.AppCleanerSettings
+import eu.darken.sdmse.appcleaner.core.forensics.BaseExpendablesFilter
 import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilter
 import eu.darken.sdmse.appcleaner.core.forensics.sieves.dynamic.DynamicSieve
 import eu.darken.sdmse.common.areas.DataArea
@@ -15,6 +16,7 @@ import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.Segments
 import eu.darken.sdmse.common.pkgs.Pkg
 import eu.darken.sdmse.common.pkgs.toPkgId
@@ -24,7 +26,8 @@ import javax.inject.Provider
 @Reusable
 class WhatsAppSentFilter @Inject constructor(
     private val dynamicSieveFactory: DynamicSieve.Factory,
-) : ExpendablesFilter {
+    private val gatewaySwitch: GatewaySwitch,
+) : BaseExpendablesFilter() {
 
     private lateinit var sieve: DynamicSieve
 
@@ -71,15 +74,23 @@ class WhatsAppSentFilter @Inject constructor(
         sieve = dynamicSieveFactory.create(configs)
     }
 
-    override suspend fun isExpendable(
+    override suspend fun match(
         pkgId: Pkg.Id,
         target: APathLookup<APath>,
         areaType: DataArea.Type,
         segments: Segments
-    ): Boolean {
-        if (segments.isNotEmpty() && IGNORED_FILES.contains(segments[segments.size - 1])) return false
+    ): ExpendablesFilter.Match? {
+        if (segments.isNotEmpty() && IGNORED_FILES.contains(segments[segments.size - 1])) return null
 
-        return segments.isNotEmpty() && sieve.matches(pkgId, areaType, segments)
+        return if (segments.isNotEmpty() && sieve.matches(pkgId, areaType, segments)) {
+            target.toDeletionMatch()
+        } else {
+            null
+        }
+    }
+
+    override suspend fun process(matches: Collection<ExpendablesFilter.Match>) {
+        matches.deleteAll(gatewaySwitch)
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/PostProcessorModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/PostProcessorModule.kt
@@ -3,13 +3,14 @@ package eu.darken.sdmse.appcleaner.core.scanner
 import dagger.Reusable
 import eu.darken.sdmse.appcleaner.core.AppCleanerSettings
 import eu.darken.sdmse.appcleaner.core.AppJunk
+import eu.darken.sdmse.appcleaner.core.excludeNestedLookups
 import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilter
+import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilterIdentifier
 import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
-import eu.darken.sdmse.common.files.APathLookup
 import eu.darken.sdmse.common.files.containsSegments
 import eu.darken.sdmse.common.files.segs
 import eu.darken.sdmse.common.flow.throttleLatest
@@ -22,12 +23,10 @@ import eu.darken.sdmse.common.shizuku.ShizukuManager
 import eu.darken.sdmse.common.shizuku.canUseShizukuNow
 import eu.darken.sdmse.exclusion.core.ExclusionManager
 import eu.darken.sdmse.exclusion.core.pathExclusions
-import eu.darken.sdmse.exclusion.core.types.excludeNestedLookups
 import eu.darken.sdmse.main.core.SDMTool
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import javax.inject.Inject
-import kotlin.reflect.KClass
 
 @Reusable
 class PostProcessorModule @Inject constructor(
@@ -92,12 +91,12 @@ class PostProcessorModule @Inject constructor(
 
         val useRoot = rootManager.canUseRootNow()
 
-        val edgeCaseMap = mutableMapOf<KClass<out ExpendablesFilter>, Collection<APathLookup<*>>>()
+        val edgeCaseMap = mutableMapOf<ExpendablesFilterIdentifier, Collection<ExpendablesFilter.Match>>()
 
         if (!useRoot && useShizuku) {
             val edgeCaseSegs = segs(before.pkg.id.name, "cache")
-            before.expendables.forEach { (type, paths) ->
-                val edgeCases = paths.filter { it.segments.containsSegments(edgeCaseSegs) }
+            before.expendables.forEach { (type, matches) ->
+                val edgeCases = matches.filter { it.path.segments.containsSegments(edgeCaseSegs) }
                 edgeCaseMap[type] = edgeCases
             }
         }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerProcessingTask.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerProcessingTask.kt
@@ -13,7 +13,7 @@ import kotlin.reflect.KClass
 
 @Parcelize
 @TypeParceler<KClass<out ExpendablesFilter>, KClassParcelizer>()
-data class AppCleanerDeleteTask(
+data class AppCleanerProcessingTask(
     val targetPkgs: Set<Installed.InstallId>? = null,
     val targetFilters: Set<KClass<out ExpendablesFilter>>? = null,
     val targetContents: Set<APath>? = null,

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/ui/details/appjunk/AppJunkFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/ui/details/appjunk/AppJunkFragment.kt
@@ -106,7 +106,7 @@ class AppJunkFragment : Fragment3(R.layout.appcleaner_appjunk_fragment) {
 
                             event.items.singleOrNull() is AppJunkElementFileVH.Item -> getString(
                                 eu.darken.sdmse.common.R.string.general_delete_confirmation_message_x,
-                                (event.items.singleOrNull() as AppJunkElementFileVH.Item).lookup.userReadableName
+                                (event.items.singleOrNull() as AppJunkElementFileVH.Item).match.path.userReadableName
                                     .get(requireContext()),
                             )
 

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/ui/details/appjunk/elements/AppJunkElementFileCategoryVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/ui/details/appjunk/elements/AppJunkElementFileCategoryVH.kt
@@ -9,7 +9,6 @@ import eu.darken.sdmse.appcleaner.ui.descriptionRes
 import eu.darken.sdmse.appcleaner.ui.details.appjunk.AppJunkElementsAdapter
 import eu.darken.sdmse.appcleaner.ui.iconsRes
 import eu.darken.sdmse.appcleaner.ui.labelRes
-import eu.darken.sdmse.common.files.APathLookup
 import eu.darken.sdmse.common.getQuantityString2
 import eu.darken.sdmse.common.lists.binding
 import eu.darken.sdmse.databinding.AppcleanerAppjunkElementFileCategoryBinding
@@ -31,8 +30,15 @@ class AppJunkElementFileCategoryVH(parent: ViewGroup) :
         icon.setImageResource(item.category.iconsRes)
         primary.text = getString(item.category.labelRes)
         secondary.apply {
-            text = Formatter.formatFileSize(context, item.paths.sumOf { it.size })
-            append(" (${context.getQuantityString2(eu.darken.sdmse.common.R.plurals.result_x_items, item.paths.size)})")
+            text = Formatter.formatFileSize(context, item.matches.sumOf { it.expectedGain })
+            append(
+                " (${
+                    context.getQuantityString2(
+                        eu.darken.sdmse.common.R.plurals.result_x_items,
+                        item.matches.size
+                    )
+                })"
+            )
         }
         description.text = getString(item.category.descriptionRes)
 
@@ -42,7 +48,7 @@ class AppJunkElementFileCategoryVH(parent: ViewGroup) :
     data class Item(
         val appJunk: AppJunk,
         val category: KClass<out ExpendablesFilter>,
-        val paths: Collection<APathLookup<*>>,
+        val matches: Collection<ExpendablesFilter.Match>,
         val onItemClick: (Item) -> Unit,
     ) : AppJunkElementsAdapter.Item {
 

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/ui/details/appjunk/elements/AppJunkElementFileVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/ui/details/appjunk/elements/AppJunkElementFileVH.kt
@@ -7,7 +7,6 @@ import eu.darken.sdmse.appcleaner.core.AppJunk
 import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilter
 import eu.darken.sdmse.appcleaner.ui.details.appjunk.AppJunkElementsAdapter
 import eu.darken.sdmse.common.coil.loadFilePreview
-import eu.darken.sdmse.common.files.APathLookup
 import eu.darken.sdmse.common.files.FileType
 import eu.darken.sdmse.common.files.labelRes
 import eu.darken.sdmse.common.lists.binding
@@ -38,14 +37,14 @@ class AppJunkElementFileVH(parent: ViewGroup) :
     ) -> Unit = binding { item ->
         lastItem = item
 
-        icon.loadFilePreview(item.lookup)
+        icon.loadFilePreview(item.match.lookup)
 
-        primary.text = item.lookup.userReadablePath.get(context)
+        primary.text = item.match.lookup.userReadablePath.get(context)
 
-        secondary.text = if (item.lookup.fileType == FileType.FILE) {
-            Formatter.formatFileSize(context, item.lookup.size)
+        secondary.text = if (item.match.lookup.fileType == FileType.FILE) {
+            Formatter.formatFileSize(context, item.match.expectedGain)
         } else {
-            getString(item.lookup.fileType.labelRes)
+            getString(item.match.lookup.fileType.labelRes)
         }
 
         root.setOnClickListener { item.onItemClick(item) }
@@ -54,12 +53,12 @@ class AppJunkElementFileVH(parent: ViewGroup) :
     data class Item(
         val appJunk: AppJunk,
         val category: KClass<out ExpendablesFilter>,
-        val lookup: APathLookup<*>,
+        val match: ExpendablesFilter.Match,
         val onItemClick: (Item) -> Unit,
     ) : AppJunkElementsAdapter.Item {
 
-        override val itemSelectionKey: String = lookup.path
-        override val stableId: Long = lookup.hashCode().toLong()
+        override val itemSelectionKey: String = match.lookup.path
+        override val stableId: Long = match.lookup.hashCode().toLong()
     }
 
 }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/ui/list/AppCleanerListViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/ui/list/AppCleanerListViewModel.kt
@@ -5,7 +5,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.sdmse.MainDirections
 import eu.darken.sdmse.appcleaner.core.AppCleaner
 import eu.darken.sdmse.appcleaner.core.hasData
-import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerDeleteTask
+import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerProcessingTask
 import eu.darken.sdmse.common.SingleLiveEvent
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
@@ -80,11 +80,11 @@ class AppCleanerListViewModel @Inject constructor(
             events.postValue(AppCleanerListEvents.ConfirmDeletion(items))
             return@launch
         }
-        val task = AppCleanerDeleteTask(targetPkgs = items.map { it.junk.identifier }.toSet())
-        val result = taskManager.submit(task) as AppCleanerDeleteTask.Result
+        val task = AppCleanerProcessingTask(targetPkgs = items.map { it.junk.identifier }.toSet())
+        val result = taskManager.submit(task) as AppCleanerProcessingTask.Result
         log(TAG) { "delete(): Result was $result" }
         when (result) {
-            is AppCleanerDeleteTask.Success -> events.postValue(AppCleanerListEvents.TaskResult(result))
+            is AppCleanerProcessingTask.Success -> events.postValue(AppCleanerListEvents.TaskResult(result))
         }
     }
 

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardEvents.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardEvents.kt
@@ -1,6 +1,6 @@
 package eu.darken.sdmse.main.ui.dashboard
 
-import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerDeleteTask
+import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerProcessingTask
 import eu.darken.sdmse.corpsefinder.core.tasks.CorpseFinderDeleteTask
 import eu.darken.sdmse.deduplicator.core.Duplicate
 import eu.darken.sdmse.deduplicator.core.tasks.DeduplicatorDeleteTask
@@ -21,7 +21,7 @@ sealed interface DashboardEvents {
     ) : DashboardEvents
 
     data class AppCleanerDeleteConfirmation(
-        val task: AppCleanerDeleteTask,
+        val task: AppCleanerProcessingTask,
     ) : DashboardEvents
 
     data class DeduplicatorDeleteConfirmation(

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModel.kt
@@ -8,7 +8,7 @@ import eu.darken.sdmse.analyzer.core.Analyzer
 import eu.darken.sdmse.analyzer.ui.AnalyzerDashCardVH
 import eu.darken.sdmse.appcleaner.core.AppCleaner
 import eu.darken.sdmse.appcleaner.core.hasData
-import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerDeleteTask
+import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerProcessingTask
 import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerScanTask
 import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerSchedulerTask
 import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerTask
@@ -192,7 +192,7 @@ class DashboardViewModel @Inject constructor(
                 launch { submitTask(AppCleanerScanTask()) }
             },
             onDelete = {
-                val task = AppCleanerDeleteTask()
+                val task = AppCleanerProcessingTask()
                 events.postValue(DashboardEvents.AppCleanerDeleteConfirmation(task))
             },
             onCancel = {
@@ -510,7 +510,7 @@ class DashboardViewModel @Inject constructor(
                 BottomBarState.Action.WORKING -> {}
                 BottomBarState.Action.DELETE -> {
                     if (appCleaner.state.first().data != null && upgradeRepo.isPro()) {
-                        submitTask(AppCleanerDeleteTask())
+                        submitTask(AppCleanerProcessingTask())
                     } else if (appCleaner.state.first().data.hasData && !corpseFinder.state.first().data.hasData && !systemCleaner.state.first().data.hasData) {
                         MainDirections.goToUpgradeFragment().navigate()
                     }
@@ -519,7 +519,7 @@ class DashboardViewModel @Inject constructor(
                 BottomBarState.Action.ONECLICK -> {
                     if (upgradeRepo.isPro()) {
                         submitTask(AppCleanerScanTask())
-                        submitTask(AppCleanerDeleteTask())
+                        submitTask(AppCleanerProcessingTask())
                     } else if (appCleaner.state.first().data.hasData && !corpseFinder.state.first().data.hasData && !systemCleaner.state.first().data.hasData) {
                         MainDirections.goToUpgradeFragment().navigate()
                     }
@@ -575,7 +575,7 @@ class DashboardViewModel @Inject constructor(
             MainDirections.goToUpgradeFragment().navigate()
             return@launch
         }
-        submitTask(AppCleanerDeleteTask())
+        submitTask(AppCleanerProcessingTask())
     }
 
     fun showAppCleanerDetails() {
@@ -624,7 +624,7 @@ class DashboardViewModel @Inject constructor(
             is AppCleanerTask.Result -> when (result) {
                 is AppCleanerScanTask.Success -> {}
                 is AppCleanerSchedulerTask.Success -> {}
-                is AppCleanerDeleteTask.Success -> events.postValue(DashboardEvents.TaskResult(result))
+                is AppCleanerProcessingTask.Success -> events.postValue(DashboardEvents.TaskResult(result))
             }
         }
     }

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/FilterSource.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/FilterSource.kt
@@ -24,10 +24,10 @@ class FilterSource @Inject constructor(
         filterFactories.forEach { log(TAG) { "Available filter: $it" } }
     }
 
-    suspend fun create(): Set<SystemCleanerFilter> {
+    suspend fun create(onlyEnabled: Boolean): Set<SystemCleanerFilter> {
         val builtInFilters = filterFactories
             .asFlow()
-            .filter { it.isEnabled() }
+            .filter { onlyEnabled && it.isEnabled() }
             .map { it.create() }
             .onEach {
                 log(TAG) { "Initializing $it" }
@@ -38,7 +38,7 @@ class FilterSource @Inject constructor(
         val customFilters = customFilterRepo.configs.first()
             .asFlow()
             .map { customFilterLoader.create(it) }
-            .filter { it.isEnabled() }
+            .filter { onlyEnabled && it.isEnabled() }
             .map { it.create() }
             .onEach {
                 log(TAG) { "Initializing $it" }

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/BaseFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/BaseFilterTest.kt
@@ -7,7 +7,11 @@ import eu.darken.sdmse.appcleaner.core.forensics.sieves.json.JsonBasedSieve
 import eu.darken.sdmse.common.areas.DataArea
 import eu.darken.sdmse.common.areas.DataArea.Type
 import eu.darken.sdmse.common.areas.DataAreaManager
-import eu.darken.sdmse.common.files.*
+import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.common.files.GatewaySwitch
+import eu.darken.sdmse.common.files.ReadException
+import eu.darken.sdmse.common.files.Segments
 import eu.darken.sdmse.common.files.local.LocalPath
 import eu.darken.sdmse.common.forensics.FileForensics
 import eu.darken.sdmse.common.pkgs.Pkg
@@ -19,6 +23,7 @@ import eu.darken.sdmse.common.storage.StorageEnvironment
 import eu.darken.sdmse.systemcleaner.core.SystemCleanerSettings
 import io.kotest.assertions.withClue
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.every
@@ -342,18 +347,19 @@ abstract class BaseFilterTest : BaseTest() {
                         c.pkgs.forEach { pkg ->
                             c.prefixFreePaths.forEach { segs ->
                                 withClue("Should match $pkg, $loc $segs") {
-                                    filter.isExpendable(pkg, target, loc, segs) shouldBe true
+                                    filter.match(pkg, target, loc, segs) shouldNotBe null
                                 }
                             }
                         }
                     }
                 }
+
                 Candidate.Type.NEGATIVE -> {
                     c.areaTypes.forEach { loc ->
                         c.pkgs.forEach { pkg ->
                             c.prefixFreePaths.forEach { segs ->
                                 withClue("Should NOT match $pkg, $loc $segs") {
-                                    filter.isExpendable(pkg, target, loc, segs) shouldBe false
+                                    filter.match(pkg, target, loc, segs) shouldBe null
                                 }
                             }
                         }

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/AdvertisementFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/AdvertisementFilterTest.kt
@@ -1,7 +1,16 @@
 package eu.darken.sdmse.appcleaner.core.forensics.filter
 
-import eu.darken.sdmse.appcleaner.core.forensics.*
-import eu.darken.sdmse.common.areas.DataArea.Type.*
+import eu.darken.sdmse.appcleaner.core.forensics.BaseFilterTest
+import eu.darken.sdmse.appcleaner.core.forensics.addCandidate
+import eu.darken.sdmse.appcleaner.core.forensics.locs
+import eu.darken.sdmse.appcleaner.core.forensics.neg
+import eu.darken.sdmse.appcleaner.core.forensics.pkgs
+import eu.darken.sdmse.appcleaner.core.forensics.pos
+import eu.darken.sdmse.appcleaner.core.forensics.prefixFree
+import eu.darken.sdmse.common.areas.DataArea.Type.PRIVATE_DATA
+import eu.darken.sdmse.common.areas.DataArea.Type.PUBLIC_DATA
+import eu.darken.sdmse.common.areas.DataArea.Type.PUBLIC_OBB
+import eu.darken.sdmse.common.areas.DataArea.Type.SDCARD
 import eu.darken.sdmse.common.rngString
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
@@ -23,6 +32,7 @@ class AdvertisementFilterTest : BaseFilterTest() {
     private fun create() = AdvertisementFilter(
         jsonBasedSieveFactory = createJsonSieveFactory(),
         environment = storageEnvironment,
+        gatewaySwitch = gatewaySwitch,
     )
 
     @Test fun testAnalyticsFilterMologiq() = runTest {

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/AnalyticsFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/AnalyticsFilterTest.kt
@@ -1,13 +1,21 @@
 package eu.darken.sdmse.appcleaner.core.forensics.filter
 
-import eu.darken.sdmse.appcleaner.core.forensics.*
-import eu.darken.sdmse.common.areas.DataArea.Type.*
+import eu.darken.sdmse.appcleaner.core.forensics.BaseFilterTest
+import eu.darken.sdmse.appcleaner.core.forensics.addCandidate
+import eu.darken.sdmse.appcleaner.core.forensics.locs
+import eu.darken.sdmse.appcleaner.core.forensics.neg
+import eu.darken.sdmse.appcleaner.core.forensics.pkgs
+import eu.darken.sdmse.appcleaner.core.forensics.pos
+import eu.darken.sdmse.appcleaner.core.forensics.prefixFree
+import eu.darken.sdmse.common.areas.DataArea.Type.PRIVATE_DATA
+import eu.darken.sdmse.common.areas.DataArea.Type.PUBLIC_DATA
+import eu.darken.sdmse.common.areas.DataArea.Type.SDCARD
 import eu.darken.sdmse.common.rngString
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import java.util.*
+import java.util.UUID
 
 class AnalyticsFilterTest : BaseFilterTest() {
 
@@ -22,7 +30,8 @@ class AnalyticsFilterTest : BaseFilterTest() {
     }
 
     private fun create() = AnalyticsFilter(
-        jsonBasedSieveFactory = createJsonSieveFactory()
+        jsonBasedSieveFactory = createJsonSieveFactory(),
+        gatewaySwitch = gatewaySwitch,
     )
 
     @Test fun testAnalyticsFilterFabric() = runTest {

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/BugReportingFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/BugReportingFilterTest.kt
@@ -30,7 +30,8 @@ class BugReportingFilterTest : BaseFilterTest() {
     }
 
     private fun create() = BugReportingFilter(
-        jsonBasedSieveFactory = createJsonSieveFactory()
+        jsonBasedSieveFactory = createJsonSieveFactory(),
+        gatewaySwitch = gatewaySwitch,
     )
 
     @Test fun testFilterFabric() = runTest {

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/CodeCacheFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/CodeCacheFilterTest.kt
@@ -23,6 +23,7 @@ class CodeCacheFilterTest : BaseFilterTest() {
 
     private fun create() = CodeCacheFilter(
         environment = storageEnvironment,
+        gatewaySwitch = gatewaySwitch,
     )
 
     @Test fun testDefaultFilter() = runTest {

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/DefaultCachesPrivateTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/DefaultCachesPrivateTest.kt
@@ -23,6 +23,7 @@ class DefaultCachesPrivateTest : BaseFilterTest() {
 
     private fun create() = DefaultCachesPrivateFilter(
         environment = storageEnvironment,
+        gatewaySwitch = gatewaySwitch,
     )
 
     @Test fun testDefaultFilter() = runTest {

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/DefaultCachesPublicTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/DefaultCachesPublicTest.kt
@@ -23,6 +23,7 @@ class DefaultCachesPublicTest : BaseFilterTest() {
 
     private fun create() = DefaultCachesPublicFilter(
         environment = storageEnvironment,
+        gatewaySwitch = gatewaySwitch,
     )
 
     @Test fun testDefaultFilter() = runTest {

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/GameFilesFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/GameFilesFilterTest.kt
@@ -1,7 +1,15 @@
 package eu.darken.sdmse.appcleaner.core.forensics.filter
 
-import eu.darken.sdmse.appcleaner.core.forensics.*
-import eu.darken.sdmse.common.areas.DataArea.Type.*
+import eu.darken.sdmse.appcleaner.core.forensics.BaseFilterTest
+import eu.darken.sdmse.appcleaner.core.forensics.addCandidate
+import eu.darken.sdmse.appcleaner.core.forensics.locs
+import eu.darken.sdmse.appcleaner.core.forensics.neg
+import eu.darken.sdmse.appcleaner.core.forensics.pkgs
+import eu.darken.sdmse.appcleaner.core.forensics.pos
+import eu.darken.sdmse.appcleaner.core.forensics.prefixFree
+import eu.darken.sdmse.common.areas.DataArea.Type.PRIVATE_DATA
+import eu.darken.sdmse.common.areas.DataArea.Type.PUBLIC_DATA
+import eu.darken.sdmse.common.areas.DataArea.Type.SDCARD
 import eu.darken.sdmse.common.rngString
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
@@ -21,7 +29,8 @@ class GameFilesFilterTest : BaseFilterTest() {
     }
 
     private fun create() = GameFilesFilter(
-        jsonBasedSieveFactory = createJsonSieveFactory()
+        jsonBasedSieveFactory = createJsonSieveFactory(),
+        gatewaySwitch = gatewaySwitch,
     )
 
     /**

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/HiddenFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/HiddenFilterTest.kt
@@ -32,6 +32,7 @@ class HiddenFilterTest : BaseFilterTest() {
     private fun create() = HiddenFilter(
         jsonBasedSieveFactory = createJsonSieveFactory(),
         environment = storageEnvironment,
+        gatewaySwitch = gatewaySwitch,
     )
 
     @Test fun testHiddenCacheDefaults() = runTest {

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/OfflineCacheFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/OfflineCacheFilterTest.kt
@@ -1,7 +1,15 @@
 package eu.darken.sdmse.appcleaner.core.forensics.filter
 
-import eu.darken.sdmse.appcleaner.core.forensics.*
-import eu.darken.sdmse.common.areas.DataArea.Type.*
+import eu.darken.sdmse.appcleaner.core.forensics.BaseFilterTest
+import eu.darken.sdmse.appcleaner.core.forensics.addCandidate
+import eu.darken.sdmse.appcleaner.core.forensics.locs
+import eu.darken.sdmse.appcleaner.core.forensics.neg
+import eu.darken.sdmse.appcleaner.core.forensics.pkgs
+import eu.darken.sdmse.appcleaner.core.forensics.pos
+import eu.darken.sdmse.appcleaner.core.forensics.prefixFree
+import eu.darken.sdmse.common.areas.DataArea.Type.PRIVATE_DATA
+import eu.darken.sdmse.common.areas.DataArea.Type.PUBLIC_DATA
+import eu.darken.sdmse.common.areas.DataArea.Type.SDCARD
 import eu.darken.sdmse.common.rngString
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
@@ -21,7 +29,8 @@ class OfflineCacheFilterTest : BaseFilterTest() {
     }
 
     private fun create() = OfflineCacheFilter(
-        jsonBasedSieveFactory = createJsonSieveFactory()
+        jsonBasedSieveFactory = createJsonSieveFactory(),
+        gatewaySwitch = gatewaySwitch,
     )
 
     @Test fun testDefaults() = runTest {

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/RecycleBinsFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/RecycleBinsFilterTest.kt
@@ -1,7 +1,15 @@
 package eu.darken.sdmse.appcleaner.core.forensics.filter
 
-import eu.darken.sdmse.appcleaner.core.forensics.*
-import eu.darken.sdmse.common.areas.DataArea.Type.*
+import eu.darken.sdmse.appcleaner.core.forensics.BaseFilterTest
+import eu.darken.sdmse.appcleaner.core.forensics.addCandidate
+import eu.darken.sdmse.appcleaner.core.forensics.locs
+import eu.darken.sdmse.appcleaner.core.forensics.neg
+import eu.darken.sdmse.appcleaner.core.forensics.pkgs
+import eu.darken.sdmse.appcleaner.core.forensics.pos
+import eu.darken.sdmse.appcleaner.core.forensics.prefixFree
+import eu.darken.sdmse.common.areas.DataArea.Type.PRIVATE_DATA
+import eu.darken.sdmse.common.areas.DataArea.Type.PUBLIC_DATA
+import eu.darken.sdmse.common.areas.DataArea.Type.SDCARD
 import eu.darken.sdmse.common.rngString
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
@@ -21,7 +29,8 @@ class RecycleBinsFilterTest : BaseFilterTest() {
     }
 
     private fun create() = RecycleBinsFilter(
-        jsonBasedSieveFactory = createJsonSieveFactory()
+        jsonBasedSieveFactory = createJsonSieveFactory(),
+        gatewaySwitch = gatewaySwitch,
     )
 
     @Test fun testDefaults() = runTest {

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/TelegramFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/TelegramFilterTest.kt
@@ -23,7 +23,8 @@ class TelegramFilterTest : BaseFilterTest() {
     }
 
     private fun create() = TelegramFilter(
-        dynamicSieveFactory = createDynamicSieveFactory()
+        dynamicSieveFactory = createDynamicSieveFactory(),
+        gatewaySwitch = gatewaySwitch,
     )
 
     @Test fun telegram() = runTest {

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/ThreemaFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/ThreemaFilterTest.kt
@@ -1,6 +1,12 @@
 package eu.darken.sdmse.appcleaner.core.forensics.filter
 
-import eu.darken.sdmse.appcleaner.core.forensics.*
+import eu.darken.sdmse.appcleaner.core.forensics.BaseFilterTest
+import eu.darken.sdmse.appcleaner.core.forensics.addCandidate
+import eu.darken.sdmse.appcleaner.core.forensics.locs
+import eu.darken.sdmse.appcleaner.core.forensics.neg
+import eu.darken.sdmse.appcleaner.core.forensics.pkgs
+import eu.darken.sdmse.appcleaner.core.forensics.pos
+import eu.darken.sdmse.appcleaner.core.forensics.prefixFree
 import eu.darken.sdmse.common.areas.DataArea.Type.SDCARD
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
@@ -20,7 +26,8 @@ class ThreemaFilterTest : BaseFilterTest() {
     }
 
     private fun create() = ThreemaFilter(
-        dynamicSieveFactory = createDynamicSieveFactory()
+        dynamicSieveFactory = createDynamicSieveFactory(),
+        gatewaySwitch = gatewaySwitch,
     )
 
     // TODO refactor to non-legacy test methods

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/ThumbnailsFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/ThumbnailsFilterTest.kt
@@ -31,6 +31,7 @@ class ThumbnailsFilterTest : BaseFilterTest() {
     private fun create() = ThumbnailsFilter(
         jsonBasedSieveFactory = createJsonSieveFactory(),
         environment = storageEnvironment,
+        gatewaySwitch = gatewaySwitch,
     )
 
     @Test fun testHiddenCacheDefaults() = runTest {

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/ViberFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/ViberFilterTest.kt
@@ -23,7 +23,8 @@ class ViberFilterTest : BaseFilterTest() {
     }
 
     private fun create() = ViberFilter(
-        dynamicSieveFactory = createDynamicSieveFactory()
+        dynamicSieveFactory = createDynamicSieveFactory(),
+        gatewaySwitch = gatewaySwitch,
     )
 
     @Test fun `Delete all files`() = runTest {

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/WeChatFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/WeChatFilterTest.kt
@@ -27,7 +27,8 @@ class WeChatFilterTest : BaseFilterTest() {
     }
 
     private fun create() = WeChatFilter(
-        dynamicSieveFactory = createDynamicSieveFactory()
+        dynamicSieveFactory = createDynamicSieveFactory(),
+        gatewaySwitch = gatewaySwitch,
     )
 
     @Test fun testFilter() = runTest {

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/WebViewCacheFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/WebViewCacheFilterTest.kt
@@ -1,7 +1,15 @@
 package eu.darken.sdmse.appcleaner.core.forensics.filter
 
-import eu.darken.sdmse.appcleaner.core.forensics.*
-import eu.darken.sdmse.common.areas.DataArea.Type.*
+import eu.darken.sdmse.appcleaner.core.forensics.BaseFilterTest
+import eu.darken.sdmse.appcleaner.core.forensics.addCandidate
+import eu.darken.sdmse.appcleaner.core.forensics.locs
+import eu.darken.sdmse.appcleaner.core.forensics.neg
+import eu.darken.sdmse.appcleaner.core.forensics.pkgs
+import eu.darken.sdmse.appcleaner.core.forensics.pos
+import eu.darken.sdmse.appcleaner.core.forensics.prefixFree
+import eu.darken.sdmse.common.areas.DataArea.Type.PRIVATE_DATA
+import eu.darken.sdmse.common.areas.DataArea.Type.PUBLIC_DATA
+import eu.darken.sdmse.common.areas.DataArea.Type.SDCARD
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -20,7 +28,8 @@ class WebViewCacheFilterTest : BaseFilterTest() {
     }
 
     private fun create() = WebViewCacheFilter(
-        jsonBasedSieveFactory = createJsonSieveFactory()
+        jsonBasedSieveFactory = createJsonSieveFactory(),
+        gatewaySwitch = gatewaySwitch,
     )
 
     @Test fun testGeneral() = runTest {

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/WhatsAppBackupsFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/WhatsAppBackupsFilterTest.kt
@@ -24,7 +24,9 @@ class WhatsAppBackupsFilterTest : BaseFilterTest() {
         super.teardown()
     }
 
-    private fun create() = WhatsAppBackupsFilter()
+    private fun create() = WhatsAppBackupsFilter(
+        gatewaySwitch = gatewaySwitch,
+    )
 
     @Test fun `delete WhatsApp msgstore`() = runTest {
         addDefaultNegatives()

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/WhatsAppReceivedFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/WhatsAppReceivedFilterTest.kt
@@ -1,7 +1,13 @@
 package eu.darken.sdmse.appcleaner.core.forensics.filter
 
 import androidx.core.util.Pair
-import eu.darken.sdmse.appcleaner.core.forensics.*
+import eu.darken.sdmse.appcleaner.core.forensics.BaseFilterTest
+import eu.darken.sdmse.appcleaner.core.forensics.addCandidate
+import eu.darken.sdmse.appcleaner.core.forensics.locs
+import eu.darken.sdmse.appcleaner.core.forensics.neg
+import eu.darken.sdmse.appcleaner.core.forensics.pkgs
+import eu.darken.sdmse.appcleaner.core.forensics.pos
+import eu.darken.sdmse.appcleaner.core.forensics.prefixFree
 import eu.darken.sdmse.common.areas.DataArea.Type.PUBLIC_MEDIA
 import eu.darken.sdmse.common.areas.DataArea.Type.SDCARD
 import kotlinx.coroutines.test.runTest
@@ -22,7 +28,8 @@ class WhatsAppReceivedFilterTest : BaseFilterTest() {
     }
 
     private fun create() = WhatsAppReceivedFilter(
-        dynamicSieveFactory = createDynamicSieveFactory()
+        dynamicSieveFactory = createDynamicSieveFactory(),
+        gatewaySwitch = gatewaySwitch,
     )
 
     // TODO refactor to non-legacy test methods

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/WhatsAppSentFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/WhatsAppSentFilterTest.kt
@@ -1,7 +1,13 @@
 package eu.darken.sdmse.appcleaner.core.forensics.filter
 
 import androidx.core.util.Pair
-import eu.darken.sdmse.appcleaner.core.forensics.*
+import eu.darken.sdmse.appcleaner.core.forensics.BaseFilterTest
+import eu.darken.sdmse.appcleaner.core.forensics.addCandidate
+import eu.darken.sdmse.appcleaner.core.forensics.locs
+import eu.darken.sdmse.appcleaner.core.forensics.neg
+import eu.darken.sdmse.appcleaner.core.forensics.pkgs
+import eu.darken.sdmse.appcleaner.core.forensics.pos
+import eu.darken.sdmse.appcleaner.core.forensics.prefixFree
 import eu.darken.sdmse.common.areas.DataArea.Type.PUBLIC_MEDIA
 import eu.darken.sdmse.common.areas.DataArea.Type.SDCARD
 import kotlinx.coroutines.test.runTest
@@ -22,7 +28,8 @@ class WhatsAppSentFilterTest : BaseFilterTest() {
     }
 
     private fun create() = WhatsAppSentFilter(
-        dynamicSieveFactory = createDynamicSieveFactory()
+        dynamicSieveFactory = createDynamicSieveFactory(),
+        gatewaySwitch = gatewaySwitch,
     )
 
     // TODO refactor to non-legacy test methods


### PR DESCRIPTION
Now we process a `ExpendablesFilter.Match` and the action applied to matches does not have to be "deletion". This paves the way for filter that do other more than just delete files, e.g. a filter that compresses data.