### PR TITLE
Dashboard: Fix task results showing inconsistently

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModel.kt
@@ -181,7 +181,7 @@ class DashboardViewModel @Inject constructor(
 
     private val titleCardItem = combine(
         upgradeInfo,
-        taskManager.state
+        taskManager.state,
     ) { upgradeInfo, taskState ->
         TitleCardVH.Item(
             upgradeInfo = upgradeInfo,

--- a/app/src/main/java/eu/darken/sdmse/scheduler/ui/manager/SchedulerManagerViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/scheduler/ui/manager/SchedulerManagerViewModel.kt
@@ -94,7 +94,7 @@ class SchedulerManagerViewModel @Inject constructor(
         schedulerManager.state,
         taskManager.state,
         showBatteryOptimizationHint,
-    ) { schedulerState, taskState, showBatteryHint ->
+    ) { schedulerState, _, showBatteryHint ->
         val items = mutableListOf<SchedulerAdapter.Item>()
 
         if (hasApiLevel(31) && showBatteryHint && schedulerState.schedules.any { it.isEnabled }) {


### PR DESCRIPTION
Improve how the task manager handles the task history. We pruned new tasks instead of old tasks.
As SD Maid uses the last task manager results to display either scan or deletion results, this lead to new scans not displaying their results in the dashboard.