### PR TITLE
SystemCleaner: Improve error handling and continue processing on deletion failures

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/SystemCleaner.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/SystemCleaner.kt
@@ -11,6 +11,7 @@ import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
@@ -188,9 +189,10 @@ class SystemCleaner @Inject constructor(
                 },
             ) {
                 try {
-                    process(targetMatches)
+                    val results = process(targetMatches)
                     log(TAG) { "Processed ${targetMatches.size} for ${filter.identifier}!" }
-                    processed.addAll(targetMatches)
+                    processed.addAll(results.filter { it.success }.map { it.match })
+                    results.filter { !it.success }.forEach { log(TAG, WARN) { "Failed to process $it" } }
                 } catch (e: PathException) {
                     log(TAG, ERROR) { "Failed to process for ${filter.identifier}: ${e.asLog()}" }
                 }

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/SystemCleanerFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/SystemCleanerFilter.kt
@@ -25,7 +25,15 @@ interface SystemCleanerFilter : Progress.Host, Progress.Client {
 
     suspend fun match(item: APathLookup<*>): Match?
 
-    suspend fun process(matches: Collection<Match>)
+    suspend fun process(matches: Collection<Match>): Collection<Processed>
+
+    data class Processed(
+        val match: Match,
+        val error: Throwable?,
+    ) {
+        val success: Boolean
+            get() = error == null
+    }
 
     interface Match {
         val expectedGain: Long

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/custom/CustomFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/custom/CustomFilter.kt
@@ -68,8 +68,10 @@ class CustomFilter @AssistedInject constructor(
         return SystemCleanerFilter.Match.Deletion(item)
     }
 
-    override suspend fun process(matches: Collection<SystemCleanerFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        matches: Collection<SystemCleanerFilter.Match>
+    ): Collection<SystemCleanerFilter.Processed> {
+        return matches.filterIsInstance<SystemCleanerFilter.Match.Deletion>().deleteAll(gatewaySwitch)
     }
 
     override fun toString(): String = "${this::class.simpleName}(${filterConfig.label})"

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/AdvertisementFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/AdvertisementFilter.kt
@@ -191,8 +191,10 @@ class AdvertisementFilter @Inject constructor(
         return SystemCleanerFilter.Match.Deletion(item)
     }
 
-    override suspend fun process(matches: Collection<SystemCleanerFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        matches: Collection<SystemCleanerFilter.Match>
+    ): Collection<SystemCleanerFilter.Processed> {
+        return matches.filterIsInstance<SystemCleanerFilter.Match.Deletion>().deleteAll(gatewaySwitch)
     }
 
     override fun toString(): String = "${this::class.simpleName}(${hashCode()})"

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/AnalyticsFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/AnalyticsFilter.kt
@@ -27,7 +27,7 @@ import eu.darken.sdmse.systemcleaner.core.filter.BaseSystemCleanerFilter
 import eu.darken.sdmse.systemcleaner.core.filter.SystemCleanerFilter
 import eu.darken.sdmse.systemcleaner.core.filter.toDeletion
 import eu.darken.sdmse.systemcleaner.core.sieve.SystemCrawlerSieve
-import eu.darken.sdmse.systemcleaner.core.sieve.SystemCrawlerSieve.*
+import eu.darken.sdmse.systemcleaner.core.sieve.SystemCrawlerSieve.Config
 import java.io.File
 import javax.inject.Inject
 import javax.inject.Provider
@@ -109,8 +109,10 @@ class AnalyticsFilter @Inject constructor(
         return match.toDeletion()
     }
 
-    override suspend fun process(matches: Collection<SystemCleanerFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        matches: Collection<SystemCleanerFilter.Match>
+    ): Collection<SystemCleanerFilter.Processed> {
+        return matches.filterIsInstance<SystemCleanerFilter.Match.Deletion>().deleteAll(gatewaySwitch)
     }
 
     override fun toString(): String = "${this::class.simpleName}(${hashCode()})"

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/AnrFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/AnrFilter.kt
@@ -88,8 +88,10 @@ class AnrFilter @Inject constructor(
         return sieve?.match(item)?.toDeletion()
     }
 
-    override suspend fun process(matches: Collection<SystemCleanerFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        matches: Collection<SystemCleanerFilter.Match>
+    ): Collection<SystemCleanerFilter.Processed> {
+        return matches.filterIsInstance<SystemCleanerFilter.Match.Deletion>().deleteAll(gatewaySwitch)
     }
 
     override fun toString(): String = "${this::class.simpleName}(${hashCode()})"

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/DataLocalTmpFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/DataLocalTmpFilter.kt
@@ -65,8 +65,10 @@ class DataLocalTmpFilter @Inject constructor(
         return sieve.match(item).toDeletion()
     }
 
-    override suspend fun process(matches: Collection<SystemCleanerFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        matches: Collection<SystemCleanerFilter.Match>
+    ): Collection<SystemCleanerFilter.Processed> {
+        return matches.filterIsInstance<SystemCleanerFilter.Match.Deletion>().deleteAll(gatewaySwitch)
     }
 
     override fun toString(): String = "${this::class.simpleName}(${hashCode()})"

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/DataLoggerFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/DataLoggerFilter.kt
@@ -69,8 +69,10 @@ class DataLoggerFilter @Inject constructor(
         return sieve.match(item).toDeletion()
     }
 
-    override suspend fun process(matches: Collection<SystemCleanerFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        matches: Collection<SystemCleanerFilter.Match>
+    ): Collection<SystemCleanerFilter.Processed> {
+        return matches.filterIsInstance<SystemCleanerFilter.Match.Deletion>().deleteAll(gatewaySwitch)
     }
 
     override fun toString(): String = "${this::class.simpleName}(${hashCode()})"

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/DownloadCacheFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/DownloadCacheFilter.kt
@@ -73,8 +73,10 @@ class DownloadCacheFilter @Inject constructor(
         return sieve.match(item).toDeletion()
     }
 
-    override suspend fun process(matches: Collection<SystemCleanerFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        matches: Collection<SystemCleanerFilter.Match>
+    ): Collection<SystemCleanerFilter.Processed> {
+        return matches.filterIsInstance<SystemCleanerFilter.Match.Deletion>().deleteAll(gatewaySwitch)
     }
 
     override fun toString(): String = "${this::class.simpleName}(${hashCode()})"

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/EmptyDirectoryFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/EmptyDirectoryFilter.kt
@@ -133,8 +133,10 @@ class EmptyDirectoryFilter @Inject constructor(
         }
     }
 
-    override suspend fun process(matches: Collection<SystemCleanerFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        matches: Collection<SystemCleanerFilter.Match>
+    ): Collection<SystemCleanerFilter.Processed> {
+        return matches.filterIsInstance<SystemCleanerFilter.Match.Deletion>().deleteAll(gatewaySwitch)
     }
 
     override fun toString(): String = "${this::class.simpleName}(${hashCode()})"

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/LinuxFilesFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/LinuxFilesFilter.kt
@@ -67,8 +67,10 @@ class LinuxFilesFilter @Inject constructor(
         return sieve.match(item).toDeletion()
     }
 
-    override suspend fun process(matches: Collection<SystemCleanerFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        matches: Collection<SystemCleanerFilter.Match>
+    ): Collection<SystemCleanerFilter.Processed> {
+        return matches.filterIsInstance<SystemCleanerFilter.Match.Deletion>().deleteAll(gatewaySwitch)
     }
 
     override fun toString(): String = "${this::class.simpleName}(${hashCode()})"

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/LogDropboxFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/LogDropboxFilter.kt
@@ -29,7 +29,7 @@ import eu.darken.sdmse.systemcleaner.core.filter.BaseSystemCleanerFilter
 import eu.darken.sdmse.systemcleaner.core.filter.SystemCleanerFilter
 import eu.darken.sdmse.systemcleaner.core.filter.toDeletion
 import eu.darken.sdmse.systemcleaner.core.sieve.SystemCrawlerSieve
-import eu.darken.sdmse.systemcleaner.core.sieve.SystemCrawlerSieve.*
+import eu.darken.sdmse.systemcleaner.core.sieve.SystemCrawlerSieve.Config
 import javax.inject.Inject
 import javax.inject.Provider
 
@@ -67,8 +67,10 @@ class LogDropboxFilter @Inject constructor(
         return sieve.match(item).toDeletion()
     }
 
-    override suspend fun process(matches: Collection<SystemCleanerFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        matches: Collection<SystemCleanerFilter.Match>
+    ): Collection<SystemCleanerFilter.Processed> {
+        return matches.filterIsInstance<SystemCleanerFilter.Match.Deletion>().deleteAll(gatewaySwitch)
     }
 
     override fun toString(): String = "${this::class.simpleName}(${hashCode()})"

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/LogFilesFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/LogFilesFilter.kt
@@ -131,8 +131,10 @@ class LogFilesFilter @Inject constructor(
         return SystemCleanerFilter.Match.Deletion(item)
     }
 
-    override suspend fun process(matches: Collection<SystemCleanerFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        matches: Collection<SystemCleanerFilter.Match>
+    ): Collection<SystemCleanerFilter.Processed> {
+        return matches.filterIsInstance<SystemCleanerFilter.Match.Deletion>().deleteAll(gatewaySwitch)
     }
 
     override fun toString(): String = "${this::class.simpleName}(${hashCode()})"

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/LostDirFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/LostDirFilter.kt
@@ -63,8 +63,10 @@ class LostDirFilter @Inject constructor(
         return sieve.match(item).toDeletion()
     }
 
-    override suspend fun process(matches: Collection<SystemCleanerFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        matches: Collection<SystemCleanerFilter.Match>
+    ): Collection<SystemCleanerFilter.Processed> {
+        return matches.filterIsInstance<SystemCleanerFilter.Match.Deletion>().deleteAll(gatewaySwitch)
     }
 
     override fun toString(): String = "${this::class.simpleName}(${hashCode()})"

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/MacFilesFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/MacFilesFilter.kt
@@ -68,8 +68,10 @@ class MacFilesFilter @Inject constructor(
         return sieve.match(item).toDeletion()
     }
 
-    override suspend fun process(matches: Collection<SystemCleanerFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        matches: Collection<SystemCleanerFilter.Match>
+    ): Collection<SystemCleanerFilter.Processed> {
+        return matches.filterIsInstance<SystemCleanerFilter.Match.Deletion>().deleteAll(gatewaySwitch)
     }
 
     override fun toString(): String = "${this::class.simpleName}(${hashCode()})"

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/PackageCacheFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/PackageCacheFilter.kt
@@ -68,8 +68,10 @@ class PackageCacheFilter @Inject constructor(
         return sieve.match(item).toDeletion()
     }
 
-    override suspend fun process(matches: Collection<SystemCleanerFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        matches: Collection<SystemCleanerFilter.Match>
+    ): Collection<SystemCleanerFilter.Processed> {
+        return matches.filterIsInstance<SystemCleanerFilter.Match.Deletion>().deleteAll(gatewaySwitch)
     }
 
     override fun toString(): String = "${this::class.simpleName}(${hashCode()})"

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/RecentTasksFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/RecentTasksFilter.kt
@@ -29,7 +29,7 @@ import eu.darken.sdmse.systemcleaner.core.filter.BaseSystemCleanerFilter
 import eu.darken.sdmse.systemcleaner.core.filter.SystemCleanerFilter
 import eu.darken.sdmse.systemcleaner.core.filter.toDeletion
 import eu.darken.sdmse.systemcleaner.core.sieve.SystemCrawlerSieve
-import eu.darken.sdmse.systemcleaner.core.sieve.SystemCrawlerSieve.*
+import eu.darken.sdmse.systemcleaner.core.sieve.SystemCrawlerSieve.Config
 import javax.inject.Inject
 import javax.inject.Provider
 
@@ -68,8 +68,10 @@ class RecentTasksFilter @Inject constructor(
         return sieve.match(item).toDeletion()
     }
 
-    override suspend fun process(matches: Collection<SystemCleanerFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        matches: Collection<SystemCleanerFilter.Match>
+    ): Collection<SystemCleanerFilter.Processed> {
+        return matches.filterIsInstance<SystemCleanerFilter.Match.Deletion>().deleteAll(gatewaySwitch)
     }
 
     override fun toString(): String = "${this::class.simpleName}(${hashCode()})"

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/ScreenshotsFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/ScreenshotsFilter.kt
@@ -76,8 +76,10 @@ class ScreenshotsFilter @Inject constructor(
         return sieve.match(item).toDeletion()
     }
 
-    override suspend fun process(matches: Collection<SystemCleanerFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        matches: Collection<SystemCleanerFilter.Match>
+    ): Collection<SystemCleanerFilter.Processed> {
+        return matches.filterIsInstance<SystemCleanerFilter.Match.Deletion>().deleteAll(gatewaySwitch)
     }
 
     override fun toString(): String = "${this::class.simpleName}(${hashCode()})"

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/SuperfluousApksFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/SuperfluousApksFilter.kt
@@ -163,8 +163,10 @@ class SuperfluousApksFilter @Inject constructor(
         return if (superfluos) SystemCleanerFilter.Match.Deletion(item) else null
     }
 
-    override suspend fun process(matches: Collection<SystemCleanerFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        matches: Collection<SystemCleanerFilter.Match>
+    ): Collection<SystemCleanerFilter.Processed> {
+        return matches.filterIsInstance<SystemCleanerFilter.Match.Deletion>().deleteAll(gatewaySwitch)
     }
 
     override fun toString(): String = "${this::class.simpleName}(${hashCode()})"

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/TempFilesFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/TempFilesFilter.kt
@@ -77,8 +77,10 @@ class TempFilesFilter @Inject constructor(
         return sieve.match(item).toDeletion()
     }
 
-    override suspend fun process(matches: Collection<SystemCleanerFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        matches: Collection<SystemCleanerFilter.Match>
+    ): Collection<SystemCleanerFilter.Processed> {
+        return matches.filterIsInstance<SystemCleanerFilter.Match.Deletion>().deleteAll(gatewaySwitch)
     }
 
     override fun toString(): String = "${this::class.simpleName}(${hashCode()})"

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/ThumbnailsFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/ThumbnailsFilter.kt
@@ -61,8 +61,10 @@ class ThumbnailsFilter @Inject constructor(
         return sieve.match(item).toDeletion()
     }
 
-    override suspend fun process(matches: Collection<SystemCleanerFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        matches: Collection<SystemCleanerFilter.Match>
+    ): Collection<SystemCleanerFilter.Processed> {
+        return matches.filterIsInstance<SystemCleanerFilter.Match.Deletion>().deleteAll(gatewaySwitch)
     }
 
     override fun toString(): String = "${this::class.simpleName}(${hashCode()})"

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/TombstonesFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/TombstonesFilter.kt
@@ -71,8 +71,10 @@ class TombstonesFilter @Inject constructor(
         return SystemCleanerFilter.Match.Deletion(item)
     }
 
-    override suspend fun process(matches: Collection<SystemCleanerFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        matches: Collection<SystemCleanerFilter.Match>
+    ): Collection<SystemCleanerFilter.Processed> {
+        return matches.filterIsInstance<SystemCleanerFilter.Match.Deletion>().deleteAll(gatewaySwitch)
     }
 
     override fun toString(): String = "${this::class.simpleName}(${hashCode()})"

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/TrashedFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/TrashedFilter.kt
@@ -63,8 +63,10 @@ class TrashedFilter @Inject constructor(
         return sieve.match(item).toDeletion()
     }
 
-    override suspend fun process(matches: Collection<SystemCleanerFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        matches: Collection<SystemCleanerFilter.Match>
+    ): Collection<SystemCleanerFilter.Processed> {
+        return matches.filterIsInstance<SystemCleanerFilter.Match.Deletion>().deleteAll(gatewaySwitch)
     }
 
     override fun toString(): String = "${this::class.simpleName}(${hashCode()})"

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/UsagestatsFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/UsagestatsFilter.kt
@@ -68,8 +68,10 @@ class UsagestatsFilter @Inject constructor(
         return sieve.match(item).toDeletion()
     }
 
-    override suspend fun process(matches: Collection<SystemCleanerFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        matches: Collection<SystemCleanerFilter.Match>
+    ): Collection<SystemCleanerFilter.Processed> {
+        return matches.filterIsInstance<SystemCleanerFilter.Match.Deletion>().deleteAll(gatewaySwitch)
     }
 
     override fun toString(): String = "${this::class.simpleName}(${hashCode()})"

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/WindowsFilesFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/WindowsFilesFilter.kt
@@ -65,8 +65,10 @@ class WindowsFilesFilter @Inject constructor(
         return sieve.match(item).toDeletion()
     }
 
-    override suspend fun process(matches: Collection<SystemCleanerFilter.Match>) {
-        matches.deleteAll(gatewaySwitch)
+    override suspend fun process(
+        matches: Collection<SystemCleanerFilter.Match>
+    ): Collection<SystemCleanerFilter.Processed> {
+        return matches.filterIsInstance<SystemCleanerFilter.Match.Deletion>().deleteAll(gatewaySwitch)
     }
 
     override fun toString(): String = "${this::class.simpleName}(${hashCode()})"


### PR DESCRIPTION
This refactoring enhances the SystemCleaner's robustness when encountering errors during file deletion:

- Changed process() method to return Collection<Processed> instead of void, allowing filters to report success/failure status
- Updated deleteAll() to accept Collection<Match.Deletion> directly for type safety
- Added proper error handling that continues processing even when individual deletions fail
- SystemCleaner now tracks successful/failed deletions separately and logs failures as warnings
- All filter implementations updated to use filterIsInstance<Match.Deletion>() for type safety

Fixes #1920 - Previously, when SD Maid encountered an error during deletion, it would abort and not update results for successfully deleted files. Now it continues processing and properly tracks both successful and failed deletions.