### PR TITLE
Refactor Client/Host cross process exception propagation

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/FileOpsClient.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/FileOpsClient.kt
@@ -7,7 +7,6 @@ import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
-import eu.darken.sdmse.common.error.getRootCause
 import eu.darken.sdmse.common.files.APathGateway
 import eu.darken.sdmse.common.files.Ownership
 import eu.darken.sdmse.common.files.Permissions
@@ -20,7 +19,6 @@ import eu.darken.sdmse.common.ipc.source
 import kotlinx.coroutines.flow.Flow
 import okio.Sink
 import okio.Source
-import java.io.IOException
 import java.time.Instant
 
 class FileOpsClient @AssistedInject constructor(
@@ -35,7 +33,7 @@ class FileOpsClient @AssistedInject constructor(
             if (Bugs.isTrace) log(TAG) { "listFiles($path) finished streaming, ${it.size} items" }
         }
     } catch (e: Exception) {
-        throw e.toFakeIOException()
+        throw e.unwrapPropagation()
     }
 
     fun lookUp(path: LocalPath): LocalPathLookup = try {
@@ -43,7 +41,7 @@ class FileOpsClient @AssistedInject constructor(
             if (Bugs.isTrace) log(TAG, VERBOSE) { "lookup($path): $it" }
         }
     } catch (e: Exception) {
-        throw e.toFakeIOException()
+        throw e.unwrapPropagation()
     }
 
     /**
@@ -54,7 +52,7 @@ class FileOpsClient @AssistedInject constructor(
             if (Bugs.isTrace) log(TAG, VERBOSE) { "lookupFiles($path) finished streaming, ${it.size} items" }
         }
     } catch (e: Exception) {
-        throw e.toFakeIOException()
+        throw e.unwrapPropagation()
     }
 
     /**
@@ -68,7 +66,7 @@ class FileOpsClient @AssistedInject constructor(
             ) { "lookupFilesExtendedStream($path) finished streaming, ${it.size} items" }
         }
     } catch (e: Exception) {
-        throw e.toFakeIOException()
+        throw e.unwrapPropagation()
     }
 
     /**
@@ -86,7 +84,7 @@ class FileOpsClient @AssistedInject constructor(
                 (options.pathDoesNotContain ?: emptyList()).toMutableList(),
             )
         } catch (e: Exception) {
-            throw e.toFakeIOException()
+            throw e.unwrapPropagation()
         }
         return output.toLocalPathLookupFlow()
     }
@@ -94,90 +92,79 @@ class FileOpsClient @AssistedInject constructor(
     fun du(path: LocalPath): Long = try {
         fileOpsConnection.du(path)
     } catch (e: Exception) {
-        throw e.toFakeIOException()
+        throw e.unwrapPropagation()
     }
 
     fun readFile(path: LocalPath): Source = try {
         fileOpsConnection.readFile(path).source()
     } catch (e: Exception) {
-        throw e.toFakeIOException()
+        throw e.unwrapPropagation()
     }
 
     fun writeFile(path: LocalPath): Sink = try {
         fileOpsConnection.writeFile(path).sink()
     } catch (e: Exception) {
-        throw e.toFakeIOException()
+        throw e.unwrapPropagation()
     }
 
     fun mkdirs(path: LocalPath): Boolean = try {
         fileOpsConnection.mkdirs(path)
     } catch (e: Exception) {
-        throw e.toFakeIOException()
+        throw e.unwrapPropagation()
     }
 
     fun createNewFile(path: LocalPath): Boolean = try {
         fileOpsConnection.createNewFile(path)
     } catch (e: Exception) {
-        throw e.toFakeIOException()
+        throw e.unwrapPropagation()
     }
 
     fun canRead(path: LocalPath): Boolean = try {
         fileOpsConnection.canRead(path)
     } catch (e: Exception) {
-        throw e.toFakeIOException()
+        throw e.unwrapPropagation()
     }
 
     fun canWrite(path: LocalPath): Boolean = try {
         fileOpsConnection.canWrite(path)
     } catch (e: Exception) {
-        throw e.toFakeIOException()
+        throw e.unwrapPropagation()
     }
 
     fun exists(path: LocalPath): Boolean = try {
         fileOpsConnection.exists(path)
     } catch (e: Exception) {
-        throw e.toFakeIOException()
+        throw e.unwrapPropagation()
     }
 
     fun delete(path: LocalPath): Boolean = try {
         fileOpsConnection.delete(path)
     } catch (e: Exception) {
-        throw e.toFakeIOException()
+        throw e.unwrapPropagation()
     }
 
     fun createSymlink(linkPath: LocalPath, targetPath: LocalPath): Boolean = try {
         fileOpsConnection.createSymlink(linkPath, targetPath)
     } catch (e: Exception) {
-        throw e.toFakeIOException()
+        throw e.unwrapPropagation()
     }
 
     fun setModifiedAt(path: LocalPath, modifiedAt: Instant): Boolean = try {
         fileOpsConnection.setModifiedAt(path, modifiedAt.toEpochMilli())
     } catch (e: Exception) {
-        throw e.toFakeIOException()
+        throw e.unwrapPropagation()
     }
 
     fun setPermissions(path: LocalPath, permissions: Permissions): Boolean = try {
         fileOpsConnection.setPermissions(path, permissions)
     } catch (e: Exception) {
-        throw e.toFakeIOException()
+        throw e.unwrapPropagation()
     }
 
     fun setOwnership(path: LocalPath, ownership: Ownership): Boolean = try {
         fileOpsConnection.setOwnership(path, ownership)
     } catch (e: Exception) {
-        throw e.toFakeIOException()
-    }
-
-    private fun Throwable.toFakeIOException(): IOException {
-        val org = this.getRootCause()
-        val gulpPrefix = "java.io.IOException: "
-        val message = when {
-            org.message.isNullOrEmpty() -> org.toString()
-            org.message?.startsWith(gulpPrefix) == true -> org.message!!.replace(gulpPrefix, "")
-            else -> this.message
-        }
-        return IOException(message, org.cause)
+        throw e.unwrapPropagation()
     }
 
     companion object {

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/FileOpsHost.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/FileOpsHost.kt
@@ -53,7 +53,7 @@ class FileOpsHost @Inject constructor(
         result.toRemoteInputStream()
     } catch (e: Exception) {
         log(TAG, ERROR) { "lookupFiles(path=$path) failed\n${e.asLog()}" }
-        throw wrapPropagating(e)
+        throw e.wrapToPropagate()
     }
 
     override fun lookUp(path: LocalPath): LocalPathLookup = try {
@@ -63,7 +63,7 @@ class FileOpsHost @Inject constructor(
         }
     } catch (e: Exception) {
         log(TAG, ERROR) { "lookUp(path=$path) failed\n${e.asLog()}" }
-        throw wrapPropagating(e)
+        throw e.wrapToPropagate()
     }
 
     override fun lookupFilesStream(path: LocalPath): RemoteInputStream = try {
@@ -76,7 +76,7 @@ class FileOpsHost @Inject constructor(
         lookups.toRemoteInputStream()
     } catch (e: Exception) {
         log(TAG, ERROR) { "lookupFiles(path=$path) failed\n${e.asLog()}" }
-        throw wrapPropagating(e)
+        throw e.wrapToPropagate()
     }
 
     override fun lookUpExtended(path: LocalPath): LocalPathLookupExtended = try {
@@ -86,7 +86,7 @@ class FileOpsHost @Inject constructor(
         }
     } catch (e: Exception) {
         log(TAG, ERROR) { "lookUpExtended(path=$path) failed\n${e.asLog()}" }
-        throw wrapPropagating(e)
+        throw e.wrapToPropagate()
     }
 
     override fun lookupFilesExtended(path: LocalPath): List<LocalPathLookupExtended> = try {
@@ -99,7 +99,7 @@ class FileOpsHost @Inject constructor(
             .also { if (Bugs.isTrace) log(TAG, VERBOSE) { "lookupFilesExtended($path) done: ${it.size} items" } }
     } catch (e: Exception) {
         log(TAG, ERROR) { "lookupFilesExtended(path=$path) failed\n${e.asLog()}" }
-        throw wrapPropagating(e)
+        throw e.wrapToPropagate()
     }
 
     override fun walkStream(path: LocalPath, pathDoesNotContain: List<String>): RemoteInputStream = try {
@@ -114,7 +114,7 @@ class FileOpsHost @Inject constructor(
         }
     } catch (e: Exception) {
         log(TAG, ERROR) { "walkStream(path=$path) failed\n${e.asLog()}" }
-        throw wrapPropagating(e)
+        throw e.wrapToPropagate()
     }
 
     override fun lookupFilesExtendedStream(path: LocalPath): RemoteInputStream = try {
@@ -127,7 +127,7 @@ class FileOpsHost @Inject constructor(
         lookups.toRemoteInputStream()
     } catch (e: Exception) {
         log(TAG, ERROR) { "lookupFilesExtendedStream(path=$path) failed\n${e.asLog()}" }
-        throw wrapPropagating(e)
+        throw e.wrapToPropagate()
     }
 
     override fun du(path: LocalPath): Long = try {
@@ -135,7 +135,7 @@ class FileOpsHost @Inject constructor(
         runBlocking { path.asFile().walkTopDown().map { it.length() }.sum() }
     } catch (e: Exception) {
         log(TAG, ERROR) { "exists(path=$path) failed\n${e.asLog()}" }
-        throw wrapPropagating(e)
+        throw e.wrapToPropagate()
     }
 
     override fun readFile(path: LocalPath): RemoteInputStream = try {
@@ -143,7 +143,7 @@ class FileOpsHost @Inject constructor(
         FileInputStream(path.asFile()).remoteInputStream()
     } catch (e: Exception) {
         log(TAG, ERROR) { "readFile(path=$path) failed\n${e.asLog()}" }
-        throw wrapPropagating(e)
+        throw e.wrapToPropagate()
     }
 
     override fun writeFile(path: LocalPath): RemoteOutputStream = try {
@@ -151,7 +151,7 @@ class FileOpsHost @Inject constructor(
         FileOutputStream(path.asFile()).toRemoteOutputStream()
     } catch (e: Exception) {
         log(TAG, ERROR) { "writeFile(path=$path) failed\n${e.asLog()}" }
-        throw wrapPropagating(e)
+        throw e.wrapToPropagate()
     }
 
     override fun mkdirs(path: LocalPath): Boolean = try {
@@ -159,7 +159,7 @@ class FileOpsHost @Inject constructor(
         path.asFile().mkdirs()
     } catch (e: Exception) {
         log(TAG, ERROR) { "mkdirs(path=$path) failed\n${e.asLog()}" }
-        throw wrapPropagating(e)
+        throw e.wrapToPropagate()
     }
 
     override fun createNewFile(path: LocalPath): Boolean = try {
@@ -181,7 +181,7 @@ class FileOpsHost @Inject constructor(
         file.createNewFile()
     } catch (e: Exception) {
         log(TAG, ERROR) { "mkdirs(path=$path) failed\n${e.asLog()}" }
-        throw wrapPropagating(e)
+        throw e.wrapToPropagate()
     }
 
     override fun canRead(path: LocalPath): Boolean = try {
@@ -189,7 +189,7 @@ class FileOpsHost @Inject constructor(
         path.asFile().canRead()
     } catch (e: Exception) {
         log(TAG, ERROR) { "path(path=$path) failed\n${e.asLog()}" }
-        throw wrapPropagating(e)
+        throw e.wrapToPropagate()
     }
 
     override fun canWrite(path: LocalPath): Boolean = try {
@@ -197,7 +197,7 @@ class FileOpsHost @Inject constructor(
         path.asFile().canWrite()
     } catch (e: Exception) {
         log(TAG, ERROR) { "canWrite(path=$path) failed\n${e.asLog()}" }
-        throw wrapPropagating(e)
+        throw e.wrapToPropagate()
     }
 
     override fun exists(path: LocalPath): Boolean = try {
@@ -205,7 +205,7 @@ class FileOpsHost @Inject constructor(
         path.asFile().exists()
     } catch (e: Exception) {
         log(TAG, ERROR) { "exists(path=$path) failed\n${e.asLog()}" }
-        throw wrapPropagating(e)
+        throw e.wrapToPropagate()
     }
 
     override fun delete(path: LocalPath): Boolean = try {
@@ -213,7 +213,7 @@ class FileOpsHost @Inject constructor(
         path.asFile().delete()
     } catch (e: Exception) {
         log(TAG, ERROR) { "delete(path=$path) failed\n${e.asLog()}" }
-        throw wrapPropagating(e)
+        throw e.wrapToPropagate()
     }
 
     override fun createSymlink(linkPath: LocalPath, targetPath: LocalPath): Boolean = try {
@@ -221,7 +221,7 @@ class FileOpsHost @Inject constructor(
         linkPath.asFile().createSymlink(targetPath.asFile())
     } catch (e: Exception) {
         log(TAG, ERROR) { "createSymlink(linkPath=$linkPath, targetPath=$targetPath) failed\n${e.asLog()}" }
-        throw wrapPropagating(e)
+        throw e.wrapToPropagate()
     }
 
     override fun setModifiedAt(path: LocalPath, modifiedAt: Long): Boolean = try {
@@ -229,7 +229,7 @@ class FileOpsHost @Inject constructor(
         path.asFile().setLastModified(modifiedAt)
     } catch (e: Exception) {
         log(TAG, ERROR) { "setModifiedAt(path=$path, modifiedAt=$modifiedAt) failed\n${e.asLog()}" }
-        throw wrapPropagating(e)
+        throw e.wrapToPropagate()
     }
 
     override fun setPermissions(path: LocalPath, permissions: Permissions): Boolean = try {
@@ -237,7 +237,7 @@ class FileOpsHost @Inject constructor(
         path.asFile().setPermissions(permissions)
     } catch (e: Exception) {
         log(TAG, ERROR) { "setModifiedAt(path=$path, permissions=$permissions) failed\n${e.asLog()}" }
-        throw wrapPropagating(e)
+        throw e.wrapToPropagate()
     }
 
     override fun setOwnership(path: LocalPath, ownership: Ownership): Boolean = try {
@@ -245,11 +245,13 @@ class FileOpsHost @Inject constructor(
         path.asFile().setOwnership(ownership)
     } catch (e: Exception) {
         log(TAG, ERROR) { "setModifiedAt(path=$path, ownership=$ownership) failed\n${e.asLog()}" }
-        throw wrapPropagating(e)
+        throw e.wrapToPropagate()
     }
 
+    // Not all exception can be passed through the binder
+    // See Parcel.writeException(...)
     private fun wrapPropagating(e: Exception): Exception {
-        return if (e is UnsupportedOperationException) e else UnsupportedOperationException(e)
+        return if (e is RuntimeException) e else RuntimeException(e)
     }
 
     companion object {

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/PackageManagerExtensions.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/PackageManagerExtensions.kt
@@ -53,7 +53,7 @@ fun PackageManager.getInstalledPackagesAsUser(
     userHandle: UserHandle2,
 ) = try {
     val functions = PackageManager::class.memberFunctions.filter { it.name == "getInstalledPackagesAsUser" }
-
+    throw RuntimeException("lol")
     if (hasApiLevel(33)) {
         @Suppress("NewApi")
         functions

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/PackageManagerExtensions.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/PackageManagerExtensions.kt
@@ -53,7 +53,6 @@ fun PackageManager.getInstalledPackagesAsUser(
     userHandle: UserHandle2,
 ) = try {
     val functions = PackageManager::class.memberFunctions.filter { it.name == "getInstalledPackagesAsUser" }
-    throw RuntimeException("lol")
     if (hasApiLevel(33)) {
         @Suppress("NewApi")
         functions

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/ipc/PkgOpsClient.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/ipc/PkgOpsClient.kt
@@ -10,14 +10,12 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
-import eu.darken.sdmse.common.error.getRootCause
 import eu.darken.sdmse.common.ipc.IpcClientModule
 import eu.darken.sdmse.common.permissions.Permission
 import eu.darken.sdmse.common.pkgs.Pkg
 import eu.darken.sdmse.common.pkgs.features.Installed
 import eu.darken.sdmse.common.user.UserHandle2
 import kotlinx.coroutines.delay
-import java.io.IOException
 
 class PkgOpsClient @AssistedInject constructor(
     @Assisted private val connection: PkgOpsConnection
@@ -26,29 +24,33 @@ class PkgOpsClient @AssistedInject constructor(
     fun getUserNameForUID(uid: Int): String? = try {
         connection.getUserNameForUID(uid)
     } catch (e: Exception) {
-        log(TAG, ERROR) { "getUserNameForUID(uid=$uid) failed: ${e.asLog()}" }
-        throw fakeIOException(e.getRootCause())
+        throw e.unwrapPropagation().also {
+            log(TAG, ERROR) { "getUserNameForUID(uid=$uid) failed: ${it.asLog()}" }
+        }
     }
 
     fun getGroupNameforGID(gid: Int): String? = try {
         connection.getGroupNameforGID(gid)
     } catch (e: Exception) {
-        log(TAG, ERROR) { "getGroupNameforGID(gid=$gid) failed: ${e.asLog()}" }
-        throw fakeIOException(e.getRootCause())
+        throw e.unwrapPropagation().also {
+            log(TAG, ERROR) { "getGroupNameforGID(gid=$gid) failed: ${it.asLog()}" }
+        }
     }
 
     fun forceStop(packageName: String): Boolean = try {
         connection.forceStop(packageName)
     } catch (e: Exception) {
-        log(TAG, ERROR) { "forceStop(packageName=$packageName) failed: ${e.asLog()}" }
-        throw fakeIOException(e.getRootCause())
+        throw e.unwrapPropagation().also {
+            log(TAG, ERROR) { "forceStop(packageName=$packageName) failed: ${it.asLog()}" }
+        }
     }
 
     fun isRunning(pkgId: Pkg.Id): Boolean = try {
         connection.isRunning(pkgId.name)
     } catch (e: Exception) {
-        log(TAG, ERROR) { "isRunning(pkgId=$pkgId) failed: ${e.asLog()}" }
-        throw fakeIOException(e.getRootCause())
+        throw e.unwrapPropagation().also {
+            log(TAG, ERROR) { "isRunning(pkgId=$pkgId) failed: ${it.asLog()}" }
+        }
     }
 
     suspend fun clearCache(installId: Installed.InstallId): Boolean = try {
@@ -60,8 +62,9 @@ class PkgOpsClient @AssistedInject constructor(
             connection.clearCacheAsUser(installId.pkgId.name, installId.userHandle.handleId)
         }
     } catch (e: Exception) {
-        log(TAG, ERROR) { "clearCache(installId=$installId) failed: ${e.asLog()}" }
-        throw fakeIOException(e.getRootCause())
+        throw e.unwrapPropagation().also {
+            log(TAG, ERROR) { "clearCache(installId=$installId) failed: ${it.asLog()}" }
+        }
     }
 
     suspend fun clearCache(pkgId: Pkg.Id): Boolean = try {
@@ -73,8 +76,9 @@ class PkgOpsClient @AssistedInject constructor(
             connection.clearCache(pkgId.name)
         }
     } catch (e: Exception) {
-        log(TAG, ERROR) { "clearCache(pkgId=$pkgId) failed: ${e.asLog()}" }
-        throw fakeIOException(e.getRootCause())
+        throw e.unwrapPropagation().also {
+            log(TAG, ERROR) { "clearCache(pkgId=$pkgId) failed: ${it.asLog()}" }
+        }
     }
 
     suspend fun trimCaches(desiredBytes: Long, storageId: String? = null): Boolean = try {
@@ -86,8 +90,9 @@ class PkgOpsClient @AssistedInject constructor(
             connection.trimCaches(desiredBytes, storageId)
         }
     } catch (e: Exception) {
-        log(TAG, ERROR) { "trimCaches(desiredBytes=$desiredBytes, storageId=$storageId) failed: ${e.asLog()}" }
-        throw fakeIOException(e.getRootCause())
+        throw e.unwrapPropagation().also {
+            log(TAG, ERROR) { "trimCaches(desiredBytes=$desiredBytes, storageId=$storageId) failed: ${it.asLog()}" }
+        }
     }
 
     /**
@@ -97,58 +102,53 @@ class PkgOpsClient @AssistedInject constructor(
     fun getInstalledPackagesAsUser(flags: Long, userHandle: UserHandle2): List<PackageInfo> = try {
         connection.getInstalledPackagesAsUser(flags, userHandle.handleId)
     } catch (e: Exception) {
-        log(TAG, ERROR) { "getInstalledPackagesAsUser(flags=$flags, userHandle=$userHandle) failed: ${e.asLog()}" }
-        throw fakeIOException(e.getRootCause())
+        throw e.unwrapPropagation().also {
+            log(TAG, ERROR) { "getInstalledPackagesAsUser(flags=$flags, userHandle=$userHandle) failed: ${it.asLog()}" }
+        }
     }
 
     fun getInstalledPackagesAsUserStream(flags: Long, userHandle: UserHandle2): List<PackageInfo> = try {
         connection.getInstalledPackagesAsUserStream(flags, userHandle.handleId).toPackageInfos()
     } catch (e: Exception) {
-        log(
-            TAG,
-            ERROR
-        ) { "getInstalledPackagesAsUserStream(flags=$flags, userHandle=$userHandle) failed: ${e.asLog()}" }
-        throw fakeIOException(e.getRootCause())
+        throw e.unwrapPropagation().also {
+            log(TAG, ERROR) {
+                "getInstalledPackagesAsUserStream(flags=$flags, userHandle=$userHandle) failed: ${it.asLog()}"
+            }
+        }
     }
 
     fun setApplicationEnabledSetting(packageName: String, newState: Int, flags: Int): Unit = try {
         connection.setApplicationEnabledSetting(packageName, newState, flags)
     } catch (e: Exception) {
-        log(TAG, ERROR) {
-            "setApplicationEnabledSetting(packageName=$packageName, newState=$newState, flags=$flags) failed: ${e.asLog()}"
+        throw e.unwrapPropagation().also {
+            log(TAG, ERROR) {
+                "setApplicationEnabledSetting(packageName=$packageName, newState=$newState, flags=$flags) failed: ${it.asLog()}"
+            }
         }
-        throw fakeIOException(e.getRootCause())
-    }
-
-    private fun fakeIOException(e: Throwable): IOException {
-        val gulpExceptionPrefix = "java.io.IOException: "
-        val message = when {
-            e.message.isNullOrEmpty() -> e.toString()
-            e.message?.startsWith(gulpExceptionPrefix) == true -> e.message!!.replace(gulpExceptionPrefix, "")
-            else -> ""
-        }
-        return IOException(message, e.cause)
     }
 
     fun grantPermission(id: Installed.InstallId, permission: Permission): Boolean = try {
         connection.grantPermission(id.pkgId.name, id.userHandle.handleId, permission.permissionId)
     } catch (e: Exception) {
-        log(TAG, ERROR) { "grantPermission(id=$id, permission=$permission) failed: ${e.asLog()}" }
-        throw fakeIOException(e.getRootCause())
+        throw e.unwrapPropagation().also {
+            log(TAG, ERROR) { "grantPermission(id=$id, permission=$permission) failed: ${it.asLog()}" }
+        }
     }
 
     fun revokePermission(id: Installed.InstallId, permission: Permission): Boolean = try {
         connection.revokePermission(id.pkgId.name, id.userHandle.handleId, permission.permissionId)
     } catch (e: Exception) {
-        log(TAG, ERROR) { "revokePermission(id=$id, permission=$permission) failed: ${e.asLog()}" }
-        throw fakeIOException(e.getRootCause())
+        throw e.unwrapPropagation().also {
+            log(TAG, ERROR) { "revokePermission(id=$id, permission=$permission) failed: ${it.asLog()}" }
+        }
     }
 
     fun setAppOps(id: Installed.InstallId, key: String, value: String): Boolean = try {
         connection.setAppOps(id.pkgId.name, id.userHandle.handleId, key, value)
     } catch (e: Exception) {
-        log(TAG, ERROR) { "setAppOps(id=$id, key=$key, value=$value) failed: ${e.asLog()}" }
-        throw fakeIOException(e.getRootCause())
+        throw e.unwrapPropagation().also {
+            log(TAG, ERROR) { "setAppOps(id=$id, key=$key, value=$value) failed: ${it.asLog()}" }
+        }
     }
 
     @AssistedFactory

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/ipc/PkgOpsHost.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/ipc/PkgOpsHost.kt
@@ -40,15 +40,15 @@ class PkgOpsHost @Inject constructor(
     override fun getUserNameForUID(uid: Int): String? = try {
         libcoreTool.getNameForUid(uid)
     } catch (e: Exception) {
-        log(TAG, ERROR) { "getUserNameForUID(uid=$uid) failed." }
-        throw wrapPropagating(e)
+        log(TAG, ERROR) { "getUserNameForUID(uid=$uid) failed: ${e.asLog()}" }
+        throw e.wrapToPropagate()
     }
 
     override fun getGroupNameforGID(gid: Int): String? = try {
         libcoreTool.getNameForGid(gid)
     } catch (e: Exception) {
-        log(TAG, ERROR) { "getGroupNameforGID(gid=$gid) failed." }
-        throw wrapPropagating(e)
+        log(TAG, ERROR) { "getGroupNameforGID(gid=$gid) failed: ${e.asLog()}" }
+        throw e.wrapToPropagate()
     }
 
     override fun isRunning(packageName: String): Boolean = try {
@@ -59,7 +59,7 @@ class PkgOpsHost @Inject constructor(
                 ?: emptyList()
             runningAppProcesses.any { it == packageName }
         } catch (e: Exception) {
-            log(TAG, ERROR) { "isRunning($packageName): runningAppProcesses failed due to ${e.asLog()} " }
+            log(TAG, ERROR) { "isRunning($packageName): runningAppProcesses failed due to $e " }
             runBlocking {
                 sharedShell.useRes {
                     Cmd.builder("pidof $packageName").execute(it)
@@ -69,8 +69,8 @@ class PkgOpsHost @Inject constructor(
         log(TAG, VERBOSE) { "isRunning(packageName=$packageName)=$result" }
         result
     } catch (e: Exception) {
-        log(TAG, ERROR) { "isRunning(packageName=$packageName) failed." }
-        throw wrapPropagating(e)
+        log(TAG, ERROR) { "isRunning(packageName=$packageName) failed: ${e.asLog()}" }
+        throw e.wrapToPropagate()
     }
 
     override fun forceStop(packageName: String): Boolean = try {
@@ -81,32 +81,32 @@ class PkgOpsHost @Inject constructor(
         forceStopPackage.invoke(am, packageName)
         true
     } catch (e: Exception) {
-        log(TAG, ERROR) { "forceStop(packageName=$packageName) failed." }
-        throw wrapPropagating(e)
+        log(TAG, ERROR) { "forceStop(packageName=$packageName) failed: ${e.asLog()}" }
+        throw e.wrapToPropagate()
     }
 
     override fun clearCacheAsUser(packageName: String, handleId: Int): Boolean = try {
         log(TAG, VERBOSE) { "clearCache(packageName=$packageName, handleId=$handleId)..." }
         runBlocking { pm.deleteApplicationCacheFilesAsUser(packageName, handleId) }
     } catch (e: Exception) {
-        log(TAG, ERROR) { "clearCache(packageName=$packageName, handleId=$handleId) failed." }
-        throw wrapPropagating(e)
+        log(TAG, ERROR) { "clearCache(packageName=$packageName, handleId=$handleId) failed: ${e.asLog()}" }
+        throw e.wrapToPropagate()
     }
 
     override fun clearCache(packageName: String): Boolean = try {
         log(TAG, VERBOSE) { "clearCache(packageName=$packageName)..." }
         runBlocking { pm.deleteApplicationCacheFiles(packageName) }
     } catch (e: Exception) {
-        log(TAG, ERROR) { "clearCache(packageName=$packageName) failed." }
-        throw wrapPropagating(e)
+        log(TAG, ERROR) { "clearCache(packageName=$packageName) failed: ${e.asLog()}" }
+        throw e.wrapToPropagate()
     }
 
     override fun trimCaches(desiredBytes: Long, storageId: String?): Boolean = try {
         log(TAG, VERBOSE) { "trimCaches(desiredBytes=$desiredBytes, storageId=$storageId)..." }
         runBlocking { pm.freeStorageAndNotify(desiredBytes, storageId) }
     } catch (e: Exception) {
-        log(TAG, ERROR) { "trimCaches(desiredBytes=$desiredBytes, storageId=$storageId) failed." }
-        throw wrapPropagating(e)
+        log(TAG, ERROR) { "trimCaches(desiredBytes=$desiredBytes, storageId=$storageId) failed: ${e.asLog()}" }
+        throw e.wrapToPropagate()
     }
 
     override fun getInstalledPackagesAsUser(flags: Long, handleId: Int): List<PackageInfo> = try {
@@ -116,18 +116,18 @@ class PkgOpsHost @Inject constructor(
             log(TAG) { "getInstalledPackagesAsUser($flags, $handleId): ${it.size}" }
         }
     } catch (e: Exception) {
-        log(TAG, ERROR) { "getInstalledPackagesAsUser(flags=$flags, handleId=$handleId) failed." }
-        throw wrapPropagating(e)
+        log(TAG, ERROR) { "getInstalledPackagesAsUser(flags=$flags, handleId=$handleId) failed: ${e.asLog()}" }
+        throw e.wrapToPropagate()
     }
 
     override fun getInstalledPackagesAsUserStream(flags: Long, handleId: Int): RemoteInputStream = try {
         log(TAG, VERBOSE) { "getInstalledPackagesAsUserStream($flags, $handleId)..." }
         pm.getInstalledPackagesAsUser(flags, UserHandle2(handleId)).also {
-            log(TAG) { "getInstalledPackagesAsUser($flags, $handleId): ${it.size}" }
+            log(TAG) { "getInstalledPackagesAsUserStream($flags, $handleId): ${it.size}" }
         }.toRemoteInputStream()
     } catch (e: Exception) {
-        log(TAG, ERROR) { "getInstalledPackagesAsUser(flags=$flags, handleId=$handleId) failed." }
-        throw wrapPropagating(e)
+        log(TAG, ERROR) { "getInstalledPackagesAsUserStream(flags=$flags, handleId=$handleId) failed: ${e.asLog()}" }
+        throw e.wrapToPropagate()
     }
 
     override fun setApplicationEnabledSetting(packageName: String, newState: Int, flags: Int) = try {
@@ -135,8 +135,8 @@ class PkgOpsHost @Inject constructor(
         pm.setApplicationEnabledSetting(packageName, newState, flags)
         log(TAG, VERBOSE) { "setApplicationEnabledSetting($packageName, $newState, $flags) succesful" }
     } catch (e: Exception) {
-        log(TAG, ERROR) { "setApplicationEnabledSetting($packageName, $newState, $flags) failed ($e)" }
-        throw wrapPropagating(e)
+        log(TAG, ERROR) { "setApplicationEnabledSetting($packageName, $newState, $flags) failed: ${e.asLog()}" }
+        throw e.wrapToPropagate()
     }
 
     override fun grantPermission(packageName: String, handleId: Int, permissionId: String): Boolean = try {
@@ -148,8 +148,8 @@ class PkgOpsHost @Inject constructor(
         }
         result.exitCode == Cmd.ExitCode.OK
     } catch (e: Exception) {
-        log(TAG, ERROR) { "grantPermission($packageName, $handleId, $permissionId) failed: $e" }
-        throw wrapPropagating(e)
+        log(TAG, ERROR) { "grantPermission($packageName, $handleId, $permissionId) failed: ${e.asLog()}" }
+        throw e.wrapToPropagate()
     }
 
     override fun revokePermission(packageName: String, handleId: Int, permissionId: String): Boolean = try {
@@ -161,8 +161,8 @@ class PkgOpsHost @Inject constructor(
         }
         result.exitCode == Cmd.ExitCode.OK
     } catch (e: Exception) {
-        log(TAG, ERROR) { "revokePermission($packageName, $handleId, $permissionId) failed: $e" }
-        throw wrapPropagating(e)
+        log(TAG, ERROR) { "revokePermission($packageName, $handleId, $permissionId) failed: ${e.asLog()}" }
+        throw e.wrapToPropagate()
     }
 
     override fun setAppOps(packageName: String, handleId: Int, key: String, value: String): Boolean = try {
@@ -174,13 +174,8 @@ class PkgOpsHost @Inject constructor(
         }
         result.exitCode == Cmd.ExitCode.OK
     } catch (e: Exception) {
-        log(TAG, ERROR) { "setAppOps($packageName, $handleId, $key, $value) failed: $e" }
-        throw wrapPropagating(e)
-    }
-
-    private fun wrapPropagating(e: Exception): Exception {
-        return if (e is UnsupportedOperationException) e
-        else UnsupportedOperationException(e)
+        log(TAG, ERROR) { "setAppOps($packageName, $handleId, $key, $value) failed: ${e.asLog()}" }
+        throw e.wrapToPropagate()
     }
 
     companion object {

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/shell/ipc/ShellOpsHost.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/shell/ipc/ShellOpsHost.kt
@@ -35,12 +35,7 @@ class ShellOpsHost @Inject constructor(
         }
     } catch (e: Exception) {
         log(TAG, ERROR) { "execute(cmd=$cmd) failed." }
-        throw wrapPropagating(e)
-    }
-
-    private fun wrapPropagating(e: Exception): Exception {
-        return if (e is UnsupportedOperationException) e
-        else UnsupportedOperationException(e)
+        throw e.wrapToPropagate()
     }
 
     companion object {

--- a/app-common/src/main/java/eu/darken/sdmse/common/ipc/IpcClientModule.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/ipc/IpcClientModule.kt
@@ -1,21 +1,52 @@
 package eu.darken.sdmse.common.ipc
 
+import eu.darken.sdmse.common.debug.Bugs
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
+import java.io.ByteArrayInputStream
+import java.io.ObjectInputStream
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
 
 interface IpcClientModule {
 
+    @OptIn(ExperimentalEncodingApi::class)
+    fun String.decodeStacktrace(): Array<StackTraceElement>? = try {
+        val decodedBytes = Base64.decode(this)
+        ObjectInputStream(ByteArrayInputStream(decodedBytes)).use {
+            it.readObject() as Array<StackTraceElement>
+        }
+    } catch (e: Exception) {
+        null
+    }
+
     fun Throwable.unwrapPropagation(): Throwable {
-        val matchResult = Regex("^[a-zA-Z0-9.]+Exception").find((message ?: ""))
-        val exceptionName = matchResult?.value ?: return this
-        val exceptionMessage = message!!.removePrefix("$exceptionName: ").trim()
+        val matchResult = Regex("^([a-zA-Z0-9.]+Exception): ").find((message ?: ""))
+        val exceptionName = matchResult?.groupValues?.get(1) ?: return this
+        val messageParts = message!!
+            .removePrefix(matchResult.groupValues.first())
+            .trim()
+            .split(IpcHostModule.STACK_MARKER)
 
         return try {
             Class.forName(exceptionName)
                 .asSubclass(Throwable::class.java)
                 .getConstructor(String::class.java)
-                .newInstance(exceptionMessage)
-                .also { it.stackTrace = this.stackTrace }
+                .newInstance(messageParts.first())
+                .also { newException ->
+                    //  TODO: Couldn't find a way to keep the trace through parceling
+                    // it.stackTrace = this.stackTrace
+                    if (Bugs.isDebug && messageParts.size > 1) {
+                        log(VERBOSE) { "Decoding stacktrace..." }
+                        messageParts[1].decodeStacktrace()?.let { remoteTrace ->
+                            // Stacktrace on this side of the binder + the stacktrace on the other side of it
+                            newException.stackTrace = (remoteTrace + stackTrace).filter {
+                                !it.className.startsWith("android.os.Binder") && !it.className.startsWith("android.os.Parcel")
+                            }.toTypedArray()
+                        }
+                    }
+                }
         } catch (e: Exception) {
             log(WARN) { "Failed to unwrap exception: $this" }
             this

--- a/app-common/src/main/java/eu/darken/sdmse/common/ipc/IpcClientModule.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/ipc/IpcClientModule.kt
@@ -1,3 +1,25 @@
 package eu.darken.sdmse.common.ipc
 
-interface IpcClientModule
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.log
+
+interface IpcClientModule {
+
+    fun Throwable.unwrapPropagation(): Throwable {
+        val matchResult = Regex("^[a-zA-Z0-9.]+Exception").find((message ?: ""))
+        val exceptionName = matchResult?.value ?: return this
+        val exceptionMessage = message!!.removePrefix("$exceptionName: ").trim()
+
+        return try {
+            Class.forName(exceptionName)
+                .asSubclass(Throwable::class.java)
+                .getConstructor(String::class.java)
+                .newInstance(exceptionMessage)
+                .also { it.stackTrace = this.stackTrace }
+        } catch (e: Exception) {
+            log(WARN) { "Failed to unwrap exception: $this" }
+            this
+        }
+    }
+
+}

--- a/app-common/src/main/java/eu/darken/sdmse/common/ipc/IpcHostModule.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/ipc/IpcHostModule.kt
@@ -1,3 +1,19 @@
 package eu.darken.sdmse.common.ipc
 
-interface IpcHostModule
+interface IpcHostModule {
+
+    // Not all exception can be passed through the binder
+    // See Parcel.writeException(...)
+    fun Throwable.wrapToPropagate(): Exception {
+        val msgBuilder = StringBuilder()
+        msgBuilder.append(this.toString())
+        cause?.let {
+            msgBuilder.append("\nCaused by: ")
+            msgBuilder.append(it.toString())
+        }
+        return UnsupportedOperationException(msgBuilder.toString()).also {
+            it.stackTrace = this.stackTrace
+            // The stacktrace is still lost and not encoded for some reason...
+        }
+    }
+}


### PR DESCRIPTION
#1233 and #1234 would have been easier to debug with this.

It's not as good as I hoped for because the stacktrace doesn't propagate through the binder correctly. Serializing the trace into the exception message is hackyasf but I didn't find a better solution. If anyone finds a better way :beers: are on me. This is only used if `isDebug==true` so I think we can live with the hacky solution.