### PR TITLE
General: Migrate from applicationVariants to androidComponents Variant API

### DIFF
--- a/buildSrc/src/main/java/ProjectExtensions.kt
+++ b/buildSrc/src/main/java/ProjectExtensions.kt
@@ -1,4 +1,4 @@
-import com.android.build.gradle.LibraryExtension
+import com.android.build.api.dsl.LibraryExtension
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.tasks.testing.Test

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,5 +24,5 @@ android.uniquePackageNames=false
 android.dependency.useConstraints=true
 android.r8.strictFullModeForKeepRules=false
 android.generateSyncIssueWhenLibraryConstraintsAreEnabled=false
-# Required: applicationVariants in build.gradle.kts uses old DSL API
+# Required until Hilt plugin supports android.newDsl=true
 android.newDsl=false


### PR DESCRIPTION
## Summary
- Replace deprecated `applicationVariants` API with modern `androidComponents` Variant API for APK renaming
- Update `LibraryExtension` import to use new DSL API (`com.android.build.api.dsl.LibraryExtension`)
- Fix task lookup to use `tasks.matching` for lazy resolution (avoids task-not-found errors)

## Details
The `applicationVariants` API is deprecated in AGP 9.0 and will be removed in AGP 10.0. This PR migrates the APK renaming logic to use the new `androidComponents.onVariants` callback with:
- `SingleArtifact.APK` for accessing the APK directory
- `BuiltArtifactsLoader` for loading artifact metadata
- Dedicated rename tasks registered via `tasks.register`

Note: `android.newDsl=false` is still required due to Hilt plugin compatibility. Once Hilt supports the new DSL, this can be removed.

## Test plan
- [x] Build FOSS debug: `./gradlew assembleFossDebug`
- [x] Build FOSS release: `./gradlew assembleFossRelease`
- [x] Verify APK renamed correctly: `eu.darken.sdmse-v1.5.7-rc0-10507000-FOSS-RELEASE.apk`