### PR TITLE
AppCleaner: ACS support for `DOOGEE` ROMs/devices

### DIFF
--- a/app-common/src/main/java/eu/darken/sdmse/common/device/DeviceDetective.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/device/DeviceDetective.kt
@@ -7,6 +7,8 @@ import android.content.res.Configuration
 import android.os.Build
 import dagger.Reusable
 import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.hasApiLevel
 import eu.darken.sdmse.common.isInstalled
@@ -16,6 +18,10 @@ import javax.inject.Inject
 class DeviceDetective @Inject constructor(
     @ApplicationContext private val context: Context,
 ) {
+
+    init {
+        log(TAG, VERBOSE) { "Loaded." }
+    }
 
     private fun isAndroidTV(): Boolean {
         val uiManager = context.getSystemService(Context.UI_MODE_SERVICE) as UiModeManager
@@ -86,6 +92,8 @@ class DeviceDetective @Inject constructor(
         checkManufactor("vivo") -> RomType.VIVO
         // Earlier ROMs pre Android 12 run EMUI, Android 13+ is MagicOS
         checkManufactor("HONOR") -> RomType.HONOR
+        // Minimal skin, some preinstalled apps and tweaks, overall, it's near-stock Android.
+        checkManufactor("DOOGEE") -> RomType.DOOGEE
         else -> null
     } ?: RomType.AOSP
 

--- a/app-common/src/main/java/eu/darken/sdmse/common/device/RomType.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/device/RomType.kt
@@ -26,5 +26,6 @@ enum class RomType(override val label: CaString) : EnumPreference<RomType> {
     @Json(name = "SAMSUNG") ONEUI("OneUI".toCaString()),
     @Json(name = "VIVO") VIVO("VIVO".toCaString()),
     @Json(name = "HONOR") HONOR("HONOR".toCaString()),
+    @Json(name = "DOOGEE") DOOGEE("DOOGEE".toCaString()),
     ;
 }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/doogee/DoogeeSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/doogee/DoogeeSpecs.kt
@@ -1,0 +1,126 @@
+package eu.darken.sdmse.appcleaner.core.automation.specs.doogee
+
+import dagger.Binds
+import dagger.Module
+import dagger.Reusable
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoSet
+import eu.darken.sdmse.R
+import eu.darken.sdmse.appcleaner.core.automation.specs.AppCleanerSpecGenerator
+import eu.darken.sdmse.appcleaner.core.automation.specs.StorageEntryFinder
+import eu.darken.sdmse.appcleaner.core.automation.specs.aosp.AOSPLabels
+import eu.darken.sdmse.appcleaner.core.automation.specs.defaultFindAndClickClearCache
+import eu.darken.sdmse.automation.core.common.crawl
+import eu.darken.sdmse.automation.core.common.isClickyButton
+import eu.darken.sdmse.automation.core.common.pkgId
+import eu.darken.sdmse.automation.core.common.stepper.AutomationStep
+import eu.darken.sdmse.automation.core.common.stepper.Stepper
+import eu.darken.sdmse.automation.core.common.textMatchesAny
+import eu.darken.sdmse.automation.core.specs.AutomationExplorer
+import eu.darken.sdmse.automation.core.specs.AutomationSpec
+import eu.darken.sdmse.automation.core.specs.defaultFindAndClick
+import eu.darken.sdmse.automation.core.specs.defaultNodeRecovery
+import eu.darken.sdmse.automation.core.specs.windowCheck
+import eu.darken.sdmse.automation.core.specs.windowCheckDefaultSettings
+import eu.darken.sdmse.automation.core.specs.windowLauncherDefaultSettings
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.datastore.value
+import eu.darken.sdmse.common.debug.Bugs
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.debug.toVisualStrings
+import eu.darken.sdmse.common.device.DeviceDetective
+import eu.darken.sdmse.common.device.RomType
+import eu.darken.sdmse.common.funnel.IPCFunnel
+import eu.darken.sdmse.common.pkgs.features.Installed
+import eu.darken.sdmse.common.pkgs.toPkgId
+import eu.darken.sdmse.common.progress.withProgress
+import eu.darken.sdmse.main.core.GeneralSettings
+import javax.inject.Inject
+
+@Reusable
+class DoogeeSpecs @Inject constructor(
+    private val ipcFunnel: IPCFunnel,
+    private val deviceDetective: DeviceDetective,
+    private val aospLabels: AOSPLabels,
+    private val storageEntryFinder: StorageEntryFinder,
+    private val generalSettings: GeneralSettings,
+    private val stepper: Stepper,
+) : AppCleanerSpecGenerator {
+
+    override val tag: String = TAG
+
+    override suspend fun isResponsible(pkg: Installed): Boolean {
+        val romType = generalSettings.romTypeDetection.value()
+        if (romType == RomType.DOOGEE) return true
+        if (romType != RomType.AUTO) return false
+
+        return deviceDetective.getROMType() == RomType.DOOGEE
+    }
+
+    override suspend fun getClearCache(pkg: Installed): AutomationSpec = object : AutomationSpec.Explorer {
+        override val tag: String = TAG
+        override suspend fun createPlan(): suspend AutomationExplorer.Context.() -> Unit = {
+            mainPlan(pkg)
+        }
+    }
+
+    private val mainPlan: suspend AutomationExplorer.Context.(Installed) -> Unit = plan@{ pkg ->
+        log(TAG, INFO) { "Executing plan for ${pkg.installId} with context $this" }
+
+        run {
+            val storageEntryLabels =
+                aospLabels.getStorageEntryDynamic(this) + aospLabels.getStorageEntryStatic(this)
+            log(TAG) { "storageEntryLabels=${storageEntryLabels.toVisualStrings()}" }
+
+            val storageFinder = storageEntryFinder.storageFinderAOSP(storageEntryLabels, pkg)
+
+            val step = AutomationStep(
+                source = tag,
+                descriptionInternal = "Storage entry",
+                label = R.string.appcleaner_automation_progress_find_storage.toCaString(storageEntryLabels),
+                windowLaunch = windowLauncherDefaultSettings(pkg),
+                windowCheck = windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg),
+                nodeRecovery = defaultNodeRecovery(pkg),
+                nodeAction = defaultFindAndClick(finder = storageFinder),
+            )
+            stepper.withProgress(this) { process(this@plan, step) }
+        }
+
+        run {
+            val clearCacheButtonLabels =
+                aospLabels.getClearCacheDynamic(this) + aospLabels.getClearCacheStatic(this)
+            log(TAG) { "clearCacheButtonLabels=${clearCacheButtonLabels.toVisualStrings()}" }
+
+            // The storage sub screen/page has no app identifiers
+            val windowCheck = windowCheck { _, root ->
+                if (root.pkgId != SETTINGS_PKG) return@windowCheck false
+                root.crawl().map { it.node }.any { node -> node.textMatchesAny(clearCacheButtonLabels) }
+            }
+
+            val step = AutomationStep(
+                source = tag,
+                descriptionInternal = "Clear cache button",
+                label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheButtonLabels),
+                windowCheck = windowCheck,
+                nodeAction = defaultFindAndClickClearCache(isDryRun = Bugs.isDryRun, pkg) {
+                    if (!it.isClickyButton()) false else it.textMatchesAny(clearCacheButtonLabels)
+                },
+            )
+            stepper.withProgress(this) { process(this@plan, step) }
+        }
+    }
+
+    @Module @InstallIn(SingletonComponent::class)
+    abstract class DIM {
+        @Binds @IntoSet abstract fun mod(mod: DoogeeSpecs): AppCleanerSpecGenerator
+    }
+
+    companion object {
+        val SETTINGS_PKG = "com.android.settings".toPkgId()
+        val TAG: String = logTag("AppCleaner", "Automation", "DOOGEE", "Specs")
+    }
+
+}


### PR DESCRIPTION
Add `DOOGEE` as a recognized RomType and implement a basic AppCleaner spec for it. Doogee ROMs are based on AOSP, so the spec largely mirrors the AOSP one.

Fixes #1781