### PR TITLE
Debug: Show detailed version information when long pressing the changelog settings entry

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/common/preferences/IntentPreference.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/preferences/IntentPreference.kt
@@ -7,7 +7,6 @@ import android.util.AttributeSet
 import android.widget.Toast
 import androidx.annotation.AttrRes
 import androidx.annotation.StyleRes
-import androidx.preference.Preference
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
@@ -18,7 +17,7 @@ class IntentPreference @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     @AttrRes defStyleAttr: Int = androidx.preference.R.attr.preferenceStyle,
     @StyleRes defStyleRes: Int = 0,
-) : Preference(context, attrs, defStyleAttr, defStyleRes) {
+) : Preference2(context, attrs, defStyleAttr, defStyleRes) {
 
     override fun setIntent(_intent: Intent?) {
         super.setIntent(_intent)

--- a/app/src/main/java/eu/darken/sdmse/common/preferences/Preference2.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/preferences/Preference2.kt
@@ -1,0 +1,35 @@
+package eu.darken.sdmse.common.preferences
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import androidx.annotation.AttrRes
+import androidx.annotation.StyleRes
+import androidx.preference.Preference
+import androidx.preference.PreferenceViewHolder
+import eu.darken.sdmse.common.debug.logging.logTag
+
+
+open class Preference2 @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    @AttrRes defStyleAttr: Int = androidx.preference.R.attr.preferenceStyle,
+    @StyleRes defStyleRes: Int = 0,
+) : Preference(context, attrs, defStyleAttr, defStyleRes) {
+
+    private var longClickListener: View.OnLongClickListener? = null
+
+    override fun onBindViewHolder(holder: PreferenceViewHolder) {
+        super.onBindViewHolder(holder)
+
+        holder.itemView.setOnLongClickListener(longClickListener)
+    }
+
+    fun setOnLongClickListener(action: View.OnLongClickListener?) {
+        longClickListener = action
+    }
+
+    companion object {
+        private val TAG = logTag("Preference2")
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/main/core/CurriculumVitae.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/core/CurriculumVitae.kt
@@ -80,6 +80,8 @@ class CurriculumVitae @Inject constructor(
         _launchedCountBeta.value(newLaunchCount)
     }
 
+    val history = _updateHistory.flow
+
     private suspend fun updateVersionHistory() {
         val history = _updateHistory.value()
         log(TAG) { "Current version history is $history" }

--- a/app/src/main/java/eu/darken/sdmse/main/ui/settings/SettingEvents.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/settings/SettingEvents.kt
@@ -1,0 +1,5 @@
+package eu.darken.sdmse.main.ui.settings
+
+sealed class SettingEvents {
+    data class ShowVersionInfo(val info: String) : SettingEvents()
+}

--- a/app/src/main/java/eu/darken/sdmse/main/ui/settings/SettingsIndexFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/settings/SettingsIndexFragment.kt
@@ -83,7 +83,6 @@ class SettingsIndexFragment : PreferenceFragment2() {
             summary = BuildConfigWrap.VERSION_DESCRIPTION
             this.setOnLongClickListener {
                 vm.showVersionInfos()
-                Snackbar.make(requireView(), R.string.general_copied_to_clipboard_msg, Snackbar.LENGTH_SHORT).show()
                 true
             }
         }

--- a/app/src/main/java/eu/darken/sdmse/main/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/settings/SettingsViewModel.kt
@@ -49,7 +49,7 @@ class SettingsViewModel @Inject constructor(
     }
 
     private suspend fun getVersionText() = """
-            Build:`${BuildConfigWrap.VERSION_DESCRIPTION}`
+            Build: `${BuildConfigWrap.VERSION_DESCRIPTION}`
             Update history: `${curriculumVitae.history.first()}`
             ROM: `${Build.FINGERPRINT}`
         """.trimIndent()

--- a/app/src/main/java/eu/darken/sdmse/main/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/settings/SettingsViewModel.kt
@@ -1,13 +1,19 @@
 package eu.darken.sdmse.main.ui.settings
 
+import android.os.Build
 import androidx.lifecycle.SavedStateHandle
 import dagger.hilt.android.lifecycle.HiltViewModel
+import eu.darken.sdmse.common.BuildConfigWrap
+import eu.darken.sdmse.common.ClipboardHelper
+import eu.darken.sdmse.common.SingleLiveEvent
 import eu.darken.sdmse.common.WebpageTool
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.uix.ViewModel2
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
+import eu.darken.sdmse.main.core.CurriculumVitae
 import eu.darken.sdmse.setup.SetupManager
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
@@ -18,7 +24,11 @@ class SettingsViewModel @Inject constructor(
     private val upgradeRepo: UpgradeRepo,
     private val setupManager: SetupManager,
     private val webpageTool: WebpageTool,
+    private val clipboardHelper: ClipboardHelper,
+    private val curriculumVitae: CurriculumVitae,
 ) : ViewModel2(dispatcherProvider) {
+
+    val events = SingleLiveEvent<SettingEvents>()
 
     val state = combine(
         upgradeRepo.upgradeInfo.map { it.isPro },
@@ -36,6 +46,20 @@ class SettingsViewModel @Inject constructor(
 
     fun openUpgradeWebsite() {
         webpageTool.open(upgradeRepo.mainWebsite)
+    }
+
+    private suspend fun getVersionText() = """
+            Build:`${BuildConfigWrap.VERSION_DESCRIPTION}`
+            Update history: `${curriculumVitae.history.first()}`
+            ROM: `${Build.FINGERPRINT}`
+        """.trimIndent()
+
+    fun showVersionInfos() = launch {
+        events.postValue(SettingEvents.ShowVersionInfo(getVersionText()))
+    }
+
+    fun copyVersionInfos() = launch {
+        clipboardHelper.copyToClipboard(getVersionText())
     }
 
     data class State(


### PR DESCRIPTION
Implements #939


Build:`v0.18.5-beta0 (1805000) ~ bfc8bea6/FOSS/DEV`
Update history: `[0.18.4-beta0, 0.18.5-beta0]`
ROM: `samsung/r8qxeea/r8q:12/SP1A.210812.016/G781BXXS4FVK1:user/release-keys`

![Screenshot from 2024-01-19 15-00-54](https://github.com/d4rken-org/sdmaid-se/assets/1439229/890ed31b-1200-4689-b696-0e38ca510c0c)
