### PR TITLE
General: Update dependencies to latest stable versions

### DIFF
--- a/app-common-io/build.gradle.kts
+++ b/app-common-io/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     implementation(project(":app-common-shell"))
 
     addAndroidCore()
+    implementation("androidx.documentfile:documentfile:1.1.0")
     addAndroidUI()
     addDI()
     addCoroutines()

--- a/app-common-test/build.gradle.kts
+++ b/app-common-test/build.gradle.kts
@@ -40,17 +40,17 @@ dependencies {
     addSerialization()
 
     implementation("junit:junit:4.13.2")
-    implementation("org.junit.vintage:junit-vintage-engine:5.8.2")
-    implementation("androidx.test:core-ktx:1.4.0")
+    implementation("org.junit.vintage:junit-vintage-engine:5.14.2")
+    implementation("androidx.test:core-ktx:1.7.0")
 
-    implementation("io.mockk:mockk:1.12.4")
+    implementation("io.mockk:mockk:1.14.9")
 
-    runtimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.2")
-    implementation("org.junit.jupiter:junit-jupiter-api:5.8.2")
-    implementation("org.junit.jupiter:junit-jupiter-params:5.8.2")
+    runtimeOnly("org.junit.jupiter:junit-jupiter-engine:5.14.2")
+    implementation("org.junit.jupiter:junit-jupiter-api:5.14.2")
+    implementation("org.junit.jupiter:junit-jupiter-params:5.14.2")
 
 
-    implementation("io.kotest:kotest-runner-junit5:5.3.0")
-    implementation("io.kotest:kotest-assertions-core-jvm:5.3.0")
-    implementation("io.kotest:kotest-property-jvm:5.3.0")
+    implementation("io.kotest:kotest-runner-junit5:5.9.1")
+    implementation("io.kotest:kotest-assertions-core-jvm:5.9.1")
+    implementation("io.kotest:kotest-property-jvm:5.9.1")
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -61,7 +61,7 @@ android {
         create("foss") {
             dimension = "version"
             signingConfig = signingConfigs["releaseFoss"]
-            // The info block is encrypted and can only be read by google
+            // The info block is encrypted and can only be read by Google
             dependenciesInfo {
                 includeInApk = false
                 includeInBundle = false
@@ -210,15 +210,14 @@ dependencies {
     addIO()
     addRetrofit()
 
-    "gplayImplementation"("com.android.billingclient:billing:8.0.0")
-    "gplayImplementation"("com.android.billingclient:billing-ktx:8.0.0")
+    "gplayImplementation"("com.android.billingclient:billing:8.3.0")
+    "gplayImplementation"("com.android.billingclient:billing-ktx:8.3.0")
 
-    //noinspection GradleDependency See https://issuetracker.google.com/issues/374691245
-    "gplayImplementation"("com.google.android.play:review:2.0.1")
-    //noinspection GradleDependency See https://issuetracker.google.com/issues/374691245
-    "gplayImplementation"("com.google.android.play:review-ktx:2.0.1")
+    "gplayImplementation"("com.google.android.play:review:2.0.2")
+    "gplayImplementation"("com.google.android.play:review-ktx:2.0.2")
 
     addAndroidCore()
+    implementation("androidx.documentfile:documentfile:1.1.0")
     addAndroidUI()
     addWorkerManager()
 
@@ -231,14 +230,14 @@ dependencies {
     addCoil()
     addLottie()
 
-    implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
+    implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.2.0")
     implementation("com.github.reddit:IndicatorFastScroll:f9576c7") // 1.4.0
     implementation("me.zhanghai.android.fastscroll:library:1.3.0")
     implementation("androidx.recyclerview:recyclerview:1.4.0")
     implementation("androidx.recyclerview:recyclerview-selection:1.2.0")
 
-    implementation("androidx.core:core-splashscreen:1.0.0")
-    implementation("androidx.exifinterface:exifinterface:1.3.7")
+    implementation("androidx.core:core-splashscreen:1.2.0")
+    implementation("androidx.exifinterface:exifinterface:1.4.2")
     implementation("io.github.panpf.zoomimage:zoomimage-view-coil2:1.4.0")
 
     implementation("androidx.navigation:navigation-fragment-ktx:${Versions.AndroidX.Navigation.core}")
@@ -248,6 +247,6 @@ dependencies {
 
 
 
-    testImplementation("org.robolectric:robolectric:4.16")
+    testImplementation("org.robolectric:robolectric:4.16.1")
     testImplementation("androidx.test.ext:junit:1.3.0")
 }

--- a/app/src/androidTest/java/eu/darken/sdmse/main/MainActivityTest.kt
+++ b/app/src/androidTest/java/eu/darken/sdmse/main/MainActivityTest.kt
@@ -1,6 +1,6 @@
 package eu.darken.sdmse.main
 
-import android.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.liveData
 import androidx.test.core.app.launchActivity
 import dagger.hilt.android.testing.BindValue

--- a/app/src/main/java/eu/darken/sdmse/automation/core/uidumper/UiDumper.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/uidumper/UiDumper.kt
@@ -122,7 +122,7 @@ class UiDumper @Inject constructor(
                     when (parser.name) {
                         "node" -> {
                             if (nodeStack.isNotEmpty()) {
-                                val completed = nodeStack.removeLast().toUiNode()
+                                val completed = nodeStack.removeAt(nodeStack.lastIndex).toUiNode()
                                 if (nodeStack.isNotEmpty()) {
                                     nodeStack.last().children.add(completed)
                                 } else {

--- a/app/src/main/java/eu/darken/sdmse/common/picker/PickerViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/picker/PickerViewModel.kt
@@ -115,7 +115,7 @@ class PickerViewModel @Inject constructor(
 
                     // Remove the last item (the selected path itself) so it shows in the list
                     if (navPath.size > 1) {
-                        navPath.removeLast()
+                        navPath.removeAt(navPath.lastIndex)
                     }
 
                     log(TAG, INFO) { "Pre-navigating to: ${navPath.map { it.lookup.lookedUp }}" }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("projectConfig")
-    id("com.google.devtools.ksp") version "2.3.4" apply false
+    id("com.google.devtools.ksp") version "2.3.5" apply false
 }
 
 buildscript {

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -16,7 +16,7 @@ private fun DependencyHandler.testImplementation(
     dependencyNotation: String,
     dependencyConfiguration: Action<ExternalModuleDependency>
 ): ExternalModuleDependency = addDependencyTo(
-    this, "androidTestImplementation", dependencyNotation, dependencyConfiguration
+    this, "testImplementation", dependencyNotation, dependencyConfiguration
 )
 
 private fun DependencyHandler.ksp(dependencyNotation: Any): Dependency? =
@@ -87,7 +87,7 @@ fun DependencyHandlerScope.addCoil() {
 }
 
 fun DependencyHandlerScope.addLottie() {
-    implementation("com.airbnb.android:lottie:3.5.0")
+    implementation("com.airbnb.android:lottie:6.7.1")
 }
 
 fun DependencyHandlerScope.addSerialization() {
@@ -98,7 +98,7 @@ fun DependencyHandlerScope.addSerialization() {
 }
 
 fun DependencyHandlerScope.addIO() {
-    implementation("com.squareup.okio:okio:3.15.0")
+    implementation("com.squareup.okio:okio:3.16.4")
 }
 
 fun DependencyHandlerScope.addRetrofit() {
@@ -111,22 +111,22 @@ fun DependencyHandlerScope.addRetrofit() {
 }
 
 fun DependencyHandlerScope.addAndroidCore() {
-    implementation("androidx.core:core-ktx:1.8.0")
-    implementation("androidx.appcompat:appcompat:1.7.0")
-    implementation("androidx.annotation:annotation:1.4.0")
+    implementation("androidx.core:core-ktx:1.17.0")
+    implementation("androidx.appcompat:appcompat:1.7.1")
+    implementation("androidx.annotation:annotation:1.9.1")
 
-    implementation("androidx.preference:preference-ktx:1.2.0")
-    implementation("androidx.datastore:datastore-preferences:1.0.0")
+    implementation("androidx.preference:preference-ktx:1.2.1")
+    implementation("androidx.datastore:datastore-preferences:1.2.0")
 }
 
 fun DependencyHandlerScope.addRoomDb() {
-    implementation("androidx.room:room-runtime:2.7.1")
-    implementation("androidx.room:room-ktx:2.7.1")
-    ksp("androidx.room:room-compiler:2.7.1")
+    implementation("androidx.room:room-runtime:2.8.4")
+    implementation("androidx.room:room-ktx:2.8.4")
+    ksp("androidx.room:room-compiler:2.8.4")
 }
 
 fun DependencyHandlerScope.addWorkerManager() {
-    val version = "2.10.3"
+    val version = "2.11.0"
     implementation("androidx.work:work-runtime:$version")
     testImplementation("androidx.work:work-testing:$version")
     implementation("androidx.work:work-runtime-ktx:$version")
@@ -136,30 +136,30 @@ fun DependencyHandlerScope.addWorkerManager() {
 }
 
 fun DependencyHandlerScope.addAndroidUI() {
-    implementation("androidx.activity:activity-ktx:1.10.0")
+    implementation("androidx.activity:activity-ktx:1.12.4")
     implementation("androidx.fragment:fragment-ktx:1.8.9")
 
-    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.9.2")
-    implementation("androidx.lifecycle:lifecycle-viewmodel-savedstate:2.9.2")
-    implementation("androidx.lifecycle:lifecycle-common-java8:2.9.2")
-    implementation("androidx.lifecycle:lifecycle-process:2.9.2")
-    implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.9.2")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.9.4")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-savedstate:2.9.4")
+    implementation("androidx.lifecycle:lifecycle-common-java8:2.9.4")
+    implementation("androidx.lifecycle:lifecycle-process:2.9.4")
+    implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.9.4")
 
     implementation("androidx.constraintlayout:constraintlayout:2.2.1")
-    implementation("com.google.android.material:material:1.13.0-alpha12")
+    implementation("com.google.android.material:material:1.13.0")
 }
 
 fun DependencyHandlerScope.addTesting() {
     testImplementation("junit:junit:4.13.2")
-    testImplementation("org.junit.vintage:junit-vintage-engine:5.13.0")
-    testImplementation("androidx.test:core-ktx:1.6.1")
+    testImplementation("org.junit.vintage:junit-vintage-engine:5.14.2")
+    testImplementation("androidx.test:core-ktx:1.7.0")
 
-    testImplementation("io.mockk:mockk:1.14.5")
-    androidTestImplementation("io.mockk:mockk-android:1.14.5")
+    testImplementation("io.mockk:mockk:1.14.9")
+    androidTestImplementation("io.mockk:mockk-android:1.14.9")
 
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.13.0")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.13.0")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:5.13.0")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.14.2")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.14.2")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:5.14.2")
 
 
     testImplementation("io.kotest:kotest-runner-junit5:5.9.1")
@@ -170,15 +170,15 @@ fun DependencyHandlerScope.addTesting() {
 
     testImplementation("androidx.arch.core:core-testing:2.2.0")
     androidTestImplementation("androidx.arch.core:core-testing:2.2.0")
-    debugImplementation("androidx.test:core-ktx:1.6.1")
+    debugImplementation("androidx.test:core-ktx:1.7.0")
 
-    androidTestImplementation("androidx.test.ext:junit:1.2.1")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
+    androidTestImplementation("androidx.test.ext:junit:1.3.0")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.7.0")
 
-    androidTestImplementation("androidx.test:runner:1.6.2")
-    androidTestImplementation("androidx.test:rules:1.6.1")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
-    androidTestImplementation("androidx.test.espresso:espresso-contrib:3.6.1")
-    androidTestImplementation("androidx.test.espresso:espresso-intents:3.6.1")
-    androidTestImplementation("androidx.test.espresso.idling:idling-concurrent:3.6.1")
+    androidTestImplementation("androidx.test:runner:1.7.0")
+    androidTestImplementation("androidx.test:rules:1.7.0")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.7.0")
+    androidTestImplementation("androidx.test.espresso:espresso-contrib:3.7.0")
+    androidTestImplementation("androidx.test.espresso:espresso-intents:3.7.0")
+    androidTestImplementation("androidx.test.espresso.idling:idling-concurrent:3.7.0")
 }

--- a/buildSrc/src/main/java/ProjectConfigPlugin.kt
+++ b/buildSrc/src/main/java/ProjectConfigPlugin.kt
@@ -8,7 +8,7 @@ open class ProjectConfig {
     val packageName = "eu.darken.sdmse"
     val minSdk = 26
 
-    val compileSdk = 35
+    val compileSdk = 36
     val compileSdkPreview: String? = null
     val targetSdk = 35
     val targetSdkPreview: String? = null

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -5,7 +5,7 @@ object Versions {
     }
 
     object Dagger {
-        const val core = "2.58"
+        const val core = "2.59.2"
     }
 
     object AndroidX {


### PR DESCRIPTION
## What changed

Updated all project dependencies to their latest stable versions and fixed several build issues discovered during the upgrade.

## Developer TLDR

**Dependency bumps (20+ libraries):**
- Dagger/Hilt 2.58→2.59.2, KSP 2.3.4→2.3.5
- Material 1.13.0-alpha12→1.13.0 (stable), core-ktx 1.8.0→1.17.0
- activity-ktx 1.10.0→1.12.4, lifecycle 2.9.2→2.9.4
- Room 2.7.1→2.8.4, WorkManager 2.10.3→2.11.0, DataStore 1.0.0→1.2.0
- Lottie 3.5.0→6.7.1, Okio 3.15.0→3.16.4
- Billing 8.0.0→8.3.0, Play Review 2.0.1→2.0.2
- Test deps: JUnit Jupiter 5.14.2, MockK 1.14.9, Espresso 3.7.0, Kotest 5.9.1
- Also: appcompat 1.7.1, annotation 1.9.1, preference-ktx 1.2.1

**Build fixes:**
- compileSdk 35→36 (required by core-ktx 1.17.0 and activity-ktx 1.12.4)
- Fix `Dependencies.kt` routing bug: `testImplementation(String, Action)` overload was incorrectly routing to `androidTestImplementation`
- Add explicit `documentfile:1.1.0` dependency (dropped as transitive dep after core-ktx upgrade)
- Fix `MutableList.removeLast()` calls in `PickerViewModel` and `UiDumper` — compileSdk 36 causes Java's `List.removeLast()` (API 35) to shadow Kotlin's extension function
- Align `app-common-test` hardcoded test dependency versions with `addTesting()` (was stuck on JUnit 5.8.2, MockK 1.12.4, Kotest 5.3.0)
- Fix pre-AndroidX import in `MainActivityTest`
