### PR TITLE
AppControl: Fix apps appearing frozen on HyperOS devices

### DIFF
--- a/app-common-pkgs/src/main/java/eu/darken/sdmse/common/pkgs/sources/NormalPkgsSource.kt
+++ b/app-common-pkgs/src/main/java/eu/darken/sdmse/common/pkgs/sources/NormalPkgsSource.kt
@@ -81,6 +81,9 @@ class NormalPkgsSource @Inject constructor(
         if (pkgInfos.none { it.packageName == BuildConfigWrap.APPLICATION_ID }) {
             throw InvalidPkgInventoryException("Returned package data didn't contain us")
         }
+        if (pkgInfos.none { it.packageName == "android" }) {
+            throw InvalidPkgInventoryException("Returned package data didn't contain `android` core package")
+        }
 
         val currentHandle = userManager.currentUser().handle
         val installerData = pkgOps.getInstallerData(pkgInfos)


### PR DESCRIPTION
Added validation to detect when the system returns incomplete package data, which was causing all apps except SD Maid to appear frozen/disabled in App Control on some HyperOS devices. The fix ensures the core 'android' system package is present in query results to validate data integrity.

Closes #1863