### PR TITLE
General: Make debug card translatable

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/items/DebugCardVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/items/DebugCardVH.kt
@@ -70,6 +70,7 @@ class DebugCardVH(parent: ViewGroup) :
         logviewAction.setOnClickListener { item.onViewLog() }
 
         acsDebugAction.apply {
+            isVisible = BuildConfigWrap.DEBUG
             setOnClickListener { item.onAcsDebug() }
             text = if (item.acsTask != null) "Stop ACS debug" else "Start ACS debug"
         }

--- a/app/src/main/res/layout/dashboard_debug_item.xml
+++ b/app/src/main/res/layout/dashboard_debug_item.xml
@@ -29,7 +29,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="8dp"
-            android:text="Debug mode is enabled"
+            android:text="@string/debug_card_title"
             android:textColor="?colorOnSecondaryContainer"
             app:layout_constraintStart_toEndOf="@id/icon"
             app:layout_constraintTop_toTopOf="parent"
@@ -47,7 +47,7 @@
                 style="@style/Widget.Material3.CompoundButton.MaterialSwitch"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="Enable trace mode"
+                android:text="@string/debug_card_trace_mode_label"
                 android:textColor="?colorOnSecondaryContainer" />
 
             <com.google.android.material.materialswitch.MaterialSwitch
@@ -55,7 +55,7 @@
                 style="@style/Widget.Material3.CompoundButton.MaterialSwitch"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="Dry-run mode (disable deletion)"
+                android:text="@string/debug_card_dryrun_mode_label"
                 android:textColor="?colorOnSecondaryContainer" />
 
             <com.google.android.material.button.MaterialButton
@@ -64,7 +64,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
-                android:text="Reload data areas"
+                android:text="@string/debug_card_areas_reload_action"
                 android:textColor="?colorOnSecondaryContainer" />
 
             <com.google.android.material.button.MaterialButton
@@ -72,7 +72,7 @@
                 style="@style/Widget.Material3.Button.OutlinedButton"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="Reload apps"
+                android:text="@string/debug_card_pkgs_reload_action"
                 android:textColor="?colorOnSecondaryContainer" />
 
             <com.google.android.material.textview.MaterialTextView
@@ -89,7 +89,7 @@
                 style="@style/Widget.Material3.Button.OutlinedButton"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="Test root"
+                android:text="@string/debug_card_root_test_action"
                 android:textColor="?colorOnSecondaryContainer" />
 
             <com.google.android.material.textview.MaterialTextView
@@ -106,7 +106,7 @@
                 style="@style/Widget.Material3.Button.OutlinedButton"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="Test Shizuku"
+                android:text="@string/debug_card_shizuku_test_action"
                 android:textColor="?colorOnSecondaryContainer" />
 
             <com.google.android.material.button.MaterialButton

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -870,4 +870,12 @@
     <string name="shortcuts_settings_category">الاختصارات</string>
     <string name="shortcuts_onetap_enabled_title">اختصار بنقرة واحدة</string>
     <string name="shortcuts_onetap_enabled_summary">أظهر الاختصار \"فحص + حذف\" عند الضغط المطول على أيقونة التطبيق. يستخدم نفس الأدوات مثل لوحة التحكم بنقرة واحدة.</string>
+    <!-- Debug card (dashboard) -->
+    <string name="debug_card_title">وضع التصحيح مُفعّل</string>
+    <string name="debug_card_trace_mode_label">تفعيل وضع التتبع</string>
+    <string name="debug_card_dryrun_mode_label">وضع المحاكاة (تعطيل الحذف)</string>
+    <string name="debug_card_areas_reload_action">إعادة تحميل مناطق البيانات</string>
+    <string name="debug_card_pkgs_reload_action">إعادة تحميل التطبيقات</string>
+    <string name="debug_card_root_test_action">اختبار root</string>
+    <string name="debug_card_shizuku_test_action">اختبار Shizuku</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -823,4 +823,12 @@
     <string name="shortcuts_settings_category">Zkratky</string>
     <string name="shortcuts_onetap_enabled_title">Zkratka jedním klepnutím</string>
     <string name="shortcuts_onetap_enabled_summary">Zobrazení zkratky \"Skenovat + smazat\" při dlouhém stisknutí ikony aplikace. Používá stejné nástroje jako ovládací panel jedním klepnutím.</string>
