### PR TITLE
Stats: Change reset UI and displayed info

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/stats/core/db/ReportsDatabase.kt
+++ b/app/src/main/java/eu/darken/sdmse/stats/core/db/ReportsDatabase.kt
@@ -1,7 +1,6 @@
 package eu.darken.sdmse.stats.core.db
 
 import android.content.Context
-import android.database.sqlite.SQLiteDatabase
 import androidx.room.Room
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.sdmse.common.coroutine.AppScope
@@ -165,22 +164,6 @@ class ReportsDatabase @Inject constructor(
 
     suspend fun clear() = withContext(dispatcherProvider.IO) {
         log(TAG, INFO) { "clear()" }
-        val walFile = File(context.getDatabasePath(DB_NAME).parent, "$DB_NAME-wal")
-        val shmFile = File(context.getDatabasePath(DB_NAME).parent, "$DB_NAME-shm")
-
-        if (walFile.exists() || shmFile.exists()) {
-            SQLiteDatabase.openDatabase(
-                dbFile.path,
-                null,
-                SQLiteDatabase.OPEN_READWRITE
-            ).use {
-                it.rawQuery("PRAGMA wal_checkpoint(FULL)", null).use { }
-            }
-        }
-
-        walFile.delete()
-        shmFile.delete()
-
         database.clearAllTables()
 
         databaseSize.value = getDatabaseSize()

--- a/app/src/main/java/eu/darken/sdmse/stats/ui/settings/StatsSettingsFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/stats/ui/settings/StatsSettingsFragment.kt
@@ -1,7 +1,6 @@
 package eu.darken.sdmse.stats.ui.settings
 
 import android.os.Bundle
-import android.text.format.Formatter
 import android.view.View
 import androidx.annotation.Keep
 import androidx.annotation.StringRes
@@ -59,8 +58,9 @@ class StatsSettingsFragment : PreferenceFragment3() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         vm.state.observe2 { state ->
-            preferenceSize.summary = Formatter.formatShortFileSize(requireContext(),
-                state.databaseSize.takeIf { it > 32 * 1024 } ?: 0L
+            preferenceSize.summary = getQuantityString2(
+                eu.darken.sdmse.common.R.plurals.result_x_items,
+                state.reportsCount
             )
         }
         super.onViewCreated(view, savedInstanceState)

--- a/app/src/main/java/eu/darken/sdmse/stats/ui/settings/StatsSettingsViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/stats/ui/settings/StatsSettingsViewModel.kt
@@ -17,7 +17,7 @@ class StatsSettingsViewModel @Inject constructor(
 
     val state = statsRepo.state.map {
         State(
-            databaseSize = it.databaseSize
+            reportsCount = it.reportsCount
         )
     }.asLiveData2()
 
@@ -27,7 +27,7 @@ class StatsSettingsViewModel @Inject constructor(
     }
 
     data class State(
-        val databaseSize: Long,
+        val reportsCount: Int,
     )
 
     companion object {

--- a/app/src/main/res/xml/preferences_statistics.xml
+++ b/app/src/main/res/xml/preferences_statistics.xml
@@ -21,11 +21,11 @@
             app:summary="@string/stats_settings_retention_paths_desc"
             app:title="@string/stats_settings_retention_paths_label" />
         <Preference
-            app:icon="@drawable/ic_weight_24"
+            app:icon="@drawable/baseline_settings_backup_restore_24"
             app:key="reports.size"
             app:singleLineTitle="false"
             app:summary="~"
-            app:title="@string/general_size_label" />
+            app:title="@string/stats_settings_reset_all_label" />
     </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
Show item count and not database size.
Due to the database using -shm and -wal files, showing a size will confuse users trying to get it to "0KB". The previous checkpoint+deletion approach could cause crashes if the database was being accessed at that time.