### PR TITLE
Test: Refine `SegmentCriterium` path matching

### DIFF
--- a/app/src/test/java/eu/darken/sdmse/common/sieve/SegmentCriteriumTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/common/sieve/SegmentCriteriumTest.kt
@@ -42,6 +42,8 @@ class SegmentCriteriumTest : BaseTest() {
         SegmentCriterium("ab", mode = Mode.Start(allowPartial = true)).matchRaw("abc/def") shouldBe true
         SegmentCriterium("abc/d", mode = Mode.Start(allowPartial = false)).matchRaw("abc/def") shouldBe false
         SegmentCriterium("abc/d", mode = Mode.Start(allowPartial = true)).matchRaw("abc/def") shouldBe true
+        SegmentCriterium(segs("abc", ""), mode = Mode.Start(allowPartial = true)).matchRaw("abc/") shouldBe true
+        SegmentCriterium(segs("abc", ""), mode = Mode.Start(allowPartial = true)).match(segs("abc", "")) shouldBe true
     }
 
     @Test

--- a/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/sieve/SystemCrawlerSieveTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/sieve/SystemCrawlerSieveTest.kt
@@ -193,13 +193,6 @@ class SystemCrawlerSieveTest : BaseTest() {
                 SegmentCriterium(segs("", "sdcard", "abc", ""), mode = SegmentCriterium.Mode.Start(allowPartial = true))
             )
         ).match(baseLookup.copy(lookedUp = basePath.child("abc"))).matches shouldBe false
-        Config(
-            pathCriteria = setOf(
-                SegmentCriterium(
-                    segs("", "sdcard", "abc", ""), mode = SegmentCriterium.Mode.Start(allowPartial = false)
-                )
-            )
-        ).match(baseLookup.copy(lookedUp = basePath.child("abc", "/"))).matches shouldBe true
 
         Config(
             pathCriteria = setOf(


### PR DESCRIPTION
`basePath.child("abc", "/")` created an invalid test case as `/` can not be the name of a child.

This commit removes a redundant test case from `SystemCrawlerSieveTest` that was already covered by `SegmentCriteriumTest`. It also adds new test cases to `SegmentCriteriumTest` to verify correct matching of paths ending with a separator, especially when `allowPartial = true`.