### PR TITLE
General: Reduce log noise for cross-profile packages

### DIFF
--- a/app-common-pkgs/src/main/java/eu/darken/sdmse/common/pkgs/sources/ShellLookUpPkgsSource.kt
+++ b/app-common-pkgs/src/main/java/eu/darken/sdmse/common/pkgs/sources/ShellLookUpPkgsSource.kt
@@ -81,7 +81,13 @@ class ShellLookUpPkgsSource @Inject constructor(
 
                 log(TAG) { "Potentially hidden pkg: $pkgName" }
 
-                val sourcePath = LocalPath.build(match.groupValues[1])
+                val rawPath = match.groupValues[1]
+                if (rawPath == "null") {
+                    log(TAG, VERBOSE) { "No APK path for $pkgName (cross-profile)" }
+                    return@mapNotNull null
+                }
+
+                val sourcePath = LocalPath.build(rawPath)
                 log(TAG, VERBOSE) { "Reading archive $sourcePath" }
                 val apkInfo = pkgOps.viewArchive(sourcePath)
 


### PR DESCRIPTION
## What changed

Reduced unnecessary warning logs during package scanning on devices with multiple user profiles (Private space, Island, work profiles).

## Technical Context

- `pm list packages` returns `package:null=<pkg>` for packages in other user profiles where the APK path is inaccessible from the querying context
- Previously, this constructed a LocalPath from the literal string "null", called `viewArchive()` (which returned null), and logged a WARN per package on every scan — dozens of warnings on multi-profile devices
- Now detects the "null" path early and skips with a VERBOSE log, avoiding the unnecessary `viewArchive()` call and WARN noise
