### PR TITLE
Storage Analyzer: Improve UX for exclusion creation and selection

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalGateway.kt
@@ -66,14 +66,14 @@ class LocalGateway @Inject constructor(
 
     private suspend fun <T> rootOps(action: suspend (FileOpsClient) -> T): T {
         if (!rootManager.canUseRootNow()) throw RootUnavailableException()
-        return keepResourcesAlive(setOf(rootManager.serviceClient)) {
+        return keepResourcesAlive(rootManager.serviceClient) {
             rootManager.serviceClient.runModuleAction(FileOpsClient::class.java) { action(it) }
         }
     }
 
     private suspend fun <T> adbOps(action: suspend (FileOpsClient) -> T): T {
         if (!adbManager.canUseAdbNow()) throw AdbUnavailableException()
-        return keepResourcesAlive(setOf(adbManager.serviceClient)) {
+        return keepResourcesAlive(adbManager.serviceClient) {
             adbManager.serviceClient.runModuleAction(FileOpsClient::class.java) { action(it) }
         }
     }

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/PkgOps.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/PkgOps.kt
@@ -78,14 +78,14 @@ class PkgOps @Inject constructor(
 
     private suspend fun <T> adbOps(action: suspend (PkgOpsClient) -> T): T {
         if (!adbManager.canUseAdbNow()) throw AdbUnavailableException()
-        return keepResourcesAlive(setOf(adbManager.serviceClient)) {
+        return keepResourcesAlive(adbManager.serviceClient) {
             adbManager.serviceClient.runModuleAction(PkgOpsClient::class.java) { action(it) }
         }
     }
 
     private suspend fun <T> rootOps(action: suspend (PkgOpsClient) -> T): T {
         if (!rootManager.canUseRootNow()) throw RootUnavailableException()
-        return keepResourcesAlive(setOf(rootManager.serviceClient)) {
+        return keepResourcesAlive(rootManager.serviceClient) {
             rootManager.serviceClient.runModuleAction(PkgOpsClient::class.java) { action(it) }
         }
     }

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/shell/ShellOps.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/shell/ShellOps.kt
@@ -43,14 +43,14 @@ class ShellOps @Inject constructor(
 
     private suspend fun <T> adbOps(action: suspend (ShellOpsClient) -> T): T {
         if (!adbManager.canUseAdbNow()) throw AdbUnavailableException()
-        return keepResourcesAlive(setOf(adbManager.serviceClient)) {
+        return keepResourcesAlive(adbManager.serviceClient) {
             adbManager.serviceClient.runModuleAction(ShellOpsClient::class.java) { action(it) }
         }
     }
 
     private suspend fun <T> rootOps(action: suspend (ShellOpsClient) -> T): T {
         if (!rootManager.canUseRootNow()) throw RootUnavailableException()
-        return keepResourcesAlive(setOf(rootManager.serviceClient)) {
+        return keepResourcesAlive(rootManager.serviceClient) {
             rootManager.serviceClient.runModuleAction(ShellOpsClient::class.java) { action(it) }
         }
     }

--- a/app/src/main/java/eu/darken/sdmse/analyzer/core/Analyzer.kt
+++ b/app/src/main/java/eu/darken/sdmse/analyzer/core/Analyzer.kt
@@ -67,7 +67,6 @@ class Analyzer @Inject constructor(
 
     override val type: SDMTool.Type = SDMTool.Type.ANALYZER
 
-    private val usedResources = setOf(gatewaySwitch)
     override val sharedResource = SharedResource.createKeepAlive(TAG, appScope)
 
     private val progressPub = MutableStateFlow<Progress.Data?>(null)
@@ -116,7 +115,7 @@ class Analyzer @Inject constructor(
         log(TAG) { "submit($task) starting..." }
         updateProgress { Progress.Data() }
         try {
-            val result = keepResourceHoldersAlive(usedResources) {
+            val result = keepResourceHoldersAlive(gatewaySwitch) {
                 when (task) {
                     is DeviceStorageScanTask -> scanStorageDevices(task)
                     is StorageScanTask -> scanStorageContents(task)

--- a/app/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentFragment.kt
@@ -74,6 +74,13 @@ class ContentFragment : Fragment3(R.layout.analyzer_content_fragment) {
         installListSelection(
             adapter = adapter,
             cabMenuRes = R.menu.menu_analyzer_content_list_cab,
+            onPrepare = { tracker, mode, menu ->
+                val selectedItems = tracker.selection.map { key -> adapter.data.first { it.itemSelectionKey == key } }
+                val hasInaccessible = selectedItems.any { it !is ContentItemVH.Item || it.content.inaccessible }
+                menu.findItem(R.id.action_delete_selected)?.isVisible = !hasInaccessible
+                menu.findItem(R.id.action_create_filter_selected)?.isVisible = !hasInaccessible
+                true
+            },
             onSelected = { tracker: SelectionTracker<String>, item: MenuItem, selected: List<ContentAdapter.Item> ->
                 when (item.itemId) {
                     R.id.action_exclude_selected -> {
@@ -131,11 +138,15 @@ class ContentFragment : Fragment3(R.layout.analyzer_content_fragment) {
                 is ContentItemEvents.ExclusionsCreated -> Snackbar
                     .make(
                         requireView(),
-                        getQuantityString2(R.plurals.exclusion_x_new_exclusions, event.count),
+                        getQuantityString2(R.plurals.exclusion_x_new_exclusions, event.items.size),
                         Snackbar.LENGTH_LONG
                     )
                     .setAction(eu.darken.sdmse.common.R.string.general_view_action) {
-                        ContentFragmentDirections.goToExclusions().navigate()
+                        if (event.items.size == 1) {
+                            vm.openExclusion(event.items.single())
+                        } else {
+                            ContentFragmentDirections.goToExclusions().navigate()
+                        }
                     }
                     .show()
 

--- a/app/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentItemEvents.kt
+++ b/app/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentItemEvents.kt
@@ -5,7 +5,7 @@ import eu.darken.sdmse.analyzer.core.content.ContentItem
 
 sealed class ContentItemEvents {
     data class ShowNoAccessHint(val item: ContentItem) : ContentItemEvents()
-    data class ExclusionsCreated(val count: Int) : ContentItemEvents()
+    data class ExclusionsCreated(val items: List<ContentItem>) : ContentItemEvents()
     data class ContentDeleted(val count: Int, val freedSpace: Long) : ContentItemEvents()
     data class OpenContent(val intent: Intent) : ContentItemEvents()
 }

--- a/app/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentItemVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentItemVH.kt
@@ -91,10 +91,7 @@ class ContentItemVH(parent: ViewGroup) :
     ) : ContentAdapter.Item {
 
         override val stableId: Long = content.path.hashCode().toLong()
-        override val itemSelectionKey: String? = when {
-            content.inaccessible -> null
-            else -> content.path.path
-        }
+        override val itemSelectionKey: String = content.path.path
     }
 
 }

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
@@ -63,21 +63,19 @@ import javax.inject.Singleton
 @Singleton
 class AppCleaner @Inject constructor(
     @AppScope private val appScope: CoroutineScope,
-    fileForensics: FileForensics,
+    private val fileForensics: FileForensics,
     private val appScannerProvider: Provider<AppScanner>,
     private val inaccessibleDeleterProvider: Provider<InaccessibleDeleter>,
     private val exclusionManager: ExclusionManager,
-    gatewaySwitch: GatewaySwitch,
-    pkgOps: PkgOps,
+    private val gatewaySwitch: GatewaySwitch,
+    private val pkgOps: PkgOps,
     usageStatsSetupModule: UsageStatsSetupModule,
     rootManager: RootManager,
     adbManager: AdbManager,
-    shellOps: ShellOps,
+    private val shellOps: ShellOps,
     private val filterFactories: Set<@JvmSuppressWildcards ExpendablesFilter.Factory>,
     private val appInventorySetupModule: InventorySetupModule,
 ) : SDMTool, Progress.Client {
-
-    private val usedResources = setOf(fileForensics, gatewaySwitch, pkgOps, shellOps)
 
     override val sharedResource = SharedResource.createKeepAlive(TAG, appScope)
 
@@ -114,7 +112,7 @@ class AppCleaner @Inject constructor(
         log(TAG) { "submit(): Starting...$task" }
         updateProgress { Progress.Data() }
         try {
-            val result = keepResourceHoldersAlive(usedResources) {
+            val result = keepResourceHoldersAlive(fileForensics, gatewaySwitch, pkgOps, shellOps) {
                 when (task) {
                     is AppCleanerScanTask -> performScan(task)
                     is AppCleanerProcessingTask -> performProcessing(task)

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/AppControl.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/AppControl.kt
@@ -78,7 +78,6 @@ class AppControl @Inject constructor(
     private val appScan: AppScan,
 ) : SDMTool, Progress.Client {
 
-    private val usedResources = setOf(appScan)
     override val sharedResource = SharedResource.createKeepAlive(TAG, appScope)
 
     private val progressPub = MutableStateFlow<Progress.Data?>(null)
@@ -118,7 +117,7 @@ class AppControl @Inject constructor(
         log(TAG) { "submit($task) starting..." }
         updateProgress { Progress.Data() }
         try {
-            val result = keepResourceHoldersAlive(usedResources) {
+            val result = keepResourceHoldersAlive(appScan) {
                 when (task) {
                     is AppControlScanTask -> performScan(task)
                     is AppControlToggleTask -> performToggle(task)

--- a/app/src/main/java/eu/darken/sdmse/corpsefinder/core/CorpseFinder.kt
+++ b/app/src/main/java/eu/darken/sdmse/corpsefinder/core/CorpseFinder.kt
@@ -65,7 +65,7 @@ import javax.inject.Singleton
 class CorpseFinder @Inject constructor(
     @AppScope private val appScope: CoroutineScope,
     private val filterFactories: Set<@JvmSuppressWildcards CorpseFilter.Factory>,
-    fileForensics: FileForensics,
+    private val fileForensics: FileForensics,
     private val gatewaySwitch: GatewaySwitch,
     private val exclusionManager: ExclusionManager,
     private val userManager: UserManager2,
@@ -78,7 +78,6 @@ class CorpseFinder @Inject constructor(
 
     override val type: SDMTool.Type = SDMTool.Type.CORPSEFINDER
 
-    private val usedResources = setOf(fileForensics, gatewaySwitch, pkgOps)
     override val sharedResource = SharedResource.createKeepAlive(TAG, appScope)
 
     private val progressPub = MutableStateFlow<Progress.Data?>(null)
@@ -114,7 +113,7 @@ class CorpseFinder @Inject constructor(
         updateProgress { Progress.Data() }
 
         try {
-            val result = keepResourceHoldersAlive(usedResources) {
+            val result = keepResourceHoldersAlive(fileForensics, gatewaySwitch, pkgOps) {
                 when (task) {
                     is CorpseFinderScanTask -> performScan(task)
                     is CorpseFinderDeleteTask -> deleteCorpses(task)

--- a/app/src/main/java/eu/darken/sdmse/deduplicator/core/Deduplicator.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/core/Deduplicator.kt
@@ -43,7 +43,7 @@ import javax.inject.Singleton
 @Singleton
 class Deduplicator @Inject constructor(
     @AppScope private val appScope: CoroutineScope,
-    gatewaySwitch: GatewaySwitch,
+    private val gatewaySwitch: GatewaySwitch,
     private val exclusionManager: ExclusionManager,
     private val scanner: Provider<DuplicatesScanner>,
     private val deleter: Provider<DuplicatesDeleter>,
@@ -52,7 +52,6 @@ class Deduplicator @Inject constructor(
 
     override val type: SDMTool.Type = SDMTool.Type.DEDUPLICATOR
 
-    private val usedResources = setOf(gatewaySwitch)
     override val sharedResource = SharedResource.createKeepAlive(TAG, appScope)
 
     private val progressPub = MutableStateFlow<Progress.Data?>(null)
@@ -83,7 +82,7 @@ class Deduplicator @Inject constructor(
         updateProgress { Progress.Data() }
 
         try {
-            val result = keepResourceHoldersAlive(usedResources) {
+            val result = keepResourceHoldersAlive(gatewaySwitch) {
                 when (task) {
                     is DeduplicatorScanTask -> performScan(task)
                     is DeduplicatorDeleteTask -> performDelete(task)

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/SystemCleaner.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/SystemCleaner.kt
@@ -55,16 +55,14 @@ import javax.inject.Singleton
 @Singleton
 class SystemCleaner @Inject constructor(
     @AppScope private val appScope: CoroutineScope,
-    fileForensics: FileForensics,
-    gatewaySwitch: GatewaySwitch,
+    private val fileForensics: FileForensics,
+    private val gatewaySwitch: GatewaySwitch,
     private val crawler: SystemCrawler,
     private val exclusionManager: ExclusionManager,
     private val filterSourceProvider: Provider<FilterSource>,
-    pkgOps: PkgOps,
+    private val pkgOps: PkgOps,
     rootManager: RootManager,
 ) : SDMTool, Progress.Client {
-
-    private val usedResources = setOf(fileForensics, gatewaySwitch, pkgOps)
 
     override val sharedResource = SharedResource.createKeepAlive(TAG, appScope)
 
@@ -97,7 +95,7 @@ class SystemCleaner @Inject constructor(
         updateProgress { Progress.Data() }
 
         try {
-            val result = keepResourceHoldersAlive(usedResources) {
+            val result = keepResourceHoldersAlive(fileForensics, gatewaySwitch, pkgOps) {
                 when (task) {
                     is SystemCleanerScanTask -> performScan(task)
                     is SystemCleanerProcessingTask -> performProcessing(task)

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/SystemCrawler.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/SystemCrawler.kt
@@ -26,6 +26,7 @@ import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.common.progress.updateProgressCount
 import eu.darken.sdmse.common.progress.updateProgressPrimary
 import eu.darken.sdmse.common.progress.updateProgressSecondary
+import eu.darken.sdmse.common.sharedresource.useRes
 import eu.darken.sdmse.exclusion.core.ExclusionManager
 import eu.darken.sdmse.exclusion.core.pathExclusions
 import eu.darken.sdmse.exclusion.core.types.match
@@ -91,7 +92,7 @@ class SystemCrawler @Inject constructor(
 
         val sieveContents = mutableMapOf<FilterIdentifier, Set<SystemCleanerFilter.Match>>()
 
-        gatewaySwitch.useRes {
+        listOf(gatewaySwitch, forensics).useRes {
             targetAreas
                 .asFlow()
                 .flowOn(dispatcherProvider.Default)


### PR DESCRIPTION
- Always enable selection for all items, regardless of accessibility.
- Disable "Delete" and "Create Filter" actions in the CAB menu if any selected item is inaccessible.
- When a single item is excluded, the "View" action in the Snackbar now directly opens the created exclusion instead of navigating to the general exclusions list.
- Refactored event handling for exclusion creation to pass the affected content items, enabling more specific UI updates.

Implements #1643

Draft: Check #1644 and #1645