### PR TITLE
Fix: Prevent app freezing during startup on Google Play version

### DIFF
--- a/app/src/gplay/java/eu/darken/sdmse/common/debug/autoreport/GooglePlayReporting.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/debug/autoreport/GooglePlayReporting.kt
@@ -1,30 +1,14 @@
 package eu.darken.sdmse.common.debug.autoreport
 
 import android.app.Application
-import android.content.Context
-import dagger.hilt.android.qualifiers.ApplicationContext
-import eu.darken.sdmse.common.SDMId
-import eu.darken.sdmse.common.datastore.valueBlocking
 import eu.darken.sdmse.common.debug.AutomaticBugReporter
-import eu.darken.sdmse.common.debug.DebugSettings
-import eu.darken.sdmse.common.debug.logging.log
-import eu.darken.sdmse.common.debug.logging.logTag
-import eu.darken.sdmse.main.core.GeneralSettings
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class GooglePlayReporting @Inject constructor(
-    @ApplicationContext private val context: Context,
-    private val generalSettings: GeneralSettings,
-    private val debugSettings: DebugSettings,
-    private val sdmId: SDMId,
-) : AutomaticBugReporter {
+class GooglePlayReporting @Inject constructor() : AutomaticBugReporter {
 
     override fun setup(application: Application) {
-        val isEnabled = generalSettings.isBugReporterEnabled.valueBlocking
-        log(TAG) { "setup(): isEnabled=$isEnabled" }
-
         // NOOP
     }
 
@@ -34,9 +18,5 @@ class GooglePlayReporting @Inject constructor(
 
     override fun notify(throwable: Throwable) {
         // NOOP
-    }
-
-    companion object {
-        private val TAG = logTag("Debug", "GooglePlayReporting")
     }
 }


### PR DESCRIPTION
## What changed

Fixed an app freeze (ANR) that could occur during startup on the Google Play version of the app.

## Technical Context

- Root cause: `GooglePlayReporting.setup()` called `valueBlocking` (which uses `runBlocking` on the main thread) during `App.onCreate()` to read a DataStore setting, but the method body was a complete NOOP — it read the value, logged it, and did nothing with it
- Under DataStore initialization contention (multiple instances initializing, `getFilesDir()` synchronized locks, `StorageManager` IPC calls), this blocked the main thread long enough to trigger an ANR
- Fix: removed the dead code, making `GooglePlayReporting` a true NOOP matching `FossAutoReporting`
- Removed unused constructor parameters (`GeneralSettings`, `DebugSettings`, `SDMId`, `Context`) and their imports
