### PR TITLE
Analyzer: Fix crash when scanning USB storage devices

### DIFF
--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/AppStorageScanner.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/AppStorageScanner.kt
@@ -62,13 +62,14 @@ class AppStorageScanner @AssistedInject constructor(
 
             else -> candidates.single()
         }
-            ?.path
-            ?.let { LocalPath.build(it) }
-            ?.let {
-                when {
-                    it.segments.last() == "emulated" -> it.child("${currentUser.handleId}")
-                    else -> it
-                }
+            ?.let { volume ->
+                volume.getPathForUser(currentUser.handleId)?.let { LocalPath.build(it) }
+                    ?: volume.path?.let { LocalPath.build(it) }?.let {
+                        when {
+                            it.segments.last() == "emulated" -> it.child("${currentUser.handleId}")
+                            else -> it
+                        }
+                    }
             }
         setOfNotNull(mainPath)
     }

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/storage/AppStorageScannerTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/storage/AppStorageScannerTest.kt
@@ -60,11 +60,13 @@ class AppStorageScannerTest : BaseTest() {
         isPrivate: Boolean = false,
         mountUserId: Int? = 0,
         path: File = File("/storage/emulated"),
+        pathForUser: File? = File("/storage/emulated/0"),
     ) = mockk<VolumeInfoX>().apply {
         every { this@apply.fsUuid } returns fsUuid
         every { this@apply.isPrivate } returns isPrivate
         every { this@apply.mountUserId } returns mountUserId
         every { this@apply.path } returns path
+        every { this@apply.getPathForUser(any()) } returns pathForUser
         every { this@apply.isMounted } returns true
     }
 


### PR DESCRIPTION
## What changed

Fixed a crash that occurred when tapping on USB or portable storage devices in the Storage Analyzer. The app would throw the user back to the main screen instead of showing storage contents.

## Technical Context

- Root cause: `publicDataPaths` and `publicMediaPaths` in `AppStorageScanner` call `gatewaySwitch.exists()` which throws `ReadException` on USB storage without SAF permissions, instead of returning false. The exception propagated uncaught and killed the entire `StorageScanTask`.
- The gateway escalation chain goes: LocalGateway fails with "No matching mode available" (can't access `/mnt/media_rw/` path) → SAFGateway fails with `MissingUriPermissionException` (no SAF permission for the USB device's `Android/data`).
- Fix: Wrap `exists()` calls in try/catch, treating failures as "path doesn't exist". The scan continues gracefully, just without listing `Android/data` or `Android/media` for that storage.
