### PR TITLE
Fix: Restore progress state after clearing app caches

### DIFF
--- a/app-common/src/main/java/eu/darken/sdmse/common/progress/ProgressExtensions.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/progress/ProgressExtensions.kt
@@ -108,5 +108,7 @@ suspend fun <T : Progress.Host, R> T.withProgress(
     } finally {
         forwardingJob.cancelAndJoin()
         scope.cancel("Finished scope")
+        // Flow's onCompletion doesn't restore because isActive is false after cancellation
+        client.updateProgress { onCompletion(it) }
     }
 }


### PR DESCRIPTION
## What changed

Fixed incorrect progress tracking during the AppCleaner cache clearing phase. After cleaning an app's accessible cache files, the progress indicator could get stuck in an indeterminate state instead of showing the correct percentage, causing log spam and potentially confusing progress display.

## Technical Context

- Root cause: `withProgress()` in `ProgressExtensions.kt` cancels the progress-forwarding flow when the action completes. The flow's `onCompletion` callback was supposed to restore the parent's progress state, but it checks `currentCoroutineContext().isActive` — which is `false` after cancellation. So the restore never executed.
- After any filter ran inside `withProgress`, the parent's progress count was left in the filter's state (Indeterminate) instead of being restored to the original Percent counter. This caused ~30 `Can't increaseProgress()` errors per run.
- Fix: explicitly call the `onCompletion` callback in the `finally` block after cancelling the forwarding job, ensuring progress is always restored.
- This affects all `withProgress` callers, not just AppCleaner — the restore was silently broken everywhere.

Closes #2307
