### PR TITLE
Root: Fix root service connection crashing on Android 14

### DIFF
--- a/app-common-root/src/main/java/eu/darken/sdmse/common/root/service/internal/RootConnectionReceiver.kt
+++ b/app-common-root/src/main/java/eu/darken/sdmse/common/root/service/internal/RootConnectionReceiver.kt
@@ -12,6 +12,7 @@ import android.os.IBinder
 import android.os.IBinder.DeathRecipient
 import android.os.RemoteException
 import androidx.annotation.Keep
+import androidx.core.content.ContextCompat
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
@@ -122,7 +123,7 @@ abstract class RootConnectionReceiver constructor(private val pairingCode: Strin
         }
 
         this.contextRef = WeakReference(context)
-        context.registerReceiver(receiver, filter, null, handler)
+        ContextCompat.registerReceiver(context, receiver, filter, null, handler, ContextCompat.RECEIVER_NOT_EXPORTED)
     }
 
     /**


### PR DESCRIPTION
Missing receiver flags about export status.
Tested with Magisk 27.0 but should also fix it for KernelSU

Fixes #1073
Fixes #1069