### PR TITLE
Scheduler: Fix missing notification on execution error

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/scheduler/core/SchedulerNotifications.kt
+++ b/app/src/main/java/eu/darken/sdmse/scheduler/core/SchedulerNotifications.kt
@@ -144,6 +144,20 @@ SDMTool.Type.SQUEEZER -> R.string.squeezer_tool_name
         notificationManager.notify(id, notification)
     }
 
+    fun notifyError(scheduleId: ScheduleId) {
+        val baseId = (scheduleId.hashCode() and Int.MAX_VALUE) % 101
+        val id = NOTIFICATION_ID_RANGE_RESULT + baseId
+        val notification = getBaseResultBuilder().apply {
+            setContentTitle(context.getString(R.string.scheduler_notification_result_title))
+            val text = context.getString(R.string.scheduler_notification_result_failure_message)
+            setContentText(text)
+            setStyle(NotificationCompat.BigTextStyle().bigText(text))
+        }.build()
+        log(TAG) { "notifyError($id, $scheduleId)" }
+        notificationManager.notify(id, notification)
+    }
+
+
     data class Results(
         val task: SDMTool.Task,
         val result: SDMTool.Task.Result? = null,

--- a/app/src/main/java/eu/darken/sdmse/scheduler/core/SchedulerWorker.kt
+++ b/app/src/main/java/eu/darken/sdmse/scheduler/core/SchedulerWorker.kt
@@ -110,6 +110,7 @@ class SchedulerWorker @AssistedInject constructor(
         if (e !is CancellationException) {
             log(TAG, ERROR) { "Execution failed: ${e.asLog()}" }
             finishedWithError = true
+            schedulerNotifications.notifyError(scheduleId)
 
             Result.failure(inputData)
         } else {


### PR DESCRIPTION
## Summary
- When `doDoWork()` throws an exception, `executedAt` is updated in the `finally` block but `notifyResult()` is never called, causing a gap between the dashboard's "last execution" date and the notification history
- Add `notifyError()` to `SchedulerNotifications` and call it from the `catch` block when a non-cancellation exception occurs

## Test plan
- [ ] Build compiles: `./gradlew assembleFossDebug`
- [ ] Unit tests pass: `./gradlew test`
- [ ] Verify error notification appears in notification history when scheduler execution fails