### PR TITLE
AppCleaner: Improve ACS performance

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
@@ -105,8 +105,10 @@ class ClearCacheModule @AssistedInject constructor(
         task as ClearCacheTask
         updateProgressPrimary(eu.darken.sdmse.common.R.string.general_progress_loading)
 
-        host.changeOptions { old ->
-            old.copy(
+        host.changeOptions {
+            AutomationHost.Options(
+                controlPanelTitle = R.string.appcleaner_automation_title.toCaString(),
+                controlPanelSubtitle = R.string.appcleaner_automation_subtitle_default_caches.toCaString(),
                 accessibilityServiceInfo = AccessibilityServiceInfo().apply {
                     flags = (
                             AccessibilityServiceInfo.FLAG_RETRIEVE_INTERACTIVE_WINDOWS
@@ -117,8 +119,6 @@ class ClearCacheModule @AssistedInject constructor(
                     feedbackType = AccessibilityServiceInfo.FEEDBACK_GENERIC
                     notificationTimeout = 250L
                 },
-                controlPanelTitle = R.string.appcleaner_automation_title.toCaString(),
-                controlPanelSubtitle = R.string.appcleaner_automation_subtitle_default_caches.toCaString(),
             )
         }
 

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/AppControlAutomation.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/AppControlAutomation.kt
@@ -90,9 +90,10 @@ class AppControlAutomation @AssistedInject constructor(
 
     override suspend fun process(task: AutomationTask): AutomationTask.Result {
         updateProgressPrimary(eu.darken.sdmse.common.R.string.general_progress_loading)
-        host.changeOptions { old ->
-            old.copy(
-                showVeil = true,
+        host.changeOptions {
+            AutomationHost.Options(
+                controlPanelTitle = R.string.appcontrol_automation_title.toCaString(),
+                controlPanelSubtitle = R.string.appcontrol_automation_subtitle_force_stopping.toCaString(),
                 accessibilityServiceInfo = AccessibilityServiceInfo().apply {
                     flags = (
                             AccessibilityServiceInfo.FLAG_RETRIEVE_INTERACTIVE_WINDOWS
@@ -102,8 +103,6 @@ class AppControlAutomation @AssistedInject constructor(
                     eventTypes = AccessibilityEvent.TYPES_ALL_MASK
                     feedbackType = AccessibilityServiceInfo.FEEDBACK_GENERIC
                 },
-                controlPanelTitle = R.string.appcontrol_automation_title.toCaString(),
-                controlPanelSubtitle = R.string.appcontrol_automation_subtitle_force_stopping.toCaString(),
             )
         }
 

--- a/app/src/main/java/eu/darken/sdmse/automation/core/AutomationHost.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/AutomationHost.kt
@@ -2,7 +2,6 @@ package eu.darken.sdmse.automation.core
 
 import android.accessibilityservice.AccessibilityService
 import android.accessibilityservice.AccessibilityServiceInfo
-import android.view.Gravity
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
 import eu.darken.sdmse.R
@@ -26,15 +25,15 @@ interface AutomationHost : Progress.Client {
     val events: Flow<AccessibilityEvent>
 
     data class State(
-        val hasOverlay: Boolean
+        val hasOverlay: Boolean = false,
+        val passthrough: Boolean = false,
     )
 
     val state: Flow<State>
 
     data class Options(
-        val hideOverlay: Boolean = Bugs.isTrace,
-        val showVeil: Boolean = true,
-        val panelGravity: Int = Gravity.BOTTOM,
+        val showOverlay: Boolean = !Bugs.isTrace,
+        val passthrough: Boolean = false,
         val accessibilityServiceInfo: AccessibilityServiceInfo = AccessibilityServiceInfo(),
         val controlPanelTitle: CaString = R.string.automation_active_title.toCaString(),
         val controlPanelSubtitle: CaString = eu.darken.sdmse.common.R.string.general_progress_loading.toCaString(),
@@ -49,7 +48,7 @@ interface AutomationHost : Progress.Client {
             } catch (e: NullPointerException) {
                 "NPE"
             }
-            return "AutomationHost.Options(hideOverlay=$hideOverlay, showVeil=$showVeil, acsInfo=$acsInfo)"
+            return "AutomationHost.Options(showOverlay=$showOverlay, acsInfo=$acsInfo)"
         }
     }
 }

--- a/app/src/main/java/eu/darken/sdmse/automation/core/common/AutomationContextExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/common/AutomationContextExtensions.kt
@@ -78,27 +78,27 @@ fun AutomationExplorer.Context.defaultClick(
 
 suspend fun AutomationExplorer.Context.gestureClick(node: AccessibilityNodeInfo): Boolean {
     val rect = Rect().apply { node.getBoundsInScreen(this) }
-    return gestureClick(rect.centerX(), rect.centerY())
+    return gestureClick(rect.centerX().toFloat(), rect.centerY().toFloat())
 }
 
-suspend fun AutomationExplorer.Context.gestureClick(x: Int, y: Int): Boolean {
+suspend fun AutomationExplorer.Context.gestureClick(x: Float, y: Float): Boolean {
     val path = Path().apply {
-        moveTo(x.toFloat(), y.toFloat())
+        moveTo(x, y)
         lineTo(x + 1f, y + 1f)
     }
     val gesture = GestureDescription.Builder().apply {
         addStroke(GestureDescription.StrokeDescription(path, 0, ViewConfiguration.getTapTimeout().toLong()))
     }.build()
 
-    log(TAG, VERBOSE) { "gestureClick(): Waiting for overlay to hide..." }
-    host.changeOptions { it.copy(hideOverlay = true) }
-    host.state.filter { !it.hasOverlay }.first()
+    log(TAG, VERBOSE) { "gestureClick(): Waiting for passthrough..." }
+    host.changeOptions { it.copy(passthrough = true) }
+    host.state.filter { it.passthrough }.first()
 
     log(TAG) { "gestureClick(): Performing CLICK gesture at X=$x,Y=$y" }
     val success = host.dispatchGesture(gesture)
 
-    host.changeOptions { it.copy(hideOverlay = false) }
-    host.state.filter { it.hasOverlay }.first()
+    host.changeOptions { it.copy(passthrough = false) }
+    host.state.filter { !it.passthrough }.first()
 
     return success
 }

--- a/app/src/main/java/eu/darken/sdmse/automation/core/debug/DebugTaskModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/debug/DebugTaskModule.kt
@@ -37,20 +37,17 @@ class DebugTaskModule @AssistedInject constructor(
         log(TAG) { "process(): $task" }
         updateProgressPrimary("Debug: Accessibility service")
         updateProgressSecondary("Setting host options...")
-        host.changeOptions { old ->
-            old
-                .copy(
-                    showVeil = true,
-                    accessibilityServiceInfo = AccessibilityServiceInfo().apply {
-                        flags = AccessibilityServiceInfo.DEFAULT or
-                                AccessibilityServiceInfo.FLAG_INCLUDE_NOT_IMPORTANT_VIEWS or
-                                AccessibilityServiceInfo.FLAG_REPORT_VIEW_IDS
-                        eventTypes = AccessibilityEvent.TYPES_ALL_MASK
-                        feedbackType = AccessibilityServiceInfo.FEEDBACK_GENERIC
-                    },
-                    controlPanelSubtitle = caString { "Debug module is active" }
-                )
-                .also { log(TAG) { "Updating options from $old to $it" } }
+        host.changeOptions {
+            AutomationHost.Options(
+                controlPanelSubtitle = caString { "Debug module is active" },
+                accessibilityServiceInfo = AccessibilityServiceInfo().apply {
+                    flags = AccessibilityServiceInfo.DEFAULT or
+                            AccessibilityServiceInfo.FLAG_INCLUDE_NOT_IMPORTANT_VIEWS or
+                            AccessibilityServiceInfo.FLAG_REPORT_VIEW_IDS
+                    eventTypes = AccessibilityEvent.TYPES_ALL_MASK
+                    feedbackType = AccessibilityServiceInfo.FEEDBACK_GENERIC
+                },
+            )
         }
 
         log(TAG) { "process(): Host options adjusted" }

--- a/app/src/main/java/eu/darken/sdmse/automation/ui/AutomationControlView.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/ui/AutomationControlView.kt
@@ -12,6 +12,7 @@ import androidx.core.view.isVisible
 import eu.darken.sdmse.common.ca.CaString
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.getColorForAttr
 import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.common.progress.Progress.Count
@@ -28,7 +29,7 @@ class AutomationControlView @JvmOverloads constructor(
     private val ui = AutomationControlViewBinding.inflate(layoutInflator, this)
 
     fun setProgress(data: Progress.Data?) {
-        log(VERBOSE) { "setProgress($data)" }
+        log(TAG, VERBOSE) { "setProgress($data)" }
         isVisible = data != null
 
         if (data == null) {
@@ -84,17 +85,19 @@ class AutomationControlView @JvmOverloads constructor(
     }
 
     fun setTitle(title: CaString, subtitle: CaString) {
-        ui.title.text = title.get(context)
-        ui.subtitle.text = subtitle.get(context)
-    }
-
-    fun showVeil(show: Boolean) {
-        ui.clickScreen.isVisible = show
-        ui.clickScreenExplanation.isVisible = show
-        ui.clickScreenMascotContainer.isVisible = show
+        val t = title.get(context)
+        val s = subtitle.get(context)
+        log(TAG, VERBOSE) { "setTitle($t,$s)" }
+        ui.title.text = t
+        ui.subtitle.text = s
     }
 
     fun setCancelListener(listener: OnClickListener?) {
+        log(TAG) { "setCancelListener($listener)" }
         ui.cancelAction.setOnClickListener(listener)
+    }
+
+    companion object {
+        val TAG: String = logTag("Automation", "Service", "ControlView")
     }
 }


### PR DESCRIPTION
* Refactor `changeOptions` and `updateProgress` to perform fewer UI updates.
* When affected by #1648, instead of hiding the overlay temporarily, let's just make it invisible to touch for a moment to pass through the tap gesture.