### PR TITLE
Ensure full scrollability in Debug Recorder

### DIFF
--- a/app/src/main/res/layout/debug_recorder_activity.xml
+++ b/app/src/main/res/layout/debug_recorder_activity.xml
@@ -11,14 +11,14 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:clipToPadding="false"
-        android:fillViewport="false">
+        android:fillViewport="true">
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical"
             android:padding="16dp"
-            android:paddingBottom="88dp"
+            android:paddingBottom="16dp"
             android:clipToPadding="false">
 
             <!-- Hero Section -->
@@ -270,6 +270,9 @@
                 android:id="@+id/list"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:minHeight="48dp"
+                android:paddingBottom="88dp"
+                android:clipToPadding="false"
                 android:nestedScrollingEnabled="false" />
 
         </LinearLayout>


### PR DESCRIPTION
This commit addresses a layout issue in the Debug Recorder where the content was not fully scrollable.

Key changes:
- Set `android:fillViewport="true"` on the `NestedScrollView` to allow the content to fill the scroll view's viewport, enabling scrolling even if the content is smaller than the viewport.
- Adjusted padding on the inner `LinearLayout` and added `minHeight`, `paddingBottom`, and `clipToPadding` to the `RecyclerView` (`@id/list`) to ensure all items are visible and scrollable, particularly the last items which were previously obscured.