### PR TITLE
General: Fix crash on Georgian locale in stats dashboard

### DIFF
--- a/app/src/main/res/values-ka-rGE/strings.xml
+++ b/app/src/main/res/values-ka-rGE/strings.xml
@@ -672,8 +672,8 @@
         <item quantity="other">%s ზომა</item>
     </plurals>
     <plurals name="stats_dash_body_count">
-        <item quantity="one">%d ელემენტი</item>
-        <item quantity="other">%d ელემენტი</item>
+        <item quantity="one">%s ელემენტი</item>
+        <item quantity="other">%s ელემენტი</item>
     </plurals>
     <string name="stats_report_status_success">წარმატება</string>
     <string name="stats_report_status_partial_success">ნაწილობრივი წარმატება</string>


### PR DESCRIPTION
## Summary
- Fix `IllegalFormatConversionException` crash for users with Georgian locale
- Georgian translation used `%d` (integer) format specifier in `stats_dash_body_count` plurals, but the code passes a `String` argument
- Changed `%d` to `%s` to match the base English string and all other translations

## Test plan
- [x] `assembleFossDebug` passes
- [x] `lintVitalFossRelease` passes