### PR TITLE
General: Fix CI release build signing regression

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,15 +39,16 @@ android {
 
     signingConfigs {
         val basePath = File(System.getProperty("user.home"), ".appconfig/${projectConfig.packageName}")
+        val hasEnvCredentials = System.getenv("STORE_PATH")?.let { File(it).exists() } == true
         create("releaseFoss") {
-            if (basePath.exists()) {
+            if (hasEnvCredentials || basePath.exists()) {
                 setupCredentials(File(basePath, "signing-foss.properties"))
             } else {
                 initWith(signingConfigs["debug"])
             }
         }
         create("releaseGplay") {
-            if (basePath.exists()) {
+            if (hasEnvCredentials || basePath.exists()) {
                 setupCredentials(File(basePath, "signing-gplay-upload.properties"))
             } else {
                 initWith(signingConfigs["debug"])


### PR DESCRIPTION
## Summary
- Fix CI release builds by checking for `STORE_PATH` environment variable before falling back to debug signing
- Commit `0da9fcc6` broke CI release builds by only checking for the local `~/.appconfig` directory

## Test plan
- [x] Local build succeeds with `./gradlew assembleFossDebug`
- [ ] CI release builds should now properly use `STORE_PATH` environment variable credentials
- [ ] Forks without credentials still fall back to debug signing