### PR TITLE
CorpseFinder: Detect leftover data from CX File Explorer

### DIFF
--- a/app/src/main/assets/clutter/db_clutter_markers.json
+++ b/app/src/main/assets/clutter/db_clutter_markers.json
@@ -12606,5 +12606,8 @@
 	{"loc": "APP_APP", "path": "preinstall_history"},
 	{"loc": "APP_APP", "path": "preinstall_package_path"}
   ]
+}, {
+  "pkgs": ["com.ace.ex.file.manager"],
+  "mrks": [{"loc": "SDCARD", "path": ".aceself"}]
 }
 ]


### PR DESCRIPTION
## What changed

CX File Explorer creates a hidden `.aceself` folder on shared storage (`/storage/emulated/0/.aceself/`) containing a SQLite database for custom folder icon mappings. This folder is now detected as clutter when the app is no longer installed.

## Technical Context

- CX File Explorer's Android package is `com.ace.ex.file.manager`; the internal Java package is `com.ace.fileexplorer`
- The `.aceself/folder_icon_link.db` database is created by `AppFolderInfoManager` to persist folder-to-icon associations
- Identified via stacktrace in [LSPosed/CorePatch#143](https://github.com/LSPosed/CorePatch/issues/143)
