### PR TITLE
Analyzer: Keep scanning when app is in the background

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/analyzer/ui/storage/storage/StorageContentFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/analyzer/ui/storage/storage/StorageContentFragment.kt
@@ -2,6 +2,7 @@ package eu.darken.sdmse.analyzer.ui.storage.storage
 
 import android.os.Bundle
 import android.view.View
+import androidx.activity.OnBackPressedCallback
 import androidx.core.view.isInvisible
 import androidx.fragment.app.viewModels
 import androidx.navigation.findNavController
@@ -20,6 +21,18 @@ class StorageContentFragment : Fragment3(R.layout.analyzer_storage_fragment) {
 
     override val vm: StorageContentViewModel by viewModels()
     override val ui: AnalyzerStorageFragmentBinding by viewBinding()
+
+    private val onBackPressedcallback = object : OnBackPressedCallback(true) {
+        override fun handleOnBackPressed() {
+            vm.cancel()
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        requireActivity().onBackPressedDispatcher.addCallback(this, onBackPressedcallback)
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         ui.toolbar.apply {
             setupWithNavController(findNavController())
@@ -28,7 +41,7 @@ class StorageContentFragment : Fragment3(R.layout.analyzer_storage_fragment) {
                     else -> false
                 }
             }
-
+            setNavigationOnClickListener { vm.cancel() }
         }
 
         val adapter = StorageContentAdapter()

--- a/app/src/main/java/eu/darken/sdmse/analyzer/ui/storage/storage/StorageContentViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/analyzer/ui/storage/storage/StorageContentViewModel.kt
@@ -21,6 +21,8 @@ import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.navigation.navArgs
 import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.common.uix.ViewModel3
+import eu.darken.sdmse.main.core.SDMTool
+import eu.darken.sdmse.main.core.taskmanager.TaskManager
 import kotlinx.coroutines.flow.*
 import javax.inject.Inject
 
@@ -28,7 +30,8 @@ import javax.inject.Inject
 class StorageContentViewModel @Inject constructor(
     @Suppress("unused") private val handle: SavedStateHandle,
     dispatcherProvider: DispatcherProvider,
-    private val analyzer: Analyzer,
+    analyzer: Analyzer,
+    private val taskManager: TaskManager,
 ) : ViewModel3(dispatcherProvider) {
 
     private val navArgs by handle.navArgs<StorageContentFragmentArgs>()
@@ -38,7 +41,7 @@ class StorageContentViewModel @Inject constructor(
         analyzer.data
             .filter { it.categories[targetStorageId].isNullOrEmpty() }
             .take(1)
-            .onEach { analyzer.submit(StorageScanTask(targetStorageId)) }
+            .onEach { taskManager.submit(StorageScanTask(targetStorageId)) }
             .catch {
                 log(TAG, WARN) { "Storage unavailable $navArgs: ${it.asLog()}" }
                 StorageContentFragmentDirections.goToDashboard().navigate()
@@ -103,7 +106,12 @@ class StorageContentViewModel @Inject constructor(
 
     fun refresh() = launch {
         log(TAG) { "refresh()" }
-        analyzer.submit(StorageScanTask(target = targetStorageId))
+        taskManager.submit(StorageScanTask(target = targetStorageId))
+    }
+
+    fun cancel() = launch {
+        log(TAG) { "cancel()" }
+        taskManager.cancel(SDMTool.Type.ANALYZER)
     }
 
     data class State(


### PR DESCRIPTION
Decouple the long storage scans from the view model lifecycle and make it a background operation so the scan continues if the user put SD Maid in the background.

See https://github.com/d4rken-org/sdmaid-se/issues/876#issuecomment-1894806587