### PR TITLE
Refactor: Add AutomationService.Snapshot and debug logging

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/hyperos/HyperOsSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/hyperos/HyperOsSpecs.kt
@@ -120,6 +120,7 @@ class HyperOsSpecs @Inject constructor(
             }
             // Wait for correct base window
             host.events
+                .map { it.event }
                 .filter { event -> event.pkgId == SETTINGS_PKG_HYPEROS || event.pkgId == SETTINGS_PKG_AOSP }
                 .mapNotNull { host.windowRoot() }
                 .first { root ->
@@ -161,6 +162,8 @@ class HyperOsSpecs @Inject constructor(
 
     private fun isSecurityCenterMissingPermission(): Boolean = try {
         val appOps = context.getSystemService(Context.APP_OPS_SERVICE) as AppOpsManager
+
+        @Suppress("DEPRECATION")
         val mode = appOps.checkOp(
             AppOpsManager.OPSTR_GET_USAGE_STATS,
             context.packageManager.getApplicationInfo(SETTINGS_PKG_HYPEROS.name, 0).uid,

--- a/app/src/main/java/eu/darken/sdmse/automation/core/AutomationHost.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/AutomationHost.kt
@@ -2,9 +2,9 @@ package eu.darken.sdmse.automation.core
 
 import android.accessibilityservice.AccessibilityService
 import android.accessibilityservice.AccessibilityServiceInfo
-import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
 import eu.darken.sdmse.R
+import eu.darken.sdmse.automation.core.AutomationService.Snapshot
 import eu.darken.sdmse.common.ca.CaString
 import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.progress.Progress
@@ -21,7 +21,7 @@ interface AutomationHost : Progress.Client {
 
     suspend fun changeOptions(action: (Options) -> Options)
 
-    val events: Flow<AccessibilityEvent>
+    val events: Flow<Snapshot>
 
     data class State(
         val hasOverlay: Boolean = false,
@@ -44,7 +44,7 @@ interface AutomationHost : Progress.Client {
                 //    at android.accessibilityservice.AccessibilityServiceInfo.getId(AccessibilityServiceInfo.java:759)
                 //    at android.accessibilityservice.AccessibilityServiceInfo.toString(AccessibilityServiceInfo.java:1105)
                 accessibilityServiceInfo.toString()
-            } catch (e: NullPointerException) {
+            } catch (_: NullPointerException) {
                 "NPE"
             }
             return "AutomationHost.Options(showOverlay=$showOverlay, passthrough=$passthrough, acsInfo=$acsInfo)"

--- a/app/src/main/java/eu/darken/sdmse/automation/core/debug/DebugTaskModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/debug/DebugTaskModule.kt
@@ -63,7 +63,7 @@ class DebugTaskModule @AssistedInject constructor(
                 log(TAG, VERBOSE) { "Event: $it" }
                 val crawled = host.waitForWindowRoot().crawl().toList()
                 crawled.forEach { log(TAG, VERBOSE) { it.infoShort } }
-                updateProgressSecondary("Event: ${it.eventType} (depth: ${crawled.last().level})")
+                updateProgressSecondary("Event: ${it.event.eventType} (depth: ${crawled.last().level})")
             }
             .onEach {
 //                host.waitForWindowRoot().crawl()

--- a/app/src/main/java/eu/darken/sdmse/automation/core/specs/SpecGeneratorExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/specs/SpecGeneratorExtensions.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onStart
 
@@ -52,7 +53,7 @@ fun SpecGenerator.windowLauncherDefaultSettings(
 fun SpecGenerator.windowCheck(
     condition: suspend StepContext.(event: AccessibilityEvent?, root: AccessibilityNodeInfo) -> Boolean,
 ): suspend StepContext.() -> AccessibilityNodeInfo = {
-    val events: Flow<AccessibilityEvent?> = host.events
+    val events: Flow<AccessibilityEvent?> = host.events.map { it.event }
     val (event, root) = events
         .onStart {
             // we may already be ready


### PR DESCRIPTION
Introduce a `Snapshot` data class to wrap `AccessibilityEvent`s within the `AutomationService`. This `Snapshot` now includes a unique ID.

Modify the event flow exposed by `AutomationHost` to emit `Snapshot`s instead of raw `AccessibilityEvent`s. Update usages in `HyperOsSpecs`, `SpecGeneratorExtensions`, and `DebugTaskModule` to extract the event from the `Snapshot`.

Implement debug logging for screen snapshots in `AutomationService`. This includes logging the snapshot ID, the event, and the crawled node hierarchy, with a timeout to prevent blocking. This logging is enabled only in debug builds.