### PR TITLE
ACS: Fix screen-overlay becoming visible again without active task

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
@@ -114,6 +114,7 @@ class ClearCacheModule @AssistedInject constructor(
 
         host.changeOptions {
             AutomationHost.Options(
+                showOverlay = true,
                 controlPanelTitle = R.string.appcleaner_automation_title.toCaString(),
                 controlPanelSubtitle = R.string.appcleaner_automation_subtitle_default_caches.toCaString(),
                 accessibilityServiceInfo = AccessibilityServiceInfo().apply {

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/AppControlAutomation.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/AppControlAutomation.kt
@@ -92,6 +92,7 @@ class AppControlAutomation @AssistedInject constructor(
         updateProgressPrimary(eu.darken.sdmse.common.R.string.general_progress_loading)
         host.changeOptions {
             AutomationHost.Options(
+                showOverlay = true,
                 controlPanelTitle = R.string.appcontrol_automation_title.toCaString(),
                 controlPanelSubtitle = R.string.appcontrol_automation_subtitle_force_stopping.toCaString(),
                 accessibilityServiceInfo = AccessibilityServiceInfo().apply {

--- a/app/src/main/java/eu/darken/sdmse/automation/core/AutomationHost.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/AutomationHost.kt
@@ -7,7 +7,6 @@ import android.view.accessibility.AccessibilityNodeInfo
 import eu.darken.sdmse.R
 import eu.darken.sdmse.common.ca.CaString
 import eu.darken.sdmse.common.ca.toCaString
-import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.progress.Progress
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
@@ -32,8 +31,8 @@ interface AutomationHost : Progress.Client {
     val state: Flow<State>
 
     data class Options(
-        val showOverlay: Boolean = !Bugs.isTrace,
-        val passthrough: Boolean = false,
+        val showOverlay: Boolean = false,
+        val passthrough: Boolean = true,
         val accessibilityServiceInfo: AccessibilityServiceInfo = AccessibilityServiceInfo(),
         val controlPanelTitle: CaString = R.string.automation_active_title.toCaString(),
         val controlPanelSubtitle: CaString = eu.darken.sdmse.common.R.string.general_progress_loading.toCaString(),

--- a/app/src/main/java/eu/darken/sdmse/automation/core/AutomationManager.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/AutomationManager.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.isActive
@@ -43,6 +44,18 @@ class AutomationManager @Inject constructor(
     private val setupHelper: SetupHelper,
     private val settingsProvider: SystemSettingsProvider,
 ) {
+
+    private val currentTaskHolder = MutableStateFlow<AutomationTask?>(null)
+    val currentTask: Flow<AutomationTask?> = currentTaskHolder
+
+    internal fun setCurrentTask(task: AutomationTask?) {
+        log(TAG, VERBOSE) { "setCurrentTask($task)" }
+        currentTaskHolder.value = task
+    }
+
+    fun cancelTask(): Boolean {
+        return currentService()?.cancelTask() ?: false
+    }
 
     val useAcs: Flow<Boolean> = settings.hasAcsConsent.flow
         .mapLatest { consent ->

--- a/app/src/main/java/eu/darken/sdmse/automation/core/common/AccessibilityNodeExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/common/AccessibilityNodeExtensions.kt
@@ -3,7 +3,6 @@ package eu.darken.sdmse.automation.core.common
 import android.graphics.Rect
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
-import eu.darken.sdmse.automation.core.errors.AutomationException
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
@@ -80,28 +79,6 @@ fun AccessibilityNodeInfo.isRadioButton(): Boolean {
 
 fun AccessibilityNodeInfo.children() = (0 until childCount).mapNotNull { getChild(it) }
 
-fun AccessibilityNodeInfo.searchUp(
-    maxNesting: Int = 1,
-    predicate: (AccessibilityNodeInfo) -> Boolean
-): AccessibilityNodeInfo {
-    var curParent = this.parent
-
-    for (i in 0 until maxNesting) {
-        val desiredSibling = curParent.children().firstOrNull { relative ->
-            if (relative == this) {
-                false
-            } else {
-                predicate(relative)
-            }
-        }
-        if (desiredSibling != null) return desiredSibling
-
-        if (curParent.parent != null) curParent = curParent.parent
-    }
-
-    throw AutomationException("No sibling found.")
-}
-
 fun AccessibilityNodeInfo.findParentOrNull(
     maxNesting: Int = 3,
     predicate: (AccessibilityNodeInfo) -> Boolean
@@ -139,7 +116,7 @@ fun AccessibilityNodeInfo.crawl(debug: Boolean = false): Sequence<CrawledNode> =
     while (!queue.isEmpty()) {
         val cur = queue.poll()!!
 
-        if (debug) log(TAG) { cur.infoShort }
+        if (debug) log(TAG, VERBOSE) { cur.infoShort }
 
         yield(cur)
 

--- a/app/src/main/java/eu/darken/sdmse/automation/core/debug/DebugTask.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/debug/DebugTask.kt
@@ -1,8 +1,11 @@
 package eu.darken.sdmse.automation.core.debug
 
 import eu.darken.sdmse.automation.core.AutomationTask
+import java.util.UUID
 
-class DebugTask : AutomationTask {
+data class DebugTask(
+    val runId: UUID = UUID.randomUUID(),
+) : AutomationTask {
 
     data class Result(val task: DebugTask) : AutomationTask.Result
 }

--- a/app/src/main/java/eu/darken/sdmse/automation/core/debug/DebugTaskModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/debug/DebugTaskModule.kt
@@ -17,6 +17,7 @@ import eu.darken.sdmse.automation.core.AutomationTask
 import eu.darken.sdmse.automation.core.common.crawl
 import eu.darken.sdmse.automation.core.waitForWindowRoot
 import eu.darken.sdmse.common.ca.caString
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.funnel.IPCFunnel
@@ -58,8 +59,9 @@ class DebugTaskModule @AssistedInject constructor(
         updateProgressSecondary("Listening to events...")
         val eventJob = host.events
             .onEach {
-                log(TAG) { "Event: $it" }
-                val crawled = host.waitForWindowRoot().crawl(debug = true).toList()
+                log(TAG, VERBOSE) { "Event: $it" }
+                val crawled = host.waitForWindowRoot().crawl().toList()
+                crawled.forEach { log(TAG, VERBOSE) { it.infoShort } }
                 updateProgressSecondary("Event: ${it.eventType} (depth: ${crawled.last().level})")
             }
             .launchIn(moduleScope)

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/items/DebugCardVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/items/DebugCardVH.kt
@@ -5,13 +5,13 @@ import android.graphics.Typeface
 import android.view.ViewGroup
 import androidx.core.view.isVisible
 import eu.darken.sdmse.R
+import eu.darken.sdmse.automation.core.AutomationTask
 import eu.darken.sdmse.common.BuildConfigWrap
 import eu.darken.sdmse.common.debug.DebugCardProvider
 import eu.darken.sdmse.common.lists.binding
 import eu.darken.sdmse.common.setChecked2
 import eu.darken.sdmse.databinding.DashboardDebugItemBinding
 import eu.darken.sdmse.main.ui.dashboard.DashboardAdapter
-import kotlinx.coroutines.Job
 
 
 class DebugCardVH(parent: ViewGroup) :
@@ -89,7 +89,7 @@ class DebugCardVH(parent: ViewGroup) :
         val onTestShizuku: () -> Unit,
         val onViewLog: () -> Unit,
         val onAcsDebug: () -> Unit,
-        val acsTask: Job?,
+        val acsTask: AutomationTask?,
     ) : DashboardAdapter.Item {
         override val stableId: Long = this.javaClass.hashCode().toLong()
     }


### PR DESCRIPTION
Refactor the overlay logic:

* Explicitly add and remove the overlay for each task, without task, there can't be an added overlay
* Change screen availability check to set an `isOverlayExtraHidden` that prevents new tasks or option changes from making the overlay visible
* Only instantiate overlay when there is a task to reduce memory footprint when SD Maid is not active

Fixes #1670