### PR TITLE
Implement release party screen

### DIFF
--- a/app/src/foss/java/eu/darken/sdmse/common/updater/FossUpdateChecker.kt
+++ b/app/src/foss/java/eu/darken/sdmse/common/updater/FossUpdateChecker.kt
@@ -44,7 +44,7 @@ class FossUpdateChecker @Inject constructor(
             } else {
                 log(TAG) { "Fetching new release data" }
                 when (channel) {
-                    UpdateChecker.Channel.BETA -> checker.allReleases(OWNER, REPO).firstOrNull { it.isPreRelease }
+                    UpdateChecker.Channel.BETA -> checker.allReleases(OWNER, REPO).last()
                     UpdateChecker.Channel.PROD -> checker.latestRelease(OWNER, REPO)
                 }.also {
                     log(TAG, INFO) { "getLatest($channel) new data is $it" }

--- a/app/src/foss/java/eu/darken/sdmse/common/updater/FossUpdateChecker.kt
+++ b/app/src/foss/java/eu/darken/sdmse/common/updater/FossUpdateChecker.kt
@@ -3,7 +3,6 @@ package eu.darken.sdmse.common.updater
 import android.content.Context
 import dagger.Reusable
 import dagger.hilt.android.qualifiers.ApplicationContext
-import eu.darken.sdmse.common.BuildConfigWrap
 import eu.darken.sdmse.common.WebpageTool
 import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
@@ -24,12 +23,6 @@ class FossUpdateChecker @Inject constructor(
     private val webpageTool: WebpageTool,
     private val settings: FossUpdateSettings,
 ) : UpdateChecker {
-
-    override suspend fun currentChannel(): UpdateChecker.Channel = when (BuildConfigWrap.BUILD_TYPE) {
-        BuildConfigWrap.BuildType.RELEASE -> UpdateChecker.Channel.PROD
-        BuildConfigWrap.BuildType.BETA -> UpdateChecker.Channel.BETA
-        BuildConfigWrap.BuildType.DEV -> UpdateChecker.Channel.BETA
-    }
 
     override suspend fun getLatest(channel: UpdateChecker.Channel): UpdateChecker.Update? {
         log(TAG) { "getLatest($channel) checking..." }

--- a/app/src/foss/java/eu/darken/sdmse/common/updater/GithubReleaseCheck.kt
+++ b/app/src/foss/java/eu/darken/sdmse/common/updater/GithubReleaseCheck.kt
@@ -31,6 +31,9 @@ class GithubReleaseCheck @Inject constructor(
         }.build().create(GithubApi::class.java)
     }
 
+    /**
+     * Only returns non-pre-releases
+     */
     suspend fun latestRelease(
         owner: String,
         repo: String

--- a/app/src/foss/res/values-de/strings.xml
+++ b/app/src/foss/res/values-de/strings.xml
@@ -15,9 +15,4 @@
     <string name="upgrade_screen_sponsor_action">Weiterentwicklung unterstützen</string>
     <string name="upgrade_screen_sponsor_action_hint">Die Alternative sind Anzeigen, Analysen und Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Vielen Dank für Deine Unterstützung der Open-Source-Entwicklung ❤️</string>
-    <string name="nudge_betagoodbye_title">SD Maid 2/SE v1 🥳</string>
-    <string name="nudge_betagoodbye_body">Gemeinsam haben wir es bis zur ersten Veröffentlichung geschafft! Danke, dass Du mir beim Testen geholfen hast! Die Entwicklung wird natürlich fortgesetzt, aber Du kannst jetzt zu Nicht-Beta-Builds wechseln, indem Du die neueste stabile Version herunterlädst.</string>
-    <string name="nudge_betagoodbye_hint">Kleiner Hinweis: Während des Tests abgegebene Bewertungen sind nur für mich sichtbar, ich würde mich freuen, wenn Du SD Maid eine öffentliche Bewertung geben könnten, wenn Du zufrieden bist.</string>
-    <string name="nudge_betagoodbye_positive_action">Ablehnen</string>
-    <string name="nudge_betagoodbye_negative_action">Weiter testen</string>
 </resources>

--- a/app/src/foss/res/values/strings.xml
+++ b/app/src/foss/res/values/strings.xml
@@ -19,9 +19,9 @@
     <string name="upgrade_screen_sponsor_action_hint">The alternative are ads, analytics and Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Thank you for supporting open-source development ❤️</string>
 
-    <string name="nudge_betagoodbye_title">SD Maid 2/SE v1 🥳</string>
-    <string name="nudge_betagoodbye_body">Together, we made it to the first release! Thank you for helping me test! Development will of course continue, but you can now switch to non-beta builds. Do this by downloading the latest stable release.</string>
-    <string name="nudge_betagoodbye_hint">Small note: Ratings given during testing are only visible to me, I\'d appreciate it if you could give SD Maid a public rating if you are happy.</string>
-    <string name="nudge_betagoodbye_positive_action">Opt-out</string>
-    <string name="nudge_betagoodbye_negative_action">Keep testing</string>
+    <string name="nudge_betagoodbye_title">Version 1.0 🥳</string>
+    <string name="nudge_betagoodbye_body">Thank you. We made it this far only together. Development will continue of course, but you can now switch to a release track.</string>
+    <string name="nudge_betagoodbye_hint">This is already a normal version. Just opt out of testing and you will only receive release updates in the future.</string>
+    <string name="nudge_betagoodbye_positive_action">Switch to release track</string>
+    <string name="nudge_betagoodbye_negative_action">Keep getting pre-releases</string>
 </resources>

--- a/app/src/gplay/java/eu/darken/sdmse/common/updater/GplayUpdateChecker.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/updater/GplayUpdateChecker.kt
@@ -9,9 +9,6 @@ import javax.inject.Inject
 class GplayUpdateChecker @Inject constructor(
 
 ) : UpdateChecker {
-    override suspend fun currentChannel(): UpdateChecker.Channel {
-        return UpdateChecker.Channel.PROD
-    }
 
     override suspend fun getLatest(channel: UpdateChecker.Channel): UpdateChecker.Update? {
         return null

--- a/app/src/gplay/res/values-de/strings.xml
+++ b/app/src/gplay/res/values-de/strings.xml
@@ -26,9 +26,4 @@
     <string name="upgrade_screen_restore_troubleshooting_msg">Fehlerbehebungstipps bei nicht erkannten Upgrades:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Die Synchronisation im Play Store kann etwas dauern. Versuch es mit einem Neustart, leere den Google Play Cache oder warte einfach.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Mehrere Konten können Google Play durcheinanderbringen. Melde dich von anderen Konten ab oder installiere über die Google Play-Website, um die Zuordnung zu einem bestimmten Konto zu erzwingen.</string>
-    <string name="nudge_betagoodbye_title">SD Maid 2/SE v1 🥳</string>
-    <string name="nudge_betagoodbye_body">Gemeinsam haben wir es bis zur ersten Veröffentlichung geschafft! Danke, dass Du mir geholfen hast! Die Entwicklung wird natürlich fortgesetzt, aber Du kannst jetzt auf stabilere Builds umsteigen, wenn Du möchtest. Deaktiviere dazu das Testen bei Google Play.</string>
-    <string name="nudge_betagoodbye_hint">Kleiner Hinweis: Während des Tests abgegebene Bewertungen sind nur für mich sichtbar, ich würde mich freuen, wenn Du SD Maid eine öffentliche Bewertung geben könntest, falls Du zufrieden bist.</string>
-    <string name="nudge_betagoodbye_positive_action">Ablehnen</string>
-    <string name="nudge_betagoodbye_negative_action">Weiter testen</string>
 </resources>

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -30,9 +30,9 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store synchronization may take time. Try rebooting, clearing Google Play cache or simply wait.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Multiple accounts can confuse Google Play. Log out of other accounts or install through the Google Play website, which forces associations with a specific account.</string>
 
-    <string name="nudge_betagoodbye_title">SD Maid 2/SE v1 🥳</string>
-    <string name="nudge_betagoodbye_body">Together, we made it to the first release! Thank you for helping me! Development will of course continue, but you can now switch to more stable builds, if you want to. Do this by opting-out of testing on Google Play.</string>
-    <string name="nudge_betagoodbye_hint">Small note: Ratings given during testing are only visible to me, I\'d appreciate it if you could give SD Maid a public rating if you are happy.</string>
-    <string name="nudge_betagoodbye_positive_action">Opt-out</string>
+    <string name="nudge_betagoodbye_title">Version 1.0 🥳</string>
+    <string name="nudge_betagoodbye_body">Thank you. We made it this far only together. Development will continue of course, but you can now install SD Maid without opting in for testing on Google Play.</string>
+    <string name="nudge_betagoodbye_hint">You don\'t have to re-install the app. This is already a normal version. Just opt out of testing and you will only receive release updates in the future.</string>
+    <string name="nudge_betagoodbye_positive_action">Leave testing programm</string>
     <string name="nudge_betagoodbye_negative_action">Keep testing</string>
 </resources>

--- a/app/src/main/java/eu/darken/sdmse/common/updater/UpdateChecker.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/updater/UpdateChecker.kt
@@ -1,7 +1,6 @@
 package eu.darken.sdmse.common.updater
 
 interface UpdateChecker {
-    suspend fun currentChannel(): Channel
 
     suspend fun getLatest(channel: Channel): Update?
 

--- a/app/src/main/java/eu/darken/sdmse/common/updater/UpdateService.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/updater/UpdateService.kt
@@ -6,6 +6,7 @@ import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.flow.replayingShare
 import eu.darken.sdmse.common.flow.setupCommonEventHandlers
 import eu.darken.sdmse.main.core.GeneralSettings
+import eu.darken.sdmse.main.core.release.ReleaseManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -22,6 +23,7 @@ class UpdateService @Inject constructor(
     @AppScope private val appScope: CoroutineScope,
     private val updateChecker: UpdateChecker,
     generalSettings: GeneralSettings,
+    releaseManager: ReleaseManager,
 ) {
 
     private val updateCheckTrigger = MutableStateFlow(UUID.randomUUID())
@@ -37,7 +39,7 @@ class UpdateService @Inject constructor(
                 updateCheckTrigger
             ) { isEnabled, _ ->
                 if (isEnabled) {
-                    updateChecker.getUpdate()
+                    updateChecker.getUpdate(betaConsent = releaseManager.hasBetaConsent())
                 } else {
                     log(TAG) { "Update check is not enabled!" }
                     null

--- a/app/src/main/java/eu/darken/sdmse/common/updater/UpdaterExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/updater/UpdaterExtensions.kt
@@ -17,13 +17,17 @@ fun UpdateChecker.Update.isNewer(): Boolean = try {
     false
 }
 
-suspend fun UpdateChecker.getUpdate(): UpdateChecker.Update? {
+suspend fun UpdateChecker.getUpdate(betaConsent: Boolean): UpdateChecker.Update? {
     if (!isCheckSupported()) {
         log(TAG, INFO) { "Update check is not supported" }
         return null
     }
 
-    val currentChannel = currentChannel()
+    val currentChannel = when (BuildConfigWrap.BUILD_TYPE) {
+        BuildConfigWrap.BuildType.RELEASE -> if (betaConsent) UpdateChecker.Channel.BETA else UpdateChecker.Channel.PROD
+        BuildConfigWrap.BuildType.BETA -> UpdateChecker.Channel.BETA
+        BuildConfigWrap.BuildType.DEV -> UpdateChecker.Channel.BETA
+    }
     val update = getLatest(currentChannel)
 
     if (update == null) {

--- a/app/src/main/java/eu/darken/sdmse/main/core/CurriculumVitae.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/core/CurriculumVitae.kt
@@ -12,9 +12,13 @@ import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.datastore.createValue
 import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import io.github.z4kn4fein.semver.Version
+import io.github.z4kn4fein.semver.VersionFormatException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import java.time.Instant
 import javax.inject.Inject
@@ -80,7 +84,16 @@ class CurriculumVitae @Inject constructor(
         _launchedCountBeta.value(newLaunchCount)
     }
 
-    val history = _updateHistory.flow
+    val history = _updateHistory.flow.map { versions ->
+        versions.mapNotNull {
+            try {
+                Version.parse(it, false)
+            } catch (e: VersionFormatException) {
+                log(TAG, WARN) { "Invalid version format: $it out of $versions" }
+                null
+            }
+        }
+    }
 
     private suspend fun updateVersionHistory() {
         val history = _updateHistory.value()

--- a/app/src/main/java/eu/darken/sdmse/main/core/release/ReleaseManager.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/core/release/ReleaseManager.kt
@@ -1,0 +1,89 @@
+package eu.darken.sdmse.main.core.release
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.sdmse.common.datastore.value
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.main.core.CurriculumVitae
+import io.github.z4kn4fein.semver.Version
+import io.github.z4kn4fein.semver.VersionFormatException
+import kotlinx.coroutines.flow.firstOrNull
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ReleaseManager @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val settings: ReleaseSettings,
+    private val curriculumVitae: CurriculumVitae,
+) {
+
+    private val ourVersion: Version by lazy {
+        val versionName = context.packageManager.getPackageInfo(context.packageName, 0).versionName
+        try {
+            Version.parse(versionName, strict = false).also { log(TAG) { "Current version is $it" } }
+        } catch (e: VersionFormatException) {
+            log(TAG, ERROR) { "Version parsing failed for $versionName" }
+            Version(0, 0, 0)
+        }
+    }
+
+    suspend fun hasBetaConsent() = if (ourVersion >= CUTOFF) settings.wantsBeta.value() else true
+
+    suspend fun releaseParty(): Boolean {
+        if (settings.didReleasePartyCheck.value()) {
+            log(TAG) { "releaseParty(): Already had a party (wantsBeta=${settings.wantsBeta.value()})" }
+            return false
+        }
+
+        val updateHistory = curriculumVitae.history.firstOrNull()
+        log(TAG) { "releaseParty(): Checking via update history: $updateHistory" }
+        if (updateHistory.isNullOrEmpty()) return false
+
+        val usedBetaBeforeCutoff = updateHistory.any { it < CUTOFF }
+
+        return when {
+            ourVersion < CUTOFF -> {
+                log(TAG, INFO) { "releaseParty(): Before CUTOFF, no party yet." }
+                false
+            }
+
+            ourVersion >= CUTOFF && usedBetaBeforeCutoff -> {
+                log(TAG, INFO) { "releaseParty(): Party time" }
+                true
+            }
+
+            else -> {
+                log(TAG, INFO) { "releaseParty(): User isn't invited." }
+                settings.didReleasePartyCheck.value(true)
+                false
+            }
+        }
+    }
+
+    suspend fun checkEarlyAdopter() {
+        val earlyAdopter = settings.earlyAdopter.value()
+        if (earlyAdopter != null) {
+            log(TAG) { "checkEarlyAdopter(): State already set ($earlyAdopter)" }
+            return
+        }
+        val updateHistory = curriculumVitae.history.firstOrNull()
+        if (updateHistory.isNullOrEmpty()) {
+            log(TAG) { "checkEarlyAdopter(): Update history is empty, not an early adopter." }
+            settings.earlyAdopter.value(false)
+            return
+        }
+
+        val hasHadBeta = updateHistory.any { it < CUTOFF }
+        log(TAG) { "checkEarlyAdopter(): Has had beta installed before cutoff? earlyAdopter=$hasHadBeta" }
+        settings.earlyAdopter.value(hasHadBeta)
+    }
+
+    companion object {
+        private val CUTOFF = Version(1, 0, 0, "rc0")
+        private val TAG = logTag("Release", "Manager")
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/main/core/release/ReleaseSettings.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/core/release/ReleaseSettings.kt
@@ -1,0 +1,36 @@
+package eu.darken.sdmse.main.core.release
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.sdmse.common.datastore.PreferenceScreenData
+import eu.darken.sdmse.common.datastore.PreferenceStoreMapper
+import eu.darken.sdmse.common.datastore.createValue
+import eu.darken.sdmse.common.debug.logging.logTag
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ReleaseSettings @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : PreferenceScreenData {
+
+    private val Context.dataStore by preferencesDataStore(name = "settings_release")
+
+    override val dataStore: DataStore<Preferences>
+        get() = context.dataStore
+
+    val didReleasePartyCheck = dataStore.createValue("release.party.checked", false)
+    val wantsBeta = dataStore.createValue("release.prerelease.consent", false)
+    val earlyAdopter = dataStore.createValue("release.earlyadopter", null as Boolean?)
+
+    override val mapper = PreferenceStoreMapper(
+
+    )
+
+    companion object {
+        internal val TAG = logTag("Release", "Settings")
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModel.kt
@@ -52,6 +52,7 @@ import eu.darken.sdmse.deduplicator.ui.DeduplicatorDashCardVH
 import eu.darken.sdmse.main.core.GeneralSettings
 import eu.darken.sdmse.main.core.SDMTool
 import eu.darken.sdmse.main.core.motd.MotdRepo
+import eu.darken.sdmse.main.core.release.ReleaseManager
 import eu.darken.sdmse.main.core.taskmanager.TaskManager
 import eu.darken.sdmse.main.ui.dashboard.items.*
 import eu.darken.sdmse.scheduler.core.SchedulerManager
@@ -93,11 +94,22 @@ class DashboardViewModel @Inject constructor(
     private val updateService: UpdateService,
     private val recorderModule: RecorderModule,
     private val motdRepo: MotdRepo,
+    private val releaseManager: ReleaseManager,
 ) : ViewModel3(dispatcherProvider = dispatcherProvider) {
 
     init {
         if (!generalSettings.isOnboardingCompleted.valueBlocking) {
             DashboardFragmentDirections.actionDashboardFragmentToOnboardingWelcomeFragment().navigate()
+        } else {
+            launch {
+                releaseManager.checkEarlyAdopter()
+                when {
+                    releaseManager.releaseParty() -> {
+                        log(TAG) { "Release party required, navigating..." }
+                        DashboardFragmentDirections.actionDashboardFragmentToBetaGoodbyeFragment().navigate()
+                    }
+                }
+            }
         }
     }
 

--- a/app/src/main/java/eu/darken/sdmse/main/ui/release/BetaGoodbyeFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/release/BetaGoodbyeFragment.kt
@@ -1,0 +1,33 @@
+package eu.darken.sdmse.main.ui.release
+
+import android.os.Bundle
+import android.view.View
+import androidx.activity.OnBackPressedCallback
+import androidx.fragment.app.viewModels
+import dagger.hilt.android.AndroidEntryPoint
+import eu.darken.sdmse.R
+import eu.darken.sdmse.common.uix.Fragment3
+import eu.darken.sdmse.common.viewbinding.viewBinding
+import eu.darken.sdmse.databinding.BetaGoodbyeFragmentBinding
+
+@AndroidEntryPoint
+class BetaGoodbyeFragment : Fragment3(R.layout.beta_goodbye_fragment) {
+
+    override val vm: BetaGoodbyeViewModel by viewModels()
+    override val ui: BetaGoodbyeFragmentBinding by viewBinding()
+
+    private val onBackPressedcallback = object : OnBackPressedCallback(true) {
+        override fun handleOnBackPressed() {}
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        requireActivity().onBackPressedDispatcher.addCallback(this, onBackPressedcallback)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        ui.stayBetaAction.setOnClickListener { vm.consentPrerelease(true) }
+        ui.optOutAction.setOnClickListener { vm.consentPrerelease(false) }
+        super.onViewCreated(view, savedInstanceState)
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/main/ui/release/BetaGoodbyeViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/release/BetaGoodbyeViewModel.kt
@@ -1,0 +1,48 @@
+package eu.darken.sdmse.main.ui.release
+
+import androidx.lifecycle.SavedStateHandle
+import dagger.hilt.android.lifecycle.HiltViewModel
+import eu.darken.sdmse.common.BuildConfigWrap
+import eu.darken.sdmse.common.WebpageTool
+import eu.darken.sdmse.common.coroutine.DispatcherProvider
+import eu.darken.sdmse.common.datastore.value
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.uix.ViewModel3
+import eu.darken.sdmse.main.core.release.ReleaseSettings
+import eu.darken.sdmse.main.ui.dashboard.items.*
+import kotlinx.coroutines.flow.*
+import javax.inject.Inject
+
+@HiltViewModel
+class BetaGoodbyeViewModel @Inject constructor(
+    @Suppress("unused") private val handle: SavedStateHandle,
+    dispatcherProvider: DispatcherProvider,
+    private val releaseSettings: ReleaseSettings,
+    private val webpageTool: WebpageTool,
+) : ViewModel3(dispatcherProvider = dispatcherProvider) {
+
+    fun consentPrerelease(consent: Boolean) = launch {
+        log(TAG) { "consentPrerelease($consent)" }
+        when (BuildConfigWrap.FLAVOR) {
+            BuildConfigWrap.Flavor.GPLAY -> {
+                if (!consent) {
+                    webpageTool.open("https://play.google.com/apps/testing/eu.darken.sdmse")
+                }
+            }
+
+            BuildConfigWrap.Flavor.FOSS -> {
+                // NOOP
+            }
+
+            BuildConfigWrap.Flavor.NONE -> throw IllegalStateException("Why is there no flavor?")
+        }
+        releaseSettings.wantsBeta.value(consent)
+        releaseSettings.didReleasePartyCheck.value(true)
+        popNavStack()
+    }
+
+    companion object {
+        private val TAG = logTag("Release", "BetaGoodbye", "ViewModel")
+    }
+}

--- a/app/src/main/res/layout/beta_goodbye_fragment.xml
+++ b/app/src/main/res/layout/beta_goodbye_fragment.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ScrollView
+        android:id="@+id/scrollView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toTopOf="@id/footer"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="32dp">
+
+            <ImageView
+                android:id="@+id/icon"
+                android:layout_width="128dp"
+                android:layout_height="128dp"
+                android:layout_gravity="center"
+                android:layout_marginTop="16dp"
+                android:src="@drawable/sdm_happy" />
+
+            <com.google.android.material.textview.MaterialTextView
+                style="@style/TextAppearance.Material3.HeadlineMedium"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:gravity="center"
+                android:text="@string/nudge_betagoodbye_title" />
+
+            <com.google.android.material.textview.MaterialTextView
+                style="@style/TextAppearance.Material3.BodyLarge"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:text="@string/nudge_betagoodbye_body" />
+
+            <com.google.android.material.card.MaterialCardView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:backgroundTint="?colorSecondaryContainer">
+
+                <com.google.android.material.textview.MaterialTextView
+                    style="@style/TextAppearance.Material3.BodyMedium"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="16dp"
+                    android:text="@string/nudge_betagoodbye_hint" />
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.card.MaterialCardView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:backgroundTint="?colorTertiaryContainer">
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content">
+
+                    <LinearLayout
+                        android:id="@+id/ribbon"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="-50dp"
+                        android:layout_marginTop="8dp"
+                        android:background="?colorError"
+                        android:orientation="vertical"
+                        android:paddingVertical="4dp"
+                        android:paddingStart="8dp"
+                        android:rotation="-45"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent">
+
+                        <com.google.android.material.textview.MaterialTextView
+                            android:id="@+id/ribbon_primary"
+                            style="@style/TextAppearance.Material3.BodySmall"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:paddingHorizontal="52dp"
+                            android:text="Beta"
+                            android:textColor="?colorOnError"
+                            android:textSize="14dp"
+                            android:textStyle="bold"
+                            app:iconTint="?colorOnError"
+                            tools:ignore="HardcodedText,SpUsage" />
+
+                        <com.google.android.material.textview.MaterialTextView
+                            android:id="@+id/ribbon_secondary"
+                            style="@style/TextAppearance.Material3.LabelSmall"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="center"
+                            android:text="v0.1.2-beta0"
+                            android:textColor="?colorOnError"
+                            android:textSize="10dp"
+                            app:iconTint="?colorOnError"
+                            tools:ignore="HardcodedText,SpUsage" />
+                    </LinearLayout>
+
+                    <com.google.android.material.textview.MaterialTextView
+                        style="@style/TextAppearance.Material3.BodySmall"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="-24dp"
+                        android:layout_marginTop="16dp"
+                        android:layout_marginEnd="16dp"
+                        android:layout_marginBottom="16dp"
+                        android:text="@string/beta_version_indicator_desc"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toEndOf="@id/ribbon"
+                        app:layout_constraintTop_toTopOf="parent" />
+
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+            </com.google.android.material.card.MaterialCardView>
+        </LinearLayout>
+    </ScrollView>
+
+    <LinearLayout
+        android:id="@+id/footer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/scrollView">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/opt_out_action"
+            style="@style/SDMButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="32dp"
+            android:layout_marginTop="16dp"
+            android:text="@string/nudge_betagoodbye_positive_action">
+
+            <requestFocus />
+        </com.google.android.material.button.MaterialButton>
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/stay_beta_action"
+            style="@style/SDMButton.Text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="32dp"
+            android:layout_marginBottom="16dp"
+            android:text="@string/nudge_betagoodbye_negative_action" />
+
+    </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/main_nav.xml
+++ b/app/src/main/res/navigation/main_nav.xml
@@ -84,6 +84,9 @@
         <action
             android:id="@+id/action_dashboardFragment_to_deduplicatorListFragment"
             app:destination="@id/deduplicatorListFragment" />
+        <action
+            android:id="@+id/action_dashboardFragment_to_betaGoodbyeFragment"
+            app:destination="@id/betaGoodbyeFragment" />
     </fragment>
 
     <action
@@ -468,4 +471,8 @@
             android:name="item"
             app:argType="eu.darken.sdmse.common.previews.item.PreviewItem" />
     </fragment>
+    <fragment
+        android:id="@+id/betaGoodbyeFragment"
+        android:name="eu.darken.sdmse.main.ui.release.BetaGoodbyeFragment"
+        tools:layout="@layout/beta_goodbye_fragment" />
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -657,4 +657,7 @@
     <string name="updatecheck_setting_enabled_label">Update check</string>
     <string name="updatecheck_setting_enabled_explanation">Allow SD Maid to check for updates to let you know if a newer version is available.</string>
     <string name="device_settings_category">Device</string>
+
+    <string name="beta_version_indicator_desc">Pre-release versions display a litte ribbon on the start screen. They are updated more frequently, might have more features, but could also have more bugs.</string>
+
 </resources>


### PR DESCRIPTION
When SD Maid goes from <1.0.0 to >= 1.0.0 we display a little release party screen.
The screen indicates that non-prereleases are available and helps the user switch to the release track.
For FOSS builds this means internally using the PROD instead of BETA channel for SD Maids updater.
For GPLAY builds it opens the testing opt-out page: https://play.google.com/apps/testing/eu.darken.sdmse

We also save whether the user has had any pre 1.0.0 versions installed to mark them as early adopter.
Later on we use this flag to ask for a re-review of SD Maid as any rating given during testing is not publicly displayed.

[Screenshot_20240425_153551](https://github.com/d4rken-org/sdmaid-se/assets/1439229/9f637c66-701a-40c6-b6cd-70d1b4b3a5cc)
[Screenshot_20240425_153514](https://github.com/d4rken-org/sdmaid-se/assets/1439229/d3f8f62b-7a9f-482b-ae0b-6d2b1e4f0ab9)
