### PR TITLE
AppControl: Sort by screen time

### DIFF
--- a/app-common-pkgs/src/main/java/eu/darken/sdmse/common/pkgs/PkgRepo.kt
+++ b/app-common-pkgs/src/main/java/eu/darken/sdmse/common/pkgs/PkgRepo.kt
@@ -154,16 +154,6 @@ class PkgRepo @Inject constructor(
         return mergedData
     }
 
-    suspend fun refresh(
-        id: Pkg.Id,
-        userHandle: UserHandle2? = null
-    ): Collection<Installed> {
-        log(TAG) { "refresh(): $id" }
-        // TODO refreshing the whole cache is inefficient, implement single target refresh?
-        refresh()
-        return queryCache(id, userHandle).mapNotNull { it.data }
-    }
-
     suspend fun refresh(): Collection<Installed> {
         val before = cache.value()
         log(TAG) { "refresh()... (before=${before.pkgCount})" }

--- a/app-common/src/main/java/eu/darken/sdmse/common/TimeExtensions.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/TimeExtensions.kt
@@ -1,9 +1,15 @@
 package eu.darken.sdmse.common
 
+import android.icu.text.MeasureFormat
+import android.icu.util.Measure
+import android.icu.util.MeasureUnit
+import android.text.format.DateUtils
+import java.time.Duration
 import java.time.Instant
 import java.time.OffsetDateTime
 import java.time.ZoneId
 import java.time.ZonedDateTime
+import java.util.Locale
 
 fun OffsetDateTime.toSystemTimezone(): ZonedDateTime = this
     .atZoneSameInstant(ZoneId.systemDefault())
@@ -13,3 +19,34 @@ fun Instant.toSystemTimezone(): ZonedDateTime = this
 
 fun Instant.toUtcTimezone(): ZonedDateTime = this
     .atZone(ZoneId.of("UTC"))
+
+/**
+ * Returns the given duration in a human-friendly format. For example,
+ * "4 minutes" or "1 second". Returns only the largest meaningful unit of time,
+ * from seconds up to hours.
+ * <p>
+ * You can use abbrev to specify a preference for abbreviations (but note that some
+ * locales may not have abbreviations). Use LENGTH_LONG for the full spelling (e.g. "2 hours"),
+ * LENGTH_SHORT for the abbreviated spelling if available (e.g. "2 hr"), and LENGTH_SHORTEST for
+ * the briefest form available (e.g. "2h").
+ */
+fun Duration.formatDuration(abbrev: Int = DateUtils.LENGTH_SHORT): String {
+    val width = when (abbrev) {
+        DateUtils.LENGTH_LONG -> MeasureFormat.FormatWidth.WIDE
+        DateUtils.LENGTH_SHORT, DateUtils.LENGTH_SHORTER, DateUtils.LENGTH_MEDIUM -> MeasureFormat.FormatWidth.SHORT
+        DateUtils.LENGTH_SHORTEST -> MeasureFormat.FormatWidth.NARROW
+        else -> MeasureFormat.FormatWidth.WIDE
+    }
+    val millis = toMillis()
+    val formatter = MeasureFormat.getInstance(Locale.getDefault(), width)
+    if (millis >= DateUtils.HOUR_IN_MILLIS) {
+        val hours = ((millis + 1800000) / DateUtils.HOUR_IN_MILLIS).toInt()
+        return formatter.format(Measure(hours, MeasureUnit.HOUR))
+    } else if (millis >= DateUtils.MINUTE_IN_MILLIS) {
+        val minutes = ((millis + 30000) / DateUtils.MINUTE_IN_MILLIS).toInt()
+        return formatter.format(Measure(minutes, MeasureUnit.MINUTE))
+    } else {
+        val seconds = ((millis + 500) / DateUtils.SECOND_IN_MILLIS).toInt()
+        return formatter.format(Measure(seconds, MeasureUnit.SECOND))
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/AppControlScanTask.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/AppControlScanTask.kt
@@ -9,6 +9,7 @@ import kotlinx.parcelize.Parcelize
 data class AppControlScanTask(
     val pkgIdFilter: Set<Pkg.Id> = emptySet(),
     val refreshPkgCache: Boolean = false,
+    val screenTime: Boolean = false,
 ) : AppControlTask {
 
     @Parcelize

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/AppInfo.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/AppInfo.kt
@@ -1,6 +1,7 @@
 package eu.darken.sdmse.appcontrol.core
 
 import eu.darken.sdmse.appcontrol.core.export.AppExportType
+import eu.darken.sdmse.appcontrol.core.usage.UsageInfo
 import eu.darken.sdmse.common.ca.CaString
 import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.isNotNullOrEmpty
@@ -13,6 +14,7 @@ data class AppInfo(
     val pkg: Installed,
     val isActive: Boolean?,
     val sizes: PkgOps.SizeStats?,
+    val usage: UsageInfo?,
     val canBeToggled: Boolean,
     val canBeStopped: Boolean,
     val canBeExported: Boolean,

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/AppScan.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/AppScan.kt
@@ -1,0 +1,131 @@
+package eu.darken.sdmse.appcontrol.core
+
+import android.app.usage.UsageStatsManager
+import eu.darken.sdmse.appcontrol.core.usage.UsageInfo
+import eu.darken.sdmse.appcontrol.core.usage.UsageTool
+import eu.darken.sdmse.common.coroutine.AppScope
+import eu.darken.sdmse.common.coroutine.DispatcherProvider
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.pkgs.Pkg
+import eu.darken.sdmse.common.pkgs.PkgRepo
+import eu.darken.sdmse.common.pkgs.container.NormalPkg
+import eu.darken.sdmse.common.pkgs.current
+import eu.darken.sdmse.common.pkgs.features.Installed
+import eu.darken.sdmse.common.pkgs.features.SourceAvailable
+import eu.darken.sdmse.common.pkgs.pkgops.PkgOps
+import eu.darken.sdmse.common.sharedresource.HasSharedResource
+import eu.darken.sdmse.common.sharedresource.SharedResource
+import eu.darken.sdmse.common.user.UserHandle2
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.plus
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import javax.inject.Inject
+
+class AppScan @Inject constructor(
+    @AppScope private val appScope: CoroutineScope,
+    dispatcherProvider: DispatcherProvider,
+    private val statsManager: UsageStatsManager,
+    private val pkgRepo: PkgRepo,
+    private val pkgOps: PkgOps,
+    private val usageTool: UsageTool,
+) : HasSharedResource<Any> {
+
+    override val sharedResource = SharedResource.createKeepAlive(PkgOps.TAG, appScope + dispatcherProvider.IO)
+
+    private val mutex = Mutex()
+    private val activeCache = mutableMapOf<Installed.InstallId, Boolean?>()
+    private val sizeCache = mutableMapOf<Installed.InstallId, PkgOps.SizeStats?>()
+    private val usageCache = mutableMapOf<Installed.InstallId, UsageInfo?>()
+
+    suspend fun refresh() = mutex.withLock {
+        activeCache.clear()
+        sizeCache.clear()
+        usageCache.clear()
+        pkgRepo.refresh()
+    }
+
+    suspend fun allApps(
+        user: UserHandle2,
+        includeUsage: Boolean,
+        includeActive: Boolean,
+        includeSize: Boolean,
+    ): Set<AppInfo> = mutex.withLock {
+        log(TAG, VERBOSE) { "allApps($user)" }
+        val pkgs = pkgRepo.current()
+        return pkgs
+            .filter { it.userHandle == user }
+            .map {
+                it.toAppInfo(
+                    includeUsage = includeUsage,
+                    includeActive = includeActive,
+                    includeSize = includeSize,
+                )
+            }
+            .toSet()
+    }
+
+    suspend fun app(
+        installId: Installed.InstallId,
+        includeUsage: Boolean,
+        includeActive: Boolean,
+        includeSize: Boolean,
+    ): AppInfo = mutex.withLock {
+        log(TAG, VERBOSE) { "app($installId)" }
+        pkgRepo.current()
+            .single { it.installId == installId }
+            .toAppInfo(
+                includeUsage = includeUsage,
+                includeActive = includeActive,
+                includeSize = includeSize,
+            )
+    }
+
+    suspend fun app(
+        pkgId: Pkg.Id,
+        includeUsage: Boolean,
+        includeActive: Boolean,
+        includeSize: Boolean,
+    ): Set<AppInfo> = mutex.withLock {
+        log(TAG, VERBOSE) { "app($pkgId)" }
+        pkgRepo.current()
+            .filter { it.id == pkgId }
+            .map {
+                it.toAppInfo(
+                    includeUsage = includeUsage,
+                    includeActive = includeActive,
+                    includeSize = includeSize,
+                )
+            }
+            .toSet()
+    }
+
+
+    private suspend fun Installed.toAppInfo(
+        includeActive: Boolean,
+        includeSize: Boolean,
+        includeUsage: Boolean,
+    ): AppInfo = AppInfo(
+        pkg = this,
+        isActive = if (includeActive) {
+            activeCache[installId] ?: pkgOps.isRunning(installId).also { activeCache[installId] = it }
+        } else null,
+        sizes = if (includeSize) {
+            sizeCache[installId] ?: pkgOps.querySizeStats(installId).also { sizeCache[installId] = it }
+        } else null,
+        usage = if (includeUsage) {
+            if (usageCache.isEmpty()) usageCache.putAll(usageTool.lastMonth().map { it.installId to it })
+            usageCache[installId]
+        } else null,
+        canBeToggled = this is NormalPkg,
+        canBeStopped = this is NormalPkg,
+        canBeExported = this is SourceAvailable,
+        canBeDeleted = true,
+    )
+
+    companion object {
+        private val TAG = logTag("AppControl", "AppScan")
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/SortSettings.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/SortSettings.kt
@@ -15,6 +15,7 @@ data class SortSettings(
         @Json(name = "INSTALLED_AT") INSTALLED_AT,
         @Json(name = "PACKAGENAME") PACKAGENAME,
         @Json(name = "SIZE") SIZE,
+        @Json(name = "SCREEN_TIME") SCREEN_TIME,
         ;
     }
 }

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/usage/UsageInfo.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/usage/UsageInfo.kt
@@ -1,0 +1,21 @@
+package eu.darken.sdmse.appcontrol.core.usage
+
+import android.app.usage.UsageStats
+import eu.darken.sdmse.common.hasApiLevel
+import eu.darken.sdmse.common.pkgs.features.Installed
+import java.time.Duration
+import java.time.Instant
+
+data class UsageInfo(
+    val installId: Installed.InstallId,
+    val stats: List<UsageStats>,
+) {
+    val screenTime: Duration
+        get() = Duration.ofMillis(
+            @Suppress("NewApi")
+            stats.sumOf { if (hasApiLevel(29)) it.totalTimeVisible else it.totalTimeInForeground }
+        )
+
+    val screenTimeSince: Instant
+        get() = Instant.ofEpochMilli(stats.minOf { it.firstTimeStamp })
+}

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/usage/UsageTool.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/usage/UsageTool.kt
@@ -1,0 +1,60 @@
+package eu.darken.sdmse.appcontrol.core.usage
+
+import android.app.usage.UsageStatsManager
+import dagger.Reusable
+import eu.darken.sdmse.common.coroutine.AppScope
+import eu.darken.sdmse.common.coroutine.DispatcherProvider
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.DEBUG
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.pkgs.features.Installed
+import eu.darken.sdmse.common.pkgs.toPkgId
+import eu.darken.sdmse.common.sharedresource.HasSharedResource
+import eu.darken.sdmse.common.sharedresource.SharedResource
+import eu.darken.sdmse.common.user.UserManager2
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.plus
+import java.util.Calendar
+import javax.inject.Inject
+
+@Reusable
+class UsageTool @Inject constructor(
+    @AppScope private val appScope: CoroutineScope,
+    dispatcherProvider: DispatcherProvider,
+    private val statsManager: UsageStatsManager,
+    private val userManager2: UserManager2,
+) : HasSharedResource<Any> {
+
+    override val sharedResource = SharedResource.createKeepAlive(TAG, appScope + dispatcherProvider.IO)
+
+    suspend fun lastMonth(): Set<UsageInfo> {
+        log(TAG, DEBUG) { "lastMonth()" }
+        val calendar = Calendar.getInstance()
+        calendar.add(Calendar.MONTH, -1)
+        val stats = statsManager.queryUsageStats(
+            UsageStatsManager.INTERVAL_MONTHLY,
+            calendar.timeInMillis,
+            System.currentTimeMillis()
+        )
+        log(TAG, VERBOSE) { "${stats.size} stats for last month" }
+        // TODO how do we get infos for other users?
+        val currentUser = userManager2.currentUser()
+        return stats
+            .groupBy { it.packageName }
+            .map { entry ->
+                UsageInfo(
+                    installId = Installed.InstallId(
+                        pkgId = entry.key.toPkgId(),
+                        userHandle = currentUser.handle,
+                    ),
+                    stats = entry.value,
+                )
+            }
+            .toSet()
+    }
+
+    companion object {
+        private val TAG = logTag("AppControl", "UsageTool")
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListFragment.kt
@@ -223,6 +223,7 @@ class AppControlListFragment : Fragment3(R.layout.appcontrol_list_fragment) {
                     SortSettings.Mode.LAST_UPDATE -> getRowItem(pos)?.lablrUpdated
                     SortSettings.Mode.INSTALLED_AT -> getRowItem(pos)?.lablrInstalled
                     SortSettings.Mode.SIZE -> getRowItem(pos)?.lablrSize
+                    SortSettings.Mode.SCREEN_TIME -> getRowItem(pos)?.lablrScreenTime
                 }
                 FastScrollItemIndicator.Text(lbl ?: "?")
             }
@@ -260,6 +261,7 @@ class AppControlListFragment : Fragment3(R.layout.appcontrol_list_fragment) {
                 SortSettings.Mode.INSTALLED_AT -> R.id.sortmode_installed
                 SortSettings.Mode.PACKAGENAME -> R.id.sortmode_packagename
                 SortSettings.Mode.SIZE -> R.id.sortmode_size
+                SortSettings.Mode.SCREEN_TIME -> R.id.sortmode_screentime
             }
             sortmodeGroup.apply {
                 clearOnButtonCheckedListeners()
@@ -272,6 +274,7 @@ class AppControlListFragment : Fragment3(R.layout.appcontrol_list_fragment) {
                         R.id.sortmode_installed -> SortSettings.Mode.INSTALLED_AT
                         R.id.sortmode_packagename -> SortSettings.Mode.PACKAGENAME
                         R.id.sortmode_size -> SortSettings.Mode.SIZE
+                        R.id.sortmode_screentime -> SortSettings.Mode.SCREEN_TIME
                         else -> throw IllegalArgumentException("Unknown sortmode $checkedId")
                     }
                     vm.updateSortMode(mode)

--- a/app/src/main/res/layout/appcontrol_list_fragment.xml
+++ b/app/src/main/res/layout/appcontrol_list_fragment.xml
@@ -173,6 +173,15 @@
                     android:insetTop="0dp"
                     android:insetBottom="0dp"
                     android:text="@string/appcontrol_list_sortmode_size_label" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/sortmode_screentime"
+                    style="@style/SDMButton.Outlined"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:insetTop="0dp"
+                    android:insetBottom="0dp"
+                    android:text="@string/appcontrol_list_sortmode_screentime_label" />
             </com.google.android.material.button.MaterialButtonToggleGroup>
 
             <com.google.android.material.button.MaterialButton

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -517,6 +517,7 @@
     <string name="appcontrol_list_sortmode_installed_label">First installed</string>
     <string name="appcontrol_list_sortmode_packagename_label">Packagename</string>
     <string name="appcontrol_list_sortmode_size_label">Size</string>
+    <string name="appcontrol_list_sortmode_screentime_label">Screen time</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">App sizes are estimated for performance reasons. Use the StorageAnalyzer tool for more accurate data.</string>
     <string name="appcontrol_progress_uninstalling_app">Uninstalling app</string>
     <plurals name="appcontrol_uninstall_result_message_x">
@@ -564,6 +565,7 @@
     <string name="appcontrol_automation_subtitle_force_stopping">Force stopping…</string>
     <string name="appcontrol_automation_progress_find_force_stop">Looking for \"Force stop\" button (keywords: %s)</string>
     <string name="appcontrol_automation_progress_find_ok_confirmation">Trying to confirm previous action (keywords: %s)</string>
+    <string name="appcontrol_item_screentime_x_since_y_label">Screen time: %1$s since %2$s</string>
 
     <string name="analyzer_tool_name">StorageAnalyzer</string>
     <string name="analyzer_explanation_short">Find out what is taking up space on your device.</string>


### PR DESCRIPTION
Allow sorting by screen time.
If screen time is selected as sortmode then each row will display the screen time and tertiary info.

Closes #1596