### PR TITLE
AppControl: Fix crash when trying to export app and the phone's files picker is unavailable

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/actions/AppActionDialog.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/actions/AppActionDialog.kt
@@ -1,6 +1,7 @@
 package eu.darken.sdmse.appcontrol.ui.list.actions
 
 import android.app.Activity
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -22,6 +23,7 @@ import eu.darken.sdmse.common.coil.loadAppIcon
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.error.asErrorDialogBuilder
 import eu.darken.sdmse.common.lists.differ.update
 import eu.darken.sdmse.common.lists.setupDefaults
 import eu.darken.sdmse.common.navigation.getQuantityString2
@@ -80,7 +82,12 @@ class AppActionDialog : BottomSheetDialogFragment2() {
         vm.events.observe2(ui) { event ->
             when (event) {
                 is AppActionEvents.SelectExportPath -> {
-                    exportPath.launch(event.intent)
+                    try {
+                        exportPath.launch(event.intent)
+                    } catch (e: ActivityNotFoundException) {
+                        log(TAG, WARN) { "Documents app is missing for $event" }
+                        e.asErrorDialogBuilder(requireActivity()).show()
+                    }
                 }
 
                 is AppActionEvents.ExportResult -> {


### PR DESCRIPTION
From a

>  samsung a05m (Galaxy A05)
>  Android 14 (SDK 34)

e.g.

```
Exception android.content.ActivityNotFoundException: No Activity found to handle Intent { act=android.intent.action.OPEN_DOCUMENT_TREE }
  at android.app.Instrumentation.checkStartActivityResult (Instrumentation.java:2252)
  at android.app.Instrumentation.execStartActivity (Instrumentation.java:1878)
  at android.app.Activity.startActivityForResult (Activity.java:5743)
  at androidx.activity.ComponentActivity.startActivityForResult (ComponentActivity.java:2)
  at androidx.core.app.ActivityCompat$Api16Impl.startActivityForResult
  at androidx.activity.ComponentActivity$1.onLaunch (ComponentActivity.java)
  at androidx.activity.result.ActivityResultLauncher.launch (ActivityResultLauncher.java:132)
  at eu.darken.sdmse.appcontrol.ui.list.actions.AppActionDialog$onViewCreated$$inlined$observe2$2.invoke (AppActionDialog.java:132)
  at eu.darken.sdmse.appcontrol.ui.list.actions.AppActionDialog$onViewCreated$$inlined$observe2$2.invoke (AppActionDialog.java:29)
  at androidx.lifecycle.LiveData.considerNotify (LiveData.java)
  at androidx.lifecycle.LiveData.dispatchingValue (LiveData.java)
  at androidx.lifecycle.MutableLiveData.setValue (MutableLiveData.java)
  at eu.darken.sdmse.common.SingleLiveEvent.setValue (SingleLiveEvent.java)
  at androidx.lifecycle.LiveData$1.run
  at android.os.Handler.handleCallback (Handler.java:958)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loopOnce (Looper.java:230)
  at android.os.Looper.loop (Looper.java:319)
  at android.app.ActivityThread.main (ActivityThread.java:8900)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:608)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1103)
  ```