### PR TITLE
AppCleaner: Mark system apps in scan results

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppJunk.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppJunk.kt
@@ -8,6 +8,7 @@ import eu.darken.sdmse.common.ca.CaString
 import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.pkgs.features.InstallId
 import eu.darken.sdmse.common.pkgs.features.Installed
+import eu.darken.sdmse.common.pkgs.isSystemApp
 import eu.darken.sdmse.common.user.UserProfile2
 
 data class AppJunk(
@@ -23,6 +24,9 @@ data class AppJunk(
 
     val label: CaString
         get() = pkg.label ?: pkg.packageName.toCaString()
+
+    val isSystemApp: Boolean
+        get() = pkg.isSystemApp
 
     val itemCount by lazy {
         var count = 0

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/ui/details/appjunk/elements/AppJunkElementHeaderVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/ui/details/appjunk/elements/AppJunkElementHeaderVH.kt
@@ -47,11 +47,12 @@ class AppJunkElementHeaderVH(parent: ViewGroup) :
 
         sizeValue.text = Formatter.formatFileSize(context, junk.size)
 
-        userLabel.isVisible = junk.userProfile != null
-        userValue.apply {
-            isVisible = junk.userProfile != null
-            text = junk.userProfile?.getHumanLabel()?.get(context)
-        }
+        userOwnerContainer.isVisible = junk.userProfile != null || junk.isSystemApp
+
+        userInfoContainer.isVisible = junk.userProfile != null
+        userValue.text = junk.userProfile?.getHumanLabel()?.get(context)
+
+        systemAppContainer.isVisible = junk.isSystemApp
 
         val hasHint = false
         hintsLabel.isGone = !hasHint

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/ui/list/AppCleanerListRowVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/ui/list/AppCleanerListRowVH.kt
@@ -3,6 +3,7 @@ package eu.darken.sdmse.appcleaner.ui.list
 import android.content.res.ColorStateList
 import android.text.format.Formatter
 import android.view.ViewGroup
+import androidx.core.view.isVisible
 import eu.darken.sdmse.R
 import eu.darken.sdmse.appcleaner.core.AppJunk
 import eu.darken.sdmse.common.coil.loadAppIcon
@@ -49,6 +50,7 @@ class AppCleanerListRowVH(parent: ViewGroup) :
         }
         primary.text = junk.label.get(context)
         secondary.text = junk.pkg.packageName
+        systemAppIndicator.isVisible = junk.isSystemApp
 
         items.text = getQuantityString(eu.darken.sdmse.common.R.plurals.result_x_items, junk.itemCount)
         size.text = Formatter.formatShortFileSize(context, junk.size)

--- a/app/src/main/res/layout/appcleaner_appjunk_element_header.xml
+++ b/app/src/main/res/layout/appcleaner_appjunk_element_header.xml
@@ -77,23 +77,82 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/size_value">
 
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/user_label"
-                style="@style/TextAppearance.Material3.LabelSmall"
-                android:layout_width="wrap_content"
+            <LinearLayout
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/appcleaner_junk_userprofile_label"
+                android:orientation="horizontal"
                 android:visibility="gone"
-                tools:visibility="visible" />
+                android:id="@+id/user_owner_container"
+                tools:visibility="visible">
 
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/user_value"
-                style="@style/TextAppearance.Material3.BodySmall"
-                android:layout_width="wrap_content"
-                android:layout_height="match_parent"
-                android:visibility="gone"
-                tools:text="Owner (0)"
-                tools:visibility="visible" />
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:id="@+id/user_info_container"
+                    android:layout_weight="1"
+                    android:visibility="gone"
+                    tools:visibility="visible"
+                    android:orientation="vertical">
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:id="@+id/user_label"
+                        style="@style/TextAppearance.Material3.LabelSmall"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/appcleaner_junk_userprofile_label"
+                        tools:visibility="visible" />
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:id="@+id/user_value"
+                        style="@style/TextAppearance.Material3.BodySmall"
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        tools:text="Owner (0)"
+                        tools:visibility="visible" />
+                </LinearLayout>
+
+                <LinearLayout
+                    android:id="@+id/system_app_container"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:orientation="vertical"
+                    android:visibility="gone"
+                    tools:visibility="visible">
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:id="@+id/system_app_label"
+                        style="@style/TextAppearance.Material3.LabelSmall"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/general_type_label"
+                        tools:visibility="visible" />
+
+                    <LinearLayout
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical">
+
+                        <com.google.android.material.textview.MaterialTextView
+                            android:id="@+id/system_app_value"
+                            style="@style/TextAppearance.Material3.BodySmall"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/appcontrol_tag_system"
+                            tools:visibility="visible" />
+
+                        <ImageView
+                            android:id="@+id/system_app_icon"
+                            android:layout_width="16dp"
+                            android:layout_height="16dp"
+                            android:layout_marginStart="4dp"
+                            android:src="@drawable/ic_apps"
+                            tools:visibility="visible" />
+                    </LinearLayout>
+                </LinearLayout>
+
+            </LinearLayout>
 
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/hints_label"

--- a/app/src/main/res/layout/appcleaner_list_item.xml
+++ b/app/src/main/res/layout/appcleaner_list_item.xml
@@ -36,15 +36,32 @@
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/secondary"
         style="@style/TextAppearance.Material3.BodySmall"
-        android:layout_width="0dp"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:ellipsize="end"
         android:singleLine="true"
+        app:layout_constrainedWidth="true"
         app:layout_constraintBottom_toTopOf="@id/items"
-        app:layout_constraintEnd_toEndOf="@id/primary"
+        app:layout_constraintEnd_toStartOf="@id/system_app_indicator"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintHorizontal_chainStyle="packed"
         app:layout_constraintStart_toStartOf="@id/primary"
         app:layout_constraintTop_toBottomOf="@id/primary"
         tools:text="eu.darken.sdmse" />
+
+    <ImageView
+        android:id="@+id/system_app_indicator"
+        android:layout_width="16dp"
+        android:layout_height="16dp"
+        android:layout_marginStart="4dp"
+        android:layout_marginEnd="8dp"
+        android:src="@drawable/ic_apps"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="@id/secondary"
+        app:layout_constraintEnd_toEndOf="@id/primary"
+        app:layout_constraintStart_toEndOf="@id/secondary"
+        app:layout_constraintTop_toTopOf="@id/secondary"
+        tools:visibility="visible" />
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/items"


### PR DESCRIPTION
System apps are now visually distinguished in both the list view and details:
- List view shows a small system icon next to the package name
- Details header displays "Type: System" with icon in two-column layout
- Added isSystemApp property to AppJunk for accessing pkg.isSystemApp
- Fixed text cutoff in list items using layout_constrainedWidth

The system indicator uses the same ic_apps icon as the "Include system apps" setting for consistency. In the details view, the system app info appears alongside user profile information in an efficient two-column layout.