### PR TITLE
Analyzer: Show Android folder on USB storage

### DIFF
--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/StorageScanner.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/StorageScanner.kt
@@ -142,7 +142,7 @@ class StorageScanner @Inject constructor(
 
                 val folders = storageDir?.lookedUp
                     ?.listFiles(gatewaySwitch)
-                    ?.filter { it.name != "Android" }
+                    ?.filter { storage.type == DeviceStorage.Type.PORTABLE || it.name != "Android" }
                     ?.mapNotNull { fileForensics.findOwners(it) }
                     ?.filter { setOf(DataArea.Type.SDCARD, DataArea.Type.PORTABLE).contains(it.areaInfo.type) }
                     ?.onEach { log(TAG) { "Top level dir: $it" } }


### PR DESCRIPTION
## What changed

The Android folder on USB storage devices was invisible in the Storage Analyzer. It didn't appear in user files or anywhere else.

## Technical Context

- The `Android` folder was filtered from user files for all storage types (line 145 in `StorageScanner`), assuming the app scanner would handle `Android/data` and `Android/media` separately.
- On PRIMARY and SECONDARY (SD card) storage, the app scanner covers this. But on PORTABLE (USB) storage, no apps store data there — the app scanner returns null and the `Android` folder becomes completely invisible.
- Fix: Only filter `Android` from user files on PRIMARY and SECONDARY storage. On PORTABLE storage, include it in user files where it belongs.
