### PR TITLE
Setup: Disable fastscroll in setup list

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/setup/SetupFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/SetupFragment.kt
@@ -81,6 +81,7 @@ class SetupFragment : Fragment3(R.layout.setup_fragment) {
         ui.list.setupDefaults(
             setupAdapter,
             verticalDividers = false,
+            fastscroll = false,
             layouter = GridLayoutManager(context, getSpanCount(widthDp = 720), GridLayoutManager.VERTICAL, false),
         )
 


### PR DESCRIPTION
The fastscroll feature is not necessary for the setup list and has been disabled to simplify the UI.

Fixes #1881