### PR TITLE
Analyzer: Prevent hang and memory issues for large apps

### DIFF
--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/Analyzer.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/Analyzer.kt
@@ -54,7 +54,9 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.minutes
 import javax.inject.Named
 import javax.inject.Provider
 import javax.inject.Singleton
@@ -274,10 +276,17 @@ class Analyzer @Inject constructor(
 
         val start = System.currentTimeMillis()
 
-        val updatedApp = storageScanner.get().withProgress(this) { deepScanApp(targetStorage, targetApp) }
+        val updatedApp = withTimeoutOrNull(DEEP_SCAN_TIMEOUT) {
+            storageScanner.get().withProgress(this@Analyzer) { deepScanApp(targetStorage, targetApp) }
+        }
 
         val stop = System.currentTimeMillis()
         log(TAG) { "deepScanApp() took ${stop - start}ms" }
+
+        if (updatedApp == null) {
+            log(TAG, WARN) { "deepScanApp() timed out after ${stop - start}ms, keeping shallow data" }
+            return AppDeepScanTask.Result(false)
+        }
 
         storageCategories.value = storageCategories.value.mutate {
             this[targetStorage.id] = this[targetStorage.id]!!.map { category ->
@@ -307,6 +316,7 @@ class Analyzer @Inject constructor(
     }
 
     companion object {
+        private val DEEP_SCAN_TIMEOUT = 5.minutes
         private val TAG = logTag("Analyzer")
     }
 }

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/AppStorageScanner.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/AppStorageScanner.kt
@@ -127,7 +127,7 @@ class AppStorageScanner @AssistedInject constructor(
                 ?.let { codeDir ->
                     if (!request.shallow && useRoot) {
                         try {
-                            return@let codeDir.walkContentItem(gatewaySwitch)
+                            return@let codeDir.walkContentItem(gatewaySwitch, maxItems = WALK_MAX_ITEMS)
                         } catch (e: ReadException) {
                             log(TAG, ERROR) { "Failed to read $codeDir despire root access? ${e.asLog()}" }
                         }
@@ -162,8 +162,8 @@ class AppStorageScanner @AssistedInject constructor(
                     }
 
                     gatewaySwitch.exists(pubData, type = GatewaySwitch.Type.AUTO) -> try {
-                        pubData.walkContentItem(gatewaySwitch)
-                    } catch (e: ReadException) {
+                        pubData.walkContentItem(gatewaySwitch, maxItems = WALK_MAX_ITEMS)
+                    } catch (_: ReadException) {
                         ContentItem.fromInaccessible(pubData)
                     }
 
@@ -180,7 +180,7 @@ class AppStorageScanner @AssistedInject constructor(
                     return@run request.pkg
                         .getPrivateDataDirs(dataAreas)
                         .filter { gatewaySwitch.exists(it, type = GatewaySwitch.Type.CURRENT) }
-                        .map { it.walkContentItem(gatewaySwitch) }
+                        .map { it.walkContentItem(gatewaySwitch, maxItems = WALK_MAX_ITEMS) }
                 } catch (e: ReadException) {
                     log(TAG, ERROR) { "Failed to read private data dirs for $request.pkg: ${e.asLog()}" }
                 }
@@ -215,9 +215,9 @@ class AppStorageScanner @AssistedInject constructor(
                     if (request.shallow) {
                         path.sizeContentItem(gatewaySwitch)
                     } else {
-                        path.walkContentItem(gatewaySwitch)
+                        path.walkContentItem(gatewaySwitch, maxItems = WALK_MAX_ITEMS)
                     }
-                } catch (e: ReadException) {
+                } catch (_: ReadException) {
                     null
                 }
             }
@@ -236,9 +236,9 @@ class AppStorageScanner @AssistedInject constructor(
                     if (request.shallow) {
                         path.sizeContentItem(gatewaySwitch)
                     } else {
-                        path.walkContentItem(gatewaySwitch)
+                        path.walkContentItem(gatewaySwitch, maxItems = WALK_MAX_ITEMS)
                     }
-                } catch (e: ReadException) {
+                } catch (_: ReadException) {
                     null
                 }
             }
@@ -306,6 +306,7 @@ class AppStorageScanner @AssistedInject constructor(
     }
 
     companion object {
+        private const val WALK_MAX_ITEMS = 100_000
         private val TAG = logTag("Analyzer", "Storage", "Scanner", "Pkg")
     }
 }

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/StorageScannerExtensions.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/StorageScannerExtensions.kt
@@ -14,49 +14,53 @@ import eu.darken.sdmse.common.files.Segments
 import eu.darken.sdmse.common.files.du
 import eu.darken.sdmse.common.files.walk
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import java.util.LinkedList
 
 
 fun Collection<ContentItem>.toNestedContent(): Collection<ContentItem> {
     val workList = this.sortedBy { it.path.segments.size }.reversed().toMutableList()
+    val topLevelIndices = mutableListOf<Int>()
 
-    val topLevel = mutableListOf<ContentItem>()
+    // Normalize root segments: [""] and emptyList() both represent root
+    fun Segments.normalized(): Segments = if (isEmpty() || singleOrNull() == "") emptyList() else this
 
-    val parentIndexMap = mutableMapOf<Segments, Int>()
+    // Pre-build index for O(1) parent lookup instead of O(n) indexOfFirst
+    val segmentToIndex = HashMap<Segments, Int>(workList.size)
+    workList.forEachIndexed { index, item ->
+        segmentToIndex[item.path.segments.normalized()] = index
+    }
 
-    for (item in workList) {
+    // Collect child indices per parent to avoid repeated set copies via .plus()
+    val childIndices = arrayOfNulls<MutableList<Int>>(workList.size)
+
+    for ((idx, item) in workList.withIndex()) {
         val childSegs = item.path.segments
         if (childSegs.isEmpty() || childSegs.singleOrNull() == "") {
-            topLevel.add(item)
+            topLevelIndices.add(idx)
             continue
         }
 
-        val parentSegs = childSegs.subList(0, childSegs.size - 1)
+        val parentSegs = childSegs.subList(0, childSegs.size - 1).normalized()
+        val parentIndex = segmentToIndex[parentSegs]
 
-        val parentIndex = parentIndexMap[parentSegs]
-            ?: workList.indexOfFirst {
-                val segs = it.path.segments
-                if (parentSegs.isEmpty()) {
-                    segs.isEmpty() || segs.singleOrNull() == ""
-                } else {
-                    segs == parentSegs
-                }
-            }.also { parentIndexMap[parentSegs] = it }
-
-        if (parentIndex != -1) {
-            val parent = workList[parentIndex]
-
-            val updatedParent = parent.copy(
-                children = parent.children.plus(item)
-            )
-            workList[parentIndex] = updatedParent
+        if (parentIndex != null) {
+            val list = childIndices[parentIndex]
+                ?: mutableListOf<Int>().also { childIndices[parentIndex] = it }
+            list.add(idx)
         } else {
-            topLevel.add(item)
+            topLevelIndices.add(idx)
         }
     }
 
-    return topLevel
+    // Freeze: merge children into parents (deepest-first, so children are already updated)
+    for (i in workList.indices) {
+        val indices = childIndices[i] ?: continue
+        workList[i] = workList[i].copy(children = workList[i].children + indices.map { workList[it] })
+    }
+
+    return topLevelIndices.map { workList[it] }
 }
 
 fun Collection<ContentItem>.toFlatContent(): Collection<ContentItem> =
@@ -89,18 +93,34 @@ fun Collection<ContentItem>.findContent(filter: (ContentItem) -> Boolean): Conte
 }
 
 
-suspend fun APath.walkContentItem(gatewaySwitch: GatewaySwitch): ContentItem {
+suspend fun APath.walkContentItem(
+    gatewaySwitch: GatewaySwitch,
+    maxItems: Int = Int.MAX_VALUE,
+): ContentItem {
     log(TAG, VERBOSE) { "Walking content items for $this" }
 
     // What ever `this` is , the gatewaySwitch should make sure we end up with something usable
     val lookup = gatewaySwitch.lookup(this, type = GatewaySwitch.Type.AUTO)
 
     return if (lookup.fileType == FileType.DIRECTORY) {
+        val start = System.currentTimeMillis()
+
         val children = try {
-            lookup.walk(gatewaySwitch).map { ContentItem.fromLookup(it) }.toList()
+            lookup.walk(gatewaySwitch)
+                .map { ContentItem.fromLookup(it) }
+                .let { flow -> if (maxItems < Int.MAX_VALUE) flow.take(maxItems + 1) else flow }
+                .toList()
         } catch (e: ReadException) {
             log(TAG, WARN) { "Failed to walk $this: ${e.asLog()}" }
-            emptySet()
+            emptyList()
+        }
+
+        val elapsed = System.currentTimeMillis() - start
+        log(TAG) { "Walked $this: ${children.size} items in ${elapsed}ms (limit=$maxItems)" }
+
+        if (children.size > maxItems) {
+            log(TAG, WARN) { "Walk item limit ($maxItems) exceeded for $this, falling back to du" }
+            return this.sizeContentItem(gatewaySwitch)
         }
 
         children.plus(ContentItem.fromLookup(lookup)).toNestedContent().single()

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/StorageScannerExtensionsTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/StorageScannerExtensionsTest.kt
@@ -4,8 +4,18 @@ import eu.darken.sdmse.analyzer.core.content.ContentItem
 import eu.darken.sdmse.analyzer.core.storage.findContent
 import eu.darken.sdmse.analyzer.core.storage.toFlatContent
 import eu.darken.sdmse.analyzer.core.storage.toNestedContent
+import eu.darken.sdmse.analyzer.core.storage.walkContentItem
+import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.common.files.FileType
+import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.files.local.LocalPathLookup
 import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 
@@ -109,5 +119,56 @@ class StorageScannerExtensionsTest : BaseTest() {
         postNesting.findContent {
             it.path == LocalPath.build("folder1", "folder2B", "folder3")
         } shouldBe item3B
+    }
+
+    private fun mockLookup(
+        path: LocalPath,
+        fileType: FileType = FileType.DIRECTORY,
+        size: Long = 4096L,
+    ) = mockk<LocalPathLookup> {
+        coEvery { lookedUp } returns path
+        coEvery { this@mockk.fileType } returns fileType
+        coEvery { this@mockk.size } returns size
+    }
+
+    @Test
+    fun `walkContentItem with default maxItems does not overflow`() = runTest {
+        val path = LocalPath.build("test", "dir")
+        val dirLookup = mockLookup(path)
+        val childLookup = mockLookup(LocalPath.build("test", "dir", "file1"), FileType.FILE, 100L)
+
+        val gatewaySwitch = mockk<GatewaySwitch> {
+            coEvery { lookup(any(), type = any()) } returns dirLookup as APathLookup<APath>
+            coEvery { walk(any(), any()) } returns flowOf(childLookup as APathLookup<APath>)
+        }
+
+        // Default maxItems=Int.MAX_VALUE must not crash with take(Int.MAX_VALUE + 1) overflow
+        val result = path.walkContentItem(gatewaySwitch)
+        result.path shouldBe path
+        result.children.size shouldBe 1
+    }
+
+    @Test
+    fun `walkContentItem falls back to du when maxItems exceeded`() = runTest {
+        val path = LocalPath.build("test", "dir")
+        val dirLookup = mockLookup(path)
+        val child1 = mockLookup(LocalPath.build("test", "dir", "f1"), FileType.FILE, 100L)
+        val child2 = mockLookup(LocalPath.build("test", "dir", "f2"), FileType.FILE, 200L)
+        val child3 = mockLookup(LocalPath.build("test", "dir", "f3"), FileType.FILE, 300L)
+
+        val gatewaySwitch = mockk<GatewaySwitch> {
+            coEvery { lookup(any(), type = any()) } returns dirLookup as APathLookup<APath>
+            coEvery { walk(any(), any()) } returns flowOf(
+                child1 as APathLookup<APath>,
+                child2 as APathLookup<APath>,
+                child3 as APathLookup<APath>,
+            )
+            coEvery { du(any(), any()) } returns 600L
+        }
+
+        // maxItems=2 but 3 items exist, should fall back to sizeContentItem (du)
+        val result = path.walkContentItem(gatewaySwitch, maxItems = 2)
+        result.inaccessible shouldBe true
+        result.itemSize shouldBe (4096L + 600L)  // lookup.size + du result
     }
 }


### PR DESCRIPTION
## What changed

Fixed a potential crash and hang when viewing app details in the Analyzer for apps with very large numbers of files (e.g. WeChat with 100K+ files). The deep scan now has safety limits to prevent running out of memory or getting stuck indefinitely.

## Technical Context

- Root cause (hang): `AppDetailsViewModel` auto-triggers a deep scan with no timeout. If the root service stalls (e.g. race condition during shutdown), the scan blocks indefinitely — observed hanging for 6+ hours in a user's debug log.
- Root cause (OOM risk): `walkContentItem()` called `.toList()` on the full recursive walk flow, materializing every file into memory. `toNestedContent()` then did O(n²) parent lookups via `indexOfFirst` and O(n) set copies per child via `.plus()`.
- Fix: `toNestedContent()` now uses a pre-built HashMap for O(1) parent lookup and index-based child tracking to batch-merge children in one pass. `walkContentItem()` accepts an opt-in `maxItems` cap (default unlimited) — deep scan call sites pass 100K, falling back to `du`-based sizing when exceeded. `deepScanApp()` is wrapped in a 5-minute timeout.
- Added timing and item count logging to `walkContentItem` for future threshold calibration from debug logs.
