### PR TITLE
General: Show text file previews as thumbnails

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/common/coil/PathPreviewFetcher.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/coil/PathPreviewFetcher.kt
@@ -3,6 +3,7 @@ package eu.darken.sdmse.common.coil
 import android.content.Context
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
+import android.graphics.drawable.BitmapDrawable
 import androidx.core.content.ContextCompat
 import coil.ImageLoader
 import coil.decode.DataSource
@@ -11,9 +12,14 @@ import coil.fetch.FetchResult
 import coil.fetch.Fetcher
 import coil.fetch.SourceResult
 import coil.request.Options
+import coil.size.Dimension
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.sdmse.common.MimeTypeTool
 import eu.darken.sdmse.common.datastore.value
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.asLog
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APathLookup
 import eu.darken.sdmse.common.files.FileType
 import eu.darken.sdmse.common.files.GatewaySwitch
@@ -22,6 +28,8 @@ import eu.darken.sdmse.common.files.extension
 import eu.darken.sdmse.common.files.iconRes
 import eu.darken.sdmse.common.files.local.LocalPath
 import eu.darken.sdmse.main.core.GeneralSettings
+import okio.buffer
+import java.io.IOException
 import javax.inject.Inject
 
 class PathPreviewFetcher @Inject constructor(
@@ -30,6 +38,7 @@ class PathPreviewFetcher @Inject constructor(
     private val generalSettings: GeneralSettings,
     private val gatewaySwitch: GatewaySwitch,
     private val mimeTypeTool: MimeTypeTool,
+    private val textPreviewRenderer: TextPreviewRenderer,
     private val data: APathLookup<*>,
     private val options: Options,
 ) : Fetcher {
@@ -86,8 +95,57 @@ class PathPreviewFetcher @Inject constructor(
                 } ?: fallbackIcon
             }
 
+            isTextFile(data) -> {
+                renderTextPreview() ?: fallbackIcon
+            }
+
             else -> fallbackIcon
         }
