### PR TITLE
SystemCleaner: Add Thumbnails filter

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/AppScanner.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/AppScanner.kt
@@ -66,7 +66,6 @@ import eu.darken.sdmse.exclusion.core.ExclusionManager
 import eu.darken.sdmse.exclusion.core.pathExclusions
 import eu.darken.sdmse.exclusion.core.pkgExclusions
 import eu.darken.sdmse.main.core.SDMTool
-import eu.darken.sdmse.setup.usagestats.UsageStatsSetupModule
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.toList
@@ -89,7 +88,6 @@ class AppScanner @Inject constructor(
     private val inaccessibleCacheProvider: InaccessibleCacheProvider,
     private val userManager: UserManager2,
     private val pkgOps: PkgOps,
-    private val usageStatsSetupModule: UsageStatsSetupModule,
 ) : Progress.Host, Progress.Client {
 
     private val progressPub = MutableStateFlow<Progress.Data?>(

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/SystemCleanerSettings.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/SystemCleanerSettings.kt
@@ -34,6 +34,7 @@ class SystemCleanerSettings @Inject constructor(
     val filterLostDirEnabled = dataStore.createValue("filter.lostdir.enabled", true)
     val filterLinuxFilesEnabled = dataStore.createValue("filter.linuxfiles.enabled", true)
     val filterMacFilesEnabled = dataStore.createValue("filter.macfiles.enabled", true)
+    val filterThumbnailsEnabled = dataStore.createValue("filter.thumbnails.enabled", false)
     val filterTempFilesEnabled = dataStore.createValue("filter.tempfiles.enabled", true)
     val filterAnalyticsEnabled = dataStore.createValue("filter.analytics.enabled", true)
     val filterWindowsFilesEnabled = dataStore.createValue("filter.windowsfiles.enabled", true)
@@ -70,6 +71,7 @@ class SystemCleanerSettings @Inject constructor(
         filterLostDirEnabled,
         filterLinuxFilesEnabled,
         filterMacFilesEnabled,
+        filterThumbnailsEnabled,
         filterTempFilesEnabled,
         filterAnalyticsEnabled,
         filterWindowsFilesEnabled,

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/ThumbnailsFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/ThumbnailsFilter.kt
@@ -1,0 +1,88 @@
+package eu.darken.sdmse.systemcleaner.core.filter.stock
+
+import dagger.Binds
+import dagger.Module
+import dagger.Reusable
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoSet
+import eu.darken.sdmse.R
+import eu.darken.sdmse.common.areas.DataArea
+import eu.darken.sdmse.common.ca.CaDrawable
+import eu.darken.sdmse.common.ca.CaString
+import eu.darken.sdmse.common.ca.toCaDrawable
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.datastore.value
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.common.files.GatewaySwitch
+import eu.darken.sdmse.common.sieve.SegmentCriterium
+import eu.darken.sdmse.systemcleaner.core.SystemCleanerSettings
+import eu.darken.sdmse.systemcleaner.core.filter.BaseSystemCleanerFilter
+import eu.darken.sdmse.systemcleaner.core.filter.SystemCleanerFilter
+import eu.darken.sdmse.systemcleaner.core.filter.toDeletion
+import eu.darken.sdmse.systemcleaner.core.sieve.SystemCrawlerSieve
+import javax.inject.Inject
+import javax.inject.Provider
+
+class ThumbnailsFilter @Inject constructor(
+    private val sieveFactory: SystemCrawlerSieve.Factory,
+    private val gatewaySwitch: GatewaySwitch,
+) : BaseSystemCleanerFilter() {
+
+    override suspend fun getIcon(): CaDrawable = R.drawable.ic_thumb_up_24.toCaDrawable()
+
+    override suspend fun getLabel(): CaString = R.string.systemcleaner_filter_thumbnails_label.toCaString()
+
+    override suspend fun getDescription(): CaString = R.string.systemcleaner_filter_thumbnails_summary.toCaString()
+
+    override suspend fun targetAreas(): Set<DataArea.Type> = setOf(
+        DataArea.Type.SDCARD,
+        DataArea.Type.PUBLIC_MEDIA,
+        DataArea.Type.PORTABLE,
+    )
+
+    private lateinit var sieve: SystemCrawlerSieve
+
+    override suspend fun initialize() {
+        val config = SystemCrawlerSieve.Config(
+            areaTypes = targetAreas(),
+            pfpCriteria = setOf(
+                SegmentCriterium(".thumbnails", mode = SegmentCriterium.Mode.Contain())
+            ),
+        )
+        sieve = sieveFactory.create(config)
+        log(TAG) { "initialized() with $config" }
+    }
+
+
+    override suspend fun match(item: APathLookup<*>): SystemCleanerFilter.Match? {
+        return sieve.match(item).toDeletion()
+    }
+
+    override suspend fun process(matches: Collection<SystemCleanerFilter.Match>) {
+        matches.deleteAll(gatewaySwitch)
+    }
+
+    override fun toString(): String = "${this::class.simpleName}(${hashCode()})"
+
+    @Reusable
+    class Factory @Inject constructor(
+        private val settings: SystemCleanerSettings,
+        private val filterProvider: Provider<ThumbnailsFilter>
+    ) : SystemCleanerFilter.Factory {
+        override suspend fun isEnabled(): Boolean = settings.filterThumbnailsEnabled.value()
+        override suspend fun create(): SystemCleanerFilter = filterProvider.get()
+    }
+
+    @InstallIn(SingletonComponent::class)
+    @Module
+    abstract class DIM {
+        @Binds @IntoSet abstract fun mod(mod: Factory): SystemCleanerFilter.Factory
+    }
+
+    companion object {
+        private val TAG = logTag("SystemCleaner", "Filter", "Thumbnails")
+    }
+}

--- a/app/src/main/res/drawable/ic_thumb_up_24.xml
+++ b/app/src/main/res/drawable/ic_thumb_up_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M23,10C23,8.89 22.1,8 21,8H14.68L15.64,3.43C15.66,3.33 15.67,3.22 15.67,3.11C15.67,2.7 15.5,2.32 15.23,2.05L14.17,1L7.59,7.58C7.22,7.95 7,8.45 7,9V19A2,2 0 0,0 9,21H18C18.83,21 19.54,20.5 19.84,19.78L22.86,12.73C22.95,12.5 23,12.26 23,12V10M1,21H5V9H1V21Z" />
+</vector>

--- a/app/src/main/res/xml/preferences_systemcleaner.xml
+++ b/app/src/main/res/xml/preferences_systemcleaner.xml
@@ -85,6 +85,12 @@
             app:summary="@string/systemcleaner_filter_tempfiles_summary"
             app:title="@string/systemcleaner_filter_tempfiles_label" />
         <CheckBoxPreference
+            app:icon="@drawable/ic_thumb_up_24"
+            app:key="filter.thumbnails.enabled"
+            app:singleLineTitle="false"
+            app:summary="@string/systemcleaner_filter_thumbnails_summary"
+            app:title="@string/systemcleaner_filter_thumbnails_label" />
+        <CheckBoxPreference
             app:icon="@drawable/ic_analytics_onsurface"
             app:key="filter.analytics.enabled"
             app:singleLineTitle="false"

--- a/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/ThumbnailsFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/ThumbnailsFilterTest.kt
@@ -1,0 +1,47 @@
+package eu.darken.sdmse.systemcleaner.core.filter.stock
+
+import eu.darken.sdmse.systemcleaner.core.filter.SystemCleanerFilterTest
+import eu.darken.sdmse.systemcleaner.core.sieve.SystemCrawlerSieve
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class ThumbnailsFilterTest : SystemCleanerFilterTest() {
+
+    @BeforeEach
+    override fun setup() {
+        super.setup()
+    }
+
+    @AfterEach
+    override fun teardown() {
+        super.teardown()
+    }
+
+    private fun create() = ThumbnailsFilter(
+        sieveFactory = object : SystemCrawlerSieve.Factory {
+            override fun create(config: SystemCrawlerSieve.Config): SystemCrawlerSieve =
+                SystemCrawlerSieve(config, fileForensics)
+        },
+        gatewaySwitch = gatewaySwitch,
+    )
+
+    @Test fun testFilter() = runTest {
+        mockDefaults()
+
+        create().targetAreas().forEach {
+            neg(it, "folder", Flag.Dir)
+            pos(it, ".thumbnails", Flag.Dir)
+            pos(it, "folder/.thumbnails", Flag.Dir)
+            pos(it, "folder/.thumbnails/subfolder", Flag.Dir)
+            pos(it, "folder/.thumbnails/subfolder/file", Flag.File)
+
+            neg(it, "thumbnails", Flag.Dir)
+            neg(it, "my.thumbnails", Flag.Dir)
+            neg(it, ".thumbnails-db", Flag.Dir)
+        }
+
+        confirm(create())
+    }
+}


### PR DESCRIPTION
This commit introduces a new filter to SystemCleaner for deleting thumbnail files and folders (e.g., `.thumbnails`).

The filter targets SDCARD, PUBLIC_MEDIA, and PORTABLE data areas. It is disabled by default.

A corresponding setting and UI element have been added to the SystemCleaner preferences. Tests for the new filter have also been included.

Implements #1522