### PR TITLE
CorpseFinder: Fix content deletion paths missing from results

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/corpsefinder/core/CorpseFinder.kt
+++ b/app/src/main/java/eu/darken/sdmse/corpsefinder/core/CorpseFinder.kt
@@ -348,7 +348,7 @@ class CorpseFinder @Inject constructor(
 
         return CorpseFinderDeleteTask.Success(
             affectedSpace = deletedCorpses.sumOf { it.size } + deletedContentSize,
-            affectedPaths = deletedCorpses.map { it.lookup.lookedUp }.toSet(),
+            affectedPaths = deletedCorpses.map { it.lookup.lookedUp }.toSet() + deletedContents.flatMap { it.value },
         )
     }
 


### PR DESCRIPTION
Content deletion is the deletion of "sub items", i.e. files within a corpse itself, if the corpse is a directory. Usually you would delete the whole corpse though, anyways, the paths should be included in the results as otherwise result messages are wrong (0 items deleted) and statistics are incorrect.