### PR TITLE
General: Fix short-recording warning surviving app restarts and show recording duration

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModule.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.content.res.Resources
 import android.os.Build
 import android.os.Environment
-import android.os.SystemClock
 import androidx.core.content.pm.PackageInfoCompat
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.sdmse.common.BuildConfigWrap
@@ -35,7 +34,11 @@ import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.plus
+import kotlinx.coroutines.withContext
 import java.io.File
+import java.nio.file.Files
+import java.nio.file.attribute.BasicFileAttributes
+import java.time.Duration
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -46,7 +49,7 @@ import javax.inject.Singleton
 class RecorderModule @Inject constructor(
     @ApplicationContext private val context: Context,
     @AppScope private val appScope: CoroutineScope,
-    dispatcherProvider: DispatcherProvider,
+    private val dispatcherProvider: DispatcherProvider,
     private val dataAreaManager: DataAreaManager,
     private val sdmId: SDMId,
     private val debugSettings: DebugSettings,
@@ -80,7 +83,6 @@ class RecorderModule @Inject constructor(
 
                 internalState.updateBlocking {
                     if (!isRecording && shouldRecord) {
-                        val isResuming = debugSettings.recorderPath.value() != null
                         val logDir = debugSettings.recorderPath.value()?.let {
                             log(TAG) { "Continuing existing log: $it" }
                             File(it)
@@ -98,8 +100,6 @@ class RecorderModule @Inject constructor(
                         copy(
                             recorder = newRecorder,
                             currentLogDir = logDir,
-                            // null for resumed recordings → skips duration check, never "too short"
-                            recordingStartedAtMillis = if (isResuming) null else SystemClock.elapsedRealtime(),
                         )
                     } else if (!shouldRecord && isRecording) {
                         log(TAG) { "Stopping log recorder for: $currentLogDir" }
@@ -121,7 +121,6 @@ class RecorderModule @Inject constructor(
 
                         copy(
                             recorder = null,
-                            recordingStartedAtMillis = null,
                         )
                     } else {
                         this
@@ -179,18 +178,24 @@ class RecorderModule @Inject constructor(
         val currentState = internalState.value()
         if (!currentState.isRecording) return StopResult.NotRecording
 
-        val startedAt = currentState.recordingStartedAtMillis
-        if (startedAt != null) {
-            val elapsedMs = SystemClock.elapsedRealtime() - startedAt
-            val elapsedSeconds = elapsedMs / 1000
-            if (elapsedSeconds < MIN_RECORDING_SECONDS) {
-                log(TAG) { "Recording too short: ${elapsedSeconds}s < ${MIN_RECORDING_SECONDS}s" }
-                return StopResult.TooShort(elapsedSeconds)
+        val logDir = currentState.currentLogDir
+        if (logDir != null) {
+            try {
+                val attrs = withContext(dispatcherProvider.IO) {
+                    Files.readAttributes(logDir.toPath(), BasicFileAttributes::class.java)
+                }
+                val elapsedSeconds = Duration.between(attrs.creationTime().toInstant(), Instant.now()).seconds
+                if (elapsedSeconds < MIN_RECORDING_SECONDS) {
+                    log(TAG) { "Recording too short: ${elapsedSeconds}s < ${MIN_RECORDING_SECONDS}s" }
+                    return StopResult.TooShort(elapsedSeconds)
+                }
+            } catch (e: Exception) {
+                log(TAG, WARN) { "Failed to read log dir creation time: ${e.asLog()}" }
             }
         }
 
-        val logDir = stopRecorder() ?: return StopResult.NotRecording
-        return StopResult.Stopped(logDir)
+        val stoppedDir = stopRecorder() ?: return StopResult.NotRecording
+        return StopResult.Stopped(stoppedDir)
     }
 
     suspend fun stopRecorder(): File? {
@@ -250,7 +255,6 @@ class RecorderModule @Inject constructor(
         val shouldRecord: Boolean = false,
         internal val recorder: Recorder? = null,
         val currentLogDir: File? = null,
-        val recordingStartedAtMillis: Long? = null,
     ) {
         val isRecording: Boolean
             get() = recorder != null

--- a/app/src/main/java/eu/darken/sdmse/common/debug/recorder/ui/RecorderActivity.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/debug/recorder/ui/RecorderActivity.kt
@@ -92,11 +92,18 @@ class RecorderActivity : Activity2() {
                 val sizeText = state.compressedSize?.let {
                     Formatter.formatShortFileSize(this@RecorderActivity, it)
                 } ?: "?"
+                val durationText = state.recordingDuration?.let { d ->
+                    val totalSeconds = d.seconds
+                    val minutes = totalSeconds / 60
+                    val seconds = totalSeconds % 60
+                    if (minutes > 0) "${minutes}m ${seconds}s" else "${seconds}s"
+                } ?: "?"
                 text = resources.getQuantityString(
                     R.plurals.debug_debuglog_screen_log_files_ready,
                     state.logEntries.size,
                     state.logEntries.size,
-                    sizeText
+                    sizeText,
+                    durationText,
                 )
             }
             adapter.update(state.logEntries)

--- a/app/src/main/java/eu/darken/sdmse/common/debug/recorder/ui/RecorderViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/debug/recorder/ui/RecorderViewModel.kt
@@ -21,6 +21,10 @@ import eu.darken.sdmse.common.files.core.local.deleteAll
 import eu.darken.sdmse.common.flow.DynamicStateFlow
 import eu.darken.sdmse.common.uix.ViewModel3
 import java.io.File
+import java.nio.file.Files
+import java.nio.file.attribute.BasicFileAttributes
+import java.time.Duration
+import java.time.Instant
 import javax.inject.Inject
 
 @HiltViewModel
@@ -45,6 +49,15 @@ class RecorderViewModel @Inject constructor(
     init {
         launch {
             if (sessionPath == null) throw IllegalStateException("No recorded path found")
+
+            val recordingDuration = try {
+                val attrs = Files.readAttributes(sessionPath.toPath(), BasicFileAttributes::class.java)
+                Duration.between(attrs.creationTime().toInstant(), Instant.now())
+            } catch (e: Exception) {
+                log(TAG, WARN) { "Failed to read session dir creation time: $e" }
+                null
+            }
+            stater.updateBlocking { copy(recordingDuration = recordingDuration) }
 
             log(TAG) { "Getting log files in dir: $sessionPath" }
             val logFiles = sessionPath.listFiles() ?: throw IllegalStateException("No log files found")
@@ -115,6 +128,7 @@ class RecorderViewModel @Inject constructor(
         val logEntries: List<LogFileAdapter.Entry.Item> = emptyList(),
         val compressedFile: File? = null,
         val compressedSize: Long? = null,
+        val recordingDuration: Duration? = null,
         val isWorking: Boolean = true,
     )
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,8 +20,8 @@
     <string name="debug_debuglog_screen_session_path_label">Session Path</string>
     <string name="debug_debuglog_screen_log_files_label">Log Files</string>
     <plurals name="debug_debuglog_screen_log_files_ready">
-        <item quantity="one">%1$d file ready (%2$s)</item>
-        <item quantity="other">%1$d files ready (%2$s)</item>
+        <item quantity="one">%1$d file ready (%2$s) · %3$s</item>
+        <item quantity="other">%1$d files ready (%2$s) · %3$s</item>
     </plurals>
     <string name="settings_debuglog_explanation">This feature records everything the app is doing into a shareable file. The generated file contains sensitive information (e.g. file names and installed apps). Only share it with trusted parties (e.g. a developer troubleshooting an issue).</string>
     <string name="debug_debuglog_short_recording_title">Very short recording</string>


### PR DESCRIPTION
## What changed

The warning about stopping debug log recording too quickly now works even if the app was restarted during recording. Previously, restarting the app and immediately stopping would skip the warning.

The recording summary screen now also shows how long the recording lasted (e.g. "1 file ready (96KB) · 2m 15s").

## Developer TLDR

- Replaced in-memory `recordingStartedAtMillis` (`SystemClock.elapsedRealtime()`) with NIO `BasicFileAttributes.creationTime()` on the log directory
- Removed `recordingStartedAtMillis` from `RecorderModule.State` and the `isResuming` branch that set it to null
- `requestStopRecorder()` now reads the directory's filesystem creation time, which persists across app kills and reboots
- Added `recordingDuration: Duration?` to `RecorderViewModel.State`, computed from the same directory creation time
- `RecorderActivity` formats and displays duration in the file summary caption
- Graceful fallback: if reading creation time fails, the warning is skipped and duration shows "?"
