### PR TITLE
AppCleaner: Add option to force-stop apps before clearing cache

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleanerSettings.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleanerSettings.kt
@@ -29,6 +29,8 @@ class AppCleanerSettings @Inject constructor(
 
     val includeInaccessibleEnabled = dataStore.createValue("include.inaccessible.enabled", true)
 
+    val forceStopBeforeClearing = dataStore.createValue("forcestop.before.clearing.enabled", false)
+
     val includeSystemAppsEnabled = dataStore.createValue("include.systemapps.enabled", false)
     val includeRunningAppsEnabled = dataStore.createValue("include.runningapps.enabled", true)
     val includeOtherUsersEnabled = dataStore.createValue("include.multiuser.enabled", false)
@@ -68,6 +70,7 @@ class AppCleanerSettings @Inject constructor(
         includeRunningAppsEnabled,
         includeOtherUsersEnabled,
         includeInaccessibleEnabled,
+        forceStopBeforeClearing,
         minCacheSizeBytes,
         minCacheAgeMs,
         filterDefaultCachesPublicEnabled,

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/ui/settings/AppCleanerSettingsFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/ui/settings/AppCleanerSettingsFragment.kt
@@ -37,6 +37,9 @@ class AppCleanerSettingsFragment : PreferenceFragment2() {
     private val includeInaccessibleCaches: BadgedCheckboxPreference
         get() = findPreference(settings.includeInaccessibleEnabled.keyName)!!
 
+    private val forceStopBeforeClearing: BadgedCheckboxPreference
+        get() = findPreference(settings.forceStopBeforeClearing.keyName)!!
+
     override fun onPreferencesCreated() {
         super.onPreferencesCreated()
 
@@ -76,6 +79,9 @@ class AppCleanerSettingsFragment : PreferenceFragment2() {
         includeInaccessibleCaches.badgedAction = {
             setOf(SetupModule.Type.USAGE_STATS, SetupModule.Type.AUTOMATION).showFixSetupHint(this)
         }
+        forceStopBeforeClearing.badgedAction = {
+            setOf(SetupModule.Type.USAGE_STATS, SetupModule.Type.AUTOMATION).showFixSetupHint(this)
+        }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -85,6 +91,10 @@ class AppCleanerSettingsFragment : PreferenceFragment2() {
             includeOtherUsers.isRestricted = !state.isOtherUsersAvailable
             includeRunningApps.isRestricted = !state.isRunningAppsDetectionAvailable
             includeInaccessibleCaches.apply {
+                isRestricted = !state.isInaccessibleCacheAvailable
+                isVisible = state.isAcsRequired
+            }
+            forceStopBeforeClearing.apply {
                 isRestricted = !state.isInaccessibleCacheAvailable
                 isVisible = state.isAcsRequired
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -479,6 +479,9 @@
     <string name="appcleaner_automation_error_no_settings_body">This system app has no settings screen. Cache clearing via accessibility service is not possible. Exclude it to speed up cache clearing.</string>
     <string name="appcleaner_automation_error_securitycenter_permission_title">System app misconfigured</string>
     <string name="appcleaner_automation_error_securitycenter_permission_body">HyperOS\'s Security app (com.miui.securitycenter) is missing the Usage Stats permission (GET_USAGE_STATS). This breaks features like "Clear Data" in app details and cache clearing via accessibility. Grant the permission to restore full functionality.</string>
+    <string name="appcleaner_forcestop_before_clearing_label">Force-stop before clearing</string>
+    <string name="appcleaner_forcestop_before_clearing_summary">Force-stop apps before clearing their cache. Can help with clearing some apps but also has potential side effects. Interrupted apps may misbehave and require to be opened manually to restart.</string>
+    <string name="appcleaner_progress_force_stopping">Force-stopping apps…</string>
 
     <string name="deduplicator_tool_name">Deduplicator</string>
     <string name="deduplicator_explanation_short">Find duplicate data on your device.</string>

--- a/app/src/main/res/xml/preferences_appcleaner.xml
+++ b/app/src/main/res/xml/preferences_appcleaner.xml
@@ -46,6 +46,14 @@
         app:summary="@string/appcleaner_include_inaccessible_summary"
         app:title="@string/appcleaner_include_inaccessible_label" />
 
+    <eu.darken.sdmse.common.preferences.BadgedCheckboxPreference
+        app:enabled="false"
+        app:icon="@drawable/ic_cancel"
+        app:key="forcestop.before.clearing.enabled"
+        app:singleLineTitle="false"
+        app:summary="@string/appcleaner_forcestop_before_clearing_summary"
+        app:title="@string/appcleaner_forcestop_before_clearing_label" />
+
     <PreferenceCategory android:title="@string/settings_category_filter_generic">
         <CheckBoxPreference
             app:icon="@drawable/ic_baseline_format_list_bulleted_24"


### PR DESCRIPTION
## Summary
- Add optional setting to force-stop apps before clearing their inaccessible cache
- Helps with apps like Play Store that cannot have their cache cleared while running
- Uses ROOT/ADB when available, falls back to automation

## Test plan
- [x] Enable the setting in AppCleaner settings
- [x] Run AppCleaner and verify apps are force-stopped before cache clearing
- [x] Test with ROOT/ADB path
- [x] Test with automation fallback

Closes #1136