### PR TITLE
AppCleaner/CorpseFinder: Improve matching for `SHAREit` et al.

### DIFF
--- a/app/src/main/assets/clutter/db_clutter_markers.json
+++ b/app/src/main/assets/clutter/db_clutter_markers.json
@@ -3801,11 +3801,21 @@
   "pkgs": ["com.uei.lg.quicksetsdk.lite"],
   "mrks": [{"loc": "SDCARD", "path": "QuicksetLite Setup"}]
 }, {
-  "pkgs": ["com.lenovo.anyshare.gps", "com.lenovo.anyshare"],
+  "pkgs": ["com.lenovo.anyshare.gps", "com.lenovo.anyshare", "shareit.lite", "shareit.premium"],
   "mrks": [
 	{"loc": "SDCARD", "path": "QieZi"},
 	{"loc": "SDCARD", "path": ".SHAREit"},
-	{"loc": "SDCARD", "path": "SHAREit", "flags": ["keeper"]}
+	{"loc": "SDCARD", "path": "SHAREit", "flags": ["keeper"]},
+	{"loc": "SDCARD", "path": "SHAREit_Lite"},
+	{"loc": "SDCARD", "path": "SHAREit Lite"},
+	{"loc": "SDCARD", "path": "SHAREit Premium"},
+	{"loc": "SDCARD", "path": "Android/cache"},
+	{"loc": "SDCARD", "path": "Android/AndroidSystemProperties"},
+	{"loc": "SDCARD", "path": "com.android.settings"},
+	{"loc": "SDCARD", "path": "sepolicy_extends"},
+	{"loc": "SDCARD", "path": ".system_config"},
+	{"loc": "SDCARD", "path": "DCIM/.shareit_beyla_ids.cfg"},
+	{"loc": "SDCARD", "path": "DCIM/.sys_install_s_time.cfg"}
   ]
 }, {
   "pkgs": ["com.tencent.game.rhythmmaster"],
@@ -10996,9 +11006,6 @@
 }, {
   "pkgs": ["com.weitetech.WiiWatchPro"],
   "mrks": [{"loc": "SDCARD", "path": "WiiWatch_Files_log"}]
-}, {
-  "pkgs": ["shareit.lite"],
-  "mrks": [{"loc": "SDCARD", "path": "SHAREit_Lite"}]
 }, {
   "pkgs": ["com.media.bestrecorder.audiorecorder"],
   "mrks": [{"loc": "SDCARD", "path": "Recorders", "flags": ["keeper", "common"]}]

--- a/app/src/main/assets/expendables/db_advertisement_files.json
+++ b/app/src/main/assets/expendables/db_advertisement_files.json
@@ -147,6 +147,23 @@
 		  ]
 		}
 	  ]
+	}, {
+	  "packages": [
+		"com.lenovo.anyshare.gps",
+		"com.lenovo.anyshare",
+		"shareit.lite",
+		"shareit.premium"
+	  ],
+	  "fileFilter": [
+		{
+		  "locations": ["PUBLIC_DATA"],
+		  "contains": [
+			"/files/mb/",
+			"/files/cooperation/",
+			"/files/.ad/"
+		  ]
+		}
+	  ]
 	}
   ]
 }

--- a/app/src/main/assets/expendables/db_hidden_caches_files.json
+++ b/app/src/main/assets/expendables/db_hidden_caches_files.json
@@ -1340,6 +1340,30 @@
 		  ]
 		}
 	  ]
+	}, {
+	  "packages": [
+		"com.lenovo.anyshare.gps",
+		"com.lenovo.anyshare",
+		"shareit.lite",
+		"shareit.premium"
+	  ],
+	  "fileFilter": [
+		{
+		  "locations": ["PUBLIC_DATA"],
+		  "contains": [
+			"/files/SHAREit/.caches/",
+			"/files/SHAREit Lite/.caches/",
+			"/files/SHAREit Premium/.caches/"
+		  ]
+		}, {
+		  "locations": ["SDCARD"],
+		  "startsWith": [
+			"SHAREit/.caches/",
+			"SHAREit Lite/.caches/",
+			"SHAREit Premium/.caches/"
+		  ]
+		}
+	  ]
 	}
   ]
 }

--- a/app/src/main/assets/expendables/db_offline_cache_files.json
+++ b/app/src/main/assets/expendables/db_offline_cache_files.json
@@ -84,6 +84,30 @@
 		  "patterns": ["^\\.estrongs/\\.app_icon_back/.+?$"]
 		}
 	  ]
