### PR TITLE
AppCleaner: Skip locked system apps on Android 12 and 13 too

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/automation/core/common/AutomationContextExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/common/AutomationContextExtensions.kt
@@ -220,7 +220,7 @@ fun AutomationExplorer.Context.getAospClearCacheClick(
         }
 
         when {
-            hasApiLevel(34) && pkg.isSystemApp && allButtonsAreDisabled -> {
+            hasApiLevel(31) && pkg.isSystemApp && allButtonsAreDisabled -> {
                 // https://github.com/d4rken-org/sdmaid-se/issues/1178
                 log(TAG, WARN) { "Locked system app, can't click clear cache for ${pkg.installId}" }
                 throw PlanAbortException("Locked system app, can't clear cache: ${pkg.installId}")


### PR DESCRIPTION
Via user email, affected device is `BLU/B135DL/B135DL:12/SP1A.210812.016/1738747440:user/release-keys`

Similar to #1178