### PR TITLE
ACS: More details when debug logging

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/automation/core/AutomationService.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/AutomationService.kt
@@ -13,6 +13,7 @@ import androidx.annotation.Keep
 import androidx.appcompat.view.ContextThemeWrapper
 import dagger.hilt.android.AndroidEntryPoint
 import eu.darken.sdmse.R
+import eu.darken.sdmse.automation.core.common.crawl
 import eu.darken.sdmse.automation.core.common.toStringShort
 import eu.darken.sdmse.automation.core.errors.AutomationNoConsentException
 import eu.darken.sdmse.automation.core.errors.UserCancelledAutomationException
@@ -200,8 +201,6 @@ class AutomationService : AccessibilityService(), AutomationHost, Progress.Host,
 
         if (!automationProcessor.hasTask) return
 
-        if (Bugs.isTrace) log(TAG, VERBOSE) { "onAccessibilityEvent(eventType=${event.eventType})" }
-
         val eventCopy = if (hasApiLevel(30)) {
             @Suppress("NewApi")
             AccessibilityEvent(event)
@@ -213,6 +212,12 @@ class AutomationService : AccessibilityService(), AutomationHost, Progress.Host,
                 log(TAG, ERROR) { "Failed to obtain accessibility event copy $event" }
                 return
             }
+        }
+
+        if (Bugs.isDebug) {
+            log(TAG, VERBOSE) { "ACS-DEBUG -- START -- $eventCopy" }
+            rootInActiveWindow?.crawl()?.forEach { log(TAG, VERBOSE) { "ACS-DEBUG: ${it.infoShort}" } }
+            log(TAG, VERBOSE) { "ACS-DEBUG -- STOP -- -------------------------------------------------------------" }
         }
 
         // TODO use a queue here?

--- a/app/src/main/java/eu/darken/sdmse/automation/core/common/CrawledNode.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/common/CrawledNode.kt
@@ -7,7 +7,7 @@ data class CrawledNode(
     val level: Int
 ) {
 
-    private val levelPrefix = "crawl():${INDENT.substring(0, level)}${level}"
+    private val levelPrefix = "${INDENT.substring(0, level)}${level}"
 
     val infoFull: String = "$levelPrefix: $node"
 


### PR DESCRIPTION
The new automation failure pop-up has shown that there are a lot more issues to fix where users previously thought it was just working slow.

Logging the screen state on errors is not enough, when recording a debug log, we need to log it everytime there is an event.