### PR TITLE
Analyzer: Speed up scans

### DIFF
--- a/app-common-io/src/main/aidl/eu/darken/sdmse/common/files/local/ipc/FileOpsConnection.aidl
+++ b/app-common-io/src/main/aidl/eu/darken/sdmse/common/files/local/ipc/FileOpsConnection.aidl
@@ -34,6 +34,8 @@ interface FileOpsConnection {
 
     RemoteInputStream walkStream(in LocalPath path, in List<String> pathDoesNotContain);
 
+    long du(in LocalPath path);
+
     boolean createSymlink(in LocalPath linkPath, in LocalPath targetPath);
 
     boolean setModifiedAt(in LocalPath path, in long modifiedAt);

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathExtensions.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathExtensions.kt
@@ -2,12 +2,12 @@ package eu.darken.sdmse.common.files
 
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.log
-import eu.darken.sdmse.common.files.local.*
+import eu.darken.sdmse.common.files.local.LocalPath
 import eu.darken.sdmse.common.files.local.crumbsTo
 import eu.darken.sdmse.common.files.local.isAncestorOf
 import eu.darken.sdmse.common.files.local.isParentOf
 import eu.darken.sdmse.common.files.local.startsWith
-import eu.darken.sdmse.common.files.saf.*
+import eu.darken.sdmse.common.files.saf.SAFPath
 import eu.darken.sdmse.common.files.saf.crumbsTo
 import eu.darken.sdmse.common.files.saf.isAncestorOf
 import eu.darken.sdmse.common.files.saf.isParentOf
@@ -18,7 +18,7 @@ import okio.Source
 import java.io.File
 import java.io.IOException
 import java.time.Instant
-import java.util.*
+import java.util.Collections
 import eu.darken.sdmse.common.files.local.removePrefix as removePrefixLocalPath
 import eu.darken.sdmse.common.files.saf.removePrefix as removePrefixSafPath
 
@@ -45,6 +45,14 @@ suspend fun <P : APath, PL : APathLookup<P>, PLE : APathLookupExtended<P>, GT : 
     options: APathGateway.WalkOptions<P, PL> = APathGateway.WalkOptions()
 ): Flow<PL> {
     return gateway.walk(this, options)
+}
+
+
+suspend fun <P : APath, PL : APathLookup<P>, PLE : APathLookupExtended<P>, GT : APathGateway<P, PL, PLE>> P.du(
+    gateway: GT,
+    options: APathGateway.DuOptions<P, PL> = APathGateway.DuOptions()
+): Long {
+    return gateway.du(this, options)
 }
 
 suspend fun <T : APath> T.exists(gateway: APathGateway<T, out APathLookup<T>, out APathLookupExtended<T>>): Boolean {

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathGateway.kt
@@ -38,6 +38,15 @@ interface APathGateway<
             get() = onFilter == null && onError == null
     }
 
+    suspend fun du(
+        path: P,
+        options: DuOptions<P, PLU> = DuOptions()
+    ): Long
+
+    data class DuOptions<P : APath, PLU : APathLookup<P>>(
+        val abortOnError: Boolean = false,
+    )
+
     suspend fun exists(path: P): Boolean
 
     suspend fun canWrite(path: P): Boolean

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathLookupExtensions.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathLookupExtensions.kt
@@ -21,6 +21,11 @@ suspend fun <P : APath, PL : APathLookup<P>, PLE : APathLookupExtended<P>, GT : 
     options: APathGateway.WalkOptions<P, PL> = APathGateway.WalkOptions()
 ): Flow<PL> = lookedUp.walk(gateway, options)
 
+suspend fun <P : APath, PL : APathLookup<P>, PLE : APathLookupExtended<P>, GT : APathGateway<P, PL, PLE>> PL.du(
+    gateway: GT,
+    options: APathGateway.DuOptions<P, PL> = APathGateway.DuOptions()
+): Long = lookedUp.du(gateway, options)
+
 suspend fun <P : APath, PL : APathLookup<P>> PL.exists(
     gateway: APathGateway<P, out APathLookup<P>, out APathLookupExtended<P>>
 ): Boolean = lookedUp.exists(gateway)

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/GatewaySwitch.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/GatewaySwitch.kt
@@ -143,6 +143,14 @@ class GatewaySwitch @Inject constructor(
         return useGateway(path) { walk(path, options) }
     }
 
+
+    override suspend fun du(
+        path: APath,
+        options: APathGateway.DuOptions<APath, APathLookup<APath>>
+    ): Long {
+        return useGateway(path) { du(path, options) }
+    }
+
     override suspend fun listFiles(path: APath): Collection<APath> {
         return useGateway(path) { listFiles(path) }
     }

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/EscalatingWalker.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/EscalatingWalker.kt
@@ -21,10 +21,10 @@ import java.util.LinkedList
 /**
  * Prevents unnecessary lookups in Mode.NORMAL for nested directories
  */
