### PR TITLE
Scheduler: Improve automation error messages

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/automation/core/errors/AutomationSchedulerException.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/errors/AutomationSchedulerException.kt
@@ -1,0 +1,24 @@
+package eu.darken.sdmse.automation.core.errors
+
+import eu.darken.sdmse.R
+import eu.darken.sdmse.common.ca.caString
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.error.HasLocalizedError
+import eu.darken.sdmse.common.error.LocalizedError
+
+class AutomationSchedulerException(
+    override val cause: Throwable,
+) : AutomationException(cause = cause), HasLocalizedError {
+    override fun getLocalizedError() = LocalizedError(
+        throwable = this,
+        label = R.string.automation_error_scheduler_title.toCaString(),
+        description = caString {
+            val sb = StringBuilder(it.getString(R.string.automation_error_scheduler_body))
+            if (cause is HasLocalizedError) {
+                sb.append("\n\n")
+                sb.append((cause as HasLocalizedError).getLocalizedError().description.get(it))
+            }
+            sb.toString()
+        },
+    )
+}

--- a/app/src/main/java/eu/darken/sdmse/scheduler/core/SchedulerNotifications.kt
+++ b/app/src/main/java/eu/darken/sdmse/scheduler/core/SchedulerNotifications.kt
@@ -15,6 +15,7 @@ import eu.darken.sdmse.common.BuildConfigWrap
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.hasApiLevel
+import eu.darken.sdmse.common.error.localized
 import eu.darken.sdmse.common.notifications.PendingIntentCompat
 import eu.darken.sdmse.main.core.SDMTool
 import eu.darken.sdmse.main.ui.MainActivity
@@ -123,7 +124,7 @@ class SchedulerNotifications @Inject constructor(
 SDMTool.Type.SQUEEZER -> R.string.squeezer_tool_name
                         SDMTool.Type.SWIPER -> R.string.swiper_tool_name
                     }
-                    context.getString(toolNameId) to it.error.toString()
+                    context.getString(toolNameId) to it.error!!.localized(context).asText().get(context)
                 }
             "$errorMsg\n${errorTools.joinToString("\n") { "${it.first}: ${it.second}" }}"
         } else {

--- a/app/src/main/java/eu/darken/sdmse/scheduler/core/SchedulerWorker.kt
+++ b/app/src/main/java/eu/darken/sdmse/scheduler/core/SchedulerWorker.kt
@@ -20,7 +20,10 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.error.hasCause
 import eu.darken.sdmse.common.root.RootManager
+import eu.darken.sdmse.automation.core.errors.AutomationException
+import eu.darken.sdmse.automation.core.errors.AutomationSchedulerException
 import eu.darken.sdmse.common.root.canUseRootNow
 import eu.darken.sdmse.common.shell.ShellOps
 import eu.darken.sdmse.common.shell.ipc.ShellOpsCmd
@@ -166,7 +169,12 @@ class SchedulerWorker @AssistedInject constructor(
                     SchedulerNotifications.Results(task, result = result)
                 } catch (e: Exception) {
                     log(TAG, ERROR) { "Scheduler task failed ($task): ${e.asLog()}" }
-                    SchedulerNotifications.Results(task, error = e)
+                    val wrappedError = if (e.hasCause(AutomationException::class)) {
+                        AutomationSchedulerException(e)
+                    } else {
+                        e
+                    }
+                    SchedulerNotifications.Results(task, error = wrappedError)
                 }
             }
         }

--- a/app/src/main/java/eu/darken/sdmse/stats/core/StatsRepo.kt
+++ b/app/src/main/java/eu/darken/sdmse/stats/core/StatsRepo.kt
@@ -8,6 +8,7 @@ import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.error.localized
 import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.flow.shareLatest
 import eu.darken.sdmse.common.flow.throttleLatest
@@ -83,7 +84,7 @@ class StatsRepo @Inject constructor(
             },
             primaryMessage = task.result?.primaryInfo?.get(context),
             secondaryMessage = task.result?.secondaryInfo?.get(context),
-            errorMessage = task.error?.toString(),
+            errorMessage = task.error?.localized(context)?.asText()?.get(context),
             affectedCount = reportDetails?.affectedCount,
             affectedSpace = reportDetails?.affectedSpace,
             extra = null,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -886,6 +886,8 @@
     <string name="automation_error_timeout_body">SD Maid did not complete all steps within the time limit. If this keeps happening, I might need to adjust the app for your device. Check for updates or reach out to me so I can fix it.</string>
     <string name="automation_error_overlay_title">Automation overlay</string>
     <string name="automation_error_overlay_body">SD Maid could not show the automation overlay. Check permissions and try rebooting your device.</string>
+    <string name="automation_error_scheduler_title">Scheduled automation failed</string>
+    <string name="automation_error_scheduler_body">A scheduled task tried to use the accessibility service, but it was unavailable. If you don\'t need this, disable the \"Accessibility service\" option in the scheduler settings.</string>
 
     <string name="history_label">History</string>
     <string name="history_description">A chronological list of recent actions and affected data.</string>


### PR DESCRIPTION
## What changed

Improved error messages when scheduled tasks fail due to accessibility service issues. Instead of showing raw Java exception names (e.g., `ScreenUnavailableException: Screen is unavailable!`), the scheduler notification and history screen now display human-readable explanations with actionable advice.

## Developer TLDR

- Created `AutomationSchedulerException` implementing `HasLocalizedError` with scheduler-specific advice text
- `SchedulerWorker` wraps `AutomationException` causes into `AutomationSchedulerException` before building notifications
- `SchedulerNotifications` uses `localized()` instead of `toString()` to render error text
- `StatsRepo` uses `localized()` instead of `toString()` when persisting error messages to the reports database
- Added `automation_error_scheduler_title` and `_body` strings

References #2205
