### PR TITLE
AppCleaner: Add collapse/expand functionality for file categories

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/ui/details/appjunk/elements/AppJunkElementFileCategoryVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/ui/details/appjunk/elements/AppJunkElementFileCategoryVH.kt
@@ -42,6 +42,13 @@ class AppJunkElementFileCategoryVH(parent: ViewGroup) :
         }
         description.text = getString(item.category.descriptionRes)
 
+        collapseAction.apply {
+            setIconResource(
+                if (item.isCollapsed) R.drawable.ic_expand_more else R.drawable.ic_expand_less
+            )
+            setOnClickListener { item.onCollapseToggle() }
+        }
+
         root.setOnClickListener { item.onItemClick(item) }
     }
 
@@ -50,6 +57,8 @@ class AppJunkElementFileCategoryVH(parent: ViewGroup) :
         val category: KClass<out ExpendablesFilter>,
         val matches: Collection<ExpendablesFilter.Match>,
         val onItemClick: (Item) -> Unit,
+        val isCollapsed: Boolean,
+        val onCollapseToggle: () -> Unit,
     ) : AppJunkElementsAdapter.Item {
 
         override val itemSelectionKey: String? = null

--- a/app/src/main/res/layout/appcleaner_appjunk_element_file_category.xml
+++ b/app/src/main/res/layout/appcleaner_appjunk_element_file_category.xml
@@ -27,7 +27,7 @@
         android:ellipsize="end"
         android:singleLine="true"
         app:layout_constraintBottom_toTopOf="@id/secondary"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/collapse_action"
         app:layout_constraintStart_toEndOf="@id/icon"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_chainStyle="packed"
@@ -46,6 +46,18 @@
         app:layout_constraintTop_toBottomOf="@id/primary"
         app:layout_constraintVertical_chainStyle="packed"
         tools:text="999.99 KB (2 items)" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/collapse_action"
+        style="@style/Widget.Material3.Button.IconButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        app:icon="@drawable/ic_expand_less"
+        app:iconTint="?colorOnBackground"
+        app:layout_constraintBottom_toBottomOf="@id/secondary"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@id/primary" />
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/description"


### PR DESCRIPTION
Users can now collapse and expand file categories in the AppCleaner details view to better navigate through long lists of files. This helps prevent accidental deletions and improves the user experience when reviewing files.

- Added collapse state tracking in AppJunkViewModel
- File categories now have a collapse/expand button that toggles visibility
- Category headers remain visible with item count and size information
- Icons change between expand_less (expanded) and expand_more (collapsed)
- Files under collapsed categories are hidden from the list

This addresses user concerns about navigating lists with many items (e.g., 103 items in public cache) and reduces the risk of accidentally deleting important files.

Closes #1951