### PR TITLE
General: Fix ANR in RecyclerView data binding and improve list infrastructure

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/analyzer/ui/storage/app/AppDetailsAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/analyzer/ui/storage/app/AppDetailsAdapter.kt
@@ -28,7 +28,7 @@ class AppDetailsAdapter @Inject constructor() :
     override fun getItemCount(): Int = data.size
 
     init {
-        addMod(DataBinderMod(data))
+        addMod(DataBinderMod({ data }))
         addMod(TypedVHCreatorMod({ data[it] is AppDetailsHeaderVH.Item }) { AppDetailsHeaderVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is AppDetailsAppCodeVH.Item }) { AppDetailsAppCodeVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is AppDetailsAppDataVH.Item }) { AppDetailsAppDataVH(it) })

--- a/app/src/main/java/eu/darken/sdmse/analyzer/ui/storage/apps/AppsAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/analyzer/ui/storage/apps/AppsAdapter.kt
@@ -23,7 +23,7 @@ class AppsAdapter @Inject constructor() :
     override fun getItemCount(): Int = data.size
 
     init {
-        addMod(DataBinderMod(data))
+        addMod(DataBinderMod({ data }))
         addMod(TypedVHCreatorMod({ data[it] is AppsItemVH.Item }) { AppsItemVH(it) })
     }
 

--- a/app/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentAdapter.kt
@@ -25,7 +25,7 @@ class ContentAdapter @Inject constructor() :
     override fun getItemCount(): Int = data.size
 
     init {
-        addMod(DataBinderMod(data))
+        addMod(DataBinderMod({ data }))
         addMod(TypedVHCreatorMod({ data[it] is ContentItemListVH.Item }) { ContentItemListVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is ContentItemGridVH.Item }) { ContentItemGridVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is ContentGroupVH.Item }) { ContentGroupVH(it) })

--- a/app/src/main/java/eu/darken/sdmse/analyzer/ui/storage/device/DeviceStorageAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/analyzer/ui/storage/device/DeviceStorageAdapter.kt
@@ -23,7 +23,7 @@ class DeviceStorageAdapter @Inject constructor() :
     override fun getItemCount(): Int = data.size
 
     init {
-        addMod(DataBinderMod(data))
+        addMod(DataBinderMod({ data }))
         addMod(TypedVHCreatorMod({ data[it] is DeviceStorageItemVH.Item }) { DeviceStorageItemVH(it) })
     }
 

