### PR TITLE
FileOps: Add logging for failed file deletions

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/FileOpsHost.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/FileOpsHost.kt
@@ -216,6 +216,8 @@ class FileOpsHost @Inject constructor(
             if (success) log(TAG, WARN) { "Tried to delete file, but it's already gone: $path" }
         }
 
+        if (!success) log(TAG, WARN) { "Failed to delete: $path (canWrite=${javaFile.canWrite()})" }
+
         success
     } catch (e: Exception) {
         log(TAG, ERROR) { "delete(path=$path,recursive=$recursive,dryRun=$dryRun) failed\n${e.asLog()}" }


### PR DESCRIPTION
Log when a file deletion operation fails, including the `canWrite` status of the file, to help diagnose permission issues.

See #1920