### PR TITLE
General: Fix storage trend graph not showing cleaning impact

### DIFF
--- a/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/SpaceHistoryRepo.kt
+++ b/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/SpaceHistoryRepo.kt
@@ -43,7 +43,6 @@ class SpaceHistoryRepo @Inject constructor(
                     if (latest.spaceFree == spaceFree && latest.spaceCapacity == spaceCapacity) {
                         return@withTransaction false
                     }
-                    reportsDatabase.spaceSnapshotDao.deleteById(latest.id)
                 }
             }
 

--- a/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/SpaceTracker.kt
+++ b/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/SpaceTracker.kt
@@ -38,7 +38,7 @@ class SpaceTracker @Inject constructor(
             val storages = readCurrentStorages()
             val inserted = insertSnapshots(storages, now)
 
-            if (inserted > 0 || force) {
+            if (inserted > 0) {
                 statsSettings.lastSnapshotAt.value(now.toEpochMilli())
             }
 

--- a/app/src/main/java/eu/darken/sdmse/App.kt
+++ b/app/src/main/java/eu/darken/sdmse/App.kt
@@ -29,7 +29,7 @@ import eu.darken.sdmse.common.updater.UpdateService
 import eu.darken.sdmse.main.core.CurriculumVitae
 import eu.darken.sdmse.main.core.GeneralSettings
 import eu.darken.sdmse.main.core.shortcuts.ShortcutManager
-import eu.darken.sdmse.stats.core.SpaceTracker
+import eu.darken.sdmse.stats.core.SpaceMonitorControl
 import eu.darken.sdmse.stats.core.TaskStatsCoordinator
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.combine
@@ -55,7 +55,7 @@ open class App : Application(), Configuration.Provider {
     @Inject lateinit var coilTempFiles: CoilTempFiles
     @Inject lateinit var memoryMonitor: MemoryMonitor
     @Inject lateinit var shortcutManager: ShortcutManager
-    @Inject lateinit var spaceTracker: SpaceTracker
+    @Inject lateinit var spaceMonitorControl: SpaceMonitorControl
     @Inject lateinit var taskStatsCoordinator: TaskStatsCoordinator
 
     private val logCatLogger = LogCatLogger()
@@ -103,7 +103,7 @@ open class App : Application(), Configuration.Provider {
 
         shortcutManager.initialize()
         taskStatsCoordinator.start()
-        appScope.launch { spaceTracker.recordSnapshot() }
+        spaceMonitorControl.start()
 
         val oldHandler = Thread.getDefaultUncaughtExceptionHandler()
         Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->

--- a/app/src/main/java/eu/darken/sdmse/stats/core/SpaceMonitorControl.kt
+++ b/app/src/main/java/eu/darken/sdmse/stats/core/SpaceMonitorControl.kt
@@ -1,0 +1,54 @@
+package eu.darken.sdmse.stats.core
+
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import eu.darken.sdmse.common.BuildConfigWrap
+import eu.darken.sdmse.common.coroutine.AppScope
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class SpaceMonitorControl @Inject constructor(
+    @AppScope private val appScope: CoroutineScope,
+    private val workManager: WorkManager,
+    private val spaceTracker: SpaceTracker,
+) {
+
+    fun start() {
+        log(TAG, VERBOSE) { "start()" }
+
+        appScope.launch {
+            spaceTracker.recordSnapshot()
+        }
+
+        val workRequest = PeriodicWorkRequestBuilder<SpaceMonitorWorker>(
+            INTERVAL_HOURS,
+            TimeUnit.HOURS,
+        ).build()
+
+        workManager.enqueueUniquePeriodicWork(
+            "${BuildConfigWrap.APPLICATION_ID}.stats.space-monitor",
+            ExistingPeriodicWorkPolicy.KEEP,
+            workRequest,
+        )
+
+        log(TAG) { "Periodic space monitoring scheduled (interval=${INTERVAL_HOURS}h)" }
+    }
+
+    fun stop() {
+        log(TAG) { "stop(): Cancelling periodic space monitoring" }
+        workManager.cancelUniqueWork("${BuildConfigWrap.APPLICATION_ID}.stats.space-monitor")
+    }
+
+    companion object {
+        private const val INTERVAL_HOURS = 6L
+        private val TAG = logTag("Stats", "SpaceMonitor", "Control")
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/stats/core/SpaceMonitorWorker.kt
+++ b/app/src/main/java/eu/darken/sdmse/stats/core/SpaceMonitorWorker.kt
@@ -1,0 +1,30 @@
+package eu.darken.sdmse.stats.core
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+
+@HiltWorker
+class SpaceMonitorWorker @AssistedInject constructor(
+    @Assisted private val context: Context,
+    @Assisted private val params: WorkerParameters,
+    private val spaceTracker: SpaceTracker,
+) : CoroutineWorker(context, params) {
+
+    override suspend fun doWork(): Result {
+        log(TAG, VERBOSE) { "doWork(): Recording storage snapshot" }
+        spaceTracker.recordSnapshot()
+        log(TAG, VERBOSE) { "doWork(): Done" }
+        return Result.success()
+    }
+
+    companion object {
+        val TAG = logTag("Stats", "SpaceMonitor", "Worker")
+    }
+}


### PR DESCRIPTION
## What changed

Fixed the storage trend graph not reflecting the impact of cleaning operations. After running a cleaning tool, the graph now correctly shows a visible drop in storage usage. Also added background storage monitoring so the graph stays populated even when the app isn't actively used.

## Technical Context

- **Root cause (invisible cleaning):** The 5-minute dedup window in `SpaceHistoryRepo.insertIfNotRecent` deleted the pre-cleaning snapshot before inserting the post-cleaning one. Both points fell within the window, so the "before" data was erased. Fix: stop deleting the previous entry when values change — identical snapshots are still deduped, but changed values insert alongside the previous point.
- **Secondary bug:** `SpaceTracker` updated `lastSnapshotAt` even when `force=true` but no snapshot was actually inserted (e.g., dry run). This suppressed the next natural snapshot for 30 minutes unnecessarily. Fix: only update the timestamp when `inserted > 0`.
- **Periodic monitoring:** Added a WorkManager periodic worker (6-hour interval) that records storage snapshots in the background. This fills gaps in the graph when the app isn't open. `SpaceMonitorControl` manages the worker lifecycle and also records an immediate snapshot on app launch, replacing the previous standalone call in `App.kt`.
- `ExistingPeriodicWorkPolicy.KEEP` ensures the worker isn't reconfigured on every process start.