+    <!-- Debug card (dashboard) -->
+    <string name="debug_card_title">Režim ladění je zapnutý</string>
+    <string name="debug_card_trace_mode_label">Povolit režim stopy</string>
+    <string name="debug_card_dryrun_mode_label">Režim zkoušky (zakázat mazání)</string>
+    <string name="debug_card_areas_reload_action">Znovu načíst datové oblasti</string>
+    <string name="debug_card_pkgs_reload_action">Znovu načíst aplikace</string>
+    <string name="debug_card_root_test_action">Test root</string>
+    <string name="debug_card_shizuku_test_action">Test Shizuku</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -759,4 +759,13 @@
     <string name="shortcuts_settings_category">Verknüpfungen</string>
     <string name="shortcuts_onetap_enabled_title">Ein-Tipp-Verknüpfung</string>
     <string name="shortcuts_onetap_enabled_summary">Zeige \"Scan + Löschen\"-Verknüpfung bei langem Drücken des App-Symbols. Verwendet die gleichen Werkzeuge wie Ein-Tipp-Dashboard.</string>
+
+    <!-- Debug card (dashboard) -->
+    <string name="debug_card_title">Debug-Modus ist aktiviert</string>
+    <string name="debug_card_trace_mode_label">Trace-Modus aktivieren</string>
+    <string name="debug_card_dryrun_mode_label">Trockentest-Modus (Löschen deaktivieren)</string>
+    <string name="debug_card_areas_reload_action">Datenbereiche neu laden</string>
+    <string name="debug_card_pkgs_reload_action">Apps neu laden</string>
+    <string name="debug_card_root_test_action">root testen</string>
+    <string name="debug_card_shizuku_test_action">Shizuku testen</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -759,4 +759,12 @@
     <string name="shortcuts_settings_category">Accesos directos</string>
     <string name="shortcuts_onetap_enabled_title">Acceso directo a un toque</string>
     <string name="shortcuts_onetap_enabled_summary">Muestra el acceso directo «Escanear + Eliminar» al pulsar prolongadamente el icono de la aplicación. Utiliza las mismas herramientas que el panel de un solo toque.</string>
+    <!-- Debug card (dashboard) -->
+    <string name="debug_card_title">El modo de depuración está habilitado</string>
+    <string name="debug_card_trace_mode_label">Habilitar modo de rastreo</string>
+    <string name="debug_card_dryrun_mode_label">Modo de ejecución en seco (desactivar eliminación)</string>
+    <string name="debug_card_areas_reload_action">Recargar áreas de datos</string>
+    <string name="debug_card_pkgs_reload_action">Recargar aplicaciones</string>
+    <string name="debug_card_root_test_action">Probar root</string>
+    <string name="debug_card_shizuku_test_action">Probar Shizuku</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -759,4 +759,12 @@
     <string name="shortcuts_settings_category">Raccourcis</string>
     <string name="shortcuts_onetap_enabled_title">Raccourci à accès direct</string>
     <string name="shortcuts_onetap_enabled_summary">Afficher le raccourci « Analyser + supprimer » en touchant et maintenant l’icône de l’appli. Utilise les mêmes outils que le tableau de bord à accès direct.</string>
+    <!-- Debug card (dashboard) -->
+    <string name="debug_card_title">Le mode débogage est activé</string>
+    <string name="debug_card_trace_mode_label">Activer le mode traçage</string>
+    <string name="debug_card_dryrun_mode_label">Mode simulation (désactiver la suppression)</string>
+    <string name="debug_card_areas_reload_action">Recharger les zones de données</string>
+    <string name="debug_card_pkgs_reload_action">Recharger les applis</string>
+    <string name="debug_card_root_test_action">Tester root</string>
+    <string name="debug_card_shizuku_test_action">Tester Shizuku</string>
 </resources>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -716,4 +716,12 @@
     <string name="area_type_public_obb_label">सार्वजनिक ऐप संसाधन</string>
     <string name="area_type_private_data_label">निजी ऐप डेटा</string>
     <string name="area_type_portable_label">पोर्टेबल संग्रहण</string>
