### PR TITLE
Upgrade Google Billing Library to v8

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -191,8 +191,8 @@ dependencies {
     addIO()
     addRetrofit()
 
-    "gplayImplementation"("com.android.billingclient:billing:6.2.1")
-    "gplayImplementation"("com.android.billingclient:billing-ktx:6.2.1")
+    "gplayImplementation"("com.android.billingclient:billing:8.0.0")
+    "gplayImplementation"("com.android.billingclient:billing-ktx:8.0.0")
 
     "gplayImplementation"("com.google.android.play:review:2.0.1")
     "gplayImplementation"("com.google.android.play:review-ktx:2.0.1")

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingConnectionProvider.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingConnectionProvider.kt
@@ -5,6 +5,7 @@ import com.android.billingclient.api.BillingClient
 import com.android.billingclient.api.BillingClient.BillingResponseCode
 import com.android.billingclient.api.BillingClientStateListener
 import com.android.billingclient.api.BillingResult
+import com.android.billingclient.api.PendingPurchasesParams
 import com.android.billingclient.api.Purchase
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
@@ -34,7 +35,11 @@ class BillingConnectionProvider @Inject constructor(
         val purchaseEvents = MutableStateFlow<Pair<BillingResult, Collection<Purchase>?>?>(null)
 
         val client = BillingClient.newBuilder(context).apply {
-            enablePendingPurchases()
+            enablePendingPurchases(
+                PendingPurchasesParams.newBuilder().apply {
+                    enableOneTimeProducts()
+                }.build()
+            )
             setListener { result, purchases ->
                 if (result.isSuccess) {
                     log(TAG) {
@@ -61,6 +66,7 @@ class BillingConnectionProvider @Inject constructor(
                         val connection = BillingConnection(client, purchaseEvents)
                         trySendBlocking(connection)
                     }
+
                     else -> {
                         close(BillingClientException(result))
                     }


### PR DESCRIPTION
This commit updates the Google Play Billing Library from version 6.2.1 to 8.0.0. It adapts the code to the API changes in `queryProductDetailsAsync` and `enablePendingPurchases`.