### PR TITLE
General: Add placeholder test to app-common-adb module

### DIFF
--- a/app-common-adb/src/test/java/eu/darken/sdmse/common/adb/ExampleUnitTest.kt
+++ b/app-common-adb/src/test/java/eu/darken/sdmse/common/adb/ExampleUnitTest.kt
@@ -1,0 +1,16 @@
+package eu.darken.sdmse.common.adb
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Example local unit test, which will execute on the development machine (host).
+ *
+ * See [testing documentation](http://d.android.com/tools/testing).
+ */
+class ExampleUnitTest {
+    @Test
+    fun addition_isCorrect() {
+        assertEquals(4, 2 + 2)
+    }
+}


### PR DESCRIPTION
## Summary
- Add placeholder test to `app-common-adb` module to fix test suite failures

The module had test configuration enabled but an empty test directory, causing Gradle to fail with "No tests found" when running the test suite (`failOnNoDiscoveredTests = true` by default).

## Test plan
- [x] `./gradlew :app-common-adb:testDebugUnitTest` passes
- [x] `./gradlew test` - all 2215 tests pass