--- a/app/src/main/java/eu/darken/sdmse/analyzer/ui/storage/storage/StorageContentAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/analyzer/ui/storage/storage/StorageContentAdapter.kt
@@ -26,7 +26,7 @@ class StorageContentAdapter @Inject constructor() :
     override fun getItemCount(): Int = data.size
 
     init {
-        addMod(DataBinderMod(data))
+        addMod(DataBinderMod({ data }))
         addMod(TypedVHCreatorMod({ data[it] is AppCategoryVH.Item }) { AppCategoryVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is MediaCategoryVH.Item }) { MediaCategoryVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is SystemCategoryVH.Item }) { SystemCategoryVH(it) })

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/ui/details/appjunk/AppJunkElementsAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/ui/details/appjunk/AppJunkElementsAdapter.kt
@@ -28,7 +28,7 @@ class AppJunkElementsAdapter @Inject constructor() :
     override fun getItemCount(): Int = data.size
 
     init {
-        addMod(DataBinderMod(data))
+        addMod(DataBinderMod({ data }))
         addMod(TypedVHCreatorMod({ data[it] is AppJunkElementHeaderVH.Item }) { AppJunkElementHeaderVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is AppJunkElementFileCategoryVH.Item }) {
             AppJunkElementFileCategoryVH(it)

--- a/app/src/main/java/eu/darken/sdmse/appcleaner/ui/list/AppCleanerListAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/ui/list/AppCleanerListAdapter.kt
@@ -26,7 +26,7 @@ class AppCleanerListAdapter @Inject constructor() :
     override fun getItemCount(): Int = data.size
 
     init {
-        addMod(DataBinderMod(data))
+        addMod(DataBinderMod({ data }))
         addMod(TypedVHCreatorMod({ data[it] is AppCleanerListRowVH.Item }) { AppCleanerListRowVH(it) })
     }
 

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListAdapter.kt
@@ -25,7 +25,7 @@ class AppControlListAdapter @Inject constructor() :
     override fun getItemCount(): Int = data.size
 
     init {
-        addMod(DataBinderMod(data))
+        addMod(DataBinderMod({ data }))
         addMod(TypedVHCreatorMod({ data[it] is AppControlListRowVH.Item }) { AppControlListRowVH(it) })
     }
 

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/actions/AppActionAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/ui/list/actions/AppActionAdapter.kt
@@ -35,7 +35,7 @@ class AppActionAdapter @Inject constructor() :
     override fun getItemCount(): Int = data.size
 
     init {
-        addMod(DataBinderMod(data))
+        addMod(DataBinderMod({ data }))
         addMod(TypedVHCreatorMod({ data[it] is InfoSizeVH.Item }) { InfoSizeVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is InfoUsageVH.Item }) { InfoUsageVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is LaunchActionVH.Item }) { LaunchActionVH(it) })

--- a/app/src/main/java/eu/darken/sdmse/common/debug/logviewer/ui/LogViewerAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/debug/logviewer/ui/LogViewerAdapter.kt
@@ -28,7 +28,7 @@ class LogViewerAdapter @Inject constructor() :
     override fun getItemCount(): Int = data.size
 
     init {
-        addMod(DataBinderMod(data))
+        addMod(DataBinderMod({ data }))
         addMod(TypedVHCreatorMod({ data[it] is LogViewerRow.Item }) { LogViewerRow(it) })
     }
 

--- a/app/src/main/java/eu/darken/sdmse/common/debug/recorder/ui/LogFileAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/debug/recorder/ui/LogFileAdapter.kt
@@ -28,7 +28,7 @@ class LogFileAdapter @Inject constructor() :
     override fun getItemCount(): Int = data.size
 
     init {
-        addMod(DataBinderMod(data))
+        addMod(DataBinderMod({ data }))
         addMod(TypedVHCreatorMod({ data[it] is Entry.Item }) { Entry(it) })
     }
 

--- a/app/src/main/java/eu/darken/sdmse/common/lists/modular/mods/DataBinderMod.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/lists/modular/mods/DataBinderMod.kt
@@ -5,13 +5,13 @@ import eu.darken.sdmse.common.lists.BindableVH
 import eu.darken.sdmse.common.lists.modular.ModularAdapter
 
 class DataBinderMod<ItemT, HolderT> constructor(
-    private val data: List<ItemT>,
+    private val data: () -> List<ItemT>,
     private val customBinder: (
         (adapter: ModularAdapter<HolderT>, vh: HolderT, pos: Int, payload: MutableList<Any>) -> Unit
     )? = null
 ) : ModularAdapter.Module.Binder<HolderT> where HolderT : BindableVH<ItemT, ViewBinding>, HolderT : ModularAdapter.VH {
 
     override fun onBindModularVH(adapter: ModularAdapter<HolderT>, vh: HolderT, pos: Int, payloads: MutableList<Any>) {
-        customBinder?.invoke(adapter, vh, pos, mutableListOf()) ?: vh.bind(data[pos], payloads)
+        customBinder?.invoke(adapter, vh, pos, mutableListOf()) ?: vh.bind(data()[pos], payloads)
     }
 }

--- a/app/src/main/java/eu/darken/sdmse/common/lists/modular/mods/StableIdMod.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/lists/modular/mods/StableIdMod.kt
@@ -4,10 +4,10 @@ import androidx.recyclerview.widget.RecyclerView
 import eu.darken.sdmse.common.lists.differ.DifferItem
 import eu.darken.sdmse.common.lists.modular.ModularAdapter
 
-class StableIdMod<ItemT : DifferItem> constructor(
-    private val data: List<ItemT>,
+class StableIdMod<ItemT : DifferItem>(
+    private val data: () -> List<ItemT>,
     private val customResolver: (position: Int) -> Long = {
-        (data[it] as? DifferItem)?.stableId ?: RecyclerView.NO_ID
+        (data()[it] as? DifferItem)?.stableId ?: RecyclerView.NO_ID
     }
 ) : ModularAdapter.Module.ItemId, ModularAdapter.Module.Setup {
 
@@ -15,7 +15,7 @@ class StableIdMod<ItemT : DifferItem> constructor(
         adapter.setHasStableIds(true)
     }
 
-    override fun getItemId(adapter: ModularAdapter<*>, position: Int): Long? {
+    override fun getItemId(adapter: ModularAdapter<*>, position: Int): Long {
         return customResolver.invoke(position)
     }
 }

--- a/app/src/main/java/eu/darken/sdmse/common/lists/selection/ItemSelectionKeyProvider.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/lists/selection/ItemSelectionKeyProvider.kt
@@ -7,11 +7,27 @@ class ItemSelectionKeyProvider(
     private val adapter: DataAdapter<out SelectableItem>
 ) : ItemKeyProvider<String>(SCOPE_MAPPED) {
 
+    private var cachedData: List<SelectableItem>? = null
+    private var positionMap: Map<String, Int> = emptyMap()
+
+    private fun ensureCache(): Map<String, Int> {
+        val currentData = adapter.data
+        if (currentData !== cachedData) {
+            cachedData = currentData
+            positionMap = buildMap {
+                currentData.forEachIndexed { index, item ->
+                    item.itemSelectionKey?.let { key -> put(key, index) }
+                }
+            }
+        }
+        return positionMap
+    }
+
     override fun getKey(position: Int): String? {
-        return adapter.data[position].itemSelectionKey
+        return adapter.data.getOrNull(position)?.itemSelectionKey
     }
 
     override fun getPosition(key: String): Int {
-        return adapter.data.indexOfFirst { it.itemSelectionKey == key }
+        return ensureCache()[key] ?: -1
     }
 }

--- a/app/src/main/java/eu/darken/sdmse/common/picker/PickerAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/picker/PickerAdapter.kt
@@ -23,7 +23,7 @@ class PickerAdapter @Inject constructor() :
     override fun getItemCount(): Int = data.size
 
     init {
-        addMod(DataBinderMod(data))
+        addMod(DataBinderMod({ data }))
         addMod(TypedVHCreatorMod({ data[it] is PickerItemVH.Item }) { PickerItemVH(it) })
     }
 

--- a/app/src/main/java/eu/darken/sdmse/common/picker/PickerSelectedAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/picker/PickerSelectedAdapter.kt
@@ -23,7 +23,7 @@ class PickerSelectedAdapter @Inject constructor() :
     override fun getItemCount(): Int = data.size
 
     init {
-        addMod(DataBinderMod(data))
+        addMod(DataBinderMod({ data }))
         addMod(TypedVHCreatorMod({ data[it] is PickerSelectedVH.Item }) { PickerSelectedVH(it) })
     }
 

--- a/app/src/main/java/eu/darken/sdmse/corpsefinder/ui/details/corpse/CorpseElementsAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/corpsefinder/ui/details/corpse/CorpseElementsAdapter.kt
@@ -26,7 +26,7 @@ class CorpseElementsAdapter @Inject constructor() :
     override fun getItemCount(): Int = data.size
 
     init {
-        addMod(DataBinderMod(data))
+        addMod(DataBinderMod({ data }))
         addMod(TypedVHCreatorMod({ data[it] is CorpseElementHeaderVH.Item }) { CorpseElementHeaderVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is CorpseElementFileVH.Item }) { CorpseElementFileVH(it) })
     }

--- a/app/src/main/java/eu/darken/sdmse/corpsefinder/ui/list/CorpseFinderListAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/corpsefinder/ui/list/CorpseFinderListAdapter.kt
@@ -25,7 +25,7 @@ class CorpseFinderListAdapter @Inject constructor() :
     override fun getItemCount(): Int = data.size
 
     init {
-        addMod(DataBinderMod(data))
+        addMod(DataBinderMod({ data }))
         addMod(TypedVHCreatorMod({ data[it] is CorpseFinderListRowVH.Item }) { CorpseFinderListRowVH(it) })
     }
 

--- a/app/src/main/java/eu/darken/sdmse/deduplicator/ui/PreviewDeletionDialog.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/ui/PreviewDeletionDialog.kt
@@ -245,7 +245,7 @@ class PreviewDeletionDialog @Inject constructor(
         override fun getItemCount(): Int = data.size
 
         init {
-            addMod(DataBinderMod(data))
+            addMod(DataBinderMod({ data }))
             addMod(SimpleVHCreatorMod { VH(it) })
         }
 

--- a/app/src/main/java/eu/darken/sdmse/deduplicator/ui/details/cluster/ClusterAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/ui/details/cluster/ClusterAdapter.kt
@@ -32,7 +32,7 @@ class ClusterAdapter @Inject constructor() :
     override fun getItemCount(): Int = data.size
 
     init {
-        addMod(DataBinderMod(data))
+        addMod(DataBinderMod({ data }))
         addMod(TypedVHCreatorMod({ data[it] is ClusterHeaderVH.Item }) { ClusterHeaderVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is DirectoryHeaderVH.Item }) { DirectoryHeaderVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is ChecksumGroupHeaderVH.Item }) { ChecksumGroupHeaderVH(it) })

--- a/app/src/main/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListAdapter.kt
@@ -25,7 +25,7 @@ class DeduplicatorListAdapter @Inject constructor() :
     override fun getItemCount(): Int = data.size
 
     init {
-        addMod(DataBinderMod(data))
+        addMod(DataBinderMod({ data }))
         addMod(TypedVHCreatorMod({ data[it] is DeduplicatorListGridVH.Item }) { DeduplicatorListGridVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is DeduplicatorListLinearVH.Item }) { DeduplicatorListLinearVH(it) })
     }

--- a/app/src/main/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListLinearSubAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListLinearSubAdapter.kt
@@ -34,7 +34,7 @@ class DeduplicatorListLinearSubAdapter @Inject constructor() :
     override fun getItemCount(): Int = data.size
 
     init {
-        addMod(DataBinderMod(data))
+        addMod(DataBinderMod({ data }))
         addMod(TypedVHCreatorMod({ data[it] is DuplicateItemVH.Item }) { DuplicateItemVH(it) })
     }
 

--- a/app/src/main/java/eu/darken/sdmse/deduplicator/ui/settings/arbiter/ArbiterConfigAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/ui/settings/arbiter/ArbiterConfigAdapter.kt
@@ -25,7 +25,7 @@ class ArbiterConfigAdapter @Inject constructor() :
     override fun getItemCount(): Int = data.size
 
     init {
-        addMod(DataBinderMod(data))
+        addMod(DataBinderMod({ data }))
         addMod(TypedVHCreatorMod({ data[it] is HeaderItem }) { ArbiterConfigHeaderVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is CriteriumItem }) { ArbiterCriteriumRowVH(it) })
     }

