### PR TITLE
AppCleaner: Fix found item count

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
@@ -176,7 +176,7 @@ class AppCleaner @Inject constructor(
         )
 
         return AppCleanerScanTask.Success(
-            itemCount = results.size,
+            itemCount = results.sumOf { it.itemCount },
             recoverableSpace = results.sumOf { it.size },
         )
     }


### PR DESCRIPTION
Was "count of apps with expendable files"
Now is the sum of matches across all apps and filters