### PR TITLE
General: Update GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up JDK 21
-      uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 #v4.7.0
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 #v5.2.0
       with:
         java-version: '21'
         distribution: 'temurin'
@@ -14,7 +14,7 @@ runs:
       run: chmod +x gradlew
 
     - name: Cache Gradle Wrapper
-      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 #v4.2.3
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 #v5.0.3
       with:
         path: |
           ~/.gradle/wrapper
@@ -24,7 +24,7 @@ runs:
           ${{ runner.os }}-gradle-wrapper-
 
     - name: Cache Gradle Dependencies
-      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 #v4.2.3
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 #v5.0.3
       with:
         path: |
           ~/.gradle/caches
@@ -33,7 +33,7 @@ runs:
           ${{ runner.os }}-gradle-caches-
 
     - name: Cache Android Global Build-Cache
-      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 #v4.2.3
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 #v5.0.3
       with:
         path: |
           ~/.android/build-cache

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout source code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: Setup project and build environment
         uses: ./.github/actions/common-setup
 
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout source code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: Setup project and build environment
         uses: ./.github/actions/common-setup
 
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout source code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: Setup project and build environment
         uses: ./.github/actions/common-setup
 
@@ -62,7 +62,7 @@ jobs:
         run: ./gradlew ${{ matrix.flavor }}${{ matrix.variant }}UnitTest
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7.0.0
         if: always()
         with:
           name: test-results-${{ matrix.flavor }}-${{ matrix.variant }}
@@ -81,7 +81,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout source code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: Setup project and build environment
         uses: ./.github/actions/common-setup
 
@@ -89,7 +89,7 @@ jobs:
         run: ./gradlew ${{ matrix.task }}
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7.0.0
         if: always()
         with:
           name: test-results-${{ matrix.task }}

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -13,5 +13,5 @@ jobs:
     name: "Validation"
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
-      - uses: gradle/actions/wrapper-validation@06832c7b30a0129d7fb559bcc6e43d26f6374244 #v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+      - uses: gradle/actions/wrapper-validation@0723195856401067f7a2779048b490ace7a47d7c #v5.0.2

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (build only, no release/upload)'
+        type: boolean
+        default: true
 
 jobs:
   release-github:
@@ -24,23 +30,15 @@ jobs:
           echo "STORE_PATH=$(echo $TMP_KEYSTORE_FILE_PATH)" >> $GITHUB_ENV
 
       - name: Checkout source code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup project and build environment
         uses: ./.github/actions/common-setup
 
-      - name: Get the version
-        id: tagger
-        uses: jimschubert/query-tag-action@0b288a5fff630fea2e96d61b99047ed823ca19dc #v2.2
-        with:
-          skip-unshallow: 'true'
-          abbrev: false
-          commit-ish: HEAD
-
       - name: Assemble beta APK
-        if: contains(steps.tagger.outputs.tag, '-beta')
+        if: contains(github.ref_name, '-beta')
         run: ./gradlew assembleFossBeta
         env:
           VERSION: ${{ github.ref }}
@@ -49,7 +47,7 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
 
       - name: Assemble production APK
-        if: "!contains(steps.tagger.outputs.tag, '-beta')"
+        if: "!contains(github.ref_name, '-beta')"
         run: ./gradlew assembleFossRelease
         env:
           VERSION: ${{ github.ref }}
@@ -58,24 +56,24 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
 
       - name: Create pre-release
-        if: contains(steps.tagger.outputs.tag, '-beta')
-        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda #v2.2.1
+        if: "contains(github.ref_name, '-beta') && !(github.event_name == 'workflow_dispatch' && inputs.dry_run)"
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b #v2.5.0
         with:
           prerelease: true
-          tag_name: ${{ steps.tagger.outputs.tag }}
-          name: ${{ steps.tagger.outputs.tag }}
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
           generate_release_notes: true
           files: app/build/outputs/apk/foss/beta/eu.darken.sdmse-*.apk
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create release
-        if: "!contains(steps.tagger.outputs.tag, '-beta')"
-        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda #v2.2.1
+        if: "!contains(github.ref_name, '-beta') && !(github.event_name == 'workflow_dispatch' && inputs.dry_run)"
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b #v2.5.0
         with:
           prerelease: false
