### PR TITLE
AppCleaner: Handle "Manage space" button on HyperOS2

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleter.kt
@@ -128,6 +128,8 @@ class InaccessibleDeleter @Inject constructor(
             val remainingTargets = targets.filter { !successTargets.contains(it.identifier) }
 
             log(TAG) { "Processing ${remainingTargets.size} remaining inaccessible caches" }
+            remainingTargets.forEach { log(TAG, VERBOSE) { "Remaining ACS target: $it" } }
+
             val successFullLive = mutableSetOf<InstallId>()
             val acsTask = ClearCacheTask(
                 targets = remainingTargets.map { it.identifier },

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
@@ -34,6 +34,7 @@ import eu.darken.sdmse.automation.core.AutomationTask
 import eu.darken.sdmse.automation.core.animation.AnimationState
 import eu.darken.sdmse.automation.core.animation.AnimationTool
 import eu.darken.sdmse.automation.core.errors.AutomationCompatibilityException
+import eu.darken.sdmse.automation.core.errors.PlanAbortException
 import eu.darken.sdmse.automation.core.errors.ScreenUnavailableException
 import eu.darken.sdmse.automation.core.errors.UserCancelledAutomationException
 import eu.darken.sdmse.automation.core.finishAutomation
@@ -235,8 +236,13 @@ class ClearCacheModule @AssistedInject constructor(
                     throw e
                 }
             } catch (e: Exception) {
-                log(TAG, WARN) { "Failure for $target: ${e.asLog()}" }
-                failed.add(target)
+                if (e is PlanAbortException && e.treatAsSuccess) {
+                    log(TAG, INFO) { "Treating aborted plan as success for $target:\n${e.asLog()}" }
+                    successful.add(target)
+                } else {
+                    log(TAG, WARN) { "Failure for $target:\n${e.asLog()}" }
+                    failed.add(target)
+                }
             } finally {
                 increaseProgress()
                 opsCounter.tick()

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/hyperos/HyperOsLabels.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/hyperos/HyperOsLabels.kt
@@ -283,6 +283,13 @@ class HyperOsLabels @Inject constructor(
             else -> emptySet<String>().also { log(TAG) { "Unmapped locale: $lang $script" } }
         }
 
+    fun getManageSpaceButtonLabels(lang: String, script: String, country: String?): Set<String> =
+        getManageSpaceButtonLabelsDynamic()
+
+    private fun getManageSpaceButtonLabelsDynamic() = setOf(
+        "app_manager_manage_space"
+    ).getAsStringResources(context, SETTINGS_PKG)
+
     companion object {
         val TAG: String = logTag("AppCleaner", "Automation", "HyperOs", "Labels")
         private val SETTINGS_PKG = "com.miui.securitycenter".toPkgId()

--- a/app/src/main/java/eu/darken/sdmse/automation/core/AutomationService.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/AutomationService.kt
@@ -236,10 +236,10 @@ class AutomationService : AccessibilityService(), AutomationHost, Progress.Host,
         visible: Boolean,
         passthrough: Boolean,
     ) = withContext(dispatcher.Main) {
-        log(TAG) { "setOverlayVisibility(visible=$visible, passthrough=$passthrough)" }
+        log(TAG) { "updateOverlay(visible=$visible, passthrough=$passthrough)" }
         val cv = controlView
         if (cv == null) {
-            log(TAG, WARN) { "setOverlayVisibility(...) controlView was null" }
+            log(TAG, WARN) { "updateOverlay(...) controlView was null" }
             return@withContext
         }
 

--- a/app/src/main/java/eu/darken/sdmse/automation/core/errors/PlanAbortException.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/errors/PlanAbortException.kt
@@ -2,4 +2,5 @@ package eu.darken.sdmse.automation.core.errors
 
 open class PlanAbortException(
     message: String,
+    val treatAsSuccess: Boolean = false,
 ) : AutomationException(message)


### PR DESCRIPTION
Apps that have a `PackageInfo.manageSpaceActivityName` may display "Manage space" instead of "Clear data". It's possible that SD Maid tries to clear such an apps cache via Shizuku, but times-out, and then tries it via ACS. If the cache is then (despite the timeout) still cleared via `adb trim-caches` then SD Maid sits there starting at the "Manage space" button. We now detect this, abort the ACS plan, and treat it as success.

Fixes #1669