### PR TITLE
General: Fix display cutout handling in landscape mode

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/common/EdgeToEdgeHelper.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/EdgeToEdgeHelper.kt
@@ -25,11 +25,12 @@ class EdgeToEdgeHelper(activity: Activity) {
         ViewCompat.setOnApplyWindowInsetsListener(view) { v: View, insets: WindowInsetsCompat ->
             if (Bugs.isTrace) log(tag, VERBOSE) { "Applying padding insets to $v" }
             val systemBars: Insets = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            val displayCutout: Insets = insets.getInsets(WindowInsetsCompat.Type.displayCutout())
             v.setPadding(
-                if (left) systemBars.left else v.paddingLeft,
-                if (top) systemBars.top else v.paddingTop,
-                if (right) systemBars.right else v.paddingRight,
-                if (bottom) systemBars.bottom else v.paddingBottom,
+                if (left) maxOf(systemBars.left, displayCutout.left) else v.paddingLeft,
+                if (top) maxOf(systemBars.top, displayCutout.top) else v.paddingTop,
+                if (right) maxOf(systemBars.right, displayCutout.right) else v.paddingRight,
+                if (bottom) maxOf(systemBars.bottom, displayCutout.bottom) else v.paddingBottom,
             )
             insets
         }


### PR DESCRIPTION
## Summary

- Fix UI content being obscured by camera cutouts (notches/punch-holes) in landscape orientation
- `EdgeToEdgeHelper.insetsPadding()` now considers both `systemBars()` and `displayCutout()` insets
- Uses `maxOf()` to select the larger value for each edge, ensuring proper padding when `systemBars()` returns 0 for the cutout edge

## Test plan

- [x] Build `./gradlew assembleFossDebug` passes
- [x] Tested on device with display cutout in landscape orientation
- [x] UI content no longer obscured by cutout