### PR TITLE
AppCleaner: Fix SD Maid hanging on certain system apps

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/features/Installed.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/features/Installed.kt
@@ -9,4 +9,23 @@ interface Installed : PkgInfo {
     val installId: InstallId
         get() = InstallId(id, userHandle)
 
+    /**
+     * Has a few false positives, e.g.
+     * com.android.cts.priv.ctsshim
+     * com.android.nfc
+     * com.google.android.devicelockcontroller
+     * com.google.android.microdroid.empty_payload
+     * com.google.android.virtualmachine.res
+     * com.google.android.compos.payload
+     * com.android.cts.ctsshim
+     */
+    val hasNoSettings: Boolean
+        get() {
+            val isMainline = packageName.startsWith("com.google.mainline.")
+            if (isMainline) return true
+            val hasApexSource = applicationInfo?.sourceDir?.startsWith("/apex/") == true
+            if (hasApexSource) return true
+            val hasApexLibrary = applicationInfo?.nativeLibraryDir?.startsWith("/apex/") == true
+            return hasApexLibrary
+        }
 }

--- a/app-common/src/main/res/values/strings.xml
+++ b/app-common/src/main/res/values/strings.xml
@@ -177,4 +177,5 @@
     </plurals>
     <string name="general_advice_title">Advice</string>
     <string name="general_error_invalid_input_label">Invalid input</string>
