### PR TITLE
General: Prevent recursive file deletion from following symlinks

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalGateway.kt
@@ -21,6 +21,7 @@ import eu.darken.sdmse.common.files.WriteException
 import eu.darken.sdmse.common.files.asFile
 import eu.darken.sdmse.common.files.callbacks
 import eu.darken.sdmse.common.files.core.local.createSymlink
+import eu.darken.sdmse.common.files.core.local.deleteRecursivelySafe
 import eu.darken.sdmse.common.files.core.local.isReadable
 import eu.darken.sdmse.common.files.core.local.listFiles2
 import eu.darken.sdmse.common.files.core.local.parentsInclusive
@@ -789,7 +790,7 @@ class LocalGateway @Inject constructor(
                                 javaFile.canWrite()
                             }
 
-                            recursive -> deleteRecursively()
+                            recursive -> deleteRecursivelySafe()
                             else -> delete()
                         }
                     }

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/FileOpsHost.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/FileOpsHost.kt
@@ -13,6 +13,7 @@ import eu.darken.sdmse.common.files.Ownership
 import eu.darken.sdmse.common.files.Permissions
 import eu.darken.sdmse.common.files.asFile
 import eu.darken.sdmse.common.files.core.local.createSymlink
+import eu.darken.sdmse.common.files.core.local.deleteRecursivelySafe
 import eu.darken.sdmse.common.files.core.local.listFiles2
 import eu.darken.sdmse.common.files.local.DirectLocalWalker
 import eu.darken.sdmse.common.files.local.LocalPath
