### PR TITLE
Automation: Introduce AutomationTimeoutException and improve error reporting

### DIFF
--- a/app-common/src/main/res/values/strings.xml
+++ b/app-common/src/main/res/values/strings.xml
@@ -178,4 +178,5 @@
     <string name="general_advice_title">Advice</string>
     <string name="general_error_invalid_input_label">Invalid input</string>
     <string name="general_information_for_the_developer">Information for the developer</string>
+    <string name="general_error_report_bug_action">Report bug</string>
 </resources>

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheTask.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheTask.kt
@@ -7,6 +7,7 @@ class ClearCacheTask(
     val targets: List<InstallId>,
     val returnToApp: Boolean,
     val onSuccess: (InstallId) -> Unit,
+    val onError: (InstallId, Exception) -> Unit,
 ) : AutomationTask {
 
     data class Result(

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/AppControlAutomation.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/AppControlAutomation.kt
@@ -22,6 +22,7 @@ import eu.darken.sdmse.appcontrol.core.forcestop.ForceStopAutomationTask
 import eu.darken.sdmse.automation.core.AutomationHost
 import eu.darken.sdmse.automation.core.AutomationModule
 import eu.darken.sdmse.automation.core.AutomationTask
+import eu.darken.sdmse.automation.core.errors.AutomationTimeoutException
 import eu.darken.sdmse.automation.core.errors.ScreenUnavailableException
 import eu.darken.sdmse.automation.core.errors.UserCancelledAutomationException
 import eu.darken.sdmse.automation.core.finishAutomation
@@ -48,7 +49,6 @@ import eu.darken.sdmse.common.progress.withProgress
 import eu.darken.sdmse.common.user.UserManager2
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.delay
 import javax.inject.Provider
 
@@ -146,10 +146,9 @@ class AppControlAutomation @AssistedInject constructor(
                 successful.add(target)
             } catch (e: ScreenUnavailableException) {
                 log(TAG, WARN) { "Cancelled because screen become unavailable: ${e.asLog()}" }
-                // TODO We don't have to abort here, but this is not a normal state and should show an error?
                 throw e
-            } catch (_: TimeoutCancellationException) {
-                log(TAG, WARN) { "Timeout while processing $installed" }
+            } catch (e: AutomationTimeoutException) {
+                log(TAG, WARN) { "Timeout while processing $installed: $e" }
                 failed.add(target)
             } catch (e: CancellationException) {
                 log(TAG, WARN) { "We were cancelled: ${e.asLog()}" }

--- a/app/src/main/java/eu/darken/sdmse/automation/core/errors/AutomationTimeoutException.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/errors/AutomationTimeoutException.kt
@@ -1,33 +1,25 @@
 package eu.darken.sdmse.automation.core.errors
 
 import android.content.Intent
-import android.os.Build
 import androidx.core.net.toUri
 import eu.darken.sdmse.R
-import eu.darken.sdmse.common.BuildConfigWrap
-import eu.darken.sdmse.common.ca.caString
 import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.error.HasLocalizedError
 import eu.darken.sdmse.common.error.LocalizedError
 import eu.darken.sdmse.common.error.asErrorDialogBuilder
+import kotlinx.coroutines.TimeoutCancellationException
 
-open class AutomationCompatibilityException(
-    override val message: String = "SD Maid couldn’t figure out the screen layout. If this keeps happening, your language or setup might not be fully supported. Check for updates or reach out to me so I can fix it."
-) : AutomationException(), HasLocalizedError {
+open class AutomationTimeoutException(
+    cause: TimeoutCancellationException,
+) : AutomationException(
+    "SD Maid couldn't complete the necessary steps within the timelimit. This could mean that I need to adjust the app for your device. Consider reaching out to me so I can fix it.",
+    cause,
+), HasLocalizedError {
 
     override fun getLocalizedError(): LocalizedError = LocalizedError(
         throwable = this,
-        label = R.string.automation_error_compatibility_title.toCaString(),
-        description = caString {
-            """
-                ${getString(R.string.automation_error_compatibility_body)}
-                
-               
-                ${getString(eu.darken.sdmse.common.R.string.general_information_for_the_developer)}:
-                v${BuildConfigWrap.VERSION_NAME} (${BuildConfigWrap.VERSION_CODE}) ${BuildConfigWrap.FLAVOR} [${BuildConfigWrap.BUILD_TYPE}]
-                ${Build.FINGERPRINT}
-            """.trimIndent()
-        },
+        label = R.string.automation_error_timeout_title.toCaString(),
+        description = R.string.automation_error_timeout_body.toCaString(),
         infoActionLabel = eu.darken.sdmse.common.R.string.general_error_report_bug_action.toCaString(),
         infoAction = {
             try {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -433,9 +433,9 @@
     <string name="appcleaner_progress_shizuku_deleting_caches">Deleting caches by using Shizuku</string>
     <string name="appcleaner_progress_determining_inaccessible_caches">Determining inaccessible caches</string>
     <string name="appcleaner_automation_error_locked_appcache_title">Clear cache unavailable</string>
-    <string name="appcleaner_automation_error_locked_appcache_body">The system has disabled the "Clear cache" button for this app. Create an exclusion for this app.</string>
+    <string name="appcleaner_automation_error_locked_appcache_body">The system has disabled the "Clear cache" button for this app. Exclude it to speed up cache clearing.</string>
     <string name="appcleaner_automation_error_no_settings_title">Settings screen unavailable</string>
-    <string name="appcleaner_automation_error_no_settings_body">This system app has no settings screen. Cache clearing via accessibility service is not possible. Create an exclusion for this app.</string>
+    <string name="appcleaner_automation_error_no_settings_body">This system app has no settings screen. Cache clearing via accessibility service is not possible. Exclude it to speed up cache clearing.</string>
     <string name="appcleaner_automation_error_securitycenter_permission_title">System app misconfigured</string>
     <string name="appcleaner_automation_error_securitycenter_permission_body">HyperOS\'s Security app (com.miui.securitycenter) is missing the Usage Stats permission (GET_USAGE_STATS). This breaks features like "Clear Data" in app details and cache clearing via accessibility. Grant the permission to restore full functionality.</string>
 
@@ -668,7 +668,10 @@
     <string name="automation_error_not_running_body">Accessibility service is not running. Try rebooting the device.</string>
     <string name="automation_error_screen_unavailable_title">Screen unavailable</string>
     <string name="automation_error_screen_unavailable_body">The operation was aborted because the screen became unavailable (e.g. display off or lockscreen active).</string>
+    <string name="automation_error_compatibility_title">Automation compatibility</string>
     <string name="automation_error_compatibility_body">SD Maid couldn’t figure out the screen layout. If this keeps happening, your language or setup might not be fully supported. Check for updates or reach out to me so I can fix it.</string>
+    <string name="automation_error_timeout_title">Automation timeout</string>
+    <string name="automation_error_timeout_body">SD Maid did not complete all steps within the time limit. If this keeps happening, I might need to adjust the app for your device. Check for updates or reach out to me so I can fix it.</string>
 
     <string name="history_label">History</string>
     <string name="history_description">A chronological list of recent actions and affected data.</string>


### PR DESCRIPTION
This commit introduces a new `AutomationTimeoutException` to specifically handle cases where automation tasks time out.

Additionally, the `AutomationCompatibilityException` and the new `AutomationTimeoutException` now include an action to report a bug, guiding users to the relevant wiki page.

The AppCleaner's `ClearCacheModule` has been updated to:
- Properly handle and log `AutomationTimeoutException`.
- Limit the number of consecutive timeouts before considering it a compatibility issue, specifically when no successful operations have occurred.
- Track individual item failures during inaccessible cache deletion and include them in the result, even if the overall operation is cancelled by the user.

String resources have been updated for clarity and to include a "Report bug" action label.