### PR TITLE
AppCleaner: Support for HONOR devices with Android 13+

### DIFF
--- a/app-common/src/main/java/eu/darken/sdmse/common/DeviceDetective.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/DeviceDetective.kt
@@ -43,6 +43,8 @@ class DeviceDetective @Inject constructor(
 
     suspend fun isHuawei(): Boolean = checkManufactor("huawei")
 
+    suspend fun isHonor(): Boolean = checkManufactor("HONOR")
+
     suspend fun isLGE(): Boolean = checkManufactor("lge")
 
     suspend fun isXiaomi(): Boolean = checkManufactor("Xiaomi")

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
@@ -20,6 +20,7 @@ import eu.darken.sdmse.appcleaner.core.automation.specs.androidtv.AndroidTVSpecs
 import eu.darken.sdmse.appcleaner.core.automation.specs.aosp.AOSPSpecs
 import eu.darken.sdmse.appcleaner.core.automation.specs.coloros.ColorOSSpecs
 import eu.darken.sdmse.appcleaner.core.automation.specs.flyme.FlymeSpecs
+import eu.darken.sdmse.appcleaner.core.automation.specs.honor.HonorSpecs
 import eu.darken.sdmse.appcleaner.core.automation.specs.huawei.HuaweiSpecs
 import eu.darken.sdmse.appcleaner.core.automation.specs.lge.LGESpecs
 import eu.darken.sdmse.appcleaner.core.automation.specs.miui.MIUISpecs
@@ -83,6 +84,7 @@ class ClearCacheModule @AssistedInject constructor(
                 is AndroidTVSpecs -> 70
                 is NubiaSpecs -> 60
                 is OnePlusSpecs -> 30
+                is HonorSpecs -> 20
                 is AOSPSpecs -> -5
                 else -> 0
             }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/SpecRomType.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/SpecRomType.kt
@@ -23,5 +23,6 @@ enum class SpecRomType(override val label: CaString) : EnumPreference<SpecRomTyp
     @Json(name = "REALME") REALME("Realme".toCaString()),
     @Json(name = "SAMSUNG") SAMSUNG("Samsung".toCaString()),
     @Json(name = "VIVO") VIVO("VIVO".toCaString()),
+    @Json(name = "HONOR") HONOR("HONOR".toCaString()),
     ;
 }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/honor/HonorLabels.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/honor/HonorLabels.kt
