### PR TITLE
General: Bump Android Gradle Plugin to 9.0.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:9.0.0")
+        classpath("com.android.tools.build:gradle:9.0.1")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.Kotlin.core}")
         classpath("com.google.dagger:hilt-android-gradle-plugin:${Versions.Dagger.core}")
         classpath("androidx.navigation:navigation-safe-args-gradle-plugin:${Versions.AndroidX.Navigation.core}")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -17,7 +17,7 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    implementation("com.android.tools.build:gradle:9.0.0")
+    implementation("com.android.tools.build:gradle:9.0.1")
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.10")
     implementation("com.squareup:javapoet:1.13.0")
 }


### PR DESCRIPTION
Update Android Gradle Plugin from 9.0.0 to 9.0.1.

- `build.gradle.kts`: Update AGP classpath dependency
- `buildSrc/build.gradle.kts`: Update AGP implementation dependency
