### PR TITLE
Automation: Add AutomationBadTokenException

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
@@ -34,6 +34,7 @@ import eu.darken.sdmse.automation.core.AutomationTask
 import eu.darken.sdmse.automation.core.animation.AnimationState
 import eu.darken.sdmse.automation.core.animation.AnimationTool
 import eu.darken.sdmse.automation.core.errors.AutomationCompatibilityException
+import eu.darken.sdmse.automation.core.errors.AutomationOverlayException
 import eu.darken.sdmse.automation.core.errors.AutomationTimeoutException
 import eu.darken.sdmse.automation.core.errors.InvalidSystemStateException
 import eu.darken.sdmse.automation.core.errors.PlanAbortException
@@ -243,6 +244,9 @@ class ClearCacheModule @AssistedInject constructor(
                 } else {
                     throw e
                 }
+            } catch (e: AutomationOverlayException) {
+                log(TAG, ERROR) { "Automation overlay error: ${e.asLog()}" }
+                throw e
             } catch (e: Exception) {
                 if (e is PlanAbortException && e.treatAsSuccess) {
                     log(TAG, INFO) { "Treating aborted plan as success for $target:\n${e.asLog()}" }

--- a/app/src/main/java/eu/darken/sdmse/automation/core/errors/AutomationOverlayException.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/errors/AutomationOverlayException.kt
@@ -1,0 +1,22 @@
+package eu.darken.sdmse.automation.core.errors
+
+import android.view.WindowManager
+import eu.darken.sdmse.R
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.error.HasLocalizedError
+import eu.darken.sdmse.common.error.LocalizedError
+
+open class AutomationOverlayException(
+    cause: WindowManager.BadTokenException,
+) : AutomationException(
+    "Couldn't show overlay. This sometimes happens on certain devices — a reboot usually helps.",
+    cause,
+), HasLocalizedError {
+
+    override fun getLocalizedError(): LocalizedError = LocalizedError(
+        throwable = this,
+        label = R.string.automation_error_overlay_title.toCaString(),
+        description = R.string.automation_error_overlay_body.toCaString(),
+    )
+
+}

--- a/app/src/main/java/eu/darken/sdmse/automation/core/specs/AutomationExplorer.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/specs/AutomationExplorer.kt
@@ -1,13 +1,16 @@
 package eu.darken.sdmse.automation.core.specs
 
+import android.view.WindowManager
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import eu.darken.sdmse.automation.core.AutomationHost
+import eu.darken.sdmse.automation.core.errors.AutomationOverlayException
 import eu.darken.sdmse.automation.core.errors.AutomationTimeoutException
 import eu.darken.sdmse.automation.core.errors.PlanAbortException
 import eu.darken.sdmse.common.R
 import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
@@ -73,9 +76,20 @@ class AutomationExplorer @AssistedInject constructor(
                     }
                 }
             }
-        } catch (e: TimeoutCancellationException) {
-            log(TAG, WARN) { "Automation timed out: $e" }
-            throw AutomationTimeoutException(e)
+        } catch (e: Exception) {
+            when (e) {
+                is TimeoutCancellationException -> {
+                    log(TAG, WARN) { "Automation timed out: $e" }
+                    throw AutomationTimeoutException(e)
+                }
+
+                is WindowManager.BadTokenException -> {
+                    log(TAG, ERROR) { "Couldn't add overlay: $e" }
+                    throw AutomationOverlayException(e)
+                }
+
+                else -> throw e
+            }
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -672,6 +672,8 @@
     <string name="automation_error_compatibility_body">SD Maid couldn’t figure out the screen layout. If this keeps happening, your language or setup might not be fully supported. Check for updates or reach out to me so I can fix it.</string>
     <string name="automation_error_timeout_title">Automation timeout</string>
     <string name="automation_error_timeout_body">SD Maid did not complete all steps within the time limit. If this keeps happening, I might need to adjust the app for your device. Check for updates or reach out to me so I can fix it.</string>
+    <string name="automation_error_overlay_title">Automation overlay</string>
+    <string name="automation_error_overlay_body">SD Maid could not show the automation overlay. Check permissions and try rebooting your device.</string>
 
     <string name="history_label">History</string>
     <string name="history_description">A chronological list of recent actions and affected data.</string>


### PR DESCRIPTION
Introduces a specific exception for cases where displaying the automation overlay fails due to a `WindowManager.BadTokenException`. This exception provides a localized error message to the user, suggesting a reboot as a potential solution.

Implements #1787