### PR TITLE
AppCleaner: Add shortcut service cache cleaner

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleanerSettings.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleanerSettings.kt
@@ -46,6 +46,8 @@ class AppCleanerSettings @Inject constructor(
     val filterThumbnailsEnabled = dataStore.createValue("filter.thumbnails.enabled", true)
     val filterOfflineCachesEnabled = dataStore.createValue("filter.offlinecache.enabled", false)
     val filterRecycleBinsEnabled = dataStore.createValue("filter.recyclebins.enabled", false)
+    val filterShortcutServiceEnabled = dataStore.createValue("filter.shortcutservice.enabled", false)
+
     val filterWebviewEnabled = dataStore.createValue("filter.webview.enabled", true)
     val filterThreemaEnabled = dataStore.createValue("filter.threema.enabled", false)
     val filterTelegramEnabled = dataStore.createValue("filter.telegram.enabled", false)
@@ -80,6 +82,7 @@ class AppCleanerSettings @Inject constructor(
         filterOfflineCachesEnabled,
         filterRecycleBinsEnabled,
         filterWebviewEnabled,
+        filterShortcutServiceEnabled,
         filterThreemaEnabled,
         filterTelegramEnabled,
         filterWhatsAppBackupsEnabled,

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/ShortcutServiceFilter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/forensics/filter/ShortcutServiceFilter.kt
@@ -1,0 +1,81 @@
+package eu.darken.sdmse.appcleaner.core.forensics.filter
+
+import dagger.Binds
+import dagger.Module
+import dagger.Reusable
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoSet
+import eu.darken.sdmse.appcleaner.core.AppCleanerSettings
+import eu.darken.sdmse.appcleaner.core.forensics.BaseExpendablesFilter
+import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilter
+import eu.darken.sdmse.common.areas.DataArea
+import eu.darken.sdmse.common.datastore.value
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.common.files.GatewaySwitch
+import eu.darken.sdmse.common.files.Segments
+import eu.darken.sdmse.common.pkgs.Pkg
+import javax.inject.Inject
+import javax.inject.Provider
+
+@Reusable
+class ShortcutServiceFilter @Inject constructor(
+    private val gatewaySwitch: GatewaySwitch,
+) : BaseExpendablesFilter() {
+
+    override suspend fun initialize() {
+        log(TAG) { "initialize()" }
+    }
+
+    override suspend fun match(
+        pkgId: Pkg.Id,
+        target: APathLookup<APath>,
+        areaType: DataArea.Type,
+        pfpSegs: Segments
+    ): ExpendablesFilter.Match? {
+        // Path structure: /data/system_ce/{userId}/shortcut_service/bitmaps/{packageName}/...
+        if (areaType != DataArea.Type.DATA_SYSTEM_CE) return null
+
+        // pfpSegs: ["shortcut_service", "bitmaps", "{packageName}", "file.png", ...]
+        if (pfpSegs.size < 4) return null
+        if (pfpSegs[0] != "shortcut_service") return null
+        if (pfpSegs[1] != "bitmaps") return null
+
+        if (pfpSegs[2] != pkgId.name) return null
+
+        return target.toDeletionMatch()
+    }
+
+    override suspend fun process(
+        targets: Collection<ExpendablesFilter.Match>,
+        allMatches: Collection<ExpendablesFilter.Match>
+    ): ExpendablesFilter.ProcessResult {
+        return deleteAll(
+            targets.map { it as ExpendablesFilter.Match.Deletion },
+            gatewaySwitch,
+            allMatches
+        )
+    }
+
+    @Reusable
+    class Factory @Inject constructor(
+        private val settings: AppCleanerSettings,
+        private val filterProvider: Provider<ShortcutServiceFilter>
+    ) : ExpendablesFilter.Factory {
+        override suspend fun isEnabled(): Boolean = settings.filterShortcutServiceEnabled.value()
+        override suspend fun create(): ExpendablesFilter = filterProvider.get()
+    }
+
+    @InstallIn(SingletonComponent::class)
+    @Module
+    abstract class DIM {
+        @Binds @IntoSet abstract fun mod(mod: Factory): ExpendablesFilter.Factory
+    }
+
+    companion object {
+        private val TAG = logTag("AppCleaner", "Scanner", "Filter", "ShortcutService")
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/AppScanner.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/AppScanner.kt
@@ -234,6 +234,17 @@ class AppScanner @Inject constructor(
                 ?.map { fileForensics.identifyArea(it)!! }
                 ?.forEach { interestingPaths.add(it) }
 
+            // Check for shortcut service bitmap caches in system_ce areas
+            currentAreas
+                .filter { it.type == DataArea.Type.DATA_SYSTEM_CE }
+                .map { area ->
+                    // Path: /data/system_ce/{userId}/shortcut_service/bitmaps/{packageName}
+                    area.path.child("shortcut_service", "bitmaps", pkg.packageName)
+                }
+                .filter { it.exists(gatewaySwitch) }
+                .mapNotNull { fileForensics.identifyArea(it) }
+                .forEach { interestingPaths.add(it) }
+
             val clutterMarkerForPkg = clutterRepo.getMarkerForPkg(pkg.id)
 
             dataAreaMap.values

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/ui/AppJunkExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/ui/AppJunkExtensions.kt
@@ -15,6 +15,7 @@ import eu.darken.sdmse.appcleaner.core.forensics.filter.HiddenFilter
 import eu.darken.sdmse.appcleaner.core.forensics.filter.MobileQQFilter
 import eu.darken.sdmse.appcleaner.core.forensics.filter.OfflineCacheFilter
 import eu.darken.sdmse.appcleaner.core.forensics.filter.RecycleBinsFilter
+import eu.darken.sdmse.appcleaner.core.forensics.filter.ShortcutServiceFilter
 import eu.darken.sdmse.appcleaner.core.forensics.filter.TelegramFilter
 import eu.darken.sdmse.appcleaner.core.forensics.filter.ThreemaFilter
 import eu.darken.sdmse.appcleaner.core.forensics.filter.ThumbnailsFilter
@@ -41,6 +42,7 @@ val <T : ExpendablesFilter> KClass<T>.labelRes: Int
         OfflineCacheFilter::class -> R.string.appcleaner_filter_offlinecache_label
         RecycleBinsFilter::class -> R.string.appcleaner_filter_recyclebins_label
         WebViewCacheFilter::class -> R.string.appcleaner_filter_webview_label
+        ShortcutServiceFilter::class -> R.string.appcleaner_filter_shortcutservice_label
         WhatsAppBackupsFilter::class -> R.string.appcleaner_filter_whatsapp_backups_label
         WhatsAppReceivedFilter::class -> R.string.appcleaner_filter_whatsapp_received_label
         WhatsAppSentFilter::class -> R.string.appcleaner_filter_whatsapp_sent_label
@@ -67,6 +69,7 @@ val <T : ExpendablesFilter> KClass<T>.descriptionRes: Int
         OfflineCacheFilter::class -> R.string.appcleaner_filter_offlinecache_summary
         RecycleBinsFilter::class -> R.string.appcleaner_filter_recyclebins_summary
         WebViewCacheFilter::class -> R.string.appcleaner_filter_webview_summary
+        ShortcutServiceFilter::class -> R.string.appcleaner_filter_shortcutservice_summary
         WhatsAppBackupsFilter::class -> R.string.appcleaner_filter_whatsapp_backups_summary
         WhatsAppReceivedFilter::class -> R.string.appcleaner_filter_whatsapp_received_summary
         WhatsAppSentFilter::class -> R.string.appcleaner_filter_whatsapp_sent_summary
@@ -93,6 +96,7 @@ val <T : ExpendablesFilter> KClass<T>.iconsRes: Int
         OfflineCacheFilter::class -> R.drawable.ic_signal_off_24
         RecycleBinsFilter::class -> R.drawable.ic_recycle_bin_24
         WebViewCacheFilter::class -> R.drawable.ic_chrome_24
+        ShortcutServiceFilter::class -> R.drawable.ic_image_multiple_24
         WhatsAppBackupsFilter::class -> R.drawable.ic_whatsapp_24
         WhatsAppReceivedFilter::class -> R.drawable.ic_whatsapp_24
         WhatsAppSentFilter::class -> R.drawable.ic_whatsapp_24

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -398,6 +398,8 @@
     <string name="appcleaner_filter_recyclebins_summary">Files that have been deleted but put into a special folder to allow to restore them.</string>
     <string name="appcleaner_filter_webview_label">Webview files</string>
     <string name="appcleaner_filter_webview_summary">Files cached by Webview instances used within apps.</string>
+    <string name="appcleaner_filter_shortcutservice_label">App shortcut icons</string>
+    <string name="appcleaner_filter_shortcutservice_summary">Cached icons for app shortcuts and share menus.</string>
     <string name="appcleaner_filter_whatsapp_backups_label">WhatsApp backups</string>
     <string name="appcleaner_filter_whatsapp_backups_summary">Delete extra copies of WhatsApp backups and only keep the latest.</string>
     <string name="appcleaner_filter_whatsapp_received_summary">Files you received from people via WhatsApp.</string>

--- a/app/src/main/res/xml/preferences_appcleaner.xml
+++ b/app/src/main/res/xml/preferences_appcleaner.xml
@@ -119,6 +119,12 @@
             app:singleLineTitle="false"
             app:summary="@string/appcleaner_filter_webview_summary"
             app:title="@string/appcleaner_filter_webview_label" />
+        <CheckBoxPreference
+            app:icon="@drawable/ic_image_multiple_24"
+            app:key="filter.shortcutservice.enabled"
+            app:singleLineTitle="false"
+            app:summary="@string/appcleaner_filter_shortcutservice_summary"
+            app:title="@string/appcleaner_filter_shortcutservice_label" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/settings_category_filter_specific">

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/ShortcutServiceFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/ShortcutServiceFilterTest.kt
@@ -1,0 +1,67 @@
+package eu.darken.sdmse.appcleaner.core.forensics.filter
+
+import eu.darken.sdmse.appcleaner.core.forensics.BaseFilterTest
+import eu.darken.sdmse.appcleaner.core.forensics.neg
+import eu.darken.sdmse.appcleaner.core.forensics.pos
+import eu.darken.sdmse.common.areas.DataArea.Type
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class ShortcutServiceFilterTest : BaseFilterTest() {
+
+    @BeforeEach
+    override fun setup() {
+        super.setup()
+    }
+
+    @AfterEach
+    override fun teardown() {
+        super.teardown()
+    }
+
+    private fun create() = ShortcutServiceFilter(
+        gatewaySwitch = gatewaySwitch,
+    )
+
+    @Test fun `test shortcut service bitmap cache`() = runTest {
+        // Real-world example from Pixel 8:
+        // /data/system_ce/0/shortcut_service/bitmaps/com.google.android.gm/1760961952236.png
+
+        // Should NOT match - wrong area type
+        neg(testPkg, Type.PRIVATE_DATA, "shortcut_service", "bitmaps", testPkg, "1760961952236.png")
+        neg(testPkg, Type.PUBLIC_DATA, "shortcut_service", "bitmaps", testPkg, "1760961952236.png")
+        neg(testPkg, Type.SDCARD, "shortcut_service", "bitmaps", testPkg, "1760961952236.png")
+
+        // Should NOT match - incomplete path (need at least 4 segments)
+        neg(testPkg, Type.DATA_SYSTEM_CE, "shortcut_service")
+        neg(testPkg, Type.DATA_SYSTEM_CE, "shortcut_service", "bitmaps")
+        neg(testPkg, Type.DATA_SYSTEM_CE, "shortcut_service", "bitmaps", testPkg)
+
+        // Should NOT match - wrong path structure
+        neg(testPkg, Type.DATA_SYSTEM_CE, "wrong_path", "bitmaps", testPkg, "1760961952236.png")
+        neg(testPkg, Type.DATA_SYSTEM_CE, "shortcut_service", "wrong", testPkg, "1760961952236.png")
+
+        // Should NOT match - different package name
+        neg(testPkg, Type.DATA_SYSTEM_CE, "shortcut_service", "bitmaps", "com.other.app", "1760961952236.png")
+
+        // Should match - correct structure with matching package and timestamp-based filenames
+        pos(testPkg, Type.DATA_SYSTEM_CE, "shortcut_service", "bitmaps", testPkg, "1760961952236.png")
+        pos(testPkg, Type.DATA_SYSTEM_CE, "shortcut_service", "bitmaps", testPkg, "1761449886250.png")
+        pos(testPkg, Type.DATA_SYSTEM_CE, "shortcut_service", "bitmaps", testPkg, "1755708275821.png")
+
+        confirm(create())
+    }
+
+    @Test fun `test real world gmail example`() = runTest {
+        // Real-world data from Pixel 8: com.google.android.gm has multiple cached shortcut icons
+        val gmailPkg = "com.google.android.gm"
+
+        pos(gmailPkg, Type.DATA_SYSTEM_CE, "shortcut_service", "bitmaps", gmailPkg, "1760961952236.png")
+        pos(gmailPkg, Type.DATA_SYSTEM_CE, "shortcut_service", "bitmaps", gmailPkg, "1761449886250.png")
+        pos(gmailPkg, Type.DATA_SYSTEM_CE, "shortcut_service", "bitmaps", gmailPkg, "1755708275821.png")
+
+        confirm(create())
+    }
+}


### PR DESCRIPTION
Adds detection and cleaning of shortcut service bitmap caches stored at /data/system_ce/{userId}/shortcut_service/bitmaps/{appId}/.

The system's shortcut service generates and caches these bitmap icons for long-press menus and share dialogs. Some apps can accumulate gigabytes of these cached icons over time, as reported in the GitHub issue where one messaging app created 10GB of 50-100KB PNG files within weeks.

Implementation details:
- ShortcutServiceFilter: New filter using path-segment matching for DATA_SYSTEM_CE areas
- AppScanner: Extended buildSearchMap() to explicitly check shortcut_service paths for each installed package across all user profiles
- Settings: New toggle (disabled by default) for conservative opt-in approach
- UI: Uses ic_image_multiple_24 icon with user-friendly label "App shortcut icons" and clear description
- Tests: Comprehensive coverage including real-world data from Pixel 8

Multi-user support is automatic - the filter scans all user profiles. The filter requires root access to scan system_ce directories and gracefully handles cases where paths don't exist.

Apps automatically recreate these icons when needed, making them safe to delete without any user-visible impact.

Closes #1980