### PR TITLE
Feature: Add app shortcuts for quick access

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -60,6 +60,17 @@
             </intent-filter>
         </activity>
 
+        <activity
+            android:name="eu.darken.sdmse.main.ui.shortcuts.ShortcutActivity"
+            android:exported="true"
+            android:theme="@android:style/Theme.NoDisplay">
+            <intent-filter>
+                <action android:name="eu.darken.sdmse.ACTION_OPEN_APPCONTROL" />
+                <action android:name="eu.darken.sdmse.ACTION_SCAN_DELETE" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+
         <receiver
             android:name=".corpsefinder.core.watcher.UninstallWatcherReceiver"
             android:enabled="false"

--- a/app/src/main/java/eu/darken/sdmse/App.kt
+++ b/app/src/main/java/eu/darken/sdmse/App.kt
@@ -26,6 +26,7 @@ import eu.darken.sdmse.common.theming.Theming
 import eu.darken.sdmse.common.updater.UpdateService
 import eu.darken.sdmse.main.core.CurriculumVitae
 import eu.darken.sdmse.main.core.GeneralSettings
+import eu.darken.sdmse.main.core.shortcuts.ShortcutManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
@@ -50,6 +51,7 @@ open class App : Application(), Configuration.Provider {
     @Inject lateinit var theming: Theming
     @Inject lateinit var coilTempFiles: CoilTempFiles
     @Inject lateinit var memoryMonitor: MemoryMonitor
+    @Inject lateinit var shortcutManager: ShortcutManager
 
     private val logCatLogger = LogCatLogger()
 
@@ -94,6 +96,8 @@ open class App : Application(), Configuration.Provider {
         Coil.setImageLoader(imageLoaderFactory)
 
         curriculumVitae.updateAppLaunch()
+
+        shortcutManager.initialize()
 
         val oldHandler = Thread.getDefaultUncaughtExceptionHandler()
         Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->

--- a/app/src/main/java/eu/darken/sdmse/main/core/GeneralSettings.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/core/GeneralSettings.kt
@@ -53,6 +53,7 @@ class GeneralSettings @Inject constructor(
     val oneClickSystemCleanerEnabled = dataStore.createValue("dashboard.oneclick.systemcleaner.enabled", true)
     val oneClickAppCleanerEnabled = dataStore.createValue("dashboard.oneclick.appcleaner.enabled", true)
     val oneClickDeduplicatorEnabled = dataStore.createValue("dashboard.oneclick.deduplicator.enabled", false)
+    val shortcutOneClickEnabled = dataStore.createValue("shortcut.oneclick.enabled", false)
 
     val isUpdateCheckEnabled = dataStore.createValue("updater.check.enabled", updateChecker.isEnabledByDefault())
 
@@ -64,6 +65,7 @@ class GeneralSettings @Inject constructor(
         themeStyle,
         usePreviews,
         enableDashboardOneClick,
+        shortcutOneClickEnabled,
         motdSettings.isMotdEnabled,
         isUpdateCheckEnabled,
     )

--- a/app/src/main/java/eu/darken/sdmse/main/core/shortcuts/AppShortcut.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/core/shortcuts/AppShortcut.kt
@@ -1,0 +1,60 @@
+package eu.darken.sdmse.main.core.shortcuts
+
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ShortcutInfo
+import android.graphics.drawable.Icon
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import eu.darken.sdmse.R
+import eu.darken.sdmse.main.ui.shortcuts.ShortcutActivity
+
+sealed class AppShortcut(
+    val id: String,
+    @param:StringRes val shortLabel: Int,
+    @param:StringRes val longLabel: Int,
+    @param:DrawableRes val iconRes: Int,
+) {
+    abstract fun createIntent(context: Context): Intent
+
+    fun toShortcutInfo(context: Context): ShortcutInfo {
+        return ShortcutInfo.Builder(context, id)
+            .setShortLabel(context.getString(shortLabel))
+            .setLongLabel(context.getString(longLabel))
+            .setIcon(Icon.createWithResource(context, iconRes))
+            .setIntent(createIntent(context))
+            .build()
+    }
+
+    data object AppControl : AppShortcut(
+        id = "appcontrol",
+        shortLabel = R.string.shortcut_appcontrol_short,
+        longLabel = R.string.shortcut_appcontrol_long,
+        iconRes = R.drawable.ic_shortcut_apps
+    ) {
+        override fun createIntent(context: Context): Intent = Intent(context, ShortcutActivity::class.java).apply {
+            action = ShortcutActivity.ACTION_OPEN_APPCONTROL
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        }
+    }
+
+    sealed class MainAction(
+        id: String,
+        @StringRes shortLabel: Int,
+        @StringRes longLabel: Int,
+        @DrawableRes iconRes: Int,
+    ) : AppShortcut(id, shortLabel, longLabel, iconRes) {
+
+        override fun createIntent(context: Context): Intent = Intent(context, ShortcutActivity::class.java).apply {
+            action = ShortcutActivity.ACTION_SCAN_DELETE
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        }
+
+        object OneTap : MainAction(
+            id = "onetap",
+            shortLabel = R.string.shortcut_onetap_short,
+            longLabel = R.string.shortcut_onetap_long,
+            iconRes = R.drawable.ic_shortcut_onetap
+        )
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/main/core/shortcuts/ShortcutManager.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/core/shortcuts/ShortcutManager.kt
@@ -1,0 +1,72 @@
+package eu.darken.sdmse.main.core.shortcuts
+
+import android.content.Context
+import android.content.pm.ShortcutManager
+import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.sdmse.common.coroutine.AppScope
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
+import eu.darken.sdmse.common.debug.logging.asLog
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.main.core.GeneralSettings
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ShortcutManager @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+    @param:AppScope private val appScope: CoroutineScope,
+    private val generalSettings: GeneralSettings,
+) {
+
+    private val shortcutManager: ShortcutManager by lazy {
+        context.getSystemService(ShortcutManager::class.java)
+    }
+
+    fun initialize() {
+        log(TAG, INFO) { "Initializing" }
+        generalSettings.shortcutOneClickEnabled.flow
+            .map { oneTap ->
+                ShortcutState(
+                    oneTapShortCutEnabled = oneTap
+                )
+            }
+            .distinctUntilChanged()
+            .onEach { updateShortcuts(it) }
+            .catch { log(TAG, ERROR) { "Failed to update shortcuts: ${it.asLog()}" } }
+            .launchIn(appScope)
+    }
+
+    private data class ShortcutState(
+        val oneTapShortCutEnabled: Boolean,
+    )
+
+    private suspend fun updateShortcuts(state: ShortcutState) {
+        log(TAG, INFO) { "updateShortcuts(): $state" }
+
+        val shortcuts = buildList {
+            add(AppShortcut.AppControl.toShortcutInfo(context))
+            if (state.oneTapShortCutEnabled) {
+                add(AppShortcut.MainAction.OneTap.toShortcutInfo(context))
+            }
+        }
+
+        try {
+            shortcutManager.dynamicShortcuts = shortcuts
+            log(TAG, INFO) { "Updated shortcuts." }
+        } catch (e: Exception) {
+            log(TAG, ERROR) { "Failed to update shortcuts: $e" }
+        }
+    }
+
+    companion object {
+        private val TAG = logTag("Shortcut", "Manager")
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/main/ui/MainActivity.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/MainActivity.kt
@@ -1,5 +1,6 @@
 package eu.darken.sdmse.main.ui
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.WindowManager
 import androidx.activity.enableEdgeToEdge
@@ -17,6 +18,8 @@ import eu.darken.sdmse.common.theming.Theming
 import eu.darken.sdmse.common.uix.Activity2
 import eu.darken.sdmse.databinding.MainActivityBinding
 import eu.darken.sdmse.main.core.CurriculumVitae
+import eu.darken.sdmse.main.core.shortcuts.ShortcutManager
+import eu.darken.sdmse.main.ui.shortcuts.ShortcutActivity
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -30,6 +33,7 @@ class MainActivity : Activity2() {
 
     @Inject lateinit var curriculumVitae: CurriculumVitae
     @Inject lateinit var theming: Theming
+    @Inject lateinit var shortcutManager: ShortcutManager
 
     var showSplashScreen = true
 
@@ -66,12 +70,38 @@ class MainActivity : Activity2() {
             log(tag, VERBOSE) { "Error event: $it" }
             it.asErrorDialogBuilder(this).show()
         }
+
+        handleShortcutAction(intent)
     }
 
     override fun onResume() {
         super.onResume()
         vm.checkUpgrades()
         vm.checkErrors()
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        log(tag, VERBOSE) { "onNewIntent() called with action: ${intent.action}" }
+        handleShortcutAction(intent)
+    }
+
+    private fun handleShortcutAction(intent: Intent) {
+        val shortcutAction = intent.getStringExtra(ShortcutActivity.EXTRA_SHORTCUT_ACTION)
+        if (shortcutAction != null) {
+            log(tag, VERBOSE) { "Handling shortcut action: $shortcutAction" }
+            
+            when (shortcutAction) {
+                ShortcutActivity.ACTION_OPEN_APPCONTROL -> {
+                    navController.navigate(
+                        eu.darken.sdmse.MainDirections.goToAppControlListFragment()
+                    )
+                }
+                ShortcutActivity.ACTION_UPGRADE -> {
+                    navController.navigate(eu.darken.sdmse.MainDirections.goToUpgradeFragment())
+                }
+            }
+        }
     }
 
     override fun onSaveInstanceState(outState: Bundle) {

--- a/app/src/main/java/eu/darken/sdmse/main/ui/shortcuts/ShortcutActivity.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/shortcuts/ShortcutActivity.kt
@@ -1,0 +1,120 @@
+package eu.darken.sdmse.main.ui.shortcuts
+
+import android.content.Intent
+import android.os.Bundle
+import android.widget.Toast
+import androidx.activity.ComponentActivity
+import androidx.lifecycle.lifecycleScope
+import dagger.hilt.android.AndroidEntryPoint
+import eu.darken.sdmse.appcleaner.core.AppCleaner
+import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerOneClickTask
+import eu.darken.sdmse.common.datastore.value
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.upgrade.UpgradeRepo
+import eu.darken.sdmse.common.upgrade.isPro
+import eu.darken.sdmse.corpsefinder.core.CorpseFinder
+import eu.darken.sdmse.corpsefinder.core.tasks.CorpseFinderOneClickTask
+import eu.darken.sdmse.deduplicator.core.Deduplicator
+import eu.darken.sdmse.deduplicator.core.tasks.DeduplicatorOneClickTask
+import eu.darken.sdmse.main.core.GeneralSettings
+import eu.darken.sdmse.main.core.taskmanager.TaskManager
+import eu.darken.sdmse.main.ui.MainActivity
+import eu.darken.sdmse.systemcleaner.core.SystemCleaner
+import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerOneClickTask
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class ShortcutActivity : ComponentActivity() {
+
+    @Inject lateinit var taskManager: TaskManager
+    @Inject lateinit var upgradeRepo: UpgradeRepo
+    @Inject lateinit var generalSettings: GeneralSettings
+    @Inject lateinit var corpseFinder: CorpseFinder
+    @Inject lateinit var systemCleaner: SystemCleaner
+    @Inject lateinit var appCleaner: AppCleaner
+    @Inject lateinit var deduplicator: Deduplicator
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val action = intent?.action
+        log(TAG, INFO) { "Shortcut action received: $action" }
+
+        when (action) {
+            ACTION_OPEN_APPCONTROL -> {
+                openAppControl()
+            }
+
+            ACTION_SCAN_DELETE -> {
+                handleScanDeleteShortcut()
+            }
+
+            else -> {
+                log(TAG) { "Unknown shortcut action: $action" }
+            }
+        }
+        finish()
+    }
+
+    private fun openAppControl() {
+        val mainIntent = Intent(this, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            putExtra(EXTRA_SHORTCUT_ACTION, ACTION_OPEN_APPCONTROL)
+        }
+        startActivity(mainIntent)
+    }
+
+    private fun handleScanDeleteShortcut() {
+        lifecycleScope.launch(Dispatchers.Default) {
+            if (!upgradeRepo.isPro()) {
+                log(TAG, INFO) { "Scan/Delete shortcut requires Pro version, opening upgrade screen" }
+                val upgradeIntent = Intent(this@ShortcutActivity, MainActivity::class.java).apply {
+                    flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                    putExtra(EXTRA_SHORTCUT_ACTION, ACTION_UPGRADE)
+                }
+                withContext(Dispatchers.Main) {
+                    startActivity(upgradeIntent)
+                }
+                return@launch
+            }
+
+            log(TAG, INFO) { "Executing scan and delete tasks" }
+
+            if (generalSettings.oneClickCorpseFinderEnabled.value()) {
+                taskManager.submit(CorpseFinderOneClickTask())
+            }
+            if (generalSettings.oneClickSystemCleanerEnabled.value()) {
+                taskManager.submit(SystemCleanerOneClickTask())
+            }
+            if (generalSettings.oneClickAppCleanerEnabled.value()) {
+                taskManager.submit(AppCleanerOneClickTask())
+            }
+            if (generalSettings.oneClickDeduplicatorEnabled.value()) {
+                taskManager.submit(DeduplicatorOneClickTask())
+            }
+
+            withContext(Dispatchers.Main) {
+                Toast.makeText(
+                    this@ShortcutActivity,
+                    "Scan & delete started...",
+                    Toast.LENGTH_SHORT
+                ).show()
+            }
+        }
+    }
+
+    companion object {
+        private val TAG = logTag("Shortcut", "Activity")
+
+        const val ACTION_OPEN_APPCONTROL = "eu.darken.sdmse.ACTION_OPEN_APPCONTROL"
+        const val ACTION_SCAN_DELETE = "eu.darken.sdmse.ACTION_SCAN_DELETE"
+        const val ACTION_UPGRADE = "eu.darken.sdmse.ACTION_UPGRADE"
+
+        const val EXTRA_SHORTCUT_ACTION = "shortcut_action"
+    }
+}

--- a/app/src/main/res/drawable/ic_shortcut_apps.xml
+++ b/app/src/main/res/drawable/ic_shortcut_apps.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#424242"
+        android:pathData="M4,8h4L8,4L4,4v4zM10,20h4v-4h-4v4zM4,20h4v-4L4,16v4zM4,14h4v-4L4,10v4zM10,14h4v-4h-4v4zM16,4v4h4L20,4h-4zM10,8h4L14,4h-4v4zM16,14h4v-4h-4v4zM16,20h4v-4h-4v4z" />
+</vector>

--- a/app/src/main/res/drawable/ic_shortcut_delete.xml
+++ b/app/src/main/res/drawable/ic_shortcut_delete.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#424242"
+        android:pathData="M15,16h4v2h-4zM15,8h7v2h-7zM15,12h6v2h-6zM3,18c0,1.1 0.9,2 2,2h6c1.1,0 2,-0.9 2,-2L13,8L3,8v10zM14,5h-3l-1,-1L6,4L5,5L2,5v2h12z" />
+</vector>

--- a/app/src/main/res/drawable/ic_shortcut_onetap.xml
+++ b/app/src/main/res/drawable/ic_shortcut_onetap.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#424242"
+        android:pathData="M17 4V6H3V4H6.5L7.5 3H12.5L13.5 4H17M4 19V7H16V19C16 20.1 15.1 21 14 21H6C4.9 21 4 20.1 4 19M19 15H21V17H19V15M19 7H21V13H19V7Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_shortcut_scan.xml
+++ b/app/src/main/res/drawable/ic_shortcut_scan.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#424242"
+        android:pathData="M19.31 18.9C19.75 18.21 20 17.38 20 16.5C20 14 18 12 15.5 12S11 14 11 16.5 13 21 15.5 21C16.37 21 17.19 20.75 17.88 20.32L21 23.39L22.39 22L19.31 18.9M15.5 19C14.12 19 13 17.88 13 16.5S14.12 14 15.5 14 18 15.12 18 16.5 16.88 19 15.5 19M9.59 19.2L3 14.07L4.62 12.81L9 16.22C9 16.32 9 16.41 9 16.5C9 17.46 9.22 18.38 9.59 19.2M4.63 10.27L3 9L12 2L21 9L19.36 10.27L18.65 10.82C17.72 10.3 16.64 10 15.5 10C12.79 10 10.46 11.68 9.5 14.05L4.63 10.27Z" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -793,10 +793,6 @@
 
     <string name="shortcut_appcontrol_short">App Control</string>
     <string name="shortcut_appcontrol_long">Manage installed apps</string>
-    <string name="shortcut_scan_short">Scan</string>
-    <string name="shortcut_scan_long">Scan for items to clean</string>
-    <string name="shortcut_delete_short">Delete</string>
-    <string name="shortcut_delete_long">Delete found items</string>
     <string name="shortcut_onetap_short">Scan + Delete</string>
     <string name="shortcut_onetap_long">Scan and delete in one action</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -790,4 +790,17 @@
     <string name="area_type_public_obb_label">Public app resources</string>
     <string name="area_type_private_data_label">Private app data</string>
     <string name="area_type_portable_label">Portable storage</string>
+
+    <string name="shortcut_appcontrol_short">App Control</string>
+    <string name="shortcut_appcontrol_long">Manage installed apps</string>
+    <string name="shortcut_scan_short">Scan</string>
+    <string name="shortcut_scan_long">Scan for items to clean</string>
+    <string name="shortcut_delete_short">Delete</string>
+    <string name="shortcut_delete_long">Delete found items</string>
+    <string name="shortcut_onetap_short">Scan + Delete</string>
+    <string name="shortcut_onetap_long">Scan and delete in one action</string>
+
+    <string name="shortcuts_settings_category">Shortcuts</string>
+    <string name="shortcuts_onetap_enabled_title">One-tap shortcut</string>
+    <string name="shortcuts_onetap_enabled_summary">Show \"Scan + Delete\" shortcut when long-pressing the app icon. Uses the same tools as one-tap dashboard.</string>
 </resources>

--- a/app/src/main/res/xml/preferences_general.xml
+++ b/app/src/main/res/xml/preferences_general.xml
@@ -20,6 +20,16 @@
             app:title="@string/dashboard_settings_oneclick_tools_title" />
 
     </PreferenceCategory>
+
+    <PreferenceCategory android:title="@string/shortcuts_settings_category">
+        <CheckBoxPreference
+            app:icon="@drawable/ic_delete_alert_24"
+            app:key="shortcut.oneclick.enabled"
+            app:singleLineTitle="false"
+            app:summary="@string/shortcuts_onetap_enabled_summary"
+            app:title="@string/shortcuts_onetap_enabled_title" />
+    </PreferenceCategory>
+
     <PreferenceCategory android:title="@string/settings_category_ui_label">
 
         <eu.darken.sdmse.common.preferences.ListPreference2


### PR DESCRIPTION
Implements dynamic app shortcuts that appear when long-pressing the app icon:

• AppControl shortcut: Direct access to app management (free)
• Scan + Delete shortcut: One-tap cleaning (Pro feature, toggleable)

Key features:
- Dynamic shortcuts that update based on user settings
- Pro version check with upgrade flow for scan/delete shortcut
- Headless task execution without opening dashboard UI
- Settings toggle in General Settings → Shortcuts
- Respects existing one-click tool preferences
- Uses OneClick tasks for consistent behavior

Closes https://github.com/d4rken-org/sdmaid-se/issues/1902

<img width="328" height="451" alt="Screenshot from 2025-09-03 11-58-59" src="https://github.com/user-attachments/assets/03121e80-feed-4357-99d9-a6714f096a7a" />
