### PR TITLE
General: Fix animation state not restored after automation

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
@@ -31,8 +31,6 @@ import eu.darken.sdmse.appcleaner.core.automation.specs.realme.RealmeSpecs
 import eu.darken.sdmse.automation.core.AutomationHost
 import eu.darken.sdmse.automation.core.AutomationModule
 import eu.darken.sdmse.automation.core.AutomationTask
-import eu.darken.sdmse.automation.core.animation.AnimationState
-import eu.darken.sdmse.automation.core.animation.AnimationTool
 import eu.darken.sdmse.automation.core.errors.AutomationCompatibilityException
 import eu.darken.sdmse.automation.core.errors.AutomationOverlayException
 import eu.darken.sdmse.automation.core.errors.AutomationTimeoutException
@@ -71,8 +69,6 @@ import eu.darken.sdmse.common.user.UserManager2
 import eu.darken.sdmse.main.core.GeneralSettings
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.NonCancellable
-import kotlinx.coroutines.withContext
 import javax.inject.Provider
 
 class ClearCacheModule @AssistedInject constructor(
@@ -85,7 +81,6 @@ class ClearCacheModule @AssistedInject constructor(
     private val userManager2: UserManager2,
     private val labelDebugger: LabelDebugger,
     private val deviceDetective: DeviceDetective,
-    private val animationTool: AnimationTool,
     private val generalSettings: GeneralSettings,
 ) : AutomationModule(automationHost) {
 
@@ -139,25 +134,7 @@ class ClearCacheModule @AssistedInject constructor(
 
         labelDebugger.logAllLabels()
 
-        var prevAnimState: AnimationState? = null
-
-        val result = try {
-            if (animationTool.canChangeState()) {
-                log(TAG) { "Changing animation state" }
-                prevAnimState = animationTool.getState()
-                animationTool.setState(AnimationState.DISABLED)
-            }
-
-            log(TAG, INFO) { "Current animation state: ${animationTool.getState()}" }
-
-            processTask(task)
-
-        } finally {
-            if (prevAnimState != null) {
-                log(TAG) { "Restoring previous animation state" }
-                withContext(NonCancellable) { animationTool.setState(prevAnimState) }
-            }
-        }
+        val result = processTask(task)
 
         finishAutomation(
             userCancelled = result.cancelledByUser,

--- a/app/src/main/java/eu/darken/sdmse/automation/core/AutomationProcessor.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/AutomationProcessor.kt
@@ -3,14 +3,19 @@ package eu.darken.sdmse.automation.core
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
+import eu.darken.sdmse.automation.core.animation.AnimationState
+import eu.darken.sdmse.automation.core.animation.AnimationTool
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.progress.updateProgressPrimary
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.sync.Mutex
@@ -20,7 +25,8 @@ import kotlinx.coroutines.withContext
 class AutomationProcessor @AssistedInject constructor(
     @Assisted private val automationHost: AutomationHost,
     private val dispatcherProvider: DispatcherProvider,
-    private val moduleFactories: Set<@JvmSuppressWildcards AutomationModule.Factory>
+    private val moduleFactories: Set<@JvmSuppressWildcards AutomationModule.Factory>,
+    private val animationTool: AnimationTool,
 ) {
     private val execLock = Mutex()
 
@@ -39,7 +45,24 @@ class AutomationProcessor @AssistedInject constructor(
 
         val module = factory.create(automationHost, moduleScope)
 
+        try {
+            animationTool.restorePendingState()
+        } catch (e: Exception) {
+            log(TAG, WARN) { "process(): Failed to restore pending animation state: ${e.asLog()}" }
+        }
+
+        var prevAnimState: AnimationState? = null
+
         val result = try {
+            if (animationTool.canChangeState()) {
+                log(TAG) { "process(): Disabling animations" }
+                prevAnimState = animationTool.getState()
+                animationTool.persistPendingState(prevAnimState)
+                animationTool.setState(AnimationState.DISABLED)
+            }
+
+            log(TAG, INFO) { "process(): Current animation state: ${animationTool.getState()}" }
+
             log(TAG, VERBOSE) { "process(): Processing $task via $module" }
             withContext(dispatcherProvider.IO) {
                 module.process(task)
@@ -48,6 +71,25 @@ class AutomationProcessor @AssistedInject constructor(
             log(TAG, ERROR) { "process(): Task failed: $task\n${e.asLog()}" }
             throw e
         } finally {
+            if (prevAnimState != null) {
+                log(TAG) { "process(): Restoring previous animation state" }
+                withContext(NonCancellable) {
+                    var restored = false
+                    try {
+                        animationTool.setState(prevAnimState)
+                        restored = true
+                    } catch (e: Exception) {
+                        log(TAG, ERROR) { "process(): Failed to restore animation state: ${e.asLog()}" }
+                    }
+                    if (restored) {
+                        try {
+                            animationTool.clearPendingState()
+                        } catch (e: Exception) {
+                            log(TAG, ERROR) { "process(): Failed to clear pending state: ${e.asLog()}" }
+                        }
+                    }
+                }
+            }
             log(TAG, VERBOSE) { "process(): Canceling module scope..." }
             moduleScope.cancel()
             hasTask = false

--- a/app/src/main/java/eu/darken/sdmse/automation/core/AutomationSettings.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/AutomationSettings.kt
@@ -1,0 +1,31 @@
+package eu.darken.sdmse.automation.core
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+import com.squareup.moshi.Moshi
+import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.sdmse.automation.core.animation.AnimationState
+import eu.darken.sdmse.common.datastore.createValue
+import eu.darken.sdmse.common.debug.logging.logTag
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AutomationSettings @Inject constructor(
+    @ApplicationContext private val context: Context,
+    moshi: Moshi,
+) {
+
+    private val Context.dataStore by preferencesDataStore(name = "settings_automation")
+
+    val dataStore: DataStore<Preferences>
+        get() = context.dataStore
+
+    val animationPendingRestoreState = dataStore.createValue<AnimationState?>("animation.pending.restore.state", null, moshi)
+
+    companion object {
+        internal val TAG = logTag("Automation", "Settings")
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/automation/core/animation/AnimationState.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/animation/AnimationState.kt
@@ -1,9 +1,13 @@
 package eu.darken.sdmse.automation.core.animation
 
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
 data class AnimationState(
-    val windowAnimationScale: Float?,
-    val globalTransitionAnimationScale: Float?,
-    val globalAnimatorDurationscale: Float?,
+    @Json(name = "windowAnimationScale") val windowAnimationScale: Float?,
+    @Json(name = "globalTransitionAnimationScale") val globalTransitionAnimationScale: Float?,
+    @Json(name = "globalAnimatorDurationScale") val globalAnimatorDurationscale: Float?,
 ) {
 
     companion object {

--- a/app/src/main/java/eu/darken/sdmse/automation/core/animation/AnimationTool.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/animation/AnimationTool.kt
@@ -3,9 +3,15 @@ package eu.darken.sdmse.automation.core.animation
 import android.content.Context
 import android.provider.Settings
 import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.sdmse.automation.core.AutomationSettings
 import eu.darken.sdmse.common.adb.AdbManager
 import eu.darken.sdmse.common.adb.canUseAdbNow
+import eu.darken.sdmse.common.datastore.value
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.root.RootManager
@@ -21,11 +27,12 @@ class AnimationTool @Inject constructor(
     private val adbManager: AdbManager,
     private val rootManager: RootManager,
     private val shellOps: ShellOps,
+    private val animationSettings: AutomationSettings,
 ) {
     suspend fun canChangeState(): Boolean {
         val adb = adbManager.canUseAdbNow()
         val root = rootManager.canUseRootNow()
-        log(TAG, VERBOSE) { "canChangeState(): adb=$adb root=$rootManager" }
+        log(TAG, VERBOSE) { "canChangeState(): adb=$adb root=$root" }
         return adb || root
     }
 
@@ -38,7 +45,7 @@ class AnimationTool @Inject constructor(
         globalAnimatorDurationscale = tryGetFloat(ANIMATOR_DURATION_SCALE),
     ).also { log(TAG) { "getState(): $it" } }
 
-    private fun getCommand(key: String, value: Any): String = "settings put global $key $value"
+    private fun getCommand(key: String, value: Float): String = "settings put global $key $value"
 
     suspend fun setState(state: AnimationState) {
         val cmds = mutableListOf<String>()
@@ -54,6 +61,37 @@ class AnimationTool @Inject constructor(
             }
         )
         log(TAG) { "setState($state) result: $result" }
+    }
+
+    suspend fun persistPendingState(state: AnimationState) {
+        log(TAG) { "persistPendingState($state)" }
+        animationSettings.animationPendingRestoreState.value(state)
+    }
+
+    suspend fun clearPendingState() {
+        log(TAG) { "clearPendingState()" }
+        animationSettings.animationPendingRestoreState.value(null)
+    }
+
+    suspend fun restorePendingState(): Boolean {
+        val pending = animationSettings.animationPendingRestoreState.value() ?: return false
+
+        log(TAG, INFO) { "Found pending animation state to restore: $pending" }
+
+        if (!canChangeState()) {
+            log(TAG, WARN) { "Cannot restore pending animation state: no shell access available" }
+            return false
+        }
+
+        return try {
+            setState(pending)
+            clearPendingState()
+            log(TAG, INFO) { "Successfully restored pending animation state" }
+            true
+        } catch (e: Exception) {
+            log(TAG, ERROR) { "Failed to restore pending animation state: ${e.asLog()}" }
+            false
+        }
     }
 
     companion object {

--- a/app/src/test/java/eu/darken/sdmse/automation/core/AutomationProcessorTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/automation/core/AutomationProcessorTest.kt
@@ -1,0 +1,139 @@
+package eu.darken.sdmse.automation.core
+
+import eu.darken.sdmse.automation.core.animation.AnimationState
+import eu.darken.sdmse.automation.core.animation.AnimationTool
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.coVerifyOrder
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+
+class AutomationProcessorTest : BaseTest() {
+
+    private val automationHost: AutomationHost = mockk(relaxed = true)
+    private val animationTool: AnimationTool = mockk()
+    private val moduleFactory: AutomationModule.Factory = mockk()
+    private val module: AutomationModule = mockk()
+    private val task: AutomationTask = mockk()
+    private val taskResult: AutomationTask.Result = mockk()
+
+    private val originalState = AnimationState(
+        windowAnimationScale = 1.0f,
+        globalTransitionAnimationScale = 1.0f,
+        globalAnimatorDurationscale = 1.0f,
+    )
+
+    @BeforeEach
+    fun setup() {
+        coEvery { animationTool.restorePendingState() } returns false
+        coEvery { animationTool.canChangeState() } returns true
+        coEvery { animationTool.getState() } returns originalState
+        coEvery { animationTool.setState(any()) } returns Unit
+        coEvery { animationTool.persistPendingState(any()) } returns Unit
+        coEvery { animationTool.clearPendingState() } returns Unit
+
+        coEvery { moduleFactory.isResponsible(any()) } returns true
+        coEvery { moduleFactory.create(any(), any()) } returns module
+        coEvery { module.process(any()) } returns taskResult
+    }
+
+    private fun createProcessor() = AutomationProcessor(
+        automationHost = automationHost,
+        dispatcherProvider = TestDispatcherProvider(),
+        moduleFactories = setOf(moduleFactory),
+        animationTool = animationTool,
+    )
+
+    @Test
+    fun `animations are disabled before processing and restored after`() = runTest {
+        val processor = createProcessor()
+        val result = processor.process(task)
+
+        result shouldBe taskResult
+
+        coVerifyOrder {
+            animationTool.restorePendingState()
+            animationTool.canChangeState()
+            animationTool.getState()
+            animationTool.persistPendingState(originalState)
+            animationTool.setState(AnimationState.DISABLED)
+            module.process(task)
+            animationTool.setState(originalState)
+            animationTool.clearPendingState()
+        }
+    }
+
+    @Test
+    fun `animations are restored even when task fails`() = runTest {
+        coEvery { module.process(any()) } throws RuntimeException("Task failed")
+
+        val processor = createProcessor()
+        shouldThrow<RuntimeException> { processor.process(task) }
+
+        coVerify {
+            animationTool.setState(AnimationState.DISABLED)
+            animationTool.setState(originalState)
+            animationTool.clearPendingState()
+        }
+    }
+
+    @Test
+    fun `animations not touched when canChangeState is false`() = runTest {
+        coEvery { animationTool.canChangeState() } returns false
+
+        val processor = createProcessor()
+        processor.process(task)
+
+        coVerify(exactly = 0) { animationTool.setState(any()) }
+        coVerify(exactly = 0) { animationTool.persistPendingState(any()) }
+        coVerify(exactly = 0) { animationTool.clearPendingState() }
+    }
+
+    @Test
+    fun `clearPendingState not called when restore fails`() = runTest {
+        coEvery { animationTool.setState(originalState) } throws RuntimeException("Shell lost")
+
+        val processor = createProcessor()
+        processor.process(task)
+
+        coVerify { animationTool.setState(originalState) }
+        coVerify(exactly = 0) { animationTool.clearPendingState() }
+    }
+
+    @Test
+    fun `restorePendingState failure does not block processing`() = runTest {
+        coEvery { animationTool.restorePendingState() } throws RuntimeException("DataStore corrupted")
+
+        val processor = createProcessor()
+        val result = processor.process(task)
+
+        result shouldBe taskResult
+        coVerify { module.process(task) }
+    }
+
+    @Test
+    fun `hasTask is false after processing completes`() = runTest {
+        val processor = createProcessor()
+        processor.hasTask shouldBe false
+
+        processor.process(task)
+
+        processor.hasTask shouldBe false
+    }
+
+    @Test
+    fun `hasTask is false after processing fails`() = runTest {
+        coEvery { module.process(any()) } throws RuntimeException("Failed")
+
+        val processor = createProcessor()
+        shouldThrow<RuntimeException> { processor.process(task) }
+
+        processor.hasTask shouldBe false
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/automation/core/animation/AnimationStateTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/automation/core/animation/AnimationStateTest.kt
@@ -1,0 +1,91 @@
+package eu.darken.sdmse.automation.core.animation
+
+import com.squareup.moshi.Moshi
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.json.toComparableJson
+
+class AnimationStateTest : BaseTest() {
+
+    private val moshi = Moshi.Builder().build()
+    private val adapter = moshi.adapter(AnimationState::class.java)
+
+    @Test
+    fun `serialize full state`() {
+        val state = AnimationState(
+            windowAnimationScale = 1.0f,
+            globalTransitionAnimationScale = 1.0f,
+            globalAnimatorDurationscale = 1.0f,
+        )
+
+        val json = adapter.toJson(state)
+        json.toComparableJson() shouldBe """
+            {
+                "windowAnimationScale": 1.0,
+                "globalTransitionAnimationScale": 1.0,
+                "globalAnimatorDurationScale": 1.0
+            }
+        """.toComparableJson()
+
+        adapter.fromJson(json) shouldBe state
+    }
+
+    @Test
+    fun `serialize disabled state`() {
+        val json = adapter.toJson(AnimationState.DISABLED)
+        json.toComparableJson() shouldBe """
+            {
+                "windowAnimationScale": 0.0,
+                "globalTransitionAnimationScale": 0.0,
+                "globalAnimatorDurationScale": 0.0
+            }
+        """.toComparableJson()
+
+        adapter.fromJson(json) shouldBe AnimationState.DISABLED
+    }
+
+    @Test
+    fun `serialize state with null values`() {
+        val state = AnimationState(
+            windowAnimationScale = null,
+            globalTransitionAnimationScale = 1.5f,
+            globalAnimatorDurationscale = null,
+        )
+
+        val json = adapter.toJson(state)
+        json.toComparableJson() shouldBe """
+            {
+                "globalTransitionAnimationScale": 1.5
+            }
+        """.toComparableJson()
+
+        adapter.fromJson(json) shouldBe state
+    }
+
+    @Test
+    fun `deserialize from fixed json`() {
+        val json = """
+            {
+                "windowAnimationScale": 2.0,
+                "globalTransitionAnimationScale": 0.5,
+                "globalAnimatorDurationScale": 1.0
+            }
+        """
+
+        val state = adapter.fromJson(json)!!
+        state.windowAnimationScale shouldBe 2.0f
+        state.globalTransitionAnimationScale shouldBe 0.5f
+        state.globalAnimatorDurationscale shouldBe 1.0f
+    }
+
+    @Test
+    fun `deserialize with missing fields defaults to null`() {
+        val json = """{"windowAnimationScale": 1.0}"""
+
+        val state = adapter.fromJson(json)!!
+        state.windowAnimationScale shouldBe 1.0f
+        state.globalTransitionAnimationScale shouldBe null
+        state.globalAnimatorDurationscale shouldBe null
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/automation/core/animation/AnimationToolTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/automation/core/animation/AnimationToolTest.kt
@@ -1,0 +1,125 @@
+package eu.darken.sdmse.automation.core.animation
+
+import android.content.Context
+import eu.darken.sdmse.automation.core.AutomationSettings
+import eu.darken.sdmse.common.adb.AdbManager
+import eu.darken.sdmse.common.adb.canUseAdbNow
+import eu.darken.sdmse.common.datastore.DataStoreValue
+import eu.darken.sdmse.common.datastore.value
+import eu.darken.sdmse.common.root.RootManager
+import eu.darken.sdmse.common.root.canUseRootNow
+import eu.darken.sdmse.common.shell.ShellOps
+import eu.darken.sdmse.common.shell.ipc.ShellOpsCmd
+import eu.darken.sdmse.common.shell.ipc.ShellOpsResult
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class AnimationToolTest : BaseTest() {
+
+    private val context: Context = mockk(relaxed = true)
+    private val adbManager: AdbManager = mockk()
+    private val rootManager: RootManager = mockk()
+    private val shellOps: ShellOps = mockk()
+    private val animationSettings: AutomationSettings = mockk()
+    private val pendingRestoreState: DataStoreValue<AnimationState?> = mockk()
+
+    private val testState = AnimationState(
+        windowAnimationScale = 1.0f,
+        globalTransitionAnimationScale = 1.0f,
+        globalAnimatorDurationscale = 1.0f,
+    )
+
+    @BeforeEach
+    fun setup() {
+        mockkStatic("eu.darken.sdmse.common.adb.AdbExtensionsKt")
+        mockkStatic("eu.darken.sdmse.common.root.RootExtensionsKt")
+        mockkStatic("eu.darken.sdmse.common.datastore.DataStoreValueKt")
+
+        every { animationSettings.animationPendingRestoreState } returns pendingRestoreState
+    }
+
+    private fun createTool() = AnimationTool(
+        context = context,
+        adbManager = adbManager,
+        rootManager = rootManager,
+        shellOps = shellOps,
+        animationSettings = animationSettings,
+    )
+
+    @Test
+    fun `restorePendingState returns false when nothing pending`() = runTest {
+        coEvery { pendingRestoreState.value() } returns null
+
+        val tool = createTool()
+        tool.restorePendingState() shouldBe false
+    }
+
+    @Test
+    fun `restorePendingState restores and clears state on success`() = runTest {
+        coEvery { pendingRestoreState.value() } returns testState
+        coEvery { adbManager.canUseAdbNow() } returns true
+        coEvery { rootManager.canUseRootNow() } returns false
+        coEvery { shellOps.execute(any<ShellOpsCmd>(), any()) } returns ShellOpsResult(
+            exitCode = 0,
+            output = emptyList(),
+            errors = emptyList(),
+        )
+        coEvery { pendingRestoreState.update(any()) } returns DataStoreValue.Updated(testState, null)
+
+        val tool = createTool()
+        tool.restorePendingState() shouldBe true
+
+        coVerify { shellOps.execute(any<ShellOpsCmd>(), ShellOps.Mode.ADB) }
+    }
+
+    @Test
+    fun `restorePendingState returns false when canChangeState is false`() = runTest {
+        coEvery { pendingRestoreState.value() } returns testState
+        coEvery { adbManager.canUseAdbNow() } returns false
+        coEvery { rootManager.canUseRootNow() } returns false
+
+        val tool = createTool()
+        tool.restorePendingState() shouldBe false
+
+        coVerify(exactly = 0) { shellOps.execute(any<ShellOpsCmd>(), any()) }
+    }
+
+    @Test
+    fun `restorePendingState catches exception and returns false on failure`() = runTest {
+        coEvery { pendingRestoreState.value() } returns testState
+        coEvery { adbManager.canUseAdbNow() } returns true
+        coEvery { rootManager.canUseRootNow() } returns false
+        coEvery { shellOps.execute(any<ShellOpsCmd>(), any()) } throws RuntimeException("Shell failed")
+
+        val tool = createTool()
+        tool.restorePendingState() shouldBe false
+    }
+
+    @Test
+    fun `persistPendingState saves state to settings`() = runTest {
+        coEvery { pendingRestoreState.update(any()) } returns DataStoreValue.Updated(null, testState)
+
+        val tool = createTool()
+        tool.persistPendingState(testState)
+
+        coVerify { pendingRestoreState.update(any()) }
+    }
+
+    @Test
+    fun `clearPendingState clears settings`() = runTest {
+        coEvery { pendingRestoreState.update(any()) } returns DataStoreValue.Updated(testState, null)
+
+        val tool = createTool()
+        tool.clearPendingState()
+
+        coVerify { pendingRestoreState.update(any()) }
+    }
+}


### PR DESCRIPTION
## Summary

- Move animation disable/restore from `ClearCacheModule` to `AutomationProcessor` as a cross-cutting concern that benefits all automation modules (AppCleaner + AppControl)
- Fix unhandled exception in finally block when shell access is lost during restoration, which left device animations permanently disabled
- Fix missing recovery from process death: animation state is now persisted to DataStore before disabling, and restored on next app launch via `AutomationManager` init
- Add unit tests for `AnimationTool` persistence, `AnimationState` serialization, and `AutomationProcessor` orchestration

## Recovery Flow

```
Normal:         persist → disable → work → restore → clear
Process killed: persist → disable → [killed] → [next launch] → restorePending → clear  
Shell lost:     persist → disable → work → restore fails (caught) → [next launch] → restorePending → clear
```

## Test plan

- [x] Unit tests pass: `AnimationToolTest` (6 tests), `AnimationStateTest` (5 tests), `AutomationProcessorTest` (7 tests)
- [ ] Manual: Run AppCleaner automation, verify animations disable once → all apps processed → restore once
- [ ] Manual: Kill app during automation, relaunch, verify animations are restored on startup
- [ ] Manual: Run AppControl automation, verify animation handling works there too