### PR TITLE
Swiper: Allow cancelling scans on large folders

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/swiper/core/scanner/SwiperScanner.kt
+++ b/app/src/main/java/eu/darken/sdmse/swiper/core/scanner/SwiperScanner.kt
@@ -23,6 +23,8 @@ import eu.darken.sdmse.main.core.SDMTool
 import eu.darken.sdmse.swiper.core.SessionState
 import eu.darken.sdmse.swiper.core.db.SwipeItemEntity
 import eu.darken.sdmse.swiper.core.db.SwipeSessionEntity
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asFlow
@@ -32,6 +34,8 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flatMapMerge
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.take
+import kotlin.coroutines.coroutineContext
 import java.time.Instant
 import java.util.UUID
 import javax.inject.Inject
@@ -92,11 +96,10 @@ class SwiperScanner @Inject constructor(
 
         var count = 0
         val files = mutableListOf<APathLookup<*>>()
+        val limitedFlow = if (options.itemLimit != null) searchFlow.take(options.itemLimit) else searchFlow
 
-        searchFlow.collect { lookup ->
-            if (options.itemLimit != null && count >= options.itemLimit) {
-                return@collect
-            }
+        limitedFlow.collect { lookup ->
+            currentCoroutineContext().ensureActive()
             count++
             files.add(lookup)
             updateProgressSecondary(lookup.userReadablePath)

--- a/app/src/main/java/eu/darken/sdmse/swiper/ui/sessions/SwiperSessionsFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/swiper/ui/sessions/SwiperSessionsFragment.kt
@@ -108,10 +108,12 @@ class SwiperSessionsFragment : Fragment3(R.layout.swiper_sessions_fragment) {
                         sessionWithStats = sessionWithStats,
                         position = position,
                         isScanning = state.isSessionScanning(sessionId),
+                        isCancelling = state.isSessionCancelling(sessionId),
                         isRefreshing = state.isSessionRefreshing(sessionId),
                         onScan = { vm.scanSession(sessionId) },
                         onContinue = { vm.continueSession(sessionId) },
                         onRemove = { showDiscardConfirmation(sessionId) },
+                        onCancel = { vm.cancelScan() },
                         onRename = {
                             showRenameDialog(
                                 sessionId,

--- a/app/src/main/java/eu/darken/sdmse/swiper/ui/sessions/items/SwiperSessionsSessionVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/swiper/ui/sessions/items/SwiperSessionsSessionVH.kt
@@ -105,10 +105,11 @@ class SwiperSessionsSessionVH(parent: ViewGroup) :
         scanProgress.isVisible = item.isScanning || item.isRefreshing
         when {
             item.isScanning -> {
-                // Scanning in progress
-                actionButton.text = getString(R.string.swiper_scanning_title)
-                actionButton.icon = null
-                actionButton.isEnabled = false
+                // Scanning in progress - show cancel button (disabled if already cancelling)
+                actionButton.text = getString(eu.darken.sdmse.common.R.string.general_cancel_action)
+                actionButton.setIconResource(R.drawable.ic_cancel)
+                actionButton.isEnabled = !item.isCancelling
+                actionButton.setOnClickListener { item.onCancel() }
             }
             item.isRefreshing -> {
                 // Refreshing lookups in progress
@@ -146,11 +147,13 @@ class SwiperSessionsSessionVH(parent: ViewGroup) :
         val sessionWithStats: Swiper.SessionWithStats,
         val position: Int,
         val isScanning: Boolean,
+        val isCancelling: Boolean,
         val isRefreshing: Boolean,
         val onScan: () -> Unit,
         val onContinue: () -> Unit,
         val onRemove: () -> Unit,
         val onRename: () -> Unit,
+        val onCancel: () -> Unit,
     ) : SwiperSessionsAdapter.Item {
         override val stableId: Long = sessionWithStats.session.sessionId.hashCode().toLong()
     }


### PR DESCRIPTION
## What changed

Scanning a large or complex folder (e.g. the root of an SD card) could run for a very long time with no way to stop it. The cancel button now appears during scanning, and the remove button works immediately even while a scan is in progress.

## Developer TLDR

- `SwiperScanner`: replaced `return@collect` (which skipped items but let the upstream `walk()` flow keep running) with `take(itemLimit)` to properly cancel the filesystem walk at the limit; added `ensureActive()` for responsive cancellation
- `SwiperSessionsViewModel`: added `cancelScan()` using `taskManager.cancel(SDMTool.Type.SWIPER)`; `discardSession()` now cancels a running scan first so it doesn't block on `toolLock`
- `SwiperSessionsSessionVH`: scanning state now shows an enabled "Cancel" button instead of disabled "Scanning..." text; button disables after first press via `isCancelling` state
- `SwiperSessionsFragment`: wires `onCancel` and `isCancelling` through to the ViewHolder
