### PR TITLE
Core: Check and handle invalid app inventory data on Samsung devices

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/AKnownPkg.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/AKnownPkg.kt
@@ -38,37 +38,24 @@ sealed class AKnownPkg(override val id: Pkg.Id) : Pkg {
             ContextCompat.getDrawable(context, R.drawable.ic_default_app_icon_24)!!
         }
 
-    data object AndroidSystem : AKnownPkg("android") {
-        override val labelRes: Int = R.string.apps_known_android_system_label
-    }
+    data object AndroidSystem : AKnownPkg("android")
 
     data object GooglePlay : AKnownPkg("com.android.vending"), AppStore {
-        override val labelRes: Int = R.string.apps_known_installer_gplay_label
         override val iconRes: Int = R.drawable.ic_baseline_gplay_24
         override val urlGenerator: ((Pkg.Id) -> String) = {
             "https://play.google.com/store/apps/details?id=${it.name}"
         }
     }
 
-    data object VivoAppStore : AKnownPkg("com.vivo.appstore"), AppStore {
-        override val labelRes: Int = R.string.apps_known_installer_vivo_label
-    }
+    data object VivoAppStore : AKnownPkg("com.vivo.appstore"), AppStore
 
-    data object OppoMarket : AKnownPkg("com.oppo.market"), AppStore {
-        override val labelRes: Int = R.string.apps_known_installer_oppo_label
-    }
+    data object OppoMarket : AKnownPkg("com.oppo.market"), AppStore
 
-    data object HuaweiAppGallery : AKnownPkg("com.huawei.appmarket"), AppStore {
-        override val labelRes: Int = R.string.apps_known_installer_huawei_label
-    }
+    data object HuaweiAppGallery : AKnownPkg("com.huawei.appmarket"), AppStore
 
-    data object SamsungAppStore : AKnownPkg("com.sec.android.app.samsungapps"), AppStore {
-        override val labelRes: Int = R.string.apps_known_installer_samsung_label
-    }
+    data object SamsungAppStore : AKnownPkg("com.sec.android.app.samsungapps"), AppStore
 
