### PR TITLE
AppCleaner: Add test infrastructure for automation specs

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/hyperos/HyperOsSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/hyperos/HyperOsSpecs.kt
@@ -118,8 +118,7 @@ class HyperOsSpecs @Inject constructor(
             }
             // Wait for correct base window
             host.events
-                .map { it.event }
-                .filter { event -> event.pkgId == SETTINGS_PKG_HYPEROS || event.pkgId == SETTINGS_PKG_AOSP }
+                .filter { it.pkgId == SETTINGS_PKG_HYPEROS || it.pkgId == SETTINGS_PKG_AOSP }
                 .mapNotNull { host.windowRoot() }
                 .first { root ->
                     when {

--- a/app/src/main/java/eu/darken/sdmse/automation/core/AutomationEvent.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/AutomationEvent.kt
@@ -1,0 +1,16 @@
+package eu.darken.sdmse.automation.core
+
+import eu.darken.sdmse.common.pkgs.Pkg
+import java.util.UUID
+
+/**
+ * Abstraction for automation events, allowing testability without Android framework dependencies.
+ *
+ * In production, [AutomationService.Snapshot] implements this with real [android.view.accessibility.AccessibilityEvent].
+ * In tests, [TestAutomationEvent] provides a simple implementation.
+ */
+interface AutomationEvent {
+    val id: UUID
+    val pkgId: Pkg.Id?
+    val eventType: Int
+}

--- a/app/src/main/java/eu/darken/sdmse/automation/core/AutomationHost.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/AutomationHost.kt
@@ -3,7 +3,6 @@ package eu.darken.sdmse.automation.core
 import android.accessibilityservice.AccessibilityService
 import android.accessibilityservice.AccessibilityServiceInfo
 import eu.darken.sdmse.R
-import eu.darken.sdmse.automation.core.AutomationService.Snapshot
 import eu.darken.sdmse.automation.core.common.ACSNodeInfo
 import eu.darken.sdmse.common.ca.CaString
 import eu.darken.sdmse.common.ca.toCaString
@@ -21,7 +20,7 @@ interface AutomationHost : Progress.Client {
 
     suspend fun changeOptions(action: (Options) -> Options)
 
-    val events: Flow<Snapshot>
+    val events: Flow<AutomationEvent>
 
     data class State(
         val hasOverlay: Boolean = false,

--- a/app/src/main/java/eu/darken/sdmse/automation/core/AutomationService.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/AutomationService.kt
@@ -13,7 +13,9 @@ import dagger.hilt.android.AndroidEntryPoint
 import eu.darken.sdmse.R
 import eu.darken.sdmse.automation.core.common.ACSNodeInfo
 import eu.darken.sdmse.automation.core.common.crawl
+import eu.darken.sdmse.automation.core.common.pkgId
 import eu.darken.sdmse.automation.core.common.toNodeInfo
+import eu.darken.sdmse.common.pkgs.Pkg
 import eu.darken.sdmse.automation.core.errors.AutomationNoConsentException
 import eu.darken.sdmse.automation.core.errors.UserCancelledAutomationException
 import eu.darken.sdmse.automation.ui.AutomationControlView
@@ -83,7 +85,7 @@ class AutomationService : AccessibilityService(), AutomationHost, Progress.Host,
     private val automationEvents = MutableSharedFlow<Snapshot>(
         extraBufferCapacity = 10,
     )
-    override val events: Flow<Snapshot> = automationEvents
+    override val events: Flow<AutomationEvent> = automationEvents
 
     private val hostState = MutableStateFlow(AutomationHost.State())
     override val state = hostState
@@ -104,9 +106,14 @@ class AutomationService : AccessibilityService(), AutomationHost, Progress.Host,
     )
 
     data class Snapshot(
-        val id: UUID = UUID.randomUUID(),
+        override val id: UUID = UUID.randomUUID(),
         val event: AccessibilityEvent,
-    )
+    ) : AutomationEvent {
+        override val pkgId: Pkg.Id?
+            get() = event.pkgId
+        override val eventType: Int
+            get() = event.eventType
+    }
 
     override fun onCreate() {
         log(TAG) { "onCreate(application=$application)" }

--- a/app/src/main/java/eu/darken/sdmse/automation/core/debug/DebugTaskModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/debug/DebugTaskModule.kt
@@ -63,7 +63,7 @@ class DebugTaskModule @AssistedInject constructor(
                 log(TAG, VERBOSE) { "Event: $it" }
                 val crawled = host.waitForWindowRoot().crawl().toList()
                 crawled.forEach { log(TAG, VERBOSE) { it.infoShort } }
-                updateProgressSecondary("Event: ${it.event.eventType} (depth: ${crawled.last().level})")
+                updateProgressSecondary("Event: ${it.eventType} (depth: ${crawled.last().level})")
             }
             .onEach {
 //                host.waitForWindowRoot().crawl()

--- a/app/src/main/java/eu/darken/sdmse/automation/core/specs/SpecGeneratorExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/specs/SpecGeneratorExtensions.kt
@@ -6,8 +6,8 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.content.res.Resources
-import android.view.accessibility.AccessibilityEvent
 import eu.darken.sdmse.appcleaner.core.automation.errors.NoSettingsWindowException
+import eu.darken.sdmse.automation.core.AutomationEvent
 import eu.darken.sdmse.automation.core.common.ACSNodeInfo
 import eu.darken.sdmse.automation.core.common.crawl
 import eu.darken.sdmse.automation.core.common.pkgId
@@ -50,13 +50,13 @@ fun SpecGenerator.windowLauncherDefaultSettings(
 }
 
 fun SpecGenerator.windowCheck(
-    condition: suspend StepContext.(event: AccessibilityEvent?, root: ACSNodeInfo) -> Boolean,
+    condition: suspend StepContext.(event: AutomationEvent?, root: ACSNodeInfo) -> Boolean,
 ): suspend StepContext.() -> ACSNodeInfo = {
-    val events: Flow<AccessibilityEvent?> = host.events.map { it.event }
+    val events: Flow<AutomationEvent?> = host.events
     val (event, root) = events
         .onStart {
             // we may already be ready
-            emit(null as AccessibilityEvent?)
+            emit(null as AutomationEvent?)
         }
         .mapNotNull { event ->
             // Get a root for us to test

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/BaseAppCleanerSpecTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/BaseAppCleanerSpecTest.kt
@@ -1,0 +1,233 @@
+package eu.darken.sdmse.appcleaner.core.automation.specs
+
+import eu.darken.sdmse.automation.core.common.ACSNodeInfo
+import eu.darken.sdmse.automation.core.common.stepper.AutomationStep
+import eu.darken.sdmse.automation.core.common.stepper.StepContext
+import eu.darken.sdmse.automation.core.common.stepper.Stepper
+import eu.darken.sdmse.automation.core.specs.AutomationExplorer
+import eu.darken.sdmse.automation.core.specs.AutomationSpec
+import eu.darken.sdmse.common.device.DeviceDetective
+import eu.darken.sdmse.common.device.RomType
+import eu.darken.sdmse.common.funnel.IPCFunnel
+import eu.darken.sdmse.common.pkgs.features.InstallId
+import eu.darken.sdmse.common.pkgs.features.Installed
+import eu.darken.sdmse.common.pkgs.toPkgId
+import eu.darken.sdmse.common.progress.Progress
+import eu.darken.sdmse.common.user.UserHandle2
+import eu.darken.sdmse.main.core.GeneralSettings
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.AcsDebugParser
+import testhelpers.BaseTest
+import testhelpers.TestACSNodeInfo
+import testhelpers.automation.TestAutomationHost
+import testhelpers.mockDataStoreValue
+
+/**
+ * Base test class for AppCleaner automation specs.
+ *
+ * Provides common test infrastructure:
+ * - Shared mocks (IPCFunnel, DeviceDetective, Stepper, etc.)
+ * - Test host and context setup
+ * - Helper methods for capturing and running clear cache actions
+ * - Generic test suites for `isResponsible()` and clear cache actions
+ *
+ * Usage:
+ * ```kotlin
+ * class MySpecsTest : BaseAppCleanerSpecTest<MySpecs, MyLabels>() {
+ *     override val romType = RomType.MY_ROM
+ *     override fun createSpec() = MySpecs(ipcFunnel, deviceDetective, labels, ...)
+ *     override fun createLabels() = mockk<MyLabels>()
+ *     override fun mockLabelDefaults() { ... }
+ * }
+ * ```
+ */
+abstract class BaseAppCleanerSpecTest<S : AppCleanerSpecGenerator, L : Any> : BaseTest() {
+
+    // Common mocks - available to all spec tests
+    protected lateinit var ipcFunnel: IPCFunnel
+    protected lateinit var deviceDetective: DeviceDetective
+    protected lateinit var storageEntryFinder: StorageEntryFinder
+    protected lateinit var generalSettings: GeneralSettings
+    protected lateinit var stepper: Stepper
+
+    // Test automation host with event support
+    protected lateinit var testHost: TestAutomationHost
+    protected lateinit var testContext: AutomationExplorer.Context
+
+    // For backward compatibility - use testHost.setWindowRoot() for new tests
+    protected var testRoot: TestACSNodeInfo
+        get() = testHost.getCurrentRoot() ?: TestACSNodeInfo()
+        set(value) = testHost.setWindowRoot(value)
+
+    // Spec-specific labels mock
+    protected lateinit var labels: L
+
+    // Test scope for coroutines - set during test execution
+    private var currentTestScope: TestScope? = null
+
+    // Abstract - must be implemented by each spec test
+    abstract val romType: RomType
+    abstract fun createSpec(): S
+    abstract fun createLabels(): L
+    abstract fun mockLabelDefaults()
+
+    @BeforeEach
+    fun baseSetup() {
+        // Initialize common mocks
+        ipcFunnel = mockk()
+        deviceDetective = mockk()
+        storageEntryFinder = mockk()
+        generalSettings = mockk()
+        stepper = mockk(relaxed = true)
+
+        // Create spec-specific labels mock
+        labels = createLabels()
+
+        // TestAutomationHost will be initialized in setupTestScope()
+        // For now, create a placeholder that will be replaced
+        testHost = TestAutomationHost(TestScope())
+
+        testContext = object : AutomationExplorer.Context {
+            override val host get() = testHost
+            override val progress: Flow<Progress.Data?> = emptyFlow()
+            override fun updateProgress(update: (Progress.Data?) -> Progress.Data?) {
+                testHost.updateProgress(update)
+            }
+        }
+
+        // Mock storage finder
+        coEvery { storageEntryFinder.storageFinderAOSP(any(), any()) } returns mockk()
+
+        // Setup default label mocks
+        mockLabelDefaults()
+    }
+
+    /**
+     * Setup the test scope for TestAutomationHost.
+     * Call this at the start of tests that use event-based features.
+     */
+    protected fun setupTestScope(scope: TestScope) {
+        currentTestScope = scope
+        testHost = TestAutomationHost(scope)
+        // Re-create testContext with the new host
+        testContext = object : AutomationExplorer.Context {
+            override val host get() = testHost
+            override val progress: Flow<Progress.Data?> = emptyFlow()
+            override fun updateProgress(update: (Progress.Data?) -> Progress.Data?) {
+                testHost.updateProgress(update)
+            }
+        }
+    }
+
+    /**
+     * Creates a mock [Installed] package for testing.
+     */
+    protected fun createTestPkg(packageName: String = "test.pkg"): Installed = mockk {
+        every { installId } returns InstallId(
+            pkgId = packageName.toPkgId(),
+            userHandle = mockk<UserHandle2> { every { handleId } returns 0 },
+        )
+        every { this@mockk.packageName } returns packageName
+        every { applicationInfo } returns null
+        every { id } returns packageName.toPkgId()
+    }
+
+    /**
+     * Builds a test tree from ACS debug log format.
+     */
+    protected fun buildTestTree(acsLog: String): TestACSNodeInfo {
+        return AcsDebugParser.parseTree(acsLog) ?: TestACSNodeInfo()
+    }
+
+    /**
+     * Captures and runs the clear cache action from the spec.
+     * Returns the result of the nodeAction.
+     */
+    protected suspend fun captureAndRunClearCacheAction(
+        spec: S = createSpec(),
+        pkg: Installed = createTestPkg(),
+    ): Boolean {
+        var actionResult = false
+
+        // Capture the step when stepper.process is called and run the clear cache action
+        coEvery { stepper.process(any(), any()) } coAnswers {
+            val step = secondArg<AutomationStep>()
+            // Run nodeAction for steps that contain "cache" in description (case insensitive)
+            if (step.descriptionInternal.contains("cache", ignoreCase = true)) {
+                val stepContext = StepContext(
+                    hostContext = testContext,
+                    tag = "test",
+                    stepAttempts = 0,
+                )
+                actionResult = step.nodeAction?.invoke(stepContext) ?: false
+            }
+            Unit
+        }
+
+        val automationSpec = spec.getClearCache(pkg) as AutomationSpec.Explorer
+        val plan = automationSpec.createPlan()
+        plan.invoke(testContext)
+
+        return actionResult
+    }
+
+    // ============================================================
+    // Generic isResponsible() tests - work for any ROM spec
+    // ============================================================
+
+    @Test
+    fun `isResponsible returns true when romType matches`() = runTest {
+        every { generalSettings.romTypeDetection } returns mockDataStoreValue(romType)
+
+        val spec = createSpec()
+        val result = spec.isResponsible(createTestPkg())
+
+        result shouldBe true
+    }
+
+    @Test
+    open fun `isResponsible returns true when AUTO and device matches`() = runTest {
+        every { generalSettings.romTypeDetection } returns mockDataStoreValue(RomType.AUTO)
+        coEvery { deviceDetective.getROMType() } returns romType
+
+        val spec = createSpec()
+        val result = spec.isResponsible(createTestPkg())
+
+        result shouldBe true
+    }
+
+    @Test
+    fun `isResponsible returns false when different romType set`() = runTest {
+        // Use a different ROM type than the one this spec handles
+        val differentRom = RomType.entries.first { it != romType && it != RomType.AUTO }
+        every { generalSettings.romTypeDetection } returns mockDataStoreValue(differentRom)
+
+        val spec = createSpec()
+        val result = spec.isResponsible(createTestPkg())
+
+        result shouldBe false
+    }
+
+    @Test
+    fun `isResponsible returns false when AUTO and device is different`() = runTest {
+        every { generalSettings.romTypeDetection } returns mockDataStoreValue(RomType.AUTO)
+        // Return a different ROM type from device detection
+        val differentRom = RomType.entries.first { it != romType && it != RomType.AUTO }
+        coEvery { deviceDetective.getROMType() } returns differentRom
+
+        val spec = createSpec()
+        val result = spec.isResponsible(createTestPkg())
+
+        result shouldBe false
+    }
+
+}

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecsTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecsTest.kt
@@ -1,0 +1,141 @@
+package eu.darken.sdmse.appcleaner.core.automation.specs.aosp
+
+import eu.darken.sdmse.appcleaner.core.automation.specs.BaseAppCleanerSpecTest
+import eu.darken.sdmse.automation.core.common.ACSNodeInfo
+import eu.darken.sdmse.automation.core.common.crawl
+import eu.darken.sdmse.common.device.RomType
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import testhelpers.TestACSNodeInfo
+
+class AOSPSpecsTest : BaseAppCleanerSpecTest<AOSPSpecs, AOSPLabels>() {
+
+    override val romType = RomType.AOSP
+
+    override fun createLabels(): AOSPLabels = mockk()
+
+    override fun createSpec() = AOSPSpecs(
+        ipcFunnel = ipcFunnel,
+        deviceDetective = deviceDetective,
+        aospLabels = labels,
+        storageEntryFinder = storageEntryFinder,
+        generalSettings = generalSettings,
+        stepper = stepper,
+    )
+
+    override fun mockLabelDefaults() {
+        every { labels.getStorageEntryDynamic(any()) } returns emptySet()
+        every { labels.getStorageEntryStatic(any()) } returns setOf("Storage")
+        every { labels.getClearCacheDynamic(any()) } returns emptySet()
+        every { labels.getClearCacheStatic(any()) } returns setOf("Clear cache")
+    }
+
+    // ============================================================
+    // AOSP-specific regression tests
+    // ============================================================
+
+    @Test
+    fun `clear cache clicks directly on clicky button - standard pattern`() = runTest {
+        // Standard AOSP pattern: Clear cache is a Button with clickable=true
+        // ----------10: text='null', class=android.widget.LinearLayout
+        // -----------11: text='Clear cache', class=android.widget.Button, clickable=true
+
+        val acsLog = """
+            ACS-DEBUG: 0: text='null', class=android.widget.FrameLayout, clickable=false, checkable=false enabled=true, id=null pkg=com.android.settings, identity=root, bounds=Rect(0, 0 - 1080, 2400)
+            ACS-DEBUG: -1: text='null', class=android.widget.LinearLayout, clickable=false, checkable=false enabled=true, id=null pkg=com.android.settings, identity=layout1, bounds=Rect(0, 0 - 1080, 400)
+            ACS-DEBUG: --2: text='Clear storage', class=android.widget.Button, clickable=true, checkable=false enabled=true, id=com.android.settings:id/button1 pkg=com.android.settings, identity=btn1, bounds=Rect(50, 100 - 500, 150)
+            ACS-DEBUG: --2: text='Clear cache', class=android.widget.Button, clickable=true, checkable=false enabled=true, id=com.android.settings:id/button2 pkg=com.android.settings, identity=btn2, bounds=Rect(550, 100 - 1000, 150)
+        """.trimIndent()
+
+        testRoot = buildTestTree(acsLog)
+
+        val result = captureAndRunClearCacheAction()
+
+        result shouldBe true
+        val clearCacheButton = testRoot.crawl().first { it.node.text == "Clear cache" }.node as TestACSNodeInfo
+        clearCacheButton.performedActions shouldBe listOf(ACSNodeInfo.ACTION_CLICK)
+    }
+
+    @Test
+    fun `clear cache finds clickable parent when button is LinearLayout - Android 16 - GitHub 1794`() = runTest {
+        // Android 16 Beta pattern: Clear cache is in a non-clickable TextView,
+        // but parent LinearLayout is clickable
+        // -----------11: text='null', class=android.widget.LinearLayout, clickable=true, id=com.android.settings:id/action2
+        // ------------12: text='null', class=android.widget.Button, clickable=true, id=com.android.settings:id/button2
+        // ------------12: text='Clear cache', class=android.widget.TextView, clickable=true, id=com.android.settings:id/text2
+
+        val acsLog = """
+            ACS-DEBUG: 0: text='null', class=android.widget.FrameLayout, clickable=false, checkable=false enabled=true, id=null pkg=com.android.settings, identity=root, bounds=Rect(0, 0 - 1080, 2400)
+            ACS-DEBUG: -1: text='null', class=android.widget.LinearLayout, clickable=true, checkable=false enabled=true, id=com.android.settings:id/action2 pkg=com.android.settings, identity=action2, bounds=Rect(540, 959 - 1020, 1239)
+            ACS-DEBUG: --2: text='null', class=android.widget.Button, clickable=true, checkable=false enabled=true, id=com.android.settings:id/button2 pkg=com.android.settings, identity=btn2, bounds=Rect(691, 959 - 869, 1098)
+            ACS-DEBUG: --2: text='Clear cache', class=android.widget.TextView, clickable=true, checkable=false enabled=true, id=com.android.settings:id/text2 pkg=com.android.settings, identity=text2, bounds=Rect(628, 1113 - 931, 1181)
+        """.trimIndent()
+
+        testRoot = buildTestTree(acsLog)
+
+        val result = captureAndRunClearCacheAction()
+
+        result shouldBe true
+        // The clickable parent LinearLayout should be clicked, not the TextView
+        val clickableParent = testRoot.crawl().first { it.node.viewIdResourceName == "com.android.settings:id/action2" }.node as TestACSNodeInfo
+        clickableParent.performedActions shouldBe listOf(ACSNodeInfo.ACTION_CLICK)
+    }
+
+    @Test
+    fun `clear cache finds clickable sibling when text is not in button - Spanish localization`() = runTest {
+        // Some AOSP variants: Text "Borrar caché" is in non-clickable TextView,
+        // but has a clickable Button sibling
+        //-----------11: text='null', class=android.widget.LinearLayout, clickable=false, id=com.android.settings:id/action2
+        //------------12: text='null', class=android.widget.Button, clickable=true, id=com.android.settings:id/button2
+        //------------12: text='Borrar caché', class=android.widget.TextView, clickable=false, id=com.android.settings:id/text2
+
+        val acsLog = """
+            ACS-DEBUG: 0: text='null', class=android.widget.FrameLayout, clickable=false, checkable=false enabled=true, id=null pkg=com.android.settings, identity=root, bounds=Rect(0, 0 - 1080, 2400)
+            ACS-DEBUG: -1: text='null', class=android.widget.LinearLayout, clickable=false, checkable=false enabled=true, id=com.android.settings:id/action2 pkg=com.android.settings, identity=action2, bounds=Rect(540, 959 - 1020, 1239)
+            ACS-DEBUG: --2: text='null', class=android.widget.Button, clickable=true, checkable=false enabled=true, id=com.android.settings:id/button2 pkg=com.android.settings, identity=btn2, bounds=Rect(691, 959 - 869, 1098)
+            ACS-DEBUG: --2: text='Borrar caché', class=android.widget.TextView, clickable=false, checkable=false enabled=true, id=com.android.settings:id/text2 pkg=com.android.settings, identity=text2, bounds=Rect(628, 1113 - 931, 1181)
+        """.trimIndent()
+
+        testRoot = buildTestTree(acsLog)
+
+        every { labels.getClearCacheStatic(any()) } returns setOf("Borrar caché", "Clear cache")
+
+        val result = captureAndRunClearCacheAction()
+
+        result shouldBe true
+        // The clickable sibling Button should be clicked, not the TextView
+        val clickableSibling = testRoot.crawl().first { it.node.viewIdResourceName == "com.android.settings:id/button2" }.node as TestACSNodeInfo
+        clickableSibling.performedActions shouldBe listOf(ACSNodeInfo.ACTION_CLICK)
+    }
+
+    // ============================================================
+    // Event-based window transition tests
+    // ============================================================
+
+    @Test
+    fun `clear cache works with event-based window transition`() = runTest {
+        // Test that transitionTo() properly sets up window root and emits events
+        // This validates the event infrastructure in TestAutomationHost
+        setupTestScope(this)
+
+        val acsLog = """
+            ACS-DEBUG: 0: text='null', class=android.widget.FrameLayout, clickable=false, checkable=false enabled=true, id=null pkg=com.android.settings, identity=root, bounds=Rect(0, 0 - 1080, 2400)
+            ACS-DEBUG: -1: text='null', class=android.widget.LinearLayout, clickable=false, checkable=false enabled=true, id=null pkg=com.android.settings, identity=layout1, bounds=Rect(0, 0 - 1080, 400)
+            ACS-DEBUG: --2: text='Clear cache', class=android.widget.Button, clickable=true, checkable=false enabled=true, id=com.android.settings:id/button2 pkg=com.android.settings, identity=btn2, bounds=Rect(550, 100 - 1000, 150)
+        """.trimIndent()
+
+        val tree = buildTestTree(acsLog)
+
+        // Use transitionTo() to set window root AND emit event
+        testHost.transitionTo(tree, "com.android.settings")
+
+        val result = captureAndRunClearCacheAction()
+
+        result shouldBe true
+        val clearCacheButton = tree.crawl().first { it.node.text == "Clear cache" }.node as TestACSNodeInfo
+        clearCacheButton.performedActions shouldBe listOf(ACSNodeInfo.ACTION_CLICK)
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/coloros/ColorOSSpecsTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/coloros/ColorOSSpecsTest.kt
@@ -1,0 +1,99 @@
+package eu.darken.sdmse.appcleaner.core.automation.specs.coloros
+
+import eu.darken.sdmse.appcleaner.core.automation.specs.BaseAppCleanerSpecTest
+import eu.darken.sdmse.automation.core.common.ACSNodeInfo
+import eu.darken.sdmse.automation.core.common.crawl
+import eu.darken.sdmse.common.device.RomType
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.TestACSNodeInfo
+
+class ColorOSSpecsTest : BaseAppCleanerSpecTest<ColorOSSpecs, ColorOSLabels>() {
+
+    override val romType = RomType.COLOROS
+
+    override fun createLabels(): ColorOSLabels = mockk()
+
+    override fun createSpec() = ColorOSSpecs(
+        ipcFunnel = ipcFunnel,
+        deviceDetective = deviceDetective,
+        colorOSLabels = labels,
+        storageEntryFinder = storageEntryFinder,
+        generalSettings = generalSettings,
+        stepper = stepper,
+    )
+
+    override fun mockLabelDefaults() {
+        every { labels.getStorageEntryDynamic(any()) } returns emptySet()
+        every { labels.getStorageEntryLabels(any()) } returns setOf("Storage")
+        every { labels.getClearCacheDynamic(any()) } returns emptySet()
+        every { labels.getClearCacheLabels(any()) } returns setOf("Clear cache")
+    }
+
+    @BeforeEach
+    fun setupApiLevel() {
+        // ColorOS requires API 26+
+        mockkStatic("eu.darken.sdmse.common.BuildWrapKt")
+        every { eu.darken.sdmse.common.hasApiLevel(any()) } returns true
+    }
+
+    @AfterEach
+    fun cleanupApiLevel() {
+        unmockkStatic("eu.darken.sdmse.common.BuildWrapKt")
+    }
+
+    // ============================================================
+    // ColorOS-specific regression tests
+    // ============================================================
+
+    @Test
+    fun `clear cache clicks directly on clicky button - pre API 35`() = runTest {
+        // Before API 35, ColorOS requires isClickyButton()
+        every { eu.darken.sdmse.common.hasApiLevel(35) } returns false
+
+        val acsLog = """
+            ACS-DEBUG: 0: text='null', class=android.widget.FrameLayout, clickable=false, checkable=false enabled=true, id=null pkg=com.android.settings, identity=root, bounds=Rect(0, 0 - 1080, 2400)
+            ACS-DEBUG: -1: text='null', class=android.widget.LinearLayout, clickable=false, checkable=false enabled=true, id=null pkg=com.android.settings, identity=layout1, bounds=Rect(0, 0 - 1080, 400)
+            ACS-DEBUG: --2: text='Clear cache', class=android.widget.Button, clickable=true, checkable=false enabled=true, id=com.android.settings:id/button pkg=com.android.settings, identity=btn, bounds=Rect(50, 100 - 500, 150)
+        """.trimIndent()
+
+        testRoot = buildTestTree(acsLog)
+
+        val result = captureAndRunClearCacheAction()
+
+        result shouldBe true
+        val clearCacheButton = testRoot.crawl().first { it.node.text == "Clear cache" }.node as TestACSNodeInfo
+        clearCacheButton.performedActions shouldBe listOf(ACSNodeInfo.ACTION_CLICK)
+    }
+
+    @Test
+    fun `clear cache finds clickable parent when button not clickable - API 35+`() = runTest {
+        // On API 35+, ColorOS finds non-clicky buttons and traverses to clickable parent
+        // This pattern from actual device logs:
+        // RelativeLayout(clickable) → Button(text="Clear cache", clickable=false)
+        every { eu.darken.sdmse.common.hasApiLevel(35) } returns true
+
+        val acsLog = """
+            ACS-DEBUG: 0: text='null', class=android.widget.FrameLayout, clickable=false, checkable=false enabled=true, id=null pkg=com.android.settings, identity=root, bounds=Rect(0, 0 - 1080, 2400)
+            ACS-DEBUG: -1: text='null', class=android.widget.LinearLayout, clickable=false, checkable=false enabled=true, id=null pkg=com.android.settings, identity=layout1, bounds=Rect(0, 0 - 1080, 400)
+            ACS-DEBUG: --2: text='null', class=android.widget.RelativeLayout, clickable=true, checkable=false enabled=true, id=com.android.settings:id/content_rl pkg=com.android.settings, identity=content_rl, bounds=Rect(0, 100 - 1080, 200)
+            ACS-DEBUG: ---3: text='Clear cache', class=android.widget.Button, clickable=false, checkable=false enabled=true, id=com.android.settings:id/button pkg=com.android.settings, identity=btn, bounds=Rect(50, 110 - 500, 190)
+        """.trimIndent()
+
+        testRoot = buildTestTree(acsLog)
+
+        val result = captureAndRunClearCacheAction()
+
+        result shouldBe true
+        // The clickable parent RelativeLayout should be clicked
+        val clickableParent = testRoot.crawl().first { it.node.viewIdResourceName == "com.android.settings:id/content_rl" }.node as TestACSNodeInfo
+        clickableParent.performedActions shouldBe listOf(ACSNodeInfo.ACTION_CLICK)
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/huawei/HuaweiSpecsTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/huawei/HuaweiSpecsTest.kt
@@ -1,0 +1,105 @@
+package eu.darken.sdmse.appcleaner.core.automation.specs.huawei
+
+import eu.darken.sdmse.appcleaner.core.automation.specs.BaseAppCleanerSpecTest
+import eu.darken.sdmse.automation.core.common.ACSNodeInfo
+import eu.darken.sdmse.automation.core.common.crawl
+import eu.darken.sdmse.common.device.RomType
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.TestACSNodeInfo
+import testhelpers.mockDataStoreValue
+
+class HuaweiSpecsTest : BaseAppCleanerSpecTest<HuaweiSpecs, HuaweiLabels>() {
+
+    override val romType = RomType.HUAWEI
+
+    override fun createLabels(): HuaweiLabels = mockk()
+
+    override fun createSpec() = HuaweiSpecs(
+        ipcFunnel = ipcFunnel,
+        deviceDetective = deviceDetective,
+        huaweiLabels = labels,
+        storageEntryFinder = storageEntryFinder,
+        generalSettings = generalSettings,
+        stepper = stepper,
+    )
+
+    override fun mockLabelDefaults() {
+        every { labels.getStorageEntryDynamic(any()) } returns emptySet()
+        every { labels.getStorageEntryLabels(any()) } returns setOf("Storage")
+        every { labels.getClearCacheDynamic(any()) } returns emptySet()
+        every { labels.getClearCacheLabels(any()) } returns setOf("Clear cache")
+    }
+
+    @BeforeEach
+    fun setupApiLevel() {
+        // Mock hasApiLevel to return true for API 29+ since HuaweiSpecs requires it
+        mockkStatic("eu.darken.sdmse.common.BuildWrapKt")
+        every { eu.darken.sdmse.common.hasApiLevel(any()) } returns true
+    }
+
+    @AfterEach
+    fun cleanupApiLevel() {
+        unmockkStatic("eu.darken.sdmse.common.BuildWrapKt")
+    }
+
+    // Override tests that need API level mocking - Huawei requires API 29+
+    @Test
+    override fun `isResponsible returns true when AUTO and device matches`() = runTest {
+        every { generalSettings.romTypeDetection } returns mockDataStoreValue(RomType.AUTO)
+        coEvery { deviceDetective.getROMType() } returns romType
+
+        val spec = createSpec()
+        val result = spec.isResponsible(createTestPkg())
+
+        result shouldBe true
+    }
+
+    // ============================================================
+    // Huawei-specific tests
+    // ============================================================
+
+    @Test
+    fun `clear cache requires isClickyButton - clicks directly on Button with text`() = runTest {
+        // Huawei ONLY supports isClickyButton() which requires both isClickable=true AND className=Button
+        // It does NOT traverse to find clickable parents like AOSP/OneUI do
+
+        val acsLog = """
+            ACS-DEBUG: 0: text='null', class=android.widget.FrameLayout, clickable=false, checkable=false enabled=true, id=null pkg=com.android.settings, identity=root, bounds=Rect(0, 0 - 1080, 2400)
+            ACS-DEBUG: -1: text='null', class=android.widget.LinearLayout, clickable=false, checkable=false enabled=true, id=null pkg=com.android.settings, identity=layout1, bounds=Rect(0, 0 - 1080, 400)
+            ACS-DEBUG: --2: text='Clear cache', class=android.widget.Button, clickable=true, checkable=false enabled=true, id=com.android.settings:id/clear_cache_btn pkg=com.android.settings, identity=btn, bounds=Rect(50, 100 - 500, 150)
+        """.trimIndent()
+
+        testRoot = buildTestTree(acsLog)
+
+        val result = captureAndRunClearCacheAction()
+
+        result shouldBe true
+        val clearCacheButton = testRoot.crawl().first { it.node.text == "Clear cache" }.node as TestACSNodeInfo
+        clearCacheButton.performedActions shouldBe listOf(ACSNodeInfo.ACTION_CLICK)
+    }
+
+    @Test
+    fun `clear cache returns false when text is not in clickyButton - Huawei limitation`() = runTest {
+        // Huawei does NOT support findClickableParent - it only finds isClickyButton() nodes
+        // If the text is in a TextView (not a Button), Huawei cannot click it
+
+        val clearCacheText = TestACSNodeInfo(text = "Clear cache", isClickable = false, isEnabled = true)
+        val clickableParent = TestACSNodeInfo(isClickable = true, isEnabled = true).addChild(clearCacheText)
+        testRoot = TestACSNodeInfo().addChild(clickableParent)
+
+        val result = captureAndRunClearCacheAction()
+
+        // Huawei requires isClickyButton() which needs BOTH isClickable=true AND className=Button
+        // Since the text node is not a clicky button, Huawei returns false
+        result shouldBe false
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/hyperos/HyperOsSpecsTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/hyperos/HyperOsSpecsTest.kt
@@ -1,0 +1,92 @@
+package eu.darken.sdmse.appcleaner.core.automation.specs.hyperos
+
+import android.content.Context
+import eu.darken.sdmse.appcleaner.core.automation.specs.BaseAppCleanerSpecTest
+import eu.darken.sdmse.appcleaner.core.automation.specs.aosp.AOSPLabels
+import eu.darken.sdmse.automation.core.animation.AnimationState
+import eu.darken.sdmse.automation.core.animation.AnimationTool
+import eu.darken.sdmse.common.device.RomType
+import eu.darken.sdmse.common.deviceadmin.DeviceAdminManager
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+
+/**
+ * Test class for HyperOsSpecs.
+ *
+ * The basic isResponsible() tests are inherited from BaseAppCleanerSpecTest.
+ *
+ * NOTE: The HyperOS security center plan has complex multi-step dialog flows that use:
+ * - Android framework classes (Rect, etc.) that are not available in plain unit tests
+ * - Complex event-based window detection with animation settling
+ * - Multiple sub-plans with debounce timing logic
+ *
+ * Testing the full multi-step dialog flow requires either:
+ * - Robolectric for Android framework mocking
+ * - Integration/UI tests that run on a real device or emulator
+ *
+ * For now, this test class covers the basic isResponsible() logic from the base class.
+ * The complex flow tests should be added as integration tests or with Robolectric.
+ */
+class HyperOsSpecsTest : BaseAppCleanerSpecTest<HyperOsSpecs, HyperOsLabels>() {
+
+    override val romType = RomType.HYPEROS
+
+    private lateinit var context: Context
+    private lateinit var aospLabels: AOSPLabels
+    private lateinit var deviceAdminManager: DeviceAdminManager
+    private lateinit var animationTool: AnimationTool
+
+    override fun createLabels(): HyperOsLabels {
+        // Initialize additional mocks before labels are used
+        context = mockk(relaxed = true)
+        aospLabels = mockk()
+        deviceAdminManager = mockk()
+        animationTool = mockk()
+
+        // Default device admin returns empty set
+        coEvery { deviceAdminManager.getDeviceAdmins() } returns emptySet()
+
+        // Default animation state (non-disabled)
+        coEvery { animationTool.getState() } returns AnimationState(1f, 1f, 1f)
+
+        // Mock context.packageManager for version checks
+        every { context.packageManager } returns mockk(relaxed = true)
+
+        return mockk()
+    }
+
+    override fun createSpec() = HyperOsSpecs(
+        context = context,
+        ipcFunnel = ipcFunnel,
+        deviceDetective = deviceDetective,
+        hyperOsLabels = labels,
+        aospLabels = aospLabels,
+        deviceAdminManager = deviceAdminManager,
+        storageEntryFinder = storageEntryFinder,
+        generalSettings = generalSettings,
+        stepper = stepper,
+        animationTool = animationTool,
+    )
+
+    override fun mockLabelDefaults() {
+        // HyperOS labels
+        every { labels.getClearDataButtonLabels(any()) } returns setOf("Clear data")
+        every { labels.getClearCacheButtonLabels(any()) } returns setOf("Clear cache")
+        every { labels.getDialogTitles(any()) } returns setOf("Clear cache?")
+        every { labels.getManageSpaceButtonLabels(any()) } returns setOf("Manage space")
+
+        // AOSP labels (used in settingsPlan fallback)
+        every { aospLabels.getStorageEntryDynamic(any()) } returns emptySet()
+        every { aospLabels.getStorageEntryStatic(any()) } returns setOf("Storage")
+        every { aospLabels.getClearCacheDynamic(any()) } returns emptySet()
+        every { aospLabels.getClearCacheStatic(any()) } returns setOf("Clear cache")
+    }
+
+    // NOTE: HyperOS security center plan tests have been removed because they require:
+    // - Android framework classes (Rect) for window settling logic
+    // - Complex event-based window detection with animation debouncing
+    // These tests should be implemented as Robolectric or integration tests.
+    //
+    // The basic isResponsible() tests are inherited from BaseAppCleanerSpecTest and work correctly.
+}

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/oneui/OneUISpecsTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/oneui/OneUISpecsTest.kt
@@ -1,0 +1,97 @@
+package eu.darken.sdmse.appcleaner.core.automation.specs.oneui
+
+import eu.darken.sdmse.appcleaner.core.automation.specs.BaseAppCleanerSpecTest
+import eu.darken.sdmse.automation.core.common.ACSNodeInfo
+import eu.darken.sdmse.automation.core.common.crawl
+import eu.darken.sdmse.common.device.RomType
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import testhelpers.TestACSNodeInfo
+
+class OneUISpecsTest : BaseAppCleanerSpecTest<OneUISpecs, OneUILabels>() {
+
+    override val romType = RomType.ONEUI
+
+    override fun createLabels(): OneUILabels = mockk()
+
+    override fun createSpec() = OneUISpecs(
+        ipcFunnel = ipcFunnel,
+        deviceDetective = deviceDetective,
+        oneUILabels = labels,
+        storageEntryFinder = storageEntryFinder,
+        generalSettings = generalSettings,
+        stepper = stepper,
+    )
+
+    override fun mockLabelDefaults() {
+        every { labels.getStorageEntryDynamic(any()) } returns emptySet()
+        every { labels.getStorageEntryLabels(any()) } returns setOf("Storage")
+        every { labels.getClearCacheDynamic(any()) } returns emptySet()
+        every { labels.getClearCacheLabels(any()) } returns setOf("Clear cache")
+    }
+
+    // ============================================================
+    // OneUI-specific tests
+    // ============================================================
+
+    @Test
+    fun `clear cache finds button by label priority not tree order - Polish localization - GitHub 2046`() = runTest {
+        // This test verifies the fix for GitHub issue #2046
+        // In Polish: "Pamięć cache" = cache memory (label/header that appears first in tree)
+        //           "Wyczyść pamięć podręczną" = clear cache (button that should be found)
+        // Bug: tree-order search found "Pamięć cache" label before the actual button
+        // Fix: label-priority search finds "Wyczyść pamięć podręczną" first because it's first in label list
+
+        val acsLog = """
+            ACS-DEBUG: 0: text='null', class=android.widget.FrameLayout, clickable=false, checkable=false enabled=true, id=null pkg=com.android.settings, identity=root, bounds=Rect(0, 0 - 1080, 2400)
+            ACS-DEBUG: -1: text='null', class=android.widget.LinearLayout, clickable=false, checkable=false enabled=true, id=null pkg=com.android.settings, identity=layout1, bounds=Rect(0, 0 - 1080, 400)
+            ACS-DEBUG: --2: text='Pamięć cache', class=android.widget.TextView, clickable=false, checkable=false enabled=true, id=android:id/title pkg=com.android.settings, identity=cache_label, bounds=Rect(50, 100 - 500, 150)
+            ACS-DEBUG: --2: text='128 MB', class=android.widget.TextView, clickable=false, checkable=false enabled=true, id=android:id/summary pkg=com.android.settings, identity=cache_size, bounds=Rect(50, 150 - 500, 200)
+            ACS-DEBUG: -1: text='null', class=android.widget.LinearLayout, clickable=false, checkable=false enabled=true, id=null pkg=com.android.settings, identity=layout2, bounds=Rect(0, 400 - 1080, 600)
+            ACS-DEBUG: --2: text='Wyczyść pamięć podręczną', class=android.widget.Button, clickable=true, checkable=false enabled=true, id=com.android.settings:id/button pkg=com.android.settings, identity=clear_btn, bounds=Rect(50, 450 - 500, 550)
+        """.trimIndent()
+
+        testRoot = buildTestTree(acsLog)
+
+        // Labels in priority order: clear cache button label first, then cache label
+        every { labels.getClearCacheDynamic(any()) } returns emptySet()
+        every { labels.getClearCacheLabels(any()) } returns setOf(
+            "Wyczyść pamięć podręczną",  // Clear cache - should be found first (priority)
+            "Pamięć cache",               // Cache memory - should NOT be found (lower priority)
+        )
+
+        val result = captureAndRunClearCacheAction()
+
+        result shouldBe true
+        // Verify the correct button was clicked, not the cache label
+        val clearCacheButton = testRoot.crawl().first { it.node.text == "Wyczyść pamięć podręczną" }.node as TestACSNodeInfo
+        clearCacheButton.performedActions shouldBe listOf(ACSNodeInfo.ACTION_CLICK)
+    }
+
+    @Test
+    fun `clear cache handles nested button text in OneUI 8_5+ style`() = runTest {
+        // On newer One UI versions, the text "Wyczyść pamięć podręczną" is nested inside a non-clickable
+        // TextView, and the clickable parent needs to be found
+
+        val acsLog = """
+            ACS-DEBUG: 0: text='null', class=android.widget.FrameLayout, clickable=false, checkable=false enabled=true, id=null pkg=com.android.settings, identity=root, bounds=Rect(0, 0 - 1080, 2400)
+            ACS-DEBUG: -1: text='null', class=android.widget.LinearLayout, clickable=true, checkable=false enabled=true, id=com.android.settings:id/button_container pkg=com.android.settings, identity=btn_container, bounds=Rect(0, 400 - 1080, 600)
+            ACS-DEBUG: --2: text='Wyczyść pamięć podręczną', class=android.widget.TextView, clickable=false, checkable=false enabled=true, id=null pkg=com.android.settings, identity=btn_text, bounds=Rect(50, 450 - 500, 550)
+        """.trimIndent()
+
+        testRoot = buildTestTree(acsLog)
+
+        every { labels.getClearCacheDynamic(any()) } returns emptySet()
+        every { labels.getClearCacheLabels(any()) } returns setOf("Wyczyść pamięć podręczną")
+
+        val result = captureAndRunClearCacheAction()
+
+        result shouldBe true
+        // The clickable parent container should have been clicked, not the text itself
+        val buttonContainer = testRoot.crawl().first { it.node.viewIdResourceName == "com.android.settings:id/button_container" }.node as TestACSNodeInfo
+        buttonContainer.performedActions shouldBe listOf(ACSNodeInfo.ACTION_CLICK)
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/realme/RealmeSpecsTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/realme/RealmeSpecsTest.kt
@@ -1,0 +1,96 @@
+package eu.darken.sdmse.appcleaner.core.automation.specs.realme
+
+import eu.darken.sdmse.appcleaner.core.automation.specs.BaseAppCleanerSpecTest
+import eu.darken.sdmse.automation.core.common.ACSNodeInfo
+import eu.darken.sdmse.automation.core.common.crawl
+import eu.darken.sdmse.common.device.RomType
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.TestACSNodeInfo
+
+class RealmeSpecsTest : BaseAppCleanerSpecTest<RealmeSpecs, RealmeLabels>() {
+
+    override val romType = RomType.REALMEUI
+
+    override fun createLabels(): RealmeLabels = mockk()
+
+    override fun createSpec() = RealmeSpecs(
+        ipcFunnel = ipcFunnel,
+        deviceDetective = deviceDetective,
+        realmeLabels = labels,
+        storageEntryFinder = storageEntryFinder,
+        generalSettings = generalSettings,
+        stepper = stepper,
+    )
+
+    override fun mockLabelDefaults() {
+        every { labels.getStorageEntryDynamic(any()) } returns emptySet()
+        every { labels.getStorageEntryLabels(any()) } returns setOf("Storage")
+        every { labels.getClearCacheDynamic(any()) } returns emptySet()
+        every { labels.getClearCacheLabels(any()) } returns setOf("Clear cache")
+    }
+
+    @BeforeEach
+    fun setupApiLevel() {
+        mockkStatic("eu.darken.sdmse.common.BuildWrapKt")
+        every { eu.darken.sdmse.common.hasApiLevel(any()) } returns true
+    }
+
+    @AfterEach
+    fun cleanupApiLevel() {
+        unmockkStatic("eu.darken.sdmse.common.BuildWrapKt")
+    }
+
+    // ============================================================
+    // Realme-specific regression tests
+    // ============================================================
+
+    @Test
+    fun `clear cache clicks directly on clicky button - pre API 35`() = runTest {
+        // Before API 35, Realme requires isClickyButton()
+        every { eu.darken.sdmse.common.hasApiLevel(35) } returns false
+
+        val acsLog = """
+            ACS-DEBUG: 0: text='null', class=android.widget.FrameLayout, clickable=false, checkable=false enabled=true, id=null pkg=com.android.settings, identity=root, bounds=Rect(0, 0 - 1080, 2400)
+            ACS-DEBUG: -1: text='null', class=android.widget.LinearLayout, clickable=false, checkable=false enabled=true, id=null pkg=com.android.settings, identity=layout1, bounds=Rect(0, 0 - 1080, 400)
+            ACS-DEBUG: --2: text='Clear cache', class=android.widget.Button, clickable=true, checkable=false enabled=true, id=com.android.settings:id/button pkg=com.android.settings, identity=btn, bounds=Rect(50, 100 - 500, 150)
+        """.trimIndent()
+
+        testRoot = buildTestTree(acsLog)
+
+        val result = captureAndRunClearCacheAction()
+
+        result shouldBe true
+        val clearCacheButton = testRoot.crawl().first { it.node.text == "Clear cache" }.node as TestACSNodeInfo
+        clearCacheButton.performedActions shouldBe listOf(ACSNodeInfo.ACTION_CLICK)
+    }
+
+    @Test
+    fun `clear cache finds clickable parent when button not clickable - API 35+ - GitHub 1912`() = runTest {
+        // On API 35+, Realme finds any matching node then traverses to clickable parent
+        // This addresses scenarios where the clear cache button might not have a directly clickable parent
+        every { eu.darken.sdmse.common.hasApiLevel(35) } returns true
+
+        val acsLog = """
+            ACS-DEBUG: 0: text='null', class=android.widget.FrameLayout, clickable=false, checkable=false enabled=true, id=null pkg=com.android.settings, identity=root, bounds=Rect(0, 0 - 1080, 2400)
+            ACS-DEBUG: -1: text='null', class=android.widget.LinearLayout, clickable=true, checkable=false enabled=true, id=com.android.settings:id/btn_container pkg=com.android.settings, identity=btn_container, bounds=Rect(0, 100 - 1080, 200)
+            ACS-DEBUG: --2: text='Clear cache', class=android.widget.TextView, clickable=false, checkable=false enabled=true, id=null pkg=com.android.settings, identity=text, bounds=Rect(50, 110 - 500, 190)
+        """.trimIndent()
+
+        testRoot = buildTestTree(acsLog)
+
+        val result = captureAndRunClearCacheAction()
+
+        result shouldBe true
+        // The clickable parent LinearLayout should be clicked
+        val clickableParent = testRoot.crawl().first { it.node.viewIdResourceName == "com.android.settings:id/btn_container" }.node as TestACSNodeInfo
+        clickableParent.performedActions shouldBe listOf(ACSNodeInfo.ACTION_CLICK)
+    }
+}

--- a/app/src/test/java/testhelpers/AcsDebugParser.kt
+++ b/app/src/test/java/testhelpers/AcsDebugParser.kt
@@ -1,0 +1,143 @@
+package testhelpers
+
+/**
+ * Parses ACS debug output from logs into [TestACSNodeInfo] trees for testing.
+ *
+ * Input format:
+ * ```
+ * ACS-DEBUG: 0: text='null', class=android.widget.FrameLayout, clickable=false, checkable=false enabled=true, id=null pkg=com.android.settings, identity=8b03c20, bounds=Rect(0, 0 - 1220, 2712)
+ * ACS-DEBUG: -1: text='Storage', class=android.widget.TextView, clickable=false, checkable=false enabled=true, id=android:id/title pkg=com.android.settings, identity=245e8c8, bounds=Rect(91, 1972 - 1129, 2086)
+ * ACS-DEBUG: --2: text='Clear cache', class=android.widget.Button, clickable=true, checkable=false enabled=true, id=null pkg=com.android.settings, identity=abc123, bounds=Rect(100, 200 - 300, 250)
+ * ```
+ *
+ * Usage:
+ * ```kotlin
+ * val root = AcsDebugParser.parseTree(logContent)
+ * val context = createStepContextWithTree(root!!)
+ * ```
+ */
+object AcsDebugParser {
+
+    private val LINE_PATTERN = Regex(
+        """ACS-DEBUG:\s*(-*)(\d+):\s*(.+)"""
+    )
+
+    private val TEXT_PATTERN = Regex("""text='([^']*)'""")
+    private val CLASS_PATTERN = Regex("""class=([^,]+)""")
+    private val CLICKABLE_PATTERN = Regex("""clickable=(true|false)""")
+    private val CHECKABLE_PATTERN = Regex("""checkable=(true|false)""")
+    private val ENABLED_PATTERN = Regex("""enabled=(true|false)""")
+    private val SCROLLABLE_PATTERN = Regex("""scrollable=(true|false)""")
+    private val ID_PATTERN = Regex("""id=([^\s]+)\s+pkg=""")
+    private val PKG_PATTERN = Regex("""pkg=([^,]+)""")
+
+    data class ParsedNode(
+        val level: Int,
+        val text: String?,
+        val className: String?,
+        val isClickable: Boolean,
+        val isEnabled: Boolean,
+        val isCheckable: Boolean,
+        val isScrollable: Boolean,
+        val viewIdResourceName: String?,
+        val packageName: String?,
+    )
+
+    /**
+     * Parses ACS debug log content and returns a [TestACSNodeInfo] tree.
+     *
+     * @param logContent Raw log content containing ACS-DEBUG lines
+     * @return Root [TestACSNodeInfo] node, or null if parsing fails
+     */
+    fun parseTree(logContent: String): TestACSNodeInfo? {
+        val parsedNodes = logContent.lines()
+            .filter { it.contains("ACS-DEBUG:") && !it.contains("START") && !it.contains("STOP") }
+            .mapNotNull { parseLine(it) }
+
+        if (parsedNodes.isEmpty()) return null
+
+        return buildTree(parsedNodes)
+    }
+
+    /**
+     * Parses a single ACS-DEBUG line into a [ParsedNode].
+     */
+    fun parseLine(line: String): ParsedNode? {
+        val lineMatch = LINE_PATTERN.find(line) ?: return null
+
+        val dashes = lineMatch.groupValues[1]
+        val level = dashes.length
+        val properties = lineMatch.groupValues[3]
+
+        val textMatch = TEXT_PATTERN.find(properties)
+        val text = textMatch?.groupValues?.get(1)?.let { if (it == "null") null else it }
+
+        val className = CLASS_PATTERN.find(properties)?.groupValues?.get(1)?.trim()
+        val isClickable = CLICKABLE_PATTERN.find(properties)?.groupValues?.get(1) == "true"
+        val isCheckable = CHECKABLE_PATTERN.find(properties)?.groupValues?.get(1) == "true"
+        val isEnabled = ENABLED_PATTERN.find(properties)?.groupValues?.get(1) == "true"
+        val isScrollable = SCROLLABLE_PATTERN.find(properties)?.groupValues?.get(1) == "true"
+
+        val idMatch = ID_PATTERN.find(properties)
+        val viewIdResourceName = idMatch?.groupValues?.get(1)?.let { if (it == "null") null else it }
+
+        val packageName = PKG_PATTERN.find(properties)?.groupValues?.get(1)?.trim()
+
+        return ParsedNode(
+            level = level,
+            text = text,
+            className = className,
+            isClickable = isClickable,
+            isEnabled = isEnabled,
+            isCheckable = isCheckable,
+            isScrollable = isScrollable,
+            viewIdResourceName = viewIdResourceName,
+            packageName = packageName,
+        )
+    }
+
+    /**
+     * Builds a [TestACSNodeInfo] tree from a flat list of [ParsedNode]s.
+     */
+    fun buildTree(nodes: List<ParsedNode>): TestACSNodeInfo? {
+        if (nodes.isEmpty()) return null
+
+        // Create TestACSNodeInfo for each parsed node
+        val nodeInfos = nodes.map { it.toTestNodeInfo() }
+
+        // Build parent-child relationships using a stack
+        val stack = mutableListOf<Pair<Int, TestACSNodeInfo>>() // (level, node)
+
+        for ((index, node) in nodes.withIndex()) {
+            val nodeInfo = nodeInfos[index]
+            val level = node.level
+
+            // Pop nodes from stack until we find the parent (level - 1)
+            while (stack.isNotEmpty() && stack.last().first >= level) {
+                stack.removeAt(stack.lastIndex)
+            }
+
+            // If stack is not empty, add this node as child of the top node
+            if (stack.isNotEmpty()) {
+                stack.last().second.addChild(nodeInfo)
+            }
+
+            // Push current node to stack
+            stack.add(level to nodeInfo)
+        }
+
+        // Return the first node (root)
+        return nodeInfos.firstOrNull()
+    }
+
+    private fun ParsedNode.toTestNodeInfo() = TestACSNodeInfo(
+        text = text,
+        className = className,
+        packageName = packageName,
+        viewIdResourceName = viewIdResourceName,
+        isClickable = isClickable,
+        isEnabled = isEnabled,
+        isCheckable = isCheckable,
+        isScrollable = isScrollable,
+    )
+}

--- a/app/src/test/java/testhelpers/AcsDebugParserTest.kt
+++ b/app/src/test/java/testhelpers/AcsDebugParserTest.kt
@@ -1,0 +1,188 @@
+package testhelpers
+
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class AcsDebugParserTest : BaseTest() {
+
+    @Test
+    fun `parseLine extracts level from dashes`() {
+        val level0 = AcsDebugParser.parseLine(
+            "ACS-DEBUG: 0: text='null', class=android.widget.FrameLayout, clickable=false, checkable=false enabled=true, id=null pkg=com.android.settings, identity=8b03c20, bounds=Rect(0, 0 - 1220, 2712)"
+        )
+        val level1 = AcsDebugParser.parseLine(
+            "ACS-DEBUG: -1: text='null', class=android.widget.LinearLayout, clickable=false, checkable=false enabled=true, id=null pkg=com.android.settings, identity=3662a7f, bounds=Rect(0, 0 - 1220, 2712)"
+        )
+        val level2 = AcsDebugParser.parseLine(
+            "ACS-DEBUG: --2: text='App info', class=android.widget.TextView, clickable=false, checkable=false enabled=true, id=com.android.settings:id/title pkg=com.android.settings, identity=5a45202, bounds=Rect(84, 298 - 471, 437)"
+        )
+
+        level0.shouldNotBeNull()
+        level0.level shouldBe 0
+
+        level1.shouldNotBeNull()
+        level1.level shouldBe 1
+
+        level2.shouldNotBeNull()
+        level2.level shouldBe 2
+    }
+
+    @Test
+    fun `parseLine extracts text property`() {
+        val withText = AcsDebugParser.parseLine(
+            "ACS-DEBUG: 0: text='Storage', class=android.widget.TextView, clickable=false, checkable=false enabled=true, id=null pkg=com.android.settings, identity=abc, bounds=Rect(0, 0 - 100, 50)"
+        )
+        val nullText = AcsDebugParser.parseLine(
+            "ACS-DEBUG: 0: text='null', class=android.widget.FrameLayout, clickable=false, checkable=false enabled=true, id=null pkg=com.android.settings, identity=abc, bounds=Rect(0, 0 - 100, 50)"
+        )
+
+        withText.shouldNotBeNull()
+        withText.text shouldBe "Storage"
+
+        nullText.shouldNotBeNull()
+        nullText.text.shouldBeNull()
+    }
+
+    @Test
+    fun `parseLine extracts clickable and enabled properties`() {
+        val clickableEnabled = AcsDebugParser.parseLine(
+            "ACS-DEBUG: 0: text='Button', class=android.widget.Button, clickable=true, checkable=false enabled=true, id=null pkg=test, identity=abc, bounds=Rect(0, 0 - 100, 50)"
+        )
+        val notClickableDisabled = AcsDebugParser.parseLine(
+            "ACS-DEBUG: 0: text='Label', class=android.widget.TextView, clickable=false, checkable=false enabled=false, id=null pkg=test, identity=abc, bounds=Rect(0, 0 - 100, 50)"
+        )
+
+        clickableEnabled.shouldNotBeNull()
+        clickableEnabled.isClickable shouldBe true
+        clickableEnabled.isEnabled shouldBe true
+
+        notClickableDisabled.shouldNotBeNull()
+        notClickableDisabled.isClickable shouldBe false
+        notClickableDisabled.isEnabled shouldBe false
+    }
+
+    @Test
+    fun `parseLine extracts viewIdResourceName`() {
+        val withId = AcsDebugParser.parseLine(
+            "ACS-DEBUG: 0: text='Storage', class=android.widget.TextView, clickable=false, checkable=false enabled=true, id=android:id/title pkg=com.android.settings, identity=abc, bounds=Rect(0, 0 - 100, 50)"
+        )
+        val nullId = AcsDebugParser.parseLine(
+            "ACS-DEBUG: 0: text='null', class=android.widget.FrameLayout, clickable=false, checkable=false enabled=true, id=null pkg=com.android.settings, identity=abc, bounds=Rect(0, 0 - 100, 50)"
+        )
+
+        withId.shouldNotBeNull()
+        withId.viewIdResourceName shouldBe "android:id/title"
+
+        nullId.shouldNotBeNull()
+        nullId.viewIdResourceName.shouldBeNull()
+    }
+
+    @Test
+    fun `parseLine extracts className and packageName`() {
+        val node = AcsDebugParser.parseLine(
+            "ACS-DEBUG: 0: text='null', class=android.widget.FrameLayout, clickable=false, checkable=false enabled=true, id=null pkg=com.android.settings, identity=abc, bounds=Rect(0, 0 - 100, 50)"
+        )
+
+        node.shouldNotBeNull()
+        node.className shouldBe "android.widget.FrameLayout"
+        node.packageName shouldBe "com.android.settings"
+    }
+
+    @Test
+    fun `parseTree builds simple parent-child tree`() {
+        val log = """
+            ACS-DEBUG: 0: text='null', class=android.widget.FrameLayout, clickable=false, checkable=false enabled=true, id=null pkg=com.android.settings, identity=abc, bounds=Rect(0, 0 - 100, 50)
+            ACS-DEBUG: -1: text='Storage', class=android.widget.TextView, clickable=false, checkable=false enabled=true, id=null pkg=com.android.settings, identity=def, bounds=Rect(0, 0 - 100, 50)
+            ACS-DEBUG: -1: text='Clear cache', class=android.widget.Button, clickable=true, checkable=false enabled=true, id=null pkg=com.android.settings, identity=ghi, bounds=Rect(0, 0 - 100, 50)
+        """.trimIndent()
+
+        val root = AcsDebugParser.parseTree(log)
+
+        root.shouldNotBeNull()
+        root.text.shouldBeNull()
+        root.className shouldBe "android.widget.FrameLayout"
+        root.childCount shouldBe 2
+
+        val storage = root.getChild(0) as TestACSNodeInfo
+        storage.text shouldBe "Storage"
+        storage.isClickable shouldBe false
+
+        val clearCache = root.getChild(1) as TestACSNodeInfo
+        clearCache.text shouldBe "Clear cache"
+        clearCache.isClickable shouldBe true
+    }
+
+    @Test
+    fun `parseTree builds nested tree`() {
+        val log = """
+            ACS-DEBUG: 0: text='null', class=android.widget.FrameLayout, clickable=false, checkable=false enabled=true, id=null pkg=test, identity=a, bounds=Rect(0, 0 - 100, 50)
+            ACS-DEBUG: -1: text='null', class=android.widget.LinearLayout, clickable=false, checkable=false enabled=true, id=null pkg=test, identity=b, bounds=Rect(0, 0 - 100, 50)
+            ACS-DEBUG: --2: text='Title', class=android.widget.TextView, clickable=false, checkable=false enabled=true, id=null pkg=test, identity=c, bounds=Rect(0, 0 - 100, 50)
+            ACS-DEBUG: --2: text='Subtitle', class=android.widget.TextView, clickable=false, checkable=false enabled=true, id=null pkg=test, identity=d, bounds=Rect(0, 0 - 100, 50)
+            ACS-DEBUG: -1: text='Button', class=android.widget.Button, clickable=true, checkable=false enabled=true, id=null pkg=test, identity=e, bounds=Rect(0, 0 - 100, 50)
+        """.trimIndent()
+
+        val root = AcsDebugParser.parseTree(log)
+
+        root.shouldNotBeNull()
+        root.childCount shouldBe 2
+
+        val linearLayout = root.getChild(0) as TestACSNodeInfo
+        linearLayout.className shouldBe "android.widget.LinearLayout"
+        linearLayout.childCount shouldBe 2
+
+        val title = linearLayout.getChild(0) as TestACSNodeInfo
+        title.text shouldBe "Title"
+
+        val subtitle = linearLayout.getChild(1) as TestACSNodeInfo
+        subtitle.text shouldBe "Subtitle"
+
+        val button = root.getChild(1) as TestACSNodeInfo
+        button.text shouldBe "Button"
+        button.isClickable shouldBe true
+    }
+
+    @Test
+    fun `parseTree ignores START and STOP lines`() {
+        val log = """
+            ACS-DEBUG -- abc123 -- START -- EventType: TYPE_WINDOW_CONTENT_CHANGED
+            ACS-DEBUG: 0: text='null', class=android.widget.FrameLayout, clickable=false, checkable=false enabled=true, id=null pkg=test, identity=a, bounds=Rect(0, 0 - 100, 50)
+            ACS-DEBUG -- abc123 -- STOP -- ---
+        """.trimIndent()
+
+        val root = AcsDebugParser.parseTree(log)
+
+        root.shouldNotBeNull()
+        root.childCount shouldBe 0
+    }
+
+    @Test
+    fun `parseTree returns null for empty input`() {
+        AcsDebugParser.parseTree("").shouldBeNull()
+        AcsDebugParser.parseTree("no acs debug lines here").shouldBeNull()
+    }
+
+    @Test
+    fun `parseTree with real HyperOS log snippet`() {
+        // Real snippet from HyperOS showing Storage section
+        val log = """
+            ACS-DEBUG: ------------12: text='null', class=android.widget.FrameLayout, clickable=false, checkable=false enabled=true, id=null pkg=com.android.settings, identity=493c896, bounds=Rect(0, 1972 - 1220, 2086)
+            ACS-DEBUG: -------------13: text='Storage', class=android.widget.TextView, clickable=false, checkable=false enabled=true, id=android:id/title pkg=com.android.settings, identity=e0f78b8, bounds=Rect(91, 1972 - 1129, 2086)
+            ACS-DEBUG: ------------12: text='null', class=android.view.ViewGroup, clickable=true, checkable=false enabled=true, id=null pkg=com.android.settings, identity=c4d7bb1, bounds=Rect(39, 2086 - 1181, 2269)
+            ACS-DEBUG: -------------13: text='null', class=android.view.View, clickable=false, checkable=false enabled=true, id=null pkg=com.android.settings, identity=673a1f7, bounds=Rect(91, 2094 - 91, 2094)
+            ACS-DEBUG: -------------13: text='Total', class=android.widget.TextView, clickable=false, checkable=false enabled=true, id=android:id/title pkg=com.android.settings, identity=b4349f6, bounds=Rect(91, 2140 - 215, 2214)
+        """.trimIndent()
+
+        val root = AcsDebugParser.parseTree(log)
+
+        root.shouldNotBeNull()
+        // Level 12 is the root in this snippet, should have "Storage" label header child
+        root.className shouldBe "android.widget.FrameLayout"
+        root.childCount shouldBe 1
+
+        val storageLabel = root.getChild(0) as TestACSNodeInfo
+        storageLabel.text shouldBe "Storage"
+    }
+}

--- a/app/src/test/java/testhelpers/automation/TestAutomationEvent.kt
+++ b/app/src/test/java/testhelpers/automation/TestAutomationEvent.kt
@@ -1,0 +1,22 @@
+package testhelpers.automation
+
+import eu.darken.sdmse.automation.core.AutomationEvent
+import eu.darken.sdmse.common.pkgs.Pkg
+import eu.darken.sdmse.common.pkgs.toPkgId
+import java.util.UUID
+
+/**
+ * Test implementation of [AutomationEvent] for testing automation specs.
+ */
+data class TestAutomationEvent(
+    override val id: UUID = UUID.randomUUID(),
+    override val pkgId: Pkg.Id,
+    override val eventType: Int = android.view.accessibility.AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED,
+) : AutomationEvent {
+
+    companion object {
+        fun fromPkgId(pkgId: String): TestAutomationEvent = TestAutomationEvent(
+            pkgId = pkgId.toPkgId()
+        )
+    }
+}

--- a/app/src/test/java/testhelpers/automation/TestAutomationHost.kt
+++ b/app/src/test/java/testhelpers/automation/TestAutomationHost.kt
@@ -1,0 +1,110 @@
+package testhelpers.automation
+
+import eu.darken.sdmse.automation.core.AutomationEvent
+import eu.darken.sdmse.automation.core.AutomationHost
+import eu.darken.sdmse.automation.core.AutomationService
+import eu.darken.sdmse.automation.core.common.ACSNodeInfo
+import eu.darken.sdmse.common.pkgs.toPkgId
+import eu.darken.sdmse.common.progress.Progress
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import testhelpers.TestACSNodeInfo
+
+/**
+ * Test implementation of [AutomationHost] for testing automation specs.
+ *
+ * Provides:
+ * - Dynamic window roots via [setWindowRoot]
+ * - Event emission via [emitEvent] and [transitionTo]
+ * - Progress tracking for assertions
+ *
+ * Usage:
+ * ```kotlin
+ * val host = TestAutomationHost(testScope)
+ *
+ * // Set static window root
+ * host.setWindowRoot(buildTestTree("..."))
+ *
+ * // Or emit events for window detection
+ * host.transitionTo(tree, "com.android.settings")
+ * ```
+ */
+class TestAutomationHost(
+    private val testScope: CoroutineScope,
+) : AutomationHost {
+
+    // Dynamic window root
+    private val _windowRoot = MutableStateFlow<TestACSNodeInfo?>(null)
+
+    override suspend fun windowRoot(): ACSNodeInfo? = _windowRoot.value
+
+    // Event stream for specs that use host.events
+    private val _events = MutableSharedFlow<AutomationEvent>(replay = 1, extraBufferCapacity = 10)
+    override val events: Flow<AutomationEvent> = _events
+
+    // State (always available in tests by default)
+    private val _state = MutableStateFlow(AutomationHost.State(hasOverlay = false, passthrough = false))
+    override val state: Flow<AutomationHost.State> = _state
+
+    // Scope for coroutines
+    override val scope: CoroutineScope = testScope
+
+    // Service mock - using AutomationService so casts work
+    override val service: AutomationService = mockk(relaxed = true)
+
+    // Progress tracking
+    private var _progressData: Progress.Data? = null
+
+    override fun updateProgress(update: (Progress.Data?) -> Progress.Data?) {
+        _progressData = update(_progressData)
+    }
+
+    /**
+     * Get the current progress data for assertions.
+     */
+    fun getProgressData(): Progress.Data? = _progressData
+
+    override suspend fun changeOptions(action: (AutomationHost.Options) -> AutomationHost.Options) {
+        // No-op in tests
+    }
+
+    // ========== Test Helpers ==========
+
+    /**
+     * Set the current window root.
+     */
+    fun setWindowRoot(root: TestACSNodeInfo?) {
+        _windowRoot.value = root
+    }
+
+    /**
+     * Get the current window root for assertions.
+     */
+    fun getCurrentRoot(): TestACSNodeInfo? = _windowRoot.value
+
+    /**
+     * Emit an automation event. Use for testing event-based window detection.
+     */
+    suspend fun emitEvent(pkgId: String, eventType: Int = android.view.accessibility.AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED) {
+        _events.emit(TestAutomationEvent(pkgId = pkgId.toPkgId(), eventType = eventType))
+    }
+
+    /**
+     * Simulate a window transition: set new root and emit event.
+     * Use for testing specs that wait for specific window events.
+     */
+    suspend fun transitionTo(root: TestACSNodeInfo, pkgId: String) {
+        setWindowRoot(root)
+        emitEvent(pkgId)
+    }
+
+    /**
+     * Set the host state (overlay visibility, passthrough mode).
+     */
+    fun setHostState(hasOverlay: Boolean = false, passthrough: Boolean = false) {
+        _state.value = AutomationHost.State(hasOverlay = hasOverlay, passthrough = passthrough)
+    }
+}


### PR DESCRIPTION
Introduce testable automation event interface and comprehensive test infrastructure for AppCleaner automation specs:

- Add AutomationEvent interface to decouple tests from Android framework
- Create TestAutomationHost with event emission support (transitionTo, emitEvent)
- Add AcsDebugParser to build test trees from ACS debug log format
- Create BaseAppCleanerSpecTest with shared test infrastructure
- Add spec tests for AOSP, ColorOS, Huawei, HyperOS, OneUI, and Realme

The test infrastructure supports both simple window root testing and event-based window transitions. Complex multi-step dialog tests (HyperOS/MIUI) require Robolectric due to android.graphics.Rect dependencies.