### PR TITLE
General: Improve preview UI consistency and usability

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/common/previews/PreviewFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/previews/PreviewFragment.kt
@@ -10,6 +10,7 @@ import androidx.fragment.app.viewModels
 import androidx.viewpager.widget.ViewPager.OnPageChangeListener
 import dagger.hilt.android.AndroidEntryPoint
 import eu.darken.sdmse.R
+import eu.darken.sdmse.common.EdgeToEdgeHelper
 import eu.darken.sdmse.common.hasApiLevel
 import eu.darken.sdmse.common.navigation.popBackStack
 import eu.darken.sdmse.common.uix.DialogFragment3
@@ -45,6 +46,14 @@ class PreviewFragment : DialogFragment3(R.layout.preview_fragment) {
                             or View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY // Enable immersive mode
                     )
         }
+
+        // Apply display cutout (notch) insets to header
+        EdgeToEdgeHelper(requireActivity()).insetsPadding(
+            ui.previewHeaderContainer,
+            left = true,
+            top = true,
+            right = true,
+        )
 
         ui.backAction.setOnClickListener { popBackStack() }
         ui.nextAction.setOnClickListener { vm.next() }

--- a/app/src/main/java/eu/darken/sdmse/common/ui/PhotoViewPager.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/ui/PhotoViewPager.kt
@@ -1,0 +1,79 @@
+package eu.darken.sdmse.common.ui
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.MotionEvent
+import android.view.View
+import android.view.ViewGroup
+import androidx.viewpager.widget.ViewPager
+import com.github.chrisbanes.photoview.PhotoView
+
+/**
+ * ViewPager that respects PhotoView zoom state:
+ * - Zoomed out: normal paging with horizontal swipes
+ * - Zoomed in: let PhotoView handle panning
+ */
+class PhotoViewPager @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+) : ViewPager(context, attrs) {
+
+    override fun onInterceptTouchEvent(ev: MotionEvent): Boolean {
+        return try {
+            // Don't intercept if PhotoView is zoomed in
+            if (isCurrentPhotoViewZoomed()) {
+                false
+            } else {
+                super.onInterceptTouchEvent(ev)
+            }
+        } catch (e: IllegalArgumentException) {
+            // PhotoView can throw this during certain touch sequences
+            false
+        }
+    }
+
+    override fun onTouchEvent(ev: MotionEvent): Boolean {
+        return try {
+            super.onTouchEvent(ev)
+        } catch (e: IllegalArgumentException) {
+            false
+        }
+    }
+
+    private fun isCurrentPhotoViewZoomed(): Boolean {
+        val currentView = findViewByPosition(currentItem) ?: return false
+        val photoView = findPhotoView(currentView) ?: return false
+        return photoView.scale > 1.05f // Small threshold to account for floating point
+    }
+
+    private fun findViewByPosition(position: Int): View? {
+        for (i in 0 until childCount) {
+            val child = getChildAt(i)
+            val layoutParams = child.layoutParams as? LayoutParams
+            if (layoutParams != null && !layoutParams.isDecor && layoutParams.position == position) {
+                return child
+            }
+        }
+        return null
+    }
+
+    private fun findPhotoView(view: View): PhotoView? {
+        if (view is PhotoView) return view
+        if (view is ViewGroup) {
+            for (i in 0 until view.childCount) {
+                val found = findPhotoView(view.getChildAt(i))
+                if (found != null) return found
+            }
+        }
+        return null
+    }
+
+    private val LayoutParams.position: Int
+        get() = try {
+            val field = LayoutParams::class.java.getDeclaredField("position")
+            field.isAccessible = true
+            field.getInt(this)
+        } catch (e: Exception) {
+            -1
+        }
+}

--- a/app/src/main/java/eu/darken/sdmse/swiper/ui/swipe/SwiperSwipeFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/swiper/ui/swipe/SwiperSwipeFragment.kt
@@ -22,6 +22,8 @@ import eu.darken.sdmse.common.getColorForAttr
 import eu.darken.sdmse.common.uix.Fragment3
 import eu.darken.sdmse.common.viewbinding.viewBinding
 import eu.darken.sdmse.databinding.SwiperSwipeFragmentBinding
+import eu.darken.sdmse.common.previews.PreviewFragmentArgs
+import eu.darken.sdmse.common.previews.PreviewOptions
 import eu.darken.sdmse.swiper.core.SwipeDecision
 import eu.darken.sdmse.swiper.core.SwipeItem
 import java.time.ZoneId
@@ -79,6 +81,17 @@ class SwiperSwipeFragment : Fragment3(R.layout.swiper_swipe_fragment) {
 
             override fun onSwipeProgress(progress: Float, direction: SwipeCardView.SwipeDirection?) {
                 // Could add visual feedback here if needed
+            }
+
+            override fun onPreviewClick(item: SwipeItem) {
+                val options = PreviewOptions(
+                    paths = listOf(item.lookup.lookedUp),
+                    position = 0,
+                )
+                findNavController().navigate(
+                    resId = R.id.goToPreview,
+                    args = PreviewFragmentArgs(options = options).toBundle(),
+                )
             }
         }
 

--- a/app/src/main/res/layout/preview_fragment.xml
+++ b/app/src/main/res/layout/preview_fragment.xml
@@ -6,7 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.viewpager.widget.ViewPager
+    <eu.darken.sdmse.common.ui.PhotoViewPager
         android:id="@+id/viewpager"
         android:layout_width="match_parent"
         android:layout_height="0dp"
@@ -29,10 +29,9 @@
         <com.google.android.material.button.MaterialButton
             android:id="@+id/back_action"
             style="@style/Widget.Material3.Button.IconButton.Filled.Tonal"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
             android:alpha="0.65"
-            android:padding="16dp"
             app:icon="@drawable/ic_baseline_close_24"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/swiper_card_item.xml
+++ b/app/src/main/res/layout/swiper_card_item.xml
@@ -193,6 +193,17 @@
 
                 </LinearLayout>
 
+                <!-- Preview button: top-right corner -->
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/preview_action"
+                    style="@style/Widget.Material3.Button.IconButton.Filled.Tonal"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="top|end"
+                    android:layout_margin="8dp"
+                    app:icon="@drawable/ic_magnify_expand_24"
+                    tools:ignore="ContentDescription" />
+
                 <!-- Keep stamp: top-left (visible when swiping right, left side stays visible) -->
                 <LinearLayout
                     android:id="@+id/stamp_keep"


### PR DESCRIPTION
## Summary
- Changed swiper preview button icon to magnify-expand for consistency with deduplicator preview overlay
- Increased preview fragment close button size to 48dp for better touch target
- Added display cutout (notch) insets handling to preview header
- Added PhotoViewPager for pinch-to-zoom support in preview
- Wired up preview button in swiper cards to open full preview

## Test plan
- [ ] Open Swiper, verify preview button shows magnify-expand icon
- [ ] Tap preview button on a swiper card, verify full preview opens
- [ ] In preview, verify close button is larger and easier to tap
- [ ] Test on device with notch to verify header is not obscured