### PR TITLE
General: Add non-transitive R class pitfalls to architecture rules

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -57,3 +57,6 @@ SD Maid SE's cleaning tools are implemented within the main app module under `eu
 ## Pitfalls
 
 - Use `APath.segments` for path segment access — do NOT manually split path strings
+- `android.nonTransitiveRClass=true` is enabled — app's `R.attr` only contains attrs defined by the app module itself
+  - Theme attrs from dependencies must use their declaring module's R class (e.g. `com.google.android.material.R.attr.colorSecondary`)
+  - Widget attrs like `errorTextColor` are NOT theme attrs — using `MaterialColors.getColor()` with them crashes at runtime


### PR DESCRIPTION
## What changed

Added documentation about non-transitive R class pitfalls to help avoid runtime crashes when referencing theme attributes from dependency modules.

## Technical Context

- With nonTransitiveRClass enabled, using the wrong R class for theme attrs silently compiles but crashes at runtime
- Widget attrs like errorTextColor are a particularly subtle trap — they look like theme attrs but aren't, and MaterialColors.getColor() will crash
- Moved from auto-memory to rules/ since this is a persistent project convention, not a point-in-time observation