### PR TITLE
Setup: Gracefully handle QUERY_ALL_PACKAGES permission being optional on some devices

### DIFF
--- a/app-common-pkgs/src/main/java/eu/darken/sdmse/common/pkgs/PkgRepo.kt
+++ b/app-common-pkgs/src/main/java/eu/darken/sdmse/common/pkgs/PkgRepo.kt
@@ -40,6 +40,7 @@ class PkgRepo @Inject constructor(
 ) {
 
     data class CacheContainer(
+        val isSetupDone: Boolean = false,
         val isInitialized: Boolean = false,
         val pkgData: Map<CacheKey, CachedInfo> = emptyMap(),
     ) {

--- a/app-common-pkgs/src/main/java/eu/darken/sdmse/common/pkgs/sources/QueryAllPkgsPermissionMissing.kt
+++ b/app-common-pkgs/src/main/java/eu/darken/sdmse/common/pkgs/sources/QueryAllPkgsPermissionMissing.kt
@@ -1,0 +1,3 @@
+package eu.darken.sdmse.common.pkgs.sources
+
+class QueryAllPkgsPermissionMissing : IllegalStateException("QUERY_ALL_PACKAGES permission is missing")

--- a/app-common/src/main/java/eu/darken/sdmse/common/permissions/Permission.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/permissions/Permission.kt
@@ -96,6 +96,9 @@ sealed class Permission(
     data object WRITE_SECURE_SETTINGS
         : Permission("android.permission.WRITE_SECURE_SETTINGS")
 
+    data object QUERY_ALL_PACKAGES
+        : Permission("android.permission.QUERY_ALL_PACKAGES")
+
     fun Intent.resolveActivities(context: Context): Collection<ResolveInfo> =
         context.packageManager.queryIntentActivities(
             this,

--- a/app/src/main/java/eu/darken/sdmse/analyzer/core/storage/StorageScanner.kt
+++ b/app/src/main/java/eu/darken/sdmse/analyzer/core/storage/StorageScanner.kt
@@ -135,6 +135,15 @@ class StorageScanner @Inject constructor(
 
     private suspend fun scanForApps(storage: DeviceStorage): AppCategory? {
         log(TAG) { "scanForApps($storage)" }
+        if (!Permission.QUERY_ALL_PACKAGES.isGranted(context)) {
+            log(TAG, WARN) { "Permission QUERY_ALL_PACKAGES is missing, can't scan apps." }
+            return AppCategory(
+                storageId = storage.id,
+                setupIncomplete = true,
+                pkgStats = emptyMap()
+            )
+        }
+
         if (!Permission.PACKAGE_USAGE_STATS.isGranted(context)) {
             log(TAG, WARN) { "Permission PACKAGE_USAGE_STATS is missing, can't scan apps." }
             return AppCategory(

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
@@ -31,6 +31,10 @@ import eu.darken.sdmse.exclusion.core.types.Exclusion
 import eu.darken.sdmse.exclusion.core.types.PathExclusion
 import eu.darken.sdmse.exclusion.core.types.PkgExclusion
 import eu.darken.sdmse.main.core.SDMTool
+import eu.darken.sdmse.setup.IncompleteSetupException
+import eu.darken.sdmse.setup.SetupModule
+import eu.darken.sdmse.setup.inventory.InventorySetupModule
+import eu.darken.sdmse.setup.isComplete
 import eu.darken.sdmse.setup.usagestats.UsageStatsSetupModule
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
@@ -55,6 +59,7 @@ class AppCleaner @Inject constructor(
     rootManager: RootManager,
     shizukuManager: ShizukuManager,
     private val filterFactories: Set<@JvmSuppressWildcards ExpendablesFilter.Factory>,
+    private val appInventorySetupModule: InventorySetupModule,
 ) : SDMTool, Progress.Client {
 
     private val usedResources = setOf(fileForensics, gatewaySwitch, pkgOps)
@@ -113,6 +118,11 @@ class AppCleaner @Inject constructor(
 
     private suspend fun performScan(task: AppCleanerScanTask): AppCleanerScanTask.Result {
         log(TAG, VERBOSE) { "performScan(): $task" }
+
+        if (!appInventorySetupModule.isComplete()) {
+            log(TAG, WARN) { "SetupModule INVENTORY is not complete" }
+            throw IncompleteSetupException(SetupModule.Type.INVENTORY)
+        }
 
         internalData.value = null
 

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/ui/settings/AppCleanerSettingsFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/ui/settings/AppCleanerSettingsFragment.kt
@@ -173,13 +173,13 @@ class AppCleanerSettingsFragment : PreferenceFragment2() {
         }
 
         includeOtherUsers.badgedAction = {
-            listOf(SetupModule.Type.ROOT).showFixSetupHint(this)
+            setOf(SetupModule.Type.ROOT).showFixSetupHint(this)
         }
         includeRunningApps.badgedAction = {
-            listOf(SetupModule.Type.USAGE_STATS).showFixSetupHint(this)
+            setOf(SetupModule.Type.USAGE_STATS).showFixSetupHint(this)
         }
         includeInaccessibleCaches.badgedAction = {
-            listOf(SetupModule.Type.USAGE_STATS, SetupModule.Type.AUTOMATION).showFixSetupHint(this)
+            setOf(SetupModule.Type.USAGE_STATS, SetupModule.Type.AUTOMATION).showFixSetupHint(this)
         }
     }
 

--- a/app/src/main/java/eu/darken/sdmse/corpsefinder/core/CorpseFinder.kt
+++ b/app/src/main/java/eu/darken/sdmse/corpsefinder/core/CorpseFinder.kt
@@ -31,6 +31,10 @@ import eu.darken.sdmse.exclusion.core.types.Exclusion
 import eu.darken.sdmse.exclusion.core.types.PathExclusion
 import eu.darken.sdmse.exclusion.core.types.match
 import eu.darken.sdmse.main.core.SDMTool
+import eu.darken.sdmse.setup.IncompleteSetupException
+import eu.darken.sdmse.setup.SetupModule
+import eu.darken.sdmse.setup.inventory.InventorySetupModule
+import eu.darken.sdmse.setup.isComplete
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
@@ -53,6 +57,7 @@ class CorpseFinder @Inject constructor(
     private val watcherNotifications: UninstallWatcherNotifications,
     rootManager: RootManager,
     settings: CorpseFinderSettings,
+    private val appInventorySetupModule: InventorySetupModule,
 ) : SDMTool, Progress.Client {
 
     override val type: SDMTool.Type = SDMTool.Type.CORPSEFINDER
@@ -154,6 +159,11 @@ class CorpseFinder @Inject constructor(
 
     private suspend fun performScan(task: CorpseFinderScanTask): CorpseFinderTask.Result {
         log(TAG) { "performScan(): $task" }
+
+        if (!appInventorySetupModule.isComplete()) {
+            log(TAG, WARN) { "SetupModule INVENTORY is not complete" }
+            throw IncompleteSetupException(SetupModule.Type.INVENTORY)
+        }
 
         internalData.value = null
 

--- a/app/src/main/java/eu/darken/sdmse/corpsefinder/ui/settings/CorpseFinderSettingsFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/corpsefinder/ui/settings/CorpseFinderSettingsFragment.kt
@@ -48,12 +48,12 @@ class CorpseFinderSettingsFragment : PreferenceFragment2() {
     override fun onPreferencesCreated() {
         super.onPreferencesCreated()
 
-        filterPrivateDataEnabled.badgedAction = { listOf(SetupModule.Type.ROOT).showFixSetupHint(this) }
-        filterAppSourceAsecEnabled.badgedAction = { listOf(SetupModule.Type.ROOT).showFixSetupHint(this) }
-        filterDalvikCacheEnabled.badgedAction = { listOf(SetupModule.Type.ROOT).showFixSetupHint(this) }
-        filterAppLibEnabled.badgedAction = { listOf(SetupModule.Type.ROOT).showFixSetupHint(this) }
-        filterAppSourceEnabled.badgedAction = { listOf(SetupModule.Type.ROOT).showFixSetupHint(this) }
-        filterAppSourcePrivateEnabled.badgedAction = { listOf(SetupModule.Type.ROOT).showFixSetupHint(this) }
+        filterPrivateDataEnabled.badgedAction = { setOf(SetupModule.Type.ROOT).showFixSetupHint(this) }
+        filterAppSourceAsecEnabled.badgedAction = { setOf(SetupModule.Type.ROOT).showFixSetupHint(this) }
+        filterDalvikCacheEnabled.badgedAction = { setOf(SetupModule.Type.ROOT).showFixSetupHint(this) }
+        filterAppLibEnabled.badgedAction = { setOf(SetupModule.Type.ROOT).showFixSetupHint(this) }
+        filterAppSourceEnabled.badgedAction = { setOf(SetupModule.Type.ROOT).showFixSetupHint(this) }
+        filterAppSourcePrivateEnabled.badgedAction = { setOf(SetupModule.Type.ROOT).showFixSetupHint(this) }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/java/eu/darken/sdmse/setup/IncompleteSetupException.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/IncompleteSetupException.kt
@@ -1,0 +1,32 @@
+package eu.darken.sdmse.setup
+
+import androidx.navigation.Navigation
+import eu.darken.sdmse.MainDirections
+import eu.darken.sdmse.R
+import eu.darken.sdmse.common.ca.caString
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.error.HasLocalizedError
+import eu.darken.sdmse.common.error.LocalizedError
+
+class IncompleteSetupException(private val setupTypes: Set<SetupModule.Type>) : Exception(), HasLocalizedError {
+
+    constructor(setupType: SetupModule.Type) : this(setOf(setupType))
+
+    override fun getLocalizedError(): LocalizedError = LocalizedError(
+        throwable = this,
+        label = R.string.general_error_setup_require_label.toCaString(),
+        description = caString { ctx ->
+            """
+                ${ctx.getString(R.string.general_error_setup_require_msg)}
+                
+                ${setupTypes.joinToString(",") { "'${ctx.getString(it.labelRes)}'" }}
+            """.trimIndent()
+        },
+        fixActionLabel = R.string.setup_title.toCaString(),
+        fixAction = {
+            val navController = Navigation.findNavController(it, R.id.nav_host)
+            val options = SetupScreenOptions(isOnboarding = true, typeFilter = setupTypes)
+            navController.navigate(MainDirections.goToSetup(options = options))
+        }
+    )
+}

--- a/app/src/main/java/eu/darken/sdmse/setup/SetupAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/SetupAdapter.kt
@@ -12,6 +12,7 @@ import eu.darken.sdmse.common.lists.modular.ModularAdapter
 import eu.darken.sdmse.common.lists.modular.mods.DataBinderMod
 import eu.darken.sdmse.common.lists.modular.mods.TypedVHCreatorMod
 import eu.darken.sdmse.setup.automation.AutomationSetupCardVH
+import eu.darken.sdmse.setup.inventory.InventorySetupCardVH
 import eu.darken.sdmse.setup.notification.NotificationSetupCardVH
 import eu.darken.sdmse.setup.root.RootSetupCardVH
 import eu.darken.sdmse.setup.saf.SAFSetupCardVH
@@ -38,6 +39,7 @@ class SetupAdapter @Inject constructor() :
         addMod(TypedVHCreatorMod({ data[it] is RootSetupCardVH.Item }) { RootSetupCardVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is NotificationSetupCardVH.Item }) { NotificationSetupCardVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is ShizukuSetupCardVH.Item }) { ShizukuSetupCardVH(it) })
+        addMod(TypedVHCreatorMod({ data[it] is InventorySetupCardVH.Item }) { InventorySetupCardVH(it) })
     }
 
     abstract class BaseVH<D : Item, B : ViewBinding>(

--- a/app/src/main/java/eu/darken/sdmse/setup/SetupModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/SetupModule.kt
@@ -22,5 +22,6 @@ interface SetupModule {
         NOTIFICATION(R.string.setup_notification_title),
         SAF(R.string.setup_saf_card_title),
         STORAGE(R.string.setup_manage_storage_card_title),
+        INVENTORY(R.string.setup_inventory_card_title),
     }
 }

--- a/app/src/main/java/eu/darken/sdmse/setup/SetupModuleExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/SetupModuleExtensions.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.first
 
 suspend fun SetupModule.isComplete() = state.first()?.isComplete ?: false
 
-fun Collection<SetupModule.Type>.showFixSetupHint(fragment: Fragment) {
+fun Set<SetupModule.Type>.showFixSetupHint(fragment: Fragment) {
     // If the user navigates back while the snackbar is still showing
     // then we don't have access to the fragment anymore to get the navcontroller
     val navController = fragment.findNavController()
@@ -29,7 +29,7 @@ fun Collection<SetupModule.Type>.showFixSetupHint(fragment: Fragment) {
             val direction = SettingsFragmentDirections.goToSetup(
                 options = SetupScreenOptions(
                     showCompleted = true,
-                    typeFilter = this.toList()
+                    typeFilter = this
                 )
             )
             navController.navigate(direction)

--- a/app/src/main/java/eu/darken/sdmse/setup/SetupScreenOptions.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/SetupScreenOptions.kt
@@ -5,7 +5,7 @@ import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class SetupScreenOptions(
-    val typeFilter: List<SetupModule.Type>? = null,
+    val typeFilter: Set<SetupModule.Type>? = null,
     val isOnboarding: Boolean = false,
     val showCompleted: Boolean = false,
 ) : Parcelable

--- a/app/src/main/java/eu/darken/sdmse/setup/SetupViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/SetupViewModel.kt
@@ -20,6 +20,8 @@ import eu.darken.sdmse.common.pkgs.getLaunchIntent
 import eu.darken.sdmse.common.uix.ViewModel3
 import eu.darken.sdmse.setup.automation.AutomationSetupCardVH
 import eu.darken.sdmse.setup.automation.AutomationSetupModule
+import eu.darken.sdmse.setup.inventory.InventorySetupCardVH
+import eu.darken.sdmse.setup.inventory.InventorySetupModule
 import eu.darken.sdmse.setup.notification.NotificationSetupCardVH
 import eu.darken.sdmse.setup.notification.NotificationSetupModule
 import eu.darken.sdmse.setup.root.RootSetupCardVH
@@ -40,7 +42,7 @@ import javax.inject.Inject
 class SetupViewModel @Inject constructor(
     @Suppress("unused") private val handle: SavedStateHandle,
     dispatcherProvider: DispatcherProvider,
-    @ApplicationContext private val context: Context,
+    @Suppress("StaticFieldLeak") @ApplicationContext private val context: Context,
     private val setupManager: SetupManager,
     private val storageSetupModule: StorageSetupModule,
     private val safSetupModule: SAFSetupModule,
@@ -178,6 +180,18 @@ class SetupViewModel @Inject constructor(
                             }
                         )
 
+                        is InventorySetupModule.State -> InventorySetupCardVH.Item(
+                            state = state,
+                            onGrantAction = {
+                                state.missingPermission.firstOrNull()?.let {
+                                    events.postValue(SetupEvents.ShowOurDetailsPage(state.settingsIntent))
+                                }
+                            },
+                            onHelp = {
+                                webpageTool.open("https://github.com/d4rken-org/sdmaid-se/wiki/Setup#app-inventory")
+                            }
+                        )
+
                         else -> throw IllegalArgumentException("Unknown state: $state")
                     }
                 }
@@ -226,6 +240,7 @@ class SetupViewModel @Inject constructor(
                 Permission.PACKAGE_USAGE_STATS -> {}
                 Permission.POST_NOTIFICATIONS -> {}
                 Permission.WRITE_SECURE_SETTINGS -> {}
+                Permission.QUERY_ALL_PACKAGES -> {}
                 null -> {}
             }
             setupManager.refresh()
@@ -247,6 +262,8 @@ class SetupViewModel @Inject constructor(
 
     companion object {
         private val DISPLAY_ORDER = listOf(
+            InventorySetupCardVH.Item::class,
+            NotificationSetupCardVH.Item::class,
             StorageSetupCardVH.Item::class,
             SAFSetupCardVH.Item::class,
             UsageStatsSetupCardVH.Item::class,

--- a/app/src/main/java/eu/darken/sdmse/setup/inventory/InventorySetupCardVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/inventory/InventorySetupCardVH.kt
@@ -1,0 +1,40 @@
+package eu.darken.sdmse.setup.inventory
+
+import android.view.ViewGroup
+import androidx.core.view.isGone
+import eu.darken.sdmse.R
+import eu.darken.sdmse.common.lists.binding
+import eu.darken.sdmse.databinding.SetupInventoryItemBinding
+import eu.darken.sdmse.setup.SetupAdapter
+
+
+class InventorySetupCardVH(parent: ViewGroup) :
+    SetupAdapter.BaseVH<InventorySetupCardVH.Item, SetupInventoryItemBinding>(
+        R.layout.setup_inventory_item,
+        parent
+    ) {
+
+    override val viewBinding = lazy { SetupInventoryItemBinding.bind(itemView) }
+
+    override val onBindData: SetupInventoryItemBinding.(
+        item: Item,
+        payloads: List<Any>
+    ) -> Unit = binding { item ->
+        grantState.isGone = item.state.missingPermission.isNotEmpty()
+
+        grantAction.apply {
+            isGone = item.state.isComplete
+            setOnClickListener { item.onGrantAction() }
+        }
+        helpAction.setOnClickListener { item.onHelp() }
+    }
+
+    data class Item(
+        override val state: InventorySetupModule.State,
+        val onGrantAction: () -> Unit,
+        val onHelp: () -> Unit,
+    ) : SetupAdapter.Item {
+        override val stableId: Long = this.javaClass.hashCode().toLong()
+    }
+
+}

--- a/app/src/main/java/eu/darken/sdmse/setup/inventory/InventorySetupModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/inventory/InventorySetupModule.kt
@@ -1,0 +1,81 @@
+package eu.darken.sdmse.setup.inventory
+
+import android.content.Context
+import android.content.Intent
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoSet
+import eu.darken.sdmse.common.coroutine.AppScope
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.flow.replayingShare
+import eu.darken.sdmse.common.hasApiLevel
+import eu.darken.sdmse.common.permissions.Permission
+import eu.darken.sdmse.common.pkgs.getSettingsIntent
+import eu.darken.sdmse.common.pkgs.toPkgId
+import eu.darken.sdmse.common.rngString
+import eu.darken.sdmse.setup.SetupModule
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.mapLatest
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class InventorySetupModule @Inject constructor(
+    @AppScope private val appScope: CoroutineScope,
+    @ApplicationContext private val context: Context,
+) : SetupModule {
+
+    private val refreshTrigger = MutableStateFlow(rngString)
+    override val state = refreshTrigger
+        .mapLatest {
+            val requiredPermission = getRequiredPermission()
+
+            val missingPermission = requiredPermission.filter {
+                val isGranted = it.isGranted(context)
+                log(TAG) { "${it.permissionId} isGranted=$isGranted" }
+                !isGranted
+            }.toSet()
+
+            return@mapLatest State(
+                missingPermission = missingPermission,
+                settingsIntent = context.packageName.toPkgId().getSettingsIntent(context)
+            )
+        }
+        .replayingShare(appScope)
+
+    private fun getRequiredPermission(): Set<Permission> = when {
+        hasApiLevel(34) -> setOf(Permission.QUERY_ALL_PACKAGES)
+        else -> emptySet()
+    }
+
+    override suspend fun refresh() {
+        log(TAG) { "refresh()" }
+        refreshTrigger.value = rngString
+    }
+
+    data class State(
+        val missingPermission: Set<Permission>,
+        val settingsIntent: Intent,
+    ) : SetupModule.State {
+
+        override val type: SetupModule.Type
+            get() = SetupModule.Type.INVENTORY
+
+        override val isComplete: Boolean = missingPermission.isEmpty()
+
+    }
+
+    @Module @InstallIn(SingletonComponent::class)
+    abstract class DIM {
+        @Binds @IntoSet abstract fun mod(mod: InventorySetupModule): SetupModule
+    }
+
+    companion object {
+        private val TAG = logTag("Setup", "Inventory", "Module")
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/ui/settings/SystemCleanerSettingsFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/ui/settings/SystemCleanerSettingsFragment.kt
@@ -57,14 +57,14 @@ class SystemCleanerSettingsFragment : PreferenceFragment2() {
             true
         }
 
-        filterAnrEnabled.badgedAction = { listOf(SetupModule.Type.ROOT).showFixSetupHint(this) }
-        filterLocalTmpEnabled.badgedAction = { listOf(SetupModule.Type.ROOT).showFixSetupHint(this) }
-        filterDownloadCacheEnabled.badgedAction = { listOf(SetupModule.Type.ROOT).showFixSetupHint(this) }
-        filterDataLoggerEnabled.badgedAction = { listOf(SetupModule.Type.ROOT).showFixSetupHint(this) }
-        filterLogDropboxEnabled.badgedAction = { listOf(SetupModule.Type.ROOT).showFixSetupHint(this) }
-        filterRecentTasksEnabled.badgedAction = { listOf(SetupModule.Type.ROOT).showFixSetupHint(this) }
-        filterTombstonesEnabled.badgedAction = { listOf(SetupModule.Type.ROOT).showFixSetupHint(this) }
-        filterUsageStatsEnabled.badgedAction = { listOf(SetupModule.Type.ROOT).showFixSetupHint(this) }
+        filterAnrEnabled.badgedAction = { setOf(SetupModule.Type.ROOT).showFixSetupHint(this) }
+        filterLocalTmpEnabled.badgedAction = { setOf(SetupModule.Type.ROOT).showFixSetupHint(this) }
+        filterDownloadCacheEnabled.badgedAction = { setOf(SetupModule.Type.ROOT).showFixSetupHint(this) }
+        filterDataLoggerEnabled.badgedAction = { setOf(SetupModule.Type.ROOT).showFixSetupHint(this) }
+        filterLogDropboxEnabled.badgedAction = { setOf(SetupModule.Type.ROOT).showFixSetupHint(this) }
+        filterRecentTasksEnabled.badgedAction = { setOf(SetupModule.Type.ROOT).showFixSetupHint(this) }
+        filterTombstonesEnabled.badgedAction = { setOf(SetupModule.Type.ROOT).showFixSetupHint(this) }
+        filterUsageStatsEnabled.badgedAction = { setOf(SetupModule.Type.ROOT).showFixSetupHint(this) }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/res/layout/setup_inventory_item.xml
+++ b/app/src/main/res/layout/setup_inventory_item.xml
@@ -69,10 +69,23 @@
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="16dp"
             android:layout_marginTop="16dp"
-            android:layout_marginBottom="16dp"
             android:text="@string/general_grant_access_action"
-            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintTop_toBottomOf="@id/grant_state" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/explanation"
+            style="@style/TextAppearance.Material3.LabelMedium"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="16dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginBottom="16dp"
+            android:gravity="center"
+            android:text="@string/setup_inventory_card_extra"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="@id/title"
+            app:layout_constraintStart_toStartOf="@id/title"
+            app:layout_constraintTop_toBottomOf="@id/grant_action" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/setup_inventory_item.xml
+++ b/app/src/main/res/layout/setup_inventory_item.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    style="@style/DashboardCardItem"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <ImageView
+            android:id="@+id/icon"
+            android:layout_width="20dp"
+            android:layout_height="20dp"
+            android:layout_marginStart="16dp"
+            android:src="@drawable/ic_apps"
+            app:layout_constraintBottom_toBottomOf="@id/title"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@id/title" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/title"
+            style="@style/TextAppearance.Material3.TitleMedium"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginEnd="16dp"
+            android:text="@string/setup_inventory_card_title"
+            app:layout_constraintStart_toEndOf="@id/icon"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_chainStyle="packed" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/body"
+            style="@style/TextAppearance.Material3.BodyMedium"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="16dp"
+            android:layout_marginTop="8dp"
+            android:text="@string/setup_inventory_card_body"
+            app:layout_constraintBottom_toTopOf="@id/grant_state"
+            app:layout_constraintEnd_toEndOf="@id/title"
+            app:layout_constraintStart_toStartOf="@id/title"
+            app:layout_constraintTop_toBottomOf="@id/title" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/grant_state"
+            style="@style/TextAppearance.Material3.LabelLarge"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="16dp"
+            android:layout_marginTop="16dp"
+            android:drawableStart="@drawable/ic_check_circle"
+            android:drawableTint="?colorPrimary"
+            android:gravity="center"
+            android:text="@string/setup_permission_granted_label"
+            android:textColor="?colorPrimary"
+            app:layout_constraintBottom_toTopOf="@id/grant_action"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/body" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/grant_action"
+            style="@style/SDMButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="16dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginBottom="16dp"
+            android:text="@string/general_grant_access_action"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/grant_state" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/help_action"
+        style="@style/SDMButton.Icon"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="top|end"
+        app:icon="@drawable/ic_help_outline"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -108,6 +108,9 @@
     <string name="setup_title">Setup</string>
     <string name="setup_forcedshow_summary">Show setup screen again, including already completed items.</string>
 
+    <string name="general_error_setup_require_label">Setup is incomplete</string>
+    <string name="general_error_setup_require_msg">Further set up is required to use this feature. Complete the remaining setup steps.</string>
+
     <string name="setup_saf_card_title">Storage access framework</string>
     <string name="setup_saf_card_body">Improve results by granting SD Maid access to additional areas.</string>
     <string name="setup_saf_card_body2">In most cases the window will open with the correct path preselected. Entries turn green when access is granted. </string>
@@ -163,6 +166,9 @@
     <string name="setup_acs_disallow_hint">If you change your mind, you can alter this option again by going into settings and restarting the setup.</string>
     <string name="setup_acs_appops_restriction_title">Restricted settings</string>
     <string name="setup_acs_appops_restriction_body">Can\'t enable SD Maids accessibility service? Android 13+ may apply restrictions to apps not installed via Google Play. Lift these restrictions from the system\'s detail page for SD Maid. The option is in the context menu in the top right corner.</string>
+
+    <string name="setup_inventory_card_title">App inventory</string>
+    <string name="setup_inventory_card_body">SD Maid needs to know which apps you have to find files that don\'t belong to any installed apps.</string>
 
     <string name="dataarea_warningcard_empty_message">SD Maid didn\'t find any data areas that can be scanned. Did you complete the setup?</string>
     <string name="dataarea_warningcard_label">Data areas</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -169,6 +169,7 @@
 
     <string name="setup_inventory_card_title">App inventory</string>
     <string name="setup_inventory_card_body">SD Maid needs to know which apps you have to find files that don\'t belong to any installed apps.</string>
+    <string name="setup_inventory_card_extra">Look for a permission called \"App list\" or \"Query all packages\".</string>
 
     <string name="dataarea_warningcard_empty_message">SD Maid didn\'t find any data areas that can be scanned. Did you complete the setup?</string>
     <string name="dataarea_warningcard_label">Data areas</string>


### PR DESCRIPTION
Previous we always assumed that QUERY_ALL_PACKAGES was granted (which it should, by default), but Samsung seems to be doing "Just Samsung things :tm:" and this may not be the case on some of Samsungs Android 14 ROMs. So let's treat it as potentially optional and catch the error, don't crash, and guide the user to the setup.

Closes #1015