--- a/app/src/main/java/eu/darken/sdmse/exclusion/ui/list/ExclusionListAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/exclusion/ui/list/ExclusionListAdapter.kt
@@ -29,7 +29,7 @@ class ExclusionListAdapter @Inject constructor() :
     override fun getItemCount(): Int = data.size
 
     init {
-        addMod(DataBinderMod(data))
+        addMod(DataBinderMod({ data }))
         addMod(TypedVHCreatorMod({ data[it] is PackageExclusionVH.Item }) { PackageExclusionVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is PathExclusionVH.Item }) { PathExclusionVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is SegmentExclusionVH.Item }) { SegmentExclusionVH(it) })

--- a/app/src/main/java/eu/darken/sdmse/main/ui/areas/DataAreasAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/areas/DataAreasAdapter.kt
@@ -23,7 +23,7 @@ class DataAreasAdapter @Inject constructor() :
     override fun getItemCount(): Int = data.size
 
     init {
-        addMod(DataBinderMod(data))
+        addMod(DataBinderMod({ data }))
         addMod(TypedVHCreatorMod({ data[it] is DataAreaRowVH.Item }) { DataAreaRowVH(it) })
     }
 

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardAdapter.kt
@@ -7,7 +7,6 @@ import androidx.viewbinding.ViewBinding
 import dagger.hilt.android.scopes.ActivityScoped
 import eu.darken.sdmse.analyzer.ui.AnalyzerDashCardVH
 import eu.darken.sdmse.appcontrol.ui.AppControlDashCardVH
