### PR TITLE
AppCleaner: Faster deletion when using Root/Shizuku on directories with many files

### DIFF
--- a/app-common-io/src/main/aidl/eu/darken/sdmse/common/files/local/ipc/FileOpsConnection.aidl
+++ b/app-common-io/src/main/aidl/eu/darken/sdmse/common/files/local/ipc/FileOpsConnection.aidl
@@ -21,7 +21,7 @@ interface FileOpsConnection {
 
     boolean exists(in LocalPath path);
 
-    boolean delete(in LocalPath path);
+    boolean delete(in LocalPath path, boolean recursive);
 
     RemoteInputStream listFilesStream(in LocalPath path);
 

--- a/app-common-io/src/main/aidl/eu/darken/sdmse/common/files/local/ipc/FileOpsConnection.aidl
+++ b/app-common-io/src/main/aidl/eu/darken/sdmse/common/files/local/ipc/FileOpsConnection.aidl
@@ -21,7 +21,7 @@ interface FileOpsConnection {
 
     boolean exists(in LocalPath path);
 
-    boolean delete(in LocalPath path, boolean recursive);
+    boolean delete(in LocalPath path, boolean recursive, boolean dryRun);
 
     RemoteInputStream listFilesStream(in LocalPath path);
 

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathExtensions.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathExtensions.kt
@@ -107,13 +107,18 @@ suspend fun <T : APath> T.createDirIfNecessary(gateway: APathGateway<T, out APat
     return this
 }
 
-suspend fun <T : APath> T.delete(gateway: APathGateway<T, out APathLookup<T>, out APathLookupExtended<T>>) {
-    gateway.delete(this)
-    log(VERBOSE) { "APath.delete(): Deleted $this" }
+suspend fun <T : APath> T.delete(
+    gateway: APathGateway<T, out APathLookup<T>, out APathLookupExtended<T>>,
+    recursive: Boolean = false,
+) {
+    gateway.delete(
+        this,
+        recursive = recursive
+    )
+    log(VERBOSE) { "APath.delete(recursive=$recursive): Deleted $this" }
 }
 
-// TODO move this into the gateways?
-suspend fun <T : APath> T.deleteAll(
+suspend fun <T : APath> T.deleteWalk(
     gateway: APathGateway<T, out APathLookup<T>, out APathLookupExtended<T>>,
     filter: (APathLookup<*>) -> Boolean = { true }
 ) {
@@ -122,7 +127,7 @@ suspend fun <T : APath> T.deleteAll(
 
         if (lookup.isDirectory) {
             gateway.listFiles(this).forEach {
-                it.deleteAll(gateway, filter) // Recursion enter
+                it.deleteWalk(gateway, filter) // Recursion enter
             }
         }
 
@@ -141,7 +146,7 @@ suspend fun <T : APath> T.deleteAll(
     }
 
     // Recursion exit
-    this.delete(gateway)
+    this.delete(gateway, recursive = false)
 }
 
 suspend fun <T : APath> T.file(

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathGateway.kt
@@ -54,7 +54,7 @@ interface APathGateway<
 
     suspend fun file(path: P, readWrite: Boolean): FileHandle
 
-    suspend fun delete(path: P)
+    suspend fun delete(path: P, recursive: Boolean)
 
     suspend fun createSymlink(linkPath: P, targetPath: P): Boolean
 

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathLookupExtensions.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathLookupExtensions.kt
@@ -1,7 +1,5 @@
 package eu.darken.sdmse.common.files
 
-import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
-import eu.darken.sdmse.common.debug.logging.log
 import kotlinx.coroutines.flow.Flow
 import okio.FileHandle
 
@@ -30,16 +28,17 @@ suspend fun <P : APath, PL : APathLookup<P>> PL.exists(
 ): Boolean = lookedUp.exists(gateway)
 
 suspend fun <P : APath, PL : APathLookup<P>, PLE : APathLookupExtended<P>> PL.delete(
-    gateway: APathGateway<P, PL, PLE>
-) {
-    lookedUp.delete(gateway)
-    log(VERBOSE) { "APath.delete(): Deleted $this" }
-}
+    gateway: APathGateway<P, PL, PLE>,
+    recursive: Boolean = false,
+) = lookedUp.delete(
+    gateway,
+    recursive = recursive
+)
 
-suspend fun <P : APath, PL : APathLookup<P>> PL.deleteAll(
+suspend fun <P : APath, PL : APathLookup<P>> PL.deletewalk(
     gateway: APathGateway<P, out APathLookup<P>, out APathLookupExtended<P>>,
     filter: (APathLookup<*>) -> Boolean = { true }
-) = lookedUp.deleteAll(gateway, filter)
+) = lookedUp.deleteWalk(gateway, filter)
 
 suspend fun <P : APath, PL : APathLookup<P>> PL.file(
     gateway: APathGateway<P, out APathLookup<P>, out APathLookupExtended<P>>,

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/GatewaySwitch.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/GatewaySwitch.kt
@@ -182,8 +182,8 @@ class GatewaySwitch @Inject constructor(
         return useGateway(path) { file(path, readWrite) }
     }
 
-    override suspend fun delete(path: APath) {
-        return useGateway(path) { delete(path) }
+    override suspend fun delete(path: APath, recursive: Boolean) {
+        return useGateway(path) { delete(path, recursive = recursive) }
     }
 
     override suspend fun createSymlink(linkPath: APath, targetPath: APath): Boolean {

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/FileOpsClient.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/FileOpsClient.kt
@@ -129,8 +129,8 @@ class FileOpsClient @AssistedInject constructor(
         throw e.unwrapPropagation()
     }
 
-    fun delete(path: LocalPath, recursive: Boolean): Boolean = try {
-        fileOpsConnection.delete(path, recursive)
+    fun delete(path: LocalPath, recursive: Boolean, dryRun: Boolean): Boolean = try {
+        fileOpsConnection.delete(path, recursive, dryRun)
     } catch (e: Exception) {
         throw e.unwrapPropagation()
     }

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/FileOpsClient.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/FileOpsClient.kt
@@ -129,8 +129,8 @@ class FileOpsClient @AssistedInject constructor(
         throw e.unwrapPropagation()
     }
 
-    fun delete(path: LocalPath): Boolean = try {
-        fileOpsConnection.delete(path)
+    fun delete(path: LocalPath, recursive: Boolean): Boolean = try {
+        fileOpsConnection.delete(path, recursive)
     } catch (e: Exception) {
         throw e.unwrapPropagation()
     }

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/FileOpsHost.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/FileOpsHost.kt
@@ -201,11 +201,13 @@ class FileOpsHost @Inject constructor(
         throw e.wrapToPropagate()
     }
 
-    override fun delete(path: LocalPath): Boolean = try {
-        if (Bugs.isTrace) log(TAG, VERBOSE) { "exists($path)..." }
-        path.asFile().delete()
+    override fun delete(path: LocalPath, recursive: Boolean): Boolean = try {
+        log(TAG, VERBOSE) { "delete($path,=recursive$recursive)..." }
+        path.asFile().run {
+            if (recursive) deleteRecursively() else delete()
+        }
     } catch (e: Exception) {
-        log(TAG, ERROR) { "delete(path=$path) failed\n${e.asLog()}" }
+        log(TAG, ERROR) { "delete(path=$path,recursive=$recursive) failed\n${e.asLog()}" }
         throw e.wrapToPropagate()
     }
 
@@ -239,12 +241,6 @@ class FileOpsHost @Inject constructor(
     } catch (e: Exception) {
         log(TAG, ERROR) { "setModifiedAt(path=$path, ownership=$ownership) failed\n${e.asLog()}" }
         throw e.wrapToPropagate()
-    }
-
-    // Not all exception can be passed through the binder
-    // See Parcel.writeException(...)
-    private fun wrapPropagating(e: Exception): Exception {
-        return if (e is RuntimeException) e else RuntimeException(e)
     }
 
     companion object {

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/FileOpsHost.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/FileOpsHost.kt
@@ -201,13 +201,17 @@ class FileOpsHost @Inject constructor(
         throw e.wrapToPropagate()
     }
 
-    override fun delete(path: LocalPath, recursive: Boolean): Boolean = try {
-        log(TAG, VERBOSE) { "delete($path,=recursive$recursive)..." }
+    override fun delete(path: LocalPath, recursive: Boolean, dryRun: Boolean): Boolean = try {
+        log(TAG, VERBOSE) { "delete($path,recursive=$recursive,dryRun=$dryRun)..." }
         path.asFile().run {
-            if (recursive) deleteRecursively() else delete()
+            when {
+                dryRun -> canWrite()
+                recursive -> deleteRecursively()
+                else -> delete()
+            }
         }
     } catch (e: Exception) {
-        log(TAG, ERROR) { "delete(path=$path,recursive=$recursive) failed\n${e.asLog()}" }
+        log(TAG, ERROR) { "delete(path=$path,recursive=$recursive,dryRun=$dryRun) failed\n${e.asLog()}" }
         throw e.wrapToPropagate()
     }
 

--- a/app/src/main/java/eu/darken/sdmse/analyzer/core/Analyzer.kt
+++ b/app/src/main/java/eu/darken/sdmse/analyzer/core/Analyzer.kt
@@ -27,7 +27,7 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.GatewaySwitch
-import eu.darken.sdmse.common.files.deleteAll
+import eu.darken.sdmse.common.files.delete
 import eu.darken.sdmse.common.files.filterDistinctRoots
 import eu.darken.sdmse.common.files.isAncestorOf
 import eu.darken.sdmse.common.files.matches
@@ -188,7 +188,7 @@ class Analyzer @Inject constructor(
             .forEach { target ->
                 log(TAG) { "Deleting $target" }
                 updateProgressSecondary(target.userReadablePath)
-                target.deleteAll(gatewaySwitch)
+                target.delete(gatewaySwitch, recursive = true)
             }
 
         // TODO this seems convoluted, can we come up with a better data pattern?

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
@@ -230,9 +230,11 @@ class AppCleaner @Inject constructor(
                         val filter = filters.singleOrNull { it.identifier == filterIdentifier }
                             ?: throw IllegalStateException("Can't find filter for $filterIdentifier")
 
+                        updateProgressSecondary(eu.darken.sdmse.common.R.string.general_progress_loading)
+
                         filter.withProgress(
                             client = this,
-                            onUpdate = { old, new -> old?.copy(secondary = new?.secondary ?: CaString.EMPTY) },
+                            onUpdate = { old, new -> old?.copy(secondary = new?.primary ?: CaString.EMPTY) },
                             onCompletion = { it }
                         ) {
                             val result = process(targets, allMatches)

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/BaseExpendablesFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/BaseExpendablesFilter.kt
@@ -10,7 +10,7 @@ import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APathLookup
 import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.PathException
-import eu.darken.sdmse.common.files.deleteAll
+import eu.darken.sdmse.common.files.delete
 import eu.darken.sdmse.common.files.exists
 import eu.darken.sdmse.common.files.filterDistinctRoots
 import eu.darken.sdmse.common.files.isAncestorOf
@@ -54,7 +54,7 @@ abstract class BaseExpendablesFilter : ExpendablesFilter {
             val main = targets.first { it.lookup == targetRoot }
 
             val mainDeleted = try {
-                targetRoot.deleteAll(gatewaySwitch)
+                targetRoot.delete(gatewaySwitch, recursive = true)
                 log(TAG) { "Main match deleted: $main" }
                 true
             } catch (oge: PathException) {

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerProcessingTask.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerProcessingTask.kt
@@ -46,5 +46,9 @@ data class AppCleanerProcessingTask(
                     Formatter.formatFileSize(this, affectedSpace)
                 )
             }
+
+        override fun toString(): String {
+            return "AppCleanerProcessingTask.Success($affectedSpace,${affectedPaths.size} items)"
+        }
     }
 }

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/uninstall/Uninstaller.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/uninstall/Uninstaller.kt
@@ -87,7 +87,7 @@ class Uninstaller @Inject constructor(
             }
 
             else -> {
-                log(TAG) { "Using normal instant to uninstall $installId" }
+                log(TAG) { "Using normal intent to uninstall $installId" }
                 val appSettingsIntent = Intent(Intent.ACTION_DELETE).apply {
                     data = Uri.parse("package:${installId.pkgId.name}")
                     addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)

--- a/app/src/main/java/eu/darken/sdmse/automation/core/AutomationService.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/AutomationService.kt
@@ -199,7 +199,6 @@ class AutomationService : AccessibilityService(), AutomationHost, Progress.Host,
     }
 
     override fun onAccessibilityEvent(event: AccessibilityEvent) {
-        log(TAG, VERBOSE) { "onAccessibilityEvent(eventType=${event.eventType})" }
         if (!checkLaunch()) return
 
         if (generalSettings.hasAcsConsent.valueBlocking != true) {
@@ -208,6 +207,8 @@ class AutomationService : AccessibilityService(), AutomationHost, Progress.Host,
         }
 
         if (!automationProcessor.hasTask) return
+
+        log(TAG, VERBOSE) { "onAccessibilityEvent(eventType=${event.eventType})" }
 
         val eventCopy = if (hasApiLevel(30)) {
             @Suppress("NewApi")

--- a/app/src/main/java/eu/darken/sdmse/corpsefinder/core/CorpseFinder.kt
+++ b/app/src/main/java/eu/darken/sdmse/corpsefinder/core/CorpseFinder.kt
@@ -16,7 +16,7 @@ import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.WriteException
-import eu.darken.sdmse.common.files.deleteAll
+import eu.darken.sdmse.common.files.delete
 import eu.darken.sdmse.common.files.filterDistinctRoots
 import eu.darken.sdmse.common.files.isAncestorOf
 import eu.darken.sdmse.common.files.matches
@@ -288,13 +288,10 @@ class CorpseFinder @Inject constructor(
                             )
                         })
                         log(TAG) { "Deleting $targetContent..." }
+                        updateProgressSecondary(targetContent.userReadablePath)
                         try {
-                            targetContent.deleteAll(gatewaySwitch) {
-                                updateProgressSecondary(it.userReadablePath)
-                                true
-                            }
+                            targetContent.delete(gatewaySwitch, recursive = true)
                             log(TAG) { "Deleted $targetContent!" }
-
                             deleted.add(targetContent)
                         } catch (e: WriteException) {
                             log(TAG, WARN) { "Deletion failed for $targetContent: $e" }
@@ -312,7 +309,7 @@ class CorpseFinder @Inject constructor(
                 log(TAG) { "Deleting $targetCorpse..." }
                 updateProgressSecondary(corpse.lookup.userReadablePath)
                 try {
-                    corpse.lookup.deleteAll(gatewaySwitch)
+                    corpse.lookup.delete(gatewaySwitch, recursive = true)
                     log(TAG) { "Deleted $targetCorpse!" }
                     deletedCorpses.add(corpse)
                 } catch (e: WriteException) {

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/BaseSystemCleanerFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/BaseSystemCleanerFilter.kt
@@ -1,7 +1,7 @@
 package eu.darken.sdmse.systemcleaner.core.filter
 
 import eu.darken.sdmse.common.files.GatewaySwitch
-import eu.darken.sdmse.common.files.deleteAll
+import eu.darken.sdmse.common.files.delete
 import eu.darken.sdmse.common.files.filterDistinctRoots
 import eu.darken.sdmse.common.flow.throttleLatest
 import eu.darken.sdmse.common.progress.Progress
@@ -29,7 +29,7 @@ abstract class BaseSystemCleanerFilter : SystemCleanerFilter {
         .also { updateProgressCount(Progress.Count.Percent(it.size)) }
         .forEach { targetContent ->
             updateProgressPrimary(targetContent.userReadablePath)
-            targetContent.deleteAll(gatewaySwitch)
+            targetContent.delete(gatewaySwitch, recursive = true)
             increaseProgress()
         }
 }

--- a/app/src/test/java/eu/darken/sdmse/deduplicator/core/DuplicatesDeleterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/deduplicator/core/DuplicatesDeleterTest.kt
@@ -20,7 +20,7 @@ import testhelpers.BaseTest
 class DuplicatesDeleterTest : BaseTest() {
 
     private val gatewaySwitch: GatewaySwitch = mockk<GatewaySwitch>().apply {
-        coEvery { delete(any()) } returns Unit
+        coEvery { delete(any(), any()) } returns Unit
     }
     private val arbiter: DuplicatesArbiter = mockk<DuplicatesArbiter>().apply {
         coEvery { decideGroups(any()) } answers {


### PR DESCRIPTION
See commit msg:

> Stop using `deleteAll` which did the recursion at a very high level, creating a lot of churn between the processes.
Introduce and use new `recursive` flag which allows `delete` to "delete all" and handles deletion inside the gateways.
No longer going back and forth between the processes, means that deletion of a large amount of files, using root or shizuku, is now much faster.

and

https://github.com/d4rken-org/sdmaid-se/issues/1443#issuecomment-2470963574

Closes #1443