### PR TITLE
SystemCleaner: Support entering min/max size and age in custom filters

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/CustomFilterEditorFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/CustomFilterEditorFragment.kt
@@ -2,6 +2,7 @@ package eu.darken.sdmse.systemcleaner.ui.customfilter.editor
 
 import android.os.Bundle
 import android.text.Editable
+import android.text.format.Formatter
 import android.view.View
 import android.widget.LinearLayout
 import androidx.activity.OnBackPressedCallback
@@ -25,10 +26,13 @@ import eu.darken.sdmse.common.lists.setupDefaults
 import eu.darken.sdmse.common.navigation.getQuantityString2
 import eu.darken.sdmse.common.sieve.NameCriterium
 import eu.darken.sdmse.common.sieve.SegmentCriterium
+import eu.darken.sdmse.common.ui.AgeInputDialog
+import eu.darken.sdmse.common.ui.SizeInputDialog
 import eu.darken.sdmse.common.uix.Fragment3
 import eu.darken.sdmse.common.viewbinding.viewBinding
 import eu.darken.sdmse.databinding.SystemcleanerCustomfilterEditorFragmentBinding
 import eu.darken.sdmse.systemcleaner.ui.customfilter.editor.live.LiveSearchListAdapter
+import java.time.Duration
 import kotlin.math.roundToInt
 
 
@@ -137,6 +141,50 @@ class CustomFilterEditorFragment : Fragment3(R.layout.systemcleaner_customfilter
             filetypesOptionDirectories.setOnClickListener { vm.toggleFileType(FileType.DIRECTORY) }
         }
 