-import eu.darken.sdmse.squeezer.ui.SqueezerDashCardVH
 import eu.darken.sdmse.common.debug.recorder.ui.DebugRecorderCardVH
 import eu.darken.sdmse.common.lists.BindableVH
 import eu.darken.sdmse.common.lists.differ.AsyncDiffer
@@ -27,6 +26,7 @@ import eu.darken.sdmse.main.ui.dashboard.items.TitleCardVH
 import eu.darken.sdmse.main.ui.dashboard.items.UpdateCardVH
 import eu.darken.sdmse.main.ui.dashboard.items.UpgradeCardVH
 import eu.darken.sdmse.scheduler.ui.SchedulerDashCardVH
+import eu.darken.sdmse.squeezer.ui.SqueezerDashCardVH
 import eu.darken.sdmse.stats.ui.StatsDashCardVH
 import eu.darken.sdmse.swiper.ui.SwiperDashCardVH
 import javax.inject.Inject
@@ -43,7 +43,7 @@ class DashboardAdapter @Inject constructor(
     override fun getItemCount(): Int = data.size
 
     init {
-        addMod(DataBinderMod(data))
+        addMod(DataBinderMod({ data }))
         addMod(TypedVHCreatorMod({ data[it] is TitleCardVH.Item }) { TitleCardVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is DebugCardVH.Item }) { DebugCardVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is SetupCardVH.Item }) { SetupCardVH(it) })

