### PR TITLE
Deduplicator: Add directory view mode for duplicate clusters

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/deduplicator/core/DeduplicatorSettings.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/core/DeduplicatorSettings.kt
@@ -64,6 +64,8 @@ class DeduplicatorSettings @Inject constructor(
 
     val layoutMode = dataStore.createValue("ui.list.layoutmode", LayoutMode.GRID, moshi)
 
+    val isDirectoryViewEnabled = dataStore.createValue("ui.cluster.directoryview.enabled", false)
+
     override val mapper = PreferenceStoreMapper(
         allowDeleteAll,
         minSizeBytes,

--- a/app/src/main/java/eu/darken/sdmse/deduplicator/ui/details/DeduplicatorDetailsFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/ui/details/DeduplicatorDetailsFragment.kt
@@ -30,9 +30,15 @@ class DeduplicatorDetailsFragment : Fragment3(R.layout.deduplicator_details_frag
 
         ui.toolbar.apply {
             setupWithNavController(findNavController())
+            inflateMenu(R.menu.menu_deduplicator_details)
             @Suppress("DEPRECATION")
             setOnMenuItemClickListener {
                 when (it.itemId) {
+                    R.id.action_toggle_view_mode -> {
+                        vm.toggleDirectoryView()
+                        true
+                    }
+
                     else -> super.onOptionsItemSelected(it)
                 }
             }
@@ -68,6 +74,18 @@ class DeduplicatorDetailsFragment : Fragment3(R.layout.deduplicator_details_frag
                 state.items.indexOfFirst { it.identifier == state.target }
                     .takeIf { it != -1 }
                     ?.let { viewpager.currentItem = it }
+            }
+
+            toolbar.menu.findItem(R.id.action_toggle_view_mode)?.apply {
+                isVisible = state.progress == null
+                setIcon(
+                    if (state.isDirectoryViewEnabled) R.drawable.ic_baseline_format_list_bulleted_24
+                    else R.drawable.ic_folder
+                )
+                setTitle(
+                    if (state.isDirectoryViewEnabled) R.string.deduplicator_view_mode_groups_label
+                    else R.string.deduplicator_view_mode_directories_label
+                )
             }
         }
 

--- a/app/src/main/java/eu/darken/sdmse/deduplicator/ui/details/cluster/ClusterAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/ui/details/cluster/ClusterAdapter.kt
@@ -17,6 +17,7 @@ import eu.darken.sdmse.deduplicator.core.Duplicate
 import eu.darken.sdmse.deduplicator.ui.details.cluster.elements.ChecksumGroupFileVH
 import eu.darken.sdmse.deduplicator.ui.details.cluster.elements.ChecksumGroupHeaderVH
 import eu.darken.sdmse.deduplicator.ui.details.cluster.elements.ClusterHeaderVH
+import eu.darken.sdmse.deduplicator.ui.details.cluster.elements.DirectoryHeaderVH
 import eu.darken.sdmse.deduplicator.ui.details.cluster.elements.PHashGroupFileVH
 import eu.darken.sdmse.deduplicator.ui.details.cluster.elements.PHashGroupHeaderVH
 import javax.inject.Inject
@@ -33,6 +34,7 @@ class ClusterAdapter @Inject constructor() :
     init {
         addMod(DataBinderMod(data))
         addMod(TypedVHCreatorMod({ data[it] is ClusterHeaderVH.Item }) { ClusterHeaderVH(it) })
+        addMod(TypedVHCreatorMod({ data[it] is DirectoryHeaderVH.Item }) { DirectoryHeaderVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is ChecksumGroupHeaderVH.Item }) { ChecksumGroupHeaderVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is ChecksumGroupFileVH.Item }) { ChecksumGroupFileVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is PHashGroupHeaderVH.Item }) { PHashGroupHeaderVH(it) })
@@ -73,6 +75,12 @@ class ClusterAdapter @Inject constructor() :
             get() = duplicate.identifier
         val path: APath
             get() = duplicate.path
+
+        interface VH
+    }
+
+    interface DirectoryItem : Item {
+        val directory: DirectoryGroup
 
         interface VH
     }

--- a/app/src/main/java/eu/darken/sdmse/deduplicator/ui/details/cluster/DirectoryGroup.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/ui/details/cluster/DirectoryGroup.kt
@@ -1,0 +1,25 @@
+package eu.darken.sdmse.deduplicator.ui.details.cluster
+
+import eu.darken.sdmse.common.files.Segments
+import eu.darken.sdmse.common.files.joinSegments
+import eu.darken.sdmse.deduplicator.core.Duplicate
+
+/**
+ * Represents a group of duplicates that share the same parent directory.
+ * Used in directory view mode to organize duplicates by folder location.
+ */
+data class DirectoryGroup(
+    val parentSegments: Segments,
+    val duplicates: List<Duplicate>,
+) {
+    val identifier: Id
+        get() = Id(parentSegments.joinSegments())
+
+    val count: Int
+        get() = duplicates.size
+
+    val totalSize: Long
+        get() = duplicates.sumOf { it.size }
+
+    data class Id(val value: String)
+}