@@ -1,0 +1,34 @@
+package eu.darken.sdmse.appcleaner.core.automation.specs.honor
+
+import dagger.Reusable
+import eu.darken.sdmse.appcleaner.core.automation.specs.aosp.AOSPLabels
+import eu.darken.sdmse.automation.core.common.AutomationLabelSource
+import eu.darken.sdmse.common.debug.logging.logTag
+import javax.inject.Inject
+
+@Reusable
+class HonorLabels @Inject constructor(
+    private val aospLabels: AOSPLabels
+) : AutomationLabelSource {
+
+    fun getStorageEntryDynamic(): Set<String>? = aospLabels.getStorageEntryDynamic()
+
+    fun getStorageEntryStatic(lang: String, script: String): Set<String> = when {
+        "pl".toLang() == lang -> setOf(
+            // HONOR/PGT-N19EEA/HNPGT:13/HONORPGT-N49/7.1.0.176C431E3R2P3:user/release-keys
+            "Pamięć",
+        )
+
+        else -> emptySet()
+    }.tryAppend { aospLabels.getStorageEntryStatic(lang, script) }
+
+    fun getClearCacheDynamic(): Set<String>? = aospLabels.getClearCacheDynamic()
+
+    fun getClearCacheStatic(lang: String, script: String): Set<String> = when {
+        else -> emptySet<String>()
+    }.tryAppend { aospLabels.getStorageEntryStatic(lang, script) }
+
+    companion object {
+        val TAG: String = logTag("AppCleaner", "Automation", "Honor", "Labels")
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/honor/HonorSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/honor/HonorSpecs.kt
@@ -1,0 +1,142 @@
+package eu.darken.sdmse.appcleaner.core.automation.specs.honor
+
+import android.content.Context
+import android.view.accessibility.AccessibilityNodeInfo
+import dagger.Binds
+import dagger.Module
+import dagger.Reusable
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoSet
+import eu.darken.sdmse.appcleaner.core.AppCleanerSettings
+import eu.darken.sdmse.appcleaner.core.automation.specs.SpecRomType
+import eu.darken.sdmse.automation.core.common.StepProcessor
+import eu.darken.sdmse.automation.core.common.clickableParent
+import eu.darken.sdmse.automation.core.common.defaultClick
+import eu.darken.sdmse.automation.core.common.defaultWindowFilter
+import eu.darken.sdmse.automation.core.common.defaultWindowIntent
+import eu.darken.sdmse.automation.core.common.getDefaultClearCacheClick
+import eu.darken.sdmse.automation.core.common.getDefaultNodeRecovery
+import eu.darken.sdmse.automation.core.common.getSysLocale
+import eu.darken.sdmse.automation.core.common.idContains
+import eu.darken.sdmse.automation.core.common.isClickyButton
+import eu.darken.sdmse.automation.core.common.isTextView
+import eu.darken.sdmse.automation.core.common.textMatchesAny
+import eu.darken.sdmse.automation.core.common.windowCriteriaAppIdentifier
+import eu.darken.sdmse.automation.core.specs.AutomationExplorer
+import eu.darken.sdmse.automation.core.specs.AutomationSpec
+import eu.darken.sdmse.automation.core.specs.ExplorerSpecGenerator
+import eu.darken.sdmse.automation.core.specs.SpecGenerator
+import eu.darken.sdmse.common.DeviceDetective
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.datastore.value
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.funnel.IPCFunnel
+import eu.darken.sdmse.common.hasApiLevel
+import eu.darken.sdmse.common.pkgs.features.Installed
+import eu.darken.sdmse.common.pkgs.toPkgId
+import eu.darken.sdmse.common.progress.withProgress
+import java.util.*
+import javax.inject.Inject
+
+@Reusable
+class HonorSpecs @Inject constructor(
+    private val ipcFunnel: IPCFunnel,
+    @ApplicationContext private val context: Context,
+    private val deviceDetective: DeviceDetective,
+    private val honorLabels: HonorLabels,
+    private val settings: AppCleanerSettings,
+) : ExplorerSpecGenerator() {
+
+    override val label = TAG.toCaString()
+
+    override val tag: String = TAG
+
+    override suspend fun isResponsible(pkg: Installed): Boolean {
+        if (settings.romTypeDetection.value() == SpecRomType.HONOR) return true
+        if (deviceDetective.isCustomROM()) return false
+        return deviceDetective.isHonor()
+    }
+
+    override suspend fun getSpec(pkg: Installed): AutomationSpec = object : AutomationSpec.Explorer {
+        override suspend fun createPlan(): suspend AutomationExplorer.Context.() -> Unit = {
+            mainPlan(pkg)
+        }
+    }
+
+    private val mainPlan: suspend AutomationExplorer.Context.(Installed) -> Unit = { pkg ->
+        log(TAG, INFO) { "Executing plan for ${pkg.installId} with context $this" }
+
+        val locale = getSysLocale()
+        val lang = locale.language
+        val script = locale.script
+
+        log(VERBOSE) { "Getting specs for ${pkg.packageName} (lang=$lang, script=$script)" }
+
+        run {
+            val storageEntryLabels = honorLabels.getStorageEntryDynamic()
+                ?: honorLabels.getStorageEntryStatic(lang, script)
+
+            val storageFilter = when {
+                hasApiLevel(34) -> fun(node: AccessibilityNodeInfo): Boolean {
+                    if (!node.isTextView()) return false
+                    return node.textMatchesAny(storageEntryLabels)
+                }
+
+                else -> fun(node: AccessibilityNodeInfo): Boolean {
+                    if (!node.isTextView()) return false
+                    if (!hasApiLevel(33) && !node.idContains("android:id/title")) return false
+                    return node.textMatchesAny(storageEntryLabels)
+                }
+            }
+
+            val step = StepProcessor.Step(
+                parentTag = tag,
+                label = "Find & click 'Storage' (targets=$storageEntryLabels)",
+                windowIntent = defaultWindowIntent(pkg),
+                windowEventFilter = defaultWindowFilter(SETTINGS_PKG),
+                windowNodeTest = windowCriteriaAppIdentifier(SETTINGS_PKG, ipcFunnel, pkg),
+                nodeTest = storageFilter,
+                nodeRecovery = getDefaultNodeRecovery(pkg),
+                nodeMapping = clickableParent(),
+                action = defaultClick()
+            )
+            stepper.withProgress(this) { process(step) }
+        }
+
+        run {
+            val clearCacheButtonLabels = honorLabels.getClearCacheDynamic()
+                ?: honorLabels.getClearCacheStatic(lang, script)
+
+            val buttonFilter = fun(node: AccessibilityNodeInfo): Boolean {
+                if (!node.isClickyButton()) return false
+                return node.textMatchesAny(clearCacheButtonLabels)
+            }
+
+            val step = StepProcessor.Step(
+                parentTag = tag,
+                label = "Find & click 'Clear Cache' (targets=$clearCacheButtonLabels)",
+                windowNodeTest = windowCriteriaAppIdentifier(SETTINGS_PKG, ipcFunnel, pkg),
+                nodeTest = buttonFilter,
+                action = getDefaultClearCacheClick(pkg, tag)
+            )
+            stepper.withProgress(this) { process(step) }
+        }
+    }
+
+    @Module @InstallIn(SingletonComponent::class)
+    abstract class DIM {
+        @Binds @IntoSet abstract fun mod(mod: HonorSpecs): SpecGenerator
+    }
+
+    companion object {
+        val SETTINGS_PKG = "com.android.settings".toPkgId()
+
+        val TAG: String = logTag("AppCleaner", "Automation", "Honor", "Specs")
+    }
+
+}


### PR DESCRIPTION
Currently AppCleaner treats HONOR devices/ROMs as ASOP ROMs and uses the matching there.

I've got one report now that could indicate that this no longer works with Android 13+ and that we might need special handling for the ROM.


