### PR TITLE
Analyzer: Add search to app list

### DIFF
--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/apps/AppsFragment.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/apps/AppsFragment.kt
@@ -2,6 +2,7 @@ package eu.darken.sdmse.analyzer.ui.storage.apps
 
 import android.os.Bundle
 import android.view.View
+import androidx.appcompat.widget.SearchView
 import androidx.core.view.isInvisible
 import androidx.fragment.app.viewModels
 import androidx.navigation.findNavController
@@ -13,6 +14,7 @@ import eu.darken.sdmse.common.EdgeToEdgeHelper
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.lists.differ.update
 import eu.darken.sdmse.common.lists.setupDefaults
+import eu.darken.sdmse.common.navigation.getQuantityString2
 import eu.darken.sdmse.common.navigation.getSpanCount
 import eu.darken.sdmse.common.uix.Fragment3
 import eu.darken.sdmse.common.viewbinding.viewBinding
@@ -39,7 +41,18 @@ class AppsFragment : Fragment3(R.layout.analyzer_apps_fragment) {
                     else -> false
                 }
             }
+            menu.findItem(R.id.action_search)?.actionView?.apply {
+                this as SearchView
+                queryHint = getString(eu.darken.sdmse.common.R.string.general_search_action)
+                setOnQueryTextListener(object : SearchView.OnQueryTextListener {
+                    override fun onQueryTextSubmit(query: String): Boolean = false
 
+                    override fun onQueryTextChange(query: String): Boolean {
+                        vm.updateSearchQuery(query)
+                        return false
+                    }
+                })
+            }
         }
 
         val adapter = AppsAdapter()
