### PR TITLE
AppCleaner: Fix automation timeout for already-clean apps

### DIFF
--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleter.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleter.kt
@@ -129,7 +129,18 @@ class InaccessibleDeleter @Inject constructor(
             failedTargets.putAll(adbResult.failed)
         }
 
-        val remainingTargets = targets.filter { !successTargets.contains(it.identifier) }
+        val remainingTargets = targets
+            .filter { !successTargets.contains(it.identifier) }
+            .filter { junk ->
+                val currentCache = inaccessibleCacheProvider.determineCache(junk.pkg)
+                if (currentCache != null && currentCache.totalSize == 0L) {
+                    log(TAG) { "Cache now zero, skipping automation: ${junk.identifier}" }
+                    successTargets.add(junk.identifier)
+                    false
+                } else {
+                    true
+                }
+            }
 
         // Force-stop apps before clearing cache if enabled
         if (useAutomation && remainingTargets.isNotEmpty() && settings.forceStopBeforeClearing.value()) {
@@ -171,6 +182,9 @@ class InaccessibleDeleter @Inject constructor(
         } else if (!useAutomation) {
             log(TAG, INFO) { "useAutomation=false" }
         }
+
+        // Clean up contradictory bookkeeping: if an app failed earlier but succeeded later, remove from failed
+        successTargets.forEach { failedTargets.remove(it) }
 
         return InaccDelResult(
             succesful = successTargets.toSet(),
@@ -280,6 +294,22 @@ class InaccessibleDeleter @Inject constructor(
                     log(TAG, WARN) { "trimCache failed for ${junk.identifier}" }
                     failedTargets[junk.identifier] =
                         IllegalStateException("trimCache failed, single:${junk.identifier}")
+                }
+            }
+
+            // Re-check system apps — trimCaches may have cleared their caches too
+            val systemTargets = targets.filter { it.pkg.isSystemApp }
+            if (systemTargets.isNotEmpty()) {
+                log(TAG) { "Re-checking ${systemTargets.size} system app targets after trimCaches" }
+                for (junk in systemTargets) {
+                    val beforeInfo = junk.inaccessibleCache!!
+                    val newInfo = inaccessibleCacheProvider.determineCache(junk.pkg)
+                    if (newInfo != null && newInfo.totalSize < beforeInfo.totalSize) {
+                        log(TAG) { "System app cache decreased after trimCaches: ${junk.identifier}" }
+                        successTargets.add(junk.identifier)
+                    } else {
+                        log(TAG, VERBOSE) { "System app cache unchanged: ${junk.identifier}" }
+                    }
                 }
             }
         } catch (e: Exception) {

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleterTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleterTest.kt
@@ -1,0 +1,263 @@
+package eu.darken.sdmse.appcleaner.core
+
+import eu.darken.sdmse.appcleaner.core.scanner.InaccessibleCache
+import eu.darken.sdmse.appcleaner.core.scanner.InaccessibleCacheProvider
+import eu.darken.sdmse.automation.core.AutomationSubmitter
+import eu.darken.sdmse.common.adb.AdbManager
+import eu.darken.sdmse.common.coroutine.DispatcherProvider
+import eu.darken.sdmse.common.pkgs.Pkg
+import eu.darken.sdmse.common.pkgs.features.InstallId
+import eu.darken.sdmse.common.pkgs.features.Installed
+import eu.darken.sdmse.common.pkgs.pkgops.PkgOps
+import eu.darken.sdmse.common.root.RootManager
+import eu.darken.sdmse.common.user.UserHandle2
+import eu.darken.sdmse.common.user.UserManager2
+import eu.darken.sdmse.common.user.UserProfile2
+import eu.darken.sdmse.setup.SetupModule
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.maps.shouldBeEmpty
+import io.kotest.matchers.maps.shouldContainKey
+import io.kotest.matchers.maps.shouldNotContainKey
+import io.kotest.matchers.shouldBe
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class InaccessibleDeleterTest : BaseTest() {
+
+    private val testHandle = UserHandle2(handleId = 0)
+    private val testUser = UserProfile2(handle = testHandle)
+
+    @MockK lateinit var userManager: UserManager2
+    @MockK lateinit var automationManager: AutomationSubmitter
+    @MockK lateinit var adbManager: AdbManager
+    @MockK lateinit var pkgOps: PkgOps
+    @MockK lateinit var inaccessibleCacheProvider: InaccessibleCacheProvider
+    @MockK lateinit var rootManager: RootManager
+    @MockK lateinit var settings: AppCleanerSettings
+    @MockK(name = "automation") lateinit var automationSetupModule: SetupModule
+
+    private lateinit var deleter: InaccessibleDeleter
+
+    @BeforeEach
+    fun setup() {
+        MockKAnnotations.init(this)
+
+        val testDispatcher = UnconfinedTestDispatcher()
+        val dispatcherProvider = object : DispatcherProvider {
+            override val Default: CoroutineDispatcher = testDispatcher
+            override val Main: CoroutineDispatcher = testDispatcher
+            override val MainImmediate: CoroutineDispatcher = testDispatcher
+            override val Unconfined: CoroutineDispatcher = testDispatcher
+            override val IO: CoroutineDispatcher = testDispatcher
+        }
+
+        coEvery { userManager.currentUser() } returns testUser
+        every { adbManager.useAdb } returns flowOf(false)
+
+        deleter = InaccessibleDeleter(
+            dispatcherProvider = dispatcherProvider,
+            userManager = userManager,
+            automationManager = automationManager,
+            adbManager = adbManager,
+            pkgOps = pkgOps,
+            inaccessibleCacheProvider = inaccessibleCacheProvider,
+            rootManager = rootManager,
+            settings = settings,
+            automationSetupModule = automationSetupModule,
+        )
+    }
+
+    private fun createAppJunk(
+        pkgName: String,
+        cacheSize: Long,
+    ): AppJunk {
+        val installId = InstallId(Pkg.Id(pkgName), testHandle)
+        val pkg = mockk<Installed> {
+            every { id } returns Pkg.Id(pkgName)
+            every { userHandle } returns testHandle
+            every { this@mockk.installId } returns installId
+            every { packageName } returns pkgName
+            every { label } returns null
+        }
+        val cache = InaccessibleCache(
+            identifier = installId,
+            isSystemApp = false,
+            itemCount = 1,
+            totalSize = cacheSize,
+            publicSize = 0L,
+            theoreticalPaths = emptySet(),
+        )
+        return AppJunk(
+            pkg = pkg,
+            userProfile = testUser,
+            expendables = null,
+            inaccessibleCache = cache,
+        )
+    }
+
+    private fun createSnapshot(vararg junks: AppJunk) = AppCleaner.Data(junks = junks.toList())
+
+    @Test
+    fun `zero cache target is excluded from automation and marked successful`() = runTest {
+        val junk = createAppJunk("com.example.app", cacheSize = 50000)
+        val snapshot = createSnapshot(junk)
+
+        // After scan, cache has become zero
+        coEvery { inaccessibleCacheProvider.determineCache(any()) } returns InaccessibleCache(
+            identifier = junk.identifier,
+            isSystemApp = false,
+            itemCount = 0,
+            totalSize = 0L,
+            publicSize = 0L,
+            theoreticalPaths = emptySet(),
+        )
+
+        val result = deleter.deleteInaccessible(
+            snapshot = snapshot,
+            targetPkgs = null,
+            useAutomation = false,
+            isBackground = false,
+        )
+
+        result.succesful shouldContain junk.identifier
+        result.failed.shouldBeEmpty()
+    }
+
+    @Test
+    fun `non-zero cache target stays in automation queue`() = runTest {
+        val junk = createAppJunk("com.example.app", cacheSize = 50000)
+        val snapshot = createSnapshot(junk)
+
+        // Cache is still non-zero
+        coEvery { inaccessibleCacheProvider.determineCache(any()) } returns InaccessibleCache(
+            identifier = junk.identifier,
+            isSystemApp = false,
+            itemCount = 1,
+            totalSize = 30000,
+            publicSize = 0L,
+            theoreticalPaths = emptySet(),
+        )
+
+        val result = deleter.deleteInaccessible(
+            snapshot = snapshot,
+            targetPkgs = null,
+            useAutomation = false,
+            isBackground = false,
+        )
+
+        // Not marked as success (useAutomation=false so no automation ran either)
+        result.succesful shouldNotContain junk.identifier
+    }
+
+    @Test
+    fun `null cache query does not exclude target`() = runTest {
+        val junk = createAppJunk("com.example.app", cacheSize = 50000)
+        val snapshot = createSnapshot(junk)
+
+        // determineCache returns null (query failed)
+        coEvery { inaccessibleCacheProvider.determineCache(any()) } returns null
+
+        val result = deleter.deleteInaccessible(
+            snapshot = snapshot,
+            targetPkgs = null,
+            useAutomation = false,
+            isBackground = false,
+        )
+
+        // Not marked as success — would proceed to automation if enabled
+        result.succesful shouldNotContain junk.identifier
+    }
+
+    @Test
+    fun `bookkeeping cleanup removes failed entry when later successful`() = runTest {
+        val junk1 = createAppJunk("com.example.cleared", cacheSize = 50000)
+        val junk2 = createAppJunk("com.example.failed", cacheSize = 80000)
+        val snapshot = createSnapshot(junk1, junk2)
+
+        // Enable ADB path so we can create a "failed" entry from trimCaches
+        every { adbManager.useAdb } returns flowOf(true)
+        coEvery { pkgOps.trimCaches(any()) } throws RuntimeException("trimCaches failed")
+
+        // But pre-automation revalidation finds junk1's cache is now zero
+        coEvery { inaccessibleCacheProvider.determineCache(junk1.pkg) } returns InaccessibleCache(
+            identifier = junk1.identifier,
+            isSystemApp = false,
+            itemCount = 0,
+            totalSize = 0L,
+            publicSize = 0L,
+            theoreticalPaths = emptySet(),
+        )
+        coEvery { inaccessibleCacheProvider.determineCache(junk2.pkg) } returns InaccessibleCache(
+            identifier = junk2.identifier,
+            isSystemApp = false,
+            itemCount = 1,
+            totalSize = 80000,
+            publicSize = 0L,
+            theoreticalPaths = emptySet(),
+        )
+
+        val result = deleter.deleteInaccessible(
+            snapshot = snapshot,
+            targetPkgs = null,
+            useAutomation = false,
+            isBackground = false,
+        )
+
+        // junk1 was marked failed by trimCaches, but revalidation found it's now zero
+        // Bookkeeping cleanup should remove it from failed
+        result.succesful shouldContain junk1.identifier
+        result.failed shouldNotContainKey junk1.identifier
+
+        // junk2 stays as failed (trimCaches failed, cache still non-zero)
+        result.failed shouldContainKey junk2.identifier
+    }
+
+    @Test
+    fun `multiple targets - only zero cache targets are excluded`() = runTest {
+        val junkZero = createAppJunk("com.example.empty", cacheSize = 100000)
+        val junkNonZero = createAppJunk("com.example.full", cacheSize = 200000)
+        val junkNull = createAppJunk("com.example.unknown", cacheSize = 50000)
+        val snapshot = createSnapshot(junkZero, junkNonZero, junkNull)
+
+        coEvery { inaccessibleCacheProvider.determineCache(junkZero.pkg) } returns InaccessibleCache(
+            identifier = junkZero.identifier,
+            isSystemApp = false,
+            itemCount = 0,
+            totalSize = 0L,
+            publicSize = 0L,
+            theoreticalPaths = emptySet(),
+        )
+        coEvery { inaccessibleCacheProvider.determineCache(junkNonZero.pkg) } returns InaccessibleCache(
+            identifier = junkNonZero.identifier,
+            isSystemApp = false,
+            itemCount = 1,
+            totalSize = 150000,
+            publicSize = 0L,
+            theoreticalPaths = emptySet(),
+        )
+        coEvery { inaccessibleCacheProvider.determineCache(junkNull.pkg) } returns null
+
+        val result = deleter.deleteInaccessible(
+            snapshot = snapshot,
+            targetPkgs = null,
+            useAutomation = false,
+            isBackground = false,
+        )
+
+        result.succesful shouldContain junkZero.identifier
+        result.succesful shouldNotContain junkNonZero.identifier
+        result.succesful shouldNotContain junkNull.identifier
+        result.succesful.size shouldBe 1
+    }
+}


### PR DESCRIPTION
## What changed

Fixed an issue where AppCleaner automation would spend up to 20 seconds per app trying to clear cache on apps that already had zero cache, causing unnecessary delays and timeout errors during one-click cleaning.

## Technical Context

- **Root cause**: `trimCaches(Long.MAX_VALUE)` clears system app caches too (observed on Android 16 Pixel), but `InaccessibleDeleter` only observed non-system apps for size changes. System apps with stale non-zero sizes were sent to accessibility automation, which timed out because the "Clear cache" button is disabled/collapsed when cache is 0.
- Three fixes applied to `InaccessibleDeleter`:
  1. **System app re-check after trimCaches**: queries system app cache sizes after the non-system observation completes; marks apps with decreased sizes as already cleared
  2. **Pre-automation revalidation**: before sending any remaining targets to automation, re-queries each app's cache and filters out those with `totalSize == 0` — catches all paths including targeted runs that skip the ADB trim path
  3. **Result bookkeeping cleanup**: removes entries from the failed set if they were later marked successful (pre-existing issue, now more important with the revalidation path)
- Diagnosed from a support debug log: Pixel 8, Android 16, v1.6.4-rc0 — 4 system apps (`systemui`, `weather`, `dialer`, `intentresolver`) timed out consistently across two cleaning runs
