### PR TITLE
General: Replace PhotoView with ZoomImage for better zoom support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -239,7 +239,7 @@ dependencies {
 
     implementation("androidx.core:core-splashscreen:1.0.0")
     implementation("androidx.exifinterface:exifinterface:1.3.7")
-    implementation("com.github.chrisbanes:PhotoView:2.3.0")
+    implementation("io.github.panpf.zoomimage:zoomimage-view-coil2:1.4.0")
 
     implementation("androidx.navigation:navigation-fragment-ktx:${Versions.AndroidX.Navigation.core}")
     implementation("androidx.navigation:navigation-ui-ktx:${Versions.AndroidX.Navigation.core}")

--- a/app/src/main/java/eu/darken/sdmse/common/previews/item/PreviewItemFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/previews/item/PreviewItemFragment.kt
@@ -8,6 +8,7 @@ import androidx.fragment.app.viewModels
 import coil.load
 import dagger.hilt.android.AndroidEntryPoint
 import eu.darken.sdmse.R
+import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.uix.DialogFragment3
 import eu.darken.sdmse.common.viewbinding.viewBinding
 import eu.darken.sdmse.databinding.PreviewItemFragmentBinding
@@ -20,18 +21,22 @@ class PreviewItemFragment : DialogFragment3(R.layout.preview_item_fragment) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         vm.state.observe2(ui) { state ->
-            previewImage.apply {
-                isGone = state.lookup == null
-                state.lookup?.let { load(it) }
-            }
             progress.isGone = state.progress == null
 
-            previewTitle.text = state.lookup?.path
-            previewSubtitle.text = state.lookup?.let { Formatter.formatFileSize(requireContext(), it.size) }
+            val lookup = state.lookup
+            previewImage.isGone = lookup == null
+            if (lookup != null) previewImage.load(lookup)
 
-            previewFooterContainer.isGone = state.lookup == null
+            previewTitle.text = lookup?.path
+            previewSubtitle.text = lookup?.let { Formatter.formatFileSize(requireContext(), it.size) }
+
+            previewFooterContainer.isGone = lookup == null
         }
 
         super.onViewCreated(view, savedInstanceState)
+    }
+
+    companion object {
+        private val TAG = logTag("Preview", "Item", "Fragment")
     }
 }

