### PR TITLE
Prevent Google Play errors from crashing SD Maid

### DIFF
--- a/app-common/src/main/java/eu/darken/sdmse/common/ca/CaString.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/ca/CaString.kt
@@ -51,7 +51,7 @@ fun String.toCaString(): CaString = caString(this)
 
 fun Int.toCaString(): CaString = caString { getString(this@toCaString) }.cache()
 
-fun Int.toCaString(vararg args: Any): CaString = caString { it.getString(this@toCaString, *args) }.cache()
+fun Int.toCaString(vararg args: Any?): CaString = caString { it.getString(this@toCaString, *args) }.cache()
 
 fun Pair<Int, Array<out Any?>>.toCaString() = caString {
     val (res, args) = this@toCaString

--- a/app/src/foss/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoFoss.kt
+++ b/app/src/foss/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoFoss.kt
@@ -10,10 +10,12 @@ import eu.darken.sdmse.common.upgrade.UpgradeRepo
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import java.time.Instant
-import java.util.*
+import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -43,6 +45,7 @@ class UpgradeRepoFoss @Inject constructor(
         }
     }
         .setupCommonEventHandlers(TAG) { "upgradeInfo" }
+        .shareIn(appScope, SharingStarted.WhileSubscribed(3000L, 0L), replay = 1)
 
     fun launchGithubSponsorsUpgrade() = appScope.launch {
         log(TAG) { "launchGithubSponsorsUpgrade()" }
@@ -62,6 +65,7 @@ class UpgradeRepoFoss @Inject constructor(
         override val isPro: Boolean = false,
         override val upgradedAt: Instant? = null,
         val fossUpgradeType: FossUpgrade.Type? = null,
+        override val error: Throwable? = null,
     ) : UpgradeRepo.Info {
         override val type: UpgradeRepo.Type = UpgradeRepo.Type.FOSS
     }

--- a/app/src/foss/java/eu/darken/sdmse/common/upgrade/ui/UpgradeFragment.kt
+++ b/app/src/foss/java/eu/darken/sdmse/common/upgrade/ui/UpgradeFragment.kt
@@ -37,6 +37,10 @@ class UpgradeFragment : Fragment3(R.layout.upgrade_fragment) {
             vm.goGithubSponsors()
         }
 
+        vm.state.observe2 {
+
+        }
+
         super.onViewCreated(view, savedInstanceState)
     }
 

--- a/app/src/foss/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/foss/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
@@ -8,7 +8,11 @@ import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.navigation.navArgs
 import eu.darken.sdmse.common.uix.ViewModel3
 import eu.darken.sdmse.common.upgrade.core.UpgradeRepoFoss
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.take
+import java.util.UUID
 import javax.inject.Inject
 
 @HiltViewModel
@@ -30,11 +34,25 @@ class UpgradeViewModel @Inject constructor(
         }
     }
 
+    val state = upgradeRepo.upgradeInfo
+        .map { it as UpgradeRepoFoss.Info }
+        .map { current ->
+            if (!current.isPro && current.error != null) {
+                errorEvents.postValue(current.error)
+            }
+            State()
+        }
+        .asLiveData2()
+
     fun goGithubSponsors() {
         log(TAG) { "goGithubSponsors()" }
         upgradeRepo.launchGithubSponsorsUpgrade()
         popNavStack()
     }
