### PR TITLE
AppCleaner: Faster accessibility operations by temporarily disabling animations (via Shizuku)

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/automation/core/animation/AnimationState.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/animation/AnimationState.kt
@@ -1,0 +1,16 @@
+package eu.darken.sdmse.automation.core.animation
+
+data class AnimationState(
+    val windowAnimationScale: Float?,
+    val globalTransitionAnimationScale: Float?,
+    val globalAnimatorDurationscale: Float?,
+) {
+
+    companion object {
+        val DISABLED = AnimationState(
+            windowAnimationScale = 0f,
+            globalTransitionAnimationScale = 0f,
+            globalAnimatorDurationscale = 0f,
+        )
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/automation/core/animation/AnimationTool.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/animation/AnimationTool.kt
@@ -1,0 +1,65 @@
+package eu.darken.sdmse.automation.core.animation
+
+import android.content.Context
+import android.provider.Settings
+import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.sdmse.common.adb.AdbManager
+import eu.darken.sdmse.common.adb.canUseAdbNow
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.root.RootManager
+import eu.darken.sdmse.common.root.canUseRootNow
+import eu.darken.sdmse.common.shell.ShellOps
+import eu.darken.sdmse.common.shell.ipc.ShellOpsCmd
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AnimationTool @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val adbManager: AdbManager,
+    private val rootManager: RootManager,
+    private val shellOps: ShellOps,
+) {
+    suspend fun canChangeState(): Boolean {
+        val adb = adbManager.canUseAdbNow()
+        val root = rootManager.canUseRootNow()
+        log(TAG, VERBOSE) { "canChangeState(): adb=$adb root=$rootManager" }
+        return adb || root
+    }
+
+    private fun tryGetFloat(key: String): Float? =
+        Settings.Global.getFloat(context.contentResolver, key, Float.MIN_VALUE).takeIf { it != Float.MIN_VALUE }
+
+    suspend fun getState(): AnimationState = AnimationState(
+        windowAnimationScale = tryGetFloat(WINDOW_ANIMATION_SCALE),
+        globalTransitionAnimationScale = tryGetFloat(TRANSITION_ANIMATION_SCALE),
+        globalAnimatorDurationscale = tryGetFloat(ANIMATOR_DURATION_SCALE),
+    ).also { log(TAG) { "getState(): $it" } }
+
+    private fun getCommand(key: String, value: Any): String = "settings put global $key $value"
+
+    suspend fun setState(state: AnimationState) {
+        val cmds = mutableListOf<String>()
+        state.windowAnimationScale?.let { cmds.add(getCommand(WINDOW_ANIMATION_SCALE, it)) }
+        state.globalTransitionAnimationScale?.let { cmds.add(getCommand(TRANSITION_ANIMATION_SCALE, it)) }
+        state.globalAnimatorDurationscale?.let { cmds.add(getCommand(ANIMATOR_DURATION_SCALE, it)) }
+        val result = shellOps.execute(
+            ShellOpsCmd(cmds),
+            when {
+                adbManager.canUseAdbNow() -> ShellOps.Mode.ADB
+                rootManager.canUseRootNow() -> ShellOps.Mode.ROOT
+                else -> throw IllegalStateException("No ShellOps Mode available to set animation state")
+            }
+        )
+        log(TAG) { "setState($state) result: $result" }
+    }
+
+    companion object {
+        private const val WINDOW_ANIMATION_SCALE = "window_animation_scale"
+        private const val TRANSITION_ANIMATION_SCALE = "transition_animation_scale"
+        private const val ANIMATOR_DURATION_SCALE = "animator_duration_scale"
+        val TAG: String = logTag("Automation", "AnimationTool")
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/common/OpsCounter.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/OpsCounter.kt
@@ -1,0 +1,21 @@
+package eu.darken.sdmse.common
+
+class OpsCounter(
+    private val tickRate: Long = 1000,
+    private val logCall: (Float, Long) -> Unit,
+) {
+    private val start = System.currentTimeMillis()
+    private var ops = 0
+    private var lastLog = start
+
+    fun tick() {
+        ops++
+        val now = System.currentTimeMillis()
+        val elapsed = now - lastLog
+        if (elapsed >= tickRate) {
+            val opsRate = ops * tickRate.toFloat() / (now - start)
+            lastLog = now
+            logCall(opsRate, elapsed)
+        }
+    }
+}


### PR DESCRIPTION
Disable "window animation", "transition animation" and "global animations" through Shizuku when executing cache deletion through the accessibility service.

The original animation state is saved and restored after the accessibility operation finishes (or is cancelled).