### PR TITLE
AppControl: Add feature that allows exporting APKs and split APKs

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/saf/DocumentFileExtensions.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/saf/DocumentFileExtensions.kt
@@ -16,7 +16,7 @@ import java.io.IOException
 import java.util.Date
 
 
-internal enum class FileMode constructor(val value: String) {
+enum class FileMode constructor(val value: String) {
     WRITE("w"), READ("r")
 }
 

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/saf/SAFDocFile.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/saf/SAFDocFile.kt
@@ -198,7 +198,7 @@ data class SAFDocFile(
         }
     }
 
-    internal fun openPFD(contentResolver: ContentResolver, mode: FileMode): ParcelFileDescriptor {
+    fun openPFD(contentResolver: ContentResolver, mode: FileMode): ParcelFileDescriptor {
         return contentResolver.openFileDescriptor(uri, mode.value) ?: throw IOException("Couldn't open $uri")
     }
 

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/features/Installed.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/features/Installed.kt
@@ -17,6 +17,9 @@ interface Installed : PkgInfo {
     val sourceDir: APath?
         get() = applicationInfo?.sourceDir?.let { LocalPath.build(it) }
 
+    val splitSources: Set<APath>?
+        get() = applicationInfo?.splitSourceDirs?.map { LocalPath.build(it) }?.toSet()
+
     @Parcelize
     data class InstallId(
         val pkgId: Pkg.Id,

--- a/app-common/src/main/res/values/strings.xml
+++ b/app-common/src/main/res/values/strings.xml
@@ -118,6 +118,14 @@
         <item quantity="one">%s item</item>
         <item quantity="other">%s items</item>
     </plurals>
+    <plurals name="result_x_successful">
+        <item quantity="one">%d successful</item>
+        <item quantity="other">%d successful</item>
+    </plurals>
+    <plurals name="result_x_failed">
+        <item quantity="one">%d failed</item>
+        <item quantity="other">%d failed</item>
+    </plurals>
     <string name="x_space_can_be_freed">%s can be freed</string>
     <string name="general_info_label">Info</string>
     <string name="general_count_label">Count</string>

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/AppInfo.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/AppInfo.kt
@@ -1,7 +1,9 @@
 package eu.darken.sdmse.appcontrol.core
 
+import eu.darken.sdmse.appcontrol.core.export.AppExportType
 import eu.darken.sdmse.common.ca.CaString
 import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.isNotNullOrEmpty
 import eu.darken.sdmse.common.pkgs.Pkg
 import eu.darken.sdmse.common.pkgs.features.Installed
 import eu.darken.sdmse.common.pkgs.pkgops.PkgOps
@@ -19,4 +21,10 @@ data class AppInfo(
 
     val installId: Installed.InstallId
         get() = pkg.installId
+
+    val exportType: AppExportType
+        get() = when {
+            pkg.splitSources.isNotNullOrEmpty() -> AppExportType.BUNDLE
+            else -> AppExportType.APK
+        }
 }

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/export/AppExportTask.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/export/AppExportTask.kt
@@ -1,0 +1,24 @@
+package eu.darken.sdmse.appcontrol.core.export
+
+import android.net.Uri
+import eu.darken.sdmse.appcontrol.core.AppControlTask
+import eu.darken.sdmse.common.ca.CaString
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.pkgs.features.Installed
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class AppExportTask(
+    val targets: Set<Installed.InstallId> = emptySet(),
+    val savePath: Uri,
+) : AppControlTask {
+
+    @Parcelize
+    data class Result(
+        val success: Set<AppExporter.Result>,
+        val failed: Set<Installed.InstallId>,
+    ) : AppControlTask.Result {
+        override val primaryInfo: CaString
+            get() = eu.darken.sdmse.common.R.string.general_result_success_message.toCaString()
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/export/AppExportType.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/export/AppExportType.kt
@@ -1,0 +1,6 @@
+package eu.darken.sdmse.appcontrol.core.export
+
+enum class AppExportType {
+    APK,
+    BUNDLE,
+}

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/export/AppExporter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/export/AppExporter.kt
@@ -1,0 +1,144 @@
+package eu.darken.sdmse.appcontrol.core.export
+
+import android.content.ContentResolver
+import android.content.Context
+import android.net.Uri
+import android.os.ParcelFileDescriptor
+import android.os.Parcelable
+import dagger.Reusable
+import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.sdmse.appcontrol.core.AppInfo
+import eu.darken.sdmse.common.MimeTypes
+import eu.darken.sdmse.common.R
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.compression.Zipper
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.files.asFile
+import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.files.saf.FileMode
+import eu.darken.sdmse.common.files.saf.SAFDocFile
+import eu.darken.sdmse.common.flow.throttleLatest
+import eu.darken.sdmse.common.pkgs.features.Installed
+import eu.darken.sdmse.common.progress.Progress
+import eu.darken.sdmse.common.progress.updateProgressPrimary
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.parcelize.Parcelize
+import okio.IOException
+import okio.buffer
+import okio.sink
+import okio.source
+import java.io.BufferedInputStream
+import java.io.FileInputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import javax.inject.Inject
+
+@Reusable
+class AppExporter @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val contentResolver: ContentResolver,
+) : Progress.Host, Progress.Client {
+
+    private val progressPub = MutableStateFlow<Progress.Data?>(
+        Progress.Data(primary = R.string.general_progress_preparing.toCaString())
+    )
+
+    override val progress: Flow<Progress.Data?> = progressPub.throttleLatest(50)
+
+    override fun updateProgress(update: (Progress.Data?) -> Progress.Data?) {
+        progressPub.value = update(progressPub.value)
+    }
+
+    suspend fun save(target: AppInfo, directoryUri: Uri): Result {
+        log(TAG) { "save(target=$target, $directoryUri)" }
+
+        val baseApk = target.pkg.sourceDir
+        log(TAG) { "Base APK is $baseApk" }
+
+        val extraSources = target.pkg.splitSources
+        log(TAG) { "Split sources are $extraSources" }
+
+
+        val name = "${target.label.get(context)} (${target.installId.pkgId.name})"
+        val version = "${target.pkg.versionName}[${target.pkg.versionCode}]"
+        val extension = when (target.exportType) {
+            AppExportType.APK -> "apk"
+            AppExportType.BUNDLE -> "apks"
+        }
+        val finalName = "$name - $version.$extension"
+
+        val saveDir = SAFDocFile.fromTreeUri(context, contentResolver, directoryUri)
+
+        val existing = saveDir.findFile(finalName)
+        if (existing?.exists == true) log(TAG, WARN) { "Already exists: ${existing.uri}" }
+
+        // This, or the underlying SAF implementation, appends "(1)" if the file already exists
+        val savePath = saveDir.createFile(MimeTypes.Zip.value, finalName)
+        if (!savePath.writable) throw IOException("$savePath is not writable")
+
+        val pfd = savePath
+            .openPFD(contentResolver, FileMode.WRITE)
+            .let { ParcelFileDescriptor.AutoCloseOutputStream(it) }
+
+        when (target.exportType) {
+            AppExportType.APK -> {
+                if (baseApk == null) throw IllegalStateException("APK file unavilable")
+                updateProgressPrimary(baseApk.userReadablePath)
+                pfd.sink().buffer().use { sink ->
+                    (baseApk as LocalPath).file.source().buffer().use { source ->
+                        sink.writeAll(source)
+                    }
+                }
+            }
+
+            AppExportType.BUNDLE -> { // Create ZIP
+                val entries = mutableSetOf<APath>()
+                if (baseApk != null) entries.add(baseApk)
+                if (extraSources != null) entries.addAll(extraSources)
+
+                if (entries.isEmpty()) throw IllegalStateException("BUNDLE is empty")
+
+                ZipOutputStream(pfd.sink().buffer().outputStream()).use { zipOut ->
+                    entries.forEach { file ->
+                        updateProgressPrimary(file.userReadablePath)
+                        val zipEntry = ZipEntry(file.name)
+                        zipOut.putNextEntry(zipEntry)
+                        BufferedInputStream(FileInputStream(file.asFile()), Zipper.BUFFER).use { input ->
+                            input.copyTo(zipOut)
+                        }
+                        zipOut.closeEntry()
+                    }
+                }
+            }
+        }
+        val exportedSize = savePath.length
+        log(TAG, INFO) { "Exported size is $exportedSize" }
+
+        return Result(
+            installId = target.installId,
+            baseApk = baseApk,
+            extraSources = extraSources,
+            savePath = savePath.uri,
+            exportSize = exportedSize,
+        )
+    }
+
+    @Parcelize
+    data class Result(
+        val installId: Installed.InstallId,
+        val baseApk: APath?,
+        val extraSources: Set<APath>?,
+        val savePath: Uri,
+        val exportSize: Long,
+    ) : Parcelable
+
+    companion object {
+        private val TAG = logTag("AppControl", "ExportSaver")
+    }
+
+}

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/toggle/ComponentToggler.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/toggle/ComponentToggler.kt
@@ -33,5 +33,4 @@ class ComponentToggler @Inject constructor(
     companion object {
         private val TAG = logTag("AppControl", "ComponentToggler")
     }
-
 }

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListEvents.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListEvents.kt
@@ -1,8 +1,21 @@
 package eu.darken.sdmse.appcontrol.ui.list
 
+import android.content.Intent
+import eu.darken.sdmse.appcontrol.core.export.AppExporter
+import eu.darken.sdmse.common.pkgs.features.Installed
+
 sealed class AppControlListEvents {
     data class ConfirmDeletion(val items: List<AppControlListAdapter.Item>) : AppControlListEvents()
     data class ExclusionsCreated(val count: Int) : AppControlListEvents()
     data object ShowSizeSortCaveat : AppControlListEvents()
     data class ConfirmToggle(val items: List<AppControlListAdapter.Item>) : AppControlListEvents()
+    data class ExportSelectPath(
+        val items: List<AppControlListAdapter.Item>,
+        val intent: Intent
+    ) : AppControlListEvents()
+
+    data class ExportResult(
+        val successful: Collection<AppExporter.Result>,
+        val failed: Collection<Installed.InstallId>,
+    ) : AppControlListEvents()
 }

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListRowVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListRowVH.kt
@@ -4,11 +4,12 @@ import android.text.format.Formatter
 import android.view.ViewGroup
 import androidx.core.view.children
 import androidx.core.view.isGone
-import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import eu.darken.sdmse.R
 import eu.darken.sdmse.appcontrol.core.AppInfo
+import eu.darken.sdmse.appcontrol.core.export.AppExportType
 import eu.darken.sdmse.common.coil.loadAppIcon
+import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.lists.binding
 import eu.darken.sdmse.common.lists.selection.SelectableItem
 import eu.darken.sdmse.common.lists.selection.SelectableVH
@@ -43,6 +44,7 @@ class AppControlListRowVH(parent: ViewGroup) :
         primary.text = appInfo.label.get(context)
         secondary.text = appInfo.pkg.packageName
 
+        @Suppress("SetTextI18n")
         tertiary.text = "${appInfo.pkg.versionName}  (${appInfo.pkg.versionCode})"
 
         sizes.apply {
@@ -50,9 +52,11 @@ class AppControlListRowVH(parent: ViewGroup) :
             isVisible = appInfo.sizes != null
         }
 
-        tagSystem.tagSystem.isInvisible = !appInfo.pkg.isSystemApp
-        tagDisabled.tagDisabled.isInvisible = appInfo.pkg.isEnabled
-        tagActive.tagActive.isInvisible = !(appInfo.isActive ?: false)
+        tagSystem.tagSystem.isGone = !appInfo.pkg.isSystemApp
+        tagDisabled.tagDisabled.isGone = appInfo.pkg.isEnabled
+        tagActive.tagActive.isGone = appInfo.isActive != true
+        tagApkBase.tagApkBase.isGone = appInfo.exportType != AppExportType.APK && Bugs.isDebug
+        tagApkBundle.tagApkBundle.isGone = appInfo.exportType != AppExportType.BUNDLE && Bugs.isDebug
         tagContainer.isGone = tagContainer.children.none { it.isVisible }
 
         itemView.setOnClickListener { item.onItemClicked(appInfo) }

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListViewModel.kt
@@ -8,6 +8,7 @@ import android.text.format.Formatter
 import androidx.lifecycle.SavedStateHandle
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.sdmse.MainDirections
 import eu.darken.sdmse.appcontrol.core.*
 import eu.darken.sdmse.appcontrol.core.export.AppExportTask
 import eu.darken.sdmse.appcontrol.core.toggle.AppControlToggleTask
@@ -24,6 +25,8 @@ import eu.darken.sdmse.common.pkgs.isSystemApp
 import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.common.toSystemTimezone
 import eu.darken.sdmse.common.uix.ViewModel3
+import eu.darken.sdmse.common.upgrade.UpgradeRepo
+import eu.darken.sdmse.common.upgrade.isPro
 import eu.darken.sdmse.exclusion.core.ExclusionManager
 import eu.darken.sdmse.exclusion.core.types.PkgExclusion
 import kotlinx.coroutines.delay
@@ -41,6 +44,7 @@ class AppControlListViewModel @Inject constructor(
     private val appControl: AppControl,
     private val settings: AppControlSettings,
     private val exclusionManager: ExclusionManager,
+    private val upgradeRepo: UpgradeRepo,
 ) : ViewModel3(dispatcherProvider) {
 
     init {
@@ -335,6 +339,11 @@ class AppControlListViewModel @Inject constructor(
 
     fun export(items: Collection<AppControlListAdapter.Item>, saveDir: Uri? = null) = launch {
         log(TAG) { "export(${items.size}, saveDir=$saveDir)" }
+        if (items.size > 1 && !upgradeRepo.isPro()) {
+            MainDirections.goToUpgradeFragment().navigate()
+            return@launch
+        }
+
         if (saveDir == null) {
             val intent = Intent(Intent.ACTION_OPEN_DOCUMENT_TREE)
             events.postValue(AppControlListEvents.ExportSelectPath(items.toList(), intent))

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/actions/AppActionAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/actions/AppActionAdapter.kt
@@ -5,6 +5,7 @@ import androidx.annotation.LayoutRes
 import androidx.viewbinding.ViewBinding
 import eu.darken.sdmse.appcontrol.ui.list.actions.items.AppStoreActionVH
 import eu.darken.sdmse.appcontrol.ui.list.actions.items.ExcludeActionVH
+import eu.darken.sdmse.appcontrol.ui.list.actions.items.ExportActionVH
 import eu.darken.sdmse.appcontrol.ui.list.actions.items.LaunchActionVH
 import eu.darken.sdmse.appcontrol.ui.list.actions.items.SizeInfoVH
 import eu.darken.sdmse.appcontrol.ui.list.actions.items.SystemSettingsActionVH
@@ -38,6 +39,7 @@ class AppActionAdapter @Inject constructor() :
         addMod(TypedVHCreatorMod({ data[it] is AppStoreActionVH.Item }) { AppStoreActionVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is SystemSettingsActionVH.Item }) { SystemSettingsActionVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is ExcludeActionVH.Item }) { ExcludeActionVH(it) })
+        addMod(TypedVHCreatorMod({ data[it] is ExportActionVH.Item }) { ExportActionVH(it) })
     }
 
     abstract class BaseVH<D : Item, B : ViewBinding>(

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/actions/AppActionDialog.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/actions/AppActionDialog.kt
@@ -1,18 +1,27 @@
 package eu.darken.sdmse.appcontrol.ui.list.actions
 
+import android.app.Activity
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.view.children
 import androidx.core.view.isGone
-import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
+import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
+import eu.darken.sdmse.appcontrol.core.export.AppExportType
 import eu.darken.sdmse.common.coil.loadAppIcon
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.lists.differ.update
 import eu.darken.sdmse.common.lists.setupDefaults
+import eu.darken.sdmse.common.navigation.getQuantityString2
 import eu.darken.sdmse.common.pkgs.isEnabled
 import eu.darken.sdmse.common.pkgs.isSystemApp
 import eu.darken.sdmse.common.uix.BottomSheetDialogFragment2
@@ -23,17 +32,28 @@ class AppActionDialog : BottomSheetDialogFragment2() {
     override val vm: AppActionViewModel by viewModels()
     override lateinit var ui: AppcontrolActionDialogBinding
 
+    private lateinit var exportPath: ActivityResultLauncher<Intent>
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         ui = AppcontrolActionDialogBinding.inflate(inflater, container, false)
         return ui.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        exportPath = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            if (result.resultCode != Activity.RESULT_OK) {
+                log(TAG, WARN) { "exportPathPickerLauncher returned ${result.resultCode}: ${result.data}" }
+                return@registerForActivityResult
+            }
+
+            vm.exportApp(result.data?.data)
+        }
+
         val adapter = AppActionAdapter()
         // TODO fix dividers
         ui.recyclerview.setupDefaults(adapter, dividers = false)
 
-        vm.state.observe2(ui) { (progress, appInfo, actions) ->
+        vm.state.observe2(ui) { (appInfo, progress, actions) ->
             val pkg = appInfo.pkg
             icon.loadAppIcon(pkg)
             primary.text = appInfo.label.get(requireContext())
@@ -41,20 +61,41 @@ class AppActionDialog : BottomSheetDialogFragment2() {
             tertiary.text = "${pkg.versionName} (${pkg.versionCode})"
             adapter.update(actions)
 
-            tagSystem.tagSystem.isInvisible = !appInfo.pkg.isSystemApp
-            tagDisabled.tagDisabled.isInvisible = appInfo.pkg.isEnabled
+            tagSystem.tagSystem.isGone = !appInfo.pkg.isSystemApp
+            tagDisabled.tagDisabled.isGone = appInfo.pkg.isEnabled
+            tagActive.tagActive.isGone = appInfo.isActive != true
+            tagApkBase.tagApkBase.isGone = appInfo.exportType != AppExportType.APK
+            tagApkBundle.tagApkBundle.isGone = appInfo.exportType != AppExportType.BUNDLE
             tagContainer.isGone = tagContainer.children.none { it.isVisible }
 
-            ui.recyclerview.isInvisible = progress != null
+            ui.recyclerview.isGone = progress != null
             ui.loadingOverlay.setProgress(progress)
         }
 
         vm.events.observe2(ui) { event ->
             when (event) {
-                else -> {}
+                is AppActionEvents.SelectExportPath -> {
+                    exportPath.launch(event.intent)
+                }
+
+                is AppActionEvents.ExportResult -> {
+                    val msgSuccessful = getQuantityString2(
+                        eu.darken.sdmse.common.R.plurals.result_x_successful,
+                        event.successful.size
+                    )
+                    val msgFailed = getQuantityString2(
+                        eu.darken.sdmse.common.R.plurals.result_x_failed,
+                        event.failed.size
+                    )
+                    Snackbar.make(requireView(), "$msgSuccessful, $msgFailed", Snackbar.LENGTH_SHORT).show()
+                }
             }
         }
 
         super.onViewCreated(view, savedInstanceState)
+    }
+
+    companion object {
+        private val TAG = logTag("AppControl", "Action", "Dialog")
     }
 }

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/actions/AppActionEvents.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/actions/AppActionEvents.kt
@@ -1,3 +1,18 @@
 package eu.darken.sdmse.appcontrol.ui.list.actions
 
-sealed class AppActionEvents
+import android.content.Intent
+import eu.darken.sdmse.appcontrol.core.AppInfo
+import eu.darken.sdmse.appcontrol.core.export.AppExporter
+import eu.darken.sdmse.common.pkgs.features.Installed
+
+sealed class AppActionEvents {
+    data class SelectExportPath(
+        val appInfo: AppInfo,
+        val intent: Intent,
+    ) : AppActionEvents()
+
+    data class ExportResult(
+        val successful: Collection<AppExporter.Result>,
+        val failed: Collection<Installed.InstallId>,
+    ) : AppActionEvents()
+}

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/actions/items/ExportActionVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/actions/items/ExportActionVH.kt
@@ -1,0 +1,36 @@
+package eu.darken.sdmse.appcontrol.ui.list.actions.items
+
+import android.view.ViewGroup
+import eu.darken.sdmse.R
+import eu.darken.sdmse.appcontrol.core.AppInfo
+import eu.darken.sdmse.appcontrol.ui.list.actions.AppActionAdapter
+import eu.darken.sdmse.common.lists.binding
+import eu.darken.sdmse.databinding.AppcontrolActionBackupItemBinding
+
+
+class ExportActionVH(parent: ViewGroup) :
+    AppActionAdapter.BaseVH<ExportActionVH.Item, AppcontrolActionBackupItemBinding>(
+        R.layout.appcontrol_action_backup_item,
+        parent
+    ) {
+
+    override val viewBinding = lazy { AppcontrolActionBackupItemBinding.bind(itemView) }
+
+    override val onBindData: AppcontrolActionBackupItemBinding.(
+        item: Item,
+        payloads: List<Any>
+    ) -> Unit = binding { item ->
+        val appInfo = item.appInfo
+
+        itemView.setOnClickListener { item.onBackup(appInfo) }
+    }
+
+    data class Item(
+        val appInfo: AppInfo,
+        val onBackup: (AppInfo) -> Unit,
+    ) : AppActionAdapter.Item {
+
+        override val stableId: Long = this::class.java.hashCode().toLong()
+    }
+
+}

--- a/app/src/main/java/eu/darken/sdmse/common/MimeTypeTool.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/MimeTypeTool.kt
@@ -10,10 +10,6 @@ class MimeTypeTool @Inject constructor() {
 
     suspend fun determineMimeType(lookup: APathLookup<*>): String {
         val ext = MimeTypeMap.getFileExtensionFromUrl(lookup.name)
-        return MimeTypeMap.getSingleton().getMimeTypeFromExtension(ext) ?: UNKNOWN_TYPE
-    }
-
-    companion object {
-        private const val UNKNOWN_TYPE = "application/octet-stream"
+        return MimeTypeMap.getSingleton().getMimeTypeFromExtension(ext) ?: MimeTypes.Unknown.value
     }
 }

--- a/app/src/main/java/eu/darken/sdmse/common/MimeTypes.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/MimeTypes.kt
@@ -2,5 +2,7 @@ package eu.darken.sdmse.common
 
 sealed class MimeTypes(val value: String) {
 
+    data object Zip : MimeTypes("application/x-zip")
     data object Json : MimeTypes("application/json")
+    data object Unknown : MimeTypes("application/octet-stream")
 }

--- a/app/src/main/res/layout/appcontrol_action_backup_item.xml
+++ b/app/src/main/res/layout/appcontrol_action_backup_item.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?selectableItemBackground"
+    android:paddingVertical="4dp">
+
+    <ImageView
+        android:id="@+id/icon"
+        style="@style/ListItemIconSecondary"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginBottom="16dp"
+        android:contentDescription="Action icon"
+        android:src="@drawable/ic_baseline_save_24"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:ignore="HardcodedText" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/primary"
+        style="@style/TextAppearance.Material3.BodyMedium"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:text="@string/appcontrol_export_title"
+        app:layout_constraintBottom_toTopOf="@+id/secondary"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/icon"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_chainStyle="packed"
+        app:layout_goneMarginBottom="8dp" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/secondary"
+        style="@style/TextAppearance.Material3.BodySmall"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:text="@string/appcontrol_export_description"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/icon"
+        app:layout_constraintTop_toBottomOf="@+id/primary" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/appcontrol_action_dialog.xml
+++ b/app/src/main/res/layout/appcontrol_action_dialog.xml
@@ -34,8 +34,8 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="16dp"
             android:ellipsize="end"
-            android:textIsSelectable="true"
             android:singleLine="true"
+            android:textIsSelectable="true"
             app:layout_constraintBottom_toTopOf="@id/secondary"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/icon"
@@ -49,8 +49,8 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:ellipsize="end"
-            android:textIsSelectable="true"
             android:singleLine="true"
+            android:textIsSelectable="true"
             app:layout_constraintBottom_toTopOf="@id/tertiary"
             app:layout_constraintEnd_toEndOf="@id/primary"
             app:layout_constraintStart_toStartOf="@id/primary"
@@ -70,12 +70,11 @@
             app:layout_constraintTop_toBottomOf="@id/secondary"
             tools:text="v0.0.0-beta99 (0123456789)" />
 
-        <LinearLayout
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/tag_container"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
-            android:orientation="horizontal"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -83,22 +82,41 @@
             app:layout_goneMarginBottom="8dp">
 
             <include
+                android:id="@+id/tag_apk_base"
+                layout="@layout/appcontrol_tag_apk_base_view"
+                tools:visibility="visible" />
+
+            <include
+                android:id="@+id/tag_apk_bundle"
+                layout="@layout/appcontrol_tag_apk_bundle_view"
+                tools:visibility="visible" />
+
+            <include
                 android:id="@+id/tag_system"
-                layout="@layout/appcontrol_tag_system_view" />
+                layout="@layout/appcontrol_tag_system_view"
+                tools:visibility="visible" />
 
             <include
                 android:id="@+id/tag_disabled"
-                layout="@layout/appcontrol_tag_disabled_view" />
+                layout="@layout/appcontrol_tag_disabled_view"
+                tools:visibility="visible" />
 
             <include
-                android:visibility="invisible"
-                layout="@layout/appcontrol_tag_disabled_view" />
+                android:id="@+id/tag_active"
+                layout="@layout/appcontrol_tag_active_view"
+                tools:visibility="visible" />
 
-            <include
-                android:visibility="invisible"
-                layout="@layout/appcontrol_tag_disabled_view" />
+            <androidx.constraintlayout.helper.widget.Flow
+                android:id="@+id/tag_flow"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                app:constraint_referenced_ids="tag_apk_base,tag_apk_bundle,tag_system,tag_disabled,tag_active"
+                style="@style/AppControlTagContainerFlow"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
 
-        </LinearLayout>
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
@@ -117,7 +135,7 @@
             style="@style/BaseRecyclerList"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:visibility="invisible"
+            android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -126,6 +144,8 @@
         <eu.darken.sdmse.common.progress.ProgressOverlayView
             android:id="@+id/loading_overlay"
             android:layout_width="match_parent"
-            android:layout_height="match_parent" />
+            android:layout_height="match_parent"
+            android:layout_gravity="center_vertical"
+            android:layout_marginTop="24dp" />
     </FrameLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/appcontrol_list_item.xml
+++ b/app/src/main/res/layout/appcontrol_list_item.xml
@@ -52,8 +52,8 @@
         style="@style/TextAppearance.Material3.LabelSmall"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:singleLine="true"
         android:layout_marginEnd="16dp"
+        android:singleLine="true"
         app:layout_constraintBottom_toTopOf="@id/tag_container"
         app:layout_constraintEnd_toStartOf="@id/sizes"
         app:layout_constraintStart_toStartOf="@id/primary"
@@ -77,7 +77,7 @@
         tools:text="345 MB"
         tools:visibility="visible" />
 
-    <LinearLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/tag_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -104,9 +104,27 @@
         <include
             android:id="@+id/tag_active"
             layout="@layout/appcontrol_tag_active_view"
-            android:visibility="invisible"
             tools:visibility="visible" />
 
-    </LinearLayout>
+        <include
+            android:id="@+id/tag_apk_base"
+            layout="@layout/appcontrol_tag_apk_base_view"
+            tools:visibility="visible" />
+
+        <include
+            android:id="@+id/tag_apk_bundle"
+            layout="@layout/appcontrol_tag_apk_bundle_view"
+            tools:visibility="visible" />
+
+        <androidx.constraintlayout.helper.widget.Flow
+            android:id="@+id/tag_flow"
+            style="@style/AppControlTagContainerFlow"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:constraint_referenced_ids="tag_apk_base,tag_apk_bundle,tag_system,tag_disabled,tag_active"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/appcontrol_tag_apk_base_view.xml
+++ b/app/src/main/res/layout/appcontrol_tag_apk_base_view.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/tag_apk_base"
+    style="@style/AppControlTagStyle"
+    tools:visibility="visible"
+    android:background="@drawable/bg_tag_box"
+    android:textColor="?colorOnPrimary"
+    android:backgroundTint="?colorPrimary"
+    app:iconTint="?colorOnPrimary"
+    android:text="@string/appcontrol_tag_apk_base"
+    android:visibility="gone" />

--- a/app/src/main/res/layout/appcontrol_tag_apk_bundle_view.xml
+++ b/app/src/main/res/layout/appcontrol_tag_apk_bundle_view.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/tag_apk_bundle"
+    style="@style/AppControlTagStyle"
+    android:background="@drawable/bg_tag_box"
+    android:backgroundTint="?colorSecondary"
+    android:text="@string/appcontrol_tag_apk_bundle"
+    android:textColor="?colorOnSecondary"
+    android:visibility="gone"
+    app:iconTint="?colorOnSecondary"
+    tools:visibility="visible" />

--- a/app/src/main/res/menu/menu_appcontrol_list_cab.xml
+++ b/app/src/main/res/menu/menu_appcontrol_list_cab.xml
@@ -18,6 +18,11 @@
         android:title="@string/appcontrol_toggle_app_selection_action"
         app:showAsAction="ifRoom" />
     <item
+        android:id="@+id/action_export_selection"
+        android:icon="@drawable/ic_baseline_save_24"
+        android:title="@string/appcontrol_export_app_selection_action"
+        app:showAsAction="ifRoom" />
+    <item
         android:id="@+id/action_select_all"
         android:icon="@drawable/baseline_select_all_24"
         android:title="@string/general_list_select_all_action"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -447,6 +447,8 @@
     <string name="appcontrol_app_exclude_edit_description">This app is currently excluded from one or more tools.</string>
     <string name="appcontrol_tag_user">User</string>
     <string name="appcontrol_tag_active">Recently active</string>
+    <string name="appcontrol_tag_apk_base">APK</string>
+    <string name="appcontrol_tag_apk_bundle">Bundle</string>
     <string name="appcontrol_tag_system">System</string>
     <string name="appcontrol_tag_enabled">Enabled</string>
     <string name="appcontrol_tag_disabled">Disabled</string>
@@ -473,6 +475,10 @@
     <string name="appcontrol_settings_module_sizing_enabled_description">Get a rough estimate of each app\'s size.</string>
     <string name="appcontrol_settings_module_activity_enabled_label">Determine activity</string>
     <string name="appcontrol_settings_module_activity_enabled_description">Find out if an app is (or recently was) active.</string>
+    <string name="appcontrol_export_app_selection_action">Export apps</string>
+    <string name="appcontrol_export_title">Export app</string>
+    <string name="appcontrol_export_description">Save this app\'s install files to your device. This does not include app data.</string>
+    <string name="appcontrol_progress_exporting_x">Exporting %s</string>
 
     <string name="analyzer_tool_name">StorageAnalyzer</string>
     <string name="analyzer_explanation_short">Find out what is taking up space on your device.</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -150,7 +150,7 @@
     </style>
 
     <style name="AppControlTagStyle" parent="TextAppearance.Material3.LabelSmall">
-        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_gravity">center</item>
         <item name="android:layout_marginLeft">2dp</item>
@@ -162,6 +162,16 @@
         <item name="android:fontFamily">sans-serif</item>
         <item name="android:gravity">center</item>
         <item name="android:textSize">12sp</item>
+    </style>
+
+    <style name="AppControlTagContainerFlow">
+        <item name="flow_horizontalBias">0</item>
+        <item name="flow_horizontalGap">2dp</item>
+        <item name="flow_horizontalStyle">packed</item>
+        <item name="flow_verticalBias">0</item>
+        <item name="flow_verticalGap">2dp</item>
+        <item name="flow_verticalStyle">packed</item>
+        <item name="flow_wrapMode">chain2</item>
     </style>
 
     <style name="PreviewRoundedBox">
@@ -191,7 +201,7 @@
         <item name="backgroundTint">@color/sdm_button_bg_tint</item>
     </style>
 
-    <style name="SDMButton.Icon" parent="Widget.Material3.Button.IconButton"></style>
+    <style name="SDMButton.Icon" parent="Widget.Material3.Button.IconButton" />
 
     <style name="SDMButton.Icon.Outlined" parent="Widget.Material3.Button.IconButton.Outlined">
 


### PR DESCRIPTION
Closes #664

Examples:

```bash
r8q:/sdcard/exporttest $ ls -l
total 31224
-rw-rw---- 1 root everybody 26804541 2024-02-22 17:14 YouTube\ Music\ (com.google.android.apps.youtube.music)\ -\ 6.37.50[63750240].apks
-rw-rw---- 1 root everybody  5131806 2024-02-22 17:14 ZArchiver\ (ru.zdevs.zarchiver)\ -\ 1.0.9[10925].apk
```

`.apks` bundles are installable by common apps like ZArchiver, XAPKs Installer or APK Mirror Installer. 

![Screenshot from 2024-02-22 17-16-39](https://github.com/d4rken-org/sdmaid-se/assets/1439229/8fb81b54-6cd0-40cd-9325-bba3b0f98cf9)
![Screenshot from 2024-02-22 17-16-22](https://github.com/d4rken-org/sdmaid-se/assets/1439229/8bbb452c-4c75-4e39-b0f4-052de873060f)
