### PR TITLE
General: Raise target SDK to Android 16

### DIFF
--- a/app-common/src/main/java/eu/darken/sdmse/common/BuildWrap.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/BuildWrap.kt
@@ -38,10 +38,11 @@ fun hasApiLevel(level: Int): Boolean = when {
     BuildWrap.VERSION.SDK_INT >= level -> true
     level == 34 && BuildWrap.VERSION.CODENAME == "UpsideDownCake" -> true
     level == 35 && BuildWrap.VERSION.CODENAME == "VanillaIceCream" -> true
+    level == 36 && BuildWrap.VERSION.CODENAME == "Baklava" -> true
     else -> false
 }
 
-const val UNTESTED_API = 36
+const val UNTESTED_API = 37
 
 inline fun <reified R> ifApiLevel(level: Int, block: () -> R): R? = if (hasApiLevel(level)) block() else null
 

--- a/app-common/src/test/java/eu/darken/sdmse/common/HasApiLevelTest.kt
+++ b/app-common/src/test/java/eu/darken/sdmse/common/HasApiLevelTest.kt
@@ -1,0 +1,75 @@
+package eu.darken.sdmse.common
+
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class HasApiLevelTest : BaseTest() {
+
+    @BeforeEach
+    fun setup() {
+        mockkObject(BuildWrap)
+        mockkObject(BuildWrap.VERSION)
+    }
+
+    @AfterEach
+    fun teardown() {
+        unmockkObject(BuildWrap)
+        unmockkObject(BuildWrap.VERSION)
+    }
+
+    @Test
+    fun `returns true when SDK_INT is at or above requested level`() {
+        every { BuildWrap.VERSION.SDK_INT } returns 36
+        every { BuildWrap.VERSION.CODENAME } returns "REL"
+
+        hasApiLevel(36) shouldBe true
+        hasApiLevel(35) shouldBe true
+        hasApiLevel(26) shouldBe true
+    }
+
+    @Test
+    fun `returns false when SDK_INT is below requested level and no matching codename`() {
+        every { BuildWrap.VERSION.SDK_INT } returns 35
+        every { BuildWrap.VERSION.CODENAME } returns "REL"
+
+        hasApiLevel(36) shouldBe false
+    }
+
+    @Test
+    fun `detects API 36 via Baklava codename on preview device`() {
+        every { BuildWrap.VERSION.SDK_INT } returns 35
+        every { BuildWrap.VERSION.CODENAME } returns "Baklava"
+
+        hasApiLevel(36) shouldBe true
+    }
+
+    @Test
+    fun `detects API 35 via VanillaIceCream codename on preview device`() {
+        every { BuildWrap.VERSION.SDK_INT } returns 34
+        every { BuildWrap.VERSION.CODENAME } returns "VanillaIceCream"
+
+        hasApiLevel(35) shouldBe true
+    }
+
+    @Test
+    fun `detects API 34 via UpsideDownCake codename on preview device`() {
+        every { BuildWrap.VERSION.SDK_INT } returns 33
+        every { BuildWrap.VERSION.CODENAME } returns "UpsideDownCake"
+
+        hasApiLevel(34) shouldBe true
+    }
+
+    @Test
+    fun `Baklava codename does not match wrong API level`() {
+        every { BuildWrap.VERSION.SDK_INT } returns 35
+        every { BuildWrap.VERSION.CODENAME } returns "Baklava"
+
+        hasApiLevel(37) shouldBe false
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/main/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/settings/SettingsFragment.kt
@@ -77,8 +77,7 @@ class SettingsFragment : Fragment2(R.layout.settings_fragment),
             screens.lastOrNull()?.let { setCurrentScreenInfo(it) }
         }
 
-        @Suppress("DEPRECATION")
-        ui.toolbar.setNavigationOnClickListener { requireActivity().onBackPressed() }
+        ui.toolbar.setNavigationOnClickListener { requireActivity().onBackPressedDispatcher.onBackPressed() }
 
         super.onViewCreated(view, savedInstanceState)
     }

--- a/buildSrc/src/main/java/ProjectConfigPlugin.kt
+++ b/buildSrc/src/main/java/ProjectConfigPlugin.kt
@@ -10,7 +10,7 @@ open class ProjectConfig {
 
     val compileSdk = 36
     val compileSdkPreview: String? = null
-    val targetSdk = 35
+    val targetSdk = 36
     val targetSdkPreview: String? = null
 
     lateinit var version: Version


### PR DESCRIPTION
## What changed

Updated the app's target SDK level to Android 16 (API 36) to comply with upcoming Google Play requirements. Also fixed a deprecated back navigation call in Settings that would break with the new predictive back gesture behavior on Android 16.

## Developer TLDR

- `targetSdk` 35 → 36 in `ProjectConfigPlugin.kt`
- Added `Baklava` codename detection in `hasApiLevel()` for API 36 preview devices
- Bumped `UNTESTED_API` to 37
- Replaced deprecated `requireActivity().onBackPressed()` with `onBackPressedDispatcher.onBackPressed()` in `SettingsFragment`
- Added `HasApiLevelTest` with 6 test cases covering codename detection for API 34-36
