### PR TITLE
General: Detect and warn when accessibility shortcut/button is accidentally enabled

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/setup/automation/AutomationSetupCardVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/automation/AutomationSetupCardVH.kt
@@ -107,7 +107,7 @@ class AutomationSetupCardVH(parent: ViewGroup) :
             setOnClickListener { item.onGrantAction() }
 
         }
-        shortcutHint.isVisible = state.hasConsent != true || !state.isServiceRunning
+        shortcutHint.isVisible = state.hasConsent == true && state.isShortcutOrButtonEnabled
 
         disallowAction.apply {
             isVisible = state.hasConsent != false

--- a/app/src/main/java/eu/darken/sdmse/setup/automation/AutomationSetupModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/automation/AutomationSetupModule.kt
@@ -56,6 +56,9 @@ class AutomationSetupModule @Inject constructor(
         val canSelfEnable = automationManager.canSelfEnable()
         log(TAG) { "canSelfEnable=$canSelfEnable" }
 
+        val isShortcutOrButtonEnabled = automationManager.isShortcutOrButtonEnabled()
+        log(TAG) { "isShortcutOrButtonEnabled=$isShortcutOrButtonEnabled" }
+
         val mightBeRestricted = context.mightBeRestrictedDueToSideload()
         log(TAG) { "mightBeRestricted=$mightBeRestricted" }
 
@@ -86,6 +89,7 @@ class AutomationSetupModule @Inject constructor(
             canSelfEnable = canSelfEnable,
             isServiceEnabled = isServiceEnabled,
             isServiceRunning = isServiceRunning,
+            isShortcutOrButtonEnabled = isShortcutOrButtonEnabled,
             needsXiaomiAutostart = deviceDetective.getROMType() == RomType.MIUI && !canSelfEnable,
             liftRestrictionsIntent = liftRestrictionsIntent,
             showAppOpsRestrictionHint = showAppOpsRestrictionHint,
@@ -129,6 +133,7 @@ class AutomationSetupModule @Inject constructor(
         val canSelfEnable: Boolean,
         val isServiceEnabled: Boolean,
         val isServiceRunning: Boolean,
+        val isShortcutOrButtonEnabled: Boolean,
         val needsXiaomiAutostart: Boolean,
         val liftRestrictionsIntent: Intent,
         val showAppOpsRestrictionHint: Boolean,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -190,7 +190,7 @@
     <string name="setup_acs_state_stopped_hint_miui">If the service keeps getting disabled after a while, try enabling the "Auto Start" option for SD Maid in the system settings.</string>
     <string name="setup_acs_consent_positive_action">Enable service and grant access</string>
     <string name="setup_acs_consent_negative_action">Don\'t use accessibility service</string>
-    <string name="setup_acs_allow_hint">If you see a little icon on the screen edge, then you accidentally enabled the "shortcut" option.</string>
+    <string name="setup_acs_allow_hint">The accessibility shortcut or button for SD Maid SE is enabled. Open your device\'s Accessibility settings and disable the shortcut/button option to prevent an unwanted icon on the screen edge.</string>
     <string name="setup_acs_disallow_hint">If you change your mind, you can alter this option again by going into settings and restarting the setup.</string>
     <string name="setup_acs_appops_restriction_title">Restricted settings</string>
     <string name="setup_acs_appops_restriction_body">Can\'t enable SD Maids accessibility service? Android 13+ may apply restrictions to apps not installed via Google Play. Lift these restrictions from the system\'s detail page for SD Maid. The option is in the context menu in the top right corner.</string>

--- a/app/src/test/java/eu/darken/sdmse/automation/core/AutomationManagerTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/automation/core/AutomationManagerTest.kt
@@ -1,0 +1,72 @@
+package eu.darken.sdmse.automation.core
+
+import android.content.ComponentName
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class AutomationManagerTest : BaseTest() {
+
+    private val ourComp = ComponentName("eu.darken.sdmse", "eu.darken.sdmse.automation.core.AutomationService")
+    private val otherComp = ComponentName("com.other.app", "com.other.app.SomeService")
+
+    @Test fun `parseAccessibilityTargets - both null returns empty`() {
+        AutomationManager.parseAccessibilityTargets(null, null) shouldBe emptySet()
+    }
+
+    @Test fun `parseAccessibilityTargets - single null returns empty`() {
+        AutomationManager.parseAccessibilityTargets(null) shouldBe emptySet()
+    }
+
+    @Test fun `parseAccessibilityTargets - shortcut setting contains our component`() {
+        val result = AutomationManager.parseAccessibilityTargets(ourComp.flattenToString(), null)
+        result shouldBe setOf(ourComp)
+    }
+
+    @Test fun `parseAccessibilityTargets - button setting contains our component`() {
+        val result = AutomationManager.parseAccessibilityTargets(null, ourComp.flattenToString())
+        result shouldBe setOf(ourComp)
+    }
+
+    @Test fun `parseAccessibilityTargets - both settings contain our component`() {
+        val result = AutomationManager.parseAccessibilityTargets(
+            ourComp.flattenToString(),
+            ourComp.flattenToString(),
+        )
+        result shouldBe setOf(ourComp)
+    }
+
+    @Test fun `parseAccessibilityTargets - multi-entry list contains our component`() {
+        val setting = "${otherComp.flattenToString()}:${ourComp.flattenToString()}"
+        val result = AutomationManager.parseAccessibilityTargets(setting, null)
+        result shouldBe setOf(otherComp, ourComp)
+    }
+
+    @Test fun `parseAccessibilityTargets - neither setting contains our component`() {
+        val result = AutomationManager.parseAccessibilityTargets(otherComp.flattenToString(), null)
+        (ourComp in result) shouldBe false
+    }
+
+    @Test fun `parseAccessibilityTargets - blank entries are filtered`() {
+        val setting = ":${ourComp.flattenToString()}:"
+        val result = AutomationManager.parseAccessibilityTargets(setting)
+        result shouldBe setOf(ourComp)
+    }
+
+    @Test fun `parseAccessibilityTargets - malformed entry (no slash) is skipped, valid entry is kept`() {
+        // ComponentName.unflattenFromString returns null when there is no '/'
+        val setting = "notvalid:${ourComp.flattenToString()}"
+        val result = AutomationManager.parseAccessibilityTargets(setting)
+        result shouldBe setOf(ourComp)
+    }
+
+    @Test fun `parseAccessibilityTargets - empty string returns empty`() {
+        AutomationManager.parseAccessibilityTargets("") shouldBe emptySet()
+    }
+}


### PR DESCRIPTION
## What changed

Some devices (notably Samsung) automatically enable the accessibility shortcut or floating button when the user enables SD Maid SE's accessibility service during setup. This can cause a small icon to appear on the screen edge without any explanation.

The warning message in the setup card was previously shown at the wrong time — it appeared before the service was enabled and disappeared right after setup completed. SD Maid SE now reads the system accessibility settings to detect whether the shortcut or button is actually enabled, and shows the warning only when the problem exists.

## Developer TLDR

- `AutomationManager`: Added `isShortcutOrButtonEnabled()` reading both `accessibility_shortcut_target_service` and `accessibility_button_targets` from `Settings.Secure` with `runCatching` fallback
- `AutomationSetupModule.Result`: Added `isShortcutOrButtonEnabled: Boolean` field
- `AutomationSetupCardVH`: Fixed inverted hint visibility — was `hasConsent != true || !isServiceRunning`, now `hasConsent == true && isShortcutOrButtonEnabled`
- Added `AutomationManagerTest` with 10 Robolectric tests for the ComponentName parsing logic
