### PR TITLE
Fix: Prevent crash when browsing files

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/common/picker/PickerViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/picker/PickerViewModel.kt
@@ -1,7 +1,6 @@
 package eu.darken.sdmse.common.picker
 
 import androidx.lifecycle.SavedStateHandle
-import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.sdmse.common.SingleLiveEvent
 import eu.darken.sdmse.common.areas.DataAreaManager
@@ -99,7 +98,7 @@ class PickerViewModel @Inject constructor(
                         val childPath = targetArea.path.child(*childSegments)
                         val lookup = try {
                             childPath.lookup(gatewaySwitch)
-                        } catch (e: Exception) {
+                        } catch (e: IOException) {
                             log(TAG) { "Failed to lookup nav path segment: $childPath" }
                             break
                         }
@@ -205,7 +204,7 @@ class PickerViewModel @Inject constructor(
             hasChanges = selected.map { it.lookedUp } != request.selectedPaths,
             progress = null,
         ).run { emit(this) }
-    }.replayingShare(viewModelScope)
+    }.replayingShare(vmScope)
 
     val state = internalState.asLiveData2()
 

--- a/app/src/main/java/eu/darken/sdmse/exclusion/ui/editor/path/PathExclusionViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/exclusion/ui/editor/path/PathExclusionViewModel.kt
@@ -1,7 +1,6 @@
 package eu.darken.sdmse.exclusion.ui.editor.path
 
 import androidx.lifecycle.SavedStateHandle
-import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.sdmse.common.SingleLiveEvent
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
@@ -39,7 +38,7 @@ class PathExclusionViewModel @Inject constructor(
 
     val events = SingleLiveEvent<PathEditorEvents>()
 
-    private val currentState = DynamicStateFlow(TAG, viewModelScope) {
+    private val currentState = DynamicStateFlow(TAG, vmScope) {
         val origExclusion = exclusionManager.current().singleOrNull { it.id == identifier } as PathExclusion?
 
         if (origExclusion == null && initialOptions == null) {

--- a/app/src/main/java/eu/darken/sdmse/exclusion/ui/editor/pkg/PkgExclusionViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/exclusion/ui/editor/pkg/PkgExclusionViewModel.kt
@@ -1,7 +1,6 @@
 package eu.darken.sdmse.exclusion.ui.editor.pkg
 
 import androidx.lifecycle.SavedStateHandle
-import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.sdmse.common.SingleLiveEvent
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
@@ -37,7 +36,7 @@ class PkgExclusionViewModel @Inject constructor(
 
     val events = SingleLiveEvent<PkgExclusionEvents>()
 
-    private val currentState = DynamicStateFlow(TAG, viewModelScope) {
+    private val currentState = DynamicStateFlow(TAG, vmScope) {
         val origExclusion = exclusionManager.current().singleOrNull { it.id == identifier } as PkgExclusion?
 
         if (origExclusion == null && initialOptions == null) {

--- a/app/src/main/java/eu/darken/sdmse/exclusion/ui/editor/segment/SegmentExclusionViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/exclusion/ui/editor/segment/SegmentExclusionViewModel.kt
@@ -1,7 +1,6 @@
 package eu.darken.sdmse.exclusion.ui.editor.segment
 
 import androidx.lifecycle.SavedStateHandle
-import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.sdmse.common.SingleLiveEvent
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
@@ -38,7 +37,7 @@ class SegmentExclusionViewModel @Inject constructor(
 
     val events = SingleLiveEvent<SegmentExclusionEvents>()
 
-    private val currentState = DynamicStateFlow(TAG, viewModelScope) {
+    private val currentState = DynamicStateFlow(TAG, vmScope) {
         val origExclusion = exclusionManager.current().singleOrNull { it.id == identifier } as SegmentExclusion?
 
         if (origExclusion == null && initialOptions == null) {

--- a/app/src/main/java/eu/darken/sdmse/scheduler/ui/manager/create/ScheduleItemViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/scheduler/ui/manager/create/ScheduleItemViewModel.kt
@@ -1,7 +1,6 @@
 package eu.darken.sdmse.scheduler.ui.manager.create
 
 import androidx.lifecycle.SavedStateHandle
-import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.debug.logging.log
@@ -25,7 +24,7 @@ class ScheduleItemViewModel @Inject constructor(
 
     private val scheduleId: String = navArgs.scheduleId
 
-    private val internalState = DynamicStateFlow<State>(parentScope = viewModelScope) {
+    private val internalState = DynamicStateFlow<State>(parentScope = vmScope) {
         val existing = schedulerManager.getSchedule(scheduleId)
         State(
             existing = existing,

--- a/app/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/CustomFilterEditorViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/CustomFilterEditorViewModel.kt
@@ -1,7 +1,6 @@
 package eu.darken.sdmse.systemcleaner.ui.customfilter.editor
 
 import androidx.lifecycle.SavedStateHandle
-import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.sdmse.common.SingleLiveEvent
 import eu.darken.sdmse.common.areas.DataArea
@@ -60,7 +59,7 @@ class CustomFilterEditorViewModel @Inject constructor(
 
     val events = SingleLiveEvent<CustomFilterEditorEvents>()
 
-    private val currentState = DynamicStateFlow(TAG, viewModelScope) {
+    private val currentState = DynamicStateFlow(TAG, vmScope) {
         val originalConfig = filterRepo.currentConfigs().singleOrNull { it.identifier == identifier }
 
         if (originalConfig == null && initialOptions == null) {

--- a/app/src/test/java/eu/darken/sdmse/common/uix/ViewModel2ScopeTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/common/uix/ViewModel2ScopeTest.kt
@@ -1,0 +1,61 @@
+package eu.darken.sdmse.common.uix
+
+import eu.darken.sdmse.common.coroutine.DispatcherProvider
+import eu.darken.sdmse.common.files.ReadException
+import eu.darken.sdmse.common.flow.replayingShare
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import testhelpers.coroutine.runTest2
+import testhelpers.livedata.InstantExecutorExtension
+
+@ExtendWith(InstantExecutorExtension::class)
+class ViewModel2ScopeTest : BaseTest() {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @BeforeEach
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterEach
+    fun teardown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `vmScope catches exceptions from replayingShare flows`() = runTest2(
+        context = testDispatcher,
+    ) {
+        val vm = TestViewModel(TestDispatcherProvider(testDispatcher))
+
+        vm.state.first()
+        advanceUntilIdle()
+
+        val postedError = vm.errorEvents.value
+        postedError.shouldBeInstanceOf<ReadException>()
+    }
+
+    private class TestViewModel(
+        dispatcherProvider: DispatcherProvider,
+    ) : ViewModel3(dispatcherProvider) {
+        val state = flow<String> {
+            throw ReadException(message = "No matching mode available.")
+        }
+            .onStart { emit("loading") }
+            .replayingShare(vmScope)
+    }
+}


### PR DESCRIPTION
## What changed
Fixed a crash that could happen when browsing files on devices without root or ADB access.

## Developer TLDR
- `viewModelScope` → `vmScope` in `PickerViewModel` and 5 other ViewModels using `DynamicStateFlow`
- `vmScope` includes `CoroutineExceptionHandler` that routes errors to `errorEvents` instead of crashing
- Narrowed `catch(Exception)` to `catch(IOException)` in `PickerViewModel` to avoid swallowing `CancellationException`
- Added `ViewModel2ScopeTest` regression test
