### PR TITLE
Analyzer: Make System Data card non-clickable

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/analyzer/ui/storage/storage/StorageContentViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/analyzer/ui/storage/storage/StorageContentViewModel.kt
@@ -98,13 +98,6 @@ class StorageContentViewModel @Inject constructor(
                     is SystemCategory -> SystemCategoryVH.Item(
                         storage = storage,
                         content = content,
-                        onItemClick = {
-                            if (content.groups.isEmpty()) return@Item
-                            StorageContentFragmentDirections.actionStorageFragmentToContentFragment(
-                                storageId = targetStorageId,
-                                groupId = content.groups.single().id,
-                            ).navigate()
-                        }
                     )
                 }
             }

--- a/app/src/main/java/eu/darken/sdmse/analyzer/ui/storage/storage/categories/SystemCategoryVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/analyzer/ui/storage/storage/categories/SystemCategoryVH.kt
@@ -36,13 +36,14 @@ class SystemCategoryVH(parent: ViewGroup) :
         )
         progress.progress = totalPercent
 
-        root.setOnClickListener { item.onItemClick() }
+        // System Data is informational only - no navigation available
+        root.isClickable = false
+        root.isFocusable = false
     }
 
     data class Item(
         val storage: DeviceStorage,
         val content: SystemCategory,
-        val onItemClick: () -> Unit,
     ) : StorageContentAdapter.Item {
 
         override val stableId: Long = this.javaClass.hashCode().toLong()


### PR DESCRIPTION
## Summary
- Make System Data card in Storage Analyzer purely informational (non-clickable)
- Remove confusing "No direct access available" message when users tap the card

## Test plan
- [x] Verify System Data card is displayed with correct space info
- [x] Verify clicking the System Data card does nothing (no ripple, no navigation)
- [x] Verify App and Media categories still navigate correctly when clicked

Closes #917