### PR TITLE
Prevent read errors on non-existing directories from crashing Shizuku/Root services.

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/PathExceptions.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/PathExceptions.kt
@@ -1,5 +1,6 @@
 package eu.darken.sdmse.common.files
 
+import androidx.annotation.Keep
 import eu.darken.sdmse.common.ca.caString
 import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.error.HasLocalizedError
@@ -7,12 +8,14 @@ import eu.darken.sdmse.common.error.LocalizedError
 import eu.darken.sdmse.common.error.localized
 import java.io.IOException
 
+@Keep
 open class PathException(
     message: String? = "Error during access.",
     val path: APath?,
     cause: Throwable? = null,
 ) : IOException(if (path != null) "$message <-> ${path.path}" else message, cause)
 
+@Keep
 open class ReadException @JvmOverloads constructor(
     message: String? = "Can't read from path.",
     path: APath? = null,
@@ -42,6 +45,7 @@ open class ReadException @JvmOverloads constructor(
     )
 }
 
+@Keep
 class WriteException @JvmOverloads constructor(
     message: String? = "Can't write to path.",
     path: APath? = null,

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/LocalPathLookupResult.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/LocalPathLookupResult.kt
@@ -1,0 +1,113 @@
+package eu.darken.sdmse.common.files.local.ipc
+
+import android.os.Parcel
+import android.os.Parcelable
+import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.files.PathException
+import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.files.local.LocalPathLookup
+
+sealed class LocalPathLookupResult : Parcelable {
+
+    data class Success(
+        val lookup: LocalPathLookup
+    ) : LocalPathLookupResult() {
+        constructor(parcel: Parcel) : this(
+            parcel.readParcelable(LocalPathLookup::class.java.classLoader)!!
+        )
+
+        override fun writeToParcel(parcel: Parcel, flags: Int) {
+            parcel.writeParcelable(lookup, flags)
+        }
+
+        override fun describeContents(): Int = 0
+
+        companion object CREATOR : Parcelable.Creator<Success> {
+            override fun createFromParcel(parcel: Parcel): Success = Success(parcel)
+            override fun newArray(size: Int): Array<Success?> = arrayOfNulls(size)
+        }
+    }
+
+    data class Error(
+        val exceptionClass: String,
+        val message: String?,
+        val pathString: String? = null
+    ) : LocalPathLookupResult() {
+        constructor(parcel: Parcel) : this(
+            parcel.readString()!!,
+            parcel.readString(),
+            parcel.readString()
+        )
+
+        constructor(exception: Exception) : this(
+            exception::class.java.name,
+            exception.message,
+            (exception as? PathException)?.path?.path
+        )
+
+        override fun writeToParcel(parcel: Parcel, flags: Int) {
+            parcel.writeString(exceptionClass)
+            parcel.writeString(message)
+            parcel.writeString(pathString)
+        }
+
+        override fun describeContents(): Int = 0
+
+        fun toException(): Exception {
+            return try {
+                val clazz = Class.forName(exceptionClass)
+                when {
+                    PathException::class.java.isAssignableFrom(clazz) -> {
+                        // PathException and its subclasses require (message, path, cause) constructor
+                        val path = pathString?.let { LocalPath.build(it) }
+                        clazz
+                            .getConstructor(String::class.java, APath::class.java, Throwable::class.java)
+                            .newInstance(message, path, null) as Exception
+                    }
+
+                    else -> {
+                        // Try standard Exception constructor
+                        clazz
+                            .asSubclass(Exception::class.java)
+                            .getConstructor(String::class.java)
+                            .newInstance(message)
+                    }
+                }
+            } catch (_: Exception) {
+                // Fallback to generic exception if reconstruction fails
+                Exception("$exceptionClass: $message")
+            }
+        }
+
+        companion object CREATOR : Parcelable.Creator<Error> {
+            override fun createFromParcel(parcel: Parcel): Error = Error(parcel)
+            override fun newArray(size: Int): Array<Error?> = arrayOfNulls(size)
+        }
+    }
+
+    companion object CREATOR : Parcelable.Creator<LocalPathLookupResult> {
+        override fun createFromParcel(parcel: Parcel): LocalPathLookupResult {
+            return when (parcel.readInt()) {
+                0 -> Success.createFromParcel(parcel)
+                1 -> Error.createFromParcel(parcel)
+                else -> throw IllegalArgumentException("Unknown result type")
+            }
+        }
+
+        override fun newArray(size: Int): Array<LocalPathLookupResult?> = arrayOfNulls(size)
+    }
+
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        when (this) {
+            is Success -> {
+                parcel.writeInt(0)
+                writeToParcel(parcel, flags)
+            }
+
+            is Error -> {
+                parcel.writeInt(1)
+                writeToParcel(parcel, flags)
+            }
+        }
+    }
+}

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/LocalPathLookupResultsIPCWrapper.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/LocalPathLookupResultsIPCWrapper.kt
@@ -1,0 +1,26 @@
+package eu.darken.sdmse.common.files.local.ipc
+
+import android.os.Parcel
+import android.os.Parcelable
+
+data class LocalPathLookupResultsIPCWrapper(
+    val payload: List<LocalPathLookupResult>,
+) : Parcelable, IPCWrapper {
+    constructor(parcel: Parcel) : this(
+        parcel.readParcelableArray(LocalPathLookupResult::class.java.classLoader)!!
+            .toList() as List<LocalPathLookupResult>
+    )
+
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        parcel.writeParcelableArray(payload.toTypedArray(), flags)
+    }
+
+    override fun describeContents(): Int = 0
+
+    companion object CREATOR : Parcelable.Creator<LocalPathLookupResultsIPCWrapper> {
+        override fun createFromParcel(parcel: Parcel): LocalPathLookupResultsIPCWrapper =
+            LocalPathLookupResultsIPCWrapper(parcel)
+
+        override fun newArray(size: Int): Array<LocalPathLookupResultsIPCWrapper?> = arrayOfNulls(size)
+    }
+}


### PR DESCRIPTION
Propagate exceptions via LocalPathLookupResult to prevent IPC from crashing. Client-side should get ReadException now instead of DeadObjectException.

This commit modifies the IPC mechanism for `LocalPathLookup` to also transmit exceptions. It introduces a sealed class `LocalPathLookupResult` which can be either a `Success` (containing the `LocalPathLookup`) or an `Error` (containing exception details).

The `LocalPathLookupIPCFlow` is updated to serialize and deserialize `LocalPathLookupResult` instances, allowing exceptions from the producing flow to be re-thrown in the collecting flow. `PathException` and its subclasses are now annotated with `@Keep`.