### PR TITLE
AppCleaner: Fix ACS based cache clearing not working on OnePlus and Vivo devices with Android 14/15

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/oneplus/OnePlusSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/oneplus/OnePlusSpecs.kt
@@ -115,7 +115,16 @@ class OnePlusSpecs @Inject constructor(
                 label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheButtonLabels),
                 windowNodeTest = windowCriteriaAppIdentifier(SETTINGS_PKG, ipcFunnel, pkg),
                 nodeMapping = when {
-                    hasApiLevel(34) && isUnclickableButton -> clickableParent()
+                    hasApiLevel(34) -> {
+                        // Function that is evaluated later, has access to vars in this scope
+                        { node ->
+                            when {
+                                isUnclickableButton -> clickableParent().invoke(node)
+                                else -> node
+                            }
+                        }
+                    }
+
                     else -> null
                 },
                 nodeTest = buttonFilter,

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/vivo/VivoSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/vivo/VivoSpecs.kt
@@ -126,7 +126,15 @@ class VivoSpecs @Inject constructor(
                 windowNodeTest = windowCriteriaAppIdentifier(SETTINGS_PKG, ipcFunnel, pkg),
                 nodeTest = buttonFilter,
                 nodeMapping = when {
-                    hasApiLevel(34) && isUnclickableLabelButton -> clickableParent()
+                    hasApiLevel(34) -> {
+                        // Pass a function that is evaluated later, and has access to vars in this scope
+                        { node ->
+                            when {
+                                isUnclickableLabelButton -> clickableParent().invoke(node)
+                                else -> node
+                            }
+                        }
+                    }
                     else -> null
                 },
                 action = getAospClearCacheClick(pkg, tag)

--- a/app/src/main/java/eu/darken/sdmse/automation/core/common/AccessibilityNodeExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/common/AccessibilityNodeExtensions.kt
@@ -100,10 +100,10 @@ fun AccessibilityNodeInfo.findParentOrNull(
     maxNesting: Int = 3,
     predicate: (AccessibilityNodeInfo) -> Boolean
 ): AccessibilityNodeInfo? {
-    var target = this
+    var target = this.parent ?: return null
     for (i in 1..maxNesting) {
         if (predicate(target)) return target
-        if (target.parent != null) target = target.parent
+        target = target.parent ?: break
     }
     return null
 }

--- a/app/src/main/java/eu/darken/sdmse/automation/core/common/AutomationContextExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/common/AutomationContextExtensions.kt
@@ -10,6 +10,7 @@ import android.view.accessibility.AccessibilityNodeInfo
 import eu.darken.sdmse.automation.core.errors.AutomationException
 import eu.darken.sdmse.automation.core.errors.DisabledTargetException
 import eu.darken.sdmse.automation.core.errors.PlanAbortException
+import eu.darken.sdmse.automation.core.errors.UnclickableTargetException
 import eu.darken.sdmse.automation.core.specs.AutomationExplorer
 import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
@@ -61,7 +62,8 @@ fun AutomationExplorer.Context.defaultClick(
     when {
         !node.isEnabled -> onDisabled?.invoke(node) ?: throw DisabledTargetException("Clickable target is disabled.")
         isDryRun -> node.performAction(AccessibilityNodeInfo.ACTION_SELECT)
-        else -> node.performAction(AccessibilityNodeInfo.ACTION_CLICK)
+        node.isClickable -> node.performAction(AccessibilityNodeInfo.ACTION_CLICK)
+        else -> throw UnclickableTargetException("Target is not clickable")
     }
 }
 
@@ -81,6 +83,7 @@ fun AutomationExplorer.Context.clickableParent(
     maxNesting: Int = 6
 ): suspend (AccessibilityNodeInfo) -> AccessibilityNodeInfo = { us ->
     us.findParentOrNull(maxNesting = maxNesting) {
+        log(TAG, VERBOSE) { "isClickable? ${it.toStringShort()}" }
         it.isClickable
     } ?: throw AutomationException("No clickable parent found (within $maxNesting)")
 }

--- a/app/src/main/java/eu/darken/sdmse/automation/core/errors/UnclickableTargetException.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/errors/UnclickableTargetException.kt
@@ -3,9 +3,6 @@ package eu.darken.sdmse.automation.core.errors
 import androidx.annotation.Keep
 
 @Keep
-open class AutomationException(
-    message: String? = null,
-    cause: Throwable? = null
-) : Exception(message, cause) {
+open class UnclickableTargetException(message: String?, cause: Throwable?) : AutomationException(message, cause) {
     constructor(message: String?) : this(message, null)
 }


### PR DESCRIPTION
We need to pass a function to `nodeMapping` that is evaluated later.
The `when` evaluated immediately, when `isUnclickableButton=false`.

Also fixes the same issue for Vivo devices.