+
+    data class State(
+        val tbd: UUID = UUID.randomUUID()
+    )
 
     companion object {
         private val TAG = logTag("Upgrade", "ViewModel")

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplay.kt
@@ -1,6 +1,7 @@
 package eu.darken.sdmse.common.upgrade.core
 
 import android.app.Activity
+import com.android.billingclient.api.BillingResult
 import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.datastore.value
@@ -13,6 +14,7 @@ import eu.darken.sdmse.common.error.asErrorDialogBuilder
 import eu.darken.sdmse.common.flow.setupCommonEventHandlers
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
 import eu.darken.sdmse.common.upgrade.core.billing.BillingData
+import eu.darken.sdmse.common.upgrade.core.billing.BillingException
 import eu.darken.sdmse.common.upgrade.core.billing.BillingManager
 import eu.darken.sdmse.common.upgrade.core.billing.PurchasedSku
 import eu.darken.sdmse.common.upgrade.core.billing.Sku
@@ -77,7 +79,7 @@ class UpgradeRepoGplay @Inject constructor(
                 log(TAG, VERBOSE) { "We are not pro, but were recently, and just and an error, what is GPlay doing???" }
                 emit(Info(gracePeriod = true, billingData = null))
             } else {
-                throw it
+                emit(Info(billingData = null, error = it))
             }
         }
         .setupCommonEventHandlers(TAG) { "upgradeInfo2" }
@@ -107,6 +109,7 @@ class UpgradeRepoGplay @Inject constructor(
     data class Info(
         private val gracePeriod: Boolean = false,
         private val billingData: BillingData?,
+        override val error: Throwable? = null,
     ) : UpgradeRepo.Info {
 
         override val type: UpgradeRepo.Type = UpgradeRepo.Type.GPLAY

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingException.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingException.kt
@@ -1,6 +1,18 @@
 package eu.darken.sdmse.common.upgrade.core.billing
 
+import eu.darken.sdmse.R
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.error.HasLocalizedError
+import eu.darken.sdmse.common.error.LocalizedError
+
 open class BillingException(
     override val message: String? = null,
     override val cause: Throwable? = null,
-) : Exception()
+) : Exception(), HasLocalizedError {
+
+    override fun getLocalizedError(): LocalizedError = LocalizedError(
+        throwable = this,
+        label = R.string.upgrades_gplay_billing_error_label.toCaString(),
+        description = R.string.upgrades_gplay_billing_error_description.toCaString(message)
+    )
+}

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
@@ -74,6 +74,11 @@ class UpgradeViewModel @Inject constructor(
         if (iap == null && sub == null) {
             throw GplayServiceUnavailableException(RuntimeException("IAP and SUB data request timed out."))
         }
+
+        if (!current.isPro && current.error != null) {
+            errorEvents.postValue(current.error)
+        }
+
         Pricing(
             iap = iap?.first(),
             sub = sub?.first(),

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -11,7 +11,11 @@
 
     <string name="upgrades_gplay_unavailable_error_title">Google Play is unavailable</string>
     <string name="upgrades_gplay_unavailable_error_description">SD Maid can\'t connect to Google Play. Is Google Play installed and up to date? Is your Google Account logged in? Try clearing the cache of the Google Play app and rebooting your device.</string>
+    <string name="upgrades_gplay_billing_error_label">Google Play Issue</string>
+    <string name="upgrades_gplay_billing_error_description">There was a problem with Google Play. Please try again later or restart your device.\n\nDetails: %s</string>
+
     <string name="upgrades_no_purchases_found_check_account">No purchases found. Are you using the right account?</string>
+
     <string name="upgrade_screen_title">Get SD Maid SE Pro</string>
     <string name="upgrade_screen_preamble">SD Maid has no ads and doesn\'t sell user data. My work is financed by you ❤️.</string>
     <string name="upgrade_screen_benefits_title">Advantages</string>

--- a/app/src/main/java/eu/darken/sdmse/common/upgrade/UpgradeRepo.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/upgrade/UpgradeRepo.kt
@@ -16,6 +16,8 @@ interface UpgradeRepo {
         val isPro: Boolean
 
         val upgradedAt: Instant?
+
+        val error: Throwable?
     }
 
     enum class Type {


### PR DESCRIPTION
The UpgradeRepo could throw an error which would people up (after 7 days grace period) and hit the app-level coroutine scope, which could crash the app.

Let's catch that error, default to "isPro=false", and if the user visits the upgrade screen, show error specifics.