### PR TITLE
Catch new NPE when querying app sizes on Android 15

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/PkgOps.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/PkgOps.kt
@@ -20,6 +20,7 @@ import eu.darken.sdmse.common.ModeUnavailableException
 import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.DEBUG
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
@@ -486,6 +487,7 @@ class PkgOps @Inject constructor(
         installId: Installed.InstallId,
         storageUUID: UUID = StorageManager.UUID_DEFAULT
     ): SizeStats? = try {
+        log(TAG, VERBOSE) { "querySizeStats($installId,$storageUUID)" }
         val stats = storageStatsManager.queryStatsForPackage(
             storageUUID,
             installId.pkgId.name,
@@ -499,8 +501,11 @@ class PkgOps @Inject constructor(
                 stats.externalCacheBytes
             } else null,
             dataBytes = stats.dataBytes,
-        )
+        ).also { log(TAG, VERBOSE) { "querySizeStats($installId,$storageUUID) -> $it" } }
     } catch (e: NameNotFoundException) {
+        null
+    } catch (e: Exception) {
+        log(TAG, ERROR) { "Failed to querySizeStats for $installId: ${e.asLog()}" }
         null
     }
 


### PR DESCRIPTION
Reported for a Pixel 8 Pro @ Android 15.
Couldn't reproduce myself

According to the log only happened to one app (SnapChat), but several apps before that didn't throw an NPE.

```java
java.lang.NullPointerException
	at android.os.Parcel.createExceptionOrNull(Parcel.java:3248)
	at android.os.Parcel.createException(Parcel.java:3226)
	at android.os.Parcel.readException(Parcel.java:3209)
	at android.os.Parcel.readException(Parcel.java:3151)
	at android.app.usage.IStorageStatsManager$Stub$Proxy.queryStatsForPackage(IStorageStatsManager.java:505)
	at android.app.usage.StorageStatsManager.queryStatsForPackage(StorageStatsManager.java:211)
	at eu.darken.sdmse.appcontrol.core.AppControl.toAppInfo(Unknown Source:268)
	at eu.darken.sdmse.appcontrol.core.AppControl.performScan(Unknown Source:351)
	at eu.darken.sdmse.appcontrol.core.AppControl.submit(Unknown Source:216)
	at eu.darken.sdmse.main.core.taskmanager.TaskManager$execute$2$result$1.invokeSuspend(Unknown Source:32)
	at eu.darken.sdmse.main.core.taskmanager.TaskManager$execute$2$result$1.invoke(Unknown Source:10)
	at kotlin.ResultKt.useRes(Unknown Source:93)
	at eu.darken.sdmse.common.sharedresource.HasSharedResource.useRes(Unknown Source:4)
	at eu.darken.sdmse.main.core.taskmanager.TaskManager.access$execute(Unknown Source:239)
	at eu.darken.sdmse.main.core.taskmanager.TaskManager$submit$job$1.invokeSuspend(Unknown Source:133)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(Unknown Source:8)
	at kotlinx.coroutines.UndispatchedCoroutine.afterResume(Unknown Source:53)
	at kotlinx.coroutines.AbstractCoroutine.resumeWith(Unknown Source:22)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(Unknown Source:31)
	at kotlinx.coroutines.DispatchedTask.run(Unknown Source:112)
	at androidx.work.Worker$2.run(Unknown Source:53)
	at kotlinx.coroutines.scheduling.TaskImpl.run(Unknown Source:2)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(Unknown Source:95)
Caused by: android.os.RemoteException: Remote stack trace:
	at java.io.File.<init>(File.java:288)
	at com.android.server.usage.StorageStatsService.computeAppStatsByDataTypes(StorageStatsService.java:960)
	at com.android.server.usage.StorageStatsService.queryStatsForUid(StorageStatsService.java:456)
	at com.android.server.usage.StorageStatsService.queryStatsForPackage(StorageStatsService.java:383)
	at android.app.usage.IStorageStatsManager$Stub.onTransact(IStorageStatsManager.java:265)
```