### PR TITLE
IO: Improve scan performance with Root & Shizuku

### DIFF
--- a/app-common-io/src/main/aidl/eu/darken/sdmse/common/files/local/ipc/FileOpsConnection.aidl
+++ b/app-common-io/src/main/aidl/eu/darken/sdmse/common/files/local/ipc/FileOpsConnection.aidl
@@ -34,7 +34,7 @@ interface FileOpsConnection {
     List<LocalPathLookupExtended> lookupFilesExtended(in LocalPath path);
     RemoteInputStream lookupFilesExtendedStream(in LocalPath path);
 
-    RemoteInputStream walkStream(in LocalPath path);
+    RemoteInputStream walkStream(in LocalPath path, in List<String> pathDoesNotContain);
 
     boolean createSymlink(in LocalPath linkPath, in LocalPath targetPath);
 

--- a/app-common-io/src/main/aidl/eu/darken/sdmse/common/files/local/ipc/FileOpsConnection.aidl
+++ b/app-common-io/src/main/aidl/eu/darken/sdmse/common/files/local/ipc/FileOpsConnection.aidl
@@ -34,6 +34,8 @@ interface FileOpsConnection {
     List<LocalPathLookupExtended> lookupFilesExtended(in LocalPath path);
     RemoteInputStream lookupFilesExtendedStream(in LocalPath path);
 
+    RemoteInputStream walkStream(in LocalPath path);
+
     boolean createSymlink(in LocalPath linkPath, in LocalPath targetPath);
 
     boolean setModifiedAt(in LocalPath path, in long modifiedAt);

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathExtensions.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathExtensions.kt
@@ -42,9 +42,9 @@ fun APath.asFile(): File = when (this) {
 
 suspend fun <P : APath, PL : APathLookup<P>, PLE : APathLookupExtended<P>, GT : APathGateway<P, PL, PLE>> P.walk(
     gateway: GT,
-    filter: (suspend (PL) -> Boolean)? = null
+    options: APathGateway.WalkOptions<P, PL> = APathGateway.WalkOptions()
 ): Flow<PL> {
-    return gateway.walk(this, filter)
+    return gateway.walk(this, options)
 }
 
 suspend fun <T : APath> T.exists(gateway: APathGateway<T, out APathLookup<T>, out APathLookupExtended<T>>): Boolean {

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathExtensions.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathExtensions.kt
@@ -44,7 +44,7 @@ suspend fun <P : APath, PL : APathLookup<P>, PLE : APathLookupExtended<P>, GT : 
     gateway: GT,
     filter: (suspend (PL) -> Boolean)? = null
 ): Flow<PL> {
-    return PathTreeFlow(gateway, this, filter ?: { true })
+    return gateway.walk(this, filter)
 }
 
 suspend fun <T : APath> T.exists(gateway: APathGateway<T, out APathLookup<T>, out APathLookupExtended<T>>): Boolean {

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathExtensions.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathExtensions.kt
@@ -12,6 +12,7 @@ import eu.darken.sdmse.common.files.saf.crumbsTo
 import eu.darken.sdmse.common.files.saf.isAncestorOf
 import eu.darken.sdmse.common.files.saf.isParentOf
 import eu.darken.sdmse.common.files.saf.startsWith
+import kotlinx.coroutines.flow.Flow
 import okio.Sink
 import okio.Source
 import java.io.File
@@ -39,11 +40,11 @@ fun APath.asFile(): File = when (this) {
     else -> File(this.path)
 }
 
-fun <P : APath, PL : APathLookup<P>, PLE : APathLookupExtended<P>, GT : APathGateway<P, PL, PLE>> P.walk(
+suspend fun <P : APath, PL : APathLookup<P>, PLE : APathLookupExtended<P>, GT : APathGateway<P, PL, PLE>> P.walk(
     gateway: GT,
-    filter: suspend (PL) -> Boolean = { true }
-): PathTreeFlow<P, PL, PLE, GT> {
-    return PathTreeFlow(gateway, this, filter)
+    filter: (suspend (PL) -> Boolean)? = null
+): Flow<PL> {
+    return PathTreeFlow(gateway, this, filter ?: { true })
 }
 
 suspend fun <T : APath> T.exists(gateway: APathGateway<T, out APathLookup<T>, out APathLookupExtended<T>>): Boolean {

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathGateway.kt
@@ -26,9 +26,17 @@ interface APathGateway<
 
     suspend fun walk(
         path: P,
-        onFilter: (suspend (PLU) -> Boolean)? = null,
-        onError: (suspend (PLU, Exception) -> Boolean)? = null
+        options: WalkOptions<P, PLU> = WalkOptions()
     ): Flow<PLU>
+
+    data class WalkOptions<P : APath, PLU : APathLookup<P>>(
+        val pathDoesNotContain: Set<String>? = null,
+        val onFilter: (suspend (PLU) -> Boolean)? = null,
+        val onError: (suspend (PLU, Exception) -> Boolean)? = null
+    ) {
+        val isDirect: Boolean
+            get() = onFilter == null && onError == null
+    }
 
     suspend fun exists(path: P): Boolean
 

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathGateway.kt
@@ -1,6 +1,7 @@
 package eu.darken.sdmse.common.files
 
 import eu.darken.sdmse.common.sharedresource.HasSharedResource
+import kotlinx.coroutines.flow.Flow
 import okio.Sink
 import okio.Source
 import java.time.Instant
@@ -22,6 +23,12 @@ interface APathGateway<
     suspend fun lookupFiles(path: P): Collection<PLU>
 
     suspend fun lookupFilesExtended(path: P): Collection<PLUE>
+
+    suspend fun walk(
+        path: P,
+        onFilter: (suspend (PLU) -> Boolean)? = null,
+        onError: (suspend (PLU, Exception) -> Boolean)? = null
+    ): Flow<PLU>
 
     suspend fun exists(path: P): Boolean
 

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathLookupExtensions.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathLookupExtensions.kt
@@ -18,8 +18,8 @@ val APathLookup<*>.isFile: Boolean
 
 suspend fun <P : APath, PL : APathLookup<P>, PLE : APathLookupExtended<P>, GT : APathGateway<P, PL, PLE>> PL.walk(
     gateway: GT,
-    filter: (suspend (PL) -> Boolean)? = null
-): Flow<PL> = lookedUp.walk(gateway, filter)
+    options: APathGateway.WalkOptions<P, PL> = APathGateway.WalkOptions()
+): Flow<PL> = lookedUp.walk(gateway, options)
 
 suspend fun <P : APath, PL : APathLookup<P>> PL.exists(
     gateway: APathGateway<P, out APathLookup<P>, out APathLookupExtended<P>>

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathLookupExtensions.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathLookupExtensions.kt
@@ -2,6 +2,7 @@ package eu.darken.sdmse.common.files
 
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.log
+import kotlinx.coroutines.flow.Flow
 import okio.Sink
 import okio.Source
 
@@ -15,10 +16,10 @@ val APathLookup<*>.isSymlink: Boolean
 val APathLookup<*>.isFile: Boolean
     get() = fileType == FileType.FILE
 
-fun <P : APath, PL : APathLookup<P>, PLE : APathLookupExtended<P>, GT : APathGateway<P, PL, PLE>> PL.walk(
+suspend fun <P : APath, PL : APathLookup<P>, PLE : APathLookupExtended<P>, GT : APathGateway<P, PL, PLE>> PL.walk(
     gateway: GT,
-    filter: suspend (PL) -> Boolean = { true }
-): PathTreeFlow<P, PL, PLE, GT> = lookedUp.walk(gateway, filter)
+    filter: (suspend (PL) -> Boolean)? = null
+): Flow<PL> = lookedUp.walk(gateway, filter)
 
 suspend fun <P : APath, PL : APathLookup<P>> PL.exists(
     gateway: APathGateway<P, out APathLookup<P>, out APathLookupExtended<P>>

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/GatewaySwitch.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/GatewaySwitch.kt
@@ -11,7 +11,7 @@ import eu.darken.sdmse.common.sharedresource.SharedResource
 import eu.darken.sdmse.common.sharedresource.adoptChildResource
 import eu.darken.sdmse.common.storage.PathMapper
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.plus
 import okio.IOException
 import okio.Sink
@@ -104,6 +104,14 @@ class GatewaySwitch @Inject constructor(
         return useGateway(path) { lookupFilesExtended(path) }
     }
 
+    override suspend fun walk(
+        path: APath,
+        filter: (suspend (APathLookup<APath>) -> Boolean)?,
+        onError: (suspend (APathLookup<APath>, Exception) -> Boolean)?
+    ): Flow<APathLookup<APath>> {
+        return useGateway(path) { walk(path, filter, onError) }
+    }
+
     override suspend fun listFiles(path: APath): Collection<APath> {
         return useGateway(path) { listFiles(path) }
     }
@@ -158,11 +166,6 @@ class GatewaySwitch @Inject constructor(
 
     override suspend fun setOwnership(path: APath, ownership: Ownership): Boolean {
         return useGateway(path) { setOwnership(path, ownership) }
-    }
-
-    suspend fun walk(path: APath): Collection<APathLookup<APath>> {
-        // TODO use safMapper to change path types if error occurs?
-        return path.walk(this).toList()
     }
 
     private suspend fun APath.toTargetType(type: Type): APath = when (type) {

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/GatewaySwitch.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/GatewaySwitch.kt
@@ -106,10 +106,9 @@ class GatewaySwitch @Inject constructor(
 
     override suspend fun walk(
         path: APath,
-        filter: (suspend (APathLookup<APath>) -> Boolean)?,
-        onError: (suspend (APathLookup<APath>, Exception) -> Boolean)?
+        options: APathGateway.WalkOptions<APath, APathLookup<APath>>
     ): Flow<APathLookup<APath>> {
-        return useGateway(path) { walk(path, filter, onError) }
+        return useGateway(path) { walk(path, options) }
     }
 
     override suspend fun listFiles(path: APath): Collection<APath> {

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/PathTreeFlow.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/PathTreeFlow.kt
@@ -52,13 +52,15 @@ class PathTreeFlow<
                 .filter {
                     val allowed = onFilter(it)
                     if (Bugs.isTrace) {
-                        if (allowed) log(tag, VERBOSE) { "Walking: $it" }
-                        else log(tag, VERBOSE) { "Not walking (filter): $it" }
+                        if (!allowed) log(tag, VERBOSE) { "Skipping (filter): $it" }
                     }
                     allowed
                 }
                 .forEach { child ->
-                    if (child.isDirectory) queue.addFirst(child)
+                    if (child.isDirectory) {
+                        if (Bugs.isTrace) log(tag, VERBOSE) { "Walking: $child" }
+                        queue.addFirst(child)
+                    }
                     collector.emit(child)
                 }
         }

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/PathWalker.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/PathWalker.kt
@@ -12,7 +12,7 @@ import java.util.LinkedList
 
 // TODO support symlinks?
 // TODO unit test coverage
-class PathTreeFlow<
+class PathWalker<
         P : APath,
         PL : APathLookup<P>,
         PLE : APathLookupExtended<P>,

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/DirectLocalWalker.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/DirectLocalWalker.kt
@@ -1,0 +1,73 @@
+package eu.darken.sdmse.common.files.local
+
+import eu.darken.sdmse.common.debug.Bugs
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.files.asFile
+import eu.darken.sdmse.common.files.core.local.listFiles2
+import eu.darken.sdmse.common.files.isDirectory
+import eu.darken.sdmse.common.files.isFile
+import kotlinx.coroutines.flow.AbstractFlow
+import kotlinx.coroutines.flow.FlowCollector
+import java.io.IOException
+import java.util.LinkedList
+
+// TODO support symlinks?
+// TODO unit test coverage
+class DirectLocalWalker constructor(
+    private val start: LocalPath,
+    private val onFilter: suspend (LocalPathLookup) -> Boolean,
+    private val onError: suspend (LocalPathLookup, Exception) -> Boolean,
+) : AbstractFlow<LocalPathLookup>() {
+    private val tag = "$TAG#${hashCode()}"
+
+    override suspend fun collectSafely(collector: FlowCollector<LocalPathLookup>) {
+        val startLookUp = start.performLookup()
+        if (startLookUp.isFile) {
+            collector.emit(startLookUp)
+            return
+        }
+
+        val queue = LinkedList(listOf(startLookUp))
+
+        while (!queue.isEmpty()) {
+
+            val lookUp = queue.removeFirst()
+
+            val newBatch = try {
+                lookUp.lookedUp.asFile()
+                    .listFiles2()
+                    .map { it.toLocalPath().performLookup() }
+            } catch (e: IOException) {
+                log(TAG, ERROR) { "Failed to read $lookUp: $e" }
+                if (onError(lookUp, e)) {
+                    emptyList()
+                } else {
+                    throw e
+                }
+            }
+
+            newBatch
+                .filter {
+                    val allowed = onFilter(it)
+                    if (Bugs.isTrace) {
+                        if (!allowed) log(tag, VERBOSE) { "Skipping (filter): $it" }
+                    }
+                    allowed
+                }
+                .forEach { child ->
+                    if (child.isDirectory) {
+                        if (Bugs.isTrace) log(tag, VERBOSE) { "Walking: $child" }
+                        queue.addFirst(child)
+                    }
+                    collector.emit(child)
+                }
+        }
+    }
+
+    companion object {
+        private val TAG = logTag("Gateway", "Local", "Walker")
+    }
+}

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/DirectLocalWalker.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/DirectLocalWalker.kt
@@ -18,7 +18,7 @@ import java.util.LinkedList
 // TODO unit test coverage
 class DirectLocalWalker constructor(
     private val start: LocalPath,
-    private val onFilter: suspend (LocalPathLookup) -> Boolean,
+    private val onFilter: suspend (LocalPathLookup) -> Boolean = { true },
     private val onError: suspend (LocalPathLookup, Exception) -> Boolean = { _, _ -> true },
 ) : AbstractFlow<LocalPathLookup>() {
     private val tag = "$TAG#${hashCode()}"

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/EscalatingWalker.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/EscalatingWalker.kt
@@ -18,6 +18,9 @@ import java.util.LinkedList
 
 // TODO support symlinks?
 // TODO unit test coerage
+/**
+ * Prevents unnecessary lookups in Mode.NORMAL for nested directories
+ */
 class EscalatingWalker constructor(
     private val gateway: LocalGateway,
     private val start: LocalPath,

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/EscalatingWalker.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/EscalatingWalker.kt
@@ -1,0 +1,101 @@
+package eu.darken.sdmse.common.files.local
+
+import eu.darken.sdmse.common.debug.Bugs
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.DEBUG
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.files.asFile
+import eu.darken.sdmse.common.files.core.local.listFiles2
+import eu.darken.sdmse.common.files.isDirectory
+import eu.darken.sdmse.common.files.isFile
+import kotlinx.coroutines.flow.AbstractFlow
+import kotlinx.coroutines.flow.FlowCollector
+import java.io.IOException
+import java.util.LinkedList
+
+// TODO support symlinks?
+// TODO unit test coerage
+class EscalatingWalker constructor(
+    private val gateway: LocalGateway,
+    private val start: LocalPath,
+    private val onFilter: suspend (LocalPathLookup) -> Boolean = { true },
+    private val onError: suspend (LocalPathLookup, Exception) -> Boolean = { _, _ -> true }
+) : AbstractFlow<LocalPathLookup>() {
+    private val tag = "$TAG#${hashCode()}"
+
+    override suspend fun collectSafely(collector: FlowCollector<LocalPathLookup>) {
+        val startLookUp = gateway.lookup(start)
+
+        if (startLookUp.isFile) {
+            collector.emit(startLookUp)
+            return
+        }
+
+        val escalationMode = when {
+            gateway.hasRoot() -> LocalGateway.Mode.ROOT
+            gateway.hasShizuku() -> LocalGateway.Mode.ADB
+            else -> null
+        }
+
+        val queue = LinkedList(listOf(startLookUp))
+
+        suspend fun Collection<LocalPathLookup>.process() = this
+            .filter {
+                val allowed = onFilter(it)
+                if (Bugs.isTrace) {
+                    if (!allowed) log(tag, VERBOSE) { "Skipping (filter): $it" }
+                }
+                allowed
+            }
+            .forEach { child ->
+                if (child.isDirectory) {
+                    if (Bugs.isTrace) log(tag, VERBOSE) { "Walking: $child" }
+                    queue.addFirst(child)
+                }
+                collector.emit(child)
+            }
+
+        while (!queue.isEmpty()) {
+            val lookUp = queue.removeFirst()
+            var blockingError: Exception? = null
+
+            try {
+                lookUp.lookedUp.asFile()
+                    .listFiles2()
+                    .map { it.toLocalPath().performLookup() }
+                    .process()
+                continue
+            } catch (e: IOException) {
+                blockingError = e
+            }
+
+            if (escalationMode != null) {
+                log(TAG, VERBOSE) { "Escalating to $escalationMode for $lookUp" }
+                try {
+                    gateway
+                        .lookupFiles(lookUp.lookedUp, escalationMode)
+                        .process()
+                    continue
+                } catch (e: IOException) {
+                    log(TAG, DEBUG) { "Failed to read despite escalation ($escalationMode) $lookUp: $e" }
+                    blockingError = e
+                }
+            }
+
+            if (blockingError != null) {
+                log(TAG, WARN) { "Failed to read $lookUp: $blockingError" }
+                if (onError(lookUp, blockingError)) {
+                    continue
+                } else {
+                    throw blockingError
+                }
+            }
+        }
+    }
+
+    companion object {
+        private val TAG = logTag("Gateway", "Local", "Walker", "Escalating")
+    }
+}

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/EscalatingWalker.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/EscalatingWalker.kt
@@ -57,8 +57,8 @@ class EscalatingWalker constructor(
                             .map { it.toLocalPath().performLookup() }
                             .filter {
                                 val allowed = options.onFilter?.invoke(it) ?: true
-                                if (Bugs.isTrace) {
-                                    if (!allowed) log(tag, VERBOSE) { "Skipping (filter): $it" }
+                                if (Bugs.isTrace && !allowed) {
+                                    log(tag, VERBOSE) { "Skipping (filter): $it" }
                                 }
                                 allowed
                             }
@@ -85,9 +85,7 @@ class EscalatingWalker constructor(
                                 mode = item.targetMode
                             )
                             .collect { child ->
-                                if (child.isDirectory) {
-                                    queue.addFirst(item.toSubItem(child))
-                                }
+                                // `walk` already processes all subdirectories, no need to queue them again
                                 collector.emit(child)
                             }
                         continue

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/EscalatingWalker.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/EscalatingWalker.kt
@@ -6,6 +6,7 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.files.APathGateway
 import eu.darken.sdmse.common.files.asFile
 import eu.darken.sdmse.common.files.core.local.listFiles2
 import eu.darken.sdmse.common.files.isDirectory
@@ -20,8 +21,7 @@ import java.util.LinkedList
 class EscalatingWalker constructor(
     private val gateway: LocalGateway,
     private val start: LocalPath,
-    private val onFilter: suspend (LocalPathLookup) -> Boolean = { true },
-    private val onError: suspend (LocalPathLookup, Exception) -> Boolean = { _, _ -> true }
+    private val options: APathGateway.WalkOptions<LocalPath, LocalPathLookup>,
 ) : AbstractFlow<LocalPathLookup>() {
     private val tag = "$TAG#${hashCode()}"
 
@@ -39,60 +39,82 @@ class EscalatingWalker constructor(
             else -> null
         }
 
-        val queue = LinkedList(listOf(startLookUp))
-
-        suspend fun Collection<LocalPathLookup>.process() = this
-            .filter {
-                val allowed = onFilter(it)
-                if (Bugs.isTrace) {
-                    if (!allowed) log(tag, VERBOSE) { "Skipping (filter): $it" }
-                }
-                allowed
-            }
-            .forEach { child ->
-                if (child.isDirectory) {
-                    if (Bugs.isTrace) log(tag, VERBOSE) { "Walking: $child" }
-                    queue.addFirst(child)
-                }
-                collector.emit(child)
-            }
+        val queue = LinkedList<QueuedItem>().apply {
+            add(QueuedItem(startLookUp, LocalGateway.Mode.NORMAL))
+        }
 
         while (!queue.isEmpty()) {
-            val lookUp = queue.removeFirst()
-            var blockingError: Exception? = null
+            val item = queue.removeFirst()
 
-            try {
-                lookUp.lookedUp.asFile()
-                    .listFiles2()
-                    .map { it.toLocalPath().performLookup() }
-                    .process()
-                continue
-            } catch (e: IOException) {
-                blockingError = e
-            }
-
-            if (escalationMode != null) {
-                log(TAG, VERBOSE) { "Escalating to $escalationMode for $lookUp" }
-                try {
-                    gateway
-                        .lookupFiles(lookUp.lookedUp, escalationMode)
-                        .process()
-                    continue
-                } catch (e: IOException) {
-                    log(TAG, DEBUG) { "Failed to read despite escalation ($escalationMode) $lookUp: $e" }
-                    blockingError = e
+            when {
+                item.targetMode == LocalGateway.Mode.NORMAL -> {
+                    try {
+                        item.target.lookedUp.asFile()
+                            .listFiles2()
+                            .map { it.toLocalPath().performLookup() }
+                            .filter {
+                                val allowed = options.onFilter?.invoke(it) ?: true
+                                if (Bugs.isTrace) {
+                                    if (!allowed) log(tag, VERBOSE) { "Skipping (filter): $it" }
+                                }
+                                allowed
+                            }
+                            .forEach { child ->
+                                if (child.isDirectory) {
+                                    if (Bugs.isTrace) log(tag, VERBOSE) { "Walking: $child" }
+                                    queue.addFirst(item.toSubItem(child))
+                                }
+                                collector.emit(child)
+                            }
+                        continue
+                    } catch (e: IOException) {
+                        log(TAG, VERBOSE) { "Escalating ${item.target.lookedUp} to $escalationMode due to: $e" }
+                        queue.addFirst(item.copy(targetMode = escalationMode, error = e))
+                    }
                 }
-            }
 
-            if (blockingError != null) {
-                log(TAG, WARN) { "Failed to read $lookUp: $blockingError" }
-                if (onError(lookUp, blockingError)) {
-                    continue
-                } else {
-                    throw blockingError
+                item.targetMode == LocalGateway.Mode.ROOT || item.targetMode == LocalGateway.Mode.ADB -> {
+                    try {
+                        gateway
+                            .walk(
+                                path = item.target.lookedUp,
+                                options = options,
+                                mode = item.targetMode
+                            )
+                            .collect { child ->
+                                if (child.isDirectory) {
+                                    queue.addFirst(item.toSubItem(child))
+                                }
+                                collector.emit(child)
+                            }
+                        continue
+                    } catch (e: IOException) {
+                        log(TAG, DEBUG) { "Failed to read despite escalation: ${item.target.lookedUp}: $e" }
+                        queue.addFirst(item.copy(targetMode = null, error = e))
+                    }
+                }
+
+                item.error != null -> {
+                    log(TAG, WARN) { "Failed to read ${item.target}: ${item.error}" }
+                    if (options.onError?.invoke(item.target, item.error) != false) {
+                        continue
+                    } else {
+                        throw item.error
+                    }
                 }
             }
         }
+    }
+
+    data class QueuedItem(
+        val target: LocalPathLookup,
+        val targetMode: LocalGateway.Mode? = LocalGateway.Mode.NORMAL,
+        val error: IOException? = null,
+    ) {
+        fun toSubItem(target: LocalPathLookup) = copy(
+            target = target,
+            error = null,
+        )
     }
 
     companion object {

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalGateway.kt
@@ -402,14 +402,14 @@ class LocalGateway @Inject constructor(
                 mode == Mode.NORMAL || canRead && mode == Mode.AUTO -> {
                     log(TAG, VERBOSE) { "walk($mode->NORMAL, direct): $path" }
                     if (!canRead) throw ReadException(path)
-                    DirectLocalWalker(
+                    // The `canRead` check for Mode.NORMAL can return true even if we lack permissions for subdirectories
+                    // We need the indirect walker here to be able to escalate to other available modes
+                    IndirectLocalWalker(
+                        gateway = this@LocalGateway,
+                        mode = Mode.AUTO,
                         start = path,
-                        onFilter = { file: LocalPathLookup ->
-                            options.onFilter?.invoke(file) ?: true
-                        },
-                        onError = { file: LocalPathLookup, exception: Exception ->
-                            options.onError?.invoke(file, exception) ?: true
-                        }
+                        onFilter = { lookup -> options.onFilter?.invoke(lookup) ?: true },
+                        onError = { lookup, exception -> options.onError?.invoke(lookup, exception) ?: true },
                     )
                 }
 

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalGateway.kt
@@ -405,8 +405,7 @@ class LocalGateway @Inject constructor(
                     EscalatingWalker(
                         gateway = this@LocalGateway,
                         start = path,
-                        onFilter = { lookup -> options.onFilter?.invoke(lookup) ?: true },
-                        onError = { lookup, exception -> options.onError?.invoke(lookup, exception) ?: true },
+                        options = options,
                     )
                 }
 

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalGateway.kt
@@ -399,9 +399,18 @@ class LocalGateway @Inject constructor(
             }
 
             when {
-                mode == Mode.NORMAL || canRead && mode == Mode.AUTO -> {
+                mode == Mode.NORMAL -> {
                     log(TAG, VERBOSE) { "walk($mode->NORMAL, direct): $path" }
                     if (!canRead) throw ReadException(path)
+                    DirectLocalWalker(
+                        start = path,
+                        onFilter = { lookup -> options.onFilter?.invoke(lookup) ?: true },
+                        onError = { lookup, exception -> options.onError?.invoke(lookup, exception) ?: true },
+                    )
+                }
+
+                canRead && mode == Mode.AUTO -> {
+                    log(TAG, VERBOSE) { "walk($mode->NORMAL, direct): $path" }
                     EscalatingWalker(
                         gateway = this@LocalGateway,
                         start = path,

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/FileOpsClient.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/FileOpsClient.kt
@@ -85,6 +85,17 @@ class FileOpsClient @AssistedInject constructor(
         throw e.toFakeIOException()
     }
 
+    /**
+     * Doesn't run into IPC buffer overflows on large directories
+     */
+    fun walk(path: LocalPath): Collection<LocalPathLookup> = try {
+        fileOpsConnection.walkStream(path).toLocalPathLookups().also {
+            if (Bugs.isTrace) log(TAG, VERBOSE) { "walk($path) finished streaming, ${it.size} items" }
+        }
+    } catch (e: Exception) {
+        throw e.toFakeIOException()
+    }
+
     fun readFile(path: LocalPath): Source = try {
         fileOpsConnection.readFile(path).source()
     } catch (e: Exception) {

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/FileOpsHost.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/FileOpsHost.kt
@@ -119,13 +119,14 @@ class FileOpsHost @Inject constructor(
         throw wrapPropagating(e)
     }
 
-    override fun walkStream(path: LocalPath): RemoteInputStream = try {
+    override fun walkStream(path: LocalPath, pathDoesNotContain: List<String>): RemoteInputStream = try {
         if (Bugs.isTrace) log(TAG, VERBOSE) { "walkStream($path)..." }
         runBlocking {
             DirectLocalWalker(
                 start = path,
-                onFilter = { true },
-                onError = { _, _ -> true }
+                onFilter = { lookup ->
+                    pathDoesNotContain.none { lookup.path.contains(it) }
+                },
             )
                 .toList()
         }.toRemoteInputStream()

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/AppScanner.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/AppScanner.kt
@@ -25,6 +25,7 @@ import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.files.APathGateway
 import eu.darken.sdmse.common.files.APathLookup
 import eu.darken.sdmse.common.files.FileType
 import eu.darken.sdmse.common.files.GatewaySwitch
@@ -405,13 +406,12 @@ class AppScanner @Inject constructor(
                 searchPath.file
                     .walk(
                         gatewaySwitch,
-                        filter = {
-                            when {
-                                it.path.contains("/org.winehq.wine/files/prefix") -> false
-                                it.path.contains("/.wine/") -> false
-                                else -> true
-                            }
-                        }
+                        options = APathGateway.WalkOptions(
+                            pathDoesNotContain = setOf(
+                                "/org.winehq.wine/files/prefix",
+                                "/.wine/",
+                            )
+                        )
                     )
                     .toList()
             } catch (e: IOException) {

--- a/app/src/main/java/eu/darken/sdmse/common/debug/DebugCardProvider.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/debug/DebugCardProvider.kt
@@ -8,13 +8,14 @@ import eu.darken.sdmse.common.datastore.valueBlocking
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.GatewaySwitch
+import eu.darken.sdmse.common.files.local.toLocalPath
+import eu.darken.sdmse.common.files.walk
 import eu.darken.sdmse.common.navigation.navVia
 import eu.darken.sdmse.common.pkgs.PkgRepo
 import eu.darken.sdmse.common.pkgs.pkgops.PkgOps
 import eu.darken.sdmse.common.root.RootManager
 import eu.darken.sdmse.common.root.RootSettings
 import eu.darken.sdmse.common.root.service.RootServiceClient
-import eu.darken.sdmse.common.sharedresource.useRes
 import eu.darken.sdmse.common.shell.ShellOps
 import eu.darken.sdmse.common.shell.ipc.ShellOpsCmd
 import eu.darken.sdmse.common.shizuku.ShizukuManager
@@ -25,11 +26,12 @@ import eu.darken.sdmse.common.uix.ViewModel3
 import eu.darken.sdmse.main.ui.dashboard.DashboardFragmentDirections
 import eu.darken.sdmse.main.ui.dashboard.items.DebugCardVH
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.withTimeoutOrNull
+import java.io.File
 import java.util.UUID
 import javax.inject.Inject
 
@@ -143,18 +145,15 @@ class DebugCardProvider @Inject constructor(
             },
             onRunTest = {
                 vm.launch {
-                    shizukuClient.useRes {
-                        val base = it.ipc.pkgOps.forceStop("com.android.vending")
-                        log(TAG) { "###BASE Shizuku: $base" }
-                        delay(10 * 60 * 1000L)
-                    }
-                }
-                vm.launch {
-                    rootClient.useRes {
-                        val base = it.ipc.pkgOps.forceStop("com.android.vending")
-                        log(TAG) { "###BASE Root: $base" }
-                        delay(10 * 60 * 1000L)
-                    }
+                    File("/data/system/graphicsstats")
+                        .toLocalPath()
+                        .walk(
+                            gatewaySwitch
+                        )
+                        .toList()
+                        .forEach {
+                            log(TAG) { "###TEST walked: $it" }
+                        }
                 }
             }
         )

--- a/app/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/SdcardCorpseFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/SdcardCorpseFilter.kt
@@ -188,7 +188,9 @@ class SdcardCorpseFilter @Inject constructor(
             // <sdcard(level0|1)>/(level1|2)/(level2|3)/(level3|4)/corpse
             val files = candidateResolved.walk(
                 gatewaySwitch,
-                filter = { item -> item.segments.size <= (4 + area.path.segments.size) }
+                options = APathGateway.WalkOptions(
+                    onFilter = { item -> item.segments.size <= (4 + area.path.segments.size) }
+                )
             )
                 .onEach { log(TAG, INFO) { "Walking: $it" } }
                 .toList()

--- a/app/src/main/java/eu/darken/sdmse/deduplicator/core/scanner/checksum/ChecksumSleuth.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/core/scanner/checksum/ChecksumSleuth.kt
@@ -19,6 +19,7 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.files.APathGateway
 import eu.darken.sdmse.common.files.APathLookup
 import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.Segments
@@ -132,7 +133,12 @@ class ChecksumSleuth @Inject constructor(
                             exclusions.none { it.match(toCheck) }
                         }
                     }
-                    area.path.walk(gatewaySwitch, filter)
+                    area.path.walk(
+                        gatewaySwitch,
+                        options = APathGateway.WalkOptions(
+                            onFilter = filter
+                        )
+                    )
                 }
                 .buffer(1024)
                 .filter {

--- a/app/src/main/java/eu/darken/sdmse/deduplicator/core/scanner/phash/PHashSleuth.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/core/scanner/phash/PHashSleuth.kt
@@ -25,6 +25,7 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.files.APathGateway
 import eu.darken.sdmse.common.files.APathLookup
 import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.Segments
@@ -143,7 +144,12 @@ class PHashSleuth @Inject constructor(
                             exclusions.none { it.match(toCheck) }
                         }
                     }
-                    area.path.walk(gatewaySwitch, filter)
+                    area.path.walk(
+                        gatewaySwitch,
+                        options = APathGateway.WalkOptions(
+                            onFilter = filter,
+                        )
+                    )
                 }
                 .buffer(1024)
                 .filter {

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/SystemCrawler.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/SystemCrawler.kt
@@ -12,6 +12,7 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.files.APathGateway
 import eu.darken.sdmse.common.files.APathLookup
 import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.Segments
@@ -115,7 +116,12 @@ class SystemCrawler @Inject constructor(
                             exclusions.none { it.match(toCheck) }
                         }
                     }
-                    area.path.walk(gatewaySwitch, filter).map { area to it }
+                    area.path.walk(
+                        gatewaySwitch,
+                        options = APathGateway.WalkOptions(
+                            onFilter = filter
+                        )
+                    ).map { area to it }
                 }
                 .buffer(1024)
                 .collect { (area, item) ->


### PR DESCRIPTION
Less back and forth between SD Maid and root/shizuku processes when traversing nested directories. If we handle all the traversing on one side (in one process) then we don't have to proxy extra calls for each directory through the IPC buffer. 🥳 

TODO: Some of the access type mechanisms fail when with this optimisation, i.e. tries NORMAL, but not ADB when in `Mode.AUTO` 🤔 