### PR TITLE
General: Fix crash when selecting list items during data changes

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentFragment.kt
@@ -21,6 +21,7 @@ import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.error.asErrorDialogBuilder
 import eu.darken.sdmse.common.lists.differ.update
 import eu.darken.sdmse.common.lists.installListSelection
+import eu.darken.sdmse.common.lists.resolveSelection
 import eu.darken.sdmse.common.lists.setupDefaults
 import eu.darken.sdmse.common.navigation.getQuantityString2
 import eu.darken.sdmse.common.navigation.getSpanCount
@@ -82,7 +83,7 @@ class ContentFragment : Fragment3(R.layout.analyzer_content_fragment) {
             adapter = adapter,
             cabMenuRes = R.menu.menu_analyzer_content_list_cab,
             onPrepare = { tracker, mode, menu ->
-                val selectedItems = tracker.selection.map { key -> adapter.data.first { it.itemSelectionKey == key } }
+                val selectedItems = resolveSelection(tracker, adapter.data, "onPrepare")
                 val hasInaccessible = selectedItems.any {
                     when (it) {
                         is ContentItemListVH.Item -> it.content.inaccessible


### PR DESCRIPTION
## Summary
- Fix `NoSuchElementException` crash when CAB action is clicked while adapter data has changed (e.g. from a scheduled scan completing)
- Replace unsafe `.first {}` with `.firstOrNull {}` at three locations: `onActionItemClicked`, `onSelectionChanged`, and ContentFragment's `onPrepare`
- Extract shared `resolveSelection()` helper that logs a warning when stale selection keys are detected

## Test plan
- Build succeeds with `./gradlew assembleFossDebug`
- Select items in any list with CAB, trigger a scan from scheduler, verify no crash when tapping CAB action after scan completes