### PR TITLE
Automation: Add package name to internal step description

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/alcatel/AlcatelSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/alcatel/AlcatelSpecs.kt
@@ -79,7 +79,7 @@ class AlcatelSpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = tag,
-                descriptionInternal = "Storage entry",
+                descriptionInternal = "Storage entry for $pkg",
                 label = R.string.appcleaner_automation_progress_find_storage.toCaString(storageEntryLabels),
                 windowLaunch = windowLauncherDefaultSettings(pkg),
                 windowCheck = windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg),
@@ -96,7 +96,7 @@ class AlcatelSpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = tag,
-                descriptionInternal = "Clear cache button",
+                descriptionInternal = "Clear cache button for $pkg",
                 label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheButtonLabels),
                 windowCheck = windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg),
                 nodeAction = defaultFindAndClickClearCache(isDryRun = Bugs.isDryRun, pkg) {

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/androidtv/AndroidTVSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/androidtv/AndroidTVSpecs.kt
@@ -94,7 +94,7 @@ open class AndroidTVSpecs @Inject constructor(
             }
             val step = AutomationStep(
                 source = TAG,
-                descriptionInternal = "Clear cache button",
+                descriptionInternal = "Clear cache button for $pkg",
                 label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheButtonLabels),
                 windowLaunch = windowLauncherDefaultSettings(pkg),
                 windowCheck = windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg),
@@ -145,7 +145,7 @@ open class AndroidTVSpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = TAG,
-                descriptionInternal = "Confirm action",
+                descriptionInternal = "Confirm action for $pkg",
                 label = R.string.appcleaner_automation_progress_find_ok_confirmation.toCaString(buttonLabels),
                 windowCheck = windowCheck,
                 nodeAction = action,

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/coloros/ColorOSSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/coloros/ColorOSSpecs.kt
@@ -97,7 +97,7 @@ class ColorOSSpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = TAG,
-                descriptionInternal = "Storage entry",
+                descriptionInternal = "Storage entry for $pkg",
                 label = R.string.appcleaner_automation_progress_find_storage.toCaString(storageEntryLabels),
                 windowLaunch = windowLauncherDefaultSettings(pkg),
                 windowCheck = windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg),
@@ -158,7 +158,7 @@ class ColorOSSpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = TAG,
-                descriptionInternal = "Clear cache button",
+                descriptionInternal = "Clear cache button for $pkg",
                 label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheButtonLabels),
                 windowCheck = windowCheck,
                 nodeRecovery = defaultNodeRecovery(pkg),

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/doogee/DoogeeSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/doogee/DoogeeSpecs.kt
@@ -79,7 +79,7 @@ class DoogeeSpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = tag,
-                descriptionInternal = "Storage entry",
+                descriptionInternal = "Storage entry for $pkg",
                 label = R.string.appcleaner_automation_progress_find_storage.toCaString(storageEntryLabels),
                 windowLaunch = windowLauncherDefaultSettings(pkg),
                 windowCheck = windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg),
@@ -102,7 +102,7 @@ class DoogeeSpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = tag,
-                descriptionInternal = "Clear cache button",
+                descriptionInternal = "Clear cache button for $pkg",
                 label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheButtonLabels),
                 windowCheck = windowCheck,
                 nodeAction = defaultFindAndClickClearCache(isDryRun = Bugs.isDryRun, pkg) {

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/flyme/FlymeSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/flyme/FlymeSpecs.kt
@@ -86,7 +86,7 @@ class FlymeSpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = TAG,
-                descriptionInternal = "Clear cache button",
+                descriptionInternal = "Clear cache button for $pkg",
                 label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheButtonLabels),
                 windowLaunch = windowLauncherDefaultSettings(pkg),
                 windowCheck = windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg),

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/honor/HonorSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/honor/HonorSpecs.kt
@@ -75,7 +75,7 @@ class HonorSpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = tag,
-                descriptionInternal = "Storage entry",
+                descriptionInternal = "Storage entry for $pkg",
                 label = R.string.appcleaner_automation_progress_find_storage.toCaString(storageEntryLabels),
                 windowLaunch = windowLauncherDefaultSettings(pkg),
                 windowCheck = windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg),
