### PR TITLE
General: Reorder tools in settings

### DIFF
--- a/app/src/main/res/xml/preferences_index.xml
+++ b/app/src/main/res/xml/preferences_index.xml
@@ -38,15 +38,15 @@
             app:summary="@string/deduplicator_explanation_short"
             app:title="@string/deduplicator_tool_name" />
         <Preference
-            android:icon="@drawable/ic_image_compress_24"
-            app:fragment="eu.darken.sdmse.squeezer.ui.settings.SqueezerSettingsFragment"
-            app:summary="@string/squeezer_explanation_short"
-            app:title="@string/squeezer_tool_name" />
-        <Preference
             android:icon="@drawable/ic_apps"
             app:fragment="eu.darken.sdmse.appcontrol.ui.settings.AppControlSettingsFragment"
             app:summary="@string/appcontrol_explanation_short"
             app:title="@string/appcontrol_tool_name" />
+        <Preference
+            android:icon="@drawable/ic_image_compress_24"
+            app:fragment="eu.darken.sdmse.squeezer.ui.settings.SqueezerSettingsFragment"
+            app:summary="@string/squeezer_explanation_short"
+            app:title="@string/squeezer_tool_name" />
         <Preference
             android:icon="@drawable/ic_baseline_swipe_24"
             app:fragment="eu.darken.sdmse.swiper.ui.settings.SwiperSettingsFragment"


### PR DESCRIPTION
## Summary
- Move AppControl before Squeezer in the settings tool list