### PR TITLE
Scheduler: Hint about battery optimizations

### DIFF
--- a/app-common/src/main/java/eu/darken/sdmse/common/BatteryHelper.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/BatteryHelper.kt
@@ -1,0 +1,42 @@
+package eu.darken.sdmse.common
+
+import android.content.Context
+import android.content.Intent
+import android.os.PowerManager
+import android.provider.Settings
+import dagger.Reusable
+import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.flow.intervalFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
+import kotlin.time.Duration.Companion.seconds
+
+@Reusable
+class BatteryHelper @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+
+    private val powerManager: PowerManager
+        get() = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+
+    val isIgnoringBatteryOptimizations = intervalFlow(1.seconds)
+        .map { powerManager.isIgnoringBatteryOptimizations(context.packageName) }
+        .distinctUntilChanged()
+        .onEach { log(TAG) { "isIgnoringBatteryOptimizations=$it" } }
+
+    fun createIntent(): Intent = Intent().apply {
+        action = Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS
+    }
+
+    fun createIntentFallback(): Intent = Intent().apply {
+        action = Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS
+    }
+
+    companion object {
+        private val TAG = logTag("BatteryHelper")
+    }
+}

--- a/app-common/src/main/java/eu/darken/sdmse/common/BatteryHelper.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/BatteryHelper.kt
@@ -32,10 +32,6 @@ class BatteryHelper @Inject constructor(
         action = Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS
     }
 
-    fun createIntentFallback(): Intent = Intent().apply {
-        action = Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS
-    }
-
     companion object {
         private val TAG = logTag("BatteryHelper")
     }

--- a/app-common/src/main/java/eu/darken/sdmse/common/permissions/Permission.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/permissions/Permission.kt
@@ -1,6 +1,5 @@
 package eu.darken.sdmse.common.permissions
 
-import android.annotation.SuppressLint
 import android.app.AppOpsManager
 import android.content.Context
 import android.content.Intent
@@ -9,11 +8,9 @@ import android.content.pm.ResolveInfo
 import android.net.Uri
 import android.os.Build
 import android.os.Environment
-import android.os.PowerManager
 import android.provider.Settings
 import androidx.annotation.RequiresApi
 import androidx.core.content.ContextCompat
-import eu.darken.sdmse.common.BuildConfigWrap
 import eu.darken.sdmse.common.device.DeviceDetective
 import eu.darken.sdmse.common.device.RomType
 import kotlin.reflect.full.isSubclassOf
