### PR TITLE
AppCleaner: Fix automation failing on devices with Compose-based Settings

### DIFF
--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/common/ACSNodeInfo.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/common/ACSNodeInfo.kt
@@ -39,6 +39,7 @@ interface ACSNodeInfo {
         const val ACTION_CLICK = AccessibilityNodeInfo.ACTION_CLICK
         const val ACTION_SELECT = AccessibilityNodeInfo.ACTION_SELECT
         const val ACTION_SCROLL_FORWARD = AccessibilityNodeInfo.ACTION_SCROLL_FORWARD
+        const val ACTION_SCROLL_BACKWARD = AccessibilityNodeInfo.ACTION_SCROLL_BACKWARD
         const val ACTION_FOCUS = AccessibilityNodeInfo.ACTION_FOCUS
         const val ACTION_ACCESSIBILITY_FOCUS = AccessibilityNodeInfo.ACTION_ACCESSIBILITY_FOCUS
 

--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/common/ACSNodeInfoExtensions.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/common/ACSNodeInfoExtensions.kt
@@ -128,9 +128,21 @@ fun ACSNodeInfo.scrollNode(): Boolean {
         return false
     }
 
-    log(TAG, VERBOSE) { "scrollNode(): Scrolling node: $this" }
-    return performAction(ACSNodeInfo.ACTION_SCROLL_FORWARD).also {
-        log(TAG, VERBOSE) { "scrollNode(): Successfully scrolled: $this" }
+    log(TAG, VERBOSE) { "scrollNode(): Scrolling forward: $this" }
+    return performAction(ACSNodeInfo.ACTION_SCROLL_FORWARD).also { success ->
+        log(TAG, VERBOSE) { "scrollNode(): Forward scroll success=$success: $this" }
+    }
+}
+
+fun ACSNodeInfo.scrollNodeBackward(): Boolean {
+    if (!isScrollable) {
+        log(TAG, WARN) { "scrollNodeBackward(): Not scrollable: $this" }
+        return false
+    }
+
+    log(TAG, VERBOSE) { "scrollNodeBackward(): Scrolling backward: $this" }
+    return performAction(ACSNodeInfo.ACTION_SCROLL_BACKWARD).also { success ->
+        log(TAG, VERBOSE) { "scrollNodeBackward(): Backward scroll success=$success: $this" }
     }
 }
 

--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/common/stepper/AutomationStep.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/common/stepper/AutomationStep.kt
@@ -15,7 +15,7 @@ data class AutomationStep(
     val windowCheck: (suspend StepContext.() -> ACSNodeInfo)? = null,
     val nodeRecovery: (suspend StepContext.(ACSNodeInfo) -> Boolean)? = null,
     val nodeAction: (suspend StepContext.() -> Boolean)? = null,
-    val timeout: Duration = 30.seconds, // Inner attempt timeout is 10s, queryStatsForPkg timeout is 20s
+    val timeout: Duration = 40.seconds, // Inner attempt timeout is 15s, executionTimeout is 30s
 ) {
     override fun toString(): String = "Step(source=$source, description=$descriptionInternal)"
 }

--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/common/stepper/Stepper.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/common/stepper/Stepper.kt
@@ -77,7 +77,7 @@ class Stepper @Inject constructor(
                         stepAttempts = stepAttempts++,
                     )
                     try {
-                        withTimeout(10.seconds) {
+                        withTimeout(15.seconds) {
                             val stepTime = measureTimeMillis {
                                 doProcess(stepContext, step)
                             }

--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/specs/AutomationSpec.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/specs/AutomationSpec.kt
@@ -6,7 +6,7 @@ sealed interface AutomationSpec {
     val tag: String
     interface Explorer : AutomationSpec {
         val executionTimeout: Duration
-            get() = Duration.ofSeconds(20)
+            get() = Duration.ofSeconds(30)
 
         val executionRetryCount: Int
             get() = 3

--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/specs/SpecGeneratorExtensions.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/specs/SpecGeneratorExtensions.kt
@@ -12,9 +12,11 @@ import eu.darken.sdmse.automation.core.common.ACSNodeInfo
 import eu.darken.sdmse.automation.core.common.crawl
 import eu.darken.sdmse.automation.core.common.pkgId
 import eu.darken.sdmse.automation.core.common.scrollNode
+import eu.darken.sdmse.automation.core.common.scrollNodeBackward
 import eu.darken.sdmse.automation.core.common.stepper.StepContext
 import eu.darken.sdmse.automation.core.common.stepper.clickNormal
 import eu.darken.sdmse.automation.core.common.stepper.findClickableParent
+import eu.darken.sdmse.automation.core.common.textContainsAny
 import eu.darken.sdmse.automation.core.common.textMatchesAny
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
@@ -175,27 +177,51 @@ fun SpecGenerator.defaultFindAndClick(
     clickNormal(isDryRun = isDryRun, mapped)
 }
 
+private const val BUSY_NODE_MAX_LENGTH = 30
+
 fun SpecGenerator.defaultNodeRecovery(
-    pkg: Installed
-): suspend StepContext.(ACSNodeInfo) -> Boolean = { root ->
+    pkg: Installed,
+    extraBusyLabels: Collection<String> = emptySet(),
+): suspend StepContext.(ACSNodeInfo) -> Boolean = recovery@{ root ->
     log(tag) { "Performing node recovery for ${pkg.id}" }
-    val busyNode = root.crawl().firstOrNull { it.node.textMatchesAny(listOf("...", "…")) }
+
+    // Check for busy/loading indicators: "...", "…", or any text containing them (e.g. "Computing…")
+    val busyNode = root.crawl().firstOrNull { crawled ->
+        val text = crawled.node.text?.toString() ?: return@firstOrNull false
+        if (text.length > BUSY_NODE_MAX_LENGTH) return@firstOrNull false
+        crawled.node.textContainsAny(listOf("...", "…")) ||
+                (extraBusyLabels.isNotEmpty() && crawled.node.textMatchesAny(extraBusyLabels))
+    }
     if (busyNode != null) {
         log(tag, VERBOSE) { "Found a busy-node, attempting recovery via delay: $busyNode" }
         delay(1000)
         root.refresh()
-        true
-    } else {
-        var scrolled = false
-        root.crawl()
-            .filter { it.node.isScrollable }
-            .forEach {
-                val success = it.node.scrollNode()
-                if (success) {
-                    scrolled = true
-                    it.node.refresh()
-                }
-            }
-        scrolled
+        return@recovery true
     }
+
+    // Try scrolling forward first
+    var scrolled = false
+    val scrollableNodes = root.crawl().filter { it.node.isScrollable }.toList()
+
+    for (crawled in scrollableNodes) {
+        val success = crawled.node.scrollNode()
+        if (success) {
+            scrolled = true
+            crawled.node.refresh()
+        }
+    }
+
+    // If forward scroll failed (already at bottom), try scrolling backward
+    if (!scrolled) {
+        log(tag, VERBOSE) { "Forward scroll failed, trying backward scroll" }
+        for (crawled in scrollableNodes) {
+            val success = crawled.node.scrollNodeBackward()
+            if (success) {
+                scrolled = true
+                crawled.node.refresh()
+            }
+        }
+    }
+
+    scrolled
 }

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/StorageEntryFinder.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/StorageEntryFinder.kt
@@ -161,10 +161,11 @@ class StorageEntryFinder @Inject constructor(
 
         val storageFilter: (ACSNodeInfo) -> Int? = when {
             hasApiLevel(33) -> storageFilter@{ node ->
-                if (!node.isTextView()) return@storageFilter null
                 when {
+                    // Label match: prefer TextViews but also accept other node types (Compose)
                     node.textMatchesAny(labels) -> 0
-                    matchStorage(node) -> 1
+                    // Size match: only on TextViews to avoid false positives
+                    node.isTextView() && matchStorage(node) -> 1
                     else -> null
                 }
             }

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPLabels.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPLabels.kt
@@ -27,6 +27,9 @@ class AOSPLabels @Inject constructor(
         else -> labels14Plus.getStorageEntryStatic(acsContext)
     }
 
+    fun getComputingSizeDynamic(acsContext: AutomationExplorer.Context): Set<String> =
+        labels29Plus.getComputingSizeDynamic(acsContext)
+
     fun getClearCacheDynamic(acsContext: AutomationExplorer.Context): Set<String> = when {
         hasApiLevel(29) -> labels29Plus.getClearCacheDynamic(acsContext)
         else -> labels14Plus.getClearCacheDynamic(acsContext)

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPLabels29Plus.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPLabels29Plus.kt
@@ -132,6 +132,10 @@ class AOSPLabels29Plus @Inject constructor(
         .append { aospLabels14Plus.getStorageEntryStatic(acsContext) }
         .toSet()
 
+    fun getComputingSizeDynamic(
+        acsContext: AutomationExplorer.Context,
+    ): Set<String> = acsContext.getStrings(SETTINGS_PKG, setOf("computing_size"))
+
     fun getClearCacheDynamic(acsContext: AutomationExplorer.Context): Set<String> =
         aospLabels14Plus.getClearCacheDynamic(acsContext)
 

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecs.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecs.kt
@@ -468,6 +468,9 @@ class AOSPSpecs @Inject constructor(
                 aospLabels.getStorageEntryDynamic(this) + aospLabels.getStorageEntryStatic(this)
             log(TAG) { "storageEntryLabels=${storageEntryLabels.toVisualStrings()}" }
 
+            val computingLabels = aospLabels.getComputingSizeDynamic(this)
+            log(TAG) { "computingLabels=${computingLabels.toVisualStrings()}" }
+
             val storageFinder = storageEntryFinder.storageFinderAOSP(storageEntryLabels, pkg)
 
             val step = AutomationStep(
@@ -476,7 +479,7 @@ class AOSPSpecs @Inject constructor(
                 label = R.string.appcleaner_automation_progress_find_storage.toCaString(storageEntryLabels),
                 windowLaunch = windowLauncherDefaultSettings(pkg),
                 windowCheck = windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg),
-                nodeRecovery = defaultNodeRecovery(pkg),
+                nodeRecovery = defaultNodeRecovery(pkg, extraBusyLabels = computingLabels),
                 nodeAction = defaultFindAndClick(finder = storageFinder),
             )
             stepper.withProgress(this) { process(this@plan, step) }

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecsTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecsTest.kt
@@ -48,6 +48,7 @@ class AOSPSpecsTest : BaseAppCleanerSpecTest<AOSPSpecs, AOSPLabels>() {
     override fun mockLabelDefaults() {
         every { labels.getStorageEntryDynamic(any()) } returns emptySet()
         every { labels.getStorageEntryStatic(any()) } returns setOf("Storage")
+        every { labels.getComputingSizeDynamic(any()) } returns emptySet()
         every { labels.getClearCacheDynamic(any()) } returns emptySet()
         every { labels.getClearCacheStatic(any()) } returns setOf("Clear cache")
     }

--- a/app/src/test/java/eu/darken/sdmse/automation/core/common/AccessibilityNodeExtensionsTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/automation/core/common/AccessibilityNodeExtensionsTest.kt
@@ -435,6 +435,47 @@ class AccessibilityNodeExtensionsTest : BaseTest() {
         nonScrollableNode.performedActions.shouldBeEmpty()
     }
 
+    // Tests for scrollNodeBackward()
+    @Test
+    fun `scrollNodeBackward performs backward scroll on scrollable node`() {
+        val scrollableNode = TestACSNodeInfo(isScrollable = true)
+
+        val result = scrollableNode.scrollNodeBackward()
+
+        result shouldBe true
+        scrollableNode.performedActions shouldContain ACSNodeInfo.ACTION_SCROLL_BACKWARD
+    }
+
+    @Test
+    fun `scrollNodeBackward returns false for non-scrollable node`() {
+        val nonScrollableNode = TestACSNodeInfo(isScrollable = false)
+
+        val result = nonScrollableNode.scrollNodeBackward()
+
+        result shouldBe false
+        nonScrollableNode.performedActions.shouldBeEmpty()
+    }
+
+    @Test
+    fun `scrollNodeBackward returns false when performAction fails`() {
+        val scrollableNode = TestACSNodeInfo(isScrollable = true, performActionResult = false)
+
+        val result = scrollableNode.scrollNodeBackward()
+
+        result shouldBe false
+        scrollableNode.performedActions shouldContain ACSNodeInfo.ACTION_SCROLL_BACKWARD
+    }
+
+    @Test
+    fun `scrollNode returns false when performAction fails`() {
+        val scrollableNode = TestACSNodeInfo(isScrollable = true, performActionResult = false)
+
+        val result = scrollableNode.scrollNode()
+
+        result shouldBe false
+        scrollableNode.performedActions shouldContain ACSNodeInfo.ACTION_SCROLL_FORWARD
+    }
+
     // Tests for AccessibilityEvent.pkgId extension
     @Test
     fun `pkgId returns valid package ID when package name is set`() {

--- a/app/src/test/java/eu/darken/sdmse/automation/core/specs/DefaultNodeRecoveryTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/automation/core/specs/DefaultNodeRecoveryTest.kt
@@ -1,0 +1,237 @@
+package eu.darken.sdmse.automation.core.specs
+
+import eu.darken.sdmse.automation.core.common.ACSNodeInfo
+import eu.darken.sdmse.automation.core.common.stepper.StepContext
+import eu.darken.sdmse.common.pkgs.features.Installed
+import eu.darken.sdmse.common.pkgs.toPkgId
+import eu.darken.sdmse.common.progress.Progress
+import eu.darken.sdmse.common.user.UserHandle2
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.TestACSNodeInfo
+import testhelpers.automation.TestAutomationHost
+
+class DefaultNodeRecoveryTest : BaseTest() {
+
+    private val testSpec = object : SpecGenerator {
+        override val tag: String = "TestSpec"
+        override suspend fun isResponsible(pkg: Installed): Boolean = true
+    }
+
+    private lateinit var testPkg: Installed
+    private lateinit var testHost: TestAutomationHost
+    private lateinit var stepContext: StepContext
+
+    @BeforeEach
+    fun setup() {
+        testPkg = mockk {
+            every { id } returns "test.pkg".toPkgId()
+            every { packageName } returns "test.pkg"
+            every { installId } returns mockk {
+                every { pkgId } returns "test.pkg".toPkgId()
+                every { userHandle } returns mockk<UserHandle2> { every { handleId } returns 0 }
+            }
+        }
+
+        testHost = TestAutomationHost(kotlinx.coroutines.test.TestScope())
+
+        val testContext = object : AutomationExplorer.Context {
+            override val host get() = testHost
+            override val progress: Flow<Progress.Data?> = emptyFlow()
+            override fun updateProgress(update: (Progress.Data?) -> Progress.Data?) {}
+        }
+
+        stepContext = StepContext(
+            hostContext = testContext,
+            tag = "test",
+            stepAttempts = 0,
+        )
+    }
+
+    // ============================================================
+    // Busy-node detection with textContainsAny
+    // ============================================================
+
+    @Test
+    fun `busy-node detected for exact ellipsis text`() = runTest {
+        val busyNode = TestACSNodeInfo(text = "…")
+        val root = TestACSNodeInfo().addChild(busyNode)
+
+        val recovery = testSpec.defaultNodeRecovery(testPkg)
+        val result = recovery.invoke(stepContext, root)
+
+        result shouldBe true
+    }
+
+    @Test
+    fun `busy-node detected for exact three dots text`() = runTest {
+        val busyNode = TestACSNodeInfo(text = "...")
+        val root = TestACSNodeInfo().addChild(busyNode)
+
+        val recovery = testSpec.defaultNodeRecovery(testPkg)
+        val result = recovery.invoke(stepContext, root)
+
+        result shouldBe true
+    }
+
+    @Test
+    fun `busy-node detected for Computing with ellipsis`() = runTest {
+        val busyNode = TestACSNodeInfo(text = "Computing\u2026")
+        val root = TestACSNodeInfo().addChild(busyNode)
+
+        val recovery = testSpec.defaultNodeRecovery(testPkg)
+        val result = recovery.invoke(stepContext, root)
+
+        result shouldBe true
+    }
+
+    @Test
+    fun `busy-node detected for localized computing text with ellipsis`() = runTest {
+        val busyNode = TestACSNodeInfo(text = "Berechnung\u2026")
+        val root = TestACSNodeInfo().addChild(busyNode)
+
+        val recovery = testSpec.defaultNodeRecovery(testPkg)
+        val result = recovery.invoke(stepContext, root)
+
+        result shouldBe true
+    }
+
+    @Test
+    fun `busy-node not detected for long text containing ellipsis`() = runTest {
+        val longText = "This is a very long description that happens to contain\u2026"
+        val node = TestACSNodeInfo(text = longText)
+        val scrollable = TestACSNodeInfo(isScrollable = true)
+        val root = TestACSNodeInfo().addChildren(node, scrollable)
+
+        val recovery = testSpec.defaultNodeRecovery(testPkg)
+        val result = recovery.invoke(stepContext, root)
+
+        // Should NOT trigger busy-node (text > 30 chars), should scroll instead
+        result shouldBe true
+        scrollable.performedActions shouldContain ACSNodeInfo.ACTION_SCROLL_FORWARD
+    }
+
+    @Test
+    fun `busy-node not detected for text without ellipsis`() = runTest {
+        val node = TestACSNodeInfo(text = "Storage & cache")
+        val scrollable = TestACSNodeInfo(isScrollable = true)
+        val root = TestACSNodeInfo().addChildren(node, scrollable)
+
+        val recovery = testSpec.defaultNodeRecovery(testPkg)
+        val result = recovery.invoke(stepContext, root)
+
+        // Should scroll, not delay
+        result shouldBe true
+        scrollable.performedActions shouldContain ACSNodeInfo.ACTION_SCROLL_FORWARD
+    }
+
+    // ============================================================
+    // Extra busy labels
+    // ============================================================
+
+    @Test
+    fun `extraBusyLabels matches exact localized computing text`() = runTest {
+        val busyNode = TestACSNodeInfo(text = "Berechnung\u2026")
+        val root = TestACSNodeInfo().addChild(busyNode)
+
+        val recovery = testSpec.defaultNodeRecovery(testPkg, extraBusyLabels = setOf("Berechnung\u2026"))
+        val result = recovery.invoke(stepContext, root)
+
+        result shouldBe true
+    }
+
+    @Test
+    fun `extraBusyLabels does not match unrelated text`() = runTest {
+        val node = TestACSNodeInfo(text = "Storage & cache")
+        val scrollable = TestACSNodeInfo(isScrollable = true)
+        val root = TestACSNodeInfo().addChildren(node, scrollable)
+
+        val recovery = testSpec.defaultNodeRecovery(testPkg, extraBusyLabels = setOf("Computing\u2026"))
+        val result = recovery.invoke(stepContext, root)
+
+        // Should scroll, not delay
+        scrollable.performedActions shouldContain ACSNodeInfo.ACTION_SCROLL_FORWARD
+    }
+
+    // ============================================================
+    // Scroll forward and backward
+    // ============================================================
+
+    @Test
+    fun `scrolls forward when no busy-node found`() = runTest {
+        val scrollable = TestACSNodeInfo(isScrollable = true)
+        val root = TestACSNodeInfo().addChild(scrollable)
+
+        val recovery = testSpec.defaultNodeRecovery(testPkg)
+        val result = recovery.invoke(stepContext, root)
+
+        result shouldBe true
+        scrollable.performedActions shouldContain ACSNodeInfo.ACTION_SCROLL_FORWARD
+        scrollable.performedActions shouldNotContain ACSNodeInfo.ACTION_SCROLL_BACKWARD
+    }
+
+    @Test
+    fun `scrolls backward when forward scroll fails`() = runTest {
+        // performActionResult=false means forward scroll will fail (at bottom of page)
+        // but backward should also fail since it uses same performActionResult
+        // We need a node that fails forward but succeeds backward
+        // TestACSNodeInfo doesn't support per-action results, so let's test the sequence:
+        // A node where performAction always returns false means both forward and backward fail
+        val scrollable = TestACSNodeInfo(isScrollable = true, performActionResult = false)
+        val root = TestACSNodeInfo().addChild(scrollable)
+
+        val recovery = testSpec.defaultNodeRecovery(testPkg)
+        val result = recovery.invoke(stepContext, root)
+
+        // Both forward and backward fail, so recovery returns false
+        result shouldBe false
+        scrollable.performedActions shouldContain ACSNodeInfo.ACTION_SCROLL_FORWARD
+        scrollable.performedActions shouldContain ACSNodeInfo.ACTION_SCROLL_BACKWARD
+    }
+
+    @Test
+    fun `does not scroll backward when forward scroll succeeds`() = runTest {
+        val scrollable = TestACSNodeInfo(isScrollable = true, performActionResult = true)
+        val root = TestACSNodeInfo().addChild(scrollable)
+
+        val recovery = testSpec.defaultNodeRecovery(testPkg)
+        val result = recovery.invoke(stepContext, root)
+
+        result shouldBe true
+        scrollable.performedActions shouldContain ACSNodeInfo.ACTION_SCROLL_FORWARD
+        scrollable.performedActions shouldNotContain ACSNodeInfo.ACTION_SCROLL_BACKWARD
+    }
+
+    @Test
+    fun `returns false when no scrollable nodes and no busy-nodes`() = runTest {
+        val textNode = TestACSNodeInfo(text = "Storage & cache")
+        val root = TestACSNodeInfo().addChild(textNode)
+
+        val recovery = testSpec.defaultNodeRecovery(testPkg)
+        val result = recovery.invoke(stepContext, root)
+
+        result shouldBe false
+    }
+
+    @Test
+    fun `busy-node null text does not crash`() = runTest {
+        val nullTextNode = TestACSNodeInfo(text = null)
+        val scrollable = TestACSNodeInfo(isScrollable = true)
+        val root = TestACSNodeInfo().addChildren(nullTextNode, scrollable)
+
+        val recovery = testSpec.defaultNodeRecovery(testPkg)
+        val result = recovery.invoke(stepContext, root)
+
+        result shouldBe true
+        scrollable.performedActions shouldContain ACSNodeInfo.ACTION_SCROLL_FORWARD
+    }
+}


### PR DESCRIPTION
## What changed

Fixed AppCleaner automation failing on devices where the Settings app uses Jetpack Compose (e.g. Motorola devices on Android 14). The "Storage & cache" entry would never be found, causing every app to time out with an automation compatibility error.

## Technical Context

- **Root cause**: On Compose-based Settings apps, the "Storage & cache" row loads asynchronously — a "Computing..." placeholder appears while storage size is calculated. The entry is absent from the accessibility tree until the query completes. The automation would scroll past its position before it loaded, and recovery only scrolled forward (down), never back up — so the entry was permanently missed.
- **Defense in depth**: Five complementary fixes rather than one fragile change:
  1. Busy-node detection switched from exact-match to contains-match with a 30-char length cap (catches "Computing..." in any locale)
  2. Dynamic label lookup for `computing_size` from the Settings APK (locale-aware, same pattern as existing storage/clear-cache label lookups)
  3. Bidirectional scroll recovery — scrolls backward when forward fails (at bottom of page)
  4. Relaxed `isTextView()` filter on API 33+ so label matching works even if Compose renders non-TextView nodes
  5. Increased automation timeouts (execution 20s->30s, inner step 10s->15s)
- **Non-obvious side effect**: The timeout increases and bidirectional scroll apply to all automation specs, not just AOSP. This is intentional — other Compose-based Settings apps will benefit. On devices where entries load immediately, there is no behavioral change (backward scroll only triggers when forward fails at bottom of page).
- **Review guidance**: The `defaultNodeRecovery` rewrite in `SpecGeneratorExtensions.kt` is the core change. The `extraBusyLabels` parameter is only used by AOSP specs currently but is available for other ROM specs if needed.

Closes #2377
