### PR TITLE
Google Play: Fix upgrade status being ignored

### DIFF
--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplay.kt
@@ -127,7 +127,7 @@ class UpgradeRepoGplay @Inject constructor(
             ?.flatten()
             ?: emptySet()
 
-        override val isPro: Boolean = false// upgrades.isNotEmpty() || gracePeriod
+        override val isPro: Boolean = upgrades.isNotEmpty() || gracePeriod
 
         override val upgradedAt: Instant? = upgrades
             .maxByOrNull { it.purchase.purchaseTime }

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplayTest.kt
@@ -1,0 +1,52 @@
+package eu.darken.sdmse.common.upgrade.core
+
+import com.android.billingclient.api.Purchase
+import eu.darken.sdmse.common.upgrade.core.billing.BillingData
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.time.Instant
+
+class UpgradeRepoGplayTest : BaseTest() {
+
+    @BeforeEach
+    fun setup() {
+
+    }
+
+    @AfterEach
+    fun teardown() {
+
+    }
+
+
+    @Test fun `test upgrade info pro status mapping`() {
+        UpgradeRepoGplay.Info(
+            gracePeriod = false,
+            billingData = null
+        ).isPro shouldBe false
+
+        UpgradeRepoGplay.Info(
+            gracePeriod = true,
+            billingData = null
+        ).isPro shouldBe true
+
+        val info = UpgradeRepoGplay.Info(
+            gracePeriod = false,
+            billingData = BillingData(
+                purchases = setOf(
+                    mockk<Purchase>().apply {
+                        every { products } returns OurSku.PRO_SKUS.map { it.id }
+                        every { purchaseTime } returns Instant.parse("2023-12-10T00:00:00Z").toEpochMilli()
+                    }
+                )
+            )
+        )
+        info.isPro shouldBe true
+        info.upgradedAt shouldBe Instant.parse("2023-12-10T00:00:00Z")
+    }
+}


### PR DESCRIPTION
Fix incorrect mapping of purchases to upgrade status due to mistake/regression from debugging.

Fix #959