### PR TITLE
General: Fix ANR caused by lock contention during app startup

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/common/coil/CoilTempFiles.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/coil/CoilTempFiles.kt
@@ -21,8 +21,8 @@ class CoilTempFiles @Inject constructor(
     private val dispatcherProvider: DispatcherProvider,
 ) {
 
-    private val basePath: File = File(context.cacheDir, "coil")
-    private val legacyPath: File = context.cacheDir
+    private val basePath by lazy { File(context.cacheDir, "coil") }
+    private val legacyPath by lazy { context.cacheDir }
 
     suspend fun getBaseCachePath(): File {
         val path = basePath.apply {


### PR DESCRIPTION
## Summary
- Make `basePath` and `legacyPath` in `CoilTempFiles` lazy to avoid calling `context.cacheDir` during Hilt injection on the main thread

## Details
ANR occurs when `CoilTempFiles` constructor eagerly calls `context.cacheDir` on the main thread during Hilt injection, while a worker thread holds the `ContextImpl` lock performing a slow binder IPC (`StorageManager.mkdirs()` from `RecorderModule`'s `getExternalFilesDir()` call). Making both properties lazy defers the `context.cacheDir` access to first use, which always happens on background threads (Coil fetchers and coroutine-launched cleanup).

## Test plan
- [x] `assembleFossDebug` builds successfully
- [x] All 1222 unit tests pass