### PR TITLE
Translations: Add mappings for Sicilian and Albanian

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -10,6 +10,8 @@
     #    "update_option" : "update_without_changes",
     "languages_mapping": &stringmapping {
       "android_code": {
+        "sc": "sc-rIT",
+        "sq": "sq-rAL",
         "ar": "ar",
         "am": "am",
         "hy-AM": "hy-rAM",


### PR DESCRIPTION
This change adds new language mappings for Sicilian (`sc`) and Albanian (`sq`) in the `crowdin.yml` configuration file.

- Sicilian is mapped to `sc-rIT`.
- Albanian is mapped to `sq-rAL`.