### PR TITLE
AppCleaner: Don't return to app when using accessibility functions via scheduler

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
@@ -14,15 +14,27 @@ import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerSchedulerTask
 import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerTask
 import eu.darken.sdmse.common.ca.CaString
 import eu.darken.sdmse.common.coroutine.AppScope
-import eu.darken.sdmse.common.debug.logging.Logging.Priority.*
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
-import eu.darken.sdmse.common.files.*
+import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.files.GatewaySwitch
+import eu.darken.sdmse.common.files.PathException
+import eu.darken.sdmse.common.files.isAncestorOf
+import eu.darken.sdmse.common.files.matches
 import eu.darken.sdmse.common.flow.replayingShare
 import eu.darken.sdmse.common.forensics.FileForensics
 import eu.darken.sdmse.common.pkgs.features.Installed
 import eu.darken.sdmse.common.pkgs.pkgops.PkgOps
-import eu.darken.sdmse.common.progress.*
+import eu.darken.sdmse.common.progress.Progress
+import eu.darken.sdmse.common.progress.increaseProgress
+import eu.darken.sdmse.common.progress.updateProgressCount
+import eu.darken.sdmse.common.progress.updateProgressPrimary
+import eu.darken.sdmse.common.progress.updateProgressSecondary
+import eu.darken.sdmse.common.progress.withProgress
 import eu.darken.sdmse.common.root.RootManager
 import eu.darken.sdmse.common.sharedresource.SharedResource
 import eu.darken.sdmse.common.sharedresource.keepResourceHoldersAlive
@@ -237,6 +249,7 @@ class AppCleaner @Inject constructor(
                     snapshot = snapshot,
                     targetPkgs = task.targetPkgs,
                     useAutomation = task.useAutomation,
+                    isBackground = task.isBackground
                 ).succesful
             }
         } else {

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleter.kt
@@ -67,6 +67,7 @@ class InaccessibleDeleter @Inject constructor(
         snapshot: AppCleaner.Data,
         targetPkgs: Collection<Installed.InstallId>?,
         useAutomation: Boolean,
+        isBackground: Boolean,
     ): InaccDelResult {
         log(TAG, INFO) { "deleteInaccessible() targetPkgs=${targetPkgs?.size}, $useAutomation" }
 
@@ -95,7 +96,8 @@ class InaccessibleDeleter @Inject constructor(
         return deleteInaccessible(
             targetInaccessible,
             isAllApps = targetPkgs == null,
-            useAutomation = useAutomation
+            useAutomation = useAutomation,
+            isBackground = isBackground,
         )
     }
 
@@ -103,6 +105,7 @@ class InaccessibleDeleter @Inject constructor(
         targets: Collection<AppJunk>,
         isAllApps: Boolean,
         useAutomation: Boolean,
+        isBackground: Boolean,
     ): InaccDelResult {
         log(TAG) { "${targets.size} inaccessible caches to delete." }
         if (targets.isEmpty()) return InaccDelResult()
@@ -127,7 +130,8 @@ class InaccessibleDeleter @Inject constructor(
             log(TAG) { "Processing ${remainingTargets.size} remaining inaccessible caches" }
             val successFullLive = mutableSetOf<Installed.InstallId>()
             val acsTask = ClearCacheTask(
-                remainingTargets.map { it.identifier },
+                targets = remainingTargets.map { it.identifier },
+                returnToApp = !isBackground,
                 onSuccess = { successFullLive.add(it) }
             )
             val result = try {

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
@@ -11,7 +11,8 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.R
-import eu.darken.sdmse.appcleaner.core.automation.specs.*
+import eu.darken.sdmse.appcleaner.core.automation.specs.AppCleanerSpecGenerator
+import eu.darken.sdmse.appcleaner.core.automation.specs.LabelDebugger
 import eu.darken.sdmse.appcleaner.core.automation.specs.alcatel.AlcatelSpecs
 import eu.darken.sdmse.appcleaner.core.automation.specs.androidtv.AndroidTVSpecs
 import eu.darken.sdmse.appcleaner.core.automation.specs.aosp.AOSPSpecs
@@ -36,7 +37,9 @@ import eu.darken.sdmse.automation.core.specs.AutomationExplorer
 import eu.darken.sdmse.automation.core.specs.AutomationSpec
 import eu.darken.sdmse.common.ca.CaString
 import eu.darken.sdmse.common.ca.toCaString
-import eu.darken.sdmse.common.debug.logging.Logging.Priority.*
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
@@ -44,7 +47,12 @@ import eu.darken.sdmse.common.funnel.IPCFunnel
 import eu.darken.sdmse.common.pkgs.PkgRepo
 import eu.darken.sdmse.common.pkgs.features.Installed
 import eu.darken.sdmse.common.pkgs.getPkg
-import eu.darken.sdmse.common.progress.*
+import eu.darken.sdmse.common.progress.Progress
+import eu.darken.sdmse.common.progress.increaseProgress
+import eu.darken.sdmse.common.progress.updateProgressCount
+import eu.darken.sdmse.common.progress.updateProgressPrimary
+import eu.darken.sdmse.common.progress.updateProgressSecondary
+import eu.darken.sdmse.common.progress.withProgress
 import eu.darken.sdmse.common.user.UserManager2
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -165,8 +173,12 @@ class ClearCacheModule @AssistedInject constructor(
             }
         }
 
-        // If we aborted due to an exception and the reason is "User has cancelled", then still clean up
-        returnToSDMaid(cancelledByUser)
+        if (task.returnToApp) {
+            // If we aborted due to an exception and the reason is "User has cancelled", then still clean up
+            returnToSDMaid(cancelledByUser)
+        } else {
+            log(TAG) { "Return to app is disabled." }
+        }
 
         return ClearCacheTask.Result(
             successful = successful,

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheTask.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheTask.kt
@@ -5,6 +5,7 @@ import eu.darken.sdmse.common.pkgs.features.Installed
 
 class ClearCacheTask(
     val targets: List<Installed.InstallId>,
+    val returnToApp: Boolean,
     val onSuccess: (Installed.InstallId) -> Unit,
 ) : AutomationTask {
 

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerProcessingTask.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerProcessingTask.kt
@@ -20,6 +20,7 @@ data class AppCleanerProcessingTask(
     val includeInaccessible: Boolean = true,
     val onlyInaccessible: Boolean = false,
     val useAutomation: Boolean = true,
+    val isBackground: Boolean = false,
 ) : AppCleanerTask {
 
     sealed interface Result : AppCleanerTask.Result

--- a/app/src/main/java/eu/darken/sdmse/automation/core/AutomationExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/AutomationExtensions.kt
@@ -34,6 +34,7 @@ suspend fun AutomationHost.waitForWindowRoot(delayMs: Long = 250): Accessibility
 suspend fun AutomationModule.returnToSDMaid(
     userCancelled: Boolean
 ) = withContext(if (userCancelled) NonCancellable else EmptyCoroutineContext) {
+    log { "Returning to SD Maid" }
     val returnIntern = Intent(context, MainActivity::class.java).apply {
         flags = Intent.FLAG_ACTIVITY_NEW_TASK or
                 Intent.FLAG_ACTIVITY_CLEAR_TOP or


### PR DESCRIPTION
If automation is used from the background (scheduler or a future widget), don't return to the main app after operations are finished. Previously this was also the case, but due to going back by "back button", it wasn't that visible.