### PR TITLE
Dashboard: Fix One-Tap-Mode sometimes not executing deletion task

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
@@ -7,6 +7,7 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilter
 import eu.darken.sdmse.appcleaner.core.scanner.AppScanner
+import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerOneClickTask
 import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerProcessingTask
 import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerScanTask
 import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerSchedulerTask
@@ -104,8 +105,13 @@ class AppCleaner @Inject constructor(
                     is AppCleanerScanTask -> performScan(task)
                     is AppCleanerProcessingTask -> performProcessing(task)
                     is AppCleanerSchedulerTask -> {
-                        performScan(AppCleanerScanTask())
+                        performScan()
                         performProcessing(AppCleanerProcessingTask(useAutomation = task.useAutomation))
+                    }
+
+                    is AppCleanerOneClickTask -> {
+                        performScan()
+                        performProcessing()
                     }
                 }
             }
@@ -116,7 +122,9 @@ class AppCleaner @Inject constructor(
         }
     }
 
-    private suspend fun performScan(task: AppCleanerScanTask): AppCleanerScanTask.Result {
+    private suspend fun performScan(
+        task: AppCleanerScanTask = AppCleanerScanTask()
+    ): AppCleanerScanTask.Result {
         log(TAG, VERBOSE) { "performScan(): $task" }
 
         if (!appInventorySetupModule.isComplete()) {
@@ -148,7 +156,9 @@ class AppCleaner @Inject constructor(
         )
     }
 
-    private suspend fun performProcessing(task: AppCleanerProcessingTask): AppCleanerProcessingTask.Result {
+    private suspend fun performProcessing(
+        task: AppCleanerProcessingTask = AppCleanerProcessingTask()
+    ): AppCleanerProcessingTask.Result {
         log(TAG, VERBOSE) { "performProcessing(): $task" }
 
         val snapshot = internalData.value ?: throw IllegalStateException("Data is null")

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerOneClickTask.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerOneClickTask.kt
@@ -1,0 +1,28 @@
+package eu.darken.sdmse.appcleaner.core.tasks
+
+import android.text.format.Formatter
+import eu.darken.sdmse.common.ca.CaString
+import eu.darken.sdmse.common.ca.caString
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class AppCleanerOneClickTask(
+    val noop: Boolean = true
+) : AppCleanerTask {
+
+    sealed interface Result : AppCleanerTask.Result
+
+    @Parcelize
+    data class Success(
+        private val deletedCount: Int,
+        private val recoveredSpace: Long
+    ) : Result {
+        override val primaryInfo: CaString
+            get() = caString {
+                it.getString(
+                    eu.darken.sdmse.common.R.string.general_result_x_space_freed,
+                    Formatter.formatShortFileSize(it, recoveredSpace)
+                )
+            }
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/corpsefinder/core/CorpseFinder.kt
+++ b/app/src/main/java/eu/darken/sdmse/corpsefinder/core/CorpseFinder.kt
@@ -140,8 +140,13 @@ class CorpseFinder @Inject constructor(
                     }
 
                     is CorpseFinderSchedulerTask -> {
-                        performScan(CorpseFinderScanTask())
-                        deleteCorpses(CorpseFinderDeleteTask())
+                        performScan()
+                        deleteCorpses()
+                    }
+
+                    is CorpseFinderOneClickTask -> {
+                        performScan()
+                        deleteCorpses()
                     }
                 }
             }
@@ -157,7 +162,9 @@ class CorpseFinder @Inject constructor(
         }
     }
 
-    private suspend fun performScan(task: CorpseFinderScanTask): CorpseFinderTask.Result {
+    private suspend fun performScan(
+        task: CorpseFinderScanTask = CorpseFinderScanTask()
+    ): CorpseFinderTask.Result {
         log(TAG) { "performScan(): $task" }
 
         if (!appInventorySetupModule.isComplete()) {
@@ -229,7 +236,9 @@ class CorpseFinder @Inject constructor(
         )
     }
 
-    private suspend fun deleteCorpses(task: CorpseFinderDeleteTask): CorpseFinderDeleteTask.Success {
+    private suspend fun deleteCorpses(
+        task: CorpseFinderDeleteTask = CorpseFinderDeleteTask()
+    ): CorpseFinderDeleteTask.Success {
         log(TAG) { "deleteCorpses(): $task" }
 
         val deletedCorpses = mutableSetOf<Corpse>()

--- a/app/src/main/java/eu/darken/sdmse/corpsefinder/core/tasks/CorpseFinderOneClickTask.kt
+++ b/app/src/main/java/eu/darken/sdmse/corpsefinder/core/tasks/CorpseFinderOneClickTask.kt
@@ -1,0 +1,28 @@
+package eu.darken.sdmse.corpsefinder.core.tasks
+
+import android.text.format.Formatter
+import eu.darken.sdmse.common.ca.CaString
+import eu.darken.sdmse.common.ca.caString
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class CorpseFinderOneClickTask(
+    val noop: Boolean = true,
+) : CorpseFinderTask {
+
+    sealed interface Result : CorpseFinderTask.Result
+
+    @Parcelize
+    data class Success(
+        val deletedItems: Int,
+        val recoveredSpace: Long
+    ) : Result {
+        override val primaryInfo: CaString
+            get() = caString {
+                it.getString(
+                    eu.darken.sdmse.common.R.string.general_result_x_space_freed,
+                    Formatter.formatShortFileSize(it, recoveredSpace)
+                )
+            }
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/deduplicator/core/Deduplicator.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/core/Deduplicator.kt
@@ -21,6 +21,7 @@ import eu.darken.sdmse.deduplicator.core.scanner.DuplicatesScanner
 import eu.darken.sdmse.deduplicator.core.scanner.checksum.ChecksumDuplicate
 import eu.darken.sdmse.deduplicator.core.scanner.phash.PHashDuplicate
 import eu.darken.sdmse.deduplicator.core.tasks.DeduplicatorDeleteTask
+import eu.darken.sdmse.deduplicator.core.tasks.DeduplicatorOneClickTask
 import eu.darken.sdmse.deduplicator.core.tasks.DeduplicatorScanTask
 import eu.darken.sdmse.deduplicator.core.tasks.DeduplicatorTask
 import eu.darken.sdmse.exclusion.core.*
@@ -84,6 +85,10 @@ class Deduplicator @Inject constructor(
                 when (task) {
                     is DeduplicatorScanTask -> performScan(task)
                     is DeduplicatorDeleteTask -> performDelete(task)
+                    is DeduplicatorOneClickTask -> {
+                        performScan()
+                        performDelete()
+                    }
                 }
             }
             lastResult.value = result
@@ -96,7 +101,9 @@ class Deduplicator @Inject constructor(
         }
     }
 
-    private suspend fun performScan(task: DeduplicatorScanTask): DeduplicatorScanTask.Result {
+    private suspend fun performScan(
+        task: DeduplicatorScanTask = DeduplicatorScanTask()
+    ): DeduplicatorScanTask.Result {
         log(TAG) { "performScan(): $task" }
 
         internalData.value = null
@@ -121,7 +128,9 @@ class Deduplicator @Inject constructor(
         )
     }
 
-    private suspend fun performDelete(task: DeduplicatorDeleteTask): DeduplicatorDeleteTask.Result {
+    private suspend fun performDelete(
+        task: DeduplicatorDeleteTask = DeduplicatorDeleteTask()
+    ): DeduplicatorDeleteTask.Result {
         log(TAG) { "performDelete(): $task" }
 
         val snapshot = internalData.value!!

--- a/app/src/main/java/eu/darken/sdmse/deduplicator/core/tasks/DeduplicatorOneClickTask.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/core/tasks/DeduplicatorOneClickTask.kt
@@ -1,0 +1,28 @@
+package eu.darken.sdmse.deduplicator.core.tasks
+
+import android.text.format.Formatter
+import eu.darken.sdmse.common.ca.CaString
+import eu.darken.sdmse.common.ca.caString
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class DeduplicatorOneClickTask(
+    val noop: Boolean = true,
+) : DeduplicatorTask {
+
+    sealed interface Result : DeduplicatorTask.Result
+
+    @Parcelize
+    data class Success(
+        val deletedItems: Int,
+        val recoveredSpace: Long
+    ) : Result {
+        override val primaryInfo: CaString
+            get() = caString {
+                it.getString(
+                    eu.darken.sdmse.common.R.string.general_result_x_space_freed,
+                    Formatter.formatShortFileSize(it, recoveredSpace)
+                )
+            }
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModel.kt
@@ -8,6 +8,7 @@ import eu.darken.sdmse.analyzer.core.Analyzer
 import eu.darken.sdmse.analyzer.ui.AnalyzerDashCardVH
 import eu.darken.sdmse.appcleaner.core.AppCleaner
 import eu.darken.sdmse.appcleaner.core.hasData
+import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerOneClickTask
 import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerProcessingTask
 import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerScanTask
 import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerSchedulerTask
@@ -43,6 +44,7 @@ import eu.darken.sdmse.corpsefinder.core.tasks.*
 import eu.darken.sdmse.corpsefinder.ui.CorpseFinderDashCardVH
 import eu.darken.sdmse.deduplicator.core.Deduplicator
 import eu.darken.sdmse.deduplicator.core.tasks.DeduplicatorDeleteTask
+import eu.darken.sdmse.deduplicator.core.tasks.DeduplicatorOneClickTask
 import eu.darken.sdmse.deduplicator.core.tasks.DeduplicatorScanTask
 import eu.darken.sdmse.deduplicator.ui.DeduplicatorDashCardVH
 import eu.darken.sdmse.main.core.GeneralSettings
@@ -55,6 +57,7 @@ import eu.darken.sdmse.scheduler.ui.SchedulerDashCardVH
 import eu.darken.sdmse.setup.SetupManager
 import eu.darken.sdmse.systemcleaner.core.SystemCleaner
 import eu.darken.sdmse.systemcleaner.core.hasData
+import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerOneClickTask
 import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerProcessingTask
 import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerScanTask
 import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerSchedulerTask
@@ -473,10 +476,7 @@ class DashboardViewModel @Inject constructor(
                     submitTask(CorpseFinderDeleteTask())
                 }
 
-                BottomBarState.Action.ONECLICK -> {
-                    submitTask(CorpseFinderScanTask())
-                    submitTask(CorpseFinderDeleteTask())
-                }
+                BottomBarState.Action.ONECLICK -> submitTask(CorpseFinderOneClickTask())
             }
         }
         launch {
@@ -493,10 +493,7 @@ class DashboardViewModel @Inject constructor(
                     submitTask(SystemCleanerProcessingTask())
                 }
 
-                BottomBarState.Action.ONECLICK -> {
-                    submitTask(SystemCleanerScanTask())
-                    submitTask(SystemCleanerProcessingTask())
-                }
+                BottomBarState.Action.ONECLICK -> submitTask(SystemCleanerOneClickTask())
             }
         }
         launch {
@@ -519,8 +516,7 @@ class DashboardViewModel @Inject constructor(
 
                 BottomBarState.Action.ONECLICK -> {
                     if (upgradeRepo.isPro()) {
-                        submitTask(AppCleanerScanTask())
-                        submitTask(AppCleanerProcessingTask())
+                        submitTask(AppCleanerOneClickTask())
                     } else if (appCleaner.state.first().data.hasData && !corpseFinder.state.first().data.hasData && !systemCleaner.state.first().data.hasData) {
                         MainDirections.goToUpgradeFragment().navigate()
                     }
@@ -541,10 +537,7 @@ class DashboardViewModel @Inject constructor(
                     submitTask(DeduplicatorDeleteTask())
                 }
 
-                BottomBarState.Action.ONECLICK -> {
-                    submitTask(DeduplicatorScanTask())
-                    submitTask(DeduplicatorDeleteTask())
-                }
+                BottomBarState.Action.ONECLICK -> submitTask(DeduplicatorOneClickTask())
             }
         }
     }
@@ -614,18 +607,21 @@ class DashboardViewModel @Inject constructor(
                 is UninstallWatcherTask.Success -> {}
                 is CorpseFinderSchedulerTask.Success -> {}
                 is CorpseFinderDeleteTask.Success -> events.postValue(DashboardEvents.TaskResult(result))
+                is CorpseFinderOneClickTask.Success -> events.postValue(DashboardEvents.TaskResult(result))
             }
 
             is SystemCleanerTask.Result -> when (result) {
                 is SystemCleanerScanTask.Success -> {}
                 is SystemCleanerSchedulerTask.Success -> {}
                 is SystemCleanerProcessingTask.Success -> events.postValue(DashboardEvents.TaskResult(result))
+                is SystemCleanerOneClickTask.Success -> events.postValue(DashboardEvents.TaskResult(result))
             }
 
             is AppCleanerTask.Result -> when (result) {
                 is AppCleanerScanTask.Success -> {}
                 is AppCleanerSchedulerTask.Success -> {}
                 is AppCleanerProcessingTask.Success -> events.postValue(DashboardEvents.TaskResult(result))
+                is AppCleanerOneClickTask.Success -> events.postValue(DashboardEvents.TaskResult(result))
             }
         }
     }

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/SystemCleaner.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/SystemCleaner.kt
@@ -28,6 +28,7 @@ import eu.darken.sdmse.systemcleaner.core.filter.FilterIdentifier
 import eu.darken.sdmse.systemcleaner.core.filter.FilterSource
 import eu.darken.sdmse.systemcleaner.core.filter.SystemCleanerFilter
 import eu.darken.sdmse.systemcleaner.core.filter.excludeNestedLookups
+import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerOneClickTask
 import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerProcessingTask
 import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerScanTask
 import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerSchedulerTask
@@ -89,8 +90,13 @@ class SystemCleaner @Inject constructor(
                     is SystemCleanerScanTask -> performScan(task)
                     is SystemCleanerProcessingTask -> performProcessing(task)
                     is SystemCleanerSchedulerTask -> {
-                        performScan(SystemCleanerScanTask())
-                        performProcessing(SystemCleanerProcessingTask())
+                        performScan()
+                        performProcessing()
+                    }
+
+                    is SystemCleanerOneClickTask -> {
+                        performScan()
+                        performProcessing()
                     }
                 }
             }
@@ -101,7 +107,9 @@ class SystemCleaner @Inject constructor(
         }
     }
 
-    private suspend fun performScan(task: SystemCleanerScanTask): SystemCleanerTask.Result {
+    private suspend fun performScan(
+        task: SystemCleanerScanTask = SystemCleanerScanTask()
+    ): SystemCleanerTask.Result {
         log(TAG, VERBOSE) { "performScan(): $task" }
         updateProgressPrimary(eu.darken.sdmse.common.R.string.general_progress_searching)
 
@@ -125,7 +133,9 @@ class SystemCleaner @Inject constructor(
         )
     }
 
-    private suspend fun performProcessing(task: SystemCleanerProcessingTask): SystemCleanerTask.Result {
+    private suspend fun performProcessing(
+        task: SystemCleanerProcessingTask = SystemCleanerProcessingTask()
+    ): SystemCleanerTask.Result {
         log(TAG, VERBOSE) { "performProcessing(): $task" }
 
         val snapshot = internalData.value ?: throw IllegalStateException("Data is null")

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/tasks/SystemCleanerOneClickTask.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/tasks/SystemCleanerOneClickTask.kt
@@ -1,0 +1,28 @@
+package eu.darken.sdmse.systemcleaner.core.tasks
+
+import android.text.format.Formatter
+import eu.darken.sdmse.common.ca.CaString
+import eu.darken.sdmse.common.ca.caString
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class SystemCleanerOneClickTask(
+    val noop: Boolean = true,
+) : SystemCleanerTask {
+
+    sealed interface Result : SystemCleanerTask.Result
+
+    @Parcelize
+    data class Success(
+        private val processedItems: Int,
+        private val recoveredSpace: Long
+    ) : Result {
+        override val primaryInfo: CaString
+            get() = caString {
+                it.getString(
+                    eu.darken.sdmse.common.R.string.general_result_x_space_freed,
+                    Formatter.formatShortFileSize(it, recoveredSpace)
+                )
+            }
+    }
+}


### PR DESCRIPTION
One-Tap-Mode was tied to the viewmodel lifecycle and a combination of the default scan-task and delete-task, if the viewmodel gets collected (e.g. due to ACS opening system settings over SD Maids main UI, than the coroutine that would have launched the follow up deletion task, is cancelled. The scan task still continues because after a task is launched, it is tied to the global app scope.

So let's fix this by just creating a special One-Click-Task that will internally perform scan + delete.