@@ -92,7 +92,7 @@ class HonorSpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = tag,
-                descriptionInternal = "Clear cache button",
+                descriptionInternal = "Clear cache button for $pkg",
                 label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheButtonLabels),
                 windowCheck = windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg),
                 nodeAction = defaultFindAndClickClearCache(isDryRun = Bugs.isDryRun, pkg) {

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/huawei/HuaweiSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/huawei/HuaweiSpecs.kt
@@ -76,7 +76,7 @@ class HuaweiSpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = tag,
-                descriptionInternal = "Storage entry",
+                descriptionInternal = "Storage entry for $pkg",
                 label = R.string.appcleaner_automation_progress_find_storage.toCaString(storageEntryLabels),
                 windowLaunch = windowLauncherDefaultSettings(pkg),
                 windowCheck = windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg),
@@ -93,7 +93,7 @@ class HuaweiSpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = tag,
-                descriptionInternal = "Clear cache button",
+                descriptionInternal = "Clear cache button for $pkg",
                 label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheButtonLabels),
                 windowCheck = windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg),
                 nodeAction = defaultFindAndClickClearCache(isDryRun = Bugs.isDryRun, pkg) {

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/hyperos/HyperOsSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/hyperos/HyperOsSpecs.kt
@@ -145,7 +145,7 @@ class HyperOsSpecs @Inject constructor(
 
         val step = AutomationStep(
             source = TAG,
-            descriptionInternal = "Storage entry (main plan)",
+            descriptionInternal = "Storage entry (main plan) for $pkg",
             label = R.string.appcleaner_automation_progress_find_storage.toCaString(""),
             windowLaunch = windowLauncherDefaultSettings(pkg),
             windowCheck = windowCheck,
@@ -187,7 +187,7 @@ class HyperOsSpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = TAG,
-                descriptionInternal = "Storage entry (settings plan)",
+                descriptionInternal = "Storage entry (settings plan) for $pkg",
                 label = R.string.appcleaner_automation_progress_find_storage.toCaString(storageEntryLabels),
                 nodeRecovery = defaultNodeRecovery(pkg),
                 nodeAction = defaultFindAndClick(finder = storageFinder),
@@ -201,7 +201,7 @@ class HyperOsSpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = TAG,
-                descriptionInternal = "Clear cache (settings plan)",
+                descriptionInternal = "Clear cache (settings plan) for $pkg",
                 label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheButtonLabels),
                 nodeAction = defaultFindAndClickClearCache(isDryRun = isDryRun, pkg) {
                     if (!it.isClickyButton()) false else it.textMatchesAny(clearCacheButtonLabels)
@@ -266,7 +266,7 @@ class HyperOsSpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = TAG,
-                descriptionInternal = "Clear data button (security center plan)",
+                descriptionInternal = "Clear data button (security center plan) for $pkg",
                 label = R.string.appcleaner_automation_progress_find_clear_data.toCaString(clearDataLabels),
                 windowCheck = windowCheckDefaultSettings(SETTINGS_PKG_HYPEROS, ipcFunnel, pkg),
                 nodeRecovery = defaultNodeRecovery(pkg),
@@ -278,7 +278,7 @@ class HyperOsSpecs @Inject constructor(
         if (useAlternativeStep) {
             val alternativeStep = AutomationStep(
                 source = TAG,
-                descriptionInternal = "Clear cache button (alternative security center plan)",
+                descriptionInternal = "Clear cache button (alternative security center plan) for $pkg",
                 label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheLabels),
                 windowCheck = windowCheckDefaultSettings(SETTINGS_PKG_HYPEROS, ipcFunnel, pkg),
                 nodeAction = defaultFindAndClick(
@@ -355,7 +355,7 @@ class HyperOsSpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = TAG,
-                descriptionInternal = "Clear cache button (security center plan)",
+                descriptionInternal = "Clear cache button (security center plan) for $pkg",
                 label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheLabels),
                 windowCheck = windowCheck,
                 nodeAction = action,
@@ -397,7 +397,7 @@ class HyperOsSpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = TAG,
-                descriptionInternal = "Confirm clear cache (security center plan)",
+                descriptionInternal = "Confirm clear cache (security center plan) for $pkg",
                 label = R.string.appcleaner_automation_progress_find_ok_confirmation.toCaString(""),
                 windowCheck = windowCheck,
                 nodeAction = action,

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/lge/LGESpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/lge/LGESpecs.kt
@@ -74,7 +74,7 @@ class LGESpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = TAG,
-                descriptionInternal = "Storage entry",
+                descriptionInternal = "Storage entry for $pkg",
                 label = R.string.appcleaner_automation_progress_find_storage.toCaString(storageEntryLabels),
                 windowLaunch = windowLauncherDefaultSettings(pkg),
                 windowCheck = windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg),
@@ -89,7 +89,7 @@ class LGESpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = TAG,
-                descriptionInternal = "Clear cache",
+                descriptionInternal = "Clear cache for $pkg",
                 label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheButtonLabels),
                 windowCheck = windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg),
                 nodeAction = defaultFindAndClickClearCache(isDryRun = Bugs.isDryRun, pkg) {

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/miui/MIUISpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/miui/MIUISpecs.kt
@@ -132,7 +132,7 @@ class MIUISpecs @Inject constructor(
 
         val step = AutomationStep(
             source = TAG,
-            descriptionInternal = "Storage entry (main plan)",
+            descriptionInternal = "Storage entry (main plan) for $pkg",
             label = R.string.appcleaner_automation_progress_find_storage.toCaString(""),
             windowLaunch = windowLauncherDefaultSettings(pkg),
             windowCheck = windowCheck,
@@ -158,7 +158,7 @@ class MIUISpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = TAG,
-                descriptionInternal = "Storage entry (settings plan)",
+                descriptionInternal = "Storage entry (settings plan) for $pkg",
                 label = R.string.appcleaner_automation_progress_find_storage.toCaString(storageEntryLabels),
                 nodeRecovery = defaultNodeRecovery(pkg),
                 nodeAction = defaultFindAndClick(finder = storageFinder),
@@ -172,7 +172,7 @@ class MIUISpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = TAG,
-                descriptionInternal = "Clear cache (settings plan)",
+                descriptionInternal = "Clear cache (settings plan) for $pkg",
                 label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheButtonLabels),
                 nodeAction = defaultFindAndClickClearCache(isDryRun = Bugs.isDryRun, pkg) {
                     if (!it.isClickyButton()) false else it.textMatchesAny(clearCacheButtonLabels)
@@ -228,7 +228,7 @@ class MIUISpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = TAG,
-                descriptionInternal = "Clear data (security center plan)",
+                descriptionInternal = "Clear data (security center plan) for $pkg",
                 label = R.string.appcleaner_automation_progress_find_clear_data.toCaString(clearDataLabels),
                 windowCheck = windowCheckDefaultSettings(SETTINGS_PKG_MIUI, ipcFunnel, pkg),
                 nodeRecovery = defaultNodeRecovery(pkg),
@@ -255,7 +255,7 @@ class MIUISpecs @Inject constructor(
             }
             val alternativeStep = AutomationStep(
                 source = TAG,
-                descriptionInternal = "Clear cache (alternative security center plan)",
+                descriptionInternal = "Clear cache (alternative security center plan) for $pkg",
                 label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheLabels),
                 windowCheck = windowCheckDefaultSettings(SETTINGS_PKG_MIUI, ipcFunnel, pkg),
                 nodeAction = action,
@@ -312,7 +312,7 @@ class MIUISpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = TAG,
-                descriptionInternal = "Clear cache button (security center plan)",
+                descriptionInternal = "Clear cache button (security center plan) for $pkg",
                 label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheLabels),
                 windowCheck = windowCheck,
                 nodeAction = action,
@@ -353,7 +353,7 @@ class MIUISpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = TAG,
-                descriptionInternal = "Confirm clear cache (security center plan)",
+                descriptionInternal = "Confirm clear cache (security center plan) for $pkg",
                 label = R.string.appcleaner_automation_progress_find_ok_confirmation.toCaString(""),
                 windowCheck = windowCheck,
                 nodeAction = action,

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/nubia/NubiaSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/nubia/NubiaSpecs.kt
@@ -79,7 +79,7 @@ class NubiaSpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = TAG,
-                descriptionInternal = "Storage entry",
+                descriptionInternal = "Storage entry for $pkg",
                 label = R.string.appcleaner_automation_progress_find_storage.toCaString(storageEntryLabels),
                 windowLaunch = windowLauncherDefaultSettings(pkg),
                 windowCheck = windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg),
@@ -96,7 +96,7 @@ class NubiaSpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = TAG,
-                descriptionInternal = "Clear cache",
+                descriptionInternal = "Clear cache for $pkg",
                 label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheButtonLabels),
                 windowCheck = windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg),
                 nodeAction = defaultFindAndClickClearCache(isDryRun = Bugs.isDryRun, pkg) {

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/oneui/OneUISpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/oneui/OneUISpecs.kt
@@ -75,7 +75,7 @@ class OneUISpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = TAG,
-                descriptionInternal = "Storage entry",
+                descriptionInternal = "Storage entry for $pkg",
                 label = R.string.appcleaner_automation_progress_find_storage.toCaString(storageEntryLabels),
                 windowLaunch = windowLauncherDefaultSettings(pkg),
                 windowCheck = windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg),
@@ -92,7 +92,7 @@ class OneUISpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = TAG,
-                descriptionInternal = "Clear cache",
+                descriptionInternal = "Clear cache for $pkg",
                 label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheButtonLabels),
                 windowCheck = windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg),
                 nodeAction = defaultFindAndClickClearCache(isDryRun = Bugs.isDryRun, pkg) {

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/oukitel/OukitelSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/oukitel/OukitelSpecs.kt
@@ -90,7 +90,7 @@ class OukitelSpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = tag,
-                descriptionInternal = "Storage entry",
+                descriptionInternal = "Storage entry for $pkg",
                 label = R.string.appcleaner_automation_progress_find_storage.toCaString(storageEntryLabels),
                 windowLaunch = windowLauncherDefaultSettings(pkg),
                 windowCheck = windowCheck,
@@ -114,7 +114,7 @@ class OukitelSpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = tag,
-                descriptionInternal = "Clear cache button",
+                descriptionInternal = "Clear cache button for $pkg",
                 label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheButtonLabels),
                 windowCheck = windowCheck,
                 nodeAction = defaultFindAndClickClearCache(isDryRun = Bugs.isDryRun, pkg) {

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/oxygenos/OxygenOSSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/oxygenos/OxygenOSSpecs.kt
@@ -79,7 +79,7 @@ class OxygenOSSpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = TAG,
-                descriptionInternal = "Storage entry",
+                descriptionInternal = "Storage entry for $pkg",
                 label = R.string.appcleaner_automation_progress_find_storage.toCaString(storageEntryLabels),
                 windowLaunch = windowLauncherDefaultSettings(pkg),
                 windowCheck = windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg),