-    data object XiaomiAppStore : AKnownPkg("com.xiaomi.mipicks"), AppStore {
-        override val labelRes: Int = R.string.apps_known_installer_xiaomi_label
-    }
+    data object XiaomiAppStore : AKnownPkg("com.xiaomi.mipicks"), AppStore
 
     companion object {
         val values: List<AKnownPkg> = listOf(

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/IllegalPkgDataException.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/IllegalPkgDataException.kt
@@ -1,5 +1,0 @@
-package eu.darken.sdmse.common.pkgs.pkgops
-
-class IllegalPkgDataException(
-    override val message: String
-) : IllegalStateException()

--- a/app-common-io/src/main/res/values/strings.xml
+++ b/app-common-io/src/main/res/values/strings.xml
@@ -1,9 +1,0 @@
-<resources>
-    <string name="apps_known_installer_gplay_label">Google Play Store</string>
-    <string name="apps_known_installer_vivo_label">Vivo V-AppStore</string>
-    <string name="apps_known_installer_oppo_label">Oppo App Market</string>
-    <string name="apps_known_installer_huawei_label">Huawei AppGallery</string>
-    <string name="apps_known_installer_samsung_label">Samsung Galaxy Store</string>
-    <string name="apps_known_installer_xiaomi_label">Xiaomi GetApps</string>
-    <string name="apps_known_android_system_label">Android System</string>
-</resources>

--- a/app-common-pkgs/src/main/java/eu/darken/sdmse/common/pkgs/InvalidPkgInventoryException.kt
+++ b/app-common-pkgs/src/main/java/eu/darken/sdmse/common/pkgs/InvalidPkgInventoryException.kt
@@ -1,0 +1,16 @@
+package eu.darken.sdmse.common.pkgs
+
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.error.HasLocalizedError
+import eu.darken.sdmse.common.error.LocalizedError
+
+class InvalidPkgInventoryException(
+    override val message: String
+) : IllegalStateException(), HasLocalizedError {
+
+    override fun getLocalizedError(): LocalizedError = LocalizedError(
+        throwable = this,
+        label = R.string.pkgrepo_invalid_inventory_error_title.toCaString(),
+        description = R.string.pkgrepo_invalid_inventory_error_description.toCaString(),
+    )
+}

--- a/app-common-pkgs/src/main/java/eu/darken/sdmse/common/pkgs/PkgRepoExtensions.kt
+++ b/app-common-pkgs/src/main/java/eu/darken/sdmse/common/pkgs/PkgRepoExtensions.kt
@@ -2,22 +2,24 @@ package eu.darken.sdmse.common.pkgs
 
 import eu.darken.sdmse.common.pkgs.features.Installed
 import eu.darken.sdmse.common.user.UserHandle2
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 
+fun PkgRepo.pkgs(): Flow<Collection<Installed>> = data.map { it.pkgs }
 
-suspend fun PkgRepo.currentPkgs(): Collection<Installed> = this.pkgs.first()
+suspend fun PkgRepo.current(): Collection<Installed> = pkgs().first()
 
-suspend fun PkgRepo.getPkg(
+suspend fun PkgRepo.get(
     pkgId: Pkg.Id,
 ): Collection<Installed> = query(pkgId, null)
 
-suspend fun PkgRepo.getPkg(
+suspend fun PkgRepo.get(
     pkgId: Pkg.Id,
     userHandle: UserHandle2?,
 ): Installed? = query(pkgId, userHandle).singleOrNull()
 
-
-suspend fun PkgRepo.getPkg(
+suspend fun PkgRepo.get(
     installId: Installed.InstallId
 ): Installed? = query(installId.pkgId, installId.userHandle).singleOrNull()
 

--- a/app-common-pkgs/src/main/java/eu/darken/sdmse/common/pkgs/sources/NormalPkgsSource.kt
+++ b/app-common-pkgs/src/main/java/eu/darken/sdmse/common/pkgs/sources/NormalPkgsSource.kt
@@ -16,11 +16,11 @@ import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.hasApiLevel
 import eu.darken.sdmse.common.permissions.Permission
+import eu.darken.sdmse.common.pkgs.InvalidPkgInventoryException
 import eu.darken.sdmse.common.pkgs.PkgDataSource
 import eu.darken.sdmse.common.pkgs.container.NormalPkg
 import eu.darken.sdmse.common.pkgs.features.Installed
 import eu.darken.sdmse.common.pkgs.features.InstallerInfo
-import eu.darken.sdmse.common.pkgs.pkgops.IllegalPkgDataException
 import eu.darken.sdmse.common.pkgs.pkgops.PkgOps
 import eu.darken.sdmse.common.root.RootManager
 import eu.darken.sdmse.common.root.canUseRootNow
@@ -76,10 +76,10 @@ class NormalPkgsSource @Inject constructor(
         // FYI: MATCH_ALL does not include MATCH_UNINSTALLED_PACKAGES
         val pkgInfos = pkgOps.queryPkgs(PackageManager.MATCH_ALL)
         if (pkgInfos.isEmpty()) {
-            throw IllegalPkgDataException("No installed packages")
+            throw InvalidPkgInventoryException("Could not retrieve list of installed packages")
         }
         if (pkgInfos.none { it.packageName == BuildConfigWrap.APPLICATION_ID }) {
-            throw IllegalPkgDataException("Returned package data didn't contain us")
+            throw InvalidPkgInventoryException("Returned package data didn't contain us")
         }
 
         val currentHandle = userManager.currentUser().handle

--- a/app-common-pkgs/src/main/res/values/strings.xml
+++ b/app-common-pkgs/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+    <string name="pkgrepo_invalid_inventory_error_title">Invalid app inventory</string>
+    <string name="pkgrepo_invalid_inventory_error_description">The system provided an invalid list of installed apps to SD Maid.</string>
+</resources>

--- a/app-common/src/main/java/eu/darken/sdmse/common/WebpageTool.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/WebpageTool.kt
@@ -16,18 +16,23 @@ class WebpageTool @Inject constructor(
 ) {
 
     fun open(address: String) {
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(address)).apply {
-            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        }
-        try {
-            context.startActivity(intent)
-        } catch (e: ActivityNotFoundException) {
-            log(ERROR) { "Failed to launch. No compatible activity!" }
-        } catch (e: SecurityException) {
-            // Permission Denial: starting Intent { act=android.intent.action.VIEW dat=https://github.com/...
-            // flg=0x10000000 cmp=com.mxtech.videoplayer.pro/com.mxtech.videoplayer.ActivityWebBrowser }
-            log(ERROR) { "Failed to launch activity due to $e" }
-        }
+        open(context, address)
     }
 
+    companion object {
+        fun open(context: Context, address: String) {
+            val intent = Intent(Intent.ACTION_VIEW, Uri.parse(address)).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+            try {
+                context.startActivity(intent)
+            } catch (e: ActivityNotFoundException) {
+                log(ERROR) { "Failed to launch. No compatible activity!" }
+            } catch (e: SecurityException) {
+                // Permission Denial: starting Intent { act=android.intent.action.VIEW dat=https://github.com/...
+                // flg=0x10000000 cmp=com.mxtech.videoplayer.pro/com.mxtech.videoplayer.ActivityWebBrowser }
+                log(ERROR) { "Failed to launch activity due to $e" }
+            }
+        }
+    }
 }

--- a/app-common/src/main/java/eu/darken/sdmse/common/error/LocalizedError.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/error/LocalizedError.kt
@@ -26,7 +26,7 @@ fun Throwable.localized(c: Context): LocalizedError = when {
     this is HasLocalizedError -> this.getLocalizedError()
     this is ActivityNotFoundException -> LocalizedError(
         throwable = this,
-        label = caString { "${c.getString(R.string.general_error_label)} - ${this::class.simpleName!!}" },
+        label = caString { "${c.getString(R.string.general_error_label)} - ${this@localized::class.simpleName!!}" },
         description = caString {
             "${it.getString(R.string.general_error_no_compatible_app_found_msg)}\n$localizedMessage"
         }
@@ -34,13 +34,13 @@ fun Throwable.localized(c: Context): LocalizedError = when {
 
     localizedMessage != null -> LocalizedError(
         throwable = this,
-        label = caString { "${c.getString(R.string.general_error_label)} - ${this::class.simpleName!!}" },
+        label = caString { "${c.getString(R.string.general_error_label)} - ${this@localized::class.simpleName!!}" },
         description = caString { localizedMessage ?: getStackTracePeek() }
     )
 
     else -> LocalizedError(
         throwable = this,
-        label = caString { "${c.getString(R.string.general_error_label)} - ${this::class.simpleName!!}" },
+        label = caString { "${c.getString(R.string.general_error_label)} - ${this@localized::class.simpleName!!}" },
         description = caString { getStackTracePeek() }
     )
 }

--- a/app/src/main/java/eu/darken/sdmse/analyzer/core/storage/StorageScanner.kt
+++ b/app/src/main/java/eu/darken/sdmse/analyzer/core/storage/StorageScanner.kt
@@ -28,7 +28,7 @@ import eu.darken.sdmse.common.flow.throttleLatest
 import eu.darken.sdmse.common.forensics.FileForensics
 import eu.darken.sdmse.common.forensics.OwnerInfo
 import eu.darken.sdmse.common.pkgs.PkgRepo
-import eu.darken.sdmse.common.pkgs.currentPkgs
+import eu.darken.sdmse.common.pkgs.current
 import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.common.progress.increaseProgress
 import eu.darken.sdmse.common.progress.updateProgressCount
@@ -165,7 +165,7 @@ class StorageScanner @Inject constructor(
 
         updateProgressPrimary(R.string.analyzer_progress_scanning_apps)
 
-        val targetPkgs = pkgRepo.currentPkgs()
+        val targetPkgs = pkgRepo.current()
             .filter { it.packageName != "android" }
             .filter { it.applicationInfo != null }
 

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
@@ -47,7 +47,7 @@ import eu.darken.sdmse.common.device.DeviceDetective
 import eu.darken.sdmse.common.funnel.IPCFunnel
 import eu.darken.sdmse.common.pkgs.PkgRepo
 import eu.darken.sdmse.common.pkgs.features.Installed
-import eu.darken.sdmse.common.pkgs.getPkg
+import eu.darken.sdmse.common.pkgs.get
 import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.common.progress.increaseProgress
 import eu.darken.sdmse.common.progress.updateProgressCount
@@ -131,7 +131,7 @@ class ClearCacheModule @AssistedInject constructor(
                 throw UnsupportedOperationException("ACS based deletion is not support for other users ($target)")
             }
 
-            val installed = pkgRepo.getPkg(target.pkgId, target.userHandle)
+            val installed = pkgRepo.get(target.pkgId, target.userHandle)
 
             if (installed == null) {
                 log(TAG, WARN) { "$target is not in package repo" }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/AppScanner.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/AppScanner.kt
@@ -45,7 +45,7 @@ import eu.darken.sdmse.common.forensics.identifyArea
 import eu.darken.sdmse.common.pkgs.Pkg
 import eu.darken.sdmse.common.pkgs.PkgRepo
 import eu.darken.sdmse.common.pkgs.container.NormalPkg
-import eu.darken.sdmse.common.pkgs.currentPkgs
+import eu.darken.sdmse.common.pkgs.current
 import eu.darken.sdmse.common.pkgs.features.Installed
 import eu.darken.sdmse.common.pkgs.getPrivateDataDirs
 import eu.darken.sdmse.common.pkgs.isEnabled
@@ -133,7 +133,7 @@ class AppScanner @Inject constructor(
 
         val currentUser = userManager.currentUser()
         val allUsers = userManager.allUsers()
-        val allCurrentPkgs = pkgRepo.currentPkgs()
+        val allCurrentPkgs = pkgRepo.current()
             .filter { includeOtherUsers || it.userHandle == currentUser.handle }
             .filter { includeSystemApps || !it.isSystemApp }
             .filter { includeRunningApps || !pkgOps.isRunning(it.installId) }

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/AppControl.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/AppControl.kt
@@ -28,7 +28,7 @@ import eu.darken.sdmse.common.flow.replayingShare
 import eu.darken.sdmse.common.pkgs.Pkg
 import eu.darken.sdmse.common.pkgs.PkgRepo
 import eu.darken.sdmse.common.pkgs.container.NormalPkg
-import eu.darken.sdmse.common.pkgs.currentPkgs
+import eu.darken.sdmse.common.pkgs.current
 import eu.darken.sdmse.common.pkgs.features.Installed
 import eu.darken.sdmse.common.pkgs.features.SourceAvailable
 import eu.darken.sdmse.common.pkgs.isEnabled
@@ -151,7 +151,7 @@ class AppControl @Inject constructor(
         }
 
         val currentUserHandle = userManager.currentUser().handle
-        val pkgs = if (task.refreshPkgCache) pkgRepo.refresh() else pkgRepo.currentPkgs()
+        val pkgs = if (task.refreshPkgCache) pkgRepo.refresh() else pkgRepo.current()
         val appInfos = pkgs
             .filter { it.userHandle == currentUserHandle }
             .map { it.toAppInfo() }

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/AppControlAutomation.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/AppControlAutomation.kt
@@ -36,7 +36,7 @@ import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.device.DeviceDetective
 import eu.darken.sdmse.common.pkgs.PkgRepo
 import eu.darken.sdmse.common.pkgs.features.Installed
-import eu.darken.sdmse.common.pkgs.getPkg
+import eu.darken.sdmse.common.pkgs.get
 import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.common.progress.updateProgressCount
 import eu.darken.sdmse.common.progress.updateProgressPrimary
@@ -124,7 +124,7 @@ class AppControlAutomation @AssistedInject constructor(
                 throw UnsupportedOperationException("ACS based force-stop is not support for other users ($target)")
             }
 
-            val installed = pkgRepo.getPkg(target.pkgId, target.userHandle)
+            val installed = pkgRepo.get(target.pkgId, target.userHandle)
 
             if (installed == null) {
                 log(TAG, WARN) { "$target is not in package repo" }

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/uninstall/Uninstaller.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/uninstall/Uninstaller.kt
@@ -15,6 +15,7 @@ import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.pkgs.PkgRepo
+import eu.darken.sdmse.common.pkgs.pkgs
 import eu.darken.sdmse.common.root.RootManager
 import eu.darken.sdmse.common.root.canUseRootNow
 import eu.darken.sdmse.common.sharedresource.HasSharedResource
@@ -105,7 +106,7 @@ class Uninstaller @Inject constructor(
             log(TAG) { "Waiting for system uninstall process (timeout=$timeoutSeconds)" }
             // Wait until the app is no longer installed
             withTimeout(timeoutSeconds * 1000) {
-                pkgRepo.pkgs.first { pkgs ->
+                pkgRepo.pkgs().first { pkgs ->
                     pkgs.none { it.installId == installId }
                 }
             }

--- a/app/src/main/java/eu/darken/sdmse/common/clutter/manual/ManualMarkerSource.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/clutter/manual/ManualMarkerSource.kt
@@ -9,7 +9,7 @@ import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.pkgs.Pkg
 import eu.darken.sdmse.common.pkgs.PkgRepo
-import eu.darken.sdmse.common.pkgs.currentPkgs
+import eu.darken.sdmse.common.pkgs.current
 import eu.darken.sdmse.common.pkgs.features.Installed
 import eu.darken.sdmse.common.pkgs.toPkgId
 import kotlinx.coroutines.sync.Mutex
@@ -78,7 +78,7 @@ open class ManualMarkerSource(
         log(TAG, VERBOSE) { "buildDatabase(entries=${clutterEntries.size})..." }
 
         val startTimeMarkerGeneration = System.currentTimeMillis()
-        val installedApps: Collection<Installed> = pkgRepo.currentPkgs()
+        val installedApps: Collection<Installed> = pkgRepo.current()
         var markerCount: Long = 0
         val clutterMap: HashMap<Pkg.Id, MutableCollection<ManualMarker>> = LinkedHashMap()
         var counter = 0

--- a/app/src/main/java/eu/darken/sdmse/common/forensics/csi/dalvik/tools/CustomDexOptCheck.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/forensics/csi/dalvik/tools/CustomDexOptCheck.kt
@@ -6,7 +6,7 @@ import eu.darken.sdmse.common.forensics.AreaInfo
 import eu.darken.sdmse.common.forensics.Owner
 import eu.darken.sdmse.common.forensics.csi.dalvik.DalvikCheck
 import eu.darken.sdmse.common.pkgs.PkgRepo
-import eu.darken.sdmse.common.pkgs.currentPkgs
+import eu.darken.sdmse.common.pkgs.current
 import java.io.File
 import javax.inject.Inject
 
@@ -19,7 +19,7 @@ class CustomDexOptCheck @Inject constructor(
         areaInfo: AreaInfo,
     ): Pair<DalvikCheck.Result, LocalPath?> {
         val owners = mutableSetOf<Owner>()
-        val currentPkgs = pkgRepo.currentPkgs()
+        val currentPkgs = pkgRepo.current()
         var extraPathToCheck: LocalPath? = null
 
         // Custom apk/jar subfile that has been optimized manually

--- a/app/src/main/java/eu/darken/sdmse/common/forensics/csi/dalvik/tools/SourceDirCheck.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/forensics/csi/dalvik/tools/SourceDirCheck.kt
@@ -6,7 +6,7 @@ import eu.darken.sdmse.common.forensics.AreaInfo
 import eu.darken.sdmse.common.forensics.Owner
 import eu.darken.sdmse.common.forensics.csi.dalvik.DalvikCheck
 import eu.darken.sdmse.common.pkgs.PkgRepo
-import eu.darken.sdmse.common.pkgs.currentPkgs
+import eu.darken.sdmse.common.pkgs.current
 import eu.darken.sdmse.common.pkgs.features.SourceAvailable
 import javax.inject.Inject
 
@@ -16,7 +16,7 @@ class SourceDirCheck @Inject constructor(
 ) : DalvikCheck {
 
     suspend fun check(areaInfo: AreaInfo, candidates: Collection<LocalPath>): DalvikCheck.Result {
-        val ownerPkg = pkgRepo.currentPkgs()
+        val ownerPkg = pkgRepo.current()
             .filterIsInstance<SourceAvailable>()
             .filter { it.sourceDir != null }
             .firstOrNull { pkg -> candidates.any { it.path == pkg.sourceDir?.path } }

--- a/app/src/main/java/eu/darken/sdmse/common/forensics/csi/source/AppSourceLibCSI.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/forensics/csi/source/AppSourceLibCSI.kt
@@ -21,7 +21,7 @@ import eu.darken.sdmse.common.forensics.Owner
 import eu.darken.sdmse.common.forensics.csi.LocalCSIProcessor
 import eu.darken.sdmse.common.forensics.csi.toOwners
 import eu.darken.sdmse.common.pkgs.PkgRepo
-import eu.darken.sdmse.common.pkgs.currentPkgs
+import eu.darken.sdmse.common.pkgs.current
 import eu.darken.sdmse.common.pkgs.isInstalled
 import eu.darken.sdmse.common.pkgs.toPkgId
 import javax.inject.Inject
@@ -61,7 +61,7 @@ class AppSourceLibCSI @Inject constructor(
             ?.let { owners.add(Owner(it, userHandle)) }
 
         if (owners.isEmpty()) {
-            pkgRepo.currentPkgs()
+            pkgRepo.current()
                 .filter { it.applicationInfo != null }
                 .filter { pkg ->
                     val nativLibDir = pkg.applicationInfo?.nativeLibraryDir?.let {

--- a/app/src/main/java/eu/darken/sdmse/common/forensics/csi/source/tools/SimilarityFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/forensics/csi/source/tools/SimilarityFilter.kt
@@ -8,7 +8,7 @@ import eu.darken.sdmse.common.forensics.AreaInfo
 import eu.darken.sdmse.common.forensics.Owner
 import eu.darken.sdmse.common.pkgs.PkgRepo
 import eu.darken.sdmse.common.pkgs.features.SourceAvailable
-import eu.darken.sdmse.common.pkgs.getPkg
+import eu.darken.sdmse.common.pkgs.get
 import javax.inject.Inject
 
 
@@ -37,7 +37,7 @@ class SimilarityFilter @Inject constructor(
         return toCheck.filter { candidate ->
 
             val userHandle = areaInfo.userHandle
-            val sourceDir = pkgRepo.getPkg(candidate.pkgId, userHandle)
+            val sourceDir = pkgRepo.get(candidate.pkgId, userHandle)
                 ?.let { it as? SourceAvailable }
                 ?.sourceDir ?: return@filter true
 

--- a/app/src/main/java/eu/darken/sdmse/common/ui/TextViewExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/ui/TextViewExtensions.kt
@@ -1,0 +1,27 @@
+package eu.darken.sdmse.common.ui
+
+import android.content.res.ColorStateList
+import androidx.annotation.AttrRes
+import androidx.annotation.DrawableRes
+import androidx.core.content.ContextCompat
+import androidx.core.widget.TextViewCompat
+import com.google.android.material.textview.MaterialTextView
+import eu.darken.sdmse.common.getColorForAttr
+
+fun MaterialTextView.setLeftIcon(
+    @DrawableRes iconRes: Int,
+    @AttrRes tintRes: Int? = null,
+) {
+    setCompoundDrawablesRelativeWithIntrinsicBounds(
+        ContextCompat.getDrawable(context, iconRes),
+        null,
+        null,
+        null,
+    )
+    if (tintRes != null) {
+        TextViewCompat.setCompoundDrawableTintList(
+            this,
+            ColorStateList.valueOf(context.getColorForAttr(tintRes))
+        )
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/exclusion/ui/editor/pkg/PkgExclusionViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/exclusion/ui/editor/pkg/PkgExclusionViewModel.kt
@@ -11,7 +11,7 @@ import eu.darken.sdmse.common.flow.DynamicStateFlow
 import eu.darken.sdmse.common.navigation.navArgs
 import eu.darken.sdmse.common.pkgs.Pkg
 import eu.darken.sdmse.common.pkgs.PkgRepo
-import eu.darken.sdmse.common.pkgs.getPkg
+import eu.darken.sdmse.common.pkgs.get
 import eu.darken.sdmse.common.uix.ViewModel3
 import eu.darken.sdmse.exclusion.core.ExclusionManager
 import eu.darken.sdmse.exclusion.core.current
@@ -52,7 +52,7 @@ class PkgExclusionViewModel @Inject constructor(
         State(
             original = origExclusion,
             current = newExcl,
-            pkg = pkgRepo.getPkg(newExcl.pkgId).firstOrNull(),
+            pkg = pkgRepo.get(newExcl.pkgId).firstOrNull(),
         )
     }
 

--- a/app/src/main/java/eu/darken/sdmse/exclusion/ui/list/ExclusionListViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/exclusion/ui/list/ExclusionListViewModel.kt
@@ -19,6 +19,7 @@ import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.pkgs.PkgRepo
+import eu.darken.sdmse.common.pkgs.pkgs
 import eu.darken.sdmse.common.readAsText
 import eu.darken.sdmse.common.uix.ViewModel3
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
@@ -82,7 +83,7 @@ class ExclusionListViewModel @Inject constructor(
 
     val state = combine(
         exclusionManager.exclusions,
-        pkgRepo.pkgs.onStart { emit(emptySet()) },
+        pkgRepo.pkgs().onStart { emit(emptySet()) },
         lookups.onStart { emit(emptyMap()) },
         showDefaults,
     ) { holders, pkgs, lookups, showDefaults ->

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardAdapter.kt
@@ -16,8 +16,8 @@ import eu.darken.sdmse.common.lists.differ.setupDiffer
 import eu.darken.sdmse.common.lists.modular.ModularAdapter
 import eu.darken.sdmse.common.lists.modular.mods.DataBinderMod
 import eu.darken.sdmse.common.lists.modular.mods.TypedVHCreatorMod
-import eu.darken.sdmse.main.ui.dashboard.items.DataAreaCardVH
 import eu.darken.sdmse.main.ui.dashboard.items.DebugCardVH
+import eu.darken.sdmse.main.ui.dashboard.items.ErrorDataAreaVH
 import eu.darken.sdmse.main.ui.dashboard.items.MotdCardVH
 import eu.darken.sdmse.main.ui.dashboard.items.ReviewCardVH
 import eu.darken.sdmse.main.ui.dashboard.items.SetupCardVH
@@ -46,7 +46,6 @@ class DashboardAdapter @Inject constructor(
         addMod(TypedVHCreatorMod({ data[it] is SetupCardVH.Item }) { SetupCardVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is UpgradeCardVH.Item }) { UpgradeCardVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is UpdateCardVH.Item }) { UpdateCardVH(it) })
-        addMod(TypedVHCreatorMod({ data[it] is DataAreaCardVH.Item }) { DataAreaCardVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is DashboardToolCard.Item }) { DashboardToolCard(it) })
         addMod(TypedVHCreatorMod({ data[it] is AppControlDashCardVH.Item }) { AppControlDashCardVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is AnalyzerDashCardVH.Item }) { AnalyzerDashCardVH(it) })
@@ -55,6 +54,7 @@ class DashboardAdapter @Inject constructor(
         addMod(TypedVHCreatorMod({ data[it] is MotdCardVH.Item }) { MotdCardVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is ReviewCardVH.Item }) { ReviewCardVH(activity, it) })
         addMod(TypedVHCreatorMod({ data[it] is StatsDashCardVH.Item }) { StatsDashCardVH(it) })
+        addMod(TypedVHCreatorMod({ data[it] is ErrorDataAreaVH.Item }) { ErrorDataAreaVH(it) })
     }
 
     abstract class BaseVH<D : Item, B : ViewBinding>(

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardEvents.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardEvents.kt
@@ -1,5 +1,6 @@
 package eu.darken.sdmse.main.ui.dashboard
 
+import android.content.Intent
 import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerProcessingTask
 import eu.darken.sdmse.corpsefinder.core.tasks.CorpseFinderDeleteTask
 import eu.darken.sdmse.deduplicator.core.Duplicate
@@ -32,4 +33,6 @@ sealed interface DashboardEvents {
     data class TaskResult(
         val result: SDMTool.Task.Result
     ) : DashboardEvents
+
+    data class OpenIntent(val intent: Intent) : DashboardEvents
 }

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardFragment.kt
@@ -1,5 +1,6 @@
 package eu.darken.sdmse.main.ui.dashboard
 
+import android.content.ActivityNotFoundException
 import android.content.res.ColorStateList
 import android.os.Bundle
 import android.text.format.Formatter
@@ -13,6 +14,7 @@ import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 import eu.darken.sdmse.R
 import eu.darken.sdmse.common.easterEggProgressMsg
+import eu.darken.sdmse.common.error.asErrorDialogBuilder
 import eu.darken.sdmse.common.getColorForAttr
 import eu.darken.sdmse.common.lists.differ.update
 import eu.darken.sdmse.common.lists.setupDefaults
@@ -229,6 +231,12 @@ class DashboardFragment : Fragment3(R.layout.dashboard_fragment) {
                 is DashboardEvents.TodoHint -> MaterialAlertDialogBuilder(requireContext()).apply {
                     setMessage(eu.darken.sdmse.common.R.string.general_todo_msg)
                 }.show()
+
+                is DashboardEvents.OpenIntent -> try {
+                    startActivity(event.intent)
+                } catch (e: ActivityNotFoundException) {
+                    e.asErrorDialogBuilder(requireActivity()).show()
+                }
             }
         }
 

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/items/ErrorDataAreaVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/items/ErrorDataAreaVH.kt
@@ -4,19 +4,19 @@ import android.view.ViewGroup
 import eu.darken.sdmse.R
 import eu.darken.sdmse.common.areas.DataAreaManager
 import eu.darken.sdmse.common.lists.binding
-import eu.darken.sdmse.databinding.DashboardDataareaItemBinding
+import eu.darken.sdmse.databinding.DashboardErrorDataareaItemBinding
 import eu.darken.sdmse.main.ui.dashboard.DashboardAdapter
 
 
-class DataAreaCardVH(parent: ViewGroup) :
-    DashboardAdapter.BaseVH<DataAreaCardVH.Item, DashboardDataareaItemBinding>(
-        R.layout.dashboard_dataarea_item,
+class ErrorDataAreaVH(parent: ViewGroup) :
+    DashboardAdapter.BaseVH<ErrorDataAreaVH.Item, DashboardErrorDataareaItemBinding>(
+        R.layout.dashboard_error_dataarea_item,
         parent
     ) {
 
-    override val viewBinding = lazy { DashboardDataareaItemBinding.bind(itemView) }
+    override val viewBinding = lazy { DashboardErrorDataareaItemBinding.bind(itemView) }
 
-    override val onBindData: DashboardDataareaItemBinding.(
+    override val onBindData: DashboardErrorDataareaItemBinding.(
         item: Item,
         payloads: List<Any>
     ) -> Unit = binding { item ->

--- a/app/src/main/java/eu/darken/sdmse/setup/SetupViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/SetupViewModel.kt
@@ -212,12 +212,10 @@ class SetupViewModel @Inject constructor(
                             is SetupModule.State.Current -> InventorySetupCardVH.Item(
                                 state = state as InventorySetupModule.Result,
                                 onGrantAction = {
-                                    state.missingPermission.firstOrNull()?.let {
-                                        events.postValue(SetupEvents.ShowOurDetailsPage(state.settingsIntent))
-                                    }
+                                    events.postValue(SetupEvents.ShowOurDetailsPage(state.settingsIntent))
                                 },
                                 onHelp = {
-                                    webpageTool.open("https://github.com/d4rken-org/sdmaid-se/wiki/Setup#app-inventory")
+                                    webpageTool.open(InventorySetupModule.INFO_URL)
                                 }
                             )
 

--- a/app/src/main/java/eu/darken/sdmse/setup/automation/AutomationSetupCardVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/automation/AutomationSetupCardVH.kt
@@ -1,13 +1,11 @@
 package eu.darken.sdmse.setup.automation
 
-import android.content.res.ColorStateList
 import android.view.ViewGroup
-import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
-import androidx.core.widget.TextViewCompat
 import eu.darken.sdmse.R
 import eu.darken.sdmse.common.getColorForAttr
 import eu.darken.sdmse.common.lists.binding
+import eu.darken.sdmse.common.ui.setLeftIcon
 import eu.darken.sdmse.databinding.SetupAutomationItemBinding
 import eu.darken.sdmse.setup.SetupAdapter
 
@@ -27,30 +25,21 @@ class AutomationSetupCardVH(parent: ViewGroup) :
         val state = item.state
         enabledState.apply {
             isVisible = state.hasConsent == true
-            setCompoundDrawablesRelativeWithIntrinsicBounds(
-                ContextCompat.getDrawable(
-                    context, when {
-                        state.isServiceEnabled -> R.drawable.ic_check_circle
-                        state.canSelfEnable -> R.drawable.ic_baseline_access_time_filled_24
-                        else -> R.drawable.ic_cancel
-                    }
-                ),
-                null,
-                null,
-                null,
-            )
-            TextViewCompat.setCompoundDrawableTintList(
-                this,
-                ColorStateList.valueOf(
-                    context.getColorForAttr(
-                        when {
-                            state.isServiceEnabled -> androidx.appcompat.R.attr.colorPrimary
-                            state.canSelfEnable -> com.google.android.material.R.attr.colorSecondary
-                            else -> androidx.appcompat.R.attr.colorError
-                        }
-                    )
+
+            when {
+                state.isServiceEnabled -> setLeftIcon(
+                    R.drawable.ic_check_circle,
+                    androidx.appcompat.R.attr.colorPrimary
                 )
-            )
+
+                state.canSelfEnable -> setLeftIcon(
+                    R.drawable.ic_baseline_access_time_filled_24,
+                    com.google.android.material.R.attr.colorSecondary
+                )
+
+                else -> setLeftIcon(R.drawable.ic_cancel, androidx.appcompat.R.attr.colorError)
+            }
+
             setTextColor(
                 context.getColorForAttr(
                     when {
@@ -82,20 +71,19 @@ class AutomationSetupCardVH(parent: ViewGroup) :
 
         runningState.apply {
             isVisible = state.isServiceEnabled && state.hasConsent == true
-            setCompoundDrawablesRelativeWithIntrinsicBounds(
-                ContextCompat.getDrawable(
-                    context, if (state.isServiceRunning) R.drawable.ic_check_circle else R.drawable.ic_cancel
-                ),
-                null,
-                null,
-                null,
-            )
-            TextViewCompat.setCompoundDrawableTintList(
-                this,
-                ColorStateList.valueOf(
-                    context.getColorForAttr(if (state.isServiceRunning) androidx.appcompat.R.attr.colorPrimary else androidx.appcompat.R.attr.colorError)
+
+            when {
+                state.isServiceRunning -> setLeftIcon(
+                    R.drawable.ic_check_circle,
+                    androidx.appcompat.R.attr.colorPrimary
                 )
-            )
+
+                else -> setLeftIcon(
+                    R.drawable.ic_cancel,
+                    androidx.appcompat.R.attr.colorError
+                )
+            }
+
             setTextColor(
                 context.getColorForAttr(
                     if (state.isServiceRunning) androidx.appcompat.R.attr.colorPrimary else androidx.appcompat.R.attr.colorError

--- a/app/src/main/java/eu/darken/sdmse/setup/inventory/InventorySetupCardVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/inventory/InventorySetupCardVH.kt
@@ -4,6 +4,7 @@ import android.view.ViewGroup
 import androidx.core.view.isGone
 import eu.darken.sdmse.R
 import eu.darken.sdmse.common.lists.binding
+import eu.darken.sdmse.common.ui.setLeftIcon
 import eu.darken.sdmse.databinding.SetupInventoryItemBinding
 import eu.darken.sdmse.setup.SetupAdapter
 
@@ -20,12 +21,51 @@ class InventorySetupCardVH(parent: ViewGroup) :
         item: Item,
         payloads: List<Any>
     ) -> Unit = binding { item ->
-        grantState.isGone = item.state.missingPermission.isNotEmpty()
+        val state = item.state
+
+        grantState.apply {
+            setTextColor(
+                getColorForAttr(
+                    when {
+                        state.isAccessFaked -> com.google.android.material.R.attr.colorError
+                        else -> com.google.android.material.R.attr.colorPrimary
+                    }
+                )
+            )
+            text = when {
+                state.isAccessFaked -> getString(R.string.setup_permission_error_label)
+                else -> getString(R.string.setup_permission_granted_label)
+            }
+
+            when {
+                state.isAccessFaked -> setLeftIcon(
+                    R.drawable.ic_error_onsurface,
+                    com.google.android.material.R.attr.colorError
+                )
+
+                else -> setLeftIcon(
+                    R.drawable.ic_check_circle,
+                    com.google.android.material.R.attr.colorPrimary
+                )
+            }
+
+            isGone = item.state.missingPermission.isNotEmpty()
+        }
+
+        grantHint.apply {
+            text = getString(R.string.setup_inventory_invalid_message)
+            isGone = !state.isAccessFaked
+        }
 
         grantAction.apply {
+            text = when {
+                state.isAccessFaked -> getString(eu.darken.sdmse.common.R.string.general_open_system_settings_action)
+                else -> getString(eu.darken.sdmse.common.R.string.general_grant_access_action)
+            }
             isGone = item.state.isComplete
             setOnClickListener { item.onGrantAction() }
         }
+
         helpAction.setOnClickListener { item.onHelp() }
     }
 

--- a/app/src/main/java/eu/darken/sdmse/stats/ui/pkgs/AffectedPkgsViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/stats/ui/pkgs/AffectedPkgsViewModel.kt
@@ -6,7 +6,7 @@ import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.pkgs.PkgRepo
-import eu.darken.sdmse.common.pkgs.getPkg
+import eu.darken.sdmse.common.pkgs.get
 import eu.darken.sdmse.common.uix.ViewModel3
 import eu.darken.sdmse.stats.core.AffectedPkg
 import eu.darken.sdmse.stats.core.Report
@@ -58,7 +58,7 @@ class AffectedPkgsViewModel @Inject constructor(
 
         affectedPkgs
             .sortedBy { it.pkgId.name }
-            .map { pkg -> AffectedPkgVH.Item(pkg, pkgRepo.getPkg(pkg.pkgId).firstOrNull()) }
+            .map { pkg -> AffectedPkgVH.Item(pkg, pkgRepo.get(pkg.pkgId).firstOrNull()) }
             .run { elements.addAll(this) }
 
         State(elements)

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/SuperfluousApksFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/SuperfluousApksFilter.kt
@@ -29,7 +29,7 @@ import eu.darken.sdmse.common.files.read
 import eu.darken.sdmse.common.files.segs
 import eu.darken.sdmse.common.hashing.Hasher
 import eu.darken.sdmse.common.pkgs.PkgRepo
-import eu.darken.sdmse.common.pkgs.getPkg
+import eu.darken.sdmse.common.pkgs.get
 import eu.darken.sdmse.common.pkgs.pkgops.PkgOps
 import eu.darken.sdmse.systemcleaner.core.SystemCleanerSettings
 import eu.darken.sdmse.systemcleaner.core.filter.BaseSystemCleanerFilter
@@ -149,7 +149,7 @@ class SuperfluousApksFilter @Inject constructor(
         log(TAG) { "Checking status for ${apkInfo.packageName} (${apkInfo.versionCode})" }
 
         // TODO Multiple profiles can't have different versions of the same APK, right?
-        val installed = pkgRepo.getPkg(apkInfo.id).firstOrNull() ?: return null
+        val installed = pkgRepo.get(apkInfo.id).firstOrNull() ?: return null
 
         val superfluos = installed.versionCode >= apkInfo.versionCode
         if (superfluos) {

--- a/app/src/main/res/layout/dashboard_error_dataarea_item.xml
+++ b/app/src/main/res/layout/dashboard_error_dataarea_item.xml
@@ -4,7 +4,7 @@
     style="@style/DashboardCardItem"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:backgroundTint="?colorTertiaryContainer">
+    android:backgroundTint="?colorErrorContainer">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/dashboard_preview_layout.xml
+++ b/app/src/main/res/layout/dashboard_preview_layout.xml
@@ -10,7 +10,7 @@
 
     <include layout="@layout/dashboard_setup_item" />
 
-    <include layout="@layout/dashboard_dataarea_item" />
+    <include layout="@layout/dashboard_error_dataarea_item" />
 
     <include layout="@layout/dashboard_tool_card" />
 

--- a/app/src/main/res/layout/setup_inventory_item.xml
+++ b/app/src/main/res/layout/setup_inventory_item.xml
@@ -57,10 +57,24 @@
             android:gravity="center"
             android:text="@string/setup_permission_granted_label"
             android:textColor="?colorPrimary"
-            app:layout_constraintBottom_toTopOf="@id/grant_action"
+            app:layout_constraintBottom_toTopOf="@id/grant_hint"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/body" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/grant_hint"
+            style="@style/TextAppearance.Material3.BodyMedium"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="16dp"
+            android:layout_marginTop="16dp"
+            android:text="@string/setup_inventory_invalid_message"
+            android:textColor="?colorError"
+            app:layout_constraintBottom_toTopOf="@id/grant_action"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/grant_state" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/grant_action"
@@ -70,7 +84,7 @@
             android:layout_marginHorizontal="16dp"
             android:layout_marginTop="16dp"
             android:text="@string/general_grant_access_action"
-            app:layout_constraintTop_toBottomOf="@id/grant_state" />
+            app:layout_constraintTop_toBottomOf="@id/grant_hint" />
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/explanation"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -144,6 +144,7 @@
 
     <string name="setup_dismiss_hint">You can find the setup screen again via the settings menu.</string>
     <string name="setup_permission_granted_label">Permission granted</string>
+    <string name="setup_permission_error_label">Permission error</string>
 
     <string name="setup_usagestats_title">Usage statistics</string>
     <string name="setup_usagestats_body">The usage statistics permission grants access to more app details. SD Maid uses it to determine additional cache sizes.</string>
@@ -175,6 +176,8 @@
     <string name="setup_inventory_card_title">App inventory</string>
     <string name="setup_inventory_card_body">SD Maid needs to know which apps you have to find files that don\'t belong to any installed apps.</string>
     <string name="setup_inventory_card_extra">Look for a permission called \"App list\" or \"Query all packages\".</string>
+
+    <string name="setup_inventory_invalid_message">The system provided an invalid list of installed apps (e.g. too few or some were missing). Go to system settings and allow SD Maid access to \"App list\".</string>
 
     <string name="dataarea_warningcard_empty_message">SD Maid didn\'t find any data areas that can be scanned. Did you complete the setup?</string>
     <string name="dataarea_warningcard_label">Data areas</string>

--- a/app/src/test/java/eu/darken/sdmse/common/clutter/manual/MarkerSourceTestTool.kt
+++ b/app/src/test/java/eu/darken/sdmse/common/clutter/manual/MarkerSourceTestTool.kt
@@ -3,7 +3,10 @@ package eu.darken.sdmse.common.clutter.manual
 import android.content.Context
 import android.content.res.AssetManager
 import eu.darken.sdmse.common.areas.DataArea
-import eu.darken.sdmse.common.areas.DataArea.Type.*
+import eu.darken.sdmse.common.areas.DataArea.Type.DATA
+import eu.darken.sdmse.common.areas.DataArea.Type.PRIVATE_DATA
+import eu.darken.sdmse.common.areas.DataArea.Type.PUBLIC_DATA
+import eu.darken.sdmse.common.areas.DataArea.Type.SDCARD
 import eu.darken.sdmse.common.clutter.Marker
 import eu.darken.sdmse.common.clutter.MarkerSource
 import eu.darken.sdmse.common.clutter.manual.MarkerSourceTestTool.Candi.MatchType.NEG
@@ -42,7 +45,9 @@ class MarkerSourceTestTool(private val assetPath: String) {
             File(arg<String>(0)).inputStream()
         }
 
-        every { pkgRepo.pkgs } returns flowOf(testApps)
+        every { pkgRepo.data } returns flowOf(
+            mockk<PkgRepo.PkgData>().apply { every { pkgs } returns testApps }
+        )
     }
 
     fun getMarkerSource(): MarkerSource {

--- a/app/src/test/java/eu/darken/sdmse/common/forensics/csi/BaseCSITest.kt
+++ b/app/src/test/java/eu/darken/sdmse/common/forensics/csi/BaseCSITest.kt
@@ -54,7 +54,7 @@ abstract class BaseCSITest : BaseTest() {
         every { storageEnvironment.dataDir } returns LocalPath.build("/data")
 
         coEvery { pkgRepo.query(any(), any()) } returns emptySet()
-        every { pkgRepo.pkgs } returns flowOf(pkgs)
+        every { pkgRepo.data } answers { flowOf(PkgRepo.PkgData.from(pkgs)) }
         coEvery { pkgOps.viewArchive(any(), any()) } returns null
     }
 
@@ -82,6 +82,7 @@ abstract class BaseCSITest : BaseTest() {
             every { id } returns pkgId
             every { sourceDir } returns source
             every { packageInfo } returns mockk()
+            every { this@apply.userHandle } returns userHandle
         }
         coEvery { pkgRepo.query(pkgId, UserHandle2(-1)) } returns setOf(mockPkg)
         coEvery { pkgRepo.query(pkgId, userHandle) } returns setOf(mockPkg)

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -101,6 +101,12 @@
     #    "update_option" : "update_without_changes",
     "languages_mapping": *stringmapping
   }, {
+    "source": "/app-common-pkgs/src/main/res/values/strings.xml",
+    "dest": "/strings-app-common-pkgs.xml",
+    "translation": "/app-common-pkgs/src/main/res/values-%android_code%/strings.xml",
+    #    "update_option" : "update_without_changes",
+    "languages_mapping": *stringmapping
+  }, {
     "source": "/fastlane/metadata/android/en-US/full_description.txt",
     "dest": "/store-description.txt",
     "translation": "/fastlane/metadata/android/%locale%/full_description.txt",


### PR DESCRIPTION
`QUERY_ALL_PACKAGES` is a permission that is automatically granted, at least according to documentation. Except, of course, on some Samsung devices running Android 14, because why not do things differently...

This PR prevents SD Maid from crashing in these cases. A specific error is shown. The state is now detected and treated as a permission error and will show as incomplete-setup.

Fixes #1354

![Screenshot from 2024-08-06 20-06-10](https://github.com/user-attachments/assets/4febd030-31bf-454b-b084-2411db53efc0)
