### PR TITLE
Deduplicator: Improve file display with separate name and path

### DIFF
--- a/app-common/src/main/java/eu/darken/sdmse/common/StringExtensions.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/StringExtensions.kt
@@ -28,3 +28,14 @@ fun String.toColored(
 ): SpannableString = SpannableString(this).apply {
     setSpan(ForegroundColorSpan(ContextCompat.getColor(context, colorRes)), 0, this.length, 0)
 }
+
+fun String.replaceLast(old: String, new: String): String {
+    if (old.isEmpty()) return this
+    val i = lastIndexOf(old)
+    if (i < 0) return this
+    val sb = StringBuilder(length - old.length + new.length)
+    sb.append(this, 0, i)
+    sb.append(new)
+    sb.append(this, i + old.length, length)
+    return sb.toString()
+}

--- a/app/src/main/java/eu/darken/sdmse/deduplicator/ui/details/cluster/elements/ChecksumGroupFileVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/ui/details/cluster/elements/ChecksumGroupFileVH.kt
@@ -5,6 +5,7 @@ import eu.darken.sdmse.R
 import eu.darken.sdmse.common.lists.binding
 import eu.darken.sdmse.common.lists.selection.SelectableItem
 import eu.darken.sdmse.common.lists.selection.SelectableVH
+import eu.darken.sdmse.common.replaceLast
 import eu.darken.sdmse.databinding.DeduplicatorClusterElementChecksumgroupFileBinding
 import eu.darken.sdmse.deduplicator.core.scanner.checksum.ChecksumDuplicate
 import eu.darken.sdmse.deduplicator.ui.details.cluster.ClusterAdapter
@@ -31,9 +32,11 @@ class ChecksumGroupFileVH(parent: ViewGroup) :
         payloads: List<Any>
     ) -> Unit = binding { item ->
         lastItem = item
-        val duplicate = item.duplicate
+        val dupe = item.duplicate
 
-        primary.text = duplicate.lookup.userReadablePath.get(context)
+        val fileName = dupe.path.userReadableName.get(context)
+        name.text = fileName
+        path.text = dupe.path.userReadablePath.get(context).replaceLast(fileName, "")
 
         root.setOnClickListener { item.onItemClick(item) }
     }

--- a/app/src/main/java/eu/darken/sdmse/deduplicator/ui/details/cluster/elements/PHashGroupFileVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/ui/details/cluster/elements/PHashGroupFileVH.kt
@@ -8,6 +8,7 @@ import eu.darken.sdmse.common.coil.loadFilePreview
 import eu.darken.sdmse.common.lists.binding
 import eu.darken.sdmse.common.lists.selection.SelectableItem
 import eu.darken.sdmse.common.lists.selection.SelectableVH
+import eu.darken.sdmse.common.replaceLast
 import eu.darken.sdmse.databinding.DeduplicatorClusterElementPhashgroupFileBinding
 import eu.darken.sdmse.deduplicator.core.scanner.phash.PHashDuplicate
 import eu.darken.sdmse.deduplicator.ui.details.cluster.ClusterAdapter
@@ -40,7 +41,11 @@ class PHashGroupFileVH(parent: ViewGroup) :
             transformations(RoundedCornersTransformation(36F))
         }
         previewImage.setOnClickListener { item.onPreviewClick(item) }
-        primary.text = dupe.lookup.userReadablePath.get(context)
+
+        val fileName = dupe.path.userReadableName.get(context)
+        name.text = fileName
+        path.text = dupe.path.userReadablePath.get(context).replaceLast(fileName, "")
+
         secondary.text = String.format("%.2f%%", dupe.similarity * 100)
         sizeValue.text = Formatter.formatShortFileSize(context, dupe.size)
 

--- a/app/src/main/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListLinearSubAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListLinearSubAdapter.kt
@@ -20,6 +20,7 @@ import eu.darken.sdmse.common.lists.modular.mods.DataBinderMod
 import eu.darken.sdmse.common.lists.modular.mods.TypedVHCreatorMod
 import eu.darken.sdmse.common.lists.selection.SelectableItem
 import eu.darken.sdmse.common.lists.selection.SelectableVH
+import eu.darken.sdmse.common.replaceLast
 import eu.darken.sdmse.databinding.DeduplicatorListLinearSubItemBinding
 import eu.darken.sdmse.deduplicator.core.Duplicate
 import javax.inject.Inject
@@ -84,7 +85,7 @@ class DeduplicatorListLinearSubAdapter @Inject constructor() :
 
             val fileName = dupe.path.userReadableName.get(context)
             name.text = fileName
-            path.text = dupe.path.userReadablePath.get(context).replace(fileName, "")
+            path.text = dupe.path.userReadablePath.get(context).replaceLast(fileName, "")
 
             secondary.text = Formatter.formatShortFileSize(context, dupe.size)
 

