### PR TITLE
AppCleaner: Fix automation not working on Black Shark devices

### DIFF
--- a/app-common/src/main/java/eu/darken/sdmse/common/device/DeviceDetective.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/device/DeviceDetective.kt
@@ -75,7 +75,8 @@ class DeviceDetective @Inject constructor(
         // LG UX, last devices run Android, close to AOSP
         manufactor("lge") -> RomType.LGUX
 
-        manufactor("Xiaomi") || manufactor("POCO") -> when {
+        // Black Shark is a Xiaomi sub-brand running JoyUI (MIUI fork)
+        manufactor("Xiaomi") || manufactor("POCO") || manufactor("blackshark") -> when {
             versionStarts(HYPEROS_VERSION_STARTS) -> when {
                 // HyperOS 1.0 is based on Android 14 / API34, some backports exist (e.g. pissarropro)
                 hasApiLevel(33) -> RomType.HYPEROS

--- a/app-common/src/test/java/eu/darken/sdmse/common/device/DeviceDetectiveTest.kt
+++ b/app-common/src/test/java/eu/darken/sdmse/common/device/DeviceDetectiveTest.kt
@@ -307,6 +307,18 @@ class DeviceDetectiveTest : BaseTest() {
     }
 
     @Test
+    fun `detect MIUI V12 on Black Shark 5 - blackshark patriot Android 12`() {
+        // blackshark/PAR-H0/patriot:12/PTRT2206200OS00MP1/V12.0.1.0.RBICNBS:user/release-keys
+        val context = deviceFromFingerprint(
+            "blackshark/PAR-H0/patriot:12/PTRT2206200OS00MP1/V12.0.1.0.RBICNBS:user/release-keys",
+            installedPackages = setOf("com.miui.securitycenter")
+        )
+        detective = DeviceDetective(context)
+
+        detective.getROMType() shouldBe RomType.MIUI
+    }
+
+    @Test
     fun `detect Nubia device`() {
         val context = mockDevice {
             manufacturer = "nubia"


### PR DESCRIPTION
## What changed

Fixed AppCleaner automation getting stuck in an endless retry loop on Black Shark devices (Xiaomi gaming sub-brand). The app now correctly recognizes Black Shark phones as MIUI devices, allowing the automation to navigate the settings UI properly.

## Technical Context

- Root cause: `DeviceDetective.getROMType()` only checked for manufacturers "Xiaomi" and "POCO" when detecting MIUI. Black Shark devices report manufacturer as "blackshark", so they fell through to the AOSP default.
- This caused `ClearCacheModule` to select `AOSPSpecs` instead of `MIUISpecs`. Since Black Shark uses `com.miui.securitycenter` for app info (not standard Android Settings), the AOSP stepper couldn't find the "Storage entry" button and retried 5 times per app indefinitely.
- Black Shark used JoyUI (a MIUI fork). The brand is now defunct (no phones after 2022, never transitioned to HyperOS), so only the MIUI detection path matters.
- Fix: add `manufactor("blackshark")` to the existing Xiaomi/POCO manufacturer check.
