### PR TITLE
Setup: If Shizuku is available use it automatically to start the accessibility service on demand if required

### DIFF
--- a/app-common-io/src/main/aidl/eu/darken/sdmse/common/pkgs/pkgops/ipc/PkgOpsConnection.aidl
+++ b/app-common-io/src/main/aidl/eu/darken/sdmse/common/pkgs/pkgops/ipc/PkgOpsConnection.aidl
@@ -27,5 +27,7 @@ interface PkgOpsConnection {
 
     boolean grantPermission(String packageName, int handleId, String permissionId);
 
+    boolean revokePermission(String packageName, int handleId, String permissionId);
+
     boolean setAppOps(String packageName, int handleId, String key, String value);
 }

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/ipc/PkgOpsClient.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/ipc/PkgOpsClient.kt
@@ -137,6 +137,13 @@ class PkgOpsClient @AssistedInject constructor(
         throw fakeIOException(e.getRootCause())
     }
 
+    fun revokePermission(id: Installed.InstallId, permission: Permission): Boolean = try {
+        connection.revokePermission(id.pkgId.name, id.userHandle.handleId, permission.permissionId)
+    } catch (e: Exception) {
+        log(TAG, ERROR) { "revokePermission(id=$id, permission=$permission) failed: ${e.asLog()}" }
+        throw fakeIOException(e.getRootCause())
+    }
+
     fun setAppOps(id: Installed.InstallId, key: String, value: String): Boolean = try {
         connection.setAppOps(id.pkgId.name, id.userHandle.handleId, key, value)
     } catch (e: Exception) {

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/ipc/PkgOpsHost.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/ipc/PkgOpsHost.kt
@@ -157,6 +157,19 @@ class PkgOpsHost @Inject constructor(
         throw wrapPropagating(e)
     }
 
+    override fun revokePermission(packageName: String, handleId: Int, permissionId: String): Boolean = try {
+        log(TAG, VERBOSE) { "revokePermission($packageName, $handleId, $permissionId)..." }
+        val result = runBlocking {
+            sharedShell.useRes {
+                Cmd.builder("pm revoke --user $handleId $packageName $permissionId").execute(it)
+            }
+        }
+        result.exitCode == Cmd.ExitCode.OK
+    } catch (e: Exception) {
+        log(TAG, ERROR) { "revokePermission($packageName, $handleId, $permissionId) failed: $e" }
+        throw wrapPropagating(e)
+    }
+
     override fun setAppOps(packageName: String, handleId: Int, key: String, value: String): Boolean = try {
         log(TAG, VERBOSE) { "setAppOps($packageName, $handleId, $key, $value)..." }
         val result = runBlocking {

--- a/app/src/main/java/eu/darken/sdmse/automation/core/AutomationManager.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/AutomationManager.kt
@@ -102,7 +102,7 @@ class AutomationManager @Inject constructor(
             return service
         }
 
-        if (!setupHelper.checkSecureSettings()) {
+        if (!setupHelper.hasSecureSettings()) {
             log(TAG, WARN) { "startService(): Service is not running and we don't have secure settings access." }
             throw AutomationNotEnabledException()
         }
@@ -141,7 +141,7 @@ class AutomationManager @Inject constructor(
 
     private suspend fun stopService() {
         log(TAG, VERBOSE) { "stopService()" }
-        if (!setupHelper.checkSecureSettings()) {
+        if (!setupHelper.hasSecureSettings()) {
             throw IllegalStateException("stopService(): Trying to stop service but secure settings permission isn't available")
         }
 
@@ -166,7 +166,7 @@ class AutomationManager @Inject constructor(
         val serviceWasRunning = isServiceLaunched()
         log(TAG) { "serviceLauncher: serviceWasRunning=$serviceWasRunning" }
 
-        val canToggle = setupHelper.checkSecureSettings()
+        val canToggle = setupHelper.hasSecureSettings()
         log(TAG) { "serviceLauncher: canToggle=$canToggle" }
 
         val service = if (canToggle) {

--- a/app/src/main/java/eu/darken/sdmse/setup/shizuku/ShizukuSetupCardVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/shizuku/ShizukuSetupCardVH.kt
@@ -50,7 +50,7 @@ class ShizukuSetupCardVH(parent: ViewGroup) :
 
         shizukuOpenAction.apply {
             setOnClickListener { item.onOpen() }
-            isGone = !item.state.isInstalled || item.state.useShizuku != true
+            isGone = !item.state.isInstalled || item.state.useShizuku != true || item.state.isComplete
         }
 
         helpAction.setOnClickListener { item.onHelp() }


### PR DESCRIPTION
If Shizuku is available and user wants to use the accessibility service (has given consent in setup) then grant SD Maid `WRITE_SECURE_SETTINGS` permission via Shizuku, so the accessibility service can be enabled on-demand.