### PR TITLE
General: Safer navigation argument passing

### DIFF
--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/app/AppDetailsViewModel.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/app/AppDetailsViewModel.kt
@@ -8,6 +8,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.sdmse.analyzer.R
 import eu.darken.sdmse.analyzer.core.Analyzer
+import eu.darken.sdmse.analyzer.ui.storage.content.ContentViewModel
 import eu.darken.sdmse.analyzer.core.device.DeviceStorage
 import eu.darken.sdmse.analyzer.core.storage.AppDeepScanTask
 import eu.darken.sdmse.analyzer.core.storage.categories.AppCategory
@@ -43,8 +44,9 @@ class AppDetailsViewModel @Inject constructor(
     private val analyzer: Analyzer,
 ) : ViewModel3(dispatcherProvider) {
 
-    private val targetStorageId: StorageId = handle.get<StorageId>("storageId")!!
-    private val targetInstallId: InstallId = handle.get<InstallId>("installId")!!
+    private val args = Args.from(handle)
+    private val targetStorageId: StorageId = args.storageId
+    private val targetInstallId: InstallId = args.installId
 
     init {
         // Handle process death+restore
@@ -113,11 +115,11 @@ class AppDetailsViewModel @Inject constructor(
                     onViewAction = {
                         navDirections(
                             R.id.action_appDetailsFragment_to_contentFragment,
-                            bundleOf(
-                                "storageId" to targetStorageId,
-                                "groupId" to group.id,
-                                "installId" to pkgStat.id,
-                            )
+                            ContentViewModel.Args(
+                                storageId = targetStorageId,
+                                groupId = group.id,
+                                installId = pkgStat.id,
+                            ).toBundle()
                         ).navigate()
                     }
                 )
@@ -133,11 +135,11 @@ class AppDetailsViewModel @Inject constructor(
                     onViewAction = {
                         navDirections(
                             R.id.action_appDetailsFragment_to_contentFragment,
-                            bundleOf(
-                                "storageId" to targetStorageId,
-                                "groupId" to group.id,
-                                "installId" to pkgStat.id,
-                            )
+                            ContentViewModel.Args(
+                                storageId = targetStorageId,
+                                groupId = group.id,
+                                installId = pkgStat.id,
+                            ).toBundle()
                         ).navigate()
                     }
                 )
@@ -153,11 +155,11 @@ class AppDetailsViewModel @Inject constructor(
                     onViewAction = {
                         navDirections(
                             R.id.action_appDetailsFragment_to_contentFragment,
-                            bundleOf(
-                                "storageId" to targetStorageId,
-                                "groupId" to group.id,
-                                "installId" to pkgStat.id,
-                            )
+                            ContentViewModel.Args(
+                                storageId = targetStorageId,
+                                groupId = group.id,
+                                installId = pkgStat.id,
+                            ).toBundle()
                         ).navigate()
                     }
                 )
@@ -173,11 +175,11 @@ class AppDetailsViewModel @Inject constructor(
                     onViewAction = {
                         navDirections(
                             R.id.action_appDetailsFragment_to_contentFragment,
-                            bundleOf(
-                                "storageId" to targetStorageId,
-                                "groupId" to group.id,
-                                "installId" to pkgStat.id,
-                            )
+                            ContentViewModel.Args(
+                                storageId = targetStorageId,
+                                groupId = group.id,
+                                installId = pkgStat.id,
+                            ).toBundle()
                         ).navigate()
                     }
                 )
@@ -198,6 +200,26 @@ class AppDetailsViewModel @Inject constructor(
         val items: List<AppDetailsAdapter.Item>?,
         val progress: Progress.Data?,
     )
+
+    data class Args(
+        val storageId: StorageId,
+        val installId: InstallId,
+    ) {
+        fun toBundle() = bundleOf(
+            KEY_STORAGE_ID to storageId,
+            KEY_INSTALL_ID to installId,
+        )
+
+        companion object {
+            private const val KEY_STORAGE_ID = "storageId"
+            private const val KEY_INSTALL_ID = "installId"
+
+            fun from(handle: SavedStateHandle) = Args(
+                storageId = handle.get<StorageId>(KEY_STORAGE_ID)!!,
+                installId = handle.get<InstallId>(KEY_INSTALL_ID)!!,
+            )
+        }
+    }
 
     companion object {
         private val TAG = logTag("Analyzer", "App", "Details", "ViewModel")

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/apps/AppsViewModel.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/apps/AppsViewModel.kt
@@ -8,6 +8,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.sdmse.analyzer.R
 import eu.darken.sdmse.analyzer.core.Analyzer
+import eu.darken.sdmse.analyzer.ui.storage.app.AppDetailsViewModel
 import eu.darken.sdmse.analyzer.core.device.DeviceStorage
 import eu.darken.sdmse.analyzer.core.storage.categories.AppCategory
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
@@ -31,7 +32,7 @@ class AppsViewModel @Inject constructor(
     analyzer: Analyzer,
 ) : ViewModel3(dispatcherProvider) {
 
-    private val targetStorageId: StorageId = handle.get<StorageId>("storageId")!!
+    private val targetStorageId: StorageId = Args.from(handle).storageId
 
     private val searchQuery = MutableStateFlow("")
 
@@ -94,10 +95,10 @@ class AppsViewModel @Inject constructor(
                     onItemClicked = {
                         navDirections(
                             R.id.action_appsFragment_to_appDetailsFragment,
-                            bundleOf(
-                                "storageId" to storage.id,
-                                "installId" to installId,
-                            )
+                            AppDetailsViewModel.Args(
+                                storageId = storage.id,
+                                installId = installId,
+                            ).toBundle()
                         ).navigate()
                     }
                 )
@@ -123,6 +124,20 @@ class AppsViewModel @Inject constructor(
         val isSearchActive: Boolean = false,
         val progress: Progress.Data?,
     )
+
+    data class Args(
+        val storageId: StorageId,
+    ) {
+        fun toBundle() = bundleOf(KEY_STORAGE_ID to storageId)
+
+        companion object {
+            private const val KEY_STORAGE_ID = "storageId"
+
+            fun from(handle: SavedStateHandle) = Args(
+                storageId = handle.get<StorageId>(KEY_STORAGE_ID)!!,
+            )
+        }
+    }
 
     companion object {
         private val TAG = logTag("Analyzer", "Content", "Apps", "ViewModel")

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentViewModel.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentViewModel.kt
@@ -58,9 +58,10 @@ class ContentViewModel @Inject constructor(
     private val swiperSessionCreator: SwiperSessionCreator,
 ) : ViewModel3(dispatcherProvider) {
 
-    private val targetStorageId: StorageId = handle.get<StorageId>("storageId")!!
-    private val targetGroupId: ContentGroup.Id = handle.get<ContentGroup.Id>("groupId")!!
-    private val targetInstallId: InstallId? = handle.get<InstallId>("installId")
+    private val args = Args.from(handle)
+    private val targetStorageId: StorageId = args.storageId
+    private val targetGroupId: ContentGroup.Id = args.groupId
+    private val targetInstallId: InstallId? = args.installId
 
     val events = SingleLiveEvent<ContentItemEvents>()
 
@@ -317,6 +318,30 @@ class ContentViewModel @Inject constructor(
         val layoutMode: LayoutMode,
         val progress: Progress.Data?,
     )
+
+    data class Args(
+        val storageId: StorageId,
+        val groupId: ContentGroup.Id,
+        val installId: InstallId?,
+    ) {
+        fun toBundle() = bundleOf(
+            KEY_STORAGE_ID to storageId,
+            KEY_GROUP_ID to groupId,
+            KEY_INSTALL_ID to installId,
+        )
+
+        companion object {
+            private const val KEY_STORAGE_ID = "storageId"
+            private const val KEY_GROUP_ID = "groupId"
+            private const val KEY_INSTALL_ID = "installId"
+
+            fun from(handle: SavedStateHandle) = Args(
+                storageId = handle.get<StorageId>(KEY_STORAGE_ID)!!,
+                groupId = handle.get<ContentGroup.Id>(KEY_GROUP_ID)!!,
+                installId = handle.get<InstallId>(KEY_INSTALL_ID),
+            )
+        }
+    }
 
     companion object {
         private val TAG = logTag("Analyzer", "Content", "ViewModel")

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/device/DeviceStorageViewModel.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/device/DeviceStorageViewModel.kt
@@ -1,10 +1,11 @@
 package eu.darken.sdmse.analyzer.ui.storage.device
 
-import androidx.lifecycle.SavedStateHandle
 import androidx.core.os.bundleOf
+import androidx.lifecycle.SavedStateHandle
 import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.sdmse.analyzer.R
 import eu.darken.sdmse.analyzer.core.Analyzer
+import eu.darken.sdmse.analyzer.ui.storage.storage.StorageContentViewModel
 import eu.darken.sdmse.analyzer.core.device.DeviceStorageScanTask
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.debug.logging.log
@@ -67,7 +68,7 @@ class DeviceStorageViewModel @Inject constructor(
                         } else {
                             navDirections(
                                 R.id.action_deviceStorageFragment_to_storageFragment,
-                                bundleOf("storageId" to it.storage.id)
+                                StorageContentViewModel.Args(storageId = it.storage.id).toBundle()
                             ).navigate()
                         }
                     },

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/storage/StorageContentViewModel.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/storage/StorageContentViewModel.kt
@@ -5,6 +5,8 @@ import androidx.lifecycle.SavedStateHandle
 import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.sdmse.analyzer.R
 import eu.darken.sdmse.analyzer.core.Analyzer
+import eu.darken.sdmse.analyzer.ui.storage.apps.AppsViewModel
+import eu.darken.sdmse.analyzer.ui.storage.content.ContentViewModel
 import eu.darken.sdmse.analyzer.core.device.DeviceStorage
 import eu.darken.sdmse.analyzer.core.storage.StorageScanTask
 import eu.darken.sdmse.analyzer.core.storage.categories.AppCategory
@@ -40,7 +42,7 @@ class StorageContentViewModel @Inject constructor(
     private val taskSubmitter: TaskSubmitter,
 ) : ViewModel3(dispatcherProvider) {
 
-    private val targetStorageId: StorageId = handle.get<StorageId>("storageId")!!
+    private val targetStorageId: StorageId = Args.from(handle).storageId
 
     init {
         analyzer.data
@@ -79,7 +81,7 @@ class StorageContentViewModel @Inject constructor(
                             } else {
                                 navDirections(
                                     R.id.action_storageFragment_to_appsFragment,
-                                    bundleOf("storageId" to targetStorageId)
+                                    AppsViewModel.Args(storageId = targetStorageId).toBundle()
                                 ).navigate()
                             }
                         }
@@ -92,10 +94,11 @@ class StorageContentViewModel @Inject constructor(
                             if (content.groups.isEmpty()) return@Item
                             navDirections(
                                 R.id.action_storageFragment_to_contentFragment,
-                                bundleOf(
-                                    "storageId" to targetStorageId,
-                                    "groupId" to content.groups.single().id,
-                                )
+                                ContentViewModel.Args(
+                                    storageId = targetStorageId,
+                                    groupId = content.groups.single().id,
+                                    installId = null,
+                                ).toBundle()
                             ).navigate()
                         }
                     )
@@ -137,6 +140,20 @@ class StorageContentViewModel @Inject constructor(
         val content: List<StorageContentAdapter.Item>?,
         val progress: Progress.Data?,
     )
+
+    data class Args(
+        val storageId: StorageId,
+    ) {
+        fun toBundle() = bundleOf(KEY_STORAGE_ID to storageId)
+
+        companion object {
+            private const val KEY_STORAGE_ID = "storageId"
+
+            fun from(handle: SavedStateHandle) = Args(
+                storageId = handle.get<StorageId>(KEY_STORAGE_ID)!!,
+            )
+        }
+    }
 
     companion object {
         private val TAG = logTag("Analyzer", "Storage", "Content", "ViewModel")

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/details/AppJunkDetailsPagerAdapter.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/details/AppJunkDetailsPagerAdapter.kt
@@ -1,11 +1,11 @@
 package eu.darken.sdmse.appcleaner.ui.details
 
-import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
 import eu.darken.sdmse.appcleaner.core.AppJunk
 import eu.darken.sdmse.appcleaner.ui.details.appjunk.AppJunkFragment
+import eu.darken.sdmse.appcleaner.ui.details.appjunk.AppJunkViewModel
 import eu.darken.sdmse.common.getSpanCount
 import eu.darken.sdmse.common.pkgs.features.InstallId
 import eu.darken.sdmse.common.uix.DetailsPagerAdapter3
@@ -18,7 +18,7 @@ class AppJunkDetailsPagerAdapter(
     override fun getPageWidth(position: Int): Float = 1f / context.getSpanCount()
 
     override fun onCreateFragment(item: AppJunk): Fragment = AppJunkFragment().apply {
-        arguments = bundleOf("identifier" to item.identifier)
+        arguments = AppJunkViewModel.Args(identifier = item.identifier).toBundle()
     }
 
     override fun getPageTitle(position: Int): CharSequence = data[position].label.get(activity)

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/details/AppJunkDetailsViewModel.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/details/AppJunkDetailsViewModel.kt
@@ -7,6 +7,7 @@ import eu.darken.sdmse.appcleaner.core.AppJunk
 import eu.darken.sdmse.appcleaner.core.hasData
 import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerTask
 import eu.darken.sdmse.common.SingleLiveEvent
+import androidx.core.os.bundleOf
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
@@ -36,7 +37,7 @@ class AppJunkDetailsViewModel @Inject constructor(
     private val taskSubmitter: TaskSubmitter,
 ) : ViewModel3(dispatcherProvider = dispatcherProvider) {
 
-    private val identifier: InstallId? = handle.get<InstallId>("identifier")
+    private val identifier: InstallId? = Args.from(handle).identifier
 
     private var currentTarget: InstallId? by handle.mutableState("target")
     private var lastPosition: Int? by handle.mutableState("position")
@@ -100,6 +101,20 @@ class AppJunkDetailsViewModel @Inject constructor(
     fun updatePage(identifier: InstallId) {
         log(TAG) { "updatePage($identifier)" }
         currentTarget = identifier
+    }
+
+    data class Args(
+        val identifier: InstallId?,
+    ) {
+        fun toBundle() = bundleOf(KEY_IDENTIFIER to identifier)
+
+        companion object {
+            private const val KEY_IDENTIFIER = "identifier"
+
+            fun from(handle: SavedStateHandle) = Args(
+                identifier = handle.get<InstallId>(KEY_IDENTIFIER),
+            )
+        }
     }
 
     companion object {

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/details/appjunk/AppJunkViewModel.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/details/appjunk/AppJunkViewModel.kt
@@ -10,6 +10,7 @@ import eu.darken.sdmse.appcleaner.ui.details.appjunk.elements.AppJunkElementFile
 import eu.darken.sdmse.appcleaner.ui.details.appjunk.elements.AppJunkElementFileVH
 import eu.darken.sdmse.appcleaner.ui.details.appjunk.elements.AppJunkElementHeaderVH
 import eu.darken.sdmse.appcleaner.ui.details.appjunk.elements.AppJunkElementInaccessibleVH
+import androidx.core.os.bundleOf
 import eu.darken.sdmse.common.SingleLiveEvent
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.debug.logging.log
@@ -38,7 +39,7 @@ class AppJunkViewModel @Inject constructor(
     private val taskSubmitter: TaskSubmitter,
 ) : ViewModel3(dispatcherProvider = dispatcherProvider) {
 
-    private val identifier: InstallId = handle.get<InstallId>("identifier")!!
+    private val identifier: InstallId = Args.from(handle).identifier
 
     val events = SingleLiveEvent<AppJunkEvents>()
 
@@ -174,6 +175,20 @@ class AppJunkViewModel @Inject constructor(
             collapsedCategories.value = current - category
         } else {
             collapsedCategories.value = current + category
+        }
+    }
+
+    data class Args(
+        val identifier: InstallId,
+    ) {
+        fun toBundle() = bundleOf(KEY_IDENTIFIER to identifier)
+
+        companion object {
+            private const val KEY_IDENTIFIER = "identifier"
+
+            fun from(handle: SavedStateHandle) = Args(
+                identifier = handle.get<InstallId>(KEY_IDENTIFIER)!!,
+            )
         }
     }
 

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/list/AppCleanerListViewModel.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/list/AppCleanerListViewModel.kt
@@ -1,12 +1,12 @@
 package eu.darken.sdmse.appcleaner.ui.list
 
-import androidx.core.os.bundleOf
 import androidx.lifecycle.SavedStateHandle
 import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.sdmse.appcleaner.R
 import eu.darken.sdmse.appcleaner.core.AppCleaner
 import eu.darken.sdmse.appcleaner.core.hasData
 import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerProcessingTask
+import eu.darken.sdmse.appcleaner.ui.details.AppJunkDetailsViewModel
 import eu.darken.sdmse.common.SingleLiveEvent
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
@@ -69,7 +69,7 @@ class AppCleanerListViewModel @Inject constructor(
         log(TAG, INFO) { "showDetails(${item.junk.identifier})" }
         navDirections(
             R.id.action_appCleanerListFragment_to_appCleanerDetailsFragment2,
-            bundleOf("identifier" to item.junk.identifier)
+            AppJunkDetailsViewModel.Args(identifier = item.junk.identifier).toBundle()
         ).navigate()
     }
 

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListViewModel.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListViewModel.kt
@@ -8,7 +8,6 @@ import android.text.format.Formatter
 import androidx.lifecycle.SavedStateHandle
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
-import androidx.core.os.bundleOf
 import eu.darken.sdmse.appcontrol.core.AppControl
 import eu.darken.sdmse.appcontrol.core.AppControlScanTask
 import eu.darken.sdmse.appcontrol.core.AppControlSettings
@@ -23,6 +22,7 @@ import eu.darken.sdmse.appcontrol.core.toggle.AppControlToggleTask
 import eu.darken.sdmse.appcontrol.core.uninstall.UninstallTask
 import eu.darken.sdmse.common.SingleLiveEvent
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
+import eu.darken.sdmse.appcontrol.ui.list.actions.AppActionViewModel
 import eu.darken.sdmse.common.navigation.navDirections
 import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.logging.log
@@ -264,7 +264,7 @@ class AppControlListViewModel @Inject constructor(
                         onItemClicked = {
                             navDirections(
                                 eu.darken.sdmse.appcontrol.R.id.action_appControlListFragment_to_appActionDialog,
-                                bundleOf("installId" to content.installId)
+                                AppActionViewModel.Args(installId = content.installId).toBundle()
                             ).navigate()
                         },
                     )

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/actions/AppActionViewModel.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/actions/AppActionViewModel.kt
@@ -75,7 +75,7 @@ class AppActionViewModel @Inject constructor(
     private val userManager2: UserManager2,
 ) : ViewModel3(dispatcherProvider) {
 
-    private val installId: InstallId = handle.get<InstallId>("installId")!!
+    private val installId: InstallId = Args.from(handle).installId
 
     init {
         appControl.state
@@ -354,6 +354,20 @@ class AppActionViewModel @Inject constructor(
         val progress: Progress.Data?,
         val actions: List<AppActionAdapter.Item>? = null,
     )
+
+    data class Args(
+        val installId: InstallId,
+    ) {
+        fun toBundle() = bundleOf(KEY_INSTALL_ID to installId)
+
+        companion object {
+            private const val KEY_INSTALL_ID = "installId"
+
+            fun from(handle: SavedStateHandle) = Args(
+                installId = handle.get<InstallId>(KEY_INSTALL_ID)!!,
+            )
+        }
+    }
 
     companion object {
         private val TAG = logTag("AppControl", "Action", "Dialog", "ViewModel")

--- a/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/ui/details/CorpseDetailsPagerAdapter.kt
+++ b/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/ui/details/CorpseDetailsPagerAdapter.kt
@@ -1,6 +1,5 @@
 package eu.darken.sdmse.corpsefinder.ui.details
 
-import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
@@ -9,6 +8,7 @@ import eu.darken.sdmse.common.getSpanCount
 import eu.darken.sdmse.common.uix.DetailsPagerAdapter3
 import eu.darken.sdmse.corpsefinder.core.Corpse
 import eu.darken.sdmse.corpsefinder.ui.details.corpse.CorpseFragment
+import eu.darken.sdmse.corpsefinder.ui.details.corpse.CorpseViewModel
 
 class CorpseDetailsPagerAdapter(
     activity: FragmentActivity,
@@ -18,7 +18,7 @@ class CorpseDetailsPagerAdapter(
     override fun getPageWidth(position: Int): Float = 1f / context.getSpanCount()
 
     override fun onCreateFragment(item: Corpse): Fragment = CorpseFragment().apply {
-        arguments = bundleOf("identifier" to item.identifier)
+        arguments = CorpseViewModel.Args(identifier = item.identifier).toBundle()
     }
 
     override fun getPageTitle(position: Int): CharSequence = data[position].lookup.name

--- a/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/ui/details/CorpseDetailsViewModel.kt
+++ b/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/ui/details/CorpseDetailsViewModel.kt
@@ -3,6 +3,7 @@ package eu.darken.sdmse.corpsefinder.ui.details
 import androidx.lifecycle.SavedStateHandle
 import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.sdmse.common.SingleLiveEvent
+import androidx.core.os.bundleOf
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
@@ -36,7 +37,7 @@ class CorpseDetailsViewModel @Inject constructor(
     corpseFinder: CorpseFinder,
     private val taskSubmitter: TaskSubmitter,
 ) : ViewModel3(dispatcherProvider = dispatcherProvider) {
-    private val corpsePath: APath? = handle.get<APath>("corpsePath")
+    private val corpsePath: APath? = Args.from(handle).corpsePath
     private var currentTarget: CorpseIdentifier? by handle.mutableState("target")
     private var lastPosition: Int? by handle.mutableState("position")
 
@@ -101,6 +102,20 @@ class CorpseDetailsViewModel @Inject constructor(
     fun updatePage(identifier: CorpseIdentifier) {
         log(TAG) { "updatePage($identifier)" }
         currentTarget = identifier
+    }
+
+    data class Args(
+        val corpsePath: APath?,
+    ) {
+        fun toBundle() = bundleOf(KEY_CORPSE_PATH to corpsePath)
+
+        companion object {
+            private const val KEY_CORPSE_PATH = "corpsePath"
+
+            fun from(handle: SavedStateHandle) = Args(
+                corpsePath = handle.get<APath>(KEY_CORPSE_PATH),
+            )
+        }
     }
 
     companion object {

--- a/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/ui/details/corpse/CorpseViewModel.kt
+++ b/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/ui/details/corpse/CorpseViewModel.kt
@@ -3,6 +3,7 @@ package eu.darken.sdmse.corpsefinder.ui.details.corpse
 import androidx.lifecycle.SavedStateHandle
 import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.sdmse.common.SingleLiveEvent
+import androidx.core.os.bundleOf
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.log
@@ -26,7 +27,7 @@ class CorpseViewModel @Inject constructor(
     private val taskSubmitter: TaskSubmitter,
 ) : ViewModel3(dispatcherProvider = dispatcherProvider) {
 
-    private val identifier: APath = handle.get<APath>("identifier")!!
+    private val identifier: APath = Args.from(handle).identifier
 
     val events = SingleLiveEvent<CorpseEvents>()
 
@@ -95,6 +96,20 @@ class CorpseViewModel @Inject constructor(
 
         if (items.singleOrNull() is CorpseElementHeaderVH.Item) {
             corpseFinder.exclude(setOf(corpse.identifier))
+        }
+    }
+
+    data class Args(
+        val identifier: APath,
+    ) {
+        fun toBundle() = bundleOf(KEY_IDENTIFIER to identifier)
+
+        companion object {
+            private const val KEY_IDENTIFIER = "identifier"
+
+            fun from(handle: SavedStateHandle) = Args(
+                identifier = handle.get<APath>(KEY_IDENTIFIER)!!,
+            )
         }
     }
 

--- a/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/ui/list/CorpseFinderListViewModel.kt
+++ b/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/ui/list/CorpseFinderListViewModel.kt
@@ -1,6 +1,5 @@
 package eu.darken.sdmse.corpsefinder.ui.list
 
-import androidx.core.os.bundleOf
 import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.sdmse.common.SingleLiveEvent
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
@@ -12,6 +11,7 @@ import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.common.uix.ViewModel3
 import eu.darken.sdmse.corpsefinder.R
 import eu.darken.sdmse.corpsefinder.core.CorpseFinder
+import eu.darken.sdmse.corpsefinder.ui.details.CorpseDetailsViewModel
 import eu.darken.sdmse.corpsefinder.core.hasData
 import eu.darken.sdmse.corpsefinder.core.tasks.CorpseFinderDeleteTask
 import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
@@ -101,7 +101,7 @@ class CorpseFinderListViewModel @Inject constructor(
         log(TAG, INFO) { "showDetails(item=$item)" }
         navDirections(
             R.id.action_corpseFinderListFragment_to_corpseFinderDetailsFragment,
-            bundleOf("corpsePath" to (item as CorpseFinderListRowVH.Item).corpse.identifier)
+            CorpseDetailsViewModel.Args(corpsePath = (item as CorpseFinderListRowVH.Item).corpse.identifier).toBundle()
         ).navigate()
     }
 

--- a/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/details/DeduplicatorDetailsPagerAdapter.kt
+++ b/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/details/DeduplicatorDetailsPagerAdapter.kt
@@ -3,11 +3,11 @@ package eu.darken.sdmse.deduplicator.ui.details
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
-import androidx.core.os.bundleOf
 import eu.darken.sdmse.common.getSpanCount
 import eu.darken.sdmse.common.uix.DetailsPagerAdapter3
 import eu.darken.sdmse.deduplicator.core.Duplicate
 import eu.darken.sdmse.deduplicator.ui.details.cluster.ClusterFragment
+import eu.darken.sdmse.deduplicator.ui.details.cluster.ClusterViewModel
 
 class DeduplicatorDetailsPagerAdapter(
     activity: FragmentActivity,
@@ -17,7 +17,7 @@ class DeduplicatorDetailsPagerAdapter(
     override fun getPageWidth(position: Int): Float = 1f / context.getSpanCount()
 
     override fun onCreateFragment(item: Duplicate.Cluster): Fragment = ClusterFragment().apply {
-        arguments = bundleOf("identifier" to item.identifier)
+        arguments = ClusterViewModel.Args(identifier = item.identifier).toBundle()
     }
 
     override fun getPageTitle(position: Int): CharSequence = context.getString(

--- a/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/details/DeduplicatorDetailsViewModel.kt
+++ b/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/details/DeduplicatorDetailsViewModel.kt
@@ -3,6 +3,7 @@ package eu.darken.sdmse.deduplicator.ui.details
 import androidx.lifecycle.SavedStateHandle
 import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.sdmse.common.SingleLiveEvent
+import androidx.core.os.bundleOf
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
@@ -36,7 +37,7 @@ class DeduplicatorDetailsViewModel @Inject constructor(
     private val taskSubmitter: TaskSubmitter,
     private val settings: DeduplicatorSettings,
 ) : ViewModel3(dispatcherProvider = dispatcherProvider) {
-    private val identifier: Duplicate.Cluster.Id? = handle.get<Duplicate.Cluster.Id>("identifier")
+    private val identifier: Duplicate.Cluster.Id? = Args.from(handle).identifier
     private var currentTarget: Duplicate.Cluster.Id? by handle.mutableState("target")
     private var lastPosition: Int? by handle.mutableState("position")
 
@@ -108,6 +109,20 @@ class DeduplicatorDetailsViewModel @Inject constructor(
     fun toggleDirectoryView() = launch {
         log(TAG) { "toggleDirectoryView()" }
         settings.isDirectoryViewEnabled.update { !it }
+    }
+
+    data class Args(
+        val identifier: Duplicate.Cluster.Id?,
+    ) {
+        fun toBundle() = bundleOf(KEY_IDENTIFIER to identifier)
+
+        companion object {
+            private const val KEY_IDENTIFIER = "identifier"
+
+            fun from(handle: SavedStateHandle) = Args(
+                identifier = handle.get<Duplicate.Cluster.Id>(KEY_IDENTIFIER),
+            )
+        }
     }
 
     companion object {

--- a/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/details/cluster/ClusterViewModel.kt
+++ b/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/details/cluster/ClusterViewModel.kt
@@ -2,6 +2,7 @@ package eu.darken.sdmse.deduplicator.ui.details.cluster
 
 import androidx.lifecycle.SavedStateHandle
 import dagger.hilt.android.lifecycle.HiltViewModel
+import androidx.core.os.bundleOf
 import eu.darken.sdmse.common.navigation.navDirections
 import eu.darken.sdmse.common.SingleLiveEvent
 import eu.darken.sdmse.common.ViewIntentTool
@@ -48,7 +49,7 @@ class ClusterViewModel @Inject constructor(
     private val arbiter: DuplicatesArbiter,
 ) : ViewModel3(dispatcherProvider = dispatcherProvider) {
 
-    private val identifier: Duplicate.Cluster.Id = handle.get<Duplicate.Cluster.Id>("identifier")!!
+    private val identifier: Duplicate.Cluster.Id = Args.from(handle).identifier
 
     val events = SingleLiveEvent<ClusterEvents>()
 
@@ -392,6 +393,20 @@ class ClusterViewModel @Inject constructor(
             }
         }
         delete(duplicateItems)
+    }
+
+    data class Args(
+        val identifier: Duplicate.Cluster.Id,
+    ) {
+        fun toBundle() = bundleOf(KEY_IDENTIFIER to identifier)
+
+        companion object {
+            private const val KEY_IDENTIFIER = "identifier"
+
+            fun from(handle: SavedStateHandle) = Args(
+                identifier = handle.get<Duplicate.Cluster.Id>(KEY_IDENTIFIER)!!,
+            )
+        }
     }
 
     companion object {

--- a/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListViewModel.kt
+++ b/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListViewModel.kt
@@ -1,6 +1,5 @@
 package eu.darken.sdmse.deduplicator.ui.list
 
-import androidx.core.os.bundleOf
 import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.sdmse.common.SingleLiveEvent
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
@@ -11,6 +10,7 @@ import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.navigation.navDirections
 import eu.darken.sdmse.common.previews.PreviewOptions
+import eu.darken.sdmse.deduplicator.ui.details.DeduplicatorDetailsViewModel
 import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.common.ui.LayoutMode
 import eu.darken.sdmse.common.uix.ViewModel3
@@ -183,7 +183,7 @@ class DeduplicatorListViewModel @Inject constructor(
         log(TAG, INFO) { "showDetails(id=$id)" }
         navDirections(
             R.id.action_deduplicatorListFragment_to_deduplicatorDetailsFragment,
-            bundleOf("identifier" to id)
+            DeduplicatorDetailsViewModel.Args(identifier = id).toBundle()
         ).navigate()
     }
 

--- a/app-tool-scheduler/src/main/java/eu/darken/sdmse/scheduler/ui/manager/SchedulerManagerViewModel.kt
+++ b/app-tool-scheduler/src/main/java/eu/darken/sdmse/scheduler/ui/manager/SchedulerManagerViewModel.kt
@@ -3,7 +3,6 @@ package eu.darken.sdmse.scheduler.ui.manager
 import android.annotation.SuppressLint
 import android.content.Context
 import androidx.lifecycle.SavedStateHandle
-import androidx.core.os.bundleOf
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.sdmse.common.BatteryHelper
@@ -29,6 +28,7 @@ import eu.darken.sdmse.scheduler.core.Schedule
 import eu.darken.sdmse.scheduler.core.ScheduleId
 import eu.darken.sdmse.scheduler.core.SchedulerManager
 import eu.darken.sdmse.scheduler.core.SchedulerSettings
+import eu.darken.sdmse.scheduler.ui.manager.create.ScheduleItemViewModel
 import eu.darken.sdmse.scheduler.ui.manager.items.AlarmHintRowVH
 import eu.darken.sdmse.scheduler.ui.manager.items.BatteryHintRowVH
 import eu.darken.sdmse.scheduler.ui.manager.items.ScheduleRowVH
@@ -118,7 +118,7 @@ class SchedulerManagerViewModel @Inject constructor(
                 onEdit = {
                     navDirections(
                         R.id.action_schedulerManagerFragment_to_scheduleItemDialog,
-                        bundleOf("scheduleId" to schedule.id)
+                        ScheduleItemViewModel.Args(scheduleId = schedule.id).toBundle()
                     ).navigate()
                 },
                 onToggle = {
@@ -178,7 +178,7 @@ class SchedulerManagerViewModel @Inject constructor(
         log(TAG) { "createNew()" }
         navDirections(
             R.id.action_schedulerManagerFragment_to_scheduleItemDialog,
-            bundleOf("scheduleId" to UUID.randomUUID().toString())
+            ScheduleItemViewModel.Args(scheduleId = UUID.randomUUID().toString()).toBundle()
         ).navigate()
     }
 

--- a/app-tool-scheduler/src/main/java/eu/darken/sdmse/scheduler/ui/manager/create/ScheduleItemViewModel.kt
+++ b/app-tool-scheduler/src/main/java/eu/darken/sdmse/scheduler/ui/manager/create/ScheduleItemViewModel.kt
@@ -2,6 +2,7 @@ package eu.darken.sdmse.scheduler.ui.manager.create
 
 import androidx.lifecycle.SavedStateHandle
 import dagger.hilt.android.lifecycle.HiltViewModel
+import androidx.core.os.bundleOf
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
@@ -20,7 +21,7 @@ class ScheduleItemViewModel @Inject constructor(
     private val schedulerManager: SchedulerManager,
 ) : ViewModel3(dispatcherProvider) {
 
-    private val scheduleId: String = handle.get<String>("scheduleId")!!
+    private val scheduleId: String = Args.from(handle).scheduleId
 
     private val internalState = DynamicStateFlow<State>(parentScope = vmScope) {
         val existing = schedulerManager.getSchedule(scheduleId)
@@ -91,6 +92,20 @@ class ScheduleItemViewModel @Inject constructor(
         val canSave: Boolean
             get() = label != null && hour != null && minute != null
 
+    }
+
+    data class Args(
+        val scheduleId: String,
+    ) {
+        fun toBundle() = bundleOf(KEY_SCHEDULE_ID to scheduleId)
+
+        companion object {
+            private const val KEY_SCHEDULE_ID = "scheduleId"
+
+            fun from(handle: SavedStateHandle) = Args(
+                scheduleId = handle.get<String>(KEY_SCHEDULE_ID)!!,
+            )
+        }
     }
 
     companion object {

--- a/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/sessions/SwiperSessionsViewModel.kt
+++ b/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/sessions/SwiperSessionsViewModel.kt
@@ -14,8 +14,8 @@ import eu.darken.sdmse.main.core.SDMTool
 import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
 import eu.darken.sdmse.common.navigation.navDirections
 import eu.darken.sdmse.swiper.R
-import androidx.core.os.bundleOf
 import eu.darken.sdmse.swiper.core.FileTypeFilter
+import eu.darken.sdmse.swiper.ui.swipe.SwiperSwipeViewModel
 import eu.darken.sdmse.swiper.core.Swiper
 import eu.darken.sdmse.swiper.core.SwiperSettings
 import eu.darken.sdmse.swiper.core.tasks.SwiperScanTask
@@ -88,7 +88,7 @@ class SwiperSessionsViewModel @Inject constructor(
         } else {
             log(TAG) { "Cache hit for session $sessionId, skipping refresh" }
         }
-        navDirections(R.id.action_swiperSessionsFragment_to_swiperSwipeFragment, bundleOf("sessionId" to sessionId)).navigate()
+        navDirections(R.id.action_swiperSessionsFragment_to_swiperSwipeFragment, SwiperSwipeViewModel.Args(sessionId = sessionId).toBundle()).navigate()
     }
 
     fun scanSession(sessionId: String) = launch {

--- a/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/status/SwiperStatusViewModel.kt
+++ b/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/status/SwiperStatusViewModel.kt
@@ -12,6 +12,7 @@ import eu.darken.sdmse.common.uix.ViewModel3
 import eu.darken.sdmse.swiper.R
 import androidx.core.os.bundleOf
 import eu.darken.sdmse.exclusion.core.ExclusionManager
+import eu.darken.sdmse.swiper.ui.swipe.SwiperSwipeViewModel
 import eu.darken.sdmse.exclusion.core.save
 import eu.darken.sdmse.exclusion.core.types.Exclusion
 import eu.darken.sdmse.exclusion.core.types.PathExclusion
@@ -34,7 +35,7 @@ class SwiperStatusViewModel @Inject constructor(
     private val exclusionManager: ExclusionManager,
 ) : ViewModel3(dispatcherProvider = dispatcherProvider) {
 
-    private val sessionId: String = handle.get<String>("sessionId")!!
+    private val sessionId: String = Args.from(handle).sessionId
 
     val events = SingleLiveEvent<SwiperStatusEvents>()
 
@@ -88,7 +89,7 @@ class SwiperStatusViewModel @Inject constructor(
         if (currentPosition < 0) return
         navDirections(
             R.id.action_swiperStatusFragment_to_swiperSwipeFragment,
-            bundleOf("sessionId" to sessionId, "startIndex" to currentPosition),
+            SwiperSwipeViewModel.Args(sessionId = sessionId, startIndex = currentPosition).toBundle(),
         ).navigate()
     }
 
@@ -158,6 +159,20 @@ class SwiperStatusViewModel @Inject constructor(
         val canDone: Boolean = deletedCount > 0 && deleteCount == 0 && !isProcessing
         // Has already processed items from previous partial finalization
         val hasProcessedItems: Boolean = alreadyKeptCount > 0 || alreadyDeletedCount > 0
+    }
+
+    data class Args(
+        val sessionId: String,
+    ) {
+        fun toBundle() = bundleOf(KEY_SESSION_ID to sessionId)
+
+        companion object {
+            private const val KEY_SESSION_ID = "sessionId"
+
+            fun from(handle: SavedStateHandle) = Args(
+                sessionId = handle.get<String>(KEY_SESSION_ID)!!,
+            )
+        }
     }
 
     companion object {

--- a/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/swipe/SwiperSwipeViewModel.kt
+++ b/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/swipe/SwiperSwipeViewModel.kt
@@ -15,6 +15,7 @@ import eu.darken.sdmse.common.ViewIntentTool
 import eu.darken.sdmse.swiper.R
 import androidx.core.os.bundleOf
 import eu.darken.sdmse.exclusion.core.ExclusionManager
+import eu.darken.sdmse.swiper.ui.status.SwiperStatusViewModel
 import eu.darken.sdmse.exclusion.core.save
 import eu.darken.sdmse.exclusion.core.types.Exclusion
 import eu.darken.sdmse.exclusion.core.types.PathExclusion
@@ -36,8 +37,9 @@ class SwiperSwipeViewModel @Inject constructor(
     private val viewIntentTool: ViewIntentTool,
 ) : ViewModel3(dispatcherProvider = dispatcherProvider) {
 
-    private val sessionId: String = requireNotNull(handle.get<String>("sessionId")) { "sessionId argument is required" }
-    private val startIndex: Int = handle.get<Int>("startIndex") ?: -1
+    private val args = Args.from(handle)
+    private val sessionId: String = args.sessionId
+    private val startIndex: Int = args.startIndex
 
     private val currentIndexOverride = MutableStateFlow<Int?>(
         if (startIndex >= 0) startIndex else null
@@ -225,7 +227,7 @@ class SwiperSwipeViewModel @Inject constructor(
 
     fun navigateToStatus() {
         log(TAG, INFO) { "navigateToStatus()" }
-        navDirections(R.id.action_swiperSwipeFragment_to_swiperStatusFragment, bundleOf("sessionId" to sessionId)).navigate()
+        navDirections(R.id.action_swiperSwipeFragment_to_swiperStatusFragment, SwiperStatusViewModel.Args(sessionId = sessionId).toBundle()).navigate()
     }
 
     fun dismissGestureOverlay() = launch {
@@ -275,6 +277,23 @@ class SwiperSwipeViewModel @Inject constructor(
         val currentItemOriginalIndex: Int? = currentItem?.itemIndex
         val progressPercent: Int = if (totalItems > 0) ((keepCount + deleteCount) * 100 / totalItems) else 0
         val sessionLabel: String? = session?.label
+    }
+
+    data class Args(
+        val sessionId: String,
+        val startIndex: Int = -1,
+    ) {
+        fun toBundle() = bundleOf(KEY_SESSION_ID to sessionId, KEY_START_INDEX to startIndex)
+
+        companion object {
+            private const val KEY_SESSION_ID = "sessionId"
+            private const val KEY_START_INDEX = "startIndex"
+
+            fun from(handle: SavedStateHandle) = Args(
+                sessionId = requireNotNull(handle.get<String>(KEY_SESSION_ID)) { "sessionId argument is required" },
+                startIndex = handle.get<Int>(KEY_START_INDEX) ?: -1,
+            )
+        }
     }
 
     companion object {

--- a/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/details/FilterContentDetailsPagerAdapter.kt
+++ b/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/details/FilterContentDetailsPagerAdapter.kt
@@ -6,8 +6,8 @@ import androidx.fragment.app.FragmentManager
 import eu.darken.sdmse.common.getSpanCount
 import eu.darken.sdmse.common.uix.DetailsPagerAdapter3
 import eu.darken.sdmse.systemcleaner.core.FilterContent
-import androidx.core.os.bundleOf
 import eu.darken.sdmse.systemcleaner.ui.details.filtercontent.FilterContentFragment
+import eu.darken.sdmse.systemcleaner.ui.details.filtercontent.FilterContentViewModel
 
 class FilterContentDetailsPagerAdapter(
     private val activity: FragmentActivity,
@@ -17,7 +17,7 @@ class FilterContentDetailsPagerAdapter(
     override fun getPageWidth(position: Int): Float = 1f / context.getSpanCount()
 
     override fun onCreateFragment(item: FilterContent): Fragment = FilterContentFragment().apply {
-        arguments = bundleOf("identifier" to item.identifier)
+        arguments = FilterContentViewModel.Args(identifier = item.identifier).toBundle()
     }
 
     override fun getPageTitle(position: Int): CharSequence = data[position].label.get(activity)

--- a/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/details/FilterContentDetailsViewModel.kt
+++ b/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/details/FilterContentDetailsViewModel.kt
@@ -3,6 +3,7 @@ package eu.darken.sdmse.systemcleaner.ui.details
 import androidx.lifecycle.SavedStateHandle
 import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.sdmse.common.SingleLiveEvent
+import androidx.core.os.bundleOf
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
@@ -35,7 +36,7 @@ class FilterContentDetailsViewModel @Inject constructor(
     systemCleaner: SystemCleaner,
     private val taskSubmitter: TaskSubmitter,
 ) : ViewModel3(dispatcherProvider = dispatcherProvider) {
-    private val filterIdentifier: String? = handle.get<String>("filterIdentifier")
+    private val filterIdentifier: String? = Args.from(handle).filterIdentifier
     private var currentTarget: FilterIdentifier? by handle.mutableState("target")
     private var lastPosition: Int? by handle.mutableState("position")
 
@@ -102,6 +103,20 @@ class FilterContentDetailsViewModel @Inject constructor(
     fun updatePage(identifier: FilterIdentifier) {
         log(TAG) { "updatePage($identifier)" }
         currentTarget = identifier
+    }
+
+    data class Args(
+        val filterIdentifier: String?,
+    ) {
+        fun toBundle() = bundleOf(KEY_FILTER_IDENTIFIER to filterIdentifier)
+
+        companion object {
+            private const val KEY_FILTER_IDENTIFIER = "filterIdentifier"
+
+            fun from(handle: SavedStateHandle) = Args(
+                filterIdentifier = handle.get<String>(KEY_FILTER_IDENTIFIER),
+            )
+        }
     }
 
     companion object {

--- a/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/details/filtercontent/FilterContentViewModel.kt
+++ b/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/details/filtercontent/FilterContentViewModel.kt
@@ -36,7 +36,7 @@ class FilterContentViewModel @Inject constructor(
     private val taskSubmitter: TaskSubmitter,
 ) : ViewModel3(dispatcherProvider = dispatcherProvider) {
 
-    private val identifier: String = handle.get<String>("identifier")!!
+    private val identifier: String = Args.from(handle).identifier
 
     val events = SingleLiveEvent<FilterContentEvents>()
 
@@ -140,6 +140,20 @@ class FilterContentViewModel @Inject constructor(
         val items: List<FilterContentElementsAdapter.Item>,
         val progress: Progress.Data?,
     )
+
+    data class Args(
+        val identifier: String,
+    ) {
+        fun toBundle() = bundleOf(KEY_IDENTIFIER to identifier)
+
+        companion object {
+            private const val KEY_IDENTIFIER = "identifier"
+
+            fun from(handle: SavedStateHandle) = Args(
+                identifier = handle.get<String>(KEY_IDENTIFIER)!!,
+            )
+        }
+    }
 
     companion object {
         private val TAG = logTag("SystemCleaner", "Details", "ViewModel")

--- a/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/list/SystemCleanerListViewModel.kt
+++ b/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/list/SystemCleanerListViewModel.kt
@@ -8,10 +8,10 @@ import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.common.uix.ViewModel3
-import androidx.core.os.bundleOf
 import eu.darken.sdmse.common.navigation.navDirections
 import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
 import eu.darken.sdmse.systemcleaner.R
+import eu.darken.sdmse.systemcleaner.ui.details.FilterContentDetailsViewModel
 import eu.darken.sdmse.systemcleaner.core.SystemCleaner
 import eu.darken.sdmse.systemcleaner.core.hasData
 import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerProcessingTask
@@ -78,7 +78,7 @@ class SystemCleanerListViewModel @Inject constructor(
         log(TAG, INFO) { "showDetails(filterContent=${item.content.identifier})" }
         navDirections(
             R.id.action_systemCleanerListFragment_to_systemCleanerDetailsFragment,
-            bundleOf("filterIdentifier" to item.content.identifier)
+            FilterContentDetailsViewModel.Args(filterIdentifier = item.content.identifier).toBundle()
         ).navigate()
     }
 


### PR DESCRIPTION
## What changed

Navigation arguments between screens are now passed through typed helper classes instead of loose string keys, reducing the risk of typos or type mismatches causing crashes.

## Technical Context

- Each receiver ViewModel gets a nested `Args` data class with `toBundle()` and `from(SavedStateHandle)` methods
- Senders reference `ReceiverViewModel.Args(...)` instead of raw `bundleOf("key" to value)`, so key strings are defined once
- Key constants match nav graph XML `<argument>` declarations — this is required because `NavController` validates required argument keys at runtime
- A `@Parcelize` single-key approach was considered but rejected: Navigation's `addInDefaultArgs()` validates required `<argument>` entries by key name, so changing keys would cause `IllegalArgumentException`
- All 8 tool modules updated: Analyzer, AppCleaner, AppControl, CorpseFinder, Deduplicator, Scheduler, Swiper, SystemCleaner
- PagerAdapter `getItemPosition` methods left as-is (they read back what `onCreateFragment` wrote through Args)
