### PR TITLE
Deduplicator: Fix file viewing issues when opening PDFs and other files

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/common/ViewIntentTool.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/ViewIntentTool.kt
@@ -1,0 +1,49 @@
+package eu.darken.sdmse.common
+
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.FileProvider
+import dagger.Reusable
+import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.common.files.core.local.File
+import eu.darken.sdmse.common.files.local.LocalPathLookup
+import javax.inject.Inject
+
+@Reusable
+class ViewIntentTool @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val mimeTypeTool: MimeTypeTool,
+) {
+
+    suspend fun create(lookup: APathLookup<*>): Intent? {
+        log(TAG) { "create(): Creating intent for $lookup" }
+
+        if (lookup !is LocalPathLookup) {
+            log(TAG) { "create(): Unsupported path type: ${lookup.pathType}" }
+            return null
+        }
+
+        val javaPath = File(lookup.path)
+        val uri = FileProvider.getUriForFile(context, "${context.packageName}.provider", javaPath)
+        val mimeType = mimeTypeTool.determineMimeType(lookup)
+        log(TAG, VERBOSE) { "create(): MimeType is $mimeType for ${lookup.path}" }
+
+        val intent = Intent(Intent.ACTION_VIEW).apply {
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
+            setDataAndType(uri, mimeType)
+        }
+
+        return Intent.createChooser(intent, lookup.name).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+    }
+
+    companion object {
+        private val TAG = logTag("ViewIntentTool")
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/deduplicator/ui/details/cluster/ClusterEvents.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/ui/details/cluster/ClusterEvents.kt
@@ -1,6 +1,6 @@
 package eu.darken.sdmse.deduplicator.ui.details.cluster
 
-import eu.darken.sdmse.common.files.APathLookup
+import android.content.Intent
 import eu.darken.sdmse.common.previews.PreviewOptions
 
 sealed class ClusterEvents {
@@ -9,7 +9,7 @@ sealed class ClusterEvents {
         val allowDeleteAll: Boolean
     ) : ClusterEvents()
 
-    data class OpenDuplicate(val lookup: APathLookup<*>) : ClusterEvents()
+    data class OpenDuplicate(val intent: Intent) : ClusterEvents()
 
     data class ViewDuplicate(val options: PreviewOptions) : ClusterEvents()
 }

--- a/app/src/main/java/eu/darken/sdmse/deduplicator/ui/details/cluster/ClusterFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/ui/details/cluster/ClusterFragment.kt
@@ -1,8 +1,6 @@
 package eu.darken.sdmse.deduplicator.ui.details.cluster
 
 import android.content.ActivityNotFoundException
-import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import android.view.MenuItem
 import android.view.View
@@ -150,11 +148,7 @@ class ClusterFragment : Fragment3(R.layout.deduplicator_cluster_fragment) {
 
                 is ClusterEvents.OpenDuplicate -> {
                     try {
-                        val intent = Intent(
-                            Intent.ACTION_VIEW,
-                            Uri.parse(event.lookup.userReadablePath.get(requireContext()))
-                        )
-                        startActivity(intent)
+                        startActivity(event.intent)
                     } catch (e: ActivityNotFoundException) {
                         e.asErrorDialogBuilder(requireActivity()).show()
                     }

--- a/app/src/main/java/eu/darken/sdmse/deduplicator/ui/details/cluster/ClusterViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/ui/details/cluster/ClusterViewModel.kt
@@ -4,9 +4,11 @@ import androidx.lifecycle.SavedStateHandle
 import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.sdmse.MainDirections
 import eu.darken.sdmse.common.SingleLiveEvent
+import eu.darken.sdmse.common.ViewIntentTool
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.previews.PreviewOptions
@@ -37,6 +39,7 @@ class ClusterViewModel @Inject constructor(
     private val settings: DeduplicatorSettings,
     private val taskManager: TaskManager,
     private val upgradeRepo: UpgradeRepo,
+    private val viewIntentTool: ViewIntentTool,
 ) : ViewModel3(dispatcherProvider = dispatcherProvider) {
 
     private val args = ClusterFragmentArgs.fromSavedStateHandle(handle)
@@ -195,7 +198,12 @@ class ClusterViewModel @Inject constructor(
 
     fun open(item: ClusterAdapter.DuplicateItem) = launch {
         log(TAG, INFO) { "open(): $item" }
-        events.postValue(ClusterEvents.OpenDuplicate(item.duplicate.lookup))
+        val intent = viewIntentTool.create(item.duplicate.lookup)
+        if (intent == null) {
+            log(TAG, WARN) { "open(): Unable to create view intent for ${item.duplicate.lookup}" }
+            return@launch
+        }
+        events.postValue(ClusterEvents.OpenDuplicate(intent))
     }
 
     companion object {


### PR DESCRIPTION
Created ViewIntentTool to centralize file viewing intent creation. Previously, opening files (especially PDFs) would fail with ActivityNotFoundException because:
- Missing MIME type specification
- Using raw file:// URIs instead of FileProvider content:// URIs
- Missing FLAG_GRANT_READ_URI_PERMISSION

The new tool properly:
- Creates FileProvider URIs with correct authority
- Determines and sets MIME types using MimeTypeTool
- Adds necessary permission flags for external apps
- Creates chooser intent for better UX
- Returns null for unsupported path types

Also refactored ContentViewModel to use the same logic, eliminating code duplication.

Closes #1974