@@ -29,24 +26,6 @@ sealed class Permission(
 
     object POST_NOTIFICATIONS
         : Permission("android.permission.POST_NOTIFICATIONS"), RuntimePermission
-
-    @SuppressLint("BatteryLife")
-    object IGNORE_BATTERY_OPTIMIZATION
-        : Permission("android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"), Specialpermission {
-        override fun isGranted(context: Context): Boolean {
-            val pwm = context.getSystemService(Context.POWER_SERVICE) as PowerManager
-            return pwm.isIgnoringBatteryOptimizations(BuildConfigWrap.APPLICATION_ID)
-        }
-
-        override fun createIntent(context: Context, deviceDetective: DeviceDetective): Intent = Intent().apply {
-            action = Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS
-            data = Uri.fromParts("package", context.packageName, null)
-        }
-
-        override fun createIntentFallback(context: Context): Intent = Intent().apply {
-            Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS
-        }
-    }
 
     @RequiresApi(Build.VERSION_CODES.R)
     object MANAGE_EXTERNAL_STORAGE

--- a/app-common/src/main/res/values/strings.xml
+++ b/app-common/src/main/res/values/strings.xml
@@ -164,4 +164,5 @@
         <item quantity="one">%s file</item>
         <item quantity="other">%s files</item>
     </plurals>
+    <string name="general_advice_title">Advice</string>
 </resources>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,7 +5,6 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
     <!--    For some reason this affects PackageManager.getSharedLibraries() results, i.e. trichromelibrary-->
     <uses-permission android:name="android.permission.REQUEST_DELETE_PACKAGES" />

--- a/app/src/main/java/eu/darken/sdmse/scheduler/core/SchedulerSettings.kt
+++ b/app/src/main/java/eu/darken/sdmse/scheduler/core/SchedulerSettings.kt
@@ -29,6 +29,8 @@ class SchedulerSettings @Inject constructor(
 
     val createdDefaultEntry = dataStore.createValue("default.entry.created", false)
 
+    val hintBatteryDismissed = dataStore.createValue("hint.battery.optimization.dismissed", false)
+
     override val mapper = PreferenceStoreMapper(
         skipWhenPowerSaving,
         skipWhenNotCharging,

--- a/app/src/main/java/eu/darken/sdmse/scheduler/ui/manager/SchedulerAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/scheduler/ui/manager/SchedulerAdapter.kt
@@ -12,6 +12,7 @@ import eu.darken.sdmse.common.lists.modular.ModularAdapter
 import eu.darken.sdmse.common.lists.modular.mods.DataBinderMod
 import eu.darken.sdmse.common.lists.modular.mods.TypedVHCreatorMod
 import eu.darken.sdmse.scheduler.ui.manager.items.AlarmHintRowVH
+import eu.darken.sdmse.scheduler.ui.manager.items.BatteryHintRowVH
 import eu.darken.sdmse.scheduler.ui.manager.items.ScheduleRowVH
 import javax.inject.Inject
 
@@ -28,6 +29,7 @@ class SchedulerAdapter @Inject constructor() :
         addMod(DataBinderMod(data))
         addMod(TypedVHCreatorMod({ data[it] is ScheduleRowVH.Item }) { ScheduleRowVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is AlarmHintRowVH.Item }) { AlarmHintRowVH(it) })
+        addMod(TypedVHCreatorMod({ data[it] is BatteryHintRowVH.Item }) { BatteryHintRowVH(it) })
     }
 
     abstract class BaseVH<D : Item, B : ViewBinding>(

--- a/app/src/main/java/eu/darken/sdmse/scheduler/ui/manager/SchedulerManagerEvents.kt
+++ b/app/src/main/java/eu/darken/sdmse/scheduler/ui/manager/SchedulerManagerEvents.kt
@@ -1,7 +1,13 @@
 package eu.darken.sdmse.scheduler.ui.manager
 
+import android.content.Intent
 import eu.darken.sdmse.scheduler.core.Schedule
 
 sealed interface SchedulerManagerEvents {
     data class FinalCommandsEdit(val schedule: Schedule) : SchedulerManagerEvents
+
+    data class ShowBatteryOptimizationSettings(
+        val primary: Intent,
+        val fallback: Intent,
+    ) : SchedulerManagerEvents
 }

--- a/app/src/main/java/eu/darken/sdmse/scheduler/ui/manager/SchedulerManagerEvents.kt
+++ b/app/src/main/java/eu/darken/sdmse/scheduler/ui/manager/SchedulerManagerEvents.kt
@@ -6,8 +6,5 @@ import eu.darken.sdmse.scheduler.core.Schedule
 sealed interface SchedulerManagerEvents {
     data class FinalCommandsEdit(val schedule: Schedule) : SchedulerManagerEvents
 
-    data class ShowBatteryOptimizationSettings(
-        val primary: Intent,
-        val fallback: Intent,
-    ) : SchedulerManagerEvents
+    data class ShowBatteryOptimizationSettings(val intent: Intent) : SchedulerManagerEvents
 }

--- a/app/src/main/java/eu/darken/sdmse/scheduler/ui/manager/SchedulerManagerFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/scheduler/ui/manager/SchedulerManagerFragment.kt
@@ -80,7 +80,7 @@ class SchedulerManagerFragment : Fragment3(R.layout.scheduler_manager_fragment) 
 
                 is SchedulerManagerEvents.ShowBatteryOptimizationSettings -> {
                     try {
-                        startActivity(event.primary)
+                        startActivity(event.intent)
                     } catch (e: ActivityNotFoundException) {
                         e.asErrorDialogBuilder(requireActivity()).show()
                     }

--- a/app/src/main/java/eu/darken/sdmse/scheduler/ui/manager/SchedulerManagerFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/scheduler/ui/manager/SchedulerManagerFragment.kt
@@ -1,5 +1,6 @@
 package eu.darken.sdmse.scheduler.ui.manager
 
+import android.content.ActivityNotFoundException
 import android.os.Bundle
 import android.view.View
 import androidx.core.view.isGone
@@ -11,6 +12,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import eu.darken.sdmse.R
 import eu.darken.sdmse.common.WebpageTool
 import eu.darken.sdmse.common.debug.Bugs
+import eu.darken.sdmse.common.error.asErrorDialogBuilder
 import eu.darken.sdmse.common.lists.differ.update
 import eu.darken.sdmse.common.lists.setupDefaults
 import eu.darken.sdmse.common.uix.Fragment3
@@ -74,6 +76,14 @@ class SchedulerManagerFragment : Fragment3(R.layout.scheduler_manager_fragment) 
                         }
                         setNegativeButton(eu.darken.sdmse.common.R.string.general_cancel_action) { _, _ -> }
                     }.show()
+                }
+
+                is SchedulerManagerEvents.ShowBatteryOptimizationSettings -> {
+                    try {
+                        startActivity(event.primary)
+                    } catch (e: ActivityNotFoundException) {
+                        e.asErrorDialogBuilder(requireActivity()).show()
+                    }
                 }
             }
         }

