### PR TITLE
SystemCleaner: Fix custom filter edit "unsaved changes" prompt

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/custom/CustomFilterConfig.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/custom/CustomFilterConfig.kt
@@ -33,4 +33,12 @@ data class CustomFilterConfig(
 ) : Parcelable {
     val isUnderdefined: Boolean
         get() = pathCriteria.isNullOrEmpty() && nameCriteria.isNullOrEmpty()
+
+    val isDefault: Boolean
+        get() = this == CustomFilterConfig(
+            identifier = identifier,
+            createdAt = createdAt,
+            modifiedAt = modifiedAt,
+            label = "",
+        )
 }

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/CustomFilterEditorViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/CustomFilterEditorViewModel.kt
@@ -210,7 +210,8 @@ class CustomFilterEditorViewModel @Inject constructor(
     ) {
         val canRemove: Boolean = original != null
         val canSave: Boolean = original != current && !current.isUnderdefined && current.label.isNotEmpty()
-        val hasUnchanged: Boolean = original != current
+        val hasUnchanged: Boolean = if (original != null) original != current else !current.isDefault
+
     }
 
     val liveSearch = currentState.flow


### PR DESCRIPTION
It shouldn't prompt for unsaved changes when creating a new filter and just exiting without changing anything.