--- a/app/src/main/java/eu/darken/sdmse/deduplicator/ui/details/cluster/elements/DirectoryHeaderVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/ui/details/cluster/elements/DirectoryHeaderVH.kt
@@ -1,0 +1,67 @@
+package eu.darken.sdmse.deduplicator.ui.details.cluster.elements
+
+import android.text.format.Formatter
+import android.view.ViewGroup
+import eu.darken.sdmse.R
+import eu.darken.sdmse.common.files.joinSegments
+import eu.darken.sdmse.common.getQuantityString2
+import eu.darken.sdmse.common.lists.binding
+import eu.darken.sdmse.common.lists.selection.SelectableItem
+import eu.darken.sdmse.databinding.DeduplicatorClusterElementDirectoryHeaderBinding
+import eu.darken.sdmse.deduplicator.ui.details.cluster.ClusterAdapter
+import eu.darken.sdmse.deduplicator.ui.details.cluster.DirectoryGroup
+
+
+class DirectoryHeaderVH(parent: ViewGroup) :
+    ClusterAdapter.BaseVH<DirectoryHeaderVH.Item, DeduplicatorClusterElementDirectoryHeaderBinding>(
+        R.layout.deduplicator_cluster_element_directory_header,
+        parent
+    ), ClusterAdapter.DirectoryItem.VH {
+
+    override val viewBinding = lazy { DeduplicatorClusterElementDirectoryHeaderBinding.bind(itemView) }
+
+    override val onBindData: DeduplicatorClusterElementDirectoryHeaderBinding.(
+        item: Item,
+        payloads: List<Any>,
+    ) -> Unit = binding { item ->
+        val group = item.directoryGroup
+
+        primary.text = group.parentSegments.joinSegments()
+
+        secondary.apply {
+            text = Formatter.formatFileSize(context, group.totalSize)
+            append(
+                " (${
+                    context.getQuantityString2(
+                        eu.darken.sdmse.common.R.plurals.result_x_items,
+                        group.count
+                    )
+                })"
+            )
+        }
+
+        collapseAction.apply {
+            setIconResource(
+                if (item.isCollapsed) R.drawable.ic_expand_more else R.drawable.ic_expand_less
+            )
+            setOnClickListener { item.onCollapseToggle() }
+        }
+
+        root.setOnClickListener { item.onItemClick(item) }
+    }
+
+    data class Item(
+        val directoryGroup: DirectoryGroup,
+        val onItemClick: (Item) -> Unit,
+        val isCollapsed: Boolean,
+        val onCollapseToggle: () -> Unit,
+    ) : ClusterAdapter.Item, ClusterAdapter.DirectoryItem, SelectableItem {
+
+        override val directory: DirectoryGroup
+            get() = directoryGroup
+
+        override val itemSelectionKey: String? = null
+
+        override val stableId: Long = directoryGroup.identifier.hashCode().toLong()
+    }
+}

--- a/app/src/main/res/layout/deduplicator_cluster_element_directory_header.xml
+++ b/app/src/main/res/layout/deduplicator_cluster_element_directory_header.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?selectableItemBackground">
+
+    <ImageView
+        android:id="@+id/icon"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_marginStart="16dp"
+        android:contentDescription="@null"
+        android:src="@drawable/ic_folder"
+        app:layout_constraintBottom_toBottomOf="@id/secondary"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/primary"
+        app:tint="?colorOnBackground" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/primary"
+        style="@style/TextAppearance.Material3.BodyMedium"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="16dp"
+        android:ellipsize="start"
+        android:singleLine="true"
+        app:layout_constraintBottom_toTopOf="@id/secondary"
+        app:layout_constraintEnd_toStartOf="@id/collapse_action"
+        app:layout_constraintStart_toEndOf="@id/icon"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_chainStyle="packed"
+        tools:text="/storage/emulated/0/Download/Photos" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/secondary"
+        style="@style/TextAppearance.Material3.LabelSmall"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:ellipsize="end"
+        android:singleLine="true"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="@id/primary"
+        app:layout_constraintStart_toStartOf="@id/primary"
+        app:layout_constraintTop_toBottomOf="@id/primary"
+        app:layout_constraintVertical_chainStyle="packed"
+        tools:text="999.99 KB (2 items)" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/collapse_action"
+        style="@style/Widget.Material3.Button.IconButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        app:icon="@drawable/ic_expand_less"
+        app:iconTint="?colorOnBackground"
+        app:layout_constraintBottom_toBottomOf="@id/secondary"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@id/primary" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/menu/menu_deduplicator_details.xml
+++ b/app/src/main/res/menu/menu_deduplicator_details.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/action_toggle_view_mode"
+        android:icon="@drawable/ic_folder"
+        android:title="@string/deduplicator_view_mode_directories_label"
+        app:showAsAction="ifRoom" />
+
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -559,6 +559,9 @@
     <string name="deduplicator_arbiter_mode_prefer_larger">Prefer larger files</string>
     <string name="deduplicator_arbiter_mode_prefer_smaller">Prefer smaller files</string>
 
+    <string name="deduplicator_view_mode_groups_label">Groups</string>
+    <string name="deduplicator_view_mode_directories_label">Directories</string>
+
 
     <string name="appcontrol_tool_name">AppControl</string>
     <string name="appcontrol_explanation_short">Apps installed on your device.</string>


### PR DESCRIPTION
## Summary
- Adds a new view mode that groups duplicate files by their parent directory
- Toggle between default and directory view via toolbar menu
- Directory headers display path, total size, and file count
- Collapsible directory groups for better organization
- View mode preference persists across sessions

## Test plan
- [x] Enable Deduplicator and scan for duplicates
- [x] Open a duplicate cluster with files from multiple directories
- [x] Toggle directory view mode from toolbar menu
- [x] Verify paths display correctly (single leading slash)
- [x] Verify directory headers show correct counts and sizes
- [x] Collapse/expand directory groups
- [x] Close and reopen the screen to verify preference persists

Closes #1584