### PR TITLE
AppCleaner: Improve DPAD cache clearing on Android 17

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/StorageSnapshotDelta.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/StorageSnapshotDelta.kt
@@ -1,0 +1,23 @@
+package eu.darken.sdmse.appcleaner.core.automation.specs.aosp
+
+internal data class StorageSnapshot(val values: List<ParsedSize>) {
+    internal data class ParsedSize(val bytes: Long?, val rawText: String)
+}
+
+internal enum class DeltaResult { SUCCESS, SKIP_SUCCESS, NO_CHANGE, INCONCLUSIVE }
+
+internal fun compareSnapshots(pre: StorageSnapshot, post: StorageSnapshot): DeltaResult {
+    if (pre.values.isEmpty() || post.values.isEmpty()) return DeltaResult.INCONCLUSIVE
+    if (pre.values.size != post.values.size) return DeltaResult.INCONCLUSIVE
+
+    val pairs = pre.values.zip(post.values).mapNotNull { (a, b) ->
+        if (a.bytes != null && b.bytes != null) a.bytes to b.bytes else null
+    }
+    if (pairs.isEmpty()) return DeltaResult.INCONCLUSIVE
+
+    if (pairs.any { (before, after) -> after < before }) return DeltaResult.SUCCESS
+
+    if (pre.values.any { it.bytes == 0L }) return DeltaResult.SKIP_SUCCESS
+
+    return DeltaResult.NO_CHANGE
+}

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/StorageSnapshotDeltaTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/StorageSnapshotDeltaTest.kt
@@ -1,0 +1,190 @@
+package eu.darken.sdmse.appcleaner.core.automation.specs.aosp
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class StorageSnapshotDeltaTest : BaseTest() {
+
+    @Test
+    fun `detects full clear as SUCCESS`() {
+        val pre = StorageSnapshot(
+            listOf(
+                StorageSnapshot.ParsedSize(57340, "57.34 kB"),
+                StorageSnapshot.ParsedSize(1160000, "1.16 MB"),
+                StorageSnapshot.ParsedSize(143000, "143 kB"),
+                StorageSnapshot.ParsedSize(1360000, "1.36 MB"),
+            )
+        )
+        val post = StorageSnapshot(
+            listOf(
+                StorageSnapshot.ParsedSize(57340, "57.34 kB"),
+                StorageSnapshot.ParsedSize(1160000, "1.16 MB"),
+                StorageSnapshot.ParsedSize(0, "0 B"),
+                StorageSnapshot.ParsedSize(1220000, "1.22 MB"),
+            )
+        )
+        compareSnapshots(pre, post) shouldBe DeltaResult.SUCCESS
+    }
+
+    @Test
+    fun `detects partial clear as SUCCESS`() {
+        val pre = StorageSnapshot(
+            listOf(
+                StorageSnapshot.ParsedSize(57340, "57.34 kB"),
+                StorageSnapshot.ParsedSize(1160000, "1.16 MB"),
+                StorageSnapshot.ParsedSize(500000, "500 kB"),
+                StorageSnapshot.ParsedSize(1717340, "1.72 MB"),
+            )
+        )
+        val post = StorageSnapshot(
+            listOf(
+                StorageSnapshot.ParsedSize(57340, "57.34 kB"),
+                StorageSnapshot.ParsedSize(1160000, "1.16 MB"),
+                StorageSnapshot.ParsedSize(200000, "200 kB"),
+                StorageSnapshot.ParsedSize(1417340, "1.42 MB"),
+            )
+        )
+        compareSnapshots(pre, post) shouldBe DeltaResult.SUCCESS
+    }
+
+    @Test
+    fun `detects already zero as SKIP_SUCCESS`() {
+        val snapshot = StorageSnapshot(
+            listOf(
+                StorageSnapshot.ParsedSize(57340, "57.34 kB"),
+                StorageSnapshot.ParsedSize(1160000, "1.16 MB"),
+                StorageSnapshot.ParsedSize(0, "0 B"),
+                StorageSnapshot.ParsedSize(1217340, "1.22 MB"),
+            )
+        )
+        compareSnapshots(snapshot, snapshot) shouldBe DeltaResult.SKIP_SUCCESS
+    }
+
+    @Test
+    fun `detects no change as NO_CHANGE`() {
+        val snapshot = StorageSnapshot(
+            listOf(
+                StorageSnapshot.ParsedSize(57340, "57.34 kB"),
+                StorageSnapshot.ParsedSize(1160000, "1.16 MB"),
+                StorageSnapshot.ParsedSize(143000, "143 kB"),
+                StorageSnapshot.ParsedSize(1360000, "1.36 MB"),
+            )
+        )
+        compareSnapshots(snapshot, snapshot) shouldBe DeltaResult.NO_CHANGE
+    }
+
+    @Test
+    fun `returns INCONCLUSIVE when all values unparseable`() {
+        val snapshot = StorageSnapshot(
+            listOf(
+                StorageSnapshot.ParsedSize(null, "unknown"),
+                StorageSnapshot.ParsedSize(null, "data"),
+            )
+        )
+        compareSnapshots(snapshot, snapshot) shouldBe DeltaResult.INCONCLUSIVE
+    }
+
+    @Test
+    fun `returns INCONCLUSIVE when row count changes`() {
+        val pre = StorageSnapshot(
+            listOf(
+                StorageSnapshot.ParsedSize(57340, "57.34 kB"),
+                StorageSnapshot.ParsedSize(1160000, "1.16 MB"),
+                StorageSnapshot.ParsedSize(143000, "143 kB"),
+                StorageSnapshot.ParsedSize(1360000, "1.36 MB"),
+            )
+        )
+        val post = StorageSnapshot(
+            listOf(
+                StorageSnapshot.ParsedSize(57340, "57.34 kB"),
+                StorageSnapshot.ParsedSize(1160000, "1.16 MB"),
+                StorageSnapshot.ParsedSize(0, "0 B"),
+            )
+        )
+        compareSnapshots(pre, post) shouldBe DeltaResult.INCONCLUSIVE
+    }
+
+    @Test
+    fun `returns INCONCLUSIVE when pre is empty`() {
+        val pre = StorageSnapshot(emptyList())
+        val post = StorageSnapshot(
+            listOf(StorageSnapshot.ParsedSize(1000, "1 kB")),
+        )
+        compareSnapshots(pre, post) shouldBe DeltaResult.INCONCLUSIVE
+    }
+
+    @Test
+    fun `returns INCONCLUSIVE when post is empty`() {
+        val pre = StorageSnapshot(
+            listOf(StorageSnapshot.ParsedSize(1000, "1 kB")),
+        )
+        val post = StorageSnapshot(emptyList())
+        compareSnapshots(pre, post) shouldBe DeltaResult.INCONCLUSIVE
+    }
+
+    @Test
+    fun `returns INCONCLUSIVE when both are empty`() {
+        val empty = StorageSnapshot(emptyList())
+        compareSnapshots(empty, empty) shouldBe DeltaResult.INCONCLUSIVE
+    }
+
+    @Test
+    fun `single value decrease is SUCCESS`() {
+        val pre = StorageSnapshot(listOf(StorageSnapshot.ParsedSize(5000, "5 kB")))
+        val post = StorageSnapshot(listOf(StorageSnapshot.ParsedSize(1000, "1 kB")))
+        compareSnapshots(pre, post) shouldBe DeltaResult.SUCCESS
+    }
+
+    @Test
+    fun `single value increase is NO_CHANGE`() {
+        val pre = StorageSnapshot(listOf(StorageSnapshot.ParsedSize(1000, "1 kB")))
+        val post = StorageSnapshot(listOf(StorageSnapshot.ParsedSize(5000, "5 kB")))
+        compareSnapshots(pre, post) shouldBe DeltaResult.NO_CHANGE
+    }
+
+    @Test
+    fun `mixed parseable and unparseable still detects decrease`() {
+        val pre = StorageSnapshot(
+            listOf(
+                StorageSnapshot.ParsedSize(null, "unknown"),
+                StorageSnapshot.ParsedSize(5000, "5 kB"),
+            )
+        )
+        val post = StorageSnapshot(
+            listOf(
+                StorageSnapshot.ParsedSize(null, "unknown"),
+                StorageSnapshot.ParsedSize(1000, "1 kB"),
+            )
+        )
+        compareSnapshots(pre, post) shouldBe DeltaResult.SUCCESS
+    }
+
+    @Test
+    fun `mixed parseable and unparseable detects no change`() {
+        val snapshot = StorageSnapshot(
+            listOf(
+                StorageSnapshot.ParsedSize(null, "unknown"),
+                StorageSnapshot.ParsedSize(5000, "5 kB"),
+            )
+        )
+        compareSnapshots(snapshot, snapshot) shouldBe DeltaResult.NO_CHANGE
+    }
+
+    @Test
+    fun `SUCCESS takes priority over SKIP_SUCCESS when both apply`() {
+        val pre = StorageSnapshot(
+            listOf(
+                StorageSnapshot.ParsedSize(0, "0 B"),
+                StorageSnapshot.ParsedSize(5000, "5 kB"),
+            )
+        )
+        val post = StorageSnapshot(
+            listOf(
+                StorageSnapshot.ParsedSize(0, "0 B"),
+                StorageSnapshot.ParsedSize(1000, "1 kB"),
+            )
+        )
+        compareSnapshots(pre, post) shouldBe DeltaResult.SUCCESS
+    }
+}


### PR DESCRIPTION
## Summary
- Remove `canInjectInput` gate from the quick-try path so non-Shizuku devices succeed in ~1.1s instead of needing 2 cycle-loop iterations (~2s extra per app)
- Replace single-position blind fallback with a multi-position sweep (positions 2-4) for apps where "Clear cache" isn't at position 1 from the anchor
- Extract `StorageSnapshot`/`DeltaResult`/`compareSnapshots` into dedicated `StorageSnapshotDelta.kt` with 14 unit tests

## Test plan
- [x] Unit tests pass (33 tests across AOSPSpecsTest + StorageSnapshotDeltaTest)
- [x] Tested on Pixel 7a with Android 17 beta (no Shizuku): quick-try succeeds in ~1.1s per app
- [x] Bulk delete tested: all visible apps cleared via quick-try path

Relates to #2056
