### PR TITLE
Fix: Prevent app freeze during startup

### DIFF
--- a/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/db/db/ReportsDatabase.kt
+++ b/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/db/db/ReportsDatabase.kt
@@ -20,6 +20,7 @@ import eu.darken.sdmse.stats.core.StatsSettings
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
@@ -63,7 +64,7 @@ class ReportsDatabase @Inject constructor(
         return total
     }
 
-    val databaseSize = MutableStateFlow(getDatabaseSize())
+    val databaseSize = MutableStateFlow(0L)
 
     private val reportsDao: ReportsDao
         get() = database.reports()
@@ -140,6 +141,10 @@ class ReportsDatabase @Inject constructor(
             }
             .catch { log(TAG, ERROR) { "Failed to clean up snapshots: ${it.asLog()}" } }
             .launchIn(appScope + dispatcherProvider.IO)
+
+        appScope.launch(dispatcherProvider.IO) {
+            databaseSize.value = getDatabaseSize()
+        }
     }
 
     val reports = reportsDao.waterfall()


### PR DESCRIPTION
## What changed

Fixed a potential app freeze on startup caused by blocking file I/O on the main thread during initialization.

## Technical Context

- Root cause: `ReportsDatabase.databaseSize` property was initialized synchronously via `getDatabaseSize()` during Hilt singleton construction in `App.onCreate()`. This calls `context.getDatabasePath()` which acquires `ContextImpl.mSync`.
- Concurrently, `RecorderModule`'s init calls `context.getExternalFilesDir()` on IO dispatcher, holding the same lock during slow `mkdirs` I/O — blocking the main thread.
- Fix initializes `databaseSize` with `0L` and computes the real value asynchronously on the IO dispatcher. The brief `0` is invisible since the UI hasn't rendered yet.