### PR TITLE
IO: Improve resource management during file operations

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/root/service/RootServiceClient.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/root/service/RootServiceClient.kt
@@ -2,10 +2,8 @@ package eu.darken.sdmse.common.root.service
 
 import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.datastore.value
-import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.debug.DebugSettings
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
-import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
@@ -106,12 +104,6 @@ class RootServiceClient @Inject constructor(
     ) {
         inline fun <reified T> getModule(): T = clientModules.single { it is T } as T
     }
-
-    suspend fun <T> runSessionAction(action: suspend (Connection) -> T): T = get().use {
-        if (Bugs.isTrace) log(TAG, VERBOSE) { "runSessionAction(action=$action)" }
-        action(it.item)
-    }
-
 
     companion object {
 

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/root/service/RootServiceClientExtensions.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/root/service/RootServiceClientExtensions.kt
@@ -3,6 +3,7 @@ package eu.darken.sdmse.common.root.service
 import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.sharedresource.runSessionAction
 
 
 @Suppress("UNCHECKED_CAST")

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/shizuku/service/ShizukuServiceClient.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/shizuku/service/ShizukuServiceClient.kt
@@ -2,10 +2,8 @@ package eu.darken.sdmse.common.shizuku.service
 
 import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.datastore.value
-import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.debug.DebugSettings
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
-import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
@@ -106,11 +104,6 @@ class ShizukuServiceClient @Inject constructor(
         val clientModules: List<IpcClientModule>
     ) {
         inline fun <reified T> getModule(): T = clientModules.single { it is T } as T
-    }
-
-    suspend fun <T> runSessionAction(action: suspend (Connection) -> T): T = get().use {
-        if (Bugs.isTrace) log(TAG, VERBOSE) { "runSessionAction(action=$action)" }
-        action(it.item)
     }
 
     companion object {

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/shizuku/service/ShizukuServiceClientExtensions.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/shizuku/service/ShizukuServiceClientExtensions.kt
@@ -3,6 +3,7 @@ package eu.darken.sdmse.common.shizuku.service
 import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.sharedresource.runSessionAction
 
 
 @Suppress("UNCHECKED_CAST")

--- a/app-common/src/main/java/eu/darken/sdmse/common/sharedresource/SharedResourceExtensions.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/sharedresource/SharedResourceExtensions.kt
@@ -43,3 +43,7 @@ suspend inline fun <C : HasSharedResource<*>, R> C.keepResourcesAlive(
         keepAlives.closeAll()
     }
 }
+
+suspend fun <T, A : Any> SharedResource<A>.runSessionAction(action: suspend (A) -> T): T = get().use {
+    action(it.item)
+}

--- a/app/src/main/java/eu/darken/sdmse/common/debug/DebugCardProvider.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/debug/DebugCardProvider.kt
@@ -15,6 +15,7 @@ import eu.darken.sdmse.common.pkgs.pkgops.PkgOps
 import eu.darken.sdmse.common.root.RootManager
 import eu.darken.sdmse.common.root.RootSettings
 import eu.darken.sdmse.common.root.service.RootServiceClient
+import eu.darken.sdmse.common.sharedresource.runSessionAction
 import eu.darken.sdmse.common.shell.ShellOps
 import eu.darken.sdmse.common.shell.ipc.ShellOpsCmd
 import eu.darken.sdmse.common.shizuku.ShizukuManager


### PR DESCRIPTION
While the parent (LocalGateway or PkgOps) is active and they themself as resource are being kept alive, make sure we keep childs like Shizuku or Root sessions alive too. Closing and opening the service connections (releasing the child resources) while the parent resource is alive, just adds extra churn.

Also see #1360

```
18:46:35.645 SDMSE:TaskManager:SR                 D  get(205551414): Reviving SharedResource
18:46:35.650 SDMSE:TaskManager:SR                 D  Acquiring shared resource...
18:46:35.653 SDMSE:AppCleaner:SR                  D  get(163473936): Reviving SharedResource
18:46:35.656 SDMSE:AppCleaner:SR                  D  Acquiring shared resource...
18:46:35.664 SDMSE:CSI:FileForensics:SR           D  get(54980210): Reviving SharedResource
18:46:35.666 SDMSE:CSI:FileForensics:SR           D  Acquiring shared resource...
18:46:35.670 SDMSE:Gateway:Switch:SR              D  get(214268849): Reviving SharedResource
18:46:35.673 SDMSE:Gateway:Switch:SR              D  Acquiring shared resource...
18:46:35.676 SDMSE:Pkg:Ops:SR                     D  get(250454437): Reviving SharedResource
18:46:35.679 SDMSE:Pkg:Ops:SR                     D  Acquiring shared resource...
18:46:35.747 SDMSE:Gateway:Local:SR               D  get(252054746): Reviving SharedResource
18:46:35.749 SDMSE:Gateway:Local:SR               D  Acquiring shared resource...
18:46:35.788 SDMSE:Shizuku:Service:Client:SR      D  get(27747328): Reviving SharedResource
18:46:35.790 SDMSE:Shizuku:Service:Client:SR      D  Acquiring shared resource...
18:46:45.315 SDMSE:TaskManager                    D  Releasing resource lock for 267d2fe2-b3f0-4f94-90f6-2a1369b22794
18:46:46.328 SDMSE:TaskManager:SR                 D  Shared resource flow completed.
18:46:47.356 SDMSE:AppCleaner:SR                  D  Shared resource flow completed.
18:46:48.376 SDMSE:CSI:FileForensics:SR           D  Shared resource flow completed.
18:46:49.387 SDMSE:Pkg:Ops:SR                     D  Shared resource flow completed.
18:46:49.390 SDMSE:Gateway:Switch:SR              D  Shared resource flow completed.
18:46:50.397 SDMSE:Gateway:Local:SR               D  Shared resource flow completed.
18:46:51.441 SDMSE:Shizuku:Service:Client:SR      D  Shared resource flow completed.
```