### PR TITLE
Exclusions: Allow segment exclusions specific to SystemCleaner

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/exclusion/ui/editor/segment/SegmentExclusionFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/exclusion/ui/editor/segment/SegmentExclusionFragment.kt
@@ -98,6 +98,10 @@ class SegmentExclusionFragment : Fragment3(R.layout.exclusion_editor_segment_fra
                 isChecked = exclusion.tags.contains(Exclusion.Tag.CORPSEFINDER)
                 setOnClickListener { vm.toggleTag(Exclusion.Tag.CORPSEFINDER) }
             }
+            ui.toolsSystemcleaner.apply {
+                isChecked = exclusion.tags.contains(Exclusion.Tag.SYSTEMCLEANER)
+                setOnClickListener { vm.toggleTag(Exclusion.Tag.SYSTEMCLEANER) }
+            }
             ui.toolsAppcleaner.apply {
                 isChecked = exclusion.tags.contains(Exclusion.Tag.APPCLEANER)
                 setOnClickListener { vm.toggleTag(Exclusion.Tag.APPCLEANER) }

--- a/app/src/main/res/layout/exclusion_editor_segment_fragment.xml
+++ b/app/src/main/res/layout/exclusion_editor_segment_fragment.xml
@@ -150,6 +150,12 @@
                         android:text="@string/corpsefinder_tool_name" />
 
                     <com.google.android.material.checkbox.MaterialCheckBox
+                        android:id="@+id/tools_systemcleaner"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/systemcleaner_tool_name" />
+
+                    <com.google.android.material.checkbox.MaterialCheckBox
                         android:id="@+id/tools_appcleaner"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"


### PR DESCRIPTION
Don't see a reason why this was not possible, seems like an oversight.

Noticed via #1331