### PR TITLE
AppControl: Include self in `findClickableParent` for AOSP force stop

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/aosp/AOSPSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/aosp/AOSPSpecs.kt
@@ -80,7 +80,7 @@ class AOSPSpecs @Inject constructor(
                     node.textMatchesAny(forceStopLabels)
                 } ?: return@action false
 
-                var target = findClickableParent(maxNesting = 3, node = candidate)
+                var target = findClickableParent(maxNesting = 3, includeSelf = true, node = candidate)
 
                 // Seen on Pixel 8 with Android 16 (beta)
                 // Force stop may consist of a button (no text)) and a textview (unclickable), same layout as everything else


### PR DESCRIPTION
The AOSP force stop automation was failing on some devices (`motorola/lima_32_amx/lima:10/QMDS30.47-34-5/5cfb4:user/release-keys`) where the text label itself is the clickable element. This commit adjusts `findClickableParent` to include the starting node in its search, fixing the force stop action.