### PR TITLE
General: Show parent screen name in settings toolbar

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/main/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/settings/SettingsFragment.kt
@@ -30,7 +30,8 @@ class SettingsFragment : Fragment2(R.layout.settings_fragment),
     @Parcelize
     data class Screen(
         val fragmentClass: String,
-        val screenTitle: String?
+        val screenTitle: String?,
+        val screenSubtitle: String? = null,
     ) : Parcelable
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -90,7 +91,8 @@ class SettingsFragment : Fragment2(R.layout.settings_fragment),
     override fun onPreferenceStartFragment(caller: PreferenceFragmentCompat, pref: Preference): Boolean {
         val screenInfo = Screen(
             fragmentClass = pref.fragment!!,
-            screenTitle = pref.title?.toString()
+            screenTitle = pref.title?.toString(),
+            screenSubtitle = ui.toolbar.title?.toString(),
         )
 
         val args = Bundle().apply {
@@ -121,6 +123,7 @@ class SettingsFragment : Fragment2(R.layout.settings_fragment),
     private fun setCurrentScreenInfo(info: Screen) {
         ui.toolbar.apply {
             title = info.screenTitle
+            subtitle = info.screenSubtitle
         }
     }
 


### PR DESCRIPTION
## What changed

Settings subscreens now show the parent screen name as a subtitle in the toolbar, giving better orientation when navigating deeper into settings. For example, opening "Support" from Settings shows "Settings" as a subtitle below the title.

## Technical Context

- Added `screenSubtitle` to the existing `Screen` parcelable — captures the current toolbar title before navigating forward
- Subtitle clears automatically at the root screen via the default `null` parameter, no explicit handling needed
- Propagates through the existing `screens` stack and `onSaveInstanceState`, so it survives config changes and back navigation
