### PR TITLE
IO: When detecting available data areas, perform a `listFiles` in addition to `lookup` to check access

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalGateway.kt
@@ -241,6 +241,7 @@ class LocalGateway @Inject constructor(
                     else -> if (javaFile.canRead()) javaFile.listFiles2() else null
                 }
             } catch (e: Exception) {
+                log(TAG) { "listFiles($path, $mode) failed: $e" }
                 null
             }
 

--- a/app/src/main/java/eu/darken/sdmse/common/areas/modules/pub/PublicDataModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/areas/modules/pub/PublicDataModule.kt
@@ -18,6 +18,7 @@ import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.canRead
+import eu.darken.sdmse.common.files.listFiles
 import eu.darken.sdmse.common.files.local.LocalPath
 import eu.darken.sdmse.common.files.lookup
 import eu.darken.sdmse.common.files.saf.SAFPath
@@ -60,11 +61,19 @@ class PublicDataModule @Inject constructor(
 
                 try {
                     path.lookup(gatewaySwitch)
-                    true
-                } catch (e: Exception) {
-                    log(TAG, ERROR) { "Failed to lookup $area: ${e.asLog()}" }
-                    false
+                } catch (e: IOException) {
+                    log(TAG, ERROR) { "Failed lookup() for $area: ${e.asLog()}" }
+                    return@filter false
                 }
+
+                try {
+                    path.listFiles(gatewaySwitch)
+                } catch (e: IOException) {
+                    log(TAG, ERROR) { "Failed listFiles() for $area: ${e.asLog()}" }
+                    return@filter false
+                }
+
+                true
             }
             .map { (parentArea, path) ->
                 DataArea(

--- a/app/src/main/java/eu/darken/sdmse/common/areas/modules/pub/PublicMediaModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/areas/modules/pub/PublicMediaModule.kt
@@ -18,9 +18,11 @@ import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.canRead
 import eu.darken.sdmse.common.files.canWrite
+import eu.darken.sdmse.common.files.listFiles
 import eu.darken.sdmse.common.files.lookup
 import eu.darken.sdmse.common.storage.StorageEnvironment
 import eu.darken.sdmse.common.user.UserManager2
+import java.io.IOException
 import javax.inject.Inject
 
 @Reusable
@@ -48,11 +50,19 @@ class PublicMediaModule @Inject constructor(
 
                 try {
                     path.lookup(gatewaySwitch)
-                    true
-                } catch (e: Exception) {
-                    log(TAG, ERROR) { "Failed to lookup $area: ${e.asLog()}" }
-                    false
+                } catch (e: IOException) {
+                    log(TAG, ERROR) { "Failed lookup() for $area: ${e.asLog()}" }
+                    return@filter false
                 }
+
+                try {
+                    path.listFiles(gatewaySwitch)
+                } catch (e: IOException) {
+                    log(TAG, ERROR) { "Failed listFiles() for $area: ${e.asLog()}" }
+                    return@filter false
+                }
+
+                true
             }
             .map { (parentArea, path) ->
                 DataArea(

--- a/app/src/main/java/eu/darken/sdmse/common/areas/modules/pub/PublicObbModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/areas/modules/pub/PublicObbModule.kt
@@ -18,6 +18,7 @@ import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.canRead
+import eu.darken.sdmse.common.files.listFiles
 import eu.darken.sdmse.common.files.local.LocalPath
 import eu.darken.sdmse.common.files.lookup
 import eu.darken.sdmse.common.files.saf.SAFPath
@@ -60,11 +61,19 @@ class PublicObbModule @Inject constructor(
 
                 try {
                     path.lookup(gatewaySwitch)
-                    true
-                } catch (e: Exception) {
-                    log(TAG, ERROR) { "Failed to lookup $area: ${e.asLog()}" }
-                    false
+                } catch (e: IOException) {
+                    log(TAG, ERROR) { "Failed lookup() for $area: ${e.asLog()}" }
+                    return@filter false
                 }
+
+                try {
+                    path.listFiles(gatewaySwitch)
+                } catch (e: IOException) {
+                    log(TAG, ERROR) { "Failed listFiles() for $area: ${e.asLog()}" }
+                    return@filter false
+                }
+
+                true
             }
             .map { (parentArea, path) ->
                 DataArea(


### PR DESCRIPTION
Potential fix for

```java
2024-02-04T12:34:53.242Z  I/SDMSE:Debug:Log:Recorder:Module: APILEVEL: 34
2024-02-04T12:34:53.242Z  I/SDMSE:Debug:Log:Recorder:Module: Build.FINGERPRINT: samsung/dm2qxeea/dm2q:14/UP1A.231005.007/S916BXXS3BWL3:user/release-keys
2024-02-04T12:34:53.242Z  I/SDMSE:Debug:Log:Recorder:Module: Build.MANUFACTOR: samsung
2024-02-04T12:34:53.242Z  I/SDMSE:Debug:Log:Recorder:Module: Build.BRAND: samsung
2024-02-04T12:34:53.242Z  I/SDMSE:Debug:Log:Recorder:Module: Build.PRODUCT: dm2qxeea
2024-02-04T12:34:53.242Z  I/SDMSE:Debug:Log:Recorder:Module: App: eu.darken.sdmse - 0.19.1-beta0 (1901000) 
2024-02-04T12:34:53.242Z  I/SDMSE:Debug:Log:Recorder:Module: Build: GPLAY-BETA
2024-02-04T12:34:53.244Z  I/SDMSE:Debug:Log:Recorder:Module: App locales: [de_DE]
2024-02-04T12:34:53.244Z  I/SDMSE:Debug:Log:Recorder:Module: Data areas: (2)
2024-02-04T12:34:53.244Z  I/SDMSE:Debug:Log:Recorder:Module: #0 DataArea(path=LocalPath(/storage/emulated/0), type=SDCARD, label=eu.darken.sdmse.common.ca.CaStringKt$caString$1@5e064ba, flags=[PRIMARY], userHandle=UserHandle2(handleId=0))
2024-02-04T12:34:53.244Z  I/SDMSE:Debug:Log:Recorder:Module: #1 DataArea(path=LocalPath(/storage/emulated/0/Android/media), type=PUBLIC_MEDIA, label=eu.darken.sdmse.common.ca.CaStringKt$caString$1@4a01286, flags=[PRIMARY], userHandle=UserHandle2(handleId=0))
```

![Screenshot_20240204_133533_SD Maid SE](https://github.com/d4rken-org/sdmaid-se/assets/1439229/d92e4a1e-f846-4f56-b47f-1c9bca32eb9d)
