### PR TITLE
Fix: Prevent crash when a cleaning task gets stuck

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/main/core/taskmanager/TaskManager.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/core/taskmanager/TaskManager.kt
@@ -33,10 +33,14 @@ import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import java.time.Instant
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -189,7 +193,14 @@ class TaskManager @Inject constructor(
         val entry: TaskEntry = tempEntry ?: throw IllegalStateException("Can't find task $taskId")
 
         val tool = entry.tool
-        val result = tool.useRes { tool.submit(entry.task) }
+        val timeout = getTaskTimeout(entry.task.type)
+        val result = try {
+            withTimeout(timeout) {
+                tool.useRes { tool.submit(entry.task) }
+            }
+        } catch (e: TimeoutCancellationException) {
+            throw TaskTimeoutException(entry.task.type, timeout)
+        }
 
         val stop = System.currentTimeMillis()
         log(TAG) { "execute() after ${stop - start}ms: $result : $tempEntry" }
@@ -289,6 +300,17 @@ class TaskManager @Inject constructor(
                     }
             }
         }
+    }
+
+    private fun getTaskTimeout(type: SDMTool.Type): Duration = when (type) {
+        SDMTool.Type.APPCLEANER -> 4.hours
+        SDMTool.Type.CORPSEFINDER -> 4.hours
+        SDMTool.Type.SYSTEMCLEANER -> 4.hours
+        SDMTool.Type.DEDUPLICATOR -> 6.hours
+        SDMTool.Type.ANALYZER -> 4.hours
+        SDMTool.Type.APPCONTROL -> 2.hours
+        SDMTool.Type.SQUEEZER -> 4.hours
+        SDMTool.Type.SWIPER -> 2.hours
     }
 
     companion object {

--- a/app/src/main/java/eu/darken/sdmse/main/core/taskmanager/TaskTimeoutException.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/core/taskmanager/TaskTimeoutException.kt
@@ -1,0 +1,20 @@
+package eu.darken.sdmse.main.core.taskmanager
+
+import eu.darken.sdmse.R
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.error.HasLocalizedError
+import eu.darken.sdmse.common.error.LocalizedError
+import eu.darken.sdmse.main.core.SDMTool
+import kotlin.time.Duration
+
+class TaskTimeoutException(
+    val toolType: SDMTool.Type,
+    val timeout: Duration,
+) : Exception("Task for $toolType timed out after $timeout"), HasLocalizedError {
+
+    override fun getLocalizedError() = LocalizedError(
+        throwable = this,
+        label = R.string.tasks_timeout_error_label.toCaString(),
+        description = R.string.tasks_timeout_error_desc.toCaString(),
+    )
+}

--- a/app/src/main/java/eu/darken/sdmse/main/core/taskmanager/TaskWorker.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/core/taskmanager/TaskWorker.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.onEach
+import eu.darken.sdmse.common.hasApiLevel
 import kotlinx.coroutines.withTimeoutOrNull
 
 @HiltWorker
@@ -75,6 +76,12 @@ class TaskWorker @AssistedInject constructor(
             finishedWithError = true
             Result.failure(inputData)
         } else {
+            if (hasApiLevel(31)) {
+                @Suppress("NewApi")
+                log(TAG, WARN) { "Worker cancelled, stopReason=$stopReason" }
+            } else {
+                log(TAG, WARN) { "Worker cancelled" }
+            }
             Result.success()
         }
     } finally {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,6 +41,8 @@
     </plurals>
     <string name="tasks_result_notification_channel_label">Task results</string>
     <string name="tasks_result_subtext">Task result</string>
+    <string name="tasks_timeout_error_label">Task timed out</string>
+    <string name="tasks_timeout_error_desc">The task took too long and was stopped. Please try again.</string>
 
     <string name="onboarding_welcome_title">Welcome</string>
     <string name="onboarding_welcome_body1">SD Maid SE manages files, apps and storage.</string>

--- a/app/src/test/java/eu/darken/sdmse/main/core/taskmanager/TaskTimeoutExceptionTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/core/taskmanager/TaskTimeoutExceptionTest.kt
@@ -1,0 +1,41 @@
+package eu.darken.sdmse.main.core.taskmanager
+
+import eu.darken.sdmse.common.error.HasLocalizedError
+import eu.darken.sdmse.main.core.SDMTool
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNot
+import io.kotest.matchers.types.beInstanceOf
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import kotlin.time.Duration.Companion.hours
+
+class TaskTimeoutExceptionTest : BaseTest() {
+
+    @Test
+    fun `is not a CancellationException`() {
+        val exception = TaskTimeoutException(SDMTool.Type.APPCLEANER, 4.hours)
+        exception shouldNot beInstanceOf<kotlinx.coroutines.CancellationException>()
+    }
+
+    @Test
+    fun `implements HasLocalizedError`() {
+        val exception = TaskTimeoutException(SDMTool.Type.APPCLEANER, 4.hours)
+        exception.shouldBeInstanceOf<HasLocalizedError>()
+        val localized = exception.getLocalizedError()
+        localized.throwable shouldBe exception
+    }
+
+    @Test
+    fun `message contains tool type and timeout`() {
+        val exception = TaskTimeoutException(SDMTool.Type.DEDUPLICATOR, 6.hours)
+        exception.message shouldBe "Task for DEDUPLICATOR timed out after 6h"
+    }
+
+    @Test
+    fun `stores tool type and timeout`() {
+        val exception = TaskTimeoutException(SDMTool.Type.CORPSEFINDER, 4.hours)
+        exception.toolType shouldBe SDMTool.Type.CORPSEFINDER
+        exception.timeout shouldBe 4.hours
+    }
+}


### PR DESCRIPTION
## What changed

Fixed a crash (`ForegroundServiceDidNotStopInTimeException`) that could occur on Android 15+ when a cleaning task gets stuck and never finishes. Instead of crashing, stuck tasks are now stopped after a safety timeout and the user is shown a "Task timed out" error. For scheduled tasks running in the background, a notification is shown instead of a silent crash.

## Technical Context

- Root cause: On Android 15, `dataSync` foreground services have a 24-hour system timeout. If a task hangs (e.g., on I/O or root shell), `TaskManager.state.isIdle` never becomes `true`, so `TaskWorker` never stops, and the foreground service runs until the system kills it
- Fix: wrap `tool.useRes { tool.submit(task) }` with `withTimeout()` per tool type (2–6 hours depending on tool). `TimeoutCancellationException` is caught and converted to `TaskTimeoutException` (not a `CancellationException`) so it propagates through the existing error handling as a real error
- `TaskTimeoutException` implements `HasLocalizedError` for user-friendly display in both the UI error handler and scheduler result notifications
- Added `stopReason` logging in `TaskWorker` (API 31+) for better diagnostics when the system cancels the worker
- `withTimeout` only cancels at coroutine suspension points, so truly blocking JNI/binder calls won't be interrupted — this is an acceptable limitation for this defensive measure

### Original stacktrace

```
Exception android.app.RemoteServiceException$ForegroundServiceDidNotStopInTimeException:
  at android.app.ActivityThread.generateForegroundServiceDidNotStopInTimeException (ActivityThread.java:2420)
  at android.app.ActivityThread.throwRemoteServiceException (ActivityThread.java:2382)
  at android.app.ActivityThread.-$Nest$mthrowRemoteServiceException (Unknown Source)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:2707)
  at android.os.Handler.dispatchMessage (Handler.java:107)
  at android.os.Looper.loopOnce (Looper.java:311)
  at android.os.Looper.loop (Looper.java:408)
  at android.app.ActivityThread.main (ActivityThread.java:9119)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:627)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:970)
```
