### PR TITLE
Setup: Fix crash on Android 11/12

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/PkgOps.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/PkgOps.kt
@@ -119,7 +119,7 @@ class PkgOps @Inject constructor(
     suspend fun queryPkg(id: Pkg.Id, flags: Long, userHandle: UserHandle2, mode: Mode = Mode.AUTO): PackageInfo? {
         log(TAG) { "queryPkg($id, $flags, $userHandle, $mode)" }
         return when {
-            mode == Mode.NORMAL -> ipcFunnel.use {
+            mode == Mode.NORMAL || (mode == Mode.AUTO && userHandle == userManager2.currentUser().handle) -> ipcFunnel.use {
                 try {
                     ipcFunnel.use {
                         if (hasApiLevel(33)) {

--- a/app/src/main/java/eu/darken/sdmse/setup/saf/SAFSetupModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/saf/SAFSetupModule.kt
@@ -38,7 +38,7 @@ import eu.darken.sdmse.common.rngString
 import eu.darken.sdmse.common.storage.PathMapper
 import eu.darken.sdmse.common.storage.StorageEnvironment
 import eu.darken.sdmse.common.storage.StorageManager2
-import eu.darken.sdmse.common.user.UserHandle2
+import eu.darken.sdmse.common.user.UserManager2
 import eu.darken.sdmse.setup.SetupModule
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
@@ -61,6 +61,7 @@ class SAFSetupModule @Inject constructor(
     private val gatewaySwitch: GatewaySwitch,
     private val deviceDetective: DeviceDetective,
     private val pkgOps: PkgOps,
+    private val userManager: UserManager2,
 ) : SetupModule {
 
     private val refreshTrigger = MutableStateFlow(rngString)
@@ -153,7 +154,7 @@ class SAFSetupModule @Inject constructor(
             val isRestricted = pkgOps.queryPkg(
                 id = "com.google.android.documentsui".toPkgId(),
                 flags = 0,
-                userHandle = UserHandle2()
+                userHandle = userManager.currentUser().handle,
             )?.let { pkg ->
                 log(TAG) { "Files-DocumentsUI: appInfos=$pkg" }
                 log(TAG) { "Files-DocumentsUI: targetSdkVersion=${pkg.applicationInfo?.targetSdkVersion}" }


### PR DESCRIPTION
Use normal query for current user in AUTO mode

When `PkgOps.queryPkg` is called with `Mode.AUTO` and the `userHandle` matches the current user, this change optimizes the query to use the "normal" (non-root) path. This avoids unnecessary root operations for the common case of querying packages for the active user.