### PR TITLE
General: Fix crash when files disappear during directory scan

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalGateway.kt
@@ -311,7 +311,14 @@ class LocalGateway @Inject constructor(
                     if (nonRootList == null) throw ReadException(path = path)
                     nonRootList
                         .map { it.toLocalPath() }
-                        .map { it.performLookup() }
+                        .mapNotNull {
+                            try {
+                                it.performLookup()
+                            } catch (e: IOException) {
+                                log(TAG, WARN) { "lookupFiles($path): Failed to lookup child $it: ${e.asLog()}" }
+                                null
+                            }
+                        }
                 }
 
                 hasRoot() && (mode == Mode.ROOT || nonRootList == null && mode == Mode.AUTO) -> {
@@ -361,7 +368,14 @@ class LocalGateway @Inject constructor(
                         if (nonRootList == null) throw ReadException(path = path)
                         nonRootList
                             .map { it.toLocalPath() }
-                            .map { it.performLookupExtended(ipcFunnel, libcoreTool) }
+                            .mapNotNull {
+                                try {
+                                    it.performLookupExtended(ipcFunnel, libcoreTool)
+                                } catch (e: IOException) {
+                                    log(TAG, WARN) { "lookupFilesExtended($path): Failed to lookup child $it: ${e.asLog()}" }
+                                    null
+                                }
+                            }
                     }
 
                     hasRoot() && (mode == Mode.ROOT || nonRootList == null && mode == Mode.AUTO) -> {


### PR DESCRIPTION
## Summary
- Fix ReadException crash in LocalGateway.lookupFiles caused by a TOCTOU race condition
- When a file is deleted between listFiles2() and performLookup(), the individual file is now skipped instead of crashing the entire directory scan

## Details
Files can disappear between listing directory contents and looking up each child
(e.g., temporary/cache files deleted by other apps). Previously, a single vanished
file would throw a ReadException that crashed the entire lookupFiles/lookupFilesExtended
operation. Now individual lookup failures are logged and skipped using mapNotNull.