### PR TITLE
AppCleaner: Fix automation on HyperOS 2.x devices

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/hyperos/HyperOsLabels.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/hyperos/HyperOsLabels.kt
@@ -218,7 +218,12 @@ class HyperOsLabels @Inject constructor() : AppCleanerLabelSource {
 
     private fun getClearDataButtonLabelsDynamic(
         acsContext: AutomationExplorer.Context
-    ) = acsContext.getStrings(SETTINGS_PKG, setOf("app_manager_menu_clear_data"))
+    ) = acsContext.getStrings(SETTINGS_PKG, setOf(
+        "app_manager_menu_clear_data",
+        // HyperOS 2.x uses "Clear all data" instead of "Clear data"
+        // POCO/duchamp_global/duchamp:15/AP3A.240905.015.A2/OS2.0.207.0.VNLMIXM
+        "app_manager_clear_all_data",
+    ))
 
     private fun getClearDataButtonLabelsFallback(
         acsContext: AutomationExplorer.Context


### PR DESCRIPTION
The "Clear data" button label changed to "Clear all data" in HyperOS 2.x. Add the new resource key `app_manager_clear_all_data` to the dynamic lookup so automation can find the button on newer devices.

Tested on: POCO/duchamp_global/duchamp:15/AP3A.240905.015.A2/OS2.0.207.0.VNLMIXM

Closes #2055