### PR TITLE
Swiper: Add help onboarding and improved descriptions

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/swiper/core/SwiperSettings.kt
+++ b/app/src/main/java/eu/darken/sdmse/swiper/core/SwiperSettings.kt
@@ -25,6 +25,7 @@ class SwiperSettings @Inject constructor(
     val swapSwipeDirections = dataStore.createValue("swipe.directions.swapped", false)
     val showFileDetailsOverlay = dataStore.createValue("swipe.details.overlay.enabled", true)
     val hapticFeedbackEnabled = dataStore.createValue("swipe.haptic.enabled", true)
+    val hasShownGestureOverlay = dataStore.createValue("swipe.gesture.overlay.shown", false)
 
     override val mapper = PreferenceStoreMapper(
         swapSwipeDirections,

--- a/app/src/main/java/eu/darken/sdmse/swiper/ui/swipe/SwiperSwipeViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/swiper/ui/swipe/SwiperSwipeViewModel.kt
@@ -67,13 +67,15 @@ class SwiperSwipeViewModel @Inject constructor(
         settings.swapSwipeDirections.flow,
         settings.showFileDetailsOverlay.flow,
         undoHistory,
+        settings.hasShownGestureOverlay.flow,
     ) { session: SwipeSession?,
         items: List<SwipeItem>,
         allSessions: List<Swiper.SessionWithStats>,
         indexOverride: Int?,
         swapDirections: Boolean,
         showDetails: Boolean,
-        undoStack: List<UndoEntry> ->
+        undoStack: List<UndoEntry>,
+        hasShownOverlay: Boolean ->
         // Clear stale override when session was reset to 0 (e.g., after deletion)
         val currentIndex = when {
             session?.currentIndex == 0 && indexOverride != null && indexOverride > 0 -> {
@@ -107,6 +109,7 @@ class SwiperSwipeViewModel @Inject constructor(
             showDetails = showDetails,
             sessionPosition = sessionPosition,
             canUndo = undoStack.isNotEmpty(),
+            showGestureOverlay = !hasShownOverlay,
         )
     }.asLiveData2()
 
@@ -222,6 +225,11 @@ class SwiperSwipeViewModel @Inject constructor(
         SwiperSwipeFragmentDirections.actionSwiperSwipeFragmentToSwiperStatusFragment(sessionId).navigate()
     }
 
+    fun dismissGestureOverlay() = launch {
+        log(TAG, INFO) { "dismissGestureOverlay()" }
+        settings.hasShownGestureOverlay.value(true)
+    }
+
     fun excludeAndRemove(item: SwipeItem) = launch {
         log(TAG, INFO) { "excludeAndRemove(${item.lookup.lookedUp})" }
         val exclusion = PathExclusion(
@@ -248,6 +256,7 @@ class SwiperSwipeViewModel @Inject constructor(
         val showDetails: Boolean,
         val sessionPosition: Int?,
         val canUndo: Boolean,
+        val showGestureOverlay: Boolean,
     ) {
         val currentItem: SwipeItem? = items.getOrNull(currentIndex)
         val currentItemOriginalIndex: Int? = currentItem?.itemIndex

--- a/app/src/main/res/layout/swiper_gesture_overlay.xml
+++ b/app/src/main/res/layout/swiper_gesture_overlay.xml
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/gesture_overlay"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#CC000000"
+    android:clickable="true"
+    android:focusable="true">
+
+    <!-- Left direction label -->
+    <LinearLayout
+        android:id="@+id/overlay_left_container"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:orientation="vertical"
+        android:layout_marginStart="32dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <ImageView
+            android:id="@+id/overlay_left_icon"
+            android:layout_width="32dp"
+            android:layout_height="32dp"
+            android:importantForAccessibility="no"
+            android:src="@drawable/ic_delete"
+            app:tint="@android:color/white" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/overlay_left_label"
+            style="@style/TextAppearance.Material3.TitleMedium"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:text="@string/swiper_gesture_overlay_left_delete"
+            android:textColor="@android:color/white" />
+
+    </LinearLayout>
+
+    <!-- Right direction label -->
+    <LinearLayout
+        android:id="@+id/overlay_right_container"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:orientation="vertical"
+        android:layout_marginEnd="32dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <ImageView
+            android:id="@+id/overlay_right_icon"
+            android:layout_width="32dp"
+            android:layout_height="32dp"
+            android:importantForAccessibility="no"
+            android:src="@drawable/ic_heart"
+            app:tint="@android:color/white" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/overlay_right_label"
+            style="@style/TextAppearance.Material3.TitleMedium"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:text="@string/swiper_gesture_overlay_right_keep"
+            android:textColor="@android:color/white" />
+
+    </LinearLayout>
+
+    <!-- Up direction label (Skip) -->
+    <LinearLayout
+        android:id="@+id/overlay_up_container"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:orientation="vertical"
+        android:layout_marginTop="80dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <ImageView
+            android:layout_width="32dp"
+            android:layout_height="32dp"
+            android:importantForAccessibility="no"
+            android:src="@drawable/ic_baseline_skip_next_24"
+            app:tint="@android:color/white" />
+
+        <com.google.android.material.textview.MaterialTextView
+            style="@style/TextAppearance.Material3.TitleMedium"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:text="@string/swiper_gesture_overlay_up_skip"
+            android:textColor="@android:color/white" />
+
+    </LinearLayout>
+
+    <!-- Down direction label (Undo) -->
+    <LinearLayout
+        android:id="@+id/overlay_down_container"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:orientation="vertical"
+        android:layout_marginBottom="80dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent">
+
+        <ImageView
+            android:layout_width="32dp"
+            android:layout_height="32dp"
+            android:importantForAccessibility="no"
+            android:src="@drawable/ic_settings_backup_restore_24"
+            app:tint="@android:color/white" />
+
+        <com.google.android.material.textview.MaterialTextView
+            style="@style/TextAppearance.Material3.TitleMedium"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:text="@string/swiper_gesture_overlay_down_undo"
+            android:textColor="@android:color/white" />
+
+    </LinearLayout>
+
+    <!-- Center: dismiss hint + button -->
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:orientation="vertical"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <com.google.android.material.textview.MaterialTextView
+            style="@style/TextAppearance.Material3.BodyLarge"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/swiper_gesture_overlay_dismiss"
+            android:textColor="#B3FFFFFF" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/overlay_dismiss_action"
+            style="@style/Widget.Material3.Button.TonalButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:contentDescription="@string/swiper_gesture_overlay_dismiss_action"
+            android:text="@string/swiper_gesture_overlay_dismiss_action" />
+
+    </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/swiper_swipe_fragment.xml
+++ b/app/src/main/res/layout/swiper_swipe_fragment.xml
@@ -296,4 +296,11 @@
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
+    <include
+        android:id="@+id/gesture_overlay"
+        layout="@layout/swiper_gesture_overlay"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone" />
+
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/menu/menu_swiper_swipe.xml
+++ b/app/src/main/res/menu/menu_swiper_swipe.xml
@@ -3,6 +3,12 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
+        android:id="@+id/action_help"
+        android:icon="@drawable/ic_help_outline"
+        android:title="@string/swiper_help_action"
+        app:showAsAction="ifRoom" />
+
+    <item
         android:id="@+id/action_review"
         android:icon="@drawable/baseline_list_alt_24"
         android:title="@string/swiper_review_action"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1016,11 +1016,11 @@
 
     <string name="swiper_label">Swiper</string>
     <string name="swiper_tool_name">Swiper</string>
-    <string name="swiper_tool_description">Swipe through files to decide what to keep or delete.</string>
-    <string name="swiper_dashcard_description">Manually review files in specific folders. Swipe to decide what to keep or delete.</string>
+    <string name="swiper_tool_description">Declutter folders fast — swipe through files to keep, delete, or skip.</string>
+    <string name="swiper_dashcard_description">Declutter specific folders faster than a file explorer — just swipe each file.</string>
     <string name="swiper_start_action">Start swiping</string>
     <string name="swiper_continue_action">Continue session</string>
-    <string name="swiper_sessions_description">Some files need a human decision. Swipe through items and choose what to keep or delete. Skip anything you’re unsure about. This tool lets you review specific folders manually, and nothing is removed until you confirm.</string>
+    <string name="swiper_sessions_description">Review files in 3 simple steps:\n\n1. Pick a folder to scan\n2. Swipe through files to keep, delete, or skip\n3. Review your choices and confirm\n\nNothing is removed until you tap the final delete button.</string>
     <string name="swiper_select_folders_action">Select folders</string>
     <string name="swiper_scanning_title">Scanning…</string>
     <plurals name="swiper_result_x_items_found">
@@ -1149,4 +1149,19 @@
     <string name="swiper_stamp_undo_2">Back!</string>
     <string name="swiper_stamp_undo_3">Oops!</string>
     <string name="swiper_stamp_undo_4">Wait!</string>
+
+    <!-- Swiper gesture overlay -->
+    <string name="swiper_gesture_overlay_dismiss">Tap anywhere to start</string>
+    <string name="swiper_gesture_overlay_dismiss_action">Got it</string>
+    <string name="swiper_gesture_overlay_left_delete">← Delete</string>
+    <string name="swiper_gesture_overlay_right_keep">Keep →</string>
+    <string name="swiper_gesture_overlay_left_keep">← Keep</string>
+    <string name="swiper_gesture_overlay_right_delete">Delete →</string>
+    <string name="swiper_gesture_overlay_up_skip">↑ Skip</string>
+    <string name="swiper_gesture_overlay_down_undo">↓ Undo</string>
+
+    <!-- Swiper help dialog -->
+    <string name="swiper_help_action">Help</string>
+    <string name="swiper_help_title">How Swiper works</string>
+    <string name="swiper_help_message">Swipe each file to make a decision:\n\n← Swipe left: %1$s\n→ Swipe right: %2$s\n↑ Swipe up: Skip\n↓ Swipe down: Undo (after first swipe)\n\nYou can also use the buttons at the bottom.\n\nWhen you\'re done, tap \"Review\" to see all your decisions. Nothing is deleted until you confirm on the review screen.</string>
 </resources>


### PR DESCRIPTION
## Summary
- Add a first-use gesture overlay on the swipe screen showing all swipe directions (keep, delete, skip, undo), dismissed on tap
- Add a help menu item in the swipe toolbar that opens a dialog explaining gestures and workflow
- Update tool description, dashboard card, and session header text with clearer value proposition and 3-step workflow
- All direction-specific text is dynamic based on the swap directions setting

## Notes
- The gesture overlay is shown once to all users (new and existing) — no migration needed
- Overlay includes an explicit dismiss button for accessibility alongside tap-to-dismiss
