### PR TITLE
ACS: Increase delay after changing overlay options

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/automation/core/AutomationService.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/AutomationService.kt
@@ -291,7 +291,7 @@ class AutomationService : AccessibilityService(), AutomationHost, Progress.Host,
             updateOverlay(visible = newOptions.showOverlay, passthrough = newOptions.passthrough)
         }
 
-        delay(80) // approx ~3 frames
+        delay(200)
         log(TAG, VERBOSE) { "changeOptions(): Updating new hostState" }
         currentOptions = newOptions
         hostState.update {


### PR DESCRIPTION
Some Xiaomi devices with HyperOS2 are still getting stuck at the manual gesture to click the Clear cache button. This is my best guess, the delay is not long enough. The system UI has not adapted to the new options yet and the click is not going through.