### PR TITLE
General: Fix HyperOS detection on global variants without Security Center

### DIFF
--- a/app-common/src/main/java/eu/darken/sdmse/common/device/DeviceDetective.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/device/DeviceDetective.kt
@@ -76,7 +76,7 @@ class DeviceDetective @Inject constructor(
         manufactor("lge") -> RomType.LGUX
 
         manufactor("Xiaomi") || manufactor("POCO") -> when {
-            apps(HYPEROS_PKGS) && versionStarts(HYPEROS_VERSION_STARTS) -> when {
+            versionStarts(HYPEROS_VERSION_STARTS) -> when {
                 // HyperOS 1.0 is based on Android 14 / API34, some backports exist (e.g. pissarropro)
                 hasApiLevel(33) -> RomType.HYPEROS
                 // Otherwise it is likely a false positive MIUI detection
@@ -142,9 +142,6 @@ class DeviceDetective @Inject constructor(
             "OS2",
             // POCO/miro_eea/miro:16/BP2A.250605.031.A3/OS3.0.3.0.WOMEUXM:user/release-keys
             "OS3",
-        )
-        private val HYPEROS_PKGS = setOf(
-            "com.miui.securitycenter"
         )
         private val FLYME_PKGS = setOf(
             "com.meizu.flyme.update"

--- a/app-common/src/test/java/eu/darken/sdmse/common/device/DeviceDetectiveTest.kt
+++ b/app-common/src/test/java/eu/darken/sdmse/common/device/DeviceDetectiveTest.kt
@@ -639,4 +639,31 @@ class DeviceDetectiveTest : BaseTest() {
 
         detective.getROMType() shouldBe RomType.HYPEROS
     }
+
+    @Test
+    fun `detect HyperOS without securitycenter - POCO duchamp global`() {
+        // POCO/duchamp_global/duchamp:15/AP3A.240905.015.A2/OS2.0.207.0.VNLMIXM:user/release-keys
+        // Some global HyperOS variants don't have com.miui.securitycenter installed
+        val context = deviceFromFingerprint(
+            "POCO/duchamp_global/duchamp:15/AP3A.240905.015.A2/OS2.0.207.0.VNLMIXM:user/release-keys",
+            installedPackages = emptySet()
+        )
+        detective = DeviceDetective(context)
+
+        detective.getROMType() shouldBe RomType.HYPEROS
+    }
+
+    @Test
+    fun `detect HyperOS without securitycenter - Xiaomi device`() {
+        // Xiaomi devices without com.miui.securitycenter should still detect as HyperOS
+        val context = mockDevice {
+            manufacturer = "Xiaomi"
+            versionIncremental = "OS2.0.6.0.VMLMIXM"
+            sdkInt = 35
+            installedPackages = emptySet()
+        }
+        detective = DeviceDetective(context)
+
+        detective.getROMType() shouldBe RomType.HYPEROS
+    }
 }


### PR DESCRIPTION
Some global HyperOS variants (e.g., POCO duchamp_global) don't have `com.miui.securitycenter` installed, causing them to be detected as AOSP.

The package check was unnecessary for HyperOS since the version string patterns (OS1, OS2, OS3, V816.) combined with manufacturer and API level checks are specific enough to avoid false positives.

Closes #2028