### PR TITLE
AppControl: Add Debug tag for debuggable apps

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/PkgExtensions.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/PkgExtensions.kt
@@ -35,5 +35,8 @@ val Pkg.isSystemApp: Boolean
 val Pkg.isUpdatedSystemApp: Boolean
     get() = isSystemApp && (this is InstallDetails) && this.isUpdatedSystemApp
 
+val Pkg.isDebuggable: Boolean
+    get() = (this is InstallDetails) && this.isDebuggable
+
 fun Pkg.Id.getLaunchIntent(context: Context) =
     context.packageManager.getLaunchIntentForPackage(this.name)

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/features/InstallDetails.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/features/InstallDetails.kt
@@ -14,6 +14,9 @@ interface InstallDetails : PkgInfo {
     val isUpdatedSystemApp: Boolean
         get() = applicationInfo?.run { flags and ApplicationInfo.FLAG_UPDATED_SYSTEM_APP != 0 } ?: true
 
+    val isDebuggable: Boolean
+        get() = applicationInfo?.run { flags and ApplicationInfo.FLAG_DEBUGGABLE != 0 } ?: false
+
     val installedAt: Instant?
         get() = packageInfo.firstInstallTime.takeIf { it != 0L }?.let { Instant.ofEpochMilli(it) }
 

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/ui/AppInfoTagView.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/ui/AppInfoTagView.kt
@@ -11,6 +11,7 @@ import androidx.core.view.isVisible
 import eu.darken.sdmse.appcontrol.core.AppInfo
 import eu.darken.sdmse.appcontrol.core.export.AppExportType
 import eu.darken.sdmse.common.pkgs.isArchived
+import eu.darken.sdmse.common.pkgs.isDebuggable
 import eu.darken.sdmse.common.pkgs.isEnabled
 import eu.darken.sdmse.common.pkgs.isSystemApp
 import eu.darken.sdmse.common.pkgs.isUninstalled
@@ -35,6 +36,7 @@ class AppInfoTagView @JvmOverloads constructor(
 
     fun setPkg(appInfo: AppInfo) = ui.apply {
         tagSystem.tagSystem.isVisible = appInfo.pkg.isSystemApp
+        tagDebug.tagDebug.isVisible = appInfo.pkg.isDebuggable
 
         tagArchived.tagArchived.isVisible = appInfo.pkg.isArchived
         tagUninstalled.tagUninstalled.isVisible = appInfo.pkg.isUninstalled

--- a/app/src/main/res/layout/appcontrol_appinfo_tag_view.xml
+++ b/app/src/main/res/layout/appcontrol_appinfo_tag_view.xml
@@ -12,6 +12,11 @@
         tools:visibility="visible" />
 
     <include
+        android:id="@+id/tag_debug"
+        layout="@layout/appcontrol_tag_debug_view"
+        tools:visibility="visible" />
+
+    <include
         android:id="@+id/tag_archived"
         layout="@layout/appcontrol_tag_archived_view"
         tools:visibility="visible" />
@@ -46,7 +51,7 @@
         style="@style/AppControlTagContainerFlow"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        app:constraint_referenced_ids="tag_system,tag_apk_base,tag_apk_bundle,tag_archived,tag_uninstalled,tag_disabled,tag_active"
+        app:constraint_referenced_ids="tag_system,tag_debug,tag_apk_base,tag_apk_bundle,tag_archived,tag_uninstalled,tag_disabled,tag_active"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/layout/appcontrol_tag_debug_view.xml
+++ b/app/src/main/res/layout/appcontrol_tag_debug_view.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/tag_debug"
+    style="@style/AppControlTagStyle"
+    android:background="@drawable/bg_tag_box"
+    android:backgroundTint="?colorTertiary"
+    android:text="@string/appcontrol_tag_debug"
+    android:textColor="?colorOnTertiary"
+    android:visibility="gone"
+    app:iconTint="?colorOnTertiary"
+    tools:visibility="visible" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -588,6 +588,7 @@
     <string name="appcontrol_tag_not_installed">Not installed</string>
     <string name="appcontrol_tag_enabled">Enabled</string>
     <string name="appcontrol_tag_disabled">Disabled</string>
+    <string name="appcontrol_tag_debug">Debug</string>
     <string name="appcontrol_progress_enabling_package">Enabling app</string>
     <string name="appcontrol_progress_disabling_package">Disabling app</string>
     <string name="appcontrol_list_filteroptions_label">Filter options</string>


### PR DESCRIPTION
## Summary
- Display a "Debug" tag in AppControl for apps signed with a debug certificate
- Helps identify debug builds when managing apps
- Uses tertiary color styling to distinguish from other tags

## Test plan
- [x] Install debug APK on device/emulator
- [x] Open AppControl and verify SD Maid SE shows "Debug" tag
- [x] Verify system apps and release apps do NOT show "Debug" tag
- [x] Verify tag appears in both list view and app action dialog