### PR TITLE
Debug: Fix debug log causing crash loop on Android 14

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -38,6 +38,8 @@
         android:name="android.permission.WRITE_SECURE_SETTINGS"
         tools:ignore="ProtectedPermissions" />
 
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
+
     <application
         android:name="eu.darken.sdmse.App"
         android:allowBackup="true"
@@ -128,7 +130,13 @@
             android:name="eu.darken.sdmse.common.debug.recorder.ui.RecorderActivity"
             android:theme="@style/AppThemeFloating" />
 
-        <service android:name="eu.darken.sdmse.common.debug.recorder.core.RecorderService" />
+        <service
+            android:name="eu.darken.sdmse.common.debug.recorder.core.RecorderService"
+            android:foregroundServiceType="specialUse">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="This service is part of a bug reporting mechanism. It is explicitly launched by the user to create debug logs and troubleshoot issues within SD Maid itself. While a debug log is being created, this service shows an on-going foreground notification notification that allows the user to control the debug log functionality." />
+        </service>
     </application>
 
 </manifest>

--- a/app/src/main/java/eu/darken/sdmse/common/debug/recorder/core/RecorderService.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/debug/recorder/core/RecorderService.kt
@@ -11,6 +11,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import eu.darken.sdmse.R
 import eu.darken.sdmse.common.BuildConfigWrap
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
+import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.notifications.PendingIntentCompat
@@ -22,6 +23,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 
 
@@ -81,8 +83,12 @@ class RecorderService : Service2() {
             )
         }
 
-        startForeground(NOTIFICATION_ID, builder.build())
-
+        try {
+            startForeground(NOTIFICATION_ID, builder.build())
+        } catch (e: Exception) {
+            log(TAG) { "Halt stop! Service can't go foreground: ${e.asLog()}" }
+            runBlocking { recorderModule.stopRecorder() }
+        }
         recorderModule.state
             .onEach {
                 if (it.isRecording) {


### PR DESCRIPTION
Also add a safeguard that automatically stops the log again if the service crashes.