### PR TITLE
Deduplicator: Show both total and freeable size in cluster cards

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/deduplicator/ui/details/cluster/elements/ClusterHeaderVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/ui/details/cluster/elements/ClusterHeaderVH.kt
@@ -37,7 +37,13 @@ class ClusterHeaderVH(parent: ViewGroup) :
             cluster.groups.filterIsInstance<PHashDuplicate.Group>().sumOf { it.count }
         )
 
-        sizeValue.text = Formatter.formatShortFileSize(context, cluster.totalSize)
+        val totalSize = Formatter.formatShortFileSize(context, cluster.totalSize)
+        val freeable = context.getQuantityString2(
+            eu.darken.sdmse.common.R.plurals.x_space_can_be_freed,
+            1,
+            Formatter.formatShortFileSize(context, cluster.redundantSize),
+        )
+        sizeValue.text = "$totalSize ($freeable)"
 
         deleteAction.setOnClickListener { item.onDeleteAllClicked(item) }
         excludeAction.setOnClickListener { item.onExcludeClicked(item) }

--- a/app/src/main/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListGridVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListGridVH.kt
@@ -43,7 +43,13 @@ class DeduplicatorListGridVH(parent: ViewGroup) :
             }
         }
 
-        primary.text = Formatter.formatShortFileSize(context, cluster.totalSize)
+        val totalSize = Formatter.formatShortFileSize(context, cluster.totalSize)
+        val freeable = context.getQuantityString2(
+            eu.darken.sdmse.common.R.plurals.x_space_can_be_freed,
+            1,
+            Formatter.formatShortFileSize(context, cluster.redundantSize),
+        )
+        primary.text = "$totalSize ($freeable)"
         secondary.text = context.getQuantityString2(eu.darken.sdmse.common.R.plurals.result_x_items, cluster.count)
 
         matchTypeChecksum.isVisible = item.cluster.types.contains(Duplicate.Type.CHECKSUM)

--- a/app/src/main/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListLinearVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListLinearVH.kt
@@ -53,7 +53,13 @@ class DeduplicatorListLinearVH(parent: ViewGroup) :
             setOnClickListener { item.onPreviewClicked(item) }
         }
 
-        primary.text = Formatter.formatShortFileSize(context, cluster.totalSize)
+        val totalSize = Formatter.formatShortFileSize(context, cluster.totalSize)
+        val freeable = context.getQuantityString2(
+            eu.darken.sdmse.common.R.plurals.x_space_can_be_freed,
+            1,
+            Formatter.formatShortFileSize(context, cluster.redundantSize),
+        )
+        primary.text = "$totalSize ($freeable)"
         secondary.text = context.getQuantityString2(eu.darken.sdmse.common.R.plurals.result_x_items, cluster.count)
 
         matchTypeChecksum.isVisible = item.cluster.types.contains(Duplicate.Type.CHECKSUM)


### PR DESCRIPTION
## Summary
- Cluster cards now display both total size and freeable space
- Format: "12GB (8GB can be freed)"
- Uses existing localized `x_space_can_be_freed` string

## Test plan
- [x] Open Deduplicator and scan for duplicates
- [x] Verify cluster cards show format "X (Y can be freed)"
- [x] Verify the detail view header also shows the new format

Closes #2044