### PR TITLE
Fix `ShellOps` not being kept active by tools that use it

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/PkgOps.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/PkgOps.kt
@@ -54,7 +54,6 @@ import eu.darken.sdmse.common.sharedresource.HasSharedResource
 import eu.darken.sdmse.common.sharedresource.SharedResource
 import eu.darken.sdmse.common.sharedresource.keepResourcesAlive
 import eu.darken.sdmse.common.user.UserHandle2
-import eu.darken.sdmse.common.user.UserManager2
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.plus
 import java.util.UUID
@@ -67,7 +66,6 @@ class PkgOps @Inject constructor(
     dispatcherProvider: DispatcherProvider,
     @ApplicationContext private val context: Context,
     private val ipcFunnel: IPCFunnel,
-    private val userManager: UserManager2,
     private val rootManager: RootManager,
     private val adbManager: AdbManager,
     private val usageStatsManager: UsageStatsManager,
@@ -161,7 +159,6 @@ class PkgOps @Inject constructor(
             @Suppress("NewApi")
             packageManager.getInstalledPackages(PackageInfoFlags.of(flags))
         } else {
-            @Suppress("DEPRECATION")
             packageManager.getInstalledPackages(flags.toInt())
         }
     }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
@@ -38,6 +38,7 @@ import eu.darken.sdmse.common.progress.withProgress
 import eu.darken.sdmse.common.root.RootManager
 import eu.darken.sdmse.common.sharedresource.SharedResource
 import eu.darken.sdmse.common.sharedresource.keepResourceHoldersAlive
+import eu.darken.sdmse.common.shell.ShellOps
 import eu.darken.sdmse.exclusion.core.ExclusionManager
 import eu.darken.sdmse.exclusion.core.types.Exclusion
 import eu.darken.sdmse.exclusion.core.types.PathExclusion
@@ -71,11 +72,12 @@ class AppCleaner @Inject constructor(
     usageStatsSetupModule: UsageStatsSetupModule,
     rootManager: RootManager,
     adbManager: AdbManager,
+    shellOps: ShellOps,
     private val filterFactories: Set<@JvmSuppressWildcards ExpendablesFilter.Factory>,
     private val appInventorySetupModule: InventorySetupModule,
 ) : SDMTool, Progress.Client {
 
-    private val usedResources = setOf(fileForensics, gatewaySwitch, pkgOps)
+    private val usedResources = setOf(fileForensics, gatewaySwitch, pkgOps, shellOps)
 
     override val sharedResource = SharedResource.createKeepAlive(TAG, appScope)
 

--- a/app/src/main/java/eu/darken/sdmse/common/areas/modules/DataAreaFactory.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/areas/modules/DataAreaFactory.kt
@@ -13,18 +13,20 @@ import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.pkgs.pkgops.PkgOps
 import eu.darken.sdmse.common.sharedresource.closeAll
+import eu.darken.sdmse.common.shell.ShellOps
 import javax.inject.Inject
 
 @Reusable
 class DataAreaFactory @Inject constructor(
     private val pkgOps: PkgOps,
     private val gatewaySwitch: GatewaySwitch,
+    private val shellOps: ShellOps,
     private val areaModules: Set<@JvmSuppressWildcards DataAreaModule>,
 ) {
 
     suspend fun build(): Collection<DataArea> {
         log(TAG) { "build()" }
-        val leases = setOf(pkgOps, gatewaySwitch).map { it.sharedResource.get() }
+        val leases = setOf(pkgOps, gatewaySwitch, shellOps).map { it.sharedResource.get() }
 
         val firstPass = areaModules.map { it.firstPass() }.flatten()
         log(TAG, VERBOSE) { "build(): First pass: ${firstPass.joinToString("\n")}" }


### PR DESCRIPTION
`UserManager2.allUsers()` uses `ShellOps` internally to get current user info from the shell. Tools (like AppCleaner) and core classes like DataAreaFactory and PkgOps should keep ShellOps alive if they use it.

This prevents shell sessions from being repeatedly started meaning faster execution.