### PR TITLE
Fix: Broken navigation after multi-module migration

### DIFF
--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/list/AppCleanerListViewModel.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/list/AppCleanerListViewModel.kt
@@ -68,7 +68,7 @@ class AppCleanerListViewModel @Inject constructor(
     fun showDetails(item: AppCleanerListAdapter.Item) = launch {
         log(TAG, INFO) { "showDetails(${item.junk.identifier})" }
         navDirections(
-            R.id.action_appCleanerListFragment_to_appCleanerDetailsFragment,
+            R.id.action_appCleanerListFragment_to_appCleanerDetailsFragment2,
             bundleOf("identifier" to item.junk.identifier)
         ).navigate()
     }

--- a/app-tool-appcleaner/src/main/res/values/ids.xml
+++ b/app-tool-appcleaner/src/main/res/values/ids.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Navigation action IDs used by AppCleaner UI -->
-    <item name="action_appCleanerListFragment_to_appCleanerDetailsFragment" type="id" />
+    <item name="action_appCleanerListFragment_to_appCleanerDetailsFragment2" type="id" />
 </resources>

--- a/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/sessions/SwiperSessionsViewModel.kt
+++ b/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/sessions/SwiperSessionsViewModel.kt
@@ -82,7 +82,7 @@ class SwiperSessionsViewModel @Inject constructor(
         } else {
             log(TAG) { "Cache hit for session $sessionId, skipping refresh" }
         }
-        navDirections(R.id.action_swiperSessionsFragmentToSwiperSwipeFragment, bundleOf("sessionId" to sessionId)).navigate()
+        navDirections(R.id.action_swiperSessionsFragment_to_swiperSwipeFragment, bundleOf("sessionId" to sessionId)).navigate()
     }
 
     fun scanSession(sessionId: String) = launch {

--- a/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/status/SwiperStatusViewModel.kt
+++ b/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/status/SwiperStatusViewModel.kt
@@ -87,7 +87,7 @@ class SwiperStatusViewModel @Inject constructor(
         val currentPosition = currentItems.indexOfFirst { it.id == itemId }
         if (currentPosition < 0) return
         navDirections(
-            R.id.action_swiperStatusFragmentToSwiperSwipeFragment,
+            R.id.action_swiperStatusFragment_to_swiperSwipeFragment,
             bundleOf("sessionId" to sessionId, "startIndex" to currentPosition),
         ).navigate()
     }

--- a/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/swipe/SwiperSwipeFragment.kt
+++ b/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/swipe/SwiperSwipeFragment.kt
@@ -145,7 +145,9 @@ class SwiperSwipeFragment : Fragment3(R.layout.swiper_swipe_fragment) {
         vm.events.observe2(ui) { event ->
             when (event) {
                 SwiperSwipeEvents.NavigateToSessions -> {
-                    findNavController().popBackStack(eu.darken.sdmse.common.R.id.swiperSessionsFragment, inclusive = false)
+                    if (!findNavController().popBackStack(eu.darken.sdmse.common.R.id.swiperSessionsFragment, inclusive = false)) {
+                        findNavController().popBackStack()
+                    }
                 }
 
                 SwiperSwipeEvents.TriggerHapticFeedback -> {

--- a/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/swipe/SwiperSwipeViewModel.kt
+++ b/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/swipe/SwiperSwipeViewModel.kt
@@ -34,7 +34,7 @@ class SwiperSwipeViewModel @Inject constructor(
     private val exclusionManager: ExclusionManager,
 ) : ViewModel3(dispatcherProvider = dispatcherProvider) {
 
-    private val sessionId: String = handle.get<String>("sessionId")!!
+    private val sessionId: String = requireNotNull(handle.get<String>("sessionId")) { "sessionId argument is required" }
     private val startIndex: Int = handle.get<Int>("startIndex") ?: -1
 
     private val currentIndexOverride = MutableStateFlow<Int?>(
@@ -223,7 +223,7 @@ class SwiperSwipeViewModel @Inject constructor(
 
     fun navigateToStatus() {
         log(TAG, INFO) { "navigateToStatus()" }
-        navDirections(R.id.action_swiperSwipeFragmentToSwiperStatusFragment, bundleOf("sessionId" to sessionId)).navigate()
+        navDirections(R.id.action_swiperSwipeFragment_to_swiperStatusFragment, bundleOf("sessionId" to sessionId)).navigate()
     }
 
     fun dismissGestureOverlay() = launch {

--- a/app-tool-swiper/src/main/res/values/ids.xml
+++ b/app-tool-swiper/src/main/res/values/ids.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <item name="action_swiperStatusFragmentToSwiperSwipeFragment" type="id" />
-    <item name="action_swiperSwipeFragmentToSwiperStatusFragment" type="id" />
-    <item name="action_swiperSessionsFragmentToSwiperSwipeFragment" type="id" />
+    <item name="action_swiperStatusFragment_to_swiperSwipeFragment" type="id" />
+    <item name="action_swiperSwipeFragment_to_swiperStatusFragment" type="id" />
+    <item name="action_swiperSessionsFragment_to_swiperSwipeFragment" type="id" />
 </resources>

--- a/app/src/test/java/eu/darken/sdmse/main/core/NavigationIdConsistencyTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/core/NavigationIdConsistencyTest.kt
@@ -1,0 +1,57 @@
+package eu.darken.sdmse.main.core
+
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+import org.w3c.dom.Element
+
+class NavigationIdConsistencyTest : BaseTest() {
+
+    private val docBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder()
+
+    @Test
+    fun `all tool module action IDs must exist in main_nav xml`() {
+        val projectRoot = File("..")
+
+        val navGraphActions = parseNavGraphActionIds(
+            File(projectRoot, "app/src/main/res/navigation/main_nav.xml")
+        )
+        navGraphActions.shouldNotBeEmpty()
+
+        val toolModuleIds = projectRoot.listFiles { f -> f.isDirectory && f.name.startsWith("app-tool-") }
+            ?.flatMap { moduleDir ->
+                val idsFile = File(moduleDir, "src/main/res/values/ids.xml")
+                if (!idsFile.exists()) return@flatMap emptyList()
+                parseIdsXmlActionIds(idsFile).map { actionName -> moduleDir.name to actionName }
+            }
+            ?: emptyList()
+
+        toolModuleIds.shouldNotBeEmpty()
+
+        val mismatches = toolModuleIds.filter { (_, actionName) -> actionName !in navGraphActions }
+        mismatches shouldBe emptyList()
+    }
+
+    private fun parseNavGraphActionIds(navFile: File): Set<String> {
+        val doc = docBuilder.parse(navFile)
+        val actions = doc.getElementsByTagName("action")
+        return (0 until actions.length).mapNotNull { i ->
+            val id = (actions.item(i) as Element).getAttribute("android:id")
+            id.removePrefix("@+id/").removePrefix("@id/").takeIf { it.startsWith("action_") }
+        }.toSet()
+    }
+
+    private fun parseIdsXmlActionIds(idsFile: File): List<String> {
+        val doc = docBuilder.parse(idsFile)
+        val items = doc.getElementsByTagName("item")
+        return (0 until items.length).mapNotNull { i ->
+            val element = items.item(i) as Element
+            val name = element.getAttribute("name")
+            val type = element.getAttribute("type")
+            name.takeIf { type == "id" && it.startsWith("action_") }
+        }
+    }
+}


### PR DESCRIPTION
## What changed

Fixed navigation that stopped working after the multi-module migration. Tapping a swiper session card or an app in AppCleaner did nothing — the screen just stayed the same.

Also added a CI test to catch this class of bug automatically in the future.

## Technical Context

- Root cause: `ids.xml` files in tool modules defined navigation action IDs with names that didn't match `main_nav.xml`. Swiper used camelCase (`FragmentToSwiperSwipeFragment`) while the nav graph used underscores (`Fragment_to_swiperSwipeFragment`). AppCleaner was missing a `2` suffix. With `android.nonTransitiveRClass=true`, mismatched names produce different resource integers, so `NavController.navigate()` silently dropped the action.
- Added `NavigationIdConsistencyTest` that cross-references all tool module `ids.xml` action entries against `main_nav.xml` — catches name mismatches in CI before they reach users.
- Hardened `SwiperSwipeViewModel` to use `requireNotNull` instead of `!!` for the `sessionId` argument, and added a `popBackStack` fallback in `SwiperSwipeFragment` when the target destination isn't in the back stack.