+    <string name="general_information_for_the_developer">Information for the developer</string>
 </resources>

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
@@ -222,7 +222,7 @@ class ClearCacheModule @AssistedInject constructor(
             } catch (e: TimeoutCancellationException) {
                 log(TAG, WARN) { "Timeout while processing $installed" }
                 failed.add(target)
-                if (timeoutCount > 2 && successful.isEmpty()) break else timeoutCount++
+                if (timeoutCount > 8 && successful.isEmpty()) break else timeoutCount++
             } catch (e: CancellationException) {
                 log(TAG, WARN) { "We were cancelled: ${e.asLog()}" }
                 updateProgressPrimary(eu.darken.sdmse.common.R.string.general_cancel_action)

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecs.kt
@@ -1,6 +1,5 @@
 package eu.darken.sdmse.appcleaner.core.automation.specs.aosp
 
-import android.view.accessibility.AccessibilityNodeInfo
 import dagger.Binds
 import dagger.Module
 import dagger.Reusable
@@ -14,10 +13,8 @@ import eu.darken.sdmse.appcleaner.core.automation.specs.defaultFindAndClickClear
 import eu.darken.sdmse.automation.core.common.getSysLocale
 import eu.darken.sdmse.automation.core.common.isClickyButton
 import eu.darken.sdmse.automation.core.common.stepper.AutomationStep
-import eu.darken.sdmse.automation.core.common.stepper.StepContext
 import eu.darken.sdmse.automation.core.common.stepper.Stepper
 import eu.darken.sdmse.automation.core.common.textMatchesAny
-import eu.darken.sdmse.automation.core.errors.PlanAbortException
 import eu.darken.sdmse.automation.core.specs.AutomationExplorer
 import eu.darken.sdmse.automation.core.specs.AutomationSpec
 import eu.darken.sdmse.automation.core.specs.defaultFindAndClick
@@ -81,13 +78,6 @@ class AOSPSpecs @Inject constructor(
                 aospLabels.getStorageEntryDynamic() + aospLabels.getStorageEntryStatic(lang, script)
             log(TAG) { "storageEntryLabels=$storageEntryLabels" }
 
-            val windowCheck: suspend StepContext.() -> AccessibilityNodeInfo = {
-                if (stepAttempts >= 1 && WITHOUT_SETTINGS.contains(pkg.id)) {
-                    throw PlanAbortException("${pkg.packageName} has no settings window.")
-                }
-                windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg)()
-            }
-
             val storageFilter = onTheFlyLabler.getAOSPStorageFilter(storageEntryLabels, pkg)
 
             val step = AutomationStep(
@@ -95,7 +85,7 @@ class AOSPSpecs @Inject constructor(
                 descriptionInternal = "Storage entry",
                 label = R.string.appcleaner_automation_progress_find_storage.toCaString(storageEntryLabels),
                 windowLaunch = windowLauncherDefaultSettings(pkg),
-                windowCheck = windowCheck,
+                windowCheck = windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg),
                 nodeRecovery = defaultNodeRecovery(pkg),
                 nodeAction = defaultFindAndClick(predicate = storageFilter),
             )
@@ -127,16 +117,6 @@ class AOSPSpecs @Inject constructor(
 
     companion object {
         val SETTINGS_PKG = "com.android.settings".toPkgId()
-        val WITHOUT_SETTINGS = setOf(
-            "com.google.android.bluetooth",
-            "com.google.android.photopicker",
-            "com.google.android.rkpdapp",
-            "com.google.android.cellbroadcastreceiver",
-            "com.google.android.providers.media.module",
-            "com.google.android.networkstack.tethering",
-            "com.google.android.cellbroadcastservice",
-        ).map { it.toPkgId() }
-
         val TAG: String = logTag("AppCleaner", "Automation", "AOSP", "Specs")
     }
 

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/hyperos/HyperOsSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/hyperos/HyperOsSpecs.kt
@@ -103,6 +103,9 @@ class HyperOsSpecs @Inject constructor(
         var windowPkg: Pkg.Id? = null
 
         val windowCheck: suspend StepContext.() -> AccessibilityNodeInfo = {
+            if (stepAttempts >= 1 && pkg.hasNoSettings) {
+                throw PlanAbortException("${pkg.packageName} has no settings window.")
+            }
             // Wait for correct base window
             host.events
                 .filter { event -> event.pkgId == SETTINGS_PKG_HYPEROS || event.pkgId == SETTINGS_PKG_AOSP }
@@ -229,7 +232,7 @@ class HyperOsSpecs @Inject constructor(
                 }
 
                 val mapped = findClickableParent(node = clearDataTarget) ?: return@action false
-                clickNormal(isDryRun = isDryRun, mapped)
+                clickNormal(node = mapped)
             }
 
             val step = AutomationStep(

--- a/app/src/main/java/eu/darken/sdmse/automation/core/errors/AutomationCompatibilityException.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/errors/AutomationCompatibilityException.kt
@@ -1,6 +1,8 @@
 package eu.darken.sdmse.automation.core.errors
 
+import android.os.Build
 import eu.darken.sdmse.R
+import eu.darken.sdmse.common.ca.caString
 import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.error.HasLocalizedError
 import eu.darken.sdmse.common.error.LocalizedError
@@ -12,7 +14,16 @@ open class AutomationCompatibilityException(
     override fun getLocalizedError(): LocalizedError = LocalizedError(
         throwable = this,
         label = R.string.automation_error_no_consent_title.toCaString(),
-        description = R.string.automation_error_compatibility_body.toCaString(),
+        description = caString {
+            """
+                ${getString(R.string.automation_error_compatibility_body)}
+                
+               
+                ${getString(eu.darken.sdmse.common.R.string.general_information_for_the_developer)}:
+                
+                ${Build.FINGERPRINT}
+            """.trimIndent()
+        },
     )
 
 }

--- a/app/src/main/java/eu/darken/sdmse/automation/core/specs/SpecGeneratorExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/specs/SpecGeneratorExtensions.kt
@@ -14,6 +14,7 @@ import eu.darken.sdmse.automation.core.common.stepper.clickNormal
 import eu.darken.sdmse.automation.core.common.stepper.findClickableParent
 import eu.darken.sdmse.automation.core.common.stepper.findNode
 import eu.darken.sdmse.automation.core.common.textMatchesAny
+import eu.darken.sdmse.automation.core.errors.PlanAbortException
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.asLog
@@ -72,8 +73,13 @@ fun SpecGenerator.windowCheckDefaultSettings(
     windowPkgId: Pkg.Id,
     ipcFunnel: IPCFunnel,
     pkgInfo: Installed
-) = windowCheck { _, root ->
-    root.pkgId == windowPkgId && checkAppIdentifier(ipcFunnel, pkgInfo)(root)
+): suspend StepContext.() -> AccessibilityNodeInfo = {
+    if (stepAttempts >= 1 && pkgInfo.hasNoSettings) {
+        throw PlanAbortException("${pkgInfo.packageName} has no settings window.")
+    }
+    windowCheck { _, root ->
+        root.pkgId == windowPkgId && checkAppIdentifier(ipcFunnel, pkgInfo)(root)
+    }()
 }
 
 suspend fun SpecGenerator.checkAppIdentifier(


### PR DESCRIPTION
* Abort ACS operations on apex apps after failing to open settings one time, assume app has no settings screen
* Raise timeout limit until "SD Maid does not recognize your screen" to 10 apps
* Add device/os info to the error dialog (people keep sending me screenshots of it)