### PR TITLE
AppCleaner: Improve ACS based cache clearing resilience by detecting storage entries "on-the-fly" via app size values

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/analyzer/core/storage/AppStorageScanner.kt
+++ b/app/src/main/java/eu/darken/sdmse/analyzer/core/storage/AppStorageScanner.kt
@@ -76,7 +76,7 @@ class AppStorageScanner @AssistedInject constructor(
         topLevelDirs: Set<OwnerInfo>,
     ): Result {
         val appStorStats = try {
-            statsManager.queryStatsForPkg(storage.id, pkg)
+            statsManager.queryStatsForAppUid(storage.id, pkg)
         } catch (e: Exception) {
             log(TAG, WARN) { "Failed to query stats for ${pkg.id} due to $e" }
             null

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/OnTheFlyLabler.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/OnTheFlyLabler.kt
@@ -1,0 +1,97 @@
+package eu.darken.sdmse.appcleaner.core.automation.specs
+
+import android.app.usage.StorageStats
+import android.content.Context
+import android.text.format.Formatter
+import android.view.accessibility.AccessibilityNodeInfo
+import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.sdmse.automation.core.common.idContains
+import eu.darken.sdmse.automation.core.common.isTextView
+import eu.darken.sdmse.automation.core.common.textContainsAny
+import eu.darken.sdmse.automation.core.common.textMatchesAny
+import eu.darken.sdmse.automation.core.common.textVariants
+import eu.darken.sdmse.common.debug.Bugs
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.asLog
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.hasApiLevel
+import eu.darken.sdmse.common.permissions.Permission
+import eu.darken.sdmse.common.pkgs.features.Installed
+import eu.darken.sdmse.common.storage.StorageId
+import eu.darken.sdmse.common.storage.StorageStatsManager2
+import javax.inject.Inject
+
+class OnTheFlyLabler @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val statsManager: StorageStatsManager2,
+) {
+    suspend fun isStorageEntry(pkg: Installed, node: AccessibilityNodeInfo): Boolean {
+        if (!Permission.PACKAGE_USAGE_STATS.isGranted(context)) {
+            log(TAG) { "isStorageEntry(...): Missing PACKAGE_USAGE_STATS" }
+            return false
+        }
+
+        val storageId = pkg.applicationInfo?.storageUuid?.let { StorageId(internalId = null, externalId = it) }
+        if (storageId == null) {
+            log(TAG, WARN) { "Couldn't determine StorageId via appInfo=${pkg.applicationInfo}" }
+            return false
+        }
+
+        val stats1: StorageStats = try {
+            // OS uses queryStatsForPkg and NOT queryStatsForAppUid
+            // https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/packages/SettingsLib/SpaPrivileged/src/com/android/settingslib/spaprivileged/template/app/AppStorageSize.kt;l=51
+            statsManager.queryStatsForPkg(storageId, pkg)
+        } catch (e: SecurityException) {
+            log(TAG, WARN) { "Don't have permission to query app size for ${pkg.id}: $e" }
+            return false
+        } catch (e: Exception) {
+            log(TAG, ERROR) { "Unexpected error when querying app size for ${pkg.id}: ${e.asLog()}" }
+            return false
+        }
+
+        val targetSize = stats1.appBytes + stats1.dataBytes
+
+        val targetTexts = setOf(
+            // https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/packages/SettingsLib/SpaPrivileged/src/com/android/settingslib/spaprivileged/template/app/AppStorageSize.kt
+            Formatter.formatFileSize(context, targetSize),
+            Formatter.formatShortFileSize(context, targetSize),
+        )
+
+        return node.textContainsAny(targetTexts).also {
+            if (Bugs.isDebug) {
+                if (it) log(TAG) { "Matched for $targetTexts on ${node.textVariants} from ${pkg.installId}" }
+                else log(TAG, VERBOSE) { "Miss for $targetTexts on ${node.textVariants} from ${pkg.installId}" }
+            }
+
+        }
+    }
+
+    fun getAOSPStorageFilter(
+        labels: Collection<String>,
+        pkg: Installed,
+    ): suspend (AccessibilityNodeInfo) -> Boolean = when {
+        hasApiLevel(33) -> storageFilter@{ node ->
+            if (!node.isTextView()) return@storageFilter false
+            node.textMatchesAny(labels) || isStorageEntry(pkg, node)
+        }
+
+        else -> storageFilter@{ node ->
+            if (!node.isTextView()) return@storageFilter false
+
+            if (node.idContains("android:id/title")) {
+                node.textMatchesAny(labels)
+            } else if (node.idContains("android:id/summary")) {
+                isStorageEntry(pkg, node)
+            } else {
+                false
+            }
+        }
+    }
+
+    companion object {
+        val TAG: String = logTag("AppCleaner", "Automation", "OnTheFlyLabler")
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/alcatel/AlcatelSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/alcatel/AlcatelSpecs.kt
@@ -1,28 +1,24 @@
 package eu.darken.sdmse.appcleaner.core.automation.specs.alcatel
 
-import android.content.Context
 import android.view.accessibility.AccessibilityNodeInfo
 import dagger.Binds
 import dagger.Module
 import dagger.Reusable
 import dagger.hilt.InstallIn
-import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.appcleaner.core.AppCleanerSettings
+import eu.darken.sdmse.appcleaner.core.automation.specs.OnTheFlyLabler
 import eu.darken.sdmse.appcleaner.core.automation.specs.SpecRomType
-
 import eu.darken.sdmse.automation.core.common.StepProcessor
 import eu.darken.sdmse.automation.core.common.clickableParent
 import eu.darken.sdmse.automation.core.common.defaultClick
 import eu.darken.sdmse.automation.core.common.defaultWindowFilter
 import eu.darken.sdmse.automation.core.common.defaultWindowIntent
-import eu.darken.sdmse.automation.core.common.getDefaultClearCacheClick
+import eu.darken.sdmse.automation.core.common.getAospClearCacheClick
 import eu.darken.sdmse.automation.core.common.getDefaultNodeRecovery
 import eu.darken.sdmse.automation.core.common.getSysLocale
-import eu.darken.sdmse.automation.core.common.idContains
 import eu.darken.sdmse.automation.core.common.isClickyButton
-import eu.darken.sdmse.automation.core.common.isTextView
 import eu.darken.sdmse.automation.core.common.textMatchesAny
 import eu.darken.sdmse.automation.core.common.windowCriteriaAppIdentifier
 import eu.darken.sdmse.automation.core.specs.AutomationExplorer
@@ -46,10 +42,10 @@ import javax.inject.Inject
 @Reusable
 class AlcatelSpecs @Inject constructor(
     ipcFunnel: IPCFunnel,
-    @ApplicationContext private val context: Context,
     private val deviceDetective: DeviceDetective,
     private val alcatelLabels: AlcatelLabels,
     private val settings: AppCleanerSettings,
+    private val onTheFlyLabler: OnTheFlyLabler,
 ) : ExplorerSpecGenerator() {
 
     override val label = TAG.toCaString()
@@ -83,11 +79,7 @@ class AlcatelSpecs @Inject constructor(
             val storageEntryLabels =
                 alcatelLabels.getStorageEntryDynamic() + alcatelLabels.getStorageEntryStatic(lang, script)
 
-            val storageFilter = fun(node: AccessibilityNodeInfo): Boolean {
-                if (!node.isTextView()) return false
-                if (!hasApiLevel(33) && !node.idContains("android:id/title")) return false
-                return node.textMatchesAny(storageEntryLabels)
-            }
+            val storageFilter = onTheFlyLabler.getAOSPStorageFilter(storageEntryLabels, pkg)
 
             val step = StepProcessor.Step(
                 parentTag = tag,
@@ -117,7 +109,7 @@ class AlcatelSpecs @Inject constructor(
                 label = "Find & click 'Clear Cache' (targets=$clearCacheButtonLabels)",
                 windowNodeTest = windowCriteriaAppIdentifier(SETTINGS_PKG, ipcFunnel, pkg),
                 nodeTest = buttonFilter,
-                action = getDefaultClearCacheClick(pkg, tag)
+                action = getAospClearCacheClick(pkg, tag)
             )
             stepper.withProgress(this) { process(step) }
         }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/androidtv/AndroidTVSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/androidtv/AndroidTVSpecs.kt
@@ -17,7 +17,7 @@ import eu.darken.sdmse.automation.core.common.crawl
 import eu.darken.sdmse.automation.core.common.defaultClick
 import eu.darken.sdmse.automation.core.common.defaultWindowFilter
 import eu.darken.sdmse.automation.core.common.defaultWindowIntent
-import eu.darken.sdmse.automation.core.common.getDefaultClearCacheClick
+import eu.darken.sdmse.automation.core.common.getAospClearCacheClick
 import eu.darken.sdmse.automation.core.common.getSysLocale
 import eu.darken.sdmse.automation.core.common.idMatches
 import eu.darken.sdmse.automation.core.common.pkgId
@@ -92,7 +92,7 @@ open class AndroidTVSpecs @Inject constructor(
                 nodeTest = buttonFilter,
                 nodeRecovery = { it.scrollNode() },
                 nodeMapping = clickableParent(),
-                action = getDefaultClearCacheClick(pkg, TAG)
+                action = getAospClearCacheClick(pkg, TAG)
             )
             stepper.withProgress(this) { process(step) }
         }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecs.kt
@@ -1,27 +1,24 @@
 package eu.darken.sdmse.appcleaner.core.automation.specs.aosp
 
-import android.content.Context
 import android.view.accessibility.AccessibilityNodeInfo
 import dagger.Binds
 import dagger.Module
 import dagger.Reusable
 import dagger.hilt.InstallIn
-import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.appcleaner.core.AppCleanerSettings
+import eu.darken.sdmse.appcleaner.core.automation.specs.OnTheFlyLabler
 import eu.darken.sdmse.appcleaner.core.automation.specs.SpecRomType
 import eu.darken.sdmse.automation.core.common.StepProcessor
 import eu.darken.sdmse.automation.core.common.clickableParent
 import eu.darken.sdmse.automation.core.common.defaultClick
 import eu.darken.sdmse.automation.core.common.defaultWindowFilter
 import eu.darken.sdmse.automation.core.common.defaultWindowIntent
-import eu.darken.sdmse.automation.core.common.getDefaultClearCacheClick
+import eu.darken.sdmse.automation.core.common.getAospClearCacheClick
 import eu.darken.sdmse.automation.core.common.getDefaultNodeRecovery
 import eu.darken.sdmse.automation.core.common.getSysLocale
-import eu.darken.sdmse.automation.core.common.idContains
 import eu.darken.sdmse.automation.core.common.isClickyButton
-import eu.darken.sdmse.automation.core.common.isTextView
 import eu.darken.sdmse.automation.core.common.textMatchesAny
 import eu.darken.sdmse.automation.core.common.windowCriteriaAppIdentifier
 import eu.darken.sdmse.automation.core.specs.AutomationExplorer
@@ -36,7 +33,6 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.funnel.IPCFunnel
-import eu.darken.sdmse.common.hasApiLevel
 import eu.darken.sdmse.common.pkgs.features.Installed
 import eu.darken.sdmse.common.pkgs.toPkgId
 import eu.darken.sdmse.common.progress.withProgress
@@ -46,10 +42,10 @@ import javax.inject.Inject
 @Reusable
 class AOSPSpecs @Inject constructor(
     private val ipcFunnel: IPCFunnel,
-    @ApplicationContext private val context: Context,
     private val deviceDetective: DeviceDetective,
     private val aospLabels: AOSPLabels,
     private val settings: AppCleanerSettings,
+    private val onTheFlyLabler: OnTheFlyLabler,
 ) : ExplorerSpecGenerator() {
 
     override val label = TAG.toCaString()
@@ -80,18 +76,7 @@ class AOSPSpecs @Inject constructor(
             val storageEntryLabels =
                 aospLabels.getStorageEntryDynamic() + aospLabels.getStorageEntryStatic(lang, script)
 
-            val storageFilter = when {
-                hasApiLevel(34) -> fun(node: AccessibilityNodeInfo): Boolean {
-                    if (!node.isTextView()) return false
-                    return node.textMatchesAny(storageEntryLabels)
-                }
-
-                else -> fun(node: AccessibilityNodeInfo): Boolean {
-                    if (!node.isTextView()) return false
-                    if (!hasApiLevel(33) && !node.idContains("android:id/title")) return false
-                    return node.textMatchesAny(storageEntryLabels)
-                }
-            }
+            val storageFilter = onTheFlyLabler.getAOSPStorageFilter(storageEntryLabels, pkg)
 
             val step = StepProcessor.Step(
                 parentTag = tag,
@@ -121,7 +106,7 @@ class AOSPSpecs @Inject constructor(
                 label = "Find & click 'Clear Cache' (targets=$clearCacheButtonLabels)",
                 windowNodeTest = windowCriteriaAppIdentifier(SETTINGS_PKG, ipcFunnel, pkg),
                 nodeTest = buttonFilter,
-                action = getDefaultClearCacheClick(pkg, tag)
+                action = getAospClearCacheClick(pkg, tag)
             )
             stepper.withProgress(this) { process(step) }
         }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/flyme/FlymeSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/flyme/FlymeSpecs.kt
@@ -1,12 +1,10 @@
 package eu.darken.sdmse.appcleaner.core.automation.specs.flyme
 
-import android.content.Context
 import android.view.accessibility.AccessibilityNodeInfo
 import dagger.Binds
 import dagger.Module
 import dagger.Reusable
 import dagger.hilt.InstallIn
-import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.appcleaner.core.AppCleanerSettings
@@ -14,7 +12,7 @@ import eu.darken.sdmse.appcleaner.core.automation.specs.SpecRomType
 import eu.darken.sdmse.automation.core.common.StepProcessor
 import eu.darken.sdmse.automation.core.common.defaultWindowFilter
 import eu.darken.sdmse.automation.core.common.defaultWindowIntent
-import eu.darken.sdmse.automation.core.common.getDefaultClearCacheClick
+import eu.darken.sdmse.automation.core.common.getAospClearCacheClick
 import eu.darken.sdmse.automation.core.common.getDefaultNodeRecovery
 import eu.darken.sdmse.automation.core.common.getSysLocale
 import eu.darken.sdmse.automation.core.common.idContains
@@ -43,7 +41,6 @@ import javax.inject.Inject
 @Reusable
 class FlymeSpecs @Inject constructor(
     private val ipcFunnel: IPCFunnel,
-    @ApplicationContext private val context: Context,
     private val deviceDetective: DeviceDetective,
     private val pkgRepo: PkgRepo,
     private val flymeLabels: FlymeLabels,
@@ -99,7 +96,7 @@ class FlymeSpecs @Inject constructor(
                 windowNodeTest = windowCriteriaAppIdentifier(SETTINGS_PKG, ipcFunnel, pkg),
                 nodeTest = buttonFilter,
                 nodeRecovery = getDefaultNodeRecovery(pkg),
-                action = getDefaultClearCacheClick(pkg, TAG)
+                action = getAospClearCacheClick(pkg, TAG)
             )
             stepper.withProgress(this) { process(step) }
         }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/huawei/HuaweiSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/huawei/HuaweiSpecs.kt
@@ -1,15 +1,14 @@
 package eu.darken.sdmse.appcleaner.core.automation.specs.huawei
 
-import android.content.Context
 import android.view.accessibility.AccessibilityNodeInfo
 import dagger.Binds
 import dagger.Module
 import dagger.Reusable
 import dagger.hilt.InstallIn
-import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.appcleaner.core.AppCleanerSettings
+import eu.darken.sdmse.appcleaner.core.automation.specs.OnTheFlyLabler
 import eu.darken.sdmse.appcleaner.core.automation.specs.SpecRomType
 import eu.darken.sdmse.appcleaner.core.automation.specs.aosp.AOSPSpecs
 import eu.darken.sdmse.automation.core.common.StepProcessor
@@ -17,12 +16,10 @@ import eu.darken.sdmse.automation.core.common.clickableParent
 import eu.darken.sdmse.automation.core.common.defaultClick
 import eu.darken.sdmse.automation.core.common.defaultWindowFilter
 import eu.darken.sdmse.automation.core.common.defaultWindowIntent
-import eu.darken.sdmse.automation.core.common.getDefaultClearCacheClick
+import eu.darken.sdmse.automation.core.common.getAospClearCacheClick
 import eu.darken.sdmse.automation.core.common.getDefaultNodeRecovery
 import eu.darken.sdmse.automation.core.common.getSysLocale
-import eu.darken.sdmse.automation.core.common.idContains
 import eu.darken.sdmse.automation.core.common.isClickyButton
-import eu.darken.sdmse.automation.core.common.isTextView
 import eu.darken.sdmse.automation.core.common.textMatchesAny
 import eu.darken.sdmse.automation.core.common.windowCriteriaAppIdentifier
 import eu.darken.sdmse.automation.core.specs.AutomationExplorer
@@ -46,10 +43,10 @@ import javax.inject.Inject
 @Reusable
 class HuaweiSpecs @Inject constructor(
     private val ipcFunnel: IPCFunnel,
-    @ApplicationContext private val context: Context,
     private val deviceDetective: DeviceDetective,
     private val huaweiLabels: HuaweiLabels,
     private val settings: AppCleanerSettings,
+    private val onTheFlyLabler: OnTheFlyLabler,
 ) : ExplorerSpecGenerator() {
 
     override val tag: String = TAG
@@ -79,11 +76,7 @@ class HuaweiSpecs @Inject constructor(
             val storageEntryLabels =
                 huaweiLabels.getStorageEntryDynamic() + huaweiLabels.getStorageEntryLabels(lang, script)
 
-            val storageFilter = fun(node: AccessibilityNodeInfo): Boolean {
-                if (!node.isTextView()) return false
-                if (!hasApiLevel(33) && !node.idContains("android:id/title")) return false
-                return node.textMatchesAny(storageEntryLabels)
-            }
+            val storageFilter = onTheFlyLabler.getAOSPStorageFilter(storageEntryLabels, pkg)
 
             val step = StepProcessor.Step(
                 parentTag = tag,
@@ -115,7 +108,7 @@ class HuaweiSpecs @Inject constructor(
                     AOSPSpecs.SETTINGS_PKG, ipcFunnel, pkg
                 ),
                 nodeTest = buttonFilter,
-                action = getDefaultClearCacheClick(pkg, tag)
+                action = getAospClearCacheClick(pkg, tag)
             )
 
             stepper.withProgress(this) { process(step) }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/nubia/NubiaSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/nubia/NubiaSpecs.kt
@@ -1,28 +1,24 @@
 package eu.darken.sdmse.appcleaner.core.automation.specs.nubia
 
-import android.content.Context
 import android.view.accessibility.AccessibilityNodeInfo
 import dagger.Binds
 import dagger.Module
 import dagger.Reusable
 import dagger.hilt.InstallIn
-import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.appcleaner.core.AppCleanerSettings
+import eu.darken.sdmse.appcleaner.core.automation.specs.OnTheFlyLabler
 import eu.darken.sdmse.appcleaner.core.automation.specs.SpecRomType
-
 import eu.darken.sdmse.automation.core.common.StepProcessor
 import eu.darken.sdmse.automation.core.common.clickableParent
 import eu.darken.sdmse.automation.core.common.defaultClick
 import eu.darken.sdmse.automation.core.common.defaultWindowFilter
 import eu.darken.sdmse.automation.core.common.defaultWindowIntent
-import eu.darken.sdmse.automation.core.common.getDefaultClearCacheClick
+import eu.darken.sdmse.automation.core.common.getAospClearCacheClick
 import eu.darken.sdmse.automation.core.common.getDefaultNodeRecovery
 import eu.darken.sdmse.automation.core.common.getSysLocale
-import eu.darken.sdmse.automation.core.common.idContains
 import eu.darken.sdmse.automation.core.common.isClickyButton
-import eu.darken.sdmse.automation.core.common.isTextView
 import eu.darken.sdmse.automation.core.common.textMatchesAny
 import eu.darken.sdmse.automation.core.common.windowCriteriaAppIdentifier
 import eu.darken.sdmse.automation.core.specs.AutomationExplorer
@@ -47,10 +43,10 @@ import javax.inject.Inject
 @Reusable
 class NubiaSpecs @Inject constructor(
     private val ipcFunnel: IPCFunnel,
-    @ApplicationContext private val context: Context,
     private val deviceDetective: DeviceDetective,
     private val nubiaLabels: NubiaLabels,
     private val settings: AppCleanerSettings,
+    private val onTheFlyLabler: OnTheFlyLabler,
 ) : ExplorerSpecGenerator() {
 
     override val label = TAG.toCaString()
@@ -84,11 +80,7 @@ class NubiaSpecs @Inject constructor(
             val storageEntryLabels =
                 nubiaLabels.getStorageEntryDynamic() + nubiaLabels.getStorageEntryLabels(lang, script)
 
-            val storageFilter = fun(node: AccessibilityNodeInfo): Boolean {
-                if (!node.isTextView()) return false
-                if (!hasApiLevel(33) && !node.idContains("android:id/title")) return false
-                return node.textMatchesAny(storageEntryLabels)
-            }
+            val storageFilter = onTheFlyLabler.getAOSPStorageFilter(storageEntryLabels, pkg)
 
             val step = StepProcessor.Step(
                 parentTag = tag,
@@ -122,7 +114,7 @@ class NubiaSpecs @Inject constructor(
                     SETTINGS_PKG, ipcFunnel, pkg
                 ),
                 nodeTest = buttonFilter,
-                action = getDefaultClearCacheClick(pkg, tag)
+                action = getAospClearCacheClick(pkg, tag)
             )
             stepper.withProgress(this) { process(step) }
         }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/oneplus/OnePlusSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/oneplus/OnePlusSpecs.kt
@@ -1,28 +1,24 @@
 package eu.darken.sdmse.appcleaner.core.automation.specs.oneplus
 
-import android.content.Context
 import android.view.accessibility.AccessibilityNodeInfo
 import dagger.Binds
 import dagger.Module
 import dagger.Reusable
 import dagger.hilt.InstallIn
-import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.appcleaner.core.AppCleanerSettings
+import eu.darken.sdmse.appcleaner.core.automation.specs.OnTheFlyLabler
 import eu.darken.sdmse.appcleaner.core.automation.specs.SpecRomType
-
 import eu.darken.sdmse.automation.core.common.StepProcessor
 import eu.darken.sdmse.automation.core.common.clickableParent
 import eu.darken.sdmse.automation.core.common.defaultClick
 import eu.darken.sdmse.automation.core.common.defaultWindowFilter
 import eu.darken.sdmse.automation.core.common.defaultWindowIntent
-import eu.darken.sdmse.automation.core.common.getDefaultClearCacheClick
+import eu.darken.sdmse.automation.core.common.getAospClearCacheClick
 import eu.darken.sdmse.automation.core.common.getDefaultNodeRecovery
 import eu.darken.sdmse.automation.core.common.getSysLocale
-import eu.darken.sdmse.automation.core.common.idContains
 import eu.darken.sdmse.automation.core.common.isClickyButton
-import eu.darken.sdmse.automation.core.common.isTextView
 import eu.darken.sdmse.automation.core.common.textMatchesAny
 import eu.darken.sdmse.automation.core.common.windowCriteriaAppIdentifier
 import eu.darken.sdmse.automation.core.specs.AutomationExplorer
@@ -37,7 +33,6 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.funnel.IPCFunnel
-import eu.darken.sdmse.common.hasApiLevel
 import eu.darken.sdmse.common.pkgs.features.Installed
 import eu.darken.sdmse.common.pkgs.toPkgId
 import eu.darken.sdmse.common.progress.withProgress
@@ -47,10 +42,10 @@ import javax.inject.Inject
 @Reusable
 class OnePlusSpecs @Inject constructor(
     private val ipcFunnel: IPCFunnel,
-    @ApplicationContext private val context: Context,
     private val deviceDetective: DeviceDetective,
     private val onePlusLabels: OnePlusLabels,
     private val settings: AppCleanerSettings,
+    private val onTheFlyLabler: OnTheFlyLabler,
 ) : ExplorerSpecGenerator() {
 
     override val label = TAG.toCaString()
@@ -82,11 +77,7 @@ class OnePlusSpecs @Inject constructor(
             val storageEntryLabels =
                 onePlusLabels.getStorageEntryDynamic() + onePlusLabels.getStorageEntryLabels(lang, script)
 
-            val storageFilter = fun(node: AccessibilityNodeInfo): Boolean {
-                if (!node.isTextView()) return false
-                if (!hasApiLevel(33) && !node.idContains("android:id/title")) return false
-                return node.textMatchesAny(storageEntryLabels)
-            }
+            val storageFilter = onTheFlyLabler.getAOSPStorageFilter(storageEntryLabels, pkg)
 
             val step = StepProcessor.Step(
                 parentTag = tag,
@@ -116,7 +107,7 @@ class OnePlusSpecs @Inject constructor(
                 label = "Find & click 'Clear Cache' (targets=$clearCacheButtonLabels)",
                 windowNodeTest = windowCriteriaAppIdentifier(SETTINGS_PKG, ipcFunnel, pkg),
                 nodeTest = buttonFilter,
-                action = getDefaultClearCacheClick(pkg, tag)
+                action = getAospClearCacheClick(pkg, tag)
             )
             stepper.withProgress(this) { process(step) }
         }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/samsung/SamsungSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/samsung/SamsungSpecs.kt
@@ -1,28 +1,24 @@
 package eu.darken.sdmse.appcleaner.core.automation.specs.samsung
 
-import android.content.Context
 import android.view.accessibility.AccessibilityNodeInfo
 import dagger.Binds
 import dagger.Module
 import dagger.Reusable
 import dagger.hilt.InstallIn
-import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.appcleaner.core.AppCleanerSettings
+import eu.darken.sdmse.appcleaner.core.automation.specs.OnTheFlyLabler
 import eu.darken.sdmse.appcleaner.core.automation.specs.SpecRomType
-
 import eu.darken.sdmse.automation.core.common.StepProcessor
 import eu.darken.sdmse.automation.core.common.clickableParent
 import eu.darken.sdmse.automation.core.common.defaultClick
 import eu.darken.sdmse.automation.core.common.defaultWindowFilter
 import eu.darken.sdmse.automation.core.common.defaultWindowIntent
-import eu.darken.sdmse.automation.core.common.getDefaultClearCacheClick
+import eu.darken.sdmse.automation.core.common.getAospClearCacheClick
 import eu.darken.sdmse.automation.core.common.getDefaultNodeRecovery
 import eu.darken.sdmse.automation.core.common.getSysLocale
-import eu.darken.sdmse.automation.core.common.idContains
 import eu.darken.sdmse.automation.core.common.isClickyButton
-import eu.darken.sdmse.automation.core.common.isTextView
 import eu.darken.sdmse.automation.core.common.textMatchesAny
 import eu.darken.sdmse.automation.core.common.windowCriteriaAppIdentifier
 import eu.darken.sdmse.automation.core.specs.AutomationExplorer
@@ -37,7 +33,6 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.funnel.IPCFunnel
-import eu.darken.sdmse.common.hasApiLevel
 import eu.darken.sdmse.common.pkgs.features.Installed
 import eu.darken.sdmse.common.pkgs.toPkgId
 import eu.darken.sdmse.common.progress.withProgress
@@ -47,10 +42,10 @@ import javax.inject.Inject
 @Reusable
 class SamsungSpecs @Inject constructor(
     private val ipcFunnel: IPCFunnel,
-    @ApplicationContext private val context: Context,
     private val deviceDetective: DeviceDetective,
     private val samsungLabels: SamsungLabels,
-    private val settings: AppCleanerSettings
+    private val settings: AppCleanerSettings,
+    private val onTheFlyLabler: OnTheFlyLabler,
 ) : ExplorerSpecGenerator() {
 
     override val label = TAG.toCaString()
@@ -82,11 +77,7 @@ class SamsungSpecs @Inject constructor(
             val storageEntryLabels =
                 samsungLabels.getStorageEntryDynamic() + samsungLabels.getStorageEntryLabels(lang, script)
 
-            val storageFilter = fun(node: AccessibilityNodeInfo): Boolean {
-                if (!node.isTextView()) return false
-                if (!hasApiLevel(33) && !node.idContains("android:id/title")) return false
-                return node.textMatchesAny(storageEntryLabels)
-            }
+            val storageFilter = onTheFlyLabler.getAOSPStorageFilter(storageEntryLabels, pkg)
 
             val step = StepProcessor.Step(
                 parentTag = tag,
@@ -116,7 +107,7 @@ class SamsungSpecs @Inject constructor(
                 label = "Find & click 'Clear Cache' (targets=$clearCacheButtonLabels)",
                 windowNodeTest = windowCriteriaAppIdentifier(SETTINGS_PKG, ipcFunnel, pkg),
                 nodeTest = buttonFilter,
-                action = getDefaultClearCacheClick(pkg, tag)
+                action = getAospClearCacheClick(pkg, tag)
             )
             stepper.withProgress(this) { process(step) }
         }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/vivo/VivoSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/vivo/VivoSpecs.kt
@@ -1,27 +1,23 @@
 package eu.darken.sdmse.appcleaner.core.automation.specs.vivo
 
-import android.content.Context
 import android.view.accessibility.AccessibilityNodeInfo
 import dagger.Binds
 import dagger.Module
 import dagger.Reusable
 import dagger.hilt.InstallIn
-import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.appcleaner.core.AppCleanerSettings
+import eu.darken.sdmse.appcleaner.core.automation.specs.OnTheFlyLabler
 import eu.darken.sdmse.appcleaner.core.automation.specs.SpecRomType
-
 import eu.darken.sdmse.automation.core.common.StepProcessor
 import eu.darken.sdmse.automation.core.common.clickableParent
 import eu.darken.sdmse.automation.core.common.defaultClick
 import eu.darken.sdmse.automation.core.common.defaultWindowFilter
 import eu.darken.sdmse.automation.core.common.defaultWindowIntent
-import eu.darken.sdmse.automation.core.common.getDefaultClearCacheClick
+import eu.darken.sdmse.automation.core.common.getAospClearCacheClick
 import eu.darken.sdmse.automation.core.common.getDefaultNodeRecovery
 import eu.darken.sdmse.automation.core.common.getSysLocale
-import eu.darken.sdmse.automation.core.common.idContains
-import eu.darken.sdmse.automation.core.common.isTextView
 import eu.darken.sdmse.automation.core.common.textMatchesAny
 import eu.darken.sdmse.automation.core.common.windowCriteriaAppIdentifier
 import eu.darken.sdmse.automation.core.specs.AutomationExplorer
@@ -46,10 +42,10 @@ import javax.inject.Inject
 @Reusable
 class VivoSpecs @Inject constructor(
     private val ipcFunnel: IPCFunnel,
-    @ApplicationContext private val context: Context,
     private val deviceDetective: DeviceDetective,
     private val vivoLabels: VivoLabels,
     private val settings: AppCleanerSettings,
+    private val onTheFlyLabler: OnTheFlyLabler,
 ) : ExplorerSpecGenerator() {
 
     override val label = TAG.toCaString()
@@ -81,11 +77,7 @@ class VivoSpecs @Inject constructor(
             val storageEntryLabels =
                 vivoLabels.getStorageEntryDynamic() + vivoLabels.getStorageEntryStatic(lang, script)
 
-            val storageFilter = fun(node: AccessibilityNodeInfo): Boolean {
-                if (!node.isTextView()) return false
-                if (!hasApiLevel(33) && !node.idContains("android:id/title")) return false
-                return node.textMatchesAny(storageEntryLabels)
-            }
+            val storageFilter = onTheFlyLabler.getAOSPStorageFilter(storageEntryLabels, pkg)
 
             val step = StepProcessor.Step(
                 parentTag = tag,
@@ -121,7 +113,7 @@ class VivoSpecs @Inject constructor(
                 label = "Find & click 'Clear Cache' (targets=$clearCacheButtonLabels)",
                 windowNodeTest = windowCriteriaAppIdentifier(SETTINGS_PKG, ipcFunnel, pkg),
                 nodeTest = buttonFilter,
-                action = getDefaultClearCacheClick(pkg, tag)
+                action = getAospClearCacheClick(pkg, tag)
             )
             stepper.withProgress(this) { process(step) }
         }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/InaccessibleCacheProvider.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/InaccessibleCacheProvider.kt
@@ -28,7 +28,7 @@ class InaccessibleCacheProvider @Inject constructor(
         }
 
         val storageStats = try {
-            storageStatsManager.queryStatsForPkg(
+            storageStatsManager.queryStatsForAppUid(
                 StorageId(internalId = null, externalId = applicationInfo.storageUuid),
                 pkg,
             )

--- a/app/src/main/java/eu/darken/sdmse/automation/core/common/AccessibilityNodeExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/common/AccessibilityNodeExtensions.kt
@@ -35,6 +35,15 @@ fun AccessibilityNodeInfo.textMatchesAny(candidates: Collection<String>): Boolea
     return false
 }
 
+fun AccessibilityNodeInfo.textContainsAny(candidates: Collection<String>): Boolean {
+    candidates.forEach { candidate ->
+        if (textVariants.any { it.contains(candidate, ignoreCase = true) }) {
+            return true
+        }
+    }
+    return false
+}
+
 fun AccessibilityNodeInfo.textEndsWithAny(candidates: Collection<String>): Boolean {
     candidates.forEach { candidate ->
         if (textVariants.any { it.endsWith(candidate, ignoreCase = true) }) {

--- a/app/src/main/java/eu/darken/sdmse/automation/core/common/AutomationContextExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/common/AutomationContextExtensions.kt
@@ -1,3 +1,5 @@
+@file:Suppress("UnusedReceiverParameter")
+
 package eu.darken.sdmse.automation.core.common
 
 import android.content.Intent
@@ -138,7 +140,7 @@ fun AutomationExplorer.Context.getDefaultNodeRecovery(pkg: Installed): suspend (
         }
     }
 
-fun AutomationExplorer.Context.getDefaultClearCacheClick(
+fun AutomationExplorer.Context.getAospClearCacheClick(
     pkg: Installed,
     tag: String
 ): suspend (AccessibilityNodeInfo, Int) -> Boolean = scope@{ node, retryCount ->

--- a/app/src/main/java/eu/darken/sdmse/common/storage/StorageStatsManager2.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/storage/StorageStatsManager2.kt
@@ -11,13 +11,17 @@ import javax.inject.Inject
 @Reusable
 class StorageStatsManager2 @Inject constructor(
     private val osStatManager: StorageStatsManager,
+    // We don't need the direct IPCFunnel reference, but to lighten the load in the IPC buffer we use it's locking
     private val ipcFunnel: IPCFunnel,
 ) {
 
-    suspend fun queryStatsForPkg(storageId: StorageId, pkg: Installed): StorageStats = ipcFunnel.use {
-        // We don't need the direct IPCFunnel reference, but to lighten the load in the IPC buffer we use it's locking
+    suspend fun queryStatsForAppUid(storageId: StorageId, pkg: Installed): StorageStats = ipcFunnel.use {
         val appUid = pkg.applicationInfo?.uid ?: throw IllegalStateException("${pkg.id} is missing an UID")
         osStatManager.queryStatsForUid(storageId.externalId, appUid)
+    }
+
+    suspend fun queryStatsForPkg(storageId: StorageId, pkg: Installed): StorageStats = ipcFunnel.use {
+        osStatManager.queryStatsForPackage(storageId.externalId, pkg.packageName, pkg.userHandle.asUserHandle())
     }
 
     companion object {


### PR DESCRIPTION
Most "Storage" entries in system details have a summary row that says something like "604 MB in internal storage" While we don't know the translation of "in internal storage", we know the app size, so we can look for "604 MB". There is a slight chance for false-positives if the data-usage of the app is the same as the app size, but that's pretty rare. If that happens SD Maid just keeps retrying as usual.

With 218 apps this had a 99% success rate.
There was one app ("Digital Wellbeing", a system app), that showed the wrong app size (36,06 MB) on first load. Only when SD Maid retried and reloaded the settings details, the size displayed correct (35,96 MB). No idea why the size was displayed incorrectly the first time...

When clearing caches via ACS we now have 3 tier process:

1. Try to get the storage entry label via string resource ID

2. Try hard coded labels by language code

3. Try to find the summary row by looking up the app size

This should make it a lot easier to automatically support ROMs after updates, where the texts change.