+    }
+
+    private suspend fun renderTextPreview(): DrawableResult? {
+        return try {
+            val (width, height) = resolveSize()
+
+            val bytes = gatewaySwitch.file(data.lookedUp, readWrite = false).use { handle ->
+                val readSize = minOf(handle.size(), MAX_TEXT_READ_BYTES)
+                handle.source().buffer().use { source ->
+                    source.readByteArray(readSize)
+                }
+            }
+
+            if (bytes.any { it == 0.toByte() }) return null
+
+            val text = String(bytes, Charsets.UTF_8)
+                .replace("\r", "")
+                .replace("\t", "    ")
+
+            val density = context.resources.displayMetrics.density
+            val bitmap = textPreviewRenderer.render(text, width, height, density)
+
+            DrawableResult(
+                drawable = BitmapDrawable(context.resources, bitmap),
+                isSampled = false,
+                dataSource = DataSource.DISK,
+            )
+        } catch (e: IOException) {
+            log(TAG, WARN) { "Text preview failed for ${data.lookedUp}: ${e.asLog()}" }
+            null
+        }
+    }
+
+    private fun resolveSize(): Pair<Int, Int> {
+        val width = when (val w = options.size.width) {
+            is Dimension.Pixels -> w.px
+            Dimension.Undefined -> DEFAULT_SIZE_PX
+        }.coerceIn(1, MAX_SIZE_PX)
+
+        val height = when (val h = options.size.height) {
+            is Dimension.Pixels -> h.px
+            Dimension.Undefined -> DEFAULT_SIZE_PX
+        }.coerceIn(1, MAX_SIZE_PX)
+
+        return width to height
     }
 
     class Factory @Inject constructor(
@@ -96,6 +154,7 @@ class PathPreviewFetcher @Inject constructor(
         private val generalSettings: GeneralSettings,
         private val gatewaySwitch: GatewaySwitch,
         private val mimeTypeTool: MimeTypeTool,
+        private val textPreviewRenderer: TextPreviewRenderer,
     ) : Fetcher.Factory<APathLookup<*>> {
 
         override fun create(
@@ -108,9 +167,34 @@ class PathPreviewFetcher @Inject constructor(
             generalSettings,
             gatewaySwitch,
             mimeTypeTool,
+            textPreviewRenderer,
             data,
             options,
         )
+    }
+
+    companion object {
+        private val TAG = logTag("Coil", "PathPreview")
+        private const val MAX_TEXT_READ_BYTES = 8192L
+        private const val DEFAULT_SIZE_PX = 256
+        private const val MAX_SIZE_PX = 512
+
+        private val TEXT_EXTENSIONS = setOf(
+            "txt", "text", "log",
+            "html", "htm", "xhtml",
+            "xml", "json", "yaml", "yml",
+            "csv", "tsv",
+            "md", "markdown",
+            "cfg", "conf", "ini", "properties",
+            "sh", "bash",
+            "java", "kt", "kts", "py", "js", "ts",
+            "css", "scss",
+            "sql", "gradle",
+        )
+
+        fun isTextFile(data: APathLookup<*>): Boolean {
+            return data.lookedUp.extension?.lowercase() in TEXT_EXTENSIONS
+        }
     }
 }
 

--- a/app/src/main/java/eu/darken/sdmse/common/coil/TextPreviewRenderer.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/coil/TextPreviewRenderer.kt
@@ -1,0 +1,59 @@
+package eu.darken.sdmse.common.coil
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Typeface
+import android.text.TextPaint
+import dagger.Reusable
+import javax.inject.Inject
+import androidx.core.graphics.createBitmap
+
+@Reusable
+class TextPreviewRenderer @Inject constructor() {
+
+    fun render(
+        text: String,
+        width: Int,
+        height: Int,
+        density: Float,
+    ): Bitmap {
+        val bitmap = createBitmap(width, height)
+        val canvas = Canvas(bitmap)
+
+        canvas.drawColor(BACKGROUND_COLOR)
+
+        val padding = (PADDING_DP * density)
+        val textSize = (height / 20f).coerceIn(MIN_TEXT_SIZE_PX, MAX_TEXT_SIZE_PX)
+
+        val paint = TextPaint().apply {
+            isAntiAlias = true
+            color = TEXT_COLOR
+            typeface = Typeface.MONOSPACE
+            this.textSize = textSize
+        }
+
+        val lineHeight = paint.fontMetrics.let { it.descent - it.ascent + it.leading }
+        val maxWidth = width - 2 * padding
+        var y = padding - paint.fontMetrics.ascent
+        val lines = text.lines()
+
+        for (line in lines) {
+            if (y + paint.fontMetrics.descent > height - padding) break
+            canvas.save()
+            canvas.clipRect(padding, 0f, padding + maxWidth, height.toFloat())
+            canvas.drawText(line, padding, y, paint)
+            canvas.restore()
+            y += lineHeight
+        }
+
+        return bitmap
+    }
+
+    companion object {
+        private const val BACKGROUND_COLOR = 0xFFF5F5F5.toInt()
+        private const val TEXT_COLOR = 0xFF333333.toInt()
+        private const val PADDING_DP = 4f
+        private const val MIN_TEXT_SIZE_PX = 6f
+        private const val MAX_TEXT_SIZE_PX = 16f
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/common/coil/PathPreviewFetcherTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/common/coil/PathPreviewFetcherTest.kt
@@ -1,0 +1,57 @@
+package eu.darken.sdmse.common.coil
+
+import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.common.files.local.LocalPath
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class PathPreviewFetcherTest : BaseTest() {
+
+    private fun mockLookup(name: String): APathLookup<*> = mockk<APathLookup<*>>().apply {
+        every { lookedUp } returns LocalPath.build("test", name)
+    }
+
+    @Test fun `isTextFile detects txt extension`() {
+        PathPreviewFetcher.isTextFile(mockLookup("readme.txt")) shouldBe true
+    }
+
+    @Test fun `isTextFile detects log extension`() {
+        PathPreviewFetcher.isTextFile(mockLookup("app.log")) shouldBe true
+    }
+
+    @Test fun `isTextFile detects html extension`() {
+        PathPreviewFetcher.isTextFile(mockLookup("index.html")) shouldBe true
+    }
+
+    @Test fun `isTextFile detects json extension`() {
+        PathPreviewFetcher.isTextFile(mockLookup("data.json")) shouldBe true
+    }
+
+    @Test fun `isTextFile detects kotlin extension`() {
+        PathPreviewFetcher.isTextFile(mockLookup("Main.kt")) shouldBe true
+    }
+
+    @Test fun `isTextFile detects gradle extension`() {
+        PathPreviewFetcher.isTextFile(mockLookup("build.gradle")) shouldBe true
+    }
+
+    @Test fun `isTextFile rejects image extension`() {
+        PathPreviewFetcher.isTextFile(mockLookup("photo.jpg")) shouldBe false
+    }
+
+    @Test fun `isTextFile rejects apk extension`() {
+        PathPreviewFetcher.isTextFile(mockLookup("app.apk")) shouldBe false
+    }
+
+    @Test fun `isTextFile rejects no extension`() {
+        PathPreviewFetcher.isTextFile(mockLookup("noext")) shouldBe false
+    }
+
+    @Test fun `isTextFile is case insensitive`() {
+        PathPreviewFetcher.isTextFile(mockLookup("README.TXT")) shouldBe true
+        PathPreviewFetcher.isTextFile(mockLookup("Data.JSON")) shouldBe true
+    }
+}


### PR DESCRIPTION
## What changed

Text-based files (like .txt, .log, .html, .json, etc.) now show a miniature document preview as their thumbnail instead of a generic file icon. This makes it easier to visually identify text files when browsing storage.

## Developer TLDR

- New `TextPreviewRenderer` renders first 8KB of text content onto a `Bitmap` using `Canvas` + monospace `TextPaint`
- New `when` branch in `PathPreviewFetcher` for ~30 text file extensions
- Font size scales with thumbnail height (`height/20`, clamped 6-16px), bitmap dimensions resolved from Coil `options.size` with clamping (1-512px)
- Binary rejection via NUL byte heuristic prevents garbled previews for misnamed files
- `FileHandle.use {}` ensures proper cleanup for root/ADB file access
- Text normalized: tabs → 4 spaces, CR stripped, UTF-8 with replacement
- `IOException` caught and logged, falls back to file type icon
- 10 unit tests for extension detection logic