+    <!-- Debug card (dashboard) -->
+    <string name="debug_card_title">डीबग मोड सक्षम है</string>
+    <string name="debug_card_trace_mode_label">ट्रेस मोड सक्षम करें</string>
+    <string name="debug_card_dryrun_mode_label">ड्राई-रन मोड (डिलीशन अक्षम करें)</string>
+    <string name="debug_card_areas_reload_action">डेटा क्षेत्र को पुनः लोड करें</string>
+    <string name="debug_card_pkgs_reload_action">ऐप्स को पुनः लोड करें</string>
+    <string name="debug_card_root_test_action">रूट टेस्ट करें</string>
+    <string name="debug_card_shizuku_test_action">Shizuku टेस्ट करें</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -726,5 +726,13 @@
     <string name="shortcut_onetap_long">Pindai dan hapus dalam satu tindakan</string>
     <string name="shortcuts_settings_category">Pintasan</string>
     <string name="shortcuts_onetap_enabled_title">Pintasan sekali ketuk</string>
-    <string name="shortcuts_onetap_enabled_summary">Tampilkan pintasan “Pindai + Hapus” saat menekan lama ikon aplikasi. Menggunakan alat yang sama seperti dasbor sekali ketuk.</string>
+    <string name="shortcuts_onetap_enabled_summary">Tampilkan pintasan "Pindai + Hapus" saat menekan lama ikon aplikasi. Menggunakan alat yang sama seperti dasbor sekali ketuk.</string>
+    <!-- Debug card (dashboard) -->
+    <string name="debug_card_title">Mode debug diaktifkan</string>
+    <string name="debug_card_trace_mode_label">Aktifkan mode trace</string>
+    <string name="debug_card_dryrun_mode_label">Mode dry-run (nonaktifkan penghapusan)</string>
+    <string name="debug_card_areas_reload_action">Muat ulang area data</string>
+    <string name="debug_card_pkgs_reload_action">Muat ulang aplikasi</string>
+    <string name="debug_card_root_test_action">Uji root</string>
+    <string name="debug_card_shizuku_test_action">Uji Shizuku</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -721,4 +721,12 @@ Esempio: Il segmento \"DCIM/Camera\" escluderà anche \"/sdcard/DCIM/Camera/phot
     <string name="area_type_public_obb_label">Risorse app pubbliche</string>
     <string name="area_type_private_data_label">Dati app privata</string>
     <string name="area_type_portable_label">Archiviazione portatile</string>
+    <!-- Debug card (dashboard) -->
+    <string name="debug_card_title">Modalità debug abilitata</string>
+    <string name="debug_card_trace_mode_label">Abilita modalità traccia</string>
+    <string name="debug_card_dryrun_mode_label">Modalità dry-run (disabilita eliminazione)</string>
+    <string name="debug_card_areas_reload_action">Ricarica aree dati</string>
+    <string name="debug_card_pkgs_reload_action">Ricarica app</string>
+    <string name="debug_card_root_test_action">Test root</string>
+    <string name="debug_card_shizuku_test_action">Test Shizuku</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -707,4 +707,12 @@
     <string name="shortcut_appcontrol_long">インストールされたアプリを管理</string>
     <string name="shortcuts_settings_category">ショートカット</string>
     <string name="shortcuts_onetap_enabled_title">ワンタップショートカット</string>
+    <!-- Debug card (dashboard) -->
+    <string name="debug_card_title">デバッグモードが有効になっています</string>
+    <string name="debug_card_trace_mode_label">トレースモードを有効にする</string>
+    <string name="debug_card_dryrun_mode_label">ドライランモード（削除を無効にする）</string>
+    <string name="debug_card_areas_reload_action">データエリアを再読み込み</string>
+    <string name="debug_card_pkgs_reload_action">アプリを再読み込み</string>
+    <string name="debug_card_root_test_action">Root をテスト</string>
+    <string name="debug_card_shizuku_test_action">Shizuku をテスト</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -688,4 +688,12 @@
     <string name="area_type_public_obb_label">공용 앱 리소스</string>
     <string name="area_type_private_data_label">개인 앱 데이터</string>
     <string name="area_type_portable_label">휴대용 저장소</string>
