### PR TITLE
General: Fix string pluralization and rephrase force-stop summary

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/main/ui/settings/support/SupportFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/settings/support/SupportFragment.kt
@@ -80,8 +80,9 @@ class SupportFragment : PreferenceFragment2() {
                 debugLogFolderPref.summary = getString(R.string.support_debuglog_folder_empty_desc)
             } else {
                 val formattedSize = Formatter.formatShortFileSize(requireContext(), stats.totalSizeBytes)
-                debugLogFolderPref.summary = getString(
-                    R.string.support_debuglog_folder_desc,
+                debugLogFolderPref.summary = resources.getQuantityString(
+                    R.plurals.support_debuglog_folder_desc,
+                    stats.fileCount,
                     stats.fileCount,
                     formattedSize
                 )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -105,7 +105,10 @@
     <string name="support_debuglog_label">Debug log</string>
     <string name="support_debuglog_desc">Record everything the app is doing into a text file that you can share.</string>
     <string name="support_debuglog_folder_label">Debug log folder</string>
-    <string name="support_debuglog_folder_desc">%1$d files using %2$s</string>
+    <plurals name="support_debuglog_folder_desc">
+        <item quantity="one">%1$d file using %2$s</item>
+        <item quantity="other">%1$d files using %2$s</item>
+    </plurals>
     <string name="support_debuglog_folder_empty_desc">No debug logs stored</string>
     <string name="support_debuglog_folder_delete_confirmation_title">Delete all debug logs?</string>
     <string name="support_debuglog_folder_delete_confirmation_message">This will permanently delete all stored debug log sessions. This action cannot be undone.</string>
@@ -480,7 +483,7 @@
     <string name="appcleaner_automation_error_securitycenter_permission_title">System app misconfigured</string>
     <string name="appcleaner_automation_error_securitycenter_permission_body">HyperOS\'s Security app (com.miui.securitycenter) is missing the Usage Stats permission (GET_USAGE_STATS). This breaks features like "Clear Data" in app details and cache clearing via accessibility. Grant the permission to restore full functionality.</string>
     <string name="appcleaner_forcestop_before_clearing_label">Force-stop before clearing</string>
-    <string name="appcleaner_forcestop_before_clearing_summary">Force-stop apps before clearing their cache. Can help with clearing some apps but also has potential side effects. Interrupted apps may misbehave and require to be opened manually to restart.</string>
+    <string name="appcleaner_forcestop_before_clearing_summary">Force-stop apps before clearing their cache. It can help clear some apps\' caches, but may cause apps to misbehave and require manual restart.</string>
     <string name="appcleaner_progress_force_stopping">Force-stopping apps…</string>
 
     <string name="deduplicator_tool_name">Deduplicator</string>


### PR DESCRIPTION
## Summary

- Convert `support_debuglog_folder_desc` from a `<string>` to a `<plurals>` resource so "1 file using X" displays correctly instead of "1 files using X"
- Update `SupportFragment` to use `getQuantityString()` for proper plural selection
- Rephrase `appcleaner_forcestop_before_clearing_summary` to be more concise while conveying the same meaning

## Test plan

- [ ] Verify debug log folder shows "1 file using X" when there is exactly one log
- [ ] Verify debug log folder shows "N files using X" when there are multiple logs
- [ ] Verify force-stop setting summary reads naturally
- [ ] Build passes: `./gradlew assembleFossDebug`