+	}, {
+	  "packages": [
+		"com.lenovo.anyshare.gps",
+		"com.lenovo.anyshare",
+		"shareit.lite",
+		"shareit.premium"
+	  ],
+	  "fileFilter": [
+		{
+		  "locations": ["PUBLIC_DATA"],
+		  "contains": [
+			"/files/SHAREit/.offline/",
+			"/files/SHAREit Lite/.offline/",
+			"/files/SHAREit Premium/.offline/"
+		  ]
+		}, {
+		  "locations": ["SDCARD"],
+		  "startsWith": [
+			"SHAREit/.offline/",
+			"SHAREit Lite/.offline/",
+			"SHAREit Premium/.offline/"
+		  ]
+		}
+	  ]
 	}
   ]
 }

--- a/app/src/main/assets/expendables/db_thumbnail_files.json
+++ b/app/src/main/assets/expendables/db_thumbnail_files.json
@@ -87,6 +87,36 @@
 		  "patterns": ["^com\\.viber\\.voip/files/User photos/\\.thumbnails/.+?$"]
 		}
 	  ]
+	}, {
+	  "packages": [
+		"com.lenovo.anyshare.gps",
+		"com.lenovo.anyshare",
+		"shareit.lite",
+		"shareit.premium"
+	  ],
+	  "fileFilter": [
+		{
+		  "locations": ["PUBLIC_DATA"],
+		  "contains": [
+			"/files/SHAREit/.thumbnails/",
+			"/files/SHAREit Lite/.thumbnails/",
+			"/files/SHAREit Premium/.thumbnails/",
+			"/files/SHAREit/.mediathumbs/",
+			"/files/SHAREit Lite/.mediathumbs/",
+			"/files/SHAREit Premium/.mediathumbs/"
+		  ]
+		}, {
+		  "locations": ["SDCARD"],
+		  "startsWith": [
+			"SHAREit/.thumbnails/",
+			"SHAREit Lite/.thumbnails/",
+			"SHAREit Premium/.thumbnails/",
+			"SHAREit/.mediathumbs/",
+			"SHAREit Lite/.mediathumbs/",
+			"SHAREit Premium/.mediathumbs/"
+		  ]
+		}
+	  ]
 	}
   ]
 }

--- a/app/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/SdcardCorpseFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/SdcardCorpseFilter.kt
@@ -15,23 +15,45 @@ import eu.darken.sdmse.common.clutter.ClutterRepo
 import eu.darken.sdmse.common.clutter.Marker
 import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.Bugs
-import eu.darken.sdmse.common.debug.logging.Logging.Priority.*
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
-import eu.darken.sdmse.common.files.*
+import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.files.APathGateway
+import eu.darken.sdmse.common.files.GatewaySwitch
+import eu.darken.sdmse.common.files.asFile
+import eu.darken.sdmse.common.files.canRead
+import eu.darken.sdmse.common.files.canWrite
+import eu.darken.sdmse.common.files.exists
+import eu.darken.sdmse.common.files.isAncestorOf
+import eu.darken.sdmse.common.files.isDirectory
+import eu.darken.sdmse.common.files.listFiles
 import eu.darken.sdmse.common.files.local.LocalPath
 import eu.darken.sdmse.common.files.local.toLocalPath
+import eu.darken.sdmse.common.files.lookup
+import eu.darken.sdmse.common.files.walk
 import eu.darken.sdmse.common.forensics.AreaInfo
 import eu.darken.sdmse.common.forensics.FileForensics
 import eu.darken.sdmse.common.forensics.Owner
 import eu.darken.sdmse.common.forensics.OwnerInfo
 import eu.darken.sdmse.common.pkgs.PkgRepo
 import eu.darken.sdmse.common.pkgs.isInstalled
-import eu.darken.sdmse.common.progress.*
+import eu.darken.sdmse.common.progress.Progress
+import eu.darken.sdmse.common.progress.increaseProgress
+import eu.darken.sdmse.common.progress.updateProgressCount
+import eu.darken.sdmse.common.progress.updateProgressPrimary
+import eu.darken.sdmse.common.progress.updateProgressSecondary
 import eu.darken.sdmse.corpsefinder.core.Corpse
 import eu.darken.sdmse.corpsefinder.core.CorpseFinderSettings
 import eu.darken.sdmse.corpsefinder.core.RiskLevel
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.flow.toSet
 import javax.inject.Inject
 import javax.inject.Provider
 
