### PR TITLE
AppControl: ROM Type refactoring (OneUI)

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/AppControlAutomation.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/AppControlAutomation.kt
@@ -17,7 +17,7 @@ import eu.darken.sdmse.appcontrol.core.automation.specs.androidtv.AndroidTVSpecs
 import eu.darken.sdmse.appcontrol.core.automation.specs.aosp.AOSPSpecs
 import eu.darken.sdmse.appcontrol.core.automation.specs.hyperos.HyperOsSpecs
 import eu.darken.sdmse.appcontrol.core.automation.specs.miui.MIUISpecs
-import eu.darken.sdmse.appcontrol.core.automation.specs.samsung.SamsungSpecs
+import eu.darken.sdmse.appcontrol.core.automation.specs.oneui.OneUISpecs
 import eu.darken.sdmse.appcontrol.core.forcestop.ForceStopAutomationTask
 import eu.darken.sdmse.automation.core.AutomationHost
 import eu.darken.sdmse.automation.core.AutomationModule
@@ -71,7 +71,7 @@ class AppControlAutomation @AssistedInject constructor(
             when (generator) {
                 is MIUISpecs -> 190
                 is HyperOsSpecs -> 180
-                is SamsungSpecs -> 170
+                is OneUISpecs -> 170
 //                is AlcatelSpecs -> 160
 //                is RealmeSpecs -> 150
 //                is HuaweiSpecs -> 140
@@ -148,7 +148,7 @@ class AppControlAutomation @AssistedInject constructor(
                 log(TAG, WARN) { "Cancelled because screen become unavailable: ${e.asLog()}" }
                 // TODO We don't have to abort here, but this is not a normal state and should show an error?
                 throw e
-            } catch (e: TimeoutCancellationException) {
+            } catch (_: TimeoutCancellationException) {
                 log(TAG, WARN) { "Timeout while processing $installed" }
                 failed.add(target)
             } catch (e: CancellationException) {

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/oneui/OneUILabels.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/oneui/OneUILabels.kt
@@ -1,4 +1,4 @@
-package eu.darken.sdmse.appcontrol.core.automation.specs.samsung
+package eu.darken.sdmse.appcontrol.core.automation.specs.oneui
 
 import dagger.Reusable
 import eu.darken.sdmse.appcontrol.core.automation.specs.AppControlLabelSource
@@ -8,7 +8,7 @@ import eu.darken.sdmse.common.debug.logging.logTag
 import javax.inject.Inject
 
 @Reusable
-open class SamsungLabels @Inject constructor() : AppControlLabelSource {
+open class OneUILabels @Inject constructor() : AppControlLabelSource {
     fun getForceStopButtonDynamic(
         acsContext: AutomationExplorer.Context
     ): Set<String> = acsContext.getStrings(AOSPLabels.SETTINGS_PKG, setOf("force_stop"))

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/oneui/OneUISpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/oneui/OneUISpecs.kt
@@ -1,4 +1,4 @@
-package eu.darken.sdmse.appcontrol.core.automation.specs.samsung
+package eu.darken.sdmse.appcontrol.core.automation.specs.oneui
 
 import dagger.Binds
 import dagger.Module
@@ -40,10 +40,10 @@ import eu.darken.sdmse.main.core.GeneralSettings
 import javax.inject.Inject
 
 @Reusable
-class SamsungSpecs @Inject constructor(
+class OneUISpecs @Inject constructor(
     private val ipcFunnel: IPCFunnel,
     private val deviceDetective: DeviceDetective,
-    private val samsungLabels: SamsungLabels,
+    private val oneUILabels: OneUILabels,
     private val generalSettings: GeneralSettings,
     private val stepper: Stepper,
 ) : AppControlSpecGenerator {
@@ -68,7 +68,7 @@ class SamsungSpecs @Inject constructor(
     private val mainPlan: suspend AutomationExplorer.Context.(Installed) -> Unit = plan@{ pkg ->
         log(TAG, INFO) { "Executing plan for ${pkg.installId} with context $this" }
 
-        val forceStopLabels = samsungLabels.getForceStopButtonDynamic(this)
+        val forceStopLabels = oneUILabels.getForceStopButtonDynamic(this)
         var wasDisabled = false
 
         run {
@@ -101,9 +101,9 @@ class SamsungSpecs @Inject constructor(
         }
 
         run {
-            val titleLbl = samsungLabels.getForceStopDialogTitleDynamic(this) + forceStopLabels.map { "$it?" }
-            val okLbl = samsungLabels.getForceStopDialogOkDynamic(this)
-            val cancelLbl = samsungLabels.getForceStopDialogCancelDynamic(this)
+            val titleLbl = oneUILabels.getForceStopDialogTitleDynamic(this) + forceStopLabels.map { "$it?" }
+            val okLbl = oneUILabels.getForceStopDialogOkDynamic(this)
+            val cancelLbl = oneUILabels.getForceStopDialogCancelDynamic(this)
 
             val windowCheck = windowCheck { _, root ->
                 if (root.pkgId != SETTINGS_PKG) return@windowCheck false
@@ -134,7 +134,7 @@ class SamsungSpecs @Inject constructor(
 
     @Module @InstallIn(SingletonComponent::class)
     abstract class DIM {
-        @Binds @IntoSet abstract fun mod(mod: SamsungSpecs): AppControlSpecGenerator
+        @Binds @IntoSet abstract fun mod(mod: OneUISpecs): AppControlSpecGenerator
     }
 
     companion object {


### PR DESCRIPTION
Initial structure was too much based on the manufacturer, and not on the actual ROM type, which can differ for the same manufacturer. Some are already split (MIUI/HyperOS), for others we need to split them in the future, when the next issue comes up (VIVO: FuntouchOS/OriginOS)

Renamed Samsung specific code to OneUI, as future Samsung AOSP ROMs might exist.