### PR TITLE
General: Spell out abbreviated day labels in storage trend

### DIFF
--- a/app-common-stats/src/main/res/values/strings.xml
+++ b/app-common-stats/src/main/res/values/strings.xml
@@ -29,9 +29,9 @@
     <string name="stats_storage_trend_action">Storage Trend</string>
     <string name="stats_space_history_title">Storage Trend</string>
     <string name="stats_space_history_range_title">Range</string>
-    <string name="stats_space_history_range_7d">7d</string>
-    <string name="stats_space_history_range_30d">30d</string>
-    <string name="stats_space_history_range_90d">90d</string>
+    <string name="stats_space_history_range_7d">7 days</string>
+    <string name="stats_space_history_range_30d">30 days</string>
+    <string name="stats_space_history_range_90d">90 days</string>
     <string name="stats_space_history_storage_title">Storage</string>
     <string name="stats_space_history_current_used_label">Current used</string>
     <string name="stats_space_history_min_label">Minimum used</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -315,6 +315,6 @@
     <string name="shortcuts_onetap_enabled_title">One-tap shortcut</string>
     <string name="shortcuts_onetap_enabled_summary">Show \"Scan + Delete\" shortcut when long-pressing the app icon. Uses the same tools as one-tap dashboard.</string>
 
-    <string name="analyzer_storage_trend_delta_in_7d">%s in 7d</string>
+    <string name="analyzer_storage_trend_delta_in_7d">%s in 7 days</string>
     <!-- Shorter versions for side-by-side display -->
 </resources>


### PR DESCRIPTION
## What changed

Expanded abbreviated day labels ("7d", "30d", "90d") to full words ("7 days", "30 days", "90 days") in the storage trend range selector and delta display for improved readability.

## Technical Context

- Simple string resource update across two files: `app-common-stats` range selector labels and `app` analyzer delta label
- No logic changes — display text only
