### PR TITLE
General: Add dashboard card configuration

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/common/lists/differ/AsyncDiffer.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/lists/differ/AsyncDiffer.kt
@@ -32,12 +32,29 @@ class AsyncDiffer<A, T : DifferItem> internal constructor(
         adapter.addMod(position = 0, mod = StableIdMod(currentList))
     }
 
-    fun submitUpdate(newData: List<T>) {
+    fun submitUpdate(newData: List<T>, onCommit: (() -> Unit)? = null) {
         listDiffer.submitList(newData) {
             synchronized(internalList) {
                 internalList.clear()
                 internalList.addAll(newData)
             }
+            onCommit?.invoke()
+        }
+    }
+
+    /**
+     * Resets the internal state to match [newData] without calculating diff-based moves.
+     * Uses submitList(null) then submitList(newData) to avoid move operations.
+     * Call this after manual notifyItemMoved operations to sync state.
+     */
+    fun resetTo(newData: List<T>, onCommit: (() -> Unit)? = null) {
+        listDiffer.submitList(null)
+        listDiffer.submitList(newData) {
+            synchronized(internalList) {
+                internalList.clear()
+                internalList.addAll(newData)
+            }
+            onCommit?.invoke()
         }
     }
 }

--- a/app/src/main/java/eu/darken/sdmse/common/lists/differ/AsyncDifferExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/lists/differ/AsyncDifferExtensions.kt
@@ -4,10 +4,20 @@ import androidx.recyclerview.widget.RecyclerView
 import eu.darken.sdmse.common.lists.modular.ModularAdapter
 
 
-fun <X, T> X.update(newData: List<T>?)
+fun <X, T> X.update(newData: List<T>?, onCommit: (() -> Unit)? = null)
         where X : HasAsyncDiffer<T>, X : RecyclerView.Adapter<*> {
 
-    asyncDiffer.submitUpdate(newData ?: emptyList())
+    asyncDiffer.submitUpdate(newData ?: emptyList(), onCommit)
+}
+
+/**
+ * Resets the differ's internal state to [newData] without diff-based move calculations.
+ * Use after manual notifyItemMoved operations (e.g., drag-and-drop) to sync state.
+ */
+fun <X, T> X.resetTo(newData: List<T>?, onCommit: (() -> Unit)? = null)
+        where X : HasAsyncDiffer<T>, X : RecyclerView.Adapter<*> {
+
+    asyncDiffer.resetTo(newData ?: emptyList(), onCommit)
 }
 
 fun <A, T : DifferItem> A.setupDiffer(): AsyncDiffer<A, T>

