### PR TITLE
General: Fix foreground service ANR on slow startup

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/main/core/taskmanager/TaskWorker.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/core/taskmanager/TaskWorker.kt
@@ -27,7 +27,6 @@ import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.withTimeoutOrNull
 
-
 @HiltWorker
 class TaskWorker @AssistedInject constructor(
     @Assisted private val context: Context,
@@ -46,8 +45,7 @@ class TaskWorker @AssistedInject constructor(
     }
 
     override suspend fun getForegroundInfo(): ForegroundInfo {
-        val state = withTimeoutOrNull(3000) { taskManager.state.first() }
-        log(TAG) { "Supplying getForegroundInfo() with $state" }
+        val state = withTimeoutOrNull(500) { taskManager.state.first() }
         if (state == null) log(TAG, WARN) { "TaskManager state was not available" }
         return taskWorkerNotifications.getForegroundInfo(state)
     }

--- a/app/src/main/java/eu/darken/sdmse/scheduler/core/SchedulerNotifications.kt
+++ b/app/src/main/java/eu/darken/sdmse/scheduler/core/SchedulerNotifications.kt
@@ -77,13 +77,15 @@ class SchedulerNotifications @Inject constructor(
 
     private fun getStateNotification(schedule: Schedule?): Notification = getStateBuilder(schedule).build()
 
-    fun getForegroundInfo(schedule: Schedule): ForegroundInfo = getStateBuilder(schedule).toForegroundInfo(schedule)
+    fun getForegroundInfo(schedule: Schedule): ForegroundInfo = getStateBuilder(schedule).toForegroundInfo(schedule.id)
 
-    private fun NotificationCompat.Builder.toForegroundInfo(schedule: Schedule): ForegroundInfo = if (hasApiLevel(29)) {
+    fun getForegroundInfo(scheduleId: ScheduleId): ForegroundInfo = getStateBuilder(null).toForegroundInfo(scheduleId)
+
+    private fun NotificationCompat.Builder.toForegroundInfo(scheduleId: ScheduleId): ForegroundInfo = if (hasApiLevel(29)) {
         @Suppress("NewApi")
-        ForegroundInfo(schedule.id.toNotificationid(), build(), ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
+        ForegroundInfo(scheduleId.toNotificationid(), build(), ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
     } else {
-        ForegroundInfo(schedule.id.toNotificationid(), build())
+        ForegroundInfo(scheduleId.toNotificationid(), build())
     }
 
     private fun ScheduleId.toNotificationid(): Int {


### PR DESCRIPTION
## Summary
- Reduce `TaskWorker.getForegroundInfo()` timeout from 3s to 500ms to leave sufficient margin before the system's foreground service deadline
- Move `SchedulerWorker.setForeground()` before database reads so the foreground notification is posted immediately
- Add `SchedulerNotifications.getForegroundInfo(ScheduleId)` fast-path that avoids loading the full Schedule from the database

## Context
Android throws `ForegroundServiceDidNotStartInTimeException` when `startForeground()` is not called within ~5-10s. Both workers delayed this call with async operations (3s state timeout, database reads), which under resource pressure could exceed the deadline.