### PR TITLE
IO: Fix WriteException when trying to delete files that don't exist

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalGateway.kt
@@ -711,6 +711,15 @@ class LocalGateway @Inject constructor(
                             throw IOException("delete() call returned false")
                         }
                     }
+
+                    if (!success) {
+                        if (mode == Mode.AUTO && hasShizuku()) {
+                            delete(path, Mode.ADB)
+                            return@runIO
+                        } else {
+                            throw IOException("delete() call returned false")
+                        }
+                    }
                 }
 
                 hasRoot() && (mode == Mode.ROOT || mode == Mode.AUTO) -> {

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalGateway.kt
@@ -667,20 +667,13 @@ class LocalGateway @Inject constructor(
         try {
             val javaFile = path.asFile()
 
-            val (normalCanWrite, normalExists) = when {
-                mode == Mode.ROOT -> false to null
-                mode == Mode.ADB -> false to null
-                javaFile.canWrite() -> true to true
+            val normalCanWrite = when {
+                mode == Mode.ROOT -> false
+                mode == Mode.ADB -> false
+                javaFile.canWrite() -> true
                 // Does it not exist or do we lack permission?
-                !javaFile.exists() -> try {
-                    javaFile.parentFile!!.listFiles2()
-                    true to false
-                } catch (e: Exception) {
-                    log(TAG, WARN) { "Failed to differentiate between file not existing and lacking permission: $e" }
-                    false to null
-                }
-
-                else -> false to null
+                !javaFile.exists() -> javaFile.parentFile?.canRead() == true
+                else -> false
             }
 
             when {
@@ -695,7 +688,7 @@ class LocalGateway @Inject constructor(
                     }
 
                     if (!success) {
-                        success = normalExists == false || !javaFile.exists()
+                        success = !javaFile.exists()
                         if (success) {
                             log(TAG, WARN) { "Tried to delete file, but it's already gone: $path" }
                         } else if (!normalCanWrite) {

--- a/app/src/main/java/eu/darken/sdmse/common/debug/DebugCardProvider.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/debug/DebugCardProvider.kt
@@ -5,11 +5,10 @@ import eu.darken.sdmse.common.areas.DataAreaManager
 import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.datastore.valueBlocking
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.GatewaySwitch
-import eu.darken.sdmse.common.files.local.toLocalPath
-import eu.darken.sdmse.common.files.walk
 import eu.darken.sdmse.common.navigation.navVia
 import eu.darken.sdmse.common.pkgs.PkgRepo
 import eu.darken.sdmse.common.pkgs.pkgops.PkgOps
@@ -29,11 +28,10 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.withTimeoutOrNull
-import java.io.File
 import java.util.UUID
 import javax.inject.Inject
+import kotlin.system.measureTimeMillis
 
 class DebugCardProvider @Inject constructor(
     @AppScope private val appScope: CoroutineScope,
@@ -145,15 +143,13 @@ class DebugCardProvider @Inject constructor(
             },
             onRunTest = {
                 vm.launch {
-                    File("/data/system/graphicsstats")
-                        .toLocalPath()
-                        .walk(
-                            gatewaySwitch
-                        )
-                        .toList()
-                        .forEach {
-                            log(TAG) { "###TEST walked: $it" }
+                    gatewaySwitch.useRes {
+                        measureTimeMillis {
+
+                        }.also {
+                            log(TAG, INFO) { "Deletion took $it" }
                         }
+                    }
                 }
             }
         )


### PR DESCRIPTION
This usually happens if temporary files are deleted by their owner (or the system) before SD Maid can act on them.
We want to silently treat this as success.
This failed loudly though because `canWrite` returns false on a file that does not exist, so SD Maid thought no matching access mode was available.
A simple `exists()` check here is insufficient as we can't use that to differentiate between a file that does not exist, and us lacking the permission to determine if it exists.