### PR TITLE
General: Update translations from Crowdin

### DIFF
--- a/app/src/main/res/values-es-rAR/strings.xml
+++ b/app/src/main/res/values-es-rAR/strings.xml
@@ -194,7 +194,7 @@
     <string name="setup_acs_state_ondemand">El servicio se lanzará bajo demanda</string>
     <string name="setup_acs_state_stopped">El Servicio de accesibilidad está detenido</string>
     <string name="setup_acs_state_stopped_hint">El servicio está activado, pero no se está ejecutando. Desactivalo/activalo o reiniciá tu dispositivo. Comprobá que SD Maid no está siendo \"optimizado\" por el sistema.</string>
-    <string name="setup_acs_state_stopped_hint_miui">Si el servicio sigue siendo detenido después de un tiempo, intentá activando la opción \"Inicio automático\"\ para SD Maid en los ajustes del sistema.</string>
+    <string name="setup_acs_state_stopped_hint_miui">Si el servicio sigue siendo detenido después de un tiempo, intentá activando la opción \"Inicio automático\" para SD Maid en los ajustes del sistema.</string>
     <string name="setup_acs_consent_positive_action">Activar servicio y permitir acceso</string>
     <string name="setup_acs_consent_negative_action">No usar el Servicio de accesibilidad</string>
     <string name="setup_acs_allow_hint">El acceso directo o botón de accesibilidad para SD Maid SE está habilitado. Abrí la configuración de Accesibilidad de tu dispositivo y deshabiitá la opción de acceso directo/botón para evitar un ícono no deseado en el borde de la pantalla.</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -441,11 +441,11 @@
     <string name="appcleaner_automation_loading">Menyediakan automasi melalui perkhidmatan aksesibiliti</string>
     <string name="appcleaner_automation_title">Automasi AppCleaner</string>
     <string name="appcleaner_automation_subtitle_default_caches">Mengosongkan cache lalai…</string>
-    <string name="appcleaner_automation_progress_open_settings">Membuka tetapan aplikasi</string>
-    <string name="appcleaner_automation_progress_find_storage">Mencari butang storan</string>
-    <string name="appcleaner_automation_progress_find_clear_data">Mencari butang kosongkan data</string>
-    <string name="appcleaner_automation_progress_find_clear_cache">Mencari butang kosongkan cache</string>
-    <string name="appcleaner_automation_progress_find_ok_confirmation">Mencari butang pengesahan</string>
+    <string name="appcleaner_automation_progress_open_settings">Membuka tetapan aplikasi (kata kunci: %s)</string>
+    <string name="appcleaner_automation_progress_find_storage">Mencari butang storan (kata kunci: %s)</string>
+    <string name="appcleaner_automation_progress_find_clear_data">Mencari butang kosongkan data (kata kunci: %s)</string>
+    <string name="appcleaner_automation_progress_find_clear_cache">Mencari butang kosongkan cache (kata kunci: %s)</string>
+    <string name="appcleaner_automation_progress_find_ok_confirmation">Mencari butang pengesahan (kata kunci: %s)</string>
     <string name="appcleaner_item_caches_inaccessible_title">Cache lalai</string>
     <string name="appcleaner_item_caches_inaccessible_body">Cache lalai awam dan peribadi. Tidak boleh diakses secara langsung, tetapi boleh dipadamkan secara tidak langsung (cth. melalui perkhidmatan aksesibiliti).</string>
     <string name="appcleaner_automation_unavailable_title">Perkhidmatan aksesibiliti tidak tersedia</string>
@@ -727,8 +727,8 @@
     <string name="appcontrol_automation_loading">Memuatkan...</string>
     <string name="appcontrol_automation_title">Automasi</string>
     <string name="appcontrol_automation_subtitle_force_stopping">Memaksa berhenti aplikasi</string>
-    <string name="appcontrol_automation_progress_find_force_stop">Mencari butang paksa berhenti</string>
-    <string name="appcontrol_automation_progress_find_ok_confirmation">Mencari butang pengesahan</string>
+    <string name="appcontrol_automation_progress_find_force_stop">Mencari butang paksa berhenti (kata kunci: %s)</string>
+    <string name="appcontrol_automation_progress_find_ok_confirmation">Mencari butang pengesahan (kata kunci: %s)</string>
     <string name="appcontrol_automation_subtitle_archiving">Mengarkib…</string>
     <string name="appcontrol_automation_progress_find_archive">Mencari butang \"Arkib\" (kata kunci: %s)</string>
     <string name="appcontrol_automation_subtitle_restoring">Memulihkan…</string>

--- a/app/src/main/res/values-ne-rNP/strings.xml
+++ b/app/src/main/res/values-ne-rNP/strings.xml
@@ -609,7 +609,7 @@
     <string name="squeezer_compress_confirmation_message">यसले मूल छविहरूलाई संकुचित संस्करणहरूसँग प्रतिस्थापन गर्नेछ। यो कार्य पूर्ववत गर्न सकिँदैन।</string>
     <string name="squeezer_history_title">संकुचन इतिहास</string>
     <plurals name="squeezer_history_summary">
-        <item quantity="one">1 वस्तु (%2$s)</item>
+        <item quantity="one">%1$d वस्तु (%2$s)</item>
         <item quantity="other">%1$d वस्तुहरू (%2$s)</item>
     </plurals>
     <string name="squeezer_history_empty">कुनै संकुचन इतिहास छैन</string>
@@ -1026,11 +1026,11 @@
     <string name="swiper_retry_action">पुनः प्रयास गर्नुहोस्</string>
     <string name="swiper_delete_confirmation_title">फाइलहरू मेटाउने?</string>
     <plurals name="swiper_delete_confirmation_message">
