### PR TITLE
AppCleaner: Better handling for partial failure during deletion

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/BaseExpendablesFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/BaseExpendablesFilter.kt
@@ -2,6 +2,7 @@ package eu.darken.sdmse.appcleaner.core.forensics
 
 import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
@@ -28,77 +29,80 @@ abstract class BaseExpendablesFilter : ExpendablesFilter {
         progressPub.value = update(progressPub.value)
     }
 
-    suspend fun Collection<ExpendablesFilter.Match>.deleteAll(
-        gatewaySwitch: GatewaySwitch
-    ): ExpendablesFilter.ProcessResult = this
-        .map { it as ExpendablesFilter.Match.Deletion }
-        .let { deletionMatches ->
-            val successful = mutableSetOf<ExpendablesFilter.Match.Deletion>()
-            val failed = mutableSetOf<Pair<ExpendablesFilter.Match.Deletion, Exception>>()
+    suspend fun deleteAll(
+        targets: Collection<ExpendablesFilter.Match.Deletion>,
+        gatewaySwitch: GatewaySwitch,
+        allMatches: Collection<ExpendablesFilter.Match>,
+    ): ExpendablesFilter.ProcessResult {
+        log(TAG, INFO) { "deleteAll(...) Processing ${targets.size} out of ${allMatches.size} matches" }
+        val successful = mutableSetOf<ExpendablesFilter.Match>()
+        val failed = mutableSetOf<Pair<ExpendablesFilter.Match, Exception>>()
 
-            val distinctRoots = deletionMatches.map { it.lookup }.filterDistinctRoots()
+        val distinctRoots = targets.map { it.lookup }.filterDistinctRoots()
 
-            if (distinctRoots.size != deletionMatches.size) {
-                log(WARN) { "${deletionMatches.size} match objects but only ${distinctRoots.size} distinct roots" }
-                if (Bugs.isDebug) {
-                    deletionMatches
-                        .filter { !distinctRoots.contains(it.lookup) }
-                        .forEachIndexed { index, item -> log(WARN) { "Non distinct root #$index: $item" } }
-                }
+        if (distinctRoots.size != targets.size) {
+            log(TAG, INFO) { "${targets.size} match objects but only ${distinctRoots.size} distinct roots" }
+            if (Bugs.isDebug) {
+                targets
+                    .filter { !distinctRoots.contains(it.lookup) }
+                    .forEachIndexed { index, item -> log(TAG, INFO) { "Non distinct root #$index: $item" } }
             }
-
-            val workingSet = deletionMatches.toMutableSet()
-
-            distinctRoots.forEach { targetRoot ->
-                updateProgressSecondary(targetRoot.userReadablePath)
-                val mainmatch = workingSet.first { it.lookup == targetRoot }
-                val alsoAffected = workingSet
-                    .filter { it != mainmatch && mainmatch.lookup.isAncestorOf(it.lookup) }
-                    .toSet()
-
-                val mainDeleted = try {
-                    targetRoot.deleteAll(gatewaySwitch)
-                    log(TAG, VERBOSE) { "Main match deleted" }
-                    true
-                } catch (oge: PathException) {
-                    try {
-                        if (targetRoot.exists(gatewaySwitch)) {
-                            log(TAG, WARN) { "Deletion failed, file still exists" }
-                            failed.add(mainmatch to oge)
-                            false
-                        } else {
-                            log(TAG, WARN) { "Deletion failed as file no longer exists, okay..." }
-                            true
-                        }
-                    } catch (e: PathException) {
-                        log(TAG, ERROR) { "Post-deletion-failure-exist check failed too on $mainmatch due to $e" }
-                        failed.add(mainmatch to e)
-                        false
-                    }
-                }
-
-                if (mainDeleted) {
-                    workingSet.remove(mainmatch)
-                    successful.add(mainmatch)
-                    if (Bugs.isDebug) {
-                        log(TAG, VERBOSE) { "Main deleted:\n$mainmatch" }
-                    }
-                }
-
-                if (mainDeleted) {
-                    workingSet.removeAll(alsoAffected)
-                    successful.addAll(alsoAffected)
-                    if (Bugs.isDebug) {
-                        log(TAG, VERBOSE) { "Also deleted:\n${alsoAffected.joinToString("\n")}" }
-                    }
-                }
-            }
-
-            ExpendablesFilter.ProcessResult(
-                success = successful,
-                failed = failed,
-            )
         }
+
+        distinctRoots.forEach { targetRoot ->
+            updateProgressSecondary(targetRoot.userReadablePath)
+            val main = targets.first { it.lookup == targetRoot }
+
+            val mainDeleted = try {
+                targetRoot.deleteAll(gatewaySwitch)
+                log(TAG) { "Main match deleted: $main" }
+                true
+            } catch (oge: PathException) {
+                try {
+                    if (targetRoot.exists(gatewaySwitch)) {
+                        log(TAG, WARN) { "Deletion failed, file still exists" }
+                        failed.add(main to oge)
+                        false
+                    } else {
+                        log(TAG, WARN) { "Deletion failed as file no longer exists, okay..." }
+                        true
+                    }
+                } catch (e: PathException) {
+                    log(TAG, ERROR) { "Post-deletion-failure-exist check failed too on $main\n $e" }
+                    failed.add(main to e)
+                    false
+                }
+            }
+
+            // deleteAll(...) starts at leafs, children may have been deleted, even if the top-level dir wasn't
+            val affected = allMatches.filter { it != main && main.lookup.isAncestorOf(it.lookup) }
+            if (Bugs.isDebug) {
+                log(TAG) { "$main affects ${affected.size} other matches" }
+                affected.forEach { log(TAG, VERBOSE) { "Affected: $it" } }
+            }
+
+            if (mainDeleted) {
+                successful.add(main)
+                successful.addAll(affected)
+                log(TAG) { "Main match and affected files deleted" }
+            } else {
+                log(TAG, WARN) { "Main match failed to delete, checking what still exists" }
+                affected.forEach { subMatch ->
+                    if (subMatch.path.exists(gatewaySwitch)) {
+                        log(TAG, WARN) { "Sub match still exists: $subMatch" }
+                    } else {
+                        log(TAG, INFO) { "Sub match no longer exists: $subMatch" }
+                        successful.add(subMatch)
+                    }
+                }
+            }
+        }
+
+        return ExpendablesFilter.ProcessResult(
+            success = successful,
+            failed = failed,
+        )
+    }
 
     suspend fun APathLookup<*>.toDeletionMatch() = ExpendablesFilter.Match.Deletion(identifier, this)
 

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/BaseExpendablesFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/BaseExpendablesFilter.kt
@@ -2,6 +2,7 @@ package eu.darken.sdmse.appcleaner.core.forensics
 
 import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
@@ -9,7 +10,9 @@ import eu.darken.sdmse.common.files.APathLookup
 import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.PathException
 import eu.darken.sdmse.common.files.deleteAll
+import eu.darken.sdmse.common.files.exists
 import eu.darken.sdmse.common.files.filterDistinctRoots
+import eu.darken.sdmse.common.files.isAncestorOf
 import eu.darken.sdmse.common.flow.throttleLatest
 import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.common.progress.updateProgressSecondary
@@ -30,7 +33,7 @@ abstract class BaseExpendablesFilter : ExpendablesFilter {
     ): ExpendablesFilter.ProcessResult = this
         .map { it as ExpendablesFilter.Match.Deletion }
         .let { deletionMatches ->
-            val success = mutableSetOf<ExpendablesFilter.Match.Deletion>()
+            val successful = mutableSetOf<ExpendablesFilter.Match.Deletion>()
             val failed = mutableSetOf<Pair<ExpendablesFilter.Match.Deletion, Exception>>()
 
             val distinctRoots = deletionMatches.map { it.lookup }.filterDistinctRoots()
@@ -44,26 +47,63 @@ abstract class BaseExpendablesFilter : ExpendablesFilter {
                 }
             }
 
-            distinctRoots.forEach { targetContent ->
-                updateProgressSecondary(targetContent.userReadablePath)
-                val originalmatch = deletionMatches.first { it.lookup == targetContent }
-                try {
-                    targetContent.deleteAll(gatewaySwitch)
-                    success.add(originalmatch)
-                } catch (e: PathException) {
-                    log(logTag("AppCleaner,BaseExpendablesFilter"), ERROR) {
-                        "Failed to delete $originalmatch due to $e"
+            val workingSet = deletionMatches.toMutableSet()
+
+            distinctRoots.forEach { targetRoot ->
+                updateProgressSecondary(targetRoot.userReadablePath)
+                val mainmatch = workingSet.first { it.lookup == targetRoot }
+                val alsoAffected = workingSet
+                    .filter { it != mainmatch && mainmatch.lookup.isAncestorOf(it.lookup) }
+                    .toSet()
+
+                val mainDeleted = try {
+                    targetRoot.deleteAll(gatewaySwitch)
+                    log(TAG, VERBOSE) { "Main match deleted" }
+                    true
+                } catch (oge: PathException) {
+                    try {
+                        if (targetRoot.exists(gatewaySwitch)) {
+                            log(TAG, WARN) { "Deletion failed, file still exists" }
+                            failed.add(mainmatch to oge)
+                            false
+                        } else {
+                            log(TAG, WARN) { "Deletion failed as file no longer exists, okay..." }
+                            true
+                        }
+                    } catch (e: PathException) {
+                        log(TAG, ERROR) { "Post-deletion-failure-exist check failed too on $mainmatch due to $e" }
+                        failed.add(mainmatch to e)
+                        false
                     }
-                    failed.add(originalmatch to e)
+                }
+
+                if (mainDeleted) {
+                    workingSet.remove(mainmatch)
+                    successful.add(mainmatch)
+                    if (Bugs.isDebug) {
+                        log(TAG, VERBOSE) { "Main deleted:\n$mainmatch" }
+                    }
+                }
+
+                if (mainDeleted) {
+                    workingSet.removeAll(alsoAffected)
+                    successful.addAll(alsoAffected)
+                    if (Bugs.isDebug) {
+                        log(TAG, VERBOSE) { "Also deleted:\n${alsoAffected.joinToString("\n")}" }
+                    }
                 }
             }
 
             ExpendablesFilter.ProcessResult(
-                success = success,
+                success = successful,
                 failed = failed,
             )
         }
 
     suspend fun APathLookup<*>.toDeletionMatch() = ExpendablesFilter.Match.Deletion(identifier, this)
 
+
+    companion object {
+        private val TAG = logTag("AppCleaner", "BaseExpendablesFilter")
+    }
 }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/ExpendablesFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/ExpendablesFilter.kt
@@ -22,7 +22,7 @@ interface ExpendablesFilter : Progress.Host, Progress.Client {
         segments: Segments
     ): Match?
 
-    suspend fun process(matches: Collection<Match>): ProcessResult
+    suspend fun process(targets: Collection<Match>, allMatches: Collection<Match>): ProcessResult
 
     data class ProcessResult(
         val success: Collection<Match>,

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/AdvertisementFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/AdvertisementFilter.kt
@@ -92,8 +92,15 @@ class AdvertisementFilter @Inject constructor(
         }
     }
 
-    override suspend fun process(matches: Collection<ExpendablesFilter.Match>): ExpendablesFilter.ProcessResult {
-        return matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        targets: Collection<ExpendablesFilter.Match>,
+        allMatches: Collection<ExpendablesFilter.Match>
+    ): ExpendablesFilter.ProcessResult {
+        return deleteAll(
+            targets.map { it as ExpendablesFilter.Match.Deletion },
+            gatewaySwitch,
+            allMatches
+        )
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/AnalyticsFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/AnalyticsFilter.kt
@@ -50,8 +50,15 @@ class AnalyticsFilter @Inject constructor(
         }
     }
 
-    override suspend fun process(matches: Collection<ExpendablesFilter.Match>): ExpendablesFilter.ProcessResult {
-        return matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        targets: Collection<ExpendablesFilter.Match>,
+        allMatches: Collection<ExpendablesFilter.Match>
+    ): ExpendablesFilter.ProcessResult {
+        return deleteAll(
+            targets.map { it as ExpendablesFilter.Match.Deletion },
+            gatewaySwitch,
+            allMatches
+        )
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/BugReportingFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/BugReportingFilter.kt
@@ -105,8 +105,15 @@ class BugReportingFilter @Inject constructor(
         }
     }
 
-    override suspend fun process(matches: Collection<ExpendablesFilter.Match>): ExpendablesFilter.ProcessResult {
-        return matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        targets: Collection<ExpendablesFilter.Match>,
+        allMatches: Collection<ExpendablesFilter.Match>
+    ): ExpendablesFilter.ProcessResult {
+        return deleteAll(
+            targets.map { it as ExpendablesFilter.Match.Deletion },
+            gatewaySwitch,
+            allMatches
+        )
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/CodeCacheFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/CodeCacheFilter.kt
@@ -49,8 +49,15 @@ class CodeCacheFilter @Inject constructor(
         }
     }
 
-    override suspend fun process(matches: Collection<ExpendablesFilter.Match>): ExpendablesFilter.ProcessResult {
-        return matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        targets: Collection<ExpendablesFilter.Match>,
+        allMatches: Collection<ExpendablesFilter.Match>
+    ): ExpendablesFilter.ProcessResult {
+        return deleteAll(
+            targets.map { it as ExpendablesFilter.Match.Deletion },
+            gatewaySwitch,
+            allMatches
+        )
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/DefaultCachesPrivateFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/DefaultCachesPrivateFilter.kt
@@ -52,10 +52,16 @@ class DefaultCachesPrivateFilter @Inject constructor(
         }
     }
 
-    override suspend fun process(matches: Collection<ExpendablesFilter.Match>): ExpendablesFilter.ProcessResult {
-        return matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        targets: Collection<ExpendablesFilter.Match>,
+        allMatches: Collection<ExpendablesFilter.Match>
+    ): ExpendablesFilter.ProcessResult {
+        return deleteAll(
+            targets.map { it as ExpendablesFilter.Match.Deletion },
+            gatewaySwitch,
+            allMatches
+        )
     }
-
     @Reusable
     class Factory @Inject constructor(
         private val settings: AppCleanerSettings,

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/DefaultCachesPublicFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/DefaultCachesPublicFilter.kt
@@ -52,8 +52,15 @@ class DefaultCachesPublicFilter @Inject constructor(
         }
     }
 
-    override suspend fun process(matches: Collection<ExpendablesFilter.Match>): ExpendablesFilter.ProcessResult {
-        return matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        targets: Collection<ExpendablesFilter.Match>,
+        allMatches: Collection<ExpendablesFilter.Match>
+    ): ExpendablesFilter.ProcessResult {
+        return deleteAll(
+            targets.map { it as ExpendablesFilter.Match.Deletion },
+            gatewaySwitch,
+            allMatches
+        )
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/GameFilesFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/GameFilesFilter.kt
@@ -71,8 +71,15 @@ class GameFilesFilter @Inject constructor(
         }
     }
 
-    override suspend fun process(matches: Collection<ExpendablesFilter.Match>): ExpendablesFilter.ProcessResult {
-        return matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        targets: Collection<ExpendablesFilter.Match>,
+        allMatches: Collection<ExpendablesFilter.Match>
+    ): ExpendablesFilter.ProcessResult {
+        return deleteAll(
+            targets.map { it as ExpendablesFilter.Match.Deletion },
+            gatewaySwitch,
+            allMatches
+        )
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/HiddenFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/HiddenFilter.kt
@@ -108,8 +108,15 @@ class HiddenFilter @Inject constructor(
         return dirs.size >= 4 && dirs[2] == "Cache" && dirs[3].contains(".unity3d&")
     }
 
-    override suspend fun process(matches: Collection<ExpendablesFilter.Match>): ExpendablesFilter.ProcessResult {
-        return matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        targets: Collection<ExpendablesFilter.Match>,
+        allMatches: Collection<ExpendablesFilter.Match>
+    ): ExpendablesFilter.ProcessResult {
+        return deleteAll(
+            targets.map { it as ExpendablesFilter.Match.Deletion },
+            gatewaySwitch,
+            allMatches
+        )
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/MobileQQFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/MobileQQFilter.kt
@@ -79,8 +79,15 @@ class MobileQQFilter @Inject constructor(
         }
     }
 
-    override suspend fun process(matches: Collection<ExpendablesFilter.Match>): ExpendablesFilter.ProcessResult {
-        return matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        targets: Collection<ExpendablesFilter.Match>,
+        allMatches: Collection<ExpendablesFilter.Match>
+    ): ExpendablesFilter.ProcessResult {
+        return deleteAll(
+            targets.map { it as ExpendablesFilter.Match.Deletion },
+            gatewaySwitch,
+            allMatches
+        )
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/OfflineCacheFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/OfflineCacheFilter.kt
@@ -69,8 +69,15 @@ class OfflineCacheFilter @Inject constructor(
         }
     }
 
-    override suspend fun process(matches: Collection<ExpendablesFilter.Match>): ExpendablesFilter.ProcessResult {
-        return matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        targets: Collection<ExpendablesFilter.Match>,
+        allMatches: Collection<ExpendablesFilter.Match>
+    ): ExpendablesFilter.ProcessResult {
+        return deleteAll(
+            targets.map { it as ExpendablesFilter.Match.Deletion },
+            gatewaySwitch,
+            allMatches
+        )
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/RecycleBinsFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/RecycleBinsFilter.kt
@@ -89,8 +89,15 @@ class RecycleBinsFilter @Inject constructor(
         }
     }
 
-    override suspend fun process(matches: Collection<ExpendablesFilter.Match>): ExpendablesFilter.ProcessResult {
-        return matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        targets: Collection<ExpendablesFilter.Match>,
+        allMatches: Collection<ExpendablesFilter.Match>
+    ): ExpendablesFilter.ProcessResult {
+        return deleteAll(
+            targets.map { it as ExpendablesFilter.Match.Deletion },
+            gatewaySwitch,
+            allMatches
+        )
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/TelegramFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/TelegramFilter.kt
@@ -132,8 +132,15 @@ class TelegramFilter @Inject constructor(
         }
     }
 
-    override suspend fun process(matches: Collection<ExpendablesFilter.Match>): ExpendablesFilter.ProcessResult {
-        return matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        targets: Collection<ExpendablesFilter.Match>,
+        allMatches: Collection<ExpendablesFilter.Match>
+    ): ExpendablesFilter.ProcessResult {
+        return deleteAll(
+            targets.map { it as ExpendablesFilter.Match.Deletion },
+            gatewaySwitch,
+            allMatches
+        )
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/ThreemaFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/ThreemaFilter.kt
@@ -62,8 +62,15 @@ class ThreemaFilter @Inject constructor(
         }
     }
 
-    override suspend fun process(matches: Collection<ExpendablesFilter.Match>): ExpendablesFilter.ProcessResult {
-        return matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        targets: Collection<ExpendablesFilter.Match>,
+        allMatches: Collection<ExpendablesFilter.Match>
+    ): ExpendablesFilter.ProcessResult {
+        return deleteAll(
+            targets.map { it as ExpendablesFilter.Match.Deletion },
+            gatewaySwitch,
+            allMatches
+        )
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/ThumbnailsFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/ThumbnailsFilter.kt
@@ -99,8 +99,15 @@ class ThumbnailsFilter @Inject constructor(
         }
     }
 
-    override suspend fun process(matches: Collection<ExpendablesFilter.Match>): ExpendablesFilter.ProcessResult {
-        return matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        targets: Collection<ExpendablesFilter.Match>,
+        allMatches: Collection<ExpendablesFilter.Match>
+    ): ExpendablesFilter.ProcessResult {
+        return deleteAll(
+            targets.map { it as ExpendablesFilter.Match.Deletion },
+            gatewaySwitch,
+            allMatches
+        )
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/ViberFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/ViberFilter.kt
@@ -67,8 +67,15 @@ class ViberFilter @Inject constructor(
         }
     }
 
-    override suspend fun process(matches: Collection<ExpendablesFilter.Match>): ExpendablesFilter.ProcessResult {
-        return matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        targets: Collection<ExpendablesFilter.Match>,
+        allMatches: Collection<ExpendablesFilter.Match>
+    ): ExpendablesFilter.ProcessResult {
+        return deleteAll(
+            targets.map { it as ExpendablesFilter.Match.Deletion },
+            gatewaySwitch,
+            allMatches
+        )
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/WeChatFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/WeChatFilter.kt
@@ -94,8 +94,15 @@ class WeChatFilter @Inject constructor(
         }
     }
 
-    override suspend fun process(matches: Collection<ExpendablesFilter.Match>): ExpendablesFilter.ProcessResult {
-        return matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        targets: Collection<ExpendablesFilter.Match>,
+        allMatches: Collection<ExpendablesFilter.Match>
+    ): ExpendablesFilter.ProcessResult {
+        return deleteAll(
+            targets.map { it as ExpendablesFilter.Match.Deletion },
+            gatewaySwitch,
+            allMatches
+        )
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/WebViewCacheFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/WebViewCacheFilter.kt
@@ -60,8 +60,15 @@ class WebViewCacheFilter @Inject constructor(
         }
     }
 
-    override suspend fun process(matches: Collection<ExpendablesFilter.Match>): ExpendablesFilter.ProcessResult {
-        return matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        targets: Collection<ExpendablesFilter.Match>,
+        allMatches: Collection<ExpendablesFilter.Match>
+    ): ExpendablesFilter.ProcessResult {
+        return deleteAll(
+            targets.map { it as ExpendablesFilter.Match.Deletion },
+            gatewaySwitch,
+            allMatches
+        )
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/WhatsAppBackupsFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/WhatsAppBackupsFilter.kt
@@ -58,8 +58,15 @@ class WhatsAppBackupsFilter @Inject constructor(
         }
     }
 
-    override suspend fun process(matches: Collection<ExpendablesFilter.Match>): ExpendablesFilter.ProcessResult {
-        return matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        targets: Collection<ExpendablesFilter.Match>,
+        allMatches: Collection<ExpendablesFilter.Match>
+    ): ExpendablesFilter.ProcessResult {
+        return deleteAll(
+            targets.map { it as ExpendablesFilter.Match.Deletion },
+            gatewaySwitch,
+            allMatches
+        )
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/WhatsAppReceivedFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/WhatsAppReceivedFilter.kt
@@ -95,8 +95,15 @@ class WhatsAppReceivedFilter @Inject constructor(
         }
     }
 
-    override suspend fun process(matches: Collection<ExpendablesFilter.Match>): ExpendablesFilter.ProcessResult {
-        return matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        targets: Collection<ExpendablesFilter.Match>,
+        allMatches: Collection<ExpendablesFilter.Match>
+    ): ExpendablesFilter.ProcessResult {
+        return deleteAll(
+            targets.map { it as ExpendablesFilter.Match.Deletion },
+            gatewaySwitch,
+            allMatches
+        )
     }
 
     @Reusable

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/WhatsAppSentFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/WhatsAppSentFilter.kt
@@ -89,8 +89,15 @@ class WhatsAppSentFilter @Inject constructor(
         }
     }
 
-    override suspend fun process(matches: Collection<ExpendablesFilter.Match>): ExpendablesFilter.ProcessResult {
-        return matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        targets: Collection<ExpendablesFilter.Match>,
+        allMatches: Collection<ExpendablesFilter.Match>
+    ): ExpendablesFilter.ProcessResult {
+        return deleteAll(
+            targets.map { it as ExpendablesFilter.Match.Deletion },
+            gatewaySwitch,
+            allMatches
+        )
     }
 
     @Reusable


### PR DESCRIPTION
* If deletion fails, check if the file actually exists, if it doesn't, treat it as success.
* Pass all matches to the deletion routine and check (against all data) for any other files that were affected. If a top level folder fails to delete, sub folders may still have been deleted because `APath.deleteAll()` traveres the tree.

Closes https://github.com/d4rken-org/sdmaid-se/issues/1391