### PR TITLE
Fix InvalidPkgInventory exception in Huawei Virtual Machine

### DIFF
--- a/app-common-pkgs/src/main/java/eu/darken/sdmse/common/pkgs/sources/NormalPkgsSource.kt
+++ b/app-common-pkgs/src/main/java/eu/darken/sdmse/common/pkgs/sources/NormalPkgsSource.kt
@@ -81,7 +81,7 @@ class NormalPkgsSource @Inject constructor(
         if (pkgInfos.none { it.packageName == BuildConfigWrap.APPLICATION_ID }) {
             throw InvalidPkgInventoryException("Returned package data didn't contain us")
         }
-        if (pkgInfos.none { it.packageName == "android" }) {
+        if (pkgInfos.none { SANITY_PKGS.contains(it.packageName) }) {
             throw InvalidPkgInventoryException("Returned package data didn't contain `android` core package")
         }
 
@@ -142,6 +142,10 @@ class NormalPkgsSource @Inject constructor(
     }
 
     companion object {
+        private val SANITY_PKGS = setOf(
+            "android",
+            "com.android.cts.ctsshim",
+        )
         private val TAG = logTag("Pkg", "Repo", "Source", "NormalPkgs")
     }
 }


### PR DESCRIPTION
Relax package inventory sanity check.

The HarmonyOS virtual machine, called Zhuoyitong（卓易通）, returns a restricted set of packages that does not contain `android`.

Broaden the sanity check to accept either `android` or `com.android.cts.ctsshim` as a valid core package, fixing issues on some devices where `android` is missing.

Fixes #1986