### PR TITLE
General: Fix R8 merging exception classes in crash reports

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,4 +1,7 @@
 -dontobfuscate
 
+# Prevent R8 from merging exception classes, which masks real exception types in crash reports
+-keep,allowshrinking class * extends java.lang.Throwable
+
 # Accessed via reflection.
 -keep class eu.darken.sdmse.BuildConfig { *; }


### PR DESCRIPTION
## Summary

- Prevent R8 vertical class merging from merging exception classes into unrelated ones, which causes Play Console crash reports to show wrong exception types (e.g. `coil.network.HttpException` appearing in `AutomationService.onServiceConnected`)
- Add `-keep,allowshrinking class * extends java.lang.Throwable` ProGuard rule so crash reports always show the real exception type without increasing APK size

## Test plan

- [ ] Build release APK (`./gradlew assembleGplayRelease`) and verify it succeeds
- [ ] Check R8 mapping file for absence of exception class merging entries
- [ ] Verify future Play Console crash reports show correct exception types