### PR TITLE
CorpseFinder: Scan `Android/data` if Shizuku is available

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/PublicDataCorpseFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/PublicDataCorpseFilter.kt
@@ -45,8 +45,8 @@ class PublicDataCorpseFilter @Inject constructor(
 
         val gateway = gatewaySwitch.getGateway(APath.PathType.LOCAL) as LocalGateway
 
-        if (hasApiLevel(33) && !gateway.hasRoot()) {
-            log(TAG) { "LocalGateway has no root, skipping public data on Android 13" }
+        if (hasApiLevel(33) && !gateway.hasRoot() && !gateway.hasShizuku()) {
+            log(TAG) { "LocalGateway has no root/adb, skipping public data on Android 13+" }
             return emptySet()
         }
 


### PR DESCRIPTION
ADB level privileges are enough to scan `Android/data`, root isn't necessary.