### PR TITLE
AppCleaner: Improve setup behavior when ACS is not enabled but required

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleter.kt
@@ -206,6 +206,6 @@ class InaccessibleDeleter @Inject constructor(
     }
 
     companion object {
-        private val TAG = logTag("AppCleaner", "Deleter")
+        private val TAG = logTag("AppCleaner", "Deleter", "Inaccessible")
     }
 }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeletionException.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeletionException.kt
@@ -7,6 +7,7 @@ import eu.darken.sdmse.common.ca.caString
 import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.error.HasLocalizedError
 import eu.darken.sdmse.common.error.LocalizedError
+import eu.darken.sdmse.setup.SetupModule
 import eu.darken.sdmse.setup.SetupScreenOptions
 
 class InaccessibleDeletionException(
@@ -29,8 +30,16 @@ class InaccessibleDeletionException(
         fixActionLabel = R.string.setup_title.toCaString(),
         fixAction = {
             val navController = Navigation.findNavController(it, R.id.nav_host)
-            navController.navigate(MainDirections.goToSetup(options = SetupScreenOptions(isOnboarding = true)))
-        }
+            navController.navigate(
+                MainDirections.goToSetup(
+                    options = SetupScreenOptions(
+                        isOnboarding = false,
+                        showCompleted = true,
+                        typeFilter = setOf(SetupModule.Type.AUTOMATION),
+                    )
+                )
+            )
+        },
     )
 
 }

--- a/app/src/main/res/layout/dashboard_title_item.xml
+++ b/app/src/main/res/layout/dashboard_title_item.xml
@@ -56,7 +56,7 @@
         android:id="@+id/ribbon"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="-48dp"
+        android:layout_marginStart="-50dp"
         android:layout_marginTop="8dp"
         android:background="?colorError"
         android:orientation="vertical"


### PR DESCRIPTION
Previously all setup items were shown instead of just the required one, and it would kick you back to the dashboard instead of the page where the error dialog was popped.