### PR TITLE
AppCleaner: Improve recycle-bin filter on Samsung devices

### DIFF
--- a/app/src/main/assets/clutter/db_clutter_markers.json
+++ b/app/src/main/assets/clutter/db_clutter_markers.json
@@ -11162,8 +11162,7 @@
 }, {
   "pkgs": ["com.sec.android.app.myfiles"],
   "mrks": [
-	{"loc": "SDCARD", "path": "Movies/.thumbnails", "flags": ["keeper", "common"]},
-	{"loc": "SDCARD", "path": "Android/.Trash", "flags": ["keeper", "common"]}
+	{"loc": "SDCARD", "path": "Movies/.thumbnails", "flags": ["keeper", "common"]}
   ]
 }, {
   "pkgs": ["com.lecture.notes"],

--- a/app/src/main/assets/expendables/db_trash_files.json
+++ b/app/src/main/assets/expendables/db_trash_files.json
@@ -107,6 +107,20 @@
 		  "patterns": ["^(?:\\.FilesByGoogleTrash/)(.+?)$"]
 		}
 	  ]
+	}, {
+	  "packages": [
+		"com.estrongs.android.pop",
+		"com.estrongs.android.pop.cupcake",
+		"com.estrongs.android.pop.app.shortcut",
+		"com.estrongs.android.pop.pro"
+	  ],
+	  "fileFilter": [
+		{
+		  "locations": ["SDCARD"],
+		  "startsWith": [".estrongs/recycle/"],
+		  "patterns": ["^(?:\\.estrongs/recycle/)(.+?)$"]
+		}
+	  ]
 	}
   ]
 }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/AdvertisementFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/AdvertisementFilter.kt
