### PR TITLE
General: Fix KSP errors in CI logs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("projectConfig")
-    id("com.google.devtools.ksp") version "2.3.5" apply false
+    id("com.google.devtools.ksp") version "2.3.6" apply false
 }
 
 buildscript {


### PR DESCRIPTION
## What changed

Fixed spurious error lines appearing in CI build logs during KSP processing. Builds were not affected (all passed), but the errors were noisy.

## Technical Context

- KSP 2.3.5 had a bug ([google/ksp#2763](https://github.com/google/ksp/issues/2763)) where `BinaryFileTypeDecompilers` attempted to access an IntelliJ application context that doesn't exist in headless/CI environments, causing `NullPointerException` on the AWT-EventQueue thread
- Fixed in KSP 2.3.6 via [google/ksp#2785](https://github.com/google/ksp/pull/2785) by replacing the IntelliJ Core implementation with a command-line compatible version
