### PR TITLE
Fix: Wrong text highlighted in History dashboard card on non-English locales

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/items/StatsDashCardVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/items/StatsDashCardVH.kt
@@ -47,20 +47,24 @@ class StatsDashCardVH(parent: ViewGroup) :
             body.text = SpannableString(wholeText).apply {
                 val startFreed = wholeText.indexOf(space)
                 val endFreed = startFreed + space.length
-                setSpan(
-                    ForegroundColorSpan(getColorForAttr(androidx.appcompat.R.attr.colorPrimary)),
-                    startFreed,
-                    endFreed,
-                    Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
-                )
-                val startProcessed = wholeText.indexOf(processedFormatted)
+                if (startFreed >= 0 && endFreed <= wholeText.length) {
+                    setSpan(
+                        ForegroundColorSpan(getColorForAttr(androidx.appcompat.R.attr.colorPrimary)),
+                        startFreed,
+                        endFreed,
+                        Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+                    )
+                }
+                val startProcessed = wholeText.indexOf(processed, endFreed.coerceAtLeast(0))
                 val endProcessed = startProcessed + processed.length
-                setSpan(
-                    ForegroundColorSpan(getColorForAttr(androidx.appcompat.R.attr.colorPrimary)),
-                    startProcessed,
-                    endProcessed,
-                    Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
-                )
+                if (startProcessed >= 0 && endProcessed <= wholeText.length) {
+                    setSpan(
+                        ForegroundColorSpan(getColorForAttr(androidx.appcompat.R.attr.colorPrimary)),
+                        startProcessed,
+                        endProcessed,
+                        Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+                    )
+                }
             }
         } else {
             body.text = getString(StatsR.string.stats_dash_body_snapshots_only)


### PR DESCRIPTION
## What changed

Fixed the History card on the dashboard highlighting the wrong text in non-English languages. Instead of the processed-items number being colored, random characters from the surrounding sentence were highlighted.

## Technical Context

- Root cause: `indexOf(processedFormatted)` finds the start of the *sentence* containing the number, then `+ processed.length` offsets by the number's character count from there — highlighting the first N characters of the sentence instead of the number itself. Works in English by accident because `%s` is at position 0 in the format string (`"%s items processed..."`), but breaks in languages where `%s` is mid-sentence (e.g. Polish: `"Przetworzono %s elementy..."`)
- Fix uses `indexOf(processed, endFreed)` to locate the number substring directly, matching the pattern already used for the freed-space highlight
- Added bounds guards (`indexOf >= 0`) on both spans to prevent crashes if a translation accidentally omits the `%s` placeholder
