### PR TITLE
AppControl: Fix crash when passing 0 selected items from multi selection

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListFragment.kt
@@ -166,6 +166,8 @@ class AppControlListFragment : Fragment3(R.layout.appcontrol_list_fragment) {
                 true
             },
             onSelected = { tracker: SelectionTracker<String>, item: MenuItem, selected: Collection<AppControlListAdapter.Item> ->
+                if (selected.isEmpty()) return@installListSelection false
+
                 when (item.itemId) {
                     R.id.action_exclude_selected -> {
                         vm.exclude(selected)


### PR DESCRIPTION
Via playconsole

```
Exception java.util.NoSuchElementException: List is empty.
  at kotlin.collections.CollectionsKt___CollectionsKt.single (CollectionsKt___Collections.kt:2)
  at eu.darken.sdmse.appcontrol.ui.list.AppControlListFragment$onViewCreated$$inlined$observe2$2.invoke (AppControlListFragment.java)
  at eu.darken.sdmse.appcontrol.ui.list.AppControlListFragment$onViewCreated$$inlined$observe2$2.invoke (AppControlListFragment.java)
  at androidx.lifecycle.LiveData.considerNotify (LiveData.java)
  at androidx.lifecycle.LiveData.dispatchingValue (LiveData.java)
  at androidx.lifecycle.MutableLiveData.setValue (MutableLiveData.java)
  at eu.darken.sdmse.common.SingleLiveEvent.setValue (SingleLiveEvent.java)
  at androidx.lifecycle.LiveData$1.run
  at android.os.Handler.handleCallback (Handler.java:938)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loopOnce (Looper.java:210)
  at android.os.Looper.loop (Looper.java:299)
  at android.app.ActivityThread.main (ActivityThread.java:8319)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:556)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1038)
 ```