### PR TITLE
Fix: Improve debug log recording and support email reliability

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -43,8 +43,8 @@ SD Maid SE's cleaning tools are implemented within the main app module under `eu
 
 ## MVVM with Custom ViewModel Hierarchy
 
-- `ViewModel1` → `ViewModel2` → `ViewModel3` → `ViewModel4`
-- `ViewModel4` adds navigation capabilities
+- `ViewModel1` → `ViewModel2` → `ViewModel3`
+- `ViewModel3` adds navigation capabilities
 - Uses Hilt for assisted injection
 
 ## Dependency Injection

--- a/app/src/main/java/eu/darken/sdmse/common/debug/recorder/core/DebugLogSessionManager.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/debug/recorder/core/DebugLogSessionManager.kt
@@ -43,7 +43,7 @@ class DebugLogSessionManager @Inject constructor(
     private val zippingIds = MutableStateFlow<Set<SessionId>>(emptySet())
     private val failedZipIds = MutableStateFlow<Set<SessionId>>(emptySet())
     private val refreshTrigger = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
-    private val pendingAutoZips = mutableSetOf<SessionId>()
+    private val pendingAutoZips = java.util.Collections.synchronizedSet(mutableSetOf<SessionId>())
 
     val sessions: Flow<List<DebugLogSession>> = combine(
         recorderModule.state,

--- a/app/src/main/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModule.kt
@@ -105,7 +105,7 @@ class RecorderModule @Inject constructor(
                         )
                     } else if (!shouldRecord && isRecording) {
                         log(TAG) { "Stopping log recorder for: $currentLogDir" }
-                        recorder!!.stop()
+                        requireNotNull(recorder) { "Recorder was null despite isRecording" }.stop()
 
                         debugSettings.recorderPath.value(null)
                         if (triggerFile.exists() && !triggerFile.delete()) {
@@ -166,7 +166,8 @@ class RecorderModule @Inject constructor(
         internalState.updateBlocking {
             copy(shouldRecord = true)
         }
-        return internalState.flow.filter { it.isRecording }.first().currentLogDir!!
+        val state = internalState.flow.filter { it.isRecording }.first()
+        return requireNotNull(state.currentLogDir) { "currentLogDir was null despite isRecording" }
     }
 
     suspend fun requestStopRecorder(): StopResult {

--- a/app/src/main/java/eu/darken/sdmse/main/ui/settings/support/contactform/SupportContactFormViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/settings/support/contactform/SupportContactFormViewModel.kt
@@ -209,7 +209,7 @@ class SupportContactFormViewModel @Inject constructor(
                 } catch (e: Exception) {
                     log(TAG, ERROR) { "Failed to zip logs: ${e.asLog()}" }
                     events.postValue(SupportContactFormEvents.ShowError(R.string.support_contact_debuglog_zip_error))
-                    null
+                    return@launch
                 }
             }
 


### PR DESCRIPTION
## What changed

Fixed an issue where support emails could be sent without the selected debug log attachment if zipping failed. Also improved thread-safety in the debug session auto-zip system and replaced unsafe null assertions with descriptive error messages.

## Technical Context

- **Thread-safety**: `pendingAutoZips` was a plain `mutableSetOf` accessed from both the `combine` flow lambda (IO dispatcher) and `zipSessionAsync`'s `finally` block (appScope + IO) — now uses `Collections.synchronizedSet`
- **Email abort on zip failure**: `SupportContactFormViewModel.send()` previously swallowed the zip error (showed toast) but continued sending the email without the attachment the user selected. Now aborts with `return@launch`
- **requireNotNull**: `recorder!!` and `currentLogDir!!` in `RecorderModule` replaced with `requireNotNull` + descriptive messages — both are safe in practice (guarded by `isRecording` check) but now fail clearly instead of generic NPE
- **Docs**: `architecture.md` referenced non-existent `ViewModel4` — the actual hierarchy ends at `ViewModel3`
