### PR TITLE
Dashboard: Remove task result snackbar

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardFragment.kt
@@ -238,14 +238,7 @@ class DashboardFragment : Fragment3(R.layout.dashboard_fragment) {
                         .show()
                 }
 
-                is DashboardEvents.TaskResult -> Snackbar
-                    .make(
-                        requireView(),
-                        event.result.primaryInfo.get(requireContext()),
-                        Snackbar.LENGTH_LONG
-                    )
-                    .setAnchorView(ui.mainAction)
-                    .show()
+                is DashboardEvents.TaskResult -> {} // No snackbar, results shown on cards
 
                 is DashboardEvents.TodoHint -> MaterialAlertDialogBuilder(requireContext()).apply {
                     setMessage(eu.darken.sdmse.common.R.string.general_todo_msg)


### PR DESCRIPTION
## Summary
Remove the snackbar that shows after each task completion.

## Problem
- When multiple tools ran, each new snackbar dismissed the previous one
- Users only saw the last result
- Attempting to show a summary snackbar had race condition issues between task completion and state updates

## Solution
Simply remove the snackbar. Results are already visible on the dashboard cards, so the snackbar is redundant.

Closes #1164