### PR TITLE
Fix: Prevent getting stuck on Setup screen after enabling accessibility service

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/setup/SetupFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/SetupFragment.kt
@@ -111,6 +111,14 @@ class SetupFragment : Fragment3(R.layout.setup_fragment) {
             setupAdapter.update(it)
         }
 
+        var hasNavigatedBack = false
+        vm.isSetupComplete.observe2(ui) { isComplete ->
+            if (isComplete && !hasNavigatedBack) {
+                vm.navback()
+                hasNavigatedBack = true
+            }
+        }
+
         vm.events.observe2(ui) { event ->
             when (event) {
                 is SetupEvents.SafRequestAccess -> try {


### PR DESCRIPTION
## What changed

Fixed a bug where the app could get stuck on the Setup screen after
enabling the accessibility service in system settings. The screen was
supposed to close automatically once all setup steps were complete, but
the navigation event was silently dropped while the user was inside the
system Settings screen, leaving them stranded.

## Developer TLDR

- Extracted the `listItems` mapping flow to a private `StateFlow` with
  `SharingStarted.Eagerly` — always active in `vmScope`, unaffected by
  the 5-second `asLiveData2()` inactivity timeout
- Added `isSetupComplete: LiveData<Boolean>` backed by the eager `StateFlow`
- Moved auto-navigation from `ViewModel.onEach { navback() }` (fires in
  ViewModel scope, drops via `SingleLiveEvent` while fragment is STOPPED)
  to `Fragment.observe2(vm.isSetupComplete)` (lifecycle-aware, re-delivers
  on `STARTED`)
- `hasNavigatedBack` one-shot flag (set after `navback()`) prevents
  double-navigation from re-emissions while avoiding stuck-flag on
  failed navigation
