### PR TITLE
build: Bump Navigation from 2.9.3 to 2.9.6

### DIFF
--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -10,7 +10,7 @@ object Versions {
 
     object AndroidX {
         object Navigation {
-            const val core = "2.9.3"
+            const val core = "2.9.6"
         }
     }
 


### PR DESCRIPTION
Includes fixes for intermittent navigation failures caused by race conditions and timing issues in NavController.