### PR TITLE
AppCleaner: Smarter "Storage" entry finding (fixes false-positives on tablet layouts)

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/alcatel/AlcatelSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/alcatel/AlcatelSpecs.kt
@@ -8,7 +8,7 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.R
 import eu.darken.sdmse.appcleaner.core.automation.specs.AppCleanerSpecGenerator
-import eu.darken.sdmse.appcleaner.core.automation.specs.OnTheFlyLabler
+import eu.darken.sdmse.appcleaner.core.automation.specs.StorageEntryFinder
 import eu.darken.sdmse.appcleaner.core.automation.specs.defaultFindAndClickClearCache
 import eu.darken.sdmse.automation.core.common.getSysLocale
 import eu.darken.sdmse.automation.core.common.isClickyButton
@@ -43,7 +43,7 @@ class AlcatelSpecs @Inject constructor(
     ipcFunnel: IPCFunnel,
     private val deviceDetective: DeviceDetective,
     private val alcatelLabels: AlcatelLabels,
-    private val onTheFlyLabler: OnTheFlyLabler,
+    private val storageEntryFinder: StorageEntryFinder,
     private val generalSettings: GeneralSettings,
     private val stepper: Stepper,
 ) : AppCleanerSpecGenerator {
@@ -82,7 +82,7 @@ class AlcatelSpecs @Inject constructor(
                 alcatelLabels.getStorageEntryDynamic() + alcatelLabels.getStorageEntryStatic(lang, script)
             log(TAG) { "storageEntryLabels=$storageEntryLabels" }
 
-            val storageFilter = onTheFlyLabler.getAOSPStorageFilter(storageEntryLabels, pkg)
+            val storageFinder = storageEntryFinder.storageFinderAOSP(storageEntryLabels, pkg)
 
             val step = AutomationStep(
                 source = tag,
@@ -91,7 +91,7 @@ class AlcatelSpecs @Inject constructor(
                 windowLaunch = windowLauncherDefaultSettings(pkg),
                 windowCheck = windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg),
                 nodeRecovery = defaultNodeRecovery(pkg),
-                nodeAction = defaultFindAndClick { storageFilter(it) }
+                nodeAction = defaultFindAndClick(finder = storageFinder)
             )
             stepper.withProgress(this) { process(this@plan, step) }
         }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/androidtv/AndroidTVSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/androidtv/AndroidTVSpecs.kt
@@ -134,16 +134,21 @@ open class AndroidTVSpecs @Inject constructor(
 
             val buttonLabels = setOf(context.getString(android.R.string.ok))
 
-            val action = defaultFindAndClick(isDryRun = Bugs.isDryRun) { node ->
-                when {
-                    node.idMatches("com.android.tv.settings:id/guidedactions_item_content") -> true
-                    node.idMatches("com.android.tv.settings:id/guidedactions_item_title") -> {
-                        node.textMatchesAny(buttonLabels)
-                    }
+            val action = defaultFindAndClick(
+                isDryRun = Bugs.isDryRun,
+                finder = {
+                    findNode { node ->
+                        when {
+                            node.idMatches("com.android.tv.settings:id/guidedactions_item_content") -> true
+                            node.idMatches("com.android.tv.settings:id/guidedactions_item_title") -> {
+                                node.textMatchesAny(buttonLabels)
+                            }
 
-                    else -> false
+                            else -> false
+                        }
+                    }
                 }
-            }
+            )
 
             val step = AutomationStep(
                 source = TAG,

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecs.kt
@@ -8,7 +8,7 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.R
 import eu.darken.sdmse.appcleaner.core.automation.specs.AppCleanerSpecGenerator
-import eu.darken.sdmse.appcleaner.core.automation.specs.OnTheFlyLabler
+import eu.darken.sdmse.appcleaner.core.automation.specs.StorageEntryFinder
 import eu.darken.sdmse.appcleaner.core.automation.specs.defaultFindAndClickClearCache
 import eu.darken.sdmse.automation.core.common.getSysLocale
 import eu.darken.sdmse.automation.core.common.isClickyButton
@@ -42,7 +42,7 @@ class AOSPSpecs @Inject constructor(
     private val ipcFunnel: IPCFunnel,
     private val deviceDetective: DeviceDetective,
     private val aospLabels: AOSPLabels,
-    private val onTheFlyLabler: OnTheFlyLabler,
+    private val storageEntryFinder: StorageEntryFinder,
     private val generalSettings: GeneralSettings,
     private val stepper: Stepper,
 ) : AppCleanerSpecGenerator {
@@ -78,7 +78,7 @@ class AOSPSpecs @Inject constructor(
                 aospLabels.getStorageEntryDynamic() + aospLabels.getStorageEntryStatic(lang, script)
             log(TAG) { "storageEntryLabels=$storageEntryLabels" }
 
-            val storageFilter = onTheFlyLabler.getAOSPStorageFilter(storageEntryLabels, pkg)
+            val storageFinder = storageEntryFinder.storageFinderAOSP(storageEntryLabels, pkg)
 
             val step = AutomationStep(
                 source = tag,
@@ -87,7 +87,7 @@ class AOSPSpecs @Inject constructor(
                 windowLaunch = windowLauncherDefaultSettings(pkg),
                 windowCheck = windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg),
                 nodeRecovery = defaultNodeRecovery(pkg),
-                nodeAction = defaultFindAndClick(predicate = storageFilter),
+                nodeAction = defaultFindAndClick(finder = storageFinder),
             )
             stepper.withProgress(this) { process(this@plan, step) }
         }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/coloros/ColorOSSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/coloros/ColorOSSpecs.kt
@@ -8,7 +8,7 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.R
 import eu.darken.sdmse.appcleaner.core.automation.specs.AppCleanerSpecGenerator
-import eu.darken.sdmse.appcleaner.core.automation.specs.OnTheFlyLabler
+import eu.darken.sdmse.appcleaner.core.automation.specs.StorageEntryFinder
 import eu.darken.sdmse.appcleaner.core.automation.specs.clickClearCache
 import eu.darken.sdmse.automation.core.common.crawl
 import eu.darken.sdmse.automation.core.common.getSysLocale
@@ -51,7 +51,7 @@ class ColorOSSpecs @Inject constructor(
     private val ipcFunnel: IPCFunnel,
     private val deviceDetective: DeviceDetective,
     private val colorOSLabels: ColorOSLabels,
-    private val onTheFlyLabler: OnTheFlyLabler,
+    private val storageEntryFinder: StorageEntryFinder,
     private val generalSettings: GeneralSettings,
     private val stepper: Stepper,
 ) : AppCleanerSpecGenerator {
@@ -100,7 +100,7 @@ class ColorOSSpecs @Inject constructor(
                 colorOSLabels.getStorageEntryDynamic() + colorOSLabels.getStorageEntryLabels(lang, script)
             log(TAG) { "storageEntryLabels=$storageEntryLabels" }
 
-            val storageFilter = onTheFlyLabler.getAOSPStorageFilter(storageEntryLabels, pkg)
+            val storageFinder = storageEntryFinder.storageFinderAOSP(storageEntryLabels, pkg)
 
             val step = AutomationStep(
                 source = TAG,
@@ -109,7 +109,7 @@ class ColorOSSpecs @Inject constructor(
                 windowLaunch = windowLauncherDefaultSettings(pkg),
                 windowCheck = windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg),
                 nodeRecovery = defaultNodeRecovery(pkg),
-                nodeAction = defaultFindAndClick(predicate = storageFilter),
+                nodeAction = defaultFindAndClick(finder = storageFinder),
             )
 
             stepper.withProgress(this) { process(this@plan, step) }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/honor/HonorSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/honor/HonorSpecs.kt
@@ -8,7 +8,7 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.R
 import eu.darken.sdmse.appcleaner.core.automation.specs.AppCleanerSpecGenerator
-import eu.darken.sdmse.appcleaner.core.automation.specs.OnTheFlyLabler
+import eu.darken.sdmse.appcleaner.core.automation.specs.StorageEntryFinder
 import eu.darken.sdmse.appcleaner.core.automation.specs.defaultFindAndClickClearCache
 import eu.darken.sdmse.automation.core.common.getSysLocale
 import eu.darken.sdmse.automation.core.common.isClickyButton
@@ -42,7 +42,7 @@ class HonorSpecs @Inject constructor(
     private val ipcFunnel: IPCFunnel,
     private val deviceDetective: DeviceDetective,
     private val honorLabels: HonorLabels,
-    private val onTheFlyLabler: OnTheFlyLabler,
+    private val storageEntryFinder: StorageEntryFinder,
     private val generalSettings: GeneralSettings,
     private val stepper: Stepper,
 ) : AppCleanerSpecGenerator {
@@ -78,7 +78,7 @@ class HonorSpecs @Inject constructor(
                 honorLabels.getStorageEntryDynamic() + honorLabels.getStorageEntryStatic(lang, script)
             log(TAG) { "storageEntryLabels=$storageEntryLabels" }
 
-            val storageFilter = onTheFlyLabler.getAOSPStorageFilter(storageEntryLabels, pkg)
+            val storageFinder = storageEntryFinder.storageFinderAOSP(storageEntryLabels, pkg)
 
             val step = AutomationStep(
                 source = tag,
@@ -87,7 +87,7 @@ class HonorSpecs @Inject constructor(
                 windowLaunch = windowLauncherDefaultSettings(pkg),
                 windowCheck = windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg),
                 nodeRecovery = defaultNodeRecovery(pkg),
-                nodeAction = defaultFindAndClick(predicate = storageFilter),
+                nodeAction = defaultFindAndClick(finder = storageFinder),
             )
             stepper.withProgress(this) { process(this@plan, step) }
         }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/huawei/HuaweiSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/huawei/HuaweiSpecs.kt
@@ -8,7 +8,7 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.R
 import eu.darken.sdmse.appcleaner.core.automation.specs.AppCleanerSpecGenerator
-import eu.darken.sdmse.appcleaner.core.automation.specs.OnTheFlyLabler
+import eu.darken.sdmse.appcleaner.core.automation.specs.StorageEntryFinder
 import eu.darken.sdmse.appcleaner.core.automation.specs.defaultFindAndClickClearCache
 import eu.darken.sdmse.automation.core.common.getSysLocale
 import eu.darken.sdmse.automation.core.common.isClickyButton
@@ -42,7 +42,7 @@ class HuaweiSpecs @Inject constructor(
     private val ipcFunnel: IPCFunnel,
     private val deviceDetective: DeviceDetective,
     private val huaweiLabels: HuaweiLabels,
-    private val onTheFlyLabler: OnTheFlyLabler,
+    private val storageEntryFinder: StorageEntryFinder,
     private val generalSettings: GeneralSettings,
     private val stepper: Stepper,
 ) : AppCleanerSpecGenerator {
@@ -76,7 +76,7 @@ class HuaweiSpecs @Inject constructor(
                 huaweiLabels.getStorageEntryDynamic() + huaweiLabels.getStorageEntryLabels(lang, script)
             log(TAG) { "storageEntryLabels=$storageEntryLabels" }
 
-            val storageFilter = onTheFlyLabler.getAOSPStorageFilter(storageEntryLabels, pkg)
+            val storageFinder = storageEntryFinder.storageFinderAOSP(storageEntryLabels, pkg)
 
             val step = AutomationStep(
                 source = tag,
@@ -85,7 +85,7 @@ class HuaweiSpecs @Inject constructor(
                 windowLaunch = windowLauncherDefaultSettings(pkg),
                 windowCheck = windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg),
                 nodeRecovery = defaultNodeRecovery(pkg),
-                nodeAction = defaultFindAndClick(maxNesting = 7, predicate = storageFilter),
+                nodeAction = defaultFindAndClick(maxNesting = 7, finder = storageFinder),
             )
             stepper.withProgress(this) { process(this@plan, step) }
         }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/lge/LGESpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/lge/LGESpecs.kt
@@ -8,7 +8,7 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.R
 import eu.darken.sdmse.appcleaner.core.automation.specs.AppCleanerSpecGenerator
-import eu.darken.sdmse.appcleaner.core.automation.specs.OnTheFlyLabler
+import eu.darken.sdmse.appcleaner.core.automation.specs.StorageEntryFinder
 import eu.darken.sdmse.appcleaner.core.automation.specs.defaultFindAndClickClearCache
 import eu.darken.sdmse.appcleaner.core.automation.specs.huawei.HuaweiSpecs.Companion.SETTINGS_PKG
 import eu.darken.sdmse.automation.core.common.getSysLocale
@@ -43,7 +43,7 @@ class LGESpecs @Inject constructor(
     ipcFunnel: IPCFunnel,
     private val deviceDetective: DeviceDetective,
     private val lgeLabels: LGELabels,
-    private val onTheFlyLabler: OnTheFlyLabler,
+    private val storageEntryFinder: StorageEntryFinder,
     private val generalSettings: GeneralSettings,
     private val stepper: Stepper,
 ) : AppCleanerSpecGenerator {
@@ -78,7 +78,7 @@ class LGESpecs @Inject constructor(
             val storageEntryLabels = lgeLabels.getStorageEntryDynamic() + lgeLabels.getStorageEntryLabels(lang, script)
             log(TAG) { "storageEntryLabels=$storageEntryLabels" }
 
-            val storageFilter = onTheFlyLabler.getAOSPStorageFilter(storageEntryLabels, pkg)
+            val storageFinder = storageEntryFinder.storageFinderAOSP(storageEntryLabels, pkg)
 
             val step = AutomationStep(
                 source = TAG,
@@ -87,7 +87,7 @@ class LGESpecs @Inject constructor(
                 windowLaunch = windowLauncherDefaultSettings(pkg),
                 windowCheck = windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg),
                 nodeRecovery = defaultNodeRecovery(pkg),
-                nodeAction = defaultFindAndClick(predicate = storageFilter),
+                nodeAction = defaultFindAndClick(finder = storageFinder),
             )
             stepper.withProgress(this) { process(this@plan, step) }
         }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/miui/MIUISpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/miui/MIUISpecs.kt
@@ -12,7 +12,7 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.R
 import eu.darken.sdmse.appcleaner.core.automation.specs.AppCleanerSpecGenerator
-import eu.darken.sdmse.appcleaner.core.automation.specs.OnTheFlyLabler
+import eu.darken.sdmse.appcleaner.core.automation.specs.StorageEntryFinder
 import eu.darken.sdmse.appcleaner.core.automation.specs.aosp.AOSPLabels
 import eu.darken.sdmse.appcleaner.core.automation.specs.defaultFindAndClickClearCache
 import eu.darken.sdmse.automation.core.common.crawl
@@ -75,7 +75,7 @@ class MIUISpecs @Inject constructor(
     private val miuiLabels: MIUILabels,
     private val aospLabels: AOSPLabels,
     private val deviceAdminManager: DeviceAdminManager,
-    private val onTheFlyLabler: OnTheFlyLabler,
+    private val storageEntryFinder: StorageEntryFinder,
     private val generalSettings: GeneralSettings,
     private val stepper: Stepper,
 ) : AppCleanerSpecGenerator {
@@ -159,14 +159,14 @@ class MIUISpecs @Inject constructor(
             val storageEntryLabels =
                 aospLabels.getStorageEntryDynamic() + aospLabels.getStorageEntryStatic(lang, script)
 
-            val storageFilter = onTheFlyLabler.getAOSPStorageFilter(storageEntryLabels, pkg)
+            val storageFinder = storageEntryFinder.storageFinderAOSP(storageEntryLabels, pkg)
 
             val step = AutomationStep(
                 source = TAG,
                 descriptionInternal = "Storage entry (settings plan)",
                 label = R.string.appcleaner_automation_progress_find_storage.toCaString(storageEntryLabels),
                 nodeRecovery = defaultNodeRecovery(pkg),
-                nodeAction = defaultFindAndClick(predicate = storageFilter),
+                nodeAction = defaultFindAndClick(finder = storageFinder),
             )
             stepper.withProgress(this) { process(this@plan, step) }
         }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/nubia/NubiaSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/nubia/NubiaSpecs.kt
@@ -8,7 +8,7 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.R
 import eu.darken.sdmse.appcleaner.core.automation.specs.AppCleanerSpecGenerator
-import eu.darken.sdmse.appcleaner.core.automation.specs.OnTheFlyLabler
+import eu.darken.sdmse.appcleaner.core.automation.specs.StorageEntryFinder
 import eu.darken.sdmse.appcleaner.core.automation.specs.defaultFindAndClickClearCache
 import eu.darken.sdmse.automation.core.common.getSysLocale
 import eu.darken.sdmse.automation.core.common.isClickyButton
@@ -44,7 +44,7 @@ class NubiaSpecs @Inject constructor(
     private val ipcFunnel: IPCFunnel,
     private val deviceDetective: DeviceDetective,
     private val nubiaLabels: NubiaLabels,
-    private val onTheFlyLabler: OnTheFlyLabler,
+    private val storageEntryFinder: StorageEntryFinder,
     private val generalSettings: GeneralSettings,
     private val stepper: Stepper,
 ) : AppCleanerSpecGenerator {
@@ -81,7 +81,7 @@ class NubiaSpecs @Inject constructor(
                 nubiaLabels.getStorageEntryDynamic() + nubiaLabels.getStorageEntryLabels(lang, script)
             log(TAG) { "storageEntryLabels=$storageEntryLabels" }
 
-            val storageFilter = onTheFlyLabler.getAOSPStorageFilter(storageEntryLabels, pkg)
+            val storageFinder = storageEntryFinder.storageFinderAOSP(storageEntryLabels, pkg)
 
             val step = AutomationStep(
                 source = TAG,
@@ -90,7 +90,7 @@ class NubiaSpecs @Inject constructor(
                 windowLaunch = windowLauncherDefaultSettings(pkg),
                 windowCheck = windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg),
                 nodeRecovery = defaultNodeRecovery(pkg),
-                nodeAction = defaultFindAndClick(predicate = storageFilter),
+                nodeAction = defaultFindAndClick(finder = storageFinder),
             )
             stepper.withProgress(this) { process(this@plan, step) }
         }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/oneplus/OnePlusSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/oneplus/OnePlusSpecs.kt
@@ -8,7 +8,7 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.R
 import eu.darken.sdmse.appcleaner.core.automation.specs.AppCleanerSpecGenerator
-import eu.darken.sdmse.appcleaner.core.automation.specs.OnTheFlyLabler
+import eu.darken.sdmse.appcleaner.core.automation.specs.StorageEntryFinder
 import eu.darken.sdmse.appcleaner.core.automation.specs.clickClearCache
 import eu.darken.sdmse.automation.core.common.getSysLocale
 import eu.darken.sdmse.automation.core.common.isClickyButton
@@ -46,7 +46,7 @@ class OnePlusSpecs @Inject constructor(
     private val ipcFunnel: IPCFunnel,
     private val deviceDetective: DeviceDetective,
     private val onePlusLabels: OnePlusLabels,
-    private val onTheFlyLabler: OnTheFlyLabler,
+    private val storageEntryFinder: StorageEntryFinder,
     private val generalSettings: GeneralSettings,
     private val stepper: Stepper,
 ) : AppCleanerSpecGenerator {
@@ -82,7 +82,7 @@ class OnePlusSpecs @Inject constructor(
                 onePlusLabels.getStorageEntryDynamic() + onePlusLabels.getStorageEntryLabels(lang, script)
             log(TAG) { "storageEntryLabels=$storageEntryLabels" }
 
-            val storageFilter = onTheFlyLabler.getAOSPStorageFilter(storageEntryLabels, pkg)
+            val storageFinder = storageEntryFinder.storageFinderAOSP(storageEntryLabels, pkg)
 
             val step = AutomationStep(
                 source = TAG,
@@ -91,7 +91,7 @@ class OnePlusSpecs @Inject constructor(
                 windowLaunch = windowLauncherDefaultSettings(pkg),
                 windowCheck = windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg),
                 nodeRecovery = defaultNodeRecovery(pkg),
-                nodeAction = defaultFindAndClick(predicate = storageFilter),
+                nodeAction = defaultFindAndClick(finder = storageFinder),
             )
             stepper.withProgress(this) { process(this@plan, step) }
         }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/realme/RealmeSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/realme/RealmeSpecs.kt
@@ -8,7 +8,7 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.R
 import eu.darken.sdmse.appcleaner.core.automation.specs.AppCleanerSpecGenerator
-import eu.darken.sdmse.appcleaner.core.automation.specs.OnTheFlyLabler
+import eu.darken.sdmse.appcleaner.core.automation.specs.StorageEntryFinder
 import eu.darken.sdmse.appcleaner.core.automation.specs.clickClearCache
 import eu.darken.sdmse.automation.core.common.getSysLocale
 import eu.darken.sdmse.automation.core.common.isClickyButton
@@ -48,7 +48,7 @@ class RealmeSpecs @Inject constructor(
     ipcFunnel: IPCFunnel,
     private val deviceDetective: DeviceDetective,
     private val realmeLabels: RealmeLabels,
-    private val onTheFlyLabler: OnTheFlyLabler,
+    private val storageEntryFinder: StorageEntryFinder,
     private val generalSettings: GeneralSettings,
     private val stepper: Stepper,
 ) : AppCleanerSpecGenerator {
@@ -85,7 +85,7 @@ class RealmeSpecs @Inject constructor(
                 realmeLabels.getStorageEntryDynamic() + realmeLabels.getStorageEntryLabels(lang, script)
             log(TAG) { "storageEntryLabels=$storageEntryLabels" }
 
-            val storageFilter = onTheFlyLabler.getAOSPStorageFilter(storageEntryLabels, pkg)
+            val storageFinder = storageEntryFinder.storageFinderAOSP(storageEntryLabels, pkg)
 
             val step = AutomationStep(
                 source = TAG,
@@ -94,7 +94,7 @@ class RealmeSpecs @Inject constructor(
                 windowLaunch = windowLauncherDefaultSettings(pkg),
                 windowCheck = windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg),
                 nodeRecovery = defaultNodeRecovery(pkg),
-                nodeAction = defaultFindAndClick(predicate = storageFilter),
+                nodeAction = defaultFindAndClick(finder = storageFinder),
             )
             stepper.withProgress(this) { process(this@plan, step) }
         }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/samsung/SamsungSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/samsung/SamsungSpecs.kt
@@ -8,7 +8,7 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.R
 import eu.darken.sdmse.appcleaner.core.automation.specs.AppCleanerSpecGenerator
-import eu.darken.sdmse.appcleaner.core.automation.specs.OnTheFlyLabler
+import eu.darken.sdmse.appcleaner.core.automation.specs.StorageEntryFinder
 import eu.darken.sdmse.appcleaner.core.automation.specs.defaultFindAndClickClearCache
 import eu.darken.sdmse.automation.core.common.getSysLocale
 import eu.darken.sdmse.automation.core.common.isClickyButton
@@ -42,7 +42,7 @@ class SamsungSpecs @Inject constructor(
     private val ipcFunnel: IPCFunnel,
     private val deviceDetective: DeviceDetective,
     private val samsungLabels: SamsungLabels,
-    private val onTheFlyLabler: OnTheFlyLabler,
+    private val storageEntryFinder: StorageEntryFinder,
     private val generalSettings: GeneralSettings,
     private val stepper: Stepper,
 ) : AppCleanerSpecGenerator {
@@ -78,7 +78,7 @@ class SamsungSpecs @Inject constructor(
                 samsungLabels.getStorageEntryDynamic() + samsungLabels.getStorageEntryLabels(lang, script)
             log(TAG) { "storageEntryLabels=$storageEntryLabels" }
 
-            val storageFilter = onTheFlyLabler.getAOSPStorageFilter(storageEntryLabels, pkg)
+            val storageFinder = storageEntryFinder.storageFinderAOSP(storageEntryLabels, pkg)
 
             val step = AutomationStep(
                 source = TAG,
@@ -87,7 +87,7 @@ class SamsungSpecs @Inject constructor(
                 windowLaunch = windowLauncherDefaultSettings(pkg),
                 windowCheck = windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg),
                 nodeRecovery = defaultNodeRecovery(pkg),
-                nodeAction = defaultFindAndClick(predicate = storageFilter),
+                nodeAction = defaultFindAndClick(finder = storageFinder),
             )
             stepper.withProgress(this) { process(this@plan, step) }
         }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/vivo/VivoSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/vivo/VivoSpecs.kt
@@ -8,7 +8,7 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.R
 import eu.darken.sdmse.appcleaner.core.automation.specs.AppCleanerSpecGenerator
-import eu.darken.sdmse.appcleaner.core.automation.specs.OnTheFlyLabler
+import eu.darken.sdmse.appcleaner.core.automation.specs.StorageEntryFinder
 import eu.darken.sdmse.appcleaner.core.automation.specs.clickClearCache
 import eu.darken.sdmse.automation.core.common.getSysLocale
 import eu.darken.sdmse.automation.core.common.idContains
@@ -46,7 +46,7 @@ class VivoSpecs @Inject constructor(
     private val ipcFunnel: IPCFunnel,
     private val deviceDetective: DeviceDetective,
     private val vivoLabels: VivoLabels,
-    private val onTheFlyLabler: OnTheFlyLabler,
+    private val storageEntryFinder: StorageEntryFinder,
     private val generalSettings: GeneralSettings,
     private val stepper: Stepper,
 ) : AppCleanerSpecGenerator {
@@ -82,10 +82,10 @@ class VivoSpecs @Inject constructor(
                 vivoLabels.getStorageEntryDynamic() + vivoLabels.getStorageEntryStatic(lang, script)
             log(TAG) { "storageEntryLabels=$storageEntryLabels" }
 
-            val storageFilter = onTheFlyLabler.getAOSPStorageFilter(storageEntryLabels, pkg)
+            val storageFinder = storageEntryFinder.storageFinderAOSP(storageEntryLabels, pkg)
 
             val action: suspend StepContext.() -> Boolean = action@{
-                val target = findNode { storageFilter(it) } ?: return@action false
+                val target = storageFinder() ?: return@action false
                 val mapped = findClickableParent(
                     maxNesting = when {
                         hasApiLevel(29) -> 4

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/androidtv/AndroidTVSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/androidtv/AndroidTVSpecs.kt
@@ -121,12 +121,16 @@ open class AndroidTVSpecs @Inject constructor(
                 }
             }
 
-            val action = defaultFindAndClick { node ->
-                when (Bugs.isDryRun) {
-                    true -> node.textMatchesAny(cancelLbl)
-                    false -> node.textMatchesAny(okLbl)
+            val action = defaultFindAndClick(
+                finder = {
+                    findNode { node ->
+                        when (Bugs.isDryRun) {
+                            true -> node.textMatchesAny(cancelLbl)
+                            false -> node.textMatchesAny(okLbl)
+                        }
+                    }
                 }
-            }
+            )
 
             val step = AutomationStep(
                 source = TAG,

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/aosp/AOSPSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/aosp/AOSPSpecs.kt
@@ -122,12 +122,16 @@ class AOSPSpecs @Inject constructor(
                 root.crawl().map { it.node }.any { subNode -> subNode.textMatchesAny(titleLbl) }
             }
 
-            val action = defaultFindAndClick { node ->
-                when (Bugs.isDryRun) {
-                    true -> node.textMatchesAny(cancelLbl)
-                    false -> node.textMatchesAny(okLbl)
+            val action = defaultFindAndClick(
+                finder = {
+                    findNode { node ->
+                        when (Bugs.isDryRun) {
+                            true -> node.textMatchesAny(cancelLbl)
+                            false -> node.textMatchesAny(okLbl)
+                        }
+                    }
                 }
-            }
+            )
 
             val step = AutomationStep(
                 source = TAG,

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/hyperos/HyperOsSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/hyperos/HyperOsSpecs.kt
@@ -118,12 +118,16 @@ class HyperOsSpecs @Inject constructor(
                 root.crawl().map { it.node }.any { subNode -> subNode.textMatchesAny(titleLbl) }
             }
 
-            val action = defaultFindAndClick { node ->
-                when (Bugs.isDryRun) {
-                    true -> node.textMatchesAny(cancelLbl)
-                    false -> node.textMatchesAny(okLbl)
+            val action = defaultFindAndClick(
+                finder = {
+                    findNode { node ->
+                        when (Bugs.isDryRun) {
+                            true -> node.textMatchesAny(cancelLbl)
+                            false -> node.textMatchesAny(okLbl)
+                        }
+                    }
                 }
-            }
+            )
 
             val step = AutomationStep(
                 source = TAG,

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/miui/MIUISpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/miui/MIUISpecs.kt
@@ -118,12 +118,16 @@ class MIUISpecs @Inject constructor(
                 root.crawl().map { it.node }.any { subNode -> subNode.textMatchesAny(titleLbl) }
             }
 
-            val action = defaultFindAndClick { node ->
-                when (Bugs.isDryRun) {
-                    true -> node.textMatchesAny(cancelLbl)
-                    false -> node.textMatchesAny(okLbl)
+            val action = defaultFindAndClick(
+                finder = {
+                    findNode { node ->
+                        when (Bugs.isDryRun) {
+                            true -> node.textMatchesAny(cancelLbl)
+                            false -> node.textMatchesAny(okLbl)
+                        }
+                    }
                 }
-            }
+            )
 
             val step = AutomationStep(
                 source = TAG,

--- a/app/src/main/java/eu/darken/sdmse/automation/core/debug/DebugTaskModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/debug/DebugTaskModule.kt
@@ -65,6 +65,31 @@ class DebugTaskModule @AssistedInject constructor(
                 crawled.forEach { log(TAG, VERBOSE) { it.infoShort } }
                 updateProgressSecondary("Event: ${it.eventType} (depth: ${crawled.last().level})")
             }
+            .onEach {
+//                host.waitForWindowRoot().crawl()
+//                    .map { it.node }
+//                    .filter { it.textContainsAny(listOf("Storage")) }
+//                    .forEach { node ->
+//                        fun AccessibilityNodeInfo.getPanePosition(
+//                            margin: Int = 50
+//                        ): String {
+//                            val metrics = service.resources.displayMetrics
+//                            val screenMidX = metrics.widthPixels / 2
+//
+//                            val nodeBounds = Rect()
+//                            getBoundsInScreen(nodeBounds)
+//
+//                            return when {
+//                                nodeBounds.right < screenMidX - margin -> "left"
+//                                nodeBounds.left > screenMidX + margin -> "right"
+//                                else -> "full"
+//                            }
+//                        }
+//
+//                        val paneInfo = node.getPanePosition()
+//                        log(TAG) { "ACS-DEBUG: ${node.text} is $paneInfo" }
+//                    }
+            }
             .launchIn(moduleScope)
 
         eventJob.join()

--- a/app/src/main/java/eu/darken/sdmse/automation/core/specs/SpecGeneratorExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/specs/SpecGeneratorExtensions.kt
@@ -12,7 +12,6 @@ import eu.darken.sdmse.automation.core.common.scrollNode
 import eu.darken.sdmse.automation.core.common.stepper.StepContext
 import eu.darken.sdmse.automation.core.common.stepper.clickNormal
 import eu.darken.sdmse.automation.core.common.stepper.findClickableParent
-import eu.darken.sdmse.automation.core.common.stepper.findNode
 import eu.darken.sdmse.automation.core.common.textMatchesAny
 import eu.darken.sdmse.automation.core.errors.PlanAbortException
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
@@ -125,9 +124,9 @@ suspend fun SpecGenerator.checkAppIdentifier(
 fun SpecGenerator.defaultFindAndClick(
     isDryRun: Boolean = false,
     maxNesting: Int = 6,
-    predicate: suspend (AccessibilityNodeInfo) -> Boolean,
+    finder: suspend StepContext.() -> AccessibilityNodeInfo?,
 ): suspend StepContext.() -> Boolean = action@{
-    val target = findNode { predicate(it) } ?: return@action false
+    val target = finder(this) ?: return@action false
     val mapped = findClickableParent(maxNesting = maxNesting, node = target) ?: return@action false
     clickNormal(isDryRun = isDryRun, mapped)
 }


### PR DESCRIPTION
Previously we just went with the first "Storage" entry we found, but sometimes there are more, and the first one is not the one we want. This is the case on tablets or large screen devices, where the settings UI uses a "double pane" layout. Here the left pane will also contain a "Storage" entry that takes us to the whole devices storage overview.

Fixes #1720