--- a/app/src/main/java/eu/darken/sdmse/common/previews/item/PreviewItemViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/previews/item/PreviewItemViewModel.kt
@@ -27,9 +27,8 @@ class PreviewItemViewModel @Inject constructor(
 
     val state = flowOf(args.item)
         .map { item ->
-            State(
-                lookup = item.path.lookup(gatewaySwitch)
-            )
+            val lookup = item.path.lookup(gatewaySwitch)
+            State(lookup = lookup)
         }
         .onStart { emit(State(progress = Progress.Data())) }
         .asLiveData2()
@@ -38,7 +37,6 @@ class PreviewItemViewModel @Inject constructor(
         val lookup: APathLookup<*>? = null,
         val progress: Progress.Data? = null,
     )
-
 
     companion object {
         private val TAG = logTag("Preview", "Item", "ViewModel")

--- a/app/src/main/java/eu/darken/sdmse/common/ui/QualityInputDialog.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/ui/QualityInputDialog.kt
@@ -9,6 +9,7 @@ import androidx.core.view.isVisible
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.slider.Slider
 import eu.darken.sdmse.R
+import eu.darken.sdmse.common.BuildConfigWrap
 import eu.darken.sdmse.squeezer.core.CompressibleImage
 import eu.darken.sdmse.squeezer.core.CompressionEstimator
 import eu.darken.sdmse.databinding.QualityInputDialogBinding
@@ -34,6 +35,7 @@ class QualityInputDialog(
     private val exampleInputSize = 5 * 1024 * 1024L // 5 MB
 
     private val dialogLayout = QualityInputDialogBinding.inflate(activity.layoutInflater, null, false).apply {
+        if (BuildConfigWrap.DEBUG) qualitySlider.valueFrom = 1f
         qualitySlider.value = currentQuality.toFloat()
 
         fun updateUI(quality: Int) {

--- a/app/src/main/java/eu/darken/sdmse/squeezer/ui/onboarding/BitmapSampler.kt
+++ b/app/src/main/java/eu/darken/sdmse/squeezer/ui/onboarding/BitmapSampler.kt
@@ -1,0 +1,40 @@
+package eu.darken.sdmse.squeezer.ui.onboarding
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import java.io.File
+
+object BitmapSampler {
+
+    private const val MAX_DIMENSION = 2048
+
+    fun decodeSampledBitmap(file: File, maxDimension: Int = MAX_DIMENSION): Bitmap? {
+        val options = BitmapFactory.Options().apply {
+            inJustDecodeBounds = true
+        }
+        file.inputStream().use { input ->
+            BitmapFactory.decodeStream(input, null, options)
+        }
+
+        options.apply {
+            inJustDecodeBounds = false
+            inSampleSize = calculateInSampleSize(outWidth, outHeight, maxDimension)
+        }
+
+        return file.inputStream().use { input ->
+            BitmapFactory.decodeStream(input, null, options)
+        }
+    }
+
+    private fun calculateInSampleSize(width: Int, height: Int, maxDimension: Int): Int {
+        var inSampleSize = 1
+        if (width > maxDimension || height > maxDimension) {
+            val halfWidth = width / 2
+            val halfHeight = height / 2
+            while ((halfWidth / inSampleSize) >= maxDimension || (halfHeight / inSampleSize) >= maxDimension) {
+                inSampleSize *= 2
+            }
+        }
+        return inSampleSize
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/squeezer/ui/onboarding/ZoomablePreviewDialog.kt
+++ b/app/src/main/java/eu/darken/sdmse/squeezer/ui/onboarding/ZoomablePreviewDialog.kt
@@ -1,7 +1,5 @@
 package eu.darken.sdmse.squeezer.ui.onboarding
 
-import android.graphics.Bitmap
-import android.graphics.BitmapFactory
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -12,6 +10,7 @@ import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.fragment.app.DialogFragment
+import coil.load
 import eu.darken.sdmse.R
 import eu.darken.sdmse.common.dpToPx
 import eu.darken.sdmse.common.hasApiLevel
@@ -58,12 +57,7 @@ class ZoomablePreviewDialog : DialogFragment() {
 
         val filePath = args.getString(ARG_FILE_PATH)
         if (filePath != null) {
-            val bitmap = BitmapFactory.decodeFile(filePath)
-            binding.photoView.setImageBitmap(bitmap)
-        } else {
-            pendingBitmap?.let { bitmap ->
-                binding.photoView.setImageBitmap(bitmap)
-            }
+            binding.photoView.load(java.io.File(filePath))
         }
     }
 
@@ -87,7 +81,6 @@ class ZoomablePreviewDialog : DialogFragment() {
     override fun onDestroyView() {
         restoreSystemBars()
         _binding = null
-        pendingBitmap = null
         super.onDestroyView()
     }
 
@@ -109,21 +102,10 @@ class ZoomablePreviewDialog : DialogFragment() {
         private const val ARG_FILE_PATH = "file_path"
         private const val ARG_LABEL = "label"
 
-        private var pendingBitmap: Bitmap? = null
-
         fun newInstance(filePath: String, label: String): ZoomablePreviewDialog {
             return ZoomablePreviewDialog().apply {
                 arguments = Bundle().apply {
                     putString(ARG_FILE_PATH, filePath)
-                    putString(ARG_LABEL, label)
-                }
-            }
-        }
-
-        fun newInstance(bitmap: Bitmap, label: String): ZoomablePreviewDialog {
-            pendingBitmap = bitmap
-            return ZoomablePreviewDialog().apply {
-                arguments = Bundle().apply {
                     putString(ARG_LABEL, label)
                 }
             }

--- a/app/src/main/java/eu/darken/sdmse/squeezer/ui/setup/SqueezerSetupFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/squeezer/ui/setup/SqueezerSetupFragment.kt
@@ -12,6 +12,7 @@ import androidx.navigation.ui.setupWithNavController
 import dagger.hilt.android.AndroidEntryPoint
 import eu.darken.sdmse.MainDirections
 import eu.darken.sdmse.R
+import eu.darken.sdmse.common.BuildConfigWrap
 import eu.darken.sdmse.common.EdgeToEdgeHelper
 import eu.darken.sdmse.common.areas.DataArea
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.*
@@ -52,6 +53,8 @@ class SqueezerSetupFragment : Fragment3(R.layout.squeezer_setup_fragment) {
         ui.pathsCard.setOnClickListener {
             vm.openPathPicker()
         }
+
+        if (BuildConfigWrap.DEBUG) ui.qualitySlider.valueFrom = 1f
 
         ui.qualitySlider.addOnChangeListener { _, value, fromUser ->
             if (fromUser) {

--- a/app/src/main/res/layout/preview_fragment.xml
+++ b/app/src/main/res/layout/preview_fragment.xml
@@ -6,7 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <eu.darken.sdmse.common.ui.PhotoViewPager
+    <eu.darken.sdmse.common.ui.ZoomAwareViewPager
         android:id="@+id/viewpager"
         android:layout_width="match_parent"
         android:layout_height="0dp"

--- a/app/src/main/res/layout/preview_item_fragment.xml
+++ b/app/src/main/res/layout/preview_item_fragment.xml
@@ -6,11 +6,10 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <com.github.chrisbanes.photoview.PhotoView
+    <com.github.panpf.zoomimage.CoilZoomImageView
         android:id="@+id/preview_image"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:scaleType="fitCenter"
         android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/squeezer_zoomable_preview_dialog.xml
+++ b/app/src/main/res/layout/squeezer_zoomable_preview_dialog.xml
@@ -6,18 +6,17 @@
     android:layout_height="match_parent"
     android:background="@android:color/black">
 
-    <com.github.chrisbanes.photoview.PhotoView
+    <com.github.panpf.zoomimage.CoilZoomImageView
         android:id="@+id/photo_view"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:scaleType="fitCenter" />
+        android:layout_height="match_parent" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/close_action"
         style="@style/Widget.Material3.Button.IconButton.Filled.Tonal"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="top|end"
+        android:layout_gravity="top|start"
         android:layout_margin="16dp"
         android:alpha="0.65"
         app:icon="@drawable/ic_baseline_close_24" />

--- a/app/src/main/res/xml/preferences_acknowledgements.xml
+++ b/app/src/main/res/xml/preferences_acknowledgements.xml
@@ -93,13 +93,13 @@
                 android:data="https://github.com/airbnb/lottie-android" />
         </eu.darken.sdmse.common.preferences.IntentPreference>
         <eu.darken.sdmse.common.preferences.IntentPreference
-            android:key="license.photoview"
-            android:summary="Implementation of ImageView for Android that supports zooming. (APACHE 2.0)"
-            android:title="PhotoView"
+            android:key="license.zoomimage"
+            android:summary="Library for zoom images, supported Android View, Compose and Compose Multiplatform. (APACHE 2.0)"
+            android:title="ZoomImage"
             app:iconSpaceReserved="false">
             <intent
                 android:action="android.intent.action.VIEW"
-                android:data="https://github.com/Baseflow/PhotoView" />
+                android:data="https://github.com/panpf/zoomimage" />
         </eu.darken.sdmse.common.preferences.IntentPreference>
         <eu.darken.sdmse.common.preferences.IntentPreference
             android:key="license.indicatorfastscroll"


### PR DESCRIPTION
## Summary
- Replace PhotoView library with [ZoomImage](https://github.com/panpf/zoomimage) (`zoomimage-view-coil2`) for zoomable image previews
- CoilZoomImageView provides subsampling via BitmapRegionDecoder, enabling smooth zoom with tile-based rendering for any image size
- Simplify Squeezer comparison preview: compressed image written to temp file and loaded via Coil (enables subsampling on zoom)
- Allow quality slider values down to 1% in debug builds for testing

## Changes
- Swap `com.github.chrisbanes:PhotoView` → `io.github.panpf.zoomimage:zoomimage-view-coil2:1.4.0`
- Rename `PhotoViewPager` → `ZoomAwareViewPager` with ZoomImageView zoom detection
- Simplify `PreviewItemFragment`/`PreviewItemViewModel` (single Coil load replaces dual view setup)
- Add `BitmapSampler` utility for safe downsampled bitmap decoding (capped at 2048px)
- Update `ZoomablePreviewDialog` to use Coil + CoilZoomImageView
- Update acknowledgements

## Test plan
- [ ] Open file previews (AppCleaner, CorpseFinder, etc.) — verify zoom/pan works
- [ ] Swipe between preview pages — verify paging blocked when zoomed in
- [ ] Open Squeezer comparison preview — verify original vs compressed are visually different
- [ ] Zoom into both comparison images — verify tile-based subsampling renders full detail
- [ ] Debug build: set quality slider to 1% — verify extreme compression is visible in preview