### PR TITLE
Setup: Don't hang if setup checks take longer, show a loading state instead :)

### DIFF
--- a/app-common/src/main/java/eu/darken/sdmse/common/flow/intervalFlow.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/flow/intervalFlow.kt
@@ -1,0 +1,15 @@
+package eu.darken.sdmse.common.flow
+
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.isActive
+import kotlin.time.Duration
+
+fun intervalFlow(interval: Duration, intitialDelay: Duration = Duration.ZERO) = flow {
+    delay(intitialDelay)
+    while (currentCoroutineContext().isActive) {
+        emit(Unit)
+        delay(interval)
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/analyzer/core/device/DeviceStorageScanner.kt
+++ b/app/src/main/java/eu/darken/sdmse/analyzer/core/device/DeviceStorageScanner.kt
@@ -1,9 +1,7 @@
 package eu.darken.sdmse.analyzer.core.device
 
 import android.app.usage.StorageStatsManager
-import android.content.Context
 import android.os.storage.StorageManager
-import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.sdmse.R
 import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
@@ -18,15 +16,14 @@ import eu.darken.sdmse.common.progress.updateProgressSecondary
 import eu.darken.sdmse.common.storage.StorageEnvironment
 import eu.darken.sdmse.common.storage.StorageId
 import eu.darken.sdmse.common.storage.StorageManager2
+import eu.darken.sdmse.setup.isComplete
 import eu.darken.sdmse.setup.storage.StorageSetupModule
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.first
 import java.util.UUID
 import javax.inject.Inject
 
 class DeviceStorageScanner @Inject constructor(
-    @ApplicationContext private val context: Context,
     private val storageSetupModule: StorageSetupModule,
     private val environment: StorageEnvironment,
     private val storageManager2: StorageManager2,
@@ -48,7 +45,7 @@ class DeviceStorageScanner @Inject constructor(
 
         updateProgressPrimary(R.string.analyzer_progress_scanning_device)
 
-        val setupIncomplete = !storageSetupModule.state.first().isComplete
+        val setupIncomplete = !storageSetupModule.isComplete()
 
         val primaryDevice = run {
             updateProgressSecondary(R.string.analyzer_storage_type_primary_title)

--- a/app/src/main/java/eu/darken/sdmse/analyzer/core/storage/StorageScanner.kt
+++ b/app/src/main/java/eu/darken/sdmse/analyzer/core/storage/StorageScanner.kt
@@ -1,7 +1,5 @@
 package eu.darken.sdmse.analyzer.core.storage
 
-import android.content.Context
-import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.sdmse.R
 import eu.darken.sdmse.analyzer.core.content.ContentGroup
 import eu.darken.sdmse.analyzer.core.content.ContentItem
@@ -43,15 +41,14 @@ import eu.darken.sdmse.common.storage.StorageManager2
 import eu.darken.sdmse.common.user.UserHandle2
 import eu.darken.sdmse.common.user.UserManager2
 import eu.darken.sdmse.setup.inventory.InventorySetupModule
+import eu.darken.sdmse.setup.isComplete
 import eu.darken.sdmse.setup.usagestats.UsageStatsSetupModule
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.first
 import javax.inject.Inject
 
 
 class StorageScanner @Inject constructor(
-    @ApplicationContext private val context: Context,
     private val storageManager2: StorageManager2,
     private val pkgRepo: PkgRepo,
     private val rootManager: RootManager,
@@ -139,7 +136,7 @@ class StorageScanner @Inject constructor(
 
     private suspend fun scanForApps(storage: DeviceStorage): AppCategory? {
         log(TAG) { "scanForApps($storage)" }
-        if (!inventorySetupModule.state.first().isComplete) {
+        if (!inventorySetupModule.isComplete()) {
             log(TAG, WARN) { "Inventory setup is incomplete, can't scan apps." }
             return AppCategory(
                 storageId = storage.id,
@@ -148,7 +145,7 @@ class StorageScanner @Inject constructor(
             )
         }
 
-        if (!usageStatsSetupModule.state.first().isComplete) {
+        if (!usageStatsSetupModule.isComplete()) {
             log(TAG, WARN) { "Usagestats setup is incomplete, can't scan apps." }
             return AppCategory(
                 storageId = storage.id,

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/items/SetupCardVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/items/SetupCardVH.kt
@@ -1,7 +1,6 @@
 package eu.darken.sdmse.main.ui.dashboard.items
 
 import android.view.ViewGroup
-import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import eu.darken.sdmse.R
 import eu.darken.sdmse.common.lists.binding
@@ -19,21 +18,31 @@ class SetupCardVH(parent: ViewGroup) :
         item: Item,
         payloads: List<Any>
     ) -> Unit = binding { item ->
-        body.text = if (item.setupState.isHealerWorking) {
-            getString(R.string.setup_incomplete_card_healing_in_progress_body)
-        } else {
-            getString(R.string.setup_incomplete_card_body)
+        val state = item.setupState
+        title.text = when {
+            state.isIncomplete -> getString(R.string.setup_incomplete_card_title)
+            else -> getString(R.string.setup_label)
+        }
+        body.text = when {
+            state.isHealerWorking -> getString(R.string.setup_incomplete_card_healing_in_progress_body)
+            state.isLoading -> getString(R.string.setup_checking_card_body)
+            else -> getString(R.string.setup_incomplete_card_body)
         }
 
         dismissAction.apply {
-            isInvisible = item.setupState.isHealerWorking
+            isVisible = !state.isWorking
             setOnClickListener { item.onDismiss() }
         }
 
-        setupProgress.isVisible = item.setupState.isHealerWorking
+        setupProgress.isVisible = state.isWorking
+
         continueSetupAction.apply {
-            isInvisible = item.setupState.isHealerWorking
+            isVisible = !state.isHealerWorking || state.isIncomplete
             setOnClickListener { item.onContinue() }
+            text = when {
+                state.isIncomplete -> getString(R.string.setup_incomplete_card_continue_action)
+                else -> getString(eu.darken.sdmse.common.R.string.general_view_action)
+            }
         }
     }
 

--- a/app/src/main/java/eu/darken/sdmse/main/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/settings/SettingsViewModel.kt
@@ -32,7 +32,7 @@ class SettingsViewModel @Inject constructor(
 
     val state = combine(
         upgradeRepo.upgradeInfo.map { it.isPro },
-        setupManager.state.map { it.isComplete },
+        setupManager.state.map { it.isDone },
     ) { isPro, isSetUp ->
         State(
             isPro = isPro,

--- a/app/src/main/java/eu/darken/sdmse/setup/SetupAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/SetupAdapter.kt
@@ -41,6 +41,7 @@ SetupAdapter @Inject constructor() :
         addMod(TypedVHCreatorMod({ data[it] is NotificationSetupCardVH.Item }) { NotificationSetupCardVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is ShizukuSetupCardVH.Item }) { ShizukuSetupCardVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is InventorySetupCardVH.Item }) { InventorySetupCardVH(it) })
+        addMod(TypedVHCreatorMod({ data[it] is SetupModuleLoadingCardVH.Item }) { SetupModuleLoadingCardVH(it) })
     }
 
     abstract class BaseVH<D : Item, B : ViewBinding>(
@@ -51,6 +52,9 @@ SetupAdapter @Inject constructor() :
     interface Item : DifferItem {
 
         val state: SetupModule.State
+
+        override val stableId: Long
+            get() = state.type.name.hashCode().toLong()
 
         override val payloadProvider: ((DifferItem, DifferItem) -> DifferItem?)
             get() = { old, new ->

--- a/app/src/main/java/eu/darken/sdmse/setup/SetupEvents.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/SetupEvents.kt
@@ -7,7 +7,7 @@ import eu.darken.sdmse.setup.saf.SAFSetupModule
 
 sealed interface SetupEvents {
     data class SafRequestAccess(
-        val item: SAFSetupModule.State.PathAccess,
+        val item: SAFSetupModule.Result.PathAccess,
     ) : SetupEvents
 
     data class SafWrongPathError(
@@ -19,7 +19,7 @@ sealed interface SetupEvents {
     ) : SetupEvents
 
     data class ConfigureAccessibilityService(
-        val item: AutomationSetupModule.State,
+        val item: AutomationSetupModule.Result,
     ) : SetupEvents
 
     data class ShowOurDetailsPage(

--- a/app/src/main/java/eu/darken/sdmse/setup/SetupFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/SetupFragment.kt
@@ -45,7 +45,7 @@ class SetupFragment : Fragment3(R.layout.setup_fragment) {
     @Inject lateinit var webpageTool: WebpageTool
     @Inject lateinit var deviceDetective: DeviceDetective
 
-    private lateinit var safRequestLauncher: ActivityResultLauncher<SAFSetupModule.State.PathAccess>
+    private lateinit var safRequestLauncher: ActivityResultLauncher<SAFSetupModule.Result.PathAccess>
     private var awaitedPermission: Permission? = null
     private lateinit var specialPermissionLauncher: ActivityResultLauncher<Intent>
     private lateinit var runtimePermissionLauncher: ActivityResultLauncher<String>

--- a/app/src/main/java/eu/darken/sdmse/setup/SetupManager.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/SetupManager.kt
@@ -2,6 +2,7 @@ package eu.darken.sdmse.setup
 
 import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.datastore.valueBlocking
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.flow.replayingShare
@@ -10,6 +11,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.onEach
+import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -22,7 +24,9 @@ class SetupManager @Inject constructor(
 ) {
 
     val state: Flow<State> = combine(
-        combine(setupModules.map { it.state }) { it.filterNotNull().toList() },
+        combine(
+            setupModules.map { module -> module.state.onEach { log(TAG, VERBOSE) { "Module $module -> $it" } } }
+        ) { it.toList() },
         generalSettings.isSetupDismissed.flow,
         setupHealer.state,
     ) { moduleStates, isDismissed, healerState ->
@@ -51,7 +55,13 @@ class SetupManager @Inject constructor(
         val isHealerWorking: Boolean,
     ) {
 
-        val isComplete: Boolean = moduleStates.all { it.isComplete }
+        val startedLoadingAt: Instant?
+            get() = moduleStates.filterIsInstance<SetupModule.State.Loading>().minOfOrNull { it.startAt }
+
+        val isDone: Boolean = !isHealerWorking && moduleStates.all { it is SetupModule.State.Current && it.isComplete }
+        val isIncomplete: Boolean = moduleStates.filterIsInstance<SetupModule.State.Current>().any { !it.isComplete }
+        val isLoading: Boolean = moduleStates.any { it is SetupModule.State.Loading }
+        val isWorking: Boolean = isHealerWorking || isLoading
     }
 
     companion object {

--- a/app/src/main/java/eu/darken/sdmse/setup/SetupModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/SetupModule.kt
@@ -3,15 +3,23 @@ package eu.darken.sdmse.setup
 import androidx.annotation.StringRes
 import eu.darken.sdmse.R
 import kotlinx.coroutines.flow.Flow
+import java.time.Instant
 
 interface SetupModule {
-    val state: Flow<State?>
+    val state: Flow<State>
 
     suspend fun refresh()
 
-    interface State {
-        val isComplete: Boolean
+    sealed interface State {
         val type: Type
+
+        interface Loading : State {
+            val startAt: Instant
+        }
+
+        interface Current : State {
+            val isComplete: Boolean
+        }
     }
 
     enum class Type(@StringRes val labelRes: Int) {

--- a/app/src/main/java/eu/darken/sdmse/setup/SetupModuleExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/SetupModuleExtensions.kt
@@ -6,9 +6,13 @@ import com.google.android.material.snackbar.Snackbar
 import eu.darken.sdmse.R
 import eu.darken.sdmse.common.ui.enableBigText
 import eu.darken.sdmse.main.ui.settings.SettingsFragmentDirections
+import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
 
-suspend fun SetupModule.isComplete() = state.first()?.isComplete ?: false
+suspend fun SetupModule.isComplete() = state.filterIsInstance<SetupModule.State.Current>().first().isComplete
+
+val SetupModule.State.isComplete: Boolean
+    get() = this is SetupModule.State.Current && this.isComplete
 
 fun Set<SetupModule.Type>.showFixSetupHint(fragment: Fragment) {
     // If the user navigates back while the snackbar is still showing

--- a/app/src/main/java/eu/darken/sdmse/setup/SetupModuleLoadingCardVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/SetupModuleLoadingCardVH.kt
@@ -1,0 +1,52 @@
+package eu.darken.sdmse.setup
+
+import android.view.ViewGroup
+import eu.darken.sdmse.R
+import eu.darken.sdmse.common.lists.binding
+import eu.darken.sdmse.databinding.SetupModuleLoadingItemBinding
+
+
+class SetupModuleLoadingCardVH(parent: ViewGroup) :
+    SetupAdapter.BaseVH<SetupModuleLoadingCardVH.Item, SetupModuleLoadingItemBinding>(
+        R.layout.setup_module_loading_item,
+        parent
+    ) {
+
+
+    override val viewBinding = lazy { SetupModuleLoadingItemBinding.bind(itemView) }
+
+    override val onBindData: SetupModuleLoadingItemBinding.(
+        item: Item,
+        payloads: List<Any>
+    ) -> Unit = binding { item ->
+        icon.setImageResource(
+            when (item.state.type) {
+                SetupModule.Type.USAGE_STATS -> R.drawable.ic_chartbox_24
+                SetupModule.Type.AUTOMATION -> R.drawable.ic_baseline_accessibility_new_24
+                SetupModule.Type.SHIZUKU -> R.drawable.ic_shizuku_24
+                SetupModule.Type.ROOT -> R.drawable.ic_root_24
+                SetupModule.Type.NOTIFICATION -> R.drawable.ic_notification_24
+                SetupModule.Type.SAF -> R.drawable.ic_saf
+                SetupModule.Type.STORAGE -> R.drawable.ic_sd_storage
+                SetupModule.Type.INVENTORY -> R.drawable.ic_apps
+            }
+        )
+        title.setText(
+            when (item.state.type) {
+                SetupModule.Type.USAGE_STATS -> R.string.setup_usagestats_title
+                SetupModule.Type.AUTOMATION -> R.string.setup_acs_card_title
+                SetupModule.Type.SHIZUKU -> R.string.setup_shizuku_card_title
+                SetupModule.Type.ROOT -> R.string.setup_root_card_title
+                SetupModule.Type.NOTIFICATION -> R.string.setup_notification_title
+                SetupModule.Type.SAF -> R.string.setup_saf_card_title
+                SetupModule.Type.STORAGE -> R.string.setup_manage_storage_card_title
+                SetupModule.Type.INVENTORY -> R.string.setup_inventory_card_title
+            }
+        )
+        body.setText(eu.darken.sdmse.common.R.string.general_progress_loading)
+    }
+
+    data class Item(
+        override val state: SetupModule.State.Loading,
+    ) : SetupAdapter.Item
+}

--- a/app/src/main/java/eu/darken/sdmse/setup/automation/AutomationSetupCardVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/automation/AutomationSetupCardVH.kt
@@ -131,14 +131,11 @@ class AutomationSetupCardVH(parent: ViewGroup) :
     }
 
     data class Item(
-        override val state: AutomationSetupModule.State,
+        override val state: AutomationSetupModule.Result,
         val onGrantAction: () -> Unit,
         val onDismiss: () -> Unit,
         val onHelp: () -> Unit,
         val onRestrictionsHelp: () -> Unit,
         val onRestrictionsShow: () -> Unit,
-    ) : SetupAdapter.Item {
-        override val stableId: Long = this.javaClass.hashCode().toLong()
-    }
-
+    ) : SetupAdapter.Item
 }

--- a/app/src/main/java/eu/darken/sdmse/setup/inventory/InventorySetupCardVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/inventory/InventorySetupCardVH.kt
@@ -30,11 +30,8 @@ class InventorySetupCardVH(parent: ViewGroup) :
     }
 
     data class Item(
-        override val state: InventorySetupModule.State,
+        override val state: InventorySetupModule.Result,
         val onGrantAction: () -> Unit,
         val onHelp: () -> Unit,
-    ) : SetupAdapter.Item {
-        override val stableId: Long = this.javaClass.hashCode().toLong()
-    }
-
+    ) : SetupAdapter.Item
 }

--- a/app/src/main/java/eu/darken/sdmse/setup/notification/NotificationSetupCardVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/notification/NotificationSetupCardVH.kt
@@ -30,11 +30,8 @@ class NotificationSetupCardVH(parent: ViewGroup) :
     }
 
     data class Item(
-        override val state: NotificationSetupModule.State,
+        override val state: NotificationSetupModule.Result,
         val onGrantAction: () -> Unit,
         val onHelp: () -> Unit,
-    ) : SetupAdapter.Item {
-        override val stableId: Long = this.javaClass.hashCode().toLong()
-    }
-
+    ) : SetupAdapter.Item
 }

--- a/app/src/main/java/eu/darken/sdmse/setup/root/RootSetupCardVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/root/RootSetupCardVH.kt
@@ -51,11 +51,8 @@ class RootSetupCardVH(parent: ViewGroup) :
     }
 
     data class Item(
-        override val state: RootSetupModule.State,
+        override val state: RootSetupModule.Result,
         val onToggleUseRoot: (Boolean?) -> Unit,
         val onHelp: () -> Unit,
-    ) : SetupAdapter.Item {
-        override val stableId: Long = this.javaClass.hashCode().toLong()
-    }
-
+    ) : SetupAdapter.Item
 }

--- a/app/src/main/java/eu/darken/sdmse/setup/saf/SAFCardPathAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/saf/SAFCardPathAdapter.kt
@@ -31,8 +31,8 @@ class SAFCardPathAdapter @Inject constructor() :
     }
 
     data class Item(
-        val pathAccess: SAFSetupModule.State.PathAccess,
-        val onClicked: (SAFSetupModule.State.PathAccess) -> Unit,
+        val pathAccess: SAFSetupModule.Result.PathAccess,
+        val onClicked: (SAFSetupModule.Result.PathAccess) -> Unit,
     ) : DifferItem {
         override val stableId: Long = this.javaClass.hashCode().toLong()
     }

--- a/app/src/main/java/eu/darken/sdmse/setup/saf/SAFSetupCardVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/saf/SAFSetupCardVH.kt
@@ -45,11 +45,8 @@ class SAFSetupCardVH(parent: ViewGroup) :
     }
 
     data class Item(
-        override val state: SAFSetupModule.State,
-        val onPathClicked: (SAFSetupModule.State.PathAccess) -> Unit,
+        override val state: SAFSetupModule.Result,
+        val onPathClicked: (SAFSetupModule.Result.PathAccess) -> Unit,
         val onHelp: () -> Unit,
-    ) : SetupAdapter.Item {
-        override val stableId: Long = this.javaClass.hashCode().toLong()
-    }
-
+    ) : SetupAdapter.Item
 }

--- a/app/src/main/java/eu/darken/sdmse/setup/saf/SafGrantPrimaryContract.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/saf/SafGrantPrimaryContract.kt
@@ -6,11 +6,11 @@ import android.content.Intent
 import android.net.Uri
 import androidx.activity.result.contract.ActivityResultContract
 
-class SafGrantPrimaryContract : ActivityResultContract<SAFSetupModule.State.PathAccess, Uri?>() {
+class SafGrantPrimaryContract : ActivityResultContract<SAFSetupModule.Result.PathAccess, Uri?>() {
 
     override fun createIntent(
         context: Context,
-        data: SAFSetupModule.State.PathAccess
+        data: SAFSetupModule.Result.PathAccess
     ): Intent = data.grantIntent
 
     override fun parseResult(resultCode: Int, intent: Intent?): Uri? = when (resultCode) {

--- a/app/src/main/java/eu/darken/sdmse/setup/shizuku/ShizukuSetupCardVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/shizuku/ShizukuSetupCardVH.kt
@@ -57,12 +57,9 @@ class ShizukuSetupCardVH(parent: ViewGroup) :
     }
 
     data class Item(
-        override val state: ShizukuSetupModule.State,
+        override val state: ShizukuSetupModule.Result,
         val onToggleUseShizuku: (Boolean?) -> Unit,
         val onHelp: () -> Unit,
         val onOpen: () -> Unit,
-    ) : SetupAdapter.Item {
-        override val stableId: Long = this.javaClass.hashCode().toLong()
-    }
-
+    ) : SetupAdapter.Item
 }

--- a/app/src/main/java/eu/darken/sdmse/setup/storage/LocalPathCardAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/storage/LocalPathCardAdapter.kt
@@ -31,8 +31,8 @@ class LocalPathCardAdapter @Inject constructor() :
     }
 
     data class Item(
-        val pathAccess: StorageSetupModule.State.PathAccess,
-        val onClicked: (StorageSetupModule.State.PathAccess) -> Unit,
+        val pathAccess: StorageSetupModule.Result.PathAccess,
+        val onClicked: (StorageSetupModule.Result.PathAccess) -> Unit,
     ) : DifferItem {
         override val stableId: Long = this.javaClass.hashCode().toLong()
     }

--- a/app/src/main/java/eu/darken/sdmse/setup/storage/StorageSetupCardVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/storage/StorageSetupCardVH.kt
@@ -45,11 +45,8 @@ class StorageSetupCardVH(parent: ViewGroup) :
     }
 
     data class Item(
-        override val state: StorageSetupModule.State,
-        val onPathClicked: (StorageSetupModule.State.PathAccess) -> Unit,
+        override val state: StorageSetupModule.Result,
+        val onPathClicked: (StorageSetupModule.Result.PathAccess) -> Unit,
         val onHelp: () -> Unit,
-    ) : SetupAdapter.Item {
-        override val stableId: Long = this.javaClass.hashCode().toLong()
-    }
-
+    ) : SetupAdapter.Item
 }

--- a/app/src/main/java/eu/darken/sdmse/setup/usagestats/UsageStatsSetupCardVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/usagestats/UsageStatsSetupCardVH.kt
@@ -31,11 +31,8 @@ class UsageStatsSetupCardVH(parent: ViewGroup) :
     }
 
     data class Item(
-        override val state: UsageStatsSetupModule.State,
+        override val state: UsageStatsSetupModule.Result,
         val onGrantAction: () -> Unit,
         val onHelp: () -> Unit,
-    ) : SetupAdapter.Item {
-        override val stableId: Long = this.javaClass.hashCode().toLong()
-    }
-
+    ) : SetupAdapter.Item
 }

--- a/app/src/main/res/layout/dashboard_setup_item.xml
+++ b/app/src/main/res/layout/dashboard_setup_item.xml
@@ -35,16 +35,16 @@
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/body"
             style="@style/TextAppearance.Material3.BodyMedium"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
             android:text="@string/setup_incomplete_card_body"
             android:textColor="?colorOnSecondaryContainer"
             app:layout_constraintBottom_toTopOf="@id/continue_setup_action"
-            app:layout_constraintVertical_chainStyle="spread_inside"
-            app:layout_constraintEnd_toEndOf="@id/title"
-            app:layout_constraintStart_toStartOf="@id/title"
-            app:layout_constraintTop_toBottomOf="@id/title" />
+            app:layout_constraintEnd_toStartOf="@id/setup_progress"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/title"
+            app:layout_constraintVertical_chainStyle="spread_inside" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/dismiss_action"
@@ -73,14 +73,12 @@
 
         <com.google.android.material.progressindicator.CircularProgressIndicator
             android:id="@+id/setup_progress"
-            style="@style/Widget.Material3.CircularProgressIndicator.Small"
+            style="@style/Widget.Material3.CircularProgressIndicator.ExtraSmall"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:indeterminate="true"
-            app:layout_constraintBottom_toBottomOf="@id/continue_setup_action"
-            app:layout_constraintEnd_toEndOf="@id/continue_setup_action"
-            app:layout_constraintStart_toStartOf="@id/continue_setup_action"
-            app:layout_constraintTop_toTopOf="@id/continue_setup_action" />
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/setup_module_loading_item.xml
+++ b/app/src/main/res/layout/setup_module_loading_item.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    style="@style/DashboardCardItem"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <ImageView
+            android:id="@+id/icon"
+            android:layout_width="20dp"
+            android:layout_height="20dp"
+            android:layout_marginStart="16dp"
+            tools:src="@drawable/ic_chartbox_24"
+            app:layout_constraintBottom_toBottomOf="@id/title"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@id/title" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/title"
+            style="@style/TextAppearance.Material3.TitleMedium"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginEnd="16dp"
+            tools:text="@string/setup_usagestats_title"
+            app:layout_constraintStart_toEndOf="@id/icon"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_chainStyle="packed" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/body"
+            style="@style/TextAppearance.Material3.BodyMedium"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="16dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginBottom="16dp"
+            tools:text="@string/general_progress_loading"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="@id/title"
+            app:layout_constraintStart_toStartOf="@id/title"
+            app:layout_constraintTop_toBottomOf="@id/title"
+            app:layout_constraintVertical_chainStyle="packed" />
+
+        <com.google.android.material.progressindicator.CircularProgressIndicator
+            style="@style/Widget.Material3.CircularProgressIndicator.Small"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            android:indeterminate="true"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -110,6 +110,7 @@
     <string name="setup_incomplete_card_continue_action">Continue setup</string>
     <string name="setup_title">Setup</string>
     <string name="setup_forcedshow_summary">Show setup screen again, including already completed items.</string>
+    <string name="setup_checking_card_body">Verifying setup completion and functionality.</string>
 
     <string name="general_error_setup_require_label">Setup is incomplete</string>
     <string name="general_error_setup_require_msg">Further set up is required to use this feature. Complete the remaining setup steps.</string>


### PR DESCRIPTION
Previously setup modules could only emit their state or nothing. In some cases this lead to the dashboard hanging, because SD Maid was endlessly waiting for the state from the ShizukuSetupModule. Now every setup module can emit a `Loading` state and then later a `Current` state (does not have to be final). This allows us to show "loading states" for each module.

The dashboard will now load faster because we are not waiting for any setup states. Should loading any setup state take longer than 3 seconds, then we will show a setup card with a loading indicator. If there are loading states, but also incomplete setup steps, then the setup card will directly be shown. If you enter the setup screen incomplete items will be shown with loading cards in the list.

Closes #1116