### PR TITLE
Deduplicator: Add "Prefer keeping in" feature for automatic duplicate selection

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/deduplicator/core/DeduplicatorSettings.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/core/DeduplicatorSettings.kt
@@ -41,6 +41,13 @@ class DeduplicatorSettings @Inject constructor(
         @Json(name = "paths") val paths: Set<APath> = emptySet(),
     )
 
+    val keepPreferPaths = dataStore.createValue("arbiter.keep.prefer.paths", KeepPreferPaths(), moshi)
+
+    @JsonClass(generateAdapter = true)
+    data class KeepPreferPaths(
+        @Json(name = "paths") val paths: Set<APath> = emptySet(),
+    )
+
     val layoutMode = dataStore.createValue("ui.list.layoutmode", LayoutMode.GRID, moshi)
 
     override val mapper = PreferenceStoreMapper(
@@ -50,6 +57,7 @@ class DeduplicatorSettings @Inject constructor(
         isSleuthChecksumEnabled,
         isSleuthPHashEnabled,
         scanPaths,
+        keepPreferPaths,
     )
 
     companion object {

--- a/app/src/main/java/eu/darken/sdmse/deduplicator/core/arbiter/ArbiterCriterium.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/core/arbiter/ArbiterCriterium.kt
@@ -1,5 +1,7 @@
 package eu.darken.sdmse.deduplicator.core.arbiter
 
+import eu.darken.sdmse.common.files.APath
+
 sealed interface ArbiterCriterium {
 
     sealed interface Mode
@@ -57,4 +59,8 @@ sealed interface ArbiterCriterium {
             PREFER_SMALLER,
         }
     }
+
+    data class PreferredPath(
+        val keepPreferPaths: Set<APath> = emptySet(),
+    ) : ArbiterCriterium
 }

--- a/app/src/main/java/eu/darken/sdmse/deduplicator/core/arbiter/checks/PreferredPathCheck.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/core/arbiter/checks/PreferredPathCheck.kt
@@ -1,0 +1,50 @@
+package eu.darken.sdmse.deduplicator.core.arbiter.checks
+
+import dagger.Reusable
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.files.isDescendantOf
+import eu.darken.sdmse.deduplicator.core.Duplicate
+import eu.darken.sdmse.deduplicator.core.arbiter.ArbiterCheck
+import eu.darken.sdmse.deduplicator.core.arbiter.ArbiterCriterium
+import javax.inject.Inject
+
+@Reusable
+class PreferredPathCheck @Inject constructor() : ArbiterCheck {
+    suspend fun favorite(
+        before: List<Duplicate>,
+        criterium: ArbiterCriterium.PreferredPath,
+    ): List<Duplicate> {
+        if (criterium.keepPreferPaths.isEmpty()) {
+            log(TAG, VERBOSE) { "No keepPreferPaths configured, returning unchanged" }
+            return before
+        }
+
+        log(TAG) { "keepPreferPaths: ${criterium.keepPreferPaths}" }
+
+        // Files IN configured paths sort first (kept); files NOT in configured paths sort last (deleted)
+        val sorted = before.sortedBy { duplicate ->
+            val isInKeepPreferPath = criterium.keepPreferPaths.any { preferPath ->
+                val isDescendant = duplicate.path.isDescendantOf(preferPath)
+                val isEqual = duplicate.path == preferPath
+                log(TAG, VERBOSE) {
+                    "Check: ${duplicate.path} vs $preferPath -> isDescendant=$isDescendant, isEqual=$isEqual"
+                }
+                isDescendant || isEqual
+            }
+            val sortKey = if (isInKeepPreferPath) 0 else 1
+            log(TAG, VERBOSE) { "${duplicate.path} -> isInKeepPreferPath=$isInKeepPreferPath, sortKey=$sortKey" }
+            sortKey
+        }
+
+        log(TAG) { "Before: ${before.map { it.path }}" }
+        log(TAG) { "After:  ${sorted.map { it.path }}" }
+
+        return sorted
+    }
+
+    companion object {
+        private val TAG = logTag("Deduplicator", "Arbiter", "PreferredPathCheck")
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/deduplicator/ui/settings/DeduplicatorSettingsFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/ui/settings/DeduplicatorSettingsFragment.kt
@@ -36,6 +36,9 @@ class DeduplicatorSettingsFragment : PreferenceFragment2() {
     private val searchLocationsPref: Preference2
         get() = findPreference("scan.location.paths")!!
 
+    private val keepPreferPathsPref: Preference2
+        get() = findPreference("arbiter.keep.prefer.paths")!!
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         vm.state.observe2(this) { state ->
             log(TAG) { "Updating state: $state" }
@@ -64,6 +67,31 @@ class DeduplicatorSettingsFragment : PreferenceFragment2() {
                     true
                 }
             }
+            keepPreferPathsPref.apply {
+                summary = if (state.keepPreferPaths.isEmpty()) {
+                    getString(R.string.deduplicator_keep_prefer_paths_none_summary)
+                } else {
+                    state.keepPreferPaths.joinToString("\n") {
+                        it.userReadablePath.get(requireContext())
+                    }
+                }
+                setOnPreferenceClickListener {
+                    MainDirections.goToPicker(
+                        PickerRequest(
+                            requestKey = keepPreferPathsPref.key,
+                            mode = PickerRequest.PickMode.DIRS,
+                            allowedAreas = setOf(
+                                DataArea.Type.PORTABLE,
+                                DataArea.Type.SDCARD,
+                                DataArea.Type.PUBLIC_DATA,
+                                DataArea.Type.PUBLIC_MEDIA
+                            ),
+                            selectedPaths = state.keepPreferPaths
+                        )
+                    ).navigate()
+                    true
+                }
+            }
         }
         super.onViewCreated(view, savedInstanceState)
 
@@ -78,6 +106,18 @@ class DeduplicatorSettingsFragment : PreferenceFragment2() {
                 paths = pickerResult.selectedPaths,
             )
         }
+
+        requireParentFragment().parentFragmentManager.setFragmentResultListener(
+            keepPreferPathsPref.key,
+            viewLifecycleOwner
+        ) { requestKey, result ->
+            log(TAG) { "Fragment result $requestKey=$result" }
+            val pickerResult = PickerResult.fromBundle(result)
+            log(TAG, INFO) { "Picker result: $pickerResult" }
+            settings.keepPreferPaths.valueBlocking = DeduplicatorSettings.KeepPreferPaths(
+                paths = pickerResult.selectedPaths,
+            )
+        }
     }
 
     override fun onPreferencesCreated() {
@@ -85,6 +125,11 @@ class DeduplicatorSettingsFragment : PreferenceFragment2() {
 
         searchLocationsPref.setOnLongClickListener {
             vm.resetScanPaths()
+            true
+        }
+
+        keepPreferPathsPref.setOnLongClickListener {
+            vm.resetKeepPreferPaths()
             true
         }
 

--- a/app/src/main/java/eu/darken/sdmse/deduplicator/ui/settings/DeduplicatorSettingsViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/ui/settings/DeduplicatorSettingsViewModel.kt
@@ -27,11 +27,13 @@ class DeduplicatorSettingsViewModel @Inject constructor(
         deduplicator.state,
         upgradeRepo.upgradeInfo.map { it.isPro },
         settings.scanPaths.flow,
-    ) { state, isPro, scanPaths ->
+        settings.keepPreferPaths.flow,
+    ) { state, isPro, scanPaths, keepPreferPaths ->
         State(
             isPro = isPro,
             state = state,
-            scanPaths = scanPaths.paths.sortedBy { it.path }
+            scanPaths = scanPaths.paths.sortedBy { it.path },
+            keepPreferPaths = keepPreferPaths.paths.sortedBy { it.path },
         )
     }.asLiveData2()
 
@@ -39,11 +41,17 @@ class DeduplicatorSettingsViewModel @Inject constructor(
         val state: Deduplicator.State,
         val isPro: Boolean,
         val scanPaths: List<APath>,
+        val keepPreferPaths: List<APath>,
     )
 
     fun resetScanPaths() = launch {
         log(TAG) { "resetScanPaths()" }
         settings.scanPaths.value(DeduplicatorSettings.ScanPaths())
+    }
+
+    fun resetKeepPreferPaths() = launch {
+        log(TAG) { "resetKeepPreferPaths()" }
+        settings.keepPreferPaths.value(DeduplicatorSettings.KeepPreferPaths())
     }
 
     companion object {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -491,6 +491,9 @@
     <string name="deduplicator_protection_deleteall_allowed_summary">Show options that allow you to delete all files in a set of duplicates so that no file is left over.</string>
     <string name="deduplicator_search_locations_title">Search locations</string>
     <string name="deduplicator_search_locations_all_summary">All accessible areas</string>
+    <string name="deduplicator_keep_prefer_paths_title">Prefer keeping in</string>
+    <string name="deduplicator_keep_prefer_paths_summary">When deciding which duplicate to keep, prefer keeping files in these locations.</string>
+    <string name="deduplicator_keep_prefer_paths_none_summary">No locations configured</string>
     <string name="deduplicator_skip_minsize_title">Minimum size</string>
     <string name="deduplicator_skip_minsize_description">Skip files that are below the minimum size.</string>
     <string name="deduplicator_skip_uncommon_title">Skip uncommon file types</string>

--- a/app/src/main/res/xml/preferences_deduplicator.xml
+++ b/app/src/main/res/xml/preferences_deduplicator.xml
@@ -9,6 +9,13 @@
         app:singleLineTitle="false"
         app:title="@string/deduplicator_search_locations_title" />
 
+    <eu.darken.sdmse.common.preferences.Preference2
+        app:icon="@drawable/ic_folder_home_24"
+        app:key="arbiter.keep.prefer.paths"
+        app:persistent="false"
+        app:singleLineTitle="false"
+        app:title="@string/deduplicator_keep_prefer_paths_title" />
+
     <CheckBoxPreference
         app:icon="@drawable/ic_numeric_0_box_24"
         app:key="protection.deleteall.allowed"

--- a/app/src/test/java/eu/darken/sdmse/deduplicator/core/DeduplicatorSettingsSerializationTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/deduplicator/core/DeduplicatorSettingsSerializationTest.kt
@@ -1,0 +1,45 @@
+package eu.darken.sdmse.deduplicator.core
+
+import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.serialization.SerializationAppModule
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.json.toComparableJson
+
+class DeduplicatorSettingsSerializationTest : BaseTest() {
+    private val moshi = SerializationAppModule().moshi()
+
+    @Test
+    fun `KeepPreferPaths serialization roundtrip`() {
+        val original = DeduplicatorSettings.KeepPreferPaths(
+            paths = setOf(
+                LocalPath.build("storage", "emulated", "0", "Pictures"),
+                LocalPath.build("storage", "emulated", "0", "DCIM"),
+            )
+        )
+
+        val adapter = moshi.adapter(DeduplicatorSettings.KeepPreferPaths::class.java)
+        val json = adapter.toJson(original)
+
+        json.toComparableJson() shouldBe """
+            {
+                "paths": [
+                    {"file": "/storage/emulated/0/Pictures", "pathType": "LOCAL"},
+                    {"file": "/storage/emulated/0/DCIM", "pathType": "LOCAL"}
+                ]
+            }
+        """.toComparableJson()
+
+        adapter.fromJson(json) shouldBe original
+    }
+
+    @Test
+    fun `KeepPreferPaths empty paths`() {
+        val original = DeduplicatorSettings.KeepPreferPaths()
+        val adapter = moshi.adapter(DeduplicatorSettings.KeepPreferPaths::class.java)
+
+        val json = adapter.toJson(original)
+        adapter.fromJson(json) shouldBe original
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/deduplicator/core/DuplicatesArbiterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/deduplicator/core/DuplicatesArbiterTest.kt
@@ -1,41 +1,55 @@
 package eu.darken.sdmse.deduplicator.core
 
+import eu.darken.sdmse.deduplicator.core.arbiter.ArbiterStrategy
 import eu.darken.sdmse.deduplicator.core.arbiter.DuplicatesArbiter
 import eu.darken.sdmse.deduplicator.core.arbiter.checks.DuplicateTypeCheck
 import eu.darken.sdmse.deduplicator.core.arbiter.checks.LocationCheck
 import eu.darken.sdmse.deduplicator.core.arbiter.checks.MediaProviderCheck
 import eu.darken.sdmse.deduplicator.core.arbiter.checks.ModificationCheck
 import eu.darken.sdmse.deduplicator.core.arbiter.checks.NestingCheck
+import eu.darken.sdmse.deduplicator.core.arbiter.checks.PreferredPathCheck
 import eu.darken.sdmse.deduplicator.core.arbiter.checks.SizeCheck
 import eu.darken.sdmse.deduplicator.core.scanner.checksum.ChecksumDuplicate
 import eu.darken.sdmse.deduplicator.core.scanner.phash.PHashDuplicate
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 
 class DuplicatesArbiterTest : BaseTest() {
+    private val settings: DeduplicatorSettings = mockk<DeduplicatorSettings>().apply {
+        every { keepPreferPaths } returns mockk {
+            every { flow } returns flowOf(DeduplicatorSettings.KeepPreferPaths())
+        }
+    }
     private val duplicateTypeCheck = DuplicateTypeCheck()
     private val mediaProviderCheck: MediaProviderCheck = mockk()
     private val locationCheck: LocationCheck = mockk()
     private val nestingCheck: NestingCheck = mockk()
     private val modificationCheck: ModificationCheck = mockk()
     private val sizeCheck: SizeCheck = mockk()
+    private val preferredPathCheck = PreferredPathCheck()
 
     private fun create() = DuplicatesArbiter(
+        settings = settings,
         duplicateTypeCheck = duplicateTypeCheck,
         mediaProviderCheck = mediaProviderCheck,
         locationCheck = locationCheck,
         nestingCheck = nestingCheck,
         modificationCheck = modificationCheck,
         sizeCheck = sizeCheck,
+        preferredPathCheck = preferredPathCheck,
     )
 
     @Test
     fun `decide groups, require non empty groups`() = runTest {
+        val arbiter = create()
+        val strategy = arbiter.getStrategy()
         val group1 = ChecksumDuplicate.Group(
             identifier = Duplicate.Group.Id("TestID"),
             duplicates = emptySet(),
@@ -45,19 +59,23 @@ class DuplicatesArbiterTest : BaseTest() {
             duplicates = setOf(mockk()),
         )
         shouldThrow<IllegalArgumentException> {
-            create().decideGroups(setOf(group1, group2))
+            arbiter.decideGroups(setOf(group1, group2), strategy)
         }.message shouldContain "All groups must be non-empty!"
     }
 
     @Test
     fun `decide groups, require at least 1 group`() = runTest {
+        val arbiter = create()
+        val strategy = arbiter.getStrategy()
         shouldThrow<IllegalArgumentException> {
-            create().decideGroups(setOf())
+            arbiter.decideGroups(setOf(), strategy)
         }.message shouldContain "Must pass at least 1 group!"
     }
 
     @Test
     fun `decide groups`() = runTest {
+        val arbiter = create()
+        val strategy = arbiter.getStrategy()
         val group1 = ChecksumDuplicate.Group(
             identifier = Duplicate.Group.Id("TestID1"),
             duplicates = setOf(mockk()),
@@ -67,14 +85,16 @@ class DuplicatesArbiterTest : BaseTest() {
             duplicates = setOf(mockk()),
         )
 
-        create().decideGroups(setOf(group1, group2)) shouldBe (group1 to setOf(group2))
-        create().decideGroups(setOf(group2, group1)) shouldBe (group1 to setOf(group2))
+        arbiter.decideGroups(setOf(group1, group2), strategy) shouldBe (group1 to setOf(group2))
+        arbiter.decideGroups(setOf(group2, group1), strategy) shouldBe (group1 to setOf(group2))
     }
 
     @Test
     fun `decide duplicates, require at least 1 duplicate`() = runTest {
+        val arbiter = create()
+        val strategy = arbiter.getStrategy()
         shouldThrow<IllegalArgumentException> {
-            create().decideDuplicates(setOf())
+            arbiter.decideDuplicates(setOf(), strategy)
         }.message shouldContain "Must pass at least 1 duplicate!"
     }
 }

--- a/app/src/test/java/eu/darken/sdmse/deduplicator/core/DuplicatesDeleterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/deduplicator/core/DuplicatesDeleterTest.kt
@@ -5,6 +5,7 @@ import eu.darken.sdmse.common.files.APathLookup
 import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.local.LocalPath
 import eu.darken.sdmse.common.hashing.Hasher
+import eu.darken.sdmse.deduplicator.core.arbiter.ArbiterStrategy
 import eu.darken.sdmse.deduplicator.core.arbiter.DuplicatesArbiter
 import eu.darken.sdmse.deduplicator.core.deleter.DuplicatesDeleter
 import eu.darken.sdmse.deduplicator.core.scanner.checksum.ChecksumDuplicate
@@ -23,11 +24,12 @@ class DuplicatesDeleterTest : BaseTest() {
         coEvery { delete(any(), any()) } returns Unit
     }
     private val arbiter: DuplicatesArbiter = mockk<DuplicatesArbiter>().apply {
-        coEvery { decideGroups(any()) } answers {
+        coEvery { getStrategy() } returns ArbiterStrategy(criteria = emptyList())
+        coEvery { decideGroups(any(), any()) } answers {
             val groups = arg<Collection<Duplicate.Group>>(0)
             groups.first() to groups.drop(1).toSet()
         }
-        coEvery { decideDuplicates(any()) } answers {
+        coEvery { decideDuplicates(any(), any()) } answers {
             val dupes = arg<Collection<Duplicate>>(0).sortedBy { it.path.path }
             dupes.first() to dupes.drop(1).toSet()
         }

--- a/app/src/test/java/eu/darken/sdmse/deduplicator/core/checks/PreferredPathCheckTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/deduplicator/core/checks/PreferredPathCheckTest.kt
@@ -1,0 +1,109 @@
+package eu.darken.sdmse.deduplicator.core.checks
+
+import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.deduplicator.core.Duplicate
+import eu.darken.sdmse.deduplicator.core.arbiter.ArbiterCriterium
+import eu.darken.sdmse.deduplicator.core.arbiter.checks.PreferredPathCheck
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class PreferredPathCheckTest : BaseTest() {
+
+    private fun create() = PreferredPathCheck()
+
+    private val dupeInDownloads = mockk<Duplicate>().apply {
+        every { path } returns LocalPath.build("/storage/emulated/0/Download/file.txt")
+    }
+    private val dupeInAppFolder = mockk<Duplicate>().apply {
+        every { path } returns LocalPath.build("/storage/emulated/0/Android/data/com.app/files/file.txt")
+    }
+    private val dupeInPictures = mockk<Duplicate>().apply {
+        every { path } returns LocalPath.build("/storage/emulated/0/Pictures/file.txt")
+    }
+
+    @Test
+    fun `empty config returns list unchanged`() = runTest {
+        val input = listOf(dupeInDownloads, dupeInAppFolder)
+        create().favorite(
+            input,
+            ArbiterCriterium.PreferredPath(emptySet()),
+        ) shouldBe input
+    }
+
+    @Test
+    fun `files in configured paths sort first - kept`() = runTest {
+        val picturesPath = LocalPath.build("/storage/emulated/0/Pictures")
+
+        // dupeInPictures is in the keep-prefer path, so it should sort first (kept)
+        create().favorite(
+            listOf(dupeInDownloads, dupeInPictures),
+            ArbiterCriterium.PreferredPath(setOf(picturesPath)),
+        ) shouldBe listOf(dupeInPictures, dupeInDownloads)
+
+        // Order of input shouldn't matter
+        create().favorite(
+            listOf(dupeInPictures, dupeInDownloads),
+            ArbiterCriterium.PreferredPath(setOf(picturesPath)),
+        ) shouldBe listOf(dupeInPictures, dupeInDownloads)
+    }
+
+    @Test
+    fun `files outside configured paths sort last - deleted`() = runTest {
+        val picturesPath = LocalPath.build("/storage/emulated/0/Pictures")
+
+        // dupeInDownloads and dupeInAppFolder are NOT in keep-prefer path
+        // They should both sort after dupeInPictures
+        val result = create().favorite(
+            listOf(dupeInDownloads, dupeInAppFolder, dupeInPictures),
+            ArbiterCriterium.PreferredPath(setOf(picturesPath)),
+        )
+
+        // dupeInPictures should be first (kept)
+        result.first() shouldBe dupeInPictures
+        // dupeInDownloads and dupeInAppFolder should be after dupeInPictures
+        result.drop(1).toSet() shouldBe setOf(dupeInDownloads, dupeInAppFolder)
+    }
+
+    @Test
+    fun `multiple configured paths handled correctly`() = runTest {
+        val downloadPath = LocalPath.build("/storage/emulated/0/Download")
+        val picturesPath = LocalPath.build("/storage/emulated/0/Pictures")
+
+        // Both dupeInDownloads and dupeInPictures are in keep-prefer paths
+        val result = create().favorite(
+            listOf(dupeInDownloads, dupeInAppFolder, dupeInPictures),
+            ArbiterCriterium.PreferredPath(setOf(downloadPath, picturesPath)),
+        )
+
+        // dupeInAppFolder should be last (deleted)
+        result.last() shouldBe dupeInAppFolder
+    }
+
+    @Test
+    fun `nested paths handled correctly`() = runTest {
+        val parentPath = LocalPath.build("/storage/emulated/0")
+
+        // All files are under the parent path
+        val result = create().favorite(
+            listOf(dupeInDownloads, dupeInAppFolder, dupeInPictures),
+            ArbiterCriterium.PreferredPath(setOf(parentPath)),
+        )
+
+        // All files should be in keep-prefer path (sort first), so relative order is stable
+        result.size shouldBe 3
+    }
+
+    @Test
+    fun `exact path match handled correctly`() = runTest {
+        val exactPath = LocalPath.build("/storage/emulated/0/Pictures/file.txt")
+
+        create().favorite(
+            listOf(dupeInDownloads, dupeInPictures),
+            ArbiterCriterium.PreferredPath(setOf(exactPath)),
+        ) shouldBe listOf(dupeInPictures, dupeInDownloads)
+    }
+}


### PR DESCRIPTION
## Summary
Add "Prefer keeping in" feature that allows configuring which locations should be preserved when automatically deleting duplicates.

Closes #1731

## Use Case
Users with duplicate files in multiple locations (e.g., Downloads folder and app-specific folders) can now configure the deduplicator to automatically keep files in preferred locations while deleting copies elsewhere.

## Changes

### New Feature
- Added `PreferredPathCheck` arbiter criterion that prioritizes keeping files in user-configured paths
- Files matching preferred paths are sorted first (kept) while duplicates elsewhere are marked for deletion

### Implementation Details
- Reordered arbiter criteria so `PreferredPath` runs last (highest priority) to ensure it takes precedence
- Renamed setting from `deletePreferPaths` to `keepPreferPaths` for clarity
- Updated UI strings from "Prefer deleting from" to "Prefer keeping in"
- Optimized arbiter to snapshot strategy once per deletion operation instead of reading DataStore per duplicate group

## Test plan
- [x] Unit tests pass
- [x] Build succeeds
- [x] Manual testing: Configure "Prefer keeping in" with a path (e.g., SD card), verify files there are kept while copies elsewhere are deleted