### PR TITLE
AppCleaner: Fix automation clicking wrong buttons on Android 16

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecs.kt
@@ -18,8 +18,9 @@ import eu.darken.sdmse.automation.core.common.stepper.findClickableParent
 import eu.darken.sdmse.automation.core.common.stepper.findClickableSibling
 import eu.darken.sdmse.automation.core.common.stepper.findNodeByLabel
 import eu.darken.sdmse.automation.core.specs.AutomationExplorer
+import eu.darken.sdmse.automation.core.common.stepper.clickGesture
+import eu.darken.sdmse.automation.core.common.stepper.clickNormal
 import eu.darken.sdmse.automation.core.specs.AutomationSpec
-import eu.darken.sdmse.automation.core.specs.defaultFindAndClick
 import eu.darken.sdmse.automation.core.specs.defaultNodeRecovery
 import eu.darken.sdmse.automation.core.specs.windowCheckDefaultSettings
 import eu.darken.sdmse.automation.core.specs.windowLauncherDefaultSettings
@@ -35,6 +36,7 @@ import eu.darken.sdmse.common.debug.toVisualStrings
 import eu.darken.sdmse.common.device.DeviceDetective
 import eu.darken.sdmse.common.device.RomType
 import eu.darken.sdmse.common.funnel.IPCFunnel
+import eu.darken.sdmse.common.hasApiLevel
 import eu.darken.sdmse.common.pkgs.features.Installed
 import eu.darken.sdmse.common.pkgs.toPkgId
 import eu.darken.sdmse.common.progress.withProgress
@@ -78,6 +80,27 @@ class AOSPSpecs @Inject constructor(
 
             val storageFinder = storageEntryFinder.storageFinderAOSP(storageEntryLabels, pkg)
 
+            val action: suspend StepContext.() -> Boolean = action@{
+                val target = storageFinder(this) ?: return@action false
+                log(TAG) { "Storage entry target: $target" }
+                when {
+                    hasApiLevel(35) -> {
+                        val mapped = findClickableParent(maxNesting = 3, node = target)
+                        if (mapped != null) {
+                            clickNormal(node = mapped)
+                        } else {
+                            log(TAG, WARN) { "No clickable parent (API 35+), trying gesture..." }
+                            clickGesture(node = target)
+                        }
+                    }
+
+                    else -> {
+                        val mapped = findClickableParent(maxNesting = 6, node = target) ?: return@action false
+                        clickNormal(node = mapped)
+                    }
+                }
+            }
+
             val step = AutomationStep(
                 source = tag,
                 descriptionInternal = "Storage entry",
@@ -85,7 +108,7 @@ class AOSPSpecs @Inject constructor(
                 windowLaunch = windowLauncherDefaultSettings(pkg),
                 windowCheck = windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg),
                 nodeRecovery = defaultNodeRecovery(pkg),
-                nodeAction = defaultFindAndClick(finder = storageFinder),
+                nodeAction = action,
             )
             stepper.withProgress(this) { process(this@plan, step) }
         }

--- a/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/aosp/AOSPSpecs.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/aosp/AOSPSpecs.kt
@@ -15,7 +15,7 @@ import eu.darken.sdmse.automation.core.common.stepper.StepContext
 import eu.darken.sdmse.automation.core.common.stepper.Stepper
 import eu.darken.sdmse.automation.core.common.stepper.clickNormal
 import eu.darken.sdmse.automation.core.common.stepper.findClickableParent
-import eu.darken.sdmse.automation.core.common.stepper.findNearestTo
+import eu.darken.sdmse.automation.core.common.stepper.findClickableSibling
 import eu.darken.sdmse.automation.core.common.stepper.findNode
 import eu.darken.sdmse.automation.core.common.textMatchesAny
 import eu.darken.sdmse.automation.core.specs.AutomationExplorer
@@ -100,7 +100,7 @@ class AOSPSpecs @Inject constructor(
                 // Force stop may consist of a button (no text)) and a textview (unclickable), same layout as everything else
                 if (target == null && hasApiLevel(35)) {
                     log(TAG, WARN) { "No clickable parent found for $candidate" }
-                    target = findNearestTo(node = candidate) { it.isClickable }
+                    target = findClickableSibling(node = candidate)
                     if (target != null) log(TAG, INFO) { "Clickable sibling found: $target" }
                 }
 
@@ -182,7 +182,7 @@ class AOSPSpecs @Inject constructor(
 
                 if (target == null && hasApiLevel(35)) {
                     log(TAG, WARN) { "No clickable parent found for $candidate" }
-                    target = findNearestTo(node = candidate) { it.isClickable }
+                    target = findClickableSibling(node = candidate)
                     if (target != null) log(TAG, INFO) { "Clickable sibling found: $target" }
                 }
 
@@ -234,7 +234,7 @@ class AOSPSpecs @Inject constructor(
 
                 if (target == null && hasApiLevel(35)) {
                     log(TAG, WARN) { "No clickable parent found for $candidate" }
-                    target = findNearestTo(node = candidate) { it.isClickable }
+                    target = findClickableSibling(node = candidate)
                     if (target != null) log(TAG, INFO) { "Clickable sibling found: $target" }
                 }
 


### PR DESCRIPTION
## Summary
- Replace `findNearestTo` with `findClickableSibling` in AppControl AOSP force stop, archive, and restore automation to prevent clicking "Uninstall" instead of "Force stop" on Android 16 Beta
- Add SDK 35+ safe clicking for AppCleaner AOSP storage entry with `maxNesting=3` and gesture click fallback, matching the proven RealmeSpecs pattern

## Details
On Android 16 Beta (Pixel 10 Pro XL), `findNearestTo` picks the nearest clickable node by pixel distance with no semantic check. This could match an "Uninstall" button if it's closer in pixels to the "Force stop" text than the actual force stop button. `findClickableSibling` only searches within the same parent container, which is inherently safer.

For the storage entry click, `defaultFindAndClick` uses `maxNesting=6` which on Android 16 can walk too far up the view hierarchy and hit an overly large clickable container. The new approach limits to `maxNesting=3` on API 35+ and falls back to gesture click if no clickable parent is found.

## Test plan
- [x] AOSPSpecsTest passes (all 8 tests)
- [x] FOSS debug build succeeds
- [ ] Manual test on Android 16 Beta device