### PR TITLE
Dependency: Update WorkManager to 2.10.1 to fix possible background crash on updates

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/scheduler/core/SchedulerManager.kt
+++ b/app/src/main/java/eu/darken/sdmse/scheduler/core/SchedulerManager.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -107,7 +108,7 @@ class SchedulerManager @Inject constructor(
         get() = "worker-schedule-$id"
 
     private suspend fun Schedule.isScheduled(): Boolean =
-        workManager.getWorkInfosForUniqueWork(workName).await()
+        workManager.getWorkInfosForUniqueWorkFlow(workName).firstOrNull()
             ?.any { infos -> infos.state == WorkInfo.State.ENQUEUED || infos.state == WorkInfo.State.RUNNING }
             ?: false
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -130,7 +130,7 @@ fun DependencyHandlerScope.addRoomDb() {
 }
 
 fun DependencyHandlerScope.addWorkerManager() {
-    val version = "2.9.0"
+    val version = "2.10.1"
     implementation("androidx.work:work-runtime:$version")
     testImplementation("androidx.work:work-testing:$version")
     implementation("androidx.work:work-runtime-ktx:$version")


### PR DESCRIPTION
Possibly fixing this:

```java
Exception android.app.RemoteServiceException$ForegroundServiceDidNotStopInTimeException: A foreground service of type dataSync did not stop within its timeout: ComponentInfo{eu.darken.sdmse/androidx.work.impl.foreground.SystemForegroundService}
  at android.app.ActivityThread.generateForegroundServiceDidNotStopInTimeException (ActivityThread.java:2932)
  at android.app.ActivityThread.throwRemoteServiceException (ActivityThread.java:2894)
  at android.app.ActivityThread.-$$Nest$mthrowRemoteServiceException (Unknown Source)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:3255)
  at android.os.Handler.dispatchMessage (Handler.java:118)
  at android.os.Looper.loopOnce (Looper.java:237)
  at android.os.Looper.loop (Looper.java:325)
  at android.app.ActivityThread.main (ActivityThread.java:10361)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:635)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:961)
Caused by android.app.StackTrace: Last startServiceCommon() call for this service was made here
  at android.app.ContextImpl.startServiceCommon (ContextImpl.java:2117)
  at android.app.ContextImpl.startForegroundService (ContextImpl.java:2071)
  at android.content.ContextWrapper.startForegroundService (ContextWrapper.java:832)
  at androidx.core.content.ContextCompat$Api26Impl.startForegroundService (ContextCompat.java)
  at androidx.core.content.ContextCompat.startForegroundService (ContextCompat.java:700)
  at androidx.work.impl.Processor.startForeground (Processor.java:206)
  at androidx.work.impl.utils.WorkForegroundUpdater$1.run (WorkForegroundUpdater.java:100)
  at androidx.work.impl.utils.SerialExecutorImpl$Task.run (SerialExecutorImpl.java:96)
  at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1145)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:644)
  at java.lang.Thread.run (Thread.java:1012)
```