-        <item quantity="one">यसले 1 फाइल (%2$s) स्थायी रूपमा हटाउनेछ। यो कार्य अपरिवर्तनीय छ।</item>
+        <item quantity="one">यसले %1$d फाइल (%2$s) स्थायी रूपमा हटाउनेछ। यो कार्य अपरिवर्तनीय छ।</item>
         <item quantity="other">यसले %1$d फाइलहरू (%2$s) स्थायी रूपमा हटाउनेछ। यो कार्य अपरिवर्तनीय छ।</item>
     </plurals>
     <plurals name="swiper_delete_confirmation_message_partial_undecided">
-        <item quantity="one">1 अनिर्णीत वस्तु पछिको समीक्षाको लागि बाँकी रहनेछ।</item>
+        <item quantity="one">%d अनिर्णीत वस्तु पछिको समीक्षाको लागि बाँकी रहनेछ।</item>
         <item quantity="other">%d अनिर्णीत वस्तुहरू पछिको समीक्षाको लागि बाँकी रहनेछन्।</item>
     </plurals>
     <string name="swiper_delete_x_action">%1$d मेटाउनुहोस्</string>
@@ -1044,7 +1044,7 @@
     <string name="swiper_discard_session_confirmation_message">सबै निर्णयहरू हराउनेछन्। के तपाईं निश्चित हुनुहुन्छ?</string>
     <string name="swiper_no_preview_available">पूर्वावलोकन उपलब्ध छैन</string>
     <plurals name="swiper_dashcard_session_context">
-        <item quantity="one">1 दिन अघिको सत्र जारी राख्नुहोस् (%2$d%% समाप्त)</item>
+        <item quantity="one">%1$d दिन अघिको सत्र जारी राख्नुहोस् (%2$d%% समाप्त)</item>
         <item quantity="other">%1$d दिन अघिको सत्र जारी राख्नुहोस् (%2$d%% समाप्त)</item>
     </plurals>
     <plurals name="swiper_dashcard_x_sessions">
@@ -1060,11 +1060,11 @@
     <string name="swiper_sessions_empty_hint">फोल्डर चयन गर्न + ट्याप गर्नुहोस् र स्वाइप गर्न सुरु गर्नुहोस्</string>
     <string name="swiper_sessions_upgrade_body">यी सीमाहरू हटाउन र विकास समर्थन गर्न अपग्रेड गर्नुहोस्। निःशुल्क संस्करण सीमित छ:</string>
     <plurals name="swiper_sessions_upgrade_files_limit">
-        <item quantity="one">प्रति सत्र 1 फाइल</item>
+        <item quantity="one">प्रति सत्र %d फाइल</item>
         <item quantity="other">प्रति सत्र %d फाइलहरू</item>
     </plurals>
     <plurals name="swiper_sessions_upgrade_sessions_limit">
-        <item quantity="one">1 सत्र</item>
+        <item quantity="one">%d सत्र</item>
         <item quantity="other">%d सत्रहरू</item>
     </plurals>
     <string name="swiper_session_default_label">सत्र #%d</string>

--- a/app/src/main/res/values-sq-rAL/strings.xml
+++ b/app/src/main/res/values-sq-rAL/strings.xml
@@ -667,7 +667,7 @@
     <string name="appcontrol_app_exclude_edit_description">Ky aplikacion aktualisht është i përjashtuar nga një ose më shumë mjete.</string>
     <string name="appcontrol_tag_user">Përdoruesi</string>
     <string name="appcontrol_tag_active">Aktiv së fundmi</string>
-    <string name="appcontrol_tag_apk_base"></string>
+    <string name="appcontrol_tag_apk_base">APK</string>
     <string name="appcontrol_tag_apk_bundle">Pako</string>
     <string name="appcontrol_tag_system">Sistemi</string>
     <string name="appcontrol_tag_archived">Arkivuar</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -5,7 +5,6 @@
     <string name="dashboard_motd_title">ข้อความจากผู้พัฒนา</string>
     <string name="dashboard_settings_oneclick_title">โหมดแตะครั้งเดียว</string>
     <string name="dashboard_settings_oneclick_summary">เริ่มการสแกนและการลบสำหรับเครื่องมือทั้งหมดด้วยการคลิกปุ่มในแดชบอร์ด โดยไม่มีการยืนยันเพิ่มเติม</string>
-    <string name="dashboard_settings_oneclick_tools_title">Thai</string>
     <string name="dashboard_settings_oneclick_tools_desc">เครื่องมือใดที่ควรรวมอยู่ในการดำเนินการแตะครั้งเดียว?</string>
     <string name="dashboard_card_config_title">การ์ดแดชบอร์ด</string>
     <string name="dashboard_card_config_desc">กำหนดค่าการ์ดที่จะแสดงและลำดับ</string>


### PR DESCRIPTION
## What changed

Updated translations pulled from Crowdin. Fixed vandalism and broken strings found during validation.

## Technical Context

- Pulled latest translations via `crowdin.sh download`
- Removed orphaned `debug_notification_channel_label` string from 72 locale files (source string was deleted but translations remained, causing a build warning)
- Validated all 72 locales for escape issues, placeholder mismatches, and vandalism
- Fixed 4 strings across 3 locales:
  - **hu**: Removed emoji vandalism (`😁`) from notification message, restored missing `%s` placeholder in language override description
  - **mn-rMN**: Restored missing `%s` placeholder in setup requirement string
  - **vi**: Accepted improved translation wording for contact form text
- Reverted 5 locales with broken Crowdin submissions: es-rAR (stray backslash), ms (7 stripped format placeholders), ne-rNP (6 hardcoded plural values), sq-rAL (empty string), th (`"Thai"` as translation text)
- Vandalism on hu `tasks_activity_active_notification_message` was traced to Crowdin user **Csuulok** (ID 15812001)
