### PR TITLE
General: Encourage visiting sponsors page before unlocking features

### DIFF
--- a/app/src/foss/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoFoss.kt
+++ b/app/src/foss/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoFoss.kt
@@ -2,7 +2,7 @@ package eu.darken.sdmse.common.upgrade.core
 
 import eu.darken.sdmse.common.WebpageTool
 import eu.darken.sdmse.common.coroutine.AppScope
-import eu.darken.sdmse.common.datastore.valueBlocking
+import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.flow.setupCommonEventHandlers
@@ -49,13 +49,19 @@ class UpgradeRepoFoss @Inject constructor(
         .setupCommonEventHandlers(TAG) { "upgradeInfo" }
         .shareIn(appScope, SharingStarted.WhileSubscribed(3000L, 0L), replay = 1)
 
-    fun launchGithubSponsorsUpgrade() = appScope.launch {
-        log(TAG) { "launchGithubSponsorsUpgrade()" }
-        fossCache.upgrade.valueBlocking = FossUpgrade(
-            upgradedAt = Instant.now(),
-            upgradeType = FossUpgrade.Type.GITHUB_SPONSORS
-        )
+    fun openGithubSponsorsPage() = appScope.launch {
+        log(TAG) { "openGithubSponsorsPage()" }
         webpageTool.open(upgradeSite)
+    }
+
+    internal suspend fun persistUpgrade() {
+        log(TAG) { "persistUpgrade()" }
+        fossCache.upgrade.value(
+            FossUpgrade(
+                upgradedAt = Instant.now(),
+                upgradeType = FossUpgrade.Type.GITHUB_SPONSORS,
+            )
+        )
     }
 
     override suspend fun refresh() {

--- a/app/src/foss/java/eu/darken/sdmse/common/upgrade/ui/UpgradeFragment.kt
+++ b/app/src/foss/java/eu/darken/sdmse/common/upgrade/ui/UpgradeFragment.kt
@@ -6,6 +6,7 @@ import android.widget.Toast
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.ui.setupWithNavController
+import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 import eu.darken.sdmse.R
 import eu.darken.sdmse.common.EdgeToEdgeHelper
@@ -29,12 +30,15 @@ class UpgradeFragment : Fragment3(R.layout.upgrade_fragment) {
         ui.toolbar.setupWithNavController(findNavController())
 
         ui.upgradeGithubSponsorsAction.setOnClickListener {
-            Toast.makeText(
-                requireContext(),
-                R.string.upgrade_screen_thanks_toast,
-                Toast.LENGTH_LONG,
-            ).show()
             vm.goGithubSponsors()
+        }
+
+        vm.snackbarEvents.observe2 { stringRes ->
+            Snackbar.make(requireView(), stringRes, Snackbar.LENGTH_LONG).show()
+        }
+
+        vm.toastEvents.observe2 { stringRes ->
+            Toast.makeText(requireContext(), stringRes, Toast.LENGTH_LONG).show()
         }
 
         vm.state.observe2 {
@@ -44,4 +48,18 @@ class UpgradeFragment : Fragment3(R.layout.upgrade_fragment) {
         super.onViewCreated(view, savedInstanceState)
     }
 
+    private var wentToBackground = false
+
+    override fun onStop() {
+        super.onStop()
+        wentToBackground = true
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (wentToBackground) {
+            wentToBackground = false
+            vm.checkSponsorReturn()
+        }
+    }
 }

--- a/app/src/foss/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/foss/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
@@ -1,12 +1,15 @@
 package eu.darken.sdmse.common.upgrade.ui
 
+import android.os.SystemClock
 import androidx.lifecycle.SavedStateHandle
 import dagger.hilt.android.lifecycle.HiltViewModel
+import eu.darken.sdmse.common.SingleLiveEvent
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.navigation.navArgs
 import eu.darken.sdmse.common.uix.ViewModel3
+import eu.darken.sdmse.R
 import eu.darken.sdmse.common.upgrade.core.UpgradeRepoFoss
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
@@ -17,12 +20,15 @@ import javax.inject.Inject
 
 @HiltViewModel
 class UpgradeViewModel @Inject constructor(
-    @Suppress("unused") private val handle: SavedStateHandle,
+    private val handle: SavedStateHandle,
     dispatcherProvider: DispatcherProvider,
     private val upgradeRepo: UpgradeRepoFoss,
 ) : ViewModel3(dispatcherProvider = dispatcherProvider) {
 
     private val navArgs by handle.navArgs<UpgradeFragmentArgs>()
+
+    val snackbarEvents = SingleLiveEvent<Int>()
+    val toastEvents = SingleLiveEvent<Int>()
 
     init {
         if (!navArgs.forced) {
@@ -38,7 +44,6 @@ class UpgradeViewModel @Inject constructor(
         .map { it as UpgradeRepoFoss.Info }
         .map { current ->
             if (!current.isPro && current.error != null) {
-                // Linter bug
                 @Suppress("UNNECESSARY_NOT_NULL_ASSERTION")
                 errorEvents.postValue(current.error!!)
             }
@@ -48,8 +53,23 @@ class UpgradeViewModel @Inject constructor(
 
     fun goGithubSponsors() {
         log(TAG) { "goGithubSponsors()" }
-        upgradeRepo.launchGithubSponsorsUpgrade()
-        popNavStack()
+        handle[KEY_SPONSOR_PRESSED_AT] = SystemClock.elapsedRealtime()
+        upgradeRepo.openGithubSponsorsPage()
+    }
+
+    fun checkSponsorReturn() = launch {
+        val pressedAt = handle.remove<Long>(KEY_SPONSOR_PRESSED_AT) ?: return@launch
+        val elapsed = SystemClock.elapsedRealtime() - pressedAt
+        log(TAG) { "checkSponsorReturn(): elapsed=${elapsed}ms" }
+
+        if (elapsed < SPONSOR_DELAY_MS) {
+            log(TAG) { "checkSponsorReturn(): Too quick, showing snackbar" }
+            snackbarEvents.postValue(R.string.upgrade_screen_sponsor_return_too_quick)
+        } else {
+            log(TAG) { "checkSponsorReturn(): Delay passed, persisting upgrade" }
+            upgradeRepo.persistUpgrade()
+            toastEvents.postValue(R.string.upgrade_screen_thanks_toast)
+        }
     }
 
     data class State(
@@ -57,6 +77,8 @@ class UpgradeViewModel @Inject constructor(
     )
 
     companion object {
+        private const val KEY_SPONSOR_PRESSED_AT = "sponsor_pressed_at"
+        private const val SPONSOR_DELAY_MS = 10_000L
         private val TAG = logTag("Upgrade", "ViewModel")
     }
 }

--- a/app/src/foss/res/values/strings.xml
+++ b/app/src/foss/res/values/strings.xml
@@ -18,4 +18,5 @@
     <string name="upgrade_screen_sponsor_action">Sponsor development</string>
     <string name="upgrade_screen_sponsor_action_hint">The alternative are ads, analytics and Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Thank you for supporting open-source development ❤️</string>
+    <string name="upgrade_screen_sponsor_return_too_quick">Back already? Your support keeps SD Maid alive!</string>
 </resources>


### PR DESCRIPTION
## What changed

Pressing the sponsor button in the FOSS version no longer immediately unlocks all features. Users now need to spend at least 10 seconds on the GitHub Sponsors page before features are unlocked. If they return too quickly, a friendly nudge is shown instead.

## Technical Context

- Root cause: Reddit threads were sharing a tip to press the sponsor button and immediately return to get all features without actually sponsoring
- Split `launchGithubSponsorsUpgrade()` into `openGithubSponsorsPage()` (browser only) and `persistUpgrade()` (DataStore write), so the unlock is no longer immediate
- Timestamp stored in `SavedStateHandle` (not DataStore) — survives process death but not force-stop, so the user must start over if they kill the app
- Uses `SystemClock.elapsedRealtime()` instead of wall-clock time to prevent bypassing via clock manipulation
- The "too quick" snackbar clears the pending state, requiring a fresh button press — users can't just wait in-app after returning early
- `persistUpgrade()` marked `internal` to prevent accidental bypass from other call sites
