### PR TITLE
IO: Fix WriteException for already deleted files in NORMAL mode

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalGateway.kt
@@ -580,7 +580,6 @@ class LocalGateway @Inject constructor(
             when {
                 mode == Mode.NORMAL || mode == Mode.AUTO && canNormalWrite -> {
                     log(TAG, VERBOSE) { "delete($mode->NORMAL): $path" }
-                    if (!canNormalWrite) throw WriteException(path)
 
                     var success = if (Bugs.isDryRun) {
                         log(TAG, WARN) { "DRYRUN: Not deleting $javaFile" }
@@ -591,7 +590,11 @@ class LocalGateway @Inject constructor(
 
                     if (!success) {
                         success = !javaFile.exists()
-                        if (success) log(TAG, WARN) { "Tried to delete file, but it's already gone: $path" }
+                        if (success) {
+                            log(TAG, WARN) { "Tried to delete file, but it's already gone: $path" }
+                        } else if (!canNormalWrite) {
+                            throw WriteException(path)
+                        }
                     }
 
                     if (!success) {
@@ -635,12 +638,12 @@ class LocalGateway @Inject constructor(
                         }
 
                         if (!success) {
-                            // TODO We could move this into the root service for better performance?
+                            // TODO We could move this into the ADB service for better performance?
                             success = !it.exists(path)
                             if (success) log(TAG, WARN) { "Tried to delete file, but it's already gone: $path" }
                         }
 
-                        if (!success) throw IOException("Adb delete() call returned false")
+                        if (!success) throw IOException("ADB delete() call returned false")
                     }
                 }
 


### PR DESCRIPTION
`canNormalWrite` also returns `false` if the file is deleted, then we aborted early with an exception. Instead we want to run into the `exists()` check later on and not throw an exception if the file no longer exists. This worked for ROOT and ADB, but not NORMAL due to the extra writable check