@@ -224,7 +246,9 @@ class SdcardCorpseFilter @Inject constructor(
             when {
                 canidate.isOwned -> {
                     aliveItems.add(canidate)
-                    log(TAG, VERBOSE) { "Alive item, owner installed (can block other corpses): ${canidate.item}" }
+                    log(TAG, VERBOSE) {
+                        "Alive item, owner installed (can block other corpses): ${canidate.item} -> ${canidate.owners}"
+                    }
                 }
 
                 canidate.isKeeper && !includeRiskKeeper -> {

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/AdvertisementFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/AdvertisementFilterTest.kt
@@ -292,4 +292,22 @@ class AdvertisementFilterTest : BaseFilterTest() {
 
         confirm(create())
     }
+
+    @Test fun `SHAREit ads`() = runTest {
+        val pkgs = setOf(
+            "com.lenovo.anyshare.gps",
+            "com.lenovo.anyshare",
+            "shareit.lite",
+            "shareit.premium",
+        )
+        pkgs.forEach {
+            neg(it, PUBLIC_DATA, "$it/files/cooperation")
+            pos(it, PUBLIC_DATA, "$it/files/cooperation/anything")
+            neg(it, PUBLIC_DATA, "$it/files/.ad")
+            pos(it, PUBLIC_DATA, "$it/files/.ad/anything")
+            neg(it, PUBLIC_DATA, "$it/files/mb")
+            pos(it, PUBLIC_DATA, "$it/files/mb/anything")
+        }
+        confirm(create())
+    }
 }

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/HiddenFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/HiddenFilterTest.kt
@@ -2549,4 +2549,28 @@ class HiddenFilterTest : BaseFilterTest() {
 
         confirm(create())
     }
+
+    @Test fun `SHAREit caches`() = runTest {
+        val pkgs = setOf(
+            "com.lenovo.anyshare.gps",
+            "com.lenovo.anyshare",
+            "shareit.lite",
+            "shareit.premium",
+        )
+        pkgs.forEach {
+            neg(it, PUBLIC_DATA, "$it/files/SHAREit/.caches")
+            pos(it, PUBLIC_DATA, "$it/files/SHAREit/.caches/anything")
+            neg(it, PUBLIC_DATA, "$it/files/SHAREit Lite/.caches")
+            pos(it, PUBLIC_DATA, "$it/files/SHAREit Lite/.caches/anything")
+            neg(it, PUBLIC_DATA, "$it/files/SHAREit Premium/.caches")
+            pos(it, PUBLIC_DATA, "$it/files/SHAREit Premium/.caches/anything")
+            neg(it, SDCARD, "SHAREit/.caches")
+            pos(it, SDCARD, "SHAREit/.caches/anything")
+            neg(it, SDCARD, "SHAREit Lite/.caches")
+            pos(it, SDCARD, "SHAREit Lite/.caches/anything")
+            neg(it, SDCARD, "SHAREit Premium/.caches")
+            pos(it, SDCARD, "SHAREit Premium/.caches/anything")
+        }
+        confirm(create())
+    }
 }

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/OfflineCacheFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/OfflineCacheFilterTest.kt
@@ -161,4 +161,28 @@ class OfflineCacheFilterTest : BaseFilterTest() {
         }
         confirm(create())
     }
+
+    @Test fun `SHAREit offline`() = runTest {
+        val pkgs = setOf(
+            "com.lenovo.anyshare.gps",
+            "com.lenovo.anyshare",
+            "shareit.lite",
+            "shareit.premium",
+        )
+        pkgs.forEach {
+            neg(it, PUBLIC_DATA, "$it/files/SHAREit/.offline")
+            pos(it, PUBLIC_DATA, "$it/files/SHAREit/.offline/anything")
+            neg(it, PUBLIC_DATA, "$it/files/SHAREit Lite/.offline")
+            pos(it, PUBLIC_DATA, "$it/files/SHAREit Lite/.offline/anything")
+            neg(it, PUBLIC_DATA, "$it/files/SHAREit Premium/.offline")
+            pos(it, PUBLIC_DATA, "$it/files/SHAREit Premium/.offline/anything")
+            neg(it, SDCARD, "SHAREit/.offline")
+            pos(it, SDCARD, "SHAREit/.offline/anything")
+            neg(it, SDCARD, "SHAREit Lite/.offline")
+            pos(it, SDCARD, "SHAREit Lite/.offline/anything")
+            neg(it, SDCARD, "SHAREit Premium/.offline")
+            pos(it, SDCARD, "SHAREit Premium/.offline/anything")
+        }
+        confirm(create())
+    }
 }

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/ThumbnailsFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/ThumbnailsFilterTest.kt
@@ -228,4 +228,40 @@ class ThumbnailsFilterTest : BaseFilterTest() {
         neg("com.viber.voip", PRIVATE_DATA, "com.viber.voip/Cache/.thumbnails/$rngString")
         confirm(create())
     }
