### PR TITLE
Deduplicator: Fix FileForensics resource not kept alive during deletion

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/deduplicator/core/Deduplicator.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/core/Deduplicator.kt
@@ -13,6 +13,7 @@ import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.flow.replayingShare
+import eu.darken.sdmse.common.forensics.FileForensics
 import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.common.progress.withProgress
 import eu.darken.sdmse.common.sharedresource.SharedResource
@@ -44,6 +45,7 @@ import javax.inject.Singleton
 class Deduplicator @Inject constructor(
     @AppScope private val appScope: CoroutineScope,
     private val gatewaySwitch: GatewaySwitch,
+    private val fileForensics: FileForensics,
     private val exclusionManager: ExclusionManager,
     private val scanner: Provider<DuplicatesScanner>,
     private val deleter: Provider<DuplicatesDeleter>,
@@ -82,7 +84,7 @@ class Deduplicator @Inject constructor(
         updateProgress { Progress.Data() }
 
         try {
-            val result = keepResourceHoldersAlive(gatewaySwitch) {
+            val result = keepResourceHoldersAlive(gatewaySwitch, fileForensics) {
                 when (task) {
                     is DeduplicatorScanTask -> performScan(task)
                     is DeduplicatorDeleteTask -> performDelete(task)


### PR DESCRIPTION
## Summary
- Fix `FileForensics` SharedResource not being kept alive during duplicate deletion
- Resolves "Tried to add open child to closed parent" warnings when `LocationCheck` calls `identifyArea()`

## Problem
During deletion, only `gatewaySwitch` was kept alive via `keepResourceHoldersAlive()`. However, `LocationCheck` (used by the arbiter) injects `FileForensics` and calls `identifyArea()`, which requires `FileForensics` to be alive.

## Fix
Add `FileForensics` to the `keepResourceHoldersAlive()` call in `Deduplicator.submit()`.

## Test plan
- [x] Run deduplicator scan
- [x] Delete a duplicate cluster
- [x] Verify no "Tried to add open child to closed parent" warnings in logcat