### PR TITLE
General: Fix duplicate APK uploads in GitHub releases

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -65,7 +65,7 @@ jobs:
           tag_name: ${{ steps.tagger.outputs.tag }}
           name: ${{ steps.tagger.outputs.tag }}
           generate_release_notes: true
-          files: app/build/outputs/apk/foss/beta/*.apk
+          files: app/build/outputs/apk/foss/beta/eu.darken.sdmse-*.apk
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -77,7 +77,7 @@ jobs:
           tag_name: ${{ steps.tagger.outputs.tag }}
           name: ${{ steps.tagger.outputs.tag }}
           generate_release_notes: true
-          files: app/build/outputs/apk/foss/release/*.apk
+          files: app/build/outputs/apk/foss/release/eu.darken.sdmse-*.apk
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- Narrow the APK upload glob in the release workflow from `*.apk` to `eu.darken.sdmse-*.apk`
- The Gradle rename task copies (not moves) APKs to preserve AGP metadata for Android Studio deploys, so both the original and renamed APK exist in the output directory
- The `*.apk` glob was picking up both files, causing duplicate uploads to GitHub releases

## Test plan
- Next tagged release should upload only the renamed APK
