### PR TITLE
Core: Fix proguard breaking Root and Shizuku service connections on release builds

### DIFF
--- a/app-common-io/consumer-rules.pro
+++ b/app-common-io/consumer-rules.pro
@@ -1,1 +1,8 @@
 -keep class android.content.pm.IPackageDataObserver { *; }
+
+-keepclassmembers class eu.darken.sdmse.common.root.service.RootServiceConnection$Stub$Proxy {
+  *;
+}
+-keepclassmembers class eu.darken.sdmse.common.shizuku.ShizukuServiceConnection$Stub$Proxy {
+  *;
+}

--- a/app-common-root/src/main/java/eu/darken/sdmse/common/root/service/internal/RootHostLauncher.kt
+++ b/app-common-root/src/main/java/eu/darken/sdmse/common/root/service/internal/RootHostLauncher.kt
@@ -54,8 +54,11 @@ class RootHostLauncher @Inject constructor(
             override fun onConnect(connection: RootConnection) {
                 log(TAG) { "onConnect(connection=$connection)" }
 
-                val userConnection = connection.userConnection.getInterface(serviceClass)
-                    ?: throw RootException("Failed to get user connection")
+                val userConnection = try {
+                    connection.userConnection.getInterface(serviceClass) as Service
+                } catch (e: Exception) {
+                    throw RootException("Failed to get user connection (ROOT)", e)
+                }
 
                 log(TAG) { "onServiceConnected(...) -> $userConnection" }
                 trySendBlocking(ConnectionWrapper(userConnection, connection))

--- a/app-common-shizuku/src/main/java/eu/darken/sdmse/common/shizuku/service/internal/ShizukuHostLauncher.kt
+++ b/app-common-shizuku/src/main/java/eu/darken/sdmse/common/shizuku/service/internal/ShizukuHostLauncher.kt
@@ -58,8 +58,11 @@ class ShizukuHostLauncher @Inject constructor() {
                 log(TAG) { "Updating host options to $options" }
                 baseConnection.updateHostOptions(options)
 
-                val userConnection = baseConnection.userConnection.getInterface(serviceClass)
-                    ?: throw ShizukuException("Failed to get user connection")
+                val userConnection = try {
+                    baseConnection.userConnection.getInterface(serviceClass) as Service
+                } catch (e: Exception) {
+                    throw ShizukuException("Failed to get user connection (SHIZUKU)", e)
+                }
 
                 log(TAG) { "onServiceConnected(...) -> $userConnection" }
                 trySendBlocking(ConnectionWrapper(userConnection, baseConnection as Host))

--- a/app-common/src/main/java/eu/darken/sdmse/common/ipc/BinderExtensions.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/ipc/BinderExtensions.kt
@@ -1,8 +1,7 @@
 package eu.darken.sdmse.common.ipc
 
 import android.os.IBinder
-import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
-import eu.darken.sdmse.common.debug.logging.asLog
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.log
 import kotlin.reflect.KClass
 
@@ -12,8 +11,8 @@ import kotlin.reflect.KClass
  * @return T (proxy) instance or null
  */
 @Suppress("UNCHECKED_CAST")
-fun <T : Any> IBinder.getInterface(clazz: KClass<T>): T? = try {
-    // Note: This requiers proguard rules, otherwise R8 removes the field
+fun <T : Any> IBinder.getInterface(clazz: KClass<T>): T? {
+    // PROGUARD RULE REQUIRED: DESCRIPTOR field is otherwise removed
     // e.g. eu.darken.sdmse.common.root.service.RootServiceConnection.DESCRIPTOR
     val fDescriptor = Class
         .forName(clazz.qualifiedName + "\$Stub")
@@ -21,20 +20,24 @@ fun <T : Any> IBinder.getInterface(clazz: KClass<T>): T? = try {
         .apply { isAccessible = true }
 
     val intf = queryLocalInterface(fDescriptor[this] as String)
+    log(VERBOSE) { "Queried interface is $intf" }
 
     if (clazz.isInstance(intf)) {
-        // local
-        intf as T?
-    } else {
-        // remote
-        val ctorProxy = Class
-            .forName(clazz.qualifiedName + "\$Stub\$Proxy")
-            .getDeclaredConstructor(IBinder::class.java)
-            .apply { isAccessible = true }
-
-        ctorProxy.newInstance(this) as T
+        log(VERBOSE) { "Using local instance" }
+        return intf as T?
     }
-} catch (e: Exception) {
-    log(ERROR) { "getInterfaceFromBinder() failed: ${e.asLog()}" }
-    null
+
+    log(VERBOSE) { "Creating remote instance" }
+    val className = clazz.qualifiedName + "\$Stub\$Proxy"
+
+    // PROGUARD RULE REQUIRED: `Proxy` constructor is otherwise removed
+    // e.g. eu.darken.sdmse.common.shizuku.ShizukuServiceConnection$Stub$Proxy.<init> [interface android.os.IBinder]
+    log(VERBOSE) { "Creating class $className" }
+    val ctorProxy = Class
+        .forName(className)
+        .getConstructor(IBinder::class.java)
+        .apply { isAccessible = true }
+
+    return ctorProxy.newInstance(this) as T
+
 }


### PR DESCRIPTION
After bumping dependencies and gradle/AGP in #1301 the proguard/R8 behavior changed and additional rules are now required.

Fixes #1305

Thanks @chaoscalm