### PR TITLE
Picker: Update toolbar navigation icon

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/common/picker/PickerFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/picker/PickerFragment.kt
@@ -105,6 +105,14 @@ class PickerFragment : Fragment3(R.layout.common_picker_fragment) {
             if (state.progress != null) toolbar.subtitle = state.current?.lookup?.path ?: ""
             toolbar.menu.iterator().forEach { it.isVisible = state.progress == null }
 
+            toolbar.setNavigationIcon(
+                if (state.current == null) {
+                    R.drawable.ic_baseline_close_24
+                } else {
+                    R.drawable.ic_baseline_arrow_back_24
+                }
+            )
+
             if (state.progress == null) pickerAdapter.update(state.items)
 
             selectedSecondary.text = requireContext().getQuantityString2(


### PR DESCRIPTION
Dynamically set the toolbar navigation icon to a "close" icon when at the root directory and a "back" icon otherwise.

Noticed during debugging #1974