### PR TITLE
Update Gradle and dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -137,6 +137,7 @@ android {
         unitTests {
             isIncludeAndroidResources = true
         }
+        //noinspection WrongGradleMethod
         tasks.withType<Test> {
             useJUnitPlatform()
             setupTestLogging()
@@ -153,6 +154,7 @@ android {
     }
 
     androidResources {
+        @Suppress("UnstableApiUsage")
         generateLocaleConfig = true
     }
 
@@ -194,8 +196,8 @@ dependencies {
     "gplayImplementation"("com.android.billingclient:billing:8.0.0")
     "gplayImplementation"("com.android.billingclient:billing-ktx:8.0.0")
 
-    "gplayImplementation"("com.google.android.play:review:2.0.1")
-    "gplayImplementation"("com.google.android.play:review-ktx:2.0.1")
+    "gplayImplementation"("com.google.android.play:review:2.0.2")
+    "gplayImplementation"("com.google.android.play:review-ktx:2.0.2")
 
     addAndroidCore()
     addAndroidUI()
@@ -205,16 +207,16 @@ dependencies {
 
     addTesting()
 
-    implementation("io.github.z4kn4fein:semver:1.4.2")
+    implementation("io.github.z4kn4fein:semver:3.0.0")
 
     addCoil()
     addLottie()
 
     implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
     implementation("com.github.reddit:IndicatorFastScroll:f9576c7") // 1.4.0
-    implementation("me.zhanghai.android.fastscroll:library:1.2.0")
-    implementation("androidx.recyclerview:recyclerview:1.3.2")
-    implementation("androidx.recyclerview:recyclerview-selection:1.1.0")
+    implementation("me.zhanghai.android.fastscroll:library:1.3.0")
+    implementation("androidx.recyclerview:recyclerview:1.4.0")
+    implementation("androidx.recyclerview:recyclerview-selection:1.2.0")
 
     implementation("androidx.core:core-splashscreen:1.0.0")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:8.10.0")
+        classpath("com.android.tools.build:gradle:8.12.0")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.Kotlin.core}")
         classpath("com.google.dagger:hilt-android-gradle-plugin:${Versions.Dagger.core}")
         classpath("androidx.navigation:navigation-safe-args-gradle-plugin:${Versions.AndroidX.Navigation.core}")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -17,7 +17,7 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    implementation("com.android.tools.build:gradle:8.10.0")
+    implementation("com.android.tools.build:gradle:8.12.0")
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.21")
     implementation("com.squareup:javapoet:1.13.0")
 }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -130,7 +130,7 @@ fun DependencyHandlerScope.addRoomDb() {
 }
 
 fun DependencyHandlerScope.addWorkerManager() {
-    val version = "2.10.1"
+    val version = "2.10.3"
     implementation("androidx.work:work-runtime:$version")
     testImplementation("androidx.work:work-testing:$version")
     implementation("androidx.work:work-runtime-ktx:$version")

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -5,16 +5,16 @@ object Versions {
     }
 
     object Dagger {
-        const val core = "2.56.2"
+        const val core = "2.57"
     }
 
     object AndroidX {
         object Navigation {
-            const val core = "2.8.9"
+            const val core = "2.9.3"
         }
     }
 
     object Desugar {
-        const val core = "2.0.4"
+        const val core = "2.1.5"
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu May 11 11:11:29 CEST 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
This commit updates Gradle to version 8.14.3 and refreshes several dependencies, including Android Gradle Plugin, Dagger, Navigation, Desugar, Play Billing, Semver, and RecyclerView.