### PR TITLE
Build process: Use call location independent paths for loading `version.properties`

### DIFF
--- a/app-common-io/build.gradle.kts
+++ b/app-common-io/build.gradle.kts
@@ -4,14 +4,15 @@ plugins {
     id("kotlin-android")
     id("kotlin-kapt")
     id("kotlin-parcelize")
+    id("projectConfig")
 }
 
 apply(plugin = "dagger.hilt.android.plugin")
 
 android {
-    namespace = "${ProjectConfig.packageName}.common.io"
+    namespace = "${projectConfig.packageName}.common.io"
 
-    setupLibraryDefaults()
+    setupLibraryDefaults(projectConfig)
 
     setupModuleBuildTypes()
 

--- a/app-common-pkgs/build.gradle.kts
+++ b/app-common-pkgs/build.gradle.kts
@@ -4,14 +4,15 @@ plugins {
     id("kotlin-android")
     id("kotlin-kapt")
     id("kotlin-parcelize")
+    id("projectConfig")
 }
 
 apply(plugin = "dagger.hilt.android.plugin")
 
 android {
-    namespace = "${ProjectConfig.packageName}.common.pkgs"
+    namespace = "${projectConfig.packageName}.common.pkgs"
 
-    setupLibraryDefaults()
+    setupLibraryDefaults(projectConfig)
 
     setupModuleBuildTypes()
 

--- a/app-common-root/build.gradle.kts
+++ b/app-common-root/build.gradle.kts
@@ -4,14 +4,15 @@ plugins {
     id("kotlin-android")
     id("kotlin-kapt")
     id("kotlin-parcelize")
+    id("projectConfig")
 }
 
 apply(plugin = "dagger.hilt.android.plugin")
 
 android {
-    namespace = "${ProjectConfig.packageName}.common.root"
+    namespace = "${projectConfig.packageName}.common.root"
 
-    setupLibraryDefaults()
+    setupLibraryDefaults(projectConfig)
 
     setupModuleBuildTypes()
 

--- a/app-common-shell/build.gradle.kts
+++ b/app-common-shell/build.gradle.kts
@@ -4,14 +4,15 @@ plugins {
     id("kotlin-android")
     id("kotlin-kapt")
     id("kotlin-parcelize")
+    id("projectConfig")
 }
 
 apply(plugin = "dagger.hilt.android.plugin")
 
 android {
-    namespace = "${ProjectConfig.packageName}.common.shell"
+    namespace = "${projectConfig.packageName}.common.shell"
 
-    setupLibraryDefaults()
+    setupLibraryDefaults(projectConfig)
 
     setupModuleBuildTypes()
 

--- a/app-common-shizuku/build.gradle.kts
+++ b/app-common-shizuku/build.gradle.kts
@@ -4,14 +4,15 @@ plugins {
     id("kotlin-android")
     id("kotlin-kapt")
     id("kotlin-parcelize")
+    id("projectConfig")
 }
 
 apply(plugin = "dagger.hilt.android.plugin")
 
 android {
-    namespace = "${ProjectConfig.packageName}.common.shizuku"
+    namespace = "${projectConfig.packageName}.common.shizuku"
 
-    setupLibraryDefaults()
+    setupLibraryDefaults(projectConfig)
 
     setupModuleBuildTypes()
 

--- a/app-common-test/build.gradle.kts
+++ b/app-common-test/build.gradle.kts
@@ -3,12 +3,13 @@ plugins {
     id("org.jetbrains.kotlin.android")
     id("kotlin-android")
     id("kotlin-kapt")
+    id("projectConfig")
 }
 
 android {
-    namespace = "eu.darken.sdmse.common"
+    namespace = "${projectConfig.packageName}.common"
 
-    setupLibraryDefaults()
+    setupLibraryDefaults(projectConfig)
 
     setupModuleBuildTypes()
 

--- a/app-common/build.gradle.kts
+++ b/app-common/build.gradle.kts
@@ -4,14 +4,15 @@ plugins {
     id("kotlin-android")
     id("kotlin-kapt")
     id("kotlin-parcelize")
+    id("projectConfig")
 }
 
 apply(plugin = "dagger.hilt.android.plugin")
 
 android {
-    namespace = "${ProjectConfig.packageName}.common"
+    namespace = "${projectConfig.packageName}.common"
 
-    setupLibraryDefaults()
+    setupLibraryDefaults(projectConfig)
 
     setupModuleBuildTypes()
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("kotlin-android")
     id("kotlin-kapt")
     id("kotlin-parcelize")
+    id("projectConfig")
 }
 apply(plugin = "dagger.hilt.android.plugin")
 apply(plugin = "androidx.navigation.safeargs.kotlin")
@@ -10,28 +11,28 @@ apply(plugin = "androidx.navigation.safeargs.kotlin")
 val commitHashProvider = providers.of(CommitHashValueSource::class) {}
 
 android {
-    compileSdk = ProjectConfig.compileSdk
+    compileSdk = projectConfig.compileSdk
 
     defaultConfig {
-        namespace = ProjectConfig.packageName
+        namespace = projectConfig.packageName
 
-        minSdk = ProjectConfig.minSdk
-        targetSdk = ProjectConfig.targetSdk
+        minSdk = projectConfig.minSdk
+        targetSdk = projectConfig.targetSdk
 
-        versionCode = ProjectConfig.Version.code
-        versionName = ProjectConfig.Version.name
+        versionCode = projectConfig.version.code.toInt()
+        versionName = projectConfig.version.name
 
         testInstrumentationRunner = "eu.darken.sdmse.HiltTestRunner"
 
-        buildConfigField("String", "PACKAGENAME", "\"${ProjectConfig.packageName}\"")
+        buildConfigField("String", "PACKAGENAME", "\"${projectConfig.packageName}\"")
         buildConfigField("String", "GITSHA", "\"${commitHashProvider.get()}\"")
-        buildConfigField("String", "VERSION_CODE", "\"${ProjectConfig.Version.code}\"")
-        buildConfigField("String", "VERSION_NAME", "\"${ProjectConfig.Version.name}\"")
+        buildConfigField("String", "VERSION_CODE", "\"${projectConfig.version.code}\"")
+        buildConfigField("String", "VERSION_NAME", "\"${projectConfig.version.name}\"")
 
     }
 
     signingConfigs {
-        val basePath = File(System.getProperty("user.home"), ".appconfig/${ProjectConfig.packageName}")
+        val basePath = File(System.getProperty("user.home"), ".appconfig/${projectConfig.packageName}")
         create("releaseFoss") {
             setupCredentials(File(basePath, "signing-foss.properties"))
         }
@@ -95,7 +96,7 @@ android {
         val variantName: String = variantOutputImpl.name
 
         if (listOf("release", "beta").any { variantName.lowercase().contains(it) }) {
-            val outputFileName = ProjectConfig.packageName +
+            val outputFileName = projectConfig.packageName +
                     "-v${defaultConfig.versionName}-${defaultConfig.versionCode}" +
                     "-${variantName.uppercase()}-${commitHashProvider.get()}.apk"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    id("projectConfig")
+}
+
 buildscript {
     repositories {
         google()

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -3,6 +3,15 @@ plugins {
     `java-library`
 }
 
+gradlePlugin {
+    plugins {
+        create("projectConfigPlugin") {
+            id = "projectConfig"
+            implementationClass = "ProjectConfigPlugin"
+        }
+    }
+}
+
 repositories {
     google()
     mavenCentral()

--- a/buildSrc/src/main/java/CommitHashValueSource.kt
+++ b/buildSrc/src/main/java/CommitHashValueSource.kt
@@ -1,0 +1,20 @@
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.process.ExecOperations
+import java.io.ByteArrayOutputStream
+import java.nio.charset.Charset
+import javax.inject.Inject
+
+abstract class CommitHashValueSource : ValueSource<String, ValueSourceParameters.None> {
+    @get:Inject
+    abstract val execOperations: ExecOperations
+
+    override fun obtain(): String {
+        val output = ByteArrayOutputStream()
+        execOperations.exec {
+            commandLine("git", "rev-parse", "--short", "HEAD")
+            standardOutput = output
+        }
+        return String(output.toByteArray(), Charset.defaultCharset()).trim()
+    }
+}

--- a/buildSrc/src/main/java/ProjectConfigPlugin.kt
+++ b/buildSrc/src/main/java/ProjectConfigPlugin.kt
@@ -1,0 +1,56 @@
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import java.io.File
+import java.io.FileInputStream
+import java.util.Properties
+
+open class ProjectConfig {
+    val packageName = "eu.darken.sdmse"
+    val minSdk = 26
+
+    val compileSdk = 34
+    val targetSdk = 34
+
+    lateinit var version: Version
+
+    override fun toString(): String {
+        return "ProjectConfig($packageName, min=$minSdk, compile=$compileSdk, target=$targetSdk, version=$version)"
+    }
+
+    fun init(project: Project) {
+        val versionProperties = Properties().apply {
+            val propsPath = File(project.rootDir, "version.properties")
+            println("Version: From $propsPath:")
+            load(FileInputStream(propsPath))
+            println("$this")
+        }
+        version = Version(
+            major = versionProperties.getProperty("project.versioning.major").toInt(),
+            minor = versionProperties.getProperty("project.versioning.minor").toInt(),
+            patch = versionProperties.getProperty("project.versioning.patch").toInt(),
+            build = versionProperties.getProperty("project.versioning.build").toInt(),
+            type = versionProperties.getProperty("project.versioning.type"),
+        )
+    }
+
+    data class Version(
+        val major: Int,
+        val minor: Int,
+        val patch: Int,
+        val build: Int,
+        val type: String,
+    ) {
+        val name: String
+            get() = "${major}.${minor}.${patch}-$type${build}"
+        val code: Long
+            get() = major * 10000000 + minor * 100000 + patch * 1000 + build * 10L
+    }
+}
+
+class ProjectConfigPlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        val extension = project.extensions.create("projectConfig", ProjectConfig::class.java)
+        extension.init(project)
+        project.afterEvaluate { println("ProjectConfigPlugin loaded: $extension") }
+    }
+}


### PR DESCRIPTION
See #1043