### PR TITLE
AppCleaner: Fix inconsistencies when using ACS and Shizuku

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleanerExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleanerExtensions.kt
@@ -1,10 +1,8 @@
 package eu.darken.sdmse.appcleaner.core
 
 import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilter
-import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilterIdentifier
 import eu.darken.sdmse.exclusion.core.types.Exclusion
 import eu.darken.sdmse.exclusion.core.types.excludeNestedLookups
-import kotlin.reflect.KClass
 
 val AppCleaner.Data?.hasData: Boolean
     get() = this?.junks?.isNotEmpty() ?: false
@@ -18,6 +16,3 @@ suspend fun Collection<Exclusion.Path>.excludeNestedLookups(
         .filter { temp.contains(it.lookup) }
         .toSet()
 }
-
-val KClass<out ExpendablesFilter>.identifier: ExpendablesFilterIdentifier
-    get() = this

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppJunk.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppJunk.kt
@@ -33,7 +33,7 @@ data class AppJunk(
         val knownFiles = expendables?.values?.flatten()?.sumOf { it.expectedGain } ?: 0L
         val inaccessibleSize = inaccessibleCache?.run {
             val publicCacheSize = expendables
-                ?.get(DefaultCachesPublicFilter::class.identifier)
+                ?.get(DefaultCachesPublicFilter::class)
                 ?.sumOf { it.expectedGain }
             when {
                 publicCacheSize == null -> {

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppJunk.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppJunk.kt
@@ -38,17 +38,17 @@ data class AppJunk(
             when {
                 publicCacheSize == null -> {
                     // No extra info about public caches
-                    cacheBytes
+                    totalSize
                 }
 
-                externalCacheBytes != null -> {
-                    // The system knows has seperate info for pub/priv caches
-                    privateCacheSize
+                publicSize != null -> {
+                    // The system has seperate info for pub/priv caches
+                    privateSize
                 }
 
                 else -> {
                     // Assume system info includes pub caches
-                    cacheBytes - publicCacheSize
+                    totalSize - publicCacheSize
                 }
             }
         } ?: 0L

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleter.kt
@@ -91,7 +91,7 @@ class InaccessibleDeleter @Inject constructor(
                 }
                 isCurrentUser
             }
-            .sortedByDescending { it.inaccessibleCache?.totalBytes }
+            .sortedByDescending { it.inaccessibleCache?.totalSize }
 
         return deleteInaccessible(
             targetInaccessible,
@@ -193,7 +193,7 @@ class InaccessibleDeleter @Inject constructor(
                                     break
                                 }
 
-                                newInfo.cacheBytes != beforeInfo.cacheBytes -> {
+                                newInfo.totalSize != beforeInfo.totalSize -> {
                                     log(TAG, VERBOSE) { "Size has changed $beforeInfo -> $newInfo" }
                                     break
                                 }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/AppScanner.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/AppScanner.kt
@@ -164,11 +164,11 @@ class AppScanner @Inject constructor(
                 expendables?.groupBy { it.identifier }
 
             // For <API31 we can improve accuracy manually
-            if (inaccessible != null && byFilterType != null && inaccessible.externalCacheBytes == null) {
+            if (inaccessible != null && byFilterType != null && inaccessible.publicSize == null) {
                 inaccessible = inaccessible.copy(
-                    externalCacheBytes = byFilterType[DefaultCachesPublicFilter::class]?.sumOf { it.expectedGain }
+                    publicSize = byFilterType[DefaultCachesPublicFilter::class]?.sumOf { it.expectedGain }
                 )
-                log(TAG) { "Guesstimated external cache size as ${inaccessible.externalCacheBytes}" }
+                log(TAG) { "Guesstimated external cache size as ${inaccessible.publicSize}" }
             }
 
             AppJunk(

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/InaccessibleCache.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/InaccessibleCache.kt
@@ -9,8 +9,8 @@ data class InaccessibleCache(
     val identifier: Installed.InstallId,
     val isSystemApp: Boolean,
     val itemCount: Int,
-    val cacheBytes: Long,
-    val externalCacheBytes: Long?,
+    val totalSize: Long,
+    val publicSize: Long?,
     val theoreticalPaths: Set<APath>,
 ) {
 
@@ -20,10 +20,7 @@ data class InaccessibleCache(
     val userHandle: UserHandle2
         get() = identifier.userHandle
 
-    val privateCacheSize: Long = cacheBytes - (externalCacheBytes ?: 0L)
+    val privateSize: Long = totalSize - (publicSize ?: 0L)
 
-    val totalBytes: Long
-        get() = cacheBytes + (externalCacheBytes ?: 0L)
-
-    val isEmpty: Boolean = privateCacheSize == 0L
+    val isEmpty: Boolean = totalSize == 0L
 }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/InaccessibleCacheProvider.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/InaccessibleCacheProvider.kt
@@ -46,9 +46,9 @@ class InaccessibleCacheProvider @Inject constructor(
         return InaccessibleCache(
             pkg.installId,
             isSystemApp = pkg.isSystemApp,
-            itemCount = 1,
-            cacheBytes = storageStats.cacheBytes,
-            externalCacheBytes = if (hasApiLevel(31)) {
+            itemCount = 2,
+            totalSize = storageStats.cacheBytes,
+            publicSize = if (hasApiLevel(31)) {
                 @Suppress("NewApi")
                 storageStats.externalCacheBytes
             } else null,

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/PostProcessorModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/PostProcessorModule.kt
@@ -8,7 +8,6 @@ import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilter
 import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilterIdentifier
 import eu.darken.sdmse.appcleaner.core.forensics.filter.DefaultCachesPrivateFilter
 import eu.darken.sdmse.appcleaner.core.forensics.filter.DefaultCachesPublicFilter
-import eu.darken.sdmse.appcleaner.core.identifier
 import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
@@ -108,8 +107,8 @@ class PostProcessorModule @Inject constructor(
         if (!useRoot && useShizuku) {
             val edgeCaseSegs = segs(before.pkg.id.name, "cache")
             val edgeCaseFilters = setOf(
-                DefaultCachesPublicFilter::class.identifier,
-                DefaultCachesPrivateFilter::class.identifier,
+                DefaultCachesPublicFilter::class,
+                DefaultCachesPrivateFilter::class,
             )
             before.expendables
                 .filter { edgeCaseFilters.contains(it.key) }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/ui/details/appjunk/elements/AppJunkElementInaccessibleVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/ui/details/appjunk/elements/AppJunkElementInaccessibleVH.kt
@@ -22,7 +22,7 @@ class AppJunkElementInaccessibleVH(parent: ViewGroup) :
         item: Item,
         payloads: List<Any>
     ) -> Unit = binding { item ->
-        size.text = Formatter.formatFileSize(context, item.inaccessibleCache.privateCacheSize)
+        size.text = Formatter.formatFileSize(context, item.inaccessibleCache.totalSize)
 
         root.setOnClickListener { item.onItemClick(item) }
     }


### PR DESCRIPTION
The underlying issue is/was that without root we can't access "inaccessible caches", which are the default public and private caches of an app. The caches that get cleared when pressing the "Clear cache" button in the system.

If we throw Shizuku into the mix, then we can access the PUBLIC default caches, but not the private default caches.

So with Shizuku the inaccessible caches entry overlaps with the public default caches.

* When deleting the `Default caches` entry, then we also need to remove the `Public default caches` entry
* When deleting the `Public default caches` entry, then we need to subtract the size from the `Default caches` entry.

![Screenshot from 2024-08-21 16-45-08](https://github.com/user-attachments/assets/ab3a5083-6acc-4250-98b5-889c0b34dc98)