--- a/app/src/main/java/eu/darken/sdmse/main/ui/settings/cards/DashboardCardConfigAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/settings/cards/DashboardCardConfigAdapter.kt
@@ -25,7 +25,7 @@ class DashboardCardConfigAdapter @Inject constructor() :
     override fun getItemCount(): Int = data.size
 
     init {
-        addMod(DataBinderMod(data))
+        addMod(DataBinderMod({ data }))
         addMod(TypedVHCreatorMod({ data[it] is HeaderItem }) { DashboardCardConfigHeaderVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is CardItem }) { DashboardCardConfigRowVH(it) })
     }

--- a/app/src/main/java/eu/darken/sdmse/scheduler/ui/manager/SchedulerAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/scheduler/ui/manager/SchedulerAdapter.kt
@@ -26,7 +26,7 @@ class SchedulerAdapter @Inject constructor() :
     override fun getItemCount(): Int = data.size
 
     init {
-        addMod(DataBinderMod(data))
+        addMod(DataBinderMod({ data }))
         addMod(TypedVHCreatorMod({ data[it] is ScheduleRowVH.Item }) { ScheduleRowVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is AlarmHintRowVH.Item }) { AlarmHintRowVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is BatteryHintRowVH.Item }) { BatteryHintRowVH(it) })

