### PR TITLE
Fix video preview creating cache files that are not being deleted if the app is killed

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/App.kt
+++ b/app/src/main/java/eu/darken/sdmse/App.kt
@@ -8,6 +8,7 @@ import coil.ImageLoaderFactory
 import dagger.hilt.android.HiltAndroidApp
 import eu.darken.sdmse.common.BuildConfigWrap
 import eu.darken.sdmse.common.BuildWrap
+import eu.darken.sdmse.common.coil.CoilTempFiles
 import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.debug.AutomaticBugReporter
@@ -28,6 +29,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 import kotlin.system.exitProcess
 
@@ -45,6 +47,7 @@ open class App : Application(), Configuration.Provider {
     @Inject lateinit var curriculumVitae: CurriculumVitae
     @Inject lateinit var updateService: UpdateService
     @Inject lateinit var theming: Theming
+    @Inject lateinit var coilTempFiles: CoilTempFiles
 
     private val logCatLogger = LogCatLogger()
 
@@ -83,6 +86,7 @@ open class App : Application(), Configuration.Provider {
 
         theming.setup()
 
+        appScope.launch { coilTempFiles.cleanUp() }
         Coil.setImageLoader(imageLoaderFactory)
 
         curriculumVitae.updateAppLaunch()

--- a/app/src/main/java/eu/darken/sdmse/common/coil/BitmapFetcher.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/coil/BitmapFetcher.kt
@@ -18,6 +18,7 @@ import javax.inject.Inject
 
 class BitmapFetcher @Inject constructor(
     @ApplicationContext private val context: Context,
+    private val coilTempFiles: CoilTempFiles,
     private val gatewaySwitch: GatewaySwitch,
     private val mimeTypeTool: MimeTypeTool,
     private val data: Request,
@@ -38,7 +39,10 @@ class BitmapFetcher @Inject constructor(
         val buffer = gatewaySwitch.read(target.lookedUp).buffer()
 
         return SourceResult(
-            ImageSource(buffer, context),
+            ImageSource(
+                buffer,
+                coilTempFiles.getBaseCachePath(),
+            ),
             mimeType,
             dataSource = DataSource.DISK
         )
@@ -46,6 +50,7 @@ class BitmapFetcher @Inject constructor(
 
     class Factory @Inject constructor(
         @ApplicationContext private val context: Context,
+        private val coilTempFiles: CoilTempFiles,
         private val gatewaySwitch: GatewaySwitch,
         private val mimeTypeTool: MimeTypeTool,
     ) : Fetcher.Factory<Request> {
@@ -54,7 +59,7 @@ class BitmapFetcher @Inject constructor(
             data: Request,
             options: Options,
             imageLoader: ImageLoader
-        ): Fetcher = BitmapFetcher(context, gatewaySwitch, mimeTypeTool, data, options)
+        ): Fetcher = BitmapFetcher(context, coilTempFiles, gatewaySwitch, mimeTypeTool, data, options)
     }
 
     data class Request(

--- a/app/src/main/java/eu/darken/sdmse/common/coil/CoilModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/coil/CoilModule.kt
@@ -52,7 +52,7 @@ class CoilModule {
         }
         dispatcher(
             dispatcherProvider.Default.limitedParallelism(
-                (Runtime.getRuntime().availableProcessors() - 1).coerceAtLeast(2)
+                (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(2)
             )
         )
     }.build()

--- a/app/src/main/java/eu/darken/sdmse/common/coil/CoilTempFiles.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/coil/CoilTempFiles.kt
@@ -1,0 +1,64 @@
+package eu.darken.sdmse.common.coil
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.sdmse.common.coroutine.DispatcherProvider
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.asLog
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.files.core.local.listFiles2
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class CoilTempFiles @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val dispatcherProvider: DispatcherProvider,
+) {
+
+    private val basePath: File = File(context.cacheDir, "coil")
+    private val legacyPath: File = context.cacheDir
+
+    suspend fun getBaseCachePath(): File {
+        val path = basePath.apply {
+            if (mkdirs()) log(TAG) { "Cache path was created: $this" }
+        }
+        return path
+    }
+
+    suspend fun cleanUp() = withContext(dispatcherProvider.IO + NonCancellable) {
+        try {
+            log(TAG) { "Checking for legacy files in $legacyPath" }
+            legacyPath.listFiles2()
+                .filter { NAME_REGEX.matches(it.name) }
+                .forEach {
+                    log(TAG) { "Deleting legacy tmp file: $it (${it.length()} Byte)" }
+                    if (it.delete()) log(TAG, VERBOSE) { "Deleted legacy file: $it" }
+                }
+        } catch (e: Exception) {
+            log(TAG, WARN) { "Failed to clean up legacy files $basePath:\n${e.asLog()}" }
+        }
+
+        if (!basePath.exists()) return@withContext
+
+        try {
+            log(TAG) { "Cleaning up $basePath" }
+            basePath.listFiles2().forEach {
+                log(TAG) { "Deleting orphaned tmp file: $it (${it.length()} Byte)" }
+                if (it.delete()) log(TAG, VERBOSE) { "Deleted: $it" }
+            }
+        } catch (e: Exception) {
+            log(TAG, WARN) { "Failed to clean up $basePath:\n${e.asLog()}" }
+        }
+    }
+
+    companion object {
+        private val TAG = logTag("Coil", "TempFiles")
+        internal val NAME_REGEX = Regex("""tmp\d+\.tmp""")
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/common/coil/PathPreviewFetcher.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/coil/PathPreviewFetcher.kt
@@ -27,6 +27,7 @@ import javax.inject.Inject
 
 class PathPreviewFetcher @Inject constructor(
     @ApplicationContext private val context: Context,
+    private val coilTempFiles: CoilTempFiles,
     private val generalSettings: GeneralSettings,
     private val gatewaySwitch: GatewaySwitch,
     private val mimeTypeTool: MimeTypeTool,
@@ -56,7 +57,10 @@ class PathPreviewFetcher @Inject constructor(
             mimeType.startsWith("image") || mimeType.startsWith("video") -> {
                 val buffer = gatewaySwitch.read(data.lookedUp).buffer()
                 SourceResult(
-                    ImageSource(buffer, context),
+                    ImageSource(
+                        buffer,
+                        coilTempFiles.getBaseCachePath(),
+                    ),
                     mimeType,
                     dataSource = DataSource.DISK
                 )
@@ -91,6 +95,7 @@ class PathPreviewFetcher @Inject constructor(
 
     class Factory @Inject constructor(
         @ApplicationContext private val context: Context,
+        private val coilTempFiles: CoilTempFiles,
         private val generalSettings: GeneralSettings,
         private val gatewaySwitch: GatewaySwitch,
         private val mimeTypeTool: MimeTypeTool,
@@ -100,7 +105,15 @@ class PathPreviewFetcher @Inject constructor(
             data: APathLookup<*>,
             options: Options,
             imageLoader: ImageLoader
-        ): Fetcher = PathPreviewFetcher(context, generalSettings, gatewaySwitch, mimeTypeTool, data, options)
+        ): Fetcher = PathPreviewFetcher(
+            context,
+            coilTempFiles,
+            generalSettings,
+            gatewaySwitch,
+            mimeTypeTool,
+            data,
+            options,
+        )
     }
 }
 

--- a/app/src/test/java/eu/darken/sdmse/common/coil/CoilTempFilesTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/common/coil/CoilTempFilesTest.kt
@@ -1,0 +1,16 @@
+package eu.darken.sdmse.common.coil
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+
+class CoilTempFilesTest : BaseTest() {
+
+    @Test fun `legacy cleanup tmp file path matching`() {
+        CoilTempFiles.NAME_REGEX.matches("tmp9050482114132890229.tmp") shouldBe true
+        CoilTempFiles.NAME_REGEX.matches("9050482114132890229.tmp") shouldBe false
+        CoilTempFiles.NAME_REGEX.matches("tmp9050482114132890229.other") shouldBe false
+        CoilTempFiles.NAME_REGEX.matches("tmp90504229.tmp") shouldBe true
+    }
+}


### PR DESCRIPTION
When SD Maid generates thumbnails for large videos via coil, then large `.tmp` files can be created.
If SD Maid is killed before thumbnail generation has finished, then these `.tmp` can stay around until manually deleted.

This PR changes the path where these files are stored, and deletes any orphaned files `.tmp` files on the next app launch.

Also see https://github.com/coil-kt/coil/issues/2550

Thanks to [Martin](https://discord.com/channels/548521543039189022/1047079350157193236/1294625234447765547) for pointing this out :pray: 