### PR TITLE
General: Fix APK rename breaking Android Studio deployment

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -166,7 +166,7 @@ androidComponents {
                     val apkFile = File(element.outputFile)
                     val outputFileName = "$packageName-v${element.versionName}-${element.versionCode}-$formattedVariantName.apk"
                     if (apkFile.exists() && apkFile.name != outputFileName) {
-                        apkFile.renameTo(File(apkFile.parentFile, outputFileName))
+                        apkFile.copyTo(File(apkFile.parentFile, outputFileName), overwrite = true)
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Use `copyTo` instead of `renameTo` for APK output renaming so both the original and distribution-named APK coexist, preventing `FileNotFoundException` when deploying beta/release builds from Android Studio

## Test plan
- [x] `./gradlew assembleFossDebug` builds successfully
- [ ] `./gradlew assembleGplayBeta` produces both original and renamed APK in output dir
- [ ] Deploy gplay-beta from Android Studio without FileNotFoundException