--- a/app/src/main/java/eu/darken/sdmse/scheduler/ui/manager/SchedulerManagerViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/scheduler/ui/manager/SchedulerManagerViewModel.kt
@@ -101,10 +101,7 @@ class SchedulerManagerViewModel @Inject constructor(
             BatteryHintRowVH.Item(
                 onFix = {
                     events.postValue(
-                        SchedulerManagerEvents.ShowBatteryOptimizationSettings(
-                            primary = batteryHelper.createIntent(),
-                            fallback = batteryHelper.createIntentFallback()
-                        )
+                        SchedulerManagerEvents.ShowBatteryOptimizationSettings(batteryHelper.createIntent())
                     )
                 },
                 onDismiss = { settings.hintBatteryDismissed.valueBlocking = true }

--- a/app/src/main/java/eu/darken/sdmse/scheduler/ui/manager/SchedulerManagerViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/scheduler/ui/manager/SchedulerManagerViewModel.kt
@@ -7,12 +7,15 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.sdmse.MainDirections
 import eu.darken.sdmse.R
+import eu.darken.sdmse.common.BatteryHelper
 import eu.darken.sdmse.common.SingleLiveEvent
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.datastore.value
+import eu.darken.sdmse.common.datastore.valueBlocking
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.hasApiLevel
 import eu.darken.sdmse.common.root.RootManager
 import eu.darken.sdmse.common.root.canUseRootNow
 import eu.darken.sdmse.common.shizuku.ShizukuManager
@@ -21,18 +24,22 @@ import eu.darken.sdmse.common.uix.ViewModel3
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
 import eu.darken.sdmse.common.upgrade.isPro
 import eu.darken.sdmse.main.core.taskmanager.TaskManager
-import eu.darken.sdmse.main.ui.dashboard.items.*
 import eu.darken.sdmse.scheduler.core.Schedule
 import eu.darken.sdmse.scheduler.core.ScheduleId
 import eu.darken.sdmse.scheduler.core.SchedulerManager
 import eu.darken.sdmse.scheduler.core.SchedulerSettings
 import eu.darken.sdmse.scheduler.ui.manager.items.AlarmHintRowVH
+import eu.darken.sdmse.scheduler.ui.manager.items.BatteryHintRowVH
 import eu.darken.sdmse.scheduler.ui.manager.items.ScheduleRowVH
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.take
 import java.time.Duration
 import java.time.Instant
 import java.time.LocalTime
-import java.util.*
+import java.util.UUID
 import javax.inject.Inject
 
 @SuppressLint("StaticFieldLeak")
@@ -43,39 +50,65 @@ class SchedulerManagerViewModel @Inject constructor(
     dispatcherProvider: DispatcherProvider,
     taskManager: TaskManager,
     private val schedulerManager: SchedulerManager,
-    private val schedulerSettings: SchedulerSettings,
+    private val settings: SchedulerSettings,
     private val upgradeRepo: UpgradeRepo,
     private val rootManager: RootManager,
     private val shizukuManager: ShizukuManager,
+    private val batteryHelper: BatteryHelper,
 ) : ViewModel3(dispatcherProvider = dispatcherProvider) {
 
     val events = SingleLiveEvent<SchedulerManagerEvents>()
+
+    private val showBatteryOptimizationHint = combine(
+        batteryHelper.isIgnoringBatteryOptimizations,
+        settings.hintBatteryDismissed.flow,
+    ) { isIgnoring, isDismissed ->
+        !isDismissed && !isIgnoring
+    }
 
     init {
         schedulerManager.state
             .take(1)
             .onEach {
                 if (it.schedules.isNotEmpty()) return@onEach
-                if (schedulerSettings.createdDefaultEntry.value()) return@onEach
+                if (settings.createdDefaultEntry.value()) return@onEach
 
                 val defaultEntry = Schedule(
                     id = UUID.randomUUID().toString(),
                     label = context.getString(R.string.scheduler_schedule_default_name),
                 )
                 schedulerManager.saveSchedule(defaultEntry)
-                schedulerSettings.createdDefaultEntry.value(true)
+                settings.createdDefaultEntry.value(true)
             }
             .launchInViewModel()
+
+        launch {
+            if (batteryHelper.isIgnoringBatteryOptimizations.first() && settings.hintBatteryDismissed.value()) {
+                log(TAG) { "Resetting hintBatteryDismissed to false" }
+                settings.hintBatteryDismissed.value(false)
+            }
+        }
     }
 
     val items = combine(
         schedulerManager.state,
-        taskManager.state
-    ) { schedulerState, taskState ->
+        taskManager.state,
+        showBatteryOptimizationHint,
+    ) { schedulerState, taskState, showBatteryHint ->
         val items = mutableListOf<SchedulerAdapter.Item>()
 
-        if (schedulerState.schedules.any { it.isEnabled }) {
-            items.add(AlarmHintRowVH.Item(schedulerState))
+        if (hasApiLevel(31) && showBatteryHint && schedulerState.schedules.any { it.isEnabled }) {
+            BatteryHintRowVH.Item(
+                onFix = {
+                    events.postValue(
+                        SchedulerManagerEvents.ShowBatteryOptimizationSettings(
+                            primary = batteryHelper.createIntent(),
+                            fallback = batteryHelper.createIntentFallback()
+                        )
+                    )
+                },
+                onDismiss = { settings.hintBatteryDismissed.valueBlocking = true }
+            ).apply { items.add(this) }
         }
 
         val showCommands = rootManager.canUseRootNow() || shizukuManager.canUseShizukuNow()
@@ -123,6 +156,12 @@ class SchedulerManagerViewModel @Inject constructor(
                 showCommands = showCommands,
             )
         }.run { items.addAll(this) }
+
+        if (schedulerState.schedules.any { it.isEnabled }) {
+            AlarmHintRowVH.Item(
+                schedulerState
+            ).apply { items.add(this) }
+        }
 
         State(
             listItems = items,

--- a/app/src/main/java/eu/darken/sdmse/scheduler/ui/manager/items/BatteryHintRowVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/scheduler/ui/manager/items/BatteryHintRowVH.kt
@@ -1,0 +1,33 @@
+package eu.darken.sdmse.scheduler.ui.manager.items
+
+import android.view.ViewGroup
+import eu.darken.sdmse.R
+import eu.darken.sdmse.common.lists.binding
+import eu.darken.sdmse.databinding.SchedulerManagerListBatteryhintItemBinding
+import eu.darken.sdmse.scheduler.ui.manager.SchedulerAdapter
+
+
+class BatteryHintRowVH(parent: ViewGroup) :
+    SchedulerAdapter.BaseVH<BatteryHintRowVH.Item, SchedulerManagerListBatteryhintItemBinding>(
+        R.layout.scheduler_manager_list_batteryhint_item,
+        parent
+    ) {
+
+    override val viewBinding = lazy { SchedulerManagerListBatteryhintItemBinding.bind(itemView) }
+
+    override val onBindData: SchedulerManagerListBatteryhintItemBinding.(
+        item: Item,
+        payloads: List<Any>
+    ) -> Unit = binding { item ->
+        fixAction.setOnClickListener { item.onFix() }
+        dismissAction.setOnClickListener { item.onDismiss() }
+    }
+
+    data class Item(
+        val onFix: () -> Unit,
+        val onDismiss: () -> Unit,
+    ) : SchedulerAdapter.Item {
+
+        override val stableId: Long = Item::class.java.hashCode().toLong()
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/setup/SetupViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/SetupViewModel.kt
@@ -266,7 +266,6 @@ class SetupViewModel @Inject constructor(
                     storageSetupModule.onPermissionChanged(permission, granted)
                 }
 
-                Permission.IGNORE_BATTERY_OPTIMIZATION -> {}
                 Permission.PACKAGE_USAGE_STATS -> {}
                 Permission.POST_NOTIFICATIONS -> {}
                 Permission.WRITE_SECURE_SETTINGS -> {}

--- a/app/src/main/res/drawable/ic_battery_heart_24.xml
+++ b/app/src/main/res/drawable/ic_battery_heart_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12.67 4H11V2H5V4H3.33A1.34 1.34 0 0 0 2 5.33V20.67A1.34 1.34 0 0 0 3.33 22H12.67A1.34 1.34 0 0 0 14 20.67V5.33A1.34 1.34 0 0 0 12.67 4M19 16.17L18.42 15.64C16.36 13.77 15 12.54 15 11A2.18 2.18 0 0 1 17.2 8.8A2.4 2.4 0 0 1 19 9.63A2.4 2.4 0 0 1 20.8 8.8A2.18 2.18 0 0 1 23 11C23 12.5 21.64 13.74 19.58 15.61Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_battery_lock_open_24.xml
+++ b/app/src/main/res/drawable/ic_battery_lock_open_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M19.8 16H15.5V13.5C15.5 12.7 16.2 12.2 17 12.2S18.5 12.7 18.5 13.5V14H19.8V13.5C19.8 12.1 18.4 11 17 11S14.2 12.1 14.2 13.5V16C13.6 16 13 16.6 13 17.2V20.7C13 21.4 13.6 22 14.2 22H19.7C20.4 22 21 21.4 21 20.8V17.3C21 16.6 20.4 16 19.8 16M11.27 22H5.33C4.6 22 4 21.4 4 20.67V5.33C4 4.6 4.6 4 5.33 4H7V2H13V4H14.67C15.4 4 16 4.6 16 5.33V9.11C13.86 9.55 12.2 11.38 12.2 13.5V14.74C11.5 15.34 11 16.24 11 17.2V20.7C11 20.93 11.03 21.15 11.07 21.37L11.08 21.39C11.12 21.6 11.19 21.8 11.27 22Z" />
+</vector>

--- a/app/src/main/res/layout/scheduler_manager_list_alarmhint_item.xml
+++ b/app/src/main/res/layout/scheduler_manager_list_alarmhint_item.xml
@@ -1,37 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    style="@style/DashboardCardItem"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:paddingHorizontal="16dp"
+    android:paddingTop="8dp"
+    android:paddingBottom="16dp">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="match_parent"
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/primary"
+        style="@style/TextAppearance.Material3.BodySmall"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_margin="16dp">
+        android:gravity="center"
+        android:text="@string/scheduler_inaccurate_execution_hint"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
-        <ImageView
-            android:id="@+id/icon"
-            android:layout_width="24dp"
-            android:layout_height="24dp"
-            android:src="@drawable/ic_baseline_info_24"
-            app:layout_constraintBottom_toBottomOf="@id/primary"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="@id/primary" />
-
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/primary"
-            style="@style/TextAppearance.Material3.BodyMedium"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
-            android:text="@string/scheduler_inaccurate_execution_hint"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@id/icon"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintVertical_chainStyle="packed" />
-
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-</com.google.android.material.card.MaterialCardView>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/scheduler_manager_list_batteryhint_item.xml
+++ b/app/src/main/res/layout/scheduler_manager_list_batteryhint_item.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    style="@style/DashboardCardItem"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp">
+
+        <ImageView
+            android:id="@+id/icon"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:src="@drawable/sdm_normal"
+            app:layout_constraintBottom_toBottomOf="@id/title"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@id/title" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:layout_width="wrap_content"
+            android:id="@+id/title"
+            android:layout_marginStart="8dp"
+            android:text="@string/general_advice_title"
+            style="@style/TextAppearance.Material3.TitleMedium"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toEndOf="@id/icon"
+            android:layout_height="wrap_content" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/primary"
+            style="@style/TextAppearance.Material3.BodyMedium"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@string/scheduler_battery_optimization_hint"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/title"
+            android:layout_marginTop="8dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintVertical_chainStyle="packed" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/dismiss_action"
+            style="@style/SDMButton.Text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/general_dismiss_action"
+            android:textColor="?colorOnSecondaryContainer"
+            app:iconTint="?colorOnSecondaryContainer"
+            app:layout_constraintBottom_toBottomOf="@id/fix_action"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@id/fix_action" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/fix_action"
+            style="@style/DashboardCardButton.Filled"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/general_fix_action"
+            app:icon="@drawable/ic_battery_lock_open_24"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="1.0"
+            app:layout_constraintStart_toEndOf="@id/dismiss_action"
+            app:layout_constraintTop_toBottomOf="@id/primary" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -677,6 +677,7 @@
     <string name="scheduler_notification_result_failure_message">Some scheduled tasks failed or encountered errors. Try running them manually.</string>
     <string name="scheduler_commands_after_schedule_label">Post-schedule commands</string>
     <string name="scheduler_commands_after_schedule_desc">Android shell commands that will be executed at the end of a schedule.</string>
+    <string name="scheduler_battery_optimization_hint">Consider disabling battery optimizations for SD Maid if you experience issues with background execution.</string>
 
     <string name="updates_dashcard_title">Update available</string>
     <string name="updates_dashcard_body">An update is available. You have %1$s and the latest version is %2$s.</string>


### PR DESCRIPTION
Show a hint about disabling battery optimizations on newer Android versions where this may affect launching a foreground task, e.g. Android 14+.

I tested various API levels and starting with Android 12 (API31), we get an exception when starting foreground services while optimizations are enabled.

We didn't use `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` and shouldn't as black box Google Play is potentially allergic to it's use. Do the safe way of directing the user to the system settings.

Also see #1273 and #1247

```
14:15:39.704 SDMSE:Scheduler:Worker               D  Declaring as foreground task
14:15:39.704 SDMSE:Scheduler:Worker               D  Supplying getForegroundInfo() with Schedule(id=96b7c483-863d-4c9f-9baa-b5e1b6083ddc, createdAt=2024-07-05T12:14:14.886Z, scheduledAt=2024-07-05T12:14:14.886Z, hour=14, minute=15, label=Test Schedule 96b7c483-863d-4c9f-9baa-b5e1b6083ddc, repeatInterval=PT24H, useCorpseFinder=false, useSystemCleaner=false, useAppCleaner=false, commandsAfterSchedule=[], executedAt=null)
14:15:39.705 WM-Processor                         I  Moving WorkSpec (5bb950de-d2c4-4622-91bf-58408fbbbf8c) to the foreground
14:15:39.707 ActivityManager                      W  Background started FGS: Disallowed [callingPackage: eu.darken.sdmse; callingUid: 10149; uidState: CEM ; intent: Intent { act=ACTION_START_FOREGROUND cmp=eu.darken.sdmse/androidx.work.impl.foreground.SystemForegroundService (has extras) }; code:DENIED; tempAllowListReason:<null>; targetSdkVersion:34; callerTargetSdkVersion:34; startForegroundCount:0; bindFromPackage:null]
14:15:39.707 ActivityManager                      W  startForegroundService() not allowed due to mAllowStartForeground false: service eu.darken.sdmse/androidx.work.impl.foreground.SystemForegroundService
14:15:39.708 SDMSE:Scheduler:Worker               E  Can't execute in foreground: android.app.ForegroundServiceStartNotAllowedException: startForegroundService() not allowed due to mAllowStartForeground false: service eu.darken.sdmse/androidx.work.impl.foreground.SystemForegroundService
                                                     	at android.app.ForegroundServiceStartNotAllowedException$1.createFromParcel(ForegroundServiceStartNotAllowedException.java:54)
                                                     	at android.app.ForegroundServiceStartNotAllowedException$1.createFromParcel(ForegroundServiceStartNotAllowedException.java:50)
                                                     	at android.os.Parcel.readParcelable(Parcel.java:3334)
                                                     	at android.os.Parcel.createExceptionOrNull(Parcel.java:2421)
                                                     	at android.os.Parcel.createException(Parcel.java:2410)
                                                     	at android.os.Parcel.readException(Parcel.java:2393)
                                                     	at android.os.Parcel.readException(Parcel.java:2335)
                                                     	at android.app.IActivityManager$Stub$Proxy.startService(IActivityManager.java:6033)
                                                     	at android.app.ContextImpl.startServiceCommon(ContextImpl.java:1856)
                                                     	at android.app.ContextImpl.startForegroundService(ContextImpl.java:1832)
                                                     	at android.content.ContextWrapper.startForegroundService(ContextWrapper.java:781)
                                                     	at androidx.core.content.ContextCompat$Api26Impl.startForegroundService(ContextCompat.java:1091)
                                                     	at androidx.core.content.ContextCompat.startForegroundService(ContextCompat.java:749)
                                                     	at androidx.work.impl.Processor.startForeground(Processor.java:161)
                                                     	at androidx.work.impl.utils.WorkForegroundUpdater$1.run(WorkForegroundUpdater.java:100)
                                                     	at androidx.work.impl.utils.SerialExecutor$Task.run(SerialExecutor.java:91)
                                                     	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
                                                     	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
                                                     	at java.lang.Thread.run(Thread.java:920)
---------------------------- PROCESS STARTED (6577) for package eu.darken.sdmse ----------------------------
14:15:40.786 ActivityManager                      W  Background start not allowed: service Intent { act=ACTION_STOP_FOREGROUND cmp=eu.darken.sdmse/androidx.work.impl.foreground.SystemForegroundService } to eu.darken.sdmse/androidx.work.impl.foreground.SystemForegroundService from pid=6577 uid=10149 pkg=eu.darken.sdmse startFg?=false
14:15:40.786 WM-Processor                         E  Unable to stop foreground service
                                                     android.app.BackgroundServiceStartNotAllowedException: Not allowed to start service Intent { act=ACTION_STOP_FOREGROUND cmp=eu.darken.sdmse/androidx.work.impl.foreground.SystemForegroundService }: app is in background uid UidRecord{da4fe1f u0a149 CEM  idle change:cached procs:0 seq(0,0,0)}
                                                     	at android.app.ContextImpl.startServiceCommon(ContextImpl.java:1870)
                                                     	at android.app.ContextImpl.startService(ContextImpl.java:1826)
                                                     	at android.content.ContextWrapper.startService(ContextWrapper.java:776)
                                                     	at androidx.work.impl.Processor.stopForegroundService(Processor.java:318)
                                                     	at androidx.work.impl.Processor.stopForeground(Processor.java:224)
                                                     	at androidx.work.impl.WorkerWrapper.resolve(WorkerWrapper.java:460)
                                                     	at androidx.work.impl.WorkerWrapper.setSucceededAndResolve(WorkerWrapper.java:600)
                                                     	at androidx.work.impl.WorkerWrapper.handleResult(WorkerWrapper.java:477)
                                                     	at androidx.work.impl.WorkerWrapper.onWorkFinished(WorkerWrapper.java:354)
                                                     	at androidx.work.impl.WorkerWrapper$2.run(WorkerWrapper.java:331)
                                                     	at androidx.work.impl.utils.SerialExecutor$Task.run(SerialExecutor.java:91)
                                                     	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
                                                     	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
                                                     	at java.lang.Thread.run(Thread.java:920)
```