### PR TITLE
Exclusions: Fix internally mixing up user exclusions and default exclusions

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/deduplicator/core/scanner/phash/PHashSleuth.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/core/scanner/phash/PHashSleuth.kt
@@ -120,7 +120,6 @@ class PHashSleuth @Inject constructor(
         log(TAG) { "Global skip segments: $globalSkips" }
 
         val minSize = settings.minSizeBytes.value()
-        val skipUncommon = settings.skipUncommon.value()
 
         val suspects = mutableSetOf<APathLookup<*>>()
 

--- a/app/src/main/java/eu/darken/sdmse/exclusion/core/DefaultExclusions.kt
+++ b/app/src/main/java/eu/darken/sdmse/exclusion/core/DefaultExclusions.kt
@@ -19,7 +19,9 @@ import javax.inject.Inject
 class DefaultExclusions @Inject constructor(
     private val exclusionSettings: ExclusionSettings,
 ) {
-
+    // Due to a bug before v0.23.3-beta0, some of the user exclusions can be inside the removedDefaultExclusions
+    // These are just the strings IDs though and shouldn't cause any issue
+    // Downstream we don't combine removed defaults and user exclusions
     val exclusions: Flow<Collection<DefaultExclusion>> = exclusionSettings.removedDefaultExclusions.flow
         .onEach { log(TAG, INFO) { "Removed default exclusions are: $it" } }
         .map { removed -> DATA.filter { !removed.contains(it.id) } }

--- a/app/src/main/java/eu/darken/sdmse/exclusion/core/ExclusionManager.kt
+++ b/app/src/main/java/eu/darken/sdmse/exclusion/core/ExclusionManager.kt
@@ -2,16 +2,21 @@ package eu.darken.sdmse.exclusion.core
 
 import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
-import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.flow.DynamicStateFlow
+import eu.darken.sdmse.common.flow.setupCommonEventHandlers
 import eu.darken.sdmse.exclusion.core.types.Exclusion
 import eu.darken.sdmse.exclusion.core.types.ExclusionId
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.shareIn
@@ -28,24 +33,24 @@ class ExclusionManager @Inject constructor(
 ) {
 
     // TODO Think about making this a SharedResource?
-    private val _exclusions = DynamicStateFlow(parentScope = appScope + dispatcherProvider.IO) {
-        exclusionStorage.load() ?: emptySet()
+    private val userExclusions = DynamicStateFlow(parentScope = appScope + dispatcherProvider.IO) {
+        (exclusionStorage.load() ?: emptySet()).also {
+            log(TAG) { "Initialized with ${it.size} user exclusions:\n${it.joinToString("\n")}" }
+        }
     }
+
     val exclusions: Flow<Collection<Exclusion>> = combine(
-        _exclusions.flow,
+        userExclusions.flow,
         defaultExclusions.exclusions,
     ) { user, defaults ->
-        val exclusions = mutableSetOf<Exclusion>()
-        exclusions.addAll(user)
-        defaults.forEach { def ->
-            if (exclusions.none { it.id == def.id }) {
-                log(TAG, VERBOSE) { "Injecting default $def" }
-                exclusions.add(def)
-            } else {
-                log(TAG, VERBOSE) { "User exclusions overlap with $def" }
-            }
+        val uniqDefaults = defaults.filter { def ->
+            val notCovered = user.none { it.id == def.id }
+            if (!notCovered) log(TAG, WARN) { "User exclusions overlap with $def" }
+            notCovered
         }
-        exclusions
+        (user + uniqDefaults).also {
+            log(TAG, INFO) { "Exclusions (${it.size}) are:\n${it.joinToString("\n")}" }
+        }
     }
         .setupCommonEventHandlers(TAG) { "exclusions" }
         .shareIn(
@@ -56,7 +61,9 @@ class ExclusionManager @Inject constructor(
 
 
     init {
-        _exclusions.flow
+        userExclusions.flow
+            .drop(1)
+            .distinctUntilChanged()
             .onEach { exclusionStorage.save(it) }
             .launchIn(appScope + dispatcherProvider.IO)
     }
@@ -64,7 +71,7 @@ class ExclusionManager @Inject constructor(
     suspend fun save(toSave: Set<Exclusion>): Collection<Exclusion> {
         log(TAG) { "save(): $toSave" }
         val newOrUpdated = mutableSetOf<Exclusion>()
-        _exclusions.updateBlocking {
+        userExclusions.updateBlocking {
             val newExclusions = toSave.filter {
                 val isDupe = this.contains(it)
                 if (isDupe) log(TAG) { "Exclusion already exists: $it" }
@@ -79,12 +86,23 @@ class ExclusionManager @Inject constructor(
     }
 
     suspend fun remove(ids: Set<ExclusionId>) {
-        log(TAG) { "remove(): $ids" }
-        val targets = currentExclusions().filter { ids.contains(it.id) }.toSet()
-        log(TAG) { "remove(): $targets" }
-        _exclusions.updateBlocking { this - targets }
+        log(TAG, INFO) { "remove($ids)..." }
 
-        defaultExclusions.remove(ids)
+        val userTargets = userExclusions.flow.first().filter { ids.contains(it.id) }.toSet()
+        if (userTargets.isNotEmpty()) {
+            log(TAG) { "remove(): Removing user exclusions: $userTargets" }
+            userExclusions.updateBlocking { this - userTargets }
+        }
+
+        val defaultTargets = defaultExclusions.exclusions.first()
+        if (defaultTargets.isNotEmpty()) {
+            log(TAG) { "remove(): Removing defaults exclusion: $defaultTargets" }
+            defaultExclusions.remove(ids)
+        }
+
+        if (userTargets.isEmpty() && defaultTargets.isEmpty()) {
+            log(TAG, WARN) { "remove(): Unknown IDs, can't remove $ids" }
+        }
     }
 
     companion object {

--- a/app/src/main/java/eu/darken/sdmse/exclusion/core/ExclusionManager.kt
+++ b/app/src/main/java/eu/darken/sdmse/exclusion/core/ExclusionManager.kt
@@ -47,6 +47,7 @@ class ExclusionManager @Inject constructor(
         }
         exclusions
     }
+        .setupCommonEventHandlers(TAG) { "exclusions" }
         .shareIn(
             scope = appScope,
             started = SharingStarted.Lazily,


### PR DESCRIPTION
No user-visible impact but wasn't stored the way it was intended.
User exclusions were added to the "removed default exclusions" data set.

Unrelated but noticed when checking logs from https://github.com/d4rken-org/sdmaid-se/issues/1135