### PR TITLE
General: Show PDF file previews as thumbnails

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/common/coil/FileHandleProxyPfd.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/coil/FileHandleProxyPfd.kt
@@ -1,0 +1,48 @@
+package eu.darken.sdmse.common.coil
+
+import android.os.Handler
+import android.os.HandlerThread
+import android.os.ParcelFileDescriptor
+import android.os.ProxyFileDescriptorCallback
+import android.os.storage.StorageManager
+import android.system.ErrnoException
+import android.system.OsConstants
+import okio.FileHandle
+import java.io.IOException
+
+internal fun FileHandle.toProxyPfd(storageManager: StorageManager): ParcelFileDescriptor {
+    val fileHandle = this
+    val handlerThread = HandlerThread("coil-proxy-pfd").apply { start() }
+    val handler = Handler(handlerThread.looper)
+
+    val callback = object : ProxyFileDescriptorCallback() {
+        override fun onGetSize(): Long = try {
+            fileHandle.size()
+        } catch (e: IOException) {
+            throw ErrnoException("onGetSize", OsConstants.EIO, e)
+        }
+
+        override fun onRead(offset: Long, size: Int, data: ByteArray): Int {
+            val read = fileHandle.read(offset, data, 0, size)
+            // ProxyFileDescriptorCallback interprets 0 as EOF
+            return if (read == -1) 0 else read
+        }
+
+        override fun onRelease() {
+            fileHandle.close()
+            handlerThread.quitSafely()
+        }
+    }
+
+    return try {
+        storageManager.openProxyFileDescriptor(
+            ParcelFileDescriptor.MODE_READ_ONLY,
+            callback,
+            handler,
+        )
+    } catch (e: Exception) {
+        fileHandle.close()
+        handlerThread.quitSafely()
+        throw e
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/common/coil/PdfPageRenderer.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/coil/PdfPageRenderer.kt
@@ -1,0 +1,34 @@
+package eu.darken.sdmse.common.coil
+
+import android.graphics.Bitmap
+import android.graphics.Color
+import android.graphics.pdf.PdfRenderer
+import android.os.ParcelFileDescriptor
+import java.io.IOException
+import androidx.core.graphics.createBitmap
+
+internal fun renderPdfFirstPage(pfd: ParcelFileDescriptor, maxDimension: Int = 512): Bitmap? = try {
+    PdfRenderer(pfd).use { renderer ->
+        if (renderer.pageCount == 0) return@use null
+
+        renderer.openPage(0).use { page ->
+            if (page.width <= 0 || page.height <= 0) return@use null
+
+            val (width, height) = scaleToFit(page.width, page.height, maxDimension)
+            val bitmap = createBitmap(width, height)
+            bitmap.eraseColor(Color.WHITE)
+            page.render(bitmap, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
+            bitmap
+        }
+    }
+} catch (_: SecurityException) {
+    null
+} catch (_: IOException) {
+    null
+}
+
+private fun scaleToFit(srcWidth: Int, srcHeight: Int, maxDim: Int): Pair<Int, Int> {
+    if (srcWidth <= maxDim && srcHeight <= maxDim) return srcWidth to srcHeight
+    val scale = maxDim.toFloat() / maxOf(srcWidth, srcHeight)
+    return (srcWidth * scale).toInt().coerceAtLeast(1) to (srcHeight * scale).toInt().coerceAtLeast(1)
+}


### PR DESCRIPTION
## What changed

PDF files now show a thumbnail preview of their first page when browsing files, instead of a generic file icon. Works across all access methods including root and ADB.

## Developer TLDR

- `FileHandleProxyPfd`: wraps okio `FileHandle` as a seekable `ParcelFileDescriptor` via `StorageManager.openProxyFileDescriptor()` (FUSE proxy, no temp file copy)
- `PdfPageRenderer`: renders PDF page 0 as a scaled bitmap (max 512px, white background, aspect-ratio preserved)
- `PathPreviewFetcher`: new `application/pdf` branch with 50MB size cap, proper `CancellationException` handling, and resource cleanup on error paths