--- a/app/src/main/res/layout/deduplicator_cluster_element_checksumgroup_file.xml
+++ b/app/src/main/res/layout/deduplicator_cluster_element_checksumgroup_file.xml
@@ -7,21 +7,36 @@
     android:background="@drawable/bg_listitem_selectable">
 
     <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/primary"
+        android:id="@+id/name"
         style="@style/TextAppearance.Material3.BodyMedium"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:layout_marginTop="8dp"
         android:layout_marginEnd="8dp"
-        android:layout_marginBottom="8dp"
-        android:ellipsize="end"
-        android:minLines="2"
-        app:layout_constraintBottom_toBottomOf="parent"
+        android:ellipsize="middle"
+        android:maxLines="1"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_chainStyle="packed"
-        tools:text=".../some/happy/little/file" />
+        tools:text="A file name for the preview" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/path"
+        style="@style/TextAppearance.Material3.BodySmall"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginBottom="8dp"
+        android:ellipsize="start"
+        android:maxLines="1"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/name"
+        app:layout_constraintVertical_chainStyle="packed"
+        tools:text="/storage/emulated/0/some/happy/little/file" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/deduplicator_cluster_element_phashgroup_file.xml
+++ b/app/src/main/res/layout/deduplicator_cluster_element_phashgroup_file.xml
@@ -18,44 +18,62 @@
         app:layout_constraintTop_toTopOf="parent"
         tools:src="?colorPrimary" />
 
+
     <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/primary"
+        android:id="@+id/name"
         style="@style/TextAppearance.Material3.BodyMedium"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
+        android:layout_marginHorizontal="16dp"
         android:layout_marginTop="8dp"
-        android:layout_marginEnd="16dp"
-        android:ellipsize="end"
-        app:layout_constraintBottom_toTopOf="@id/secondary"
+        android:ellipsize="middle"
+        android:maxLines="1"
+        app:layout_constraintBottom_toTopOf="@id/path"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/preview_image"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_chainStyle="packed"
-        tools:text=".../some/happy/little/file" />
+        tools:text="A file name for the preview" />
 
     <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/secondary"
+        android:id="@+id/path"
         style="@style/TextAppearance.Material3.BodySmall"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:ellipsize="start"
+        android:maxLines="1"
+        app:layout_constraintBottom_toTopOf="@id/secondary"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/preview_image"
+        app:layout_constraintTop_toBottomOf="@id/name"
+        app:layout_constraintVertical_chainStyle="packed"
+        tools:text="/storage/emulated/0/some/happy/little/file" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/secondary"
+        style="@style/TextAppearance.Material3.LabelMedium"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
         android:layout_marginEnd="16dp"
         android:layout_marginBottom="8dp"
         android:ellipsize="end"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/size_value"
-        app:layout_constraintStart_toStartOf="@id/primary"
-        app:layout_constraintTop_toBottomOf="@id/primary"
+        app:layout_constraintStart_toStartOf="@id/path"
+        app:layout_constraintTop_toBottomOf="@id/path"
         app:layout_constraintVertical_chainStyle="packed"
         tools:text="97.14% similar" />
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/size_value"
-        style="@style/TextAppearance.Material3.BodySmall"
+        style="@style/TextAppearance.Material3.LabelMedium"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
         app:layout_constraintBottom_toBottomOf="@id/secondary"
-        app:layout_constraintEnd_toEndOf="@id/primary"
+        app:layout_constraintEnd_toEndOf="@id/name"
         app:layout_constraintTop_toTopOf="@id/secondary"
         tools:text="123.45 MB" />
 

--- a/app/src/main/res/layout/deduplicator_list_linear_sub_item.xml
+++ b/app/src/main/res/layout/deduplicator_list_linear_sub_item.xml
@@ -52,13 +52,14 @@
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/secondary"
-        style="@style/TextAppearance.Material3.LabelSmall"
+        style="@style/TextAppearance.Material3.LabelMedium"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="16dp"
         android:layout_marginBottom="4dp"
+        android:layout_marginTop="2dp"
         android:ellipsize="end"
-        android:gravity="start"
+        android:gravity="end"
         android:singleLine="true"
         android:textColor="?colorOnBackground"
         app:layout_constraintBottom_toBottomOf="parent"


### PR DESCRIPTION
Separate filename display from full path in duplicate file listings for better readability. File names are now shown prominently with ellipsis in the middle, while paths are displayed below with start ellipsis to show relevant folder context.

Changes:
- Add replaceLast() string extension for proper filename removal from paths
- Update ChecksumGroupFileVH and PHashGroupFileVH to use split display
- Modify DeduplicatorListLinearSubAdapter to use replaceLast() instead of replace()
- Update XML layouts to show filename and path as separate text views
- Improve ellipsis strategies: middle for names, start for paths

This addresses user feedback about file identification being difficult when only seeing truncated full paths.