@@ -50,7 +63,11 @@ class AppsFragment : Fragment3(R.layout.analyzer_apps_fragment) {
         )
 
         vm.state.observe2(ui) { state ->
-            toolbar.subtitle = state.storage.label.get(requireContext())
+            toolbar.subtitle = if (state.isSearchActive) {
+                getQuantityString2(eu.darken.sdmse.common.R.plurals.result_x_items, state.apps.size)
+            } else {
+                state.storage.label.get(requireContext())
+            }
 
             adapter.update(state.apps)
             loadingOverlay.setProgress(state.progress)

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/apps/AppsViewModel.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/apps/AppsViewModel.kt
@@ -1,8 +1,11 @@
 package eu.darken.sdmse.analyzer.ui.storage.apps
 
+import android.annotation.SuppressLint
+import android.content.Context
 import androidx.core.os.bundleOf
 import androidx.lifecycle.SavedStateHandle
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.sdmse.analyzer.R
 import eu.darken.sdmse.analyzer.core.Analyzer
 import eu.darken.sdmse.analyzer.core.device.DeviceStorage
@@ -12,20 +15,29 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.navigation.navDirections
+import eu.darken.sdmse.common.pkgs.Pkg
 import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.common.storage.StorageId
 import eu.darken.sdmse.common.uix.ViewModel3
 import kotlinx.coroutines.flow.*
 import javax.inject.Inject
 
+@SuppressLint("StaticFieldLeak")
 @HiltViewModel
 class AppsViewModel @Inject constructor(
     @Suppress("unused") private val handle: SavedStateHandle,
     dispatcherProvider: DispatcherProvider,
+    @ApplicationContext private val context: Context,
     analyzer: Analyzer,
 ) : ViewModel3(dispatcherProvider) {
 
     private val targetStorageId: StorageId = handle.get<StorageId>("storageId")!!
+
+    private val searchQuery = MutableStateFlow("")
+
+    private var lastCategory: AppCategory? = null
+    private val queryCacheLabel = mutableMapOf<Pkg.Id, String>()
+    private val queryCachePkg = mutableMapOf<Pkg.Id, String>()
 
     init {
         // Handle process death+restore
@@ -47,36 +59,68 @@ class AppsViewModel @Inject constructor(
         // Handle process death+restore
         analyzer.data.filter { it.findAppCategory() != null },
         analyzer.progress,
-    ) { data, progress ->
+        searchQuery,
+    ) { data, progress, query ->
         val storage = data.storages.single { it.id == targetStorageId }
         val category = data.findAppCategory()!!
+        val queryNormalized = query.lowercase().trim()
+
+        if (category !== lastCategory) {
+            queryCacheLabel.clear()
+            queryCachePkg.clear()
+            lastCategory = category
+        }
+
+        val apps = category.pkgStats
+            .filter { (_, pkgStat) ->
+                if (queryNormalized.isEmpty()) return@filter true
+
+                val normalizedPkg = queryCachePkg.getOrPut(pkgStat.pkg.id) {
+                    pkgStat.pkg.packageName.lowercase()
+                }
+                if (normalizedPkg.contains(queryNormalized)) return@filter true
+
+                val normalizedLabel = queryCacheLabel.getOrPut(pkgStat.pkg.id) {
+                    pkgStat.label.get(context).lowercase().trim()
+                }
+                if (normalizedLabel.contains(queryNormalized)) return@filter true
+
+                return@filter false
+            }
+            .map { (installId, pkgStat) ->
+                AppsItemVH.Item(
+                    appCategory = category,
+                    pkgStat = pkgStat,
+                    onItemClicked = {
+                        navDirections(
+                            R.id.action_appsFragment_to_appDetailsFragment,
+                            bundleOf(
+                                "storageId" to storage.id,
+                                "installId" to installId,
+                            )
+                        ).navigate()
+                    }
+                )
+            }
+            .sortedByDescending { it.pkgStat.totalSize }
 
         State(
             storage = storage,
-            apps = category.pkgStats
-                .map { (installId, pkgStat) ->
-                    AppsItemVH.Item(
-                        appCategory = category,
-                        pkgStat = pkgStat,
-                        onItemClicked = {
-                            navDirections(
-                                R.id.action_appsFragment_to_appDetailsFragment,
-                                bundleOf(
-                                    "storageId" to storage.id,
-                                    "installId" to installId,
-                                )
-                            ).navigate()
-                        }
-                    )
-                }
-                .sortedByDescending { it.pkgStat.totalSize },
+            apps = apps,
+            isSearchActive = queryNormalized.isNotEmpty(),
             progress = progress,
         )
     }.asLiveData2()
 
+    fun updateSearchQuery(query: String) {
+        log(TAG) { "updateSearchQuery($query)" }
+        searchQuery.value = query
+    }
+
     data class State(
         val storage: DeviceStorage,
-        val apps: List<AppsItemVH.Item>?,
+        val apps: List<AppsItemVH.Item>,
+        val isSearchActive: Boolean = false,
         val progress: Progress.Data?,
     )
 

--- a/app-tool-analyzer/src/main/res/layout/analyzer_apps_fragment.xml
+++ b/app-tool-analyzer/src/main/res/layout/analyzer_apps_fragment.xml
@@ -17,6 +17,7 @@
             style="@style/SDMToolbar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            app:menu="@menu/menu_analyzer_apps"
             app:title="@string/analyzer_storage_content_type_app_label" />
 
     </com.google.android.material.appbar.AppBarLayout>

--- a/app-tool-analyzer/src/main/res/menu/menu_analyzer_apps.xml
+++ b/app-tool-analyzer/src/main/res/menu/menu_analyzer_apps.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/action_search"
+        android:icon="@drawable/ic_baseline_manage_search_24"
+        android:title="@string/general_search_action"
+        app:actionViewClass="androidx.appcompat.widget.SearchView"
+        app:showAsAction="ifRoom|collapseActionView" />
+</menu>


### PR DESCRIPTION
## What changed

Added a search icon to the Analyzer's app list toolbar. Tapping it opens a search field where users can type an app name or package name to filter the list in real-time.

## Technical Context

- Follows the existing AppControl SearchView pattern (menu XML + `MutableStateFlow` query + `combine` filtering)
- Matches case-insensitively against both app label and package name, with label resolution cached per `Pkg.Id`
- Caches are invalidated when the underlying `AppCategory` data changes (e.g., after a re-scan)
- Toolbar subtitle switches to show filtered result count while a search is active
- Search query is ephemeral — not persisted to DataStore or SavedStateHandle
