### PR TITLE
AppCleaner: Fix slow automation timeout on HyperOS/MIUI devices

### DIFF
--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/hyperos/HyperOsSpecs.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/hyperos/HyperOsSpecs.kt
@@ -60,6 +60,7 @@ import eu.darken.sdmse.common.deviceadmin.DeviceAdminManager
 import eu.darken.sdmse.common.funnel.IPCFunnel
 import eu.darken.sdmse.common.pkgs.Pkg
 import eu.darken.sdmse.common.pkgs.features.Installed
+import eu.darken.sdmse.common.pkgs.isSystemApp
 import eu.darken.sdmse.common.pkgs.getPackageInfo2
 import eu.darken.sdmse.common.pkgs.toPkgId
 import eu.darken.sdmse.common.progress.withProgress
@@ -256,12 +257,14 @@ class HyperOsSpecs @Inject constructor(
                             SecurityCenterMissingPermissionException()
                         }
 
-                        else -> {
-                            log(TAG, WARN) { "Clear data button is disabled, not a permission issue, skipping: $e" }
+                        pkg.isSystemApp -> {
+                            log(TAG, WARN) { "Clear data button is disabled for system app, skipping: $e" }
                             PlanAbortException(
-                                message = "Clear data button disabled for ${pkg.packageName}, can't clear cache via security center.",
+                                message = "Clear data button disabled for system app ${pkg.packageName}, can't clear cache via security center.",
                             )
                         }
+
+                        else -> e
                     }
                 }
             }

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/miui/MIUISpecs.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/miui/MIUISpecs.kt
@@ -59,6 +59,7 @@ import eu.darken.sdmse.common.deviceadmin.DeviceAdminManager
 import eu.darken.sdmse.common.funnel.IPCFunnel
 import eu.darken.sdmse.common.pkgs.Pkg
 import eu.darken.sdmse.common.pkgs.features.Installed
+import eu.darken.sdmse.common.pkgs.isSystemApp
 import eu.darken.sdmse.common.pkgs.getPackageInfo2
 import eu.darken.sdmse.common.pkgs.toPkgId
 import eu.darken.sdmse.common.progress.withProgress
@@ -227,12 +228,14 @@ class MIUISpecs @Inject constructor(
                             SecurityCenterMissingPermissionException()
                         }
 
-                        else -> {
-                            log(TAG, WARN) { "Clear data button is disabled, not a permission issue, skipping: $e" }
+                        pkg.isSystemApp -> {
+                            log(TAG, WARN) { "Clear data button is disabled for system app, skipping: $e" }
                             PlanAbortException(
-                                message = "Clear data button disabled for ${pkg.packageName}, can't clear cache via security center.",
+                                message = "Clear data button disabled for system app ${pkg.packageName}, can't clear cache via security center.",
                             )
                         }
+
+                        else -> e
                     }
                 }
             }


### PR DESCRIPTION
## What changed

Fixed automation taking ~30 seconds per app to fail when system apps have a disabled "Clear data" button in the MIUI/HyperOS Security Center. The automation now detects the disabled button immediately and skips the app, instead of retrying 50 times until timeout.

## Technical Context

- Root cause: In the security center plan, `DisabledTargetException` is caught and checked for missing Security Center permissions. When permissions are fine (the common case for system apps with permanently disabled buttons), the exception was re-thrown as a generic `Exception`, causing the stepper to retry every 300ms until the 30-second step timeout.
- The AOSP-style specs already had fail-fast detection for disabled buttons via `clickClearCache()` in `AppCleanerSpecGeneratorExtensions.kt`, but the MIUI/HyperOS security center plan used `clickNormal()` directly and lacked this handling.
- Fix: throw `PlanAbortException` (treatAsSuccess=false) instead of re-throwing `DisabledTargetException` — the app still shows as an error with the Exclude button, but the automation proceeds immediately to the next app.
- Applied the same fix to both `HyperOsSpecs` and `MIUISpecs` which share the identical pattern.

Closes #2305
