### PR TITLE
General: Changelog button in settings now opens the website changelog

### DIFF
--- a/app/src/main/res/xml/preferences_index.xml
+++ b/app/src/main/res/xml/preferences_index.xml
@@ -102,7 +102,7 @@
             app:summary="v?.?.?">
             <intent
                 android:action="android.intent.action.VIEW"
-                android:data="https://github.com/d4rken-org/sdmaid-se/releases" />
+                android:data="https://sdmse.darken.eu/changelog" />
         </eu.darken.sdmse.common.preferences.IntentPreference>
 
         <Preference


### PR DESCRIPTION
## What changed

The changelog button in settings now opens the SD Maid SE website changelog instead of GitHub releases, matching the link shown in app store listings.

## Developer TLDR

- Changed intent URL in `preferences_index.xml` from `github.com/d4rken-org/sdmaid-se/releases` to `sdmse.darken.eu/changelog`
- Aligns with all fastlane `default.txt` changelogs which already point to the website