### PR TITLE
AppCleaner: Improve window label search, handling of different locales and ZWSP

### DIFF
--- a/app-common/src/main/java/eu/darken/sdmse/common/debug/DebugExtensions.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/debug/DebugExtensions.kt
@@ -7,3 +7,14 @@ import eu.darken.sdmse.common.error.getStackTraceString
 inline fun traceCall() = CallTrace().getStackTraceString()
 
 class CallTrace : Throwable()
+
+fun CharSequence.toVisualString(): String = map { c ->
+    when {
+        c.isLetterOrDigit() -> c.toString()
+        c.isWhitespace() -> c.toString()
+        c in '!'..'~' -> c.toString()
+        else -> "\\u%04x".format(c.code)
+    }
+}.joinToString("")
+
+fun Collection<String>.toVisualStrings(): Collection<String> = map { it.toVisualString() }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/LabelDebugger.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/LabelDebugger.kt
@@ -6,6 +6,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.sdmse.automation.core.common.AutomationLabelSource
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.debug.toVisualString
 import eu.darken.sdmse.common.device.DeviceDetective
 import eu.darken.sdmse.common.isInstalled
 import eu.darken.sdmse.common.locale.toList
@@ -27,7 +28,7 @@ class LabelDebugger @Inject constructor(
                 Resources.getSystem().configuration.locales.toList().forEach { locale ->
                     ALL_RES_IDS.forEach { resId ->
                         val label = context.get3rdPartyString(pkgId, resId, locale)
-                        log(TAG) { "$pkgId: '$resId' -> '$label'" }
+                        log(TAG) { "$pkgId: '$resId' -> '${label?.toVisualString()}'" }
                     }
                 }
             }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/alcatel/AlcatelSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/alcatel/AlcatelSpecs.kt
@@ -26,6 +26,7 @@ import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.debug.toVisualStrings
 import eu.darken.sdmse.common.device.DeviceDetective
 import eu.darken.sdmse.common.device.RomType
 import eu.darken.sdmse.common.funnel.IPCFunnel
