### PR TITLE
General: Update Gradle wrapper to 9.3.0

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
-#Thu May 11 11:11:29 CEST 2023
+#Tue Jan 20 11:53:55 CET 2026
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionSha256Sum=0d585f69da091fc5b2beced877feab55a3064d43b8a1d46aeb07996b0915e0e0
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary
- Update Gradle wrapper from 9.1.0 to 9.3.0

## Gradle 9.3.0 Highlights
- Test reporting improvements
- Error and warning improvements
- Build authoring improvements

See [release notes](https://docs.gradle.org/9.3.0/release-notes.html) for full details.

## Test plan
- [x] Verified `./gradlew --version` runs successfully with new version