### PR TITLE
General: Replace string-based setup qualifiers with type-safe annotation

### DIFF
--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/AutomationService.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/AutomationService.kt
@@ -62,7 +62,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import java.util.UUID
 import javax.inject.Inject
-import javax.inject.Named
+import eu.darken.sdmse.setup.SetupBinding
 import kotlin.coroutines.resume
 
 @Keep
@@ -78,7 +78,7 @@ class AutomationService : AccessibilityService(), AutomationHost, AutomationServ
 
     @Inject lateinit var generalSettings: GeneralSettings
     @Inject lateinit var automationManager: AutomationManager
-    @Inject @Named("automation") lateinit var automationSetupModule: SetupModule
+    @Inject @SetupBinding(SetupModule.Type.AUTOMATION) lateinit var automationSetupModule: SetupModule
     @Inject lateinit var screenState: ScreenState
 
     private lateinit var windowManager: WindowManager

--- a/app-common-setup/src/main/java/eu/darken/sdmse/setup/SetupBinding.kt
+++ b/app-common-setup/src/main/java/eu/darken/sdmse/setup/SetupBinding.kt
@@ -1,0 +1,14 @@
+package eu.darken.sdmse.setup
+
+import javax.inject.Qualifier
+
+@Qualifier
+@MustBeDocumented
+@Target(
+    AnnotationTarget.FIELD,
+    AnnotationTarget.VALUE_PARAMETER,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY_GETTER,
+)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class SetupBinding(val type: SetupModule.Type)

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/Analyzer.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/Analyzer.kt
@@ -57,7 +57,7 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.minutes
-import javax.inject.Named
+import eu.darken.sdmse.setup.SetupBinding
 import javax.inject.Provider
 import javax.inject.Singleton
 
