### PR TITLE
General: Fix crash when accessing ViewBinding after view destroyed

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/common/lists/RecyclerViewExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/lists/RecyclerViewExtensions.kt
@@ -134,6 +134,7 @@ fun <AdapterT, ItemT : SelectableItem> Fragment3.installListSelection(
 
     tracker.addObserver(object : SelectionTracker.SelectionObserver<String>() {
         override fun onSelectionChanged() {
+            if (this@installListSelection.view == null) return
             onChange(tracker)
             when {
                 tracker.hasSelection() -> {


### PR DESCRIPTION
## Summary

- Guard `installListSelection`'s `onSelectionChanged` callback against firing after view destruction by checking `view == null` early-return
- Store and explicitly remove `AppBarLayout.OnOffsetChangedListener` in `SwiperStatusFragment.onDestroyView()`

Fixes crashes in `ExclusionListFragment`, `SqueezerListFragment`, `CustomFilterListFragment`, and `SwiperStatusFragment` where callbacks dispatched via the Looper (long-press gesture handler, AppBar animation frames) access the `ui` ViewBinding delegate after `onDestroyView()`, causing `viewLifecycleOwner` to throw `IllegalStateException`.

## Stacktrace

```
Exception java.lang.IllegalStateException:
  at androidx.fragment.app.Fragment.getViewLifecycleOwner (Fragment.java:390)
  at eu.darken.sdmse.exclusion.ui.list.ExclusionListFragment$special$inlined$viewBinding$2.invoke (ExclusionListFragment.java:8)
  at eu.darken.sdmse.common.viewbinding.ViewBindingProperty.getValue (ViewBindingProperty.java:86)
  at eu.darken.sdmse.exclusion.ui.list.ExclusionListFragment.getUi (ExclusionListFragment.kt:40)
  at eu.darken.sdmse.exclusion.ui.list.ExclusionListFragment.onViewCreated$lambda$17 (ExclusionListFragment.kt:183)
  at eu.darken.sdmse.common.lists.RecyclerViewExtensionsKt$installListSelection$4.onSelectionChanged (RecyclerViewExtensions.kt:137)
  at androidx.recyclerview.selection.DefaultSelectionTracker.notifySelectionChanged (DefaultSelectionTracker.java:473)
  at androidx.recyclerview.selection.DefaultSelectionTracker.select (DefaultSelectionTracker.java:236)
  at androidx.recyclerview.selection.MotionInputHandler.selectItem (MotionInputHandler.java:60)
  at androidx.recyclerview.selection.TouchInputHandler.onLongPress (TouchInputHandler.java:164)
  at androidx.recyclerview.selection.GestureRouter.onLongPress (GestureRouter.java:97)
  at android.view.GestureDetector.dispatchLongPress (GestureDetector.java:1014)
  at android.view.GestureDetector.-$Nest$mdispatchLongPress (Unknown Source)
  at android.view.GestureDetector$GestureHandler.handleMessage (GestureDetector.java:358)
  at android.os.Handler.dispatchMessage (Handler.java:106)
  at android.os.Looper.loopOnce (Looper.java:230)
  at android.os.Looper.loop (Looper.java:319)
  at android.app.ActivityThread.main (ActivityThread.java:8919)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:578)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1103)
```
