### PR TITLE
Improve debug log management

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModule.kt
@@ -55,7 +55,7 @@ class RecorderModule @Inject constructor(
     private val triggerFile by lazy {
         try {
             File(context.getExternalFilesDir(null), FORCE_FILE)
-        } catch (e: Exception) {
+        } catch (_: Exception) {
             File(
                 Environment.getExternalStorageDirectory(),
                 "/Android/data/${BuildConfigWrap.APPLICATION_ID}/files/$FORCE_FILE"
@@ -134,7 +134,7 @@ class RecorderModule @Inject constructor(
         val logId = sdmId.id.take(4)
         var sessionDir: File? = null
 
-        File(File(context.externalCacheDir, "debug/logs"), "${pkg}_${version}_${timestamp}_$logId").apply {
+        File(File(context.getExternalFilesDir(null), "debug/logs"), "${pkg}_${version}_${timestamp}_$logId").apply {
             @Suppress("SetWorldWritable", "SetWorldReadable")
             if (mkdirs()) {
                 log(TAG) { "Public session dir created" }
@@ -173,6 +173,20 @@ class RecorderModule @Inject constructor(
         }
         internalState.flow.filter { !it.isRecording }.first()
         return currentPath
+    }
+
+    fun getLogDirectories(): List<File> {
+        val dirs = mutableListOf<File>()
+
+        // Primary location: external files dir
+        context.getExternalFilesDir(null)?.let { externalDir ->
+            File(externalDir, "debug/logs").takeIf { it.exists() }?.let { dirs.add(it) }
+        }
+
+        // Fallback location: cache dir
+        File(context.cacheDir, "debug/logs").takeIf { it.exists() }?.let { dirs.add(it) }
+
+        return dirs
     }
 
     private suspend fun logInfos() {

--- a/app/src/main/java/eu/darken/sdmse/main/ui/settings/support/SupportViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/settings/support/SupportViewModel.kt
@@ -6,8 +6,11 @@ import eu.darken.sdmse.common.SDMId
 import eu.darken.sdmse.common.SingleLiveEvent
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.debug.recorder.core.RecorderModule
+import eu.darken.sdmse.common.flow.replayingShare
 import eu.darken.sdmse.common.uix.ViewModel3
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
@@ -23,17 +26,79 @@ class SupportViewModel @Inject constructor(
 
     val isRecording = recorderModule.state.map { it.isRecording }.asLiveData2()
 
+    private val debugLogFolderStatsInternal = MutableStateFlow(DebugLogFolderStats())
+    val debugLogFolderStats = debugLogFolderStatsInternal
+        .replayingShare(vmScope)
+        .asLiveData2()
+
+    data class DebugLogFolderStats(
+        val fileCount: Int = 0,
+        val totalSizeBytes: Long = 0L,
+    )
+
+    init {
+        launch {
+            refreshDebugLogFolderStats()
+        }
+    }
+
     fun copyInstallID() = launch {
         clipboardEvent.postValue(sdmId.id)
     }
 
     fun startDebugLog() = launch {
-        log { "startDebugLog()" }
+        log(TAG) { "startDebugLog()" }
         recorderModule.startRecorder()
     }
 
     fun stopDebugLog() = launch {
-        log { "stopDebugLog()" }
+        log(TAG) { "stopDebugLog()" }
         recorderModule.stopRecorder()
+    }
+
+    fun refreshDebugLogFolderStats() = launch {
+        log(TAG) { "refreshDebugLogFolderStats()" }
+
+        val logDirs = recorderModule.getLogDirectories()
+        var fileCount = 0
+        var totalSize = 0L
+
+        logDirs.forEach { logDir ->
+            logDir.walkTopDown()
+                .filter { it.isFile }
+                .forEach { file ->
+                    fileCount++
+                    totalSize += file.length()
+                }
+        }
+
+        debugLogFolderStatsInternal.value = DebugLogFolderStats(
+            fileCount = fileCount,
+            totalSizeBytes = totalSize,
+        )
+
+        log(TAG) { "Debug log folder stats: $fileCount files, $totalSize bytes" }
+    }
+
+    fun deleteAllDebugLogs() = launch {
+        log(TAG) { "deleteAllDebugLogs()" }
+
+        val logDirs = recorderModule.getLogDirectories()
+        logDirs.forEach { logDir ->
+            logDir.listFiles()?.forEach { sessionDir ->
+                try {
+                    sessionDir.deleteRecursively()
+                    log(TAG) { "Deleted debug log session: ${sessionDir.name}" }
+                } catch (e: Exception) {
+                    log(TAG) { "Failed to delete debug log session: ${sessionDir.name} - ${e.message}" }
+                }
+            }
+        }
+
+        refreshDebugLogFolderStats()
+    }
+
+    companion object {
+        private val TAG = logTag("Support", "ViewModel")
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -101,6 +101,11 @@
     <string name="support_installid_desc">Automatic error reports are anonymous. Share your install ID if the developer needs to find your error reports.</string>
     <string name="support_debuglog_label">Debug log</string>
     <string name="support_debuglog_desc">Record everything the app is doing into a text file that you can share.</string>
+    <string name="support_debuglog_folder_label">Debug log folder</string>
+    <string name="support_debuglog_folder_desc">%1$d files using %2$s</string>
+    <string name="support_debuglog_folder_empty_desc">No debug logs stored</string>
+    <string name="support_debuglog_folder_delete_confirmation_title">Delete all debug logs?</string>
+    <string name="support_debuglog_folder_delete_confirmation_message">This will permanently delete all stored debug log sessions. This action cannot be undone.</string>
     <string name="discord_label">Discord</string>
     <string name="discord_description">A place to hang out in and ask questions.</string>
 

--- a/app/src/main/res/xml/file_provider_paths.xml
+++ b/app/src/main/res/xml/file_provider_paths.xml
@@ -3,7 +3,7 @@
     <cache-path
         name="debug_logs"
         path="debug/logs" />
-    <external-cache-path
+    <external-files-path
         name="debug_logs"
         path="debug/logs" />
     <root-path

--- a/app/src/main/res/xml/preferences_support.xml
+++ b/app/src/main/res/xml/preferences_support.xml
@@ -38,5 +38,10 @@
             android:key="support.debuglog"
             android:summary="@string/support_debuglog_desc"
             android:title="@string/support_debuglog_label" />
+        <Preference
+            android:icon="@drawable/ic_baseline_folder_open_24"
+            android:key="support.debuglog.folder"
+            android:summary="@string/support_debuglog_folder_empty_desc"
+            android:title="@string/support_debuglog_folder_label" />
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
Move primary debug log location from `cache` to `files` to prevent SD Maid from deleting it's own log when debugging AppCleaner issues (e.g. #2004).

To prevent "inaccessible" logs piling up, there is no also a settings entry that shows current log sizes and pressing it will clear all debug sessions, if there are any orphaned ones.