### PR TITLE
General: Close settings windows after automation finishes

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
@@ -134,13 +134,16 @@ class ClearCacheModule @AssistedInject constructor(
 
         labelDebugger.logAllLabels()
 
-        val result = processTask(task)
-
-        finishAutomation(
-            userCancelled = result.cancelledByUser,
-            returnToApp = task.returnToApp,
-            deviceDetective = deviceDetective,
-        )
+        var result: ProcessedTask? = null
+        try {
+            result = processTask(task)
+        } finally {
+            finishAutomation(
+                userCancelled = result?.cancelledByUser ?: false,
+                returnToApp = task.returnToApp,
+                deviceDetective = deviceDetective,
+            )
+        }
 
         if (Bugs.isDebug) {
             result.failed.forEach { (id, e) -> log(TAG, WARN) { "$id failed with $e" } }

--- a/app/src/main/java/eu/darken/sdmse/automation/core/specs/SpecGeneratorExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/specs/SpecGeneratorExtensions.kt
@@ -39,10 +39,11 @@ fun SpecGenerator.windowLauncherDefaultSettings(
     pkgInfo: Installed
 ): suspend StepContext.() -> Unit = {
     val intent = pkgInfo.getSettingsIntent(androidContext).apply {
-        flags = Intent.FLAG_ACTIVITY_NEW_TASK or
-                Intent.FLAG_ACTIVITY_CLEAR_TASK or
-                Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS or
-                Intent.FLAG_ACTIVITY_NO_ANIMATION
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)
+        addFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS)
+        addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION)
+        addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY)
     }
     log(tag, INFO) { "Launching $intent" }
     host.service.startActivity(intent)


### PR DESCRIPTION
## What changed

After automation-based cache clearing, force-stopping, or archiving/restoring apps, the system settings windows that were opened during the process would remain in the background. When users later closed SD Maid, the stale settings screen would appear unexpectedly. This fix ensures all settings windows are properly closed when automation finishes.

## Developer TLDR

- `finishAutomation(returnToApp=true)` now loops BACK presses until SD Maid is the foreground app, closing all intermediate settings screens (App Info → Storage, etc.)
- Falls back to intent navigation if BACK loop doesn't reach SD Maid within 10 attempts
- Added `FLAG_ACTIVITY_NO_HISTORY` to settings launch intent as extra insurance (doesn't fully solve it alone due to `FLAG_ACTIVITY_NEW_TASK`, but helps)
- Switched settings intent flags from `flags = ...` to `addFlags()` to preserve any flags set by `getSettingsIntent()`
- Wrapped `processTask`/`processForceStop`/`processOperation` in try-finally so `finishAutomation()` runs even on fatal exceptions (`AutomationOverlayException`, `InvalidSystemStateException`, etc.)

Related: #624, #825, #1213, #1970
