### PR TITLE
DeviceDetective: Detect UGOOS devices as AOSP

### DIFF
--- a/app-common/src/main/java/eu/darken/sdmse/common/device/DeviceDetective.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/device/DeviceDetective.kt
@@ -57,7 +57,12 @@ class DeviceDetective @Inject constructor(
     }
 
     fun getROMType(): RomType = when {
-        isAndroidTV() -> RomType.ANDROID_TV
+        isAndroidTV() -> when {
+            // #1826, it's a "tv box" but runs a phone-style ROM
+            manufactor("UGOOS") -> RomType.AOSP
+            else -> RomType.ANDROID_TV
+        }
+
         display("lineage") || product("lineage") || apps(LINEAGE_PKGS) -> RomType.LINEAGE
         // run mostly near-stock Android
         brand("alcatel") -> RomType.ALCATEL


### PR DESCRIPTION
UGOOS devices, while sometimes marketed as TV boxes, run a phone-style AOSP ROM rather than Android TV. This change correctly identifies them as `RomType.AOSP`.

Closes #1826