### PR TITLE
Setup: Monitor Shizuku state and automatically request missing permission

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/scheduler/core/SchedulerWorker.kt
+++ b/app/src/main/java/eu/darken/sdmse/scheduler/core/SchedulerWorker.kt
@@ -19,9 +19,11 @@ import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.root.RootManager
+import eu.darken.sdmse.common.root.canUseRootNow
 import eu.darken.sdmse.common.shell.ShellOps
 import eu.darken.sdmse.common.shell.ipc.ShellOpsCmd
 import eu.darken.sdmse.common.shizuku.ShizukuManager
+import eu.darken.sdmse.common.shizuku.canUseShizukuNow
 import eu.darken.sdmse.corpsefinder.core.tasks.CorpseFinderSchedulerTask
 import eu.darken.sdmse.main.core.SDMTool
 import eu.darken.sdmse.main.core.taskmanager.TaskManager
@@ -170,8 +172,8 @@ class SchedulerWorker @AssistedInject constructor(
             cmds.forEachIndexed { index, s -> log(TAG, INFO) { "Command #$index: $s" } }
 
             val shellOpsMode = when {
-                rootManager.isRooted() -> ShellOps.Mode.ROOT
-                shizukuManager.isShizukud() -> ShellOps.Mode.ADB
+                rootManager.canUseRootNow() -> ShellOps.Mode.ROOT
+                shizukuManager.canUseShizukuNow() -> ShellOps.Mode.ADB
                 else -> ShellOps.Mode.NORMAL
             }
             val result = shellOps.execute(ShellOpsCmd(cmds = cmds), shellOpsMode)

--- a/app/src/main/java/eu/darken/sdmse/scheduler/ui/manager/SchedulerManagerViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/scheduler/ui/manager/SchedulerManagerViewModel.kt
@@ -14,7 +14,9 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.root.RootManager
+import eu.darken.sdmse.common.root.canUseRootNow
 import eu.darken.sdmse.common.shizuku.ShizukuManager
+import eu.darken.sdmse.common.shizuku.canUseShizukuNow
 import eu.darken.sdmse.common.uix.ViewModel3
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
 import eu.darken.sdmse.common.upgrade.isPro
@@ -76,7 +78,7 @@ class SchedulerManagerViewModel @Inject constructor(
             items.add(AlarmHintRowVH.Item(schedulerState))
         }
 
-        val showCommands = rootManager.isRooted() || shizukuManager.isShizukud()
+        val showCommands = rootManager.canUseRootNow() || shizukuManager.canUseShizukuNow()
 
         schedulerState.schedules.map { schedule ->
             ScheduleRowVH.Item(


### PR DESCRIPTION
Previously if SD Maid was first setup for Shizuku, and then Shizuku is launched without restarting SD Maid, then you'd have to toggle Shizuku on/off in SD Maid again for SD Maid to ask for access to Shizuku.