### PR TITLE
AppCleaner: Fix dry run mode for cache clearing on Pixel devices

### DIFF
--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecs.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecs.kt
@@ -199,6 +199,8 @@ class AOSPSpecs @Inject constructor(
         sizeParser: SizeParser?,
         timeoutMs: Long = 3000,
     ): Boolean {
+        if (Bugs.isDryRun) return true
+
         val eventOk = validateClickEffect(source, timeoutMs)
         if (!eventOk) return false
 


### PR DESCRIPTION
## What changed

Fixed the debug dry run mode failing when clearing app caches on Pixel devices running Android 16+. Dry run would always report failure on these devices because it tried to verify storage changes that never happened (since dry run doesn't actually click anything).

## Technical Context

- On Android 16+ Pixels, clear cache buttons are NAF (Not Accessibility Focusable), so SD Maid uses DPAD keyboard navigation as a fallback (see #2056)
- The DPAD path validates success via `validateWithDelta`, which compares storage snapshots before/after clicking. In dry run mode no click is dispatched, so storage never changes and validation always fails
- `validateClickEffect` already had an `isDryRun` early return — `validateWithDelta` was missing the same guard
- The normal (non-DPAD) path was unaffected because it handles dry run at the click level via `clickNormal`
