### PR TITLE
Fix crash when selecting certain ROM-types

### DIFF
--- a/app-common/src/main/java/eu/darken/sdmse/common/device/RomType.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/device/RomType.kt
@@ -29,5 +29,4 @@ enum class RomType(override val label: CaString) : EnumPreference<RomType> {
     @Json(name = "HONOR") HONOR("HONOR".toCaString()),
     @Json(name = "DOOGEE") DOOGEE("DOOGEE".toCaString()),
     @Json(name = "OUKITEL") OUKITEL("OUKITEL".toCaString()),
-    ;
 }

--- a/app-common/src/test/java/eu/darken/sdmse/common/device/RomTypeTest.kt
+++ b/app-common/src/test/java/eu/darken/sdmse/common/device/RomTypeTest.kt
@@ -1,0 +1,54 @@
+package eu.darken.sdmse.common.device
+
+import com.squareup.moshi.Moshi
+import eu.darken.sdmse.common.serialization.SerializationCommonModule
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class RomTypeTest : BaseTest() {
+
+    private val moshi: Moshi = SerializationCommonModule().moshi()
+    private val adapter = moshi.adapter(RomType::class.java)
+
+    @Test
+    fun `serialization uses Json name annotation`() {
+        val romType = RomType.FUNTOUCHOS
+        val json = adapter.toJson(romType)
+        json shouldBe "\"VIVO\""
+    }
+
+    @Test
+    fun `deserialization uses Json name annotation`() {
+        val json = "\"VIVO\""
+        val romType = adapter.fromJson(json)
+        romType shouldBe RomType.FUNTOUCHOS
+    }
+
+    @Test
+    fun `VIVO maps to FUNTOUCHOS enum constant`() {
+        val json = "\"VIVO\""
+        val deserialized = adapter.fromJson(json)
+        deserialized shouldBe RomType.FUNTOUCHOS
+        deserialized?.name shouldBe "FUNTOUCHOS"
+    }
+
+    @Test
+    fun `other enum values work correctly`() {
+        val testCases = mapOf(
+            "\"AUTO\"" to RomType.AUTO,
+            "\"SAMSUNG\"" to RomType.ONEUI,
+            "\"MIUI\"" to RomType.MIUI,
+            "\"ONEPLUS\"" to RomType.OXYGENOS,
+            "\"HONOR\"" to RomType.HONOR
+        )
+
+        testCases.forEach { (json, expectedEnum) ->
+            val deserialized = adapter.fromJson(json)
+            deserialized shouldBe expectedEnum
+
+            val serialized = adapter.toJson(expectedEnum)
+            serialized shouldBe json
+        }
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/common/preferences/PreferenceExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/preferences/PreferenceExtensions.kt
@@ -16,7 +16,7 @@ inline fun <reified T> ListPreference.setupWithEnum(preference: DataStoreValue<T
     val startValue = preference.valueBlocking
 
     entries = enumValues<T>().map { it.label.get(context) }.toTypedArray()
-    entryValues = enumValues<T>().map { it.name }.toTypedArray()
+    entryValues = enumValues<T>().map { (preference.writer(it) as String).removeSurrounding("\"") }.toTypedArray()
     value = (preference.writer(startValue) as String).removeSurrounding("\"")
 
     setOnPreferenceChangeListener { _, newValueRaw ->


### PR DESCRIPTION
This commit updates the `RomType` enum to improve its JSON serialization and deserialization using Moshi.

`PreferenceExtensions.kt` has been updated to correctly derive `entryValues` for enum preferences by using the preference's writer and removing surrounding quotes, aligning it with the JSON representation.

New tests (`RomTypeTest`) have been added to verify that the `@Json(name = "...")` annotations are correctly used, ensuring that, for example, `RomType.FUNTOUCHOS` serializes to `"VIVO"` and vice-versa.