### PR TITLE
Fix: Crash when previewing images found via root or ADB in Media Squeeze

### DIFF
--- a/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/ui/onboarding/BitmapSampler.kt
+++ b/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/ui/onboarding/BitmapSampler.kt
@@ -2,13 +2,18 @@ package eu.darken.sdmse.squeezer.ui.onboarding
 
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.*
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 import java.io.File
+import java.io.IOException
 
 object BitmapSampler {
 
+    private val TAG = logTag("Squeezer", "BitmapSampler")
     private const val MAX_DIMENSION = 2048
 
-    fun decodeSampledBitmap(file: File, maxDimension: Int = MAX_DIMENSION): Bitmap? {
+    fun decodeSampledBitmap(file: File, maxDimension: Int = MAX_DIMENSION): Bitmap? = try {
         val options = BitmapFactory.Options().apply {
             inJustDecodeBounds = true
         }
@@ -21,9 +26,12 @@ object BitmapSampler {
             inSampleSize = calculateInSampleSize(outWidth, outHeight, maxDimension)
         }
 
-        return file.inputStream().use { input ->
+        file.inputStream().use { input ->
             BitmapFactory.decodeStream(input, null, options)
         }
+    } catch (e: IOException) {
+        log(TAG, WARN) { "Failed to decode bitmap from ${file.path}: ${e.message}" }
+        null
     }
 
     private fun calculateInSampleSize(width: Int, height: Int, maxDimension: Int): Int {

--- a/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/ui/onboarding/SqueezerOnboardingDialog.kt
+++ b/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/ui/onboarding/SqueezerOnboardingDialog.kt
@@ -1,17 +1,21 @@
 package eu.darken.sdmse.squeezer.ui.onboarding
 
-import android.app.Dialog
 import android.graphics.BitmapFactory
 import android.text.format.Formatter
 import android.view.LayoutInflater
-import android.view.View
+import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.*
+import eu.darken.sdmse.common.debug.logging.asLog
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.files.GatewaySwitch
+import eu.darken.sdmse.common.files.copyToAutoClose
 import eu.darken.sdmse.squeezer.R
-import eu.darken.sdmse.common.files.local.LocalPath
-import eu.darken.sdmse.squeezer.databinding.SqueezerOnboardingDialogBinding
 import eu.darken.sdmse.squeezer.core.CompressibleImage
+import eu.darken.sdmse.squeezer.databinding.SqueezerOnboardingDialogBinding
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -22,6 +26,7 @@ import javax.inject.Inject
 
 class SqueezerOnboardingDialog @Inject constructor(
     private val fragment: Fragment,
+    private val gatewaySwitch: GatewaySwitch,
 ) {
 
     fun show(
@@ -33,9 +38,6 @@ class SqueezerOnboardingDialog @Inject constructor(
         val layoutInflater = LayoutInflater.from(context)
         val binding = SqueezerOnboardingDialogBinding.inflate(layoutInflater)
 
-        val path = (sampleImage.path as? LocalPath)?.path ?: sampleImage.path.path
-        val imageFile = File(path)
-
         // Display sizes immediately (no bitmap work needed)
         val originalSize = sampleImage.size
         val compressedSize = sampleImage.estimatedCompressedSize ?: originalSize
@@ -43,13 +45,52 @@ class SqueezerOnboardingDialog @Inject constructor(
         binding.compressedSize.text = "~${Formatter.formatShortFileSize(context, compressedSize)}"
 
         binding.qualityIndicator.text = context.getString(
-            eu.darken.sdmse.squeezer.R.string.squeezer_onboarding_quality_label,
+            R.string.squeezer_onboarding_quality_label,
             quality,
         )
 
-        // Load and compress thumbnails off the main thread
+        val dialog = MaterialAlertDialogBuilder(context).apply {
+            setTitle(R.string.squeezer_onboarding_title)
+            setView(binding.root)
+            setPositiveButton(eu.darken.sdmse.common.R.string.general_gotit_action) { _, _ ->
+                onDismiss()
+            }
+            // Listener set after cache copy succeeds
+            setNeutralButton(R.string.squeezer_compare_action, null)
+            setOnCancelListener {
+                onDismiss()
+            }
+            setOnDismissListener {
+                // Recycle bitmaps when dialog is dismissed
+                (binding.originalImage.drawable as? android.graphics.drawable.BitmapDrawable)?.bitmap?.recycle()
+                (binding.compressedImage.drawable as? android.graphics.drawable.BitmapDrawable)?.bitmap?.recycle()
+            }
+        }.show() as AlertDialog
+
+        // Disable compare until the image is cached locally via gateway
+        dialog.getButton(AlertDialog.BUTTON_NEUTRAL).isEnabled = false
+
+        // Cache image via gateway and load thumbnails off the main thread
         fragment.viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
-            val sampledBitmap = BitmapSampler.decodeSampledBitmap(imageFile, maxDimension = 512)
+            val previewDir = File(context.cacheDir, "squeezer_preview")
+            previewDir.mkdirs()
+            val cachedFile = File(previewDir, "original")
+
+            try {
+                gatewaySwitch.file(sampleImage.path, readWrite = false).use { handle ->
+                    handle.source().copyToAutoClose(cachedFile)
+                }
+            } catch (e: Exception) {
+                log(TAG, WARN) { "Failed to cache image via gateway: ${e.asLog()}" }
+                withContext(Dispatchers.Main) {
+                    binding.originalImage.setImageResource(R.drawable.splash_mascot)
+                    binding.compressedImage.setImageResource(R.drawable.splash_mascot)
+                    binding.compressedSize.text = context.getString(R.string.squeezer_no_savings_expected)
+                }
+                return@launch
+            }
+
+            val sampledBitmap = BitmapSampler.decodeSampledBitmap(cachedFile, maxDimension = 512)
 
             if (sampledBitmap != null) {
                 val format = sampleImage.compressFormat
@@ -66,39 +107,31 @@ class SqueezerOnboardingDialog @Inject constructor(
                 withContext(Dispatchers.Main) {
                     binding.originalImage.setImageResource(R.drawable.splash_mascot)
                     binding.compressedImage.setImageResource(R.drawable.splash_mascot)
-                    binding.compressedSize.text = context.getString(eu.darken.sdmse.squeezer.R.string.squeezer_no_savings_expected)
+                    binding.compressedSize.text = context.getString(R.string.squeezer_no_savings_expected)
                 }
             }
-        }
 
-        val dialog: Dialog = MaterialAlertDialogBuilder(context).apply {
-            setTitle(eu.darken.sdmse.squeezer.R.string.squeezer_onboarding_title)
-            setView(binding.root)
-            setPositiveButton(eu.darken.sdmse.common.R.string.general_gotit_action) { _, _ ->
-                onDismiss()
-            }
-            setNeutralButton(eu.darken.sdmse.squeezer.R.string.squeezer_compare_action) { _, _ ->
-                ComparisonDialog.newInstance(path, quality, sampleImage.isWebp)
-                    .show(fragment.childFragmentManager, "comparison")
-                onDismiss()
-            }
-            setOnCancelListener {
-                onDismiss()
-            }
-            setOnDismissListener {
-                // Recycle bitmaps when dialog is dismissed
-                (binding.originalImage.drawable as? android.graphics.drawable.BitmapDrawable)?.bitmap?.recycle()
-                (binding.compressedImage.drawable as? android.graphics.drawable.BitmapDrawable)?.bitmap?.recycle()
-            }
-        }.show()
+            // Enable compare now that the cached file is ready
+            withContext(Dispatchers.Main) {
+                val cachedPath = cachedFile.absolutePath
+                val openComparison = {
+                    dialog.dismiss()
+                    ComparisonDialog.newInstance(cachedPath, quality, sampleImage.isWebp)
+                        .show(fragment.childFragmentManager, "comparison")
+                    onDismiss()
+                }
 
-        val openComparison = View.OnClickListener {
-            dialog.dismiss()
-            ComparisonDialog.newInstance(path, quality, sampleImage.isWebp)
-                .show(fragment.childFragmentManager, "comparison")
-            onDismiss()
+                dialog.getButton(AlertDialog.BUTTON_NEUTRAL).apply {
+                    isEnabled = true
+                    setOnClickListener { openComparison() }
+                }
+                binding.originalImage.setOnClickListener { openComparison() }
+                binding.compressedImage.setOnClickListener { openComparison() }
+            }
         }
-        binding.originalImage.setOnClickListener(openComparison)
-        binding.compressedImage.setOnClickListener(openComparison)
+    }
+
+    companion object {
+        private val TAG = logTag("Squeezer", "OnboardingDialog")
     }
 }


### PR DESCRIPTION
## What changed

Fixed a crash when tapping "Show Example" in Media Squeeze setup on devices using root or ADB access. The image preview dialog would crash with a permission error because it tried to read image files directly instead of going through the access method that originally found them.

## Technical Context

- Root cause: `BitmapSampler` opened a raw `FileInputStream` on paths discovered via root/ADB/Shizuku gateways — the app process doesn't have direct read permission for those paths, causing `FileNotFoundException: EACCES`
- Fix caches the image locally through `GatewaySwitch` before preview, so the cached copy is always readable by the app process
- Added `IOException` safety net in `BitmapSampler.decodeSampledBitmap()` that returns `null` with a warning log instead of crashing
- Compare button and image click handlers are now disabled until the gateway cache copy completes, preventing interaction before the file is ready
