### PR TITLE
Deduplicator: Fix previews and "common" file type detection

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/common/MimeTypeTool.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/MimeTypeTool.kt
@@ -9,7 +9,7 @@ import javax.inject.Inject
 class MimeTypeTool @Inject constructor() {
 
     suspend fun determineMimeType(lookup: APathLookup<*>): String {
-        val ext = MimeTypeMap.getFileExtensionFromUrl(lookup.name)
+        val ext = lookup.name.substringAfterLast('.', "").lowercase()
         return MimeTypeMap.getSingleton().getMimeTypeFromExtension(ext) ?: MimeTypes.Unknown.value
     }
 }


### PR DESCRIPTION
Improve MIME type determination from file extension

This commit refactors the `determineMimeType` function in `MimeTypeTool.kt`.

The file extension is now extracted by taking the substring after the last dot in the filename and converting it to lowercase. This approach is more robust than `MimeTypeMap.getFileExtensionFromUrl()` for determining the extension.

Reported by @MeloriTensei, Thanks!