### PR TITLE
History: Auto-hide dashboard card when retention is disabled

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/stats/ui/settings/StatsSettingsFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/stats/ui/settings/StatsSettingsFragment.kt
@@ -4,15 +4,21 @@ import android.os.Bundle
 import android.view.View
 import androidx.annotation.Keep
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.preference.Preference
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
+import eu.darken.sdmse.MainDirections
 import eu.darken.sdmse.R
+import eu.darken.sdmse.common.ByteFormatter
 import eu.darken.sdmse.common.datastore.valueBlocking
 import eu.darken.sdmse.common.navigation.getQuantityString2
 import eu.darken.sdmse.common.ui.AgeInputDialog
 import eu.darken.sdmse.common.uix.PreferenceFragment3
+import eu.darken.sdmse.common.upgrade.UpgradeRepo
+import eu.darken.sdmse.common.upgrade.isPro
 import eu.darken.sdmse.stats.core.StatsSettings
+import kotlinx.coroutines.launch
 import java.time.Duration
 import javax.inject.Inject
 
@@ -23,15 +29,31 @@ class StatsSettingsFragment : PreferenceFragment3() {
     override val vm: StatsSettingsViewModel by viewModels()
 
     @Inject lateinit var _settings: StatsSettings
+    @Inject lateinit var upgradeRepo: UpgradeRepo
 
     override val settings: StatsSettings by lazy { _settings }
     override val preferenceFile: Int = R.xml.preferences_statistics
+
+    private val preferenceView: Preference
+        get() = findPreference("stats.view")!!
 
     private val preferenceSize: Preference
         get() = findPreference("reports.size")!!
 
     override fun onPreferencesCreated() {
         super.onPreferencesCreated()
+
+        preferenceView.setOnPreferenceClickListener {
+            lifecycleScope.launch {
+                val isPro = upgradeRepo.isPro()
+                if (isPro) {
+                    MainDirections.goToReportsFragment().navigate()
+                } else {
+                    MainDirections.goToUpgradeFragment().navigate()
+                }
+            }
+            true
+        }
 
         settings.retentionReports.let { setting ->
             findPreference<Preference>(setting.keyName)!!.setOnPreferenceClickListener { it ->
@@ -77,6 +99,23 @@ class StatsSettingsFragment : PreferenceFragment3() {
                 eu.darken.sdmse.common.R.plurals.result_x_items,
                 state.reportsCount
             )
+
+            // Update stats view preference summary
+            val (space, spaceQuantity) = ByteFormatter.formatSize(requireContext(), state.totalSpaceFreed)
+            val spaceFormatted = getQuantityString2(
+                R.plurals.stats_dash_body_size,
+                spaceQuantity,
+                space
+            )
+
+            val processed = state.itemsProcessed.toString()
+            val processedQuantity = state.itemsProcessed
+            val processedFormatted = getQuantityString2(
+                R.plurals.stats_dash_body_count,
+                processedQuantity.toInt(),
+                processed,
+            )
+            preferenceView.summary = "$spaceFormatted $processedFormatted"
         }
         super.onViewCreated(view, savedInstanceState)
     }

--- a/app/src/main/java/eu/darken/sdmse/stats/ui/settings/StatsSettingsViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/stats/ui/settings/StatsSettingsViewModel.kt
@@ -17,7 +17,9 @@ class StatsSettingsViewModel @Inject constructor(
 
     val state = statsRepo.state.map {
         State(
-            reportsCount = it.reportsCount
+            reportsCount = it.reportsCount,
+            totalSpaceFreed = it.totalSpaceFreed,
+            itemsProcessed = it.itemsProcessed,
         )
     }.asLiveData2()
 
@@ -28,6 +30,8 @@ class StatsSettingsViewModel @Inject constructor(
 
     data class State(
         val reportsCount: Int,
+        val totalSpaceFreed: Long,
+        val itemsProcessed: Long,
     )
 
     companion object {

--- a/app/src/main/res/navigation/main_nav.xml
+++ b/app/src/main/res/navigation/main_nav.xml
@@ -139,6 +139,9 @@
     <action
         android:id="@+id/goToUpgradeFragment"
         app:destination="@id/upgradeFragment" />
+    <action
+        android:id="@+id/goToReportsFragment"
+        app:destination="@id/reportsFragment" />
     <fragment
         android:id="@+id/upgradeFragment"
         android:name="eu.darken.sdmse.common.upgrade.ui.UpgradeFragment"

--- a/app/src/main/res/xml/preferences_statistics.xml
+++ b/app/src/main/res/xml/preferences_statistics.xml
@@ -7,6 +7,13 @@
 
     </PreferenceCategory>
 
+    <Preference
+        app:icon="@drawable/ic_chartbox_24"
+        app:key="stats.view"
+        app:singleLineTitle="false"
+        app:summary="~"
+        app:title="@string/stats_label" />
+
     <PreferenceCategory android:title="@string/stats_settings_retention_category">
         <Preference
             app:icon="@drawable/chart_box_outline_24"


### PR DESCRIPTION
The dashboard history card now automatically hides when both retention settings (general reports and detailed path information) are set to 0.

Stats summary is now always displayed at the top of History settings, showing cumulative space freed and items processed. This preference is tappable and navigates to detailed reports (Pro) or upgrade screen (Free).

Implementation details:
- DashboardViewModel checks both retentionReports and retentionPaths flows
- Card hides when both equal Duration.ZERO
- StatsSettingsViewModel now exposes totalSpaceFreed and itemsProcessed
- Settings screen formats stats using same logic as dashboard card
- Added global navigation action goToReportsFragment

This respects user preference to disable history tracking while keeping stats accessible in the logical location (History settings).