### PR TITLE
Fix: Prevent crash when app is launched during automatic backup

### DIFF
--- a/app-common/src/main/java/eu/darken/sdmse/common/InjectionHelpers.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/InjectionHelpers.kt
@@ -1,8 +1,11 @@
 package eu.darken.sdmse.common
 
 import android.app.Service
+import android.content.Context
 import dagger.hilt.internal.GeneratedComponentManager
 
-fun Service.isValidAndroidEntryPoint(): Boolean {
-    return application is GeneratedComponentManager<*>
+fun Context.isValidHiltContext(): Boolean {
+    return applicationContext is GeneratedComponentManager<*>
 }
+
+fun Service.isValidAndroidEntryPoint(): Boolean = (this as Context).isValidHiltContext()

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/restore/UnarchiveReceiver.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/restore/UnarchiveReceiver.kt
@@ -4,16 +4,18 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageInstaller
-import dagger.hilt.android.AndroidEntryPoint
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.android.EntryPointAccessors
+import dagger.hilt.components.SingletonComponent
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
-import javax.inject.Inject
+import eu.darken.sdmse.common.isValidHiltContext
 
-@AndroidEntryPoint
 class UnarchiveReceiver : BroadcastReceiver() {
-
-    @Inject lateinit var unarchiveManager: UnarchiveManager
 
     override fun onReceive(context: Context, intent: Intent) {
         log(TAG, VERBOSE) { "onReceive($context, $intent)" }
@@ -29,6 +31,18 @@ class UnarchiveReceiver : BroadcastReceiver() {
             return
         }
 
+        if (!context.isValidHiltContext()) {
+            log(TAG, WARN) { "Invalid Hilt context (${context.applicationContext.javaClass}), skipping (backup/restore?)" }
+            return
+        }
+
+        val entryPoint = try {
+            EntryPointAccessors.fromApplication(context, ReceiverEntryPoint::class.java)
+        } catch (e: Exception) {
+            log(TAG, ERROR) { "Failed to get entry point: $e" }
+            return
+        }
+
         val status = intent.getIntExtra(PackageInstaller.EXTRA_UNARCHIVE_STATUS, -1)
         val statusMessage = intent.getStringExtra(PackageInstaller.EXTRA_STATUS_MESSAGE)
         val packageName = intent.getStringExtra(PackageInstaller.EXTRA_PACKAGE_NAME) ?: ""
@@ -41,10 +55,16 @@ class UnarchiveReceiver : BroadcastReceiver() {
             statusMessage = statusMessage,
         )
 
-        unarchiveManager.onUnarchiveResult(requestCode, result)
+        entryPoint.unarchiveManager().onUnarchiveResult(requestCode, result)
     }
 
     companion object {
         private val TAG = logTag("AppControl", "UnarchiveReceiver")
+
+        @EntryPoint
+        @InstallIn(SingletonComponent::class)
+        interface ReceiverEntryPoint {
+            fun unarchiveManager(): UnarchiveManager
+        }
     }
 }

--- a/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/watcher/ExternalWatcherTaskReceiver.kt
+++ b/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/watcher/ExternalWatcherTaskReceiver.kt
@@ -3,7 +3,10 @@ package eu.darken.sdmse.corpsefinder.core.watcher
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import dagger.hilt.android.AndroidEntryPoint
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.android.EntryPointAccessors
+import dagger.hilt.components.SingletonComponent
 import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
@@ -12,21 +15,14 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
-import eu.darken.sdmse.corpsefinder.core.CorpseFinderSettings
+import eu.darken.sdmse.common.isValidHiltContext
 import eu.darken.sdmse.corpsefinder.core.tasks.UninstallWatcherTask
 import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
-@AndroidEntryPoint
 class ExternalWatcherTaskReceiver : BroadcastReceiver() {
-
-    @Inject @AppScope lateinit var appScope: CoroutineScope
-    @Inject lateinit var taskSubmitter: TaskSubmitter
-    @Inject lateinit var corpseFinderSettings: CorpseFinderSettings
-    @Inject lateinit var watcherNotifications: WatcherNotifications
 
     override fun onReceive(context: Context, intent: Intent) {
         log(TAG) { "onReceive($context,$intent)" }
@@ -45,12 +41,24 @@ class ExternalWatcherTaskReceiver : BroadcastReceiver() {
             log(TAG, INFO) { "Received task is $externalTask" }
         }
 
+        if (!context.isValidHiltContext()) {
+            log(TAG, WARN) { "Invalid Hilt context (${context.applicationContext.javaClass}), skipping (backup/restore?)" }
+            return
+        }
+
+        val entryPoint = try {
+            EntryPointAccessors.fromApplication(context, ReceiverEntryPoint::class.java)
+        } catch (e: Exception) {
+            log(TAG, ERROR) { "Failed to get entry point: $e" }
+            return
+        }
+
         val asyncPi = goAsync()
 
         Bugs.leaveBreadCrumb("Watcher task event")
 
-        appScope.launch {
-            watcherNotifications.clearNotifications()
+        entryPoint.appScope().launch {
+            entryPoint.uninstallWatcherNotifications().clearNotifications()
 
             val internalTask = when (externalTask) {
                 is ExternalWatcherTask.Delete -> UninstallWatcherTask(
@@ -61,13 +69,13 @@ class ExternalWatcherTaskReceiver : BroadcastReceiver() {
 
             try {
                 log(TAG) { "Submitting task: $internalTask" }
-                taskSubmitter.submit(internalTask)
+                entryPoint.taskSubmitter().submit(internalTask)
             } catch (e: Exception) {
                 log(TAG, ERROR) { "Uninstall task ($internalTask) failed: ${e.asLog()}" }
             }
         }
 
-        appScope.launch {
+        entryPoint.appScope().launch {
             delay(3000)
             log(TAG) { "Finished watcher trigger" }
             asyncPi.finish()
@@ -78,5 +86,13 @@ class ExternalWatcherTaskReceiver : BroadcastReceiver() {
         const val EXTRA_TASK = "corpsefinder.watcher.uninstall.task"
         const val TASK_INTENT = "corpsefinder.watcher.uninstall.intent.NEW_TASK"
         internal val TAG = logTag("CorpseFinder", "Watcher", "Task", "Receiver")
+
+        @EntryPoint
+        @InstallIn(SingletonComponent::class)
+        interface ReceiverEntryPoint {
+            @AppScope fun appScope(): CoroutineScope
+            fun taskSubmitter(): TaskSubmitter
+            fun uninstallWatcherNotifications(): UninstallWatcherNotifications
+        }
     }
 }

--- a/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/watcher/UninstallWatcherReceiver.kt
+++ b/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/watcher/UninstallWatcherReceiver.kt
@@ -3,7 +3,10 @@ package eu.darken.sdmse.corpsefinder.core.watcher
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import dagger.hilt.android.AndroidEntryPoint
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.android.EntryPointAccessors
+import dagger.hilt.components.SingletonComponent
 import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.Bugs
@@ -13,6 +16,7 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.isValidHiltContext
 import eu.darken.sdmse.common.pkgs.toPkgId
 import eu.darken.sdmse.corpsefinder.core.CorpseFinderSettings
 import eu.darken.sdmse.corpsefinder.core.tasks.UninstallWatcherTask
@@ -20,14 +24,8 @@ import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
-@AndroidEntryPoint
 class UninstallWatcherReceiver : BroadcastReceiver() {
-
-    @Inject @AppScope lateinit var appScope: CoroutineScope
-    @Inject lateinit var taskSubmitter: TaskSubmitter
-    @Inject lateinit var corpseFinderSettings: CorpseFinderSettings
 
     override fun onReceive(context: Context, intent: Intent) {
         log(TAG) { "onReceive($context,$intent)" }
@@ -45,29 +43,42 @@ class UninstallWatcherReceiver : BroadcastReceiver() {
 
         log(TAG, INFO) { "$pkg was uninstalled" }
 
+        if (!context.isValidHiltContext()) {
+            log(TAG, WARN) { "Invalid Hilt context (${context.applicationContext.javaClass}), skipping (backup/restore?)" }
+            return
+        }
+
+        val entryPoint = try {
+            EntryPointAccessors.fromApplication(context, ReceiverEntryPoint::class.java)
+        } catch (e: Exception) {
+            log(TAG, ERROR) { "Failed to get entry point: $e" }
+            return
+        }
+
+
         val asyncPi = goAsync()
 
         Bugs.leaveBreadCrumb("Uninstall event")
 
-        appScope.launch {
-            if (!corpseFinderSettings.isWatcherEnabled.value()) {
+        entryPoint.appScope().launch {
+            if (!entryPoint.corpseFinderSettings().isWatcherEnabled.value()) {
                 log(TAG, WARN) { "Uninstall watcher is disabled in settings, skipping." }
                 return@launch
             }
 
             val task = UninstallWatcherTask(
                 target = pkg,
-                autoDelete = corpseFinderSettings.isWatcherAutoDeleteEnabled.value()
+                autoDelete = entryPoint.corpseFinderSettings().isWatcherAutoDeleteEnabled.value()
             )
             try {
                 log(TAG) { "Submitting task: $task" }
-                taskSubmitter.submit(task)
+                entryPoint.taskSubmitter().submit(task)
             } catch (e: Exception) {
                 log(TAG, ERROR) { "Uninstall task ($task) failed: ${e.asLog()}" }
             }
         }
 
-        appScope.launch {
+        entryPoint.appScope().launch {
             delay(3000)
             log(TAG) { "Finished watcher trigger" }
             asyncPi.finish()
@@ -76,5 +87,13 @@ class UninstallWatcherReceiver : BroadcastReceiver() {
 
     companion object {
         internal val TAG = logTag("CorpseFinder", "Watcher", "Uninstall", "Receiver")
+
+        @EntryPoint
+        @InstallIn(SingletonComponent::class)
+        interface ReceiverEntryPoint {
+            @AppScope fun appScope(): CoroutineScope
+            fun taskSubmitter(): TaskSubmitter
+            fun corpseFinderSettings(): CorpseFinderSettings
+        }
     }
 }

--- a/app-tool-scheduler/src/main/java/eu/darken/sdmse/scheduler/core/SchedulerRestoreReceiver.kt
+++ b/app-tool-scheduler/src/main/java/eu/darken/sdmse/scheduler/core/SchedulerRestoreReceiver.kt
@@ -3,31 +3,43 @@ package eu.darken.sdmse.scheduler.core
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import dagger.hilt.android.AndroidEntryPoint
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.android.EntryPointAccessors
+import dagger.hilt.components.SingletonComponent
 import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.isValidHiltContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 
-@AndroidEntryPoint
 class SchedulerRestoreReceiver : BroadcastReceiver() {
-
-    @Inject @AppScope lateinit var appScope: CoroutineScope
-    @Inject lateinit var schedulerManager: SchedulerManager
 
     override fun onReceive(context: Context, intent: Intent) {
         log(TAG) { "onReceive($context,$intent)" }
         if (!ALLOWED_INTENTS.contains(intent.action)) {
             log(TAG, ERROR) { "Unknown intent: $intent" }
+            return
+        }
+
+        if (!context.isValidHiltContext()) {
+            log(TAG, WARN) { "Invalid Hilt context (${context.applicationContext.javaClass}), skipping (backup/restore?)" }
+            return
+        }
+
+        val entryPoint = try {
+            EntryPointAccessors.fromApplication(context, ReceiverEntryPoint::class.java)
+        } catch (e: Exception) {
+            log(TAG, ERROR) { "Failed to get entry point: $e" }
             return
         }
 
@@ -37,8 +49,8 @@ class SchedulerRestoreReceiver : BroadcastReceiver() {
 
         Bugs.leaveBreadCrumb("Scheduler restore")
 
-        appScope.launch {
-            schedulerManager.state.take(1).first()
+        entryPoint.appScope().launch {
+            entryPoint.schedulerManager().state.take(1).first()
             // The manager checks the scheduling states automatically when initialised, so just give it some time
             delay(3000)
 
@@ -54,5 +66,12 @@ class SchedulerRestoreReceiver : BroadcastReceiver() {
             Intent.ACTION_BOOT_COMPLETED
         )
         internal val TAG = logTag("Scheduler", "Receiver", "Restore")
+
+        @EntryPoint
+        @InstallIn(SingletonComponent::class)
+        interface ReceiverEntryPoint {
+            @AppScope fun appScope(): CoroutineScope
+            fun schedulerManager(): SchedulerManager
+        }
     }
 }

--- a/app/src/test/java/eu/darken/sdmse/common/BroadcastReceiverBackupGuardTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/common/BroadcastReceiverBackupGuardTest.kt
@@ -3,7 +3,6 @@ package eu.darken.sdmse.common
 import android.app.Application
 import android.content.Context
 import android.content.Intent
-import eu.darken.sdmse.appcontrol.core.restore.UnarchiveManager
 import eu.darken.sdmse.appcontrol.core.restore.UnarchiveReceiver
 import eu.darken.sdmse.corpsefinder.core.watcher.ExternalWatcherTask
 import eu.darken.sdmse.corpsefinder.core.watcher.ExternalWatcherTaskReceiver
@@ -38,8 +37,8 @@ class BroadcastReceiverBackupGuardTest : BaseTest() {
     @Test
     fun `UnarchiveReceiver does not crash with restricted context`() {
         val intent = mockk<Intent>(relaxed = true).apply {
-            every { action } returns UnarchiveManager.ACTION_UNARCHIVE_RESULT
-            every { getIntExtra(UnarchiveManager.EXTRA_REQUEST_CODE, -1) } returns 42
+            every { action } returns "eu.darken.sdmse.action.UNARCHIVE_RESULT"
+            every { getIntExtra("eu.darken.sdmse.extra.REQUEST_CODE", -1) } returns 42
         }
         UnarchiveReceiver().onReceive(restrictedContext, intent)
     }

--- a/app/src/test/java/eu/darken/sdmse/common/BroadcastReceiverBackupGuardTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/common/BroadcastReceiverBackupGuardTest.kt
@@ -1,0 +1,67 @@
+package eu.darken.sdmse.common
+
+import android.app.Application
+import android.content.Context
+import android.content.Intent
+import eu.darken.sdmse.appcontrol.core.restore.UnarchiveManager
+import eu.darken.sdmse.appcontrol.core.restore.UnarchiveReceiver
+import eu.darken.sdmse.corpsefinder.core.watcher.ExternalWatcherTask
+import eu.darken.sdmse.corpsefinder.core.watcher.ExternalWatcherTaskReceiver
+import eu.darken.sdmse.corpsefinder.core.watcher.UninstallWatcherReceiver
+import eu.darken.sdmse.scheduler.core.SchedulerRestoreReceiver
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+/**
+ * Regression test for https://github.com/d4rken-org/sdmaid-se/issues/1274
+ *
+ * During Android Auto Backup, BroadcastReceivers are invoked with a RestrictedContext
+ * whose applicationContext is a plain android.app.Application (not our @HiltAndroidApp App).
+ * Receivers must silently return without crashing.
+ */
+class BroadcastReceiverBackupGuardTest : BaseTest() {
+
+    private val restrictedContext = mockk<Context>(relaxed = true).apply {
+        every { applicationContext } returns mockk<Application>()
+    }
+
+    @Test
+    fun `SchedulerRestoreReceiver does not crash with restricted context`() {
+        val intent = mockk<Intent>(relaxed = true).apply {
+            every { action } returns Intent.ACTION_BOOT_COMPLETED
+        }
+        SchedulerRestoreReceiver().onReceive(restrictedContext, intent)
+    }
+
+    @Test
+    fun `UnarchiveReceiver does not crash with restricted context`() {
+        val intent = mockk<Intent>(relaxed = true).apply {
+            every { action } returns UnarchiveManager.ACTION_UNARCHIVE_RESULT
+            every { getIntExtra(UnarchiveManager.EXTRA_REQUEST_CODE, -1) } returns 42
+        }
+        UnarchiveReceiver().onReceive(restrictedContext, intent)
+    }
+
+    @Test
+    fun `UninstallWatcherReceiver does not crash with restricted context`() {
+        val intent = mockk<Intent>(relaxed = true).apply {
+            every { action } returns Intent.ACTION_PACKAGE_FULLY_REMOVED
+            every { data } returns mockk {
+                every { schemeSpecificPart } returns "com.example.app"
+            }
+        }
+        UninstallWatcherReceiver().onReceive(restrictedContext, intent)
+    }
+
+    @Test
+    fun `ExternalWatcherTaskReceiver does not crash with restricted context`() {
+        val intent = mockk<Intent>(relaxed = true).apply {
+            every { action } returns ExternalWatcherTaskReceiver.TASK_INTENT
+            @Suppress("DEPRECATION")
+            every { getParcelableExtra<ExternalWatcherTask>(ExternalWatcherTaskReceiver.EXTRA_TASK) } returns mockk<ExternalWatcherTask.Delete>()
+        }
+        ExternalWatcherTaskReceiver().onReceive(restrictedContext, intent)
+    }
+}


### PR DESCRIPTION
## What changed

Fixed a crash that could happen when SD Maid was launched while Android's automatic backup was running. On Android 13 and below, this crash could also break subsequent app launches until the device was restarted.

## Developer TLDR

- Removed `@AndroidEntryPoint` from all 4 `BroadcastReceiver`s (`SchedulerRestoreReceiver`, `UnarchiveReceiver`, `UninstallWatcherReceiver`, `ExternalWatcherTaskReceiver`)
- Hilt's bytecode transformation injects `super.onReceive()` before any user code, making it impossible to guard with `@AndroidEntryPoint`. Switched to manual `EntryPointAccessors.fromApplication()` per [Dagger team recommendation](https://github.com/google/dagger/issues/2798)
- Added `Context.isValidHiltContext()` helper in `InjectionHelpers.kt` and consolidated existing `Service.isValidAndroidEntryPoint()` to delegate to it
- Each receiver validates intent/extras before DI lookup (cheap checks first), with try-catch defense-in-depth around `EntryPointAccessors`
- Dropped unused `CorpseFinderSettings` injection from `ExternalWatcherTaskReceiver`
- Added `BroadcastReceiverBackupGuardTest` regression test verifying all 4 receivers silently return with a restricted context

## Background & research

### Root cause

When Android Auto Backup runs, it invokes registered `BroadcastReceiver`s with a `RestrictedContext` whose `applicationContext` is a plain `android.app.Application` — not our `@HiltAndroidApp App`. Hilt's Gradle plugin performs bytecode transformation on `@AndroidEntryPoint` receivers, inserting a `super.onReceive()` call at the very beginning of `onReceive()` — before any user code. This makes it impossible to add a guard check while using `@AndroidEntryPoint`.

On Android <= 13, there's a platform bug ([Google issue #160946170](https://issuetracker.google.com/issues/160946170)) where crashing during backup causes the "restricted" flag to persist, breaking subsequent app launches until the device is restarted.

### Why `EntryPointAccessors` instead of alternatives

| Approach | Verdict |
|---|---|
| Keep `@AndroidEntryPoint` + add guard in `onReceive` | Not possible — Hilt bytecode transformation injects `super.onReceive()` before our code |
| `android:allowBackup="false"` | Works but users lose backup/restore entirely |
| Custom `BackupAgent` | Significant extra work, doesn't prevent the receiver from being invoked |
| Remove `@AndroidEntryPoint` + manual `EntryPointAccessors` | Dagger team's recommended approach ([#2798](https://github.com/google/dagger/issues/2798)) |

### Known tradeoff

With `@AndroidEntryPoint`, adding a dependency was just `@Inject lateinit var foo: Foo`. Now someone needs to also add the method to the `ReceiverEntryPoint` interface and call it manually. Forgetting the interface method is a compile error (Dagger can't find the binding), so it's not silent — just more friction.

### Related issues

- [Dagger #2798: Provide warning about using "allowBackup" with Hilt](https://github.com/google/dagger/issues/2798) — Dagger team acknowledged but only proposed documentation changes, no code-level fix
- [Google #160946170: Restricted mode persists after backup crash](https://issuetracker.google.com/issues/160946170) — Android platform bug, no public fix
- [Dagger #1918: Hilt injection not working in BroadcastReceiver](https://github.com/google/dagger/issues/1918) — related general discussion

Closes #1274
