### PR TITLE
AppControl: Enhance share list with Markdown format and store links

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/AKnownPkg.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/AKnownPkg.kt
@@ -42,20 +42,38 @@ sealed class AKnownPkg(override val id: Pkg.Id) : Pkg {
 
     data object GooglePlay : AKnownPkg("com.android.vending"), AppStore {
         override val iconRes: Int = R.drawable.ic_baseline_gplay_24
+        override val storeLabel: String = "Google Play"
         override val urlGenerator: ((Pkg.Id) -> String) = {
             "https://play.google.com/store/apps/details?id=${it.name}"
         }
     }
 
-    data object VivoAppStore : AKnownPkg("com.vivo.appstore"), AppStore
+    data object VivoAppStore : AKnownPkg("com.vivo.appstore"), AppStore {
+        override val storeLabel: String = "Vivo App Store"
+    }
 
-    data object OppoMarket : AKnownPkg("com.oppo.market"), AppStore
+    data object OppoMarket : AKnownPkg("com.oppo.market"), AppStore {
+        override val storeLabel: String = "Oppo Market"
+    }
 
-    data object HuaweiAppGallery : AKnownPkg("com.huawei.appmarket"), AppStore
+    data object HuaweiAppGallery : AKnownPkg("com.huawei.appmarket"), AppStore {
+        override val storeLabel: String = "Huawei AppGallery"
+    }
 
-    data object SamsungAppStore : AKnownPkg("com.sec.android.app.samsungapps"), AppStore
+    data object SamsungAppStore : AKnownPkg("com.sec.android.app.samsungapps"), AppStore {
+        override val storeLabel: String = "Samsung Galaxy Store"
+    }
 
-    data object XiaomiAppStore : AKnownPkg("com.xiaomi.mipicks"), AppStore
+    data object XiaomiAppStore : AKnownPkg("com.xiaomi.mipicks"), AppStore {
+        override val storeLabel: String = "Xiaomi GetApps"
+    }
+
+    data object FDroid : AKnownPkg("org.fdroid.fdroid"), AppStore {
+        override val storeLabel: String = "F-Droid"
+        override val urlGenerator: ((Pkg.Id) -> String) = {
+            "https://f-droid.org/packages/${it.name}"
+        }
+    }
 
     companion object {
         val values: List<AKnownPkg> = listOf(
@@ -65,7 +83,8 @@ sealed class AKnownPkg(override val id: Pkg.Id) : Pkg {
             OppoMarket,
             HuaweiAppGallery,
             SamsungAppStore,
-            XiaomiAppStore
+            XiaomiAppStore,
+            FDroid,
         )
 
         val APP_STORES by lazy { values.filterIsInstance<AppStore>() }

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/features/AppStore.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/features/AppStore.kt
@@ -4,6 +4,8 @@ import eu.darken.sdmse.common.pkgs.Pkg
 
 interface AppStore : Pkg {
 
+    val storeLabel: String
+
     val urlGenerator: ((Pkg.Id) -> String)?
         get() = null
 }

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListEvents.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListEvents.kt
@@ -17,4 +17,5 @@ sealed class AppControlListEvents {
     data class ConfirmArchive(val items: List<AppControlListAdapter.Item>) : AppControlListEvents()
     data class ConfirmRestore(val items: List<AppControlListAdapter.Item>) : AppControlListEvents()
     data class ShowResult(val result: AppControlTask.Result) : AppControlListEvents()
+    data class ShareList(val text: String) : AppControlListEvents()
 }

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListFragment.kt
@@ -206,6 +206,12 @@ class AppControlListFragment : Fragment3(R.layout.appcontrol_list_fragment) {
                         true
                     }
 
+                    R.id.action_share_selection -> {
+                        vm.shareList(selected)
+                        tracker.clearSelection()
+                        true
+                    }
+
                     else -> false
                 }
             }
@@ -420,6 +426,14 @@ class AppControlListFragment : Fragment3(R.layout.appcontrol_list_fragment) {
                         event.result.primaryInfo.get(requireContext()),
                         Snackbar.LENGTH_SHORT
                     ).show()
+                }
+
+                is AppControlListEvents.ShareList -> {
+                    val shareIntent = Intent(Intent.ACTION_SEND).apply {
+                        type = "text/plain"
+                        putExtra(Intent.EXTRA_TEXT, event.text)
+                    }
+                    startActivity(Intent.createChooser(shareIntent, null))
                 }
             }
         }

--- a/app/src/main/res/menu/menu_appcontrol_list_cab.xml
+++ b/app/src/main/res/menu/menu_appcontrol_list_cab.xml
@@ -42,4 +42,9 @@
         android:icon="@drawable/ic_select_all_24"
         android:title="@string/general_list_select_all_action"
         app:showAsAction="ifRoom" />
+    <item
+        android:id="@+id/action_share_selection"
+        android:icon="@drawable/outline_share_24"
+        android:title="@string/appcontrol_share_list_action"
+        app:showAsAction="ifRoom" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -657,6 +657,9 @@
         <item quantity="other">%d apps were exported</item>
     </plurals>
     <string name="appcontrol_progress_exporting_x">Exporting %s</string>
+    <string name="appcontrol_share_list_action">Share list</string>
+    <string name="appcontrol_share_list_title">My Apps</string>
+    <string name="appcontrol_share_list_footer">Shared via SD Maid SE</string>
     <string name="appcontrol_force_stop_selection_action">Force stop apps</string>
     <string name="appcontrol_force_stop_action">Force stop</string>
     <string name="appcontrol_force_stop_confirm_title">Confirm force stop</string>


### PR DESCRIPTION
## Summary
- Enhanced "Share list" feature to output detailed app info in Markdown format
- Each app shows: name, package name, version name, and version code
- Apps from Google Play or F-Droid include clickable store links
- Added title header and SD Maid SE footer to shared content
- Added F-Droid as a known app store with URL generator

## Format Example
```
# My Apps

- **Chrome** `com.android.chrome` v120.0.6099.144 (609914400) [Google Play](https://play.google.com/store/apps/details?id=com.android.chrome)
- **F-Droid** `org.fdroid.fdroid` v1.19.2 (1019002) [F-Droid](https://f-droid.org/packages/org.fdroid.fdroid)
- **Sideloaded App** `com.example.sideloaded` v1.0 (1)

---
*Shared via SD Maid SE*
```

## Test plan
- [x] Open AppControl, select multiple apps from different sources (Play Store, F-Droid, sideloaded)
- [x] Tap "Share list" in the CAB menu
- [x] Verify output includes correct app info and store links where applicable

Closes #1172