### PR TITLE
General: Add storage space tracking over time with chart visualization

### DIFF
--- a/app/schemas/eu.darken.sdmse.stats.core.db.ReportsRoomDb/2.json
+++ b/app/schemas/eu.darken.sdmse.stats.core.db.ReportsRoomDb/2.json
@@ -1,0 +1,217 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "d6e941a35eede8ad4d2c2a6855124a63",
+    "entities": [
+      {
+        "tableName": "reports",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `report_id` TEXT NOT NULL, `start_at` INTEGER NOT NULL, `end_at` INTEGER NOT NULL, `tool` TEXT NOT NULL, `status` TEXT NOT NULL, `primary_message` TEXT, `secondary_message` TEXT, `error_message` TEXT, `affected_count` INTEGER, `affected_space` INTEGER, `extra` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reportId",
+            "columnName": "report_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startAt",
+            "columnName": "start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endAt",
+            "columnName": "end_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tool",
+            "columnName": "tool",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "primaryMessage",
+            "columnName": "primary_message",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "secondaryMessage",
+            "columnName": "secondary_message",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "error_message",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "affectedCount",
+            "columnName": "affected_count",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "affectedSpace",
+            "columnName": "affected_space",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "extra",
+            "columnName": "extra",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "affected_paths",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `report_id` TEXT NOT NULL, `action` TEXT NOT NULL, `path` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reportId",
+            "columnName": "report_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "action",
+            "columnName": "action",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "affected_pkgs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `report_id` TEXT NOT NULL, `action` TEXT NOT NULL, `pkg_id` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reportId",
+            "columnName": "report_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "action",
+            "columnName": "action",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pkgId",
+            "columnName": "pkg_id",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "space_snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `storage_id` TEXT NOT NULL, `recorded_at` INTEGER NOT NULL, `space_free` INTEGER NOT NULL, `space_capacity` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storageId",
+            "columnName": "storage_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recordedAt",
+            "columnName": "recorded_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spaceFree",
+            "columnName": "space_free",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spaceCapacity",
+            "columnName": "space_capacity",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_space_snapshots_storage_id_recorded_at",
+            "unique": false,
+            "columnNames": [
+              "storage_id",
+              "recorded_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_space_snapshots_storage_id_recorded_at` ON `${TABLE_NAME}` (`storage_id`, `recorded_at`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'd6e941a35eede8ad4d2c2a6855124a63')"
+    ]
+  }
+}

--- a/app/src/main/java/eu/darken/sdmse/App.kt
+++ b/app/src/main/java/eu/darken/sdmse/App.kt
@@ -27,6 +27,8 @@ import eu.darken.sdmse.common.updater.UpdateService
 import eu.darken.sdmse.main.core.CurriculumVitae
 import eu.darken.sdmse.main.core.GeneralSettings
 import eu.darken.sdmse.main.core.shortcuts.ShortcutManager
