### PR TITLE
Exclusions: Improve filter performance by keeping exclusion data loaded

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/exclusion/core/ExclusionManager.kt
+++ b/app/src/main/java/eu/darken/sdmse/exclusion/core/ExclusionManager.kt
@@ -10,9 +10,11 @@ import eu.darken.sdmse.exclusion.core.types.Exclusion
 import eu.darken.sdmse.exclusion.core.types.ExclusionId
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.plus
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -25,6 +27,7 @@ class ExclusionManager @Inject constructor(
     private val defaultExclusions: DefaultExclusions,
 ) {
 
+    // TODO Think about making this a SharedResource?
     private val _exclusions = DynamicStateFlow(parentScope = appScope + dispatcherProvider.IO) {
         exclusionStorage.load() ?: emptySet()
     }
@@ -44,6 +47,11 @@ class ExclusionManager @Inject constructor(
         }
         exclusions
     }
+        .shareIn(
+            scope = appScope,
+            started = SharingStarted.Lazily,
+            replay = 1
+        )
 
 
     init {


### PR DESCRIPTION
We access `val current = exclusions.first()` a lot which would previously do the data merge (user+defaults) every time, that's wasted performance, let's do it once and keep it in memory.

This increases RAM usage, but as exclusions are used in all tools anyways, it shouldn't matter.

Might be cool though to make exclusions a `SharedResource` in the future to scope it better, like other modules (e.g. `FileForensics`).