+
+    @Test fun `SHAREit thumbs`() = runTest {
+        val pkgs = setOf(
+            "com.lenovo.anyshare.gps",
+            "com.lenovo.anyshare",
+            "shareit.lite",
+            "shareit.premium",
+        )
+        pkgs.forEach {
+            neg(it, PUBLIC_DATA, "$it/files/SHAREit/.thumbnails")
+            pos(it, PUBLIC_DATA, "$it/files/SHAREit/.thumbnails/anything")
+            neg(it, PUBLIC_DATA, "$it/files/SHAREit Lite/.thumbnails")
+            pos(it, PUBLIC_DATA, "$it/files/SHAREit Lite/.thumbnails/anything")
+            neg(it, PUBLIC_DATA, "$it/files/SHAREit Premium/.thumbnails")
+            pos(it, PUBLIC_DATA, "$it/files/SHAREit Premium/.thumbnails/anything")
+            neg(it, PUBLIC_DATA, "$it/files/SHAREit/.mediathumbs")
+            pos(it, PUBLIC_DATA, "$it/files/SHAREit/.mediathumbs/anything")
+            neg(it, PUBLIC_DATA, "$it/files/SHAREit Lite/.mediathumbs")
+            pos(it, PUBLIC_DATA, "$it/files/SHAREit Lite/.mediathumbs/anything")
+            neg(it, PUBLIC_DATA, "$it/files/SHAREit Premium/.mediathumbs")
+            pos(it, PUBLIC_DATA, "$it/files/SHAREit Premium/.mediathumbs/anything")
+            neg(it, SDCARD, "SHAREit/.thumbnails")
+            pos(it, SDCARD, "SHAREit/.thumbnails/anything")
+            neg(it, SDCARD, "SHAREit Lite/.thumbnails")
+            pos(it, SDCARD, "SHAREit Lite/.thumbnails/anything")
+            neg(it, SDCARD, "SHAREit Premium/.thumbnails")
+            pos(it, SDCARD, "SHAREit Premium/.thumbnails/anything")
+            neg(it, SDCARD, "SHAREit/.mediathumbs")
+            pos(it, SDCARD, "SHAREit/.mediathumbs/anything")
+            neg(it, SDCARD, "SHAREit Lite/.mediathumbs")
+            pos(it, SDCARD, "SHAREit Lite/.mediathumbs/anything")
+            neg(it, SDCARD, "SHAREit Premium/.mediathumbs")
+            pos(it, SDCARD, "SHAREit Premium/.mediathumbs/anything")
+        }
+        confirm(create())
+    }
 }


### PR DESCRIPTION
Dirty dirty app... ಠ_ಠ

```
drwxrws--- 2 u0_a257  media_rw     3452 2024-11-06 15:26 .SHAREit
drwxrws--- 3 u0_a257  media_rw     3452 2024-11-06 15:26 DCIM
drwxrws--- 2 u0_a257  media_rw     3452 2024-11-06 15:26 com.android.settings
drwxrws--x 6 media_rw media_rw     3452 2024-11-06 15:26 Android
drwxrws--- 3 u0_a257  media_rw     3452 2024-11-06 15:26 sepolicy_extends
drwxrws--- 3 u0_a257  media_rw     3452 2024-11-06 15:26 .system_config
```

```
Android/AndroidSystemProperties
Android/cache
Android/cache/.system_cache
```

```
.system_config/
.system_config/system_apps
.system_config/system_apps/system_apps_config.xml
```

```
sepolicy_extends/
sepolicy_extends/system
sepolicy_extends/system/sepolicy
```

```
DCIM/.shareit_beyla_ids.cfg
DCIM/.shareit_lite_install.cfg
```

Via Discord report: https://discord.com/channels/548521543039189022/1047079350157193236/1303414682492735632