### PR TITLE
ACS: Explicitly disable service after use if it can be enabled again (root/adb)

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/automation/core/AutomationManager.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/AutomationManager.kt
@@ -190,8 +190,8 @@ class AutomationManager @Inject constructor(
         log(TAG) { "serviceLauncher: Service provided, waiting for close..." }
         awaitClose {
             log(TAG) { "serviceLauncher: Closing..." }
-            if (!serviceWasRunning) {
-                log(TAG) { "serviceLauncher: Service wasn't running, let's toggle it off again" }
+            if (canToggle) {
+                log(TAG) { "serviceLauncher: Can be launched on demand, stopping it after use..." }
                 runBlocking { stopService() }
             }
         }

--- a/app/src/main/java/eu/darken/sdmse/setup/SetupHealer.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/SetupHealer.kt
@@ -174,7 +174,7 @@ class SetupHealer @Inject constructor(
         }
 
         return setupHelper.setSecureSettings(true).also {
-            log(TAG, INFO) { "AUTOMATION: Heal attempt succes=$it" }
+            log(TAG, INFO) { "AUTOMATION: Heal attempt success=$it" }
         }
     }
 


### PR DESCRIPTION
Previously SD Maid only did this if the service was not running before.

Fixes #1990