### PR TITLE
General: Improve Google Play billing error messages

### DIFF
--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplay.kt
@@ -17,6 +17,7 @@ import eu.darken.sdmse.common.upgrade.core.billing.BillingManager
 import eu.darken.sdmse.common.upgrade.core.billing.PurchasedSku
 import eu.darken.sdmse.common.upgrade.core.billing.Sku
 import eu.darken.sdmse.common.upgrade.core.billing.SkuDetails
+import eu.darken.sdmse.common.upgrade.core.billing.UserCanceledBillingException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -94,6 +95,10 @@ class UpgradeRepoGplay @Inject constructor(
             try {
                 billingManager.startIapFlow(activity, sku, offer)
             } catch (e: Exception) {
+                if (e is UserCanceledBillingException) {
+                    log(TAG) { "User canceled billing flow" }
+                    return@launch
+                }
                 log(TAG) { "startIapFlow failed:${e.asLog()}" }
                 withContext(dispatcherProvider.Main) {
                     e.asErrorDialogBuilder(activity).show()

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManager.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManager.kt
@@ -153,10 +153,14 @@ class BillingManager @Inject constructor(
             if (this !is BillingClientException) return this
 
             return when (result.responseCode) {
+                BillingResponseCode.USER_CANCELED -> UserCanceledBillingException(this)
                 BillingResponseCode.BILLING_UNAVAILABLE,
                 BillingResponseCode.SERVICE_UNAVAILABLE,
                 BillingResponseCode.SERVICE_DISCONNECTED,
                 BillingResponseCode.SERVICE_TIMEOUT -> GplayServiceUnavailableException(this)
+                BillingResponseCode.ERROR -> InternalBillingException(this)
+                BillingResponseCode.NETWORK_ERROR -> NetworkBillingException(this)
+                BillingResponseCode.ITEM_ALREADY_OWNED -> ItemAlreadyOwnedBillingException(this)
                 else -> this
             }
         }

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/InternalBillingException.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/InternalBillingException.kt
@@ -1,0 +1,16 @@
+package eu.darken.sdmse.common.upgrade.core.billing
+
+import eu.darken.sdmse.R
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.error.HasLocalizedError
+import eu.darken.sdmse.common.error.LocalizedError
+
+class InternalBillingException(cause: Throwable) :
+    BillingException("An internal Google Play error occurred.", cause), HasLocalizedError {
+
+    override fun getLocalizedError(): LocalizedError = LocalizedError(
+        throwable = this,
+        label = R.string.upgrades_gplay_internal_error_title.toCaString(),
+        description = R.string.upgrades_gplay_internal_error_description.toCaString(),
+    )
+}

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/ItemAlreadyOwnedBillingException.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/ItemAlreadyOwnedBillingException.kt
@@ -1,0 +1,16 @@
+package eu.darken.sdmse.common.upgrade.core.billing
+
+import eu.darken.sdmse.R
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.error.HasLocalizedError
+import eu.darken.sdmse.common.error.LocalizedError
+
+class ItemAlreadyOwnedBillingException(cause: Throwable) :
+    BillingException("Item is already owned.", cause), HasLocalizedError {
+
+    override fun getLocalizedError(): LocalizedError = LocalizedError(
+        throwable = this,
+        label = R.string.upgrades_gplay_already_owned_error_title.toCaString(),
+        description = R.string.upgrades_gplay_already_owned_error_description.toCaString(),
+    )
+}

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/NetworkBillingException.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/NetworkBillingException.kt
@@ -1,0 +1,16 @@
+package eu.darken.sdmse.common.upgrade.core.billing
+
+import eu.darken.sdmse.R
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.error.HasLocalizedError
+import eu.darken.sdmse.common.error.LocalizedError
+
+class NetworkBillingException(cause: Throwable) :
+    BillingException("Unable to connect to Google Play.", cause), HasLocalizedError {
+
+    override fun getLocalizedError(): LocalizedError = LocalizedError(
+        throwable = this,
+        label = R.string.upgrades_gplay_network_error_title.toCaString(),
+        description = R.string.upgrades_gplay_network_error_description.toCaString(),
+    )
+}

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/UserCanceledBillingException.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/UserCanceledBillingException.kt
@@ -1,0 +1,8 @@
+package eu.darken.sdmse.common.upgrade.core.billing
+
+/**
+ * Exception thrown when user cancels the billing flow.
+ * Does NOT implement HasLocalizedError - should be dismissed silently.
+ */
+class UserCanceledBillingException(cause: Throwable) :
+    BillingException("User canceled billing flow.", cause)

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -14,6 +14,15 @@
     <string name="upgrades_gplay_billing_error_label">Google Play Issue</string>
     <string name="upgrades_gplay_billing_error_description">There was a problem with Google Play. Please try again later or restart your device.\n\nDetails: %s</string>
 
+    <string name="upgrades_gplay_internal_error_title">Google Play error</string>
+    <string name="upgrades_gplay_internal_error_description">An internal Google Play error occurred. Please try the following:\n\n• Restart your device\n• Clear Google Play Store cache\n• Try again later</string>
+
+    <string name="upgrades_gplay_network_error_title">Connection error</string>
+    <string name="upgrades_gplay_network_error_description">Unable to connect to Google Play. Please check your internet connection and try again.</string>
+
+    <string name="upgrades_gplay_already_owned_error_title">Already purchased</string>
+    <string name="upgrades_gplay_already_owned_error_description">You already own this item. Use the \"Restore purchase\" option to restore your purchase. If the issue persists, try clearing Google Play cache and restarting your device.</string>
+
     <string name="upgrades_no_purchases_found_check_account">No purchases found. Are you using the right account?</string>
 
     <string name="upgrade_screen_title">Get SD Maid SE Pro</string>


### PR DESCRIPTION
## Summary
- Replace raw `BillingClientException` messages with user-friendly error descriptions
- Add dedicated exception classes for specific billing error codes (USER_CANCELED, ERROR, NETWORK_ERROR, ITEM_ALREADY_OWNED)
- Handle user cancellation silently without showing error dialogs
- Provide actionable troubleshooting steps in error messages

## Test plan
- [x] Force stop Google Play to trigger service unavailable errors
- [x] Cancel billing flow mid-purchase - should dismiss silently
- [x] Verify lint and unit tests pass

Closes #1365