### PR TITLE
FOSS: Remove Google's encrypted DEPENDENCY_INFO_BLOCK from FOSS builds

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,6 +45,11 @@ android {
         create("foss") {
             dimension = "version"
             signingConfig = signingConfigs["releaseFoss"]
+            // The info block is encrypted and can only be read by google
+            dependenciesInfo {
+                includeInApk = false
+                includeInBundle = false
+            }
         }
         create("gplay") {
             dimension = "version"


### PR DESCRIPTION
See https://github.com/6eero/NewPass/issues/1#issuecomment-2021340229

Randomly stumbled upon the above issue and think this is worthwhile to do too.

@IzzySoft I could swear that you raised this topic for SD Maid SE too, but I can't find anything. Deja vu...? :thinking: 