### PR TITLE
Update privacy policy layout

### DIFF
--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -1,6 +1,12 @@
+---
+layout: plain
+permalink: /privacy
+title: "Privacy Policy"
+---
+
 # Privacy policy
 
-This is the privacy policy for the Android app "SD Maid 2/SE".
+This is the privacy policy for the Android app "SD Maid 2/SE" by Matthias Urhahn (darken).
 
 ## Preamble
 

--- a/_layouts/plain.html
+++ b/_layouts/plain.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="{{ page.lang | default: site.lang | default: 'en' }}">
+
+{%- include head.html -%}
+
+<body>
+
+<main class="page-content" aria-label="Content">
+    <div class="wrapper">
+        {{ content }}
+    </div>
+</main>
+
+{%- include footer.html -%}
+
+</body>
+
+</html>

--- a/app-common/src/main/java/eu/darken/sdmse/common/SdmSeLinks.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/SdmSeLinks.kt
@@ -2,5 +2,5 @@ package eu.darken.sdmse.common
 
 object SdmSeLinks {
     const val ISSUES = "https://github.com/d4rken-org/sdmaid-se/issues"
-    const val PRIVACY_POLICY = "https://github.com/d4rken-org/sdmaid-se/blob/main/PRIVACY_POLICY.md"
+    const val PRIVACY_POLICY = "https://sdmse.darken.eu/privacy"
 }


### PR DESCRIPTION
Switching to GitHub pages to deal with Google no longer allowing direct links to GitHub.