### PR TITLE
General: Remove stale CLAUDE.md exclusion from _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -33,4 +33,3 @@ exclude:
   - motd
   - tooling
   - CONTRIBUTING.md
-  - CLAUDE.md


### PR DESCRIPTION
## Summary
- Remove stale `CLAUDE.md` entry from the `exclude:` list in `_config.yml`
- `CLAUDE.md` no longer exists at the repo root — it lives under `.claude/CLAUDE.md`, which Jekyll already ignores by default (dot-prefixed directories are excluded)

## Test plan
- Verified `CLAUDE.md` does not exist at the repo root
- Verified `.claude/CLAUDE.md` exists and is covered by Jekyll's dot-directory convention