### PR TITLE
AppCleaner: Fix timeout when querying app size for large apps

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/StorageEntryFinder.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/StorageEntryFinder.kt
@@ -155,8 +155,9 @@ class StorageEntryFinder @Inject constructor(
     suspend fun storageFinderAOSP(
         labels: Collection<String>,
         pkg: Installed,
-    ): suspend StepContext.() -> ACSNodeInfo? = {
-        val matchStorage = createSizeMatcher(pkg) ?: { false }
+    ): suspend StepContext.() -> ACSNodeInfo? {
+        val matchStorage = createSizeMatcher(pkg) ?: { _: ACSNodeInfo -> false }
+        return {
 
         val storageFilter: (ACSNodeInfo) -> Int? = when {
             hasApiLevel(33) -> storageFilter@{ node ->
@@ -240,6 +241,7 @@ class StorageEntryFinder @Inject constructor(
         }
 
         matches.firstOrNull()
+        }
     }
 
     enum class ACSNodePaneState {

--- a/app/src/main/java/eu/darken/sdmse/automation/core/common/stepper/AutomationStep.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/common/stepper/AutomationStep.kt
@@ -15,7 +15,7 @@ data class AutomationStep(
     val windowCheck: (suspend StepContext.() -> ACSNodeInfo)? = null,
     val nodeRecovery: (suspend StepContext.(ACSNodeInfo) -> Boolean)? = null,
     val nodeAction: (suspend StepContext.() -> Boolean)? = null,
-    val timeout: Duration = 30.seconds, // StorageEntryFinder timeouts at 15s
+    val timeout: Duration = 30.seconds, // Inner attempt timeout is 10s, queryStatsForPkg timeout is 20s
 ) {
     override fun toString(): String = "Step(source=$source, description=$descriptionInternal)"
 }

--- a/app/src/main/java/eu/darken/sdmse/automation/core/common/stepper/Stepper.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/common/stepper/Stepper.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withTimeout
 import javax.inject.Inject
 import kotlin.system.measureTimeMillis
+import kotlin.time.Duration.Companion.seconds
 
 @Reusable
 class Stepper @Inject constructor(
@@ -76,7 +77,7 @@ class Stepper @Inject constructor(
                         stepAttempts = stepAttempts++,
                     )
                     try {
-                        withTimeout(5 * 1000) {
+                        withTimeout(10.seconds) {
                             val stepTime = measureTimeMillis {
                                 doProcess(stepContext, step)
                             }


### PR DESCRIPTION
When querying storage stats for large apps (e.g., Spotify, Amazon Prime Video), the system call can take 15-20 seconds. Previously, the size query happened inside the step's retry loop with a 5-second inner timeout, causing premature cancellation.

Changes:
- Increase inner attempt timeout from 5s to 10s for UI navigation
- Pre-compute size matcher before returning the storageFinder lambda, moving the 20s queryStatsForPkg call outside the step's retry loop entirely
- Update timeout comment in AutomationStep to reflect actual values

The size query now runs when storageFinderAOSP() is called (before the step is created), so retries only repeat the fast UI navigation, not the slow system query.

Closes #2032