### PR TITLE
Scheduler: Close last opened app by going to the home screen

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
@@ -32,7 +32,7 @@ import eu.darken.sdmse.automation.core.AutomationModule
 import eu.darken.sdmse.automation.core.AutomationTask
 import eu.darken.sdmse.automation.core.errors.ScreenUnavailableException
 import eu.darken.sdmse.automation.core.errors.UserCancelledAutomationException
-import eu.darken.sdmse.automation.core.returnToSDMaid
+import eu.darken.sdmse.automation.core.finishAutomation
 import eu.darken.sdmse.automation.core.specs.AutomationExplorer
 import eu.darken.sdmse.automation.core.specs.AutomationSpec
 import eu.darken.sdmse.common.ca.CaString
@@ -169,16 +169,13 @@ class ClearCacheModule @AssistedInject constructor(
                 failed.add(target)
             } finally {
                 increaseProgress()
-//                updateProgressCount(Progress.Count.Percent(task.targets.indexOf(target), task.targets.size))
             }
         }
 
-        if (task.returnToApp) {
-            // If we aborted due to an exception and the reason is "User has cancelled", then still clean up
-            returnToSDMaid(cancelledByUser)
-        } else {
-            log(TAG) { "Return to app is disabled." }
-        }
+        finishAutomation(
+            userCancelled = cancelledByUser,
+            returnToApp = task.returnToApp,
+        )
 
         return ClearCacheTask.Result(
             successful = successful,

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/AppControlAutomation.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/AppControlAutomation.kt
@@ -22,19 +22,25 @@ import eu.darken.sdmse.automation.core.AutomationModule
 import eu.darken.sdmse.automation.core.AutomationTask
 import eu.darken.sdmse.automation.core.errors.ScreenUnavailableException
 import eu.darken.sdmse.automation.core.errors.UserCancelledAutomationException
-import eu.darken.sdmse.automation.core.returnToSDMaid
+import eu.darken.sdmse.automation.core.finishAutomation
 import eu.darken.sdmse.automation.core.specs.AutomationExplorer
 import eu.darken.sdmse.automation.core.specs.AutomationSpec
 import eu.darken.sdmse.common.ca.CaString
 import eu.darken.sdmse.common.ca.toCaString
-import eu.darken.sdmse.common.debug.logging.Logging.Priority.*
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.pkgs.PkgRepo
 import eu.darken.sdmse.common.pkgs.features.Installed
 import eu.darken.sdmse.common.pkgs.getPkg
-import eu.darken.sdmse.common.progress.*
+import eu.darken.sdmse.common.progress.Progress
+import eu.darken.sdmse.common.progress.updateProgressCount
+import eu.darken.sdmse.common.progress.updateProgressPrimary
+import eu.darken.sdmse.common.progress.updateProgressSecondary
+import eu.darken.sdmse.common.progress.withProgress
 import eu.darken.sdmse.common.user.UserManager2
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -161,8 +167,10 @@ class AppControlAutomation @AssistedInject constructor(
 
         delay(250)
 
-        // If we aborted due to an exception and the reason is "User has cancelled", then still clean up
-        returnToSDMaid(cancelledByUser)
+        finishAutomation(
+            userCancelled = cancelledByUser,
+            returnToApp = true,
+        )
 
         return ForceStopAutomationTask.Result(
             successful = successful,

--- a/app/src/main/java/eu/darken/sdmse/automation/core/AutomationExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/AutomationExtensions.kt
@@ -1,8 +1,10 @@
 package eu.darken.sdmse.automation.core
 
+import android.accessibilityservice.AccessibilityService
 import android.content.Intent
 import android.view.accessibility.AccessibilityNodeInfo
 import eu.darken.sdmse.common.debug.Bugs
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.main.ui.MainActivity
@@ -31,15 +33,22 @@ suspend fun AutomationHost.waitForWindowRoot(delayMs: Long = 250): Accessibility
     return root ?: throw CancellationException("Cancelled while waiting for windowRoot")
 }
 
-suspend fun AutomationModule.returnToSDMaid(
-    userCancelled: Boolean
+suspend fun AutomationModule.finishAutomation(
+    // If we aborted due to an exception and the reason is "User has cancelled", then still clean up
+    userCancelled: Boolean,
+    returnToApp: Boolean
 ) = withContext(if (userCancelled) NonCancellable else EmptyCoroutineContext) {
-    log { "Returning to SD Maid" }
-    val returnIntern = Intent(context, MainActivity::class.java).apply {
-        flags = Intent.FLAG_ACTIVITY_NEW_TASK or
-                Intent.FLAG_ACTIVITY_CLEAR_TOP or
-                Intent.FLAG_ACTIVITY_SINGLE_TOP or
-                Intent.FLAG_ACTIVITY_NO_ANIMATION
+    if (returnToApp) {
+        log(INFO) { "finishAutomation(...): Returning to SD Maid" }
+        val returnIntern = Intent(context, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or
+                    Intent.FLAG_ACTIVITY_CLEAR_TOP or
+                    Intent.FLAG_ACTIVITY_SINGLE_TOP or
+                    Intent.FLAG_ACTIVITY_NO_ANIMATION
+        }
+        context.startActivity(returnIntern)
+    } else {
+        log(INFO) { "finishAutomation(...): Going to home screen" }
+        host.service.performGlobalAction(AccessibilityService.GLOBAL_ACTION_HOME)
     }
-    context.startActivity(returnIntern)
 }


### PR DESCRIPTION
When finishing automation actions and we launched from the background (e.g. via Scheduler), then don't open SD Maid. If we don't open SD Maid, then call the "HOME" button, so that the last opened app settings screen is not visible.

Fixes #1213