### PR TITLE
AppCleaner: Include Telegram "Stories"

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/TelegramFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/TelegramFilter.kt
@@ -38,15 +38,17 @@ class TelegramFilter @Inject constructor(
         DynamicAppSieve.MatchConfig(
             pkgNames = setOf("org.telegram.messenger".toPkgId()),
             areaTypes = setOf(DataArea.Type.SDCARD, DataArea.Type.PUBLIC_DATA),
-            startsWith = setOf(
+            ancestors = setOf(
                 "Telegram/Telegram Audio",
                 "Telegram/Telegram Documents",
                 "Telegram/Telegram Images",
                 "Telegram/Telegram Video",
+                "Telegram/Telegram Stories",
                 "org.telegram.messenger/files/Telegram/Telegram Audio",
                 "org.telegram.messenger/files/Telegram/Telegram Documents",
                 "org.telegram.messenger/files/Telegram/Telegram Images",
                 "org.telegram.messenger/files/Telegram/Telegram Video",
+                "org.telegram.messenger/files/Telegram/Telegram Stories",
             ),
             exclusions = setOf(".nomedia"),
         ).let { configs.add(it) }
@@ -54,11 +56,12 @@ class TelegramFilter @Inject constructor(
         DynamicAppSieve.MatchConfig(
             pkgNames = setOf("org.telegram.plus".toPkgId()),
             areaTypes = setOf(DataArea.Type.SDCARD),
-            startsWith = setOf(
+            ancestors = setOf(
                 "Telegram/Telegram Audio",
                 "Telegram/Telegram Documents",
                 "Telegram/Telegram Images",
                 "Telegram/Telegram Video",
+                "Telegram/Telegram Stories",
             ),
             exclusions = setOf(".nomedia"),
         ).let { configs.add(it) }
@@ -66,11 +69,12 @@ class TelegramFilter @Inject constructor(
         DynamicAppSieve.MatchConfig(
             pkgNames = setOf("org.thunderdog.challegram".toPkgId()),
             areaTypes = setOf(DataArea.Type.SDCARD, DataArea.Type.PUBLIC_DATA),
-            startsWith = setOf(
+            ancestors = setOf(
                 "Telegram/Telegram Audio",
                 "Telegram/Telegram Documents",
                 "Telegram/Telegram Images",
                 "Telegram/Telegram Video",
+                "Telegram/Telegram Stories",
                 "org.thunderdog.challegram/files/documents",
                 "org.thunderdog.challegram/files/music",
                 "org.thunderdog.challegram/files/videos",
@@ -78,6 +82,7 @@ class TelegramFilter @Inject constructor(
                 "org.thunderdog.challegram/files/animations",
                 "org.thunderdog.challegram/files/voice",
                 "org.thunderdog.challegram/files/photos",
+                "org.thunderdog.challegram/files/stories",
             ),
             exclusions = setOf(".nomedia"),
         ).let { configs.add(it) }
@@ -85,15 +90,17 @@ class TelegramFilter @Inject constructor(
         DynamicAppSieve.MatchConfig(
             pkgNames = setOf("ir.ilmili.telegraph".toPkgId()),
             areaTypes = setOf(DataArea.Type.SDCARD, DataArea.Type.PUBLIC_DATA),
-            startsWith = setOf(
+            ancestors = setOf(
                 "Telegram/Telegram Audio",
                 "Telegram/Telegram Documents",
                 "Telegram/Telegram Images",
                 "Telegram/Telegram Video",
+                "Telegram/Telegram Stories",
                 "ir.ilmili.telegraph/files/Telegram/Telegram Audio",
                 "ir.ilmili.telegraph/files/Telegram/Telegram Documents",
                 "ir.ilmili.telegraph/files/Telegram/Telegram Images",
                 "ir.ilmili.telegraph/files/Telegram/Telegram Video",
+                "ir.ilmili.telegraph/files/Telegram/Telegram Stories",
             ),
             exclusions = setOf(".nomedia"),
         ).let { configs.add(it) }
@@ -101,15 +108,17 @@ class TelegramFilter @Inject constructor(
         DynamicAppSieve.MatchConfig(
             pkgNames = setOf("org.telegram.messenger.web".toPkgId()),
             areaTypes = setOf(DataArea.Type.SDCARD, DataArea.Type.PUBLIC_DATA),
-            startsWith = setOf(
+            ancestors = setOf(
                 "Telegram/Telegram Audio",
                 "Telegram/Telegram Documents",
                 "Telegram/Telegram Images",
                 "Telegram/Telegram Video",
+                "Telegram/Telegram Stories",
                 "org.telegram.messenger.web/files/Telegram/Telegram Audio",
                 "org.telegram.messenger.web/files/Telegram/Telegram Documents",
                 "org.telegram.messenger.web/files/Telegram/Telegram Images",
                 "org.telegram.messenger.web/files/Telegram/Telegram Video",
+                "org.telegram.messenger.web/files/Telegram/Telegram Stories",
             ),
             exclusions = setOf(".nomedia"),
         ).let { configs.add(it) }

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/TelegramFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/TelegramFilterTest.kt
@@ -29,218 +29,182 @@ class TelegramFilterTest : BaseFilterTest() {
 
     @Test fun telegram() = runTest {
         addDefaultNegatives()
+        val pkg = "org.telegram.messenger"
+        neg(pkg, SDCARD, "Telegram")
+        neg(pkg, SDCARD, "Telegram/Telegram ")
+        neg(pkg, SDCARD, "WhatsApp/Telegram Audio")
+        neg(pkg, SDCARD, "WhatsApp/Telegram Documents")
+        neg(pkg, SDCARD, "WhatsApp/Telegram Images")
+        neg(pkg, SDCARD, "WhatsApp/Telegram Video")
+        neg(pkg, SDCARD, "Telegram")
+        neg(pkg, SDCARD, "Telegram/.nomedia")
+        neg(pkg, SDCARD, "Telegram/Telegram ")
+        neg(pkg, SDCARD, "Telegram/Telegram Audio/.nomedia")
+        neg(pkg, SDCARD, "Telegram/Telegram Documents/.nomedia")
+        neg(pkg, SDCARD, "Telegram/Telegram Images/.nomedia")
+        neg(pkg, SDCARD, "Telegram/Telegram Video/.nomedia")
 
-        neg("org.telegram.messenger", SDCARD, "Telegram")
-        neg("org.telegram.messenger", SDCARD, "Telegram/Telegram ")
-        neg("org.telegram.messenger", SDCARD, "WhatsApp/Telegram Audio")
-        neg("org.telegram.messenger", SDCARD, "WhatsApp/Telegram Documents")
-        neg("org.telegram.messenger", SDCARD, "WhatsApp/Telegram Images")
-        neg("org.telegram.messenger", SDCARD, "WhatsApp/Telegram Video")
-        neg("org.telegram.messenger", SDCARD, "Telegram")
-        neg("org.telegram.messenger", SDCARD, "Telegram/.nomedia")
-        neg("org.telegram.messenger", SDCARD, "Telegram/Telegram ")
-        neg("org.telegram.messenger", SDCARD, "Telegram/Telegram Audio/.nomedia")
-        neg("org.telegram.messenger", SDCARD, "Telegram/Telegram Documents/.nomedia")
-        neg("org.telegram.messenger", SDCARD, "Telegram/Telegram Images/.nomedia")
-        neg("org.telegram.messenger", SDCARD, "Telegram/Telegram Video/.nomedia")
+        pos(pkg, SDCARD, "Telegram/Telegram Audio/1213123123_123123123asdasd.ogg")
+        pos(pkg, SDCARD, "Telegram/Telegram Documents/1_376646255079588440.mp4")
+        pos(pkg, SDCARD, "Telegram/Telegram Images/425705794_239071.jpg")
+        pos(pkg, SDCARD, "Telegram/Telegram Video/1_376646255079588440.mp4")
 
-        pos("org.telegram.messenger", SDCARD, "Telegram/Telegram Audio/1213123123_123123123asdasd.ogg")
-        pos("org.telegram.messenger", SDCARD, "Telegram/Telegram Documents/1_376646255079588440.mp4")
-        pos("org.telegram.messenger", SDCARD, "Telegram/Telegram Images/425705794_239071.jpg")
-        pos("org.telegram.messenger", SDCARD, "Telegram/Telegram Video/1_376646255079588440.mp4")
-        pos(
-            "org.telegram.messenger",
-            PUBLIC_DATA,
-            "org.telegram.messenger/files/Telegram/Telegram Audio/1213123123_123123123asdasd.ogg"
-        )
-        pos(
-            "org.telegram.messenger",
-            PUBLIC_DATA,
-            "org.telegram.messenger/files/Telegram/Telegram Documents/1_376646255079588440.mp4"
-        )
-        pos(
-            "org.telegram.messenger",
-            PUBLIC_DATA,
-            "org.telegram.messenger/files/Telegram/Telegram Images/425705794_239071.jpg"
-        )
-        pos(
-            "org.telegram.messenger",
-            PUBLIC_DATA,
-            "org.telegram.messenger/files/Telegram/Telegram Video/1_376646255079588440.mp4"
-        )
-        neg("org.telegram.messenger", PUBLIC_DATA, "org.telegram.messenger/files/Telegram")
-        neg("org.telegram.messenger", PUBLIC_DATA, "org.telegram.messenger/files/Telegram/.nomedia")
-        neg("org.telegram.messenger", PUBLIC_DATA, "org.telegram.messenger/files/Telegram/Telegram ")
-        neg("org.telegram.messenger", PUBLIC_DATA, "org.telegram.messenger/files/Telegram/Telegram Audio/.nomedia")
-        neg("org.telegram.messenger", PUBLIC_DATA, "org.telegram.messenger/files/Telegram/Telegram Documents/.nomedia")
-        neg("org.telegram.messenger", PUBLIC_DATA, "org.telegram.messenger/files/Telegram/Telegram Images/.nomedia")
-        neg("org.telegram.messenger", PUBLIC_DATA, "org.telegram.messenger/files/Telegram/Telegram Video/.nomedia")
+        pos(pkg, SDCARD, "Telegram/Telegram Stories/1_376646255079588440.mp4")
+        neg(pkg, SDCARD, "Telegram/Telegram Stories/.nomedia")
+        neg(pkg, SDCARD, "Telegram/Telegram Stories")
+
+        pos(pkg, PUBLIC_DATA, "$pkg/files/Telegram/Telegram Audio/1213123123_123123123asdasd.ogg")
+        pos(pkg, PUBLIC_DATA, "$pkg/files/Telegram/Telegram Documents/1_376646255079588440.mp4")
+        pos(pkg, PUBLIC_DATA, "$pkg/files/Telegram/Telegram Images/425705794_239071.jpg")
+        pos(pkg, PUBLIC_DATA, "$pkg/files/Telegram/Telegram Video/1_376646255079588440.mp4")
+        neg(pkg, PUBLIC_DATA, "$pkg/files/Telegram")
+        neg(pkg, PUBLIC_DATA, "$pkg/files/Telegram/.nomedia")
+        neg(pkg, PUBLIC_DATA, "$pkg/files/Telegram/Telegram ")
+        neg(pkg, PUBLIC_DATA, "$pkg/files/Telegram/Telegram Audio/.nomedia")
+        neg(pkg, PUBLIC_DATA, "$pkg/files/Telegram/Telegram Documents/.nomedia")
+        neg(pkg, PUBLIC_DATA, "$pkg/files/Telegram/Telegram Images/.nomedia")
+        neg(pkg, PUBLIC_DATA, "$pkg/files/Telegram/Telegram Video/.nomedia")
+
+        pos(pkg, PUBLIC_DATA, "$pkg/files/Telegram/Telegram Stories/1_376646255079588440.mp4")
+        neg(pkg, PUBLIC_DATA, "$pkg/files/Telegram/Telegram Stories/.nomedia")
+        neg(pkg, PUBLIC_DATA, "$pkg/files/Telegram/Telegram Stories")
+
         confirm(create())
     }
 
     @Test fun telegramPlus() = runTest {
         addDefaultNegatives()
+        val pkg = "org.telegram.plus"
+        neg(pkg, SDCARD, "Telegram")
+        neg(pkg, SDCARD, "Telegram/Telegram ")
+        neg(pkg, SDCARD, "WhatsApp/Telegram Audio")
+        neg(pkg, SDCARD, "WhatsApp/Telegram Documents")
+        neg(pkg, SDCARD, "WhatsApp/Telegram Images")
+        neg(pkg, SDCARD, "WhatsApp/Telegram Video")
+        neg(pkg, SDCARD, "Telegram")
+        neg(pkg, SDCARD, "Telegram/.nomedia")
+        neg(pkg, SDCARD, "Telegram/Telegram ")
+        neg(pkg, SDCARD, "Telegram/Telegram Audio/.nomedia")
+        neg(pkg, SDCARD, "Telegram/Telegram Documents/.nomedia")
+        neg(pkg, SDCARD, "Telegram/Telegram Images/.nomedia")
+        neg(pkg, SDCARD, "Telegram/Telegram Video/.nomedia")
+        pos(pkg, SDCARD, "Telegram/Telegram Audio/1213123123_123123123asdasd.ogg")
+        pos(pkg, SDCARD, "Telegram/Telegram Documents/1_376646255079588440.mp4")
+        pos(pkg, SDCARD, "Telegram/Telegram Images/425705794_239071.jpg")
+        pos(pkg, SDCARD, "Telegram/Telegram Video/1_376646255079588440.mp4")
 
-        neg("org.telegram.plus", SDCARD, "Telegram")
-        neg("org.telegram.plus", SDCARD, "Telegram/Telegram ")
-        neg("org.telegram.plus", SDCARD, "WhatsApp/Telegram Audio")
-        neg("org.telegram.plus", SDCARD, "WhatsApp/Telegram Documents")
-        neg("org.telegram.plus", SDCARD, "WhatsApp/Telegram Images")
-        neg("org.telegram.plus", SDCARD, "WhatsApp/Telegram Video")
-        neg("org.telegram.plus", SDCARD, "Telegram")
-        neg("org.telegram.plus", SDCARD, "Telegram/.nomedia")
-        neg("org.telegram.plus", SDCARD, "Telegram/Telegram ")
-        neg("org.telegram.plus", SDCARD, "Telegram/Telegram Audio/.nomedia")
-        neg("org.telegram.plus", SDCARD, "Telegram/Telegram Documents/.nomedia")
-        neg("org.telegram.plus", SDCARD, "Telegram/Telegram Images/.nomedia")
-        neg("org.telegram.plus", SDCARD, "Telegram/Telegram Video/.nomedia")
-        pos("org.telegram.plus", SDCARD, "Telegram/Telegram Audio/1213123123_123123123asdasd.ogg")
-        pos("org.telegram.plus", SDCARD, "Telegram/Telegram Documents/1_376646255079588440.mp4")
-        pos("org.telegram.plus", SDCARD, "Telegram/Telegram Images/425705794_239071.jpg")
-        pos("org.telegram.plus", SDCARD, "Telegram/Telegram Video/1_376646255079588440.mp4")
+        pos(pkg, SDCARD, "Telegram/Telegram Stories/1_376646255079588440.mp4")
+        neg(pkg, SDCARD, "Telegram/Telegram Stories/.nomedia")
+        neg(pkg, SDCARD, "Telegram/Telegram Stories")
 
         confirm(create())
     }
 
     @Test fun testClones() = runTest {
         addDefaultNegatives()
+        val pkg = "org.thunderdog.challegram"
+        neg(pkg, SDCARD, "Telegram")
+        neg(pkg, SDCARD, "Telegram/Telegram ")
+        neg(pkg, SDCARD, "WhatsApp/Telegram Audio")
+        neg(pkg, SDCARD, "WhatsApp/Telegram Documents")
+        neg(pkg, SDCARD, "WhatsApp/Telegram Images")
+        neg(pkg, SDCARD, "WhatsApp/Telegram Video")
+        neg(pkg, SDCARD, "Telegram")
+        neg(pkg, SDCARD, "Telegram/.nomedia")
+        neg(pkg, SDCARD, "Telegram/Telegram ")
+        neg(pkg, SDCARD, "Telegram/Telegram Audio/.nomedia")
+        neg(pkg, SDCARD, "Telegram/Telegram Documents/.nomedia")
+        neg(pkg, SDCARD, "Telegram/Telegram Images/.nomedia")
+        neg(pkg, SDCARD, "Telegram/Telegram Video/.nomedia")
+        pos(pkg, SDCARD, "Telegram/Telegram Audio/1213123123_123123123asdasd.ogg")
+        pos(pkg, SDCARD, "Telegram/Telegram Documents/1_376646255079588440.mp4")
+        pos(pkg, SDCARD, "Telegram/Telegram Images/425705794_239071.jpg")
+        pos(pkg, SDCARD, "Telegram/Telegram Video/1_376646255079588440.mp4")
 
-        neg("org.thunderdog.challegram", SDCARD, "Telegram")
-        neg("org.thunderdog.challegram", SDCARD, "Telegram/Telegram ")
-        neg("org.thunderdog.challegram", SDCARD, "WhatsApp/Telegram Audio")
-        neg("org.thunderdog.challegram", SDCARD, "WhatsApp/Telegram Documents")
-        neg("org.thunderdog.challegram", SDCARD, "WhatsApp/Telegram Images")
-        neg("org.thunderdog.challegram", SDCARD, "WhatsApp/Telegram Video")
-        neg("org.thunderdog.challegram", SDCARD, "Telegram")
-        neg("org.thunderdog.challegram", SDCARD, "Telegram/.nomedia")
-        neg("org.thunderdog.challegram", SDCARD, "Telegram/Telegram ")
-        neg("org.thunderdog.challegram", SDCARD, "Telegram/Telegram Audio/.nomedia")
-        neg("org.thunderdog.challegram", SDCARD, "Telegram/Telegram Documents/.nomedia")
-        neg("org.thunderdog.challegram", SDCARD, "Telegram/Telegram Images/.nomedia")
-        neg("org.thunderdog.challegram", SDCARD, "Telegram/Telegram Video/.nomedia")
-        pos("org.thunderdog.challegram", SDCARD, "Telegram/Telegram Audio/1213123123_123123123asdasd.ogg")
-        pos("org.thunderdog.challegram", SDCARD, "Telegram/Telegram Documents/1_376646255079588440.mp4")
-        pos("org.thunderdog.challegram", SDCARD, "Telegram/Telegram Images/425705794_239071.jpg")
-        pos("org.thunderdog.challegram", SDCARD, "Telegram/Telegram Video/1_376646255079588440.mp4")
-        pos(
-            "org.thunderdog.challegram",
-            PUBLIC_DATA,
-            "org.thunderdog.challegram/files/documents/Lawnchair-alpha_2013.apk"
-        )
-        pos("org.thunderdog.challegram", PUBLIC_DATA, "org.thunderdog.challegram/files/music/strawberry")
-        pos("org.thunderdog.challegram", PUBLIC_DATA, "org.thunderdog.challegram/files/videos/strawberry")
-        pos("org.thunderdog.challegram", PUBLIC_DATA, "org.thunderdog.challegram/files/video_notes/strawberry")
-        pos(
-            "org.thunderdog.challegram",
-            PUBLIC_DATA,
-            "org.thunderdog.challegram/files/animations/ScreenRec_20190107_225020~2.mp4"
-        )
-        pos("org.thunderdog.challegram", PUBLIC_DATA, "org.thunderdog.challegram/files/voice/strawberry")
-        pos("org.thunderdog.challegram", PUBLIC_DATA, "org.thunderdog.challegram/files/photos/853536364_160037_(0).jpg")
+        pos(pkg, SDCARD, "Telegram/Telegram Stories/1_376646255079588440.mp4")
+        neg(pkg, SDCARD, "Telegram/Telegram Stories/.nomedia")
+        neg(pkg, SDCARD, "Telegram/Telegram Stories")
+
+        pos(pkg, PUBLIC_DATA, "$pkg/files/documents/Lawnchair-alpha_2013.apk")
+        pos(pkg, PUBLIC_DATA, "$pkg/files/music/strawberry")
+        pos(pkg, PUBLIC_DATA, "$pkg/files/videos/strawberry")
+        pos(pkg, PUBLIC_DATA, "$pkg/files/video_notes/strawberry")
+        pos(pkg, PUBLIC_DATA, "$pkg/files/animations/ScreenRec_20190107_225020~2.mp4")
+        pos(pkg, PUBLIC_DATA, "$pkg/files/voice/strawberry")
+        pos(pkg, PUBLIC_DATA, "$pkg/files/photos/853536364_160037_(0).jpg")
+
+        pos(pkg, PUBLIC_DATA, "$pkg/files/stories/1_376646255079588440.mp4")
+        neg(pkg, PUBLIC_DATA, "$pkg/files/stories/.nomedia")
+        neg(pkg, PUBLIC_DATA, "$pkg/files/stories")
 
         confirm(create())
     }
 
     @Test fun testGraphMessenger() = runTest {
         addDefaultNegatives()
+        val pkg = "ir.ilmili.telegraph"
+        neg(pkg, SDCARD, "Telegram")
+        neg(pkg, SDCARD, "Telegram/Telegram ")
+        neg(pkg, SDCARD, "WhatsApp/Telegram Audio")
+        neg(pkg, SDCARD, "WhatsApp/Telegram Documents")
+        neg(pkg, SDCARD, "WhatsApp/Telegram Images")
+        neg(pkg, SDCARD, "WhatsApp/Telegram Video")
+        neg(pkg, SDCARD, "Telegram")
+        neg(pkg, SDCARD, "Telegram/.nomedia")
+        neg(pkg, SDCARD, "Telegram/Telegram ")
+        neg(pkg, SDCARD, "Telegram/Telegram Audio/.nomedia")
+        neg(pkg, SDCARD, "Telegram/Telegram Documents/.nomedia")
+        neg(pkg, SDCARD, "Telegram/Telegram Images/.nomedia")
+        neg(pkg, SDCARD, "Telegram/Telegram Video/.nomedia")
 
-        neg("ir.ilmili.telegraph", SDCARD, "Telegram")
-        neg("ir.ilmili.telegraph", SDCARD, "Telegram/Telegram ")
-        neg("ir.ilmili.telegraph", SDCARD, "WhatsApp/Telegram Audio")
-        neg("ir.ilmili.telegraph", SDCARD, "WhatsApp/Telegram Documents")
-        neg("ir.ilmili.telegraph", SDCARD, "WhatsApp/Telegram Images")
-        neg("ir.ilmili.telegraph", SDCARD, "WhatsApp/Telegram Video")
-        neg("ir.ilmili.telegraph", SDCARD, "Telegram")
-        neg("ir.ilmili.telegraph", SDCARD, "Telegram/.nomedia")
-        neg("ir.ilmili.telegraph", SDCARD, "Telegram/Telegram ")
-        neg("ir.ilmili.telegraph", SDCARD, "Telegram/Telegram Audio/.nomedia")
-        neg("ir.ilmili.telegraph", SDCARD, "Telegram/Telegram Documents/.nomedia")
-        neg("ir.ilmili.telegraph", SDCARD, "Telegram/Telegram Images/.nomedia")
-        neg("ir.ilmili.telegraph", SDCARD, "Telegram/Telegram Video/.nomedia")
+        pos(pkg, SDCARD, "Telegram/Telegram Audio/1213123123_123123123asdasd.ogg")
+        pos(pkg, SDCARD, "Telegram/Telegram Documents/1_376646255079588440.mp4")
+        pos(pkg, SDCARD, "Telegram/Telegram Images/425705794_239071.jpg")
+        pos(pkg, SDCARD, "Telegram/Telegram Video/1_376646255079588440.mp4")
 
-        pos("ir.ilmili.telegraph", SDCARD, "Telegram/Telegram Audio/1213123123_123123123asdasd.ogg")
-        pos("ir.ilmili.telegraph", SDCARD, "Telegram/Telegram Documents/1_376646255079588440.mp4")
-        pos("ir.ilmili.telegraph", SDCARD, "Telegram/Telegram Images/425705794_239071.jpg")
-        pos("ir.ilmili.telegraph", SDCARD, "Telegram/Telegram Video/1_376646255079588440.mp4")
+        pos(pkg, SDCARD, "Telegram/Telegram Stories/1_376646255079588440.mp4")
+        neg(pkg, SDCARD, "Telegram/Telegram Stories/.nomedia")
+        neg(pkg, SDCARD, "Telegram/Telegram Stories")
 
-        pos(
-            "ir.ilmili.telegraph",
-            PUBLIC_DATA,
-            "ir.ilmili.telegraph/files/Telegram/Telegram Audio/1213123123_123123123asdasd.ogg"
-        )
-        pos(
-            "ir.ilmili.telegraph",
-            PUBLIC_DATA,
-            "ir.ilmili.telegraph/files/Telegram/Telegram Documents/1_376646255079588440.mp4"
-        )
-        pos(
-            "ir.ilmili.telegraph",
-            PUBLIC_DATA,
-            "ir.ilmili.telegraph/files/Telegram/Telegram Images/425705794_239071.jpg"
-        )
-        pos(
-            "ir.ilmili.telegraph",
-            PUBLIC_DATA,
-            "ir.ilmili.telegraph/files/Telegram/Telegram Video/1_376646255079588440.mp4"
-        )
+        pos(pkg, PUBLIC_DATA, "$pkg/files/Telegram/Telegram Audio/1213123123_123123123asdasd.ogg")
+        pos(pkg, PUBLIC_DATA, "$pkg/files/Telegram/Telegram Documents/1_376646255079588440.mp4")
+        pos(pkg, PUBLIC_DATA, "$pkg/files/Telegram/Telegram Images/425705794_239071.jpg")
+        pos(pkg, PUBLIC_DATA, "$pkg/files/Telegram/Telegram Video/1_376646255079588440.mp4")
 
-        neg("ir.ilmili.telegraph", PUBLIC_DATA, "ir.ilmili.telegraph/files/Telegram")
-        neg("ir.ilmili.telegraph", PUBLIC_DATA, "ir.ilmili.telegraph/files/Telegram/.nomedia")
-        neg("ir.ilmili.telegraph", PUBLIC_DATA, "ir.ilmili.telegraph/files/Telegram/Telegram ")
-        neg("ir.ilmili.telegraph", PUBLIC_DATA, "ir.ilmili.telegraph/files/Telegram/Telegram Audio/.nomedia")
-        neg("ir.ilmili.telegraph", PUBLIC_DATA, "ir.ilmili.telegraph/files/Telegram/Telegram Documents/.nomedia")
-        neg("ir.ilmili.telegraph", PUBLIC_DATA, "ir.ilmili.telegraph/files/Telegram/Telegram Images/.nomedia")
-        neg("ir.ilmili.telegraph", PUBLIC_DATA, "ir.ilmili.telegraph/files/Telegram/Telegram Video/.nomedia")
+        neg(pkg, PUBLIC_DATA, "$pkg/files/Telegram")
+        neg(pkg, PUBLIC_DATA, "$pkg/files/Telegram/.nomedia")
+        neg(pkg, PUBLIC_DATA, "$pkg/files/Telegram/Telegram ")
+        neg(pkg, PUBLIC_DATA, "$pkg/files/Telegram/Telegram Audio/.nomedia")
+        neg(pkg, PUBLIC_DATA, "$pkg/files/Telegram/Telegram Documents/.nomedia")
+        neg(pkg, PUBLIC_DATA, "$pkg/files/Telegram/Telegram Images/.nomedia")
+        neg(pkg, PUBLIC_DATA, "$pkg/files/Telegram/Telegram Video/.nomedia")
+
+        pos(pkg, PUBLIC_DATA, "$pkg/files/Telegram/Telegram Stories/1_376646255079588440.mp4")
+        neg(pkg, PUBLIC_DATA, "$pkg/files/Telegram/Telegram Stories/.nomedia")
+        neg(pkg, PUBLIC_DATA, "$pkg/files/Telegram/Telegram Stories")
 
         confirm(create())
     }
 
     @Test fun `telegram web variant`() = runTest {
         addDefaultNegatives()
-        pos(
-            "org.telegram.messenger.web",
-            PUBLIC_DATA,
-            "org.telegram.messenger.web/files/Telegram/Telegram Audio/1213123123_123123123asdasd.ogg"
-        )
-        pos(
-            "org.telegram.messenger.web",
-            PUBLIC_DATA,
-            "org.telegram.messenger.web/files/Telegram/Telegram Documents/1_376646255079588440.mp4"
-        )
-        pos(
-            "org.telegram.messenger.web",
-            PUBLIC_DATA,
-            "org.telegram.messenger.web/files/Telegram/Telegram Images/425705794_239071.jpg"
-        )
-        pos(
-            "org.telegram.messenger.web",
-            PUBLIC_DATA,
-            "org.telegram.messenger.web/files/Telegram/Telegram Video/1_376646255079588440.mp4"
-        )
+        val pkg = "org.telegram.messenger.web"
+        pos(pkg, PUBLIC_DATA, "$pkg/files/Telegram/Telegram Audio/1213123123_123123123asdasd.ogg")
+        pos(pkg, PUBLIC_DATA, "$pkg/files/Telegram/Telegram Documents/1_376646255079588440.mp4")
+        pos(pkg, PUBLIC_DATA, "$pkg/files/Telegram/Telegram Images/425705794_239071.jpg")
+        pos(pkg, PUBLIC_DATA, "$pkg/files/Telegram/Telegram Video/1_376646255079588440.mp4")
 
-        neg("org.telegram.messenger.web", PUBLIC_DATA, "org.telegram.messenger.web/files/Telegram")
-        neg("org.telegram.messenger.web", PUBLIC_DATA, "org.telegram.messenger.web/files/Telegram/.nomedia")
-        neg("org.telegram.messenger.web", PUBLIC_DATA, "org.telegram.messenger.web/files/Telegram/Telegram ")
-        neg(
-            "org.telegram.messenger.web",
-            PUBLIC_DATA,
-            "org.telegram.messenger.web/files/Telegram/Telegram Audio/.nomedia"
-        )
-        neg(
-            "org.telegram.messenger.web",
-            PUBLIC_DATA,
-            "org.telegram.messenger.web/files/Telegram/Telegram Documents/.nomedia"
-        )
-        neg(
-            "org.telegram.messenger.web",
-            PUBLIC_DATA,
-            "org.telegram.messenger.web/files/Telegram/Telegram Images/.nomedia"
-        )
-        neg(
-            "org.telegram.messenger.web",
-            PUBLIC_DATA,
-            "org.telegram.messenger.web/files/Telegram/Telegram Video/.nomedia"
-        )
+        neg(pkg, PUBLIC_DATA, "$pkg/files/Telegram")
+        neg(pkg, PUBLIC_DATA, "$pkg/files/Telegram/.nomedia")
+        neg(pkg, PUBLIC_DATA, "$pkg/files/Telegram/Telegram ")
+        neg(pkg, PUBLIC_DATA, "$pkg/files/Telegram/Telegram Audio/.nomedia")
+        neg(pkg, PUBLIC_DATA, "$pkg/files/Telegram/Telegram Documents/.nomedia")
+        neg(pkg, PUBLIC_DATA, "$pkg/files/Telegram/Telegram Images/.nomedia")
+        neg(pkg, PUBLIC_DATA, "$pkg/files/Telegram/Telegram Video/.nomedia")
+
+        pos(pkg, PUBLIC_DATA, "$pkg/files/Telegram/Telegram Stories/1_376646255079588440.mp4")
+        neg(pkg, PUBLIC_DATA, "$pkg/files/Telegram/Telegram Stories/.nomedia")
+        neg(pkg, PUBLIC_DATA, "$pkg/files/Telegram/Telegram Stories")
 
         confirm(create())
     }


### PR DESCRIPTION
The Telegram media files filter will now also include media related to "Stories"