### PR TITLE
CorpseFinder: Support scanning dalvik-cache on rooted Android 15+ ROMs

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/common/areas/modules/dalvik/DalvikProfileModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/areas/modules/dalvik/DalvikProfileModule.kt
@@ -26,6 +26,7 @@ class DalvikProfileModule @Inject constructor(
     private val gatewaySwitch: GatewaySwitch,
 ) : DataAreaModule {
 
+    // Unused since Android 16 (API36), "art-profiles" are now under `/data/misc/profiles`
     override suspend fun secondPass(firstPass: Collection<DataArea>): Collection<DataArea> {
         val gateway = gatewaySwitch.getGateway(APath.PathType.LOCAL) as LocalGateway
 

--- a/app/src/main/java/eu/darken/sdmse/common/forensics/FileForensics.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/forensics/FileForensics.kt
@@ -18,7 +18,6 @@ import eu.darken.sdmse.common.pkgs.pkgops.PkgOps
 import eu.darken.sdmse.common.sharedresource.HasSharedResource
 import eu.darken.sdmse.common.sharedresource.SharedResource
 import eu.darken.sdmse.common.sharedresource.keepResourceHoldersAlive
-import eu.darken.sdmse.common.shell.ShellOps
 import kotlinx.coroutines.CoroutineScope
 import javax.inject.Inject
 import javax.inject.Provider

--- a/app/src/main/java/eu/darken/sdmse/common/forensics/FileForensics.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/forensics/FileForensics.kt
@@ -18,6 +18,7 @@ import eu.darken.sdmse.common.pkgs.pkgops.PkgOps
 import eu.darken.sdmse.common.sharedresource.HasSharedResource
 import eu.darken.sdmse.common.sharedresource.SharedResource
 import eu.darken.sdmse.common.sharedresource.keepResourceHoldersAlive
+import eu.darken.sdmse.common.shell.ShellOps
 import kotlinx.coroutines.CoroutineScope
 import javax.inject.Inject
 import javax.inject.Provider

--- a/app/src/main/java/eu/darken/sdmse/common/forensics/csi/dalvik/tools/DexStringsCheck.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/forensics/csi/dalvik/tools/DexStringsCheck.kt
@@ -25,6 +25,7 @@ class DexStringsCheck @Inject constructor(
         val path: String = areaInfo.file.path
         val dexTarget = when {
             path.endsWith(".dex") -> path
+            path.endsWith(".odex") -> path
             path.endsWith(".vdex") -> path.removeSuffix(".vdex") + ".dex"
             path.endsWith(".art") -> path.removeSuffix(".art") + ".dex"
             else -> null

--- a/app/src/main/java/eu/darken/sdmse/common/forensics/csi/dalvik/tools/DexStringsCheck.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/forensics/csi/dalvik/tools/DexStringsCheck.kt
@@ -1,0 +1,72 @@
+package eu.darken.sdmse.common.forensics.csi.dalvik.tools
+
+import dagger.Reusable
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.forensics.AreaInfo
+import eu.darken.sdmse.common.forensics.Owner
+import eu.darken.sdmse.common.forensics.csi.dalvik.DalvikCheck
+import eu.darken.sdmse.common.pkgs.PkgRepo
+import eu.darken.sdmse.common.pkgs.get
+import eu.darken.sdmse.common.pkgs.toPkgId
+import eu.darken.sdmse.common.shell.ShellOps
+import eu.darken.sdmse.common.shell.ipc.ShellOpsCmd
+import javax.inject.Inject
+
+@Reusable
+class DexStringsCheck @Inject constructor(
+    private val shellOps: ShellOps,
+    private val pkgRepo: PkgRepo,
+) : DalvikCheck {
+
+    suspend fun check(areaInfo: AreaInfo): DalvikCheck.Result? {
+        val path: String = areaInfo.file.path
+        val dexTarget = when {
+            path.endsWith(".dex") -> path
+            path.endsWith(".vdex") -> path.removeSuffix(".vdex") + ".dex"
+            path.endsWith(".art") -> path.removeSuffix(".art") + ".dex"
+            else -> null
+        }
+        if (dexTarget == null) {
+            log(TAG, WARN) { "Couldn't map file suffix of $path" }
+            return null
+        }
+
+        val cmd = ShellOpsCmd("strings $dexTarget | grep -m1 -- '--comments=' | sed 's/.*--comments=//'")
+        val result = shellOps.execute(cmd, ShellOps.Mode.ROOT)
+        log(TAG, VERBOSE) { "strings-grep result: $result" }
+        if (!result.isSuccess) return null
+
+        if (result.errors.any { it.contains("No such file or directory") }) {
+            log(TAG, WARN) { ".vdex without .dex: $path" }
+            return DalvikCheck.Result(hasKnownUnknownOwner = true)
+        }
+
+        if (result.output.size != 1) {
+            log(TAG, WARN) { "Successful but no output for $dexTarget $result" }
+            return null
+        }
+
+        val keyMap = result.output.single().split(",").associate {
+            val (key, value) = it.split(":")
+            key to value
+        }
+
+        val pkgId = keyMap["app-name"]?.toPkgId() ?: return null
+        val pkg = pkgRepo.get(pkgId, areaInfo.userHandle) ?: return null
+
+        val versionCode = keyMap["app-version-code"]?.toLong()
+        if (versionCode != null && pkg.versionCode != versionCode) {
+            log(TAG, WARN) { "Version missmatch dex=$versionCode, installed=${pkg.versionCode}" }
+        }
+
+        log(TAG) { "Resolved $path to $pkg" }
+        return DalvikCheck.Result(setOf(Owner(pkg.id, areaInfo.userHandle)))
+    }
+
+    companion object {
+        val TAG: String = logTag("CSI", "Dalvik", "Dex", "StringsCheck")
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/AppAsecFileCorpseFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/AppAsecFileCorpseFilter.kt
@@ -50,8 +50,8 @@ class AppAsecFileCorpseFilter @Inject constructor(
             return emptySet()
         }
 
-        // TODO needs to be checked on more rooted ROMs
-        // Not seen this on API35+ yet
+        // Unseen (exists, but empty) on Android 15+
+        // https://github.com/d4rken-org/sdmaid-se/issues/1612
         if (hasApiLevel(35)) {
             log(TAG, WARN) { "Untested API level (35) skipping for safety." }
             return emptySet()

--- a/app/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/AppLibCorpseFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/AppLibCorpseFilter.kt
@@ -52,6 +52,7 @@ class AppLibCorpseFilter @Inject constructor(
         }
 
         // TODO needs to be checked on more rooted ROMs
+        // https://github.com/d4rken-org/sdmaid-se/issues/1612
         if (hasApiLevel(35)) {
             log(TAG, WARN) { "Untested API level (35) skipping for safety." }
             return emptySet()

--- a/app/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/AppSourcePrivateCorpseFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/AppSourcePrivateCorpseFilter.kt
@@ -52,6 +52,7 @@ class AppSourcePrivateCorpseFilter @Inject constructor(
         }
 
         // TODO needs to be checked on more rooted ROMs
+        // https://github.com/d4rken-org/sdmaid-se/issues/1612
         // Have not seen this on API35+ yet
         if (hasApiLevel(35)) {
             log(TAG, WARN) { "Untested API level (35) skipping for safety." }

--- a/app/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/DalvikCorpseFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/DalvikCorpseFilter.kt
@@ -69,7 +69,8 @@ class DalvikCorpseFilter @Inject constructor(
         }
 
         // TODO needs to be checked on more rooted ROMs
-        if (hasApiLevel(35)) {
+        // https://github.com/d4rken-org/sdmaid-se/issues/1612
+        if (hasApiLevel(36)) {
             log(TAG, WARN) { "Untested API level (35) skipping for safety." }
             return emptySet()
         }

--- a/app/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/DalvikCorpseFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/DalvikCorpseFilter.kt
@@ -68,10 +68,10 @@ class DalvikCorpseFilter @Inject constructor(
             return emptySet()
         }
 
-        // TODO needs to be checked on more rooted ROMs
         // https://github.com/d4rken-org/sdmaid-se/issues/1612
-        if (hasApiLevel(36)) {
-            log(TAG, WARN) { "Untested API level (35) skipping for safety." }
+        // https://github.com/d4rken-org/sdmaid-se/issues/1896
+        if (hasApiLevel(37)) {
+            log(TAG, WARN) { "Untested API level (37) skipping for safety." }
             return emptySet()
         }
 
@@ -84,6 +84,7 @@ class DalvikCorpseFilter @Inject constructor(
 
         val pathExclusions = exclusionManager.pathExclusions(SDMTool.Type.CORPSEFINDER)
 
+        // Android 16 (API36) uses a new structure for Dalvik profiles in /data/misc/profiles (covered by another filter)
         val profileCorpses = areas
             .filter { it.type == DataArea.Type.DALVIK_PROFILE }
             .map { area ->

--- a/app/src/test/java/eu/darken/sdmse/common/forensics/FileForensicsTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/common/forensics/FileForensicsTest.kt
@@ -7,6 +7,7 @@ import eu.darken.sdmse.common.pkgs.PkgRepo
 import eu.darken.sdmse.common.pkgs.pkgops.PkgOps
 import eu.darken.sdmse.common.sharedresource.Resource
 import eu.darken.sdmse.common.sharedresource.SharedResource
+import eu.darken.sdmse.common.shell.ShellOps
 import io.kotest.matchers.shouldBe
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
@@ -28,6 +29,8 @@ class FileForensicsTest : BaseTest() {
     @MockK lateinit var testAreaInfo: AreaInfo
     @MockK lateinit var gatewaySwitch: GatewaySwitch
     @MockK lateinit var pkgOps: PkgOps
+    @MockK lateinit var shellOps: ShellOps
+
     val processors = mutableSetOf<CSIProcessor>()
     private val processorsProvider = Provider<Set<CSIProcessor>> { processors }
 
@@ -53,6 +56,14 @@ class FileForensicsTest : BaseTest() {
             every { isClosed } returns true
             every { close() } returns Unit
         }
+        every { shellOps.sharedResource } returns mockk<SharedResource<Any>>().apply {
+            every { resourceId } returns "shellops:SR"
+            coEvery { get() } returns mockk<Resource<Any>>().apply {
+                every { close() } returns Unit
+            }
+            every { isClosed } returns true
+            every { close() } returns Unit
+        }
     }
 
     @AfterEach fun teardown() {
@@ -60,7 +71,7 @@ class FileForensicsTest : BaseTest() {
     }
 
     @Test fun init() = runTest2(autoCancel = true) {
-        val forensics = FileForensics(this, context, pkgRepo, processorsProvider, gatewaySwitch, pkgOps)
+        val forensics = FileForensics(this, context, pkgRepo, processorsProvider, gatewaySwitch, pkgOps, shellOps)
         val testPath = LocalPath.build("/test")
         val areaInfo = forensics.identifyArea(testPath)
         areaInfo shouldBe testAreaInfo

--- a/app/src/test/java/eu/darken/sdmse/common/forensics/FileForensicsTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/common/forensics/FileForensicsTest.kt
@@ -71,7 +71,7 @@ class FileForensicsTest : BaseTest() {
     }
 
     @Test fun init() = runTest2(autoCancel = true) {
-        val forensics = FileForensics(this, context, pkgRepo, processorsProvider, gatewaySwitch, pkgOps, shellOps)
+        val forensics = FileForensics(this, context, pkgRepo, processorsProvider, gatewaySwitch, pkgOps)
         val testPath = LocalPath.build("/test")
         val areaInfo = forensics.identifyArea(testPath)
         areaInfo shouldBe testAreaInfo

--- a/app/src/test/java/eu/darken/sdmse/common/forensics/csi/BaseCSITest.kt
+++ b/app/src/test/java/eu/darken/sdmse/common/forensics/csi/BaseCSITest.kt
@@ -13,6 +13,8 @@ import eu.darken.sdmse.common.pkgs.PkgRepo
 import eu.darken.sdmse.common.pkgs.features.Installed
 import eu.darken.sdmse.common.pkgs.features.SourceAvailable
 import eu.darken.sdmse.common.pkgs.pkgops.PkgOps
+import eu.darken.sdmse.common.shell.ShellOps
+import eu.darken.sdmse.common.shell.ipc.ShellOpsResult
 import eu.darken.sdmse.common.storage.StorageEnvironment
 import eu.darken.sdmse.common.user.UserHandle2
 import eu.darken.sdmse.common.user.UserManager2
@@ -39,6 +41,7 @@ abstract class BaseCSITest : BaseTest() {
     @MockK lateinit var userManager2: UserManager2
     @MockK lateinit var storageEnvironment: StorageEnvironment
     @MockK lateinit var pkgOps: PkgOps
+    @MockK lateinit var shellOps: ShellOps
 
     private val pkgs = mutableSetOf<Installed>()
 
@@ -56,6 +59,7 @@ abstract class BaseCSITest : BaseTest() {
         coEvery { pkgRepo.query(any(), any()) } returns emptySet()
         every { pkgRepo.data } answers { flowOf(PkgRepo.PkgData.from(pkgs)) }
         coEvery { pkgOps.viewArchive(any(), any()) } returns null
+        coEvery { shellOps.execute(any(), any()) } returns ShellOpsResult(-1, emptyList(), emptyList())
     }
 
     @AfterEach

--- a/app/src/test/java/eu/darken/sdmse/common/forensics/csi/dalvik/DalvikDexCSITest.kt
+++ b/app/src/test/java/eu/darken/sdmse/common/forensics/csi/dalvik/DalvikDexCSITest.kt
@@ -10,6 +10,7 @@ import eu.darken.sdmse.common.forensics.csi.dalvik.tools.ApkCheck
 import eu.darken.sdmse.common.forensics.csi.dalvik.tools.CustomDexOptCheck
 import eu.darken.sdmse.common.forensics.csi.dalvik.tools.DalvikCandidateGenerator
 import eu.darken.sdmse.common.forensics.csi.dalvik.tools.DalvikClutterCheck
+import eu.darken.sdmse.common.forensics.csi.dalvik.tools.DexStringsCheck
 import eu.darken.sdmse.common.forensics.csi.dalvik.tools.ExistCheck
 import eu.darken.sdmse.common.forensics.csi.dalvik.tools.OddOnesCheck
 import eu.darken.sdmse.common.forensics.csi.dalvik.tools.RuntimeTool
@@ -142,6 +143,7 @@ class CSIDalvikDexTest : BaseCSITest() {
                 )
             }
         ),
+        dexStringsCheck = DexStringsCheck(shellOps, pkgRepo)
     )
 
     @Test override fun `test jurisdiction`() = runTest {


### PR DESCRIPTION
Additional sanity check via `DexStringsCheck`, checks the cmd --comment field of `.dex` files. Faster than the APK check, so we gain some speed here.

See #1612