### PR TITLE
Analyzer: Allow deleting individual storage trend entries

### DIFF
--- a/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/SpaceHistoryRepo.kt
+++ b/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/SpaceHistoryRepo.kt
@@ -27,6 +27,11 @@ class SpaceHistoryRepo @Inject constructor(
 
     fun getReports(since: Instant): Flow<List<ReportEntity>> = reportsDatabase.getReportsSince(since)
 
+    suspend fun deleteStorage(storageId: String) {
+        reportsDatabase.spaceSnapshotDao.deleteByStorageId(storageId)
+        reportsDatabase.refreshDatabaseSize()
+    }
+
     suspend fun insertIfNotRecent(
         storageId: String,
         recordedAt: Instant,

--- a/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/db/db/SpaceSnapshotDao.kt
+++ b/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/db/db/SpaceSnapshotDao.kt
@@ -30,6 +30,9 @@ interface SpaceSnapshotDao {
     @Query("DELETE FROM space_snapshots WHERE id = :snapshotId")
     suspend fun deleteById(snapshotId: Long)
 
+    @Query("DELETE FROM space_snapshots WHERE storage_id = :storageId")
+    suspend fun deleteByStorageId(storageId: String)
+
     @Query("SELECT DISTINCT storage_id FROM space_snapshots")
     fun getDistinctStorageIds(): Flow<List<String>>
 

--- a/app-common-stats/src/main/java/eu/darken/sdmse/stats/ui/spacehistory/SpaceHistoryFragment.kt
+++ b/app-common-stats/src/main/java/eu/darken/sdmse/stats/ui/spacehistory/SpaceHistoryFragment.kt
@@ -14,6 +14,7 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.ui.setupWithNavController
 import com.google.android.material.chip.Chip
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
 import eu.darken.sdmse.common.ByteFormatter
 import eu.darken.sdmse.common.EdgeToEdgeHelper
@@ -112,6 +113,17 @@ class SpaceHistoryFragment : Fragment3(R.layout.stats_space_history_fragment) {
                     isCheckable = true
                     isChecked = storage.id == state.selectedStorageId
                     setOnClickListener { vm.selectStorage(storage.id) }
+                    setOnLongClickListener {
+                        MaterialAlertDialogBuilder(requireContext()).apply {
+                            setTitle(R.string.stats_space_history_delete_storage_title)
+                            setMessage(R.string.stats_space_history_delete_storage_desc)
+                            setPositiveButton(eu.darken.sdmse.common.R.string.general_delete_action) { _, _ ->
+                                vm.deleteStorage(storage.id)
+                            }
+                            setNegativeButton(eu.darken.sdmse.common.R.string.general_cancel_action) { _, _ -> }
+                        }.show()
+                        true
+                    }
                 }
                 storageChipGroup.addView(chip)
             }

--- a/app-common-stats/src/main/java/eu/darken/sdmse/stats/ui/spacehistory/SpaceHistoryViewModel.kt
+++ b/app-common-stats/src/main/java/eu/darken/sdmse/stats/ui/spacehistory/SpaceHistoryViewModel.kt
@@ -138,6 +138,14 @@ class SpaceHistoryViewModel @Inject constructor(
         selectedStorageId.value = storageId
     }
 
+    fun deleteStorage(storageId: String) = launch {
+        log(TAG) { "deleteStorage($storageId)" }
+        spaceHistoryRepo.deleteStorage(storageId)
+        if (selectedStorageId.value == storageId) {
+            selectedStorageId.value = null
+        }
+    }
+
     fun openUpgrade() {
         log(TAG) { "openUpgrade()" }
         navDirections(eu.darken.sdmse.common.R.id.goToUpgradeFragment).navigate()

--- a/app-common-stats/src/main/res/values/strings.xml
+++ b/app-common-stats/src/main/res/values/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">Primary storage</string>
     <string name="stats_storage_type_secondary">Secondary storage</string>
     <string name="stats_storage_type_portable">Portable storage</string>
+    <string name="stats_space_history_delete_storage_title">Delete storage history?</string>
+    <string name="stats_space_history_delete_storage_desc">All trend data for this storage will be permanently deleted.</string>
     <string name="stats_settings_retention_snapshots_label">Storage snapshots</string>
     <string name="stats_settings_retention_snapshots_desc">Number of days to keep storage space snapshots.</string>
 </resources>


### PR DESCRIPTION
## What changed

Added the ability to delete storage trend history for individual storage volumes. Previously, entries from disconnected USB devices (or other secondary storage) lingered on the storage trend screen until the retention period expired (up to 90 days), with no way to remove them except resetting all statistics.

Now, long-pressing any storage chip on the storage trend screen shows a confirmation dialog to delete that storage's history.

## Technical Context

- Root cause of the clutter: each USB device gets a unique filesystem UUID tracked in the `space_snapshots` table. Disconnected devices' entries persist until time-based retention prunes them. There was no `deleteByStorageId` query — only `deleteAll` and `deleteOlderThan`.
- Long-press + confirmation dialog pattern matches the existing "Reset all" dialog in stats settings.
- All storage chips are deletable (including primary). Primary gets recreated on the next snapshot event, so deletion just gives it a fresh start — consistent UX without special-casing.
- After deletion, `getDistinctStorageIds()` naturally stops returning the deleted ID, so the chip disappears and selection auto-falls back to the first remaining storage.
