### PR TITLE
General: Reorder dashboard cards to show Swiper before Squeezer

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/main/core/DashboardCardType.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/core/DashboardCardType.kt
@@ -16,8 +16,8 @@ enum class DashboardCardType(
     DEDUPLICATOR(R.string.deduplicator_tool_name, R.drawable.ic_content_duplicate_24),
     APPCONTROL(R.string.appcontrol_tool_name, R.drawable.ic_apps),
     ANALYZER(R.string.analyzer_tool_name, R.drawable.baseline_data_usage_24),
-SQUEEZER(R.string.squeezer_tool_name, R.drawable.ic_image_compress_24),
-    SWIPER(R.string.swiper_tool_name, R.drawable.ic_baseline_swipe_24),
+SWIPER(R.string.swiper_tool_name, R.drawable.ic_baseline_swipe_24),
+    SQUEEZER(R.string.squeezer_tool_name, R.drawable.ic_image_compress_24),
     SCHEDULER(R.string.scheduler_label, R.drawable.ic_alarm_check_24),
     STATS(R.string.stats_label, R.drawable.ic_chartbox_24),
 }


### PR DESCRIPTION
## Summary
- Change the default dashboard card order so that Swiper appears before Squeezer

## Test plan
- [ ] Fresh install should show Swiper card before Squeezer in dashboard
- [ ] Existing users with custom card order are unaffected