### PR TITLE
Squeezer: Show total savings in results and use error color for compress button

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/squeezer/ui/list/SqueezerListFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/squeezer/ui/list/SqueezerListFragment.kt
@@ -127,7 +127,14 @@ class SqueezerListFragment : Fragment3(R.layout.squeezer_list_fragment) {
 
             toolbar.apply {
                 subtitle = if (state.progress == null) {
-                    getQuantityString2(eu.darken.sdmse.common.R.plurals.result_x_items, state.items.size)
+                    val count = state.items.size
+                    val totalSavings = state.items.mapNotNull { it.image.estimatedSavings }.sum()
+                    if (totalSavings > 0) {
+                        val savingsText = Formatter.formatShortFileSize(requireContext(), totalSavings)
+                        getQuantityString2(eu.darken.sdmse.common.R.plurals.result_x_items, count) + " • ~$savingsText"
+                    } else {
+                        getQuantityString2(eu.darken.sdmse.common.R.plurals.result_x_items, count)
+                    }
                 } else {
                     null
                 }

--- a/app/src/main/res/layout/squeezer_list_fragment.xml
+++ b/app/src/main/res/layout/squeezer_list_fragment.xml
@@ -52,11 +52,12 @@
 
         <com.google.android.material.floatingactionbutton.FloatingActionButton
             android:id="@+id/fab_compress_all"
-            style="@style/Widget.Material3.FloatingActionButton.Primary"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_margin="32dp"
             android:contentDescription="@string/squeezer_compress_all_action"
+            app:backgroundTint="?attr/colorErrorContainer"
+            app:tint="?attr/colorOnErrorContainer"
             app:srcCompat="@drawable/ic_image_compress_24" />
 
     </FrameLayout>


### PR DESCRIPTION
## Summary
- Show total estimated savings in the toolbar subtitle alongside item count (e.g. "42 items • ~12 MB")
- Change compress FAB from primary (green) to error container (red) to signal lossy/destructive action

## Test plan
- [ ] Run a Squeezer scan with compressible images
- [ ] Verify toolbar subtitle shows item count and total estimated savings
- [ ] Verify subtitle falls back to just item count when savings are zero
- [ ] Verify FAB is red (error container color) instead of green (primary)