### PR TITLE
General: Add diagnostics for navigation failure after process death

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/common/navigation/NavControllerExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/navigation/NavControllerExtensions.kt
@@ -23,7 +23,12 @@ fun NavController.doNavigate(direction: NavDirections) {
         return
     }
     log(TAG, WARN) {
-        "Navigation dropped: ${direction.javaClass.simpleName} not found on ${curDest?.label ?: "null"}"
+        "Navigation dropped:" +
+            " action=${direction.javaClass.simpleName}" +
+            " (0x${Integer.toHexString(direction.actionId)})" +
+            " curDest=${curDest?.label ?: "null"}" +
+            " (${curDest?.id?.let { "0x${Integer.toHexString(it)}" } ?: "null"})" +
+            " graphSet=${isGraphSet()}"
     }
 }
 

--- a/app/src/main/java/eu/darken/sdmse/main/ui/MainActivity.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/MainActivity.kt
@@ -40,6 +40,7 @@ class MainActivity : Activity2() {
     @Inject lateinit var recorderModule: RecorderModule
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        log(tag) { "onCreate(restoringState=${savedInstanceState != null})" }
         super.onCreate(savedInstanceState)
 
         val splashScreen = installSplashScreen()

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardFragment.kt
@@ -267,6 +267,7 @@ class DashboardFragment : Fragment3(R.layout.dashboard_fragment) {
         super.onResume()
         val navController = findNavController()
         val curDest = navController.currentDestination
+        log(tag) { "onResume(): currentDestination=${curDest?.label} (${curDest?.id?.let { "0x${Integer.toHexString(it)}" } ?: "null"})" }
         if (curDest != null && curDest.id != R.id.dashboardFragment) {
             log(tag, WARN) { "Dashboard resumed but currentDestination is ${curDest.label}, recovering" }
             navController.popBackStack(R.id.dashboardFragment, false)


### PR DESCRIPTION
## What changed

No user-facing behavior change. Added diagnostic logging to help identify why navigation sometimes stops working after the app is restored from the background.

## Developer TLDR

- `NavController.doNavigate()`: Enriched the WARN log when navigation is dropped — now includes action ID (hex), destination ID (hex), and graph-set status
- `DashboardFragment.onResume()`: Always log `currentDestination` on every resume (previously only logged when recovery triggered)
- `MainActivity.onCreate()`: Log whether the activity is restoring from saved state

These logs will capture the exact navigation state on next occurrence, making root cause identification straightforward. Filter logcat for `SDMSE:Navigation` and `SDMSE:Fragment:Dashboard` tags.
