### PR TITLE
AppCleaner: Fix ArrayIndexOutOfBoundsException when scanning via Storage Access Framework

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/saf/SAFPathExtensions.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/saf/SAFPathExtensions.kt
@@ -70,20 +70,26 @@ fun SAFPath.isParentOf(child: SAFPath): Boolean {
 
 fun SAFPath.startsWith(prefix: SAFPath): Boolean {
     if (treeRoot != prefix.treeRoot) return false
+    // We share the same treeRoot, and the prefix is just the treeRoot, so startWith is true
+    if (prefix.segments.isEmpty()) return true
     if (this == prefix) return true
     if (segments.size < prefix.segments.size) return false
-
     return when {
         prefix.segments.size == 1 -> {
             segments.first().startsWith(prefix.segments.first())
         }
+
         segments.size == prefix.segments.size -> {
             val match = prefix.segments.dropLast(1) == segments.dropLast(1)
             match && segments.last().startsWith(prefix.segments.last())
         }
+
         else -> {
-            val match = prefix.segments.dropLast(1) == segments.dropLast(segments.size - prefix.segments.size + 1)
-            match && segments[prefix.segments.size - 1].startsWith(prefix.segments.last())
+            // Do all segments up to the closest ancestor match?
+            val ancestors = prefix.segments.dropLast(1) == segments.dropLast(segments.size - prefix.segments.size + 1)
+            // Compare the last common segment
+            val commonSegment = segments[prefix.segments.size - 1].startsWith(prefix.segments.last())
+            ancestors && commonSegment
         }
     }
 }

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/APathExtensionTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/APathExtensionTest.kt
@@ -746,6 +746,14 @@ class APathExtensionTest : BaseTest() {
         }
     }
 
+    // https://github.com/d4rken-org/sdmaid-se/issues/1100
+    @Test fun `remove prefix SAF - issue 1100`() {
+        val searchpath: APath = SAFPath.build(treeUri)
+        val path: APath = SAFPath.build(treeUri, "nextcloud", "folder")
+
+        path.removePrefix(searchpath, overlap = 0) shouldBe segs("nextcloud", "folder")
+    }
+
     @Test fun `filterDistinctRoots operator - LocalPath`() {
         val file1: APath = LocalPath.build("test", "file1")
         val file1s: APath = LocalPath.build("test", "file1", "sub")

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/LocalPathExtensionsTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/LocalPathExtensionsTest.kt
@@ -337,6 +337,8 @@ class LocalPathExtensionsTest : BaseTest() {
         }
         prefixLookup.removePrefix(preLookup) shouldBe segs("fix")
         prefixLookup.removePrefix(pre) shouldBe segs("fix")
+
+        prefix.removePrefix(LocalPath.build()) shouldBe segs("pre", "fix")
     }
 
 

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/saf/SAFPathExtensionsTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/saf/SAFPathExtensionsTest.kt
@@ -324,6 +324,8 @@ class SAFPathExtensionsTest : BaseTest() {
         }
         prefixLookup.removePrefix(preLookup) shouldBe segs("fix")
         prefixLookup.removePrefix(pre) shouldBe segs("fix")
+
+        prefix.removePrefix(SAFPath.build(baseTreeUri)) shouldBe segs("pre", "fix")
     }
 
     @Test fun `remove prefix with overlap`() {


### PR DESCRIPTION
Filters work with prefix free paths, i.e. they don't care about the specific "sdcard name". #1059  removed the overlap when passing scanned paths to filters, so filters get more path information. Before filters worked with "/sdcard/nextcloud/folderA" -> "folderA" After filters worked with "/sdcard/nextcloud/folderA" -> "nextcloud/folderA"

This worked for `LocalPath` but caused a bug with `SAFPath` because paths here are split into a `treeUri` and segments. The path logic failed when we tried to check `SAFPath(treeUri,1-segment).startsWith(SAFPath(treeUri,0-segments))`.

Closes #1100