### PR TITLE
General: Add "New" badge for dashboard tool cards

### DIFF
--- a/app-common/src/main/res/values/strings.xml
+++ b/app-common/src/main/res/values/strings.xml
@@ -35,6 +35,7 @@
     <string name="general_edit_action">Edit</string>
     <string name="general_na_label">N/A</string>
     <string name="general_empty_label">Empty</string>
+    <string name="general_new_badge_label">New</string>
     <string name="general_dismiss_action">Dismiss</string>
     <string name="general_maybe_later_action">Maybe later</string>
     <string name="general_manage_action">Manage</string>

--- a/app/src/main/res/drawable/bg_new_badge.xml
+++ b/app/src/main/res/drawable/bg_new_badge.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="?colorTertiary" />
+    <corners android:radius="4dp" />
+</shape>

--- a/app/src/main/res/layout/view_new_badge.xml
+++ b/app/src/main/res/layout/view_new_badge.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.textview.MaterialTextView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/new_badge"
+    style="@style/TextAppearance.Material3.LabelSmall"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:background="@drawable/bg_new_badge"
+    android:paddingHorizontal="6dp"
+    android:paddingVertical="2dp"
+    android:text="@string/general_new_badge_label"
+    android:textColor="?colorOnTertiary"
+    android:visibility="gone"
+    tools:visibility="visible" />


### PR DESCRIPTION
## Summary
- Add reusable inline badge component to highlight newly released features on dashboard tool cards
- Badge is controlled by an `isNew` boolean flag in DashboardToolCard.Item
- Material 3 styling with tertiary colors

## Test plan
- [x] Build and run the app
- [x] Temporarily set `isNew = true` on a tool card item in DashboardViewModel
- [x] Verify badge appears inline next to the tool title
- [x] Verify badge is hidden when `isNew = false`

Closes #2139