--- a/app/src/main/java/eu/darken/sdmse/main/core/DashboardCardConfig.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/core/DashboardCardConfig.kt
@@ -1,0 +1,19 @@
+package eu.darken.sdmse.main.core
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class DashboardCardConfig(
+    @Json(name = "cards") val cards: List<CardEntry> = defaultCards,
+) {
+    @JsonClass(generateAdapter = true)
+    data class CardEntry(
+        @Json(name = "type") val type: DashboardCardType,
+        @Json(name = "isVisible") val isVisible: Boolean = true,
+    )
+
+    companion object {
+        val defaultCards: List<CardEntry> = DashboardCardType.entries.map { CardEntry(it) }
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/main/core/DashboardCardType.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/core/DashboardCardType.kt
@@ -1,0 +1,21 @@
+package eu.darken.sdmse.main.core
+
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import com.squareup.moshi.JsonClass
+import eu.darken.sdmse.R
+
+@JsonClass(generateAdapter = false)
+enum class DashboardCardType(
+    @StringRes val labelRes: Int,
+    @DrawableRes val iconRes: Int,
+) {
+    CORPSEFINDER(R.string.corpsefinder_tool_name, R.drawable.ghost),
+    SYSTEMCLEANER(R.string.systemcleaner_tool_name, R.drawable.ic_baseline_view_list_24),
+    APPCLEANER(R.string.appcleaner_tool_name, R.drawable.ic_recycle),
+    DEDUPLICATOR(R.string.deduplicator_tool_name, R.drawable.ic_content_duplicate_24),
+    APPCONTROL(R.string.appcontrol_tool_name, R.drawable.ic_apps),
+    ANALYZER(R.string.analyzer_tool_name, R.drawable.baseline_data_usage_24),
+    SCHEDULER(R.string.scheduler_label, R.drawable.ic_alarm_check_24),
+    STATS(R.string.stats_label, R.drawable.ic_chartbox_24),
+}

--- a/app/src/main/java/eu/darken/sdmse/main/core/GeneralSettings.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/core/GeneralSettings.kt
@@ -61,6 +61,13 @@ class GeneralSettings @Inject constructor(
 
     val anniversaryDismissedYear = dataStore.createValue<Int?>("core.anniversary.dismissed.year", null, moshi)
 
+    val dashboardCardConfig = dataStore.createValue(
+        key = "dashboard.cards.config",
+        defaultValue = DashboardCardConfig(),
+        moshi = moshi,
+        fallbackToDefault = true,
+    )
+
     override val mapper = PreferenceStoreMapper(
         debugSettings.isDebugMode,
         themeMode,

--- a/app/src/main/java/eu/darken/sdmse/main/ui/settings/cards/DashboardCardConfigAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/settings/cards/DashboardCardConfigAdapter.kt
@@ -1,0 +1,74 @@
+package eu.darken.sdmse.main.ui.settings.cards
+
+import android.view.ViewGroup
+import androidx.annotation.LayoutRes
+import androidx.recyclerview.widget.RecyclerView
+import androidx.viewbinding.ViewBinding
+import eu.darken.sdmse.common.lists.BindableVH
+import eu.darken.sdmse.common.lists.differ.AsyncDiffer
+import eu.darken.sdmse.common.lists.differ.DifferItem
+import eu.darken.sdmse.common.lists.differ.HasAsyncDiffer
+import eu.darken.sdmse.common.lists.differ.setupDiffer
+import eu.darken.sdmse.common.lists.modular.ModularAdapter
+import eu.darken.sdmse.common.lists.modular.mods.DataBinderMod
+import eu.darken.sdmse.common.lists.modular.mods.TypedVHCreatorMod
+import eu.darken.sdmse.main.core.DashboardCardConfig
+import javax.inject.Inject
+
+
+class DashboardCardConfigAdapter @Inject constructor() :
+    ModularAdapter<DashboardCardConfigAdapter.BaseVH<DashboardCardConfigAdapter.Item, ViewBinding>>(),
+    HasAsyncDiffer<DashboardCardConfigAdapter.Item> {
+
+    override val asyncDiffer: AsyncDiffer<*, Item> = setupDiffer()
+
+    override fun getItemCount(): Int = data.size
+
+    init {
+        addMod(DataBinderMod(data))
+        addMod(TypedVHCreatorMod({ data[it] is HeaderItem }) { DashboardCardConfigHeaderVH(it) })
+        addMod(TypedVHCreatorMod({ data[it] is CardItem }) { DashboardCardConfigRowVH(it) })
+    }
+
+    private var dragStartListener: ((RecyclerView.ViewHolder) -> Unit)? = null
+
+    fun setOnDragStartListener(listener: (RecyclerView.ViewHolder) -> Unit) {
+        dragStartListener = listener
+    }
+
+    fun onStartDrag(viewHolder: RecyclerView.ViewHolder) {
+        dragStartListener?.invoke(viewHolder)
+    }
+
+    abstract class BaseVH<D : Item, B : ViewBinding>(
+        @LayoutRes layoutId: Int,
+        parent: ViewGroup,
+    ) : VH(layoutId, parent), BindableVH<D, B>
+
+    interface Item : DifferItem {
+        override val payloadProvider: ((DifferItem, DifferItem) -> DifferItem?)
+            get() = { old, new -> if (new::class.isInstance(old)) new else null }
+    }
+
+    data class HeaderItem(
+        val id: String = "header",
+    ) : Item {
+        override val stableId: Long = id.hashCode().toLong()
+    }
+
+    class CardItem(
+        val cardEntry: DashboardCardConfig.CardEntry,
+        val position: Int,
+        val onVisibilityToggle: (CardItem) -> Unit,
+    ) : Item {
+        override val stableId: Long = cardEntry.type.hashCode().toLong()
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is CardItem) return false
+            return cardEntry == other.cardEntry
+        }
+
+        override fun hashCode(): Int = cardEntry.hashCode()
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/main/ui/settings/cards/DashboardCardConfigFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/settings/cards/DashboardCardConfigFragment.kt
@@ -1,0 +1,142 @@
+package eu.darken.sdmse.main.ui.settings.cards
+
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import androidx.navigation.ui.setupWithNavController
+import androidx.recyclerview.widget.DefaultItemAnimator
+import androidx.recyclerview.widget.ItemTouchHelper
+import androidx.recyclerview.widget.RecyclerView
+import dagger.hilt.android.AndroidEntryPoint
+import eu.darken.sdmse.R
+import eu.darken.sdmse.common.EdgeToEdgeHelper
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.lists.differ.resetTo
+import eu.darken.sdmse.common.lists.differ.update
+import eu.darken.sdmse.common.lists.setupDefaults
+import eu.darken.sdmse.common.uix.Fragment3
+import eu.darken.sdmse.common.viewbinding.viewBinding
+import eu.darken.sdmse.databinding.DashboardCardConfigFragmentBinding
+import java.util.Collections
+
+@AndroidEntryPoint
+class DashboardCardConfigFragment : Fragment3(R.layout.dashboard_card_config_fragment) {
+
+    override val vm: DashboardCardConfigViewModel by viewModels()
+    override val ui: DashboardCardConfigFragmentBinding by viewBinding()
+
+    private val adapter by lazy { DashboardCardConfigAdapter() }
+    private var currentItems: MutableList<DashboardCardConfigAdapter.Item> = mutableListOf()
+    private var isDragging = false
+    private var pendingReorderConfirmation = false
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        EdgeToEdgeHelper(requireActivity()).apply {
+            insetsPadding(ui.root, left = true, right = true)
+            insetsPadding(ui.appbarlayout, top = true)
+            insetsPadding(ui.list, bottom = true)
+        }
+
+        ui.toolbar.apply {
+            setupWithNavController(findNavController())
+            setOnMenuItemClickListener {
+                when (it.itemId) {
+                    R.id.menu_action_reset -> {
+                        vm.resetToDefaults()
+                        true
+                    }
+
+                    else -> false
+                }
+            }
+        }
+
+        ui.list.setupDefaults(adapter, verticalDividers = false)
+        (ui.list.itemAnimator as? DefaultItemAnimator)?.supportsChangeAnimations = false
+
+        val itemTouchHelper = ItemTouchHelper(object : ItemTouchHelper.SimpleCallback(
+            ItemTouchHelper.UP or ItemTouchHelper.DOWN,
+            0,
+        ) {
+            override fun onMove(
+                recyclerView: RecyclerView,
+                viewHolder: RecyclerView.ViewHolder,
+                target: RecyclerView.ViewHolder,
+            ): Boolean {
+                val fromPos = viewHolder.bindingAdapterPosition
+                val toPos = target.bindingAdapterPosition
+                if (fromPos == RecyclerView.NO_POSITION || toPos == RecyclerView.NO_POSITION) {
+                    return false
+                }
+                // Don't allow moving to position 0 (header)
+                if (toPos == 0) return false
+
+                Collections.swap(currentItems, fromPos, toPos)
+                adapter.notifyItemMoved(fromPos, toPos)
+                return true
+            }
+
+            override fun canDropOver(
+                recyclerView: RecyclerView,
+                current: RecyclerView.ViewHolder,
+                target: RecyclerView.ViewHolder,
+            ): Boolean {
+                // Don't allow dropping over the header
+                return target.bindingAdapterPosition != 0
+            }
+
+            override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) {
+                // Not used
+            }
+
+            override fun onSelectedChanged(viewHolder: RecyclerView.ViewHolder?, actionState: Int) {
+                super.onSelectedChanged(viewHolder, actionState)
+                isDragging = actionState == ItemTouchHelper.ACTION_STATE_DRAG
+            }
+
+            override fun clearView(recyclerView: RecyclerView, viewHolder: RecyclerView.ViewHolder) {
+                super.clearView(recyclerView, viewHolder)
+                pendingReorderConfirmation = true
+                vm.onItemsReordered(currentItems.toList())
+                isDragging = false
+            }
+
+            override fun isLongPressDragEnabled(): Boolean = false
+        })
+        itemTouchHelper.attachToRecyclerView(ui.list)
+
+        adapter.setOnDragStartListener { viewHolder -> itemTouchHelper.startDrag(viewHolder) }
+
+        vm.state.observe2(ui) { state ->
+            val isReorderConfirmation = pendingReorderConfirmation && state.items.hasSameOrderAs(currentItems)
+            pendingReorderConfirmation = false
+            currentItems = state.items.toMutableList()
+            if (!isDragging) {
+                if (isReorderConfirmation) {
+                    // Reset AsyncListDiffer's state without move calculations
+                    val animator = ui.list.itemAnimator
+                    ui.list.itemAnimator = null
+                    adapter.resetTo(state.items) {
+                        ui.list.post { ui.list.itemAnimator = animator }
+                    }
+                } else {
+                    adapter.update(state.items)
+                }
+            }
+        }
+
+        super.onViewCreated(view, savedInstanceState)
+    }
+
+    private fun List<DashboardCardConfigAdapter.Item>.hasSameOrderAs(
+        other: List<DashboardCardConfigAdapter.Item>,
+    ): Boolean {
+        if (size != other.size) return false
+        return indices.all { this[it].stableId == other[it].stableId }
+    }
+
+    companion object {
+        private val TAG = logTag("Dashboard", "CardConfig", "Fragment")
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/main/ui/settings/cards/DashboardCardConfigHeaderVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/settings/cards/DashboardCardConfigHeaderVH.kt
@@ -1,0 +1,23 @@
+package eu.darken.sdmse.main.ui.settings.cards
+
+import android.view.ViewGroup
+import eu.darken.sdmse.R
+import eu.darken.sdmse.common.lists.binding
+import eu.darken.sdmse.databinding.DashboardCardConfigHeaderBinding
+
+
+class DashboardCardConfigHeaderVH(parent: ViewGroup) :
+    DashboardCardConfigAdapter.BaseVH<DashboardCardConfigAdapter.HeaderItem, DashboardCardConfigHeaderBinding>(
+        R.layout.dashboard_card_config_header,
+        parent,
+    ) {
+
+    override val viewBinding = lazy { DashboardCardConfigHeaderBinding.bind(itemView) }
+
+    override val onBindData: DashboardCardConfigHeaderBinding.(
+        item: DashboardCardConfigAdapter.HeaderItem,
+        payloads: List<Any>,
+    ) -> Unit = binding { _ ->
+        // Static content - nothing to bind
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/main/ui/settings/cards/DashboardCardConfigRowVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/settings/cards/DashboardCardConfigRowVH.kt
@@ -1,0 +1,43 @@
+package eu.darken.sdmse.main.ui.settings.cards
+
+import android.annotation.SuppressLint
+import android.view.MotionEvent
+import android.view.ViewGroup
+import eu.darken.sdmse.R
+import eu.darken.sdmse.common.lists.binding
+import eu.darken.sdmse.databinding.DashboardCardConfigRowBinding
+
+class DashboardCardConfigRowVH(parent: ViewGroup) :
+    DashboardCardConfigAdapter.BaseVH<DashboardCardConfigAdapter.CardItem, DashboardCardConfigRowBinding>(
+        R.layout.dashboard_card_config_row,
+        parent,
+    ) {
+
+    override val viewBinding = lazy { DashboardCardConfigRowBinding.bind(itemView) }
+
+    @SuppressLint("ClickableViewAccessibility")
+    override val onBindData: DashboardCardConfigRowBinding.(
+        item: DashboardCardConfigAdapter.CardItem,
+        payloads: List<Any>,
+    ) -> Unit = binding { item ->
+        val cardEntry = item.cardEntry
+
+        icon.setImageResource(cardEntry.type.iconRes)
+        title.setText(cardEntry.type.labelRes)
+
+        visibilityToggle.apply {
+            setOnCheckedChangeListener(null)
+            isChecked = cardEntry.isVisible
+            setOnCheckedChangeListener { _, _ ->
+                item.onVisibilityToggle(item)
+            }
+        }
+
+        dragHandle.setOnTouchListener { _, event ->
+            if (event.actionMasked == MotionEvent.ACTION_DOWN) {
+                (bindingAdapter as? DashboardCardConfigAdapter)?.onStartDrag(this@DashboardCardConfigRowVH)
+            }
+            false
+        }
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/main/ui/settings/cards/DashboardCardConfigViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/settings/cards/DashboardCardConfigViewModel.kt
@@ -1,0 +1,69 @@
+package eu.darken.sdmse.main.ui.settings.cards
+
+import androidx.lifecycle.SavedStateHandle
+import dagger.hilt.android.lifecycle.HiltViewModel
+import eu.darken.sdmse.common.coroutine.DispatcherProvider
+import eu.darken.sdmse.common.datastore.value
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.uix.ViewModel3
+import eu.darken.sdmse.main.core.DashboardCardConfig
+import eu.darken.sdmse.main.core.GeneralSettings
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+@HiltViewModel
+class DashboardCardConfigViewModel @Inject constructor(
+    @Suppress("unused") private val handle: SavedStateHandle,
+    dispatcherProvider: DispatcherProvider,
+    private val generalSettings: GeneralSettings,
+) : ViewModel3(dispatcherProvider) {
+
+    val state = generalSettings.dashboardCardConfig.flow.map { config ->
+        val cardItems = config.cards.mapIndexed { index, entry ->
+            DashboardCardConfigAdapter.CardItem(
+                cardEntry = entry,
+                position = index,
+                onVisibilityToggle = { toggleVisibility(it) },
+            )
+        }
+        State(
+            items = listOf(DashboardCardConfigAdapter.HeaderItem()) + cardItems,
+        )
+    }.asLiveData2()
+
+    data class State(
+        val items: List<DashboardCardConfigAdapter.Item>,
+    )
+
+    fun onItemsReordered(items: List<DashboardCardConfigAdapter.Item>) = launch {
+        val cardItems = items.filterIsInstance<DashboardCardConfigAdapter.CardItem>()
+        log(TAG) { "onItemsReordered(): ${cardItems.map { it.cardEntry.type }}" }
+        val newConfig = DashboardCardConfig(
+            cards = cardItems.map { it.cardEntry }
+        )
+        generalSettings.dashboardCardConfig.value(newConfig)
+    }
+
+    private fun toggleVisibility(item: DashboardCardConfigAdapter.CardItem) = launch {
+        log(TAG) { "toggleVisibility(): ${item.cardEntry.type} -> ${!item.cardEntry.isVisible}" }
+        val currentConfig = generalSettings.dashboardCardConfig.value()
+        val newCards = currentConfig.cards.map { entry ->
+            if (entry.type == item.cardEntry.type) {
+                entry.copy(isVisible = !entry.isVisible)
+            } else {
+                entry
+            }
+        }
+        generalSettings.dashboardCardConfig.value(DashboardCardConfig(cards = newCards))
+    }
+
+    fun resetToDefaults() = launch {
+        log(TAG) { "resetToDefaults()" }
+        generalSettings.dashboardCardConfig.value(DashboardCardConfig())
+    }
+
+    companion object {
+        private val TAG = logTag("Dashboard", "CardConfig", "ViewModel")
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/main/ui/settings/general/GeneralSettingsFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/settings/general/GeneralSettingsFragment.kt
@@ -38,6 +38,8 @@ class GeneralSettingsFragment : PreferenceFragment3() {
         get() = findPreference(settings.isUpdateCheckEnabled.keyName)!!
     private val oneClickTools: Preference
         get() = findPreference("dashboard.oneclick.tools")!!
+    private val dashboardCardConfig: Preference
+        get() = findPreference("dashboard.card.config")!!
     private val languageOverride: Preference
         get() = findPreference("core.ui.language")!!
 
@@ -54,6 +56,11 @@ class GeneralSettingsFragment : PreferenceFragment3() {
 
         oneClickTools.setOnPreferenceClickListener {
             oneClickToolDialog.show(requireContext())
+            true
+        }
+
+        dashboardCardConfig.setOnPreferenceClickListener {
+            MainDirections.goToDashboardCardConfig().navigate()
             true
         }
 

--- a/app/src/main/res/layout/dashboard_card_config_fragment.xml
+++ b/app/src/main/res/layout/dashboard_card_config_fragment.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    style="@style/BaseScreen"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbarlayout"
+        style="@style/SDMAppBar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            style="@style/SDMToolbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:menu="@menu/menu_dashboard_card_config"
+            app:title="@string/dashboard_card_config_title" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/list"
+        style="@style/BaseRecyclerList"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:clipToPadding="false"
+        android:contentDescription="@string/dashboard_card_config_title"
+        android:paddingVertical="8dp"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+        tools:listitem="@layout/dashboard_card_config_row" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/dashboard_card_config_header.xml
+++ b/app/src/main/res/layout/dashboard_card_config_header.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    style="@style/Widget.Material3.CardView.Filled"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginHorizontal="16dp"
+    android:layout_marginTop="8dp"
+    android:layout_marginBottom="4dp"
+    app:cardBackgroundColor="?colorSurfaceVariant">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:padding="16dp">
+
+        <ImageView
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_marginEnd="12dp"
+            android:contentDescription="@null"
+            android:src="@drawable/ic_baseline_info_24"
+            app:tint="?colorOnSurfaceVariant" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/explanation"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/dashboard_card_config_header_title"
+            android:textAppearance="?textAppearanceBodySmall"
+            android:textColor="?colorOnSurfaceVariant" />
+
+    </LinearLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/dashboard_card_config_row.xml
+++ b/app/src/main/res/layout/dashboard_card_config_row.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    style="@style/Widget.Material3.CardView.Outlined"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginHorizontal="16dp"
+    android:layout_marginVertical="4dp"
+    android:focusable="true">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingVertical="12dp">
+
+        <ImageView
+            android:id="@+id/icon"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_marginStart="16dp"
+            android:importantForAccessibility="no"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:tint="?colorOnSurfaceVariant"
+            tools:src="@drawable/ghost" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/title"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:textAppearance="?textAppearanceBodyLarge"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/visibility_toggle"
+            app:layout_constraintStart_toEndOf="@id/icon"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="CorpseFinder" />
+
+        <com.google.android.material.materialswitch.MaterialSwitch
+            android:id="@+id/visibility_toggle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/drag_handle"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:checked="true" />
+
+        <ImageView
+            android:id="@+id/drag_handle"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:contentDescription="@string/general_drag_handle_description"
+            android:padding="12dp"
+            android:src="@drawable/ic_drag_vertical_24"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:tint="?colorOnSurfaceVariant" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/menu/menu_dashboard_card_config.xml
+++ b/app/src/main/res/menu/menu_dashboard_card_config.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/menu_action_reset"
+        android:icon="@drawable/ic_baseline_refresh_24"
+        android:title="@string/general_reset_action"
+        app:iconTint="?colorOnSurface"
+        app:showAsAction="ifRoom" />
+
+</menu>

--- a/app/src/main/res/navigation/main_nav.xml
+++ b/app/src/main/res/navigation/main_nav.xml
@@ -528,6 +528,13 @@
     <action
         android:id="@+id/goToArbiterConfig"
         app:destination="@id/arbiterConfigFragment" />
+    <action
+        android:id="@+id/goToDashboardCardConfig"
+        app:destination="@id/dashboardCardConfigFragment" />
+    <fragment
+        android:id="@+id/dashboardCardConfigFragment"
+        android:name="eu.darken.sdmse.main.ui.settings.cards.DashboardCardConfigFragment"
+        tools:layout="@layout/dashboard_card_config_fragment" />
     <fragment
         android:id="@+id/pickerFragment"
         android:name="eu.darken.sdmse.common.picker.PickerFragment"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,9 @@
     <string name="dashboard_settings_oneclick_summary">Start scan and deletion for all tools with a tap on the dashboard\'s action button, no extra confirmations.</string>
     <string name="dashboard_settings_oneclick_tools_title">One-Tap Tools</string>
     <string name="dashboard_settings_oneclick_tools_desc">Which tools should be included in one-tap operations?</string>
+    <string name="dashboard_card_config_title">Dashboard cards</string>
+    <string name="dashboard_card_config_desc">Configure which cards are shown and their order</string>
+    <string name="dashboard_card_config_header_title">Drag to reorder, toggle to show/hide</string>
 
     <string name="debug_notification_channel_label">Debug notifications</string>
     <string name="debug_debuglog_file_label">Recorded log file</string>

--- a/app/src/main/res/xml/preferences_general.xml
+++ b/app/src/main/res/xml/preferences_general.xml
@@ -19,6 +19,14 @@
             app:singleLineTitle="false"
             app:title="@string/dashboard_settings_oneclick_tools_title" />
 
+        <Preference
+            android:summary="@string/dashboard_card_config_desc"
+            app:icon="@drawable/baseline_grid_view_24"
+            app:key="dashboard.card.config"
+            app:persistent="false"
+            app:singleLineTitle="false"
+            app:title="@string/dashboard_card_config_title" />
+
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/shortcuts_settings_category">

--- a/app/src/test/java/eu/darken/sdmse/main/core/DashboardCardConfigTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/core/DashboardCardConfigTest.kt
@@ -1,0 +1,152 @@
+package eu.darken.sdmse.main.core
+
+import com.squareup.moshi.JsonDataException
+import eu.darken.sdmse.common.serialization.SerializationAppModule
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.json.toComparableJson
+
+class DashboardCardConfigTest : BaseTest() {
+    private val moshi = SerializationAppModule().moshi()
+
+    @Test
+    fun `DashboardCardType enum values serialize correctly`() {
+        val adapter = moshi.adapter(DashboardCardType::class.java)
+        DashboardCardType.entries.forEach { type ->
+            val json = adapter.toJson(type)
+            json shouldBe "\"${type.name}\""
+            adapter.fromJson(json) shouldBe type
+        }
+    }
+
+    @Test
+    fun `DashboardCardConfig round trip with default cards`() {
+        val adapter = moshi.adapter(DashboardCardConfig::class.java)
+        val original = DashboardCardConfig()
+
+        val json = adapter.toJson(original)
+        adapter.fromJson(json) shouldBe original
+    }
+
+    @Test
+    fun `DashboardCardConfig default cards contains all types visible`() {
+        val defaultConfig = DashboardCardConfig()
+
+        defaultConfig.cards.size shouldBe DashboardCardType.entries.size
+        defaultConfig.cards.forEach { entry ->
+            entry.isVisible shouldBe true
+        }
+        defaultConfig.cards.map { it.type } shouldBe DashboardCardType.entries
+    }
+
+    @Test
+    fun `DashboardCardConfig serialization format`() {
+        val adapter = moshi.adapter(DashboardCardConfig::class.java)
+        val config = DashboardCardConfig(
+            cards = listOf(
+                DashboardCardConfig.CardEntry(DashboardCardType.CORPSEFINDER, isVisible = true),
+                DashboardCardConfig.CardEntry(DashboardCardType.APPCLEANER, isVisible = false),
+            )
+        )
+
+        val json = adapter.toJson(config)
+        json.toComparableJson() shouldBe """
+            {
+                "cards": [
+                    {"type": "CORPSEFINDER", "isVisible": true},
+                    {"type": "APPCLEANER", "isVisible": false}
+                ]
+            }
+        """.toComparableJson()
+
+        adapter.fromJson(json) shouldBe config
+    }
+
+    @Test
+    fun `DashboardCardConfig empty cards list`() {
+        val adapter = moshi.adapter(DashboardCardConfig::class.java)
+        val config = DashboardCardConfig(cards = emptyList())
+
+        val json = adapter.toJson(config)
+        json.toComparableJson() shouldBe """{"cards":[]}""".toComparableJson()
+
+        adapter.fromJson(json) shouldBe config
+    }
+
+    @Test
+    fun `DashboardCardConfig card order is preserved`() {
+        val adapter = moshi.adapter(DashboardCardConfig::class.java)
+        val reorderedCards = listOf(
+            DashboardCardConfig.CardEntry(DashboardCardType.SCHEDULER),
+            DashboardCardConfig.CardEntry(DashboardCardType.ANALYZER),
+            DashboardCardConfig.CardEntry(DashboardCardType.CORPSEFINDER),
+        )
+        val config = DashboardCardConfig(cards = reorderedCards)
+
+        val json = adapter.toJson(config)
+        val deserialized = adapter.fromJson(json)!!
+
+        deserialized.cards.map { it.type } shouldBe listOf(
+            DashboardCardType.SCHEDULER,
+            DashboardCardType.ANALYZER,
+            DashboardCardType.CORPSEFINDER,
+        )
+    }
+
+    @Test
+    fun `CardEntry with isVisible false`() {
+        val adapter = moshi.adapter(DashboardCardConfig.CardEntry::class.java)
+        val entry = DashboardCardConfig.CardEntry(
+            type = DashboardCardType.DEDUPLICATOR,
+            isVisible = false,
+        )
+
+        val json = adapter.toJson(entry)
+        json.toComparableJson() shouldBe """
+            {"type": "DEDUPLICATOR", "isVisible": false}
+        """.toComparableJson()
+
+        adapter.fromJson(json) shouldBe entry
+    }
+
+    @Test
+    fun `CardEntry isVisible defaults to true when missing`() {
+        val adapter = moshi.adapter(DashboardCardConfig.CardEntry::class.java)
+        val json = """{"type":"CORPSEFINDER"}"""
+
+        val entry = adapter.fromJson(json)!!
+        entry.type shouldBe DashboardCardType.CORPSEFINDER
+        entry.isVisible shouldBe true
+    }
+
+    @Test
+    fun `unknown DashboardCardType throws JsonDataException`() {
+        val adapter = moshi.adapter(DashboardCardType::class.java)
+
+        shouldThrow<JsonDataException> {
+            adapter.fromJson("\"UNKNOWN_CARD\"")
+        }
+    }
+
+    @Test
+    fun `CardEntry with unknown type throws JsonDataException`() {
+        val adapter = moshi.adapter(DashboardCardConfig.CardEntry::class.java)
+        val json = """{"type":"FUTURE_CARD_TYPE","isVisible":true}"""
+
+        shouldThrow<JsonDataException> {
+            adapter.fromJson(json)
+        }
+    }
+
+    @Test
+    fun `DashboardCardConfig with malformed JSON throws exception`() {
+        val adapter = moshi.adapter(DashboardCardConfig::class.java)
+        val json = """{"cards": [{"type": invalid}]}"""
+
+        shouldThrow<Exception> {
+            adapter.fromJson(json)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Allow users to customize which tool cards appear on the dashboard
- Enable drag-and-drop reordering of cards
- Add visibility toggles for individual cards
- Include reset to defaults option

Accessible via **General Settings > Dashboard cards**.

## Test plan
- [x] Navigate to General Settings > Dashboard cards
- [x] Toggle card visibility and verify cards appear/disappear on dashboard
- [x] Drag cards to reorder and verify order persists after app restart
- [x] Use "Reset" menu option and verify default configuration restored
- [x] Rotate device during drag operation to verify no crashes

Closes #1879