### PR TITLE
Better error messages if remote service connection dies (`DeadObjectException`)

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/FileOpsClient.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/FileOpsClient.kt
@@ -31,7 +31,7 @@ class FileOpsClient @AssistedInject constructor(
             if (Bugs.isTrace) log(TAG) { "listFiles($path) finished streaming, ${it.size} items" }
         }
     } catch (e: Exception) {
-        throw e.unwrapPropagation()
+        throw e.refineException()
     }
 
     fun lookUp(path: LocalPath): LocalPathLookup = try {
@@ -39,7 +39,7 @@ class FileOpsClient @AssistedInject constructor(
             if (Bugs.isTrace) log(TAG, VERBOSE) { "lookup($path): $it" }
         }
     } catch (e: Exception) {
-        throw e.unwrapPropagation()
+        throw e.refineException()
     }
 
     /**
@@ -50,7 +50,7 @@ class FileOpsClient @AssistedInject constructor(
             if (Bugs.isTrace) log(TAG, VERBOSE) { "lookupFiles($path) finished streaming, ${it.size} items" }
         }
     } catch (e: Exception) {
-        throw e.unwrapPropagation()
+        throw e.refineException()
     }
 
     /**
@@ -64,7 +64,7 @@ class FileOpsClient @AssistedInject constructor(
             ) { "lookupFilesExtendedStream($path) finished streaming, ${it.size} items" }
         }
     } catch (e: Exception) {
-        throw e.unwrapPropagation()
+        throw e.refineException()
     }
 
     /**
@@ -82,7 +82,7 @@ class FileOpsClient @AssistedInject constructor(
                 (options.pathDoesNotContain ?: emptyList()).toMutableList(),
             )
         } catch (e: Exception) {
-            throw e.unwrapPropagation()
+            throw e.refineException()
         }
         return output.toLocalPathLookupFlow()
     }
@@ -90,73 +90,73 @@ class FileOpsClient @AssistedInject constructor(
     fun du(path: LocalPath): Long = try {
         fileOpsConnection.du(path)
     } catch (e: Exception) {
-        throw e.unwrapPropagation()
+        throw e.refineException()
     }
 
     fun file(path: LocalPath, readWrite: Boolean): FileHandle = try {
         fileOpsConnection.file(path, readWrite).fileHandle(readWrite)
     } catch (e: Exception) {
-        throw e.unwrapPropagation()
+        throw e.refineException()
     }
 
     fun mkdirs(path: LocalPath): Boolean = try {
         fileOpsConnection.mkdirs(path)
     } catch (e: Exception) {
-        throw e.unwrapPropagation()
+        throw e.refineException()
     }
 
     fun createNewFile(path: LocalPath): Boolean = try {
         fileOpsConnection.createNewFile(path)
     } catch (e: Exception) {
-        throw e.unwrapPropagation()
+        throw e.refineException()
     }
 
     fun canRead(path: LocalPath): Boolean = try {
         fileOpsConnection.canRead(path)
     } catch (e: Exception) {
-        throw e.unwrapPropagation()
+        throw e.refineException()
     }
 
     fun canWrite(path: LocalPath): Boolean = try {
         fileOpsConnection.canWrite(path)
     } catch (e: Exception) {
-        throw e.unwrapPropagation()
+        throw e.refineException()
     }
 
     fun exists(path: LocalPath): Boolean = try {
         fileOpsConnection.exists(path)
     } catch (e: Exception) {
-        throw e.unwrapPropagation()
+        throw e.refineException()
     }
 
     fun delete(path: LocalPath, recursive: Boolean, dryRun: Boolean): Boolean = try {
         fileOpsConnection.delete(path, recursive, dryRun)
     } catch (e: Exception) {
-        throw e.unwrapPropagation()
+        throw e.refineException()
     }
 
     fun createSymlink(linkPath: LocalPath, targetPath: LocalPath): Boolean = try {
         fileOpsConnection.createSymlink(linkPath, targetPath)
     } catch (e: Exception) {
-        throw e.unwrapPropagation()
+        throw e.refineException()
     }
 
     fun setModifiedAt(path: LocalPath, modifiedAt: Instant): Boolean = try {
         fileOpsConnection.setModifiedAt(path, modifiedAt.toEpochMilli())
     } catch (e: Exception) {
-        throw e.unwrapPropagation()
+        throw e.refineException()
     }
 
     fun setPermissions(path: LocalPath, permissions: Permissions): Boolean = try {
         fileOpsConnection.setPermissions(path, permissions)
     } catch (e: Exception) {
-        throw e.unwrapPropagation()
+        throw e.refineException()
     }
 
     fun setOwnership(path: LocalPath, ownership: Ownership): Boolean = try {
         fileOpsConnection.setOwnership(path, ownership)
     } catch (e: Exception) {
-        throw e.unwrapPropagation()
+        throw e.refineException()
     }
 
     companion object {

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/ipc/PkgOpsClient.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/ipc/PkgOpsClient.kt
@@ -1,6 +1,7 @@
 package eu.darken.sdmse.common.pkgs.pkgops.ipc
 
 import android.content.pm.PackageInfo
+import android.os.DeadObjectException
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -21,7 +22,7 @@ class PkgOpsClient @AssistedInject constructor(
     fun getUserNameForUID(uid: Int): String? = try {
         connection.getUserNameForUID(uid)
     } catch (e: Exception) {
-        throw e.unwrapPropagation().also {
+        throw e.refineException().also {
             log(TAG, ERROR) { "getUserNameForUID(uid=$uid) failed: ${it.asLog()}" }
         }
     }
@@ -29,7 +30,7 @@ class PkgOpsClient @AssistedInject constructor(
     fun getGroupNameforGID(gid: Int): String? = try {
         connection.getGroupNameforGID(gid)
     } catch (e: Exception) {
-        throw e.unwrapPropagation().also {
+        throw e.refineException().also {
             log(TAG, ERROR) { "getGroupNameforGID(gid=$gid) failed: ${it.asLog()}" }
         }
     }
@@ -37,7 +38,7 @@ class PkgOpsClient @AssistedInject constructor(
     fun forceStop(packageName: String): Boolean = try {
         connection.forceStop(packageName)
     } catch (e: Exception) {
-        throw e.unwrapPropagation().also {
+        throw e.refineException().also {
             log(TAG, ERROR) { "forceStop(packageName=$packageName) failed: ${it.asLog()}" }
         }
     }
@@ -45,7 +46,7 @@ class PkgOpsClient @AssistedInject constructor(
     fun getRunningPackages(): Set<InstallId> = try {
         connection.getRunningPackages().pkgs
     } catch (e: Exception) {
-        throw e.unwrapPropagation().also {
+        throw e.refineException().also {
             log(TAG, ERROR) { "getRunningPackages() failed: ${it.asLog()}" }
         }
     }
@@ -53,7 +54,7 @@ class PkgOpsClient @AssistedInject constructor(
     suspend fun clearCache(installId: InstallId, dryRun: Boolean): Boolean = try {
         connection.clearCacheAsUser(installId.pkgId.name, installId.userHandle.handleId, dryRun)
     } catch (e: Exception) {
-        throw e.unwrapPropagation().also {
+        throw e.refineException().also {
             log(TAG, ERROR) { "clearCache(installId=$installId) failed: ${it.asLog()}" }
         }
     }
@@ -61,7 +62,7 @@ class PkgOpsClient @AssistedInject constructor(
     suspend fun clearCache(pkgId: Pkg.Id, dryRun: Boolean): Boolean = try {
         connection.clearCache(pkgId.name, dryRun)
     } catch (e: Exception) {
-        throw e.unwrapPropagation().also {
+        throw e.refineException().also {
             log(TAG, ERROR) { "clearCache(pkgId=$pkgId) failed: ${it.asLog()}" }
         }
     }
@@ -69,7 +70,7 @@ class PkgOpsClient @AssistedInject constructor(
     suspend fun trimCaches(desiredBytes: Long, storageId: String? = null, dryRun: Boolean): Boolean = try {
         connection.trimCaches(desiredBytes, storageId, dryRun)
     } catch (e: Exception) {
-        throw e.unwrapPropagation().also {
+        throw e.refineException().also {
             log(TAG, ERROR) { "trimCaches(desiredBytes=$desiredBytes, storageId=$storageId) failed: ${it.asLog()}" }
         }
     }
@@ -81,7 +82,7 @@ class PkgOpsClient @AssistedInject constructor(
     fun getInstalledPackagesAsUser(flags: Long, userHandle: UserHandle2): List<PackageInfo> = try {
         connection.getInstalledPackagesAsUser(flags, userHandle.handleId)
     } catch (e: Exception) {
-        throw e.unwrapPropagation().also {
+        throw e.refineException().also {
             log(TAG, ERROR) { "getInstalledPackagesAsUser(flags=$flags, userHandle=$userHandle) failed: ${it.asLog()}" }
         }
     }
@@ -89,7 +90,7 @@ class PkgOpsClient @AssistedInject constructor(
     fun getInstalledPackagesAsUserStream(flags: Long, userHandle: UserHandle2): List<PackageInfo> = try {
         connection.getInstalledPackagesAsUserStream(flags, userHandle.handleId).toPackageInfos()
     } catch (e: Exception) {
-        throw e.unwrapPropagation().also {
+        throw e.refineException().also {
             log(TAG, ERROR) {
                 "getInstalledPackagesAsUserStream(flags=$flags, userHandle=$userHandle) failed: ${it.asLog()}"
             }
@@ -99,7 +100,7 @@ class PkgOpsClient @AssistedInject constructor(
     fun setApplicationEnabledSetting(packageName: String, newState: Int, flags: Int): Unit = try {
         connection.setApplicationEnabledSetting(packageName, newState, flags)
     } catch (e: Exception) {
-        throw e.unwrapPropagation().also {
+        throw e.refineException().also {
             log(TAG, ERROR) {
                 "setApplicationEnabledSetting(packageName=$packageName, newState=$newState, flags=$flags) failed: ${it.asLog()}"
             }
@@ -109,7 +110,7 @@ class PkgOpsClient @AssistedInject constructor(
     fun grantPermission(id: InstallId, permission: Permission): Boolean = try {
         connection.grantPermission(id.pkgId.name, id.userHandle.handleId, permission.permissionId)
     } catch (e: Exception) {
-        throw e.unwrapPropagation().also {
+        throw e.refineException().also {
             log(TAG, ERROR) { "grantPermission(id=$id, permission=$permission) failed: ${it.asLog()}" }
         }
     }
@@ -117,7 +118,7 @@ class PkgOpsClient @AssistedInject constructor(
     fun revokePermission(id: InstallId, permission: Permission): Boolean = try {
         connection.revokePermission(id.pkgId.name, id.userHandle.handleId, permission.permissionId)
     } catch (e: Exception) {
-        throw e.unwrapPropagation().also {
+        throw e.refineException().also {
             log(TAG, ERROR) { "revokePermission(id=$id, permission=$permission) failed: ${it.asLog()}" }
         }
     }
@@ -125,7 +126,7 @@ class PkgOpsClient @AssistedInject constructor(
     fun setAppOps(id: InstallId, key: String, value: String): Boolean = try {
         connection.setAppOps(id.pkgId.name, id.userHandle.handleId, key, value)
     } catch (e: Exception) {
-        throw e.unwrapPropagation().also {
+        throw e.refineException().also {
             log(TAG, ERROR) { "setAppOps(id=$id, key=$key, value=$value) failed: ${it.asLog()}" }
         }
     }

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/shell/ipc/ShellOpsClient.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/shell/ipc/ShellOpsClient.kt
@@ -21,7 +21,7 @@ class ShellOpsClient @AssistedInject constructor(
             connection.execute(cmd)
         }
     } catch (e: Exception) {
-        throw e.unwrapPropagation().also {
+        throw e.refineException().also {
             log(TAG, ERROR) { "execute($cmd) failed: ${it.asLog()}" }
         }
     }

--- a/app-common/src/main/java/eu/darken/sdmse/common/error/LocalizedError.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/error/LocalizedError.kt
@@ -46,7 +46,7 @@ fun Throwable.localized(c: Context): LocalizedError = when {
     )
 }
 
-private fun Throwable.getStackTracePeek() = this.stackTraceToString()
+internal fun Throwable.getStackTracePeek() = this.stackTraceToString()
     .lines()
     .filterIndexed { index, _ -> index > 1 }
     .take(3)

--- a/app-common/src/main/java/eu/darken/sdmse/common/ipc/IpcClientModule.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/ipc/IpcClientModule.kt
@@ -1,5 +1,6 @@
 package eu.darken.sdmse.common.ipc
 
+import android.os.DeadObjectException
 import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
@@ -20,8 +21,13 @@ interface IpcClientModule {
             @Suppress("UNCHECKED_CAST")
             it.readObject() as Array<StackTraceElement>
         }
-    } catch (e: Exception) {
+    } catch (_: Exception) {
         null
+    }
+
+    fun Throwable.refineException(): Throwable = when (this) {
+        is DeadObjectException -> ServiceConnectionLostException(this)
+        else -> unwrapPropagation()
     }
 
     fun Throwable.unwrapPropagation(): Throwable {

--- a/app-common/src/main/java/eu/darken/sdmse/common/ipc/ServiceConnectionLostException.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/ipc/ServiceConnectionLostException.kt
@@ -1,0 +1,26 @@
+package eu.darken.sdmse.common.ipc
+
+import android.os.DeadObjectException
+import eu.darken.sdmse.common.R
+import eu.darken.sdmse.common.ca.caString
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.error.HasLocalizedError
+import eu.darken.sdmse.common.error.LocalizedError
+import eu.darken.sdmse.common.error.getStackTracePeek
+
+class ServiceConnectionLostException(
+    override val cause: DeadObjectException
+) : Exception(), HasLocalizedError {
+
+    override fun getLocalizedError(): LocalizedError = LocalizedError(
+        throwable = this,
+        label = R.string.general_error_ipc_deadobject_title.toCaString(),
+        description = caString {
+            var message = it.getString(R.string.general_error_ipc_deadobject_description)
+            message += "\n\n"
+            message += cause.getStackTracePeek()
+            message
+        }
+    )
+
+}

--- a/app-common/src/main/res/values/strings.xml
+++ b/app-common/src/main/res/values/strings.xml
@@ -179,4 +179,6 @@
     <string name="general_error_invalid_input_label">Invalid input</string>
     <string name="general_information_for_the_developer">Information for the developer</string>
     <string name="general_error_report_bug_action">Report bug</string>
+    <string name="general_error_ipc_deadobject_title">Service Connection Lost</string>
+    <string name="general_error_ipc_deadobject_description">The connection to a critical service (e.g., Magisk, Shizuku, or other system-level services) was unexpectedly lost. Please reboot your device. If the issue persists, check for updates or reach out to me so I can fix it.</string>
 </resources>

--- a/app-common/src/test/java/eu/darken/sdmse/common/ipc/ExceptionPropagationTest.kt
+++ b/app-common/src/test/java/eu/darken/sdmse/common/ipc/ExceptionPropagationTest.kt
@@ -37,7 +37,7 @@ class ExceptionPropagationTest : BaseTest(), IpcHostModule, IpcClientModule {
                 
                 #STACK#:rO0ABXVyAB5bTGphdmEubGFuZy5TdGFja1RyYWNlRWxlbWVudDsCRio8PP0iOQIAAHhwAAAABXNyABtqYXZhLmxhbmcuU3RhY2tUcmFjZUVsZW1lbnRhCcWaJjbdhQIABEkACmxpbmVOdW1iZXJMAA5kZWNsYXJpbmdDbGFzc3QAEkxqYXZhL2xhbmcvU3RyaW5nO0wACGZpbGVOYW1lcQB+AANMAAptZXRob2ROYW1lcQB+AAN4cAAAAId0ABdjb2lsLmRlY29kZS5EZWNvZGVVdGlsc3B0AA1wZXJmb3JtTG9va3Vwc3EAfgACAAAAdXQAMmV1LmRhcmtlbi5zZG1zZS5jb21tb24uZmlsZXMubG9jYWwuaXBjLkZpbGVPcHNIb3N0cHQAEWxvb2t1cEZpbGVzU3RyZWFtc3EAfgACAAAEn3QAPWV1LmRhcmtlbi5zZG1zZS5jb21tb24uZmlsZXMubG9jYWwuaXBjLkZpbGVPcHNDb25uZWN0aW9uJFN0dWJwdAAKb25UcmFuc2FjdHNxAH4AAgAAA/10ABFhbmRyb2lkLm9zLkJpbmRlcnQAC0JpbmRlci5qYXZhdAAUZXhlY1RyYW5zYWN0SW50ZXJuYWxzcQB+AAIAAAPidAARYW5kcm9pZC5vcy5CaW5kZXJ0AAtCaW5kZXIuamF2YXQADGV4ZWNUcmFuc2FjdA==
             """.trimIndent()
-        ).unwrapPropagation().apply {
+        ).refineException().apply {
             this shouldBe instanceOf<TopLevelException>()
             message shouldBe "Does not exist or can't be read <-> /storage/1F67-A3A5/.android_secure"
             stackTraceToString().lines().take(5).joinToString("\n").trimIndent() shouldBe """
@@ -56,7 +56,7 @@ class ExceptionPropagationTest : BaseTest(), IpcHostModule, IpcClientModule {
             """
                 eu.darken.sdmse.common.ipc.ExceptionPropagationTest${'$'}BaseTestException: Does not exist or can't be read <-> /storage/1F67-A3A5/.android_secure
             """.trimIndent()
-        ).unwrapPropagation().apply {
+        ).refineException().apply {
             this shouldBe instanceOf<BaseTestException>()
             message shouldBe "Does not exist or can't be read <-> /storage/1F67-A3A5/.android_secure"
         }


### PR DESCRIPTION
Closes #1821

* See also #131 which was a DeadObjectException but what bubbled up was an IOException, because we wrapped the DeadObjectException again in the IO gateways?
* Similar #1358 bubble up as Remote Exception
* Or #1117
* Root service crash #1173