### PR TITLE
AppCleaner: Don't open SD Maid at the end if accessibility action is run via scheduler

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
@@ -118,7 +118,12 @@ class AppCleaner @Inject constructor(
                     is AppCleanerProcessingTask -> performProcessing(task)
                     is AppCleanerSchedulerTask -> {
                         performScan()
-                        performProcessing(AppCleanerProcessingTask(useAutomation = task.useAutomation))
+                        performProcessing(
+                            AppCleanerProcessingTask(
+                                useAutomation = task.useAutomation,
+                                isBackground = true,
+                            )
+                        )
                     }
 
                     is AppCleanerOneClickTask -> {


### PR DESCRIPTION
Fixes #1197