--- a/app/src/main/java/eu/darken/sdmse/setup/SetupAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/SetupAdapter.kt
@@ -32,7 +32,7 @@ SetupAdapter @Inject constructor() :
     override fun getItemCount(): Int = data.size
 
     init {
-        addMod(DataBinderMod(data))
+        addMod(DataBinderMod({ data }))
         addMod(TypedVHCreatorMod({ data[it] is StorageSetupCardVH.Item }) { StorageSetupCardVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is UsageStatsSetupCardVH.Item }) { UsageStatsSetupCardVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is SAFSetupCardVH.Item }) { SAFSetupCardVH(it) })

--- a/app/src/main/java/eu/darken/sdmse/setup/saf/SAFCardPathAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/saf/SAFCardPathAdapter.kt
@@ -26,7 +26,7 @@ class SAFCardPathAdapter @Inject constructor() :
     override fun getItemCount(): Int = data.size
 
     init {
-        addMod(DataBinderMod(data))
+        addMod(DataBinderMod({ data }))
         addMod(SimpleVHCreatorMod { VH(it) })
     }
 

--- a/app/src/main/java/eu/darken/sdmse/setup/storage/LocalPathCardAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/storage/LocalPathCardAdapter.kt
@@ -26,7 +26,7 @@ class LocalPathCardAdapter @Inject constructor() :
     override fun getItemCount(): Int = data.size
 
     init {
-        addMod(DataBinderMod(data))
+        addMod(DataBinderMod({ data }))
         addMod(SimpleVHCreatorMod { VH(it) })
     }
 

--- a/app/src/main/java/eu/darken/sdmse/squeezer/ui/list/SqueezerListAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/squeezer/ui/list/SqueezerListAdapter.kt
@@ -25,7 +25,7 @@ class SqueezerListAdapter @Inject constructor() :
     override fun getItemCount(): Int = data.size
 
     init {
-        addMod(DataBinderMod(data))
+        addMod(DataBinderMod({ data }))
         addMod(TypedVHCreatorMod({ data[it] is SqueezerListGridVH.Item }) { SqueezerListGridVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is SqueezerListLinearVH.Item }) { SqueezerListLinearVH(it) })
     }

--- a/app/src/main/java/eu/darken/sdmse/stats/ui/paths/AffectedPathsAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/stats/ui/paths/AffectedPathsAdapter.kt
@@ -25,7 +25,7 @@ class AffectedPathsAdapter @Inject constructor() :
     override fun getItemCount(): Int = data.size
 
     init {
-        addMod(DataBinderMod(data))
+        addMod(DataBinderMod({ data }))
         addMod(TypedVHCreatorMod({ data[it] is AffectedPathsHeaderVH.Item }) { AffectedPathsHeaderVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is AffectedPathVH.Item }) { AffectedPathVH(it) })
     }

--- a/app/src/main/java/eu/darken/sdmse/stats/ui/pkgs/AffectedPkgsAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/stats/ui/pkgs/AffectedPkgsAdapter.kt
@@ -25,7 +25,7 @@ class AffectedPkgsAdapter @Inject constructor() :
     override fun getItemCount(): Int = data.size
 
     init {
-        addMod(DataBinderMod(data))
+        addMod(DataBinderMod({ data }))
         addMod(TypedVHCreatorMod({ data[it] is AffectedPkgsHeaderVH.Item }) { AffectedPkgsHeaderVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is AffectedPkgVH.Item }) { AffectedPkgVH(it) })
     }

--- a/app/src/main/java/eu/darken/sdmse/stats/ui/reports/ReportsAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/stats/ui/reports/ReportsAdapter.kt
@@ -23,7 +23,7 @@ class ReportsAdapter @Inject constructor() :
     override fun getItemCount(): Int = data.size
 
     init {
-        addMod(DataBinderMod(data))
+        addMod(DataBinderMod({ data }))
         addMod(TypedVHCreatorMod({ data[it] is ReportBaseRowVH.Item }) { ReportBaseRowVH(it) })
     }
 

