### PR TITLE
Root: Add SukiSU-Ultra to known root managers

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/root/RootManager.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/root/RootManager.kt
@@ -129,6 +129,7 @@ class RootManager @Inject constructor(
             "me.weishu.kernelsu",
             "com.rifsxd.ksunext",
             "me.bmax.apatch",
+            "com.sukisu.ultra",
         )
     }
 }


### PR DESCRIPTION
SukiSU-Ultra is another fork of tiann/KernelSU

Offtopic: Why is the website sukisu.org instead of sukisu.com? Or why is the package name com.sukisu.ultra instead of org.sukisu.ultra?