### PR TITLE
CorpseFinder: Add missing clutter markers for popular apps

### DIFF
--- a/app/src/main/assets/clutter/db_clutter_markers.json
+++ b/app/src/main/assets/clutter/db_clutter_markers.json
@@ -5488,6 +5488,9 @@
   "pkgs": ["org.telegram.messenger", "org.telegram.plus", "org.telegram.messenger.web"],
   "mrks": [
 	{"loc": "SDCARD", "path": "Telegram", "flags": ["keeper"]},
+	{"loc": "SDCARD", "path": "Telegram Audio", "flags": ["keeper"]},
+	{"loc": "SDCARD", "path": "Telegram Documents", "flags": ["keeper"]},
+	{"loc": "SDCARD", "path": "Telegram Video", "flags": ["keeper"]},
 	{"loc": "SDCARD", "path": "Pictures/Telegram", "flags": ["keeper"]},
 	{"loc": "SDCARD", "path": "Plus", "flags": ["common", "keeper"]}
   ]
@@ -8047,7 +8050,8 @@
   "pkgs": ["com.mxtech.videoplayer.ad", "com.mxtech.videoplayer.pro"],
   "mrks": [
 	{"loc": "SDCARD", "path": "Subtitles", "flags": ["common", "keeper"]},
-	{"loc": "SDCARD", "path": ".ColombiaMedia"}
+	{"loc": "SDCARD", "path": ".ColombiaMedia"},
+	{"loc": "SDCARD", "path": "MXShare"}
   ]
 }, {
   "pkgs": ["com.halo.wifikey.wifilocating"],
@@ -12609,5 +12613,14 @@
 }, {
   "pkgs": ["com.ace.ex.file.manager"],
   "mrks": [{"loc": "SDCARD", "path": ".aceself"}]
+}, {
+  "pkgs": ["com.duckduckgo.mobile.android"],
+  "mrks": [{"loc": "SDCARD", "path": "Download/DuckDuckGo"}]
+}, {
+  "pkgs": ["org.xbmc.kodi"],
+  "mrks": [{"loc": "SDCARD", "path": "xbmc_env.properties"}]
+}, {
+  "pkgs": ["com.stevesoltys.seedvault"],
+  "mrks": [{"loc": "SDCARD", "path": ".SeedVaultAndroidBackup", "flags": ["keeper"]}]
 }
 ]


### PR DESCRIPTION
## What changed

CorpseFinder now recognizes additional folders created by Telegram, MX Player, DuckDuckGo browser, Kodi, and Seedvault. Previously, these folders could be flagged as unknown or deleted when the app was uninstalled.

The Seedvault entry is especially important — a user reported losing 80+ GB of backup data because SD Maid didn't recognize the hidden `.SeedVaultAndroidBackup` folder (#2237).

## Technical Context

- **Telegram**: Added `Telegram Audio`, `Telegram Documents`, `Telegram Video` as keepers — these are legacy media download folders alongside the already-tracked `Telegram` root folder
- **MX Player**: Added `MXShare` — the hardcoded file transfer folder documented in [security research](https://medium.com/tenable-techblog/android-mx-player-path-traversal-to-code-execution-9134b623eb34)
- **DuckDuckGo**: New entry for `Download/DuckDuckGo` — confirmed by [user reports](https://github.com/duckduckgo/Android/issues/981)
- **Kodi**: New entry for `xbmc_env.properties` — a config file created at sdcard root per [official Kodi wiki](https://kodi.wiki/view/HOW-TO:Change_data_location_for_Android)
- **Seedvault**: New entry for `.SeedVaultAndroidBackup` as keeper — the backup app bundled with CalyxOS, LineageOS, and GrapheneOS. All ROMs use the same package name `com.stevesoltys.seedvault`

All 106 clutter marker tests pass.

Closes #2237