@@ -207,7 +208,7 @@ class FileOpsHost @Inject constructor(
 
         var success = when {
             dryRun -> javaFile.canWrite()
-            recursive -> javaFile.deleteRecursively()
+            recursive -> javaFile.deleteRecursivelySafe()
             else -> javaFile.delete()
         }
 

--- a/app-common/src/main/java/eu/darken/sdmse/common/files/core/local/FileExtensionsBase.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/files/core/local/FileExtensionsBase.kt
@@ -5,30 +5,14 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
 import java.io.File
-import java.io.FileNotFoundException
 import java.io.IOException
 
-@Suppress("FunctionName")
 fun File(vararg crumbs: String): File {
     var compacter = File(crumbs[0])
     for (i in 1 until crumbs.size) {
         compacter = File(compacter, crumbs[i])
     }
     return compacter
-}
-
-fun File.requireExists(): File {
-    if (!exists()) {
-        throw IllegalStateException("Path doesn't exist, but should: $this")
-    }
-    return this
-}
-
-fun File.requireNotExists(): File {
-    if (exists()) {
-        throw IllegalStateException("Path exist, but shouldn't: $this")
-    }
-    return this
 }
 
 fun File.tryMkDirs(): File {
@@ -69,18 +53,25 @@ fun File.tryMkFile(): File {
     }
 }
 
-@Throws(IOException::class)
-fun File.deleteAll() {
+fun File.deleteRecursivelySafe(): Boolean {
+    // readLink() is fail-open: returns null on any error, treating the path as "not a symlink".
+    // Safe because: as root (the dangerous context), readlink never fails on permission;
+    // as non-root, permission errors also block listFiles()/delete(), so recursion goes nowhere.
+    val linkTarget = readLink()
+    if (linkTarget != null) {
+        log(WARN) { "deleteRecursivelySafe(): Symlink detected, deleting link only: $this -> $linkTarget" }
+        return delete()
+    }
+    var success = true
     if (isDirectory) {
-        listFiles()?.forEach { it.deleteAll() }
+        val children = listFiles()
+        if (children != null) {
+            for (child in children) {
+                if (!child.deleteRecursivelySafe()) success = false
+            }
+        }
     }
-    if (delete()) {
-        log(VERBOSE) { "File.release(): Deleted $this" }
-    } else if (!exists()) {
-        log(WARN) { "File.release(): File didn't exist: $this" }
-    } else {
-        throw FileNotFoundException("Failed to delete file: $this")
-    }
+    return if (success) delete() else false
 }
 
 fun File.listFiles2(): List<File> {
@@ -100,7 +91,7 @@ fun File.createSymlink(target: File): Boolean {
 
 fun File.readLink(): String? = try {
     Os.readlink(this.path)
-} catch (e: Exception) {
+} catch (_: Exception) {
     null
 }
 
@@ -113,11 +104,9 @@ fun File.isReadable(): Boolean = try {
         reader().use { it.read() }
         true
     }
-} catch (e: Exception) {
+} catch (_: Exception) {
     false
 }
-
-fun File.canReadExecute(): Boolean = canRead() && canExecute()
 
 val File.parents: Sequence<File>
     get() = sequence {
@@ -130,5 +119,3 @@ val File.parents: Sequence<File>
 
 val File.parentsInclusive: Sequence<File>
     get() = sequenceOf(this) + parents
-
-fun String.fixSlashes(): String = replace("/", File.separator)

--- a/app-common/src/test/java/eu/darken/sdmse/common/files/core/local/FileExtensionsBaseTest.kt
+++ b/app-common/src/test/java/eu/darken/sdmse/common/files/core/local/FileExtensionsBaseTest.kt
@@ -1,0 +1,129 @@
+package eu.darken.sdmse.common.files.core.local
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.io.File
+import java.nio.file.Files
+
+/**
+ * Tests the safety property of symlink-aware recursive deletion.
+ *
+ * Since [isSymbolicLink] uses Android's `Os.readlink()` (unavailable on JVM),
+ * these tests use `java.nio.file.Files` to create real symlinks and a NIO-based
+ * mirror of the same algorithm to verify the core safety property:
+ * recursive deletion must NOT follow symlinks into target directories.
+ */
+class FileExtensionsBaseTest : BaseTest() {
+
+    private val testDir = File(IO_TEST_BASEDIR, "symlink-delete-test")
+
+    @BeforeEach
+    fun setup() {
+        testDir.mkdirs()
+    }
+
+    @AfterEach
+    fun cleanup() {
+        deleteRecursivelySafeNio(testDir)
+    }
+
+    @Test
+    fun `symlink to directory - target contents survive deletion`() {
+        val targetDir = File(testDir, "real-data").apply { mkdirs() }
+        val targetFile = File(targetDir, "precious.txt").apply { writeText("keep me") }
+
+        val appDir = File(testDir, "app-data").apply { mkdirs() }
+        val symlink = File(appDir, "sneaky-link")
+        Files.createSymbolicLink(symlink.toPath(), targetDir.toPath())
+
+        deleteRecursivelySafeNio(appDir) shouldBe true
+
+        appDir.exists() shouldBe false
+        targetDir.exists() shouldBe true
+        targetFile.exists() shouldBe true
+        targetFile.readText() shouldBe "keep me"
+    }
+
+    @Test
+    fun `symlink to file - target file survives deletion`() {
+        val targetFile = File(testDir, "real-file.txt").apply { writeText("important") }
+
+        val appDir = File(testDir, "app-data").apply { mkdirs() }
+        val symlink = File(appDir, "link-to-file")
+        Files.createSymbolicLink(symlink.toPath(), targetFile.toPath())
+
+        deleteRecursivelySafeNio(appDir) shouldBe true
+
+        appDir.exists() shouldBe false
+        targetFile.exists() shouldBe true
+        targetFile.readText() shouldBe "important"
+    }
+
+    @Test
+    fun `broken symlink - deleted without error`() {
+        val appDir = File(testDir, "app-data").apply { mkdirs() }
+        val nonExistent = File(testDir, "does-not-exist")
+        val symlink = File(appDir, "broken-link")
+        Files.createSymbolicLink(symlink.toPath(), nonExistent.toPath())
+
+        Files.isSymbolicLink(symlink.toPath()) shouldBe true
+
+        deleteRecursivelySafeNio(appDir) shouldBe true
+
+        appDir.exists() shouldBe false
+    }
+
+    @Test
+    fun `regular directory tree - deleted normally`() {
+        val dir = File(testDir, "normal-dir").apply { mkdirs() }
+        File(dir, "sub").apply { mkdirs() }
+        File(dir, "sub/file.txt").apply { writeText("data") }
+        File(dir, "root-file.txt").apply { writeText("data") }
+
+        deleteRecursivelySafeNio(dir) shouldBe true
+
+        dir.exists() shouldBe false
+    }
+
+    @Test
+    fun `nested directory with symlink deeper in tree - target survives`() {
+        val targetDir = File(testDir, "real-media").apply { mkdirs() }
+        val targetFile = File(targetDir, "photo.jpg").apply { writeText("image data") }
+
+        val appDir = File(testDir, "app-data").apply { mkdirs() }
+        val subDir = File(appDir, "files").apply { mkdirs() }
+        val symlink = File(subDir, "DCIM")
+        Files.createSymbolicLink(symlink.toPath(), targetDir.toPath())
+
+        File(appDir, "some-file.txt").apply { writeText("app data") }
+
+        deleteRecursivelySafeNio(appDir) shouldBe true
+
+        appDir.exists() shouldBe false
+        targetDir.exists() shouldBe true
+        targetFile.exists() shouldBe true
+        targetFile.readText() shouldBe "image data"
+    }
+
+    /**
+     * NIO-based mirror of [deleteRecursivelySafe] for JVM testing.
+     * Same algorithm, but uses [Files.isSymbolicLink] instead of [Os.readlink].
+     */
+    private fun deleteRecursivelySafeNio(file: File): Boolean {
+        if (Files.isSymbolicLink(file.toPath())) {
+            return file.delete()
+        }
+        if (file.isDirectory) {
+            val children = file.listFiles()
+            if (children != null) {
+                for (child in children) {
+                    if (!deleteRecursivelySafeNio(child)) return false
+                }
+            }
+        }
+        return file.delete()
+    }
+}

--- a/app-common/src/test/java/eu/darken/sdmse/common/hashing/HasherTest.kt
+++ b/app-common/src/test/java/eu/darken/sdmse/common/hashing/HasherTest.kt
@@ -1,6 +1,6 @@
 package eu.darken.sdmse.common.hashing
 
-import eu.darken.sdmse.common.files.core.local.deleteAll
+import eu.darken.sdmse.common.files.core.local.deleteRecursivelySafe
 import eu.darken.sdmse.common.hashing.Hasher.Type
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest
@@ -17,7 +17,7 @@ class HasherTest : BaseTest() {
 
     @AfterEach
     fun cleanup() {
-        testFolder.deleteAll()
+        testFolder.deleteRecursivelySafe()
     }
 
     @Test fun `MD5 direct`() = runTest {

--- a/app-tool-scheduler/src/test/java/eu/darken/sdmse/scheduler/core/ScheduleStorageTest.kt
+++ b/app-tool-scheduler/src/test/java/eu/darken/sdmse/scheduler/core/ScheduleStorageTest.kt
@@ -1,7 +1,7 @@
 package eu.darken.sdmse.scheduler.core
 
 import android.content.Context
-import eu.darken.sdmse.common.files.core.local.deleteAll
+import eu.darken.sdmse.common.files.core.local.deleteRecursivelySafe
 import eu.darken.sdmse.common.serialization.SerializationIOModule
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -17,14 +17,14 @@ import java.time.Duration
 import java.time.Instant
 
 class ScheduleStorageTest : BaseTest() {
-    private val testDir = File(IO_TEST_BASEDIR)
+    private val testDir = File(IO_TEST_BASEDIR, "schedule-storage-test")
     private val context: Context = mockk<Context>().apply {
         every { filesDir } returns testDir
     }
 
     @AfterEach
     fun cleanup() {
-        testDir.deleteAll()
+        testDir.deleteRecursivelySafe()
     }
 
     private fun create() = ScheduleStorage(

--- a/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/ui/onboarding/ComparisonDialog.kt
+++ b/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/ui/onboarding/ComparisonDialog.kt
@@ -17,6 +17,7 @@ import coil.load
 import coil.request.CachePolicy
 import eu.darken.sdmse.squeezer.R
 import eu.darken.sdmse.common.dpToPx
+import eu.darken.sdmse.common.files.core.local.deleteRecursivelySafe
 import eu.darken.sdmse.common.hasApiLevel
 import eu.darken.sdmse.squeezer.databinding.SqueezerComparisonDialogBinding
 import eu.darken.sdmse.squeezer.core.CompressibleImage
@@ -144,7 +145,7 @@ class ComparisonDialog : DialogFragment() {
         _binding = null
         val cacheDir = requireContext().cacheDir
         lifecycleScope.launch(Dispatchers.IO) {
-            File(cacheDir, "squeezer_preview").deleteRecursively()
+            File(cacheDir, "squeezer_preview").deleteRecursivelySafe()
         }
         super.onDestroyView()
     }

--- a/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/SuperfluousApksFilter.kt
+++ b/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/SuperfluousApksFilter.kt
@@ -23,7 +23,7 @@ import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APathLookup
 import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.copyToAutoClose
-import eu.darken.sdmse.common.files.core.local.deleteAll
+import eu.darken.sdmse.common.files.core.local.deleteRecursivelySafe
 import eu.darken.sdmse.common.files.file
 import eu.darken.sdmse.common.files.inputStream
 import eu.darken.sdmse.common.files.local.toLocalPath
@@ -73,7 +73,7 @@ class SuperfluousApksFilter @Inject constructor(
             dir.mkdirs()
             dir.let { it.listFiles()?.toList() }?.forEach {
                 log(TAG, WARN) { "Deleting stale cache data: $it" }
-                it.deleteAll()
+                it.deleteRecursivelySafe()
             }
         }
     }
@@ -141,7 +141,7 @@ class SuperfluousApksFilter @Inject constructor(
 
                     if (extractedBase.exists()) pkgOps.viewArchive(extractedBase.toLocalPath()) else null
                 } finally {
-                    extractedDir.deleteAll()
+                    extractedDir.deleteRecursivelySafe()
                 }
             }
 

--- a/app/src/main/java/eu/darken/sdmse/common/debug/recorder/core/DebugLogSessionManager.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/debug/recorder/core/DebugLogSessionManager.kt
@@ -9,6 +9,7 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.files.core.local.deleteRecursivelySafe
 import eu.darken.sdmse.common.flow.replayingShare
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -189,8 +190,9 @@ class DebugLogSessionManager @Inject constructor(
             recorderModule.getLogDirectories().forEach { parent ->
                 File(parent, baseName).let { dir ->
                     if (dir.exists()) {
-                        dir.deleteRecursively()
-                        log(TAG) { "Deleted session dir: ${dir.path}" }
+                        if (dir.deleteRecursivelySafe()) {
+                            log(TAG) { "Deleted session dir: ${dir.path}" }
+                        }
                     }
                 }
                 File(parent, "$baseName.zip").let { zip ->
@@ -215,8 +217,9 @@ class DebugLogSessionManager @Inject constructor(
                     if (sessionId in currentZipping) return@forEach
                     if (activeDir != null && file.isDirectory && file.absolutePath == activeDir.absolutePath) return@forEach
 
-                    file.deleteRecursively()
-                    log(TAG) { "Deleted: ${file.path}" }
+                    if (file.deleteRecursivelySafe()) {
+                        log(TAG) { "Deleted: ${file.path}" }
+                    }
                 }
             }
         }


### PR DESCRIPTION
## What changed

Prevented a scenario where cleaning up app directories could follow symlinks and delete files outside the intended directory tree. This protects against potential data loss when apps create symlinks pointing to important user folders.

## Technical Context

- Root cause: Kotlin's `File.deleteRecursively()` uses `File.isDirectory` which follows symlinks — a symlink to a directory is entered and its contents deleted
- SD Maid's own walkers already detect symlinks correctly (`getAPathFileType()` checks `isSymbolicLink()` first), but the deletion path bypassed this and went straight to Kotlin stdlib
- Replaced both `deleteRecursively()` and `deleteAll()` with a unified `deleteRecursivelySafe()` that checks for symlinks before recursing, returning Boolean for caller compatibility
- The fix applies to all recursive deletion paths: LocalGateway (normal), FileOpsHost (root/ADB), and secondary call sites (debug log cleanup, cache cleanup)
- `readLink()` is fail-open by design — as root, readlink never fails on permission; as non-root, permission errors also block listFiles()/delete()

Closes #1499
