### PR TITLE
AppCleaner: Fix accessibility based cache deletion on Realme devices with Android 15

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/realme/RealmeSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/realme/RealmeSpecs.kt
@@ -86,7 +86,7 @@ class RealmeSpecs @Inject constructor(
                 val target = storageFinder(this) ?: return@action false
                 log(TAG) { "Found target $target" }
                 when {
-                    hasApiLevel(36) -> {
+                    hasApiLevel(35) -> {
                         val mapped = findClickableParent(maxNesting = 3, node = target)
                         if (mapped != null) {
                             clickNormal(node = mapped)


### PR DESCRIPTION
This commit refactors the interaction logic for storage entries on Realme devices within the app cleaner automation.

For Android U (API 36) and above:
- The system now attempts to find a clickable parent for the storage entry node first.
- If a clickable parent is not found, it falls back to using a click gesture on the node itself. This addresses scenarios where the storage entry might not have a directly clickable parent.

For older Android versions:
- The logic for finding and clicking the storage entry remains the same (max nesting of 6 for finding a clickable parent).

This change aims to provide a more robust way of interacting with storage entries across different Android versions on Realme devices.

* Closes #1912