### PR TITLE
DeviceDetective, AppControl, AppCleaner: Add OUKITEL ROM type and specs

### DIFF
--- a/app-common/src/main/java/eu/darken/sdmse/common/device/DeviceDetective.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/device/DeviceDetective.kt
@@ -94,6 +94,9 @@ class DeviceDetective @Inject constructor(
         checkManufactor("HONOR") -> RomType.HONOR
         // Minimal skin, some preinstalled apps and tweaks, overall, it's near-stock Android.
         checkManufactor("DOOGEE") -> RomType.DOOGEE
+        // OUKITEL/OT5_EEA/OT5:13/TP1A.220624.014/20240528:user/release-keys
+        // Stock ROM for the OUKITEL OT5 (European variant)
+        checkManufactor("OUKITEL") -> RomType.OUKITEL
         else -> null
     } ?: RomType.AOSP
 

--- a/app-common/src/main/java/eu/darken/sdmse/common/device/RomType.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/device/RomType.kt
@@ -27,5 +27,6 @@ enum class RomType(override val label: CaString) : EnumPreference<RomType> {
     @Json(name = "VIVO") VIVO("VIVO".toCaString()),
     @Json(name = "HONOR") HONOR("HONOR".toCaString()),
     @Json(name = "DOOGEE") DOOGEE("DOOGEE".toCaString()),
+    @Json(name = "OUKITEL") OUKITEL("OUKITEL".toCaString()),
     ;
 }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/LabelDebugger.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/LabelDebugger.kt
@@ -55,7 +55,11 @@ class LabelDebugger @Inject constructor(
         private val RES_IDS_DIALOGTITLES = setOf(
             "app_manager_dlg_clear_cache_title",
         )
-        private val ALL_RES_IDS = RES_IDS_STORAGE + RES_IDS_CLEARDATA + RES_IDS_CLEARCACHE + RES_IDS_DIALOGTITLES
+        private val RES_IDS_WINDOW_TITLES = setOf(
+            "application_info_label",
+        )
+        private val ALL_RES_IDS =
+            RES_IDS_STORAGE + RES_IDS_CLEARDATA + RES_IDS_CLEARCACHE + RES_IDS_DIALOGTITLES + RES_IDS_WINDOW_TITLES
         private val TAG = logTag("Automation", "LabelDebugger")
     }
 }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPLabels.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPLabels.kt
