### PR TITLE
General: Fix ANR caused by unnecessary TabLayout tab recreation

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/ui/details/AppJunkDetailsFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/ui/details/AppJunkDetailsFragment.kt
@@ -14,6 +14,7 @@ import eu.darken.sdmse.common.EdgeToEdgeHelper
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.ui.updateLiftStatus
 import eu.darken.sdmse.common.uix.Fragment3
+import eu.darken.sdmse.common.uix.setDataIfChanged
 import eu.darken.sdmse.common.viewbinding.viewBinding
 import eu.darken.sdmse.databinding.AppcleanerDetailsFragmentBinding
 import eu.darken.sdmse.main.ui.dashboard.DashboardAdapter
@@ -67,14 +68,12 @@ class AppJunkDetailsFragment : Fragment3(R.layout.appcleaner_details_fragment) {
             viewpager.isInvisible = state.progress != null
 
             if (state.progress == null) {
-                pagerAdapter.apply {
-                    setData(state.items)
-                    notifyDataSetChanged()
+                if (pagerAdapter.setDataIfChanged(state.items) { it.identifier }) {
+                    log { "state.target: ${state.target}" }
+                    state.items.indexOfFirst { it.identifier == state.target }
+                        .takeIf { it != -1 }
+                        ?.let { viewpager.currentItem = it }
                 }
-                log { "state.target: ${state.target}" }
-                state.items.indexOfFirst { it.identifier == state.target }
-                    .takeIf { it != -1 }
-                    ?.let { viewpager.currentItem = it }
             }
         }
 

--- a/app/src/main/java/eu/darken/sdmse/common/uix/FragmentStatePagerAdapter4Extensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/uix/FragmentStatePagerAdapter4Extensions.kt
@@ -1,0 +1,13 @@
+package eu.darken.sdmse.common.uix
+
+fun <T> FragmentStatePagerAdapter4<T>.setDataIfChanged(
+    newData: List<T>,
+    identifier: (T) -> Any,
+): Boolean {
+    if (data.map(identifier) != newData.map(identifier)) {
+        setData(newData)
+        notifyDataSetChanged()
+        return true
+    }
+    return false
+}

--- a/app/src/main/java/eu/darken/sdmse/corpsefinder/ui/details/CorpseDetailsFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/corpsefinder/ui/details/CorpseDetailsFragment.kt
@@ -13,6 +13,7 @@ import eu.darken.sdmse.R
 import eu.darken.sdmse.common.EdgeToEdgeHelper
 import eu.darken.sdmse.common.ui.updateLiftStatus
 import eu.darken.sdmse.common.uix.Fragment3
+import eu.darken.sdmse.common.uix.setDataIfChanged
 import eu.darken.sdmse.common.viewbinding.viewBinding
 import eu.darken.sdmse.databinding.CorpsefinderDetailsFragmentBinding
 
@@ -61,13 +62,11 @@ class CorpseDetailsFragment : Fragment3(R.layout.corpsefinder_details_fragment) 
             viewpager.isInvisible = state.progress != null
 
             if (state.progress == null) {
-                pagerAdapter.apply {
-                    setData(state.items)
-                    notifyDataSetChanged()
+                if (pagerAdapter.setDataIfChanged(state.items) { it.identifier }) {
+                    state.items.indexOfFirst { it.identifier == state.target }
+                        .takeIf { it != -1 }
+                        ?.let { viewpager.currentItem = it }
                 }
-                state.items.indexOfFirst { it.identifier == state.target }
-                    .takeIf { it != -1 }
-                    ?.let { viewpager.currentItem = it }
             }
         }
 

--- a/app/src/main/java/eu/darken/sdmse/deduplicator/ui/details/DeduplicatorDetailsFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/deduplicator/ui/details/DeduplicatorDetailsFragment.kt
@@ -13,6 +13,7 @@ import eu.darken.sdmse.R
 import eu.darken.sdmse.common.EdgeToEdgeHelper
 import eu.darken.sdmse.common.ui.updateLiftStatus
 import eu.darken.sdmse.common.uix.Fragment3
+import eu.darken.sdmse.common.uix.setDataIfChanged
 import eu.darken.sdmse.common.viewbinding.viewBinding
 import eu.darken.sdmse.databinding.DeduplicatorDetailsFragmentBinding
 
@@ -67,13 +68,11 @@ class DeduplicatorDetailsFragment : Fragment3(R.layout.deduplicator_details_frag
             viewpager.isInvisible = state.progress != null
 
             if (state.progress == null) {
-                pagerAdapter.apply {
-                    setData(state.items)
-                    notifyDataSetChanged()
+                if (pagerAdapter.setDataIfChanged(state.items) { it.identifier }) {
+                    state.items.indexOfFirst { it.identifier == state.target }
+                        .takeIf { it != -1 }
+                        ?.let { viewpager.currentItem = it }
                 }
-                state.items.indexOfFirst { it.identifier == state.target }
-                    .takeIf { it != -1 }
-                    ?.let { viewpager.currentItem = it }
             }
 
             toolbar.menu.findItem(R.id.action_toggle_view_mode)?.apply {

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/ui/details/FilterContentDetailsFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/ui/details/FilterContentDetailsFragment.kt
@@ -13,6 +13,7 @@ import eu.darken.sdmse.R
 import eu.darken.sdmse.common.EdgeToEdgeHelper
 import eu.darken.sdmse.common.ui.updateLiftStatus
 import eu.darken.sdmse.common.uix.Fragment3
+import eu.darken.sdmse.common.uix.setDataIfChanged
 import eu.darken.sdmse.common.viewbinding.viewBinding
 import eu.darken.sdmse.databinding.SystemcleanerDetailsFragmentBinding
 
@@ -61,13 +62,11 @@ class FilterContentDetailsFragment : Fragment3(R.layout.systemcleaner_details_fr
             viewpager.isInvisible = state.progress != null
 
             if (state.progress == null) {
-                pagerAdapter.apply {
-                    setData(state.items)
-                    notifyDataSetChanged()
+                if (pagerAdapter.setDataIfChanged(state.items) { it.identifier }) {
+                    state.items.indexOfFirst { it.identifier == state.target }
+                        .takeIf { it != -1 }
+                        ?.let { viewpager.currentItem = it }
                 }
-                state.items.indexOfFirst { it.identifier == state.target }
-                    .takeIf { it != -1 }
-                    ?.let { viewpager.currentItem = it }
             }
         }
 


### PR DESCRIPTION
## Summary
- Add `setDataIfChanged()` extension on `FragmentStatePagerAdapter4` that skips `notifyDataSetChanged()` when item identifiers haven't changed
- Apply to all 4 detail fragments (Deduplicator, AppCleaner, CorpseFinder, SystemCleaner)
- Move `currentItem` navigation inside the data-changed guard to prevent snapping users back to the target tab on redundant state emissions

## Context
The ViewModel's `state` flow re-emits when `progress` transitions to null or `isDirectoryViewEnabled` toggles, even though the item list is unchanged. Each `notifyDataSetChanged()` triggers `TabLayout.populateFromPagerAdapter()`, which recreates all tabs and synchronously loads fonts — causing an ANR with many tabs.

## Test plan
- [ ] Build: `./gradlew assembleFossDebug`
- [ ] Open Deduplicator details with many clusters, trigger a delete, confirm no ANR when progress indicator disappears
- [ ] Swipe to a different tab, toggle directory view mode, confirm you stay on the swiped-to tab