### PR TITLE
AppCleaner: Don't abort processing (deletion) a filter if a single file fails

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/ExpendablesFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/ExpendablesFilter.kt
@@ -22,7 +22,12 @@ interface ExpendablesFilter : Progress.Host, Progress.Client {
         segments: Segments
     ): Match?
 
-    suspend fun process(matches: Collection<Match>)
+    suspend fun process(matches: Collection<Match>): ProcessResult
+
+    data class ProcessResult(
+        val success: Collection<Match>,
+        val failed: Collection<Pair<Match, Exception>>,
+    )
 
     interface Match {
         val identifier: ExpendablesFilterIdentifier

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/AdvertisementFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/AdvertisementFilter.kt
@@ -92,8 +92,8 @@ class AdvertisementFilter @Inject constructor(
         }
     }
 
-    override suspend fun process(matches: Collection<ExpendablesFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(matches: Collection<ExpendablesFilter.Match>): ExpendablesFilter.ProcessResult {
+        return matches.deleteAll(gatewaySwitch)
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/AnalyticsFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/AnalyticsFilter.kt
@@ -50,8 +50,8 @@ class AnalyticsFilter @Inject constructor(
         }
     }
 
-    override suspend fun process(matches: Collection<ExpendablesFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(matches: Collection<ExpendablesFilter.Match>): ExpendablesFilter.ProcessResult {
+        return matches.deleteAll(gatewaySwitch)
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/BugReportingFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/BugReportingFilter.kt
@@ -21,7 +21,6 @@ import eu.darken.sdmse.common.files.Segments
 import eu.darken.sdmse.common.files.lowercase
 import eu.darken.sdmse.common.pkgs.Pkg
 import eu.darken.sdmse.common.storage.StorageEnvironment
-import java.util.*
 import javax.inject.Inject
 import javax.inject.Provider
 
@@ -106,8 +105,8 @@ class BugReportingFilter @Inject constructor(
         }
     }
 
-    override suspend fun process(matches: Collection<ExpendablesFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(matches: Collection<ExpendablesFilter.Match>): ExpendablesFilter.ProcessResult {
+        return matches.deleteAll(gatewaySwitch)
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/CodeCacheFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/CodeCacheFilter.kt
@@ -49,8 +49,8 @@ class CodeCacheFilter @Inject constructor(
         }
     }
 
-    override suspend fun process(matches: Collection<ExpendablesFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(matches: Collection<ExpendablesFilter.Match>): ExpendablesFilter.ProcessResult {
+        return matches.deleteAll(gatewaySwitch)
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/DefaultCachesPrivateFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/DefaultCachesPrivateFilter.kt
@@ -52,8 +52,8 @@ class DefaultCachesPrivateFilter @Inject constructor(
         }
     }
 
-    override suspend fun process(matches: Collection<ExpendablesFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(matches: Collection<ExpendablesFilter.Match>): ExpendablesFilter.ProcessResult {
+        return matches.deleteAll(gatewaySwitch)
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/DefaultCachesPublicFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/DefaultCachesPublicFilter.kt
@@ -52,8 +52,8 @@ class DefaultCachesPublicFilter @Inject constructor(
         }
     }
 
-    override suspend fun process(matches: Collection<ExpendablesFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(matches: Collection<ExpendablesFilter.Match>): ExpendablesFilter.ProcessResult {
+        return matches.deleteAll(gatewaySwitch)
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/GameFilesFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/GameFilesFilter.kt
@@ -71,8 +71,8 @@ class GameFilesFilter @Inject constructor(
         }
     }
 
-    override suspend fun process(matches: Collection<ExpendablesFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(matches: Collection<ExpendablesFilter.Match>): ExpendablesFilter.ProcessResult {
+        return matches.deleteAll(gatewaySwitch)
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/HiddenFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/HiddenFilter.kt
@@ -21,7 +21,6 @@ import eu.darken.sdmse.common.files.Segments
 import eu.darken.sdmse.common.files.lowercase
 import eu.darken.sdmse.common.pkgs.Pkg
 import eu.darken.sdmse.common.storage.StorageEnvironment
-import java.util.*
 import javax.inject.Inject
 import javax.inject.Provider
 
@@ -109,8 +108,8 @@ class HiddenFilter @Inject constructor(
         return dirs.size >= 4 && dirs[2] == "Cache" && dirs[3].contains(".unity3d&")
     }
 
-    override suspend fun process(matches: Collection<ExpendablesFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(matches: Collection<ExpendablesFilter.Match>): ExpendablesFilter.ProcessResult {
+        return matches.deleteAll(gatewaySwitch)
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/MobileQQFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/MobileQQFilter.kt
@@ -79,8 +79,8 @@ class MobileQQFilter @Inject constructor(
         }
     }
 
-    override suspend fun process(matches: Collection<ExpendablesFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(matches: Collection<ExpendablesFilter.Match>): ExpendablesFilter.ProcessResult {
+        return matches.deleteAll(gatewaySwitch)
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/OfflineCacheFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/OfflineCacheFilter.kt
@@ -20,7 +20,6 @@ import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.Segments
 import eu.darken.sdmse.common.files.lowercase
 import eu.darken.sdmse.common.pkgs.Pkg
-import java.util.*
 import javax.inject.Inject
 import javax.inject.Provider
 
@@ -70,8 +69,8 @@ class OfflineCacheFilter @Inject constructor(
         }
     }
 
-    override suspend fun process(matches: Collection<ExpendablesFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(matches: Collection<ExpendablesFilter.Match>): ExpendablesFilter.ProcessResult {
+        return matches.deleteAll(gatewaySwitch)
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/RecycleBinsFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/RecycleBinsFilter.kt
@@ -22,7 +22,6 @@ import eu.darken.sdmse.common.files.isAncestorOf
 import eu.darken.sdmse.common.files.lowercase
 import eu.darken.sdmse.common.files.segs
 import eu.darken.sdmse.common.pkgs.Pkg
-import java.util.*
 import javax.inject.Inject
 import javax.inject.Provider
 
@@ -90,8 +89,8 @@ class RecycleBinsFilter @Inject constructor(
         }
     }
 
-    override suspend fun process(matches: Collection<ExpendablesFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(matches: Collection<ExpendablesFilter.Match>): ExpendablesFilter.ProcessResult {
+        return matches.deleteAll(gatewaySwitch)
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/TelegramFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/TelegramFilter.kt
@@ -132,8 +132,8 @@ class TelegramFilter @Inject constructor(
         }
     }
 
-    override suspend fun process(matches: Collection<ExpendablesFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(matches: Collection<ExpendablesFilter.Match>): ExpendablesFilter.ProcessResult {
+        return matches.deleteAll(gatewaySwitch)
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/ThreemaFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/ThreemaFilter.kt
@@ -62,8 +62,8 @@ class ThreemaFilter @Inject constructor(
         }
     }
 
-    override suspend fun process(matches: Collection<ExpendablesFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(matches: Collection<ExpendablesFilter.Match>): ExpendablesFilter.ProcessResult {
+        return matches.deleteAll(gatewaySwitch)
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/ThumbnailsFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/ThumbnailsFilter.kt
@@ -21,7 +21,6 @@ import eu.darken.sdmse.common.files.Segments
 import eu.darken.sdmse.common.files.lowercase
 import eu.darken.sdmse.common.pkgs.Pkg
 import eu.darken.sdmse.common.storage.StorageEnvironment
-import java.util.*
 import javax.inject.Inject
 import javax.inject.Provider
 
@@ -100,8 +99,8 @@ class ThumbnailsFilter @Inject constructor(
         }
     }
 
-    override suspend fun process(matches: Collection<ExpendablesFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(matches: Collection<ExpendablesFilter.Match>): ExpendablesFilter.ProcessResult {
+        return matches.deleteAll(gatewaySwitch)
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/ViberFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/ViberFilter.kt
@@ -67,8 +67,8 @@ class ViberFilter @Inject constructor(
         }
     }
 
-    override suspend fun process(matches: Collection<ExpendablesFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(matches: Collection<ExpendablesFilter.Match>): ExpendablesFilter.ProcessResult {
+        return matches.deleteAll(gatewaySwitch)
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/WeChatFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/WeChatFilter.kt
@@ -94,8 +94,8 @@ class WeChatFilter @Inject constructor(
         }
     }
 
-    override suspend fun process(matches: Collection<ExpendablesFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(matches: Collection<ExpendablesFilter.Match>): ExpendablesFilter.ProcessResult {
+        return matches.deleteAll(gatewaySwitch)
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/WebViewCacheFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/WebViewCacheFilter.kt
@@ -14,9 +14,14 @@ import eu.darken.sdmse.common.areas.DataArea
 import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
-import eu.darken.sdmse.common.files.*
+import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.common.files.GatewaySwitch
+import eu.darken.sdmse.common.files.Segments
+import eu.darken.sdmse.common.files.isAncestorOf
+import eu.darken.sdmse.common.files.prepend
+import eu.darken.sdmse.common.files.toSegs
 import eu.darken.sdmse.common.pkgs.Pkg
-import java.util.*
 import javax.inject.Inject
 import javax.inject.Provider
 
@@ -55,8 +60,8 @@ class WebViewCacheFilter @Inject constructor(
         }
     }
 
-    override suspend fun process(matches: Collection<ExpendablesFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(matches: Collection<ExpendablesFilter.Match>): ExpendablesFilter.ProcessResult {
+        return matches.deleteAll(gatewaySwitch)
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/WhatsAppBackupsFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/WhatsAppBackupsFilter.kt
@@ -13,7 +13,12 @@ import eu.darken.sdmse.common.areas.DataArea
 import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
-import eu.darken.sdmse.common.files.*
+import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.common.files.GatewaySwitch
+import eu.darken.sdmse.common.files.Segments
+import eu.darken.sdmse.common.files.startsWith
+import eu.darken.sdmse.common.files.toSegs
 import eu.darken.sdmse.common.pkgs.Pkg
 import eu.darken.sdmse.common.pkgs.toPkgId
 import java.time.Duration
@@ -53,8 +58,8 @@ class WhatsAppBackupsFilter @Inject constructor(
         }
     }
 
-    override suspend fun process(matches: Collection<ExpendablesFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(matches: Collection<ExpendablesFilter.Match>): ExpendablesFilter.ProcessResult {
+        return matches.deleteAll(gatewaySwitch)
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/WhatsAppReceivedFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/WhatsAppReceivedFilter.kt
@@ -95,8 +95,8 @@ class WhatsAppReceivedFilter @Inject constructor(
         }
     }
 
-    override suspend fun process(matches: Collection<ExpendablesFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(matches: Collection<ExpendablesFilter.Match>): ExpendablesFilter.ProcessResult {
+        return matches.deleteAll(gatewaySwitch)
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/WhatsAppSentFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/WhatsAppSentFilter.kt
@@ -89,8 +89,8 @@ class WhatsAppSentFilter @Inject constructor(
         }
     }
 
-    override suspend fun process(matches: Collection<ExpendablesFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(matches: Collection<ExpendablesFilter.Match>): ExpendablesFilter.ProcessResult {
+        return matches.deleteAll(gatewaySwitch)
     }
 
     @Reusable


### PR DESCRIPTION
Instead of aborting the whole processing of a `ExpendablesFilter` if an error occurs, we note the error and just continue. Previously we continued but only with the next `ExpendablesFilter`, so this PR changes it from "on filter level" to "on match level".

Closes #1332