### PR TITLE
General: Fix crash when accessibility service is launched by foreign app

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/automation/core/AutomationService.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/AutomationService.kt
@@ -199,6 +199,10 @@ class AutomationService : AccessibilityService(), AutomationHost, Progress.Host,
 
     override fun onServiceConnected() {
         log(TAG) { "onServiceConnected()" }
+        if (!this::automationManager.isInitialized) {
+            log(TAG, WARN) { "onServiceConnected() called before injection completed, ignoring." }
+            return
+        }
         instance = this
         automationManager.setCurrentService(this)
         windowManager = getSystemService(WINDOW_SERVICE) as WindowManager


### PR DESCRIPTION
## Summary
- Fix `UninitializedPropertyAccessException` crash in `AutomationService.onServiceConnected()` when `onCreate()` fails due to a foreign application launching the service
- When Hilt injection fails in `onCreate()`, `disableSelf()` is called but `onServiceConnected()` can still fire asynchronously, accessing uninitialized `lateinit` properties
- Added `::automationManager.isInitialized` guard to safely skip service connection when injection hasn't completed

## Test plan
- [x] Build succeeds with `./gradlew assembleFossDebug`
- [ ] Verify `onServiceConnected()` returns early when injection hasn't completed