### PR TITLE
Overhaul internal resource management

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/ipc/RemoteFileHandleExtensions.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/ipc/RemoteFileHandleExtensions.kt
@@ -33,7 +33,7 @@ internal fun FileHandle.remoteFileHandle(): RemoteFileHandle.Stub = object : Rem
 
     override fun read(fileOffset: Long, array: ByteArray, arrayOffset: Int, byteCount: Int): Int = try {
         this@remoteFileHandle.read(fileOffset, array, arrayOffset, byteCount).also {
-            if (Bugs.isDive) {
+            if (Bugs.isTrace) {
                 log(VERBOSE) { "read(rootside-p): $fileOffset, ${array.size}, $arrayOffset, $byteCount, read $it into ${array.toHex()}" }
             }
         }
@@ -73,7 +73,7 @@ internal fun RemoteFileHandle.fileHandle(readWrite: Boolean): FileHandle = objec
     @Throws(IOException::class)
     override fun protectedRead(fileOffset: Long, array: ByteArray, arrayOffset: Int, byteCount: Int): Int = try {
         this@fileHandle.read(fileOffset, array, arrayOffset, byteCount).also {
-            if (Bugs.isDive) {
+            if (Bugs.isTrace) {
                 log(VERBOSE) { "read(appside-p): $fileOffset, ${array.size}, $arrayOffset, $byteCount, read $it into ${array.toHex()}" }
             }
             if (it == -2) throw IOException("Remote Exception")

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/ipc/RemoteFileHandleExtensions.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/ipc/RemoteFileHandleExtensions.kt
@@ -33,7 +33,7 @@ internal fun FileHandle.remoteFileHandle(): RemoteFileHandle.Stub = object : Rem
 
     override fun read(fileOffset: Long, array: ByteArray, arrayOffset: Int, byteCount: Int): Int = try {
         this@remoteFileHandle.read(fileOffset, array, arrayOffset, byteCount).also {
-            if (Bugs.isTraceDeepDive) {
+            if (Bugs.isDive) {
                 log(VERBOSE) { "read(rootside-p): $fileOffset, ${array.size}, $arrayOffset, $byteCount, read $it into ${array.toHex()}" }
             }
         }
@@ -73,7 +73,7 @@ internal fun RemoteFileHandle.fileHandle(readWrite: Boolean): FileHandle = objec
     @Throws(IOException::class)
     override fun protectedRead(fileOffset: Long, array: ByteArray, arrayOffset: Int, byteCount: Int): Int = try {
         this@fileHandle.read(fileOffset, array, arrayOffset, byteCount).also {
-            if (Bugs.isTraceDeepDive) {
+            if (Bugs.isDive) {
                 log(VERBOSE) { "read(appside-p): $fileOffset, ${array.size}, $arrayOffset, $byteCount, read $it into ${array.toHex()}" }
             }
             if (it == -2) throw IOException("Remote Exception")

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/root/service/RootServiceClient.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/root/service/RootServiceClient.kt
@@ -43,9 +43,9 @@ class RootServiceClient @Inject constructor(
     private val pkgOpsClientFactory: PkgOpsClient.Factory,
     private val shellOpsClientFactory: ShellOpsClient.Factory,
 ) : SharedResource<RootServiceClient.Connection>(
-    TAG,
-    coroutineScope,
-    callbackFlow {
+    tag = TAG,
+    parentScope = coroutineScope,
+    source = callbackFlow {
         log(TAG) { "Instantiating Root launcher..." }
         if (rootSettings.useRoot.value() != true) throw RootUnavailableException("Root is not enabled")
 
@@ -99,7 +99,6 @@ class RootServiceClient @Inject constructor(
                 )
             )
         }
-
 ) {
 
     data class Connection(

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/shell/ShellOps.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/shell/ShellOps.kt
@@ -55,13 +55,7 @@ class ShellOps @Inject constructor(
         }
     }
 
-    private suspend fun <T> runIO(
-        block: suspend CoroutineScope.() -> T
-    ): T = withContext(dispatcherProvider.IO) {
-        block()
-    }
-
-    suspend fun execute(cmd: ShellOpsCmd, mode: Mode): ShellOpsResult = runIO {
+    suspend fun execute(cmd: ShellOpsCmd, mode: Mode): ShellOpsResult = withContext(dispatcherProvider.IO) {
         try {
             var result: ShellOpsResult? = null
             if (mode == Mode.NORMAL) {

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/user/UserManager2.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/user/UserManager2.kt
@@ -55,8 +55,11 @@ class UserManager2 @Inject constructor(
         log(TAG) { "allUsers(): shellMode=$shellMode" }
 
         if (shellMode != null) {
-            val shellResult = shellOps.execute(ShellOpsCmd("pm list users"), shellMode)
-            if (shellResult.isSuccess) {
+            try {
+                val shellResult = shellOps.execute(ShellOpsCmd("pm list users"), shellMode)
+                log(TAG) { "allUser() result: $shellResult" }
+                if (!shellResult.isSuccess) throw IllegalStateException("allUser() failed: ")
+
                 shellResult.output
                     .mapNotNull { userListRegex.matchEntire(it) }
                     .mapNotNull { match ->
@@ -73,6 +76,8 @@ class UserManager2 @Inject constructor(
                         }
                     }
                     .run { profiles.addAll(this) }
+            } catch (e: Exception) {
+                log(TAG, ERROR) { "allUsers(): Lookup failed ${e.asLog()}" }
             }
         }
 

--- a/app-common-root/src/main/java/eu/darken/sdmse/common/root/service/internal/RootIPC.kt
+++ b/app-common-root/src/main/java/eu/darken/sdmse/common/root/service/internal/RootIPC.kt
@@ -95,7 +95,7 @@ class RootIPC @AssistedInject constructor(
         }
 
         override fun bye(self: IBinder) {
-            log(TAG) { "self(self=$self)" }
+            log(TAG) { "bye(self=$self)" }
             // The non-root process is either informing us it is going away, or it already died
             synchronized(connections) {
                 getConnection(self)?.let { conn ->
@@ -205,6 +205,7 @@ class RootIPC @AssistedInject constructor(
                     log { "pruneConnections() $con: isBinderAlive=$it" }
                 }
             }
+            connections.forEach { log { "Remaining connection after pruning: $it" } }
             if (!connectionSeen && connections.size > 0) {
                 connectionSeen = true
                 synchronized(helloWaiter) { helloWaiter.notifyAll() }

--- a/app-common-shell/src/main/java/eu/darken/flowshell/core/FlowShellDebug.kt
+++ b/app-common-shell/src/main/java/eu/darken/flowshell/core/FlowShellDebug.kt
@@ -4,4 +4,5 @@ import eu.darken.sdmse.common.debug.Bugs
 
 object FlowShellDebug {
     var isDebug: Boolean = Bugs.isTrace
+    var tag = "SDMSE:FS"
 }

--- a/app-common-shell/src/main/java/eu/darken/flowshell/core/process/FlowProcessExtensions.kt
+++ b/app-common-shell/src/main/java/eu/darken/flowshell/core/process/FlowProcessExtensions.kt
@@ -1,5 +1,6 @@
 package eu.darken.flowshell.core.process
 
+import eu.darken.flowshell.core.FlowShellDebug
 import eu.darken.flowshell.core.FlowShellDebug.isDebug
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
@@ -16,7 +17,7 @@ import java.io.InputStream
 import java.io.OutputStreamWriter
 import java.util.regex.Pattern
 
-private const val TAG = "FS:FlowProcess:Extensions"
+private val TAG = "${FlowShellDebug.tag}:FlowProcess:Extensions"
 private val PID_PATTERN = Pattern.compile("^.+?pid=(\\d+).+?$")
 private val SPACES_PATTERN = Pattern.compile("\\s+")
 

--- a/app-common-shell/src/main/java/eu/darken/sdmse/common/shell/SharedShell.kt
+++ b/app-common-shell/src/main/java/eu/darken/sdmse/common/shell/SharedShell.kt
@@ -1,6 +1,7 @@
 package eu.darken.sdmse.common.shell
 
 import eu.darken.flowshell.core.cmd.FlowCmdShell
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
@@ -24,7 +25,7 @@ class SharedShell(
 ) : HasSharedResource<FlowCmdShell.Session> {
     private val aTag = "$tag:SharedShell"
     private val source = callbackFlow {
-        log(aTag) { "Launching SharedShell session" }
+        log(aTag, INFO) { "Launching SharedShell session" }
 
         invokeOnClose { log(aTag) { "Shared shell invokeOnClose!" } }
 
@@ -37,16 +38,20 @@ class SharedShell(
             throw e
         }
 
-        log(aTag, VERBOSE) { "Sending obtained session instance: $session" }
+        log(aTag, INFO) { "Sending obtained session instance: $session" }
         send(session)
 
         log(aTag) { "Shared shell is open, waiting until close" }
         session.waitFor()
         awaitClose {
-            log(aTag) { "Closing!" }
+            // Why is this never reached if we cancel the source job
+            log(aTag, INFO) { "Closing!" }
             runBlocking {
                 try {
-                    withTimeoutOrNull(5 * 1000) { session.close() } ?: session.cancel()
+                    withTimeoutOrNull(5 * 1000) { session.close() } ?: run {
+                        log(aTag, WARN) { "Session did not close in time, canceling" }
+                        session.cancel()
+                    }
                     val exitCode = session.waitFor()
                     log(aTag) { "FlowCmdShell finished with exitcode $exitCode" }
                 } catch (e: CancellationException) {

--- a/app-common-shell/src/main/java/eu/darken/sdmse/common/shell/SharedShell.kt
+++ b/app-common-shell/src/main/java/eu/darken/sdmse/common/shell/SharedShell.kt
@@ -1,6 +1,7 @@
 package eu.darken.sdmse.common.shell
 
 import eu.darken.flowshell.core.cmd.FlowCmdShell
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.flow.replayingShare
@@ -23,18 +24,24 @@ class SharedShell(
 ) : HasSharedResource<FlowCmdShell.Session> {
     private val aTag = "$tag:SharedShell"
     private val source = callbackFlow {
-        log(aTag) { "Initiating connection to host." }
+        log(aTag) { "Launching SharedShell session" }
+
+        invokeOnClose { log(aTag) { "Shared shell invokeOnClose!" } }
 
         val session = try {
             val sharedSession = FlowCmdShell().session.replayingShare(this)
             sharedSession.launchIn(this + Dispatchers.IO)
+            log(aTag, VERBOSE) { "Shared shell is launched" }
             sharedSession.first()
         } catch (e: Exception) {
             throw e
         }
 
+        log(aTag, VERBOSE) { "Sending obtained session instance: $session" }
         send(session)
 
+        log(aTag) { "Shared shell is open, waiting until close" }
+        session.waitFor()
         awaitClose {
             log(aTag) { "Closing!" }
             runBlocking {

--- a/app-common-shell/src/test/java/eu/darken/flowshell/core/process/FlowProcessTest.kt
+++ b/app-common-shell/src/test/java/eu/darken/flowshell/core/process/FlowProcessTest.kt
@@ -61,7 +61,7 @@ class FlowProcessTest : BaseTest() {
         var stopped = -1L
         val flow = FlowProcess(
             launch = {
-                ProcessBuilder("sleep", "1").start().also {
+                ProcessBuilder("sleep", "2").start().also {
                     started = System.currentTimeMillis()
                 }
             },

--- a/app-common-shell/src/test/java/eu/darken/sdmse/common/shell/SharedShellTest.kt
+++ b/app-common-shell/src/test/java/eu/darken/sdmse/common/shell/SharedShellTest.kt
@@ -1,0 +1,94 @@
+package eu.darken.sdmse.common.shell
+
+
+import eu.darken.flowshell.core.FlowShellDebug
+import eu.darken.flowshell.core.cmd.FlowCmd
+import eu.darken.flowshell.core.cmd.execute
+import eu.darken.sdmse.common.debug.Bugs
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.plus
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+import kotlin.time.Duration.Companion.seconds
+
+class SharedShellTest : BaseTest() {
+    @BeforeEach
+    fun setup() {
+        FlowShellDebug.isDebug = true
+        Bugs.apply {
+            isDebug = true
+            isTrace = true
+            isDive = true
+        }
+    }
+
+    @AfterEach
+    fun teardown() {
+        FlowShellDebug.isDebug = false
+        Bugs.apply {
+            isDebug = false
+            isTrace = false
+            isDive = false
+        }
+    }
+
+    @Test fun `base operation`() = runTest2(autoCancel = true) {
+        val sharedShell = SharedShell("SDMSE", this + Dispatchers.Default)
+
+        sharedShell.useRes { FlowCmd("echo test").execute(it) }.apply {
+            isSuccessful shouldBe true
+        }
+    }
+
+    @Test fun `reuse in the same session`() = runTest2(autoCancel = true, timeout = 600.seconds) {
+        val sharedShell = SharedShell("SDMSE", this + Dispatchers.Default)
+        sharedShell.useRes {
+            (1..100).forEach { count ->
+                FlowCmd("echo test-$count").execute(it).apply {
+                    isSuccessful shouldBe true
+                }
+            }
+        }
+    }
+
+    @Test fun `reuse while closing the sessions`() = runTest2(autoCancel = true, timeout = 600.seconds) {
+        val sharedShell = SharedShell("SDMSE", this + Dispatchers.Default)
+
+        (1..100).forEach { count ->
+            sharedShell.useRes { FlowCmd("echo test-$count").execute(it) }.apply {
+                isSuccessful shouldBe true
+                output shouldBe listOf("test-$count")
+            }
+        }
+    }
+
+    @Test fun `reuse with cancel`() = runTest2(autoCancel = true, timeout = 600.seconds) {
+        val sharedShell = SharedShell("SDMSE", this + Dispatchers.Default)
+
+        shouldThrow<CancellationException> {
+            coroutineScope {
+                sharedShell.useRes { session ->
+                    (1..100).forEach { count ->
+                        FlowCmd("echo test-$count").execute(session).isSuccessful shouldBe true
+                    }
+                    launch {
+                        this@coroutineScope.cancel()
+                    }
+                }
+            }
+        }
+
+        (1..100).forEach { count ->
+            sharedShell.useRes { FlowCmd("echo test-$count").execute(it) }.isSuccessful shouldBe true
+        }
+    }
+}

--- a/app-common-shell/src/test/java/eu/darken/sdmse/common/shell/SharedShellTest.kt
+++ b/app-common-shell/src/test/java/eu/darken/sdmse/common/shell/SharedShellTest.kt
@@ -27,7 +27,6 @@ class SharedShellTest : BaseTest() {
         Bugs.apply {
             isDebug = true
             isTrace = true
-            isDive = true
         }
     }
 
@@ -37,7 +36,6 @@ class SharedShellTest : BaseTest() {
         Bugs.apply {
             isDebug = false
             isTrace = false
-            isDive = false
         }
     }
 

--- a/app-common-shell/src/test/java/eu/darken/sdmse/common/shell/SharedShellTest.kt
+++ b/app-common-shell/src/test/java/eu/darken/sdmse/common/shell/SharedShellTest.kt
@@ -43,7 +43,6 @@ class SharedShellTest : BaseTest() {
 
     @Test fun `base operation`() = runTest2(autoCancel = true) {
         val sharedShell = SharedShell("SDMSE", this + Dispatchers.Default)
-
         sharedShell.useRes { FlowCmd("echo test").execute(it) }.apply {
             isSuccessful shouldBe true
         }
@@ -52,7 +51,7 @@ class SharedShellTest : BaseTest() {
     @Test fun `reuse in the same session`() = runTest2(autoCancel = true, timeout = 600.seconds) {
         val sharedShell = SharedShell("SDMSE", this + Dispatchers.Default)
         sharedShell.useRes {
-            (1..100).forEach { count ->
+            (1..1000).forEach { count ->
                 FlowCmd("echo test-$count").execute(it).apply {
                     isSuccessful shouldBe true
                 }
@@ -62,8 +61,7 @@ class SharedShellTest : BaseTest() {
 
     @Test fun `reuse while closing the sessions`() = runTest2(autoCancel = true, timeout = 600.seconds) {
         val sharedShell = SharedShell("SDMSE", this + Dispatchers.Default)
-
-        (1..100).forEach { count ->
+        (1..1000).forEach { count ->
             sharedShell.useRes { FlowCmd("echo test-$count").execute(it) }.apply {
                 isSuccessful shouldBe true
                 output shouldBe listOf("test-$count")
@@ -77,7 +75,7 @@ class SharedShellTest : BaseTest() {
         shouldThrow<CancellationException> {
             coroutineScope {
                 sharedShell.useRes { session ->
-                    (1..100).forEach { count ->
+                    (1..1000).forEach { count ->
                         FlowCmd("echo test-$count").execute(session).isSuccessful shouldBe true
                     }
                     launch {

--- a/app-common-test/src/main/java/testhelpers/coroutine/TestExtensions.kt
+++ b/app-common-test/src/main/java/testhelpers/coroutine/TestExtensions.kt
@@ -1,6 +1,7 @@
 package testhelpers.coroutine
 
 import eu.darken.sdmse.common.debug.logging.asLog
+import eu.darken.sdmse.common.debug.logging.log
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.TestScope
@@ -8,17 +9,22 @@ import kotlinx.coroutines.test.runTest
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.reflect.KClass
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 fun runTest2(
     autoCancel: Boolean = false,
     context: CoroutineContext = EmptyCoroutineContext,
     expectedError: KClass<out Throwable>? = null,
+    timeout: Duration = 60.seconds,
     testBody: suspend TestScope.() -> Unit
 ) {
     try {
         val scope = TestScope(context = context)
         try {
-            scope.runTest {
+            scope.runTest(
+                timeout = timeout
+            ) {
                 testBody()
                 if (autoCancel) scope.cancel("autoCancel")
             }
@@ -28,7 +34,7 @@ fun runTest2(
         }
     } catch (e: CancellationException) {
         if (e.message == "autoCancel" && autoCancel) {
-            io.kotest.mpp.log { "Test was auto-cancelled ${e.asLog()}" }
+            log("test") { "Test was auto-cancelled ${e.asLog()}" }
         } else {
             throw e
         }

--- a/app-common/src/main/java/eu/darken/sdmse/common/JUnitLogger.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/JUnitLogger.kt
@@ -11,8 +11,8 @@ class JUnitLogger(private val minLogLevel: Logging.Priority = Logging.Priority.V
 
     override fun log(priority: Logging.Priority, tag: String, message: String, metaData: Map<String, Any>?) {
         val now = Instant.now()
-        val seconds = Duration.between(startTime, now).seconds
-        println("${now.toEpochMilli()} ($seconds) ${priority.shortLabel}/$tag: $message")
+        val ms = Duration.between(startTime, now).toMillis()
+        println("${now.toEpochMilli()} ($ms) ${priority.shortLabel}/$tag: $message")
     }
 
 }

--- a/app-common/src/main/java/eu/darken/sdmse/common/debug/Bugs.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/debug/Bugs.kt
@@ -27,9 +27,6 @@ object Bugs {
     var isDryRun = false
     var isDebug = false
     var isTrace = false
-    var isDeepDive = false
-    val isTraceDeepDive: Boolean
-        get() = isTrace && isDeepDive
 
     var processTag: String = "Default"
 

--- a/app-common/src/main/java/eu/darken/sdmse/common/sharedresource/Resource.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/sharedresource/Resource.kt
@@ -4,7 +4,7 @@ import kotlin.coroutines.cancellation.CancellationException
 
 data class Resource<T>(
     private val _item: T,
-    val lease: SharedResource<*>.ActiveLease,
+    val lease: SharedResource<*>.Lease,
 ) : KeepAlive by lease {
     val item: T
         get() {

--- a/app-common/src/main/java/eu/darken/sdmse/common/sharedresource/SharedResource.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/sharedresource/SharedResource.kt
@@ -7,6 +7,7 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.traceCall
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
@@ -14,7 +15,6 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.awaitClose
-import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
@@ -22,189 +22,266 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.isActive
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.newCoroutineContext
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.yield
+import java.time.Duration
 import java.util.UUID
 
 /**
  * A utility class to create child/parent dependencies for expensive resources.
  * Allows keeping reusable resources alive until it is no longer needed by anyone.
  */
-@Suppress("ProtectedInFinal")
 open class SharedResource<T : Any>(
     tag: String,
     parentScope: CoroutineScope,
     private val source: Flow<T>,
+    private val stopTimeout: Duration = Duration.ofSeconds(3),
 ) : KeepAlive {
     private val iTag = "$tag:SR"
     override val resourceId: String = iTag
 
+    private val coreLock = Mutex()
+
     private val leaseScope = CoroutineScope(parentScope.newCoroutineContext(SupervisorJob()))
 
-    private val lock = Mutex()
+    private val leaseCheckLock = Mutex()
+    private var leaseCheckJob: Job? = null
 
     private val leases = mutableSetOf<Lease>()
     private val children = mutableMapOf<SharedResource<*>, KeepAlive>()
 
+    private var sId: String? = null
+    private var sourceJob: Job? = null
+    private var sourceValue: T? = null
+    private var sourceError: Throwable? = null
+
     override val isClosed: Boolean
         get() = sourceJob == null
 
-    private var sId: String? = null
-
-    private var sourceJob: Job? = null
-    private var sourceValue: T? = null
-
-    suspend fun get(): Resource<T> = lock.withLock {
+    suspend fun get(): Resource<T> {
         val lId = "L:${UUID.randomUUID().toString().takeLast(4)}"
-
         if (Bugs.isTrace) {
-            if (isClosed) {
-                log(iTag, DEBUG) { "Lease($lId).get($sId): Getting new sourceValue" }
-            } else {
-                log(iTag, VERBOSE) { "Lease($lId).get($sId): Getting current sourceValue ($sId)" }
-            }
+            val call = traceCall()
+            log(iTag, VERBOSE) { "[$sId|$lId]-get() ... via $call" }
         }
 
-        if (sourceJob == null) {
-            sId = "S:${UUID.randomUUID().toString().takeLast(4)}"
-
-            log(iTag, DEBUG) { "Core($sId): Launching source job..." }
-            var sourceError: Throwable? = null
-            sourceJob = source
-                .onEach {
-                    sourceValue = it.also { log(iTag) { "Core($sId): sourceValue=$it" } }
-                }
-                .catch { error ->
-                    log(iTag, WARN) { "Core($sId): Source ERROR, closing SharedResource: ${error.asLog()}" }
-                    sourceError = error
-                }
-                .onCompletion { error ->
-                    log(iTag, DEBUG) { "Core($sId): Source completed, closing SharedResource..." }
-                    closeInternal()
-                }
-                .launchIn(leaseScope)
-
-            if (Bugs.isDive) log(iTag, VERBOSE) { "Lease($lId).get($sId): Waiting for resource" }
-            while (sourceValue == null && currentCoroutineContext().isActive) {
-                sourceError?.let { throw it }
-                delay(1)
-            }
+        if (sourceJob?.isActive == false) {
+            if (Bugs.isTrace) log(iTag, DEBUG) { "[$sId|$lId]-get() Source is currently closing, waiting..." }
+            while (sourceJob != null) yield()
         }
 
-        val lease = withContext(NonCancellable) {
-            Lease(
-                id = lId,
-                job = leaseScope.launch {
-                    if (Bugs.isDive) log(iTag, VERBOSE) { "Lease($lId).get($sId): Lease is active" }
-                    awaitCancellation()
-                },
-                traceTag = if (Bugs.isDive) traceCall() else null
-            ).also { leases.add(it) }
-        }
+        var lease: Lease? = null
 
-        if (Bugs.isTrace) {
-            val leaseSize = leases.size
-            log(iTag, VERBOSE) { "Lease($lId).get($sId): Now holding $leaseSize lease(s)" }
-
-            if (Bugs.isDive) {
-                try {
-                    leases.toList().forEachIndexed { i, l ->
-                        log(iTag, VERBOSE) { "Lease($lId).get($sId): Now holding #$i - $l" }
+        coreLock.withLock("[$sId|$lId]-get()-sourcejob") {
+            withContext(NonCancellable) {
+                if (Bugs.isTrace) log(iTag, VERBOSE) { "[$sId|$lId]-get() getting lease..." }
+                lease = Lease(
+                    id = lId,
+                    job = leaseScope.launch {
+                        if (Bugs.isTrace) log(iTag, VERBOSE) { "[$sId|$lId]-get() Lease is active" }
+                        awaitCancellation()
+                    },
+                ).also {
+                    leases.add(it)
+                    if (Bugs.isTrace) {
+                        log(iTag, VERBOSE) { "[$sId|$lId]-get() Now holding ${leases.size} lease(s)" }
+                        leases.toList().forEachIndexed { i, l ->
+                            log(iTag, VERBOSE) { "[$sId|$lId]-get() Now holding #$i - $l" }
+                        }
                     }
-                } catch (e: Exception) {
-                    log(iTag, VERBOSE) { "Lease($lId).get($sId): Lease logging concurrency error" }
                 }
+
+                if (Bugs.isTrace) log(iTag, DEBUG) { "[$sId|$lId]-get() Checking for source job..." }
+                if (sourceJob != null) {
+                    if (Bugs.isTrace) log(iTag, VERBOSE) { "[$sId|$lId]-get() Source job already exists" }
+                    return@withContext
+                }
+
+                if (Bugs.isTrace) log(iTag, DEBUG) { "[$sId|$lId]-get() Launching source job..." }
+                sId = "S:${UUID.randomUUID().toString().takeLast(4)}"
+                sourceError = null
+                sourceJob = source
+                    .onStart {
+                        if (Bugs.isTrace) log(iTag) { "[$sId|$lId]-source: Starting source..." }
+                    }
+                    .onEach {
+                        if (Bugs.isTrace) log(iTag) { "[$sId|$lId]-source: sourceValue=$it" }
+                        sourceValue = it
+                    }
+                    .onCompletion { reason ->
+                        if (Bugs.isTrace) log(iTag, DEBUG) { "[$sId|$lId]-source: onCompletion due to $reason" }
+                        sourceError = reason
+                        if (reason is InternalCancelationException) {
+                            if (Bugs.isTrace) log(iTag, DEBUG) { "[$sId|$lId]-source: Internal cancel, no cleanup" }
+                            return@onCompletion
+                        }
+                        leaseScope.launch(NonCancellable) {
+                            if (Bugs.isTrace) {
+                                log(iTag, DEBUG) { "[$sId|$lId]-source: onCompletion calling closeLeases()" }
+                            }
+                            closeLeases("onCompletion")
+                            if (Bugs.isTrace) {
+                                log(iTag, VERBOSE) {
+                                    "[$sId|$lId]-source: onCompletion calling leaseCheck(forced=true)"
+                                }
+                            }
+                            leaseCheck("onCompletion", forced = true)
+                        }
+                        if (Bugs.isTrace) log(iTag, DEBUG) { "[$sId|$lId]-source: onCompletion done" }
+                    }
+                    .catch { error -> log(iTag, WARN) { "[$sId|$lId]-source ERROR: ${error.asLog()}" } }
+                    .launchIn(leaseScope)
+                if (Bugs.isTrace) log(iTag, DEBUG) { "[$sId|$lId]-get() ...source job launched $sourceJob" }
             }
         }
 
-        Resource(sourceValue!!, lease).also {
-            if (Bugs.isTrace) log(iTag) { "Lease($lId).get($sId) --> ${it.item}" }
+        var value: T? = sourceValue
+        var error: Throwable? = sourceError
+        if (Bugs.isTrace) log(iTag, VERBOSE) { "[$sId|$lId]-get() Now waiting... (value=$value, error=$error)" }
+        while (value == null && error == null) {
+            value = sourceValue?.also {
+                if (Bugs.isTrace) log(iTag, DEBUG) { "[$sId|$lId]-get() sourceValue loop, got $it" }
+            }
+            error = sourceError?.also {
+                if (Bugs.isTrace) log(iTag, DEBUG) { "[$sId|$lId]-get() sourceError loop, got $it" }
+            }
+            yield()
         }
+
+        if (value == null) {
+            if (Bugs.isTrace) log(iTag, DEBUG) { "[$sId|$lId]-get() sourceValue failed, waiting for cleanup" }
+            while (sourceJob != null) yield()
+            if (Bugs.isTrace) log(iTag, WARN) { "[$sId|$lId]-get() sourceValue failed, throwing $error" }
+            throw error!!
+        }
+
+        if (Bugs.isTrace) log(iTag) { "[$sId|$lId]-get() returning value $value" }
+        return Resource(value, lease!!)
     }
 
-    private suspend fun closeLeaseInternal(lease: Lease): Unit = withContext(NonCancellable) {
+    // Must be called with coreLock.withLock { }
+    private suspend fun closeLease(tag: String, lease: Lease): Unit = withContext(NonCancellable) {
         val lId = lease.id
-        if (Bugs.isDive) log(iTag, VERBOSE) { "Lease($lId).close(): Closing..." }
+        if (Bugs.isTrace) log(iTag, VERBOSE) { "[$sId|$lId]-closeLease()-$tag on $lease" }
 
         leases.remove(lease).also {
             if (Bugs.isTrace) {
                 val leaseSize = leases.size
-                if (it) log(iTag, VERBOSE) { "Lease($lId).close(): Removed! (now $leaseSize)" }
-                else log(iTag, WARN) { "Lease($lId).close(): Already removed? (now $leaseSize) " }
+                if (it) log(iTag, VERBOSE) { "[$sId|$lId]-closeLease()-$tag Removed this lease (now $leaseSize)" }
+                else log(iTag, WARN) { "[$sId|$lId]-closeLease()-$tag Already removed? (now $leaseSize) " }
             }
         }
 
-        if (Bugs.isDive) log(iTag) { "Lease($lId).close(): Canceling lease job: ${lease.job}" }
+        if (Bugs.isTrace) log(iTag) { "[$sId|$lId]-closeLease()-$tag Canceling lease job: ${lease.job}" }
         lease.job.cancelAndJoin()
-        if (Bugs.isDive) log(iTag, VERBOSE) { "Lease($lId).close(): Lease job is completed" }
-
-        if (leases.isEmpty()) {
-            log(iTag, DEBUG) { "Lease($lId).close(): ZERO leases left for $sId, canceling source and waiting" }
-            sourceJob!!.cancelAndJoin()
-
-            children.apply {
-                if (isEmpty()) return@apply
-                onEachIndexed { index, entry ->
-                    if (Bugs.isDebug) log(iTag, VERBOSE) { "Core($sId): Closing child #$index $entry" }
-                    entry.value.close()
-                }
-                clear()
-
-                if (Bugs.isDebug) log(iTag, VERBOSE) { "Core($sId): Remaining children have been cleared" }
-            }
-
-            leases.apply {
-                if (isEmpty()) return@apply
-                forEachIndexed { index, lease ->
-                    if (Bugs.isTrace) log(iTag, VERBOSE) { "Core($sId): Canceling lease #$index: $lease..." }
-                    lease.job.cancelAndJoin()
-                }
-                clear()
-                if (Bugs.isDebug) log(iTag, VERBOSE) { "Core($sId): Remaining leases have been cleared" }
-            }
-        } else {
-            if (Bugs.isDive) {
-                try {
-                    leases.toList().forEachIndexed { index, lease ->
-                        log(iTag, VERBOSE) { "Lease($lId).close(): Remaining lease #$index - $lease" }
-                    }
-                } catch (e: Exception) {
-                    log(iTag, VERBOSE) { "Lease($lId).close(): Lease logging concurrency error" }
-                }
+        if (Bugs.isTrace) {
+            log(iTag, VERBOSE) { "[$sId|$lId]-closeLease()-$tag Lease job completed" }
+            leases.forEachIndexed { index, lease ->
+                log(iTag, VERBOSE) { "[$sId|$lId]-closeLease()-$tag Remaining lease #$index - $lease" }
             }
         }
+    }
+
+    private suspend fun leaseCheck(tag: String, forced: Boolean) = leaseCheckLock.withLock {
+        if (Bugs.isTrace) log(iTag, DEBUG) { "[$sId|_]-leaseCheck(forced=$forced)-$tag" }
+
+        if (leaseCheckJob != null) {
+            if (Bugs.isTrace) log(iTag, DEBUG) { "[$sId|_]-leaseCheck()-$tag canceling previous lease check..." }
+            leaseCheckJob!!.cancelAndJoin()
+            if (Bugs.isTrace) log(iTag, DEBUG) { "[$sId|_]-leaseCheck()-$tag ... previous check cancelled" }
+        }
+
+        if (forced || stopTimeout == Duration.ZERO) {
+            if (Bugs.isTrace) log(iTag, DEBUG) { "[$sId|_]-leaseCheck()-$tag Running doLeasecheck() immediately" }
+            doLeaseCheck(tag)
+        } else {
+            if (Bugs.isTrace) log(iTag, DEBUG) { "[$sId|_]-leaseCheck()-$tag Launching delayed doLeaseCheck() job" }
+            leaseCheckJob = leaseScope.launch {
+                if (Bugs.isTrace) {
+                    log(iTag, DEBUG) { "[$sId|_]-leaseCheck()-$tag waiting for expiration ($stopTimeout)" }
+                }
+                delay(stopTimeout.toMillis())
+                doLeaseCheck(tag)
+            }
+        }
+    }
+
+    private suspend fun doLeaseCheck(tag: String) = coreLock.withLock("doLeaseCheck()-$tag") {
+        if (leases.isNotEmpty()) {
+            if (Bugs.isTrace) {
+                log(iTag, DEBUG) { "[$sId|_]-doLeaseCheck()-$tag There are leases (${leases.size}), aborting" }
+                leases.forEachIndexed { index, lease ->
+                    log(iTag, VERBOSE) { "[$sId|_]-doLeaseCheck()-$tag Current lease #$index - $lease" }
+                }
+            }
+            return
+        }
+        if (Bugs.isTrace) log(iTag, DEBUG) { "[$sId|_]-doLeaseCheck()-$tag ZERO leases left" }
+
+        if (sourceJob == null) {
+            if (Bugs.isTrace) log(iTag, DEBUG) { "[$sId|_]-doLeaseCheck()-$tag sourceJob was already null" }
+            return@withLock
+        }
+
+        if (Bugs.isTrace) log(iTag, DEBUG) { "[$sId|_]-doLeaseCheck()-$tag Cancelling sourceJob" }
+        sourceJob!!.cancel(InternalCancelationException("[$sId|_]-doLeaseCheck()-$tag ZERO leases left"))
+        sourceJob!!.join() // Waits till source.onComplete is done
+        if (Bugs.isTrace) log(iTag, DEBUG) { "[$sId|_]-doLeaseCheck()-$tag sourceJob has completed" }
+
+        children.apply {
+            if (isEmpty()) return@apply
+            onEachIndexed { index, entry ->
+                if (Bugs.isTrace) {
+                    log(iTag, VERBOSE) { "[$sId|_]-doLeaseCheck()-$tag Closing child #$index ${entry.value}" }
+                }
+                entry.value.close()
+            }
+            clear()
+
+            if (Bugs.isTrace) log(iTag, VERBOSE) { "[$sId|_]-doLeaseCheck() Remaining children have been cleared" }
+        }
+
+        sourceValue = null
+        sourceJob = null
+        if (Bugs.isTrace) log(iTag, VERBOSE) { "[$sId|_]-doLeaseCheck()-$tag Source nulled. fin." }
+        sId = null
     }
 
     override fun close() {
         if (isClosed) {
-            if (Bugs.isTrace) log(iTag) { "Core($sId).close() already closed" }
+            if (Bugs.isTrace) log(iTag) { "[$sId|_]-close() already closed" }
             return
         } else {
-            if (Bugs.isTrace) {
-                log(iTag) { "Core($sId).close()ing via ${Exception().asLog()}" }
-            } else {
-                log(iTag) { "Core($sId).close()ing..." }
-            }
+            if (Bugs.isTrace) log(iTag) { "[$sId|_]-close() via ${Exception().asLog()}" }
         }
 
-        runBlocking {
-            lock.withLock { closeInternal() }
+        runBlocking(NonCancellable) {
+            if (Bugs.isTrace) log(iTag) { "[$sId|_]-close() calling closeLeases()" }
+            closeLeases("close()")
+            leaseCheck("close", forced = false)
         }
     }
 
-    private suspend fun closeInternal() = withContext(NonCancellable) {
-        while (leases.isNotEmpty()) {
-            log(iTag) { "Core($sId).close(): Current leases: ${leases.map { it.resourceId }}" }
-            closeLeaseInternal(leases.first())
+    private suspend fun closeLeases(tag: String) = coreLock.withLock("closeLeases()-$tag") {
+        if (leases.isEmpty()) {
+            if (Bugs.isTrace) log(iTag, VERBOSE) { "[$sId|_]-closeLeases()-$tag No leases to close" }
+            return@withLock
         }
-        sourceValue = null
-        sourceJob = null
-        log(iTag, DEBUG) { "Core($sId): Shared resource flow completed." }
+
+        if (Bugs.isTrace) log(iTag, VERBOSE) { "[$sId|_]-closeLeases()-$tag Current leases=${leases.size}" }
+        while (leases.isNotEmpty()) {
+            if (Bugs.isTrace) log(iTag) { "[$sId|_]-closeLeases()-$tag Current leases: ${leases.map { it.id }}" }
+            val lease = leases.first()
+            closeLease("closeLeases", lease)
+        }
+
+        if (Bugs.isTrace) log(iTag, DEBUG) { "[$sId|_]-closeLeases()-$tag All leases closed" }
     }
 
     /**
@@ -214,50 +291,73 @@ open class SharedResource<T : Any>(
      * When the root shell closes, the backup module needs to "close" too.
      * But the backupmodule, while open, keeps the root shell alive.
      */
-    suspend fun addChild(child: SharedResource<*>) = lock.withLock {
+    suspend fun addChild(child: SharedResource<*>) = coreLock.withLock("addChild-${child.resourceId}") {
         if (children.contains(child)) {
-            if (Bugs.isDive) {
-                log(iTag, VERBOSE) { "Core($sId).addChild(): Already keeping child alive: $child" }
+            if (Bugs.isTrace) {
+                log(iTag, VERBOSE) { "[$sId|_]-addChild() Already keeping child alive: $child" }
             }
             return@withLock
         }
 
         if (isClosed) {
-            log(iTag, VERBOSE) { "Core($sId).addChild(): Can't add child, we are not alive: $child" }
+            if (Bugs.isTrace) {
+                log(iTag, VERBOSE) { "[$sId|_]-addChild() Can't add child, we are not alive: $child" }
+            }
+            if (!child.isClosed) {
+                val trace = IllegalStateException("Adding open child to closed parent")
+                log(iTag, WARN) { "[$sId|_]-addChild() we are closed, but child is open $child:\n${trace.asLog()}" }
+            }
             child.close()
             return@withLock
         }
+
+        if (Bugs.isTrace) log(iTag, VERBOSE) { "[$sId|_]-addChild() Adding child to us: $child" }
 
         val keepAlive = child.get()
         val wrapped = Child(child, keepAlive)
         children[child] = wrapped
 
-        if (Bugs.isDive) {
+        if (Bugs.isTrace) {
             val childrenSize = children.size
-            log(iTag, VERBOSE) { "Core($sId).addChild(): Resource now has $childrenSize children: $child" }
+            log(iTag, VERBOSE) { "[$sId|_]-addChild() Resource now has $childrenSize " }
+            if (Bugs.isTrace) {
+                children.onEachIndexed { index, entry ->
+                    log(iTag, VERBOSE) { "[$sId|_]-addChild() Now has #$index ${entry.value} " }
+                }
+            }
         }
     }
 
     override fun toString(): String =
-        "SharedResource(tag=$iTag, leases=${leases.size}, children=${children.size})"
+        "SharedResource(tag=$iTag, sId=$sId, leases=${leases.size}, children=${children.size})"
 
     inner class Lease(
         internal val id: String,
         internal val job: Job,
-        private val traceTag: String? = null
     ) : KeepAlive {
         override val resourceId: String = this@SharedResource.resourceId
 
         override val isClosed: Boolean
             get() = !job.isActive
 
-        override fun close() = runBlocking {
-            lock.withLock {
-                closeLeaseInternal(this@Lease)
+        override fun close() = runBlocking(NonCancellable) {
+            if (Bugs.isTrace) log(iTag, VERBOSE) { "[$sId|$id]-Lease.close() Close called on lease..." }
+
+            if (isClosed) {
+                if (Bugs.isTrace) log(iTag, VERBOSE) { "[$sId|$id]-Lease.close() Already closed" }
+                return@runBlocking
             }
+
+            coreLock.withLock("[$sId|$id]-Lease.close()") {
+                closeLease("Lease.close", this@Lease)
+            }
+
+            leaseCheck("Lease.close", forced = false)
+
+            if (Bugs.isTrace) log(iTag, VERBOSE) { "[$sId|$id]-Lease.close() ... finished close on lease" }
         }
 
-        override fun toString(): String = "Lease(id=$id, job=$job)" + (traceTag?.let { "\nCreated at $it" } ?: "")
+        override fun toString(): String = "Lease(id=$id, job=$job)"
     }
 
     private inner class Child(
@@ -272,8 +372,10 @@ open class SharedResource<T : Any>(
             get() = closed || ourKeepAlive.isClosed
 
         override fun close() {
+            if (Bugs.isTrace) log(iTag, VERBOSE) { "[$sId|_]-Child.close() Close called on $child" }
             closed = true
             ourKeepAlive.close()
+            if (Bugs.isTrace) log(iTag, VERBOSE) { "[$sId|_]-Child.close() ... finished close on $child" }
         }
 
         override fun toString(): String = "ChildResource(isClosed=$isClosed, child=$child)"
@@ -288,11 +390,18 @@ open class SharedResource<T : Any>(
         override fun hashCode(): Int = resourceId.hashCode()
     }
 
+    private class InternalCancelationException(override val message: String) : CancellationException()
+
     companion object {
-        fun createKeepAlive(tag: String, scope: CoroutineScope): SharedResource<Any> = SharedResource(
-            tag,
-            scope,
-            callbackFlow {
+        fun createKeepAlive(
+            tag: String,
+            scope: CoroutineScope,
+            stopTimeout: Duration = Duration.ofSeconds(3),
+        ): SharedResource<Any> = SharedResource(
+            tag = tag,
+            parentScope = scope,
+            stopTimeout = stopTimeout,
+            source = callbackFlow {
                 send("$tag{${Any().hashCode()}}")
                 awaitClose()
             }

--- a/app-common/src/main/java/eu/darken/sdmse/common/sharedresource/SharedResource.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/sharedresource/SharedResource.kt
@@ -300,14 +300,11 @@ open class SharedResource<T : Any>(
         }
 
         if (isClosed) {
-            if (Bugs.isTrace) {
-                log(iTag, VERBOSE) { "[$sId|_]-addChild() Can't add child, we are not alive: $child" }
-            }
+            if (Bugs.isTrace) log(iTag, VERBOSE) { "[$sId|_]-addChild() Can't add child, we are not alive: $child" }
             if (!child.isClosed) {
-                val trace = IllegalStateException("Adding open child to closed parent")
-                log(iTag, WARN) { "[$sId|_]-addChild() we are closed, but child is open $child:\n${trace.asLog()}" }
+                val trace = IllegalStateException("Tried to add open child to closed parent")
+                log(iTag, WARN) { "[$sId|_]-addChild() We are closed! Can't add open child $child:\n${trace.asLog()}" }
             }
-            child.close()
             return@withLock
         }
 

--- a/app-common/src/main/java/eu/darken/sdmse/common/sharedresource/SharedResource.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/sharedresource/SharedResource.kt
@@ -14,6 +14,8 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.callbackFlow
@@ -25,11 +27,14 @@ import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.shareIn
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.newCoroutineContext
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import java.util.UUID
 
 /**
  * A utility class to create child/parent dependencies for expensive resources.
@@ -48,34 +53,43 @@ open class SharedResource<T : Any>(
 
     private val lock = Mutex()
 
-    private val leases = mutableSetOf<ActiveLease>()
+    private val leases = mutableSetOf<Lease>()
     private val children = mutableMapOf<SharedResource<*>, KeepAlive>()
 
     override val isClosed: Boolean
         get() = !isAlive
 
-    private var isAlive: Boolean = false
+    private var isAlive = false
+    private var isClosing = false
+    private var rId: String? = null
 
     private val resourceHolder: Flow<Event<T>> = source
         .onStart {
             lock.withLock {
                 isAlive = true
-                log(iTag, DEBUG) { "Acquiring shared resource..." }
+                rId = "R:${UUID.randomUUID().toString().takeLast(4)}"
+                log(iTag, DEBUG) { "Core($rId): Creating shared resource..." }
 
                 if (children.isNotEmpty()) {
                     val _children = children.values.toList()
-                    log(iTag, WARN) { "Non-empty child references: $_children" }
+                    log(iTag, WARN) { "Core($rId): Non-empty child references: $_children" }
                     children.clear()
                 }
             }
         }
+        .map {
+            @Suppress("USELESS_CAST")
+            Event.Resource(rId!!, it) as Event<T>
+        }
+        .onEach { log(iTag) { "Core($rId): Resource ready: $it" } }
+        .catch { log(iTag, WARN) { "Core($rId): Failed to provide resource: ${it.asLog()}" } }
         .onCompletion {
             lock.withLock {
                 isAlive = false
-                if (Bugs.isDebug) log(iTag, VERBOSE) { "Releasing shared resource..." }
+                if (Bugs.isDebug) log(iTag, VERBOSE) { "Core($rId): Releasing shared resource..." }
 
                 children.values.forEach {
-                    if (Bugs.isDebug) log(iTag, VERBOSE) { "Closing child resource: $it" }
+                    if (Bugs.isDebug) log(iTag, VERBOSE) { "Core($rId): Closing child resource: $it" }
                     it.close()
                 }
                 children.clear()
@@ -83,146 +97,103 @@ open class SharedResource<T : Any>(
                 if (leases.isNotEmpty()) {
                     if (Bugs.isDebug) {
                         val remainingLeases = leases.joinToString()
-                        log(iTag, VERBOSE) { "Cleaning up remaining leases: $remainingLeases" }
+                        log(iTag, VERBOSE) { "Core($rId): Cleaning up remaining leases: $remainingLeases" }
                     }
 
                     leases
                         .filter { it.job.isActive }
-                        .forEachIndexed { index, activeLease ->
-                            if (Bugs.isTrace) log(iTag, VERBOSE) { "Canceling #$index: $activeLease..." }
-                            activeLease.job.cancelAndJoin()
+                        .forEachIndexed { index, lease ->
+                            if (Bugs.isTrace) log(iTag, VERBOSE) { "Core($rId): Canceling #$index: $lease..." }
+                            lease.job.cancelAndJoin()
                         }
 
-                    if (Bugs.isDebug) log(iTag, VERBOSE) { "Remaining leases have been cleaned up." }
+                    if (Bugs.isDebug) log(iTag, VERBOSE) { "Core($rId): Remaining leases have been cleaned up." }
 
                     leases.clear()
                 }
 
                 val orphanedLeases = leaseScope.coroutineContext.job.children.filter { it.isActive }.toList()
                 if (orphanedLeases.isNotEmpty()) {
-                    log(iTag, WARN) { "Orphaned leases: $orphanedLeases" }
+                    log(iTag, WARN) { "Core($rId): Orphaned leases: $orphanedLeases" }
                     // This cancels all active leases, at the latest.
                     leaseScope.coroutineContext.cancelChildren()
                 }
-
-                log(iTag, DEBUG) { "Shared resource flow completed." }
+                log(iTag, DEBUG) { "Core($rId): Shared resource flow completed." }
             }
-        }
-        .map {
-            @Suppress("USELESS_CAST")
-            Event.Resource(it) as Event<T>
-        }
-        .onEach { log(iTag, VERBOSE) { "Resource ready: $it" } }
-        .catch {
-            log(iTag, WARN) { "Failed to provide resource: ${it.asLog()}" }
-            emit(Event.Error(it))
+            parentScope.launch {
+                // Needs to set isClosed AFTER the resourceHolder is REALLY finished
+                // TODO this sucks but I really have not found a better way
+                delay(50)
+                if (Bugs.isDive) log(iTag, VERBOSE) { "Core($rId): Waiting for lock to set isClosing=false" }
+                lock.withLock {
+                    if (Bugs.isDive) log(iTag, VERBOSE) { "Core($rId): Setting isClosing=false" }
+                    isClosing = false
+                }
+            }
         }
         .shareIn(
             parentScope,
-            SharingStarted.WhileSubscribed(stopTimeoutMillis = 1000, replayExpirationMillis = 0),
-            replay = 1
+            SharingStarted.WhileSubscribed(stopTimeoutMillis = 0, replayExpirationMillis = 0),
+            replay = 1,
         )
 
     suspend fun get(): Resource<T> {
-        val c = Any().hashCode()
+        val lId = "L:${UUID.randomUUID().toString().takeLast(4)}"
 
-        if (Bugs.isTrace && !isAlive) {
-            log(iTag, DEBUG) { "get($c): Reviving SharedResource" }
-            log(iTag, VERBOSE) { "get($c): Revive call origin: ${traceCall()}" }
+        if (isClosing) {
+            if (Bugs.isDive) log(iTag, VERBOSE) { "Lease($lId).get($rId): Resource is closing waiting..." }
+            while (isClosing && currentCoroutineContext().isActive) {
+                delay(1)
+            }
         }
 
-        val activeLease = lock.withLock {
+        val lease = lock.withLock {
+            if (Bugs.isTrace) {
+                if (isAlive) {
+                    log(iTag, VERBOSE) { "Lease($lId).get($rId): Getting existing resource ($rId)" }
+                } else {
+                    log(iTag, DEBUG) { "Lease($lId).get($rId): Reviving SharedResource" }
+                    log(iTag, VERBOSE) { "Lease($lId).get($rId): Revive call origin: ${traceCall()}" }
+                }
+            }
+
             val job = resourceHolder.launchIn(leaseScope).apply {
                 invokeOnCompletion {
-                    if (Bugs.isTraceDeepDive) {
-                        val leaseSize = leases.size
-                        log(iTag, VERBOSE) { "get($c): Lease completed (now=$leaseSize, $job)." }
+                    if (Bugs.isDive) {
+                        val count = leases.size
+                        log(iTag, VERBOSE) { "Lease($lId).get($rId): Lease on $rId completed (now=$count, $job)." }
                     }
                 }
             }
 
-            ActiveLease(
-                job,
-                if (Bugs.isTraceDeepDive) traceCall() else null
+            Lease(
+                id = lId,
+                job = job,
+                traceTag = if (Bugs.isDive) traceCall() else null
             ).also {
-                if (Bugs.isTraceDeepDive) {
-                    log(iTag, VERBOSE) { "get($c): Adding new lease ($job)" }
-                }
-
                 leases.add(it)
 
-                if (Bugs.isTraceDeepDive) {
+                if (Bugs.isDive) {
+                    log(iTag, VERBOSE) { "Lease($lId).get($rId): Added new lease ($job)" }
                     val leaseSize = leases.size
-                    log(iTag, VERBOSE) { "get($c): Now holding $leaseSize lease(s)" }
+                    log(iTag, VERBOSE) { "Lease($lId).get($rId): Now holding $leaseSize lease(s)" }
                 }
             }
         }
 
-        val resource = try {
-            if (Bugs.isTraceDeepDive) log(iTag, VERBOSE) { "get($c): Retrieving resource" }
+        val resourceEvent = try {
+            if (Bugs.isDive) log(iTag, VERBOSE) { "Lease($lId).get($rId): Retrieving resource" }
             when (val event = resourceHolder.first()) {
                 is Event.Error -> throw event.error
-                is Event.Resource -> event.resource
+                is Event.Resource -> event
             }
         } catch (e: Exception) {
-            log(iTag, WARN) { "get($c): Failed to retrieve resource (${e.asLog()}" }
-            activeLease.close()
+            log(iTag, WARN) { "Lease($lId).get($rId): Failed to retrieve resource (${e.asLog()}" }
+            lease.close()
             throw e.tryUnwrap()
         }
-
-        return Resource(resource, activeLease)
-    }
-
-    inner class ActiveLease(
-        internal val job: Job,
-        private val traceTag: String? = null
-    ) : KeepAlive {
-        override val resourceId: String = this@SharedResource.resourceId
-
-        override val isClosed: Boolean
-            get() = !job.isActive
-
-        override fun close() {
-            if (Bugs.isTraceDeepDive) {
-                log(iTag, VERBOSE) { "Closing keep alive ($job)." }
-            }
-            leaseScope.launch {
-                if (Bugs.isTraceDeepDive) log(iTag, VERBOSE) { "Close code running, waiting for lock! ($job)" }
-                val removed = lock.withLock {
-                    if (Bugs.isTraceDeepDive) log(iTag, VERBOSE) { "Close code running, WITH lock! ($job)" }
-
-                    leases.remove(this@ActiveLease).also {
-                        if (Bugs.isTraceDeepDive) log(iTag, VERBOSE) { "Lease removed, will cancel! ($job)" }
-
-                        if (job.isActive) {
-                            job.cancel()
-                        } else {
-                            if (Bugs.isTrace) log(iTag, WARN) { "Already closed! ($job)" }
-                        }
-                    }
-                }
-
-                if (Bugs.isTraceDeepDive) {
-                    val leaseSize = leases.size
-                    if (removed) {
-                        log(iTag, VERBOSE) { "Active lease removed (now $leaseSize) ($job)" }
-                    } else {
-                        log(iTag, WARN) { "Lease was already removed? (now $leaseSize) ($job)" }
-                    }
-
-                    try {
-                        leases.toList().forEachIndexed { index, activeLease ->
-                            log(iTag, VERBOSE) { "Lease #$index - $activeLease" }
-                        }
-                    } catch (e: Exception) {
-                        log(iTag, VERBOSE) { "Lease logging concurrency error" }
-                    }
-                }
-            }
-
-        }
-
-        override fun toString(): String = "ActiveLease(job=$job)${traceTag?.let { "\nCreated at $it" } ?: ""}"
+        if (Bugs.isTrace) log(iTag) { "Lease($lId).get($rId): Resource retrieved: $resourceEvent" }
+        return Resource(resourceEvent.resource, lease)
     }
 
     /**
@@ -234,12 +205,14 @@ open class SharedResource<T : Any>(
      */
     suspend fun addChild(child: SharedResource<*>) = lock.withLock {
         if (children.contains(child)) {
-            if (Bugs.isTraceDeepDive) log(iTag, VERBOSE) { "Already keeping child alive: $child" }
+            if (Bugs.isDive) {
+                log(iTag, VERBOSE) { "Core($rId).addChild(): Already keeping child alive: $child" }
+            }
             return@withLock
         }
 
         if (!isAlive) {
-            log(iTag, VERBOSE) { "addChild(): Can't add child, we are not alive: $child" }
+            log(iTag, VERBOSE) { "Core($rId).addChild(): Can't add child, we are not alive: $child" }
             child.close()
             return@withLock
         }
@@ -248,20 +221,95 @@ open class SharedResource<T : Any>(
         val wrapped = Child(child, keepAlive)
         children[child] = wrapped
 
-        if (Bugs.isTraceDeepDive) {
+        if (Bugs.isDive) {
             val childrenSize = children.size
-            log(iTag, VERBOSE) { "addChild(): Resource now has $childrenSize children: $child" }
+            log(iTag, VERBOSE) { "Core($rId).addChild(): Resource now has $childrenSize children: $child" }
         }
     }
 
     override fun close() {
         if (!isAlive) return
-        log(iTag) { "close()" }
+        if (Bugs.isTrace) {
+            log(iTag) { "Core($rId).close() by ${Exception().asLog()}" }
+        } else {
+            log(iTag) { "Core($rId).close()" }
+        }
         leaseScope.coroutineContext.cancelChildren()
+        // TODO, do we need to lock and set isClosing?
     }
 
     override fun toString(): String =
         "SharedResource(tag=$iTag, leases=${leases.size}, children=${children.size})"
+
+
+    inner class Lease(
+        internal val id: String,
+        internal val job: Job,
+        private val traceTag: String? = null
+    ) : KeepAlive {
+        override val resourceId: String = this@SharedResource.resourceId
+
+        override val isClosed: Boolean
+            get() = !job.isActive
+
+        override fun close() {
+            if (Bugs.isTrace) log(iTag, VERBOSE) { "Lease($id).close(): Closing... ($job)." }
+
+            runBlocking {
+                if (Bugs.isDive) {
+                    log(iTag, VERBOSE) { "Lease($id).close(): Close code running, waiting for lock! ($job)" }
+                }
+                lock.withLock {
+                    if (Bugs.isDive) {
+                        log(iTag, VERBOSE) { "Lease($id).close(): Lock acquired, removing our lease! ($job)" }
+                    }
+                    leases.remove(this@Lease).also {
+                        val leaseSize = leases.size
+                        if (Bugs.isTrace) {
+                            if (it) {
+                                log(iTag, VERBOSE) { "Lease($id).close(): Removed! (now $leaseSize) ($job)" }
+                            } else {
+                                log(iTag, WARN) { "Lease($id).close(): Already removed? (now $leaseSize) ($job)" }
+                            }
+                        }
+                    }
+
+                    if (leases.isEmpty()) {
+                        isClosing = true
+                        log(iTag, DEBUG) { "Lease($id).close(): ZERO leases left for $rId, setting isClosing=true" }
+                    }
+
+                    if (job.isActive) {
+                        if (Bugs.isTrace) log(iTag) { "Lease($id).close(): Canceling job! ($job)" }
+                        job.cancel()
+                    } else {
+                        if (Bugs.isTrace) log(iTag, WARN) { "Lease($id).close(): Already cancelled! ($job)" }
+                    }
+
+                    if (job.isCompleted) {
+                        if (Bugs.isDive) log(iTag, VERBOSE) { "Lease($id).close(): Job is completed ($job)" }
+                    } else {
+                        if (Bugs.isDive) log(iTag, VERBOSE) { "Lease($id).close(): Waiting for completion ($job)" }
+                        job.join()
+                        if (Bugs.isDive) log(iTag, VERBOSE) { "Lease($id).close(): Job is now completed ($job)" }
+                    }
+                }
+
+                if (Bugs.isDive) {
+                    try {
+                        leases.toList().forEachIndexed { index, lease ->
+                            log(iTag, VERBOSE) { "Lease($id).close(): Remaining lease #$index - $lease" }
+                        }
+                    } catch (e: Exception) {
+                        log(iTag, VERBOSE) { "Lease($id).close(): Lease logging concurrency error" }
+                    }
+                }
+            }
+
+        }
+
+        override fun toString(): String = "Lease(id=$id, job=$job)" + (traceTag?.let { "\nCreated at $it" } ?: "")
+    }
 
     private inner class Child(
         private val child: SharedResource<*>,
@@ -291,10 +339,9 @@ open class SharedResource<T : Any>(
         override fun hashCode(): Int = resourceId.hashCode()
     }
 
-    sealed class Event<T> {
-
-        data class Resource<T>(val resource: T) : Event<T>()
-        data class Error<T>(val error: Throwable) : Event<T>()
+    sealed interface Event<T> {
+        data class Resource<T>(val id: String, val resource: T) : Event<T>
+        data class Error<T>(val error: Throwable) : Event<T>
     }
 
     companion object {

--- a/app-common/src/test/java/eu/darken/sdmse/common/sharedresource/SharedResourceTest.kt
+++ b/app-common/src/test/java/eu/darken/sdmse/common/sharedresource/SharedResourceTest.kt
@@ -1,16 +1,29 @@
 package eu.darken.sdmse.common.sharedresource
 
 import eu.darken.sdmse.common.debug.Bugs
+import eu.darken.sdmse.common.debug.logging.asLog
+import eu.darken.sdmse.common.debug.logging.log
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
+import kotlinx.coroutines.runBlocking
+import okio.IOException
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.runTest2
+import java.time.Duration
 
 class SharedResourceTest : BaseTest() {
     @BeforeEach
@@ -18,7 +31,6 @@ class SharedResourceTest : BaseTest() {
         Bugs.apply {
             isDebug = true
             isTrace = true
-            isDive = true
         }
     }
 
@@ -27,13 +39,12 @@ class SharedResourceTest : BaseTest() {
         Bugs.apply {
             isDebug = false
             isTrace = false
-            isDive = false
         }
     }
 
     @Test fun `Lease-close closes Core`() = runTest2(autoCancel = true) {
         (1..100).forEach {
-            val sr = SharedResource.createKeepAlive("test", this + Dispatchers.IO)
+            val sr = SharedResource.createKeepAlive("test", this + Dispatchers.IO, Duration.ZERO)
 
             sr.isClosed shouldBe true
             val lease = sr.get()
@@ -44,7 +55,7 @@ class SharedResourceTest : BaseTest() {
     }
 
     @Test fun `multiple leases`() = runTest2(autoCancel = true) {
-        val sr = SharedResource.createKeepAlive("test", this + Dispatchers.IO)
+        val sr = SharedResource.createKeepAlive("test", this + Dispatchers.IO, Duration.ZERO)
 
         sr.isClosed shouldBe true
 
@@ -65,7 +76,7 @@ class SharedResourceTest : BaseTest() {
     }
 
     @Test fun `Core-close closes all leases`() = runTest2(autoCancel = true) {
-        val sr = SharedResource.createKeepAlive("test", this + Dispatchers.IO)
+        val sr = SharedResource.createKeepAlive("test", this + Dispatchers.IO, Duration.ZERO)
 
         sr.isClosed shouldBe true
 
@@ -85,8 +96,8 @@ class SharedResourceTest : BaseTest() {
     }
 
     @Test fun `started parents start children`() = runTest2(autoCancel = true) {
-        val srParent = SharedResource.createKeepAlive("parent", this + Dispatchers.IO)
-        val srChild = SharedResource.createKeepAlive("child", this + Dispatchers.IO)
+        val srParent = SharedResource.createKeepAlive("parent", this + Dispatchers.IO, Duration.ZERO)
+        val srChild = SharedResource.createKeepAlive("child", this + Dispatchers.IO, Duration.ZERO)
 
         srParent.get()
 
@@ -95,9 +106,9 @@ class SharedResourceTest : BaseTest() {
         srChild.isClosed shouldBe false
     }
 
-    @Test fun `closed parents dont add children`() = runTest2(autoCancel = true) {
-        val srParent = SharedResource.createKeepAlive("parent", this + Dispatchers.IO)
-        val srChild = SharedResource.createKeepAlive("child", this + Dispatchers.IO)
+    @Test fun `closed parents dont add closed children`() = runTest2(autoCancel = true) {
+        val srParent = SharedResource.createKeepAlive("parent", this + Dispatchers.IO, Duration.ZERO)
+        val srChild = SharedResource.createKeepAlive("child", this + Dispatchers.IO, Duration.ZERO)
 
         srChild.isClosed shouldBe true
         srParent.addChild(srChild)
@@ -109,18 +120,31 @@ class SharedResourceTest : BaseTest() {
     }
 
     @Test fun `closed parents close added children`() = runTest2(autoCancel = true) {
-        val srParent = SharedResource.createKeepAlive("parent", this + Dispatchers.IO)
-        val srChild = SharedResource.createKeepAlive("child", this + Dispatchers.IO)
+        val srParent = SharedResource.createKeepAlive("parent", this + Dispatchers.IO, Duration.ZERO)
+        val srChild = SharedResource.createKeepAlive("child", this + Dispatchers.IO, Duration.ZERO)
 
         srChild.get()
         srChild.isClosed shouldBe false
+        srParent.isClosed shouldBe true
+
         srParent.addChild(srChild)
         srChild.isClosed shouldBe true
+        srParent.isClosed shouldBe true
+    }
+
+    @Test fun `adding a closed child to a closed parent`() = runTest2(autoCancel = true) {
+        val srParent = SharedResource.createKeepAlive("parent", this + Dispatchers.IO, Duration.ZERO)
+        val srChild = SharedResource.createKeepAlive("child", this + Dispatchers.IO, Duration.ZERO)
+
+        srChild.isClosed shouldBe true
+        srParent.addChild(srChild)
+        srChild.isClosed shouldBe true
+        srParent.isClosed shouldBe true
     }
 
     @Test fun `childs dont keep parents alive`() = runTest2(autoCancel = true) {
-        val srParent = SharedResource.createKeepAlive("parent", this + Dispatchers.IO)
-        val srChild = SharedResource.createKeepAlive("child", this + Dispatchers.IO)
+        val srParent = SharedResource.createKeepAlive("parent", this + Dispatchers.IO, Duration.ZERO)
+        val srChild = SharedResource.createKeepAlive("child", this + Dispatchers.IO, Duration.ZERO)
 
         val lease1 = srParent.get().apply {
             isClosed shouldBe false
@@ -136,27 +160,45 @@ class SharedResourceTest : BaseTest() {
         srParent.isClosed shouldBe true
     }
 
+    @Test fun `Core-close() closes children`() = runTest2(autoCancel = true) {
+        val srParent = SharedResource.createKeepAlive("parent", this + Dispatchers.IO, Duration.ZERO)
+        val srChild1 = SharedResource.createKeepAlive("child1", this + Dispatchers.IO, Duration.ZERO)
+
+        (1..10).forEach {
+            srParent.get()
+
+            srParent.addChild(srChild1)
+            srChild1.isClosed shouldBe false
+
+            log { "Closing srParent" }
+            srParent.close()
+            srChild1.isClosed shouldBe true
+        }
+    }
+
     @Test fun `Core-close() closes all children`() = runTest2(autoCancel = true) {
-        val srParent = SharedResource.createKeepAlive("parent", this + Dispatchers.IO)
-        val srChild1 = SharedResource.createKeepAlive("child", this + Dispatchers.IO)
-        val srChild2 = SharedResource.createKeepAlive("child", this + Dispatchers.IO)
+        val srParent = SharedResource.createKeepAlive("parent", this + Dispatchers.IO, Duration.ZERO)
+        val srChild1 = SharedResource.createKeepAlive("child1", this + Dispatchers.IO, Duration.ZERO)
+        val srChild2 = SharedResource.createKeepAlive("child2", this + Dispatchers.IO, Duration.ZERO)
 
-        srParent.get()
+        (1..10).forEach {
+            srParent.get()
 
-        srParent.addChild(srChild1)
-        srChild1.isClosed shouldBe false
+            srParent.addChild(srChild1)
+            srChild1.isClosed shouldBe false
 
-        srParent.addChild(srChild2)
-        srChild2.isClosed shouldBe false
-
-        srParent.close()
-        srChild1.isClosed shouldBe true
-        srChild2.isClosed shouldBe true
+            srParent.addChild(srChild2)
+            srChild2.isClosed shouldBe false
+            log { "Closing srParent" }
+            srParent.close()
+            srChild1.isClosed shouldBe true
+            srChild2.isClosed shouldBe true
+        }
     }
 
     @Test fun `addChild double call is noop`() = runTest2(autoCancel = true) {
-        val srParent = SharedResource.createKeepAlive("parent", this + Dispatchers.IO)
-        val srChild = SharedResource.createKeepAlive("child", this + Dispatchers.IO)
+        val srParent = SharedResource.createKeepAlive("parent", this + Dispatchers.IO, Duration.ZERO)
+        val srChild = SharedResource.createKeepAlive("child", this + Dispatchers.IO, Duration.ZERO)
 
         srParent.get()
 
@@ -170,10 +212,263 @@ class SharedResourceTest : BaseTest() {
         val srError = SharedResource<Unit>(
             tag = "parent",
             parentScope = this@runTest2 + Dispatchers.IO,
-            source = flow { throw IllegalStateException() }
+            stopTimeout = Duration.ZERO,
+            source = flow { throw IOException() }
         )
 
-        shouldThrow<IllegalStateException> { srError.get() }
-        shouldThrow<IllegalStateException> { srError.get() }
+        shouldThrow<IOException> { srError.get() }
+        shouldThrow<IOException> { srError.get() }
+        shouldThrow<IOException> { srError.get() }
+    }
+
+    @Test fun `cancel during source creation`(): Unit = runBlocking {
+        val srCancel = SharedResource<Unit>(
+            tag = "parent",
+            parentScope = this + Dispatchers.IO,
+            stopTimeout = Duration.ZERO,
+            source = flow {
+                emit(Unit)
+                awaitCancellation()
+            }
+        )
+        (1..100).forEach {
+            val job1 = launch(Dispatchers.IO) {
+                srCancel.get().apply {
+                    isClosed shouldBe false
+                    close()
+                }
+            }
+            val job2 = launch(Dispatchers.IO) {
+                delay(1)
+                srCancel.get().apply {
+                    isClosed shouldBe false
+                    close()
+                }
+            }
+            job1.cancelAndJoin()
+            job2.join()
+        }
+    }
+
+    @Test fun `racing to get() - zerg rush`(): Unit = runBlocking {
+        val srRace = SharedResource<Unit>(
+            tag = "parent",
+            parentScope = this + Dispatchers.Default,
+            stopTimeout = Duration.ZERO,
+            source = flow {
+                emit(Unit)
+                awaitCancellation()
+            }
+        )
+        val dispatcher = Dispatchers.IO.limitedParallelism(128)
+        val jobs = (1..100).map {
+            launch(dispatcher) {
+                srRace.get().apply {
+                    isClosed shouldBe false
+                    delay(1)
+                    close()
+                }
+            }
+        }
+        log { "Waiting for jobs to join" }
+        jobs.joinAll()
+    }
+
+    @Test fun `racing to get() - team up`(): Unit = runBlocking {
+        val sr = SharedResource<Unit>(
+            tag = "sr",
+            parentScope = this@runBlocking + Dispatchers.Default,
+            stopTimeout = Duration.ZERO,
+            source = flow {
+                delay(1)
+                emit(Unit)
+                awaitCancellation()
+            }
+        )
+
+        (1..100).map { i ->
+            val jobs = mutableSetOf<Job>()
+
+            launch(Dispatchers.IO) {
+                val leadLease = sr.get()
+
+                launch(Dispatchers.IO) {
+                    shouldNotThrowAny {
+                        sr.get().close()
+                    }
+                }.also { jobs.add(it) }
+
+                launch(Dispatchers.IO) {
+                    shouldNotThrowAny {
+                        leadLease.close()
+                    }
+                }.also { jobs.add(it) }
+
+            }.also { jobs.add(it) }
+
+            jobs.joinAll()
+        }
+
+        sr.isClosed shouldBe true
+    }
+
+    @Test fun `parent closes with already closed child`() = runTest2(autoCancel = true) {
+        val srParent = SharedResource.createKeepAlive("parent", this + Dispatchers.IO, Duration.ZERO)
+        val srChild = SharedResource.createKeepAlive("child", this + Dispatchers.IO, Duration.ZERO)
+
+        srParent.get()
+        srParent.isClosed shouldBe false
+        srParent.addChild(srChild)
+        srChild.isClosed shouldBe false
+
+        srChild.close()
+        srChild.isClosed shouldBe true
+        srParent.isClosed shouldBe false
+
+        srParent.close()
+        srParent.isClosed shouldBe true
+    }
+
+    @Test fun `closing on the same scope deadlock check`() = runTest2(autoCancel = true) {
+        val sr = SharedResource.createKeepAlive("test", this + Dispatchers.IO, Duration.ZERO)
+
+        sr.isClosed shouldBe true
+        val lease = sr.get()
+        sr.isClosed shouldBe false
+        lease.close()
+        sr.isClosed shouldBe true
+        sr.get()
+        sr.isClosed shouldBe false
+    }
+
+    @Test fun `lease check is NOT pre-empted by global close`() = runBlocking {
+        var counter = 0
+        val sr = SharedResource(
+            tag = "parent",
+            parentScope = this + Dispatchers.Default,
+            stopTimeout = Duration.ofMillis(1000),
+            source = flow {
+                counter++
+                emit(counter)
+                awaitCancellation()
+            }
+        )
+
+        val lease1 = sr.get().apply {
+            item shouldBe 1
+        }
+        sr.close()
+        lease1.isClosed shouldBe true
+        sr.isClosed shouldBe false
+
+        delay(500)
+
+        sr.isClosed shouldBe false
+        val lease2 = sr.get().apply {
+            item shouldBe 1
+        }
+        sr.close()
+        lease2.isClosed shouldBe true
+        sr.isClosed shouldBe false
+
+        delay(1500)
+
+        sr.isClosed shouldBe true
+        val lease3 = sr.get().apply {
+            item shouldBe 2
+        }
+        sr.close()
+        lease3.isClosed shouldBe true
+        sr.isClosed shouldBe false
+
+        delay(1500)
+
+        sr.isClosed shouldBe true
+    }
+
+    @Test fun `lease check is cancelled by adding new leases`() = runBlocking {
+        var counter = 0
+        val sr = SharedResource(
+            tag = "parent",
+            parentScope = this + Dispatchers.Default,
+            stopTimeout = Duration.ofMillis(1000),
+            source = flow {
+                counter++
+                emit(counter)
+                awaitCancellation()
+            }
+        )
+
+        val lease1 = sr.get().apply {
+            item shouldBe 1
+            close()
+        }
+        lease1.isClosed shouldBe true
+        sr.isClosed shouldBe false
+
+        delay(500)
+
+        sr.isClosed shouldBe false
+        val lease2 = sr.get().apply {
+            item shouldBe 1
+            close()
+        }
+        lease2.isClosed shouldBe true
+        sr.isClosed shouldBe false
+
+        delay(1500)
+
+        sr.isClosed shouldBe true
+        val lease3 = sr.get().apply {
+            item shouldBe 2
+            close()
+        }
+        lease3.isClosed shouldBe true
+        sr.isClosed shouldBe false
+
+        delay(1500)
+
+        sr.isClosed shouldBe true
+    }
+
+    @Test fun `racing global close`(): Unit = runBlocking {
+        val sr = SharedResource<Unit>(
+            tag = "sr",
+            parentScope = this@runBlocking + Dispatchers.Default,
+            stopTimeout = Duration.ZERO,
+            source = flow {
+                delay(1)
+                emit(Unit)
+                awaitCancellation()
+            }
+        )
+
+        (1..100).map { i ->
+            val jobs = mutableSetOf<Job>()
+
+            launch(Dispatchers.IO) {
+                sr.get()
+
+                launch(Dispatchers.IO) {
+                    try {
+                        sr.get().close()
+                    } catch (e: Exception) {
+                        log { "Thrown ${e.asLog()}" }
+                        (e is CancellationException) shouldBe true
+                    }
+                }.also { jobs.add(it) }
+
+                launch(Dispatchers.IO) {
+                    shouldNotThrowAny {
+                        sr.close()
+                    }
+                }.also { jobs.add(it) }
+
+            }.also { jobs.add(it) }
+
+            jobs.joinAll()
+        }
+
+        sr.isClosed shouldBe true
     }
 }

--- a/app-common/src/test/java/eu/darken/sdmse/common/sharedresource/SharedResourceTest.kt
+++ b/app-common/src/test/java/eu/darken/sdmse/common/sharedresource/SharedResourceTest.kt
@@ -119,7 +119,7 @@ class SharedResourceTest : BaseTest() {
         srChild.isClosed shouldBe true
     }
 
-    @Test fun `closed parents close added children`() = runTest2(autoCancel = true) {
+    @Test fun `closed parents dont close added children`() = runTest2(autoCancel = true) {
         val srParent = SharedResource.createKeepAlive("parent", this + Dispatchers.IO, Duration.ZERO)
         val srChild = SharedResource.createKeepAlive("child", this + Dispatchers.IO, Duration.ZERO)
 
@@ -128,7 +128,7 @@ class SharedResourceTest : BaseTest() {
         srParent.isClosed shouldBe true
 
         srParent.addChild(srChild)
-        srChild.isClosed shouldBe true
+        srChild.isClosed shouldBe false
         srParent.isClosed shouldBe true
     }
 

--- a/app-common/src/test/java/eu/darken/sdmse/common/sharedresource/SharedResourceTest.kt
+++ b/app-common/src/test/java/eu/darken/sdmse/common/sharedresource/SharedResourceTest.kt
@@ -1,0 +1,179 @@
+package eu.darken.sdmse.common.sharedresource
+
+import eu.darken.sdmse.common.debug.Bugs
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.plus
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+
+class SharedResourceTest : BaseTest() {
+    @BeforeEach
+    fun setup() {
+        Bugs.apply {
+            isDebug = true
+            isTrace = true
+            isDive = true
+        }
+    }
+
+    @AfterEach
+    fun teardown() {
+        Bugs.apply {
+            isDebug = false
+            isTrace = false
+            isDive = false
+        }
+    }
+
+    @Test fun `Lease-close closes Core`() = runTest2(autoCancel = true) {
+        (1..100).forEach {
+            val sr = SharedResource.createKeepAlive("test", this + Dispatchers.IO)
+
+            sr.isClosed shouldBe true
+            val lease = sr.get()
+            sr.isClosed shouldBe false
+            lease.close()
+            sr.isClosed shouldBe true
+        }
+    }
+
+    @Test fun `multiple leases`() = runTest2(autoCancel = true) {
+        val sr = SharedResource.createKeepAlive("test", this + Dispatchers.IO)
+
+        sr.isClosed shouldBe true
+
+        val lease1 = sr.get()
+        lease1.isClosed shouldBe false
+        sr.isClosed shouldBe false
+
+        val lease2 = sr.get()
+        lease2.isClosed shouldBe false
+
+        sr.isClosed shouldBe false
+
+        lease2.close()
+
+        lease1.isClosed shouldBe false
+        lease2.isClosed shouldBe true
+        sr.isClosed shouldBe false
+    }
+
+    @Test fun `Core-close closes all leases`() = runTest2(autoCancel = true) {
+        val sr = SharedResource.createKeepAlive("test", this + Dispatchers.IO)
+
+        sr.isClosed shouldBe true
+
+        val lease1 = sr.get().apply {
+            isClosed shouldBe false
+        }
+
+        val lease2 = sr.get().apply {
+            isClosed shouldBe false
+        }
+
+        sr.close()
+
+        sr.isClosed shouldBe true
+        lease1.isClosed shouldBe true
+        lease2.isClosed shouldBe true
+    }
+
+    @Test fun `started parents start children`() = runTest2(autoCancel = true) {
+        val srParent = SharedResource.createKeepAlive("parent", this + Dispatchers.IO)
+        val srChild = SharedResource.createKeepAlive("child", this + Dispatchers.IO)
+
+        srParent.get()
+
+        srChild.isClosed shouldBe true
+        srParent.addChild(srChild)
+        srChild.isClosed shouldBe false
+    }
+
+    @Test fun `closed parents dont add children`() = runTest2(autoCancel = true) {
+        val srParent = SharedResource.createKeepAlive("parent", this + Dispatchers.IO)
+        val srChild = SharedResource.createKeepAlive("child", this + Dispatchers.IO)
+
+        srChild.isClosed shouldBe true
+        srParent.addChild(srChild)
+        srChild.isClosed shouldBe true
+
+        srParent.get()
+
+        srChild.isClosed shouldBe true
+    }
+
+    @Test fun `closed parents close added children`() = runTest2(autoCancel = true) {
+        val srParent = SharedResource.createKeepAlive("parent", this + Dispatchers.IO)
+        val srChild = SharedResource.createKeepAlive("child", this + Dispatchers.IO)
+
+        srChild.get()
+        srChild.isClosed shouldBe false
+        srParent.addChild(srChild)
+        srChild.isClosed shouldBe true
+    }
+
+    @Test fun `childs dont keep parents alive`() = runTest2(autoCancel = true) {
+        val srParent = SharedResource.createKeepAlive("parent", this + Dispatchers.IO)
+        val srChild = SharedResource.createKeepAlive("child", this + Dispatchers.IO)
+
+        val lease1 = srParent.get().apply {
+            isClosed shouldBe false
+        }
+
+        srChild.isClosed shouldBe true
+        srParent.addChild(srChild)
+        srChild.isClosed shouldBe false
+
+        lease1.close()
+        lease1.isClosed shouldBe true
+        srChild.isClosed shouldBe true
+        srParent.isClosed shouldBe true
+    }
+
+    @Test fun `Core-close() closes all children`() = runTest2(autoCancel = true) {
+        val srParent = SharedResource.createKeepAlive("parent", this + Dispatchers.IO)
+        val srChild1 = SharedResource.createKeepAlive("child", this + Dispatchers.IO)
+        val srChild2 = SharedResource.createKeepAlive("child", this + Dispatchers.IO)
+
+        srParent.get()
+
+        srParent.addChild(srChild1)
+        srChild1.isClosed shouldBe false
+
+        srParent.addChild(srChild2)
+        srChild2.isClosed shouldBe false
+
+        srParent.close()
+        srChild1.isClosed shouldBe true
+        srChild2.isClosed shouldBe true
+    }
+
+    @Test fun `addChild double call is noop`() = runTest2(autoCancel = true) {
+        val srParent = SharedResource.createKeepAlive("parent", this + Dispatchers.IO)
+        val srChild = SharedResource.createKeepAlive("child", this + Dispatchers.IO)
+
+        srParent.get()
+
+        srChild.isClosed shouldBe true
+        srParent.addChild(srChild)
+        srParent.addChild(srChild)
+        srChild.isClosed shouldBe false
+    }
+
+    @Test fun `error during creation is forwarded`() = runTest2(autoCancel = true) {
+        val srError = SharedResource<Unit>(
+            tag = "parent",
+            parentScope = this@runTest2 + Dispatchers.IO,
+            source = flow { throw IllegalStateException() }
+        )
+
+        shouldThrow<IllegalStateException> { srError.get() }
+        shouldThrow<IllegalStateException> { srError.get() }
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/common/forensics/FileForensicsTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/common/forensics/FileForensicsTest.kt
@@ -42,6 +42,7 @@ class FileForensicsTest : BaseTest() {
             coEvery { get() } returns mockk<Resource<Any>>().apply {
                 every { close() } returns Unit
             }
+            every { isClosed } returns true
             every { close() } returns Unit
         }
         every { pkgOps.sharedResource } returns mockk<SharedResource<Any>>().apply {
@@ -49,6 +50,7 @@ class FileForensicsTest : BaseTest() {
             coEvery { get() } returns mockk<Resource<Any>>().apply {
                 every { close() } returns Unit
             }
+            every { isClosed } returns true
             every { close() } returns Unit
         }
     }

--- a/app/src/test/java/eu/darken/sdmse/common/forensics/FileForensicsTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/common/forensics/FileForensicsTest.kt
@@ -38,12 +38,14 @@ class FileForensicsTest : BaseTest() {
         processors.add(csiProcessor)
 
         every { gatewaySwitch.sharedResource } returns mockk<SharedResource<Any>>().apply {
+            every { resourceId } returns "gateway:SR"
             coEvery { get() } returns mockk<Resource<Any>>().apply {
                 every { close() } returns Unit
             }
             every { close() } returns Unit
         }
         every { pkgOps.sharedResource } returns mockk<SharedResource<Any>>().apply {
+            every { resourceId } returns "pkgops:SR"
             coEvery { get() } returns mockk<Resource<Any>>().apply {
                 every { close() } returns Unit
             }


### PR DESCRIPTION
A rewrite of `SharedResource`, which is a class that manages the lifecycle of costly dependencies. These costly services are mostly Root and ADB related (launching a service in an extra process and connecting to it).

Replacing RXShell (#1529) made flaws within the old `SharedResource` visible, where we could trigger a race condition if one consumer gets a new lease, while another closes the last one.

I couldn't get the `Flow.shareIn` logic (on which the old `SharedResource` was based) to work. This is custom solution which gives me finer control over the behavior.

This should get us

* Less overhead when sharing resources
* No more random errors related to root or ADB :crossed_fingers: 
* Less resource use due to better re-use of the shared resource
* Now we have test coverage for this part