### PR TITLE
General: Fix usage statistics permission detection on HONOR devices

### DIFF
--- a/app-common/src/main/java/eu/darken/sdmse/common/permissions/PermissionExtensions.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/permissions/PermissionExtensions.kt
@@ -1,9 +1,0 @@
-package eu.darken.sdmse.common.permissions
-
-import android.content.Context
-import android.content.pm.PackageManager
-import androidx.core.content.ContextCompat
-
-
-fun Context.hasPermission(permission: Permission): Boolean =
-    ContextCompat.checkSelfPermission(this, permission.permissionId) == PackageManager.PERMISSION_GRANTED


### PR DESCRIPTION
On HONOR devices (and some MIUI/HyperOS ROMs), AppOpsManager.checkOpNoThrow() returns MODE_DEFAULT instead of MODE_ALLOWED even when the PACKAGE_USAGE_STATS permission toggle is enabled in system settings.

Previously, SD Maid only checked for MODE_ALLOWED, causing it to incorrectly report the permission as denied on HONOR devices, leading to persistent "Grant access" prompts.

Changes:
- Handle all AppOpsManager modes (ALLOWED, IGNORED, ERRORED, DEFAULT, unknown)
- For MODE_DEFAULT, fallback to checkSelfPermission() as recommended by Android docs
- Add comprehensive VERBOSE logging to track permission check results
- Consolidate MODE_IGNORED and MODE_ERRORED handling (both deny permission)

This follows the official Android recommendation for handling MODE_DEFAULT found in Stack Overflow discussions about PACKAGE_USAGE_STATS permission checking.

Closes #1971