### PR TITLE
Deduplicator: Add configurable arbiter criteria settings

### DIFF
--- a/app-common/src/main/java/eu/darken/sdmse/common/datastore/DataStoreValueMoshi.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/datastore/DataStoreValueMoshi.kt
@@ -4,15 +4,31 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.squareup.moshi.Moshi
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 
 inline fun <reified T> moshiReader(
     moshi: Moshi,
     defaultValue: T,
+    fallbackToDefault: Boolean = false,
 ): (Any?) -> T {
     val adapter = moshi.adapter(T::class.java)
     return { rawValue ->
         rawValue as String?
-        rawValue?.let { adapter.fromJson(it) } ?: defaultValue
+        if (rawValue == null) {
+            defaultValue
+        } else if (fallbackToDefault) {
+            try {
+                adapter.fromJson(rawValue) ?: defaultValue
+            } catch (e: Exception) {
+                val tag = logTag("DataStore", "Value", "Moshi")
+                log(tag, ERROR) { "Failed to parse JSON, using default: ${e.message}" }
+                defaultValue
+            }
+        } else {
+            adapter.fromJson(rawValue) ?: defaultValue
+        }
     }
 }
 
@@ -29,9 +45,10 @@ inline fun <reified T : Any?> DataStore<Preferences>.createValue(
     key: String,
     defaultValue: T = null as T,
     moshi: Moshi,
+    fallbackToDefault: Boolean = false,
 ) = DataStoreValue(
     dataStore = this,
     key = stringPreferencesKey(key),
-    reader = moshiReader(moshi, defaultValue),
+    reader = moshiReader(moshi, defaultValue, fallbackToDefault),
     writer = moshiWriter(moshi),
 )

--- a/app-common/src/main/res/values/strings.xml
+++ b/app-common/src/main/res/values/strings.xml
@@ -26,6 +26,7 @@
     <string name="general_cancel_action">Cancel</string>
     <string name="general_discard_action">Discard</string>
     <string name="general_reset_action">Reset</string>
+    <string name="general_drag_handle_description">Drag to reorder</string>
     <string name="general_save_action">Save</string>
     <string name="general_thanks_action">Thanks</string>
     <string name="general_gotit_action">Got it</string>

