### PR TITLE
AppCleaner: Fix ACS label lookup on OPPO and Android TV devices

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/androidtv/AndroidTVLabels.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/androidtv/AndroidTVLabels.kt
@@ -2,6 +2,7 @@ package eu.darken.sdmse.appcleaner.core.automation.specs.androidtv
 
 import dagger.Reusable
 import eu.darken.sdmse.appcleaner.core.automation.specs.AppCleanerLabelSource
+import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import javax.inject.Inject
 
@@ -70,7 +71,7 @@ open class AndroidTVLabels @Inject constructor(
         "hr".toLang() == lang -> setOf("Očisti predmemoriju")
         "bn".toLang() == lang -> setOf("ক্যাশে সাফ করুন")
         "lv".toLang() == lang -> setOf("Notīrīt kešatmiņu")
-        else -> throw UnsupportedOperationException()
+        else -> emptySet<String>().also { log(TAG) { "Unmapped locale: $lang $script" } }
     }
 
     companion object {

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/androidtv/AndroidTVSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/androidtv/AndroidTVSpecs.kt
@@ -30,6 +30,7 @@ import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.device.DeviceDetective
@@ -79,6 +80,11 @@ open class AndroidTVSpecs @Inject constructor(
         run {
             val clearCacheButtonLabels = androidTVLabels.getClearCacheLabels(lang, script)
 
+            if (clearCacheButtonLabels.isNotEmpty()) {
+                log(TAG, WARN) { "clearCacheButtonLabels was empty" }
+                throw UnsupportedOperationException("This system language is not supported")
+            }
+
             val buttonFilter = fun(node: AccessibilityNodeInfo): Boolean {
                 if (!node.idMatches("android:id/title")) return false
                 return node.textMatchesAny(clearCacheButtonLabels)
@@ -97,6 +103,7 @@ open class AndroidTVSpecs @Inject constructor(
             )
             stepper.withProgress(this) { process(step) }
         }
+
         run {
             val clearCacheTexts = androidTVLabels.getClearCacheLabels(lang, script)
 

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/coloros/ColorOSLabels.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/coloros/ColorOSLabels.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import dagger.Reusable
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.sdmse.appcleaner.core.automation.specs.AppCleanerLabelSource
+import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.pkgs.toPkgId
 import javax.inject.Inject
@@ -47,7 +48,7 @@ class ColorOSLabels @Inject constructor(
         "fr".toLang() == lang -> setOf("Utilisation du stockage")
         "vi".toLang() == lang -> setOf("Sử dụng lưu trữ")
         "ms".toLang() == lang -> setOf("Penggunaan storan")
-        else -> throw UnsupportedOperationException()
+        else -> emptySet<String>().also { log(TAG) { "Unmapped locale: $lang $script" } }
     }
 
     fun getClearCacheDynamic(): Set<String> = setOf(
@@ -101,7 +102,7 @@ class ColorOSLabels @Inject constructor(
         "fa".toLang() == lang -> setOf("پاک کردن حافظهٔ پنهان")
         "th".toLang() == lang -> setOf("ล้างแคช")
         "ja".toLang() == lang -> setOf("キャッシュを消去")
-        else -> throw UnsupportedOperationException()
+        else -> emptySet<String>().also { log(TAG) { "Unmapped locale: $lang $script" } }
     }
 
     companion object {

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/flyme/FlymeLabels.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/flyme/FlymeLabels.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import dagger.Reusable
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.sdmse.appcleaner.core.automation.specs.AppCleanerLabelSource
+import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.pkgs.toPkgId
 import javax.inject.Inject
@@ -113,7 +114,7 @@ class FlymeLabels @Inject constructor(
         "hr".toLang() == lang -> setOf("Očisti predmemoriju")
         "bn".toLang() == lang -> setOf("ক্যাশে সাফ করুন")
         "lv".toLang() == lang -> setOf("Notīrīt kešatmiņu")
-        else -> throw UnsupportedOperationException()
+        else -> emptySet<String>().also { log(TAG) { "Unmapped locale: $lang $script" } }
     }
 
     companion object {

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/flyme/FlymeSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/flyme/FlymeSpecs.kt
@@ -24,6 +24,7 @@ import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.device.DeviceDetective
@@ -75,6 +76,11 @@ class FlymeSpecs @Inject constructor(
             // Do this beforehand so we crash early if unsupported
             val clearCacheButtonLabels =
                 flymeLabels.getClearCacheDynamic() + flymeLabels.getClearCacheLabels(lang, script)
+
+            if (clearCacheButtonLabels.isNotEmpty()) {
+                log(TAG, WARN) { "clearCacheButtonLabels was empty" }
+                throw UnsupportedOperationException("This system language is not supported")
+            }
 
             val buttonFilter = fun(node: AccessibilityNodeInfo): Boolean {
                 if (!node.isClickable) return false

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/miui/MIUILabels.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/miui/MIUILabels.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import dagger.Reusable
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.sdmse.appcleaner.core.automation.specs.AppCleanerLabelSource
+import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.pkgs.toPkgId
 import javax.inject.Inject
@@ -105,7 +106,7 @@ class MIUILabels @Inject constructor(
         "km".toLang() == lang -> setOf("ជម្រះឃ្លាំងសម្ងាត់ឬ?")
         "or".toLang() == lang -> setOf("କ୍ୟାଚେ ସଫା କରିବେ?")
         "lo".toLang() == lang -> setOf("ລົບ\u200Bລ້າງ Cache?")
-        else -> throw UnsupportedOperationException()
+        else -> emptySet<String>().also { log(TAG) { "Unmapped locale: $lang $script" } }
     }
 
     fun getClearCacheButtonLabels(lang: String, script: String, country: String?): Set<String> =
@@ -193,7 +194,7 @@ class MIUILabels @Inject constructor(
             "km".toLang() == lang -> setOf("ជម្រះឃ្លាំងសម្ងាត់")
             "or".toLang() == lang -> setOf("କ୍ୟାଚେ ସଫା କରନ୍ତୁ")
             "lo".toLang() == lang -> setOf("ລົບ\u200Bລ້າງ Cache")
-            else -> throw UnsupportedOperationException()
+            else -> emptySet<String>().also { log(TAG) { "Unmapped locale: $lang $script" } }
         }
 
     fun getClearDataButtonLabels(lang: String, script: String, country: String?): Set<String> =
@@ -279,7 +280,7 @@ class MIUILabels @Inject constructor(
             "km".toLang() == lang -> setOf("ជម្រះទិន្នន័យ")
             "or".toLang() == lang -> setOf("ଡାଟା ଖାଲିକରନ୍ତୁ")
             "lo".toLang() == lang -> setOf("ລົບ\u200Bລ້າງ\u200Bຂໍ້\u200Bມູນ")
-            else -> throw UnsupportedOperationException()
+            else -> emptySet<String>().also { log(TAG) { "Unmapped locale: $lang $script" } }
         }
 
     companion object {

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/realme/RealmeSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/realme/RealmeSpecs.kt
@@ -10,7 +10,6 @@ import dagger.multibindings.IntoSet
 import eu.darken.sdmse.R
 import eu.darken.sdmse.appcleaner.core.automation.specs.AppCleanerSpecGenerator
 import eu.darken.sdmse.appcleaner.core.automation.specs.OnTheFlyLabler
-import eu.darken.sdmse.appcleaner.core.automation.specs.alcatel.AlcatelSpecs
 import eu.darken.sdmse.automation.core.common.StepProcessor
 import eu.darken.sdmse.automation.core.common.clickableParent
 import eu.darken.sdmse.automation.core.common.defaultClick
@@ -27,7 +26,8 @@ import eu.darken.sdmse.automation.core.specs.AutomationExplorer
 import eu.darken.sdmse.automation.core.specs.AutomationSpec
 import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.datastore.value
-import eu.darken.sdmse.common.debug.logging.Logging
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.device.DeviceDetective
@@ -67,13 +67,13 @@ class RealmeSpecs @Inject constructor(
     }
 
     private val mainPlan: suspend AutomationExplorer.Context.(Installed) -> Unit = { pkg ->
-        log(AlcatelSpecs.TAG, Logging.Priority.INFO) { "Executing plan for ${pkg.installId} with context $this" }
+        log(TAG, INFO) { "Executing plan for ${pkg.installId} with context $this" }
 
         val locale = getSysLocale()
         val lang = locale.language
         val script = locale.script
 
-        log(Logging.Priority.VERBOSE) { "Getting specs for ${pkg.packageName} (lang=$lang, script=$script)" }
+        log(VERBOSE) { "Getting specs for ${pkg.packageName} (lang=$lang, script=$script)" }
 
         run {
             val storageEntryLabels =


### PR DESCRIPTION
Fix accessibility based cache clearing aborting with an error because extra language labels could not be looked up even tough we had at least one label we could work with.

Static lookups can be empty can be empty, we still might have labels from dynamic lookups or can even match via onthefly lookups.