-          tag_name: ${{ steps.tagger.outputs.tag }}
-          name: ${{ steps.tagger.outputs.tag }}
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
           generate_release_notes: true
           files: app/build/outputs/apk/foss/release/eu.darken.sdmse-*.apk
         env:
@@ -107,29 +105,21 @@ jobs:
           echo "SUPPLY_JSON_KEY=$(echo $TMP_SERVICEKEY_FILE_PATH)" >> $GITHUB_ENV
 
       - name: Checkout source code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup project and build environment
         uses: ./.github/actions/common-setup
 
-      - name: Get the version
-        id: tagger
-        uses: jimschubert/query-tag-action@0b288a5fff630fea2e96d61b99047ed823ca19dc #v2.2
-        with:
-          skip-unshallow: 'true'
-          abbrev: false
-          commit-ish: HEAD
-
       - name: Set up ruby env
-        uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 #v1.229.0
+        uses: ruby/setup-ruby@4eb9f110bac952a8b68ecf92e3b5c7a987594ba6 #v1.292.0
         with:
           ruby-version: 3.3.6
           bundler-cache: true
 
       - name: Assemble beta and upload to Google Play
-        if: contains(steps.tagger.outputs.tag, '-beta')
+        if: "contains(github.ref_name, '-beta') && !(github.event_name == 'workflow_dispatch' && inputs.dry_run)"
         run: bundle exec fastlane beta
         env:
           STORE_PASSWORD: ${{ secrets.STORE_PASSWORD }}
@@ -137,7 +127,7 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
 
       - name: Assemble production and upload to Google Play
-        if: "!contains(steps.tagger.outputs.tag, '-beta')"
+        if: "!contains(github.ref_name, '-beta') && !(github.event_name == 'workflow_dispatch' && inputs.dry_run)"
         run: bundle exec fastlane production
         env:
           STORE_PASSWORD: ${{ secrets.STORE_PASSWORD }}

--- a/.github/workflows/test-reports.yml
+++ b/.github/workflows/test-reports.yml
@@ -18,7 +18,7 @@ jobs:
     if: always()
     steps:
       - name: Test Report - FOSS Debug
-        uses: dorny/test-reporter@v2.1.1
+        uses: dorny/test-reporter@5540be7d257d0059d55ee0c144ab5a516329d0a1 #v2.6.0
         if: always()
         with:
           name: 'Unit Tests - testFoss Debug'
@@ -31,7 +31,7 @@ jobs:
           max-annotations: 10
 
       - name: Test Report - GPlay Debug
-        uses: dorny/test-reporter@v2.1.1
+        uses: dorny/test-reporter@5540be7d257d0059d55ee0c144ab5a516329d0a1 #v2.6.0
         if: always()
         with:
           name: 'Unit Tests - testGplay Debug'


### PR DESCRIPTION
## What changed

Updated all GitHub Actions to their latest Node.js 24-compatible versions ahead of the Node.js 20 deprecation (June 2026). Replaced the abandoned `jimschubert/query-tag-action` with the built-in `github.ref_name` context variable. Added a `workflow_dispatch` trigger with a `dry_run` option to the release workflow for safer manual testing.

## Technical Context

- All action SHAs verified against their respective GitHub release tags
- `actions/upload-artifact` jumps v4 to v7 — our usage is simple (upload test result XMLs consumed by `dorny/test-reporter`), so this should be safe
- `jimschubert/query-tag-action` is abandoned; `github.ref_name` is a direct replacement since the workflow already triggers on tag push
- Dry run guards use `!(github.event_name == 'workflow_dispatch' && inputs.dry_run)` to skip release creation and Google Play upload steps while still allowing the build to run
- Previously unpinned actions (`upload-artifact`, `test-reporter`) are now SHA-pinned for supply chain safety