### PR TITLE
Fix: Show localized error instead of raw exception when automation overlay fails

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/automation/core/AutomationService.kt
+++ b/app/src/main/java/eu/darken/sdmse/automation/core/AutomationService.kt
@@ -17,6 +17,7 @@ import eu.darken.sdmse.automation.core.common.pkgId
 import eu.darken.sdmse.automation.core.common.toNodeInfo
 import eu.darken.sdmse.common.pkgs.Pkg
 import eu.darken.sdmse.automation.core.errors.AutomationNoConsentException
+import eu.darken.sdmse.automation.core.errors.AutomationOverlayException
 import eu.darken.sdmse.automation.core.errors.UserCancelledAutomationException
 import eu.darken.sdmse.automation.ui.AutomationControlView
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
@@ -362,7 +363,12 @@ class AutomationService : AccessibilityService(), AutomationHost, Progress.Host,
                 }
                 alpha = 0f
                 log(TAG) { "submit($id): Adding controlView" }
-                windowManager.addView(this, overlayParams)
+                try {
+                    windowManager.addView(this, overlayParams)
+                } catch (e: WindowManager.BadTokenException) {
+                    log(TAG, ERROR) { "submit($id): Failed to add controlView: ${e.asLog()}" }
+                    throw AutomationOverlayException(e)
+                }
             }
         }
 


### PR DESCRIPTION
## What changed

Fixed an unhelpful error dialog that showed a raw "BadTokenException" message when the automation overlay couldn't be displayed. Users now see a clear, localized message explaining the issue and suggesting to check permissions or reboot the device.

## Developer TLDR

- `windowManager.addView()` in `AutomationService.submit()` can throw `WindowManager.BadTokenException` during overlay setup
- The existing catch in `AutomationExplorer.process()` never fires for this case because the exception occurs *before* the explorer is invoked
- Added try-catch around `addView()` that wraps `BadTokenException` as `AutomationOverlayException`, which implements `HasLocalizedError` and provides user-friendly strings
