### PR TITLE
AppCleaner: Correctly update inaccessible item count after deletion

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
@@ -324,7 +324,6 @@ class AppCleaner @Inject constructor(
 
                     val deletedSize = deletedInaccessible.sumOf { it.expectedGain }
                     inacc.copy(
-                        itemCount = 1,
                         totalSize = inacc.totalSize - deletedSize,
                         publicSize = inacc.publicSize?.let { it - deletedSize }?.coerceAtLeast(0L),
                     )


### PR DESCRIPTION
The `itemCount` for inaccessible items was incorrectly hardcoded to `1`, which would be wrong if multiple files contributed to the inaccessible size. This change removes the incorrect `itemCount` update, ensuring the `totalSize` and `publicSize` are correctly adjusted after deleting inaccessible files.