### PR TITLE
AppCleaner: Fix ACS based cache deletion on HyperOS ROMs (part 2)

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/automation/core/AutomationProcessor.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/AutomationProcessor.kt
@@ -50,11 +50,11 @@ class AutomationProcessor @AssistedInject constructor(
         } finally {
             log(TAG, VERBOSE) { "process(): Canceling module scope..." }
             moduleScope.cancel()
+            hasTask = false
         }
 
         log(TAG) { "process(): Result is $result" }
 
-        hasTask = false
         result
     }
 

--- a/app/src/main/java/eu/darken/sdmse/automation/core/common/AccessibilityNodeExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/common/AccessibilityNodeExtensions.kt
@@ -18,7 +18,7 @@ private val TAG: String = logTag("Automation", "Crawler", "Common")
 fun AccessibilityNodeInfo.toStringShort(): String {
     val identity = Integer.toHexString(System.identityHashCode(this))
     val bounds = Rect().apply { getBoundsInScreen(this) }
-    return "text='${this.text}', class=${this.className}, clickable=${this.isClickable}, enabled=${this.isEnabled}, id=${this.viewIdResourceName}, pkg=${this.packageName}, identity=$identity, bounds=$bounds}"
+    return "text='${this.text}', class=${this.className}, clickable=$isClickable, checkable=$isCheckable enabled=$isEnabled, id=$viewIdResourceName} pkg=$packageName, identity=$identity, bounds=$bounds}"
 }
 
 val AccessibilityNodeInfo.textVariants: Set<String>


### PR DESCRIPTION
The version check was too strict, the problematic `com.miui.securitycenter` package has different versions on different ROMs. Relaxing this now to just check the element type, if it is a radiobutton we use the click gesture otherwise we use the normal click action.

Re #1652
Fixes #1648