### PR TITLE
General: Suppress deprecation and unchecked cast warnings

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -15,6 +15,7 @@
 - Add trailing commas for multi-line parameter lists and collections
 - When using `if` that is not single-line, always use brackets
 - Use `FlowCombineExtensions` instead of nesting multiple combine statements
+- Place `@Suppress` annotations as close as possible to the affected code (e.g., on a constructor or function, not the entire class)
 
 ## UI Patterns
 

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/LocalPathLookupExtendedIPCWrapper.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/LocalPathLookupExtendedIPCWrapper.kt
@@ -10,6 +10,7 @@ import eu.darken.sdmse.common.ipc.source
 data class LocalPathLookupExtendedIPCWrapper(
     val payload: List<LocalPathLookupExtended>,
 ) : Parcelable, IPCWrapper {
+    @Suppress("DEPRECATION", "UNCHECKED_CAST")
     constructor(parcel: Parcel) : this(
         parcel.readParcelableArray(LocalPathLookupExtended::class.java.classLoader)!!
             .toList() as List<LocalPathLookupExtended>

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/LocalPathLookupResult.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/LocalPathLookupResult.kt
@@ -12,6 +12,7 @@ sealed class LocalPathLookupResult : Parcelable {
     data class Success(
         val lookup: LocalPathLookup
     ) : LocalPathLookupResult() {
+        @Suppress("DEPRECATION")
         constructor(parcel: Parcel) : this(
             parcel.readParcelable(LocalPathLookup::class.java.classLoader)!!
         )

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/LocalPathLookupResultsIPCWrapper.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/LocalPathLookupResultsIPCWrapper.kt
@@ -6,6 +6,7 @@ import android.os.Parcelable
 data class LocalPathLookupResultsIPCWrapper(
     val payload: List<LocalPathLookupResult>,
 ) : Parcelable, IPCWrapper {
+    @Suppress("DEPRECATION", "UNCHECKED_CAST")
     constructor(parcel: Parcel) : this(
         parcel.readParcelableArray(LocalPathLookupResult::class.java.classLoader)!!
             .toList() as List<LocalPathLookupResult>

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/LocalPathLookupsIPCWrapper.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/LocalPathLookupsIPCWrapper.kt
@@ -10,6 +10,7 @@ import eu.darken.sdmse.common.ipc.source
 data class LocalPathLookupsIPCWrapper(
     val payload: List<LocalPathLookup>,
 ) : Parcelable, IPCWrapper {
+    @Suppress("DEPRECATION", "UNCHECKED_CAST")
     constructor(parcel: Parcel) : this(
         parcel.readParcelableArray(LocalPathLookup::class.java.classLoader)!!.toList() as List<LocalPathLookup>
     )

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/LocalPathsIPCWrapper.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/LocalPathsIPCWrapper.kt
@@ -11,6 +11,7 @@ import eu.darken.sdmse.common.ipc.source
 data class LocalPathsIPCWrapper(
     val payload: List<LocalPath>,
 ) : Parcelable, IPCWrapper {
+    @Suppress("DEPRECATION", "UNCHECKED_CAST")
     constructor(parcel: Parcel) : this(
         parcel.readParcelableArray(LocalPathLookup::class.java.classLoader)!!.toList() as List<LocalPath>
     )

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/container/LibraryPkg.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/container/LibraryPkg.kt
@@ -37,7 +37,8 @@ data class LibraryPkg(
             return rawId.toPkgId()
         }
 
-    @get:SuppressLint("NewApi", "DEPRECATION")
+    @Suppress("DEPRECATION")
+    @get:SuppressLint("NewApi")
     override val versionCode: Long
         get() = if (hasApiLevel(28)) {
             sharedLibraryInfo.longVersion

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/ipc/PackageInfoPayload.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/ipc/PackageInfoPayload.kt
@@ -14,6 +14,7 @@ import okio.Buffer
 data class PackageInfoPayload(
     val payload: List<PackageInfo>,
 ) : Parcelable {
+    @Suppress("DEPRECATION", "UNCHECKED_CAST")
     constructor(parcel: Parcel) : this(
         parcel.readParcelableArray(PackageInfo::class.java.classLoader)!!.toList() as List<PackageInfo>
     )

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/storage/StorageVolumeX.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/storage/StorageVolumeX.kt
@@ -17,6 +17,7 @@ import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.hasApiLevel
+import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parceler
 import kotlinx.parcelize.Parcelize
 import kotlinx.parcelize.TypeParceler
@@ -65,6 +66,7 @@ class StorageVolumeX(
     val isMounted: Boolean
         get() = volume.state == Environment.MEDIA_MOUNTED
 
+    @IgnoredOnParcel
     private val methodGetPath: Method? by lazy {
         try {
             volumeClass.getMethod("getPath")
@@ -82,6 +84,7 @@ class StorageVolumeX(
             directory?.path
         }
 
+    @IgnoredOnParcel
     private val methodGetPathFile: Method? by lazy {
         try {
             volumeClass.getMethod("getPathFile")
@@ -91,6 +94,7 @@ class StorageVolumeX(
         }
     }
 
+    @IgnoredOnParcel
     private val methodGetUserLabel: Method? by lazy {
         try {
             volumeClass.getMethod("getUserLabel")
@@ -108,6 +112,7 @@ class StorageVolumeX(
             null
         }
 
+    @IgnoredOnParcel
     private val methodGetDescription: Method? by lazy {
         try {
             volumeClass.getMethod("getDescription", Context::class.java)
@@ -133,6 +138,7 @@ class StorageVolumeX(
         }
     }
 
+    @IgnoredOnParcel
     private val methodGetOwner: Method? by lazy {
         try {
             volumeClass.getMethod("getOwner")
@@ -153,6 +159,7 @@ class StorageVolumeX(
             null
         }
 
+    @Suppress("DEPRECATION")
     fun createAccessIntent(directory: String? = null): Intent? {
         return volume.createAccessIntent(directory)
 //        return Intent(ACTION_OPEN_EXTERNAL_DIRECTORY).apply {
@@ -162,6 +169,7 @@ class StorageVolumeX(
     }
 
     val rootUri: Uri
+        @Suppress("DEPRECATION")
         @SuppressLint("NewApi")
         get() = if (hasApiLevel(29)) {
             volume.createOpenDocumentTreeIntent().getParcelableExtra(DocumentsContract.EXTRA_INITIAL_URI)!!
@@ -229,6 +237,7 @@ class StorageVolumeX(
     }
 }
 
+@Suppress("DEPRECATION")
 internal object AnyParceler : Parceler<Any> {
     override fun create(parcel: Parcel): Any = parcel.readParcelable(StorageVolumeX::class.java.classLoader)!!
 

--- a/app-common-root/src/main/java/eu/darken/sdmse/common/root/service/internal/BaseRootHost.kt
+++ b/app-common-root/src/main/java/eu/darken/sdmse/common/root/service/internal/BaseRootHost.kt
@@ -112,6 +112,7 @@ abstract class BaseRootHost(
             // a prepared Looper is required for the calls below to succeed
             if (Looper.getMainLooper() == null) {
                 try {
+                    @Suppress("DEPRECATION")
                     Looper.prepareMainLooper()
                 } catch (e: Exception) {
                     log(ERROR) { "Failed prepareMainLooper() for systemContext" }

--- a/app-common/src/main/java/eu/darken/sdmse/common/TimeExtensions.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/TimeExtensions.kt
@@ -30,6 +30,7 @@ fun Instant.toUtcTimezone(): ZonedDateTime = this
  * LENGTH_SHORT for the abbreviated spelling if available (e.g. "2 hr"), and LENGTH_SHORTEST for
  * the briefest form available (e.g. "2h").
  */
+@Suppress("DEPRECATION")
 fun Duration.formatDuration(abbrev: Int = DateUtils.LENGTH_SHORT): String {
     val width = when (abbrev) {
         DateUtils.LENGTH_LONG -> MeasureFormat.FormatWidth.WIDE

--- a/app-common/src/main/java/eu/darken/sdmse/common/parcel/ParcelableExtensions.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/parcel/ParcelableExtensions.kt
@@ -8,6 +8,7 @@ inline fun <reified T> T.marshall(): ByteArray where T : Parcelable = Parcel.obt
     marshall()
 }
 
+@Suppress("DEPRECATION")
 inline fun <reified T> ByteArray.unmarshall(): T where T : Any, T : Parcelable = Parcel.obtain().use {
     unmarshall(this@unmarshall, 0, size)
     setDataPosition(0)

--- a/app-common/src/main/java/eu/darken/sdmse/common/permissions/Permission.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/permissions/Permission.kt
@@ -59,6 +59,7 @@ sealed class Permission(
         private val TAG = logTag("Permission", "UsageStats")
 
 
+        @Suppress("DEPRECATION")
         override fun isGranted(context: Context): Boolean {
             val applicationInfo = context.packageManager.getApplicationInfo(context.packageName, 0)
             val appOpsManager = context.getSystemService(Context.APP_OPS_SERVICE) as AppOpsManager

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/ui/details/AppJunkDetailsFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/ui/details/AppJunkDetailsFragment.kt
@@ -35,6 +35,7 @@ class AppJunkDetailsFragment : Fragment3(R.layout.appcleaner_details_fragment) {
 
         ui.toolbar.apply {
             setupWithNavController(findNavController())
+            @Suppress("DEPRECATION")
             setOnMenuItemClickListener {
                 when (it.itemId) {
                     else -> super.onOptionsItemSelected(it)

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/ui/list/AppCleanerListFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/ui/list/AppCleanerListFragment.kt
@@ -40,6 +40,7 @@ class AppCleanerListFragment : Fragment3(R.layout.appcleaner_list_fragment) {
 
         ui.toolbar.apply {
             setupWithNavController(findNavController())
+            @Suppress("DEPRECATION")
             setOnMenuItemClickListener {
                 when (it.itemId) {
                     else -> super.onOptionsItemSelected(it)

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListFragment.kt
@@ -99,6 +99,7 @@ class AppControlListFragment : Fragment3(R.layout.appcontrol_list_fragment) {
 
         ui.toolbar.apply {
             setupWithNavController(findNavController())
+            @Suppress("DEPRECATION")
             setOnMenuItemClickListener {
                 when (it.itemId) {
                     R.id.action_filterpane -> {

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/actions/items/InfoUsageVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/actions/items/InfoUsageVH.kt
@@ -48,6 +48,7 @@ class InfoUsageVH(parent: ViewGroup) :
             } else {
                 val formatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)
                 val since = appInfo.usage.screenTimeSince.toSystemTimezone().format(formatter)
+                @Suppress("DEPRECATION")
                 val durationTxt = appInfo.usage.screenTime.formatDuration(abbrev = DateUtils.LENGTH_LONG)
                 getString(R.string.appcontrol_item_screentime_x_since_y_label, durationTxt, since)
             }

--- a/app/src/main/java/eu/darken/sdmse/common/DividerItemDecoration2.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/DividerItemDecoration2.kt
@@ -91,6 +91,7 @@ class DividerItemDecoration2 constructor(
         for (i in 0 until childCount) {
             val child: View = parent.getChildAt(i)
             parent.getDecoratedBoundsWithMargins(child, bounds)
+            @Suppress("DEPRECATION")
             val bottom: Int = bounds.bottom + Math.round(ViewCompat.getTranslationY(child))
             val top: Int = bottom - divider.intrinsicHeight
             divider.setBounds(left, top, right, bottom)
@@ -122,6 +123,7 @@ class DividerItemDecoration2 constructor(
         for (i in 0 until childCount) {
             val child: View = parent.getChildAt(i)
             parent.layoutManager!!.getDecoratedBoundsWithMargins(child, bounds)
+            @Suppress("DEPRECATION")
             val right: Int = bounds.right + Math.round(ViewCompat.getTranslationX(child))
             val left: Int = right - divider.intrinsicWidth
             divider.setBounds(left, top, right, bottom)

--- a/app/src/main/java/eu/darken/sdmse/common/debug/recorder/core/RecorderService.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/debug/recorder/core/RecorderService.kt
@@ -98,6 +98,7 @@ class RecorderService : Service2() {
                     }
                     notificationManager.notify(NOTIFICATION_ID, builder.build())
                 } else {
+                    @Suppress("DEPRECATION")
                     stopForeground(true)
                     stopSelf()
                 }

--- a/app/src/main/java/eu/darken/sdmse/common/lists/ViewHolderBasedDivider.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/lists/ViewHolderBasedDivider.kt
@@ -57,6 +57,7 @@ class ViewHolderBasedDivider constructor(
             if (!filter(previousVH, thisVH, nextVH)) continue
 
             parent.getDecoratedBoundsWithMargins(thisChild, bounds)
+            @Suppress("DEPRECATION")
             val bottom: Int = bounds.bottom + ViewCompat.getTranslationY(thisChild).roundToInt()
             val top: Int = bottom - divider.intrinsicHeight
             divider.setBounds(left, top, right, bottom)

--- a/app/src/main/java/eu/darken/sdmse/common/previews/PreviewFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/previews/PreviewFragment.kt
@@ -96,6 +96,7 @@ class PreviewFragment : DialogFragment3(R.layout.preview_fragment) {
                 show(WindowInsetsCompat.Type.statusBars())
                 show(WindowInsetsCompat.Type.navigationBars())
                 // Enable immersive mode
+                @Suppress("DEPRECATION")
                 systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_BARS_BY_TOUCH
             }
         } else {

--- a/app/src/main/java/eu/darken/sdmse/common/ui/BreadCrumbBar.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/ui/BreadCrumbBar.kt
@@ -35,6 +35,7 @@ class BreadCrumbBar<ItemT : APath> @JvmOverloads constructor(
 
     override fun onFinishInflate() {
         if (isInEditMode) {
+            @Suppress("UNCHECKED_CAST")
             setCrumbs(
                 listOf(
                     *RawPath.build("/this/is/darkens/test").path.split(File.separator.toRegex())

--- a/app/src/main/java/eu/darken/sdmse/common/uix/BottomSheetDialogFragment2.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/uix/BottomSheetDialogFragment2.kt
@@ -57,6 +57,7 @@ abstract class BottomSheetDialogFragment2 : BottomSheetDialogFragment() {
         super.onViewCreated(view, savedInstanceState)
     }
 
+    @Suppress("DEPRECATION")
     @Deprecated("Deprecated in Java")
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         log(tag, VERBOSE) { "onActivityCreated(savedInstanceState=$savedInstanceState)" }
@@ -88,6 +89,7 @@ abstract class BottomSheetDialogFragment2 : BottomSheetDialogFragment() {
         super.onDestroy()
     }
 
+    @Suppress("DEPRECATION")
     @Deprecated("Deprecated in Java")
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         log(tag, VERBOSE) { "onActivityResult(requestCode=$requestCode, resultCode=$resultCode, data=$data)" }

--- a/app/src/main/java/eu/darken/sdmse/common/uix/DialogFragment2.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/uix/DialogFragment2.kt
@@ -44,6 +44,7 @@ abstract class DialogFragment2(@LayoutRes val layoutRes: Int?) : DialogFragment(
         super.onViewCreated(view, savedInstanceState)
     }
 
+    @Suppress("DEPRECATION")
     @Deprecated("Deprecated in Java")
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         log(tag, VERBOSE) { "onActivityCreated(savedInstanceState=$savedInstanceState)" }
@@ -75,6 +76,7 @@ abstract class DialogFragment2(@LayoutRes val layoutRes: Int?) : DialogFragment(
         super.onDestroy()
     }
 
+    @Suppress("DEPRECATION")
     @Deprecated("Deprecated in Java")
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         log(tag, VERBOSE) { "onActivityResult(requestCode=$requestCode, resultCode=$resultCode, data=$data)" }

--- a/app/src/main/java/eu/darken/sdmse/common/uix/Fragment2.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/uix/Fragment2.kt
@@ -44,6 +44,7 @@ abstract class Fragment2(@LayoutRes val layoutRes: Int?) : Fragment(layoutRes ?:
         super.onViewCreated(view, savedInstanceState)
     }
 
+    @Suppress("DEPRECATION")
     @Deprecated("Deprecated in Java")
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         log(tag, VERBOSE) { "onActivityCreated(savedInstanceState=$savedInstanceState)" }
@@ -75,6 +76,7 @@ abstract class Fragment2(@LayoutRes val layoutRes: Int?) : Fragment(layoutRes ?:
         super.onDestroy()
     }
 
+    @Suppress("DEPRECATION")
     @Deprecated("Deprecated in Java")
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         log(tag, VERBOSE) { "onActivityResult(requestCode=$requestCode, resultCode=$resultCode, data=$data)" }

--- a/app/src/main/java/eu/darken/sdmse/common/uix/FragmentStatePagerAdapter4.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/uix/FragmentStatePagerAdapter4.kt
@@ -65,8 +65,10 @@ abstract class FragmentStatePagerAdapter4<T> @JvmOverloads constructor(
         if (currentTransaction == null) currentTransaction = fragmentManager.beginTransaction()
         val actualPosition = getItemPosition(fragment)
         if (enableSavedStates && actualPosition >= 0) {
+            @Suppress("DEPRECATION")
             savedStateArray.put(actualPosition, fragmentManager.saveFragmentInstanceState(fragment))
         }
+        @Suppress("DEPRECATION")
         fragmentArray.delete(position)
         currentTransaction!!.remove(fragment)
     }
@@ -134,12 +136,14 @@ abstract class FragmentStatePagerAdapter4<T> @JvmOverloads constructor(
                 }
             } else if (enableSavedStates && key.startsWith("s")) {
                 val index = key.substring(1).toInt()
+                @Suppress("DEPRECATION")
                 val savedState = bundle.getParcelable<Fragment.SavedState>(key)
                 if (savedState != null) savedStateArray.put(index, savedState)
             }
         }
     }
 
+    @Suppress("DEPRECATION")
     fun setItemVisible(item: Fragment, visible: Boolean) {
         item.setHasOptionsMenu(visible)
         item.setMenuVisibility(visible)

--- a/app/src/main/java/eu/darken/sdmse/corpsefinder/core/watcher/ExternalWatcherTaskReceiver.kt
+++ b/app/src/main/java/eu/darken/sdmse/corpsefinder/core/watcher/ExternalWatcherTaskReceiver.kt
@@ -35,6 +35,7 @@ class ExternalWatcherTaskReceiver : BroadcastReceiver() {
             return
         }
 
+        @Suppress("DEPRECATION")
         val externalTask = intent.getParcelableExtra<ExternalWatcherTask>(EXTRA_TASK)
 
         if (externalTask == null) {

--- a/app/src/main/java/eu/darken/sdmse/corpsefinder/ui/details/CorpseDetailsFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/corpsefinder/ui/details/CorpseDetailsFragment.kt
@@ -30,6 +30,7 @@ class CorpseDetailsFragment : Fragment3(R.layout.corpsefinder_details_fragment) 
 
         ui.toolbar.apply {
             setupWithNavController(findNavController())
+            @Suppress("DEPRECATION")
             setOnMenuItemClickListener {
                 when (it.itemId) {
                     else -> super.onOptionsItemSelected(it)

--- a/app/src/main/java/eu/darken/sdmse/corpsefinder/ui/list/CorpseFinderListFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/corpsefinder/ui/list/CorpseFinderListFragment.kt
@@ -39,6 +39,7 @@ class CorpseFinderListFragment : Fragment3(R.layout.corpsefinder_list_fragment) 
 
         ui.toolbar.apply {
             setupWithNavController(findNavController())
+            @Suppress("DEPRECATION")
             setOnMenuItemClickListener {
                 when (it.itemId) {
                     else -> super.onOptionsItemSelected(it)

--- a/app/src/main/java/eu/darken/sdmse/deduplicator/ui/details/DeduplicatorDetailsFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/ui/details/DeduplicatorDetailsFragment.kt
@@ -30,6 +30,7 @@ class DeduplicatorDetailsFragment : Fragment3(R.layout.deduplicator_details_frag
 
         ui.toolbar.apply {
             setupWithNavController(findNavController())
+            @Suppress("DEPRECATION")
             setOnMenuItemClickListener {
                 when (it.itemId) {
                     else -> super.onOptionsItemSelected(it)

--- a/app/src/main/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListFragment.kt
@@ -47,6 +47,7 @@ class DeduplicatorListFragment : Fragment3(R.layout.deduplicator_list_fragment) 
 
         ui.toolbar.apply {
             setupWithNavController(findNavController())
+            @Suppress("DEPRECATION")
             setOnMenuItemClickListener {
                 when (it.itemId) {
                     R.id.action_toggle_layout_mode -> {

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/items/MotdCardVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/items/MotdCardVH.kt
@@ -27,6 +27,7 @@ class MotdCardVH(parent: ViewGroup) :
 
         body.apply {
             text = item.state.motd.message
+            @Suppress("DEPRECATION")
             autoLinkMask = Linkify.ALL
             movementMethod = LinkMovementMethod.getInstance()
         }

--- a/app/src/main/java/eu/darken/sdmse/main/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/settings/SettingsFragment.kt
@@ -70,12 +70,14 @@ class SettingsFragment : Fragment2(R.layout.settings_fragment),
                     .commit()
             }
         } else {
+            @Suppress("DEPRECATION")
             savedInstanceState.getParcelableArrayList<Screen>(BKEY_SCREEN_INFOS)?.let {
                 screens.addAll(it)
             }
             screens.lastOrNull()?.let { setCurrentScreenInfo(it) }
         }
 
+        @Suppress("DEPRECATION")
         ui.toolbar.setNavigationOnClickListener { requireActivity().onBackPressed() }
 
         super.onViewCreated(view, savedInstanceState)
@@ -97,6 +99,7 @@ class SettingsFragment : Fragment2(R.layout.settings_fragment),
             putString(BKEY_SCREEN_TITLE, screenInfo.screenTitle)
         }
 
+        @Suppress("DEPRECATION")
         val fragment = childFragmentManager.fragmentFactory
             .instantiate(this::class.java.classLoader!!, pref.fragment!!)
             .apply {

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/CustomFilterEditorFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/CustomFilterEditorFragment.kt
@@ -121,6 +121,7 @@ class CustomFilterEditorFragment : Fragment3(R.layout.systemcleaner_customfilter
             DataArea.Type.PRIVATE_DATA,
             DataArea.Type.PORTABLE,
         ).forEach { type ->
+            @Suppress("DEPRECATION")
             val chip = Chip(
                 context,
                 null,

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/TaggedInputView.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/TaggedInputView.kt
@@ -197,6 +197,7 @@ class TaggedInputView @JvmOverloads constructor(
 
     private fun Chip.toTag(): ChipTag = this.tag as ChipTag
 
+    @Suppress("DEPRECATION")
     private fun ChipTag.toChip(): Chip = Chip(
         context,
         null,

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/ui/details/FilterContentDetailsFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/ui/details/FilterContentDetailsFragment.kt
@@ -30,6 +30,7 @@ class FilterContentDetailsFragment : Fragment3(R.layout.systemcleaner_details_fr
 
         ui.toolbar.apply {
             setupWithNavController(findNavController())
+            @Suppress("DEPRECATION")
             setOnMenuItemClickListener {
                 when (it.itemId) {
                     else -> super.onOptionsItemSelected(it)

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/ui/list/SystemCleanerListFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/ui/list/SystemCleanerListFragment.kt
@@ -39,6 +39,7 @@ class SystemCleanerListFragment : Fragment3(R.layout.systemcleaner_list_fragment
 
         ui.toolbar.apply {
             setupWithNavController(findNavController())
+            @Suppress("DEPRECATION")
             setOnMenuItemClickListener {
                 when (it.itemId) {
                     else -> super.onOptionsItemSelected(it)

--- a/app/src/main/res/values-my-rMM/strings.xml
+++ b/app/src/main/res/values-my-rMM/strings.xml
@@ -312,7 +312,7 @@
     <string name="analyzer_storage_content_app_media_description">ဤအက်ပ်မှ မီဒီယာ ဖိုင်များ၊ ဥပမာ - လက်ခံရရှိသော WhatsApp ဓာတ်ပုံများ။</string>
     <string name="analyzer_storage_content_app_extra_label">အပို အက်ပ် ဖိုင်များ</string>
     <string name="analyzer_storage_content_app_extra_description">ဤအက်ပ်သည် မူလ လမ်းကြောင်းများ အပြင်ဘက်တွင် ထားရှိထားသော အပို ဒေတာ၊ ဥပမာ - ဓာတ်ပုံများ သို့မဟုတ် ဒေါင်းလုဒ်များ။</string>
-    <string name="analyzer_app_details_app_occupies_x_on_y">ဤအက်ပ်သည် \"%2\" တွင် %1 ယူထားသည်။</string>
+    <string name="analyzer_app_details_app_occupies_x_on_y">ဤအက်ပ်သည် \"%2$s\" တွင် %1$s ယူထားသည်။</string>
     <string name="analyzer_app_details_app_is_archived">ဤအက်ပ်ကို မှတ်တမ်းတင်ထားသည်။</string>
     <string name="data_area_public_app_data_official_label">မူလ အများပြည်သူ အက်ပ် ဒေတာ</string>
     <string name="data_area_public_app_assets_official_label">မူလ အများပြည်သူ အက်ပ် ပစ္စည်းများ</string>

--- a/buildSrc/src/main/java/ProjectExtensions.kt
+++ b/buildSrc/src/main/java/ProjectExtensions.kt
@@ -55,11 +55,9 @@ fun Project.setupKotlinOptions() {
                     "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
                     "-opt-in=kotlinx.coroutines.FlowPreview",
                     "-opt-in=kotlin.time.ExperimentalTime",
-                    "-opt-in=kotlin.RequiresOptIn",
                     "-Xjvm-default=all",
-                    "-XXLanguage:+DataObjects",
-                    "-Xcontext-receivers",
-                    "-XXLanguage:+PropertyParamAnnotationDefaultTargetMode",
+                    "-Xcontext-parameters",
+                    "-Xannotation-default-target=param-property",
                 )
             )
         }

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -5,7 +5,7 @@ object Versions {
     }
 
     object Dagger {
-        const val core = "2.57"
+        const val core = "2.58"
     }
 
     object AndroidX {

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,12 +20,9 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 android.nonFinalResIds=true
 org.gradle.unsafe.configuration-cache=true
-android.defaults.buildfeatures.resvalues=true
-android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
-android.enableAppCompileTimeRClass=false
-android.usesSdkInManifest.disallowed=false
 android.uniquePackageNames=false
 android.dependency.useConstraints=true
 android.r8.strictFullModeForKeepRules=false
-android.r8.optimizedResourceShrinking=false
+android.generateSyncIssueWhenLibraryConstraintsAreEnabled=false
+# Required: applicationVariants in build.gradle.kts uses old DSL API
 android.newDsl=false


### PR DESCRIPTION
## Summary
- Add compiler flag `-Xannotation-default-target=param-property` to suppress ~200+ KT-73255 annotation warnings
- Add `@Suppress("DEPRECATION")` for deprecated Android APIs (Fragment methods, Parcelable APIs, ViewCompat, etc.)
- Add `@Suppress("UNCHECKED_CAST")` for IPC wrapper Parcel operations
- Fix Myanmar translation format string

## Test plan
- [x] Build passes: `./gradlew assembleFossDebug`
- [x] Unit tests pass: `./gradlew testFossDebugUnitTest` (1019 tests)