### PR TITLE
General: Add dry run support for Squeezer and Swiper

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/squeezer/core/Squeezer.kt
+++ b/app/src/main/java/eu/darken/sdmse/squeezer/core/Squeezer.kt
@@ -7,6 +7,7 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.datastore.value
+import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.*
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
@@ -146,7 +147,9 @@ class Squeezer @Inject constructor(
 
         updateProgress { Progress.Data() }
 
-        internalData.value = snapshot.prune(result.success.map { it.identifier }.toSet())
+        if (!Bugs.isDryRun) {
+            internalData.value = snapshot.prune(result.success.map { it.identifier }.toSet())
+        }
 
         return SqueezerProcessTask.Success(
             affectedSpace = result.savedSpace,


### PR DESCRIPTION
## Summary
- Add `Bugs.isDryRun` guards to Squeezer so image compression is simulated (accurate savings calculated) but no files are modified on disk
- Skip history DB recording and snapshot pruning during dry run to avoid poisoning future real runs
- Guard Swiper's deletion loop so no gateway calls, DB state changes, or MediaScanner notifications happen during dry run

## Test plan
- [ ] Enable debug mode + dry run in debug settings
- [ ] Run Squeezer scan → process: images should report savings but files remain unchanged
- [ ] Run Swiper delete: items should remain on disk, DB should not mark them as DELETED
- [ ] Disable dry run, re-run both tools: actual compression/deletion should work normally