### PR TITLE
Shortcuts: Don't return to app if AppCleaner uses ACS

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
@@ -133,7 +133,11 @@ class AppCleaner @Inject constructor(
 
                     is AppCleanerOneClickTask -> {
                         performScan()
-                        performProcessing().let {
+                        performProcessing(
+                            AppCleanerProcessingTask(
+                                isBackground = task.shortcutMode,
+                            )
+                        ).let {
                             AppCleanerOneClickTask.Success(
                                 affectedSpace = it.affectedSpace,
                                 affectedPaths = it.affectedPaths,

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerOneClickTask.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerOneClickTask.kt
@@ -11,7 +11,7 @@ import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class AppCleanerOneClickTask(
-    val noop: Boolean = true
+    val shortcutMode: Boolean = false,
 ) : AppCleanerTask, Reportable {
 
     sealed interface Result : AppCleanerTask.Result

--- a/app/src/main/java/eu/darken/sdmse/main/ui/shortcuts/ShortcutActivity.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/shortcuts/ShortcutActivity.kt
@@ -101,7 +101,7 @@ class ShortcutActivity : ComponentActivity() {
         }
         if (generalSettings.oneClickAppCleanerEnabled.value()) {
             try {
-                taskManager.submit(AppCleanerOneClickTask())
+                taskManager.submit(AppCleanerOneClickTask(shortcutMode = true))
             } catch (e: Exception) {
                 log(TAG) { "Failed to submit AppCleanerOneClickTask: $e" }
             }


### PR DESCRIPTION
If ACS operations are launched via shortcut, don't return to SD Maid at the end.