### PR TITLE
Git: Ignore Kotlin daemon sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ build/
 .externalNativeBuild
 .cxx
 .DS_Store
+.kotlin/sessions


### PR DESCRIPTION
This commit adds `.kotlin/sessions` to the `.gitignore` file to prevent Kotlin daemon session files from being tracked by Git.