-class EscalatingWalker constructor(
+class EscalatingWalker(
     private val gateway: LocalGateway,
     private val start: LocalPath,
-    private val options: APathGateway.WalkOptions<LocalPath, LocalPathLookup>,
+    private val options: APathGateway.WalkOptions<LocalPath, LocalPathLookup> = APathGateway.WalkOptions()
 ) : AbstractFlow<LocalPathLookup>() {
     private val tag = "$TAG#${hashCode()}"
 

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalPathExtensions.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalPathExtensions.kt
@@ -45,7 +45,6 @@ fun LocalPath.performLookup(): LocalPathLookup {
         lookedUp = this,
         size = file.length(),
         modifiedAt = Instant.ofEpochMilli(file.lastModified()),
-
         target = file.readLink()?.let { LocalPath.build(it) }
     )
 }

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/FileOpsClient.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/FileOpsClient.kt
@@ -91,6 +91,12 @@ class FileOpsClient @AssistedInject constructor(
         return output.toLocalPathLookupFlow()
     }
 
+    fun du(path: LocalPath): Long = try {
+        fileOpsConnection.du(path)
+    } catch (e: Exception) {
+        throw e.toFakeIOException()
+    }
+
     fun readFile(path: LocalPath): Source = try {
         fileOpsConnection.readFile(path).source()
     } catch (e: Exception) {

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/FileOpsHost.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/FileOpsHost.kt
@@ -44,7 +44,7 @@ class FileOpsHost @Inject constructor(
     private val ipcFunnel: IPCFunnel,
 ) : FileOpsConnection.Stub(), IpcHostModule {
 
-   private fun listFiles(path: LocalPath): List<LocalPath> = path.asFile().listFiles2().map { LocalPath.build(it) }
+    private fun listFiles(path: LocalPath): List<LocalPath> = path.asFile().listFiles2().map { LocalPath.build(it) }
 
     override fun listFilesStream(path: LocalPath): RemoteInputStream = try {
         if (Bugs.isTrace) log(TAG, VERBOSE) { "listFilesStream($path)..." }
@@ -127,6 +127,14 @@ class FileOpsHost @Inject constructor(
         lookups.toRemoteInputStream()
     } catch (e: Exception) {
         log(TAG, ERROR) { "lookupFilesExtendedStream(path=$path) failed\n${e.asLog()}" }
+        throw wrapPropagating(e)
+    }
+
+    override fun du(path: LocalPath): Long = try {
+        if (Bugs.isTrace) log(TAG, VERBOSE) { "du($path)..." }
+        runBlocking { path.asFile().walkTopDown().map { it.length() }.sum() }
+    } catch (e: Exception) {
+        log(TAG, ERROR) { "exists(path=$path) failed\n${e.asLog()}" }
         throw wrapPropagating(e)
     }
 

--- a/app/src/main/java/eu/darken/sdmse/analyzer/core/storage/AppDeepScanTask.kt
+++ b/app/src/main/java/eu/darken/sdmse/analyzer/core/storage/AppDeepScanTask.kt
@@ -1,0 +1,23 @@
+package eu.darken.sdmse.analyzer.core.storage
+
+import eu.darken.sdmse.analyzer.core.AnalyzerTask
+import eu.darken.sdmse.common.ca.CaString
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.pkgs.features.Installed
+import eu.darken.sdmse.common.storage.StorageId
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class AppDeepScanTask(
+    val storageId: StorageId,
+    val installId: Installed.InstallId,
+) : AnalyzerTask {
+
+    @Parcelize
+    data class Result(
+        private val success: Boolean,
+    ) : AnalyzerTask.Result {
+        override val primaryInfo: CaString
+            get() = eu.darken.sdmse.common.R.string.general_result_success_message.toCaString()
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/analyzer/core/storage/categories/AppCategory.kt
+++ b/app/src/main/java/eu/darken/sdmse/analyzer/core/storage/categories/AppCategory.kt
@@ -22,6 +22,7 @@ data class AppCategory(
 
     data class PkgStat(
         val pkg: Installed,
+        val isShallow: Boolean,
         val appCode: ContentGroup?,
         val appData: ContentGroup?,
         val appMedia: ContentGroup?,


### PR DESCRIPTION
Defer scanning apps in details until the user actually needs it. During the first pass of all apps, we only do a "shallow" scan, and then only if the enters the app details, then we do a deep scan.

The "shallow" scan uses the systems app storage stats as base information, actually scanning the files of each then only happens on demand.

This is a little less accurate, but a lot faster, and worth the trade off imho.