### PR TITLE
UI: Add setting to open language changer on Android 13

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/common/locale/LocaleExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/locale/LocaleExtensions.kt
@@ -1,0 +1,9 @@
+package eu.darken.sdmse.common.locale
+
+import android.os.LocaleList
+import java.util.Locale
+
+fun LocaleList.toList(): List<Locale> = List(this.size()) { index -> this.get(index) }
+
+val LocaleList.primary: Locale
+    get() = get(0)

--- a/app/src/main/java/eu/darken/sdmse/common/locale/LocaleManager.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/locale/LocaleManager.kt
@@ -1,0 +1,124 @@
+package eu.darken.sdmse.common.locale
+
+import android.content.ActivityNotFoundException
+import android.content.BroadcastReceiver
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.net.Uri
+import android.os.Build
+import android.os.LocaleList
+import android.provider.Settings
+import androidx.annotation.RequiresApi
+import androidx.core.content.ContextCompat
+import androidx.core.content.ContextCompat.RECEIVER_NOT_EXPORTED
+import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.sdmse.common.coroutine.AppScope
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.sdmse.common.debug.logging.asLog
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.flow.setupCommonEventHandlers
+import eu.darken.sdmse.common.flow.shareLatest
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class LocaleManager @Inject constructor(
+    @ApplicationContext private val context: Context,
+    @AppScope private val appScope: CoroutineScope,
+) {
+
+    private suspend fun getCurrentLocales() = context.resources.configuration.locales
+
+    val currentLocales: Flow<LocaleList> = callbackFlow {
+        fun updateLocales() = launch {
+            val locales = getCurrentLocales()
+            log(TAG) { "updateLocales(): $locales" }
+            send(locales)
+        }
+
+        val receiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context, intent: Intent) {
+                log(TAG) { "onReceive(context=$context, intent=$intent)" }
+
+                when (intent.action) {
+                    Intent.ACTION_LOCALE_CHANGED -> updateLocales()
+
+                    else -> log(ERROR) { "Unknown intent: $intent" }
+                }
+            }
+
+        }
+
+        ContextCompat.registerReceiver(
+            context,
+            receiver,
+            IntentFilter(Intent.ACTION_LOCALE_CHANGED),
+            RECEIVER_NOT_EXPORTED
+        )
+
+        updateLocales()
+
+        awaitClose {
+            log { "unregisterReceiver($receiver)" }
+            context.unregisterReceiver(receiver)
+        }
+    }
+        .setupCommonEventHandlers(TAG) { "currentLocales" }
+        .shareLatest(appScope, SharingStarted.WhileSubscribed(stopTimeoutMillis = 3000))
+
+    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
+    suspend fun showLanguagePicker() {
+        fun startPicker(intent: Intent) {
+            context.startActivity(intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+        }
+        try {
+            startPicker(defaultIntent)
+            return
+        } catch (e: ActivityNotFoundException) {
+            log(TAG, ERROR) { "Failed to open ACTION_APP_LOCALE_SETTINGS: ${e.asLog()}" }
+        }
+        try {
+            startPicker(directIntent)
+            return
+        } catch (e: ActivityNotFoundException) {
+            log(TAG, ERROR) { "Failed to open AppLocalePickerActivity: ${e.asLog()}" }
+        }
+
+        // This always works, well it should, otherwise let the caller handle the exception
+        startPicker(fallbackIntent)
+    }
+
+    @get:RequiresApi(Build.VERSION_CODES.TIRAMISU)
+    private val defaultIntent: Intent
+        get() = Intent(Settings.ACTION_APP_LOCALE_SETTINGS).apply {
+            data = Uri.fromParts("package", context.packageName, null)
+        }
+
+    @get:RequiresApi(Build.VERSION_CODES.TIRAMISU)
+    private val directIntent: Intent
+        get() = Intent().apply {
+            component = ComponentName(
+                "com.android.settings",
+                "com.android.settings.localepicker.AppLocalePickerActivity",
+            )
+            data = Uri.fromParts("package", context.packageName, null)
+        }
+
+    private val fallbackIntent: Intent
+        get() = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+            data = Uri.fromParts("package", context.packageName, null)
+        }
+
+    companion object {
+        private val TAG = logTag("Locale", "Manager")
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/main/ui/settings/general/GeneralSettingsViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/settings/general/GeneralSettingsViewModel.kt
@@ -1,8 +1,12 @@
 package eu.darken.sdmse.main.ui.settings.general
 
+import android.annotation.SuppressLint
 import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
+import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.hasApiLevel
+import eu.darken.sdmse.common.locale.LocaleManager
 import eu.darken.sdmse.common.uix.ViewModel3
 import eu.darken.sdmse.common.updater.UpdateChecker
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
@@ -15,11 +19,24 @@ class GeneralSettingsViewModel @Inject constructor(
     dispatcherProvider: DispatcherProvider,
     upgradeRepo: UpgradeRepo,
     private val updateChecker: UpdateChecker,
+    private val localeManager: LocaleManager,
 ) : ViewModel3(dispatcherProvider) {
 
     val isPro = upgradeRepo.upgradeInfo.map { it.isPro }.asLiveData2()
 
     val isUpdateCheckSupported = flow { emit(updateChecker.isCheckSupported()) }.asLiveData2()
+
+    val currentLocales = localeManager.currentLocales.asLiveData2()
+
+    @SuppressLint("NewApi")
+    fun showLanguagePicker() = launch {
+        log(TAG) { "showLanguagPicker()" }
+        if (hasApiLevel(33)) {
+            localeManager.showLanguagePicker()
+        } else {
+            throw IllegalStateException("This should not be clickable below API 33...")
+        }
+    }
 
     companion object {
         private val TAG = logTag("Settings", "General", "ViewModel")

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -84,6 +84,9 @@
     <string name="ui_previews_title">File previews</string>
     <string name="ui_previews_summary">Display file previews in all tools (e.g. image and video thumbnails).</string>
 
+    <string name="ui_language_override_label">App language</string>
+    <string name="ui_language_override_desc">Select a different language for SD Maid, independent of your system\'s default language. Currently: %s</string>
+
     <string name="settings_support_label">Support</string>
     <string name="settings_support_description">Read documentation, report issues, chat with others or record debug logs.</string>
     <string name="documentation_label">Documentation</string>

--- a/app/src/main/res/xml/preferences_general.xml
+++ b/app/src/main/res/xml/preferences_general.xml
@@ -42,6 +42,16 @@
             app:singleLineTitle="false"
             app:summary="@string/ui_previews_summary"
             app:title="@string/ui_previews_title" />
+
+        <Preference
+            android:summary="@string/ui_language_override_desc"
+            app:icon="@drawable/ic_language_onsurface"
+            app:isPreferenceVisible="false"
+            app:key="core.ui.language"
+            app:persistent="false"
+            app:singleLineTitle="false"
+            app:title="@string/ui_language_override_label"
+            tools:isPreferenceVisible="true" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/settings_category_other_label">


### PR DESCRIPTION
Shows the current language and opens the system's app specific language picker. Only available on Android 13+ as this uses a new system API.

Closes #1046

Also see #991