@@ -72,7 +73,7 @@ class AlcatelSpecs @Inject constructor(
         run {
             val storageEntryLabels =
                 alcatelLabels.getStorageEntryDynamic(this) + alcatelLabels.getStorageEntryStatic(this)
-            log(TAG) { "storageEntryLabels=$storageEntryLabels" }
+            log(TAG) { "storageEntryLabels=${storageEntryLabels.toVisualStrings()}" }
 
             val storageFinder = storageEntryFinder.storageFinderAOSP(storageEntryLabels, pkg)
 
@@ -91,7 +92,7 @@ class AlcatelSpecs @Inject constructor(
         run {
             val clearCacheButtonLabels =
                 alcatelLabels.getClearCacheDynamic(this) + alcatelLabels.getClearCacheStatic(this)
-            log(TAG) { "clearCacheButtonLabels=$clearCacheButtonLabels" }
+            log(TAG) { "clearCacheButtonLabels=${clearCacheButtonLabels.toVisualStrings()}" }
 
             val step = AutomationStep(
                 source = tag,

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/androidtv/AndroidTVSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/androidtv/AndroidTVSpecs.kt
@@ -34,6 +34,7 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.debug.toVisualStrings
 import eu.darken.sdmse.common.device.DeviceDetective
 import eu.darken.sdmse.common.device.RomType
 import eu.darken.sdmse.common.funnel.IPCFunnel
@@ -75,7 +76,7 @@ open class AndroidTVSpecs @Inject constructor(
 
         run {
             val clearCacheButtonLabels = androidTVLabels.getClearCacheLabels(this)
-            log(TAG) { "clearCacheButtonLabels=$clearCacheButtonLabels" }
+            log(TAG) { "clearCacheButtonLabels=${clearCacheButtonLabels.toVisualStrings()}" }
 
             if (clearCacheButtonLabels.isEmpty()) {
                 log(TAG, WARN) { "clearCacheButtonLabels was empty" }
@@ -105,7 +106,7 @@ open class AndroidTVSpecs @Inject constructor(
 
         run {
             val clearCacheTexts = androidTVLabels.getClearCacheLabels(this)
-            log(TAG) { "clearCacheTexts=$clearCacheTexts" }
+            log(TAG) { "clearCacheTexts=${clearCacheTexts.toVisualStrings()}" }
 
             val windowCheck = windowCheck { _, root ->
                 if (root.pkgId != SETTINGS_PKG) return@windowCheck false

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecs.kt
@@ -26,6 +26,7 @@ import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.debug.toVisualStrings
 import eu.darken.sdmse.common.device.DeviceDetective
 import eu.darken.sdmse.common.device.RomType
 import eu.darken.sdmse.common.funnel.IPCFunnel
@@ -68,7 +69,7 @@ class AOSPSpecs @Inject constructor(
         run {
             val storageEntryLabels =
                 aospLabels.getStorageEntryDynamic(this) + aospLabels.getStorageEntryStatic(this)
-            log(TAG) { "storageEntryLabels=$storageEntryLabels" }
+            log(TAG) { "storageEntryLabels=${storageEntryLabels.toVisualStrings()}" }
 
             val storageFinder = storageEntryFinder.storageFinderAOSP(storageEntryLabels, pkg)
 
@@ -87,7 +88,7 @@ class AOSPSpecs @Inject constructor(
         run {
             val clearCacheButtonLabels =
                 aospLabels.getClearCacheDynamic(this) + aospLabels.getClearCacheStatic(this)
-            log(TAG) { "clearCacheButtonLabels=$clearCacheButtonLabels" }
+            log(TAG) { "clearCacheButtonLabels=${clearCacheButtonLabels.toVisualStrings()}" }
 
             val step = AutomationStep(
                 source = tag,

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/coloros/ColorOSSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/coloros/ColorOSSpecs.kt
@@ -34,6 +34,7 @@ import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.debug.toVisualStrings
 import eu.darken.sdmse.common.device.DeviceDetective
 import eu.darken.sdmse.common.device.RomType
 import eu.darken.sdmse.common.funnel.IPCFunnel
@@ -90,7 +91,7 @@ class ColorOSSpecs @Inject constructor(
 
             val storageEntryLabels =
                 colorOSLabels.getStorageEntryDynamic(this) + colorOSLabels.getStorageEntryLabels(this)
-            log(TAG) { "storageEntryLabels=$storageEntryLabels" }
+            log(TAG) { "storageEntryLabels=${storageEntryLabels.toVisualStrings()}" }
 
             val storageFinder = storageEntryFinder.storageFinderAOSP(storageEntryLabels, pkg)
 
@@ -110,7 +111,7 @@ class ColorOSSpecs @Inject constructor(
         run {
             val clearCacheButtonLabels =
                 colorOSLabels.getClearCacheDynamic(this) + colorOSLabels.getClearCacheLabels(this)
-            log(TAG) { "clearCacheButtonLabels=$clearCacheButtonLabels" }
+            log(TAG) { "clearCacheButtonLabels=${clearCacheButtonLabels.toVisualStrings()}" }
 
             val windowCheck = windowCheck { _, root ->
                 if (root.pkgId != SETTINGS_PKG) return@windowCheck false

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/flyme/FlymeSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/flyme/FlymeSpecs.kt
@@ -25,6 +25,7 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.debug.toVisualStrings
 import eu.darken.sdmse.common.device.DeviceDetective
 import eu.darken.sdmse.common.device.RomType
 import eu.darken.sdmse.common.funnel.IPCFunnel
@@ -69,7 +70,7 @@ class FlymeSpecs @Inject constructor(
             // Do this beforehand so we crash early if unsupported
             val clearCacheButtonLabels =
                 flymeLabels.getClearCacheDynamic(this) + flymeLabels.getClearCacheLabels(this)
-            log(TAG) { "clearCacheButtonLabels=$clearCacheButtonLabels" }
+            log(TAG) { "clearCacheButtonLabels=${clearCacheButtonLabels.toVisualStrings()}" }
 
             if (clearCacheButtonLabels.isNotEmpty()) {
                 log(TAG, WARN) { "clearCacheButtonLabels was empty" }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/honor/HonorSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/honor/HonorSpecs.kt
@@ -26,6 +26,7 @@ import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.debug.toVisualStrings
 import eu.darken.sdmse.common.device.DeviceDetective
 import eu.darken.sdmse.common.device.RomType
 import eu.darken.sdmse.common.funnel.IPCFunnel
@@ -68,7 +69,7 @@ class HonorSpecs @Inject constructor(
         run {
             val storageEntryLabels =
                 honorLabels.getStorageEntryDynamic(this) + honorLabels.getStorageEntryStatic(this)
-            log(TAG) { "storageEntryLabels=$storageEntryLabels" }
+            log(TAG) { "storageEntryLabels=${storageEntryLabels.toVisualStrings()}" }
 
             val storageFinder = storageEntryFinder.storageFinderAOSP(storageEntryLabels, pkg)
 
@@ -87,7 +88,7 @@ class HonorSpecs @Inject constructor(
         run {
             val clearCacheButtonLabels =
                 honorLabels.getClearCacheDynamic(this) + honorLabels.getClearCacheStatic(this)
-            log(TAG) { "clearCacheButtonLabels=$clearCacheButtonLabels" }
+            log(TAG) { "clearCacheButtonLabels=${clearCacheButtonLabels.toVisualStrings()}" }
 
             val step = AutomationStep(
                 source = tag,

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/huawei/HuaweiSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/huawei/HuaweiSpecs.kt
@@ -26,6 +26,7 @@ import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.debug.toVisualStrings
 import eu.darken.sdmse.common.device.DeviceDetective
 import eu.darken.sdmse.common.device.RomType
 import eu.darken.sdmse.common.funnel.IPCFunnel
@@ -69,7 +70,7 @@ class HuaweiSpecs @Inject constructor(
         run {
             val storageEntryLabels =
                 huaweiLabels.getStorageEntryDynamic(this) + huaweiLabels.getStorageEntryLabels(this)
-            log(TAG) { "storageEntryLabels=$storageEntryLabels" }
+            log(TAG) { "storageEntryLabels=${storageEntryLabels.toVisualStrings()}" }
 
             val storageFinder = storageEntryFinder.storageFinderAOSP(storageEntryLabels, pkg)
 
@@ -88,7 +89,7 @@ class HuaweiSpecs @Inject constructor(
         run {
             val clearCacheButtonLabels =
                 huaweiLabels.getClearCacheDynamic(this) + huaweiLabels.getClearCacheLabels(this)
-            log(TAG) { "clearCacheButtonLabels=$clearCacheButtonLabels" }
+            log(TAG) { "clearCacheButtonLabels=${clearCacheButtonLabels.toVisualStrings()}" }
 
             val step = AutomationStep(
                 source = tag,

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/hyperos/HyperOsSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/hyperos/HyperOsSpecs.kt
@@ -57,6 +57,7 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.debug.toVisualStrings
 import eu.darken.sdmse.common.device.DeviceDetective
 import eu.darken.sdmse.common.device.RomType
 import eu.darken.sdmse.common.deviceadmin.DeviceAdminManager
@@ -211,13 +212,13 @@ class HyperOsSpecs @Inject constructor(
         log(TAG, INFO) { "Executing MIUI security center plan for ${pkg.installId} with context $this" }
 
         val clearDataLabels = hyperOsLabels.getClearDataButtonLabels(this)
-        log(TAG) { "clearDataLabels=$clearDataLabels" }
+        log(TAG) { "clearDataLabels=${clearDataLabels.toVisualStrings()}" }
         val clearCacheLabels = hyperOsLabels.getClearCacheButtonLabels(this)
-        log(TAG) { "clearCacheLabels=$clearCacheLabels" }
+        log(TAG) { "clearCacheLabels=${clearCacheLabels.toVisualStrings()}" }
         val dialogTitles = hyperOsLabels.getDialogTitles(this)
-        log(TAG) { "clearCacheLabels=$clearCacheLabels" }
+        log(TAG) { "clearCacheLabels=${clearCacheLabels.toVisualStrings()}" }
         val manageSpaceLabels = hyperOsLabels.getManageSpaceButtonLabels(this)
-        log(TAG) { "manageSpaceLabels=$manageSpaceLabels" }
+        log(TAG) { "manageSpaceLabels=${manageSpaceLabels.toVisualStrings()}" }
 
         var useAlternativeStep = deviceAdminManager.getDeviceAdmins().contains(pkg.id).also {
             if (it) log(TAG) { "${pkg.id} is a device admin, using alternative step directly." }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/miui/MIUISpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/miui/MIUISpecs.kt
@@ -47,6 +47,7 @@ import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.debug.toVisualStrings
 import eu.darken.sdmse.common.device.DeviceDetective
 import eu.darken.sdmse.common.device.RomType
 import eu.darken.sdmse.common.deviceadmin.DeviceAdminManager
@@ -186,11 +187,11 @@ class MIUISpecs @Inject constructor(
 
 
         val clearDataLabels = miuiLabels.getClearDataButtonLabels(this)
-        log(TAG) { "clearDataLabels=$clearDataLabels" }
+        log(TAG) { "clearDataLabels=${clearDataLabels.toVisualStrings()}" }
         val clearCacheLabels = miuiLabels.getClearCacheButtonLabels(this)
-        log(TAG) { "clearCacheLabels=$clearCacheLabels" }
+        log(TAG) { "clearCacheLabels=${clearCacheLabels.toVisualStrings()}" }
         val dialogTitles = miuiLabels.getDialogTitles(this)
-        log(TAG) { "clearCacheLabels=$clearCacheLabels" }
+        log(TAG) { "clearCacheLabels=${clearCacheLabels.toVisualStrings()}" }
 
         var useAlternativeStep = deviceAdminManager.getDeviceAdmins().contains(pkg.id).also {
             if (it) log(TAG) { "${pkg.id} is a device admin, using alternative step directly." }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/nubia/NubiaSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/nubia/NubiaSpecs.kt
@@ -26,6 +26,7 @@ import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.debug.toVisualStrings
 import eu.darken.sdmse.common.device.DeviceDetective
 import eu.darken.sdmse.common.device.RomType
 import eu.darken.sdmse.common.funnel.IPCFunnel
@@ -72,7 +73,7 @@ class NubiaSpecs @Inject constructor(
         run {
             val storageEntryLabels =
                 nubiaLabels.getStorageEntryDynamic(this) + nubiaLabels.getStorageEntryLabels(this)
-            log(TAG) { "storageEntryLabels=$storageEntryLabels" }
+            log(TAG) { "storageEntryLabels=${storageEntryLabels.toVisualStrings()}" }
 
             val storageFinder = storageEntryFinder.storageFinderAOSP(storageEntryLabels, pkg)
 
@@ -91,7 +92,7 @@ class NubiaSpecs @Inject constructor(
         run {
             val clearCacheButtonLabels =
                 nubiaLabels.getClearCacheDynamic(this) + nubiaLabels.getClearCacheLabels(this)
-            log(TAG) { "clearCacheButtonLabels=$clearCacheButtonLabels" }
+            log(TAG) { "clearCacheButtonLabels=${clearCacheButtonLabels.toVisualStrings()}" }
 
             val step = AutomationStep(
                 source = TAG,

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/oneui/OneUISpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/oneui/OneUISpecs.kt
@@ -26,6 +26,7 @@ import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.debug.toVisualStrings
 import eu.darken.sdmse.common.device.DeviceDetective
 import eu.darken.sdmse.common.device.RomType
 import eu.darken.sdmse.common.funnel.IPCFunnel
@@ -68,7 +69,7 @@ class OneUISpecs @Inject constructor(
         run {
             val storageEntryLabels =
                 oneUILabels.getStorageEntryDynamic(this) + oneUILabels.getStorageEntryLabels(this)
-            log(TAG) { "storageEntryLabels=$storageEntryLabels" }
+            log(TAG) { "storageEntryLabels=${storageEntryLabels.toVisualStrings()}" }
 
             val storageFinder = storageEntryFinder.storageFinderAOSP(storageEntryLabels, pkg)
 
@@ -87,7 +88,7 @@ class OneUISpecs @Inject constructor(
         run {
             val clearCacheButtonLabels =
                 oneUILabels.getClearCacheDynamic(this) + oneUILabels.getClearCacheLabels(this)
-            log(TAG) { "clearCacheButtonLabels=$clearCacheButtonLabels" }
+            log(TAG) { "clearCacheButtonLabels=${clearCacheButtonLabels.toVisualStrings()}" }
 
             val step = AutomationStep(
                 source = TAG,

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/oxygenos/OxygenOSSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/oxygenos/OxygenOSSpecs.kt
@@ -29,6 +29,7 @@ import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.debug.toVisualStrings
 import eu.darken.sdmse.common.device.DeviceDetective
 import eu.darken.sdmse.common.device.RomType
 import eu.darken.sdmse.common.funnel.IPCFunnel
@@ -72,7 +73,7 @@ class OxygenOSSpecs @Inject constructor(
         run {
             val storageEntryLabels =
                 oxygenOSLabels.getStorageEntryDynamic(this) + oxygenOSLabels.getStorageEntryLabels(this)
-            log(TAG) { "storageEntryLabels=$storageEntryLabels" }
+            log(TAG) { "storageEntryLabels=${storageEntryLabels.toVisualStrings()}" }
 
             val storageFinder = storageEntryFinder.storageFinderAOSP(storageEntryLabels, pkg)
 
@@ -91,7 +92,7 @@ class OxygenOSSpecs @Inject constructor(
         run {
             val clearCacheButtonLabels =
                 oxygenOSLabels.getClearCacheDynamic(this) + oxygenOSLabels.getClearCacheStatic(this)
-            log(TAG) { "clearCacheButtonLabels=$clearCacheButtonLabels" }
+            log(TAG) { "clearCacheButtonLabels=${clearCacheButtonLabels.toVisualStrings()}" }
 
             val action: suspend StepContext.() -> Boolean = action@{
                 var isUnclickableButton = false

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/realme/RealmeSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/realme/RealmeSpecs.kt
@@ -31,6 +31,7 @@ import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.debug.toVisualStrings
 import eu.darken.sdmse.common.device.DeviceDetective
 import eu.darken.sdmse.common.device.RomType
 import eu.darken.sdmse.common.funnel.IPCFunnel
@@ -75,7 +76,7 @@ class RealmeSpecs @Inject constructor(
         run {
             val storageEntryLabels =
                 realmeLabels.getStorageEntryDynamic(this) + realmeLabels.getStorageEntryLabels(this)
-            log(TAG) { "storageEntryLabels=$storageEntryLabels" }
+            log(TAG) { "storageEntryLabels=${storageEntryLabels.toVisualStrings()}" }
 
             val storageFinder = storageEntryFinder.storageFinderAOSP(storageEntryLabels, pkg)
 
@@ -94,7 +95,7 @@ class RealmeSpecs @Inject constructor(
         run {
             val clearCacheButtonLabels =
                 realmeLabels.getClearCacheDynamic(this) + realmeLabels.getClearCacheLabels(this)
-            log(TAG) { "clearCacheButtonLabels=$clearCacheButtonLabels" }
+            log(TAG) { "clearCacheButtonLabels=${clearCacheButtonLabels.toVisualStrings()}" }
 
             val action: suspend StepContext.() -> Boolean = action@{
                 var isUnclickableButton = false

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/vivo/VivoSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/vivo/VivoSpecs.kt
@@ -29,6 +29,7 @@ import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.debug.toVisualStrings
 import eu.darken.sdmse.common.device.DeviceDetective
 import eu.darken.sdmse.common.device.RomType
 import eu.darken.sdmse.common.funnel.IPCFunnel
@@ -72,7 +73,7 @@ class VivoSpecs @Inject constructor(
         run {
             val storageEntryLabels =
                 vivoLabels.getStorageEntryDynamic(this) + vivoLabels.getStorageEntryStatic(this)
-            log(TAG) { "storageEntryLabels=$storageEntryLabels" }
+            log(TAG) { "storageEntryLabels=${storageEntryLabels.toVisualStrings()}" }
 
             val storageFinder = storageEntryFinder.storageFinderAOSP(storageEntryLabels, pkg)
 
@@ -103,7 +104,7 @@ class VivoSpecs @Inject constructor(
         run {
             val clearCacheButtonLabels =
                 vivoLabels.getClearCacheDynamic(this) + vivoLabels.getClearCacheStatic(this)
-            log(TAG) { "clearCacheButtonLabels=$clearCacheButtonLabels" }
+            log(TAG) { "clearCacheButtonLabels=${clearCacheButtonLabels.toVisualStrings()}" }
 
             val action: suspend StepContext.() -> Boolean = action@{
                 var isUnclickableLabelButton = false


### PR DESCRIPTION
Improve the search for window labels during automation by:

- Adding a check for the application label resource ID.
- Retrieving localized application labels for comparison.
- Visualizing window identifiers in debug logs.

Fixes #1771