### PR TITLE
AppCleaner: Fix cache clearing on Android 16/17 Google Pixel devices

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,6 +19,8 @@
   "enabledPlugins": {
     "android-translation@claude-code-cafe": true,
     "debugbadger@claude-code-cafe": true,
-    "jvm-tools@claude-code-cafe": true
+    "jvm-tools@claude-code-cafe": true,
+    "frontend-design@claude-plugins-official": true,
+    "kotlin-lsp@claude-plugins-official": true
   }
 }

--- a/app-common/src/main/java/eu/darken/sdmse/common/BuildWrap.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/BuildWrap.kt
@@ -39,6 +39,7 @@ fun hasApiLevel(level: Int): Boolean = when {
     level == 34 && BuildWrap.VERSION.CODENAME == "UpsideDownCake" -> true
     level == 35 && BuildWrap.VERSION.CODENAME == "VanillaIceCream" -> true
     level == 36 && BuildWrap.VERSION.CODENAME == "Baklava" -> true
+    level == 37 && BuildWrap.VERSION.CODENAME == "CinnamonBun" -> true
     else -> false
 }
 

--- a/app-common/src/test/java/eu/darken/sdmse/common/HasApiLevelTest.kt
+++ b/app-common/src/test/java/eu/darken/sdmse/common/HasApiLevelTest.kt
@@ -66,6 +66,14 @@ class HasApiLevelTest : BaseTest() {
     }
 
     @Test
+    fun `detects API 37 via CinnamonBun codename on preview device`() {
+        every { BuildWrap.VERSION.SDK_INT } returns 36
+        every { BuildWrap.VERSION.CODENAME } returns "CinnamonBun"
+
+        hasApiLevel(37) shouldBe true
+    }
+
+    @Test
     fun `Baklava codename does not match wrong API level`() {
         every { BuildWrap.VERSION.SDK_INT } returns 35
         every { BuildWrap.VERSION.CODENAME } returns "Baklava"

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/BaseAppCleanerSpecTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/BaseAppCleanerSpecTest.kt
@@ -4,6 +4,7 @@ import eu.darken.sdmse.automation.core.common.ACSNodeInfo
 import eu.darken.sdmse.automation.core.common.stepper.AutomationStep
 import eu.darken.sdmse.automation.core.common.stepper.StepContext
 import eu.darken.sdmse.automation.core.common.stepper.Stepper
+import eu.darken.sdmse.automation.core.errors.StepAbortException
 import eu.darken.sdmse.automation.core.specs.AutomationExplorer
 import eu.darken.sdmse.automation.core.specs.AutomationSpec
 import eu.darken.sdmse.common.device.DeviceDetective
@@ -168,7 +169,20 @@ abstract class BaseAppCleanerSpecTest<S : AppCleanerSpecGenerator, L : Any> : Ba
                     tag = "test",
                     stepAttempts = 0,
                 )
-                actionResult = step.nodeAction?.invoke(stepContext) ?: false
+                val nodeAction = step.nodeAction
+                if (nodeAction != null) {
+                    try {
+                        for (i in 0 until 10) {
+                            val result = nodeAction.invoke(stepContext)
+                            if (result) {
+                                actionResult = true
+                                break
+                            }
+                        }
+                    } catch (_: StepAbortException) {
+                        actionResult = false
+                    }
+                }
             }
             Unit
         }

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecsTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecsTest.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import testhelpers.TestACSNodeInfo
 
@@ -49,6 +50,13 @@ class AOSPSpecsTest : BaseAppCleanerSpecTest<AOSPSpecs, AOSPLabels>() {
         every { labels.getStorageEntryStatic(any()) } returns setOf("Storage")
         every { labels.getClearCacheDynamic(any()) } returns emptySet()
         every { labels.getClearCacheStatic(any()) } returns setOf("Clear cache")
+    }
+
+    @BeforeEach
+    fun aospSetup() {
+        mockkObject(BuildWrap)
+        every { BuildWrap.MANUFACTOR } returns "TestOEM"
+        every { BuildWrap.PRODUCT } returns "test_product"
     }
 
     @AfterEach


### PR DESCRIPTION
## What changed

Fixed AppCleaner automation failing on Google Pixel devices running Android 16 and 17 beta. The "Clear cache" button was invisible to the accessibility service, causing cache clearing to fail with errors or time out.

Also added support for detecting Android 17 (CinnamonBun) on preview/beta devices.

## Developer TLDR

- Broadened DPAD fallback gate from `hasApiLevel(36) && isGoogle && isBetaBuild` to `hasApiLevel(36) && isGoogle` — NAF buttons persist into stable builds
- Added `DPAD_DOWN` before `DPAD_RIGHT` in quick-try, cycle loop, and blind sweep phases to reach buttons below the header anchor
- Added `validateWithDelta` retry loop (3 attempts × 250ms) to handle delayed Settings UI updates (~340ms observed on Android 17 beta)
- Removed anchor-hit-2 heuristic that could accidentally trigger "Clear Storage" instead of "Clear Cache"
- Added `StepAbortException` on DPAD exhaustion for fast-fail instead of wasting ~7s on timeout retries
- Added `CinnamonBun` codename mapping for `hasApiLevel(37)` detection
- Updated test harness `captureAndRunClearCacheAction()` to retry `nodeAction` (matching real `Stepper` behavior) and mock `BuildWrap` defaults in `AOSPSpecsTest`

Closes #2235
