### PR TITLE
AppControl: Fix inflated app sizes due to cache double-counting

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/PkgOps.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/PkgOps.kt
@@ -470,8 +470,13 @@ class PkgOps @Inject constructor(
         val externalCacheBytes: Long?,
         val dataBytes: Long,
     ) {
+        /** User data excluding cache (matches Android Settings display) */
+        val userDataBytes: Long
+            get() = (dataBytes - cacheBytes).coerceAtLeast(0)
+
+        /** Total storage. Note: dataBytes already includes cacheBytes */
         val total: Long
-            get() = appBytes + dataBytes + cacheBytes
+            get() = appBytes + dataBytes
     }
 
     suspend fun querySizeStats(

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/actions/items/InfoSizeVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/actions/items/InfoSizeVH.kt
@@ -33,7 +33,7 @@ class InfoSizeVH(parent: ViewGroup) :
             isVisible = appInfo.pkg is SourceAvailable
         }
         apkLabel.isGone = apkSize.isGone
-        dataSize.text = Formatter.formatFileSize(context, sizes.dataBytes)
+        dataSize.text = Formatter.formatFileSize(context, sizes.userDataBytes)
         cacheSize.text = Formatter.formatFileSize(context, sizes.cacheBytes)
 
         itemView.setOnClickListener { item.onClicked(appInfo) }


### PR DESCRIPTION
## Summary
- Fix app sizes showing larger than Android Settings due to cache being counted twice
- Android's `StorageStats.dataBytes` already includes cache bytes, but the total was incorrectly calculated as `appBytes + dataBytes + cacheBytes`
- Now correctly calculates total as `appBytes + dataBytes`
- Added `userDataBytes` property to show data size without cache (matching Android Settings)

## Test plan
- [x] Install and compare app sizes with Android Settings for several apps
- [x] Verify: App + Data + Cache = Total (no double-counting)

Closes #1687