### PR TITLE
Setup: Ask for MANAGE_EXTERNAL_STORAGE on AndroidTVs running Android 13+.

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/setup/storage/StorageSetupModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/storage/StorageSetupModule.kt
@@ -73,12 +73,27 @@ class StorageSetupModule @Inject constructor(
         .onStart { emit(Loading()) }
         .replayingShare(appScope)
 
-    private fun getRequiredPermission(): Set<Permission> {
-        return when {
-            hasApiLevel(30) && deviceDetective.getROMType() != RomType.ANDROID_TV -> setOf(Permission.MANAGE_EXTERNAL_STORAGE)
+    private fun getRequiredPermission(): Set<Permission> = when {
+        deviceDetective.getROMType() == RomType.ANDROID_TV -> when {
+            hasApiLevel(33) -> setOf(
+                @Suppress("NewApi")
+                Permission.MANAGE_EXTERNAL_STORAGE,
+            )
+
             else -> setOf(
                 Permission.WRITE_EXTERNAL_STORAGE,
-                Permission.READ_EXTERNAL_STORAGE
+                Permission.READ_EXTERNAL_STORAGE,
+            )
+        }
+
+        else -> when {
+            hasApiLevel(30) -> setOf(
+                @Suppress("NewApi")
+                Permission.MANAGE_EXTERNAL_STORAGE,
+            )
+            else -> setOf(
+                Permission.WRITE_EXTERNAL_STORAGE,
+                Permission.READ_EXTERNAL_STORAGE,
             )
         }
     }


### PR DESCRIPTION
Tested this on an emulator. Since Android 13 (API33), AndroidTV also needs to request `MANAGE_EXTERNAL_STORAGE`. This is a bit later than on phones where we needed that since Android 11 (API30).

Could already be manually granted via settings, but now the setup card takes the user to the right menu.