@@ -120,7 +120,7 @@ class OxygenOSSpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = TAG,
-                descriptionInternal = "Clear cache",
+                descriptionInternal = "Clear cache for $pkg",
                 label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheButtonLabels),
                 windowCheck = windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg),
                 nodeAction = action,

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/realme/RealmeSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/realme/RealmeSpecs.kt
@@ -82,7 +82,7 @@ class RealmeSpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = TAG,
-                descriptionInternal = "Storage entry",
+                descriptionInternal = "Storage entry for $pkg",
                 label = R.string.appcleaner_automation_progress_find_storage.toCaString(storageEntryLabels),
                 windowLaunch = windowLauncherDefaultSettings(pkg),
                 windowCheck = windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg),
@@ -124,7 +124,7 @@ class RealmeSpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = TAG,
-                descriptionInternal = "Clear cache",
+                descriptionInternal = "Clear cache for $pkg",
                 label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheButtonLabels),
                 windowCheck = windowCheck { _, root -> root.pkgId == SETTINGS_PKG },
                 nodeAction = action,

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/vivo/VivoSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/vivo/VivoSpecs.kt
@@ -91,7 +91,7 @@ class VivoSpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = TAG,
-                descriptionInternal = "Storage entry",
+                descriptionInternal = "Storage entry for $pkg",
                 label = R.string.appcleaner_automation_progress_find_storage.toCaString(storageEntryLabels),
                 windowLaunch = windowLauncherDefaultSettings(pkg),
                 windowCheck = windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg),
