### PR TITLE
General: Fix navigation silently failing on app open

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/common/navigation/FragmentExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/navigation/FragmentExtensions.kt
@@ -22,7 +22,13 @@ import eu.darken.sdmse.common.getCompatColor
 import eu.darken.sdmse.common.getQuantityString2
 import eu.darken.sdmse.common.getSpanCount
 
-fun Fragment.doNavigate(direction: NavDirections) = findNavController().doNavigate(direction)
+fun Fragment.doNavigate(direction: NavDirections) {
+    if (!isAdded) {
+        log(WARN) { "Trying to navigate from ${this.javaClass.simpleName} that isn't added: ${direction.javaClass.simpleName}" }
+        return
+    }
+    findNavController().doNavigate(direction)
+}
 
 fun Fragment.popBackStack(): Boolean {
     if (!isAdded) {

--- a/app/src/main/java/eu/darken/sdmse/common/navigation/NavControllerExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/navigation/NavControllerExtensions.kt
@@ -4,6 +4,11 @@ import android.os.Bundle
 import androidx.annotation.IdRes
 import androidx.navigation.NavController
 import androidx.navigation.NavDirections
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+
+private val TAG = logTag("Navigation")
 
 fun NavController.navigateIfNotThere(@IdRes resId: Int, args: Bundle? = null) {
     if (currentDestination?.id == resId) return
@@ -11,7 +16,15 @@ fun NavController.navigateIfNotThere(@IdRes resId: Int, args: Bundle? = null) {
 }
 
 fun NavController.doNavigate(direction: NavDirections) {
-    currentDestination?.getAction(direction.actionId)?.let { navigate(direction) }
+    val curDest = currentDestination
+    val action = curDest?.getAction(direction.actionId)
+    if (action != null) {
+        navigate(direction)
+        return
+    }
+    log(TAG, WARN) {
+        "Navigation dropped: ${direction.javaClass.simpleName} not found on ${curDest?.label ?: "null"}"
+    }
 }
 
 fun NavController.isGraphSet(): Boolean = try {

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardFragment.kt
@@ -15,10 +15,13 @@ import eu.darken.sdmse.R
 import eu.darken.sdmse.common.ByteFormatter
 import eu.darken.sdmse.common.EdgeToEdgeHelper
 import eu.darken.sdmse.common.easterEggProgressMsg
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.error.asErrorDialogBuilder
 import eu.darken.sdmse.common.getColorForAttr
 import eu.darken.sdmse.common.lists.differ.update
 import eu.darken.sdmse.common.lists.setupDefaults
+import androidx.navigation.fragment.findNavController
 import eu.darken.sdmse.common.navigation.getColorForAttr
 import eu.darken.sdmse.common.navigation.getQuantityString2
 import eu.darken.sdmse.common.navigation.getSpanCount
@@ -261,6 +264,16 @@ class DashboardFragment : Fragment3(R.layout.dashboard_fragment) {
         }
 
         super.onViewCreated(view, savedInstanceState)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        val navController = findNavController()
+        val curDest = navController.currentDestination
+        if (curDest != null && curDest.id != R.id.dashboardFragment) {
+            log(tag, WARN) { "Dashboard resumed but currentDestination is ${curDest.label}, recovering" }
+            navController.popBackStack(R.id.dashboardFragment, false)
+        }
     }
 
     private fun showSqueezerConfirmation(event: DashboardEvents.SqueezerProcessConfirmation) {

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -10,7 +10,7 @@ object Versions {
 
     object AndroidX {
         object Navigation {
-            const val core = "2.9.6"
+            const val core = "2.9.7"
         }
     }
 


### PR DESCRIPTION
## Summary

- Fix `NavController.doNavigate()` silently dropping all navigation when `currentDestination.getAction()` returns null — most likely triggered by process death during state restoration
- Add active recovery in `DashboardFragment.onResume()` that detects NavController state mismatches and calls `popBackStack` to fix internal state
- Add logging to `doNavigate()` for dropped navigation and `isAdded` guard to `Fragment.doNavigate()`
- Update navigation dependency 2.9.6 → 2.9.7

## Root Cause

`NavController.doNavigate()` checked `currentDestination?.getAction(direction.actionId)` and if it returned null, silently did nothing — no log, no error, no fallback. After process death, the NavController can restore `currentDestination` to a destination that doesn't match the actually-visible DashboardFragment, causing **all** navigation to permanently fail until app restart.

## Recovery Mechanism

`DashboardFragment.onResume()` now checks if the NavController's `currentDestination` matches `dashboardFragment`. If not, it calls `popBackStack(R.id.dashboardFragment, false)` to pop phantom entries and realign the internal state. This is safe because:
- `onResume` only fires when DashboardFragment is actually in the foreground
- When the user is on a sub-screen, dashboard is STOPPED — `onResume` doesn't fire
- Dashboard is always on the back stack as the start destination

## Test plan

- [ ] Build succeeds (`./gradlew assembleFossDebug` verified)
- [ ] Open the app normally, verify settings and tool navigation work
- [ ] Force-stop and reopen, verify navigation works
- [ ] Navigate to a detail screen, force-stop, reopen, verify navigation works after pressing back
- [ ] Check logcat for "Dashboard resumed but currentDestination" warnings

Closes #2148
Closes #2136
Closes #766
Closes #1218