@@ -13,6 +13,10 @@ class AOSPLabels @Inject constructor(
     private val labels29Plus: AOSPLabels29Plus,
 ) : AppCleanerLabelSource {
 
+    fun getSettingsTitleDynamic(
+        acsContext: AutomationExplorer.Context,
+    ): Set<String> = labels29Plus.getSettingsTitleDynamic(acsContext)
+
     fun getStorageEntryDynamic(acsContext: AutomationExplorer.Context): Set<String> = when {
         hasApiLevel(29) -> labels29Plus.getStorageEntryDynamic(acsContext)
         else -> labels14Plus.getStorageEntryDynamic(acsContext)

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPLabels29Plus.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPLabels29Plus.kt
@@ -1,6 +1,7 @@
 package eu.darken.sdmse.appcleaner.core.automation.specs.aosp
 
 import eu.darken.sdmse.appcleaner.core.automation.specs.AppCleanerLabelSource
+import eu.darken.sdmse.appcontrol.core.automation.specs.aosp.AOSPLabels
 import eu.darken.sdmse.automation.core.specs.AutomationExplorer
 import eu.darken.sdmse.automation.core.specs.getLocales
 import eu.darken.sdmse.common.debug.logging.logTag
@@ -10,6 +11,11 @@ import javax.inject.Inject
 class AOSPLabels29Plus @Inject constructor(
     private val aospLabels14Plus: AOSPLabels14Plus,
 ) : AppCleanerLabelSource {
+
+    // Something like "App info"
+    fun getSettingsTitleDynamic(
+        acsContext: AutomationExplorer.Context,
+    ): Set<String> = acsContext.getStrings(AOSPLabels.Companion.SETTINGS_PKG, setOf("application_info_label"))
 
     fun getStorageEntryDynamic(
         acsContext: AutomationExplorer.Context

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/oukitel/OukitelSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/oukitel/OukitelSpecs.kt
@@ -1,0 +1,133 @@
+package eu.darken.sdmse.appcleaner.core.automation.specs.oukitel
+
+import android.view.accessibility.AccessibilityNodeInfo
+import dagger.Binds
+import dagger.Module
+import dagger.Reusable
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoSet
+import eu.darken.sdmse.R
+import eu.darken.sdmse.appcleaner.core.automation.errors.NoSettingsWindowException
+import eu.darken.sdmse.appcleaner.core.automation.specs.AppCleanerSpecGenerator
+import eu.darken.sdmse.appcleaner.core.automation.specs.StorageEntryFinder
+import eu.darken.sdmse.appcleaner.core.automation.specs.aosp.AOSPLabels
+import eu.darken.sdmse.appcleaner.core.automation.specs.defaultFindAndClickClearCache
+import eu.darken.sdmse.automation.core.common.crawl
+import eu.darken.sdmse.automation.core.common.isClickyButton
+import eu.darken.sdmse.automation.core.common.pkgId
+import eu.darken.sdmse.automation.core.common.stepper.AutomationStep
+import eu.darken.sdmse.automation.core.common.stepper.StepContext
+import eu.darken.sdmse.automation.core.common.stepper.Stepper
+import eu.darken.sdmse.automation.core.common.textMatchesAny
+import eu.darken.sdmse.automation.core.specs.AutomationExplorer
+import eu.darken.sdmse.automation.core.specs.AutomationSpec
+import eu.darken.sdmse.automation.core.specs.defaultFindAndClick
+import eu.darken.sdmse.automation.core.specs.defaultNodeRecovery
+import eu.darken.sdmse.automation.core.specs.windowCheck
+import eu.darken.sdmse.automation.core.specs.windowLauncherDefaultSettings
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.datastore.value
+import eu.darken.sdmse.common.debug.Bugs
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.debug.toVisualStrings
+import eu.darken.sdmse.common.device.DeviceDetective
+import eu.darken.sdmse.common.device.RomType
+import eu.darken.sdmse.common.pkgs.features.Installed
+import eu.darken.sdmse.common.pkgs.toPkgId
+import eu.darken.sdmse.common.progress.withProgress
+import eu.darken.sdmse.main.core.GeneralSettings
+import javax.inject.Inject
+
+@Reusable
+class OukitelSpecs @Inject constructor(
+    private val deviceDetective: DeviceDetective,
+    private val aospLabels: AOSPLabels,
+    private val storageEntryFinder: StorageEntryFinder,
+    private val generalSettings: GeneralSettings,
+    private val stepper: Stepper,
+) : AppCleanerSpecGenerator {
+
+    override val tag: String = TAG
+
+    override suspend fun isResponsible(pkg: Installed): Boolean {
+        val romType = generalSettings.romTypeDetection.value()
+        if (romType == RomType.OUKITEL) return true
+        if (romType != RomType.AUTO) return false
+
+        return deviceDetective.getROMType() == RomType.OUKITEL
+    }
+
+    override suspend fun getClearCache(pkg: Installed): AutomationSpec = object : AutomationSpec.Explorer {
+        override val tag: String = TAG
+        override suspend fun createPlan(): suspend AutomationExplorer.Context.() -> Unit = {
+            mainPlan(pkg)
+        }
+    }
+
+    private val mainPlan: suspend AutomationExplorer.Context.(Installed) -> Unit = plan@{ pkg ->
+        log(TAG, INFO) { "Executing plan for ${pkg.installId} with context $this" }
+
+        val windowCheck: suspend StepContext.() -> AccessibilityNodeInfo = {
+            if (stepAttempts >= 1 && pkg.hasNoSettings) {
+                throw NoSettingsWindowException("${pkg.packageName} has no settings window.")
+            }
+            val candidates = aospLabels.getSettingsTitleDynamic(hostContext)
+            windowCheck { _, root ->
+                if (root.pkgId != SETTINGS_PKG) return@windowCheck false
+                root.crawl()
+                    .map { it.node }
+                    .any { toTest -> candidates.any { candidate -> toTest.text == candidate } }
+            }()
+        }
+
+        run {
+            val storageEntryLabels =
+                aospLabels.getStorageEntryDynamic(this) + aospLabels.getStorageEntryStatic(this)
+            log(TAG) { "storageEntryLabels=${storageEntryLabels.toVisualStrings()}" }
+
+            val storageFinder = storageEntryFinder.storageFinderAOSP(storageEntryLabels, pkg)
+
+            val step = AutomationStep(
+                source = tag,
+                descriptionInternal = "Storage entry",
+                label = R.string.appcleaner_automation_progress_find_storage.toCaString(storageEntryLabels),
+                windowLaunch = windowLauncherDefaultSettings(pkg),
+                windowCheck = windowCheck,
+                nodeRecovery = defaultNodeRecovery(pkg),
+                nodeAction = defaultFindAndClick(finder = storageFinder),
+            )
+            stepper.withProgress(this) { process(this@plan, step) }
+        }
+
+        run {
+            val clearCacheButtonLabels =
+                aospLabels.getClearCacheDynamic(this) + aospLabels.getClearCacheStatic(this)
+            log(TAG) { "clearCacheButtonLabels=${clearCacheButtonLabels.toVisualStrings()}" }
+
+            val step = AutomationStep(
+                source = tag,
+                descriptionInternal = "Clear cache button",
+                label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheButtonLabels),
+                windowCheck = windowCheck,
+                nodeAction = defaultFindAndClickClearCache(isDryRun = Bugs.isDryRun, pkg) {
+                    if (!it.isClickyButton()) false else it.textMatchesAny(clearCacheButtonLabels)
+                },
+            )
+            stepper.withProgress(this) { process(this@plan, step) }
+        }
+    }
+
+    @Module @InstallIn(SingletonComponent::class)
+    abstract class DIM {
+        @Binds @IntoSet abstract fun mod(mod: OukitelSpecs): AppCleanerSpecGenerator
+    }
+
+    companion object {
+        val SETTINGS_PKG = "com.android.settings".toPkgId()
+        val TAG: String = logTag("AppCleaner", "Automation", "OUKITEL", "Specs")
+    }
+
+}

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/aosp/AOSPLabels.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/aosp/AOSPLabels.kt
@@ -10,6 +10,11 @@ import javax.inject.Inject
 @Reusable
 class AOSPLabels @Inject constructor() : AppControlLabelSource {
 
+    // Something like "App info"
+    fun getSettingsTitleDynamic(
+        acsContext: AutomationExplorer.Context,
+    ): Set<String> = acsContext.getStrings(SETTINGS_PKG, setOf("application_info_label"))
+
     fun getForceStopButtonDynamic(
         acsContext: AutomationExplorer.Context
     ): Set<String> = acsContext.getStrings(SETTINGS_PKG, setOf("force_stop"))

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/oukitel/OukitelSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/oukitel/OukitelSpecs.kt
@@ -1,0 +1,163 @@
+package eu.darken.sdmse.appcontrol.core.automation.specs.oukitel
+
+import android.view.accessibility.AccessibilityNodeInfo
+import dagger.Binds
+import dagger.Module
+import dagger.Reusable
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoSet
+import eu.darken.sdmse.R
+import eu.darken.sdmse.appcleaner.core.automation.errors.NoSettingsWindowException
+import eu.darken.sdmse.appcontrol.core.automation.specs.AppControlSpecGenerator
+import eu.darken.sdmse.appcontrol.core.automation.specs.aosp.AOSPLabels
+import eu.darken.sdmse.automation.core.common.crawl
+import eu.darken.sdmse.automation.core.common.pkgId
+import eu.darken.sdmse.automation.core.common.stepper.AutomationStep
+import eu.darken.sdmse.automation.core.common.stepper.StepContext
+import eu.darken.sdmse.automation.core.common.stepper.Stepper
+import eu.darken.sdmse.automation.core.common.stepper.clickNormal
+import eu.darken.sdmse.automation.core.common.stepper.findClickableParent
+import eu.darken.sdmse.automation.core.common.stepper.findNode
+import eu.darken.sdmse.automation.core.common.textMatchesAny
+import eu.darken.sdmse.automation.core.specs.AutomationExplorer
+import eu.darken.sdmse.automation.core.specs.AutomationSpec
+import eu.darken.sdmse.automation.core.specs.defaultFindAndClick
+import eu.darken.sdmse.automation.core.specs.defaultNodeRecovery
+import eu.darken.sdmse.automation.core.specs.windowCheck
+import eu.darken.sdmse.automation.core.specs.windowLauncherDefaultSettings
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.datastore.value
+import eu.darken.sdmse.common.debug.Bugs
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.device.DeviceDetective
+import eu.darken.sdmse.common.device.RomType
+import eu.darken.sdmse.common.pkgs.features.Installed
+import eu.darken.sdmse.common.pkgs.toPkgId
+import eu.darken.sdmse.common.progress.withProgress
+import eu.darken.sdmse.main.core.GeneralSettings
+import javax.inject.Inject
+
+@Reusable
+class OukitelSpecs @Inject constructor(
+    private val deviceDetective: DeviceDetective,
+    private val aospLabels: AOSPLabels,
+    private val generalSettings: GeneralSettings,
+    private val stepper: Stepper,
+) : AppControlSpecGenerator {
+
+    override val tag: String = TAG
+
+    override suspend fun isResponsible(pkg: Installed): Boolean {
+        val romType = generalSettings.romTypeDetection.value()
+        if (romType == RomType.OUKITEL) return true
+        if (romType != RomType.AUTO) return false
+
+        return deviceDetective.getROMType() == RomType.OUKITEL
+    }
+
+    override suspend fun getForceStop(pkg: Installed): AutomationSpec = object : AutomationSpec.Explorer {
+        override val tag: String = TAG
+        override suspend fun createPlan(): suspend AutomationExplorer.Context.() -> Unit = {
+            mainPlan(pkg)
+        }
+    }
+
+    private val mainPlan: suspend AutomationExplorer.Context.(Installed) -> Unit = plan@{ pkg ->
+        log(TAG, INFO) { "Executing plan for ${pkg.installId} with context $this" }
+
+        val forceStopLabels = aospLabels.getForceStopButtonDynamic(this)
+        var wasDisabled = false
+
+        val windowCheck: suspend StepContext.() -> AccessibilityNodeInfo = {
+            if (stepAttempts >= 1 && pkg.hasNoSettings) {
+                throw NoSettingsWindowException("${pkg.packageName} has no settings window.")
+            }
+            val candidates = aospLabels.getSettingsTitleDynamic(hostContext)
+            windowCheck { _, root ->
+                if (root.pkgId != SETTINGS_PKG) return@windowCheck false
+                root.crawl()
+                    .map { it.node }
+                    .any { toTest -> candidates.any { candidate -> toTest.text == candidate } }
+            }()
+        }
+
+        run {
+            val action: suspend StepContext.() -> Boolean = action@{
+                val target = findNode { node ->
+                    node.textMatchesAny(forceStopLabels)
+                } ?: return@action false
+
+                val mapped = findClickableParent(node = target) ?: return@action false
+
+                if (mapped.isEnabled) {
+                    clickNormal(node = mapped)
+                } else {
+                    wasDisabled = true
+                    true
+                }
+            }
+
+            val step = AutomationStep(
+                source = TAG,
+                descriptionInternal = "Force stop button",
+                label = R.string.appcontrol_automation_progress_find_force_stop.toCaString(forceStopLabels),
+                windowLaunch = windowLauncherDefaultSettings(pkg),
+                windowCheck = windowCheck,
+                nodeRecovery = defaultNodeRecovery(pkg),
+                nodeAction = action,
+            )
+            stepper.withProgress(this) { process(this@plan, step) }
+        }
+
+        if (wasDisabled) {
+            log(TAG) { "Force stop button was disabled, app is already stopped." }
+            return@plan
+        }
+
+        run {
+            val titleLbl = aospLabels.getForceStopDialogTitleDynamic(this) + forceStopLabels.map { "$it?" }
+            val okLbl = aospLabels.getForceStopDialogOkDynamic(this)
+            val cancelLbl = aospLabels.getForceStopDialogCancelDynamic(this)
+
+            val windowCheck = windowCheck { _, root ->
+                if (root.pkgId != SETTINGS_PKG) return@windowCheck false
+                root.crawl().map { it.node }.any { subNode -> subNode.textMatchesAny(titleLbl) }
+            }
+
+            val action = defaultFindAndClick(
+                finder = {
+                    findNode { node ->
+                        when (Bugs.isDryRun) {
+                            true -> node.textMatchesAny(cancelLbl)
+                            false -> node.textMatchesAny(okLbl)
+                        }
+                    }
+                }
+            )
+
+            val step = AutomationStep(
+                source = TAG,
+                descriptionInternal = "Confirm force stop button",
+                label = R.string.appcleaner_automation_progress_find_ok_confirmation.toCaString(titleLbl + okLbl),
+                windowCheck = windowCheck,
+                nodeAction = action,
+            )
+            stepper.withProgress(this) { process(this@plan, step) }
+        }
+    }
+
+    @Module @InstallIn(SingletonComponent::class)
+    abstract class DIM {
+        @Binds @IntoSet abstract fun mod(mod: OukitelSpecs): AppControlSpecGenerator
+    }
+
+    companion object {
+        val SETTINGS_PKG = "com.android.settings".toPkgId()
+
+        val TAG: String = logTag("AppControl", "Automation", "OUKITEL", "Specs")
+    }
+
+}


### PR DESCRIPTION
Added a new ROM type `OUKITEL` to the `RomType` enum and the `DeviceDetective`. Implemented specific automation specifications for Oukitel devices in both AppControl and AppCleaner, based on AOSP behavior.

Fixes #1777