@@ -138,7 +138,7 @@ class VivoSpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = TAG,
-                descriptionInternal = "Clear cache",
+                descriptionInternal = "Clear cache for $pkg",
                 label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheButtonLabels),
                 windowCheck = windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg),
                 nodeAction = action,

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/androidtv/AndroidTVSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/androidtv/AndroidTVSpecs.kt
@@ -87,7 +87,7 @@ open class AndroidTVSpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = TAG,
-                descriptionInternal = "Force stop button",
+                descriptionInternal = "Force stop button for $pkg",
                 label = R.string.appcontrol_automation_progress_find_force_stop.toCaString(forceStopLabels),
                 windowLaunch = windowLauncherDefaultSettings(pkg),
                 windowCheck = windowCheckDefaultSettings(AlcatelSpecs.SETTINGS_PKG, ipcFunnel, pkg),
@@ -126,7 +126,7 @@ open class AndroidTVSpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = TAG,
-                descriptionInternal = "Confirm force stop",
+                descriptionInternal = "Confirm force stop for $pkg",
                 label = R.string.appcleaner_automation_progress_find_ok_confirmation.toCaString(okLbl),
                 windowCheck = windowCheck,
                 nodeAction = action,

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/aosp/AOSPSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/aosp/AOSPSpecs.kt
@@ -89,7 +89,7 @@ class AOSPSpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = TAG,
-                descriptionInternal = "Force stop button",
+                descriptionInternal = "Force stop button for $pkg",
                 label = R.string.appcontrol_automation_progress_find_force_stop.toCaString(forceStopLabels),
                 windowLaunch = windowLauncherDefaultSettings(pkg),
                 windowCheck = windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg),
