### PR TITLE
CorpseFinder: Fix detection of nested corpses on public storage

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/SdcardCorpseFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/SdcardCorpseFilter.kt
@@ -133,7 +133,7 @@ class SdcardCorpseFilter @Inject constructor(
                     .filter { area ->
                         // Only makes sense to process this nested marker if the parent actually exists
                         val areaContent = topLevelContent[area]!!
-                        areaContent.any { it.item.segments.isAncestorOf(marker.segments) }
+                        areaContent.any { it.areaInfo.prefixFreeSegments.isAncestorOf(marker.segments) }
                     }
                     .map { determineNestedCandidates(it, marker) }
                     .flatten()


### PR DESCRIPTION
The marker segments are prefix-free, so we also need to compare it with the prefix-free area information, otherwise we get no match. e.g.

Before: `{/storage/emulated/0/Android}.isAncestorOf(Android/cache)` returned false

Now: `{Android}.isAncestorOf(Android/cache)` returns true