@@ -113,7 +113,10 @@ class AdvertisementFilter @Inject constructor(
 
     companion object {
         private val TAG = logTag("AppCleaner", "Scanner", "Filter", "Advertisements")
-        private val BLACKLIST_AREAS = setOf(DataArea.Type.PRIVATE_DATA, DataArea.Type.PUBLIC_DATA)
+        private val BLACKLIST_AREAS = setOf(
+            DataArea.Type.PRIVATE_DATA,
+            DataArea.Type.PUBLIC_DATA,
+        )
         private val IGNORED_FILES: Collection<String> = listOf(
             ".nomedia",
         )

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/CodeCacheFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/CodeCacheFilter.kt
@@ -42,7 +42,7 @@ class CodeCacheFilter @Inject constructor(
     ): ExpendablesFilter.Match? {
         if (segments.isNotEmpty() && IGNORED_FILES.contains(segments[segments.size - 1])) return null
 
-        return if (segments.size >= 3 && cacheFolderPrefixes.contains(segments[1])) {
+        return if (segments.size >= 3 && areaType == DataArea.Type.PRIVATE_DATA && cacheFolderPrefixes.contains(segments[1])) {
             target.toDeletionMatch()
         } else {
             null

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/GameFilesFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/GameFilesFilter.kt
@@ -18,6 +18,7 @@ import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.files.APathLookup
 import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.Segments
+import eu.darken.sdmse.common.files.lowercase
 import eu.darken.sdmse.common.pkgs.Pkg
 import javax.inject.Inject
 import javax.inject.Provider
@@ -42,21 +43,23 @@ class GameFilesFilter @Inject constructor(
         areaType: DataArea.Type,
         segments: Segments
     ): ExpendablesFilter.Match? {
-        if (segments.isNotEmpty() && IGNORED_FILES.contains(segments[segments.size - 1].lowercase())) {
+        val lcsegments = segments.lowercase()
+
+        if (lcsegments.isNotEmpty() && IGNORED_FILES.contains(lcsegments[lcsegments.size - 1])) {
             return null
         }
 
         //    0      1     2
-        // basedir/offlinecache/file
-        if (segments.size >= 3 && TARGET_FOLDERS.contains(segments[1].lowercase())) {
+        // topdir/gamedir/file
+        if (lcsegments.size >= 3 && TARGET_FOLDERS.contains(lcsegments[1])) {
             return target.toDeletionMatch()
         }
 
         //    0      1     2     3
-        // package/files/offlinecache/file
-        if (segments.size >= 4
-            && "files" == segments[1].lowercase()
-            && TARGET_FOLDERS.contains(segments[2].lowercase())
+        // topdir/files/gamedir/file
+        if (lcsegments.size >= 4
+            && "files" == lcsegments[1]
+            && TARGET_FOLDERS.contains(lcsegments[2])
         ) {
             return target.toDeletionMatch()
         }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/HiddenFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/HiddenFilter.kt
@@ -48,10 +48,6 @@ class HiddenFilter @Inject constructor(
         areaType: DataArea.Type,
         segments: Segments
     ): ExpendablesFilter.Match? {
-        if (segments.isNotEmpty() && IGNORED_FILES.contains(segments[segments.size - 1])) {
-            return null
-        }
-
         // Default case, we don't handle that.
         // package/cache/file
         if (segments.size >= 2 && pkgId.name == segments[0] && cacheFolderPrefixes.contains(segments[1])) {
@@ -61,25 +57,29 @@ class HiddenFilter @Inject constructor(
 
         val lcsegments = segments.lowercase()
 
-        // package/cache.dat
+        if (lcsegments.isNotEmpty() && IGNORED_FILES.contains(lcsegments[lcsegments.size - 1])) {
+            return null
+        }
+
+        // topdir/cache.dat
         if (lcsegments.size == 2 && HIDDEN_CACHE_FILES.contains(lcsegments[1])) {
             return target.toDeletionMatch()
         }
 
-        // package/files/cache.dat
+        // topdir/files/cache.dat
         if (lcsegments.size == 3 && HIDDEN_CACHE_FILES.contains(lcsegments[2])) {
             return target.toDeletionMatch()
         }
 
         //    0      1     2
-        // package/.cache/file
-        if (lcsegments.size >= 3 && HIDDEN_CACHE_FOLDERS.contains(lcsegments[1])) { // weird name cache folder
+        // topdir/.cache/file
+        if (lcsegments.size >= 3 && HIDDEN_CACHE_FOLDERS.contains(lcsegments[1])) {
             return target.toDeletionMatch()
         }
         if (isException(segments)) return null
 
         //    0      1     2     3
-        // package/files/.cache/file
+        // topdir/files/.cache/file
         if (lcsegments.size >= 4
             && "files" == lcsegments[1]
             && (HIDDEN_CACHE_FOLDERS.contains(lcsegments[2]) || "cache" == lcsegments[2])

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/ThumbnailsFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/ThumbnailsFilter.kt
@@ -48,22 +48,22 @@ class ThumbnailsFilter @Inject constructor(
         areaType: DataArea.Type,
         segments: Segments
     ): ExpendablesFilter.Match? {
-        if (segments.isNotEmpty() && IGNORED_FILES.contains(segments[segments.size - 1])) {
+        val lcsegments = segments.lowercase()
+
+        if (lcsegments.isNotEmpty() && IGNORED_FILES.contains(lcsegments[lcsegments.size - 1])) {
             return null
         }
 
-        if (segments.size >= 2 && HIDDEN_FOLDERS.contains(segments[0])) {
+        if (lcsegments.size >= 2 && HIDDEN_FOLDERS.contains(lcsegments[0])) {
             return target.toDeletionMatch()
         }
 
         // Default case, we don't handle that.
         // package/cache/file
-        if (segments.size >= 2 && pkgId.name == segments[0] && cacheFolderPrefixes.contains(segments[1])) {
-            // Case matching is important here as all paths that differ in casing are hidden caches (e.g. not system made)
+        if (lcsegments.size >= 2 && pkgId.name == lcsegments[0] && cacheFolderPrefixes.contains(lcsegments[1])) {
             return null
         }
 
-        val lcsegments = segments.lowercase()
 
         // package/thumbs.dat
         if (lcsegments.size == 2 && HIDDEN_FILES.contains(lcsegments[1])) {
@@ -120,6 +120,10 @@ class ThumbnailsFilter @Inject constructor(
     }
 
     companion object {
+        private val BLACKLIST_AREAS = setOf(
+            DataArea.Type.PRIVATE_DATA,
+            DataArea.Type.PUBLIC_DATA,
+        )
         private val HIDDEN_FOLDERS: Collection<String> = listOf(
             ".thumbs",
             "thumbs",

--- a/app/src/main/java/eu/darken/sdmse/common/clutter/dynamic/NestedPackageMatcher.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/clutter/dynamic/NestedPackageMatcher.kt
@@ -11,7 +11,7 @@ import eu.darken.sdmse.common.pkgs.toPkgId
 
 open class NestedPackageMatcher(
     val areaType: DataArea.Type,
-    val baseSegments: List<String>,
+    val baseSegments: Segments,
     val badMatches: Set<String>
 ) : MarkerSource {
 

--- a/app/src/main/java/eu/darken/sdmse/common/clutter/dynamic/modules/SamsungTrashDynamicMarker.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/clutter/dynamic/modules/SamsungTrashDynamicMarker.kt
@@ -1,0 +1,26 @@
+package eu.darken.sdmse.common.clutter.dynamic.modules
+
+import dagger.Binds
+import dagger.Module
+import dagger.Reusable
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoSet
+import eu.darken.sdmse.common.areas.DataArea
+import eu.darken.sdmse.common.clutter.MarkerSource
+import eu.darken.sdmse.common.clutter.dynamic.NestedPackageMatcher
+import javax.inject.Inject
+
+@Reusable
+class SamsungTrashDynamicMarker @Inject constructor() : NestedPackageMatcher(
+    DataArea.Type.SDCARD,
+    listOf("Android", ".Trash"),
+    setOf(".nomedia")
+) {
+    override fun toString(): String = "SamsungTrashDynamicMarker"
+
+    @Module @InstallIn(SingletonComponent::class)
+    abstract class DIM {
+        @Binds @IntoSet abstract fun source(source: SamsungTrashDynamicMarker): MarkerSource
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/LinuxFilesFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/LinuxFilesFilter.kt
@@ -17,11 +17,13 @@ import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APathLookup
 import eu.darken.sdmse.common.files.GatewaySwitch
+import eu.darken.sdmse.common.files.segs
 import eu.darken.sdmse.systemcleaner.core.SystemCleanerSettings
 import eu.darken.sdmse.systemcleaner.core.filter.BaseSystemCleanerFilter
 import eu.darken.sdmse.systemcleaner.core.filter.SystemCleanerFilter
 import eu.darken.sdmse.systemcleaner.core.filter.toDeletion
 import eu.darken.sdmse.systemcleaner.core.sieve.BaseSieve
+import eu.darken.sdmse.systemcleaner.core.sieve.SegmentCriterium
 import java.io.File
 import javax.inject.Inject
 import javax.inject.Provider
@@ -52,6 +54,9 @@ class LinuxFilesFilter @Inject constructor(
             targetTypes = setOf(BaseSieve.TargetType.DIRECTORY),
             areaTypes = targetAreas(),
             pathRegexes = regexes,
+            pfpExclusions = setOf(
+                SegmentCriterium(segs("Android"), mode = SegmentCriterium.Mode.Ancestor())
+            )
         )
         sieve = baseSieveFactory.create(config)
         log(TAG) { "initialized()" }

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/AdvertisementFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/AdvertisementFilterTest.kt
@@ -262,4 +262,14 @@ class AdvertisementFilterTest : BaseFilterTest() {
         pos("com.some.pkg", PUBLIC_DATA, "com.some.pkg/files/vast_rtb_cache/$rngString")
         confirm(create())
     }
+
+    @Test fun `dont match default folder`() = runTest {
+        neg("com.some.pkg", PUBLIC_DATA, "com.some.pkg/cache/vast_rtb_cache/$rngString")
+        neg("com.some.pkg", PUBLIC_DATA, "com.some.pkg/Cache/vast_rtb_cache/$rngString")
+
+        neg("com.some.pkg", PRIVATE_DATA, "com.some.pkg/cache/vast_rtb_cache/$rngString")
+        neg("com.some.pkg", PRIVATE_DATA, "com.some.pkg/Cache/vast_rtb_cache/$rngString")
+
+        confirm(create())
+    }
 }

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/BugReportingFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/BugReportingFilterTest.kt
@@ -31,6 +31,7 @@ class BugReportingFilterTest : BaseFilterTest() {
 
     private fun create() = BugReportingFilter(
         jsonBasedSieveFactory = createJsonSieveFactory(),
+        environment = storageEnvironment,
         gatewaySwitch = gatewaySwitch,
     )
 
@@ -1279,6 +1280,22 @@ class BugReportingFilterTest : BaseFilterTest() {
         neg("com.lazada.android", PUBLIC_DATA, "com.lazada.android/files/tlog_v9")
         neg("com.lazada.android", PUBLIC_DATA, "com.lazada.android/files/tlog_v9/.nomedia")
         pos("com.lazada.android", PUBLIC_DATA, "com.lazada.android/files/tlog_v9/$rngString")
+
+        confirm(create())
+    }
+
+    @Test fun `dont match default caches`() = runTest {
+        pos("some.pkg", PUBLIC_DATA, "some.pkg/files/log.txt")
+        neg("some.pkg", PUBLIC_DATA, "some.pkg/cache/log.txt")
+        neg("some.pkg", PUBLIC_DATA, "some.pkg/Cache/log.txt")
+
+        pos("some.pkg", PRIVATE_DATA, "some.pkg/files/log.txt")
+        neg("some.pkg", PRIVATE_DATA, "some.pkg/cache/log.txt")
+        neg("some.pkg", PRIVATE_DATA, "some.pkg/Cache/log.txt")
+
+        pos("some.pkg", SDCARD, "some.pkg/files/log.txt")
+        pos("some.pkg", SDCARD, "some.pkg/cache/log.txt")
+        pos("some.pkg", SDCARD, "some.pkg/Cache/log.txt")
 
         confirm(create())
     }

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/RecycleBinsFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/RecycleBinsFilterTest.kt
@@ -144,16 +144,11 @@ class RecycleBinsFilterTest : BaseFilterTest() {
 
     @Test fun testMeizuGarbage() = runTest {
         addDefaultNegatives()
-        addCandidate(
-            neg().pkgs("com.meizu.filemanager").locs(PUBLIC_DATA)
-                .prefixFree(".com.meizu.filemanager/.garbage")
-        )
-        addCandidate(
-            pos().pkgs("com.meizu.filemanager").locs(PUBLIC_DATA)
-                .prefixFree(".com.meizu.filemanager/.garbage/something")
-        )
-        addCandidate(neg().pkgs("com.meizu.filemanager").locs(SDCARD).prefixFree(".recycle"))
-        addCandidate(pos().pkgs("com.meizu.filemanager").locs(SDCARD).prefixFree(".recycle/something"))
+        neg("com.meizu.filemanager", PUBLIC_DATA, ".com.meizu.filemanager/.garbage")
+        pos("com.meizu.filemanager", PUBLIC_DATA, ".com.meizu.filemanager/.garbage/something")
+
+        neg("com.meizu.filemanager", SDCARD, ".recycle")
+        pos("com.meizu.filemanager", SDCARD, ".recycle/something")
         confirm(create())
     }
 
@@ -198,6 +193,25 @@ class RecycleBinsFilterTest : BaseFilterTest() {
         addCandidate(neg().pkgs("com.google.android.apps.nbu.files").locs(SDCARD).prefixFree(".FilesByGoogleTrash"))
         addCandidate(
             pos().pkgs("com.google.android.apps.nbu.files").locs(SDCARD).prefixFree(".FilesByGoogleTrash/something")
+        )
+        confirm(create())
+    }
+
+    @Test fun `samsung gallery bin`() = runTest {
+        neg("badpkg", SDCARD, "Android/.Trash/com.sec.android.gallery3d")
+        neg("com.sec.android.gallery3d", SDCARD, "Android/.Trash/com.sec.android.gallery3d")
+        pos("com.sec.android.gallery3d", SDCARD, "Android/.Trash/com.sec.android.gallery3d/3317166978699451126.mp4")
+        confirm(create())
+    }
+
+    @Test fun `samsung myfiles bin`() = runTest {
+        neg("badpkg", SDCARD, "Android/.Trash/com.sec.android.app.myfiles")
+        neg("com.sec.android.app.myfiles", SDCARD, "Android/.Trash/com.sec.android.app.myfiles")
+        neg("com.sec.android.app.myfiles", SDCARD, "Android/.Trash/com.sec.android.app.myfiles/.nomedia")
+        pos(
+            "com.sec.android.app.myfiles",
+            SDCARD,
+            "Android/.Trash/com.sec.android.app.myfiles/9189e8f0-209f-4402-9851-730e5183f578T3/1710218750858/storage/emulated/0/DCIM/Camera/.!%#@\$/20240311_140825.jpg"
         )
         confirm(create())
     }

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/ThumbnailsFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/ThumbnailsFilterTest.kt
@@ -219,4 +219,13 @@ class ThumbnailsFilterTest : BaseFilterTest() {
         pos("com.rhmsoft.pulsar.pro", SDCARD, "albumthumbs/$rngString")
         confirm(create())
     }
+
+    @Test fun `dont match default caches`() = runTest {
+        neg("com.viber.voip", PUBLIC_DATA, "com.viber.voip/cache/User photos/.thumbnails/$rngString")
+        neg("com.viber.voip", PUBLIC_DATA, "com.viber.voip/Cache/.thumbnails/$rngString")
+
+        neg("com.viber.voip", PRIVATE_DATA, "com.viber.voip/cache/User photos/.thumbnails/$rngString")
+        neg("com.viber.voip", PRIVATE_DATA, "com.viber.voip/Cache/.thumbnails/$rngString")
+        confirm(create())
+    }
 }

--- a/app/src/test/java/eu/darken/sdmse/common/clutter/dynamic/modules/SamsungTrashDynamicMarkerTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/common/clutter/dynamic/modules/SamsungTrashDynamicMarkerTest.kt
@@ -1,0 +1,53 @@
+package eu.darken.sdmse.common.clutter.dynamic.modules
+
+import eu.darken.sdmse.common.areas.DataArea
+import eu.darken.sdmse.common.areas.DataArea.Type.SDCARD
+import eu.darken.sdmse.common.files.segs
+import eu.darken.sdmse.common.pkgs.toPkgId
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class SamsungTrashDynamicMarkerTest {
+    private val markerSource = SamsungTrashDynamicMarker()
+
+    @Test fun testMatching() = runTest {
+        markerSource.match(SDCARD, BASEDIR).size shouldBe 0
+        markerSource.match(SDCARD, BASEDIR + listOf("com.package.rollkuchen")).single().apply {
+            packageNames.single() shouldBe "com.package.rollkuchen".toPkgId()
+        }
+    }
+
+    @Test fun testBadMatches() = runTest {
+        markerSource.match(SDCARD, BASEDIR + listOf(".nomedia")).size shouldBe 0
+    }
+
+    @Test fun testGetForLocation() = runTest {
+        for (location in DataArea.Type.values()) {
+            val markers = markerSource.getMarkerForLocation(location)
+            if (location == SDCARD) {
+                markers.single().apply {
+                    segments shouldBe BASEDIR
+                    isDirectMatch shouldBe false
+                }
+            } else {
+                markers.size shouldBe 0
+            }
+        }
+    }
+
+    @Test fun testGetForPackageName() = runTest {
+        val testPkg = "com.pkg.test"
+        markerSource.getMarkerForPkg(testPkg.toPkgId()).single().apply {
+            segments shouldBe BASEDIR + listOf(testPkg)
+            match(SDCARD, BASEDIR + listOf(testPkg, "something")) shouldBe null
+            match(SDCARD, BASEDIR + listOf(testPkg)) shouldNotBe null
+            isDirectMatch shouldBe true
+        }
+    }
+
+    companion object {
+        private val BASEDIR = segs("Android", ".Trash")
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/LinuxFoldersFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/LinuxFoldersFilterTest.kt
@@ -38,6 +38,7 @@ class LinuxFoldersFilterTest : SystemCleanerFilterTest() {
         pos(SDCARD, "/.Trash-11", Flag.Dir)
         pos(SDCARD, "/.Trash-222", Flag.Dir)
         pos(SDCARD, "/.Trash-1000", Flag.Dir)
+        neg(SDCARD, "Android/.Trash-1000", Flag.Dir)
         confirm(create())
     }
 }


### PR DESCRIPTION
Prevent SystemCleaner's "Linux Files" filter from picking up the default trash folder on Samsung devices.
Support app specific matching of files in the system's recycle bin folder on Samsung devices

e.g.:

`/sdcard/Android/.Trash/<gallery/myfiles etc.>/<trash files>`

Closes https://github.com/d4rken-org/sdmaid-se/issues/1057