### PR TITLE
AppCleaner: When using the scheduler on Android TV use back button in stead of home button after finishing ACS operations

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
@@ -43,6 +43,7 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.device.DeviceDetective
 import eu.darken.sdmse.common.funnel.IPCFunnel
 import eu.darken.sdmse.common.pkgs.PkgRepo
 import eu.darken.sdmse.common.pkgs.features.Installed
@@ -68,6 +69,7 @@ class ClearCacheModule @AssistedInject constructor(
     private val specGenerators: Provider<Set<@JvmSuppressWildcards AppCleanerSpecGenerator>>,
     private val userManager2: UserManager2,
     private val labelDebugger: LabelDebugger,
+    private val deviceDetective: DeviceDetective,
 ) : AutomationModule(automationHost) {
 
     private fun getPriotizedSpecGenerators(): List<AppCleanerSpecGenerator> = specGenerators
@@ -175,6 +177,7 @@ class ClearCacheModule @AssistedInject constructor(
         finishAutomation(
             userCancelled = cancelledByUser,
             returnToApp = task.returnToApp,
+            deviceDetective = deviceDetective,
         )
 
         return ClearCacheTask.Result(

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/AppControlAutomation.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/AppControlAutomation.kt
@@ -33,6 +33,7 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.device.DeviceDetective
 import eu.darken.sdmse.common.pkgs.PkgRepo
 import eu.darken.sdmse.common.pkgs.features.Installed
 import eu.darken.sdmse.common.pkgs.getPkg
@@ -56,6 +57,7 @@ class AppControlAutomation @AssistedInject constructor(
     private val specGenerators: Provider<Set<@JvmSuppressWildcards AppControlSpecGenerator>>,
     private val userManager2: UserManager2,
     private val labelDebugger: AppControlLabelDebugger,
+    private val deviceDetective: DeviceDetective,
 ) : AutomationModule(automationHost) {
 
     private fun getPriotizedSpecGenerators(): List<AppControlSpecGenerator> = specGenerators
@@ -170,6 +172,7 @@ class AppControlAutomation @AssistedInject constructor(
         finishAutomation(
             userCancelled = cancelledByUser,
             returnToApp = true,
+            deviceDetective = deviceDetective,
         )
 
         return ForceStopAutomationTask.Result(

--- a/app/src/main/java/eu/darken/sdmse/automation/core/AutomationExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/AutomationExtensions.kt
@@ -7,6 +7,8 @@ import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.device.DeviceDetective
+import eu.darken.sdmse.common.device.RomType
 import eu.darken.sdmse.main.ui.MainActivity
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.NonCancellable
@@ -36,7 +38,8 @@ suspend fun AutomationHost.waitForWindowRoot(delayMs: Long = 250): Accessibility
 suspend fun AutomationModule.finishAutomation(
     // If we aborted due to an exception and the reason is "User has cancelled", then still clean up
     userCancelled: Boolean,
-    returnToApp: Boolean
+    returnToApp: Boolean,
+    deviceDetective: DeviceDetective,
 ) = withContext(if (userCancelled) NonCancellable else EmptyCoroutineContext) {
     if (returnToApp) {
         log(INFO) { "finishAutomation(...): Returning to SD Maid" }
@@ -48,7 +51,17 @@ suspend fun AutomationModule.finishAutomation(
         }
         context.startActivity(returnIntern)
     } else {
-        log(INFO) { "finishAutomation(...): Going to home screen" }
-        host.service.performGlobalAction(AccessibilityService.GLOBAL_ACTION_HOME)
+        when (deviceDetective.getROMType()) {
+            RomType.ANDROID_TV -> {
+                log(INFO) { "finishAutomation(...): Going back via back button" }
+                val backAction = host.service.performGlobalAction(AccessibilityService.GLOBAL_ACTION_BACK)
+                log(VERBOSE) { "finishAutomation(...): Back button successful=$backAction" }
+            }
+
+            else -> {
+                log(INFO) { "finishAutomation(...): Going to home screen" }
+                host.service.performGlobalAction(AccessibilityService.GLOBAL_ACTION_HOME)
+            }
+        }
     }
 }


### PR DESCRIPTION
This restores the < v0.24.0 behavior of returning to SD Maid or the previous app by using the back button after automation (ACS) operations. Using the home button can interfere with Android TV launchers (see #1240).

Fixes #1240