### PR TITLE
Swiper: Improve swipe action labels and fix sessions FAB insets

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/swiper/ui/sessions/SwiperSessionsFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/swiper/ui/sessions/SwiperSessionsFragment.kt
@@ -37,6 +37,7 @@ class SwiperSessionsFragment : Fragment3(R.layout.swiper_sessions_fragment) {
         EdgeToEdgeHelper(requireActivity()).apply {
             insetsPadding(ui.root, left = true, right = true)
             insetsPadding(ui.appbar, top = true)
+            insetsPadding(ui.fabContainer, bottom = true)
         }
 
         ui.toolbar.setupWithNavController(findNavController())

--- a/app/src/main/java/eu/darken/sdmse/swiper/ui/swipe/SwiperSwipeFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/swiper/ui/swipe/SwiperSwipeFragment.kt
@@ -160,6 +160,9 @@ class SwiperSwipeFragment : Fragment3(R.layout.swiper_swipe_fragment) {
                 // Swap icons
                 deleteAction.setImageResource(R.drawable.ic_heart)
                 keepAction.setImageResource(R.drawable.ic_delete)
+                // Swap labels
+                deleteLabel.setText(R.string.swiper_keep_action)
+                keepLabel.setText(eu.darken.sdmse.common.R.string.general_delete_action)
                 // Swap tints: left button gets primary (keep), right button gets error (delete)
                 deleteAction.backgroundTintList = ColorStateList.valueOf(
                     requireContext().getColorForAttr(com.google.android.material.R.attr.colorPrimaryContainer),
@@ -190,6 +193,9 @@ class SwiperSwipeFragment : Fragment3(R.layout.swiper_swipe_fragment) {
                 // Normal icons
                 deleteAction.setImageResource(R.drawable.ic_delete)
                 keepAction.setImageResource(R.drawable.ic_heart)
+                // Normal labels
+                deleteLabel.setText(eu.darken.sdmse.common.R.string.general_delete_action)
+                keepLabel.setText(R.string.swiper_keep_action)
                 // Normal tints: left button gets error (delete), right button gets primary (keep)
                 deleteAction.backgroundTintList = ColorStateList.valueOf(
                     requireContext().getColorForAttr(com.google.android.material.R.attr.colorErrorContainer),
@@ -258,26 +264,26 @@ class SwiperSwipeFragment : Fragment3(R.layout.swiper_swipe_fragment) {
             deleteCount.text = "${state.deleteCount}"
             undecidedCount.text = "${state.undecidedCount}"
 
-            // Animate undo button visibility
+            // Animate undo container visibility (FAB + label)
             val undoVisible = state.canUndo
-            if (undoVisible && undoAction.visibility != View.VISIBLE) {
-                undoAction.visibility = View.VISIBLE
-                undoAction.alpha = 0f
-                undoAction.scaleX = 0.5f
-                undoAction.scaleY = 0.5f
-                undoAction.animate()
+            if (undoVisible && undoContainer.visibility != View.VISIBLE) {
+                undoContainer.visibility = View.VISIBLE
+                undoContainer.alpha = 0f
+                undoContainer.scaleX = 0.5f
+                undoContainer.scaleY = 0.5f
+                undoContainer.animate()
                     .alpha(1f)
                     .scaleX(1f)
                     .scaleY(1f)
                     .setDuration(150)
                     .start()
-            } else if (!undoVisible && undoAction.visibility == View.VISIBLE) {
-                undoAction.animate()
+            } else if (!undoVisible && undoContainer.visibility == View.VISIBLE) {
+                undoContainer.animate()
                     .alpha(0f)
                     .scaleX(0.5f)
                     .scaleY(0.5f)
                     .setDuration(150)
-                    .withEndAction { undoAction.visibility = View.INVISIBLE }
+                    .withEndAction { undoContainer.visibility = View.INVISIBLE }
                     .start()
             }
         }

--- a/app/src/main/res/layout/swiper_sessions_fragment.xml
+++ b/app/src/main/res/layout/swiper_sessions_fragment.xml
@@ -61,14 +61,21 @@
         android:visibility="gone"
         app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
-    <com.google.android.material.floatingactionbutton.FloatingActionButton
-        android:id="@+id/fab"
+    <FrameLayout
+        android:id="@+id/fab_container"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom|end"
-        android:layout_margin="32dp"
-        android:contentDescription="@string/swiper_select_folders_action"
-        android:src="@drawable/ic_add"
-        app:layout_behavior="com.google.android.material.behavior.HideBottomViewOnScrollBehavior" />
+        app:layout_behavior="com.google.android.material.behavior.HideBottomViewOnScrollBehavior">
+
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/fab"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="32dp"
+            android:contentDescription="@string/swiper_select_folders_action"
+            android:src="@drawable/ic_add" />
+
+    </FrameLayout>
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/swiper_swipe_fragment.xml
+++ b/app/src/main/res/layout/swiper_swipe_fragment.xml
@@ -168,15 +168,32 @@
             app:layout_constraintTop_toBottomOf="@id/swipe_card">
 
             <!-- Delete FAB (left) -->
-            <com.google.android.material.floatingactionbutton.FloatingActionButton
-                android:id="@+id/delete_action"
+            <LinearLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:contentDescription="@string/general_delete_action"
-                app:backgroundTint="?attr/colorErrorContainer"
-                app:fabSize="normal"
-                app:srcCompat="@drawable/ic_delete"
-                app:tint="?attr/colorOnErrorContainer" />
+                android:gravity="center_horizontal"
+                android:orientation="vertical">
+
+                <com.google.android.material.floatingactionbutton.FloatingActionButton
+                    android:id="@+id/delete_action"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:contentDescription="@string/general_delete_action"
+                    app:backgroundTint="?attr/colorErrorContainer"
+                    app:fabSize="normal"
+                    app:srcCompat="@drawable/ic_delete"
+                    app:tint="?attr/colorOnErrorContainer" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/delete_label"
+                    style="@style/TextAppearance.Material3.LabelSmall"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    android:text="@string/general_delete_action"
+                    android:textColor="?attr/colorOnSurface" />
+
+            </LinearLayout>
 
             <Space
                 android:layout_width="0dp"
@@ -184,29 +201,63 @@
                 android:layout_weight="1" />
 
             <!-- Undo FAB (mini, before skip) -->
-            <com.google.android.material.floatingactionbutton.FloatingActionButton
-                android:id="@+id/undo_action"
+            <LinearLayout
+                android:id="@+id/undo_container"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="8dp"
-                android:contentDescription="@string/general_undo_action"
+                android:gravity="center_horizontal"
+                android:orientation="vertical"
                 android:visibility="invisible"
-                app:backgroundTint="?attr/colorSurfaceContainerHighest"
-                app:fabSize="mini"
-                app:srcCompat="@drawable/ic_settings_backup_restore_24"
-                app:tint="?attr/colorOnSurfaceVariant"
-                tools:visibility="visible" />
+                tools:visibility="visible">
+
+                <com.google.android.material.floatingactionbutton.FloatingActionButton
+                    android:id="@+id/undo_action"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:contentDescription="@string/general_undo_action"
+                    app:backgroundTint="?attr/colorSurfaceContainerHighest"
+                    app:fabSize="mini"
+                    app:srcCompat="@drawable/ic_settings_backup_restore_24"
+                    app:tint="?attr/colorOnSurfaceVariant" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/undo_label"
+                    style="@style/TextAppearance.Material3.LabelSmall"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    android:text="@string/general_undo_action"
+                    android:textColor="?attr/colorOnSurface" />
+
+            </LinearLayout>
 
             <!-- Skip FAB (center, smaller) -->
-            <com.google.android.material.floatingactionbutton.FloatingActionButton
-                android:id="@+id/skip_action"
+            <LinearLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:contentDescription="@string/swiper_skip_action"
-                app:backgroundTint="?attr/colorTertiaryContainer"
-                app:fabSize="mini"
-                app:srcCompat="@drawable/ic_baseline_skip_next_24"
-                app:tint="?attr/colorOnTertiaryContainer" />
+                android:gravity="center_horizontal"
+                android:orientation="vertical">
+
+                <com.google.android.material.floatingactionbutton.FloatingActionButton
+                    android:id="@+id/skip_action"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:contentDescription="@string/swiper_skip_action"
+                    app:backgroundTint="?attr/colorTertiaryContainer"
+                    app:fabSize="mini"
+                    app:srcCompat="@drawable/ic_baseline_skip_next_24"
+                    app:tint="?attr/colorOnTertiaryContainer" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    style="@style/TextAppearance.Material3.LabelSmall"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    android:text="@string/swiper_skip_action"
+                    android:textColor="?attr/colorOnSurface" />
+
+            </LinearLayout>
 
             <Space
                 android:layout_width="0dp"
@@ -214,15 +265,32 @@
                 android:layout_weight="1" />
 
             <!-- Keep FAB (right) -->
-            <com.google.android.material.floatingactionbutton.FloatingActionButton
-                android:id="@+id/keep_action"
+            <LinearLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:contentDescription="@string/swiper_keep_action"
-                app:backgroundTint="?attr/colorPrimaryContainer"
-                app:fabSize="normal"
-                app:srcCompat="@drawable/ic_heart"
-                app:tint="?attr/colorOnPrimaryContainer" />
+                android:gravity="center_horizontal"
+                android:orientation="vertical">
+
+                <com.google.android.material.floatingactionbutton.FloatingActionButton
+                    android:id="@+id/keep_action"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:contentDescription="@string/swiper_keep_action"
+                    app:backgroundTint="?attr/colorPrimaryContainer"
+                    app:fabSize="normal"
+                    app:srcCompat="@drawable/ic_heart"
+                    app:tint="?attr/colorOnPrimaryContainer" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/keep_label"
+                    style="@style/TextAppearance.Material3.LabelSmall"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    android:text="@string/swiper_keep_action"
+                    android:textColor="?attr/colorOnSurface" />
+
+            </LinearLayout>
 
         </LinearLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1020,10 +1020,10 @@
     <string name="swiper_label">Swiper</string>
     <string name="swiper_tool_name">Swiper</string>
     <string name="swiper_tool_description">Swipe through files to decide what to keep or delete.</string>
-    <string name="swiper_dashcard_description">SD Maid handles most things automatically. For everything else, there\'s swiping!</string>
+    <string name="swiper_dashcard_description">Manually review files in specific folders. Swipe to decide what to keep or delete.</string>
     <string name="swiper_start_action">Start swiping</string>
     <string name="swiper_continue_action">Continue session</string>
-    <string name="swiper_sessions_description">Some files just need a human touch. Swipe to decide their fate - nothing gets deleted until you say so. You can pause anytime and continue later.</string>
+    <string name="swiper_sessions_description">Some files need a human decision. Swipe through items and choose what to keep or delete. Skip anything you’re unsure about. This tool lets you review specific folders manually, and nothing is removed until you confirm.</string>
     <string name="swiper_select_folders_action">Select folders</string>
     <string name="swiper_scanning_title">Scanning…</string>
     <plurals name="swiper_result_x_items_found">


### PR DESCRIPTION
## Summary
- Add text labels below the delete, skip, undo, and keep action buttons on the swipe screen for better clarity
- Labels swap correctly when the user reverses the button layout
- Fix the FAB on the sessions screen being drawn under the navigation bar by wrapping it in a container with bottom insets padding
- Update swiper description strings to be more descriptive

## Test plan
- [ ] Verify action buttons on the swipe screen show labels (Delete, Skip, Undo, Keep)
- [ ] Verify labels swap correctly when button layout is reversed
- [ ] Verify the FAB on the sessions screen is not obscured by the navigation bar
- [ ] Verify undo button animation still works correctly