+        ui.sizeMinimumRow.setOnClickListener {
+            val current = vm.state.value?.current?.sizeMinimum ?: 0L
+            SizeInputDialog(
+                activity = requireActivity(),
+                titleRes = R.string.systemcleaner_customfilter_editor_size_minimum_label,
+                currentSize = current,
+                onReset = { vm.updateSizeMinimum(null) },
+                onSave = { vm.updateSizeMinimum(it) },
+            ).show()
+        }
+
+        ui.sizeMaximumRow.setOnClickListener {
+            val current = vm.state.value?.current?.sizeMaximum ?: 0L
+            SizeInputDialog(
+                activity = requireActivity(),
+                titleRes = R.string.systemcleaner_customfilter_editor_size_maximum_label,
+                currentSize = current,
+                onReset = { vm.updateSizeMaximum(null) },
+                onSave = { vm.updateSizeMaximum(it) },
+            ).show()
+        }
+
+        ui.ageMinimumRow.setOnClickListener {
+            val current = vm.state.value?.current?.ageMinimum ?: Duration.ZERO
+            AgeInputDialog(
+                activity = requireActivity(),
+                titleRes = R.string.systemcleaner_customfilter_editor_age_minimum_label,
+                currentAge = current,
+                onReset = { vm.updateAgeMinimum(null) },
+                onSave = { vm.updateAgeMinimum(it) },
+            ).show()
+        }
+
+        ui.ageMaximumRow.setOnClickListener {
+            val current = vm.state.value?.current?.ageMaximum ?: Duration.ZERO
+            AgeInputDialog(
+                activity = requireActivity(),
+                titleRes = R.string.systemcleaner_customfilter_editor_age_maximum_label,
+                currentAge = current,
+                onReset = { vm.updateAgeMaximum(null) },
+                onSave = { vm.updateAgeMaximum(it) },
+            ).show()
+        }
+
         vm.state.observe2(ui) { state ->
             val config = state.current
             toolbar.menu?.apply {
@@ -162,6 +210,22 @@ class CustomFilterEditorFragment : Fragment3(R.layout.systemcleaner_customfilter
 
             filetypesOptionFiles.isChecked = config.fileTypes?.contains(FileType.FILE) == true
             filetypesOptionDirectories.isChecked = config.fileTypes?.contains(FileType.DIRECTORY) == true
+
+            sizeMinimumValue.text = config.sizeMinimum?.let {
+                Formatter.formatShortFileSize(requireContext(), it)
+            } ?: getString(eu.darken.sdmse.common.R.string.general_na_label)
+
+            sizeMaximumValue.text = config.sizeMaximum?.let {
+                Formatter.formatShortFileSize(requireContext(), it)
+            } ?: getString(eu.darken.sdmse.common.R.string.general_na_label)
+
+            ageMinimumValue.text = config.ageMinimum?.let {
+                AgeInputDialog.formatAge(requireContext(), it)
+            } ?: getString(eu.darken.sdmse.common.R.string.general_na_label)
+
+            ageMaximumValue.text = config.ageMaximum?.let {
+                AgeInputDialog.formatAge(requireContext(), it)
+            } ?: getString(eu.darken.sdmse.common.R.string.general_na_label)
         }
 
         vm.events.observe2 {

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/CustomFilterEditorViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/CustomFilterEditorViewModel.kt
@@ -38,6 +38,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.scan
+import java.time.Duration
 import java.time.Instant
 import javax.inject.Inject
 
@@ -201,6 +202,34 @@ class CustomFilterEditorViewModel @Inject constructor(
                 setOf(type)
             }
             copy(current = current.copy(fileTypes = newFileTypes.takeIf { it.isNotEmpty() }))
+        }
+    }
+
+    fun updateSizeMinimum(size: Long?) = launch {
+        log(TAG) { "updateSizeMinimum($size)" }
+        currentState.updateBlocking {
+            copy(current = current.copy(sizeMinimum = size))
+        }
+    }
+
+    fun updateSizeMaximum(size: Long?) = launch {
+        log(TAG) { "updateSizeMaximum($size)" }
+        currentState.updateBlocking {
+            copy(current = current.copy(sizeMaximum = size))
+        }
+    }
+
+    fun updateAgeMinimum(age: Duration?) = launch {
+        log(TAG) { "updateAgeMinimum($age)" }
+        currentState.updateBlocking {
+            copy(current = current.copy(ageMinimum = age))
+        }
+    }
+
+    fun updateAgeMaximum(age: Duration?) = launch {
+        log(TAG) { "updateAgeMaximum($age)" }
+        currentState.updateBlocking {
+            copy(current = current.copy(ageMaximum = age))
         }
     }
 

--- a/app/src/main/res/layout/systemcleaner_customfilter_editor_fragment.xml
+++ b/app/src/main/res/layout/systemcleaner_customfilter_editor_fragment.xml
@@ -241,6 +241,172 @@
                 </LinearLayout>
             </com.google.android.material.card.MaterialCardView>
 
+            <com.google.android.material.card.MaterialCardView
+                style="@style/Widget.Material3.CardView.Filled"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="16dp"
+                android:layout_marginVertical="8dp">
+
+                <LinearLayout
+                    android:id="@+id/size_container"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:padding="16dp">
+
+                    <com.google.android.material.textview.MaterialTextView
+                        style="@style/TextAppearance.Material3.LabelLarge"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="8dp"
+                        android:text="@string/systemcleaner_customfilter_editor_size_label" />
+
+                    <LinearLayout
+                        android:id="@+id/size_minimum_row"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="?attr/selectableItemBackground"
+                        android:gravity="center_vertical"
+                        android:minHeight="48dp"
+                        android:orientation="horizontal"
+                        android:paddingHorizontal="4dp">
+
+                        <com.google.android.material.textview.MaterialTextView
+                            style="@style/TextAppearance.Material3.BodyMedium"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="@string/systemcleaner_customfilter_editor_size_minimum_label" />
+
+                        <com.google.android.material.textview.MaterialTextView
+                            android:id="@+id/size_minimum_value"
+                            style="@style/TextAppearance.Material3.BodyMedium"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:textColor="?attr/colorPrimary"
+                            tools:text="1.5 MB" />
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:id="@+id/size_maximum_row"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="?attr/selectableItemBackground"
+                        android:gravity="center_vertical"
+                        android:minHeight="48dp"
+                        android:orientation="horizontal"
+                        android:paddingHorizontal="4dp">
+
+                        <com.google.android.material.textview.MaterialTextView
+                            style="@style/TextAppearance.Material3.BodyMedium"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="@string/systemcleaner_customfilter_editor_size_maximum_label" />
+
+                        <com.google.android.material.textview.MaterialTextView
+                            android:id="@+id/size_maximum_value"
+                            style="@style/TextAppearance.Material3.BodyMedium"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:textColor="?attr/colorPrimary"
+                            tools:text="100 MB" />
+                    </LinearLayout>
+
+                    <com.google.android.material.textview.MaterialTextView
+                        style="@style/TextAppearance.Material3.BodySmall"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:gravity="center"
+                        android:text="@string/systemcleaner_customfilter_editor_size_explanation" />
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.card.MaterialCardView
+                style="@style/Widget.Material3.CardView.Filled"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="16dp"
+                android:layout_marginVertical="8dp">
+
+                <LinearLayout
+                    android:id="@+id/age_container"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:padding="16dp">
+
+                    <com.google.android.material.textview.MaterialTextView
+                        style="@style/TextAppearance.Material3.LabelLarge"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="8dp"
+                        android:text="@string/systemcleaner_customfilter_editor_age_label" />
+
+                    <LinearLayout
+                        android:id="@+id/age_minimum_row"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="?attr/selectableItemBackground"
+                        android:gravity="center_vertical"
+                        android:minHeight="48dp"
+                        android:orientation="horizontal"
+                        android:paddingHorizontal="4dp">
+
+                        <com.google.android.material.textview.MaterialTextView
+                            style="@style/TextAppearance.Material3.BodyMedium"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="@string/systemcleaner_customfilter_editor_age_minimum_label" />
+
+                        <com.google.android.material.textview.MaterialTextView
+                            android:id="@+id/age_minimum_value"
+                            style="@style/TextAppearance.Material3.BodyMedium"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:textColor="?attr/colorPrimary"
+                            tools:text="7 days" />
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:id="@+id/age_maximum_row"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="?attr/selectableItemBackground"
+                        android:gravity="center_vertical"
+                        android:minHeight="48dp"
+                        android:orientation="horizontal"
+                        android:paddingHorizontal="4dp">
+
+                        <com.google.android.material.textview.MaterialTextView
+                            style="@style/TextAppearance.Material3.BodyMedium"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="@string/systemcleaner_customfilter_editor_age_maximum_label" />
+
+                        <com.google.android.material.textview.MaterialTextView
+                            android:id="@+id/age_maximum_value"
+                            style="@style/TextAppearance.Material3.BodyMedium"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:textColor="?attr/colorPrimary"
+                            tools:text="30 days" />
+                    </LinearLayout>
+
+                    <com.google.android.material.textview.MaterialTextView
+                        style="@style/TextAppearance.Material3.BodySmall"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:gravity="center"
+                        android:text="@string/systemcleaner_customfilter_editor_age_explanation" />
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
             <com.google.android.material.textview.MaterialTextView
                 style="@style/TextAppearance.Material3.BodyMedium"
                 android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -360,6 +360,14 @@
     <string name="systemcleaner_customfilter_editor_name_matching_mode_equal_label">Name is equal to keyword</string>
     <string name="systemcleaner_customfilter_last_edit">Last edit: %s</string>
     <string name="systemcleaner_customfilter_editor_livesearch_label">Live search</string>
+    <string name="systemcleaner_customfilter_editor_size_label">Size restrictions</string>
+    <string name="systemcleaner_customfilter_editor_size_minimum_label">Minimum size</string>
+    <string name="systemcleaner_customfilter_editor_size_maximum_label">Maximum size</string>
+    <string name="systemcleaner_customfilter_editor_size_explanation">Limit matches based on file size. Leave unset to match any size.</string>
+    <string name="systemcleaner_customfilter_editor_age_label">Age restrictions</string>
+    <string name="systemcleaner_customfilter_editor_age_minimum_label">Minimum age</string>
+    <string name="systemcleaner_customfilter_editor_age_maximum_label">Maximum age</string>
+    <string name="systemcleaner_customfilter_editor_age_explanation">Limit matches based on file age (last modified time). Leave unset to match any age.</string>
     <string name="systemcleaner_customfilter_import_action">Import new filter</string>
     <string name="systemcleaner_customfilter_export_action">Export selected filter</string>
 


### PR DESCRIPTION
Fields in the SystemCleaner's custom filter editor to input max/min size and age.

Re-uses the slider+manual input dialogs from the AppCleaner for size and age input.

Implements #877
Also see #2023