--- a/app/src/main/java/eu/darken/sdmse/swiper/ui/sessions/SwiperSessionsAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/swiper/ui/sessions/SwiperSessionsAdapter.kt
@@ -24,7 +24,7 @@ class SwiperSessionsAdapter :
     override fun getItemCount(): Int = data.size
 
     init {
-        addMod(DataBinderMod(data))
+        addMod(DataBinderMod({ data }))
         addMod(TypedVHCreatorMod({ data[it] is SwiperSessionsHeaderVH.Item }) { SwiperSessionsHeaderVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is SwiperSessionsUpgradeVH.Item }) { SwiperSessionsUpgradeVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is SwiperSessionsSessionVH.Item }) { SwiperSessionsSessionVH(it) })

--- a/app/src/main/java/eu/darken/sdmse/swiper/ui/status/SwiperStatusAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/swiper/ui/status/SwiperStatusAdapter.kt
@@ -33,7 +33,7 @@ class SwiperStatusAdapter :
     override fun getItemCount(): Int = data.size
 
     init {
-        addMod(DataBinderMod(data))
+        addMod(DataBinderMod({ data }))
         addMod(SimpleVHCreatorMod { VH(it) })
     }
 

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/live/LiveSearchListAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/live/LiveSearchListAdapter.kt
@@ -23,7 +23,7 @@ class LiveSearchListAdapter @Inject constructor() :
     override fun getItemCount(): Int = data.size
 
     init {
-        addMod(DataBinderMod(data))
+        addMod(DataBinderMod({ data }))
         addMod(TypedVHCreatorMod({ data[it] is LiveSearchListRow.Item }) { LiveSearchListRow(it) })
     }
 

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/list/CustomFilterListAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/list/CustomFilterListAdapter.kt
@@ -27,7 +27,7 @@ class CustomFilterListAdapter @Inject constructor() :
     override fun getItemCount(): Int = data.size
 
     init {
-        addMod(DataBinderMod(data))
+        addMod(DataBinderMod({ data }))
         addMod(TypedVHCreatorMod({ data[it] is CustomFilterDefaultVH.Item }) { CustomFilterDefaultVH(it) })
     }
 

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/ui/details/filtercontent/FilterContentElementsAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/ui/details/filtercontent/FilterContentElementsAdapter.kt
@@ -26,7 +26,7 @@ class FilterContentElementsAdapter @Inject constructor() :
     override fun getItemCount(): Int = data.size
 
     init {
-        addMod(DataBinderMod(data))
+        addMod(DataBinderMod({ data }))
         addMod(TypedVHCreatorMod({ data[it] is FilterContentElementHeaderVH.Item }) {
             FilterContentElementHeaderVH(
                 it

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/ui/list/SystemCleanerListAdapter.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/ui/list/SystemCleanerListAdapter.kt
@@ -25,7 +25,7 @@ class SystemCleanerListAdapter @Inject constructor() :
     override fun getItemCount(): Int = data.size
 
     init {
-        addMod(DataBinderMod(data))
+        addMod(DataBinderMod({ data }))
         addMod(TypedVHCreatorMod({ data[it] is SystemCleanerListRowVH.Item }) { SystemCleanerListRowVH(it) })
     }
 


### PR DESCRIPTION
## Summary
- Fix ANR caused by `DataBinderMod` capturing a stale data list reference at init time — changed to a `() -> List<T>` lambda so it always reads the current `AsyncDiffer` snapshot
- Updated `StableIdMod` and `ItemSelectionKeyProvider` to use the same lambda accessor pattern
- Added KDoc on `AsyncDiffer.currentList` documenting the reference-identity contract
- Tightened list selection lookups in `RecyclerViewExtensions` and `ContentFragment` to use `map`/`first` for tracker-sourced keys (guaranteed non-null)

## Test plan
- [x] `./gradlew assembleFossDebug` passes
- [x] `./gradlew testFossDebugUnitTest` passes (1222 tests, 0 failures)
- [ ] On-device: verify list selection (long-press, select all, CAB actions) in Analyzer content screen
- [ ] On-device: verify no ANR on screens with large adapter lists (Dashboard, AppCleaner, CorpseFinder)