### PR TITLE
Analyzer: Fix storage analyzer tripping up on Samsung's "Dual Messenger"

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/setup/saf/SAFSetupModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/saf/SAFSetupModule.kt
@@ -78,16 +78,23 @@ class SAFSetupModule @Inject constructor(
     private suspend fun getAccessObjects(): List<Result.PathAccess> {
         val requestObjects = mutableListOf<Result.PathAccess>()
 
+        val currentUriPerms = contentResolver.persistedUriPermissions
+        log(TAG) { "persistedUriPermissions:\n${currentUriPerms.joinToString("\n")}" }
+
+        val allUsers = userManager.allUsers()
+        log(TAG, VERBOSE) { "allUsers:\n${allUsers.joinToString("\n")}" }
+
+        val storageVolumes = storageManager2.storageVolumes
+        log(TAG, VERBOSE) { "storageVolumes:\n${storageVolumes.joinToString("\n")}" }
+
         // Android TV doesn't have the DocumentsUI app necessary to grant us permissions
         if (deviceDetective.getROMType() == RomType.ANDROID_TV) {
             log(TAG) { "Skipping SAF setup as this is an Android TV device." }
             return requestObjects
         }
 
-        val currentUriPerms = contentResolver.persistedUriPermissions
-
         if (!hasApiLevel(30)) {
-            storageManager2.storageVolumes
+            storageVolumes
                 .filter {
                     if (it.directory == null) {
                         log(TAG, INFO) { "Storage not backed by a path: $it" }
@@ -226,7 +233,7 @@ class SAFSetupModule @Inject constructor(
         // TODO provide some more elaborate lookups for TV boxes that struggle with this?
         // See https://commonsware.com/blog/2017/12/27/storage-access-framework-missing-action.html
 
-        log(TAG) { "Generated: $requestObjects" }
+        log(TAG) { "Generated:\n${requestObjects.joinToString("\n")}" }
         return requestObjects
     }
 


### PR DESCRIPTION
Seems to be specific behavior to Android 12 and Samsung's "Dual Messenger".

SD Maid fails to get the internal storage because there are two internal storages returned by the system:

SDM wants to map this (internalId is "null"):
scan(DeviceStorage(id=StorageId(internalId=null, externalId=41217664-9172-527a-b3d5-edabb50a7d69), label=CachedCaString("Primary storage"), type=PRIMARY, hardware=BUILT_IN, spaceCapacity=137438953472, spaceFree=36861681664, setupIncomplete=false))

To these (both have uuid "null"):
StorageVolumeX(uuid=null, directory=/storage/emulated/0, userlabel=Internal shared storage, volumeX=StorageVolume: Internal shared storage, rootUri=content://com.android.externalstorage.documents/root/primary) against LocalPath(/storage/emulated/0/Android/data) StorageVolumeX(uuid=null, directory=/storage/emulated/95, userlabel=Internal shared storage, volumeX=StorageVolume: Internal shared storage, rootUri=content://com.android.externalstorage.documents/root/primary) against LocalPath(/storage/emulated/0/Android/data)

This causes the check which just expects one match to fail. My first idea was this being an extra user profile, so a multi-user system error, but I couldn't reproduce. Second thought: Work profile. But that was also not it. Specifically in both cases SD Maid was not able to see the storage paths, and the ID was wrong (ID=1, ID=10 etc.), but not ID=95. Turns out this is a special Samsung feature called "Dual Messenger" which clones apps into extra profiles with some special settings that are unlike extra-user profiles and work profiles.

Testing this on newer Samsung devices, only one StorageVolume is returned. This seems be a bug specific to Android 12 (API31) Samsung ROMs: `samsung/beyond1ltexx/beyond1:12/SP1A.210812.016/G973FXXSGHWC1:user/release-keys`