### PR TITLE
AppCleaner: Fix duplicate paths in public default caches filter

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleanerExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleanerExtensions.kt
@@ -1,12 +1,13 @@
 package eu.darken.sdmse.appcleaner.core
 
 import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilter
+import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilterIdentifier
 import eu.darken.sdmse.exclusion.core.types.Exclusion
 import eu.darken.sdmse.exclusion.core.types.excludeNestedLookups
+import kotlin.reflect.KClass
 
 val AppCleaner.Data?.hasData: Boolean
     get() = this?.junks?.isNotEmpty() ?: false
-
 
 suspend fun Collection<Exclusion.Path>.excludeNestedLookups(
     matches: Collection<ExpendablesFilter.Match>
@@ -17,3 +18,6 @@ suspend fun Collection<Exclusion.Path>.excludeNestedLookups(
         .filter { temp.contains(it.lookup) }
         .toSet()
 }
+
+val KClass<out ExpendablesFilter>.identifier: ExpendablesFilterIdentifier
+    get() = this

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/PostProcessorModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/PostProcessorModule.kt
@@ -131,6 +131,10 @@ class PostProcessorModule @Inject constructor(
             log(TAG) { "After checking exclusions: $after" }
         }
 
+        if (after.itemCount > before.itemCount) {
+            throw IllegalStateException("Item count after exclusions can't be greater than before!")
+        }
+
         return after
     }
 


### PR DESCRIPTION
The same paths were being added again due to a bug in code that checks for exclusions.

Besides shown wrong duplicate data, this could also lead to errors during deletion because SD Maid attempted to delete the same files twice.