### PR TITLE
General: Reduce Coil image loader log spam

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/common/coil/AppIconFetcher.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/coil/AppIconFetcher.kt
@@ -7,6 +7,7 @@ import coil.fetch.DrawableResult
 import coil.fetch.FetchResult
 import coil.fetch.Fetcher
 import coil.request.Options
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.funnel.IPCFunnel
 import eu.darken.sdmse.common.pkgs.Pkg
@@ -20,7 +21,7 @@ class AppIconFetcher @Inject constructor(
 ) : Fetcher {
 
     override suspend fun fetch(): FetchResult {
-        log { "Fetching $data" }
+        log(VERBOSE) { "Fetching $data" }
         val baseIcon = ipcFunnel.use {
             data.icon?.get(options.context) ?: packageManager.getIcon2(data.id)
         } ?: ContextCompat.getDrawable(options.context, eu.darken.sdmse.common.io.R.drawable.ic_default_app_icon_24)!!

--- a/app/src/main/java/eu/darken/sdmse/common/coil/CoilModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/coil/CoilModule.kt
@@ -39,7 +39,13 @@ class CoilModule {
             val logger = object : Logger {
                 override var level: Int = Log.VERBOSE
                 override fun log(tag: String, priority: Int, message: String?, throwable: Throwable?) {
-                    log("Coil:$tag", Logging.Priority.fromAndroid(priority)) { "$message ${throwable?.asLog()}" }
+                    val sdmPriority = Logging.Priority.fromAndroid(priority)
+                    val cappedPriority = if (sdmPriority == Logging.Priority.DEBUG || sdmPriority == Logging.Priority.INFO) {
+                        Logging.Priority.VERBOSE
+                    } else {
+                        sdmPriority
+                    }
+                    log("Coil:$tag", cappedPriority) { "$message ${throwable?.asLog()}" }
                 }
             }
             logger(logger)


### PR DESCRIPTION
## Summary
- Downgrade `AppIconFetcher` "Fetching" logs from DEBUG to VERBOSE
- Cap Coil's internal DEBUG/INFO logs to VERBOSE level, preserving WARN and ERROR

## Changes
- `AppIconFetcher.kt`: Use `VERBOSE` priority for fetch logging
- `CoilModule.kt`: Remap Coil logger priorities — DEBUG/INFO become VERBOSE, WARN/ERROR unchanged
