### PR TITLE
ACS: Prevent platform bug that can cause ACS to crash and deactivate

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/common/InjectionHelpers.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/InjectionHelpers.kt
@@ -1,0 +1,9 @@
+package eu.darken.sdmse.common
+
+import android.app.Service
+import dagger.hilt.internal.GeneratedComponentManager
+import eu.darken.sdmse.App
+
+fun Service.isValidAndroidEntryPoint(): Boolean {
+    return application is GeneratedComponentManager<*> || application is App
+}


### PR DESCRIPTION
Check if we are launched by a 3rd party and if we are, don't init and abort early. Crashing repeatedly could block the ACS from being launched until reboot. This can happen if the app is launched in a `restricted` mode by the system.

e.g.

```java
Exception java.lang.RuntimeException:
  at android.app.ActivityThread.handleCreateService (ActivityThread.java:4681)
  at android.app.ActivityThread.access$100 (ActivityThread.java:255)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:2204)
  at android.os.Handler.dispatchMessage (Handler.java:106)
  at android.os.Looper.loopOnce (Looper.java:238)
  at android.os.Looper.loop (Looper.java:349)
  at android.app.ActivityThread.main (ActivityThread.java:8262)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:584)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1034)
Caused by java.lang.IllegalStateException: Hilt service must be attached to an @AndroidEntryPoint Application. Found: class android.app.Application
  at dagger.hilt.internal.Preconditions.checkState (Preconditions.java:2)
  at dagger.hilt.android.internal.managers.ServiceComponentManager.generatedComponent (ServiceComponentManager.java)
  at eu.darken.sdmse.automation.core.Hilt_AutomationService.generatedComponent (Hilt_AutomationService.java)
  at eu.darken.sdmse.automation.core.Hilt_AutomationService.inject (Hilt_AutomationService.java)
  at eu.darken.sdmse.automation.core.Hilt_AutomationService.onCreate (Hilt_AutomationService.java)
  at eu.darken.sdmse.automation.core.AutomationService.onCreate (AutomationService.java)
  at android.app.ActivityThread.handleCreateService (ActivityThread.java:4668)
```