### PR TITLE
Swiper: Fix crash on Czech locale devices

### DIFF
--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1139,7 +1139,7 @@
         <item quantity="one">Pokračovat v relaci před %1$d dnem (%2$d%% dokončeno)</item>
         <item quantity="few">Pokračovat v relaci před %1$d dny (%2$d%% dokončeno)</item>
         <item quantity="many">Pokračovat v relaci před %1$d dny (%2$d%% dokončeno)</item>
-        <item quantity="other">Pokračovat v relaci před %1$d dny (%2$d% % dokončeno)</item>
+        <item quantity="other">Pokračovat v relaci před %1$d dny (%2$d%% dokončeno)</item>
     </plurals>
     <plurals name="swiper_dashcard_x_sessions">
         <item quantity="one">%d relace</item>


### PR DESCRIPTION
## What changed

Fixed a crash that occurred when viewing the Swiper dashboard card on devices set to Czech language.

## Developer TLDR

- Czech plural `swiper_dashcard_session_context` `quantity="other"` had `%2$d% %` (space between percent signs) instead of `%2$d%%`
- This caused `IllegalFormatFlagsException: Flags = ' '` when `Resources.getQuantityString()` tried to parse the format specifier
