### PR TITLE
AppCleaner: Detect if `com.miui.securitycenter` is missing the `GET_USAGE_STATS` permission

### DIFF
--- a/app-common/src/main/java/eu/darken/sdmse/common/error/LocalizedError.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/error/LocalizedError.kt
@@ -17,6 +17,7 @@ data class LocalizedError(
     val description: CaString,
     val fixActionLabel: CaString? = null,
     val fixAction: ((Activity) -> Unit)? = null,
+    val infoActionLabel: CaString? = null,
     val infoAction: ((Activity) -> Unit)? = null,
 ) {
     fun asText() = caString { "${label.get(it)}:\n${description.get(it)}" }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
@@ -34,8 +34,8 @@ import eu.darken.sdmse.automation.core.AutomationTask
 import eu.darken.sdmse.automation.core.animation.AnimationState
 import eu.darken.sdmse.automation.core.animation.AnimationTool
 import eu.darken.sdmse.automation.core.errors.AutomationCompatibilityException
+import eu.darken.sdmse.automation.core.errors.InvalidSystemStateException
 import eu.darken.sdmse.automation.core.errors.PlanAbortException
-import eu.darken.sdmse.automation.core.errors.ScreenUnavailableException
 import eu.darken.sdmse.automation.core.errors.UserCancelledAutomationException
 import eu.darken.sdmse.automation.core.finishAutomation
 import eu.darken.sdmse.automation.core.specs.AutomationExplorer
@@ -217,9 +217,8 @@ class ClearCacheModule @AssistedInject constructor(
                 log(TAG, INFO) { "Successfully cleared cache for for $target" }
                 task.onSuccess(target)
                 successful.add(target)
-            } catch (e: ScreenUnavailableException) {
-                log(TAG, WARN) { "Cancelled because screen become unavailable: ${e.asLog()}" }
-                // TODO We don't have to abort here, but this is not a normal state and should show an error?
+            } catch (e: InvalidSystemStateException) {
+                log(TAG, WARN) { "Invalid system state for ACS based cache deletion: ${e.asLog()}" }
                 throw e
             } catch (e: TimeoutCancellationException) {
                 log(TAG, WARN) { "Timeout while processing $installed" }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/hyperos/SecurityCenterMissingPermissionException.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/hyperos/SecurityCenterMissingPermissionException.kt
@@ -1,0 +1,41 @@
+package eu.darken.sdmse.appcleaner.core.automation.specs.hyperos
+
+import android.content.Intent
+import android.net.Uri
+import android.provider.Settings
+import eu.darken.sdmse.R
+import eu.darken.sdmse.automation.core.errors.InvalidSystemStateException
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.debug.logging.asLog
+import eu.darken.sdmse.common.error.HasLocalizedError
+import eu.darken.sdmse.common.error.LocalizedError
+
+class SecurityCenterMissingPermissionException(
+    message: String = "App `com.miui.securitycenter` is missing the GET_USAGE_STATS permission."
+) : InvalidSystemStateException(message), HasLocalizedError {
+    override fun getLocalizedError() = LocalizedError(
+        throwable = this,
+        label = R.string.appcleaner_automation_error_securitycenter_permission_title.toCaString(),
+        description = R.string.appcleaner_automation_error_securitycenter_permission_body.toCaString(),
+        fixActionLabel = eu.darken.sdmse.common.R.string.general_grant_access_action.toCaString(),
+        fixAction = {
+            try {
+                it.startActivity(Intent(Settings.ACTION_USAGE_ACCESS_SETTINGS))
+            } catch (e: Exception) {
+                e.asLog()
+            }
+        },
+        infoActionLabel = eu.darken.sdmse.common.R.string.general_help_action.toCaString(),
+        infoAction = {
+            try {
+                val url = Uri.parse("https://github.com/d4rken-org/sdmaid-se/wiki/AppCleaner#commiuisecuritycenter")
+                val intent = Intent(Intent.ACTION_VIEW, url).apply {
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+                it.startActivity(intent)
+            } catch (e: Exception) {
+                e.asLog()
+            }
+        }
+    )
+}

--- a/app/src/main/java/eu/darken/sdmse/automation/core/errors/InvalidSystemStateException.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/errors/InvalidSystemStateException.kt
@@ -1,0 +1,5 @@
+package eu.darken.sdmse.automation.core.errors
+
+open class InvalidSystemStateException(
+    message: String,
+) : PlanAbortException(message)

--- a/app/src/main/java/eu/darken/sdmse/automation/core/errors/ScreenUnavailableException.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/errors/ScreenUnavailableException.kt
@@ -7,7 +7,7 @@ import eu.darken.sdmse.common.error.LocalizedError
 
 class ScreenUnavailableException(
     message: String,
-) : PlanAbortException(message), HasLocalizedError {
+) : InvalidSystemStateException(message), HasLocalizedError {
     override fun getLocalizedError() = LocalizedError(
         throwable = this,
         label = R.string.automation_error_screen_unavailable_title.toCaString(),

--- a/app/src/main/java/eu/darken/sdmse/common/error/ErrorDialog.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/error/ErrorDialog.kt
@@ -54,7 +54,10 @@ fun Throwable.asErrorDialogBuilder(
 
         when {
             localizedError.infoAction != null -> {
-                setNeutralButton(R.string.general_show_details_action) { _, _ ->
+                setNeutralButton(
+                    localizedError.infoActionLabel?.get(context)
+                        ?: context.getString(R.string.general_show_details_action)
+                ) { _, _ ->
                     localizedError.infoAction!!.invoke(context)
                 }
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -436,6 +436,8 @@
     <string name="appcleaner_automation_error_locked_appcache_body">The system has disabled the "Clear cache" button for this app. Create an exclusion for this app.</string>
     <string name="appcleaner_automation_error_no_settings_title">Settings screen unavailable</string>
     <string name="appcleaner_automation_error_no_settings_body">This system app has no settings screen. Cache clearing via accessibility service is not possible. Create an exclusion for this app.</string>
+    <string name="appcleaner_automation_error_securitycenter_permission_title">System app misconfigured</string>
+    <string name="appcleaner_automation_error_securitycenter_permission_body">HyperOS\'s Security app (com.miui.securitycenter) is missing the Usage Stats permission (GET_USAGE_STATS). This breaks features like "Clear Data" in app details and cache clearing via accessibility. Grant the permission to restore full functionality.</string>
 
     <string name="deduplicator_tool_name">Deduplicator</string>
     <string name="deduplicator_explanation_short">Find duplicate data on your device.</string>


### PR DESCRIPTION
No idea how this happens but have seen this in a few reports now.

For some reason, on some devices, the security center app is missing that permission, which causes the `Clear data` button to be disabled, and thus ACS based cache clearing fails.

This change tries to detect that circumstance and shows an error dialog explaining it.