### PR TITLE
AppCleaner/StorageAnalyzer: Fix cache size calculation for apps with shared user ids

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/analyzer/core/storage/AppStorageScanner.kt
+++ b/app/src/main/java/eu/darken/sdmse/analyzer/core/storage/AppStorageScanner.kt
@@ -76,7 +76,7 @@ class AppStorageScanner @AssistedInject constructor(
         topLevelDirs: Set<OwnerInfo>,
     ): Result {
         val appStorStats = try {
-            statsManager.queryStatsForAppUid(storage.id, pkg)
+            statsManager.queryStatsForPkg(storage.id, pkg)
         } catch (e: Exception) {
             log(TAG, WARN) { "Failed to query stats for ${pkg.id} due to $e" }
             null

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/InaccessibleCacheProvider.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/InaccessibleCacheProvider.kt
@@ -28,7 +28,7 @@ class InaccessibleCacheProvider @Inject constructor(
         }
 
         val storageStats = try {
-            storageStatsManager.queryStatsForAppUid(
+            storageStatsManager.queryStatsForPkg(
                 StorageId(internalId = null, externalId = applicationInfo.storageUuid),
                 pkg,
             )


### PR DESCRIPTION
`queryStatsForAppUid` can include data sizes from other apps if they share the same user-id (common among system apps). We want "per package" i.e. `queryStatsForPkg`.

Fixes #818 
