### PR TITLE
AppControl: Add mutual exclusivity between ENABLED and NOT_INSTALLED filters

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListViewModel.kt
@@ -333,7 +333,7 @@ class AppControlListViewModel @Inject constructor(
                 FilterSettings.Tag.ENABLED -> if (existing) {
                     old.tags.minus(tag)
                 } else {
-                    old.tags.plus(tag).minus(FilterSettings.Tag.DISABLED)
+                    old.tags.plus(tag).minus(FilterSettings.Tag.DISABLED).minus(FilterSettings.Tag.NOT_INSTALLED)
                 }
 
                 FilterSettings.Tag.DISABLED -> if (existing) {
@@ -351,7 +351,7 @@ class AppControlListViewModel @Inject constructor(
                 FilterSettings.Tag.NOT_INSTALLED -> if (existing) {
                     old.tags.minus(tag)
                 } else {
-                    old.tags.plus(tag)
+                    old.tags.plus(tag).minus(FilterSettings.Tag.ENABLED)
                 }
             }
             old.copy(tags = newTags)


### PR DESCRIPTION
## Summary
- Automatically disable ENABLED filter when NOT_INSTALLED is turned on
- Automatically disable NOT_INSTALLED filter when ENABLED is turned on

## Background
Archived apps (`ArchivedPkg`) have `isEnabled = false` hardcoded, so combining the ENABLED filter with NOT_INSTALLED always produces an empty result. This follows the existing mutual exclusivity pattern used for USER/SYSTEM and ENABLED/DISABLED filters.

## Test plan
- [x] Open AppControl
- [x] Enable the ENABLED filter
- [x] Toggle NOT_INSTALLED filter ON → verify ENABLED filter turns OFF
- [x] Enable NOT_INSTALLED filter
- [x] Toggle ENABLED filter ON → verify NOT_INSTALLED filter turns OFF