### PR TITLE
AppCleaner: Fix ACS based cache deletion on HyperOS2 ROMs with updated Security app

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/AppControlAutomation.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/AppControlAutomation.kt
@@ -92,7 +92,7 @@ class AppControlAutomation @AssistedInject constructor(
         updateProgressPrimary(eu.darken.sdmse.common.R.string.general_progress_loading)
         host.changeOptions { old ->
             old.copy(
-                showOverlay = true,
+                showVeil = true,
                 accessibilityServiceInfo = AccessibilityServiceInfo().apply {
                     flags = (
                             AccessibilityServiceInfo.FLAG_RETRIEVE_INTERACTIVE_WINDOWS

--- a/app/src/main/java/eu/darken/sdmse/automation/core/AutomationHost.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/AutomationHost.kt
@@ -25,26 +25,31 @@ interface AutomationHost : Progress.Client {
 
     val events: Flow<AccessibilityEvent>
 
+    data class State(
+        val hasOverlay: Boolean
+    )
+
+    val state: Flow<State>
+
     data class Options(
-        val showOverlay: Boolean = !Bugs.isTrace,
-        val translucent: Boolean = Bugs.isTrace,
+        val hideOverlay: Boolean = Bugs.isTrace,
+        val showVeil: Boolean = true,
         val panelGravity: Int = Gravity.BOTTOM,
         val accessibilityServiceInfo: AccessibilityServiceInfo = AccessibilityServiceInfo(),
         val controlPanelTitle: CaString = R.string.automation_active_title.toCaString(),
         val controlPanelSubtitle: CaString = eu.darken.sdmse.common.R.string.general_progress_loading.toCaString(),
     ) {
-        /*
-            java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String android.content.ComponentName.flattenToShortString()' on a null object reference
-            at android.accessibilityservice.AccessibilityServiceInfo.getId(AccessibilityServiceInfo.java:759)
-            at android.accessibilityservice.AccessibilityServiceInfo.toString(AccessibilityServiceInfo.java:1105)
-            at java.lang.String.valueOf(String.java:2924)
-            at java.lang.StringBuilder.append(StringBuilder.java:132)
-            at eu.darken.sdmse.automation.core.AccessibilityConfig.toString(Unknown Source:12)
-        */
-        override fun toString(): String = try {
-            super.toString()
-        } catch (e: Exception) {
-            "AutomationHost.Options(accessibilityServiceInfo=ERROR, showOverlay=$showOverlay, panelGravity=$panelGravity)"
+
+        override fun toString(): String {
+            val acsInfo = try {
+                //    java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String android.content.ComponentName.flattenToShortString()' on a null object reference
+                //    at android.accessibilityservice.AccessibilityServiceInfo.getId(AccessibilityServiceInfo.java:759)
+                //    at android.accessibilityservice.AccessibilityServiceInfo.toString(AccessibilityServiceInfo.java:1105)
+                accessibilityServiceInfo.toString()
+            } catch (e: NullPointerException) {
+                "NPE"
+            }
+            return "AutomationHost.Options(hideOverlay=$hideOverlay, showVeil=$showVeil, acsInfo=$acsInfo)"
         }
     }
 }

--- a/app/src/main/java/eu/darken/sdmse/automation/core/AutomationService.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/AutomationService.kt
@@ -4,9 +4,8 @@ import android.accessibilityservice.AccessibilityService
 import android.content.Context
 import android.content.Intent
 import android.graphics.PixelFormat
-import android.os.Handler
-import android.os.Looper
 import android.view.Gravity
+import android.view.View
 import android.view.WindowManager
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
@@ -34,6 +33,7 @@ import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.main.core.GeneralSettings
 import eu.darken.sdmse.setup.automation.AutomationSetupModule
 import eu.darken.sdmse.setup.automation.mightBeRestrictedDueToSideload
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
@@ -45,10 +45,12 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import kotlin.coroutines.resume
 
@@ -73,14 +75,31 @@ class AutomationService : AccessibilityService(), AutomationHost, Progress.Host,
     @Inject lateinit var automationSetupModule: AutomationSetupModule
     @Inject lateinit var screenState: ScreenState
 
-    private var currentOptions = AutomationHost.Options()
     private lateinit var windowManager: WindowManager
-    private val mainThread = Handler(Looper.getMainLooper())
 
     private val automationEvents = MutableSharedFlow<AccessibilityEvent>()
     override val events: Flow<AccessibilityEvent> = automationEvents
 
-    private var controlView: AutomationControlView? = null
+    private val controlView = MutableStateFlow<AutomationControlView?>(null)
+    override val state = controlView.map {
+        AutomationHost.State(hasOverlay = it != null)
+    }
+
+    private val controlLp: WindowManager.LayoutParams = WindowManager.LayoutParams().apply {
+        type = WindowManager.LayoutParams.TYPE_ACCESSIBILITY_OVERLAY
+        format = PixelFormat.TRANSLUCENT
+        flags = flags or WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
+        width = WindowManager.LayoutParams.MATCH_PARENT
+        height = WindowManager.LayoutParams.MATCH_PARENT
+        gravity = Gravity.BOTTOM
+    }
+    private val currentOptions = MutableStateFlow(AutomationHost.Options())
+
+    override suspend fun changeOptions(action: (AutomationHost.Options) -> AutomationHost.Options) {
+        val newOptions = action(currentOptions.value)
+        if (Bugs.isTrace) log(TAG, VERBOSE) { "New options: $newOptions" }
+        currentOptions.value = newOptions
+    }
 
     private fun checkLaunch(): Boolean = if (!isValidAndroidEntryPoint()) {
         log(TAG, ERROR) { "Invalid launch: Launched by foreign application: $application" }
@@ -113,52 +132,89 @@ class AutomationService : AccessibilityService(), AutomationHost, Progress.Host,
 
         combine(
             progress,
-            screenState.state
-        ) { progressData, screenState ->
-            mainThread.post {
-                val acv = controlView
-                when {
-                    progressData == null && acv != null -> {
-                        log(TAG) { "Removing controlview: $acv" }
-                        try {
-                            windowManager.removeView(acv)
-                        } catch (e: Exception) {
-                            log(TAG, WARN) { "Failed to remove controlview, not added? $acv" }
-                        }
-                        controlView = null
-                    }
+            currentOptions,
+            screenState.state,
+        ) { progressData, options, screenState ->
+            val acv = controlView.value
+            log(TAG, VERBOSE) {
+                "ControlView update: options=$options, screenState=$screenState, progres=$progressData, view=$acv"
+            }
 
-                    progressData != null && acv == null -> {
-                        log(TAG) { "Adding controlview" }
-                        val view = AutomationControlView(ContextThemeWrapper(this, R.style.AppTheme))
-                        log(TAG) { "Adding new controlview: $view" }
-                        view.setCancelListener {
-                            view.showOverlay(false)
-                            currentTaskJob?.cancel(cause = UserCancelledAutomationException())
-                        }
+            serviceInfo = options.accessibilityServiceInfo
 
-                        try {
-                            windowManager.addView(view, controlLp)
-                            controlView = view
-                        } catch (e: Exception) {
-                            log(TAG, ERROR) { "Failed to add control view to window: ${e.asLog()}" }
-                        }
-                    }
+            controlLp.apply {
+                gravity = options.panelGravity
+                height = if (options.showVeil) {
+                    WindowManager.LayoutParams.MATCH_PARENT
+                } else {
+                    WindowManager.LayoutParams.WRAP_CONTENT
+                }
+            }
 
-                    acv != null -> {
-                        if (screenState.isScreenAvailable) {
-                            log(TAG, VERBOSE) { "Updating progress $progress" }
-                            acv.setProgress(progressData)
-                        } else {
-                            log(TAG, WARN) { "NULLing control view, screen is unavailable!" }
-                            acv.setProgress(null)
-                        }
-                    }
-
-                    else -> {
-                        log(TAG, VERBOSE) { "ControlView is $acv and progress is $progressData" }
+            if (acv != null) {
+                withContext(dispatcher.Main) {
+                    windowManager.updateViewLayout(acv, controlLp)
+                    acv.apply {
+                        setTitle(options.controlPanelTitle, options.controlPanelSubtitle)
+                        showVeil(options.showVeil)
                     }
                 }
+            }
+
+            when {
+                (progressData == null || options.hideOverlay) && acv != null -> try {
+                    log(TAG) { "Removing controlview: $acv" }
+                    val detached = CompletableDeferred<Unit>()
+                    withContext(dispatcher.Main) {
+                        acv.addOnAttachStateChangeListener(object : View.OnAttachStateChangeListener {
+                            override fun onViewDetachedFromWindow(v: View) {
+                                v.removeOnAttachStateChangeListener(this)
+                                log(TAG) { "controlview removed: $v" }
+                                detached.complete(Unit)
+                            }
+
+                            override fun onViewAttachedToWindow(v: View) {}
+                        })
+                        windowManager.removeView(acv)
+                    }
+                    detached.await()
+                    // Wait for SurfaceFlinger / WM to update
+                    delay(50)
+                    log(TAG) { "Updating controlview state" }
+                    controlView.value = null
+                } catch (e: Exception) {
+                    log(TAG, WARN) { "Failed to remove controlview, not added? $acv" }
+                    controlView.value = null
+                }
+
+                !options.hideOverlay && progressData != null && acv == null -> withContext(dispatcher.Main) {
+                    log(TAG) { "Adding controlview" }
+                    val view = AutomationControlView(ContextThemeWrapper(this@AutomationService, R.style.AppTheme))
+                    log(TAG) { "Adding new controlview: $view" }
+                    view.setCancelListener {
+                        view.showVeil(false)
+                        currentTaskJob?.cancel(cause = UserCancelledAutomationException())
+                    }
+
+                    try {
+                        windowManager.addView(view, controlLp)
+                        controlView.value = view
+                    } catch (e: Exception) {
+                        log(TAG, ERROR) { "Failed to add control view to window: ${e.asLog()}" }
+                    }
+                }
+
+                acv != null -> withContext(dispatcher.Main) {
+                    if (screenState.isScreenAvailable) {
+                        log(TAG, VERBOSE) { "Updating progress $progress" }
+                        acv.setProgress(progressData)
+                    } else {
+                        log(TAG, WARN) { "NULLing control view, screen is unavailable!" }
+                        acv.setProgress(null)
+                    }
+                }
+
+                else -> {}
             }
         }.launchIn(serviceScope)
     }
@@ -225,7 +281,7 @@ class AutomationService : AccessibilityService(), AutomationHost, Progress.Host,
 
         // TODO use a queue here?
         serviceScope.launch {
-            if (Bugs.isDebug) log(TAG) { "Providing event: $eventCopy" }
+            if (Bugs.isDebug) log(TAG) { "Providing: $eventCopy" }
             automationEvents.emit(eventCopy)
         }
     }
@@ -234,39 +290,6 @@ class AutomationService : AccessibilityService(), AutomationHost, Progress.Host,
         val rootNode: AccessibilityNodeInfo? = rootInActiveWindow
         log(TAG, VERBOSE) { "Providing windowRoot: ${rootNode?.toStringShort()}" }
         it.resume(rootNode)
-    }
-
-    private val controlLp: WindowManager.LayoutParams = WindowManager.LayoutParams().apply {
-        type = WindowManager.LayoutParams.TYPE_ACCESSIBILITY_OVERLAY
-        format = PixelFormat.TRANSLUCENT
-        flags = flags or WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
-        width = WindowManager.LayoutParams.MATCH_PARENT
-        height = WindowManager.LayoutParams.MATCH_PARENT
-        gravity = Gravity.BOTTOM
-    }
-
-    override suspend fun changeOptions(action: (AutomationHost.Options) -> AutomationHost.Options) {
-        val newOptions = action(currentOptions)
-        currentOptions = newOptions
-        serviceInfo = newOptions.accessibilityServiceInfo
-
-        mainThread.post {
-            controlView?.let { acv ->
-                controlLp.gravity = newOptions.panelGravity
-                windowManager.updateViewLayout(acv, controlLp)
-
-                if (newOptions.showOverlay) {
-                    controlLp.height = WindowManager.LayoutParams.MATCH_PARENT
-                } else {
-                    controlLp.height = WindowManager.LayoutParams.WRAP_CONTENT
-                }
-
-                windowManager.updateViewLayout(acv, controlLp)
-                acv.showOverlay(newOptions.showOverlay)
-                acv.setTranslucent(newOptions.translucent)
-                acv.setTitle(newOptions.controlPanelTitle, newOptions.controlPanelSubtitle)
-            }
-        }
     }
 
     private var currentTaskJob: Job? = null

--- a/app/src/main/java/eu/darken/sdmse/automation/core/common/AccessibilityNodeExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/common/AccessibilityNodeExtensions.kt
@@ -1,5 +1,6 @@
 package eu.darken.sdmse.automation.core.common
 
+import android.graphics.Rect
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
 import eu.darken.sdmse.automation.core.errors.AutomationException
@@ -16,7 +17,8 @@ private val TAG: String = logTag("Automation", "Crawler", "Common")
 
 fun AccessibilityNodeInfo.toStringShort(): String {
     val identity = Integer.toHexString(System.identityHashCode(this))
-    return "text='${this.text}', className=${this.className}, isClickable=${this.isClickable}, isEnabled=${this.isEnabled}, viewIdResourceName=${this.viewIdResourceName}, pkgName=${this.packageName}, identity=$identity"
+    val bounds = Rect().apply { getBoundsInScreen(this) }
+    return "text='${this.text}', class=${this.className}, clickable=${this.isClickable}, enabled=${this.isEnabled}, id=${this.viewIdResourceName}, pkg=${this.packageName}, identity=$identity, bounds=$bounds}"
 }
 
 val AccessibilityNodeInfo.textVariants: Set<String>
@@ -70,6 +72,10 @@ fun AccessibilityNodeInfo.isClickyButton(): Boolean {
 
 fun AccessibilityNodeInfo.isTextView(): Boolean {
     return className == "android.widget.TextView"
+}
+
+fun AccessibilityNodeInfo.isRadioButton(): Boolean {
+    return className == "android.widget.RadioButton"
 }
 
 fun AccessibilityNodeInfo.children() = (0 until childCount).mapNotNull { getChild(it) }

--- a/app/src/main/java/eu/darken/sdmse/automation/core/common/StepProcessor.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/common/StepProcessor.kt
@@ -136,7 +136,7 @@ class StepProcessor @AssistedInject constructor(
 
         val targetWindowRoot: AccessibilityNodeInfo = withTimeout(4000) {
             // Wait for correct window
-            if (step.windowIntent != null && step.windowEventFilter != null) {
+            if (step.windowEventFilter != null) {
                 log(TAG) { "Waiting for window event filter to pass..." }
                 host.events.filter {
                     log(TAG, VERBOSE) { "Testing window event $it" }

--- a/app/src/main/java/eu/darken/sdmse/automation/ui/AutomationControlView.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/ui/AutomationControlView.kt
@@ -88,14 +88,10 @@ class AutomationControlView @JvmOverloads constructor(
         ui.subtitle.text = subtitle.get(context)
     }
 
-    fun showOverlay(show: Boolean) {
+    fun showVeil(show: Boolean) {
         ui.clickScreen.isVisible = show
         ui.clickScreenExplanation.isVisible = show
         ui.clickScreenMascotContainer.isVisible = show
-    }
-
-    fun setTranslucent(translucent: Boolean) {
-        ui.root.alpha = if (translucent) 0.1f else 1.0f
     }
 
     fun setCancelListener(listener: OnClickListener?) {

--- a/app/src/main/res/xml/accessibility_service.xml
+++ b/app/src/main/res/xml/accessibility_service.xml
@@ -4,5 +4,6 @@
     android:accessibilityFeedbackType=""
     android:accessibilityFlags=""
     android:canRetrieveWindowContent="true"
+    android:canPerformGestures="true"
     android:description="@string/automation_accessibility_service_description"
     android:notificationTimeout="1000" />


### PR DESCRIPTION
The updated "Security" app `com.miui.securitycenter` v10.6.5-250318.1.1(40001065) has changed the UI layout.

It now uses uncommon RadioButtons that are not clickable in an animated bottom sheet dialog. There is no valid `PERFORM_CLICK` target available. We have to fall back to emulating a manual "tap" gesture and hide the overlay shortly to be able to perform it.

We also have to wait until the bottom sheet dialog animation has settled so we can get the correct coordinates of the element we want to tap.

Fixes #1648