--- a/app/src/main/java/eu/darken/sdmse/common/picker/PickerFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/picker/PickerFragment.kt
@@ -102,7 +102,7 @@ class PickerFragment : Fragment3(R.layout.common_picker_fragment) {
 
         vm.state.observe2(ui) { state ->
             log(TAG) { "updating with new state: $state" }
-            if (state.progress != null) toolbar.subtitle = state.current?.lookup?.path ?: ""
+            toolbar.subtitle = state.current?.lookup?.path ?: ""
             toolbar.menu.iterator().forEach { it.isVisible = state.progress == null }
 
             toolbar.setNavigationIcon(

--- a/app/src/main/java/eu/darken/sdmse/common/serialization/SerializationAppModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/serialization/SerializationAppModule.kt
@@ -5,7 +5,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import eu.darken.sdmse.common.serialization.*
+import eu.darken.sdmse.deduplicator.core.arbiter.ArbiterCriterium
 import eu.darken.sdmse.exclusion.core.types.Exclusion
 import javax.inject.Singleton
 
@@ -19,5 +19,6 @@ class SerializationAppModule {
         @SerializationIO moshiIO: Moshi = SerializationIOModule().moshi()
     ): Moshi = moshiIO.newBuilder().apply {
         add(Exclusion.MOSHI_FACTORY)
+        add(ArbiterCriterium.MOSHI_FACTORY)
     }.build()
 }

--- a/app/src/main/java/eu/darken/sdmse/deduplicator/core/DeduplicatorSettings.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/core/DeduplicatorSettings.kt
@@ -14,6 +14,7 @@ import eu.darken.sdmse.common.datastore.createValue
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.ui.LayoutMode
+import eu.darken.sdmse.deduplicator.core.arbiter.ArbiterCriterium
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -41,11 +42,24 @@ class DeduplicatorSettings @Inject constructor(
         @Json(name = "paths") val paths: Set<APath> = emptySet(),
     )
 
-    val keepPreferPaths = dataStore.createValue("arbiter.keep.prefer.paths", KeepPreferPaths(), moshi)
+    val arbiterConfig = dataStore.createValue(
+        key = "arbiter.config",
+        defaultValue = ArbiterConfig(),
+        moshi = moshi,
+        fallbackToDefault = true,
+    )
 
     @JsonClass(generateAdapter = true)
-    data class KeepPreferPaths(
-        @Json(name = "paths") val paths: Set<APath> = emptySet(),
+    data class ArbiterConfig(
+        @Json(name = "criteria") val criteria: List<ArbiterCriterium> = listOf(
+            ArbiterCriterium.DuplicateType(),
+            ArbiterCriterium.PreferredPath(),
+            ArbiterCriterium.MediaProvider(),
+            ArbiterCriterium.Location(),
+            ArbiterCriterium.Nesting(),
+            ArbiterCriterium.Modified(),
+            ArbiterCriterium.Size(),
+        ),
     )
 
     val layoutMode = dataStore.createValue("ui.list.layoutmode", LayoutMode.GRID, moshi)
@@ -57,7 +71,7 @@ class DeduplicatorSettings @Inject constructor(
         isSleuthChecksumEnabled,
         isSleuthPHashEnabled,
         scanPaths,
-        keepPreferPaths,
+        arbiterConfig,
     )
 
     companion object {

--- a/app/src/main/java/eu/darken/sdmse/deduplicator/core/arbiter/ArbiterCriterium.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/core/arbiter/ArbiterCriterium.kt
@@ -1,66 +1,105 @@
 package eu.darken.sdmse.deduplicator.core.arbiter
 
+import androidx.annotation.StringRes
+import com.squareup.moshi.JsonClass
+import eu.darken.sdmse.R
 import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.serialization.ValueBasedPolyJsonAdapterFactory
 
 sealed interface ArbiterCriterium {
 
-    sealed interface Mode
+    fun criteriumMode(): Mode? = null
 
+    sealed interface Mode {
+        @get:StringRes val labelRes: Int
+    }
+
+    @JsonClass(generateAdapter = true)
     data class DuplicateType(
-        val mode: Mode = Mode.PREFER_CHECKSUM
+        val mode: Mode = Mode.PREFER_CHECKSUM,
     ) : ArbiterCriterium {
-        enum class Mode : ArbiterCriterium.Mode {
-            PREFER_CHECKSUM,
-            PREFER_PHASH,
+        override fun criteriumMode(): Mode = mode
+
+        enum class Mode(@StringRes override val labelRes: Int) : ArbiterCriterium.Mode {
+            PREFER_CHECKSUM(R.string.deduplicator_arbiter_mode_prefer_checksum),
+            PREFER_PHASH(R.string.deduplicator_arbiter_mode_prefer_phash),
         }
     }
 
+    @JsonClass(generateAdapter = true)
     data class MediaProvider(
-        val mode: Mode = Mode.PREFER_INDEXED
+        val mode: Mode = Mode.PREFER_INDEXED,
     ) : ArbiterCriterium {
-        enum class Mode : ArbiterCriterium.Mode {
-            PREFER_INDEXED,
-            PREFER_UNKNOWN,
+        override fun criteriumMode(): Mode = mode
+
+        enum class Mode(@StringRes override val labelRes: Int) : ArbiterCriterium.Mode {
+            PREFER_INDEXED(R.string.deduplicator_arbiter_mode_prefer_indexed),
+            PREFER_UNKNOWN(R.string.deduplicator_arbiter_mode_prefer_unknown),
         }
     }
 
+    @JsonClass(generateAdapter = true)
     data class Location(
-        val mode: Mode = Mode.PREFER_PRIMARY
+        val mode: Mode = Mode.PREFER_PRIMARY,
     ) : ArbiterCriterium {
-        enum class Mode : ArbiterCriterium.Mode {
-            PREFER_PRIMARY,
-            PREFER_SECONDARY,
+        override fun criteriumMode(): Mode = mode
+
+        enum class Mode(@StringRes override val labelRes: Int) : ArbiterCriterium.Mode {
+            PREFER_PRIMARY(R.string.deduplicator_arbiter_mode_prefer_primary),
+            PREFER_SECONDARY(R.string.deduplicator_arbiter_mode_prefer_secondary),
         }
     }
 
+    @JsonClass(generateAdapter = true)
     data class Nesting(
-        val mode: Mode = Mode.PREFER_SHALLOW
+        val mode: Mode = Mode.PREFER_SHALLOW,
     ) : ArbiterCriterium {
-        enum class Mode : ArbiterCriterium.Mode {
-            PREFER_SHALLOW,
-            PREFER_DEEPER,
+        override fun criteriumMode(): Mode = mode
+
+        enum class Mode(@StringRes override val labelRes: Int) : ArbiterCriterium.Mode {
+            PREFER_SHALLOW(R.string.deduplicator_arbiter_mode_prefer_shallow),
+            PREFER_DEEPER(R.string.deduplicator_arbiter_mode_prefer_deeper),
         }
     }
 
+    @JsonClass(generateAdapter = true)
     data class Modified(
-        val mode: Mode = Mode.PREFER_OLDER
+        val mode: Mode = Mode.PREFER_OLDER,
     ) : ArbiterCriterium {
-        enum class Mode : ArbiterCriterium.Mode {
-            PREFER_OLDER,
-            PREFER_NEWER,
+        override fun criteriumMode(): Mode = mode
+
+        enum class Mode(@StringRes override val labelRes: Int) : ArbiterCriterium.Mode {
+            PREFER_OLDER(R.string.deduplicator_arbiter_mode_prefer_older),
+            PREFER_NEWER(R.string.deduplicator_arbiter_mode_prefer_newer),
         }
     }
 
+    @JsonClass(generateAdapter = true)
     data class Size(
-        val mode: Mode = Mode.PREFER_LARGER
+        val mode: Mode = Mode.PREFER_LARGER,
     ) : ArbiterCriterium {
-        enum class Mode : ArbiterCriterium.Mode {
-            PREFER_LARGER,
-            PREFER_SMALLER,
+        override fun criteriumMode(): Mode = mode
+
+        enum class Mode(@StringRes override val labelRes: Int) : ArbiterCriterium.Mode {
+            PREFER_LARGER(R.string.deduplicator_arbiter_mode_prefer_larger),
+            PREFER_SMALLER(R.string.deduplicator_arbiter_mode_prefer_smaller),
         }
     }
 
+    @JsonClass(generateAdapter = true)
     data class PreferredPath(
         val keepPreferPaths: Set<APath> = emptySet(),
     ) : ArbiterCriterium
+
+    companion object {
+        val MOSHI_FACTORY: ValueBasedPolyJsonAdapterFactory<ArbiterCriterium> =
+            ValueBasedPolyJsonAdapterFactory.of(ArbiterCriterium::class.java, "criteriumType")
+                .withSubtype(DuplicateType::class.java, "DUPLICATE_TYPE")
+                .withSubtype(MediaProvider::class.java, "MEDIA_PROVIDER")
+                .withSubtype(Location::class.java, "LOCATION")
+                .withSubtype(Nesting::class.java, "NESTING")
+                .withSubtype(Modified::class.java, "MODIFIED")
+                .withSubtype(Size::class.java, "SIZE")
+                .withSubtype(PreferredPath::class.java, "PREFERRED_PATH")
+    }
 }

--- a/app/src/main/java/eu/darken/sdmse/deduplicator/core/arbiter/DuplicatesArbiter.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/core/arbiter/DuplicatesArbiter.kt
@@ -28,17 +28,8 @@ class DuplicatesArbiter @Inject constructor(
 ) {
 
     suspend fun getStrategy(): ArbiterStrategy {
-        val keepPreferPaths = settings.keepPreferPaths.flow.first().paths
-        return ArbiterStrategy(
-            criteria = listOf(
-                ArbiterCriterium.DuplicateType(),
-                ArbiterCriterium.MediaProvider(),
-                ArbiterCriterium.Location(),
-                ArbiterCriterium.Nesting(),
-                ArbiterCriterium.Modified(),
-                ArbiterCriterium.PreferredPath(keepPreferPaths),
-            )
-        )
+        val arbiterConfig = settings.arbiterConfig.flow.first()
+        return ArbiterStrategy(criteria = arbiterConfig.criteria)
     }
 
     suspend fun decideGroups(
@@ -52,7 +43,9 @@ class DuplicatesArbiter @Inject constructor(
 
         var workList = litigants.toList()
 
-        strategy.criteria.forEach { crit ->
+        // Process in reverse order so that criteria at the TOP of the list have HIGHEST priority
+        // (they are processed LAST and thus have the final say in the sort order)
+        strategy.criteria.reversed().forEach { crit ->
             val favoritisedWorkList = when (crit) {
                 is ArbiterCriterium.DuplicateType -> duplicateTypeCheck.favoriteGroups(workList, crit)
                 is ArbiterCriterium.PreferredPath -> null
@@ -77,7 +70,9 @@ class DuplicatesArbiter @Inject constructor(
 
         var workList = litigants.toList()
 
-        strategy.criteria.forEach { crit ->
+        // Process in reverse order so that criteria at the TOP of the list have HIGHEST priority
+        // (they are processed LAST and thus have the final say in the sort order)
+        strategy.criteria.reversed().forEach { crit ->
             val favoritisedWorkList = when (crit) {
                 is ArbiterCriterium.DuplicateType -> duplicateTypeCheck.favorite(workList, crit)
                 is ArbiterCriterium.PreferredPath -> preferredPathCheck.favorite(workList, crit)

--- a/app/src/main/java/eu/darken/sdmse/deduplicator/ui/settings/DeduplicatorSettingsFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/ui/settings/DeduplicatorSettingsFragment.kt
@@ -36,8 +36,8 @@ class DeduplicatorSettingsFragment : PreferenceFragment2() {
     private val searchLocationsPref: Preference2
         get() = findPreference("scan.location.paths")!!
 
-    private val keepPreferPathsPref: Preference2
-        get() = findPreference("arbiter.keep.prefer.paths")!!
+    private val arbiterConfigPref: Preference2
+        get() = findPreference("arbiter.config")!!
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         vm.state.observe2(this) { state ->
@@ -67,31 +67,6 @@ class DeduplicatorSettingsFragment : PreferenceFragment2() {
                     true
                 }
             }
-            keepPreferPathsPref.apply {
-                summary = if (state.keepPreferPaths.isEmpty()) {
-                    getString(R.string.deduplicator_keep_prefer_paths_none_summary)
-                } else {
-                    state.keepPreferPaths.joinToString("\n") {
-                        it.userReadablePath.get(requireContext())
-                    }
-                }
-                setOnPreferenceClickListener {
-                    MainDirections.goToPicker(
-                        PickerRequest(
-                            requestKey = keepPreferPathsPref.key,
-                            mode = PickerRequest.PickMode.DIRS,
-                            allowedAreas = setOf(
-                                DataArea.Type.PORTABLE,
-                                DataArea.Type.SDCARD,
-                                DataArea.Type.PUBLIC_DATA,
-                                DataArea.Type.PUBLIC_MEDIA
-                            ),
-                            selectedPaths = state.keepPreferPaths
-                        )
-                    ).navigate()
-                    true
-                }
-            }
         }
         super.onViewCreated(view, savedInstanceState)
 
@@ -106,18 +81,6 @@ class DeduplicatorSettingsFragment : PreferenceFragment2() {
                 paths = pickerResult.selectedPaths,
             )
         }
-
-        requireParentFragment().parentFragmentManager.setFragmentResultListener(
-            keepPreferPathsPref.key,
-            viewLifecycleOwner
-        ) { requestKey, result ->
-            log(TAG) { "Fragment result $requestKey=$result" }
-            val pickerResult = PickerResult.fromBundle(result)
-            log(TAG, INFO) { "Picker result: $pickerResult" }
-            settings.keepPreferPaths.valueBlocking = DeduplicatorSettings.KeepPreferPaths(
-                paths = pickerResult.selectedPaths,
-            )
-        }
     }
 
     override fun onPreferencesCreated() {
@@ -128,8 +91,8 @@ class DeduplicatorSettingsFragment : PreferenceFragment2() {
             true
         }
 
-        keepPreferPathsPref.setOnLongClickListener {
-            vm.resetKeepPreferPaths()
+        arbiterConfigPref.setOnPreferenceClickListener {
+            MainDirections.goToArbiterConfig().navigate()
             true
         }
 

--- a/app/src/main/java/eu/darken/sdmse/deduplicator/ui/settings/DeduplicatorSettingsViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/ui/settings/DeduplicatorSettingsViewModel.kt
@@ -27,13 +27,11 @@ class DeduplicatorSettingsViewModel @Inject constructor(
         deduplicator.state,
         upgradeRepo.upgradeInfo.map { it.isPro },
         settings.scanPaths.flow,
-        settings.keepPreferPaths.flow,
-    ) { state, isPro, scanPaths, keepPreferPaths ->
+    ) { state, isPro, scanPaths ->
         State(
             isPro = isPro,
             state = state,
             scanPaths = scanPaths.paths.sortedBy { it.path },
-            keepPreferPaths = keepPreferPaths.paths.sortedBy { it.path },
         )
     }.asLiveData2()
 
@@ -41,17 +39,11 @@ class DeduplicatorSettingsViewModel @Inject constructor(
         val state: Deduplicator.State,
         val isPro: Boolean,
         val scanPaths: List<APath>,
-        val keepPreferPaths: List<APath>,
     )
 
     fun resetScanPaths() = launch {
         log(TAG) { "resetScanPaths()" }
         settings.scanPaths.value(DeduplicatorSettings.ScanPaths())
-    }
-
-    fun resetKeepPreferPaths() = launch {
-        log(TAG) { "resetKeepPreferPaths()" }
-        settings.keepPreferPaths.value(DeduplicatorSettings.KeepPreferPaths())
     }
 
     companion object {

--- a/app/src/main/java/eu/darken/sdmse/deduplicator/ui/settings/arbiter/ArbiterConfigAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/ui/settings/arbiter/ArbiterConfigAdapter.kt
@@ -1,0 +1,66 @@
+package eu.darken.sdmse.deduplicator.ui.settings.arbiter
+
+import android.view.ViewGroup
+import androidx.annotation.LayoutRes
+import androidx.recyclerview.widget.RecyclerView
+import androidx.viewbinding.ViewBinding
+import eu.darken.sdmse.common.lists.BindableVH
+import eu.darken.sdmse.common.lists.differ.AsyncDiffer
+import eu.darken.sdmse.common.lists.differ.DifferItem
+import eu.darken.sdmse.common.lists.differ.HasAsyncDiffer
+import eu.darken.sdmse.common.lists.differ.setupDiffer
+import eu.darken.sdmse.common.lists.modular.ModularAdapter
+import eu.darken.sdmse.common.lists.modular.mods.DataBinderMod
+import eu.darken.sdmse.common.lists.modular.mods.TypedVHCreatorMod
+import eu.darken.sdmse.deduplicator.core.arbiter.ArbiterCriterium
+import javax.inject.Inject
+
+
+class ArbiterConfigAdapter @Inject constructor() :
+    ModularAdapter<ArbiterConfigAdapter.BaseVH<ArbiterConfigAdapter.Item, ViewBinding>>(),
+    HasAsyncDiffer<ArbiterConfigAdapter.Item> {
+
+    override val asyncDiffer: AsyncDiffer<*, Item> = setupDiffer()
+
+    override fun getItemCount(): Int = data.size
+
+    init {
+        addMod(DataBinderMod(data))
+        addMod(TypedVHCreatorMod({ data[it] is HeaderItem }) { ArbiterConfigHeaderVH(it) })
+        addMod(TypedVHCreatorMod({ data[it] is CriteriumItem }) { ArbiterCriteriumRowVH(it) })
+    }
+
+    private var dragStartListener: ((RecyclerView.ViewHolder) -> Unit)? = null
+
+    fun setOnDragStartListener(listener: (RecyclerView.ViewHolder) -> Unit) {
+        dragStartListener = listener
+    }
+
+    fun onStartDrag(viewHolder: RecyclerView.ViewHolder) {
+        dragStartListener?.invoke(viewHolder)
+    }
+
+    abstract class BaseVH<D : Item, B : ViewBinding>(
+        @LayoutRes layoutId: Int,
+        parent: ViewGroup,
+    ) : VH(layoutId, parent), BindableVH<D, B>
+
+    interface Item : DifferItem {
+        override val payloadProvider: ((DifferItem, DifferItem) -> DifferItem?)
+            get() = { old, new -> if (new::class.isInstance(old)) new else null }
+    }
+
+    data class HeaderItem(
+        val id: String = "header",
+    ) : Item {
+        override val stableId: Long = id.hashCode().toLong()
+    }
+
+    data class CriteriumItem(
+        val criterium: ArbiterCriterium,
+        val position: Int,
+        val onModeClicked: (CriteriumItem) -> Unit,
+    ) : Item {
+        override val stableId: Long = criterium::class.hashCode().toLong()
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/deduplicator/ui/settings/arbiter/ArbiterConfigFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/ui/settings/arbiter/ArbiterConfigFragment.kt
@@ -1,0 +1,162 @@
+package eu.darken.sdmse.deduplicator.ui.settings.arbiter
+
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import androidx.navigation.ui.setupWithNavController
+import androidx.recyclerview.widget.ItemTouchHelper
+import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import dagger.hilt.android.AndroidEntryPoint
+import eu.darken.sdmse.MainDirections
+import eu.darken.sdmse.R
+import eu.darken.sdmse.common.EdgeToEdgeHelper
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.lists.differ.update
+import eu.darken.sdmse.common.lists.setupDefaults
+import eu.darken.sdmse.common.navigation.doNavigate
+import eu.darken.sdmse.common.picker.PickerResult
+import eu.darken.sdmse.common.uix.Fragment3
+import eu.darken.sdmse.common.viewbinding.viewBinding
+import eu.darken.sdmse.databinding.DeduplicatorArbiterConfigFragmentBinding
+import java.util.Collections
+
+@AndroidEntryPoint
+class ArbiterConfigFragment : Fragment3(R.layout.deduplicator_arbiter_config_fragment) {
+
+    override val vm: ArbiterConfigViewModel by viewModels()
+    override val ui: DeduplicatorArbiterConfigFragmentBinding by viewBinding()
+
+    private val adapter by lazy { ArbiterConfigAdapter() }
+    private var currentItems: MutableList<ArbiterConfigAdapter.Item> = mutableListOf()
+    private var isDragging = false
+    private var pendingReorderUpdate = false
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        EdgeToEdgeHelper(requireActivity()).apply {
+            insetsPadding(ui.root, left = true, right = true)
+            insetsPadding(ui.appbarlayout, top = true)
+            insetsPadding(ui.list, bottom = true)
+        }
+
+        ui.toolbar.apply {
+            setupWithNavController(findNavController())
+            setOnMenuItemClickListener {
+                when (it.itemId) {
+                    R.id.menu_action_reset -> {
+                        vm.resetToDefaults()
+                        true
+                    }
+
+                    else -> false
+                }
+            }
+        }
+
+        ui.list.setupDefaults(adapter, verticalDividers = false)
+
+        val itemTouchHelper = ItemTouchHelper(object : ItemTouchHelper.SimpleCallback(
+            ItemTouchHelper.UP or ItemTouchHelper.DOWN,
+            0,
+        ) {
+            override fun onMove(
+                recyclerView: RecyclerView,
+                viewHolder: RecyclerView.ViewHolder,
+                target: RecyclerView.ViewHolder,
+            ): Boolean {
+                val fromPos = viewHolder.bindingAdapterPosition
+                val toPos = target.bindingAdapterPosition
+                if (fromPos == RecyclerView.NO_POSITION || toPos == RecyclerView.NO_POSITION) {
+                    return false
+                }
+                // Don't allow moving to position 0 (header)
+                if (toPos == 0) return false
+
+                Collections.swap(currentItems, fromPos, toPos)
+                adapter.notifyItemMoved(fromPos, toPos)
+                return true
+            }
+
+            override fun canDropOver(
+                recyclerView: RecyclerView,
+                current: RecyclerView.ViewHolder,
+                target: RecyclerView.ViewHolder,
+            ): Boolean {
+                // Don't allow dropping over the header
+                return target.bindingAdapterPosition != 0
+            }
+
+            override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) {
+                // Not used
+            }
+
+            override fun onSelectedChanged(viewHolder: RecyclerView.ViewHolder?, actionState: Int) {
+                super.onSelectedChanged(viewHolder, actionState)
+                isDragging = actionState == ItemTouchHelper.ACTION_STATE_DRAG
+            }
+
+            override fun clearView(recyclerView: RecyclerView, viewHolder: RecyclerView.ViewHolder) {
+                super.clearView(recyclerView, viewHolder)
+                pendingReorderUpdate = true
+                vm.onItemsReordered(currentItems.toList())
+                isDragging = false
+            }
+
+            override fun isLongPressDragEnabled(): Boolean = false
+        })
+        itemTouchHelper.attachToRecyclerView(ui.list)
+
+        adapter.setOnDragStartListener { viewHolder -> itemTouchHelper.startDrag(viewHolder) }
+
+        vm.state.observe2(ui) { state ->
+            currentItems = state.items.toMutableList()
+            if (!isDragging) {
+                if (pendingReorderUpdate) {
+                    // Skip adapter update - visual state is already correct from drag
+                    pendingReorderUpdate = false
+                } else {
+                    adapter.update(state.items)
+                }
+            }
+        }
+
+        vm.modeSelectionEvents.observe2 { event -> showModeSelectionDialog(event) }
+
+        vm.pickerEvents.observe2 { request -> doNavigate(MainDirections.goToPicker(request)) }
+
+        super.onViewCreated(view, savedInstanceState)
+
+        parentFragmentManager.setFragmentResultListener(
+            ArbiterConfigViewModel.PICKER_REQUEST_KEY,
+            viewLifecycleOwner,
+        ) { requestKey, result ->
+            log(TAG) { "Fragment result $requestKey=$result" }
+            val pickerResult = PickerResult.fromBundle(result)
+            log(TAG, INFO) { "Picker result: $pickerResult" }
+            vm.updatePreferredPaths(pickerResult.selectedPaths)
+        }
+    }
+
+    private fun showModeSelectionDialog(event: ArbiterConfigViewModel.ModeSelectionEvent) {
+        val modes = event.modes
+        val currentMode = event.item.criterium.criteriumMode()
+        val labels = modes.map { getString(it.labelRes) }.toTypedArray()
+        val currentIndex = modes.indexOf(currentMode).coerceAtLeast(0)
+
+        MaterialAlertDialogBuilder(requireContext()).apply {
+            setTitle(R.string.deduplicator_arbiter_select_mode_title)
+            setSingleChoiceItems(labels, currentIndex) { dialog, which ->
+                vm.onModeSelected(event.item, modes[which])
+                dialog.dismiss()
+            }
+            setNegativeButton(eu.darken.sdmse.common.R.string.general_cancel_action, null)
+        }.show()
+    }
+
+    companion object {
+        private val TAG = logTag("Deduplicator", "Settings", "Arbiter", "Fragment")
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/deduplicator/ui/settings/arbiter/ArbiterConfigHeaderVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/ui/settings/arbiter/ArbiterConfigHeaderVH.kt
@@ -1,0 +1,23 @@
+package eu.darken.sdmse.deduplicator.ui.settings.arbiter
+
+import android.view.ViewGroup
+import eu.darken.sdmse.R
+import eu.darken.sdmse.common.lists.binding
+import eu.darken.sdmse.databinding.DeduplicatorArbiterConfigHeaderBinding
+
+
+class ArbiterConfigHeaderVH(parent: ViewGroup) :
+    ArbiterConfigAdapter.BaseVH<ArbiterConfigAdapter.HeaderItem, DeduplicatorArbiterConfigHeaderBinding>(
+        R.layout.deduplicator_arbiter_config_header,
+        parent,
+    ) {
+
+    override val viewBinding = lazy { DeduplicatorArbiterConfigHeaderBinding.bind(itemView) }
+
+    override val onBindData: DeduplicatorArbiterConfigHeaderBinding.(
+        item: ArbiterConfigAdapter.HeaderItem,
+        payloads: List<Any>,
+    ) -> Unit = binding { _ ->
+        // Static content - nothing to bind
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/deduplicator/ui/settings/arbiter/ArbiterConfigViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/ui/settings/arbiter/ArbiterConfigViewModel.kt
@@ -1,0 +1,145 @@
+package eu.darken.sdmse.deduplicator.ui.settings.arbiter
+
+import androidx.lifecycle.SavedStateHandle
+import dagger.hilt.android.lifecycle.HiltViewModel
+import eu.darken.sdmse.common.SingleLiveEvent
+import eu.darken.sdmse.common.areas.DataArea
+import eu.darken.sdmse.common.coroutine.DispatcherProvider
+import eu.darken.sdmse.common.datastore.value
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.picker.PickerRequest
+import eu.darken.sdmse.common.uix.ViewModel3
+import eu.darken.sdmse.deduplicator.core.DeduplicatorSettings
+import eu.darken.sdmse.deduplicator.core.arbiter.ArbiterCriterium
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+@HiltViewModel
+class ArbiterConfigViewModel @Inject constructor(
+    @Suppress("unused") private val handle: SavedStateHandle,
+    dispatcherProvider: DispatcherProvider,
+    private val settings: DeduplicatorSettings,
+) : ViewModel3(dispatcherProvider) {
+
+    val state = settings.arbiterConfig.flow.map { config ->
+        val criteriumItems = config.criteria.mapIndexed { index, criterium ->
+            ArbiterConfigAdapter.CriteriumItem(
+                criterium = criterium,
+                position = index,
+                onModeClicked = { showModeSelection(it) },
+            )
+        }
+        State(
+            items = listOf(ArbiterConfigAdapter.HeaderItem()) + criteriumItems,
+        )
+    }.asLiveData2()
+
+    data class State(
+        val items: List<ArbiterConfigAdapter.Item>,
+    )
+
+    fun onItemsReordered(items: List<ArbiterConfigAdapter.Item>) = launch {
+        val criteriumItems = items.filterIsInstance<ArbiterConfigAdapter.CriteriumItem>()
+        log(TAG) { "onItemsReordered(): ${criteriumItems.map { it.criterium::class.simpleName }}" }
+        val newConfig = DeduplicatorSettings.ArbiterConfig(
+            criteria = criteriumItems.map { it.criterium }
+        )
+        settings.arbiterConfig.value(newConfig)
+    }
+
+    private fun showModeSelection(item: ArbiterConfigAdapter.CriteriumItem) {
+        log(TAG) { "showModeSelection(): ${item.criterium}" }
+        when (val criterium = item.criterium) {
+            is ArbiterCriterium.PreferredPath -> {
+                pickerEvents.postValue(
+                    PickerRequest(
+                        requestKey = PICKER_REQUEST_KEY,
+                        mode = PickerRequest.PickMode.DIRS,
+                        allowedAreas = setOf(
+                            DataArea.Type.PORTABLE,
+                            DataArea.Type.SDCARD,
+                            DataArea.Type.PUBLIC_DATA,
+                            DataArea.Type.PUBLIC_MEDIA,
+                        ),
+                        selectedPaths = criterium.keepPreferPaths.toList(),
+                    )
+                )
+            }
+
+            else -> {
+                val modes = getModeOptions(item.criterium)
+                if (modes.isNotEmpty()) {
+                    modeSelectionEvents.postValue(ModeSelectionEvent(item, modes))
+                }
+            }
+        }
+    }
+
+    val modeSelectionEvents = SingleLiveEvent<ModeSelectionEvent>()
+    val pickerEvents = SingleLiveEvent<PickerRequest>()
+
+    data class ModeSelectionEvent(
+        val item: ArbiterConfigAdapter.CriteriumItem,
+        val modes: List<ArbiterCriterium.Mode>,
+    )
+
+    fun onModeSelected(item: ArbiterConfigAdapter.CriteriumItem, mode: ArbiterCriterium.Mode) = launch {
+        log(TAG) { "onModeSelected(): ${item.criterium::class.simpleName} -> $mode" }
+        val currentConfig = settings.arbiterConfig.flow.first()
+        val newCriteria = currentConfig.criteria.map { criterium ->
+            if (criterium::class == item.criterium::class) {
+                updateCriteriumMode(criterium, mode)
+            } else {
+                criterium
+            }
+        }
+        settings.arbiterConfig.value(DeduplicatorSettings.ArbiterConfig(criteria = newCriteria))
+    }
+
+    fun updatePreferredPaths(paths: Set<APath>) = launch {
+        log(TAG) { "updatePreferredPaths(): $paths" }
+        val currentConfig = settings.arbiterConfig.flow.first()
+        val newCriteria = currentConfig.criteria.map { criterium ->
+            if (criterium is ArbiterCriterium.PreferredPath) {
+                criterium.copy(keepPreferPaths = paths)
+            } else {
+                criterium
+            }
+        }
+        settings.arbiterConfig.value(DeduplicatorSettings.ArbiterConfig(criteria = newCriteria))
+    }
+
+    fun resetToDefaults() = launch {
+        log(TAG) { "resetToDefaults()" }
+        settings.arbiterConfig.value(DeduplicatorSettings.ArbiterConfig())
+    }
+
+    private fun getModeOptions(criterium: ArbiterCriterium): List<ArbiterCriterium.Mode> = when (criterium) {
+        is ArbiterCriterium.DuplicateType -> ArbiterCriterium.DuplicateType.Mode.entries
+        is ArbiterCriterium.MediaProvider -> ArbiterCriterium.MediaProvider.Mode.entries
+        is ArbiterCriterium.Location -> ArbiterCriterium.Location.Mode.entries
+        is ArbiterCriterium.Nesting -> ArbiterCriterium.Nesting.Mode.entries
+        is ArbiterCriterium.Modified -> ArbiterCriterium.Modified.Mode.entries
+        is ArbiterCriterium.Size -> ArbiterCriterium.Size.Mode.entries
+        is ArbiterCriterium.PreferredPath -> emptyList()
+    }
+
+    private fun updateCriteriumMode(criterium: ArbiterCriterium, mode: ArbiterCriterium.Mode): ArbiterCriterium =
+        when (criterium) {
+            is ArbiterCriterium.DuplicateType -> criterium.copy(mode = mode as ArbiterCriterium.DuplicateType.Mode)
+            is ArbiterCriterium.MediaProvider -> criterium.copy(mode = mode as ArbiterCriterium.MediaProvider.Mode)
+            is ArbiterCriterium.Location -> criterium.copy(mode = mode as ArbiterCriterium.Location.Mode)
+            is ArbiterCriterium.Nesting -> criterium.copy(mode = mode as ArbiterCriterium.Nesting.Mode)
+            is ArbiterCriterium.Modified -> criterium.copy(mode = mode as ArbiterCriterium.Modified.Mode)
+            is ArbiterCriterium.Size -> criterium.copy(mode = mode as ArbiterCriterium.Size.Mode)
+            is ArbiterCriterium.PreferredPath -> criterium
+        }
+
+    companion object {
+        private val TAG = logTag("Deduplicator", "Settings", "Arbiter", "ViewModel")
+        const val PICKER_REQUEST_KEY = "arbiter.keep.prefer.paths"
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/deduplicator/ui/settings/arbiter/ArbiterCriteriumRowVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/ui/settings/arbiter/ArbiterCriteriumRowVH.kt
@@ -1,0 +1,88 @@
+package eu.darken.sdmse.deduplicator.ui.settings.arbiter
+
+import android.annotation.SuppressLint
+import android.view.MotionEvent
+import android.view.ViewGroup
+import androidx.annotation.DrawableRes
+import eu.darken.sdmse.R
+import eu.darken.sdmse.common.lists.binding
+import eu.darken.sdmse.databinding.DeduplicatorArbiterConfigRowBinding
+import eu.darken.sdmse.deduplicator.core.arbiter.ArbiterCriterium
+
+
+class ArbiterCriteriumRowVH(parent: ViewGroup) :
+    ArbiterConfigAdapter.BaseVH<ArbiterConfigAdapter.CriteriumItem, DeduplicatorArbiterConfigRowBinding>(
+        R.layout.deduplicator_arbiter_config_row,
+        parent,
+    ) {
+
+    override val viewBinding = lazy { DeduplicatorArbiterConfigRowBinding.bind(itemView) }
+
+    @SuppressLint("ClickableViewAccessibility")
+    override val onBindData: DeduplicatorArbiterConfigRowBinding.(
+        item: ArbiterConfigAdapter.CriteriumItem,
+        payloads: List<Any>,
+    ) -> Unit = binding { item ->
+        val criterium = item.criterium
+
+        icon.setImageResource(getIconForCriterium(criterium))
+        title.text = getTitleForCriterium(criterium)
+        description.text = getDescriptionForCriterium(criterium)
+
+        mode.text = when (criterium) {
+            is ArbiterCriterium.PreferredPath -> {
+                if (criterium.keepPreferPaths.isEmpty()) {
+                    context.getString(R.string.deduplicator_arbiter_configure_paths_action)
+                } else {
+                    criterium.keepPreferPaths.joinToString("\n") { it.userReadablePath.get(context) }
+                }
+            }
+
+            else -> criterium.criteriumMode()?.labelRes?.let { context.getString(it) }
+        }
+
+        root.setOnClickListener { item.onModeClicked(item) }
+
+        dragHandle.setOnTouchListener { _, event ->
+            if (event.actionMasked == MotionEvent.ACTION_DOWN) {
+                (bindingAdapter as? ArbiterConfigAdapter)?.onStartDrag(this@ArbiterCriteriumRowVH)
+            }
+            false
+        }
+    }
+
+    private fun getTitleForCriterium(criterium: ArbiterCriterium): String = context.getString(
+        when (criterium) {
+            is ArbiterCriterium.DuplicateType -> R.string.deduplicator_arbiter_criterium_duplicate_type_title
+            is ArbiterCriterium.MediaProvider -> R.string.deduplicator_arbiter_criterium_media_provider_title
+            is ArbiterCriterium.Location -> R.string.deduplicator_arbiter_criterium_location_title
+            is ArbiterCriterium.Nesting -> R.string.deduplicator_arbiter_criterium_nesting_title
+            is ArbiterCriterium.Modified -> R.string.deduplicator_arbiter_criterium_modified_title
+            is ArbiterCriterium.Size -> R.string.deduplicator_arbiter_criterium_size_title
+            is ArbiterCriterium.PreferredPath -> R.string.deduplicator_arbiter_criterium_preferred_path_title
+        }
+    )
+
+    private fun getDescriptionForCriterium(criterium: ArbiterCriterium): String = context.getString(
+        when (criterium) {
+            is ArbiterCriterium.DuplicateType -> R.string.deduplicator_arbiter_criterium_duplicate_type_description
+            is ArbiterCriterium.MediaProvider -> R.string.deduplicator_arbiter_criterium_media_provider_description
+            is ArbiterCriterium.Location -> R.string.deduplicator_arbiter_criterium_location_description
+            is ArbiterCriterium.Nesting -> R.string.deduplicator_arbiter_criterium_nesting_description
+            is ArbiterCriterium.Modified -> R.string.deduplicator_arbiter_criterium_modified_description
+            is ArbiterCriterium.Size -> R.string.deduplicator_arbiter_criterium_size_description
+            is ArbiterCriterium.PreferredPath -> R.string.deduplicator_arbiter_criterium_preferred_path_description
+        }
+    )
+
+    @DrawableRes
+    private fun getIconForCriterium(criterium: ArbiterCriterium): Int = when (criterium) {
+        is ArbiterCriterium.DuplicateType -> R.drawable.ic_code_equal_box_24
+        is ArbiterCriterium.PreferredPath -> R.drawable.ic_folder_home_24
+        is ArbiterCriterium.MediaProvider -> R.drawable.ic_multimedia_24
+        is ArbiterCriterium.Location -> R.drawable.ic_sd_24
+        is ArbiterCriterium.Nesting -> R.drawable.ic_contain_24
+        is ArbiterCriterium.Modified -> R.drawable.ic_file_clock_outline_24
+        is ArbiterCriterium.Size -> R.drawable.ic_weight_24
+    }
+}

--- a/app/src/main/res/drawable/ic_drag_vertical_24.xml
+++ b/app/src/main/res/drawable/ic_drag_vertical_24.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M9,3H11V5H9V3ZM13,3H15V5H13V3ZM9,7H11V9H9V7ZM13,7H15V9H13V7ZM9,11H11V13H9V11ZM13,11H15V13H13V11ZM9,15H11V17H9V15ZM13,15H15V17H13V15ZM9,19H11V21H9V19ZM13,19H15V21H13V19Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_strategy_24.xml
+++ b/app/src/main/res/drawable/ic_strategy_24.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M6.91 5.5L9.21 7.79L7.79 9.21L5.5 6.91L3.21 9.21L1.79 7.79L4.09 5.5L1.79 3.21L3.21 1.79L5.5 4.09L7.79 1.79L9.21 3.21M22.21 16.21L20.79 14.79L18.5 17.09L16.21 14.79L14.79 16.21L17.09 18.5L14.79 20.79L16.21 22.21L18.5 19.91L20.79 22.21L22.21 20.79L19.91 18.5M20.4 6.83L17.18 11L15.6 9.73L16.77 8.23A9.08 9.08 0 0 0 10.11 13.85A4.5 4.5 0 1 1 7.5 13A4 4 0 0 1 8.28 13.08A11.27 11.27 0 0 1 16.43 6.26L15 5.18L16.27 3.6M10 17.5A2.5 2.5 0 1 0 7.5 20A2.5 2.5 0 0 0 10 17.5Z" />
+</vector>

--- a/app/src/main/res/layout/deduplicator_arbiter_config_fragment.xml
+++ b/app/src/main/res/layout/deduplicator_arbiter_config_fragment.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    style="@style/BaseScreen"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbarlayout"
+        style="@style/SDMAppBar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            style="@style/SDMToolbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:menu="@menu/menu_deduplicator_arbiter_config"
+            app:title="@string/deduplicator_arbiter_title" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/list"
+        style="@style/BaseRecyclerList"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:clipToPadding="false"
+        android:contentDescription="@string/deduplicator_arbiter_title"
+        android:paddingVertical="8dp"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+        tools:listitem="@layout/deduplicator_arbiter_config_row" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/deduplicator_arbiter_config_header.xml
+++ b/app/src/main/res/layout/deduplicator_arbiter_config_header.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    style="@style/Widget.Material3.CardView.Filled"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginHorizontal="16dp"
+    android:layout_marginTop="8dp"
+    android:layout_marginBottom="4dp"
+    app:cardBackgroundColor="?colorSurfaceVariant">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="16dp">
+
+        <ImageView
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_marginEnd="12dp"
+            android:contentDescription="@null"
+            android:src="@drawable/ic_baseline_info_24"
+            app:tint="?colorOnSurfaceVariant" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/explanation"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/deduplicator_arbiter_explanation"
+            android:textAppearance="?textAppearanceBodySmall"
+            android:textColor="?colorOnSurfaceVariant" />
+
+    </LinearLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/deduplicator_arbiter_config_row.xml
+++ b/app/src/main/res/layout/deduplicator_arbiter_config_row.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    style="@style/Widget.Material3.CardView.Outlined"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginHorizontal="16dp"
+    android:layout_marginVertical="4dp"
+    android:clickable="true"
+    android:focusable="true"
+    android:foreground="?selectableItemBackground">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingVertical="12dp">
+
+        <ImageView
+            android:id="@+id/icon"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_marginStart="16dp"
+            android:importantForAccessibility="no"
+            app:layout_constraintBottom_toBottomOf="@id/mode"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@id/title"
+            app:tint="?colorOnSurfaceVariant"
+            tools:src="@drawable/ic_code_equal_box_24" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/title"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:textAppearance="?textAppearanceBodyLarge"
+            app:layout_constraintEnd_toStartOf="@id/drag_handle"
+            app:layout_constraintStart_toEndOf="@id/icon"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="Duplicate type" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/description"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="2dp"
+            android:textAppearance="?textAppearanceBodySmall"
+            android:textColor="?colorOnSurfaceVariant"
+            app:layout_constraintEnd_toStartOf="@id/drag_handle"
+            app:layout_constraintStart_toStartOf="@id/title"
+            app:layout_constraintTop_toBottomOf="@id/title"
+            tools:text="Prefer exact matches over similar files" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/mode"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:textAppearance="?textAppearanceLabelMedium"
+            android:textColor="?colorPrimary"
+            app:layout_constraintEnd_toStartOf="@id/drag_handle"
+            app:layout_constraintStart_toStartOf="@id/title"
+            app:layout_constraintTop_toBottomOf="@id/description"
+            tools:text="Prefer exact matches" />
+
+        <ImageView
+            android:id="@+id/drag_handle"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:contentDescription="@string/general_drag_handle_description"
+            android:padding="12dp"
+            android:src="@drawable/ic_drag_vertical_24"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:tint="?colorOnSurfaceVariant" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/menu/menu_deduplicator_arbiter_config.xml
+++ b/app/src/main/res/menu/menu_deduplicator_arbiter_config.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/menu_action_reset"
+        android:icon="@drawable/ic_baseline_refresh_24"
+        android:title="@string/general_reset_action"
+        app:iconTint="?colorOnSurface"
+        app:showAsAction="ifRoom" />
+
+</menu>

--- a/app/src/main/res/navigation/main_nav.xml
+++ b/app/src/main/res/navigation/main_nav.xml
@@ -453,6 +453,10 @@
             app:destination="@id/deduplicatorDetailsFragment" />
     </fragment>
     <fragment
+        android:id="@+id/arbiterConfigFragment"
+        android:name="eu.darken.sdmse.deduplicator.ui.settings.arbiter.ArbiterConfigFragment"
+        tools:layout="@layout/deduplicator_arbiter_config_fragment" />
+    <fragment
         android:id="@+id/deduplicatorDetailsFragment"
         android:name="eu.darken.sdmse.deduplicator.ui.details.DeduplicatorDetailsFragment"
         tools:layout="@layout/deduplicator_details_fragment">
@@ -521,6 +525,9 @@
     <action
         android:id="@+id/goToPicker"
         app:destination="@id/pickerFragment" />
+    <action
+        android:id="@+id/goToArbiterConfig"
+        app:destination="@id/arbiterConfigFragment" />
     <fragment
         android:id="@+id/pickerFragment"
         android:name="eu.darken.sdmse.common.picker.PickerFragment"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -521,6 +521,37 @@
     <string name="deduplicator_details_cluster_title">Set of duplicates</string>
     <string name="deduplicator_matches_exact_label">Exact copies</string>
     <string name="deduplicator_matches_similar_label">Similar files</string>
+    <string name="deduplicator_arbiter_title">Deletion strategy</string>
+    <string name="deduplicator_arbiter_summary">Configure which files are kept and which are deleted.</string>
+    <string name="deduplicator_arbiter_explanation">When deleting duplicates, SD Maid decides which file to keep by checking each criterion in order. The first criterion that produces a clear winner determines the result. Drag to reorder, tap to change mode.</string>
+    <string name="deduplicator_arbiter_select_mode_title">Select mode</string>
+    <string name="deduplicator_arbiter_configure_paths_action">Configure paths…</string>
+    <string name="deduplicator_arbiter_criterium_duplicate_type_title">Duplicate type</string>
+    <string name="deduplicator_arbiter_criterium_duplicate_type_description">Prefer exact matches over similar files.</string>
+    <string name="deduplicator_arbiter_criterium_media_provider_title">Media indexing</string>
+    <string name="deduplicator_arbiter_criterium_media_provider_description">Consider whether files are indexed by the media provider.</string>
+    <string name="deduplicator_arbiter_criterium_location_title">Storage location</string>
+    <string name="deduplicator_arbiter_criterium_location_description">Prefer files on internal or external storage.</string>
+    <string name="deduplicator_arbiter_criterium_nesting_title">Folder depth</string>
+    <string name="deduplicator_arbiter_criterium_nesting_description">Prefer files in shallower or deeper folder structures.</string>
+    <string name="deduplicator_arbiter_criterium_modified_title">Modification date</string>
+    <string name="deduplicator_arbiter_criterium_modified_description">Prefer older or newer files based on modification time.</string>
+    <string name="deduplicator_arbiter_criterium_size_title">File size</string>
+    <string name="deduplicator_arbiter_criterium_size_description">Prefer larger or smaller files when sizes differ.</string>
+    <string name="deduplicator_arbiter_criterium_preferred_path_title">Preferred locations</string>
+    <string name="deduplicator_arbiter_criterium_preferred_path_description">Keep files in your configured preferred locations.</string>
+    <string name="deduplicator_arbiter_mode_prefer_checksum">Prefer exact matches</string>
+    <string name="deduplicator_arbiter_mode_prefer_phash">Prefer similar files</string>
+    <string name="deduplicator_arbiter_mode_prefer_indexed">Prefer indexed files</string>
+    <string name="deduplicator_arbiter_mode_prefer_unknown">Prefer non-indexed files</string>
+    <string name="deduplicator_arbiter_mode_prefer_primary">Prefer internal storage</string>
+    <string name="deduplicator_arbiter_mode_prefer_secondary">Prefer external storage</string>
+    <string name="deduplicator_arbiter_mode_prefer_shallow">Prefer shallow folders</string>
+    <string name="deduplicator_arbiter_mode_prefer_deeper">Prefer deeper folders</string>
+    <string name="deduplicator_arbiter_mode_prefer_older">Prefer older files</string>
+    <string name="deduplicator_arbiter_mode_prefer_newer">Prefer newer files</string>
+    <string name="deduplicator_arbiter_mode_prefer_larger">Prefer larger files</string>
+    <string name="deduplicator_arbiter_mode_prefer_smaller">Prefer smaller files</string>
 
 
     <string name="appcontrol_tool_name">AppControl</string>

--- a/app/src/main/res/xml/preferences_deduplicator.xml
+++ b/app/src/main/res/xml/preferences_deduplicator.xml
@@ -10,11 +10,12 @@
         app:title="@string/deduplicator_search_locations_title" />
 
     <eu.darken.sdmse.common.preferences.Preference2
-        app:icon="@drawable/ic_folder_home_24"
-        app:key="arbiter.keep.prefer.paths"
+        app:icon="@drawable/ic_strategy_24"
+        app:key="arbiter.config"
         app:persistent="false"
         app:singleLineTitle="false"
-        app:title="@string/deduplicator_keep_prefer_paths_title" />
+        app:summary="@string/deduplicator_arbiter_summary"
+        app:title="@string/deduplicator_arbiter_title" />
 
     <CheckBoxPreference
         app:icon="@drawable/ic_numeric_0_box_24"

--- a/app/src/test/java/eu/darken/sdmse/deduplicator/core/DeduplicatorSettingsSerializationTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/deduplicator/core/DeduplicatorSettingsSerializationTest.kt
@@ -1,7 +1,10 @@
 package eu.darken.sdmse.deduplicator.core
 
+import com.squareup.moshi.JsonDataException
 import eu.darken.sdmse.common.files.local.LocalPath
 import eu.darken.sdmse.common.serialization.SerializationAppModule
+import eu.darken.sdmse.deduplicator.core.arbiter.ArbiterCriterium
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
@@ -11,20 +14,98 @@ class DeduplicatorSettingsSerializationTest : BaseTest() {
     private val moshi = SerializationAppModule().moshi()
 
     @Test
-    fun `KeepPreferPaths serialization roundtrip`() {
-        val original = DeduplicatorSettings.KeepPreferPaths(
-            paths = setOf(
+    fun `ArbiterCriterium DuplicateType serialization`() {
+        val adapter = moshi.adapter(ArbiterCriterium::class.java)
+        val original = ArbiterCriterium.DuplicateType(mode = ArbiterCriterium.DuplicateType.Mode.PREFER_PHASH)
+
+        val json = adapter.toJson(original)
+        json.toComparableJson() shouldBe """
+            {"criteriumType":"DUPLICATE_TYPE","mode":"PREFER_PHASH"}
+        """.toComparableJson()
+
+        adapter.fromJson(json) shouldBe original
+    }
+
+    @Test
+    fun `ArbiterCriterium MediaProvider serialization`() {
+        val adapter = moshi.adapter(ArbiterCriterium::class.java)
+        val original = ArbiterCriterium.MediaProvider(mode = ArbiterCriterium.MediaProvider.Mode.PREFER_UNKNOWN)
+
+        val json = adapter.toJson(original)
+        json.toComparableJson() shouldBe """
+            {"criteriumType":"MEDIA_PROVIDER","mode":"PREFER_UNKNOWN"}
+        """.toComparableJson()
+
+        adapter.fromJson(json) shouldBe original
+    }
+
+    @Test
+    fun `ArbiterCriterium Location serialization`() {
+        val adapter = moshi.adapter(ArbiterCriterium::class.java)
+        val original = ArbiterCriterium.Location(mode = ArbiterCriterium.Location.Mode.PREFER_SECONDARY)
+
+        val json = adapter.toJson(original)
+        json.toComparableJson() shouldBe """
+            {"criteriumType":"LOCATION","mode":"PREFER_SECONDARY"}
+        """.toComparableJson()
+
+        adapter.fromJson(json) shouldBe original
+    }
+
+    @Test
+    fun `ArbiterCriterium Nesting serialization`() {
+        val adapter = moshi.adapter(ArbiterCriterium::class.java)
+        val original = ArbiterCriterium.Nesting(mode = ArbiterCriterium.Nesting.Mode.PREFER_DEEPER)
+
+        val json = adapter.toJson(original)
+        json.toComparableJson() shouldBe """
+            {"criteriumType":"NESTING","mode":"PREFER_DEEPER"}
+        """.toComparableJson()
+
+        adapter.fromJson(json) shouldBe original
+    }
+
+    @Test
+    fun `ArbiterCriterium Modified serialization`() {
+        val adapter = moshi.adapter(ArbiterCriterium::class.java)
+        val original = ArbiterCriterium.Modified(mode = ArbiterCriterium.Modified.Mode.PREFER_NEWER)
+
+        val json = adapter.toJson(original)
+        json.toComparableJson() shouldBe """
+            {"criteriumType":"MODIFIED","mode":"PREFER_NEWER"}
+        """.toComparableJson()
+
+        adapter.fromJson(json) shouldBe original
+    }
+
+    @Test
+    fun `ArbiterCriterium Size serialization`() {
+        val adapter = moshi.adapter(ArbiterCriterium::class.java)
+        val original = ArbiterCriterium.Size(mode = ArbiterCriterium.Size.Mode.PREFER_SMALLER)
+
+        val json = adapter.toJson(original)
+        json.toComparableJson() shouldBe """
+            {"criteriumType":"SIZE","mode":"PREFER_SMALLER"}
+        """.toComparableJson()
+
+        adapter.fromJson(json) shouldBe original
+    }
+
+    @Test
+    fun `ArbiterCriterium PreferredPath serialization`() {
+        val adapter = moshi.adapter(ArbiterCriterium::class.java)
+        val original = ArbiterCriterium.PreferredPath(
+            keepPreferPaths = setOf(
                 LocalPath.build("storage", "emulated", "0", "Pictures"),
                 LocalPath.build("storage", "emulated", "0", "DCIM"),
             )
         )
 
-        val adapter = moshi.adapter(DeduplicatorSettings.KeepPreferPaths::class.java)
         val json = adapter.toJson(original)
-
         json.toComparableJson() shouldBe """
             {
-                "paths": [
+                "criteriumType": "PREFERRED_PATH",
+                "keepPreferPaths": [
                     {"file": "/storage/emulated/0/Pictures", "pathType": "LOCAL"},
                     {"file": "/storage/emulated/0/DCIM", "pathType": "LOCAL"}
                 ]
@@ -35,11 +116,217 @@ class DeduplicatorSettingsSerializationTest : BaseTest() {
     }
 
     @Test
-    fun `KeepPreferPaths empty paths`() {
-        val original = DeduplicatorSettings.KeepPreferPaths()
-        val adapter = moshi.adapter(DeduplicatorSettings.KeepPreferPaths::class.java)
+    fun `ArbiterCriterium PreferredPath empty paths serialization`() {
+        val adapter = moshi.adapter(ArbiterCriterium::class.java)
+        val original = ArbiterCriterium.PreferredPath()
 
         val json = adapter.toJson(original)
+        json.toComparableJson() shouldBe """
+            {"criteriumType":"PREFERRED_PATH","keepPreferPaths":[]}
+        """.toComparableJson()
+
+        adapter.fromJson(json) shouldBe original
+    }
+
+    @Test
+    fun `ArbiterConfig serialization roundtrip`() {
+        val original = DeduplicatorSettings.ArbiterConfig(
+            criteria = listOf(
+                ArbiterCriterium.Modified(mode = ArbiterCriterium.Modified.Mode.PREFER_NEWER),
+                ArbiterCriterium.Location(mode = ArbiterCriterium.Location.Mode.PREFER_PRIMARY),
+            )
+        )
+        val adapter = moshi.adapter(DeduplicatorSettings.ArbiterConfig::class.java)
+        val json = adapter.toJson(original)
+
+        json.toComparableJson() shouldBe """
+            {
+                "criteria": [
+                    {"criteriumType": "MODIFIED", "mode": "PREFER_NEWER"},
+                    {"criteriumType": "LOCATION", "mode": "PREFER_PRIMARY"}
+                ]
+            }
+        """.toComparableJson()
+
+        adapter.fromJson(json) shouldBe original
+    }
+
+    @Test
+    fun `ArbiterConfig default config serialization`() {
+        val original = DeduplicatorSettings.ArbiterConfig()
+        val adapter = moshi.adapter(DeduplicatorSettings.ArbiterConfig::class.java)
+
+        val json = adapter.toJson(original)
+
+        json.toComparableJson() shouldBe """
+            {
+                "criteria": [
+                    {"criteriumType": "DUPLICATE_TYPE", "mode": "PREFER_CHECKSUM"},
+                    {"criteriumType": "PREFERRED_PATH", "keepPreferPaths": []},
+                    {"criteriumType": "MEDIA_PROVIDER", "mode": "PREFER_INDEXED"},
+                    {"criteriumType": "LOCATION", "mode": "PREFER_PRIMARY"},
+                    {"criteriumType": "NESTING", "mode": "PREFER_SHALLOW"},
+                    {"criteriumType": "MODIFIED", "mode": "PREFER_OLDER"},
+                    {"criteriumType": "SIZE", "mode": "PREFER_LARGER"}
+                ]
+            }
+        """.toComparableJson()
+
+        adapter.fromJson(json) shouldBe original
+    }
+
+    @Test
+    fun `ArbiterConfig with PreferredPath containing paths`() {
+        val original = DeduplicatorSettings.ArbiterConfig(
+            criteria = listOf(
+                ArbiterCriterium.PreferredPath(
+                    keepPreferPaths = setOf(
+                        LocalPath.build("storage", "emulated", "0", "DCIM"),
+                    )
+                ),
+                ArbiterCriterium.DuplicateType(),
+            )
+        )
+        val adapter = moshi.adapter(DeduplicatorSettings.ArbiterConfig::class.java)
+
+        val json = adapter.toJson(original)
+        adapter.fromJson(json) shouldBe original
+    }
+
+    // Missing mode variant tests
+
+    @Test
+    fun `ArbiterCriterium DuplicateType PREFER_CHECKSUM serialization`() {
+        val adapter = moshi.adapter(ArbiterCriterium::class.java)
+        val original = ArbiterCriterium.DuplicateType(mode = ArbiterCriterium.DuplicateType.Mode.PREFER_CHECKSUM)
+
+        val json = adapter.toJson(original)
+        json.toComparableJson() shouldBe """
+            {"criteriumType":"DUPLICATE_TYPE","mode":"PREFER_CHECKSUM"}
+        """.toComparableJson()
+
+        adapter.fromJson(json) shouldBe original
+    }
+
+    @Test
+    fun `ArbiterCriterium MediaProvider PREFER_INDEXED serialization`() {
+        val adapter = moshi.adapter(ArbiterCriterium::class.java)
+        val original = ArbiterCriterium.MediaProvider(mode = ArbiterCriterium.MediaProvider.Mode.PREFER_INDEXED)
+
+        val json = adapter.toJson(original)
+        json.toComparableJson() shouldBe """
+            {"criteriumType":"MEDIA_PROVIDER","mode":"PREFER_INDEXED"}
+        """.toComparableJson()
+
+        adapter.fromJson(json) shouldBe original
+    }
+
+    @Test
+    fun `ArbiterCriterium Location PREFER_PRIMARY serialization`() {
+        val adapter = moshi.adapter(ArbiterCriterium::class.java)
+        val original = ArbiterCriterium.Location(mode = ArbiterCriterium.Location.Mode.PREFER_PRIMARY)
+
+        val json = adapter.toJson(original)
+        json.toComparableJson() shouldBe """
+            {"criteriumType":"LOCATION","mode":"PREFER_PRIMARY"}
+        """.toComparableJson()
+
+        adapter.fromJson(json) shouldBe original
+    }
+
+    @Test
+    fun `ArbiterCriterium Nesting PREFER_SHALLOW serialization`() {
+        val adapter = moshi.adapter(ArbiterCriterium::class.java)
+        val original = ArbiterCriterium.Nesting(mode = ArbiterCriterium.Nesting.Mode.PREFER_SHALLOW)
+
+        val json = adapter.toJson(original)
+        json.toComparableJson() shouldBe """
+            {"criteriumType":"NESTING","mode":"PREFER_SHALLOW"}
+        """.toComparableJson()
+
+        adapter.fromJson(json) shouldBe original
+    }
+
+    @Test
+    fun `ArbiterCriterium Modified PREFER_OLDER serialization`() {
+        val adapter = moshi.adapter(ArbiterCriterium::class.java)
+        val original = ArbiterCriterium.Modified(mode = ArbiterCriterium.Modified.Mode.PREFER_OLDER)
+
+        val json = adapter.toJson(original)
+        json.toComparableJson() shouldBe """
+            {"criteriumType":"MODIFIED","mode":"PREFER_OLDER"}
+        """.toComparableJson()
+
+        adapter.fromJson(json) shouldBe original
+    }
+
+    @Test
+    fun `ArbiterCriterium Size PREFER_LARGER serialization`() {
+        val adapter = moshi.adapter(ArbiterCriterium::class.java)
+        val original = ArbiterCriterium.Size(mode = ArbiterCriterium.Size.Mode.PREFER_LARGER)
+
+        val json = adapter.toJson(original)
+        json.toComparableJson() shouldBe """
+            {"criteriumType":"SIZE","mode":"PREFER_LARGER"}
+        """.toComparableJson()
+
+        adapter.fromJson(json) shouldBe original
+    }
+
+    // Error handling tests
+
+    @Test
+    fun `ArbiterCriterium unknown criteriumType throws JsonDataException`() {
+        val adapter = moshi.adapter(ArbiterCriterium::class.java)
+        val json = """{"criteriumType":"UNKNOWN_TYPE","mode":"PREFER_NEWER"}"""
+
+        shouldThrow<JsonDataException> {
+            adapter.fromJson(json)
+        }
+    }
+
+    @Test
+    fun `ArbiterCriterium invalid mode throws JsonDataException`() {
+        val adapter = moshi.adapter(ArbiterCriterium::class.java)
+        val json = """{"criteriumType":"MODIFIED","mode":"PREFER_INVALID"}"""
+
+        shouldThrow<JsonDataException> {
+            adapter.fromJson(json)
+        }
+    }
+
+    @Test
+    fun `ArbiterCriterium missing criteriumType throws JsonDataException`() {
+        val adapter = moshi.adapter(ArbiterCriterium::class.java)
+        val json = """{"mode":"PREFER_NEWER"}"""
+
+        shouldThrow<JsonDataException> {
+            adapter.fromJson(json)
+        }
+    }
+
+    @Test
+    fun `ArbiterCriterium malformed JSON throws exception`() {
+        val adapter = moshi.adapter(ArbiterCriterium::class.java)
+        val json = """{"criteriumType":"MODIFIED", mode: invalid}"""
+
+        shouldThrow<Exception> {
+            adapter.fromJson(json)
+        }
+    }
+
+    // Edge case tests
+
+    @Test
+    fun `ArbiterConfig empty criteria list serialization`() {
+        val original = DeduplicatorSettings.ArbiterConfig(criteria = emptyList())
+        val adapter = moshi.adapter(DeduplicatorSettings.ArbiterConfig::class.java)
+
+        val json = adapter.toJson(original)
+        json.toComparableJson() shouldBe """
+            {"criteria":[]}
+        """.toComparableJson()
+
         adapter.fromJson(json) shouldBe original
     }
 }


### PR DESCRIPTION
## Summary
- Adds new settings screen for configuring how the deduplicator decides which file to keep
- Users can reorder criteria priorities via drag-and-drop
- Each criterion has configurable modes (e.g., prefer older vs newer files)
- Supports setting preferred paths to always keep files in specific directories

## Available Criteria
- **DuplicateType**: Prefer checksum vs perceptual hash matches
- **PreferredPath**: Keep files in user-specified directories
- **MediaProvider**: Prefer indexed vs unknown media
- **Location**: Prefer primary vs secondary storage
- **Nesting**: Prefer shallow vs deeper folder nesting
- **Modified**: Prefer older vs newer files
- **Size**: Prefer larger vs smaller files

## Test plan
- [x] Open Deduplicator settings and verify "Deletion strategy" option appears
- [x] Tap to open arbiter config screen
- [x] Verify drag-and-drop reordering works
- [x] Verify tapping a criterion opens mode selection
- [x] Verify PreferredPath opens path picker
- [x] Reset to defaults and verify order restores
- [x] Run deduplicator scan and verify criteria affect auto-selection

Closes #1140