@@ -67,7 +67,7 @@ class Analyzer @Inject constructor(
     private val deviceScanner: Provider<DeviceStorageScanner>,
     private val storageScanner: Provider<StorageScanner>,
     private val gatewaySwitch: GatewaySwitch,
-    @Named("inventory") private val appInventorySetupModule: SetupModule,
+    @SetupBinding(SetupModule.Type.INVENTORY) private val appInventorySetupModule: SetupModule,
     private val mediaStoreTool: MediaStoreTool,
     private val spaceTracker: SpaceTracker,
 ) : SDMTool, Progress.Client {

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/device/DeviceStorageScanner.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/device/DeviceStorageScanner.kt
@@ -17,14 +17,14 @@ import eu.darken.sdmse.common.storage.StorageManager2
 import eu.darken.sdmse.common.storage.StorageStatsManager2
 import eu.darken.sdmse.setup.SetupModule
 import eu.darken.sdmse.setup.isComplete
-import javax.inject.Named
+import eu.darken.sdmse.setup.SetupBinding
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import java.util.UUID
 import javax.inject.Inject
 
 class DeviceStorageScanner @Inject constructor(
-    @Named("storage") private val storageSetupModule: SetupModule,
+    @SetupBinding(SetupModule.Type.STORAGE) private val storageSetupModule: SetupModule,
     private val environment: StorageEnvironment,
     private val storageManager2: StorageManager2,
     private val storageStatsmanager: StorageStatsManager2,

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/StorageScanner.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/StorageScanner.kt
@@ -44,7 +44,7 @@ import eu.darken.sdmse.common.user.UserHandle2
 import eu.darken.sdmse.common.user.UserManager2
 import eu.darken.sdmse.setup.SetupModule
 import eu.darken.sdmse.setup.isComplete
-import javax.inject.Named
+import eu.darken.sdmse.setup.SetupBinding
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import javax.inject.Inject
@@ -60,8 +60,8 @@ class StorageScanner @Inject constructor(
     private val fileForensics: FileForensics,
     private val dataAreaManager: DataAreaManager,
     private val appScannerFactory: AppStorageScanner.Factory,
-    @Named("inventory") private val inventorySetupModule: SetupModule,
-    @Named("usagestats") private val usageStatsSetupModule: SetupModule,
+    @SetupBinding(SetupModule.Type.INVENTORY) private val inventorySetupModule: SetupModule,
+    @SetupBinding(SetupModule.Type.USAGE_STATS) private val usageStatsSetupModule: SetupModule,
 ) : Progress.Host, Progress.Client {
 
     private val progressPub = MutableStateFlow<Progress.Data?>(

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
@@ -55,7 +55,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
-import javax.inject.Named
+import eu.darken.sdmse.setup.SetupBinding
 import javax.inject.Provider
 import javax.inject.Singleton
 
@@ -68,12 +68,12 @@ class AppCleaner @Inject constructor(
     private val exclusionManager: ExclusionManager,
     private val gatewaySwitch: GatewaySwitch,
     private val pkgOps: PkgOps,
-    @Named("usagestats") usageStatsSetupModule: SetupModule,
+    @SetupBinding(SetupModule.Type.USAGE_STATS) usageStatsSetupModule: SetupModule,
     rootManager: RootManager,
     adbManager: AdbManager,
     private val shellOps: ShellOps,
     private val filterFactories: Set<@JvmSuppressWildcards ExpendablesFilter.Factory>,
-    @Named("inventory") private val appInventorySetupModule: SetupModule,
+    @SetupBinding(SetupModule.Type.INVENTORY) private val appInventorySetupModule: SetupModule,
 ) : SDMTool, Progress.Client {
 
     override val sharedResource = SharedResource.createKeepAlive(TAG, appScope)

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleter.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleter.kt
@@ -48,7 +48,7 @@ import kotlinx.coroutines.flow.timeout
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.isActive
 import javax.inject.Inject
-import javax.inject.Named
+import eu.darken.sdmse.setup.SetupBinding
 import kotlin.time.Duration.Companion.seconds
 
 
@@ -61,7 +61,7 @@ class InaccessibleDeleter @Inject constructor(
     private val inaccessibleCacheProvider: InaccessibleCacheProvider,
     private val rootManager: RootManager,
     private val settings: AppCleanerSettings,
-    @Named("automation") private val automationSetupModule: SetupModule,
+    @SetupBinding(SetupModule.Type.AUTOMATION) private val automationSetupModule: SetupModule,
 ) : Progress.Host, Progress.Client {
 
     private val progressPub = MutableStateFlow<Progress.Data?>(

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/AppControl.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/AppControl.kt
@@ -46,7 +46,7 @@ import eu.darken.sdmse.common.user.UserManager2
 import eu.darken.sdmse.main.core.SDMTool
 import eu.darken.sdmse.setup.IncompleteSetupException
 import eu.darken.sdmse.setup.SetupModule
-import javax.inject.Named
+import eu.darken.sdmse.setup.SetupBinding
 import eu.darken.sdmse.setup.isComplete
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
@@ -73,12 +73,12 @@ class AppControl @Inject constructor(
     private val archiver: Archiver,
     private val restorer: Restorer,
     private val archiveSupport: ArchiveSupport,
-    @Named("usagestats") usageStatsSetupModule: SetupModule,
-    @Named("storage") storageSetupModule: SetupModule,
+    @SetupBinding(SetupModule.Type.USAGE_STATS) usageStatsSetupModule: SetupModule,
+    @SetupBinding(SetupModule.Type.STORAGE) storageSetupModule: SetupModule,
     rootManager: RootManager,
     adbManager: AdbManager,
     private val appExporterProvider: Provider<AppExporter>,
-    @Named("inventory") private val appInventorySetupModule: SetupModule,
+    @SetupBinding(SetupModule.Type.INVENTORY) private val appInventorySetupModule: SetupModule,
     automationManager: AutomationSubmitter,
     private val appScan: AppScan,
 ) : SDMTool, Progress.Client {

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/archive/Archiver.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/archive/Archiver.kt
@@ -25,7 +25,7 @@ import eu.darken.sdmse.common.shell.ShellOps
 import eu.darken.sdmse.common.shell.ipc.ShellOpsCmd
 import eu.darken.sdmse.common.user.UserManager2
 import eu.darken.sdmse.setup.SetupModule
-import javax.inject.Named
+import eu.darken.sdmse.setup.SetupBinding
 import eu.darken.sdmse.setup.isComplete
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.currentCoroutineContext
@@ -47,7 +47,7 @@ class Archiver @Inject constructor(
     private val userManager2: UserManager2,
     private val archiveSupport: ArchiveSupport,
     private val automation: AutomationSubmitter,
-    @Named("automation") private val automationSetupModule: SetupModule,
+    @SetupBinding(SetupModule.Type.AUTOMATION) private val automationSetupModule: SetupModule,
 ) : HasSharedResource<Any> {
 
     override val sharedResource = SharedResource.createKeepAlive(TAG, appScope + dispatcherProvider.IO)

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/forcestop/ForceStopper.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/forcestop/ForceStopper.kt
@@ -28,7 +28,7 @@ import eu.darken.sdmse.common.sharedresource.HasSharedResource
 import eu.darken.sdmse.common.sharedresource.SharedResource
 import eu.darken.sdmse.common.sharedresource.adoptChildResource
 import eu.darken.sdmse.setup.SetupModule
-import javax.inject.Named
+import eu.darken.sdmse.setup.SetupBinding
 import eu.darken.sdmse.setup.isComplete
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
@@ -44,7 +44,7 @@ class ForceStopper @Inject constructor(
     private val automation: AutomationSubmitter,
     private val adbManager: AdbManager,
     private val rootManager: RootManager,
-    @Named("automation") private val automationSetupModule: SetupModule,
+    @SetupBinding(SetupModule.Type.AUTOMATION) private val automationSetupModule: SetupModule,
 ) : HasSharedResource<Any>, Progress.Host, Progress.Client {
 
     private val progressPub = MutableStateFlow<Progress.Data?>(

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/restore/Restorer.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/restore/Restorer.kt
@@ -24,7 +24,7 @@ import eu.darken.sdmse.common.sharedresource.HasSharedResource
 import eu.darken.sdmse.common.sharedresource.SharedResource
 import eu.darken.sdmse.common.user.UserManager2
 import eu.darken.sdmse.setup.SetupModule
-import javax.inject.Named
+import eu.darken.sdmse.setup.SetupBinding
 import eu.darken.sdmse.setup.isComplete
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.currentCoroutineContext
@@ -42,7 +42,7 @@ class Restorer @Inject constructor(
     private val pkgRepo: PkgRepo,
     private val userManager2: UserManager2,
     private val automation: AutomationSubmitter,
-    @Named("automation") private val automationSetupModule: SetupModule,
+    @SetupBinding(SetupModule.Type.AUTOMATION) private val automationSetupModule: SetupModule,
     private val unarchiveManager: UnarchiveManager,
     private val rootManager: RootManager,
     private val adbManager: AdbManager,

--- a/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/CorpseFinder.kt
+++ b/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/CorpseFinder.kt
@@ -48,7 +48,8 @@ import eu.darken.sdmse.exclusion.core.types.PathExclusion
 import eu.darken.sdmse.exclusion.core.types.match
 import eu.darken.sdmse.main.core.SDMTool
 import eu.darken.sdmse.setup.SetupHeartbeat
-import javax.inject.Named
+import eu.darken.sdmse.setup.SetupBinding
+import eu.darken.sdmse.setup.SetupModule
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
@@ -71,7 +72,7 @@ class CorpseFinder @Inject constructor(
     private val watcherNotifications: WatcherNotifications,
     rootManager: RootManager,
     settings: CorpseFinderSettings,
-    @Named("inventory") private val inventorySetupCheck: SetupHeartbeat,
+    @SetupBinding(SetupModule.Type.INVENTORY) private val inventorySetupCheck: SetupHeartbeat,
 ) : SDMTool, Progress.Client {
 
     override val type: SDMTool.Type = SDMTool.Type.CORPSEFINDER

--- a/app/src/main/java/eu/darken/sdmse/setup/SetupHeartbeatModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/SetupHeartbeatModule.kt
@@ -5,14 +5,14 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import eu.darken.sdmse.setup.inventory.InventorySetupModule
-import javax.inject.Named
+import eu.darken.sdmse.setup.SetupBinding
 
 @Module
 @InstallIn(SingletonComponent::class)
 object SetupHeartbeatModule {
 
     @Provides
-    @Named("inventory")
+    @SetupBinding(SetupModule.Type.INVENTORY)
     fun inventoryHeartbeat(module: InventorySetupModule): SetupHeartbeat = SetupHeartbeat {
         if (!module.isComplete()) {
             throw IncompleteSetupException(SetupModule.Type.INVENTORY)

--- a/app/src/main/java/eu/darken/sdmse/setup/automation/AutomationSetupModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/automation/AutomationSetupModule.kt
@@ -30,7 +30,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import java.time.Instant
 import javax.inject.Inject
-import javax.inject.Named
+import eu.darken.sdmse.setup.SetupBinding
 import javax.inject.Singleton
 
 @Singleton
@@ -160,7 +160,7 @@ class AutomationSetupModule @Inject constructor(
     @Module @InstallIn(SingletonComponent::class)
     abstract class DIM {
         @Binds @IntoSet abstract fun mod(mod: AutomationSetupModule): SetupModule
-        @Binds @Named("automation") abstract fun named(mod: AutomationSetupModule): SetupModule
+        @Binds @SetupBinding(SetupModule.Type.AUTOMATION) abstract fun named(mod: AutomationSetupModule): SetupModule
     }
 
     companion object {

--- a/app/src/main/java/eu/darken/sdmse/setup/inventory/InventorySetupModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/inventory/InventorySetupModule.kt
@@ -29,7 +29,7 @@ import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.onStart
 import java.time.Instant
 import javax.inject.Inject
-import javax.inject.Named
+import eu.darken.sdmse.setup.SetupBinding
 import javax.inject.Singleton
 
 @Singleton
@@ -112,7 +112,7 @@ class InventorySetupModule @Inject constructor(
     @Module @InstallIn(SingletonComponent::class)
     abstract class DIM {
         @Binds @IntoSet abstract fun mod(mod: InventorySetupModule): SetupModule
-        @Binds @Named("inventory") abstract fun named(mod: InventorySetupModule): SetupModule
+        @Binds @SetupBinding(SetupModule.Type.INVENTORY) abstract fun named(mod: InventorySetupModule): SetupModule
     }
 
     companion object {

--- a/app/src/main/java/eu/darken/sdmse/setup/storage/StorageSetupModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/storage/StorageSetupModule.kt
@@ -30,7 +30,7 @@ import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.onStart
 import java.time.Instant
 import javax.inject.Inject
-import javax.inject.Named
+import eu.darken.sdmse.setup.SetupBinding
 import javax.inject.Singleton
 
 @Singleton
@@ -134,7 +134,7 @@ class StorageSetupModule @Inject constructor(
     @Module @InstallIn(SingletonComponent::class)
     abstract class DIM {
         @Binds @IntoSet abstract fun mod(mod: StorageSetupModule): SetupModule
-        @Binds @Named("storage") abstract fun named(mod: StorageSetupModule): SetupModule
+        @Binds @SetupBinding(SetupModule.Type.STORAGE) abstract fun named(mod: StorageSetupModule): SetupModule
     }
 
     companion object {

--- a/app/src/main/java/eu/darken/sdmse/setup/usagestats/UsageStatsSetupModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/usagestats/UsageStatsSetupModule.kt
@@ -21,7 +21,7 @@ import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.onStart
 import java.time.Instant
 import javax.inject.Inject
-import javax.inject.Named
+import eu.darken.sdmse.setup.SetupBinding
 import javax.inject.Singleton
 
 @Singleton
@@ -75,7 +75,7 @@ class UsageStatsSetupModule @Inject constructor(
     @Module @InstallIn(SingletonComponent::class)
     abstract class DIM {
         @Binds @IntoSet abstract fun mod(mod: UsageStatsSetupModule): SetupModule
-        @Binds @Named("usagestats") abstract fun named(mod: UsageStatsSetupModule): SetupModule
+        @Binds @SetupBinding(SetupModule.Type.USAGE_STATS) abstract fun named(mod: UsageStatsSetupModule): SetupModule
     }
 
     companion object {


### PR DESCRIPTION
## What changed

No user-facing behavior change. Internal dependency injection qualifiers for setup modules are now type-safe.

## Technical Context

- The 4 setup module DI bindings (`automation`, `inventory`, `storage`, `usagestats`) used `@Named("string")` qualifiers — a typo in the string would silently break injection at runtime
- Replaced with a single `@SetupBinding(SetupModule.Type.X)` annotation backed by the existing `SetupModule.Type` enum, turning qualifier mismatches into compile-time errors
- No new annotation class needed when adding future setup types — just use the existing enum
- 17 files touched across 7 modules; purely mechanical replacement with no behavioral change
