### PR TITLE
SystemCleaner: Fix scan aborting on error instead of gracefully continuing the search

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/DirectLocalWalker.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/DirectLocalWalker.kt
@@ -11,12 +11,11 @@ import eu.darken.sdmse.common.files.isDirectory
 import eu.darken.sdmse.common.files.isFile
 import kotlinx.coroutines.flow.AbstractFlow
 import kotlinx.coroutines.flow.FlowCollector
-import java.io.IOException
 import java.util.LinkedList
 
 // TODO support symlinks?
 // TODO unit test coverage
-class DirectLocalWalker constructor(
+class DirectLocalWalker(
     private val start: LocalPath,
     private val onFilter: suspend (LocalPathLookup) -> Boolean = { true },
     private val onError: suspend (LocalPathLookup, Exception) -> Boolean = { _, _ -> true },
@@ -33,14 +32,13 @@ class DirectLocalWalker constructor(
         val queue = LinkedList(listOf(startLookUp))
 
         while (!queue.isEmpty()) {
-
             val lookUp = queue.removeFirst()
 
             val newBatch = try {
                 lookUp.lookedUp.asFile()
                     .listFiles2()
                     .map { it.toLocalPath().performLookup() }
-            } catch (e: IOException) {
+            } catch (e: Exception) {
                 log(TAG, ERROR) { "Failed to read $lookUp: $e" }
                 if (onError(lookUp, e)) {
                     emptyList()

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/EscalatingWalker.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/EscalatingWalker.kt
@@ -13,7 +13,6 @@ import eu.darken.sdmse.common.files.isDirectory
 import eu.darken.sdmse.common.files.isFile
 import kotlinx.coroutines.flow.AbstractFlow
 import kotlinx.coroutines.flow.FlowCollector
-import java.io.IOException
 import java.util.LinkedList
 
 // TODO support symlinks?
@@ -70,7 +69,7 @@ class EscalatingWalker(
                                 collector.emit(child)
                             }
                         continue
-                    } catch (e: IOException) {
+                    } catch (e: Exception) {
                         log(TAG, VERBOSE) { "Escalating ${item.target.lookedUp} to $escalationMode due to: $e" }
                         queue.addFirst(item.copy(targetMode = escalationMode, error = e))
                     }
@@ -89,7 +88,7 @@ class EscalatingWalker(
                                 collector.emit(child)
                             }
                         continue
-                    } catch (e: IOException) {
+                    } catch (e: Exception) {
                         log(TAG, DEBUG) { "Failed to read despite escalation: ${item.target.lookedUp}: $e" }
                         queue.addFirst(item.copy(targetMode = null, error = e))
                     }
@@ -110,7 +109,7 @@ class EscalatingWalker(
     data class QueuedItem(
         val target: LocalPathLookup,
         val targetMode: LocalGateway.Mode? = LocalGateway.Mode.NORMAL,
-        val error: IOException? = null,
+        val error: Exception? = null,
     ) {
         fun toSubItem(target: LocalPathLookup) = copy(
             target = target,

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/IndirectLocalWalker.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/IndirectLocalWalker.kt
@@ -9,12 +9,11 @@ import eu.darken.sdmse.common.files.isDirectory
 import eu.darken.sdmse.common.files.isFile
 import kotlinx.coroutines.flow.AbstractFlow
 import kotlinx.coroutines.flow.FlowCollector
-import java.io.IOException
 import java.util.LinkedList
 
 // TODO support symlinks?
 // TODO unit test coverage
-class IndirectLocalWalker constructor(
+class IndirectLocalWalker(
     private val gateway: LocalGateway,
     private val mode: LocalGateway.Mode = LocalGateway.Mode.AUTO,
     private val start: LocalPath,
@@ -38,7 +37,7 @@ class IndirectLocalWalker constructor(
 
             val newBatch = try {
                 gateway.lookupFiles(lookUp.lookedUp, mode)
-            } catch (e: IOException) {
+            } catch (e: Exception) {
                 log(TAG, ERROR) { "Failed to read $lookUp: $e" }
                 if (onError(lookUp, e)) {
                     emptyList()

--- a/app-common/src/main/java/eu/darken/sdmse/common/ipc/IpcClientModule.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/ipc/IpcClientModule.kt
@@ -3,6 +3,7 @@ package eu.darken.sdmse.common.ipc
 import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import java.io.ByteArrayInputStream
 import java.io.ObjectInputStream
@@ -47,7 +48,7 @@ interface IpcClientModule {
                     }
                 }
         } catch (e: Exception) {
-            log(WARN) { "Failed to unwrap exception: $this" }
+            log(WARN) { "Failed to unwrap exception: $this: ${e.asLog()}" }
             this
         }
     }


### PR DESCRIPTION
The remote exception may fail to unwrap and then not be of subtype `IOException` and so would not be caught.