+import eu.darken.sdmse.stats.core.SpaceTracker
+import eu.darken.sdmse.stats.core.TaskStatsCoordinator
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
@@ -52,6 +54,8 @@ open class App : Application(), Configuration.Provider {
     @Inject lateinit var coilTempFiles: CoilTempFiles
     @Inject lateinit var memoryMonitor: MemoryMonitor
     @Inject lateinit var shortcutManager: ShortcutManager
+    @Inject lateinit var spaceTracker: SpaceTracker
+    @Inject lateinit var taskStatsCoordinator: TaskStatsCoordinator
 
     private val logCatLogger = LogCatLogger()
 
@@ -98,6 +102,8 @@ open class App : Application(), Configuration.Provider {
         curriculumVitae.updateAppLaunch()
 
         shortcutManager.initialize()
+        taskStatsCoordinator.start()
+        appScope.launch { spaceTracker.recordSnapshot() }
 
         val oldHandler = Thread.getDefaultUncaughtExceptionHandler()
         Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->

--- a/app/src/main/java/eu/darken/sdmse/analyzer/core/Analyzer.kt
+++ b/app/src/main/java/eu/darken/sdmse/analyzer/core/Analyzer.kt
@@ -47,6 +47,7 @@ import eu.darken.sdmse.setup.IncompleteSetupException
 import eu.darken.sdmse.setup.SetupModule
 import eu.darken.sdmse.setup.inventory.InventorySetupModule
 import eu.darken.sdmse.setup.isComplete
+import eu.darken.sdmse.stats.core.SpaceTracker
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -66,6 +67,7 @@ class Analyzer @Inject constructor(
     private val gatewaySwitch: GatewaySwitch,
     private val appInventorySetupModule: InventorySetupModule,
     private val mediaStoreTool: MediaStoreTool,
+    private val spaceTracker: SpaceTracker,
 ) : SDMTool, Progress.Client {
 
     override val type: SDMTool.Type = SDMTool.Type.ANALYZER
@@ -144,6 +146,7 @@ class Analyzer @Inject constructor(
         val storages = scanner.withProgress(this) { scan() }
 
         storageDevices.value = storages
+        spaceTracker.recordSnapshot(storages)
 
         return DeviceStorageScanTask.Result(itemCount = storages.size)
     }

--- a/app/src/main/java/eu/darken/sdmse/analyzer/core/device/DeviceStorageScanner.kt
+++ b/app/src/main/java/eu/darken/sdmse/analyzer/core/device/DeviceStorageScanner.kt
@@ -4,7 +4,6 @@ import android.os.storage.StorageManager
 import eu.darken.sdmse.R
 import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
-import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.asFile
@@ -20,7 +19,6 @@ import eu.darken.sdmse.setup.isComplete
 import eu.darken.sdmse.setup.storage.StorageSetupModule
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import java.util.UUID
 import javax.inject.Inject
 
 class DeviceStorageScanner @Inject constructor(
@@ -88,22 +86,7 @@ class DeviceStorageScanner @Inject constructor(
                     volume.path?.path?.toCaString() ?: R.string.analyzer_storage_type_secondary_title.toCaString()
                 )
 
-                var volumeId: UUID? = try {
-                    UUID.fromString(volume.fsUuid)
-                } catch (e: IllegalArgumentException) {
-                    null
-                }
-                if (volumeId == null && volume.fsUuid != null) {
-                    try {
-                        // StorageManager.FAT_UUID_PREFIX
-                        volumeId = UUID.fromString(
-                            "fafafafa-fafa-5afa-8afa-fafa" + volume.fsUuid!!.replace("-", "")
-                        )
-                    } catch (e: Exception) {
-                        log(TAG, WARN) { "Failed to construct UUID: ${e.asLog()}" }
-                    }
-                }
-
+                val volumeId = StorageId.parseVolumeUuid(volume.fsUuid)
                 if (volumeId == null) {
                     log(TAG, WARN) { "Failed to determine UUID of $volume" }
                     return@mapNotNull null

--- a/app/src/main/java/eu/darken/sdmse/analyzer/ui/AnalyzerDashCardVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/analyzer/ui/AnalyzerDashCardVH.kt
@@ -1,12 +1,15 @@
 package eu.darken.sdmse.analyzer.ui
 
+import android.text.format.Formatter
 import android.view.ViewGroup
+import androidx.core.view.isVisible
 import eu.darken.sdmse.R
 import eu.darken.sdmse.analyzer.core.Analyzer
 import eu.darken.sdmse.common.lists.binding
 import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.databinding.AnalyzerDashboardItemBinding
 import eu.darken.sdmse.main.ui.dashboard.DashboardAdapter
+import kotlin.math.absoluteValue
 
 
 class AnalyzerDashCardVH(parent: ViewGroup) :
@@ -22,13 +25,34 @@ class AnalyzerDashCardVH(parent: ViewGroup) :
         payloads: List<Any>
     ) -> Unit = binding { item ->
 
-        viewAction. setOnClickListener { item.onViewDetails() }
-        root. setOnClickListener { viewAction.performClick() }
+        val combinedDelta = item.combinedDelta
+
+        trendDelta.isVisible = combinedDelta != null
+        if (combinedDelta != null) {
+            val absDelta = Formatter.formatShortFileSize(context, combinedDelta.absoluteValue)
+            val signedDelta = when {
+                combinedDelta > 0 -> "+$absDelta"
+                combinedDelta < 0 -> "-$absDelta"
+                else -> absDelta
+            }
+            trendDelta.text = getString(R.string.analyzer_storage_trend_delta_in_7d, signedDelta)
+            trendDelta.setTextColor(
+                when {
+                    combinedDelta > 0 -> getColorForAttr(android.R.attr.colorError)
+                    combinedDelta < 0 -> getColorForAttr(androidx.appcompat.R.attr.colorPrimary)
+                    else -> getColorForAttr(android.R.attr.textColorSecondary)
+                }
+            )
+        }
+
+        viewAction.setOnClickListener { item.onViewDetails() }
+        root.setOnClickListener { viewAction.performClick() }
     }
 
     data class Item(
         val data: Analyzer.Data?,
         val progress: Progress.Data?,
+        val combinedDelta: Long? = null,
         val onViewDetails: () -> Unit,
     ) : DashboardAdapter.Item {
         override val stableId: Long = this.javaClass.hashCode().toLong()

--- a/app/src/main/java/eu/darken/sdmse/analyzer/ui/storage/device/DeviceStorageViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/analyzer/ui/storage/device/DeviceStorageViewModel.kt
@@ -2,15 +2,23 @@ package eu.darken.sdmse.analyzer.ui.storage.device
 
 import androidx.lifecycle.SavedStateHandle
 import dagger.hilt.android.lifecycle.HiltViewModel
+import eu.darken.sdmse.MainDirections
 import eu.darken.sdmse.analyzer.core.Analyzer
 import eu.darken.sdmse.analyzer.core.device.DeviceStorageScanTask
-import eu.darken.sdmse.appcontrol.core.*
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.progress.Progress
+import eu.darken.sdmse.common.upgrade.UpgradeRepo
 import eu.darken.sdmse.common.uix.ViewModel3
-import kotlinx.coroutines.flow.*
+import eu.darken.sdmse.stats.core.SpaceHistoryRepo
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.take
+import java.time.Duration
+import java.time.Instant
 import javax.inject.Inject
 
 @HiltViewModel
@@ -18,6 +26,8 @@ class DeviceStorageViewModel @Inject constructor(
     @Suppress("unused") private val handle: SavedStateHandle,
     dispatcherProvider: DispatcherProvider,
     private val analyzer: Analyzer,
+    private val spaceHistoryRepo: SpaceHistoryRepo,
+    private val upgradeRepo: UpgradeRepo,
 ) : ViewModel3(dispatcherProvider) {
 
     init {
@@ -28,16 +38,22 @@ class DeviceStorageViewModel @Inject constructor(
             .launchInViewModel()
     }
 
-
     val state = combine(
         analyzer.data,
         analyzer.progress,
-    ) { data, progress ->
+        spaceHistoryRepo.getAllHistory(Instant.now() - Duration.ofDays(7)),
+        upgradeRepo.upgradeInfo.map { it.isPro },
+    ) { data, progress, snapshots, isPro ->
+        val snapshotsByStorage = snapshots.groupBy { it.storageId }
 
         State(
             storages = data.storages.map { storage ->
                 DeviceStorageItemVH.Item(
                     storage = storage,
+                    snapshots = snapshotsByStorage[storage.id.externalId.toString()]
+                        .orEmpty()
+                        .sortedBy { it.recordedAt },
+                    isPro = isPro,
                     onItemClicked = {
                         if (storage.setupIncomplete) {
                             DeviceStorageFragmentDirections.goToSetup().navigate()
@@ -46,6 +62,13 @@ class DeviceStorageViewModel @Inject constructor(
                                 it.storage.id
                             ).navigate()
                         }
+                    },
+                    onTrendClicked = { item ->
+                        if (isPro) {
+                            MainDirections.goToSpaceHistoryFragment(storageId = item.storage.id.externalId.toString())
+                        } else {
+                            MainDirections.goToUpgradeFragment()
+                        }.navigate()
                     }
                 )
             },

--- a/app/src/main/java/eu/darken/sdmse/common/storage/StorageId.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/storage/StorageId.kt
@@ -8,4 +8,21 @@ import java.util.UUID
 data class StorageId(
     val internalId: String?,
     val externalId: UUID,
-) : Parcelable
+) : Parcelable {
+
+    companion object {
+        fun parseVolumeUuid(fsUuid: String?): UUID? {
+            if (fsUuid == null) return null
+            return try {
+                UUID.fromString(fsUuid)
+            } catch (_: IllegalArgumentException) {
+                try {
+                    // StorageManager.FAT_UUID_PREFIX style fallback
+                    UUID.fromString("fafafafa-fafa-5afa-8afa-fafa${fsUuid.replace("-", "")}")
+                } catch (_: Exception) {
+                    null
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/stats/core/SpaceHistoryRepo.kt
+++ b/app/src/main/java/eu/darken/sdmse/stats/core/SpaceHistoryRepo.kt
@@ -1,0 +1,59 @@
+package eu.darken.sdmse.stats.core
+
+import eu.darken.sdmse.stats.core.db.ReportEntity
+import eu.darken.sdmse.stats.core.db.ReportsDatabase
+import eu.darken.sdmse.stats.core.db.SpaceSnapshotEntity
+import kotlinx.coroutines.flow.Flow
+import java.time.Duration
+import java.time.Instant
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class SpaceHistoryRepo @Inject constructor(
+    private val reportsDatabase: ReportsDatabase,
+) {
+    fun getHistory(storageId: String, since: Instant): Flow<List<SpaceSnapshotEntity>> {
+        return reportsDatabase.spaceSnapshotDao.getByStorageId(storageId, since)
+    }
+
+    fun getAllHistory(since: Instant): Flow<List<SpaceSnapshotEntity>> {
+        return reportsDatabase.spaceSnapshotDao.getAll(since)
+    }
+
+    fun getAvailableStorageIds(): Flow<List<String>> {
+        return reportsDatabase.spaceSnapshotDao.getDistinctStorageIds()
+    }
+
+    fun getReports(since: Instant): Flow<List<ReportEntity>> = reportsDatabase.getReportsSince(since)
+
+    suspend fun insertIfNotRecent(
+        storageId: String,
+        recordedAt: Instant,
+        spaceFree: Long,
+        spaceCapacity: Long,
+        dedupeWindow: Duration? = Duration.ofMinutes(5),
+    ): Boolean {
+        if (spaceCapacity <= 0L) return false
+
+        reportsDatabase.withTransaction {
+            if (dedupeWindow != null) {
+                val latest = reportsDatabase.spaceSnapshotDao.getLatest(storageId)
+                if (latest != null && !latest.recordedAt.isBefore(recordedAt.minus(dedupeWindow))) {
+                    reportsDatabase.spaceSnapshotDao.deleteById(latest.id)
+                }
+            }
+
+            reportsDatabase.spaceSnapshotDao.insert(
+                SpaceSnapshotEntity(
+                    storageId = storageId,
+                    recordedAt = recordedAt,
+                    spaceFree = spaceFree,
+                    spaceCapacity = spaceCapacity,
+                )
+            )
+        }
+        reportsDatabase.refreshDatabaseSize()
+        return true
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/stats/core/SpaceTracker.kt
+++ b/app/src/main/java/eu/darken/sdmse/stats/core/SpaceTracker.kt
@@ -1,0 +1,180 @@
+package eu.darken.sdmse.stats.core
+
+import android.os.storage.StorageManager
+import eu.darken.sdmse.analyzer.core.device.DeviceStorage
+import eu.darken.sdmse.common.coroutine.DispatcherProvider
+import eu.darken.sdmse.common.datastore.value
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.asLog
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.files.asFile
+import eu.darken.sdmse.common.storage.StorageEnvironment
+import eu.darken.sdmse.common.storage.StorageId
+import eu.darken.sdmse.common.storage.StorageManager2
+import eu.darken.sdmse.common.storage.StorageStatsManager2
+import kotlinx.coroutines.withContext
+import java.time.Duration
+import java.time.Instant
+import java.util.UUID
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class SpaceTracker @Inject constructor(
+    private val dispatcherProvider: DispatcherProvider,
+    private val storageStatsManager: StorageStatsManager2,
+    private val storageManager2: StorageManager2,
+    private val storageEnvironment: StorageEnvironment,
+    private val spaceHistoryRepo: SpaceHistoryRepo,
+    private val statsSettings: StatsSettings,
+) {
+
+    suspend fun recordSnapshot(force: Boolean = false) = withContext(dispatcherProvider.IO) {
+        try {
+            val now = Instant.now()
+            if (!force && isGloballyThrottled(now)) return@withContext
+
+            val storages = readCurrentStorages()
+            val inserted = insertSnapshots(storages, now)
+
+            if (inserted > 0 || force) {
+                statsSettings.lastSnapshotAt.value(now.toEpochMilli())
+            }
+
+            log(TAG) { "recordSnapshot(force=$force): inserted=$inserted, scanned=${storages.size}" }
+        } catch (e: Exception) {
+            log(TAG, WARN) { "recordSnapshot(force=$force) failed: ${e.asLog()}" }
+        }
+    }
+
+    suspend fun recordSnapshot(storages: Set<DeviceStorage>) = withContext(dispatcherProvider.IO) {
+        try {
+            if (storages.isEmpty()) return@withContext
+
+            val now = Instant.now()
+            val snapshots = storages.map {
+                StorageSnapshot(
+                    storageId = it.id.externalId.toString(),
+                    spaceFree = it.spaceFree,
+                    spaceCapacity = it.spaceCapacity,
+                )
+            }.toSet()
+
+            val inserted = insertSnapshots(snapshots, now)
+            if (inserted > 0) {
+                statsSettings.lastSnapshotAt.value(now.toEpochMilli())
+            }
+
+            log(TAG) { "recordSnapshot(storages=${storages.size}): inserted=$inserted" }
+        } catch (e: Exception) {
+            log(TAG, WARN) { "recordSnapshot(storages) failed: ${e.asLog()}" }
+        }
+    }
+
+    private suspend fun isGloballyThrottled(now: Instant): Boolean {
+        val lastAt = statsSettings.lastSnapshotAt.value()
+        if (lastAt <= 0L) return false
+
+        val last = Instant.ofEpochMilli(lastAt)
+        val blocked = !last.isBefore(now.minus(GLOBAL_THROTTLE))
+        if (blocked) log(TAG) { "Global snapshot throttle active (last=$last)" }
+        return blocked
+    }
+
+    private suspend fun insertSnapshots(storages: Set<StorageSnapshot>, now: Instant): Int {
+        var inserted = 0
+
+        storages.forEach { storage ->
+            val wasInserted = spaceHistoryRepo.insertIfNotRecent(
+                storageId = storage.storageId,
+                recordedAt = now,
+                spaceFree = storage.spaceFree,
+                spaceCapacity = storage.spaceCapacity,
+            )
+            if (wasInserted) {
+                inserted++
+            } else {
+                log(TAG) { "Skipping snapshot for ${storage.storageId}" }
+            }
+        }
+
+        return inserted
+    }
+
+    private suspend fun readCurrentStorages(): Set<StorageSnapshot> {
+        val primary = run {
+            val primaryUuid = StorageManager.UUID_DEFAULT ?: UUID.fromString("00000000-0000-0000-0000-000000000000")
+            val storageId = StorageId(
+                internalId = null,
+                externalId = primaryUuid,
+            )
+            val totalBytes = try {
+                storageStatsManager.getTotalBytes(storageId)
+            } catch (e: Exception) {
+                log(TAG, WARN) { "Failed to get total bytes for primary storage: ${e.asLog()}" }
+                storageEnvironment.dataDir.asFile().totalSpace
+            }
+            val freeBytes = try {
+                storageStatsManager.getFreeBytes(storageId)
+            } catch (e: Exception) {
+                log(TAG, WARN) { "Failed to get free bytes for primary storage: ${e.asLog()}" }
+                storageEnvironment.dataDir.asFile().freeSpace
+            }
+
+            StorageSnapshot(
+                storageId = storageId.externalId.toString(),
+                spaceFree = freeBytes,
+                spaceCapacity = totalBytes,
+            )
+        }
+
+        val secondary = (storageManager2.volumes ?: emptySet())
+            .filter { it.isPrimary == false && it.fsUuid != null && it.isMounted }
+            .mapNotNull { volume ->
+                val volumeUuid = StorageId.parseVolumeUuid(volume.fsUuid)
+                if (volumeUuid == null) {
+                    log(TAG, WARN) { "Failed to determine UUID for volume: $volume" }
+                    return@mapNotNull null
+                }
+
+                val storageId = StorageId(
+                    internalId = volume.fsUuid,
+                    externalId = volumeUuid,
+                )
+
+                val totalBytes = try {
+                    storageStatsManager.getTotalBytes(storageId)
+                } catch (e: Exception) {
+                    log(TAG, WARN) { "Failed to get total bytes for $storageId: ${e.asLog()}" }
+                    volume.path?.totalSpace ?: 0L
+                }
+                val freeBytes = try {
+                    storageStatsManager.getFreeBytes(storageId)
+                } catch (e: Exception) {
+                    log(TAG, WARN) { "Failed to get free bytes for $storageId: ${e.asLog()}" }
+                    volume.path?.freeSpace ?: 0L
+                }
+
+                StorageSnapshot(
+                    storageId = storageId.externalId.toString(),
+                    spaceFree = freeBytes,
+                    spaceCapacity = totalBytes,
+                )
+            }
+            .toSet()
+
+        return setOf(primary) + secondary
+    }
+
+    private data class StorageSnapshot(
+        val storageId: String,
+        val spaceFree: Long,
+        val spaceCapacity: Long,
+    )
+
+    companion object {
+        private val GLOBAL_THROTTLE: Duration = Duration.ofMinutes(30)
+        private val TAG = logTag("Stats", "SpaceTracker")
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/stats/core/StatsSettings.kt
+++ b/app/src/main/java/eu/darken/sdmse/stats/core/StatsSettings.kt
@@ -27,6 +27,8 @@ class StatsSettings @Inject constructor(
 
     val retentionReports = dataStore.createValue("retention.reports", DEFAULT_RETENTION_REPORTS, moshi)
     val retentionPaths = dataStore.createValue("retention.paths", DEFAULT_RETENTION_PATHS, moshi)
+    val retentionSnapshots = dataStore.createValue("retention.snapshots", DEFAULT_RETENTION_SNAPSHOTS, moshi)
+    val lastSnapshotAt = dataStore.createValue("snapshot.last.at", 0L)
 
     val totalSpaceFreed = dataStore.createValue("total.space.freed", 0L)
     val totalItemsProcessed = dataStore.createValue("total.items.processed", 0L)
@@ -35,11 +37,14 @@ class StatsSettings @Inject constructor(
     override val mapper = PreferenceStoreMapper(
         retentionReports,
         retentionPaths,
+        retentionSnapshots,
     )
 
     companion object {
         val DEFAULT_RETENTION_REPORTS: Duration = Duration.ofDays(30)
         val DEFAULT_RETENTION_PATHS: Duration = Duration.ofDays(7)
+        val DEFAULT_RETENTION_SNAPSHOTS: Duration = Duration.ofDays(90)
+        val FREE_RETENTION_SNAPSHOTS: Duration = Duration.ofDays(7)
         internal val TAG = logTag("Stats", "Settings")
     }
 }

--- a/app/src/main/java/eu/darken/sdmse/stats/core/TaskStatsCoordinator.kt
+++ b/app/src/main/java/eu/darken/sdmse/stats/core/TaskStatsCoordinator.kt
@@ -1,0 +1,67 @@
+package eu.darken.sdmse.stats.core
+
+import eu.darken.sdmse.common.coroutine.AppScope
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.asLog
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.flow.withPrevious
+import eu.darken.sdmse.main.core.taskmanager.TaskManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class TaskStatsCoordinator @Inject constructor(
+    @AppScope private val appScope: CoroutineScope,
+    private val taskManager: TaskManager,
+    private val statsRepo: StatsRepo,
+) {
+    @Volatile private var isStarted = false
+
+    fun start() {
+        if (isStarted) return
+        isStarted = true
+
+        taskManager.state
+            .map { state -> state.tasks.associateBy { task -> task.id } }
+            .withPrevious()
+            .onEach { (oldTasks, newTasks) ->
+                val oldById = oldTasks ?: emptyMap()
+                val newlyCompleted = newTasks.values.filter { task ->
+                    task.isComplete && oldById[task.id]?.isComplete != true
+                }
+                newlyCompleted.forEach { task ->
+                    try {
+                        statsRepo.report(task)
+                    } catch (e: Exception) {
+                        log(TAG, WARN) { "Failed to report task ${task.id}: ${e.asLog()}" }
+                    }
+                }
+            }
+            .launchIn(appScope)
+
+        taskManager.state
+            .map { it.isIdle }
+            .distinctUntilChanged()
+            .withPrevious()
+            .onEach { (oldIdle, newIdle) ->
+                if (oldIdle == false && newIdle) {
+                    try {
+                        statsRepo.recordSnapshot(force = true)
+                    } catch (e: Exception) {
+                        log(TAG, WARN) { "Failed to record idle snapshot: ${e.asLog()}" }
+                    }
+                }
+            }
+            .launchIn(appScope)
+    }
+
+    companion object {
+        private val TAG = logTag("Stats", "TaskCoordinator")
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/stats/core/db/ReportsDao.kt
+++ b/app/src/main/java/eu/darken/sdmse/stats/core/db/ReportsDao.kt
@@ -27,4 +27,7 @@ interface ReportsDao {
 
     @Query("DELETE FROM reports WHERE report_id IN (:ids)")
     fun delete(ids: List<ReportId>)
+
+    @Query("SELECT * FROM reports WHERE end_at >= :since AND status IN ('SUCCESS', 'PARTIAL_SUCCESS') ORDER BY end_at ASC")
+    fun getReportsSince(since: Instant): Flow<List<ReportEntity>>
 }

--- a/app/src/main/java/eu/darken/sdmse/stats/core/db/ReportsRoomDb.kt
+++ b/app/src/main/java/eu/darken/sdmse/stats/core/db/ReportsRoomDb.kt
@@ -1,6 +1,7 @@
 package eu.darken.sdmse.stats.core.db
 
 import androidx.room.Database
+import androidx.room.AutoMigration
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import eu.darken.sdmse.common.room.APathTypeConverter
@@ -16,10 +17,11 @@ import eu.darken.sdmse.stats.core.db.converter.ReportStatusConverter
         ReportEntity::class,
         AffectedPathEntity::class,
         AffectedPkgEntity::class,
+        SpaceSnapshotEntity::class,
     ],
-    version = 1,
+    version = 2,
     autoMigrations = [
-        //AutoMigration(1, 2)
+        AutoMigration(from = 1, to = 2),
     ],
     exportSchema = true,
 )
@@ -36,4 +38,5 @@ abstract class ReportsRoomDb : RoomDatabase() {
     abstract fun reports(): ReportsDao
     abstract fun paths(): AffectedPathsDao
     abstract fun pkgs(): AffectedPkgsDao
+    abstract fun spaceSnapshots(): SpaceSnapshotDao
 }

--- a/app/src/main/java/eu/darken/sdmse/stats/core/db/SpaceSnapshotDao.kt
+++ b/app/src/main/java/eu/darken/sdmse/stats/core/db/SpaceSnapshotDao.kt
@@ -1,0 +1,44 @@
+package eu.darken.sdmse.stats.core.db
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+import java.time.Instant
+
+@Dao
+interface SpaceSnapshotDao {
+    @Insert
+    suspend fun insert(entity: SpaceSnapshotEntity)
+
+    @Query(
+        "SELECT * FROM space_snapshots " +
+            "WHERE storage_id = :storageId AND recorded_at >= :since " +
+            "ORDER BY recorded_at ASC"
+    )
+    fun getByStorageId(storageId: String, since: Instant): Flow<List<SpaceSnapshotEntity>>
+
+    @Query("SELECT * FROM space_snapshots WHERE recorded_at >= :since ORDER BY recorded_at ASC")
+    fun getAll(since: Instant): Flow<List<SpaceSnapshotEntity>>
+
+    @Query("SELECT MAX(recorded_at) FROM space_snapshots WHERE storage_id = :storageId")
+    suspend fun getLatestTimestamp(storageId: String): Instant?
+
+    @Query("SELECT * FROM space_snapshots WHERE storage_id = :storageId ORDER BY recorded_at DESC LIMIT 1")
+    suspend fun getLatest(storageId: String): SpaceSnapshotEntity?
+
+    @Query("DELETE FROM space_snapshots WHERE id = :snapshotId")
+    suspend fun deleteById(snapshotId: Long)
+
+    @Query("SELECT DISTINCT storage_id FROM space_snapshots")
+    fun getDistinctStorageIds(): Flow<List<String>>
+
+    @Query("DELETE FROM space_snapshots WHERE recorded_at < :cutOff")
+    suspend fun deleteOlderThan(cutOff: Instant)
+
+    @Query("DELETE FROM space_snapshots")
+    suspend fun deleteAll()
+
+    @Query("SELECT COUNT(*) FROM space_snapshots")
+    fun snapshotCount(): Flow<Int>
+}

--- a/app/src/main/java/eu/darken/sdmse/stats/core/db/SpaceSnapshotEntity.kt
+++ b/app/src/main/java/eu/darken/sdmse/stats/core/db/SpaceSnapshotEntity.kt
@@ -1,0 +1,21 @@
+package eu.darken.sdmse.stats.core.db
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import java.time.Instant
+
+@Entity(
+    tableName = "space_snapshots",
+    indices = [
+        Index(value = ["storage_id", "recorded_at"]),
+    ],
+)
+data class SpaceSnapshotEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    @ColumnInfo(name = "storage_id") val storageId: String,
+    @ColumnInfo(name = "recorded_at") val recordedAt: Instant,
+    @ColumnInfo(name = "space_free") val spaceFree: Long,
+    @ColumnInfo(name = "space_capacity") val spaceCapacity: Long,
+)

--- a/app/src/main/java/eu/darken/sdmse/stats/ui/StatsDashCardVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/stats/ui/StatsDashCardVH.kt
@@ -24,39 +24,44 @@ class StatsDashCardVH(parent: ViewGroup) :
         item: Item,
         payloads: List<Any>
     ) -> Unit = binding { item ->
-        val (space, spaceQuantity) = ByteFormatter.formatSize(context, item.state.totalSpaceFreed)
-        val spaceFormatted = getQuantityString(
-            R.plurals.stats_dash_body_size,
-            spaceQuantity,
-            space
-        )
-
-        val processed = item.state.itemsProcessed.toString()
-        val processedQuantity = item.state.itemsProcessed
-        val processedFormatted = getQuantityString(
-            R.plurals.stats_dash_body_count,
-            processedQuantity.toInt(),
-            processed,
-        )
-        val wholeText = "$spaceFormatted $processedFormatted"
-
-        body.text = SpannableString(wholeText).apply {
-            val startFreed = wholeText.indexOf(space)
-            val endFreed = startFreed + space.length
-            setSpan(
-                ForegroundColorSpan(getColorForAttr(androidx.appcompat.R.attr.colorPrimary)),
-                startFreed,
-                endFreed,
-                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+        val hasCleanupData = item.state.reportsCount > 0 || item.state.totalSpaceFreed > 0L
+        if (hasCleanupData) {
+            val (space, spaceQuantity) = ByteFormatter.formatSize(context, item.state.totalSpaceFreed)
+            val spaceFormatted = getQuantityString(
+                R.plurals.stats_dash_body_size,
+                spaceQuantity,
+                space
             )
-            val startProcessed = wholeText.indexOf(processedFormatted)
-            val endProcessed = startProcessed + processed.length
-            setSpan(
-                ForegroundColorSpan(getColorForAttr(androidx.appcompat.R.attr.colorPrimary)),
-                startProcessed,
-                endProcessed,
-                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+
+            val processed = item.state.itemsProcessed.toString()
+            val processedQuantity = item.state.itemsProcessed
+            val processedFormatted = getQuantityString(
+                R.plurals.stats_dash_body_count,
+                processedQuantity.toInt(),
+                processed,
             )
+            val wholeText = "$spaceFormatted $processedFormatted"
+
+            body.text = SpannableString(wholeText).apply {
+                val startFreed = wholeText.indexOf(space)
+                val endFreed = startFreed + space.length
+                setSpan(
+                    ForegroundColorSpan(getColorForAttr(androidx.appcompat.R.attr.colorPrimary)),
+                    startFreed,
+                    endFreed,
+                    Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+                )
+                val startProcessed = wholeText.indexOf(processedFormatted)
+                val endProcessed = startProcessed + processed.length
+                setSpan(
+                    ForegroundColorSpan(getColorForAttr(androidx.appcompat.R.attr.colorPrimary)),
+                    startProcessed,
+                    endProcessed,
+                    Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+                )
+            }
+        } else {
+            body.text = getString(R.string.stats_dash_body_snapshots_only)
         }
         viewAction.apply {
             if (item.showProRequirement) {

--- a/app/src/main/java/eu/darken/sdmse/stats/ui/reports/ReportsFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/stats/ui/reports/ReportsFragment.kt
@@ -33,7 +33,21 @@ class ReportsFragment : Fragment3(R.layout.stats_reports_fragment) {
             insetsPadding(ui.loadingOverlay, bottom = true)
         }
 
-        ui.toolbar.setupWithNavController(findNavController())
+        ui.toolbar.apply {
+            setupWithNavController(findNavController())
+            inflateMenu(R.menu.menu_stats_reports)
+            @Suppress("DEPRECATION")
+            setOnMenuItemClickListener {
+                when (it.itemId) {
+                    R.id.action_storage_trend -> {
+                        vm.openStorageTrend()
+                        true
+                    }
+
+                    else -> super.onOptionsItemSelected(it)
+                }
+            }
+        }
 
         val adapter = ReportsAdapter()
         ui.list.setupDefaults(
@@ -47,6 +61,12 @@ class ReportsFragment : Fragment3(R.layout.stats_reports_fragment) {
             list.isGone = state.listItems == null
             state.listItems?.let {
                 toolbar.subtitle = getQuantityString2(eu.darken.sdmse.common.R.plurals.result_x_items, it.size)
+            }
+            toolbar.menu?.findItem(R.id.action_storage_trend)?.apply {
+                setIcon(
+                    if (state.isPro) R.drawable.ic_chart_bar_stacked_24
+                    else R.drawable.ic_baseline_stars_24
+                )
             }
         }
 

--- a/app/src/main/java/eu/darken/sdmse/stats/ui/spacehistory/SpaceHistoryChartView.kt
+++ b/app/src/main/java/eu/darken/sdmse/stats/ui/spacehistory/SpaceHistoryChartView.kt
@@ -1,0 +1,448 @@
+package eu.darken.sdmse.stats.ui.spacehistory
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.Path
+import android.graphics.PointF
+import android.util.AttributeSet
+import android.view.MotionEvent
+import android.view.View
+import eu.darken.sdmse.common.ByteFormatter
+import eu.darken.sdmse.common.dpToPx
+import eu.darken.sdmse.common.getColorForAttr
+import eu.darken.sdmse.common.spToPx
+import eu.darken.sdmse.stats.core.db.ReportEntity
+import eu.darken.sdmse.stats.core.db.SpaceSnapshotEntity
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+import kotlin.math.max
+import kotlin.math.sqrt
+
+class SpaceHistoryChartView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0,
+) : View(context, attrs, defStyleAttr) {
+
+    fun interface OnMarkerTapListener {
+        fun onMarkerTapped(report: ReportEntity, screenX: Int, screenY: Int)
+    }
+
+    private data class MarkerPosition(
+        val report: ReportEntity,
+        val point: PointF,
+    )
+
+    private val linePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.STROKE
+        strokeWidth = context.dpToPx(2f).toFloat()
+        strokeCap = Paint.Cap.ROUND
+        strokeJoin = Paint.Join.ROUND
+    }
+
+    private val fillPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.FILL
+    }
+
+    private val gridPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.STROKE
+        strokeWidth = context.dpToPx(1f).toFloat()
+    }
+
+    private val labelPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.FILL
+        textAlign = Paint.Align.RIGHT
+    }
+
+    private val xLabelPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.FILL
+        textAlign = Paint.Align.LEFT
+    }
+
+    private val markerPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.FILL
+    }
+
+    private val markerStrokePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.STROKE
+        strokeWidth = context.dpToPx(1.5f).toFloat()
+    }
+
+    private val selectedMarkerPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.FILL
+    }
+
+    private val dateFormatter = DateTimeFormatter.ofPattern("MMM d", Locale.getDefault())
+
+    private var snapshots: List<SpaceSnapshotEntity> = emptyList()
+    private var reports: List<ReportEntity> = emptyList()
+    var isCompact: Boolean = false
+        private set
+
+    private var markerPositions: List<MarkerPosition> = emptyList()
+    private var selectedMarkerIndex: Int = -1
+    private var markerTapListener: OnMarkerTapListener? = null
+    private val hitRadiusPx = context.dpToPx(16f).toFloat()
+
+    init {
+        context.obtainStyledAttributes(attrs, eu.darken.sdmse.R.styleable.SpaceHistoryChartView).apply {
+            try {
+                isCompact = getBoolean(eu.darken.sdmse.R.styleable.SpaceHistoryChartView_isCompact, false)
+            } finally {
+                recycle()
+            }
+        }
+        updateColors()
+        updateTextSizes()
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        updateColors()
+    }
+
+    fun setOnMarkerTapListener(listener: OnMarkerTapListener?) {
+        markerTapListener = listener
+    }
+
+    fun setData(snapshots: List<SpaceSnapshotEntity>) {
+        this.snapshots = snapshots.sortedBy { it.recordedAt }
+        selectedMarkerIndex = -1
+        invalidate()
+    }
+
+    fun setReports(reports: List<ReportEntity>) {
+        this.reports = reports
+        selectedMarkerIndex = -1
+        invalidate()
+    }
+
+    fun clearSelection() {
+        if (selectedMarkerIndex != -1) {
+            selectedMarkerIndex = -1
+            invalidate()
+        }
+    }
+
+    private var pendingTapMarkerIndex: Int = -1
+
+    @Suppress("ClickableViewAccessibility")
+    override fun onTouchEvent(event: MotionEvent): Boolean {
+        if (isCompact || markerTapListener == null) return false
+
+        when (event.actionMasked) {
+            MotionEvent.ACTION_DOWN -> {
+                val hitIndex = findHitMarker(event.x, event.y)
+                if (hitIndex >= 0) {
+                    pendingTapMarkerIndex = hitIndex
+                    parent?.requestDisallowInterceptTouchEvent(true)
+                    return true
+                }
+            }
+
+            MotionEvent.ACTION_UP -> {
+                val downIndex = pendingTapMarkerIndex
+                pendingTapMarkerIndex = -1
+                parent?.requestDisallowInterceptTouchEvent(false)
+                if (downIndex >= 0 && downIndex < markerPositions.size) {
+                    val hitIndex = findHitMarker(event.x, event.y)
+                    if (hitIndex == downIndex) {
+                        selectedMarkerIndex = hitIndex
+                        invalidate()
+                        val marker = markerPositions[hitIndex]
+                        val location = IntArray(2)
+                        getLocationOnScreen(location)
+                        markerTapListener?.onMarkerTapped(
+                            marker.report,
+                            location[0] + marker.point.x.toInt(),
+                            location[1] + marker.point.y.toInt(),
+                        )
+                        return true
+                    }
+                }
+            }
+
+            MotionEvent.ACTION_CANCEL -> {
+                pendingTapMarkerIndex = -1
+                parent?.requestDisallowInterceptTouchEvent(false)
+            }
+        }
+        return false
+    }
+
+    private fun findHitMarker(touchX: Float, touchY: Float): Int {
+        var bestIndex = -1
+        var bestDist = Float.MAX_VALUE
+        for ((index, marker) in markerPositions.withIndex()) {
+            val dx = touchX - marker.point.x
+            val dy = touchY - marker.point.y
+            val dist = sqrt(dx * dx + dy * dy)
+            if (dist <= hitRadiusPx && dist < bestDist) {
+                bestDist = dist
+                bestIndex = index
+            }
+        }
+        return bestIndex
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+        if (snapshots.isEmpty()) return
+
+        val yLabelWidth = if (isCompact) context.dpToPx(44f).toFloat() else context.dpToPx(60f).toFloat()
+        val xLabelHeight = if (isCompact) context.dpToPx(14f).toFloat() else context.dpToPx(20f).toFloat()
+        val topPadding = if (isCompact) context.dpToPx(4f).toFloat() else context.dpToPx(8f).toFloat()
+
+        val chartLeft = paddingLeft + yLabelWidth
+        val chartTop = paddingTop + topPadding
+        val chartRight = width - paddingRight.toFloat()
+        val chartBottom = height - paddingBottom.toFloat() - xLabelHeight
+
+        if (chartRight <= chartLeft || chartBottom <= chartTop) return
+
+        val minValue = snapshots.minOf { it.spaceCapacity - it.spaceFree }.toFloat()
+        val maxValue = max(snapshots.maxOf { it.spaceCapacity - it.spaceFree }.toFloat(), minValue + 1f)
+        val yRange = maxValue - minValue
+
+        val minTime = snapshots.first().recordedAt.toEpochMilli()
+        val maxTime = max(snapshots.last().recordedAt.toEpochMilli(), minTime + 1L)
+
+        if (!isCompact) {
+            drawGrid(canvas, chartLeft, chartTop, chartRight, chartBottom)
+        }
+
+        val linePath = Path()
+        val fillPath = Path()
+        snapshots.forEachIndexed { index, snapshot ->
+            val x = pointX(snapshot, index, minTime, maxTime, chartLeft, chartRight)
+            val y = pointY(snapshot.spaceCapacity - snapshot.spaceFree, minValue, yRange, chartTop, chartBottom)
+            if (index == 0) {
+                linePath.moveTo(x, y)
+                fillPath.moveTo(x, chartBottom)
+                fillPath.lineTo(x, y)
+            } else {
+                linePath.lineTo(x, y)
+                fillPath.lineTo(x, y)
+            }
+        }
+
+        val endX = pointX(snapshots.last(), snapshots.lastIndex, minTime, maxTime, chartLeft, chartRight)
+        fillPath.lineTo(endX, chartBottom)
+        fillPath.close()
+
+        canvas.drawPath(fillPath, fillPaint)
+        canvas.drawPath(linePath, linePaint)
+
+        drawMarkers(canvas, chartLeft, chartTop, chartRight, chartBottom, minTime, maxTime, minValue, yRange)
+
+        if (isCompact) {
+            drawCompactLabels(canvas, chartLeft, chartTop, chartRight, chartBottom, minValue, maxValue)
+        } else {
+            drawLabels(canvas, chartLeft, chartTop, chartRight, chartBottom, minValue, maxValue)
+        }
+    }
+
+    private fun pointX(
+        snapshot: SpaceSnapshotEntity,
+        index: Int,
+        minTime: Long,
+        maxTime: Long,
+        chartLeft: Float,
+        chartRight: Float,
+    ): Float {
+        val width = chartRight - chartLeft
+        return if (minTime == maxTime) {
+            val fraction = if (snapshots.size <= 1) 0f else index.toFloat() / (snapshots.size - 1).toFloat()
+            chartLeft + (fraction * width)
+        } else {
+            val fraction = (snapshot.recordedAt.toEpochMilli() - minTime).toFloat() / (maxTime - minTime).toFloat()
+            chartLeft + (fraction * width)
+        }
+    }
+
+    private fun pointY(
+        value: Long,
+        minValue: Float,
+        yRange: Float,
+        chartTop: Float,
+        chartBottom: Float,
+    ): Float {
+        val height = chartBottom - chartTop
+        val fraction = (value.toFloat() - minValue) / yRange
+        return chartBottom - (fraction * height)
+    }
+
+    private fun drawGrid(canvas: Canvas, left: Float, top: Float, right: Float, bottom: Float) {
+        val lines = 3
+        repeat(lines + 1) { index ->
+            val y = top + ((bottom - top) / lines.toFloat() * index)
+            canvas.drawLine(left, y, right, y, gridPaint)
+        }
+    }
+
+    private fun drawLabels(
+        canvas: Canvas,
+        left: Float,
+        top: Float,
+        right: Float,
+        bottom: Float,
+        minValue: Float,
+        maxValue: Float,
+    ) {
+        val midValue = (minValue + maxValue) / 2f
+        val labelX = left - context.dpToPx(8f)
+
+        canvas.drawText(formatBytes(maxValue.toLong()), labelX.toFloat(), top + labelPaint.textSize, labelPaint)
+        canvas.drawText(
+            formatBytes(midValue.toLong()),
+            labelX.toFloat(),
+            top + ((bottom - top) / 2f) + (labelPaint.textSize / 2f),
+            labelPaint,
+        )
+        canvas.drawText(formatBytes(minValue.toLong()), labelX.toFloat(), bottom, labelPaint)
+
+        val start = snapshots.first().recordedAt.atZone(ZoneId.systemDefault()).format(dateFormatter)
+        val end = snapshots.last().recordedAt.atZone(ZoneId.systemDefault()).format(dateFormatter)
+        val xLabelY = bottom + context.dpToPx(16f)
+
+        xLabelPaint.textAlign = Paint.Align.LEFT
+        canvas.drawText(start, left, xLabelY.toFloat(), xLabelPaint)
+
+        xLabelPaint.textAlign = Paint.Align.RIGHT
+        canvas.drawText(end, right, xLabelY.toFloat(), xLabelPaint)
+    }
+
+    private fun drawCompactLabels(
+        canvas: Canvas,
+        left: Float,
+        top: Float,
+        right: Float,
+        bottom: Float,
+        minValue: Float,
+        maxValue: Float,
+    ) {
+        val labelX = left - context.dpToPx(4f)
+
+        canvas.drawText(formatBytes(maxValue.toLong()), labelX.toFloat(), top + labelPaint.textSize, labelPaint)
+        canvas.drawText(formatBytes(minValue.toLong()), labelX.toFloat(), bottom, labelPaint)
+
+        val start = snapshots.first().recordedAt.atZone(ZoneId.systemDefault()).format(dateFormatter)
+        val end = snapshots.last().recordedAt.atZone(ZoneId.systemDefault()).format(dateFormatter)
+        val xLabelY = bottom + context.dpToPx(12f)
+
+        xLabelPaint.textAlign = Paint.Align.LEFT
+        canvas.drawText(start, left, xLabelY.toFloat(), xLabelPaint)
+
+        xLabelPaint.textAlign = Paint.Align.RIGHT
+        canvas.drawText(end, right, xLabelY.toFloat(), xLabelPaint)
+    }
+
+    private fun drawMarkers(
+        canvas: Canvas,
+        chartLeft: Float,
+        chartTop: Float,
+        chartRight: Float,
+        chartBottom: Float,
+        minTime: Long,
+        maxTime: Long,
+        minValue: Float,
+        yRange: Float,
+    ) {
+        if (reports.isEmpty() || snapshots.size < 2) {
+            markerPositions = emptyList()
+            return
+        }
+
+        val markerRadius = if (isCompact) context.dpToPx(3f).toFloat() else context.dpToPx(4f).toFloat()
+        val selectedRadius = markerRadius * 1.5f
+        val chartWidth = chartRight - chartLeft
+
+        val positions = mutableListOf<MarkerPosition>()
+
+        for ((index, report) in reports.withIndex()) {
+            val reportTime = report.endAt.toEpochMilli()
+            if (reportTime < minTime || reportTime > maxTime) continue
+
+            val fraction = (reportTime - minTime).toFloat() / (maxTime - minTime).toFloat()
+            val x = chartLeft + fraction * chartWidth
+            val y = interpolateY(reportTime, minValue, yRange, chartTop, chartBottom) ?: continue
+
+            val isSelected = index == selectedMarkerIndex
+            if (isSelected) {
+                canvas.drawCircle(x, y, selectedRadius, selectedMarkerPaint)
+                canvas.drawCircle(x, y, selectedRadius, markerStrokePaint)
+            } else {
+                canvas.drawCircle(x, y, markerRadius, markerPaint)
+                canvas.drawCircle(x, y, markerRadius, markerStrokePaint)
+            }
+
+            positions.add(MarkerPosition(report, PointF(x, y)))
+        }
+
+        markerPositions = positions
+    }
+
+    private fun interpolateY(
+        timeMillis: Long,
+        minValue: Float,
+        yRange: Float,
+        chartTop: Float,
+        chartBottom: Float,
+    ): Float? {
+        var before: SpaceSnapshotEntity? = null
+        var after: SpaceSnapshotEntity? = null
+        for (snapshot in snapshots) {
+            if (snapshot.recordedAt.toEpochMilli() <= timeMillis) {
+                before = snapshot
+            } else {
+                after = snapshot
+                break
+            }
+        }
+
+        val usedValue = when {
+            before != null && after != null -> {
+                val t0 = before.recordedAt.toEpochMilli()
+                val t1 = after.recordedAt.toEpochMilli()
+                val v0 = (before.spaceCapacity - before.spaceFree).toFloat()
+                val v1 = (after.spaceCapacity - after.spaceFree).toFloat()
+                val t = (timeMillis - t0).toFloat() / (t1 - t0).toFloat()
+                v0 + t * (v1 - v0)
+            }
+            before != null -> (before.spaceCapacity - before.spaceFree).toFloat()
+            after != null -> (after.spaceCapacity - after.spaceFree).toFloat()
+            else -> return null
+        }
+
+        val height = chartBottom - chartTop
+        val fraction = (usedValue - minValue) / yRange
+        return chartBottom - (fraction * height)
+    }
+
+    private fun formatBytes(value: Long): String = ByteFormatter.formatSize(context, value).first
+
+    private fun updateTextSizes() {
+        val textSize = if (isCompact) context.spToPx(9f) else context.spToPx(11f)
+        labelPaint.textSize = textSize
+        xLabelPaint.textSize = textSize
+    }
+
+    private fun updateColors() {
+        val primary = context.getColorForAttr(androidx.appcompat.R.attr.colorPrimary)
+        val surfaceVariant = context.getColorForAttr(com.google.android.material.R.attr.colorSurfaceVariant)
+        val textSecondary = context.getColorForAttr(android.R.attr.textColorSecondary)
+        val tertiary = context.getColorForAttr(com.google.android.material.R.attr.colorTertiary)
+        val surface = context.getColorForAttr(com.google.android.material.R.attr.colorSurface)
+
+        linePaint.color = primary
+        fillPaint.color = (primary and 0x00FFFFFF) or 0x33000000
+        gridPaint.color = surfaceVariant
+        labelPaint.color = textSecondary
+        xLabelPaint.color = textSecondary
+        markerPaint.color = tertiary
+        markerStrokePaint.color = surface
+        selectedMarkerPaint.color = (tertiary and 0x00FFFFFF) or 0xCC000000.toInt()
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/stats/ui/spacehistory/SpaceHistoryFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/stats/ui/spacehistory/SpaceHistoryFragment.kt
@@ -1,0 +1,180 @@
+package eu.darken.sdmse.stats.ui.spacehistory
+
+import android.os.Bundle
+import android.text.format.Formatter
+import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.PopupWindow
+import android.widget.TextView
+import androidx.core.view.isGone
+import androidx.core.view.isVisible
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import androidx.navigation.ui.setupWithNavController
+import com.google.android.material.chip.Chip
+import dagger.hilt.android.AndroidEntryPoint
+import eu.darken.sdmse.R
+import eu.darken.sdmse.common.ByteFormatter
+import eu.darken.sdmse.common.EdgeToEdgeHelper
+import eu.darken.sdmse.common.getColorForAttr
+import eu.darken.sdmse.common.uix.Fragment3
+import eu.darken.sdmse.common.viewbinding.viewBinding
+import eu.darken.sdmse.databinding.StatsSpaceHistoryFragmentBinding
+import eu.darken.sdmse.main.core.iconRes
+import eu.darken.sdmse.main.core.labelRes
+import eu.darken.sdmse.stats.core.db.ReportEntity
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+import kotlin.math.absoluteValue
+
+@AndroidEntryPoint
+class SpaceHistoryFragment : Fragment3(R.layout.stats_space_history_fragment) {
+
+    override val vm: SpaceHistoryViewModel by viewModels()
+    override val ui: StatsSpaceHistoryFragmentBinding by viewBinding()
+
+    private var activePopup: PopupWindow? = null
+    private val timeFormatter = DateTimeFormatter.ofPattern("h:mm a", Locale.getDefault())
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        EdgeToEdgeHelper(requireActivity()).apply {
+            insetsPadding(ui.root, left = true, right = true)
+            insetsPadding(ui.appbarlayout, top = true)
+            insetsPadding(ui.scrollView, bottom = true)
+            insetsPadding(ui.loadingOverlay, bottom = true)
+        }
+
+        ui.toolbar.setupWithNavController(findNavController())
+
+        ui.chart.setOnMarkerTapListener { report, screenX, screenY ->
+            showMarkerTooltip(report, screenX, screenY)
+        }
+
+        ui.rangeChipGroup.setOnCheckedStateChangeListener { _, checkedIds ->
+            val checkedId = checkedIds.firstOrNull() ?: return@setOnCheckedStateChangeListener
+            when (checkedId) {
+                R.id.range_7d -> vm.selectRange(SpaceHistoryViewModel.Range.DAYS_7)
+                R.id.range_30d -> vm.selectRange(SpaceHistoryViewModel.Range.DAYS_30)
+                R.id.range_90d -> vm.selectRange(SpaceHistoryViewModel.Range.DAYS_90)
+            }
+        }
+
+        ui.upgradeAction.setOnClickListener { vm.openUpgrade() }
+
+        vm.state.observe2(ui) { state ->
+            loadingOverlay.isGone = true
+            contentContainer.isVisible = true
+
+            when (state.selectedRange) {
+                SpaceHistoryViewModel.Range.DAYS_7 -> range7d.isChecked = true
+                SpaceHistoryViewModel.Range.DAYS_30 -> range30d.isChecked = true
+                SpaceHistoryViewModel.Range.DAYS_90 -> range90d.isChecked = true
+            }
+            range30d.isEnabled = state.isPro
+            range90d.isEnabled = state.isPro
+
+            chart.setData(state.snapshots)
+            chart.setReports(state.reportMarkers)
+
+            currentValue.text = state.currentUsed?.let { Formatter.formatShortFileSize(requireContext(), it) } ?: "-"
+            minValue.text = state.minUsed?.let { Formatter.formatShortFileSize(requireContext(), it) } ?: "-"
+            maxValue.text = state.maxUsed?.let { Formatter.formatShortFileSize(requireContext(), it) } ?: "-"
+            deltaValue.text = state.deltaUsed?.let { delta ->
+                val absDelta = Formatter.formatShortFileSize(requireContext(), delta.absoluteValue)
+                val signed = when {
+                    delta > 0 -> "+$absDelta"
+                    delta < 0 -> "-$absDelta"
+                    else -> absDelta
+                }
+                getString(R.string.stats_space_history_delta_in_x, signed, rangeToLabel(state.selectedRange))
+            } ?: "-"
+
+            deltaValue.setTextColor(
+                when {
+                    state.deltaUsed == null -> deltaValue.currentTextColor
+                    state.deltaUsed > 0 -> deltaValue.context.getColorForAttr(android.R.attr.colorError)
+                    state.deltaUsed < 0 -> deltaValue.context.getColorForAttr(androidx.appcompat.R.attr.colorPrimary)
+                    else -> deltaValue.context.getColorForAttr(android.R.attr.textColorSecondary)
+                }
+            )
+
+            storageTitle.isVisible = state.storages.size > 1
+            storageChipGroup.isVisible = state.storages.isNotEmpty()
+            storageChipGroup.removeAllViews()
+            state.storages.forEach { storage ->
+                val chip = (layoutInflater.inflate(
+                    R.layout.stats_space_history_storage_chip, storageChipGroup, false
+                ) as Chip).apply {
+                    text = storage.label.get(context)
+                    isCheckable = true
+                    isChecked = storage.id == state.selectedStorageId
+                    setOnClickListener { vm.selectStorage(storage.id) }
+                }
+                storageChipGroup.addView(chip)
+            }
+
+            upgradeCard.isVisible = state.showUpgradePrompt
+        }
+
+        super.onViewCreated(view, savedInstanceState)
+    }
+
+    private fun showMarkerTooltip(report: ReportEntity, screenX: Int, screenY: Int) {
+        dismissTooltip()
+
+        val tooltipView = layoutInflater.inflate(R.layout.stats_space_history_marker_tooltip, null)
+        tooltipView.findViewById<ImageView>(R.id.tooltip_icon).setImageResource(report.tool.iconRes)
+        tooltipView.findViewById<TextView>(R.id.tooltip_tool_name).setText(report.tool.labelRes)
+
+        val detail = tooltipView.findViewById<TextView>(R.id.tooltip_detail)
+        val time = report.endAt.atZone(ZoneId.systemDefault()).format(timeFormatter)
+        detail.text = if (report.affectedSpace != null && report.affectedSpace > 0) {
+            val freed = ByteFormatter.formatSize(requireContext(), report.affectedSpace).first
+            "${getString(R.string.stats_space_history_marker_freed, freed)} · $time"
+        } else {
+            time
+        }
+
+        val popup = PopupWindow(
+            tooltipView,
+            ViewGroup.LayoutParams.WRAP_CONTENT,
+            ViewGroup.LayoutParams.WRAP_CONTENT,
+            true,
+        ).apply {
+            isOutsideTouchable = true
+            elevation = 8f
+            setOnDismissListener { ui.chart.clearSelection() }
+        }
+
+        tooltipView.measure(
+            View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED),
+            View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED),
+        )
+
+        val margin = (12 * resources.displayMetrics.density).toInt()
+        val popupX = screenX - tooltipView.measuredWidth / 2
+        val popupY = screenY - tooltipView.measuredHeight - margin
+
+        popup.showAtLocation(ui.chart, Gravity.NO_GRAVITY, popupX, popupY)
+        activePopup = popup
+    }
+
+    private fun dismissTooltip() {
+        activePopup?.dismiss()
+        activePopup = null
+    }
+
+    override fun onDestroyView() {
+        dismissTooltip()
+        super.onDestroyView()
+    }
+
+    private fun rangeToLabel(range: SpaceHistoryViewModel.Range): String = when (range) {
+        SpaceHistoryViewModel.Range.DAYS_7 -> getString(R.string.stats_space_history_range_7d)
+        SpaceHistoryViewModel.Range.DAYS_30 -> getString(R.string.stats_space_history_range_30d)
+        SpaceHistoryViewModel.Range.DAYS_90 -> getString(R.string.stats_space_history_range_90d)
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/stats/ui/spacehistory/SpaceHistoryViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/stats/ui/spacehistory/SpaceHistoryViewModel.kt
@@ -1,0 +1,213 @@
+package eu.darken.sdmse.stats.ui.spacehistory
+
+import android.os.storage.StorageManager
+import androidx.lifecycle.SavedStateHandle
+import dagger.hilt.android.lifecycle.HiltViewModel
+import eu.darken.sdmse.MainDirections
+import eu.darken.sdmse.R
+import eu.darken.sdmse.common.ca.CaString
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.coroutine.DispatcherProvider
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.storage.StorageId
+import eu.darken.sdmse.common.storage.StorageManager2
+import eu.darken.sdmse.common.upgrade.UpgradeRepo
+import eu.darken.sdmse.common.upgrade.isPro
+import eu.darken.sdmse.common.uix.ViewModel3
+import eu.darken.sdmse.stats.core.SpaceHistoryRepo
+import eu.darken.sdmse.stats.core.db.ReportEntity
+import eu.darken.sdmse.stats.core.db.SpaceSnapshotEntity
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import java.time.Duration
+import java.time.Instant
+import java.util.UUID
+import javax.inject.Inject
+
+@HiltViewModel
+class SpaceHistoryViewModel @Inject constructor(
+    @Suppress("unused") private val handle: SavedStateHandle,
+    dispatcherProvider: DispatcherProvider,
+    private val spaceHistoryRepo: SpaceHistoryRepo,
+    private val upgradeRepo: UpgradeRepo,
+    private val storageManager2: StorageManager2,
+) : ViewModel3(dispatcherProvider) {
+
+    private val selectedStorageId = MutableStateFlow(handle.get<String?>("storageId"))
+    private val selectedRange = MutableStateFlow(Range.DAYS_7)
+
+    private val storages = spaceHistoryRepo.getAvailableStorageIds()
+        .map { snapshotIds -> resolveStorageOptions(snapshotIds) }
+
+    init {
+        log(TAG) { "init(storageId=${handle.get<String?>("storageId")})" }
+
+        combine(
+            storages,
+            selectedStorageId,
+        ) { storages, selectedId ->
+            storages to selectedId
+        }
+            .onEach { (storages, selectedId) ->
+                if (storages.isEmpty()) return@onEach
+                if (selectedId == null || storages.none { it.id == selectedId }) {
+                    selectedStorageId.value = storages.first().id
+                }
+            }
+            .launchInViewModel()
+
+        upgradeRepo.upgradeInfo
+            .map { it.isPro }
+            .onEach { isPro ->
+                if (!isPro && selectedRange.value != Range.DAYS_7) {
+                    selectedRange.value = Range.DAYS_7
+                }
+            }
+            .launchInViewModel()
+    }
+
+    private val snapshots = combine(
+        selectedStorageId,
+        selectedRange,
+        upgradeRepo.upgradeInfo.map { it.isPro },
+    ) { storageId, range, isPro ->
+        Query(
+            storageId = storageId,
+            since = Instant.now() - if (isPro) range.retention else Range.DAYS_7.retention,
+        )
+    }
+        .flatMapLatest { query ->
+            if (query.storageId == null) {
+                flowOf(emptyList())
+            } else {
+                spaceHistoryRepo.getHistory(query.storageId, query.since)
+            }
+        }
+
+    private val reportMarkers = combine(
+        selectedRange,
+        upgradeRepo.upgradeInfo.map { it.isPro },
+    ) { range, isPro ->
+        Instant.now() - if (isPro) range.retention else Range.DAYS_7.retention
+    }
+        .flatMapLatest { since -> spaceHistoryRepo.getReports(since) }
+
+    val state = eu.darken.sdmse.common.flow.combine(
+        upgradeRepo.upgradeInfo.map { it.isPro },
+        storages,
+        selectedStorageId,
+        selectedRange,
+        snapshots,
+        reportMarkers,
+    ) { isPro, storages, selectedStorageId, selectedRange, snapshots, reports ->
+        State(
+            isPro = isPro,
+            showUpgradePrompt = !isPro,
+            storages = storages,
+            selectedStorageId = selectedStorageId,
+            selectedRange = selectedRange,
+            snapshots = snapshots,
+            reportMarkers = reports,
+            currentUsed = snapshots.lastOrNull()?.let { it.spaceCapacity - it.spaceFree },
+            minUsed = snapshots.minOfOrNull { it.spaceCapacity - it.spaceFree },
+            maxUsed = snapshots.maxOfOrNull { it.spaceCapacity - it.spaceFree },
+            deltaUsed = if (snapshots.size >= 2) {
+                val lastUsed = snapshots.last().let { it.spaceCapacity - it.spaceFree }
+                val firstUsed = snapshots.first().let { it.spaceCapacity - it.spaceFree }
+                lastUsed - firstUsed
+            } else null,
+        )
+    }.asLiveData2()
+
+    fun selectRange(range: Range) = launch {
+        log(TAG) { "selectRange($range)" }
+        if (range != Range.DAYS_7 && !upgradeRepo.isPro()) {
+            MainDirections.goToUpgradeFragment().navigate()
+            return@launch
+        }
+        selectedRange.value = range
+    }
+
+    fun selectStorage(storageId: String) {
+        log(TAG) { "selectStorage($storageId)" }
+        selectedStorageId.value = storageId
+    }
+
+    fun openUpgrade() {
+        log(TAG) { "openUpgrade()" }
+        MainDirections.goToUpgradeFragment().navigate()
+    }
+
+    data class State(
+        val isPro: Boolean,
+        val showUpgradePrompt: Boolean,
+        val storages: List<StorageOption>,
+        val selectedStorageId: String?,
+        val selectedRange: Range,
+        val snapshots: List<SpaceSnapshotEntity>,
+        val reportMarkers: List<ReportEntity>,
+        val currentUsed: Long?,
+        val minUsed: Long?,
+        val maxUsed: Long?,
+        val deltaUsed: Long?,
+    )
+
+    data class StorageOption(
+        val id: String,
+        val label: CaString,
+    )
+
+    enum class Range(val retention: Duration) {
+        DAYS_7(Duration.ofDays(7)),
+        DAYS_30(Duration.ofDays(30)),
+        DAYS_90(Duration.ofDays(90)),
+    }
+
+    private data class Query(
+        val storageId: String?,
+        val since: Instant,
+    )
+
+    private fun resolveStorageOptions(snapshotIds: List<String>): List<StorageOption> {
+        val systemLabels = mutableMapOf<String, CaString>()
+        systemLabels[PRIMARY_STORAGE_ID] = R.string.analyzer_storage_type_primary_title.toCaString()
+
+        (storageManager2.volumes ?: emptyList())
+            .filter { it.isMounted && it.fsUuid != null }
+            .forEach { volume ->
+                val uuid = StorageId.parseVolumeUuid(volume.fsUuid) ?: return@forEach
+                val typeLabel = when {
+                    volume.isPrimary == true -> R.string.analyzer_storage_type_primary_title.toCaString()
+                    volume.disk?.isUsb == true -> R.string.analyzer_storage_type_tertiary_title.toCaString()
+                    else -> R.string.analyzer_storage_type_secondary_title.toCaString()
+                }
+                systemLabels[uuid.toString()] = typeLabel
+            }
+
+        return snapshotIds.map { storageId ->
+            StorageOption(
+                id = storageId,
+                label = systemLabels[storageId] ?: fallbackStorageLabel(storageId),
+            )
+        }
+    }
+
+    private fun fallbackStorageLabel(storageId: String): CaString {
+        return if (storageId == PRIMARY_STORAGE_ID) {
+            R.string.analyzer_storage_type_primary_title.toCaString()
+        } else {
+            R.string.analyzer_storage_type_secondary_title.toCaString()
+        }
+    }
+
+    companion object {
+        private val PRIMARY_STORAGE_ID: String =
+            (StorageManager.UUID_DEFAULT ?: UUID.fromString("00000000-0000-0000-0000-000000000000")).toString()
+        private val TAG = logTag("Stats", "SpaceHistory", "ViewModel")
+    }
+}

--- a/app/src/main/res/layout/analyzer_dashboard_item.xml
+++ b/app/src/main/res/layout/analyzer_dashboard_item.xml
@@ -45,11 +45,27 @@
             android:layout_marginTop="4dp"
             android:layout_marginEnd="8dp"
             android:text="@string/analyzer_explanation_short"
-            app:layout_constraintBottom_toTopOf="@id/view_action"
+            app:layout_constraintBottom_toTopOf="@id/trend_delta"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/title"
             app:layout_constraintVertical_chainStyle="spread_inside" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/trend_delta"
+            style="@style/TextAppearance.Material3.BodySmall"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="4dp"
+            android:layout_marginEnd="8dp"
+            android:visibility="gone"
+            app:layout_constraintBottom_toTopOf="@id/view_action"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/subtitle"
+            tools:text="+2.5 GB in 7d"
+            tools:visibility="visible" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/view_action"

--- a/app/src/main/res/layout/analyzer_device_vh.xml
+++ b/app/src/main/res/layout/analyzer_device_vh.xml
@@ -99,14 +99,43 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="4dp"
-            android:layout_marginBottom="16dp"
+            android:layout_marginBottom="8dp"
             android:textColor="?colorError"
             android:textStyle="bold"
-            app:layout_constraintBottom_toTopOf="@id/available"
+            app:layout_constraintBottom_toTopOf="@id/trend_container"
             app:layout_constraintEnd_toEndOf="@id/secondary"
             app:layout_constraintStart_toStartOf="@id/secondary"
             app:layout_constraintTop_toBottomOf="@id/secondary"
             tools:text="@string/analyzer_storage_content_type_app_setup_incomplete_hint" />
+
+        <LinearLayout
+            android:id="@+id/trend_container"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="16dp"
+            android:layout_marginBottom="8dp"
+            android:orientation="vertical"
+            android:visibility="gone"
+            app:layout_constraintBottom_toTopOf="@id/available"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/progress"
+            app:layout_constraintTop_toBottomOf="@id/tertiary"
+            tools:visibility="visible">
+
+            <eu.darken.sdmse.stats.ui.spacehistory.SpaceHistoryChartView
+                android:id="@+id/trend_chart"
+                android:layout_width="match_parent"
+                android:layout_height="80dp"
+                app:isCompact="true" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/trend_delta"
+                style="@style/TextAppearance.Material3.LabelSmall"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                tools:text="+1.2 GB in 7d" />
+        </LinearLayout>
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/available"
@@ -121,6 +150,7 @@
             app:layout_constraintEnd_toStartOf="@id/capacity"
             app:layout_constraintHorizontal_chainStyle="spread_inside"
             app:layout_constraintStart_toEndOf="@id/progress"
+            app:layout_constraintTop_toBottomOf="@id/trend_container"
             app:layout_constraintVertical_bias="1.0"
             tools:text="13.59 GB available" />
 

--- a/app/src/main/res/layout/stats_space_history_fragment.xml
+++ b/app/src/main/res/layout/stats_space_history_fragment.xml
@@ -1,0 +1,214 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    style="@style/BaseScreen"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbarlayout"
+        style="@style/SDMAppBar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            style="@style/SDMToolbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:title="@string/stats_space_history_title" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/scroll_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <LinearLayout
+            android:id="@+id/content_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="16dp">
+
+            <eu.darken.sdmse.stats.ui.spacehistory.SpaceHistoryChartView
+                android:id="@+id/chart"
+                android:layout_width="match_parent"
+                android:layout_height="250dp"
+                android:layout_marginBottom="16dp" />
+
+            <com.google.android.material.textview.MaterialTextView
+                style="@style/TextAppearance.Material3.LabelLarge"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/stats_space_history_range_title" />
+
+            <com.google.android.material.chip.ChipGroup
+                android:id="@+id/range_chip_group"
+                style="@style/Widget.Material3.ChipGroup"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:singleLine="true"
+                app:singleSelection="true">
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/range_7d"
+                    style="@style/Widget.Material3.Chip.Filter"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:checked="true"
+                    android:text="@string/stats_space_history_range_7d" />
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/range_30d"
+                    style="@style/Widget.Material3.Chip.Filter"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/stats_space_history_range_30d" />
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/range_90d"
+                    style="@style/Widget.Material3.Chip.Filter"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/stats_space_history_range_90d" />
+            </com.google.android.material.chip.ChipGroup>
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/storage_title"
+                style="@style/TextAppearance.Material3.LabelLarge"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:text="@string/stats_space_history_storage_title"
+                android:visibility="gone" />
+
+            <com.google.android.material.chip.ChipGroup
+                android:id="@+id/storage_chip_group"
+                style="@style/Widget.Material3.ChipGroup"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:singleLine="false"
+                app:singleSelection="true"
+                tools:visibility="visible" />
+
+            <com.google.android.material.card.MaterialCardView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:padding="16dp">
+
+                    <com.google.android.material.textview.MaterialTextView
+                        style="@style/TextAppearance.Material3.BodyMedium"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/stats_space_history_current_free_label" />
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:id="@+id/current_value"
+                        style="@style/TextAppearance.Material3.TitleMedium"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        tools:text="41.2 GB" />
+
+                    <com.google.android.material.textview.MaterialTextView
+                        style="@style/TextAppearance.Material3.BodyMedium"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="12dp"
+                        android:text="@string/stats_space_history_min_label" />
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:id="@+id/min_value"
+                        style="@style/TextAppearance.Material3.TitleMedium"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        tools:text="39.8 GB" />
+
+                    <com.google.android.material.textview.MaterialTextView
+                        style="@style/TextAppearance.Material3.BodyMedium"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="12dp"
+                        android:text="@string/stats_space_history_max_label" />
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:id="@+id/max_value"
+                        style="@style/TextAppearance.Material3.TitleMedium"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        tools:text="44.1 GB" />
+
+                    <com.google.android.material.textview.MaterialTextView
+                        style="@style/TextAppearance.Material3.BodyMedium"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="12dp"
+                        android:text="@string/stats_space_history_delta_label" />
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:id="@+id/delta_value"
+                        style="@style/TextAppearance.Material3.TitleMedium"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        tools:text="+1.2 GB in 7d" />
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/upgrade_card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:visibility="gone"
+                tools:visibility="visible">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:padding="16dp">
+
+                    <com.google.android.material.textview.MaterialTextView
+                        style="@style/TextAppearance.Material3.TitleMedium"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/stats_space_history_upgrade_title" />
+
+                    <com.google.android.material.textview.MaterialTextView
+                        style="@style/TextAppearance.Material3.BodyMedium"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:text="@string/stats_space_history_upgrade_body" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/upgrade_action"
+                        style="@style/Widget.Material3.Button"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="12dp"
+                        android:text="@string/general_upgrade_action" />
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+        </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
+
+    <eu.darken.sdmse.common.progress.ProgressOverlayView
+        android:id="@+id/loading_overlay"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_margin="64dp"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/stats_space_history_marker_tooltip.xml
+++ b/app/src/main/res/layout/stats_space_history_marker_tooltip.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    app:cardCornerRadius="8dp"
+    app:cardElevation="4dp">
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:paddingHorizontal="12dp"
+        android:paddingVertical="8dp">
+
+        <ImageView
+            android:id="@+id/tooltip_icon"
+            android:layout_width="20dp"
+            android:layout_height="20dp"
+            android:importantForAccessibility="no"
+            tools:src="@drawable/ic_recycle" />
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:orientation="vertical">
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/tooltip_tool_name"
+                style="@style/TextAppearance.Material3.LabelMedium"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                tools:text="AppCleaner" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/tooltip_detail"
+                style="@style/TextAppearance.Material3.BodySmall"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                tools:text="Freed 1.2 GB · 2:30 PM" />
+        </LinearLayout>
+    </LinearLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/stats_space_history_storage_chip.xml
+++ b/app/src/main/res/layout/stats_space_history_storage_chip.xml
@@ -1,0 +1,4 @@
+<com.google.android.material.chip.Chip xmlns:android="http://schemas.android.com/apk/res/android"
+    style="@style/Widget.Material3.Chip.Filter"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content" />

--- a/app/src/main/res/menu/menu_stats_reports.xml
+++ b/app/src/main/res/menu/menu_stats_reports.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/action_storage_trend"
+        android:icon="@drawable/ic_chart_bar_stacked_24"
+        android:title="@string/stats_storage_trend_action"
+        app:showAsAction="ifRoom" />
+
+</menu>

--- a/app/src/main/res/navigation/main_nav.xml
+++ b/app/src/main/res/navigation/main_nav.xml
@@ -152,6 +152,9 @@
         android:id="@+id/goToReportsFragment"
         app:destination="@id/reportsFragment" />
     <action
+        android:id="@+id/goToSpaceHistoryFragment"
+        app:destination="@id/spaceHistoryFragment" />
+    <action
         android:id="@+id/goToSwiperSessions"
         app:destination="@id/swiperSessionsFragment" />
     <fragment
@@ -537,6 +540,19 @@
         <action
             android:id="@+id/action_reportsFragment_to_affectedPkgsFragment"
             app:destination="@id/affectedPkgsFragment" />
+        <action
+            android:id="@+id/action_reportsFragment_to_spaceHistoryFragment"
+            app:destination="@id/spaceHistoryFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/spaceHistoryFragment"
+        android:name="eu.darken.sdmse.stats.ui.spacehistory.SpaceHistoryFragment"
+        tools:layout="@layout/stats_space_history_fragment">
+        <argument
+            android:name="storageId"
+            android:defaultValue="@null"
+            app:argType="string"
+            app:nullable="true" />
     </fragment>
     <fragment
         android:id="@+id/affectedFilesFragment"

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -16,4 +16,7 @@
             <enum name="party" value="4" />
         </attr>
     </declare-styleable>
+    <declare-styleable name="SpaceHistoryChartView">
+        <attr name="isCompact" format="boolean" />
+    </declare-styleable>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -971,6 +971,7 @@
         <item quantity="one">%s item processed since you invited SD Maid to your device.</item>
         <item quantity="other">%s items processed since you invited SD Maid to your device.</item>
     </plurals>
+    <string name="stats_dash_body_snapshots_only">Tracking your storage history.</string>
     <string name="stats_report_status_success">Success</string>
     <string name="stats_report_status_partial_success">Partial success</string>
     <string name="stats_report_status_partial_failure">Failure</string>
@@ -988,6 +989,22 @@
     <string name="stats_settings_reset_all_desc">Delete all reports and set all statistics to zero.</string>
     <string name="stats_affected_paths_label">Affected paths</string>
     <string name="stats_affected_pkgs_label">Affected apps</string>
+    <string name="stats_storage_trend_action">Storage Trend</string>
+    <string name="stats_space_history_title">Storage Trend</string>
+    <string name="stats_space_history_range_title">Range</string>
+    <string name="stats_space_history_range_7d">7d</string>
+    <string name="stats_space_history_range_30d">30d</string>
+    <string name="stats_space_history_range_90d">90d</string>
+    <string name="stats_space_history_storage_title">Storage</string>
+    <string name="stats_space_history_current_free_label">Current used</string>
+    <string name="stats_space_history_min_label">Minimum used</string>
+    <string name="stats_space_history_max_label">Maximum used</string>
+    <string name="stats_space_history_delta_label">Delta</string>
+    <string name="stats_space_history_delta_in_x">%1$s in %2$s</string>
+    <string name="stats_space_history_upgrade_title">Full history is a Pro feature</string>
+    <string name="stats_space_history_upgrade_body">Upgrade to unlock the full 90-day trend view for each storage device.</string>
+    <string name="stats_space_history_marker_freed">Freed %1$s</string>
+    <string name="analyzer_storage_trend_delta_in_7d">%1$s in 7d</string>
 
     <string name="picker_select_paths_title">Select paths</string>
     <string name="picker_selected_paths_title">Selected paths</string>

--- a/app/src/test/java/eu/darken/sdmse/stats/core/SpaceHistoryRepoTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/stats/core/SpaceHistoryRepoTest.kt
@@ -1,0 +1,84 @@
+package eu.darken.sdmse.stats.core
+
+import eu.darken.sdmse.stats.core.db.ReportsDatabase
+import eu.darken.sdmse.stats.core.db.SpaceSnapshotDao
+import eu.darken.sdmse.stats.core.db.SpaceSnapshotEntity
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.time.Duration
+import java.time.Instant
+
+class SpaceHistoryRepoTest : BaseTest() {
+
+    @MockK lateinit var reportsDatabase: ReportsDatabase
+    @MockK lateinit var spaceSnapshotDao: SpaceSnapshotDao
+
+    @BeforeEach
+    fun setup() {
+        MockKAnnotations.init(this)
+
+        every { reportsDatabase.spaceSnapshotDao } returns spaceSnapshotDao
+        every { reportsDatabase.refreshDatabaseSize() } returns Unit
+        coEvery { reportsDatabase.withTransaction<Any?>(any()) } coAnswers {
+            firstArg<suspend () -> Any?>().invoke()
+        }
+
+        coEvery { spaceSnapshotDao.insert(any()) } returns Unit
+        coEvery { spaceSnapshotDao.deleteById(any()) } returns Unit
+    }
+
+    @Test
+    fun `insertIfNotRecent replaces latest snapshot within dedupe window`() = runTest {
+        val now = Instant.now()
+        coEvery { spaceSnapshotDao.getLatest("primary") } returns SpaceSnapshotEntity(
+            id = 7,
+            storageId = "primary",
+            recordedAt = now.minusSeconds(60),
+            spaceFree = 10L,
+            spaceCapacity = 100L,
+        )
+
+        val repo = SpaceHistoryRepo(reportsDatabase)
+        repo.insertIfNotRecent(
+            storageId = "primary",
+            recordedAt = now,
+            spaceFree = 20L,
+            spaceCapacity = 100L,
+            dedupeWindow = Duration.ofMinutes(5),
+        )
+
+        coVerify(exactly = 1) { spaceSnapshotDao.deleteById(7) }
+        coVerify(exactly = 1) { spaceSnapshotDao.insert(any()) }
+    }
+
+    @Test
+    fun `insertIfNotRecent keeps latest snapshot when outside dedupe window`() = runTest {
+        val now = Instant.now()
+        coEvery { spaceSnapshotDao.getLatest("primary") } returns SpaceSnapshotEntity(
+            id = 8,
+            storageId = "primary",
+            recordedAt = now.minus(Duration.ofMinutes(10)),
+            spaceFree = 10L,
+            spaceCapacity = 100L,
+        )
+
+        val repo = SpaceHistoryRepo(reportsDatabase)
+        repo.insertIfNotRecent(
+            storageId = "primary",
+            recordedAt = now,
+            spaceFree = 20L,
+            spaceCapacity = 100L,
+            dedupeWindow = Duration.ofMinutes(5),
+        )
+
+        coVerify(exactly = 0) { spaceSnapshotDao.deleteById(any()) }
+        coVerify(exactly = 1) { spaceSnapshotDao.insert(any()) }
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/stats/core/SpaceTrackerTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/stats/core/SpaceTrackerTest.kt
@@ -1,0 +1,166 @@
+package eu.darken.sdmse.stats.core
+
+import eu.darken.sdmse.analyzer.core.device.DeviceStorage
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.storage.StorageEnvironment
+import eu.darken.sdmse.common.storage.StorageId
+import eu.darken.sdmse.common.storage.StorageManager2
+import eu.darken.sdmse.common.storage.StorageStatsManager2
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import java.time.Instant
+import java.util.UUID
+
+class SpaceTrackerTest : BaseTest() {
+
+    @MockK lateinit var storageStatsManager: StorageStatsManager2
+    @MockK lateinit var storageManager2: StorageManager2
+    @MockK lateinit var storageEnvironment: StorageEnvironment
+    @MockK lateinit var spaceHistoryRepo: SpaceHistoryRepo
+    @MockK lateinit var statsSettings: StatsSettings
+
+    private val lastSnapshotAt = mockk<eu.darken.sdmse.common.datastore.DataStoreValue<Long>>().apply {
+        every { flow } returns flowOf(0L)
+        coEvery { update(any()) } returns mockk()
+    }
+
+    @BeforeEach
+    fun setup() {
+        MockKAnnotations.init(this)
+        every { statsSettings.lastSnapshotAt } returns lastSnapshotAt
+        every { storageManager2.volumes } returns null
+    }
+
+    private fun createInstance() = SpaceTracker(
+        dispatcherProvider = TestDispatcherProvider(),
+        storageStatsManager = storageStatsManager,
+        storageManager2 = storageManager2,
+        storageEnvironment = storageEnvironment,
+        spaceHistoryRepo = spaceHistoryRepo,
+        statsSettings = statsSettings,
+    )
+
+    @Test
+    fun `recordSnapshot skipped when globally throttled`() = runTest {
+        // lastSnapshotAt is recent (60s ago), within the 30min throttle window
+        val recentTime = Instant.now().minusSeconds(60).toEpochMilli()
+        every { lastSnapshotAt.flow } returns flowOf(recentTime)
+
+        val tracker = createInstance()
+        tracker.recordSnapshot(force = false)
+
+        coVerify(exactly = 0) { spaceHistoryRepo.insertIfNotRecent(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `recordSnapshot force bypasses global throttle`() = runTest {
+        val recentTime = Instant.now().minusSeconds(60).toEpochMilli()
+        every { lastSnapshotAt.flow } returns flowOf(recentTime)
+
+        coEvery { storageStatsManager.getTotalBytes(any()) } returns 100_000_000L
+        coEvery { storageStatsManager.getFreeBytes(any()) } returns 50_000_000L
+        coEvery { spaceHistoryRepo.insertIfNotRecent(any(), any(), any(), any(), any()) } returns true
+
+        val tracker = createInstance()
+        tracker.recordSnapshot(force = true)
+
+        coVerify {
+            spaceHistoryRepo.insertIfNotRecent(
+                storageId = any(),
+                recordedAt = any(),
+                spaceFree = 50_000_000L,
+                spaceCapacity = 100_000_000L,
+                dedupeWindow = any(),
+            )
+        }
+    }
+
+    @Test
+    fun `recordSnapshot with DeviceStorage maps correctly`() = runTest {
+        val storageId = StorageId(internalId = null, externalId = UUID.randomUUID())
+        val storage = DeviceStorage(
+            id = storageId,
+            label = "Primary".toCaString(),
+            type = DeviceStorage.Type.PRIMARY,
+            hardware = DeviceStorage.Hardware.BUILT_IN,
+            spaceCapacity = 200_000_000L,
+            spaceFree = 80_000_000L,
+            setupIncomplete = false,
+        )
+
+        coEvery { spaceHistoryRepo.insertIfNotRecent(any(), any(), any(), any(), any()) } returns true
+
+        val tracker = createInstance()
+        tracker.recordSnapshot(setOf(storage))
+
+        coVerify {
+            spaceHistoryRepo.insertIfNotRecent(
+                storageId = storageId.externalId.toString(),
+                recordedAt = any(),
+                spaceFree = 80_000_000L,
+                spaceCapacity = 200_000_000L,
+                dedupeWindow = any(),
+            )
+        }
+    }
+
+    @Test
+    fun `recordSnapshot with empty storages is no-op`() = runTest {
+        val tracker = createInstance()
+        tracker.recordSnapshot(emptySet())
+
+        coVerify(exactly = 0) { spaceHistoryRepo.insertIfNotRecent(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `recordSnapshot updates lastSnapshotAt on insert`() = runTest {
+        val storageId = StorageId(internalId = null, externalId = UUID.randomUUID())
+        val storage = DeviceStorage(
+            id = storageId,
+            label = "Test".toCaString(),
+            type = DeviceStorage.Type.PRIMARY,
+            hardware = DeviceStorage.Hardware.BUILT_IN,
+            spaceCapacity = 100_000_000L,
+            spaceFree = 50_000_000L,
+            setupIncomplete = false,
+        )
+
+        coEvery { spaceHistoryRepo.insertIfNotRecent(any(), any(), any(), any(), any()) } returns true
+
+        val tracker = createInstance()
+        tracker.recordSnapshot(setOf(storage))
+
+        coVerify { lastSnapshotAt.update(any()) }
+    }
+
+    @Test
+    fun `recordSnapshot does not update lastSnapshotAt when nothing inserted`() = runTest {
+        val storageId = StorageId(internalId = null, externalId = UUID.randomUUID())
+        val storage = DeviceStorage(
+            id = storageId,
+            label = "Test".toCaString(),
+            type = DeviceStorage.Type.PRIMARY,
+            hardware = DeviceStorage.Hardware.BUILT_IN,
+            spaceCapacity = 100_000_000L,
+            spaceFree = 50_000_000L,
+            setupIncomplete = false,
+        )
+
+        coEvery { spaceHistoryRepo.insertIfNotRecent(any(), any(), any(), any(), any()) } returns false
+
+        val tracker = createInstance()
+        tracker.recordSnapshot(setOf(storage))
+
+        coVerify(exactly = 0) { lastSnapshotAt.update(any()) }
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/stats/core/StatsRepoTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/stats/core/StatsRepoTest.kt
@@ -1,0 +1,85 @@
+package eu.darken.sdmse.stats.core
+
+import android.content.Context
+import eu.darken.sdmse.main.core.SDMTool
+import eu.darken.sdmse.main.core.taskmanager.TaskManager
+import eu.darken.sdmse.stats.core.db.ReportsDatabase
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.time.Instant
+
+class StatsRepoTest : BaseTest() {
+
+    @MockK lateinit var context: Context
+    @MockK lateinit var reportsDatabase: ReportsDatabase
+    @MockK lateinit var statsSettings: StatsSettings
+    @MockK lateinit var spaceTracker: SpaceTracker
+
+    @BeforeEach
+    fun setup() {
+        MockKAnnotations.init(this)
+
+        every { reportsDatabase.reports } returns flowOf(emptyList())
+        every { reportsDatabase.reportCount } returns flowOf(0)
+        every { reportsDatabase.snapshotsCount } returns flowOf(0)
+        every { reportsDatabase.databaseSize } returns MutableStateFlow(0L)
+
+        every { statsSettings.totalSpaceFreed.flow } returns flowOf(0L)
+        every { statsSettings.totalItemsProcessed.flow } returns flowOf(0L)
+
+        coEvery { spaceTracker.recordSnapshot(force = any<Boolean>()) } returns Unit
+    }
+
+    @Test
+    fun `report does not record snapshot directly for non-reportable tasks`() = runTest {
+        val tool = mockk<SDMTool>(relaxed = true).also {
+            every { it.type } returns SDMTool.Type.ANALYZER
+        }
+        val task = mockk<SDMTool.Task>(relaxed = true).also {
+            every { it.type } returns SDMTool.Type.ANALYZER
+        }
+        val managedTask = TaskManager.ManagedTask(
+            id = "task-id",
+            task = task,
+            tool = tool,
+            completedAt = Instant.now(),
+        )
+
+        val repo = StatsRepo(
+            appScope = backgroundScope,
+            context = context,
+            reportsDatabase = reportsDatabase,
+            statsSettings = statsSettings,
+            spaceTracker = spaceTracker,
+        )
+
+        repo.report(managedTask)
+
+        coVerify(exactly = 0) { spaceTracker.recordSnapshot(force = any<Boolean>()) }
+    }
+
+    @Test
+    fun `recordSnapshot delegates to spaceTracker`() = runTest {
+        val repo = StatsRepo(
+            appScope = backgroundScope,
+            context = context,
+            reportsDatabase = reportsDatabase,
+            statsSettings = statsSettings,
+            spaceTracker = spaceTracker,
+        )
+
+        repo.recordSnapshot(force = true)
+
+        coVerify(exactly = 1) { spaceTracker.recordSnapshot(force = true) }
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/stats/ui/spacehistory/SpaceHistoryViewModelTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/stats/ui/spacehistory/SpaceHistoryViewModelTest.kt
@@ -1,0 +1,181 @@
+package eu.darken.sdmse.stats.ui.spacehistory
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
+import androidx.lifecycle.SavedStateHandle
+import eu.darken.sdmse.common.storage.StorageManager2
+import eu.darken.sdmse.common.upgrade.UpgradeRepo
+import eu.darken.sdmse.stats.core.SpaceHistoryRepo
+import eu.darken.sdmse.stats.core.db.SpaceSnapshotEntity
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import testhelpers.livedata.InstantExecutorExtension
+import java.time.Instant
+
+@ExtendWith(InstantExecutorExtension::class)
+class SpaceHistoryViewModelTest : BaseTest() {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @MockK lateinit var storageManager2: StorageManager2
+    @MockK lateinit var spaceHistoryRepo: SpaceHistoryRepo
+    @MockK lateinit var upgradeRepo: UpgradeRepo
+
+    private val upgradeInfo = mockk<UpgradeRepo.Info>().apply {
+        every { isPro } returns false
+    }
+
+    @BeforeEach
+    fun setup() {
+        MockKAnnotations.init(this)
+        Dispatchers.setMain(testDispatcher)
+
+        every { upgradeRepo.upgradeInfo } returns flowOf(upgradeInfo)
+        every { storageManager2.volumes } returns emptyList()
+        every { spaceHistoryRepo.getAvailableStorageIds() } returns flowOf(emptyList())
+        every { spaceHistoryRepo.getHistory(any(), any()) } returns flowOf(emptyList())
+        every { spaceHistoryRepo.getReports(any()) } returns flowOf(emptyList())
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createInstance(storageId: String? = null): SpaceHistoryViewModel {
+        val handle = SavedStateHandle().apply {
+            if (storageId != null) set("storageId", storageId)
+        }
+        return SpaceHistoryViewModel(
+            handle = handle,
+            dispatcherProvider = TestDispatcherProvider(testDispatcher),
+            spaceHistoryRepo = spaceHistoryRepo,
+            upgradeRepo = upgradeRepo,
+            storageManager2 = storageManager2,
+        )
+    }
+
+    private fun <T> LiveData<T>.getOrAwaitValue(): T {
+        var data: T? = null
+        val observer = Observer<T> { data = it }
+        observeForever(observer)
+        removeObserver(observer)
+        @Suppress("UNCHECKED_CAST")
+        return data as T
+    }
+
+    @Test
+    fun `default state has range DAYS_7`() = runTest {
+        val vm = createInstance()
+        val state = vm.state.getOrAwaitValue()
+
+        state.selectedRange shouldBe SpaceHistoryViewModel.Range.DAYS_7
+    }
+
+    @Test
+    fun `empty snapshots result in null stats`() = runTest {
+        val vm = createInstance()
+        val state = vm.state.getOrAwaitValue()
+
+        state.currentUsed.shouldBeNull()
+        state.minUsed.shouldBeNull()
+        state.maxUsed.shouldBeNull()
+        state.deltaUsed.shouldBeNull()
+    }
+
+    @Test
+    fun `storages are derived from snapshot data`() = runTest {
+        every { spaceHistoryRepo.getAvailableStorageIds() } returns flowOf(listOf("storage-a", "storage-b"))
+
+        val vm = createInstance()
+        val state = vm.state.getOrAwaitValue()
+
+        state.storages.size shouldBe 2
+        state.storages[0].id shouldBe "storage-a"
+        state.storages[1].id shouldBe "storage-b"
+    }
+
+    @Test
+    fun `storageId from nav arg is selected`() = runTest {
+        every { spaceHistoryRepo.getAvailableStorageIds() } returns flowOf(listOf("storage-a", "storage-b"))
+        every { spaceHistoryRepo.getHistory(eq("storage-b"), any()) } returns flowOf(emptyList())
+
+        val vm = createInstance(storageId = "storage-b")
+        val state = vm.state.getOrAwaitValue()
+
+        state.selectedStorageId shouldBe "storage-b"
+    }
+
+    @Test
+    fun `delta is last minus first spaceUsed`() = runTest {
+        val now = Instant.now()
+        val snapshots = listOf(
+            SpaceSnapshotEntity(
+                storageId = "primary",
+                recordedAt = now.minusSeconds(3600),
+                spaceFree = 1_000_000L,
+                spaceCapacity = 10_000_000L,
+            ),
+            SpaceSnapshotEntity(
+                storageId = "primary",
+                recordedAt = now,
+                spaceFree = 1_500_000L,
+                spaceCapacity = 10_000_000L,
+            ),
+        )
+
+        every { spaceHistoryRepo.getAvailableStorageIds() } returns flowOf(listOf("primary"))
+        every { spaceHistoryRepo.getHistory(eq("primary"), any()) } returns flowOf(snapshots)
+
+        val vm = createInstance()
+        val state = vm.state.getOrAwaitValue()
+
+        // first used = 10M - 1M = 9M, last used = 10M - 1.5M = 8.5M
+        state.deltaUsed shouldBe -500_000L
+        state.currentUsed shouldBe 8_500_000L
+        state.minUsed shouldBe 8_500_000L
+        state.maxUsed shouldBe 9_000_000L
+    }
+
+    @Test
+    fun `non-pro shows upgrade prompt`() = runTest {
+        val vm = createInstance()
+        val state = vm.state.getOrAwaitValue()
+
+        state.isPro shouldBe false
+        state.showUpgradePrompt shouldBe true
+    }
+
+    @Test
+    fun `pro user can select extended ranges`() = runTest {
+        every { upgradeInfo.isPro } returns true
+
+        every { spaceHistoryRepo.getAvailableStorageIds() } returns flowOf(listOf("primary"))
+        every { spaceHistoryRepo.getHistory(any(), any()) } returns flowOf(emptyList())
+
+        val vm = createInstance()
+        vm.selectRange(SpaceHistoryViewModel.Range.DAYS_30)
+        advanceUntilIdle()
+
+        val state = vm.state.getOrAwaitValue()
+        state.selectedRange shouldBe SpaceHistoryViewModel.Range.DAYS_30
+        state.isPro shouldBe true
+    }
+}


### PR DESCRIPTION
## Summary

- Add storage space tracking over time with periodic snapshots and database persistence
- Custom chart view (`SpaceHistoryChartView`) for visualizing space usage trends with report markers
- Dashboard and analyzer integration showing 7-day storage delta trends
- Code review fixes: deduplicated `parseVolumeUuid` into `StorageId` companion, wrapped dedup logic in DB transaction, moved sorting/computation from ViewHolders to ViewModels

## Test plan

- [ ] Unit tests pass (`testFossDebugUnitTest` — 25/25 stats+analyzer tests passing)
- [ ] Lint vital checks pass (`lintVitalFossRelease`)
- [ ] Verify space history chart renders correctly on dashboard and device storage screen
- [ ] Verify snapshot recording triggers after task completion and on app launch
- [ ] Verify storage picker works with primary + secondary/USB storage
- [ ] Verify pro-gated ranges (30d, 90d) prompt upgrade for free users

Closes #1862