### PR TITLE
General: Fix minimum size input in Korean and other locales

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/common/ui/SizeParser.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/ui/SizeParser.kt
@@ -15,9 +15,11 @@ class SizeParser(private val context: Context) {
         )
     }
     private val sizeUnitsLocalized by lazy {
-        val unitDelimiterRegex = Regex("\\s")
+        // Extract trailing letters/dots as the unit, handles locales without space between number and unit
+        val unitRegex = Regex("""[\p{L}.]+$""")
         val sizeSplitter: (Long, String) -> Pair<String, Long> = { size, fallback ->
-            val unit = Formatter.formatShortFileSize(context, size).split(unitDelimiterRegex).lastOrNull() ?: fallback
+            val formatted = Formatter.formatShortFileSize(context, size)
+            val unit = unitRegex.find(formatted)?.value ?: fallback
             unit.uppercase() to size
         }
         mapOf(

--- a/app/src/test/java/eu/darken/sdmse/common/ui/SizeParserArabicLocaleTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/common/ui/SizeParserArabicLocaleTest.kt
@@ -1,0 +1,41 @@
+package eu.darken.sdmse.common.ui
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class, qualifiers = "ar")
+class SizeParserArabicLocaleTest : BaseTest() {
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    private fun createParser(): SizeParser = SizeParser(context)
+
+    @Test
+    fun `parse with Arabic-Indic numerals`() {
+        val parser = createParser()
+        // Arabic-Indic numerals (٠١٢٣٤٥٦٧٨٩) with Arabic unit names
+        // Arabic units: بايت (B), كيلوبايت (KB), ميغابايت (MB), غيغابايت (GB)
+        parser.parse("١ ميغابايت") shouldBe 1_000_000L
+        parser.parse("١٠ ميغابايت") shouldBe 10_000_000L
+        parser.parse("١ميغابايت") shouldBe 1_000_000L
+    }
+
+    @Test
+    fun `parse with standard numerals and Arabic units`() {
+        val parser = createParser()
+        // Standard numerals with Arabic unit names
+        parser.parse("1 ميغابايت") shouldBe 1_000_000L
+        parser.parse("1ميغابايت") shouldBe 1_000_000L
+        parser.parse("1 كيلوبايت") shouldBe 1_000L
+        parser.parse("1 غيغابايت") shouldBe 1_000_000_000L
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/common/ui/SizeParserKoreanLocaleTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/common/ui/SizeParserKoreanLocaleTest.kt
@@ -1,0 +1,40 @@
+package eu.darken.sdmse.common.ui
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class, qualifiers = "ko")
+class SizeParserKoreanLocaleTest : BaseTest() {
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    private fun createParser(): SizeParser = SizeParser(context)
+
+    @Test
+    fun `parse standard units in Korean locale`() {
+        val parser = createParser()
+        // Should still work with standard unit abbreviations even in Korean locale
+        parser.parse("1 KB") shouldBe 1_000L
+        parser.parse("1KB") shouldBe 1_000L
+        parser.parse("1 MB") shouldBe 1_000_000L
+        parser.parse("1MB") shouldBe 1_000_000L
+        parser.parse("1 GB") shouldBe 1_000_000_000L
+        parser.parse("1GB") shouldBe 1_000_000_000L
+    }
+
+    @Test
+    fun `parse decimal in Korean locale`() {
+        val parser = createParser()
+        parser.parse("1.5 MB") shouldBe 1_500_000L
+        parser.parse("1.5MB") shouldBe 1_500_000L
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/common/ui/SizeParserRussianLocaleTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/common/ui/SizeParserRussianLocaleTest.kt
@@ -1,0 +1,39 @@
+package eu.darken.sdmse.common.ui
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class, qualifiers = "ru")
+class SizeParserRussianLocaleTest : BaseTest() {
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    private fun createParser(): SizeParser = SizeParser(context)
+
+    @Test
+    fun `parse Cyrillic units in Russian locale`() {
+        val parser = createParser()
+        // Russian locale uses Cyrillic unit abbreviations
+        parser.parse("1 МБ") shouldBe 1_000_000L
+        parser.parse("1МБ") shouldBe 1_000_000L
+        parser.parse("1 ГБ") shouldBe 1_000_000_000L
+        parser.parse("1ГБ") shouldBe 1_000_000_000L
+    }
+
+    @Test
+    fun `parse decimal with comma in Russian locale`() {
+        val parser = createParser()
+        // Russian uses comma as decimal separator
+        parser.parse("1,5 МБ") shouldBe 1_500_000L
+        parser.parse("1,5МБ") shouldBe 1_500_000L
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/common/ui/SizeParserTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/common/ui/SizeParserTest.kt
@@ -1,0 +1,127 @@
+package eu.darken.sdmse.common.ui
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class SizeParserTest : BaseTest() {
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    private fun createParser(): SizeParser = SizeParser(context)
+
+    @Test
+    fun `parse bytes with space`() {
+        val parser = createParser()
+        parser.parse("1 B") shouldBe 1L
+        parser.parse("100 B") shouldBe 100L
+    }
+
+    @Test
+    fun `parse bytes without space`() {
+        val parser = createParser()
+        parser.parse("1B") shouldBe 1L
+        parser.parse("100B") shouldBe 100L
+    }
+
+    @Test
+    fun `parse kilobytes with space`() {
+        val parser = createParser()
+        parser.parse("1 kB") shouldBe 1_000L
+        parser.parse("1 KB") shouldBe 1_000L
+        parser.parse("10 KB") shouldBe 10_000L
+    }
+
+    @Test
+    fun `parse kilobytes without space`() {
+        val parser = createParser()
+        parser.parse("1kB") shouldBe 1_000L
+        parser.parse("1KB") shouldBe 1_000L
+        parser.parse("10KB") shouldBe 10_000L
+    }
+
+    @Test
+    fun `parse megabytes with space`() {
+        val parser = createParser()
+        parser.parse("1 MB") shouldBe 1_000_000L
+        parser.parse("100 MB") shouldBe 100_000_000L
+    }
+
+    @Test
+    fun `parse megabytes without space`() {
+        val parser = createParser()
+        parser.parse("1MB") shouldBe 1_000_000L
+        parser.parse("100MB") shouldBe 100_000_000L
+    }
+
+    @Test
+    fun `parse gigabytes with space`() {
+        val parser = createParser()
+        parser.parse("1 GB") shouldBe 1_000_000_000L
+        parser.parse("10 GB") shouldBe 10_000_000_000L
+    }
+
+    @Test
+    fun `parse gigabytes without space`() {
+        val parser = createParser()
+        parser.parse("1GB") shouldBe 1_000_000_000L
+        parser.parse("10GB") shouldBe 10_000_000_000L
+    }
+
+    @Test
+    fun `parse decimal values with period`() {
+        val parser = createParser()
+        parser.parse("1.5 MB") shouldBe 1_500_000L
+        parser.parse("2.5 GB") shouldBe 2_500_000_000L
+        parser.parse("0.5 KB") shouldBe 500L
+    }
+
+    @Test
+    fun `parse decimal values without space`() {
+        val parser = createParser()
+        parser.parse("1.5MB") shouldBe 1_500_000L
+        parser.parse("2.5GB") shouldBe 2_500_000_000L
+    }
+
+    @Test
+    fun `parse with extra whitespace`() {
+        val parser = createParser()
+        parser.parse("  1 MB  ") shouldBe 1_000_000L
+        parser.parse("1  MB") shouldBe 1_000_000L
+    }
+
+    @Test
+    fun `case insensitive units`() {
+        val parser = createParser()
+        parser.parse("1 mb") shouldBe 1_000_000L
+        parser.parse("1 Mb") shouldBe 1_000_000L
+        parser.parse("1 mB") shouldBe 1_000_000L
+    }
+
+    @Test
+    fun `invalid input returns null`() {
+        val parser = createParser()
+        parser.parse("").shouldBeNull()
+        parser.parse("abc").shouldBeNull()
+        parser.parse("MB").shouldBeNull()
+        parser.parse("1").shouldBeNull()
+        parser.parse("1 XB").shouldBeNull()
+        parser.parse("1 TB").shouldBeNull() // TB not supported
+    }
+
+    @Test
+    fun `negative numbers are not parsed`() {
+        val parser = createParser()
+        parser.parse("-1 MB").shouldBeNull()
+    }
+}


### PR DESCRIPTION
When extracting size units from Formatter.formatShortFileSize(), the code split by whitespace which failed for locales where no space exists between number and unit (e.g., "1KB" instead of "1 KB").

Changed to use regex extraction of trailing letters to reliably get the unit regardless of locale formatting.

Added unit tests for English, Korean, Russian (Cyrillic), and Arabic (Arabic-Indic numerals) locales.

Fixes #1813