### PR TITLE
AppControl: Fix duplicate entries when changing app states

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/AppControl.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/AppControl.kt
@@ -217,6 +217,7 @@ class AppControl @Inject constructor(
                 val updatedPkgs = affectedPkgs.map {
                     appScan.app(
                         pkgId = it,
+                        user = userManager.currentUser().handle,
                         includeSize = snapshot.hasInfoSize,
                         includeActive = snapshot.hasInfoActive,
                         includeUsage = snapshot.hasInfoScreenTime
@@ -269,6 +270,7 @@ class AppControl @Inject constructor(
                 val updatedPkgs = affectedPkgs.map {
                     appScan.app(
                         pkgId = it,
+                        user = userManager.currentUser().handle,
                         includeSize = snapshot.hasInfoSize,
                         includeActive = snapshot.hasInfoActive,
                         includeUsage = snapshot.hasInfoScreenTime

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/AppScan.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/AppScan.kt
@@ -111,13 +111,15 @@ class AppScan @Inject constructor(
 
     suspend fun app(
         pkgId: Pkg.Id,
+        user: UserHandle2? = null,
         includeUsage: Boolean,
         includeActive: Boolean,
         includeSize: Boolean,
     ): Set<AppInfo> = doRun {
-        log(TAG, VERBOSE) { "app($pkgId)" }
+        log(TAG, VERBOSE) { "app($pkgId, user=$user)" }
         pkgRepo.current()
             .filter { it.id == pkgId }
+            .filter { user == null || it.userHandle == user }
             .map {
                 it.toAppInfo(
                     includeUsage = includeUsage,

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListViewModel.kt
@@ -256,7 +256,7 @@ class AppControlListViewModel @Inject constructor(
                         lablrScreenTime = if (listSort.mode == SortSettings.Mode.SCREEN_TIME) content.lablrScreenTime else null,
                         onItemClicked = {
                             AppControlListFragmentDirections.actionAppControlListFragmentToAppActionDialog(
-                                content.pkg.id
+                                content.installId,
                             ).navigate()
                         },
                     )

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/actions/AppActionViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/actions/AppActionViewModel.kt
@@ -37,8 +37,8 @@ import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.navigation.navArgs
-import eu.darken.sdmse.common.pkgs.Pkg
 import eu.darken.sdmse.common.pkgs.features.InstallDetails
+import eu.darken.sdmse.common.pkgs.features.InstallId
 import eu.darken.sdmse.common.pkgs.getLaunchIntent
 import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.common.uix.ViewModel3
@@ -68,15 +68,15 @@ class AppActionViewModel @Inject constructor(
 ) : ViewModel3(dispatcherProvider) {
 
     private val navArgs by handle.navArgs<AppActionDialogArgs>()
-    private val pkgId: Pkg.Id = navArgs.pkgId
+    private val installId: InstallId = navArgs.installId
 
     init {
         appControl.state
-            .map { state -> state.data?.apps?.singleOrNull { it.pkg.id == pkgId } }
+            .map { state -> state.data?.apps?.singleOrNull { it.installId == installId } }
             .filter { it == null }
             .take(1)
             .onEach {
-                log(TAG) { "App data for $pkgId is no longer available" }
+                log(TAG) { "App data for $installId is no longer available" }
                 popNavStack()
             }
             .launchInViewModel()
@@ -85,7 +85,7 @@ class AppActionViewModel @Inject constructor(
     val events = SingleLiveEvent<AppActionEvents>()
 
     val state = combineTransform(
-        appControl.state.mapNotNull { state -> state.data?.apps?.singleOrNull { it.pkg.id == pkgId } },
+        appControl.state.mapNotNull { state -> state.data?.apps?.singleOrNull { it.installId == installId } },
         appControl.state,
         exclusionManager.exclusions,
         appControl.progress,

--- a/app/src/main/res/navigation/main_nav.xml
+++ b/app/src/main/res/navigation/main_nav.xml
@@ -246,8 +246,8 @@
         android:name="eu.darken.sdmse.appcontrol.ui.list.actions.AppActionDialog"
         tools:layout="@layout/appcontrol_action_dialog">
         <argument
-            android:name="pkgId"
-            app:argType="eu.darken.sdmse.common.pkgs.Pkg$Id" />
+            android:name="installId"
+            app:argType="eu.darken.sdmse.common.pkgs.features.InstallId" />
     </dialog>
     <fragment
         android:id="@+id/dataAreasFragment"


### PR DESCRIPTION
On rooted or Shizuku devices, SD Maid has access to app installs from other users/profiles.
Normally only the apps of the current user are displayed in the list.
The update logic after enabling/disabling an app, did not filter out app data from other users.
So after changing the enabled/disabled state of an app that was installed for other users, suddenly duplicate entries appeared that couldn't be opened.

These extra entries will no longer appear, and if they do, they will not be openable.

I'm considering enabling multi user display in another feature PR.

Fixes #1907