### PR TITLE
Refactor: Improve PreferenceStoreMapper key lookup

### DIFF
--- a/app-common/src/main/java/eu/darken/sdmse/common/datastore/PreferenceStoreMapper.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/datastore/PreferenceStoreMapper.kt
@@ -7,43 +7,41 @@ open class PreferenceStoreMapper(
 ) : PreferenceDataStore() {
 
     @Suppress("UNCHECKED_CAST")
-    private inline fun <reified T> byKey(key: String) =
-        dataStoreValues.singleOrNull { it.keyName == key } as DataStoreValue<T>?
+    private inline fun <reified T> byKey(key: String): DataStoreValue<T> {
+        val dataStore = dataStoreValues.singleOrNull { it.keyName == key }
+        if (dataStore == null) throw NotImplementedError("No implementation found for key=$key")
+        return dataStore as DataStoreValue<T>
+    }
 
-    override fun getBoolean(key: String, defValue: Boolean): Boolean = byKey<Boolean>(key)?.valueBlocking
-        ?: throw NotImplementedError("getBoolean(key=$key, defValue=$defValue)")
+    override fun getBoolean(key: String, defValue: Boolean): Boolean = byKey<Boolean>(key).valueBlocking
 
-    override fun putBoolean(key: String, value: Boolean): Unit = byKey<Boolean>(key)
-        ?.let { it.valueBlocking = value }
-        ?: throw NotImplementedError("putBoolean(key=$key, defValue=$value)")
+    override fun putBoolean(key: String, value: Boolean) {
+        byKey<Boolean>(key).valueBlocking = value
+    }
 
-    override fun getString(key: String, defValue: String?): String? = byKey<String?>(key)?.valueBlocking
-        ?: throw NotImplementedError("getString(key=$key, defValue=$defValue)")
+    override fun getString(key: String, defValue: String?): String? = byKey<String?>(key).valueBlocking
 
-    override fun putString(key: String, value: String?): Unit = byKey<String?>(key)
-        ?.let { it.valueBlocking = value }
-        ?: throw NotImplementedError("putString(key=$key, defValue=$value)")
+    override fun putString(key: String, value: String?) {
+        byKey<String?>(key).valueBlocking = value
+    }
 
-    override fun getInt(key: String, defValue: Int): Int = byKey<Int>(key)?.valueBlocking
-        ?: throw NotImplementedError("getInt(key=$key, defValue=$defValue)")
+    override fun getInt(key: String, defValue: Int): Int = byKey<Int>(key).valueBlocking
 
-    override fun putInt(key: String, value: Int): Unit = byKey<Int>(key)
-        ?.let { it.valueBlocking = value }
-        ?: throw NotImplementedError("putInt(key=$key, defValue=$value)")
+    override fun putInt(key: String, value: Int) {
+        byKey<Int>(key).valueBlocking = value
+    }
 
-    override fun getLong(key: String, defValue: Long): Long = byKey<Long>(key)?.valueBlocking
-        ?: throw NotImplementedError("getLong(key=$key, defValue=$defValue)")
+    override fun getLong(key: String, defValue: Long): Long = byKey<Long>(key).valueBlocking
 
-    override fun putLong(key: String, value: Long): Unit = byKey<Long>(key)
-        ?.let { it.valueBlocking = value }
-        ?: throw NotImplementedError("putLong(key=$key, defValue=$value)")
+    override fun putLong(key: String, value: Long) {
+        byKey<Long>(key).valueBlocking = value
+    }
 
-    override fun getFloat(key: String, defValue: Float): Float = byKey<Float>(key)?.valueBlocking
-        ?: throw NotImplementedError("getFloat(key=$key, defValue=$defValue)")
+    override fun getFloat(key: String, defValue: Float): Float = byKey<Float>(key).valueBlocking
 
-    override fun putFloat(key: String, value: Float): Unit = byKey<Float>(key)
-        ?.let { it.valueBlocking = value }
-        ?: throw NotImplementedError("putFloat(key=$key, defValue=$value)")
+    override fun putFloat(key: String, value: Float) {
+        byKey<Float>(key).valueBlocking = value
+    }
 
     override fun putStringSet(key: String, values: MutableSet<String>?) {
         throw NotImplementedError("putStringSet(key=$key, defValue=$values)")


### PR DESCRIPTION
Fixes crash when accessing string keys with a null value

- Throw `NotImplementedError` directly in `byKey` if a `DataStoreValue` for the given key is not found.
- Remove redundant `NotImplementedError` throws in getter/setter methods as `byKey` now handles this.
- Simplify getter/setter logic by removing nullable checks, relying on `byKey`'s non-null return or exception.