### PR TITLE
General: Fix folder picker bottom padding calculation

### DIFF
--- a/app/src/main/res/layout/common_picker_fragment.xml
+++ b/app/src/main/res/layout/common_picker_fragment.xml
@@ -32,7 +32,6 @@
         android:clipToPadding="false"
         android:contentDescription="Analyzer content"
         android:paddingTop="4dp"
-        android:paddingBottom="72dp"
         app:layout_behavior="@string/appbar_scrolling_view_behavior"
         tools:ignore="HardcodedText"
         tools:listitem="@layout/analyzer_content_item_vh" />


### PR DESCRIPTION
## Summary
- Fix RecyclerView bottom padding calculation in folder picker to use actual measured position of the bottom sheet
- Previously, the padding was calculated using `maxHeight` and `slideOffset` which produced incorrect values
- Now uses `bottomSheet.top` / `selectedContainer.top` for accurate padding that matches the visible sheet height

## Test plan
- [x] Open Deduplicator folder picker
- [x] Verify collapsed state: padding should be ~64dp + nav bar insets
- [x] Verify half-expanded state: padding should match visible sheet height (no excessive overscroll)
- [x] Verify orientation change: sheet and padding should update correctly

Closes #2132