### PR TITLE
General: Fix freeze when selecting all items in large result lists

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/common/lists/RecyclerViewExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/lists/RecyclerViewExtensions.kt
@@ -171,8 +171,10 @@ internal fun <ItemT : SelectableItem> resolveSelection(
     data: List<ItemT>,
     caller: String,
 ): List<ItemT> {
-    val resolved = tracker.selection.mapNotNull { key -> data.firstOrNull { it.itemSelectionKey == key } }
-    val staleCount = tracker.selection.size() - resolved.size
+    val selectionKeys = tracker.selection.toList()
+    val dataByKey = data.associateBy { it.itemSelectionKey }
+    val resolved = selectionKeys.mapNotNull { key -> dataByKey[key] }
+    val staleCount = selectionKeys.size - resolved.size
     if (staleCount > 0) log(TAG, WARN) { "$caller: $staleCount stale selection keys" }
     return resolved
 }


### PR DESCRIPTION
## What changed

Fixed a freeze that could happen when using "Select All" on large result lists (e.g. thousands of items in AppCleaner or CorpseFinder results).

## Developer TLDR

- `resolveSelection()` in `RecyclerViewExtensions.kt` used O(n*m) nested `firstOrNull` iteration
- Replaced with `associateBy` HashMap + O(1) key lookups, total O(n+m)
- Snapshot `tracker.selection` via `toList()` to avoid iterating a live collection during mutation