### PR TITLE
General: Improve dry-run realism for Swiper and Squeezer

### DIFF
--- a/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/Squeezer.kt
+++ b/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/Squeezer.kt
@@ -7,7 +7,6 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.datastore.value
-import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.*
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
@@ -147,9 +146,7 @@ class Squeezer @Inject constructor(
 
         updateProgress { Progress.Data() }
 
-        if (!Bugs.isDryRun) {
-            internalData.value = snapshot.prune(result.success.map { it.identifier }.toSet())
-        }
+        internalData.value = snapshot.prune(result.success.map { it.identifier }.toSet())
 
         return SqueezerProcessTask.Success(
             affectedSpace = result.savedSpace,

--- a/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/processor/ImageProcessor.kt
+++ b/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/processor/ImageProcessor.kt
@@ -86,10 +86,8 @@ class ImageProcessor @Inject constructor(
                 val saved = processImage(image, quality)
                 successful.add(image)
 
-                if (!Bugs.isDryRun) {
-                    val contentHash = historyDatabase.computeContentHash(image.path)
-                    historyDatabase.recordCompression(contentHash)
-                }
+                val contentHash = historyDatabase.computeContentHash(image.path)
+                historyDatabase.recordCompression(contentHash)
 
                 if (saved > 0) {
                     totalSaved += saved

--- a/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/core/deleter/SwiperDeleter.kt
+++ b/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/core/deleter/SwiperDeleter.kt
@@ -3,7 +3,6 @@ package eu.darken.sdmse.swiper.core.deleter
 import android.content.Context
 import android.media.MediaScannerConnection
 import dagger.hilt.android.qualifiers.ApplicationContext
-import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.*
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
@@ -54,27 +53,23 @@ class SwiperDeleter @Inject constructor(
             updateProgressSecondary(item.lookup.userReadablePath)
             updateProgressCount(Progress.Count.Percent(index, items.size))
 
-            if (Bugs.isDryRun) {
-                log(TAG, INFO) { "DRYRUN: Not deleting ${item.lookup.lookedUp}" }
-            } else {
-                try {
-                    item.lookup.lookedUp.delete(gatewaySwitch)
-                    deletedPaths.add(item.lookup.lookedUp)
-                    deletedSize += item.lookup.size
-                    log(TAG, VERBOSE) { "Deleted: ${item.lookup.lookedUp}" }
+            try {
+                item.lookup.lookedUp.delete(gatewaySwitch)
+                deletedPaths.add(item.lookup.lookedUp)
+                deletedSize += item.lookup.size
+                log(TAG, VERBOSE) { "Deleted: ${item.lookup.lookedUp}" }
 
-                    // Mark item as DELETED
-                    itemDao.updateDecision(item.id, SwipeDecision.DELETED)
+                // Mark item as DELETED
+                itemDao.updateDecision(item.id, SwipeDecision.DELETED)
 
-                    // Notify MediaScanner about deleted file
-                    notifyMediaScanner(item.lookup.lookedUp)
-                } catch (e: Exception) {
-                    log(TAG, WARN) { "Failed to delete ${item.lookup.lookedUp}: ${e.message}" }
-                    failedPaths.add(item.lookup.lookedUp)
+                // Notify MediaScanner about deleted file
+                notifyMediaScanner(item.lookup.lookedUp)
+            } catch (e: Exception) {
+                log(TAG, WARN) { "Failed to delete ${item.lookup.lookedUp}: ${e.message}" }
+                failedPaths.add(item.lookup.lookedUp)
 
-                    // Mark item as DELETE_FAILED
-                    itemDao.updateDecision(item.id, SwipeDecision.DELETE_FAILED)
-                }
+                // Mark item as DELETE_FAILED
+                itemDao.updateDecision(item.id, SwipeDecision.DELETE_FAILED)
             }
         }
 


### PR DESCRIPTION
## What changed

Dry-run mode now exercises more of the real code path in Swiper and Squeezer, only skipping the actual destructive file operations at the very last moment.

## Technical Context

- **Swiper**: The `isDryRun` check in `SwiperDeleter` was redundant — the gateway layer (`LocalGateway`, `SAFDocFile`) already guards the actual filesystem delete call. Removing it means DAO updates, path/size tracking, and MediaScanner notifications now run during dry-run, matching real behavior more closely.
- **Squeezer**: Removed `isDryRun` guards around compression history recording and in-memory snapshot pruning — these are non-destructive operations. The guard in `ImageProcessor.processImage()` before the file swap is kept, since those raw `File` operations bypass the gateway.
- Pattern follows how older tools (AppCleaner automation, CorpseFinder) already work: the dry-run check lives at the lowest I/O layer, not in the tool-level business logic.