### PR TITLE
Scheduler: Fix scheduled tasks shifting by 1 hour after DST transitions

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/scheduler/ui/manager/SchedulerManagerViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/scheduler/ui/manager/SchedulerManagerViewModel.kt
@@ -39,6 +39,7 @@ import kotlinx.coroutines.flow.take
 import java.time.Duration
 import java.time.Instant
 import java.time.LocalTime
+import java.time.ZoneId
 import java.util.UUID
 import javax.inject.Inject
 
@@ -121,8 +122,12 @@ class SchedulerManagerViewModel @Inject constructor(
                 onToggle = {
                     launch {
                         if (upgradeRepo.isPro()) {
+                            val enabling = !schedule.isEnabled
                             schedulerManager.saveSchedule(
-                                schedule.copy(scheduledAt = if (!schedule.isEnabled) Instant.now() else null)
+                                schedule.copy(
+                                    scheduledAt = if (enabling) Instant.now() else null,
+                                    userZone = if (enabling) ZoneId.systemDefault().id else schedule.userZone,
+                                )
                             )
                         } else {
                             MainDirections.goToUpgradeFragment().navigate()
@@ -185,6 +190,7 @@ class SchedulerManagerViewModel @Inject constructor(
             minute = now.minute,
             repeatInterval = Duration.ofDays(1),
             scheduledAt = Instant.now(),
+            userZone = ZoneId.systemDefault().id,
         )
         schedulerManager.saveSchedule(testSchedule)
     }

--- a/app/src/test/java/eu/darken/sdmse/scheduler/core/ScheduleTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/scheduler/core/ScheduleTest.kt
@@ -1,6 +1,7 @@
 package eu.darken.sdmse.scheduler.core
 
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import java.time.Duration
@@ -19,13 +20,13 @@ class ScheduleTest : BaseTest() {
         )
 
         schedule.calcFirstExecutionAt(
-            userZone = ZoneId.of("UTC")
+            zone = ZoneId.of("UTC")
         ) shouldBe Instant.parse("2022-01-01T22:00:00Z")
         schedule.calcFirstExecutionAt(
-            userZone = ZoneId.of("GMT+1")
+            zone = ZoneId.of("GMT+1")
         ) shouldBe Instant.parse("2022-01-01T21:00:00Z")
         schedule.calcFirstExecutionAt(
-            userZone = ZoneId.of("GMT-1")
+            zone = ZoneId.of("GMT-1")
         ) shouldBe Instant.parse("2022-01-01T23:00:00Z")
     }
 
@@ -39,7 +40,7 @@ class ScheduleTest : BaseTest() {
         )
 
         schedule.calcExecutionEta(
-            userZone = ZoneId.of("UTC"),
+            zone = ZoneId.of("UTC"),
             reschedule = false,
             now = Instant.parse("2022-01-01T12:00:00Z")
         ) shouldBe Duration.ofHours(10)
@@ -55,7 +56,7 @@ class ScheduleTest : BaseTest() {
         )
 
         schedule.calcExecutionEta(
-            userZone = ZoneId.of("GMT+1"),
+            zone = ZoneId.of("GMT+1"),
             reschedule = false,
             now = Instant.parse("2022-01-01T12:00:00Z")
         ) shouldBe Duration.ofHours(9)
@@ -70,7 +71,7 @@ class ScheduleTest : BaseTest() {
             scheduledAt = Instant.parse("2022-01-01T22:00:00Z")
         )
         schedule.calcExecutionEta(
-            userZone = ZoneId.of("UTC"),
+            zone = ZoneId.of("UTC"),
             reschedule = false,
             now = Instant.parse("2022-01-01T22:00:00Z")
         ) shouldBe Duration.ofMinutes(2)
@@ -85,7 +86,7 @@ class ScheduleTest : BaseTest() {
             scheduledAt = Instant.parse("2022-01-01T22:00:00Z")
         )
         schedule.calcExecutionEta(
-            userZone = ZoneId.of("GMT-1"),
+            zone = ZoneId.of("GMT-1"),
             reschedule = false,
             now = Instant.parse("2022-01-01T22:00:00Z")
         ) shouldBe Duration.ofHours(1)
@@ -100,7 +101,7 @@ class ScheduleTest : BaseTest() {
             scheduledAt = Instant.parse("2022-01-01T22:00:00Z")
         )
         schedule.calcExecutionEta(
-            userZone = ZoneId.of("UTC"),
+            zone = ZoneId.of("UTC"),
             reschedule = false,
             now = Instant.parse("2022-01-01T22:00:00Z")
         ) shouldBe Duration.ofDays(1)
@@ -115,7 +116,7 @@ class ScheduleTest : BaseTest() {
             scheduledAt = Instant.parse("2022-01-01T22:00:00Z")
         )
         schedule.calcExecutionEta(
-            userZone = ZoneId.of("UTC"),
+            zone = ZoneId.of("UTC"),
             reschedule = false,
             now = Instant.parse("2022-01-01T22:01:00Z")
         ) shouldBe Duration.ofDays(1).minus(Duration.ofMinutes(1))
@@ -131,7 +132,7 @@ class ScheduleTest : BaseTest() {
         )
 
         schedule.calcExecutionEta(
-            userZone = ZoneId.of("UTC"),
+            zone = ZoneId.of("UTC"),
             reschedule = true,
             now = Instant.parse("2022-01-02T14:05:00Z")
         ) shouldBe Duration.ofHours(24).minusMinutes(5)
@@ -147,7 +148,7 @@ class ScheduleTest : BaseTest() {
         )
 
         schedule.calcExecutionEta(
-            userZone = ZoneId.of("UTC"),
+            zone = ZoneId.of("UTC"),
             reschedule = true,
             now = Instant.parse("2022-01-02T11:55:00Z")
         ) shouldBe Duration.ofHours(24).plusMinutes(5)
@@ -164,9 +165,220 @@ class ScheduleTest : BaseTest() {
 
         // 12 hour safety margin causes a reschedule to go to the next day
         schedule.calcExecutionEta(
-            userZone = ZoneId.of("GMT-1"),
+            zone = ZoneId.of("GMT-1"),
             reschedule = true,
             now = Instant.parse("2022-01-02T11:55:00Z")
         ) shouldBe Duration.ofHours(25).plusMinutes(5)
+    }
+
+    @Test fun `stored timezone is used for calculation`() {
+        // Schedule with stored timezone Europe/Berlin (UTC+1 in winter)
+        // User wants schedule at 22:00 Berlin time
+        val schedule = Schedule(
+            id = "id",
+            hour = 22,
+            minute = 0,
+            repeatInterval = Duration.ofDays(1),
+            scheduledAt = Instant.parse("2024-01-15T12:00:00Z"),
+            userZone = "Europe/Berlin",
+        )
+
+        // 22:00 Berlin (UTC+1) = 21:00 UTC
+        // Now is 12:00 UTC = 13:00 Berlin, so ETA to 22:00 Berlin (21:00 UTC) = 9 hours
+        schedule.calcExecutionEta(
+            now = Instant.parse("2024-01-15T12:00:00Z"),
+            reschedule = false,
+        ) shouldBe Duration.ofHours(9)
+    }
+
+    @Test fun `stored timezone differs from explicit zone parameter`() {
+        // Schedule stored with Europe/Berlin, but we pass UTC as explicit parameter
+        val schedule = Schedule(
+            id = "id",
+            hour = 22,
+            minute = 0,
+            repeatInterval = Duration.ofDays(1),
+            scheduledAt = Instant.parse("2024-01-15T12:00:00Z"),
+            userZone = "Europe/Berlin",
+        )
+
+        // When explicitly passing UTC, 22:00 UTC is used (not Berlin)
+        // Now is 12:00 UTC, ETA to 22:00 UTC = 10 hours
+        schedule.calcExecutionEta(
+            now = Instant.parse("2024-01-15T12:00:00Z"),
+            reschedule = false,
+            zone = ZoneId.of("UTC"),
+        ) shouldBe Duration.ofHours(10)
+
+        // Without explicit zone, stored Europe/Berlin is used
+        // 22:00 Berlin (UTC+1) = 21:00 UTC, ETA = 9 hours
+        schedule.calcExecutionEta(
+            now = Instant.parse("2024-01-15T12:00:00Z"),
+            reschedule = false,
+        ) shouldBe Duration.ofHours(9)
+    }
+
+    @Test fun `backward compatibility - null userZone uses provided zone parameter`() {
+        val schedule = Schedule(
+            id = "id",
+            hour = 22,
+            minute = 0,
+            repeatInterval = Duration.ofDays(1),
+            scheduledAt = Instant.parse("2022-01-01T12:00:00Z"),
+            userZone = null, // Legacy schedule without stored timezone
+        )
+
+        // Should work with explicitly provided zone
+        val eta = schedule.calcExecutionEta(
+            now = Instant.parse("2022-01-01T12:00:00Z"),
+            reschedule = false,
+            zone = ZoneId.of("UTC"),
+        )
+
+        eta shouldNotBe null
+        eta shouldBe Duration.ofHours(10)
+    }
+
+    @Test fun `backward compatibility - null userZone defaults to system timezone`() {
+        val schedule = Schedule(
+            id = "id",
+            hour = 22,
+            minute = 0,
+            repeatInterval = Duration.ofDays(1),
+            scheduledAt = Instant.parse("2022-01-01T12:00:00Z"),
+            userZone = null,
+        )
+
+        // Should not crash when using default parameter (system timezone)
+        val eta = schedule.calcExecutionEta(
+            now = Instant.parse("2022-01-01T12:00:00Z"),
+            reschedule = false,
+        )
+
+        eta shouldNotBe null
+    }
+
+    @Test fun `invalid stored timezone falls back gracefully`() {
+        val schedule = Schedule(
+            id = "id",
+            hour = 22,
+            minute = 0,
+            repeatInterval = Duration.ofDays(1),
+            scheduledAt = Instant.parse("2022-01-01T12:00:00Z"),
+            userZone = "Invalid/Timezone",
+        )
+
+        // Should not crash, falls back to system default
+        val eta = schedule.calcExecutionEta(
+            now = Instant.parse("2022-01-01T12:00:00Z"),
+            reschedule = false,
+        )
+
+        eta shouldNotBe null
+    }
+
+    // DST Tests - verify local time is preserved across daylight saving transitions
+
+    @Test fun `DST spring forward - local time preserved for daily schedule`() {
+        // Europe/Berlin DST: 2024-03-31 at 02:00 -> 03:00 (UTC+1 becomes UTC+2)
+        // Schedule at 10:00 Berlin time, daily interval
+        val schedule = Schedule(
+            id = "id",
+            hour = 10,
+            minute = 0,
+            repeatInterval = Duration.ofDays(1),
+            scheduledAt = Instant.parse("2024-03-30T08:00:00Z"), // March 30, before DST
+            userZone = "Europe/Berlin",
+        )
+
+        // Before DST (March 30): 10:00 Berlin = 09:00 UTC
+        // After DST (March 31): 10:00 Berlin = 08:00 UTC (1 hour earlier in UTC!)
+        // If using Duration.plus(24h), March 31 would run at 09:00 UTC = 11:00 Berlin (WRONG)
+        // With calendar arithmetic, it correctly runs at 08:00 UTC = 10:00 Berlin
+
+        // Query from March 31 at 07:00 UTC (= 09:00 Berlin, after DST)
+        val eta = schedule.calcExecutionEta(
+            now = Instant.parse("2024-03-31T07:00:00Z"),
+            reschedule = false,
+        )
+
+        // Should be 1 hour to reach 08:00 UTC (= 10:00 Berlin)
+        eta shouldBe Duration.ofHours(1)
+    }
+
+    @Test fun `DST fall back - local time preserved for daily schedule`() {
+        // Europe/Berlin DST: 2024-10-27 at 03:00 -> 02:00 (UTC+2 becomes UTC+1)
+        // Schedule at 10:00 Berlin time, daily interval
+        val schedule = Schedule(
+            id = "id",
+            hour = 10,
+            minute = 0,
+            repeatInterval = Duration.ofDays(1),
+            scheduledAt = Instant.parse("2024-10-26T07:00:00Z"), // Oct 26, before fall back
+            userZone = "Europe/Berlin",
+        )
+
+        // Before fall back (Oct 26): 10:00 Berlin = 08:00 UTC
+        // After fall back (Oct 27): 10:00 Berlin = 09:00 UTC (1 hour later in UTC!)
+        // If using Duration.plus(24h), Oct 27 would run at 08:00 UTC = 09:00 Berlin (WRONG)
+        // With calendar arithmetic, it correctly runs at 09:00 UTC = 10:00 Berlin
+
+        // Query from Oct 27 at 08:00 UTC (= 09:00 Berlin, after fall back)
+        val eta = schedule.calcExecutionEta(
+            now = Instant.parse("2024-10-27T08:00:00Z"),
+            reschedule = false,
+        )
+
+        // Should be 1 hour to reach 09:00 UTC (= 10:00 Berlin)
+        eta shouldBe Duration.ofHours(1)
+    }
+
+    @Test fun `DST spring forward - local time preserved for multi-day schedule`() {
+        // Schedule at 10:00 Berlin, 3-day interval, crossing DST
+        val schedule = Schedule(
+            id = "id",
+            hour = 10,
+            minute = 0,
+            repeatInterval = Duration.ofDays(3),
+            scheduledAt = Instant.parse("2024-03-28T08:00:00Z"), // March 28
+            userZone = "Europe/Berlin",
+        )
+
+        // March 28 (before DST): 10:00 Berlin = 09:00 UTC
+        // March 31 (after DST): 10:00 Berlin = 08:00 UTC
+        // 3 days later should still be at 10:00 Berlin local time
+
+        // Query from March 31 at 07:00 UTC (after DST transition)
+        val eta = schedule.calcExecutionEta(
+            now = Instant.parse("2024-03-31T07:00:00Z"),
+            reschedule = false,
+        )
+
+        // Should be 1 hour to reach 08:00 UTC (= 10:00 Berlin)
+        eta shouldBe Duration.ofHours(1)
+    }
+
+    @Test fun `DST - multiple weeks crossing transition`() {
+        // Schedule at 22:00 Berlin, weekly (7-day) interval
+        val schedule = Schedule(
+            id = "id",
+            hour = 22,
+            minute = 0,
+            repeatInterval = Duration.ofDays(7),
+            scheduledAt = Instant.parse("2024-03-24T20:00:00Z"), // March 24 (Sunday before DST)
+            userZone = "Europe/Berlin",
+        )
+
+        // March 24 (before DST): 22:00 Berlin = 21:00 UTC
+        // March 31 (after DST): 22:00 Berlin = 20:00 UTC
+
+        // Query from March 31 at 19:00 UTC (after DST)
+        val eta = schedule.calcExecutionEta(
+            now = Instant.parse("2024-03-31T19:00:00Z"),
+            reschedule = false,
+        )
+
+        // Should be 1 hour to reach 20:00 UTC (= 22:00 Berlin)
+        eta shouldBe Duration.ofHours(1)
     }
 }


### PR DESCRIPTION
Scheduled tasks now maintain correct local time across daylight saving time transitions. Previously, schedules set for 10:00 would shift to 11:00 (or 09:00) after DST changes.

The fix stores the user's timezone when enabling a schedule and uses calendar arithmetic (plusDays) instead of duration arithmetic (plus(Duration)) for time calculations. This ensures local time is preserved even when UTC offsets change.

Changes:
- Added userZone field to Schedule for storing timezone at enable time
- Changed from Duration to calendar arithmetic in calcExecutionEta
- Added resolveZone() helper with fallback for invalid/missing timezones
- Added DST-specific tests for spring forward and fall back scenarios

Closes #768