### PR TITLE
Automation: Improve reliability one Android 14 devices (OnePlus & Redmi)

### DIFF
--- a/app-common/src/main/java/eu/darken/sdmse/common/device/DeviceDetective.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/device/DeviceDetective.kt
@@ -7,8 +7,6 @@ import android.content.res.Configuration
 import android.os.Build
 import dagger.Reusable
 import dagger.hilt.android.qualifiers.ApplicationContext
-import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
-import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.isInstalled
 import javax.inject.Inject
@@ -69,8 +67,6 @@ class DeviceDetective @Inject constructor(
         checkManufactor("vivo") -> RomType.VIVO
         checkManufactor("HONOR") -> RomType.HONOR
         else -> RomType.AOSP
-    }.also {
-        log(TAG, VERBOSE) { "getROMType(): $it" }
     }
 
     companion object {

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
@@ -96,7 +96,6 @@ class ClearCacheModule @AssistedInject constructor(
 
         host.changeOptions { old ->
             old.copy(
-                showOverlay = true,
                 accessibilityServiceInfo = AccessibilityServiceInfo().apply {
                     flags = (
                             AccessibilityServiceInfo.FLAG_RETRIEVE_INTERACTIVE_WINDOWS

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
@@ -30,7 +30,7 @@ import eu.darken.sdmse.appcleaner.core.automation.specs.vivo.VivoSpecs
 import eu.darken.sdmse.automation.core.AutomationHost
 import eu.darken.sdmse.automation.core.AutomationModule
 import eu.darken.sdmse.automation.core.AutomationTask
-import eu.darken.sdmse.automation.core.common.ScreenUnavailableException
+import eu.darken.sdmse.automation.core.errors.ScreenUnavailableException
 import eu.darken.sdmse.automation.core.errors.UserCancelledAutomationException
 import eu.darken.sdmse.automation.core.specs.AutomationExplorer
 import eu.darken.sdmse.automation.core.specs.AutomationSpec

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
@@ -104,6 +104,7 @@ class ClearCacheModule @AssistedInject constructor(
                             )
                     eventTypes = AccessibilityEvent.TYPES_ALL_MASK
                     feedbackType = AccessibilityServiceInfo.FEEDBACK_GENERIC
+                    notificationTimeout = 250L
                 },
                 controlPanelTitle = R.string.appcleaner_automation_title.toCaString(),
                 controlPanelSubtitle = R.string.appcleaner_automation_subtitle_default_caches.toCaString(),

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/LabelDebugger.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/LabelDebugger.kt
@@ -5,16 +5,20 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.sdmse.automation.core.common.AutomationLabelSource
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.device.DeviceDetective
 import eu.darken.sdmse.common.isInstalled
 import eu.darken.sdmse.common.pkgs.toPkgId
 import javax.inject.Inject
 
 class LabelDebugger @Inject constructor(
     @ApplicationContext private val context: Context,
+    private val deviceDetective: DeviceDetective,
 ) : AutomationLabelSource {
 
     suspend fun logAllLabels() {
         log(TAG) { "logAllStorageLabels()" }
+        val romType = deviceDetective.getROMType()
+        log(TAG) { "ROMTYPE is $romType" }
         SETTINGS_PKGS
             .filter { context.isInstalled(it.name) }
             .forEach { pkgId ->

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/miui/MIUISpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/miui/MIUISpecs.kt
@@ -12,7 +12,6 @@ import eu.darken.sdmse.R
 import eu.darken.sdmse.appcleaner.core.automation.specs.AppCleanerSpecGenerator
 import eu.darken.sdmse.appcleaner.core.automation.specs.OnTheFlyLabler
 import eu.darken.sdmse.appcleaner.core.automation.specs.aosp.AOSPLabels
-import eu.darken.sdmse.automation.core.common.StepAbortException
 import eu.darken.sdmse.automation.core.common.StepProcessor
 import eu.darken.sdmse.automation.core.common.clickableParent
 import eu.darken.sdmse.automation.core.common.crawl
@@ -29,6 +28,7 @@ import eu.darken.sdmse.automation.core.common.pkgId
 import eu.darken.sdmse.automation.core.common.textEndsWithAny
 import eu.darken.sdmse.automation.core.common.textMatchesAny
 import eu.darken.sdmse.automation.core.common.windowCriteriaAppIdentifier
+import eu.darken.sdmse.automation.core.errors.StepAbortException
 import eu.darken.sdmse.automation.core.specs.AutomationExplorer
 import eu.darken.sdmse.automation.core.specs.AutomationSpec
 import eu.darken.sdmse.common.ca.toCaString

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/AppControlAutomation.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/AppControlAutomation.kt
@@ -21,7 +21,7 @@ import eu.darken.sdmse.appcontrol.core.forcestop.ForceStopAutomationTask
 import eu.darken.sdmse.automation.core.AutomationHost
 import eu.darken.sdmse.automation.core.AutomationModule
 import eu.darken.sdmse.automation.core.AutomationTask
-import eu.darken.sdmse.automation.core.common.ScreenUnavailableException
+import eu.darken.sdmse.automation.core.errors.ScreenUnavailableException
 import eu.darken.sdmse.automation.core.specs.AutomationExplorer
 import eu.darken.sdmse.automation.core.specs.AutomationSpec
 import eu.darken.sdmse.common.ca.CaString

--- a/app/src/main/java/eu/darken/sdmse/automation/core/AutomationExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/AutomationExtensions.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.isActive
 
 suspend fun AutomationManager.canUseAcsNow(): Boolean = useAcs.first()
 
-suspend fun AutomationHost.waitForWindowRoot(delayMs: Long = 200): AccessibilityNodeInfo {
+suspend fun AutomationHost.waitForWindowRoot(delayMs: Long = 250): AccessibilityNodeInfo {
     var root: AccessibilityNodeInfo? = null
 
     while (currentCoroutineContext().isActive) {

--- a/app/src/main/java/eu/darken/sdmse/automation/core/AutomationExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/AutomationExtensions.kt
@@ -1,5 +1,27 @@
 package eu.darken.sdmse.automation.core
 
+import android.view.accessibility.AccessibilityNodeInfo
+import eu.darken.sdmse.common.debug.Bugs
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.log
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.isActive
 
 suspend fun AutomationManager.canUseAcsNow(): Boolean = useAcs.first()
+
+suspend fun AutomationHost.waitForWindowRoot(delayMs: Long = 200): AccessibilityNodeInfo {
+    var root: AccessibilityNodeInfo? = null
+
+    while (currentCoroutineContext().isActive) {
+        root = windowRoot()
+        if (root != null) break
+
+        if (Bugs.isDebug) log(VERBOSE) { "Waiting for windowRoot..." }
+        delay(delayMs)
+    }
+
+    return root ?: throw CancellationException("Cancelled while waiting for windowRoot")
+}

--- a/app/src/main/java/eu/darken/sdmse/automation/core/AutomationHost.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/AutomationHost.kt
@@ -18,7 +18,7 @@ interface AutomationHost : Progress.Client {
 
     val scope: CoroutineScope
 
-    suspend fun windowRoot(): AccessibilityNodeInfo
+    suspend fun windowRoot(): AccessibilityNodeInfo?
 
     suspend fun changeOptions(action: (Options) -> Options)
 

--- a/app/src/main/java/eu/darken/sdmse/automation/core/AutomationService.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/AutomationService.kt
@@ -224,9 +224,8 @@ class AutomationService : AccessibilityService(), AutomationHost, Progress.Host,
 
         if (Bugs.isDebug) log(TAG, VERBOSE) { "New automation event: $eventCopy" }
 
+        // TODO use a queue here?
         serviceScope.launch {
-            // If we need fallbackRoot, don't race it
-            delay(50)
             log(TAG, VERBOSE) { "Providing event: $eventCopy" }
             automationEvents.emit(eventCopy)
         }

--- a/app/src/main/java/eu/darken/sdmse/automation/core/AutomationService.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/AutomationService.kt
@@ -199,7 +199,7 @@ class AutomationService : AccessibilityService(), AutomationHost, Progress.Host,
     }
 
     override fun onAccessibilityEvent(event: AccessibilityEvent) {
-        log(TAG) { "onAccessibilityEvent(eventType=${event.eventType})" }
+        log(TAG, VERBOSE) { "onAccessibilityEvent(eventType=${event.eventType})" }
         if (!checkLaunch()) return
 
         if (generalSettings.hasAcsConsent.valueBlocking != true) {
@@ -222,11 +222,9 @@ class AutomationService : AccessibilityService(), AutomationHost, Progress.Host,
             }
         }
 
-        if (Bugs.isDebug) log(TAG, VERBOSE) { "New automation event: $eventCopy" }
-
         // TODO use a queue here?
         serviceScope.launch {
-            log(TAG, VERBOSE) { "Providing event: $eventCopy" }
+            if (Bugs.isDebug) log(TAG) { "Providing event: $eventCopy" }
             automationEvents.emit(eventCopy)
         }
     }

--- a/app/src/main/java/eu/darken/sdmse/automation/core/AutomationService.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/AutomationService.kt
@@ -250,6 +250,7 @@ class AutomationService : AccessibilityService(), AutomationHost, Progress.Host,
     override suspend fun changeOptions(action: (AutomationHost.Options) -> AutomationHost.Options) {
         val newOptions = action(currentOptions)
         currentOptions = newOptions
+        serviceInfo = newOptions.accessibilityServiceInfo
 
         mainThread.post {
             controlView?.let { acv ->

--- a/app/src/main/java/eu/darken/sdmse/automation/core/common/AccessibilityNodeExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/common/AccessibilityNodeExtensions.kt
@@ -2,6 +2,7 @@ package eu.darken.sdmse.automation.core.common
 
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
+import eu.darken.sdmse.automation.core.errors.AutomationException
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog

--- a/app/src/main/java/eu/darken/sdmse/automation/core/common/AccessibilityNodeExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/common/AccessibilityNodeExtensions.kt
@@ -14,8 +14,10 @@ import java.util.concurrent.LinkedBlockingDeque
 
 private val TAG: String = logTag("Automation", "Crawler", "Common")
 
-fun AccessibilityNodeInfo.toStringShort() =
-    "className=${this.className}, text='${this.text}', isClickable=${this.isClickable}, isEnabled=${this.isEnabled}, viewIdResourceName=${this.viewIdResourceName}, pkgName=${this.packageName}"
+fun AccessibilityNodeInfo.toStringShort(): String {
+    val identity = Integer.toHexString(System.identityHashCode(this))
+    return "className=${this.className}, text='${this.text}', isClickable=${this.isClickable}, isEnabled=${this.isEnabled}, viewIdResourceName=${this.viewIdResourceName}, pkgName=${this.packageName}, identity=$identity"
+}
 
 val AccessibilityNodeInfo.textVariants: Set<String>
     get() {

--- a/app/src/main/java/eu/darken/sdmse/automation/core/common/AutomationContextExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/common/AutomationContextExtensions.kt
@@ -39,10 +39,13 @@ fun AutomationExplorer.Context.defaultWindowIntent(
 
 fun AutomationExplorer.Context.defaultWindowFilter(
     pkgId: Pkg.Id
-): (AccessibilityEvent) -> Boolean {
-    return fun(event: AccessibilityEvent): Boolean {
-        // We want to know that the settings window is open now
-        return event.eventType == AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED && event.pkgId == pkgId
+): (AccessibilityEvent) -> Boolean = fun(event: AccessibilityEvent): Boolean {
+    // We want to know that the settings window is open now
+    if (event.pkgId != pkgId) return false
+    return when (event.eventType) {
+        AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED -> true
+        AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED -> true
+        else -> false
     }
 }
 

--- a/app/src/main/java/eu/darken/sdmse/automation/core/common/AutomationContextExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/common/AutomationContextExtensions.kt
@@ -7,6 +7,8 @@ import android.content.pm.PackageManager
 import android.content.res.Resources
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
+import eu.darken.sdmse.automation.core.errors.AutomationException
+import eu.darken.sdmse.automation.core.errors.DisabledTargetException
 import eu.darken.sdmse.automation.core.specs.AutomationExplorer
 import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO

--- a/app/src/main/java/eu/darken/sdmse/automation/core/common/AutomationContextExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/common/AutomationContextExtensions.kt
@@ -41,7 +41,8 @@ fun AutomationExplorer.Context.defaultWindowFilter(
     pkgId: Pkg.Id
 ): (AccessibilityEvent) -> Boolean {
     return fun(event: AccessibilityEvent): Boolean {
-        return event.pkgId == pkgId
+        // We want to know that the settings window is open now
+        return event.eventType == AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED && event.pkgId == pkgId
     }
 }
 

--- a/app/src/main/java/eu/darken/sdmse/automation/core/common/AutomationException.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/common/AutomationException.kt
@@ -1,5 +1,0 @@
-package eu.darken.sdmse.automation.core.common
-
-open class AutomationException(message: String?, cause: Throwable?) : Exception(message, cause) {
-    constructor(message: String?) : this(message, null)
-}

--- a/app/src/main/java/eu/darken/sdmse/automation/core/common/StepProcessor.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/common/StepProcessor.kt
@@ -9,6 +9,10 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import eu.darken.sdmse.automation.core.AutomationHost
 import eu.darken.sdmse.automation.core.ScreenState
+import eu.darken.sdmse.automation.core.errors.AutomationException
+import eu.darken.sdmse.automation.core.errors.PlanAbortException
+import eu.darken.sdmse.automation.core.errors.ScreenUnavailableException
+import eu.darken.sdmse.automation.core.errors.StepAbortException
 import eu.darken.sdmse.common.R
 import eu.darken.sdmse.common.ca.CaDrawable
 import eu.darken.sdmse.common.ca.CaString

--- a/app/src/main/java/eu/darken/sdmse/automation/core/common/StepProcessor.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/common/StepProcessor.kt
@@ -13,6 +13,7 @@ import eu.darken.sdmse.automation.core.errors.AutomationException
 import eu.darken.sdmse.automation.core.errors.PlanAbortException
 import eu.darken.sdmse.automation.core.errors.ScreenUnavailableException
 import eu.darken.sdmse.automation.core.errors.StepAbortException
+import eu.darken.sdmse.automation.core.waitForWindowRoot
 import eu.darken.sdmse.common.R
 import eu.darken.sdmse.common.ca.CaDrawable
 import eu.darken.sdmse.common.ca.CaString
@@ -140,7 +141,7 @@ class StepProcessor @AssistedInject constructor(
             var currentRoot: AccessibilityNodeInfo? = null
 
             while (step.windowNodeTest != null && currentCoroutineContext().isActive) {
-                currentRoot = host.windowRoot().apply {
+                currentRoot = host.waitForWindowRoot().apply {
                     if (Bugs.isDebug) {
                         log(TAG, VERBOSE) { "Looking for viable window root, current nodes:" }
                         crawl().forEach { log(TAG, VERBOSE) { it.infoShort } }
@@ -151,11 +152,11 @@ class StepProcessor @AssistedInject constructor(
                     break
                 } else {
                     log(TAG) { "Not a viable root node: $currentRoot (spec=$step)" }
-                    delay(200)
+                    delay(500)
                 }
             }
 
-            currentRoot ?: host.windowRoot()
+            currentRoot ?: host.waitForWindowRoot()
         }
         log(TAG, VERBOSE) { "Current window root node is ${targetWindowRoot.toStringShort()}" }
 
@@ -189,12 +190,12 @@ class StepProcessor @AssistedInject constructor(
                         delay(100)
                     }
                     // Let's try a new one
-                    currentRootNode = host.windowRoot()
+                    currentRootNode = host.waitForWindowRoot()
                 }
                 target!!
             }
 
-            else -> host.windowRoot()
+            else -> host.waitForWindowRoot()
         }
         log(TAG, VERBOSE) { "Target node is ${targetNode.toStringShort()}" }
 

--- a/app/src/main/java/eu/darken/sdmse/automation/core/common/StepProcessor.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/common/StepProcessor.kt
@@ -156,6 +156,7 @@ class StepProcessor @AssistedInject constructor(
                 }
             }
 
+            // There was no windowNodeTest, so we continue with the first thing we got
             currentRoot ?: host.waitForWindowRoot()
         }
         log(TAG, VERBOSE) { "Current window root node is ${targetWindowRoot.toStringShort()}" }

--- a/app/src/main/java/eu/darken/sdmse/automation/core/common/StepProcessor.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/common/StepProcessor.kt
@@ -135,7 +135,7 @@ class StepProcessor @AssistedInject constructor(
                     log(TAG, VERBOSE) { "Testing window event $it" }
                     step.windowEventFilter.invoke(it)
                 }.first()
-                log(TAG, VERBOSE) { "Waiting for window event filter passed!" }
+                log(TAG, VERBOSE) { "Window event filter passed!" }
             }
 
             var currentRoot: AccessibilityNodeInfo? = null

--- a/app/src/main/java/eu/darken/sdmse/automation/core/debug/DebugTaskModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/debug/DebugTaskModule.kt
@@ -15,6 +15,7 @@ import eu.darken.sdmse.automation.core.AutomationHost
 import eu.darken.sdmse.automation.core.AutomationModule
 import eu.darken.sdmse.automation.core.AutomationTask
 import eu.darken.sdmse.automation.core.common.crawl
+import eu.darken.sdmse.automation.core.waitForWindowRoot
 import eu.darken.sdmse.common.ca.caString
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
@@ -60,7 +61,7 @@ class DebugTaskModule @AssistedInject constructor(
         val eventJob = host.events
             .onEach {
                 log(TAG) { "Event: $it" }
-                val crawled = host.windowRoot().crawl(debug = true).toList()
+                val crawled = host.waitForWindowRoot().crawl(debug = true).toList()
                 updateProgressSecondary("Event: ${it.eventType} (depth: ${crawled.last().level})")
             }
             .launchIn(moduleScope)

--- a/app/src/main/java/eu/darken/sdmse/automation/core/errors/AutomationException.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/errors/AutomationException.kt
@@ -1,5 +1,8 @@
 package eu.darken.sdmse.automation.core.errors
 
-open class AutomationException(message: String?, cause: Throwable?) : Exception(message, cause) {
+open class AutomationException(
+    message: String? = null,
+    cause: Throwable? = null
+) : Exception(message, cause) {
     constructor(message: String?) : this(message, null)
 }

--- a/app/src/main/java/eu/darken/sdmse/automation/core/errors/AutomationException.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/errors/AutomationException.kt
@@ -1,3 +1,5 @@
 package eu.darken.sdmse.automation.core.errors
 
-open class AutomationException : Exception()
+open class AutomationException(message: String?, cause: Throwable?) : Exception(message, cause) {
+    constructor(message: String?) : this(message, null)
+}

--- a/app/src/main/java/eu/darken/sdmse/automation/core/errors/DisabledTargetException.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/errors/DisabledTargetException.kt
@@ -1,4 +1,4 @@
-package eu.darken.sdmse.automation.core.common
+package eu.darken.sdmse.automation.core.errors
 
 open class DisabledTargetException(message: String?, cause: Throwable?) : AutomationException(message, cause) {
     constructor(message: String?) : this(message, null)

--- a/app/src/main/java/eu/darken/sdmse/automation/core/errors/PlanAbortException.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/errors/PlanAbortException.kt
@@ -1,4 +1,4 @@
-package eu.darken.sdmse.automation.core.common
+package eu.darken.sdmse.automation.core.errors
 
 open class PlanAbortException(
     message: String,

--- a/app/src/main/java/eu/darken/sdmse/automation/core/errors/ScreenUnavailableException.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/errors/ScreenUnavailableException.kt
@@ -1,4 +1,4 @@
-package eu.darken.sdmse.automation.core.common
+package eu.darken.sdmse.automation.core.errors
 
 import eu.darken.sdmse.R
 import eu.darken.sdmse.common.ca.toCaString

--- a/app/src/main/java/eu/darken/sdmse/automation/core/errors/StepAbortException.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/errors/StepAbortException.kt
@@ -1,4 +1,4 @@
-package eu.darken.sdmse.automation.core.common
+package eu.darken.sdmse.automation.core.errors
 
 class StepAbortException(
     message: String,

--- a/app/src/main/java/eu/darken/sdmse/automation/core/specs/AutomationExplorer.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/specs/AutomationExplorer.kt
@@ -1,13 +1,12 @@
 package eu.darken.sdmse.automation.core.specs
 
 import android.accessibilityservice.AccessibilityService
-import android.content.Context
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import eu.darken.sdmse.automation.core.AutomationHost
-import eu.darken.sdmse.automation.core.common.PlanAbortException
 import eu.darken.sdmse.automation.core.common.StepProcessor
+import eu.darken.sdmse.automation.core.errors.PlanAbortException
 import eu.darken.sdmse.common.R
 import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE

--- a/app/src/main/java/eu/darken/sdmse/automation/core/specs/AutomationExplorer.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/specs/AutomationExplorer.kt
@@ -1,6 +1,5 @@
 package eu.darken.sdmse.automation.core.specs
 
-import android.accessibilityservice.AccessibilityService
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -55,7 +54,7 @@ class AutomationExplorer @AssistedInject constructor(
             override val attempts: Int
                 get() = attempts
 
-            override val service: AccessibilityService = host.service
+            override val host: AutomationHost = this@AutomationExplorer.host
 
             override val stepper: StepProcessor = stepProcessorFactory.create(host)
         }
@@ -86,10 +85,10 @@ class AutomationExplorer @AssistedInject constructor(
 
         val attempts: Int
 
-        val service: AccessibilityService
+        val host: AutomationHost
 
         val androidContext: android.content.Context
-            get() = service
+            get() = host.service
 
         val stepper: StepProcessor
     }

--- a/app/src/main/res/xml/accessibility_service.xml
+++ b/app/src/main/res/xml/accessibility_service.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
-    android:accessibilityEventTypes="typeViewClicked|typeViewScrolled|typeWindowStateChanged"
-    android:accessibilityFeedbackType="feedbackGeneric"
-    android:accessibilityFlags="flagReportViewIds|flagRetrieveInteractiveWindows"
+    android:accessibilityEventTypes=""
+    android:accessibilityFeedbackType=""
+    android:accessibilityFlags=""
     android:canRetrieveWindowContent="true"
     android:description="@string/automation_accessibility_service_description"
     android:notificationTimeout="1000" />


### PR DESCRIPTION
Stop using the root from accessibility events as fallback if `rootInActiveWindow` is null.
Delayed event emission can leave us with an out-dated (and later recycled) root node being used by the `StepProcessor`.

Error behavior:

* Click event (e.g. clear cache being clicked) from app 1 is emitted when SD Maid starts processing app 2
* windowRoot of app 2 is not ready yet
* SD Maid starts using fallback root from the last event (the click event from app 2)
* The fallback root is no longer valid, as it corresponds to the settings screen from app 1
* SD Maids keeps retrying and the fallback root is at some point recycled
* SD Maid keeps trying to crawl an empty root

Fixes https://github.com/d4rken-org/sdmaid-se/issues/1124
Might fix https://github.com/d4rken-org/sdmaid-se/issues/1016