### PR TITLE
Fix ACS based cache deletion on HyperOS 2.0

### DIFF
--- a/app-common/src/main/java/eu/darken/sdmse/common/device/DeviceDetective.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/device/DeviceDetective.kt
@@ -23,9 +23,7 @@ class DeviceDetective @Inject constructor(
         val pm = context.packageManager
         @Suppress("DEPRECATION")
         if (pm.hasSystemFeature(PackageManager.FEATURE_TELEVISION)) return true
-        if (pm.hasSystemFeature(PackageManager.FEATURE_LEANBACK)) return true
-
-        return false
+        return pm.hasSystemFeature(PackageManager.FEATURE_LEANBACK)
     }
 
     private fun checkManufactor(name: String): Boolean {
@@ -59,6 +57,7 @@ class DeviceDetective @Inject constructor(
         checkManufactor("huawei") && hasApp(MIUI_PKGS) -> RomType.HUAWEI
         checkManufactor("lge") -> RomType.LGE
         checkManufactor("Xiaomi") && hasApp(MIUI_PKGS) && hasFingerPrint(MIUI_VERSION_STARTS) -> RomType.MIUI
+        checkManufactor("Xiaomi") && hasApp(HYPEROS_PKGS) && hasFingerPrint(HYPEROS_VERSION_STARTS) -> RomType.HYPEROS
         checkManufactor("nubia") -> RomType.NUBIA
         checkManufactor("OnePlus") -> RomType.ONEPLUS
         checkManufactor("POCO") -> RomType.POCO
@@ -88,6 +87,17 @@ class DeviceDetective @Inject constructor(
         private val MIUI_PKGS = setOf(
             "com.miui.securitycenter"
         )
+
+        val HYPEROS_VERSION_STARTS = setOf(
+            // OS1.0.12.0.ULLMIXM
+            "OS1",
+            // Xiaomi/corot_global/corot:15/AP3A.240617.008/OS2.0.6.0.VMLMIXM:user/release-keys
+            "OS2",
+        )
+        private val HYPEROS_PKGS = setOf(
+            "com.miui.securitycenter"
+        )
+
         private val FLYME_PKGS = setOf(
             "com.meizu.flyme.update"
         )

--- a/app-common/src/main/java/eu/darken/sdmse/common/device/DeviceDetective.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/device/DeviceDetective.kt
@@ -8,6 +8,7 @@ import android.os.Build
 import dagger.Reusable
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.hasApiLevel
 import eu.darken.sdmse.common.isInstalled
 import javax.inject.Inject
 
@@ -56,8 +57,9 @@ class DeviceDetective @Inject constructor(
         checkManufactor("meizu") && hasApp(FLYME_PKGS) -> RomType.FLYME
         checkManufactor("huawei") && hasApp(MIUI_PKGS) -> RomType.HUAWEI
         checkManufactor("lge") -> RomType.LGE
+        // HyperOS 1.0 is based on Android 14 / API34, so anything lower is likely a false positive of MIUI
+        checkManufactor("Xiaomi") && hasApiLevel(34) && hasApp(HYPEROS_PKGS) && hasFingerPrint(HYPEROS_VERSION_STARTS) -> RomType.HYPEROS
         checkManufactor("Xiaomi") && hasApp(MIUI_PKGS) && hasFingerPrint(MIUI_VERSION_STARTS) -> RomType.MIUI
-        checkManufactor("Xiaomi") && hasApp(HYPEROS_PKGS) && hasFingerPrint(HYPEROS_VERSION_STARTS) -> RomType.HYPEROS
         checkManufactor("nubia") -> RomType.NUBIA
         checkManufactor("OnePlus") -> RomType.ONEPLUS
         checkManufactor("POCO") -> RomType.POCO

--- a/app-common/src/main/java/eu/darken/sdmse/common/device/RomType.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/device/RomType.kt
@@ -19,6 +19,7 @@ enum class RomType(override val label: CaString) : EnumPreference<RomType> {
     @Json(name = "LGE") LGE("LGE".toCaString()),
     @Json(name = "LINEAGE") LINEAGE("LINEAGE".toCaString()),
     @Json(name = "MIUI") MIUI("MIUI".toCaString()),
+    @Json(name = "HYPEROS") HYPEROS("HyperOS".toCaString()),
     @Json(name = "NUBIA") NUBIA("Nubia".toCaString()),
     @Json(name = "ONEPLUS") ONEPLUS("OnePlus".toCaString()),
     @Json(name = "POCO") POCO("POCO".toCaString()),

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleanerSettings.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleanerSettings.kt
@@ -9,9 +9,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.sdmse.common.datastore.PreferenceScreenData
 import eu.darken.sdmse.common.datastore.PreferenceStoreMapper
 import eu.darken.sdmse.common.datastore.createValue
-import eu.darken.sdmse.common.datastore.valueBlocking
 import eu.darken.sdmse.common.debug.logging.logTag
-import eu.darken.sdmse.common.device.RomType
 import eu.darken.sdmse.main.core.GeneralSettings
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -62,13 +60,6 @@ class AppCleanerSettings @Inject constructor(
 
     // Amounts to common folders created by default
     val minCacheSizeBytes = dataStore.createValue<Long>("skip.mincachesize.bytes", MIN_CACHE_SIZE_DEFAULT)
-
-
-    init {
-        // TODO Remove in a later version
-        val oldValue = dataStore.createValue("automation.romtype.detection", RomType.AUTO, moshi).valueBlocking
-        generalSettings.romTypeDetection.valueBlocking = oldValue
-    }
 
     override val mapper = PreferenceStoreMapper(
         includeSystemAppsEnabled,

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
@@ -75,7 +75,7 @@ class ClearCacheModule @AssistedInject constructor(
     private fun getPriotizedSpecGenerators(): List<AppCleanerSpecGenerator> = specGenerators
         .get()
         .also { log(TAG) { "${it.size} step generators are available" } }
-        .onEach { log(TAG, VERBOSE) { "Loaded: $it" } }
+        .onEach { log(TAG, VERBOSE) { "Loaded: $it (${it.tag})" } }
         .sortedByDescending { generator: AppCleanerSpecGenerator ->
             when (generator) {
                 is MIUISpecs -> 190
@@ -192,10 +192,10 @@ class ClearCacheModule @AssistedInject constructor(
 
         val specGenerator = getPriotizedSpecGenerators().firstOrNull { it.isResponsible(pkg) }
             ?: getPriotizedSpecGenerators().single { it is AOSPSpecs }
-        log(TAG) { "Using spec generator: $specGenerator" }
+        log(TAG) { "Using spec generator: ${specGenerator.tag}" }
 
         val spec = specGenerator.getClearCache(pkg)
-        log(TAG) { "Generated spec for ${pkg.id} is $spec" }
+        log(TAG) { "Generated spec for ${pkg.id} is ${spec.tag}" }
 
         when (spec) {
             is AutomationSpec.Explorer -> processExplorerSpec(pkg, spec)

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
@@ -20,6 +20,7 @@ import eu.darken.sdmse.appcleaner.core.automation.specs.coloros.ColorOSSpecs
 import eu.darken.sdmse.appcleaner.core.automation.specs.flyme.FlymeSpecs
 import eu.darken.sdmse.appcleaner.core.automation.specs.honor.HonorSpecs
 import eu.darken.sdmse.appcleaner.core.automation.specs.huawei.HuaweiSpecs
+import eu.darken.sdmse.appcleaner.core.automation.specs.hyperos.HyperOsSpecs
 import eu.darken.sdmse.appcleaner.core.automation.specs.lge.LGESpecs
 import eu.darken.sdmse.appcleaner.core.automation.specs.miui.MIUISpecs
 import eu.darken.sdmse.appcleaner.core.automation.specs.nubia.NubiaSpecs
@@ -79,6 +80,7 @@ class ClearCacheModule @AssistedInject constructor(
         .sortedByDescending { generator: AppCleanerSpecGenerator ->
             when (generator) {
                 is MIUISpecs -> 190
+                is HyperOsSpecs -> 180
                 is SamsungSpecs -> 170
                 is AlcatelSpecs -> 160
                 is RealmeSpecs -> 150

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/alcatel/AlcatelSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/alcatel/AlcatelSpecs.kt
@@ -60,6 +60,9 @@ class AlcatelSpecs @Inject constructor(
     }
 
     override suspend fun getClearCache(pkg: Installed): AutomationSpec = object : AutomationSpec.Explorer {
+
+        override val tag: String = TAG
+
         override suspend fun createPlan(): suspend AutomationExplorer.Context.() -> Unit = {
             mainPlan(pkg)
         }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/alcatel/AlcatelSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/alcatel/AlcatelSpecs.kt
@@ -85,7 +85,8 @@ class AlcatelSpecs @Inject constructor(
             val storageFilter = onTheFlyLabler.getAOSPStorageFilter(storageEntryLabels, pkg)
 
             val step = StepProcessor.Step(
-                parentTag = tag,
+                source = tag,
+                descriptionInternal = "Storage entry",
                 label = R.string.appcleaner_automation_progress_find_storage.toCaString(storageEntryLabels),
                 windowIntent = defaultWindowIntent(pkg),
                 windowEventFilter = defaultWindowFilter(SETTINGS_PKG),
@@ -109,7 +110,8 @@ class AlcatelSpecs @Inject constructor(
             }
 
             val step = StepProcessor.Step(
-                parentTag = tag,
+                source = tag,
+                descriptionInternal = "Clear cache button",
                 label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheButtonLabels),
                 windowNodeTest = windowCriteriaAppIdentifier(SETTINGS_PKG, ipcFunnel, pkg),
                 nodeTest = buttonFilter,

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/androidtv/AndroidTVSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/androidtv/AndroidTVSpecs.kt
@@ -62,6 +62,7 @@ open class AndroidTVSpecs @Inject constructor(
     }
 
     override suspend fun getClearCache(pkg: Installed): AutomationSpec = object : AutomationSpec.Explorer {
+        override val tag: String = TAG
         override suspend fun createPlan(): suspend AutomationExplorer.Context.() -> Unit = {
             mainPlan(pkg)
         }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/androidtv/AndroidTVSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/androidtv/AndroidTVSpecs.kt
@@ -92,7 +92,8 @@ open class AndroidTVSpecs @Inject constructor(
             }
 
             val step = StepProcessor.Step(
-                parentTag = TAG,
+                source = TAG,
+                descriptionInternal = "Clear cache button",
                 label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheButtonLabels),
                 windowIntent = defaultWindowIntent(pkg),
                 windowEventFilter = defaultWindowFilter(SETTINGS_PKG),
@@ -139,7 +140,8 @@ open class AndroidTVSpecs @Inject constructor(
             }
 
             val step = StepProcessor.Step(
-                parentTag = TAG,
+                source = TAG,
+                descriptionInternal = "Confirm action",
                 label = R.string.appcleaner_automation_progress_find_ok_confirmation.toCaString(buttonLabels),
                 windowNodeTest = windowCriteria,
                 nodeTest = buttonFilter,

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecs.kt
@@ -58,6 +58,7 @@ class AOSPSpecs @Inject constructor(
     }
 
     override suspend fun getClearCache(pkg: Installed): AutomationSpec = object : AutomationSpec.Explorer {
+        override val tag: String = TAG
         override suspend fun createPlan(): suspend AutomationExplorer.Context.() -> Unit = {
             mainPlan(pkg)
         }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecs.kt
@@ -77,11 +77,12 @@ class AOSPSpecs @Inject constructor(
             val storageEntryLabels =
                 aospLabels.getStorageEntryDynamic() + aospLabels.getStorageEntryStatic(lang, script)
             log(TAG) { "storageEntryLabels=$storageEntryLabels" }
-            
+
             val storageFilter = onTheFlyLabler.getAOSPStorageFilter(storageEntryLabels, pkg)
 
             val step = StepProcessor.Step(
-                parentTag = tag,
+                source = tag,
+                descriptionInternal = "Storage entry",
                 label = R.string.appcleaner_automation_progress_find_storage.toCaString(storageEntryLabels),
                 windowIntent = defaultWindowIntent(pkg),
                 windowEventFilter = defaultWindowFilter(SETTINGS_PKG),
@@ -105,7 +106,8 @@ class AOSPSpecs @Inject constructor(
             }
 
             val step = StepProcessor.Step(
-                parentTag = tag,
+                source = tag,
+                descriptionInternal = "Clear cache button",
                 label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheButtonLabels),
                 windowNodeTest = windowCriteriaAppIdentifier(SETTINGS_PKG, ipcFunnel, pkg),
                 nodeTest = buttonFilter,

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/coloros/ColorOSSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/coloros/ColorOSSpecs.kt
@@ -63,6 +63,7 @@ class ColorOSSpecs @Inject constructor(
 
 
     override suspend fun getClearCache(pkg: Installed): AutomationSpec = object : AutomationSpec.Explorer {
+        override val tag: String = TAG
         override suspend fun createPlan(): suspend AutomationExplorer.Context.() -> Unit = {
             mainPlan(pkg)
         }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/coloros/ColorOSSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/coloros/ColorOSSpecs.kt
@@ -97,7 +97,8 @@ class ColorOSSpecs @Inject constructor(
             val storageFilter = onTheFlyLabler.getAOSPStorageFilter(storageEntryLabels, pkg)
 
             val step = StepProcessor.Step(
-                parentTag = TAG,
+                source = TAG,
+                descriptionInternal = "Storage entry",
                 label = R.string.appcleaner_automation_progress_find_storage.toCaString(storageEntryLabels),
                 windowIntent = defaultWindowIntent(pkg),
                 windowEventFilter = defaultWindowFilter(SETTINGS_PKG),
@@ -133,7 +134,8 @@ class ColorOSSpecs @Inject constructor(
             }
 
             val step = StepProcessor.Step(
-                parentTag = TAG,
+                source = TAG,
+                descriptionInternal = "Clear cache button",
                 label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheButtonLabels),
                 windowNodeTest = combined,
                 nodeTest = buttonFilter,

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/flyme/FlymeSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/flyme/FlymeSpecs.kt
@@ -91,7 +91,8 @@ class FlymeSpecs @Inject constructor(
             }
 
             val step = StepProcessor.Step(
-                parentTag = TAG,
+                source = TAG,
+                descriptionInternal = "Clear cache button",
                 label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheButtonLabels),
                 windowIntent = defaultWindowIntent(pkg),
                 windowEventFilter = defaultWindowFilter(SETTINGS_PKG),

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/flyme/FlymeSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/flyme/FlymeSpecs.kt
@@ -57,6 +57,7 @@ class FlymeSpecs @Inject constructor(
     }
 
     override suspend fun getClearCache(pkg: Installed): AutomationSpec = object : AutomationSpec.Explorer {
+        override val tag: String = TAG
         override suspend fun createPlan(): suspend AutomationExplorer.Context.() -> Unit = {
             mainPlan(pkg)
         }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/honor/HonorSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/honor/HonorSpecs.kt
@@ -58,6 +58,7 @@ class HonorSpecs @Inject constructor(
     }
 
     override suspend fun getClearCache(pkg: Installed): AutomationSpec = object : AutomationSpec.Explorer {
+        override val tag: String = TAG
         override suspend fun createPlan(): suspend AutomationExplorer.Context.() -> Unit = {
             mainPlan(pkg)
         }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/honor/HonorSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/honor/HonorSpecs.kt
@@ -81,7 +81,8 @@ class HonorSpecs @Inject constructor(
             val storageFilter = onTheFlyLabler.getAOSPStorageFilter(storageEntryLabels, pkg)
 
             val step = StepProcessor.Step(
-                parentTag = tag,
+                source = tag,
+                descriptionInternal = "Storage entry",
                 label = R.string.appcleaner_automation_progress_find_storage.toCaString(storageEntryLabels),
                 windowIntent = defaultWindowIntent(pkg),
                 windowEventFilter = defaultWindowFilter(SETTINGS_PKG),
@@ -105,7 +106,8 @@ class HonorSpecs @Inject constructor(
             }
 
             val step = StepProcessor.Step(
-                parentTag = tag,
+                source = tag,
+                descriptionInternal = "Clear cache button",
                 label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheButtonLabels),
                 windowNodeTest = windowCriteriaAppIdentifier(SETTINGS_PKG, ipcFunnel, pkg),
                 nodeTest = buttonFilter,

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/huawei/HuaweiSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/huawei/HuaweiSpecs.kt
@@ -59,6 +59,7 @@ class HuaweiSpecs @Inject constructor(
     }
 
     override suspend fun getClearCache(pkg: Installed): AutomationSpec = object : AutomationSpec.Explorer {
+        override val tag: String = TAG
         override suspend fun createPlan(): suspend AutomationExplorer.Context.() -> Unit = {
             mainPlan(pkg)
         }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/huawei/HuaweiSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/huawei/HuaweiSpecs.kt
@@ -80,7 +80,8 @@ class HuaweiSpecs @Inject constructor(
             val storageFilter = onTheFlyLabler.getAOSPStorageFilter(storageEntryLabels, pkg)
 
             val step = StepProcessor.Step(
-                parentTag = tag,
+                source = tag,
+                descriptionInternal = "Storage entry",
                 label = R.string.appcleaner_automation_progress_find_storage.toCaString(storageEntryLabels),
                 windowIntent = defaultWindowIntent(pkg),
                 windowEventFilter = defaultWindowFilter(SETTINGS_PKG),
@@ -104,7 +105,8 @@ class HuaweiSpecs @Inject constructor(
             }
 
             val step = StepProcessor.Step(
-                parentTag = tag,
+                source = tag,
+                descriptionInternal = "Clear cache button",
                 label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheButtonLabels),
                 windowNodeTest = windowCriteriaAppIdentifier(
                     AOSPSpecs.SETTINGS_PKG, ipcFunnel, pkg

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/hyperos/HyperOsLabels.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/hyperos/HyperOsLabels.kt
@@ -1,0 +1,290 @@
+package eu.darken.sdmse.appcleaner.core.automation.specs.hyperos
+
+import android.content.Context
+import dagger.Reusable
+import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.sdmse.appcleaner.core.automation.specs.AppCleanerLabelSource
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.pkgs.toPkgId
+import javax.inject.Inject
+
+@Reusable
+class HyperOsLabels @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : AppCleanerLabelSource {
+
+    fun getDialogTitles(lang: String, script: String, country: String?): Set<String> =
+        getDialogTitlesDynamic() + getDialogTitlesFallback(lang, script, country)
+
+    private fun getDialogTitlesDynamic() = setOf(
+        "app_manager_dlg_clear_cache_title"
+    ).getAsStringResources(context, SETTINGS_PKG)
+
+    private fun getDialogTitlesFallback(lang: String, script: String, country: String?): Set<String> = when {
+        "en".toLang() == lang -> setOf("Clear cache?")
+        "de".toLang() == lang -> setOf("Cache löschen?")
+        "cs".toLang() == lang -> setOf("Vyčistit mezipaměť?")
+        "ru".toLang() == lang -> setOf("Очистить кэш?")
+        "es".toLang() == lang -> setOf("¿Borrar caché?")
+        "zh-Hant".toLoc().let {
+            it.language == lang && (it.script == script || setOf(
+                "HK",
+                "TW"
+            ).contains(country))
+        } -> setOf("確定清除應用暫存？")
+
+        "zh".toLang() == lang -> setOf("确定清除应用缓存？")
+        "ja".toLang() == lang -> setOf("キャッシュをクリアしますか？")
+        "pt".toLang() == lang -> setOf("Limpar cache?")
+        "id".toLang() == lang -> setOf("Hapus cache?")
+        "hi".toLang() == lang -> setOf("कैशे मिटाएं?")
+        "it".toLang() == lang -> setOf("Svuotare la cache?")
+        "uk".toLang() == lang -> setOf("Очистити кеш?")
+        "fr".toLang() == lang -> setOf("Vider le cache?")
+        "tr".toLang() == lang -> setOf("Önbellek temizlensin mi?")
+        "pl".toLang() == lang -> setOf(
+            "Wyczyścić pamięć podręczną?",
+            // Xiaomi/venus/venus:11/RKQ1.200928.002/V12.5.15.0.RKBCNXM:user/release-keys
+            "Usunąć pamięć podręczną?"
+        )
+
+        "nl".toLang() == lang -> setOf("Cache wissen?")
+        "hu".toLang() == lang -> setOf("Törli a gyorsítótárat?")
+        "ko".toLang() == lang -> setOf("캐시를 지우시겠습니까?")
+        "sl".toLang() == lang -> setOf(
+            "Počistim predpomnilnik?",
+            "Počisti predpomnilnik?",
+            "Želite počistiti predpomnilnik?"
+        )
+
+        "az".toLang() == lang -> setOf("Keş təmizlənsin?")
+        "ms".toLang() == lang -> setOf("Bersihkan cache?", "Kosongkan cache")
+        "bs".toLang() == lang -> setOf("Želite li izbrisati predmemoriju?")
+        "ca".toLang() == lang -> setOf("Voleu esborra la memòria cau?")
+        "da".toLang() == lang -> setOf("Ryd cache?")
+        "et".toLang() == lang -> setOf("Kustuta vahemälu?")
+        "eu".toLang() == lang -> setOf("Cache garbitu?")
+        "gl".toLang() == lang -> setOf("Eliminar a caché?")
+        "ha".toLang() == lang -> setOf("A share gurbin bayanai?")
+        "hr".toLang() == lang -> setOf("Izbrisati predmemoriju?", "Očistiti predmemoriju?")
+        "lv".toLang() == lang -> setOf("Tīrīt kešatmiņu?")
+        "lt".toLang() == lang -> setOf("Valyti podėlį?")
+        "mt".toLang() == lang -> setOf("Trid tbattal il-cache?")
+        "nb".toLang() == lang -> setOf("Tømme cache?")
+        "uz".toLang() == lang -> setOf("Keshni tozalash?")
+        "ro".toLang() == lang -> setOf("Şterge cache?", "Șterge cache?", "Ştergeți cache?")
+        "sq".toLang() == lang -> setOf("Pastro deponë?")
+        "sk".toLang() == lang -> setOf("Vymazať cache?", "Vymazať vyrovnávaciu pamäť?")
+        "fi".toLang() == lang -> setOf("Tyhjennä välimuisti?")
+        "sv".toLang() == lang -> setOf("Rensa cache?")
+        "vi".toLang() == lang -> setOf("Xóa bộ nhớ đệm?")
+        "el".toLang() == lang -> setOf("Εκκαθάριση προσωρινή μνήμης;")
+        "be".toLang() == lang -> setOf("Ачысціць кэш?")
+        "bg".toLang() == lang -> setOf("Изчисти кеша?")
+        "kk".toLang() == lang -> setOf("Кэш тазалансын ба?")
+        "mk".toLang() == lang -> setOf("Да се избрише кеш меморијата?")
+        "sr".toLang() == lang -> setOf("Очисти кеш?", "Очистити кеш?")
+        "ka".toLang() == lang -> setOf("გავწმინდო ქეში?")
+        "hy".toLang() == lang -> setOf("Մաքրե՞լ քեշը:")
+        "iw".toLang() == lang -> setOf("לנקות מטמון?")
+        "ur".toLang() == lang -> setOf("کیشے صاف کریں؟")
+        "ar".toLang() == lang -> setOf("مسح الذاكرة المؤقتة؟")
+        "fa".toLang() == lang -> setOf("حافظه پنهان پاک شود؟")
+        "ne".toLang() == lang -> setOf("क्यास खाली गर्नुहुन्छ?")
+        "mr".toLang() == lang -> setOf("कॅचे पुसायची?")
+        "as".toLang() == lang -> setOf("কেশ্ব পৰিষ্কাৰ কৰিবনে?")
+        "bn".toLang() == lang -> setOf("ক্যাশে পরিষ্কার করবেন?")
+        "pa".toLang() == lang -> setOf("ਕੈਸ਼ੇ ਹਟਾਉਣੇ ਹਨ?")
+        "gu".toLang() == lang -> setOf("કૅશ સાફ કરીએ?")
+        "ta".toLang() == lang -> setOf("தேக்ககத்தை அழிக்கவா?")
+        "te".toLang() == lang -> setOf("కాష్\u200Cను తీసివేయాలా?")
+        "kn".toLang() == lang -> setOf("ಕ್ಯಾಶೆ ತೆರವುಗೊಳಿಸುವುದೇ?")
+        "ml".toLang() == lang -> setOf("കാഷേ മായ്\u200Cക്കണോ?")
+        "th".toLang() == lang -> setOf("ล้างหน่วยความจำแคช?", "ล้างแคช?")
+        "my".toLang() == lang -> setOf("ကက်ချ်အား ရှင်းပစ်မလား?")
+        "km".toLang() == lang -> setOf("ជម្រះឃ្លាំងសម្ងាត់ឬ?")
+        "or".toLang() == lang -> setOf("କ୍ୟାଚେ ସଫା କରିବେ?")
+        "lo".toLang() == lang -> setOf("ລົບ\u200Bລ້າງ Cache?")
+        else -> emptySet<String>().also { log(TAG) { "Unmapped locale: $lang $script" } }
+    }
+
+    fun getClearCacheButtonLabels(lang: String, script: String, country: String?): Set<String> =
+        getClearCacheButtonLabelDynamic() + getClearCacheButtonLabelsFallback(lang, script, country)
+
+    private fun getClearCacheButtonLabelDynamic() = setOf(
+        "app_manager_clear_cache"
+    ).getAsStringResources(context, SETTINGS_PKG)
+
+    private fun getClearCacheButtonLabelsFallback(lang: String, script: String, country: String?): Set<String> =
+        when {
+            "en".toLang() == lang -> setOf("Clear cache")
+            "de".toLang() == lang -> setOf("Cache löschen")
+            "cs".toLang() == lang -> setOf("Vyčistit mezipaměť")
+            "ru".toLang() == lang -> setOf("Очистить кэш")
+            "es".toLang() == lang -> setOf("Limpiar caché")
+            "zh-Hant".toLoc().let {
+                it.language == lang && (it.script == script || setOf("HK", "TW").contains(country))
+            } -> setOf("清除暫存")
+
+            "zh".toLang() == lang -> setOf("清除缓存")
+            "ja".toLang() == lang -> setOf("キャッシュをクリア")
+            "pt".toLang() == lang -> setOf("Limpar cache")
+            "id".toLang() == lang -> setOf("Bersihkan cache")
+            "hi".toLang() == lang -> setOf("कैशे मिटाएं")
+            "it".toLang() == lang -> setOf("Svuota la cache")
+            "uk".toLang() == lang -> setOf("Очистити кеш")
+            "fr".toLang() == lang -> setOf("Vider le cache")
+            "tr".toLang() == lang -> setOf("Önbelleği temizle")
+            "pl".toLang() == lang -> setOf(
+                "Wyczyść pamięć podręczną",
+                // Xiaomi/venus/venus:11/RKQ1.200928.002/V12.5.16.0.RKBCNXM:user/release-keys
+                "Czyść pamięć podręczną"
+            )
+
+            "nl".toLang() == lang -> setOf("Cache wissen")
+            "hu".toLang() == lang -> setOf("Gyorsítótártörlés")
+            "ko".toLang() == lang -> setOf("캐시 지우기")
+            "sl".toLang() == lang -> setOf("Očisti predpomnilnik", "Počisti predpomnilnik")
+            "az".toLang() == lang -> setOf("Keşi təmizlə")
+            "ms".toLang() == lang -> setOf("Bersihkan cache", "Kosongkan cache")
+            "bs".toLang() == lang -> setOf("Izbriši predmemoriju")
+            "ca".toLang() == lang -> setOf("Esborra la memòria cau")
+            "da".toLang() == lang -> setOf("Ryd cache")
+            "et".toLang() == lang -> setOf("Puhasta vahemälu")
+            "eu".toLang() == lang -> setOf("Garbitu cache-a")
+            "gl".toLang() == lang -> setOf("Eliminar a caché")
+            "ha".toLang() == lang -> setOf("Share gurbin bayanai")
+            "hr".toLang() == lang -> setOf("Očisti predmemoriju")
+            "lv".toLang() == lang -> setOf("Tīrīt kešatmiņu")
+            "lt".toLang() == lang -> setOf("Valyti podėlį")
+            "mt".toLang() == lang -> setOf("Battal il-cache")
+            "nb".toLang() == lang -> setOf("Tøm cache")
+            "uz".toLang() == lang -> setOf("Keshni tozalash")
+            "ro".toLang() == lang -> setOf("Şterge cache", "Șterge cache")
+            "sq".toLang() == lang -> setOf("Pastro deponë")
+            "sk".toLang() == lang -> setOf("Vyčistiť cache", "Vymazať vyrovnávaciu pamäť")
+            "fi".toLang() == lang -> setOf("Tyhjennä välimuisti")
+            "sv".toLang() == lang -> setOf("Rensa cache")
+            "vi".toLang() == lang -> setOf("Xóa bộ nhớ đệm")
+            "el".toLang() == lang -> setOf("Εκκαθάριση προσωρινή μνήμης")
+            "be".toLang() == lang -> setOf("Ачысціць кэш")
+            "bg".toLang() == lang -> setOf("Изчисти кеша")
+            "kk".toLang() == lang -> setOf("Кэшті тазалау")
+            "mk".toLang() == lang -> setOf("Исчисти кеш меморија")
+            "sr".toLang() == lang -> setOf("Очисти кеш")
+            "ka".toLang() == lang -> setOf("ქეშის გასუფთავება")
+            "hy".toLang() == lang -> setOf("Մաքրել քեշը")
+            "iw".toLang() == lang -> setOf("ניקוי מטמון")
+            "ur".toLang() == lang -> setOf("کیشے صاف کریں")
+            "ar".toLang() == lang -> setOf("مسح الذاكرة المؤقتة")
+            "fa".toLang() == lang -> setOf("پاک\u200Cسازی حافظه پنهان")
+            "ne".toLang() == lang -> setOf("क्यास खाली गर्नुहोस्")
+            "mr".toLang() == lang -> setOf("कॅचे पुसा")
+            "as".toLang() == lang -> setOf("কেশ্ব পৰিষ্কাৰ কৰক")
+            "bn".toLang() == lang -> setOf("ক্যাশে পরিষ্কার করুন")
+            "pa".toLang() == lang -> setOf("ਕੈਸ਼ੇ ਸਾਫ਼ ਕਰੋ")
+            "gu".toLang() == lang -> setOf("કૅશ સાફ કરો")
+            "ta".toLang() == lang -> setOf("தேக்ககத்தை அழி")
+            "te".toLang() == lang -> setOf("కాష్\u200Cని తొలగించు")
+            "kn".toLang() == lang -> setOf("ಕ್ಯಾಶೆ ಅಳಿಸಿ")
+            "ml".toLang() == lang -> setOf("കാഷേ മായ്\u200Cക്കുക")
+            "th".toLang() == lang -> setOf("ล้างหน่วยความจำแคช", "ล้างแคช")
+            "my".toLang() == lang -> setOf("ကက်ချ်ကို ရှင်းလင်းမည်")
+            "km".toLang() == lang -> setOf("ជម្រះឃ្លាំងសម្ងាត់")
+            "or".toLang() == lang -> setOf("କ୍ୟାଚେ ସଫା କରନ୍ତୁ")
+            "lo".toLang() == lang -> setOf("ລົບ\u200Bລ້າງ Cache")
+            else -> emptySet<String>().also { log(TAG) { "Unmapped locale: $lang $script" } }
+        }
+
+    fun getClearDataButtonLabels(lang: String, script: String, country: String?): Set<String> =
+        getClearDataButtonLabelsDynamic() + getClearDataButtonLabelsFallback(lang, script, country)
+
+    private fun getClearDataButtonLabelsDynamic() = setOf(
+        "app_manager_menu_clear_data"
+    ).getAsStringResources(context, SETTINGS_PKG)
+
+    private fun getClearDataButtonLabelsFallback(lang: String, script: String, country: String?): Collection<String> =
+        when {
+            "en".toLang() == lang -> setOf("Clear data")
+            "de".toLang() == lang -> setOf("Daten löschen")
+            "cs".toLang() == lang -> setOf("Vymazat data")
+            "ru".toLang() == lang -> setOf("Очистить")
+            "es".toLang() == lang -> setOf("Limpiar datos")
+            "zh-Hant".toLoc().let {
+                it.language == lang && (it.script == script || setOf(
+                    "HK",
+                    "TW"
+                ).contains(country))
+            } -> setOf("清除資料")
+
+            "zh".toLang() == lang -> setOf("清除数据")
+            "ja".toLang() == lang -> setOf("データをクリア")
+            "pt".toLang() == lang -> setOf("Limpar dados")
+            "id".toLang() == lang -> setOf("Hapus data")
+            "hi".toLang() == lang -> setOf("डेटा मिटाएं")
+            "it".toLang() == lang -> setOf("Elimina dati")
+            "uk".toLang() == lang -> setOf("Очистити дані")
+            "fr".toLang() == lang -> setOf("Effacer les données")
+            "tr".toLang() == lang -> setOf("Verileri temizle")
+            "pl".toLang() == lang -> setOf("Wyczyść dane")
+            "nl".toLang() == lang -> setOf("Gegevens wissen")
+            "hu".toLang() == lang -> setOf("Adattörlés")
+            "ko".toLang() == lang -> setOf("데이터 지우기")
+            "sl".toLang() == lang -> setOf("Počisti podatke")
+            "az".toLang() == lang -> setOf("Məlumatları təmizlə")
+            "ms".toLang() == lang -> setOf("Kosongkan data")
+            "bs".toLang() == lang -> setOf("Izbriši podatke")
+            "ca".toLang() == lang -> setOf("Esborra les dades")
+            "da".toLang() == lang -> setOf("Ryd data")
+            "et".toLang() == lang -> setOf("Puhasta andmed")
+            "eu".toLang() == lang -> setOf("Datuak ezabatu")
+            "gl".toLang() == lang -> setOf("Eliminar datos")
+            "ha".toLang() == lang -> setOf("Share bayanai")
+            "hr".toLang() == lang -> setOf("Izbriši podatke")
+            "lv".toLang() == lang -> setOf("Notīrīt datus")
+            "lt".toLang() == lang -> setOf("Išvalyti duomenis")
+            "mt".toLang() == lang -> setOf("Neħħi d-dejta")
+            "nb".toLang() == lang -> setOf("Slett data")
+            "uz".toLang() == lang -> setOf("Ma’lumotlarni tozalash")
+            "ro".toLang() == lang -> setOf("Şterge date", "Șterge date")
+            "sq".toLang() == lang -> setOf("Pastro të dhënat")
+            "sk".toLang() == lang -> setOf("Vymazať dáta")
+            "fi".toLang() == lang -> setOf("Tyhjennä tiedot")
+            "sv".toLang() == lang -> setOf("Rensa data")
+            "vi".toLang() == lang -> setOf("Xóa dữ liệu")
+            "el".toLang() == lang -> setOf("Εκκαθάριση δεδομένων")
+            "be".toLang() == lang -> setOf("Ачысціць дадзеныя")
+            "bg".toLang() == lang -> setOf("Изчисти данни")
+            "kk".toLang() == lang -> setOf("Деректерді жою")
+            "mk".toLang() == lang -> setOf("Избриши податоци")
+            "sr".toLang() == lang -> setOf("Избриши податке")
+            "ka".toLang() == lang -> setOf("მონაცემების გასუფთავება")
+            "hy".toLang() == lang -> setOf("Մաքրել տվյալները")
+            "iw".toLang() == lang -> setOf("נקה נתונים")
+            "ur".toLang() == lang -> setOf("ڈیٹا صاف کریں")
+            "ar".toLang() == lang -> setOf("مسح البيانات")
+            "fa".toLang() == lang -> setOf("پاک کردن داده\u200Cها")
+            "ne".toLang() == lang -> setOf("डाटा खाली गर्नुहोस्")
+            "mr".toLang() == lang -> setOf("डेटा साफ करा")
+            "as".toLang() == lang -> setOf("ডাটা পৰিষ্কাৰ কৰক")
+            "bn".toLang() == lang -> setOf("ডেটা পরিষ্কার করুন")
+            "pa".toLang() == lang -> setOf("ਡਾਟਾ ਸਾਫ਼ ਕਰੋ")
+            "gu".toLang() == lang -> setOf("ડેટા સાફ કરો")
+            "ta".toLang() == lang -> setOf("தரவை அழி")
+            "te".toLang() == lang -> setOf("డేటా తొలగించండి")
+            "kn".toLang() == lang -> setOf("ಡೇಟಾ ಅಳಿಸಿ")
+            "ml".toLang() == lang -> setOf("ഡാറ്റ മായ്\u200Cക്കുക")
+            "th".toLang() == lang -> setOf("ล้างข้อมูล")
+            "my".toLang() == lang -> setOf("ဒေတာရှင်းပါ")
+            "km".toLang() == lang -> setOf("ជម្រះទិន្នន័យ")
+            "or".toLang() == lang -> setOf("ଡାଟା ଖାଲିକରନ୍ତୁ")
+            "lo".toLang() == lang -> setOf("ລົບ\u200Bລ້າງ\u200Bຂໍ້\u200Bມູນ")
+            else -> emptySet<String>().also { log(TAG) { "Unmapped locale: $lang $script" } }
+        }
+
+    companion object {
+        val TAG: String = logTag("AppCleaner", "Automation", "HyperOs", "Labels")
+        private val SETTINGS_PKG = "com.miui.securitycenter".toPkgId()
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/hyperos/HyperOsSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/hyperos/HyperOsSpecs.kt
@@ -1,0 +1,303 @@
+package eu.darken.sdmse.appcleaner.core.automation.specs.hyperos
+
+import android.view.accessibility.AccessibilityNodeInfo
+import dagger.Binds
+import dagger.Module
+import dagger.Reusable
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoSet
+import eu.darken.sdmse.R
+import eu.darken.sdmse.appcleaner.core.automation.specs.AppCleanerSpecGenerator
+import eu.darken.sdmse.appcleaner.core.automation.specs.OnTheFlyLabler
+import eu.darken.sdmse.appcleaner.core.automation.specs.aosp.AOSPLabels
+import eu.darken.sdmse.automation.core.common.StepProcessor
+import eu.darken.sdmse.automation.core.common.clickableParent
+import eu.darken.sdmse.automation.core.common.crawl
+import eu.darken.sdmse.automation.core.common.defaultClick
+import eu.darken.sdmse.automation.core.common.defaultWindowIntent
+import eu.darken.sdmse.automation.core.common.getAospClearCacheClick
+import eu.darken.sdmse.automation.core.common.getDefaultNodeRecovery
+import eu.darken.sdmse.automation.core.common.getSysLocale
+import eu.darken.sdmse.automation.core.common.idContains
+import eu.darken.sdmse.automation.core.common.idMatches
+import eu.darken.sdmse.automation.core.common.isClickyButton
+import eu.darken.sdmse.automation.core.common.isTextView
+import eu.darken.sdmse.automation.core.common.pkgId
+import eu.darken.sdmse.automation.core.common.textEndsWithAny
+import eu.darken.sdmse.automation.core.common.textMatchesAny
+import eu.darken.sdmse.automation.core.common.windowCriteriaAppIdentifier
+import eu.darken.sdmse.automation.core.errors.StepAbortException
+import eu.darken.sdmse.automation.core.specs.AutomationExplorer
+import eu.darken.sdmse.automation.core.specs.AutomationSpec
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.datastore.value
+import eu.darken.sdmse.common.debug.Bugs
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.device.DeviceDetective
+import eu.darken.sdmse.common.device.RomType
+import eu.darken.sdmse.common.deviceadmin.DeviceAdminManager
+import eu.darken.sdmse.common.funnel.IPCFunnel
+import eu.darken.sdmse.common.pkgs.Pkg
+import eu.darken.sdmse.common.pkgs.features.Installed
+import eu.darken.sdmse.common.pkgs.toPkgId
+import eu.darken.sdmse.common.progress.withProgress
+import eu.darken.sdmse.main.core.GeneralSettings
+import javax.inject.Inject
+
+
+@Reusable
+class HyperOsSpecs @Inject constructor(
+    private val ipcFunnel: IPCFunnel,
+    private val deviceDetective: DeviceDetective,
+    private val hyperOsLabels: HyperOsLabels,
+    private val aospLabels: AOSPLabels,
+    private val deviceAdminManager: DeviceAdminManager,
+    private val onTheFlyLabler: OnTheFlyLabler,
+    private val generalSettings: GeneralSettings,
+) : AppCleanerSpecGenerator {
+
+    override val tag: String = TAG
+
+    override suspend fun isResponsible(pkg: Installed): Boolean {
+        val romType = generalSettings.romTypeDetection.value()
+        if (romType == RomType.HYPEROS) return true
+        if (romType != RomType.AUTO) return false
+
+        return deviceDetective.getROMType() == RomType.HYPEROS
+    }
+
+    override suspend fun getClearCache(pkg: Installed): AutomationSpec = object : AutomationSpec.Explorer {
+        override val tag: String = TAG
+        override suspend fun createPlan(): suspend AutomationExplorer.Context.() -> Unit = {
+            mainPlan(pkg)
+        }
+    }
+
+    private val mainPlan: suspend AutomationExplorer.Context.(Installed) -> Unit = { pkg ->
+        log(TAG, INFO) { "Executing plan for ${pkg.installId} with context $this" }
+
+        var windowPkg: Pkg.Id? = null
+
+        val step = StepProcessor.Step(
+            source = TAG,
+            descriptionInternal = "Storage entry (main plan)",
+            label = R.string.appcleaner_automation_progress_find_storage.toCaString(""),
+            windowIntent = defaultWindowIntent(pkg),
+            windowEventFilter = { event ->
+                // Some MIUI14 devices send the change event for the system settings app
+                event.pkgId == SETTINGS_PKG_HYPEROS || event.pkgId == SETTINGS_PKG_AOSP
+            },
+            windowNodeTest = {
+                when {
+                    windowCriteriaAppIdentifier(SETTINGS_PKG_HYPEROS, ipcFunnel, pkg)(it) -> {
+                        windowPkg = SETTINGS_PKG_HYPEROS
+                        true
+                    }
+
+                    windowCriteriaAppIdentifier(SETTINGS_PKG_AOSP, ipcFunnel, pkg)(it) -> {
+                        windowPkg = SETTINGS_PKG_AOSP
+                        true
+                    }
+
+                    else -> {
+                        log(TAG) { "Unknown window: ${it.pkgId}" }
+                        false
+                    }
+                }
+            },
+        )
+        stepper.withProgress(this) { process(step) }
+
+        log(TAG) { "Launched window pkg was $windowPkg" }
+        when (windowPkg) {
+            SETTINGS_PKG_AOSP -> settingsPlan(pkg)
+            SETTINGS_PKG_HYPEROS -> securityCenterPlan(pkg)
+            else -> throw IllegalStateException("Unknown window: $windowPkg")
+        }
+    }
+
+    private val settingsPlan: suspend AutomationExplorer.Context.(Installed) -> Unit = { pkg ->
+        log(TAG, INFO) { "Executing AOSP settings plan for ${pkg.installId} with context $this" }
+
+        val locale = getSysLocale()
+        val lang = locale.language
+        val script = locale.script
+
+        run {
+            val storageEntryLabels =
+                aospLabels.getStorageEntryDynamic() + aospLabels.getStorageEntryStatic(lang, script)
+
+            val storageFilter = onTheFlyLabler.getAOSPStorageFilter(storageEntryLabels, pkg)
+
+            val step = StepProcessor.Step(
+                source = TAG,
+                descriptionInternal = "Storage entry (settings plan)",
+                label = R.string.appcleaner_automation_progress_find_storage.toCaString(storageEntryLabels),
+                nodeTest = storageFilter,
+                nodeRecovery = getDefaultNodeRecovery(pkg),
+                nodeMapping = clickableParent(),
+                action = defaultClick()
+            )
+            stepper.withProgress(this) { process(step) }
+        }
+
+        run {
+            val clearCacheButtonLabels =
+                aospLabels.getClearCacheDynamic() + aospLabels.getClearCacheStatic(lang, script)
+
+            val buttonFilter = fun(node: AccessibilityNodeInfo): Boolean {
+                if (!node.isClickyButton()) return false
+                return node.textMatchesAny(clearCacheButtonLabels)
+            }
+
+            val step = StepProcessor.Step(
+                source = TAG,
+                descriptionInternal = "Clear cache (settings plan)",
+                label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheButtonLabels),
+                nodeTest = buttonFilter,
+                action = getAospClearCacheClick(pkg, tag)
+            )
+            stepper.withProgress(this) { process(step) }
+        }
+    }
+
+    private val securityCenterPlan: suspend AutomationExplorer.Context.(Installed) -> Unit = { pkg ->
+        log(TAG, INFO) { "Executing MIUI security center plan for ${pkg.installId} with context $this" }
+
+        val locale = getSysLocale()
+        val lang = locale.language
+        val script = locale.script
+        val country = locale.country
+
+        log(VERBOSE) { "Getting specs for ${pkg.packageName} (lang=$lang, script=$script, country=$country)" }
+
+        val clearDataLabels = hyperOsLabels.getClearDataButtonLabels(lang, script, country)
+        log(TAG) { "clearDataLabels=$clearDataLabels" }
+        val clearCacheLabels = hyperOsLabels.getClearCacheButtonLabels(lang, script, country)
+        log(TAG) { "clearCacheLabels=$clearCacheLabels" }
+        val dialogTitles = hyperOsLabels.getDialogTitles(lang, script, country)
+        log(TAG) { "clearCacheLabels=$clearCacheLabels" }
+
+        var useAlternativeStep = deviceAdminManager.getDeviceAdmins().contains(pkg.id).also {
+            if (it) log(TAG) { "${pkg.id} is a device admin, using alternative step directly." }
+        }
+
+        if (!useAlternativeStep) {
+            val clearDataFilter: suspend (AccessibilityNodeInfo) -> Boolean = filter@{ node ->
+                if (!node.isTextView()) return@filter false
+                if (node.textMatchesAny(clearDataLabels)) return@filter true
+                if (node.textMatchesAny(clearCacheLabels)) {
+                    useAlternativeStep = true
+                    throw StepAbortException("Got 'Clear cache' instead of 'Clear data' skip the action dialog step.")
+                }
+                return@filter false
+            }
+            val step = StepProcessor.Step(
+                source = TAG,
+                descriptionInternal = "Clear data button (security center plan)",
+                label = R.string.appcleaner_automation_progress_find_clear_data.toCaString(clearDataLabels),
+                windowNodeTest = windowCriteriaAppIdentifier(SETTINGS_PKG_HYPEROS, ipcFunnel, pkg),
+                nodeTest = clearDataFilter,
+                nodeRecovery = getDefaultNodeRecovery(pkg),
+                nodeMapping = clickableParent(),
+                action = defaultClick()
+            )
+            stepper.withProgress(this) { process(step) }
+        }
+
+        if (useAlternativeStep) {
+            val alternativeStep: StepProcessor.Step = StepProcessor.Step(
+                source = TAG,
+                descriptionInternal = "Clear cache button (alternative security center plan)",
+                label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheLabels),
+                windowNodeTest = windowCriteriaAppIdentifier(SETTINGS_PKG_HYPEROS, ipcFunnel, pkg),
+                nodeTest = { it.isTextView() && it.textMatchesAny(clearCacheLabels) },
+                nodeMapping = clickableParent(),
+                action = defaultClick()
+            )
+            stepper.withProgress(this) { process(alternativeStep) }
+        } else {
+            // This may be skipped when MIUI just shows a 'Clear cache' option
+
+            // Clear data
+            // -> Clear data
+            // -> Clear cache
+            // -> Cancel
+
+            val windowCriteria = fun(node: AccessibilityNodeInfo): Boolean {
+                if (node.pkgId != SETTINGS_PKG_HYPEROS) return false
+                return node.crawl().map { it.node }.any { it.idContains("id/alertTitle") }
+            }
+            val entryFilter = fun(node: AccessibilityNodeInfo): Boolean {
+                if (!node.isClickable || !node.isTextView()) return false
+                return node.textMatchesAny(clearCacheLabels)
+            }
+
+            val step = StepProcessor.Step(
+                source = TAG,
+                descriptionInternal = "Clear cache button (security center plan)",
+                label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheLabels),
+                windowNodeTest = windowCriteria,
+                nodeTest = entryFilter,
+                action = defaultClick()
+            )
+            stepper.withProgress(this) { process(step) }
+        }
+
+        // Clear cache?
+        // -> Cancel        -> Ok
+        run {
+            val windowCriteria = fun(node: AccessibilityNodeInfo): Boolean {
+                if (node.pkgId != SETTINGS_PKG_HYPEROS) return false
+                return node.crawl().map { it.node }.any { subNode ->
+                    // This is required to relax the match on the dialog texts
+                    // Otherwise it could detect the clear cache button as match
+                    if (!subNode.idContains("id/alertTitle")) return@any false
+                    return@any when {
+                        subNode.textMatchesAny(dialogTitles) -> true
+                        subNode.textMatchesAny(dialogTitles.map { it.replace("?", "") }) -> true
+                        subNode.textMatchesAny(dialogTitles.map { "$it?" }) -> true
+                        subNode.textEndsWithAny(clearCacheLabels.map { "$it?" }) -> true
+                        subNode.textEndsWithAny(clearCacheLabels) -> true
+                        else -> false
+                    }
+                }
+            }
+
+            val buttonFilter = fun(node: AccessibilityNodeInfo): Boolean {
+                if (!node.isClickyButton()) return false
+                return when (Bugs.isDryRun) {
+                    true -> node.idMatches("android:id/button2")
+                    false -> node.idMatches("android:id/button1")
+                }
+            }
+
+            val step = StepProcessor.Step(
+                source = TAG,
+                descriptionInternal = "Confirm clear cache (security center plan)",
+                label = R.string.appcleaner_automation_progress_find_ok_confirmation.toCaString(""),
+                windowNodeTest = windowCriteria,
+                nodeTest = buttonFilter,
+                action = defaultClick()
+            )
+            stepper.withProgress(this) { process(step) }
+        }
+    }
+
+    @Module @InstallIn(SingletonComponent::class)
+    abstract class DIM {
+        @Binds @IntoSet abstract fun mod(mod: HyperOsSpecs): AppCleanerSpecGenerator
+    }
+
+    companion object {
+        val TAG: String = logTag("AppCleaner", "Automation", "HyperOS", "Specs")
+        private val SETTINGS_PKG_HYPEROS = "com.miui.securitycenter".toPkgId()
+        private val SETTINGS_PKG_AOSP = "com.android.settings".toPkgId()
+
+    }
+
+}

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/lge/LGESpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/lge/LGESpecs.kt
@@ -59,6 +59,7 @@ class LGESpecs @Inject constructor(
     }
 
     override suspend fun getClearCache(pkg: Installed): AutomationSpec = object : AutomationSpec.Explorer {
+        override val tag: String = TAG
         override suspend fun createPlan(): suspend AutomationExplorer.Context.() -> Unit = {
             mainPlan(pkg)
         }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/lge/LGESpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/lge/LGESpecs.kt
@@ -81,7 +81,8 @@ class LGESpecs @Inject constructor(
             val storageFilter = onTheFlyLabler.getAOSPStorageFilter(storageEntryLabels, pkg)
 
             val step = StepProcessor.Step(
-                parentTag = tag,
+                source = TAG,
+                descriptionInternal = "Storage entry",
                 label = R.string.appcleaner_automation_progress_find_storage.toCaString(storageEntryLabels),
                 windowIntent = defaultWindowIntent(pkg),
                 windowEventFilter = defaultWindowFilter(SETTINGS_PKG),
@@ -103,7 +104,8 @@ class LGESpecs @Inject constructor(
             }
 
             val step = StepProcessor.Step(
-                parentTag = tag,
+                source = TAG,
+                descriptionInternal = "Clear cache",
                 label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheButtonLabels),
                 windowNodeTest = windowCriteriaAppIdentifier(SETTINGS_PKG, ipcFunnel, pkg),
                 nodeTest = buttonFilter,

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/miui/MIUISpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/miui/MIUISpecs.kt
@@ -73,6 +73,7 @@ class MIUISpecs @Inject constructor(
     }
 
     override suspend fun getClearCache(pkg: Installed): AutomationSpec = object : AutomationSpec.Explorer {
+        override val tag: String = TAG
         override suspend fun createPlan(): suspend AutomationExplorer.Context.() -> Unit = {
             mainPlan(pkg)
         }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/miui/MIUISpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/miui/MIUISpecs.kt
@@ -88,7 +88,8 @@ class MIUISpecs @Inject constructor(
         var windowPkg: Pkg.Id? = null
 
         val step = StepProcessor.Step(
-            parentTag = TAG,
+            source = TAG,
+            descriptionInternal = "Storage entry (main plan)",
             label = R.string.appcleaner_automation_progress_find_storage.toCaString(""),
             windowIntent = defaultWindowIntent(pkg),
             windowEventFilter = { event ->
@@ -138,7 +139,8 @@ class MIUISpecs @Inject constructor(
             val storageFilter = onTheFlyLabler.getAOSPStorageFilter(storageEntryLabels, pkg)
 
             val step = StepProcessor.Step(
-                parentTag = tag,
+                source = TAG,
+                descriptionInternal = "Storage entry (settings plan)",
                 label = R.string.appcleaner_automation_progress_find_storage.toCaString(storageEntryLabels),
                 nodeTest = storageFilter,
                 nodeRecovery = getDefaultNodeRecovery(pkg),
@@ -158,7 +160,8 @@ class MIUISpecs @Inject constructor(
             }
 
             val step = StepProcessor.Step(
-                parentTag = tag,
+                source = TAG,
+                descriptionInternal = "Clear cache (settings plan)",
                 label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheButtonLabels),
                 nodeTest = buttonFilter,
                 action = getAospClearCacheClick(pkg, tag)
@@ -206,7 +209,8 @@ class MIUISpecs @Inject constructor(
                 return@filter false
             }
             val step = StepProcessor.Step(
-                parentTag = TAG,
+                source = TAG,
+                descriptionInternal = "Clear data (security center plan)",
                 label = R.string.appcleaner_automation_progress_find_clear_data.toCaString(clearDataLabels),
                 windowNodeTest = windowCriteriaAppIdentifier(SETTINGS_PKG_MIUI, ipcFunnel, pkg),
                 nodeTest = clearDataFilter,
@@ -223,7 +227,8 @@ class MIUISpecs @Inject constructor(
 
         if (useAlternativeStep) {
             val alternativeStep: StepProcessor.Step = StepProcessor.Step(
-                parentTag = TAG,
+                source = TAG,
+                descriptionInternal = "Clear cache (alternative security center plan)",
                 label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheLabels),
                 windowNodeTest = windowCriteriaAppIdentifier(SETTINGS_PKG_MIUI, ipcFunnel, pkg),
                 nodeTest = when {
@@ -260,7 +265,8 @@ class MIUISpecs @Inject constructor(
             }
 
             val step = StepProcessor.Step(
-                parentTag = TAG,
+                source = TAG,
+                descriptionInternal = "Clear cache (security center plan)",
                 label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheLabels),
                 windowNodeTest = windowCriteria,
                 nodeTest = entryFilter,
@@ -298,7 +304,8 @@ class MIUISpecs @Inject constructor(
             }
 
             val step = StepProcessor.Step(
-                parentTag = TAG,
+                source = TAG,
+                descriptionInternal = "Confirm clear cache (security center plan)",
                 label = R.string.appcleaner_automation_progress_find_ok_confirmation.toCaString(""),
                 windowNodeTest = windowCriteria,
                 nodeTest = buttonFilter,

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/nubia/NubiaSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/nubia/NubiaSpecs.kt
@@ -61,6 +61,7 @@ class NubiaSpecs @Inject constructor(
     }
 
     override suspend fun getClearCache(pkg: Installed): AutomationSpec = object : AutomationSpec.Explorer {
+        override val tag: String = TAG
         override suspend fun createPlan(): suspend AutomationExplorer.Context.() -> Unit = {
             mainPlan(pkg)
         }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/nubia/NubiaSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/nubia/NubiaSpecs.kt
@@ -84,7 +84,8 @@ class NubiaSpecs @Inject constructor(
             val storageFilter = onTheFlyLabler.getAOSPStorageFilter(storageEntryLabels, pkg)
 
             val step = StepProcessor.Step(
-                parentTag = tag,
+                source = TAG,
+                descriptionInternal = "Storage entry",
                 label = R.string.appcleaner_automation_progress_find_storage.toCaString(storageEntryLabels),
                 windowIntent = defaultWindowIntent(pkg),
                 windowEventFilter = defaultWindowFilter(SETTINGS_PKG),
@@ -110,7 +111,8 @@ class NubiaSpecs @Inject constructor(
             }
 
             val step = StepProcessor.Step(
-                parentTag = tag,
+                source = TAG,
+                descriptionInternal = "Clear cache",
                 label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheButtonLabels),
                 windowNodeTest = windowCriteriaAppIdentifier(
                     SETTINGS_PKG, ipcFunnel, pkg

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/oneplus/OnePlusSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/oneplus/OnePlusSpecs.kt
@@ -59,6 +59,7 @@ class OnePlusSpecs @Inject constructor(
     }
 
     override suspend fun getClearCache(pkg: Installed): AutomationSpec = object : AutomationSpec.Explorer {
+        override val tag: String = TAG
         override suspend fun createPlan(): suspend AutomationExplorer.Context.() -> Unit = {
             mainPlan(pkg)
         }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/oneplus/OnePlusSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/oneplus/OnePlusSpecs.kt
@@ -82,7 +82,8 @@ class OnePlusSpecs @Inject constructor(
             val storageFilter = onTheFlyLabler.getAOSPStorageFilter(storageEntryLabels, pkg)
 
             val step = StepProcessor.Step(
-                parentTag = tag,
+                source = TAG,
+                descriptionInternal = "Storage entry",
                 label = R.string.appcleaner_automation_progress_find_storage.toCaString(storageEntryLabels),
                 windowIntent = defaultWindowIntent(pkg),
                 windowEventFilter = defaultWindowFilter(SETTINGS_PKG),
@@ -114,7 +115,8 @@ class OnePlusSpecs @Inject constructor(
             }
 
             val step = StepProcessor.Step(
-                parentTag = tag,
+                source = TAG,
+                descriptionInternal = "Clear cache",
                 label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheButtonLabels),
                 windowNodeTest = windowCriteriaAppIdentifier(SETTINGS_PKG, ipcFunnel, pkg),
                 nodeMapping = when {

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/realme/RealmeSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/realme/RealmeSpecs.kt
@@ -84,7 +84,8 @@ class RealmeSpecs @Inject constructor(
             val storageFilter = onTheFlyLabler.getAOSPStorageFilter(storageEntryLabels, pkg)
 
             val step = StepProcessor.Step(
-                parentTag = tag,
+                source = TAG,
+                descriptionInternal = "Storage entry",
                 label = R.string.appcleaner_automation_progress_find_storage.toCaString(storageEntryLabels),
                 windowIntent = defaultWindowIntent(pkg),
                 windowEventFilter = defaultWindowFilter(SETTINGS_PKG),
@@ -117,7 +118,8 @@ class RealmeSpecs @Inject constructor(
 
 
             val step = StepProcessor.Step(
-                parentTag = tag,
+                source = TAG,
+                descriptionInternal = "Clear cache",
                 label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheButtonLabels),
                 windowNodeTest = windowCriteria(SETTINGS_PKG),
                 nodeTest = buttonFilter,

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/realme/RealmeSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/realme/RealmeSpecs.kt
@@ -61,6 +61,7 @@ class RealmeSpecs @Inject constructor(
     }
 
     override suspend fun getClearCache(pkg: Installed): AutomationSpec = object : AutomationSpec.Explorer {
+        override val tag: String = TAG
         override suspend fun createPlan(): suspend AutomationExplorer.Context.() -> Unit = {
             mainPlan(pkg)
         }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/samsung/SamsungSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/samsung/SamsungSpecs.kt
@@ -58,6 +58,7 @@ class SamsungSpecs @Inject constructor(
     }
 
     override suspend fun getClearCache(pkg: Installed): AutomationSpec = object : AutomationSpec.Explorer {
+        override val tag: String = TAG
         override suspend fun createPlan(): suspend AutomationExplorer.Context.() -> Unit = {
             mainPlan(pkg)
         }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/samsung/SamsungSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/samsung/SamsungSpecs.kt
@@ -81,7 +81,8 @@ class SamsungSpecs @Inject constructor(
             val storageFilter = onTheFlyLabler.getAOSPStorageFilter(storageEntryLabels, pkg)
 
             val step = StepProcessor.Step(
-                parentTag = tag,
+                source = TAG,
+                descriptionInternal = "Storage entry",
                 label = R.string.appcleaner_automation_progress_find_storage.toCaString(storageEntryLabels),
                 windowIntent = defaultWindowIntent(pkg),
                 windowEventFilter = defaultWindowFilter(SETTINGS_PKG),
@@ -105,7 +106,8 @@ class SamsungSpecs @Inject constructor(
             }
 
             val step = StepProcessor.Step(
-                parentTag = tag,
+                source = TAG,
+                descriptionInternal = "Clear cache",
                 label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheButtonLabels),
                 windowNodeTest = windowCriteriaAppIdentifier(SETTINGS_PKG, ipcFunnel, pkg),
                 nodeTest = buttonFilter,

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/vivo/VivoSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/vivo/VivoSpecs.kt
@@ -82,7 +82,8 @@ class VivoSpecs @Inject constructor(
             val storageFilter = onTheFlyLabler.getAOSPStorageFilter(storageEntryLabels, pkg)
 
             val step = StepProcessor.Step(
-                parentTag = tag,
+                source = TAG,
+                descriptionInternal = "Storage entry",
                 label = R.string.appcleaner_automation_progress_find_storage.toCaString(storageEntryLabels),
                 windowIntent = defaultWindowIntent(pkg),
                 windowEventFilter = defaultWindowFilter(SETTINGS_PKG),
@@ -124,7 +125,8 @@ class VivoSpecs @Inject constructor(
             }
 
             val step = StepProcessor.Step(
-                parentTag = tag,
+                source = TAG,
+                descriptionInternal = "Clear cache",
                 label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheButtonLabels),
                 windowNodeTest = windowCriteriaAppIdentifier(SETTINGS_PKG, ipcFunnel, pkg),
                 nodeTest = buttonFilter,
@@ -138,6 +140,7 @@ class VivoSpecs @Inject constructor(
                             }
                         }
                     }
+
                     else -> null
                 },
                 action = getAospClearCacheClick(pkg, tag)

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/vivo/VivoSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/vivo/VivoSpecs.kt
@@ -59,6 +59,7 @@ class VivoSpecs @Inject constructor(
     }
 
     override suspend fun getClearCache(pkg: Installed): AutomationSpec = object : AutomationSpec.Explorer {
+        override val tag: String = TAG
         override suspend fun createPlan(): suspend AutomationExplorer.Context.() -> Unit = {
             mainPlan(pkg)
         }

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/androidtv/AndroidTVSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/androidtv/AndroidTVSpecs.kt
@@ -80,7 +80,8 @@ open class AndroidTVSpecs @Inject constructor(
 
         run {
             val step = StepProcessor.Step(
-                parentTag = tag,
+                source = TAG,
+                descriptionInternal = "Force stop button",
                 label = R.string.appcontrol_automation_progress_find_force_stop.toCaString(forceStopLabels),
                 windowIntent = defaultWindowIntent(pkg),
                 windowEventFilter = defaultWindowFilter(SETTINGS_PKG),
@@ -120,7 +121,8 @@ open class AndroidTVSpecs @Inject constructor(
             }
 
             val step = StepProcessor.Step(
-                parentTag = TAG,
+                source = TAG,
+                descriptionInternal = "Confirm force stop",
                 label = R.string.appcleaner_automation_progress_find_ok_confirmation.toCaString(okLbl),
                 windowNodeTest = windowCriteria,
                 nodeTest = buttonFilter,

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/androidtv/AndroidTVSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/androidtv/AndroidTVSpecs.kt
@@ -38,7 +38,6 @@ import eu.darken.sdmse.common.pkgs.features.Installed
 import eu.darken.sdmse.common.pkgs.toPkgId
 import eu.darken.sdmse.common.progress.withProgress
 import eu.darken.sdmse.main.core.GeneralSettings
-import java.util.*
 import javax.inject.Inject
 
 @Reusable
@@ -61,6 +60,7 @@ open class AndroidTVSpecs @Inject constructor(
     }
 
     override suspend fun getForceStop(pkg: Installed): AutomationSpec = object : AutomationSpec.Explorer {
+        override val tag: String = TAG
         override suspend fun createPlan(): suspend AutomationExplorer.Context.() -> Unit = {
             mainPlan(pkg)
         }

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/aosp/AOSPSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/aosp/AOSPSpecs.kt
@@ -36,7 +36,6 @@ import eu.darken.sdmse.common.pkgs.features.Installed
 import eu.darken.sdmse.common.pkgs.toPkgId
 import eu.darken.sdmse.common.progress.withProgress
 import eu.darken.sdmse.main.core.GeneralSettings
-import java.util.*
 import javax.inject.Inject
 
 @Reusable
@@ -58,6 +57,7 @@ class AOSPSpecs @Inject constructor(
     }
 
     override suspend fun getForceStop(pkg: Installed): AutomationSpec = object : AutomationSpec.Explorer {
+        override val tag: String = TAG
         override suspend fun createPlan(): suspend AutomationExplorer.Context.() -> Unit = {
             mainPlan(pkg)
         }

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/aosp/AOSPSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/aosp/AOSPSpecs.kt
@@ -77,7 +77,8 @@ class AOSPSpecs @Inject constructor(
 
         run {
             val step = StepProcessor.Step(
-                parentTag = tag,
+                source = TAG,
+                descriptionInternal = "Force stop button",
                 label = R.string.appcontrol_automation_progress_find_force_stop.toCaString(forceStopLabels),
                 windowIntent = defaultWindowIntent(pkg),
                 windowEventFilter = defaultWindowFilter(SETTINGS_PKG),
@@ -118,7 +119,8 @@ class AOSPSpecs @Inject constructor(
             }
 
             val step = StepProcessor.Step(
-                parentTag = TAG,
+                source = TAG,
+                descriptionInternal = "Confirm force stop button",
                 label = R.string.appcleaner_automation_progress_find_ok_confirmation.toCaString(titleLbl + okLbl),
                 windowNodeTest = windowCriteria,
                 nodeTest = buttonFilter,

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/miui/MIUISpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/miui/MIUISpecs.kt
@@ -77,7 +77,8 @@ class MIUISpecs @Inject constructor(
 
         run {
             val step = StepProcessor.Step(
-                parentTag = tag,
+                source = TAG,
+                descriptionInternal = "Force stop button",
                 label = R.string.appcontrol_automation_progress_find_force_stop.toCaString(forceStopLabels),
                 windowIntent = defaultWindowIntent(pkg),
                 windowEventFilter = defaultWindowFilter(SETTINGS_PKG),
@@ -118,7 +119,8 @@ class MIUISpecs @Inject constructor(
             }
 
             val step = StepProcessor.Step(
-                parentTag = TAG,
+                source = TAG,
+                descriptionInternal = "Confirm force stop",
                 label = R.string.appcleaner_automation_progress_find_ok_confirmation.toCaString(titleLbl + okLbl),
                 windowNodeTest = windowCriteria,
                 nodeTest = buttonFilter,

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/miui/MIUISpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/miui/MIUISpecs.kt
@@ -57,6 +57,7 @@ class MIUISpecs @Inject constructor(
     }
 
     override suspend fun getForceStop(pkg: Installed): AutomationSpec = object : AutomationSpec.Explorer {
+        override val tag: String = TAG
         override suspend fun createPlan(): suspend AutomationExplorer.Context.() -> Unit = {
             mainPlan(pkg)
         }

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/samsung/SamsungSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/samsung/SamsungSpecs.kt
@@ -79,7 +79,8 @@ class SamsungSpecs @Inject constructor(
 
         run {
             val step = StepProcessor.Step(
-                parentTag = tag,
+                source = TAG,
+                descriptionInternal = "Force stop button",
                 label = R.string.appcontrol_automation_progress_find_force_stop.toCaString(forceStopLabels),
                 windowIntent = defaultWindowIntent(pkg),
                 windowEventFilter = defaultWindowFilter(AOSPSpecs.SETTINGS_PKG),
@@ -120,7 +121,8 @@ class SamsungSpecs @Inject constructor(
             }
 
             val step = StepProcessor.Step(
-                parentTag = TAG,
+                source = TAG,
+                descriptionInternal = "Confirm force stop",
                 label = R.string.appcleaner_automation_progress_find_ok_confirmation.toCaString(titleLbl + okLbl),
                 windowNodeTest = windowCriteria,
                 nodeTest = buttonFilter,

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/samsung/SamsungSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/samsung/SamsungSpecs.kt
@@ -38,7 +38,6 @@ import eu.darken.sdmse.common.pkgs.features.Installed
 import eu.darken.sdmse.common.pkgs.toPkgId
 import eu.darken.sdmse.common.progress.withProgress
 import eu.darken.sdmse.main.core.GeneralSettings
-import java.util.*
 import javax.inject.Inject
 
 @Reusable
@@ -60,6 +59,7 @@ class SamsungSpecs @Inject constructor(
     }
 
     override suspend fun getForceStop(pkg: Installed): AutomationSpec = object : AutomationSpec.Explorer {
+        override val tag: String = TAG
         override suspend fun createPlan(): suspend AutomationExplorer.Context.() -> Unit = {
             mainPlan(pkg)
         }

--- a/app/src/main/java/eu/darken/sdmse/automation/core/common/StepProcessor.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/common/StepProcessor.kt
@@ -226,7 +226,8 @@ class StepProcessor @AssistedInject constructor(
     }
 
     data class Step(
-        val parentTag: String,
+        val source: String,
+        val descriptionInternal: String,
         val label: CaString,
         val icon: CaDrawable? = null,
         val windowIntent: Intent? = null,
@@ -237,9 +238,7 @@ class StepProcessor @AssistedInject constructor(
         val nodeMapping: (suspend (node: AccessibilityNodeInfo) -> AccessibilityNodeInfo)? = null,
         val action: (suspend (node: AccessibilityNodeInfo, retryCount: Int) -> Boolean)? = null
     ) {
-
-        override fun toString(): String = "Spec(parent=$parentTag, label=$label)"
-
+        override fun toString(): String = "Spec(source=$source, description=$descriptionInternal)"
     }
 
     data class Result(val success: Boolean, val exception: Exception? = null)

--- a/app/src/main/java/eu/darken/sdmse/automation/core/specs/AutomationExplorer.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/specs/AutomationExplorer.kt
@@ -57,6 +57,8 @@ class AutomationExplorer @AssistedInject constructor(
             override val host: AutomationHost = this@AutomationExplorer.host
 
             override val stepper: StepProcessor = stepProcessorFactory.create(host)
+
+            override fun toString(): String = "AutomationContext(host=$host, stepper=$stepper, attempts=$attempts)"
         }
 
         log(TAG, VERBOSE) { "Creating plan..." }

--- a/app/src/main/java/eu/darken/sdmse/automation/core/specs/AutomationExplorer.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/specs/AutomationExplorer.kt
@@ -39,7 +39,7 @@ class AutomationExplorer @AssistedInject constructor(
     }
 
     suspend fun process(spec: AutomationSpec.Explorer) {
-        log(TAG) { "process(): $spec" }
+        log(TAG) { "process(): ${spec.tag}" }
 
         var attempts = 0
 

--- a/app/src/main/java/eu/darken/sdmse/automation/core/specs/AutomationSpec.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/specs/AutomationSpec.kt
@@ -3,8 +3,8 @@ package eu.darken.sdmse.automation.core.specs
 import java.time.Duration
 
 sealed interface AutomationSpec {
+    val tag: String
     interface Explorer : AutomationSpec {
-
         val executionTimeout: Duration
             get() = Duration.ofSeconds(20)
 


### PR DESCRIPTION
* Fix ROM type override in general settings resetting
* Add ROM type detection for HyperOS 1.0 and 2.0
* Also fork the MIUI ACS logic and create a new HyperOS setup that we can expand in the future.

Fixes #1538