### PR TITLE
SystemCleaner: Remove block/inode size limit when checking for empty directories

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/EmptyDirectoryFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/EmptyDirectoryFilter.kt
@@ -123,8 +123,6 @@ class EmptyDirectoryFilter @Inject constructor(
             return null
         }
 
-        if (item.size > 65536) return null
-
         // Check for nested empty directories
         val content = item.lookupFiles(gatewaySwitch)
         return when {

--- a/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/SystemCleanerFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/SystemCleanerFilterTest.kt
@@ -379,6 +379,8 @@ abstract class SystemCleanerFilterTest : BaseTest() {
             data object Primary : Area
             data object Secondary : Area
         }
+
+        data class Size(val size: Long) : Flag
     }
 
     suspend fun pos(location: Type, path: String, vararg flags: Flag) {
@@ -413,6 +415,8 @@ abstract class SystemCleanerFilterTest : BaseTest() {
                 }
                 require(!(flagsCollection.contains(Flag.Dir) && flagsCollection.contains(Flag.File))) { "Can't be both file and dir." }
 
+                val sizeFlag = flags.filterIsInstance<Flag.Size>().singleOrNull()
+
                 val mockPath = area.path.child(targetPath)
                 val mockLookup = when (area.path.pathType) {
                     APath.PathType.LOCAL -> LocalPathLookup(
@@ -425,6 +429,7 @@ abstract class SystemCleanerFilterTest : BaseTest() {
                             throw IllegalArgumentException("Unknown file type")
                         },
                         size = when {
+                            sizeFlag != null -> sizeFlag.size
                             flagsCollection.contains(Flag.Dir) -> 512L
                             else -> 1024 * 1024L
                         },

--- a/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/EmptyDirectoryFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/EmptyDirectoryFilterTest.kt
@@ -96,4 +96,13 @@ class EmptyDirectoryFilterTest : SystemCleanerFilterTest() {
 
         confirm(create())
     }
+
+    @Test fun `empty directories - with large node sizes`() = runTest {
+        neg(SDCARD, "0", Flag.File)
+        pos(SDCARD, "1", Flag.Dir, Flag.Size(262144))
+        pos(SDCARD, "2", Flag.Dir, Flag.Size(524288))
+        pos(SDCARD, "3", Flag.Dir, Flag.Size(1048576))
+
+        confirm(create())
+    }
 }


### PR DESCRIPTION
Fixes #1385