+    <!-- Debug card (dashboard) -->
+    <string name="debug_card_title">디버그 모드가 활성화되었습니다</string>
+    <string name="debug_card_trace_mode_label">추적 모드 활성화</string>
+    <string name="debug_card_dryrun_mode_label">드라이런 모드 (삭제 비활성화)</string>
+    <string name="debug_card_areas_reload_action">데이터 영역 다시 로드</string>
+    <string name="debug_card_pkgs_reload_action">앱 다시 로드</string>
+    <string name="debug_card_root_test_action">Root 테스트</string>
+    <string name="debug_card_shizuku_test_action">Shizuku 테스트</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -759,4 +759,12 @@
     <string name="shortcuts_settings_category">Snelkoppelingen</string>
     <string name="shortcuts_onetap_enabled_title">Snelkoppeling met één tik</string>
     <string name="shortcuts_onetap_enabled_summary">Toon de snelkoppeling \'Scannen + Verwijderen\' wanneer je het app-pictogram lang ingedrukt houdt. Gebruikt hezelfde gereedschap als het one-tap dashboard.</string>
+    <!-- Debug card (dashboard) -->
+    <string name="debug_card_title">Foutopsporingsmodus is ingeschakeld</string>
+    <string name="debug_card_trace_mode_label">Traceringsmodus inschakelen</string>
+    <string name="debug_card_dryrun_mode_label">Droge uitvoering (verwijdering uitschakelen)</string>
+    <string name="debug_card_areas_reload_action">Gegevensgebieden opnieuw laden</string>
+    <string name="debug_card_pkgs_reload_action">Apps opnieuw laden</string>
+    <string name="debug_card_root_test_action">Test root</string>
+    <string name="debug_card_shizuku_test_action">Test Shizuku</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -823,4 +823,12 @@
     <string name="shortcuts_settings_category">Skróty</string>
     <string name="shortcuts_onetap_enabled_title">Skrót jednym dotknięciem</string>
     <string name="shortcuts_onetap_enabled_summary">Pokaż skrót \"Skanuj + Usuń\" po długim naciśnięciu ikony aplikacji. Korzysta z tych samych narzędzi co pulpit jednego dotknięcia.</string>
+    <!-- Debug card (dashboard) -->
+    <string name="debug_card_title">Tryb debugowania jest włączony</string>
+    <string name="debug_card_trace_mode_label">Włącz tryb śledzenia</string>
+    <string name="debug_card_dryrun_mode_label">Tryb testowy (wyłącz usuwanie)</string>
+    <string name="debug_card_areas_reload_action">Załaduj ponownie obszary danych</string>
+    <string name="debug_card_pkgs_reload_action">Załaduj ponownie aplikacje</string>
+    <string name="debug_card_root_test_action">Testuj root</string>
+    <string name="debug_card_shizuku_test_action">Testuj Shizuku</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -759,4 +759,13 @@
     <string name="shortcuts_settings_category">Atalhos</string>
     <string name="shortcuts_onetap_enabled_title">Atalho com um toque</string>
     <string name="shortcuts_onetap_enabled_summary">Mostrar atalho \"Escanear + Excluir\" ao pressionar e segurar o ícone do aplicativo. Usa as mesmas ferramentas que um toque.</string>
+
+    <!-- Debug card (dashboard) -->
+    <string name="debug_card_title">Modo de depuração está habilitado</string>
+    <string name="debug_card_trace_mode_label">Ativar modo de rastreamento</string>
+    <string name="debug_card_dryrun_mode_label">Modo de teste (desabilitar exclusão)</string>
+    <string name="debug_card_areas_reload_action">Recarregar áreas de dados</string>
+    <string name="debug_card_pkgs_reload_action">Recarregar aplicativos</string>
+    <string name="debug_card_root_test_action">Testar root</string>
+    <string name="debug_card_shizuku_test_action">Testar Shizuku</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -823,4 +823,12 @@
     <string name="shortcuts_settings_category">Ярлыки</string>
     <string name="shortcuts_onetap_enabled_title">Ярлык в одно нажатие</string>
     <string name="shortcuts_onetap_enabled_summary">Показывать ярлык «Сканирование + Удаление» при удержании нажатия на значке приложения. Использует те же инструменты, что и панель управления в одно нажатие.</string>
