### PR TITLE
IO: Fix files not being deleted in `Android/data` despite using Shizuku/Root

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalGateway.kt
@@ -731,15 +731,13 @@ class LocalGateway @Inject constructor(
                 javaFile.exists() -> false
                 // Does it not exist or do we lack permission? Also see `LocalGateway.exists(...)`
                 else -> when {
-                    // We should be able to access files, really didn't exist, not an access issue
-                    javaFile.parentFile?.canExecute() == true -> true
                     // On Android 12+ Android/data isn't accessible anymore via normal java file access.
                     hasApiLevel(32) && storageEnvironment.publicDataDirs.any { it.isAncestorOf(path) } -> false
                     // If the file path is on public storage, and it wasn't Android/data then, assume true
                     else -> storageEnvironment.externalDirs
                         .firstOrNull { it.isAncestorOf(path) }
                         ?.asFile()
-                        ?.canRead() ?: false
+                        ?.canWrite() ?: false
                 }
             }
 


### PR DESCRIPTION
The scan, e.g. listfiles or lookup, would use a different logic to check what access level is needed. Example:
In the CorpseFinder, the scan would use `listFiles` on `Android/data` and the `Mode.AUTO` would resolve to `Mode.ADB` or `Mode.ROOT`. Either mode can see files in `Android/data` and return good results. But the deletion would always hit the `javaFile.parentFile?.canExecute() == true -> true` case and resolve `Mode.AUTO` to `Mode.NORMAL`, i.e. try normal access. Normal access wouldn't see the file in `Android/data` and then assume that it had already been deleted... :(