### PR TITLE
Deduplicator: Show accurate freeable space based on deletion strategy

### DIFF
--- a/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/core/Deduplicator.kt
+++ b/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/core/Deduplicator.kt
@@ -152,13 +152,12 @@ class Deduplicator @Inject constructor(
         results.forEach { it.totalSize }
         log(TAG) { "Field warm up done." }
 
-        internalData.value = Data(
-            clusters = results
-        )
+        val data = Data(clusters = results)
+        internalData.value = data
 
         return DeduplicatorScanTask.Success(
-            itemCount = results.size,
-            recoverableSpace = results.sumOf { it.redundantSize },
+            itemCount = data.clusters.size,
+            recoverableSpace = data.redundantSize,
         )
     }
 
@@ -305,9 +304,7 @@ class Deduplicator @Inject constructor(
     data class Data(
         val clusters: Set<Duplicate.Cluster> = emptySet(),
     ) {
-        val totalSize: Long get() = clusters.sumOf { it.totalSize }
-        val redudantSize: Long get() = clusters.sumOf { it.redundantSize }
-        val totalCount: Int get() = clusters.size
+        val redundantSize: Long get() = clusters.sumOf { it.redundantSize }
     }
 
     @InstallIn(SingletonComponent::class)

--- a/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/core/Duplicate.kt
+++ b/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/core/Duplicate.kt
@@ -56,7 +56,13 @@ interface Duplicate {
         val averageSize: Double
             get() = duplicates.map { it.size }.average()
         val redundantSize: Long
-            get() = duplicates.drop(1).sumOf { it.size }
+            get() {
+                val keeperSize = keeperIdentifier
+                    ?.let { kid -> duplicates.firstOrNull { it.identifier == kid }?.size }
+                    ?: duplicates.firstOrNull()?.size
+                    ?: 0L
+                return totalSize - keeperSize
+            }
         val count: Int
             get() = duplicates.size
 
@@ -74,7 +80,12 @@ interface Duplicate {
         val totalSize: Long
             get() = groups.sumOf { it.totalSize }
         val redundantSize: Long
-            get() = groups.sumOf { it.redundantSize }
+            get() {
+                val favId = favoriteGroupIdentifier
+                return groups.sumOf { group ->
+                    if (group.identifier == favId && group.count >= 2) group.redundantSize else group.totalSize
+                }
+            }
         val count: Int
             get() = groups.sumOf { it.count }
         val types: Set<Type>

--- a/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/core/DuplicateRedundantSizeTest.kt
+++ b/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/core/DuplicateRedundantSizeTest.kt
@@ -1,0 +1,177 @@
+package eu.darken.sdmse.deduplicator.core
+
+import eu.darken.sdmse.deduplicator.core.scanner.checksum.ChecksumDuplicate
+import eu.darken.sdmse.deduplicator.core.scanner.phash.PHashDuplicate
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class DuplicateRedundantSizeTest : BaseTest() {
+
+    private fun mockChecksumDupe(id: String, size: Long): ChecksumDuplicate = mockk {
+        every { identifier } returns Duplicate.Id(id)
+        every { this@mockk.size } returns size
+    }
+
+    private fun mockPhashDupe(id: String, size: Long): PHashDuplicate = mockk {
+        every { identifier } returns Duplicate.Id(id)
+        every { this@mockk.size } returns size
+    }
+
+    @Test
+    fun `group - same size files with keeper`() {
+        val group = ChecksumDuplicate.Group(
+            identifier = Duplicate.Group.Id("g1"),
+            duplicates = setOf(
+                mockChecksumDupe("a", 100L),
+                mockChecksumDupe("b", 100L),
+                mockChecksumDupe("c", 100L),
+            ),
+            keeperIdentifier = Duplicate.Id("a"),
+        )
+        group.redundantSize shouldBe 200L
+    }
+
+    @Test
+    fun `group - different size files with keeper picks correct keeper`() {
+        val group = PHashDuplicate.Group(
+            identifier = Duplicate.Group.Id("g1"),
+            duplicates = setOf(
+                mockPhashDupe("a", 500L),
+                mockPhashDupe("b", 300L),
+                mockPhashDupe("c", 200L),
+            ),
+            keeperIdentifier = Duplicate.Id("b"),
+        )
+        // Keeper is b (300), redundant = 500 + 200 = 700
+        group.redundantSize shouldBe 700L
+    }
+
+    @Test
+    fun `group - null keeper falls back to first element`() {
+        val d1 = mockPhashDupe("a", 500L)
+        val d2 = mockPhashDupe("b", 300L)
+        val group = PHashDuplicate.Group(
+            identifier = Duplicate.Group.Id("g1"),
+            duplicates = setOf(d1, d2),
+            keeperIdentifier = null,
+        )
+        val firstSize = group.duplicates.first().size
+        group.redundantSize shouldBe group.totalSize - firstSize
+    }
+
+    @Test
+    fun `group - single duplicate has zero redundant size`() {
+        val group = ChecksumDuplicate.Group(
+            identifier = Duplicate.Group.Id("g1"),
+            duplicates = setOf(mockChecksumDupe("a", 100L)),
+            keeperIdentifier = Duplicate.Id("a"),
+        )
+        group.redundantSize shouldBe 0L
+    }
+
+    @Test
+    fun `group - keeper not found falls back to first element`() {
+        val d1 = mockPhashDupe("a", 500L)
+        val d2 = mockPhashDupe("b", 300L)
+        val group = PHashDuplicate.Group(
+            identifier = Duplicate.Group.Id("g1"),
+            duplicates = setOf(d1, d2),
+            keeperIdentifier = Duplicate.Id("nonexistent"),
+        )
+        val firstSize = group.duplicates.first().size
+        group.redundantSize shouldBe group.totalSize - firstSize
+    }
+
+    @Test
+    fun `cluster - single group with favorite`() {
+        val group = ChecksumDuplicate.Group(
+            identifier = Duplicate.Group.Id("g1"),
+            duplicates = setOf(
+                mockChecksumDupe("a", 100L),
+                mockChecksumDupe("b", 100L),
+            ),
+            keeperIdentifier = Duplicate.Id("a"),
+        )
+        val cluster = Duplicate.Cluster(
+            identifier = Duplicate.Cluster.Id("c1"),
+            groups = setOf(group),
+            favoriteGroupIdentifier = Duplicate.Group.Id("g1"),
+        )
+        cluster.redundantSize shouldBe 100L
+    }
+
+    @Test
+    fun `cluster - multi group, favorite uses redundantSize, rest uses totalSize`() {
+        val favGroup = ChecksumDuplicate.Group(
+            identifier = Duplicate.Group.Id("g1"),
+            duplicates = setOf(
+                mockChecksumDupe("a", 100L),
+                mockChecksumDupe("b", 100L),
+            ),
+            keeperIdentifier = Duplicate.Id("a"),
+        )
+        val nonFavGroup = PHashDuplicate.Group(
+            identifier = Duplicate.Group.Id("g2"),
+            duplicates = setOf(
+                mockPhashDupe("c", 200L),
+                mockPhashDupe("d", 300L),
+            ),
+            keeperIdentifier = Duplicate.Id("c"),
+        )
+        val cluster = Duplicate.Cluster(
+            identifier = Duplicate.Cluster.Id("c1"),
+            groups = setOf(favGroup, nonFavGroup),
+            favoriteGroupIdentifier = Duplicate.Group.Id("g1"),
+        )
+        // Favorite: redundantSize = 100 (keeps a=100, deletes b=100)
+        // Non-favorite: totalSize = 500 (deletes both c=200 and d=300)
+        cluster.redundantSize shouldBe 600L
+    }
+
+    @Test
+    fun `cluster - favorite group with 1 member uses totalSize`() {
+        val singleGroup = ChecksumDuplicate.Group(
+            identifier = Duplicate.Group.Id("g1"),
+            duplicates = setOf(mockChecksumDupe("a", 150L)),
+            keeperIdentifier = Duplicate.Id("a"),
+        )
+        val multiGroup = PHashDuplicate.Group(
+            identifier = Duplicate.Group.Id("g2"),
+            duplicates = setOf(
+                mockPhashDupe("b", 200L),
+                mockPhashDupe("c", 300L),
+            ),
+            keeperIdentifier = Duplicate.Id("b"),
+        )
+        val cluster = Duplicate.Cluster(
+            identifier = Duplicate.Cluster.Id("c1"),
+            groups = setOf(singleGroup, multiGroup),
+            favoriteGroupIdentifier = Duplicate.Group.Id("g1"),
+        )
+        // Favorite (1 member): totalSize = 150 (deleter deletes sole file)
+        // Non-favorite: totalSize = 500
+        cluster.redundantSize shouldBe 650L
+    }
+
+    @Test
+    fun `cluster - null favorite treats all groups as fully deletable`() {
+        val group = ChecksumDuplicate.Group(
+            identifier = Duplicate.Group.Id("g1"),
+            duplicates = setOf(
+                mockChecksumDupe("a", 100L),
+                mockChecksumDupe("b", 100L),
+            ),
+            keeperIdentifier = Duplicate.Id("a"),
+        )
+        val cluster = Duplicate.Cluster(
+            identifier = Duplicate.Cluster.Id("c1"),
+            groups = setOf(group),
+            favoriteGroupIdentifier = null,
+        )
+        // No favorite: totalSize for all groups = 200
+        cluster.redundantSize shouldBe 200L
+    }
+}


### PR DESCRIPTION
## What changed

The "space can be freed" indicator in the deduplicator now accurately reflects the actual amount of space that would be freed based on the configured deletion strategy, instead of a naive estimate.

Previously, the displayed size could differ from reality because it didn't account for which file the arbiter picks to keep or which groups are fully deleted in multi-group clusters.

## Technical Context

- **Root cause**: `Group.redundantSize` used `duplicates.drop(1)` which drops an arbitrary element from a `Set` (non-deterministic), ignoring the arbiter's `keeperIdentifier`. `Cluster.redundantSize` summed all groups equally, not accounting for non-favorite groups being entirely deleted.
- `Group.redundantSize` now uses `totalSize - keeperSize`, subtracting the arbiter-chosen keeper's size. Falls back to first element when `keeperIdentifier` is null.
- `Cluster.redundantSize` now distinguishes: favorite group with 2+ members uses `group.redundantSize`, favorite group with 1 member uses `group.totalSize` (matching deleter's `size == 1` full-delete behavior), non-favorite groups use `group.totalSize` (all files deleted).
- For checksum-only single-group clusters (the majority case), there is no visible change since all files have identical sizes.
- Removed unused computed properties from `Deduplicator.Data`, kept `redundantSize` as single source of truth for the scan result. Also fixed a typo (`redudantSize` → `redundantSize`).