+    <!-- Debug card (dashboard) -->
+    <string name="debug_card_title">Режим отладки включен</string>
+    <string name="debug_card_trace_mode_label">Включить режим трассировки</string>
+    <string name="debug_card_dryrun_mode_label">Режим пробного запуска (отключить удаление)</string>
+    <string name="debug_card_areas_reload_action">Перезагрузить области данных</string>
+    <string name="debug_card_pkgs_reload_action">Перезагрузить приложения</string>
+    <string name="debug_card_root_test_action">Проверить root</string>
+    <string name="debug_card_shizuku_test_action">Проверить Shizuku</string>
 </resources>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -685,4 +685,12 @@
     <string name="area_type_public_obb_label">ทรัพยากรแอพสาธารณะ</string>
     <string name="area_type_private_data_label">ข้อมูลแอพส่วนตัว</string>
     <string name="area_type_portable_label">พื้นที่จัดเก็บแบบพกพา</string>
+    <!-- Debug card (dashboard) -->
+    <string name="debug_card_title">เปิดใช้งานโหมดดีบัก</string>
+    <string name="debug_card_trace_mode_label">เปิดใช้งานโหมดติดตาม</string>
+    <string name="debug_card_dryrun_mode_label">โหมดทดลอง (ปิดใช้งานการลบ)</string>
+    <string name="debug_card_areas_reload_action">โหลดข้อมูลพื้นที่ใหม่</string>
+    <string name="debug_card_pkgs_reload_action">โหลดแอพใหม่</string>
+    <string name="debug_card_root_test_action">ทดสอบ root</string>
+    <string name="debug_card_shizuku_test_action">ทดสอบ Shizuku</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -760,4 +760,12 @@
     <string name="shortcuts_settings_category">Kısayollar</string>
     <string name="shortcuts_onetap_enabled_title">Tek dokunuş kısayolu</string>
     <string name="shortcuts_onetap_enabled_summary">Uygulama simgesine uzun basıldığında \"Tara + Sil\" kısayolunu gösterir. Tek dokunuşla kontrol paneliyle aynı araçları kullanır.</string>
+    <!-- Debug card (dashboard) -->
+    <string name="debug_card_title">Hata ayıklama modu etkinleştirildi</string>
+    <string name="debug_card_trace_mode_label">İzleme modunu etkinleştir</string>
+    <string name="debug_card_dryrun_mode_label">Deneme modu (silmeyi devre dışı bırak)</string>
+    <string name="debug_card_areas_reload_action">Veri alanlarını yeniden yükle</string>
+    <string name="debug_card_pkgs_reload_action">Uygulamaları yeniden yükle</string>
+    <string name="debug_card_root_test_action">Root\'u test et</string>
+    <string name="debug_card_shizuku_test_action">Shizuku\'yu test et</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -805,4 +805,13 @@
     <string name="shortcuts_settings_category">Швидкі клавіші</string>
     <string name="shortcuts_onetap_enabled_title">Швидкий доступ одним дотиком</string>
     <string name="shortcuts_onetap_enabled_summary">Показувати ярлик «Сканувати + Видалити» при довгому натисканні на значок додатка. Використовує ті ж інструменти, що й панель керування одним дотиком.</string>
+
+    <!-- Debug card (dashboard) -->
+    <string name="debug_card_title">Режим відладки увімкнено</string>
+    <string name="debug_card_trace_mode_label">Увімкнути режим трасування</string>
+    <string name="debug_card_dryrun_mode_label">Режим пробного запуску (відключити видалення)</string>
+    <string name="debug_card_areas_reload_action">Перезавантажити області даних</string>
+    <string name="debug_card_pkgs_reload_action">Перезавантажити додатки</string>
+    <string name="debug_card_root_test_action">Тест root</string>
+    <string name="debug_card_shizuku_test_action">Тест Shizuku</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -727,4 +727,12 @@
     <string name="shortcuts_settings_category">Phím tắt</string>
     <string name="shortcuts_onetap_enabled_title">Phím tắt một chạm</string>
     <string name="shortcuts_onetap_enabled_summary">Hiển thị phím tắt \"Quét + Xóa\" khi nhấn và giữ biểu tượng ứng dụng. Sử dụng các công cụ tương tự như bảng điều khiển một chạm.</string>
