### PR TITLE
General: Bump material-components version and targetSDK to 34

### DIFF
--- a/app/src/main/res/layout/dashboard_title_item.xml
+++ b/app/src/main/res/layout/dashboard_title_item.xml
@@ -76,9 +76,10 @@
             android:paddingHorizontal="52dp"
             android:text="Beta"
             android:textColor="?colorOnError"
+            android:textSize="14dp"
             android:textStyle="bold"
             app:iconTint="?colorOnError"
-            tools:ignore="HardcodedText" />
+            tools:ignore="HardcodedText,SpUsage" />
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/ribbon_secondary"
@@ -88,9 +89,9 @@
             android:layout_gravity="center"
             android:text="v?.?.?-beta?"
             android:textColor="?colorOnError"
-            android:textSize="10sp"
+            android:textSize="10dp"
             app:iconTint="?colorOnError"
-            tools:ignore="HardcodedText" />
+            tools:ignore="HardcodedText,SpUsage" />
     </LinearLayout>
 
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -99,8 +99,8 @@ fun DependencyHandlerScope.addWorkerManager() {
 }
 
 fun DependencyHandlerScope.addAndroidUI() {
-    implementation("androidx.activity:activity-ktx:1.6.1")
-    implementation("androidx.fragment:fragment-ktx:1.5.5")
+    implementation("androidx.activity:activity-ktx:1.8.2")
+    implementation("androidx.fragment:fragment-ktx:1.6.2")
 
     implementation("androidx.lifecycle:lifecycle-extensions:2.2.0")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1")
@@ -110,7 +110,7 @@ fun DependencyHandlerScope.addAndroidUI() {
     implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.5.1")
 
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
-    implementation("com.google.android.material:material:1.7.0")
+    implementation("com.google.android.material:material:1.11.0")
 }
 
 fun DependencyHandlerScope.addTesting() {

--- a/buildSrc/src/main/java/ProjectConfig.kt
+++ b/buildSrc/src/main/java/ProjectConfig.kt
@@ -24,8 +24,8 @@ object ProjectConfig {
     const val packageName = "eu.darken.sdmse"
 
     const val minSdk = 26
-    const val compileSdk = 33
-    const val targetSdk = 33
+    const val compileSdk = 34
+    const val targetSdk = 34
 
     object Version {
         val versionProperties = Properties().apply {


### PR DESCRIPTION
Was an attempt at fixing:
https://github.com/material-components/material-components-android/issues/4101

Not fixed, but let's keep the updated dependencies.