### PR TITLE
Google Play: Add extra "Restore purchase" button

### DIFF
--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplay.kt
@@ -127,7 +127,7 @@ class UpgradeRepoGplay @Inject constructor(
             ?.flatten()
             ?: emptySet()
 
-        override val isPro: Boolean = upgrades.isNotEmpty() || gracePeriod
+        override val isPro: Boolean = false// upgrades.isNotEmpty() || gracePeriod
 
         override val upgradedAt: Instant? = upgrades
             .maxByOrNull { it.purchase.purchaseTime }

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeEvents.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeEvents.kt
@@ -1,0 +1,5 @@
+package eu.darken.sdmse.common.upgrade.ui
+
+sealed class UpgradeEvents {
+    data object RestoreFailed : UpgradeEvents()
+}

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeFragment.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeFragment.kt
@@ -7,6 +7,7 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.ui.setupWithNavController
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
 import eu.darken.sdmse.R
 import eu.darken.sdmse.common.debug.logging.log
@@ -55,6 +56,7 @@ class UpgradeFragment : Fragment3(R.layout.upgrade_fragment) {
                         text = getString(R.string.upgrade_screen_subscription_trial_action)
                         setOnClickListener { vm.onGoSubscriptionTrial(requireActivity()) }
                     }
+
                     subOffer != null -> {
                         text = getString(R.string.upgrade_screen_subscription_action)
                         setOnClickListener { vm.onGoSubscription(requireActivity()) }
@@ -72,6 +74,31 @@ class UpgradeFragment : Fragment3(R.layout.upgrade_fragment) {
 
             actionBox.isVisible = true
             actionProgress.isGone = true
+
+            restoreAction.setOnClickListener {
+                vm.restorePurchase()
+            }
+        }
+
+        vm.events.observe2(ui) { event ->
+            when (event) {
+                UpgradeEvents.RestoreFailed -> MaterialAlertDialogBuilder(requireContext()).apply {
+                    setMessage(
+                        """
+                        ${getString(R.string.upgrade_screen_restore_purchase_message)}
+                        
+                        ${getString(R.string.upgrade_screen_restore_troubleshooting_msg)}
+                        
+                        ${getString(R.string.upgrade_screen_restore_sync_patience_hint)}  
+                        
+                        ${getString(R.string.upgrade_screen_restore_multiaccount_hint)}
+                        """.trimIndent()
+                    )
+                    setPositiveButton(eu.darken.sdmse.common.R.string.general_dismiss_action) { _, _ ->
+
+                    }
+                }.show()
+            }
         }
         super.onViewCreated(view, savedInstanceState)
     }

--- a/app/src/gplay/res/layout/upgrade_fragment.xml
+++ b/app/src/gplay/res/layout/upgrade_fragment.xml
@@ -9,8 +9,8 @@
         android:id="@+id/toolbar"
         style="@style/Widget.MaterialComponents.Toolbar.Surface"
         android:layout_width="0dp"
-        android:minHeight="?actionBarSize"
         android:layout_height="wrap_content"
+        android:minHeight="?actionBarSize"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
@@ -143,6 +143,14 @@
                         android:text="@string/upgrade_screen_iap_action_hint"
                         android:visibility="gone"
                         tools:visibility="visible" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/restore_action"
+                        style="@style/Widget.Material3.Button.TextButton"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:text="@string/upgrade_screen_restore_purchase_action" />
                 </LinearLayout>
             </FrameLayout>
         </LinearLayout>

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -24,6 +24,11 @@
     <string name="upgrade_screen_iap_action">One-time purchase</string>
     <string name="upgrade_screen_iap_action_hint">The one-time purchase costs %s.</string>
     <string name="upgrade_screen_thanks_toast">You are the best! ❤️</string>
+    <string name="upgrade_screen_restore_purchase_action">Restore purchase</string>
+    <string name="upgrade_screen_restore_purchase_message">Your upgrade is valid across devices on the same Google account.</string>
+    <string name="upgrade_screen_restore_troubleshooting_msg">Troubleshooting tips for unrecognized upgrades:</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">Play Store synchronization may take time. Try rebooting, clearing Google Play cache or simply wait.</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">Multiple accounts can confuse Google Play. Log out of other accounts or install through the Google Play website, which forces associations with a specific account.</string>
 
     <string name="nudge_betagoodbye_title">SD Maid 2/SE v1 🥳</string>
     <string name="nudge_betagoodbye_body">Together, we made it to the first release! Thank you for helping me! Development will of course continue, but you can now switch to more stable builds, if you want to. Do this by opting-out of testing on Google Play.</string>


### PR DESCRIPTION
Triggers a purchase data refresh and if that fails shows a few hints for common issues.