### PR TITLE
AppCleaner: If a file can't be accessed, continue with the other files

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/BaseExpendablesFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/BaseExpendablesFilter.kt
@@ -7,7 +7,7 @@ import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APathLookup
 import eu.darken.sdmse.common.files.GatewaySwitch
-import eu.darken.sdmse.common.files.WriteException
+import eu.darken.sdmse.common.files.PathException
 import eu.darken.sdmse.common.files.deleteAll
 import eu.darken.sdmse.common.files.filterDistinctRoots
 import eu.darken.sdmse.common.flow.throttleLatest
@@ -50,7 +50,7 @@ abstract class BaseExpendablesFilter : ExpendablesFilter {
                 try {
                     targetContent.deleteAll(gatewaySwitch)
                     success.add(originalmatch)
-                } catch (e: WriteException) {
+                } catch (e: PathException) {
                     log(logTag("AppCleaner,BaseExpendablesFilter"), ERROR) {
                         "Failed to delete $originalmatch due to $e"
                     }


### PR DESCRIPTION
A file that we are trying to delete, may be un-readable in addition to being un-writable. So a `ReadException` could be thrown too.

While we can't fix the underlying issue that prevents a file from being read or written, we can continue on with the other deletion tasks, and just leave this one for the user to investigate.

Closes #1391