### PR TITLE
Fix: APK files not showing icon preview in swiper

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/common/coil/PathPreviewFetcher.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/coil/PathPreviewFetcher.kt
@@ -63,7 +63,7 @@ class PathPreviewFetcher @Inject constructor(
                 )
             }
 
-            mimeType == "application/octet-stream" && data.lookedUp.extension == "apk" && data.lookedUp is LocalPath -> {
+            data.lookedUp.extension == "apk" && data.lookedUp is LocalPath -> {
                 val file = data.lookedUp.asFile()
 
                 val iconDrawable = file


### PR DESCRIPTION
## What changed

APK files in the swiper now correctly show the app icon as a preview instead of a generic file icon.

## Developer TLDR

- `PathPreviewFetcher` checked `mimeType == "application/octet-stream"` for APK files, but Android's `MimeTypeMap` returns `"application/vnd.android.package-archive"` for `.apk` — the condition never matched
- Removed the redundant MIME type check; the `.apk` extension check is sufficient