+    <!-- Debug card (dashboard) -->
+    <string name="debug_card_title">Chế độ gỡ lỗi đã được bật</string>
+    <string name="debug_card_trace_mode_label">Bật chế độ theo dõi</string>
+    <string name="debug_card_dryrun_mode_label">Chế độ thử nghiệm (tắt xóa)</string>
+    <string name="debug_card_areas_reload_action">Tải lại vùng dữ liệu</string>
+    <string name="debug_card_pkgs_reload_action">Tải lại ứng dụng</string>
+    <string name="debug_card_root_test_action">Kiểm tra root</string>
+    <string name="debug_card_shizuku_test_action">Kiểm tra Shizuku</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -723,5 +723,13 @@
     <string name="shortcut_onetap_long">一键扫描并删除</string>
     <string name="shortcuts_settings_category">快捷键</string>
     <string name="shortcuts_onetap_enabled_title">一键快捷方式</string>
-    <string name="shortcuts_onetap_enabled_summary">长按应用图标时显示“扫描+删除”快捷键。使用与一键控制面板相同的工具。</string>
+    <string name="shortcuts_onetap_enabled_summary">长按应用图标时显示"扫描+删除"快捷键。使用与一键控制面板相同的工具。</string>
+    <!-- Debug card (dashboard) -->
+    <string name="debug_card_title">调试模式已启用</string>
+    <string name="debug_card_trace_mode_label">启用跟踪模式</string>
+    <string name="debug_card_dryrun_mode_label">演练模式（禁用删除）</string>
+    <string name="debug_card_areas_reload_action">重载数据区域</string>
+    <string name="debug_card_pkgs_reload_action">重载应用</string>
+    <string name="debug_card_root_test_action">测试 Root</string>
+    <string name="debug_card_shizuku_test_action">测试 Shizuku</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -727,4 +727,12 @@
     <string name="shortcuts_settings_category">捷徑</string>
     <string name="shortcuts_onetap_enabled_title">一鍵捷徑</string>
     <string name="shortcuts_onetap_enabled_summary">長按應用程式圖示時顯示「掃描 + 刪除」捷徑。使用與一鍵式儀表板相同的工具。</string>
+    <!-- Debug card (dashboard) -->
+    <string name="debug_card_title">Debug 模式已啟用</string>
+    <string name="debug_card_trace_mode_label">啟用 trace 模式</string>
+    <string name="debug_card_dryrun_mode_label">Dry-run 模式（停用刪除）</string>
+    <string name="debug_card_areas_reload_action">重新載入資料區域</string>
+    <string name="debug_card_pkgs_reload_action">重新載入應用程式</string>
+    <string name="debug_card_root_test_action">測試 root</string>
+    <string name="debug_card_shizuku_test_action">測試 Shizuku</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -203,6 +203,14 @@
     <string name="debug_mode_explanation">Enable test options and more verbose output. App will run slower and perform differently.</string>
     <string name="debug_bugreporter_label">Automatic bug reports</string>
     <string name="debug_bugreporter_summary">Automatically reports issues, e.g. details on the app crashes so I can figure out why and fix it.</string>
+    <!-- Debug card (dashboard) -->
+    <string name="debug_card_title">Debug mode is enabled</string>
+    <string name="debug_card_trace_mode_label">Enable trace mode</string>
+    <string name="debug_card_dryrun_mode_label">Dry-run mode (disable deletion)</string>
+    <string name="debug_card_areas_reload_action">Reload data areas</string>
+    <string name="debug_card_pkgs_reload_action">Reload apps</string>
+    <string name="debug_card_root_test_action">Test root</string>
+    <string name="debug_card_shizuku_test_action">Test Shizuku</string>
 
     <string name="settings_category_tools_label">Tools</string>
     <string name="settings_category_filter">Filter</string>


### PR DESCRIPTION
Extract hardcoded strings from the debug card UI to strings.xml for localization support. Includes translations for 20 languages.

Dev-only buttons (Run tests, View log, Start ACS debug) remain hardcoded as they are hidden in release builds.

Closes #2012