@@ -127,7 +127,7 @@ class AOSPSpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = TAG,
-                descriptionInternal = "Confirm force stop button",
+                descriptionInternal = "Confirm force stop button for $pkg",
                 label = R.string.appcleaner_automation_progress_find_ok_confirmation.toCaString(titleLbl + okLbl),
                 windowCheck = windowCheck,
                 nodeAction = action,

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/hyperos/HyperOsSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/hyperos/HyperOsSpecs.kt
@@ -85,7 +85,7 @@ class HyperOsSpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = TAG,
-                descriptionInternal = "Force stop button",
+                descriptionInternal = "Force stop button for $pkg",
                 label = R.string.appcontrol_automation_progress_find_force_stop.toCaString(forceStopLabels),
                 windowLaunch = windowLauncherDefaultSettings(pkg),
                 windowCheck = windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg),
@@ -123,7 +123,7 @@ class HyperOsSpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = TAG,
-                descriptionInternal = "Confirm force stop",
+                descriptionInternal = "Confirm force stop for $pkg",
                 label = R.string.appcleaner_automation_progress_find_ok_confirmation.toCaString(titleLbl + okLbl),
                 windowCheck = windowCheck,
                 nodeAction = action,

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/miui/MIUISpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/miui/MIUISpecs.kt
@@ -85,7 +85,7 @@ class MIUISpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = TAG,
-                descriptionInternal = "Force stop button",
+                descriptionInternal = "Force stop button for $pkg",
                 label = R.string.appcontrol_automation_progress_find_force_stop.toCaString(forceStopLabels),
                 windowLaunch = windowLauncherDefaultSettings(pkg),
                 windowCheck = windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg),
@@ -123,7 +123,7 @@ class MIUISpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = TAG,
-                descriptionInternal = "Confirm force stop",
+                descriptionInternal = "Confirm force stop for $pkg",
                 label = R.string.appcleaner_automation_progress_find_ok_confirmation.toCaString(titleLbl + okLbl),
                 windowCheck = windowCheck,
                 nodeAction = action,

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/oneui/OneUISpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/oneui/OneUISpecs.kt
@@ -85,7 +85,7 @@ class OneUISpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = TAG,
-                descriptionInternal = "Force stop button",
+                descriptionInternal = "Force stop button for $pkg",
                 label = R.string.appcontrol_automation_progress_find_force_stop.toCaString(forceStopLabels),
                 windowLaunch = windowLauncherDefaultSettings(pkg),
                 windowCheck = windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg),
@@ -123,7 +123,7 @@ class OneUISpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = TAG,
-                descriptionInternal = "Confirm force stop",
+                descriptionInternal = "Confirm force stop for $pkg",
                 label = R.string.appcleaner_automation_progress_find_ok_confirmation.toCaString(titleLbl + okLbl),
                 windowCheck = windowCheck,
                 nodeAction = action,

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/oukitel/OukitelSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/oukitel/OukitelSpecs.kt
@@ -102,7 +102,7 @@ class OukitelSpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = TAG,
-                descriptionInternal = "Force stop button",
+                descriptionInternal = "Force stop button for $pkg",
                 label = R.string.appcontrol_automation_progress_find_force_stop.toCaString(forceStopLabels),
                 windowLaunch = windowLauncherDefaultSettings(pkg),
                 windowCheck = windowCheck,
@@ -140,7 +140,7 @@ class OukitelSpecs @Inject constructor(
 
             val step = AutomationStep(
                 source = TAG,
-                descriptionInternal = "Confirm force stop button",
+                descriptionInternal = "Confirm force stop button for $pkg",
                 label = R.string.appcleaner_automation_progress_find_ok_confirmation.toCaString(titleLbl + okLbl),
                 windowCheck = windowCheck,
                 nodeAction = action,


### PR DESCRIPTION
This helps with debugging when automation fails as the target package is now part of the step description.