### PR TITLE
IO: Fix LocalPath serializing transient fields for already deleted files in NORMAL mode

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalPath.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalPath.kt
@@ -32,7 +32,7 @@ data class LocalPath(
     @IgnoredOnParcel override val name: String
         get() = file.name
 
-    @IgnoredOnParcel internal var segmentsCache: Segments? = null
+    @IgnoredOnParcel @Transient internal var segmentsCache: Segments? = null
 
     @IgnoredOnParcel
     override val segments: Segments

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/LocalPathTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/LocalPathTest.kt
@@ -27,17 +27,41 @@ class LocalPathTest : BaseTest() {
     }
 
     @Test
-    fun `test direct serialization`() {
+    fun `direct serialization with transient fields`() {
         testFile.tryMkFile()
         val original = LocalPath.build(file = testFile)
 
         val adapter = moshi.adapter(LocalPath::class.java)
+
+        // segmentsCache needs to be ignored during serialization
+        println(original.segments.toString())
 
         val json = adapter.toJson(original)
         json.toComparableJson() shouldBe """
             {
                 "file": "${testFile.path}",
                 "pathType":"LOCAL"
+            }
+        """.toComparableJson()
+
+        adapter.fromJson(json) shouldBe original
+    }
+
+    @Test
+    fun `deserialization needs to respect transient fields`() {
+        testFile.tryMkFile()
+        val original = LocalPath.build(file = testFile)
+
+        val adapter = moshi.adapter(LocalPath::class.java)
+
+        val json = """
+            {
+                "file": "${testFile.path}",
+                "pathType":"LOCAL",
+                "segmentsCache": [
+                    ".",
+                    "testfile"
+                ]
             }
         """.toComparableJson()
 


### PR DESCRIPTION
`segmentsCache` is an internal performance improvement and should not be stored when serializing a `LocalPath`