### PR TITLE
Fix random crash when navigating screens

### DIFF
--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -10,7 +10,7 @@ object Versions {
 
     object AndroidX {
         object Navigation {
-            const val core = "2.9.0"
+            const val core = "2.8.9"
         }
     }
 


### PR DESCRIPTION
Downgrade Navigation Core to 2.8.9
Navigation Core version 2.9.0 seems to have a bug causing an `ConcurrentModificationException`.

See:
https://issuetracker.google.com/issues/188860458
https://issuetracker.google.com/issues/417784831

Fixes #1789