### PR TITLE
CorpseFinder: Suppress notification when 0 remnants found

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/corpsefinder/core/CorpseFinder.kt
+++ b/app/src/main/java/eu/darken/sdmse/corpsefinder/core/CorpseFinder.kt
@@ -140,11 +140,13 @@ class CorpseFinder @Inject constructor(
                                 watcherNotifications.notifyOfDeletion(watcherResult)
                             }
                         } else {
-                            val watcherResult = ExternalWatcherResult.Scan(
-                                pkgId = task.target,
-                                foundItems = targets.size
-                            )
-                            watcherNotifications.notifyOfScan(watcherResult)
+                            if (targets.isNotEmpty()) {
+                                val watcherResult = ExternalWatcherResult.Scan(
+                                    pkgId = task.target,
+                                    foundItems = targets.size
+                                )
+                                watcherNotifications.notifyOfScan(watcherResult)
+                            }
                             null
                         }
 


### PR DESCRIPTION
## Summary

- Suppress the uninstall watcher notification when no remnants are found after an app is uninstalled
- Previously, users would receive persistent notifications saying "0 remnants found" that required manual dismissal

## Changes

Only show the scan notification when `targets.isNotEmpty()`. This affects the scan notification path (when auto-delete is disabled). The auto-delete notification path remains unchanged since it reports deletion results with freed space information.

## Test plan

- [x] Enable uninstall watcher in CorpseFinder settings
- [x] Disable auto-delete
- [x] Uninstall an app that has no remnants → verify no notification appears
- [x] Uninstall an app that has remnants → verify notification appears with correct count

Closes #1248