### PR TITLE
General: Update app translations from Crowdin

### DIFF
--- a/app-common-stats/src/main/res/values-af-rZA/strings.xml
+++ b/app-common-stats/src/main/res/values-af-rZA/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">Primêre berging</string>
     <string name="stats_storage_type_secondary">Sekondêre berging</string>
     <string name="stats_storage_type_portable">Draagbare berging</string>
+    <string name="stats_space_history_delete_storage_title">Stoorgeskiedenis verwyder?</string>
+    <string name="stats_space_history_delete_storage_desc">Alle trenddata vir hierdie stoor sal permanent verwyder word.</string>
     <string name="stats_settings_retention_snapshots_label">Bergingskietkiekies</string>
     <string name="stats_settings_retention_snapshots_desc">Aantal dae om bergingspasie-kietkiekies te bewaar.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-am/strings.xml
+++ b/app-common-stats/src/main/res/values-am/strings.xml
@@ -44,4 +44,8 @@
     <string name="stats_storage_type_primary">ዋና ማጠራቀሚያ</string>
     <string name="stats_storage_type_secondary">ሁለተኛ ማጠራቀሚያ</string>
     <string name="stats_storage_type_portable">ተለዋወጂች ማጠራቀሚያ</string>
+    <string name="stats_space_history_delete_storage_title">የማስቀመጫ ታሪክ ይሰርዝ?</string>
+    <string name="stats_space_history_delete_storage_desc">ለዚህ ማስቀመጫ ያሉ ሁሉም የዝንባሌ ውሂቦች በቋሚነት ይሰረዛሉ።</string>
+    <string name="stats_settings_retention_snapshots_label">የማስቀመጫ ቅጽበታዊ ገጽ እይታዎች</string>
+    <string name="stats_settings_retention_snapshots_desc">የማስቀመጫ ቦታ ቅጽበታዊ ገጽ እይታዎችን ለማቆየት የቀናት ብዛት።</string>
 </resources>

--- a/app-common-stats/src/main/res/values-ar/strings.xml
+++ b/app-common-stats/src/main/res/values-ar/strings.xml
@@ -56,6 +56,8 @@
     <string name="stats_storage_type_primary">التخزين الأساسي</string>
     <string name="stats_storage_type_secondary">التخزين الثانوي</string>
     <string name="stats_storage_type_portable">وحدة تخزين محمولة</string>
+    <string name="stats_space_history_delete_storage_title">حذف سجل التخزين؟</string>
+    <string name="stats_space_history_delete_storage_desc">ستُحذف جميع بيانات الاتجاه لهذا التخزين نهائياً.</string>
     <string name="stats_settings_retention_snapshots_label">لقطات التخزين</string>
     <string name="stats_settings_retention_snapshots_desc">عدد الأيام للاحتفاظ بلقطات مساحة التخزين.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-az/strings.xml
+++ b/app-common-stats/src/main/res/values-az/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">Əsas yaddaş</string>
     <string name="stats_storage_type_secondary">İkinci yaddaş</string>
     <string name="stats_storage_type_portable">Taşınan yaddaş</string>
+    <string name="stats_space_history_delete_storage_title">Yaddaş tarixçəsi silinsin?</string>
+    <string name="stats_space_history_delete_storage_desc">Bu yaddaş üçün bütün trend məlumatları həmişəlik silinəcək.</string>
     <string name="stats_settings_retention_snapshots_label">Yaddaş anlıq görüntüləri</string>
     <string name="stats_settings_retention_snapshots_desc">Yaddaş məkan anlıq görüntülərini saxlamaq üçün günlərin sayı.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-be/strings.xml
+++ b/app-common-stats/src/main/res/values-be/strings.xml
@@ -50,6 +50,8 @@
     <string name="stats_storage_type_primary">Асноўнае сховішча</string>
     <string name="stats_storage_type_secondary">Дадатковае сховішча</string>
     <string name="stats_storage_type_portable">Партатыўнае сховішча</string>
+    <string name="stats_space_history_delete_storage_title">Выдаліць гісторыю сховішча?</string>
+    <string name="stats_space_history_delete_storage_desc">Усе трэндавыя даныя для гэтага сховішча будуць назаўжды выдалены.</string>
     <string name="stats_settings_retention_snapshots_label">Здымкі сховішча</string>
     <string name="stats_settings_retention_snapshots_desc">Колькасць дзён для захавання здымкаў прасторы сховішча.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-bg/strings.xml
+++ b/app-common-stats/src/main/res/values-bg/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">Основно хранилище</string>
     <string name="stats_storage_type_secondary">Вторично хранилище</string>
     <string name="stats_storage_type_portable">Преносимо хранилище</string>
+    <string name="stats_space_history_delete_storage_title">Изтриване на историята на хранилището?</string>
+    <string name="stats_space_history_delete_storage_desc">Всички данни за тенденции за това хранилище ще бъдат премахнато изтрити.</string>
     <string name="stats_settings_retention_snapshots_label">Снимки на хранилището</string>
     <string name="stats_settings_retention_snapshots_desc">Брой дни за съхранение на снимки на пространството за съхранение.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-bn-rBD/strings.xml
+++ b/app-common-stats/src/main/res/values-bn-rBD/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">প্রাথমিক স্টোরেজ</string>
     <string name="stats_storage_type_secondary">সেকেন্ডারি স্টোরেজ</string>
     <string name="stats_storage_type_portable">পোর্টেবল স্টোরেজ</string>
+    <string name="stats_space_history_delete_storage_title">স্টোরেজ ইতিহাস মুছবেন?</string>
+    <string name="stats_space_history_delete_storage_desc">এই স্টোরেজের সমস্ত ট্রেন্ড ডেটা স্থায়ীভাবে মুছে ফেলা হবে।</string>
     <string name="stats_settings_retention_snapshots_label">স্টোরেজ স্ন্যাপশট</string>
     <string name="stats_settings_retention_snapshots_desc">স্টোরেজ স্পেস স্ন্যাপশট রাখার দিনের সংখ্যা।</string>
 </resources>

--- a/app-common-stats/src/main/res/values-ca/strings.xml
+++ b/app-common-stats/src/main/res/values-ca/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">Emmagatzematge primari</string>
     <string name="stats_storage_type_secondary">Emmagatzematge secundari</string>
     <string name="stats_storage_type_portable">Emmagatzematge portàtil</string>
+    <string name="stats_space_history_delete_storage_title">Voleu suprimir l\'historial d\'emmagatzematge?</string>
+    <string name="stats_space_history_delete_storage_desc">Totes les dades de tendències d\'aquest emmagatzematge s\'eliminaran permanentment.</string>
     <string name="stats_settings_retention_snapshots_label">Instantànies d’emmagatzematge</string>
     <string name="stats_settings_retention_snapshots_desc">Nombre de dies per conservar les instantànies de l’espai d’emmagatzematge.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-ckb-rIR/strings.xml
+++ b/app-common-stats/src/main/res/values-ckb-rIR/strings.xml
@@ -9,16 +9,20 @@
         <item quantity="other">%s مادە پرۆسەسکراوە لەو کاتەی SD Maid بانی کردیت بۆ ئامێرەکەت.</item>
     </plurals>
     <string name="stats_report_status_success">سەرکەوتن</string>
-    <string name="stats_report_status_partial_success">بەشی سەرکەوتن</string>
+    <string name="stats_report_status_partial_success">بەشیکیی کەمتری</string>
     <string name="stats_report_status_partial_failure">شکست</string>
     <string name="stats_settings_desc">ئامارەکان، ڕاپۆرتەکان و پاراستنی داتای SD Maid ڕێکبخە.</string>
     <string name="stats_settings_retention_category">پاراستن</string>
+    <string name="stats_settings_retention_reports_label">ڕۆکاری «ڕۆکاری»</string>
+    <string name="stats_settings_retention_reports_desc">ژمارەی ڕۆژەی بەشیو سیلەدانیی SD Maid کەوت بێتبێتهێنرەوە.</string>
     <string name="stats_settings_retention_paths_label">زانیاری وردی ڕێگا</string>
     <string name="stats_settings_retention_paths_desc">ژمارەی ڕۆژەکان بۆ پاراستنی وردەکاری دەربارەی ڕێگاکانی کاریگەری SD Maid.</string>
     <plurals name="stats_settings_retention_x_days">
         <item quantity="one">%d ڕۆژ</item>
         <item quantity="other">%d ڕۆژ</item>
     </plurals>
+    <string name="stats_settings_reset_all_label">هەموی رێکخستنەوە</string>
+    <string name="stats_settings_reset_all_desc">هەموی ڕۆکارییکان بستبە و هەموی ئامارەکان بڮەڕێنەوە بە سیفر.</string>
     <string name="stats_affected_paths_label">ڕێگاکانی کاریگەرکراو</string>
     <string name="stats_affected_pkgs_label">ئەپەکانی کاریگەرکراو</string>
     <string name="stats_dash_body_snapshots_only">شوێنکەوتنی مێژووی ئەنبارەکەت.</string>
@@ -40,6 +44,8 @@
     <string name="stats_storage_type_primary">ئەنبارێکی سەرەکی</string>
     <string name="stats_storage_type_secondary">ئەنبارێکی دووەم</string>
     <string name="stats_storage_type_portable">ئەنبارێکی گواستانەپێز</string>
+    <string name="stats_space_history_delete_storage_title">مێژەکەی مێژێنەی حەزداری بستبەیتەوە؟</string>
+    <string name="stats_space_history_delete_storage_desc">هەموی داتای ڕووخانێ بۆ ئەم حەزدارییکە بە شێوەیەکی هەمیشەیی سماچ دەبیت.</string>
     <string name="stats_settings_retention_snapshots_label">سناپشێتی ئەنبار</string>
     <string name="stats_settings_retention_snapshots_desc">ژمارەی ڕۆژەکان بۆ چاودانی سناپشیتی ئەنباری سطحی.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-cs/strings.xml
+++ b/app-common-stats/src/main/res/values-cs/strings.xml
@@ -50,6 +50,8 @@
     <string name="stats_storage_type_primary">Primární úložiště</string>
     <string name="stats_storage_type_secondary">Sekundární úložiště</string>
     <string name="stats_storage_type_portable">Přenosné úložiště</string>
+    <string name="stats_space_history_delete_storage_title">Smazat historii úložiště?</string>
+    <string name="stats_space_history_delete_storage_desc">Všechna data trendů pro toto úložiště budou trvale smazána.</string>
     <string name="stats_settings_retention_snapshots_label">Snímky úložiště</string>
     <string name="stats_settings_retention_snapshots_desc">Počet dní pro uchování snímků úložného prostoru.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-da/strings.xml
+++ b/app-common-stats/src/main/res/values-da/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">Primær lager</string>
     <string name="stats_storage_type_secondary">Sekundær lager</string>
     <string name="stats_storage_type_portable">Flytbart lager</string>
+    <string name="stats_space_history_delete_storage_title">Slet lagerhistorik?</string>
+    <string name="stats_space_history_delete_storage_desc">Alle trenddata for dette lager vil blive slettet permanent.</string>
     <string name="stats_settings_retention_snapshots_label">Lager-snapshots</string>
     <string name="stats_settings_retention_snapshots_desc">Antal dage der skal beholdes lagerpladssnapshots.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-de/strings.xml
+++ b/app-common-stats/src/main/res/values-de/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">Primärspeicher</string>
     <string name="stats_storage_type_secondary">Sekundärspeicher</string>
     <string name="stats_storage_type_portable">Tragbarer Speicher</string>
+    <string name="stats_space_history_delete_storage_title">Speicherverlauf löschen?</string>
+    <string name="stats_space_history_delete_storage_desc">Alle Verlaufsdaten für diesen Speicher werden dauerhaft gelöscht.</string>
     <string name="stats_settings_retention_snapshots_label">Speicher-Snapshots</string>
     <string name="stats_settings_retention_snapshots_desc">Anzahl der Tage, für die Speicherplatz-Snapshots aufbewahrt werden.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-el/strings.xml
+++ b/app-common-stats/src/main/res/values-el/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">Πρωτεύων αποθηκευτικός χώρος</string>
     <string name="stats_storage_type_secondary">Δευτερεύων αποθηκευτικός χώρος</string>
     <string name="stats_storage_type_portable">Φορητός αποθηκευτικός χώρος</string>
+    <string name="stats_space_history_delete_storage_title">Διαγραφή ιστορικού αποθήκευσης;</string>
+    <string name="stats_space_history_delete_storage_desc">Όλα τα δεδομένα τάσης για αυτήν την αποθήκευση θα διαγραφούν οριστικά.</string>
     <string name="stats_settings_retention_snapshots_label">Στιγμιότυπα αποθηκευτικού χώρου</string>
     <string name="stats_settings_retention_snapshots_desc">Αριθμός ημερών διατήρησης στιγμιότυπων χώρου αποθήκευσης.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-es-rAR/strings.xml
+++ b/app-common-stats/src/main/res/values-es-rAR/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">Almacenamiento Primario</string>
     <string name="stats_storage_type_secondary">Almacenamiento Secundario</string>
     <string name="stats_storage_type_portable">Almacenamiento portátil</string>
+    <string name="stats_space_history_delete_storage_title">¿Eliminar historial de almacenamiento?</string>
+    <string name="stats_space_history_delete_storage_desc">Todos los datos de tendencia para este almacenamiento se eliminarán de forma permanente.</string>
     <string name="stats_settings_retention_snapshots_label">Instantáneas de almacenamiento</string>
     <string name="stats_settings_retention_snapshots_desc">Número de días para conservar las instantáneas del espacio de almacenamiento.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-es-rMX/strings.xml
+++ b/app-common-stats/src/main/res/values-es-rMX/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">Almacenamiento principal</string>
     <string name="stats_storage_type_secondary">Almacenamiento secundario</string>
     <string name="stats_storage_type_portable">Almacenamiento portátil</string>
+    <string name="stats_space_history_delete_storage_title">¿Eliminar historial de almacenamiento?</string>
+    <string name="stats_space_history_delete_storage_desc">Todos los datos de tendencias de este almacenamiento se eliminarán permanentemente.</string>
     <string name="stats_settings_retention_snapshots_label">Instantáneas de almacenamiento</string>
     <string name="stats_settings_retention_snapshots_desc">Número de días para conservar las instantáneas del espacio de almacenamiento.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-es/strings.xml
+++ b/app-common-stats/src/main/res/values-es/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">Almacenamiento principal</string>
     <string name="stats_storage_type_secondary">Almacenamiento secundario</string>
     <string name="stats_storage_type_portable">Almacenamiento portátil</string>
+    <string name="stats_space_history_delete_storage_title">¿Eliminar historial de almacenamiento?</string>
+    <string name="stats_space_history_delete_storage_desc">Todos los datos de tendencia de este almacenamiento se eliminarán de forma permanente.</string>
     <string name="stats_settings_retention_snapshots_label">Instantáneas de almacenamiento</string>
     <string name="stats_settings_retention_snapshots_desc">Número de días para conservar las instantáneas del espacio de almacenamiento.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-et-rEE/strings.xml
+++ b/app-common-stats/src/main/res/values-et-rEE/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">Peamine hoiustamisruum</string>
     <string name="stats_storage_type_secondary">Teisejärguline hoiustamisruum</string>
     <string name="stats_storage_type_portable">Kaasaskantav hoiustamisruum</string>
+    <string name="stats_space_history_delete_storage_title">Kustuta salvestusruumi ajalugu?</string>
+    <string name="stats_space_history_delete_storage_desc">Kõik selle salvestusruumi trendiandmed kustutatakse jäädavalt.</string>
     <string name="stats_settings_retention_snapshots_label">Hoiustamisruumi kuvatõmmised</string>
     <string name="stats_settings_retention_snapshots_desc">Päevade arv, kui kaua säilitada hoiustamisruumi kuvatõmmiseid.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-eu-rES/strings.xml
+++ b/app-common-stats/src/main/res/values-eu-rES/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">Lehen mailako biltegiratzea</string>
     <string name="stats_storage_type_secondary">Bigarren mailako biltegiratzea</string>
     <string name="stats_storage_type_portable">Biltegiratze eramangarria</string>
+    <string name="stats_space_history_delete_storage_title">Biltegiratze-historia ezabatu?</string>
+    <string name="stats_space_history_delete_storage_desc">Biltegiratze honetarako joera-datu guztiak betirako ezabatuko dira.</string>
     <string name="stats_settings_retention_snapshots_label">Biltegiratze argazkiak</string>
     <string name="stats_settings_retention_snapshots_desc">Biltegiratze-espazioaren argazkiak gordetzeko egun kopurua.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-fa/strings.xml
+++ b/app-common-stats/src/main/res/values-fa/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">حافظه اصلی</string>
     <string name="stats_storage_type_secondary">حافظه ثانویه</string>
     <string name="stats_storage_type_portable">فضای ذخیره‌سازی قابل‌حمل</string>
+    <string name="stats_space_history_delete_storage_title">تاریخچه فضای ذخیره‌سازی حذف شود؟</string>
+    <string name="stats_space_history_delete_storage_desc">تمام داده‌های روند این فضای ذخیره‌سازی به طور دائمی حذف خواهند شد.</string>
     <string name="stats_settings_retention_snapshots_label">عکس‌برداری‌های ذخیره‌سازی</string>
     <string name="stats_settings_retention_snapshots_desc">تعداد روزهای نگهداشت عکس‌برداری‌های فضای ذخیره‌سازی.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-fi/strings.xml
+++ b/app-common-stats/src/main/res/values-fi/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">Sisäinen tallennustila</string>
     <string name="stats_storage_type_secondary">Ulkoinen tallennustila</string>
     <string name="stats_storage_type_portable">Siirrettävä tallennustila</string>
+    <string name="stats_space_history_delete_storage_title">Poistetaanko tallennustilan historia?</string>
+    <string name="stats_space_history_delete_storage_desc">Kaikki tämän tallennustilan trenditiedot poistetaan pysyvästi.</string>
     <string name="stats_settings_retention_snapshots_label">Tallennustilan tilannekuvat</string>
     <string name="stats_settings_retention_snapshots_desc">Kuinka monta päivää tallennustilan tilannekuvat säilytetään.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-fil/strings.xml
+++ b/app-common-stats/src/main/res/values-fil/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">Pangunahing imbakan</string>
     <string name="stats_storage_type_secondary">Pangalawang imbakan</string>
     <string name="stats_storage_type_portable">Portable na imbakan</string>
+    <string name="stats_space_history_delete_storage_title">Burahin ang kasaysayan ng storage?</string>
+    <string name="stats_space_history_delete_storage_desc">Lahat ng trend data para sa storage na ito ay permanenteng mabubura.</string>
     <string name="stats_settings_retention_snapshots_label">Mga snapshot ng imbakan</string>
     <string name="stats_settings_retention_snapshots_desc">Bilang ng mga araw na itatago ang mga snapshot ng espasyo ng imbakan.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-fr/strings.xml
+++ b/app-common-stats/src/main/res/values-fr/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">Mémoire principale</string>
     <string name="stats_storage_type_secondary">Mémoire secondaire</string>
     <string name="stats_storage_type_portable">Unité de stockage amovible</string>
+    <string name="stats_space_history_delete_storage_title">Supprimer l’historique de stockage ?</string>
+    <string name="stats_space_history_delete_storage_desc">Toutes les données de tendance pour ce stockage seront définitivement supprimées.</string>
     <string name="stats_settings_retention_snapshots_label">Instantanés de stockage</string>
     <string name="stats_settings_retention_snapshots_desc">Nombre de jours de conservation des instantanés d’espace de stockage.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-gl-rES/strings.xml
+++ b/app-common-stats/src/main/res/values-gl-rES/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">Almacenamento principal</string>
     <string name="stats_storage_type_secondary">Almacenamento secundario</string>
     <string name="stats_storage_type_portable">Almacenamento portátil</string>
+    <string name="stats_space_history_delete_storage_title">Eliminar historial de almacenamento?</string>
+    <string name="stats_space_history_delete_storage_desc">Todos os datos de tendencia deste almacenamento eliminaránse de forma permanente.</string>
     <string name="stats_settings_retention_snapshots_label">Instantáneas de almacenamento</string>
     <string name="stats_settings_retention_snapshots_desc">Número de días para conservar as instantáneas do espazo de almacenamento.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-hi-rIN/strings.xml
+++ b/app-common-stats/src/main/res/values-hi-rIN/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">प्रारंभिक संग्रहण</string>
     <string name="stats_storage_type_secondary">माध्यमिक संग्रहण</string>
     <string name="stats_storage_type_portable">पोर्टेबल संग्रहण</string>
+    <string name="stats_space_history_delete_storage_title">स्टोरेज इतिहास हटाएं?</string>
+    <string name="stats_space_history_delete_storage_desc">इस स्टोरेज के लिए सभी ट्रेंड डेटा स्थायी रूप से हटा दिया जाएगा।</string>
     <string name="stats_settings_retention_snapshots_label">संग्रहण स्नैपशॉट</string>
     <string name="stats_settings_retention_snapshots_desc">संग्रहण स्थान स्नैपशॉट रखने के दिनों की संख्या।</string>
 </resources>

--- a/app-common-stats/src/main/res/values-hr/strings.xml
+++ b/app-common-stats/src/main/res/values-hr/strings.xml
@@ -47,6 +47,8 @@
     <string name="stats_storage_type_primary">Primarna pohrana</string>
     <string name="stats_storage_type_secondary">Sekundarna pohrana</string>
     <string name="stats_storage_type_portable">Prijenosna pohrana</string>
+    <string name="stats_space_history_delete_storage_title">Izbrisati povijest pohrane?</string>
+    <string name="stats_space_history_delete_storage_desc">Svi podaci o trendovima za ovu pohranu bit će trajno izbrisani.</string>
     <string name="stats_settings_retention_snapshots_label">Snimke pohrane</string>
     <string name="stats_settings_retention_snapshots_desc">Broj dana za čuvanje snimki prostora za pohranu.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-hu/strings.xml
+++ b/app-common-stats/src/main/res/values-hu/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">Elsődleges tároló</string>
     <string name="stats_storage_type_secondary">Másodlagos tároló</string>
     <string name="stats_storage_type_portable">Hordozható tárhely</string>
+    <string name="stats_space_history_delete_storage_title">Tárhelyelőzmények törlése?</string>
+    <string name="stats_space_history_delete_storage_desc">Az ehhez a tárhellyhez tartozó összes trendaldat véglegesen törlődik.</string>
     <string name="stats_settings_retention_snapshots_label">Tárhelyképek</string>
     <string name="stats_settings_retention_snapshots_desc">A tárhelyképek megőrzési napjainak száma.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-in/strings.xml
+++ b/app-common-stats/src/main/res/values-in/strings.xml
@@ -41,6 +41,8 @@
     <string name="stats_storage_type_primary">Penyimpanan utama</string>
     <string name="stats_storage_type_secondary">Penyimpanan cadangan</string>
     <string name="stats_storage_type_portable">Penyimpanan portabel</string>
+    <string name="stats_space_history_delete_storage_title">Hapus riwayat penyimpanan?</string>
+    <string name="stats_space_history_delete_storage_desc">Semua data tren untuk penyimpanan ini akan dihapus secara permanen.</string>
     <string name="stats_settings_retention_snapshots_label">Snapshot penyimpanan</string>
     <string name="stats_settings_retention_snapshots_desc">Jumlah hari untuk menyimpan snapshot ruang penyimpanan.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-is/strings.xml
+++ b/app-common-stats/src/main/res/values-is/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">Aðalgeymsla</string>
     <string name="stats_storage_type_secondary">Aukaleg geymsla</string>
     <string name="stats_storage_type_portable">Flætanleg geymsla</string>
+    <string name="stats_space_history_delete_storage_title">Eyða geymslusögu?</string>
+    <string name="stats_space_history_delete_storage_desc">Öll þróunargögn fyrir þessa geymslu verða eytt varanlega.</string>
     <string name="stats_settings_retention_snapshots_label">Geymslu-skyndimyndir</string>
     <string name="stats_settings_retention_snapshots_desc">Fjöldi daga til að geyma skyndimyndir af geymsluplassi.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-it/strings.xml
+++ b/app-common-stats/src/main/res/values-it/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">Archivio principale</string>
     <string name="stats_storage_type_secondary">Archivio secondario</string>
     <string name="stats_storage_type_portable">Archiviazione portatile</string>
+    <string name="stats_space_history_delete_storage_title">Eliminare la cronologia di archiviazione?</string>
+    <string name="stats_space_history_delete_storage_desc">Tutti i dati di tendenza per questa archiviazione verranno eliminati definitivamente.</string>
     <string name="stats_settings_retention_snapshots_label">Istantanee dello spazio di archiviazione</string>
     <string name="stats_settings_retention_snapshots_desc">Numero di giorni per mantenere le istantanee dello spazio di archiviazione.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-iw/strings.xml
+++ b/app-common-stats/src/main/res/values-iw/strings.xml
@@ -50,6 +50,8 @@
     <string name="stats_storage_type_primary">אחסון ראשי</string>
     <string name="stats_storage_type_secondary">אחסון משני</string>
     <string name="stats_storage_type_portable">אחסון נייד</string>
+    <string name="stats_space_history_delete_storage_title">למחוק היסטוריית אחסון?</string>
+    <string name="stats_space_history_delete_storage_desc">כל נתוני המגמה עבור אחסון זה יימחקו לצמיתות.</string>
     <string name="stats_settings_retention_snapshots_label">תמונות מצב של אחסון</string>
     <string name="stats_settings_retention_snapshots_desc">מספר ימים לשמירת תמונות מצב של שטח האחסון.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-ja/strings.xml
+++ b/app-common-stats/src/main/res/values-ja/strings.xml
@@ -41,6 +41,8 @@
     <string name="stats_storage_type_primary">プライマリストレージ</string>
     <string name="stats_storage_type_secondary">セカンダリストレージ</string>
     <string name="stats_storage_type_portable">ポータブルストレージ</string>
+    <string name="stats_space_history_delete_storage_title">ストレージ履歴を削除しますか？</string>
+    <string name="stats_space_history_delete_storage_desc">このストレージのすべてのトレンドデータが完全に削除されます。</string>
     <string name="stats_settings_retention_snapshots_label">ストレージスナップショット</string>
     <string name="stats_settings_retention_snapshots_desc">ストレージスペースのスナップショットを保持する日数。</string>
 </resources>

--- a/app-common-stats/src/main/res/values-ka-rGE/strings.xml
+++ b/app-common-stats/src/main/res/values-ka-rGE/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">ძირითადი მეხსიერება</string>
     <string name="stats_storage_type_secondary">მეორადი მეხსიერება</string>
     <string name="stats_storage_type_portable">პორტატული მეხსიერება</string>
+    <string name="stats_space_history_delete_storage_title">წაიშალოს საცავის ისტორია?</string>
+    <string name="stats_space_history_delete_storage_desc">ამ საცავის ყველა ტენდენციის მონაცემი სამუდამოდ წაიშლება.</string>
     <string name="stats_settings_retention_snapshots_label">მეხსიერების სნეფშოტები</string>
     <string name="stats_settings_retention_snapshots_desc">დღეების რაოდენობა მეხსიერების სივრცის სნეფშოტების შესანახად.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-kaa/strings.xml
+++ b/app-common-stats/src/main/res/values-kaa/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">Тийкарғы сақлау орны</string>
     <string name="stats_storage_type_secondary">Қосымша сақлау орны</string>
     <string name="stats_storage_type_portable">Алмаламалы сақлау орны</string>
+    <string name="stats_space_history_delete_storage_title">Сақлаў тарийхын өшириу?</string>
+    <string name="stats_space_history_delete_storage_desc">Бул сақлаўға байланыслы барлық трендлик мәліметлер мәңгилик өширилетуғын болады.</string>
     <string name="stats_settings_retention_snapshots_label">Сақлау орны снимоклары</string>
     <string name="stats_settings_retention_snapshots_desc">Сақлау орны снимокларын сақлаў күнлер саны.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-km-rKH/strings.xml
+++ b/app-common-stats/src/main/res/values-km-rKH/strings.xml
@@ -41,6 +41,8 @@
     <string name="stats_storage_type_primary">ឧបករណ៍ផ្ទុកចម្បង</string>
     <string name="stats_storage_type_secondary">ឧបករណ៍ផ្ទុកបន្ទាប់បន្សំ</string>
     <string name="stats_storage_type_portable">ឧបករណ៍ផ្ទុកចល័ត</string>
+    <string name="stats_space_history_delete_storage_title">លុប​ប្រវត្តិ​ឧបករណ៍​ផ្ទុក?</string>
+    <string name="stats_space_history_delete_storage_desc">ទិន្នន័យ​និន្នាការ​ទាំង​អស់​សម្រាប់​ឧបករណ៍​ផ្ទុក​នេះ​នឹង​ត្រូវ​បាន​លុប​ជា​អចិន្ត្រៃយ៍។</string>
     <string name="stats_settings_retention_snapshots_label">ថតអេក្រង់ផ្ទុក</string>
     <string name="stats_settings_retention_snapshots_desc">ចំនួនថ្ងៃដើម្បីរក្សាទុករូបថតទំហំផ្ទុក។</string>
 </resources>

--- a/app-common-stats/src/main/res/values-ko/strings.xml
+++ b/app-common-stats/src/main/res/values-ko/strings.xml
@@ -41,6 +41,8 @@
     <string name="stats_storage_type_primary">주 저장소</string>
     <string name="stats_storage_type_secondary">추가 저장소</string>
     <string name="stats_storage_type_portable">휴대용 저장소</string>
+    <string name="stats_space_history_delete_storage_title">저장소 기록을 삭제하시겠습니까?</string>
+    <string name="stats_space_history_delete_storage_desc">이 저장소의 모든 추세 데이터가 영구적으로 삭제됩니다.</string>
     <string name="stats_settings_retention_snapshots_label">저장공간 스냅샷</string>
     <string name="stats_settings_retention_snapshots_desc">저장공간 스냅샷을 보관할 일수입니다.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-lo-rLA/strings.xml
+++ b/app-common-stats/src/main/res/values-lo-rLA/strings.xml
@@ -41,6 +41,8 @@
     <string name="stats_storage_type_primary">ບ່ອນເກັບຂໍ້ມູນຫຼັກ</string>
     <string name="stats_storage_type_secondary">ບ່ອນເກັບຂໍ້ມູນສຳຮອງ</string>
     <string name="stats_storage_type_portable">ບ່ອນເກັບຂໍ້ມູນແບບພົກພາ</string>
+    <string name="stats_space_history_delete_storage_title">ລົບປະຫວັດການເກັບຮັກສາ?</string>
+    <string name="stats_space_history_delete_storage_desc">ຂໍ້ມູນທ່າອ່ຽງທັງໝົດສຳລັບການເກັບຮັກສານີ້ຈະຖືກລົບຖາວອນ.</string>
     <string name="stats_settings_retention_snapshots_label">ສະແນັບຊັອດການເກັບຂໍ້ມູນ</string>
     <string name="stats_settings_retention_snapshots_desc">ຈຳນວນວັນທີ່ຈະເກັບຮັກສາສະແນັບຊັອດພື້ນທີ່ເກັບຂໍ້ມູນ.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-lt/strings.xml
+++ b/app-common-stats/src/main/res/values-lt/strings.xml
@@ -50,6 +50,8 @@
     <string name="stats_storage_type_primary">Pagrindinė saugykla</string>
     <string name="stats_storage_type_secondary">Antrinė saugykla</string>
     <string name="stats_storage_type_portable">Nešiojama saugykla</string>
+    <string name="stats_space_history_delete_storage_title">Ištrinti saugyklos istoriją?</string>
+    <string name="stats_space_history_delete_storage_desc">Visi šios saugyklos tendencijų duomenys bus visam laikui ištrinti.</string>
     <string name="stats_settings_retention_snapshots_label">Saugyklos momentinės nuotraukos</string>
     <string name="stats_settings_retention_snapshots_desc">Dienų skaičius, kurį reikia saugoti saugyklos vietos momentines nuotraukas.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-lv/strings.xml
+++ b/app-common-stats/src/main/res/values-lv/strings.xml
@@ -47,6 +47,8 @@
     <string name="stats_storage_type_primary">Primārā krātuve</string>
     <string name="stats_storage_type_secondary">Sekundārā krātuve</string>
     <string name="stats_storage_type_portable">Pārnēsājamā krātuve</string>
+    <string name="stats_space_history_delete_storage_title">Dzēst krātuves vēsturi?</string>
+    <string name="stats_space_history_delete_storage_desc">Visi šīs krātuves tendences dati tiks neatgriezeniski dzēsti.</string>
     <string name="stats_settings_retention_snapshots_label">Krātuves momentuznēmumi</string>
     <string name="stats_settings_retention_snapshots_desc">Dienu skaits, cik ilgi saglabāt krātuves vietas momentuznēmumus.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-mk-rMK/strings.xml
+++ b/app-common-stats/src/main/res/values-mk-rMK/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">Примарно складиште</string>
     <string name="stats_storage_type_secondary">Секундарно складиште</string>
     <string name="stats_storage_type_portable">Преносливо складиште</string>
+    <string name="stats_space_history_delete_storage_title">Да се избрише историјата на складирање?</string>
+    <string name="stats_space_history_delete_storage_desc">Сите трендовски податоци за ова складирање ќе бидат трајно избришани.</string>
     <string name="stats_settings_retention_snapshots_label">Снимки на складиштето</string>
     <string name="stats_settings_retention_snapshots_desc">Број на денови за чување снимки на просторот за складирање.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-ml-rIN/strings.xml
+++ b/app-common-stats/src/main/res/values-ml-rIN/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">പ്രാഥമിക സ്റ്റോറേജ്</string>
     <string name="stats_storage_type_secondary">ദ്വിതീയ സ്റ്റോറേജ്</string>
     <string name="stats_storage_type_portable">പോർട്ടബിൾ സ്റ്റോറേജ്</string>
+    <string name="stats_space_history_delete_storage_title">സ്റ്റോറേജ് ചരിത്രം ഇല്ലാതാക്കണോ?</string>
+    <string name="stats_space_history_delete_storage_desc">ഈ സ്റ്റോറേജിനായുള്ള എല്ലാ ട്രെൻഡ് ഡേറ്റയും സ്ഥിരമായി ഇല്ലാതാക്കും.</string>
     <string name="stats_settings_retention_snapshots_label">സ്റ്റോറേജ് സ്നാപ്പ്ഷോട്ടുകൾ</string>
     <string name="stats_settings_retention_snapshots_desc">സ്റ്റോറേജ് സ്പേസ് സ്നാപ്പ്ഷോട്ടുകൾ സൂക്ഷിക്കേണ്ട ദിവസങ്ങളുടെ എണ്ണം.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-mn-rMN/strings.xml
+++ b/app-common-stats/src/main/res/values-mn-rMN/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">Үндсэн хадгалалт</string>
     <string name="stats_storage_type_secondary">Хоёрдогч хадгалалт</string>
     <string name="stats_storage_type_portable">Зөөврийн хадгалалт</string>
+    <string name="stats_space_history_delete_storage_title">Санах ойн түүхийг устгах уу?</string>
+    <string name="stats_space_history_delete_storage_desc">Энэ санах ойн бүх чиг хандлагын өгөгдөл бүрмөсөн устгагдана.</string>
     <string name="stats_settings_retention_snapshots_label">Хадгалалтын агшин зургууд</string>
     <string name="stats_settings_retention_snapshots_desc">Хадгалалтын зайн агшин зургуудыг хэдэн хоног хадгалах тоо.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-ms/strings.xml
+++ b/app-common-stats/src/main/res/values-ms/strings.xml
@@ -41,6 +41,8 @@
     <string name="stats_storage_type_primary">Storan utama</string>
     <string name="stats_storage_type_secondary">Storan sekunder</string>
     <string name="stats_storage_type_portable">Storan mudah alih</string>
+    <string name="stats_space_history_delete_storage_title">Padam sejarah storan?</string>
+    <string name="stats_space_history_delete_storage_desc">Semua data trend untuk storan ini akan dipadam secara kekal.</string>
     <string name="stats_settings_retention_snapshots_label">Syot kilat storan</string>
     <string name="stats_settings_retention_snapshots_desc">Bilangan hari untuk menyimpan syot kilat ruang storan.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-my-rMM/strings.xml
+++ b/app-common-stats/src/main/res/values-my-rMM/strings.xml
@@ -41,6 +41,8 @@
     <string name="stats_storage_type_primary">မူလသိုလှောင်မှု</string>
     <string name="stats_storage_type_secondary">ဒုတိယသိုလှောင်မှု</string>
     <string name="stats_storage_type_portable">လွယ်ကူစွာသယ်နိုင်သော သိုလှောင်မှု</string>
+    <string name="stats_space_history_delete_storage_title">သိုလှောင်မှု မှတ်တမ်းကို ဖျက်မလား?</string>
+    <string name="stats_space_history_delete_storage_desc">ဤသိုလှောင်မှုအတွက် ခေတ်ရေစီးကြောင်း ဒေတာအားလုံးကို အပြီးအပိုင် ဖျက်မည်။</string>
     <string name="stats_settings_retention_snapshots_label">သိုလှောင်မှု ဓာတ်ပုံရိုက်ချက်များ</string>
     <string name="stats_settings_retention_snapshots_desc">သိုလှောင်မှုနေရာ ဓာတ်ပုံရိုက်ချက်များကို သိမ်းဆည်းထားရမည့် ရက်အရေအတွက်။</string>
 </resources>

--- a/app-common-stats/src/main/res/values-nb/strings.xml
+++ b/app-common-stats/src/main/res/values-nb/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">Primærlagring</string>
     <string name="stats_storage_type_secondary">Sekundærlagring</string>
     <string name="stats_storage_type_portable">Bærbar lagring</string>
+    <string name="stats_space_history_delete_storage_title">Slett lagringshistorikk?</string>
+    <string name="stats_space_history_delete_storage_desc">Alle trenddata for dette lageret vil bli permanent slettet.</string>
     <string name="stats_settings_retention_snapshots_label">Lagringøyeblikksbilder</string>
     <string name="stats_settings_retention_snapshots_desc">Antall dager for å beholde øyeblikksbilder av lagringsplass.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-ne-rNP/strings.xml
+++ b/app-common-stats/src/main/res/values-ne-rNP/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">प्राथमिक भण्डारण</string>
     <string name="stats_storage_type_secondary">द्वितीयक भण्डारण</string>
     <string name="stats_storage_type_portable">पोर्टेबल भण्डारण</string>
+    <string name="stats_space_history_delete_storage_title">भण्डारण इतिहास मेटाउने?</string>
+    <string name="stats_space_history_delete_storage_desc">यस भण्डारणका सबै ट्रेन्ड डेटा स्थायी रूपमा मेटाइनेछ।</string>
     <string name="stats_settings_retention_snapshots_label">भण्डारण स्न्यापशटहरू</string>
     <string name="stats_settings_retention_snapshots_desc">भण्डारण स्थान स्न्यापशटहरू राख्ने दिनहरूको संख्या।</string>
 </resources>

--- a/app-common-stats/src/main/res/values-nl/strings.xml
+++ b/app-common-stats/src/main/res/values-nl/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">Primaire opslag</string>
     <string name="stats_storage_type_secondary">Secundaire opslag</string>
     <string name="stats_storage_type_portable">Draagbare opslag</string>
+    <string name="stats_space_history_delete_storage_title">Opslaggeschiedenis verwijderen?</string>
+    <string name="stats_space_history_delete_storage_desc">Alle trendgegevens voor deze opslag worden permanent verwijderd.</string>
     <string name="stats_settings_retention_snapshots_label">Opslagmomentopnames</string>
     <string name="stats_settings_retention_snapshots_desc">Aantal dagen om opslagruimte-momentopnames te bewaren.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-or-rIN/strings.xml
+++ b/app-common-stats/src/main/res/values-or-rIN/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">ପ୍ରାଥମିକ ଷ୍ଟୋରେଜ୍</string>
     <string name="stats_storage_type_secondary">ପରୋକ୍ଷ ଷ୍ଟୋରେଜ୍</string>
     <string name="stats_storage_type_portable">ପୋର୍ଟେବଲ୍ ଷ୍ଟୋରେଜ୍</string>
+    <string name="stats_space_history_delete_storage_title">ସଂଗ୍ରହ ଇତିହାସ ମୁଛିବେ?</string>
+    <string name="stats_space_history_delete_storage_desc">ଏହି ସଂଗ୍ରହ ପାଇଁ ସମସ୍ତ ଟ୍ରେଣ୍ଡ ତଥ୍ୟ ସ୍ଥାୟୀ ଭାବରେ ମୁଛି ଯିବ।</string>
     <string name="stats_settings_retention_snapshots_label">ଷ୍ଟୋରେଜ ସ୍ନାପସଟ</string>
     <string name="stats_settings_retention_snapshots_desc">ଷ୍ଟୋରେଜ ସ୍ପେସ ସ୍ନାପସଟ ରଖିବାର ଦିନ ସଂଖ୍ୟା।</string>
 </resources>

--- a/app-common-stats/src/main/res/values-pa-rIN/strings.xml
+++ b/app-common-stats/src/main/res/values-pa-rIN/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">ਮੁੱਖ ਸਟੋਰੇਜ</string>
     <string name="stats_storage_type_secondary">ਸੈਕੰਡਰੀ ਸਟੋਰੇਜ</string>
     <string name="stats_storage_type_portable">ਪੋਰਟੇਬਲ ਸਟੋਰੇਜ</string>
+    <string name="stats_space_history_delete_storage_title">ਸਟੋਰੇਜ ਇਤਿਹਾਸ ਮਿਟਾਓ?</string>
+    <string name="stats_space_history_delete_storage_desc">ਇਸ ਸਟੋਰੇਜ ਲਈ ਸਾਰਾ ਟ੍ਰੈਂਡ ਡੇਟਾ ਸਥਾਈ ਤੌਰ ਤੇ ਮਿਟਾ ਦਿੱਤਾ ਜਾਵੇਗਾ।</string>
     <string name="stats_settings_retention_snapshots_label">ਸਟੋਰੇਜ ਸਨੈਪਸ਼ਾਟ</string>
     <string name="stats_settings_retention_snapshots_desc">ਸਟੋਰੇਜ ਸਪੇਸ ਸਨੈਪਸ਼ਾਟ ਰੱਖਣ ਲਈ ਦਿਨਾਂ ਦੀ ਸੰਖਿਆ੍</string>
 </resources>

--- a/app-common-stats/src/main/res/values-pl/strings.xml
+++ b/app-common-stats/src/main/res/values-pl/strings.xml
@@ -7,10 +7,10 @@
         <item quantity="other">Zwolniono %s.</item>
     </plurals>
     <plurals name="stats_dash_body_count">
-        <item quantity="one">%s przetworzony element od momentu zaproszenia SD Maid do twojego urządzenia.</item>
-        <item quantity="few">%s przetworzone elementy od momentu zaproszenia SD Maid do twojego urządzenia.</item>
-        <item quantity="many">%s przetworzonych elementów od momentu zaproszenia SD Maid do twojego urządzenia.</item>
-        <item quantity="other">%s przetworzonych elementów od momentu zaproszenia SD Maid do twojego urządzenia.</item>
+        <item quantity="one">Przetworzono %s element od momentu zaproszenia SD Maid do twojego urządzenia.</item>
+        <item quantity="few">Przetworzono %s elementy od momentu zaproszenia SD Maid do twojego urządzenia.</item>
+        <item quantity="many">Przetworzono %s elementów od momentu zaproszenia SD Maid do twojego urządzenia.</item>
+        <item quantity="other">Przetworzono %s elementów od momentu zaproszenia SD Maid do twojego urządzenia.</item>
     </plurals>
     <string name="stats_report_status_success">Zakończono pomyślnie</string>
     <string name="stats_report_status_partial_success">Częściowy sukces</string>
@@ -50,6 +50,8 @@
     <string name="stats_storage_type_primary">Pamięć podstawowa</string>
     <string name="stats_storage_type_secondary">Pamięć dodatkowa</string>
     <string name="stats_storage_type_portable">Pamięć przenośna</string>
+    <string name="stats_space_history_delete_storage_title">Usunąć historię pamięci?</string>
+    <string name="stats_space_history_delete_storage_desc">Wszystkie dane trendów dla tej pamięci zostaną trwale usunięte.</string>
     <string name="stats_settings_retention_snapshots_label">Migawki pamięci</string>
     <string name="stats_settings_retention_snapshots_desc">Liczba dni przechowywania migawek pamięci.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-pt-rBR/strings.xml
+++ b/app-common-stats/src/main/res/values-pt-rBR/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">Armazenamento primário</string>
     <string name="stats_storage_type_secondary">Armazenamento secundário</string>
     <string name="stats_storage_type_portable">Armazenamento portátil</string>
+    <string name="stats_space_history_delete_storage_title">Excluir histórico de armazenamento?</string>
+    <string name="stats_space_history_delete_storage_desc">Todos os dados de tendência deste armazenamento serão excluídos permanentemente.</string>
     <string name="stats_settings_retention_snapshots_label">Instantâneos de armazenamento</string>
     <string name="stats_settings_retention_snapshots_desc">Número de dias para manter os instantâneos de espaço de armazenamento.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-pt/strings.xml
+++ b/app-common-stats/src/main/res/values-pt/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">Armazenamento primário</string>
     <string name="stats_storage_type_secondary">Armazenamento secundário</string>
     <string name="stats_storage_type_portable">Armazenamento portátil</string>
+    <string name="stats_space_history_delete_storage_title">Eliminar histórico de armazenamento?</string>
+    <string name="stats_space_history_delete_storage_desc">Todos os dados de tendências deste armazenamento serão eliminados permanentemente.</string>
     <string name="stats_settings_retention_snapshots_label">Instantâneos de armazenamento</string>
     <string name="stats_settings_retention_snapshots_desc">Número de dias para manter instantâneos do espaço de armazenamento.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-ro/strings.xml
+++ b/app-common-stats/src/main/res/values-ro/strings.xml
@@ -47,6 +47,8 @@
     <string name="stats_storage_type_primary">Stocare principală</string>
     <string name="stats_storage_type_secondary">Stocare secundară</string>
     <string name="stats_storage_type_portable">Depozitare portabilă</string>
+    <string name="stats_space_history_delete_storage_title">Ștergeți istoricul stocării?</string>
+    <string name="stats_space_history_delete_storage_desc">Toate datele de tendință pentru această stocare vor fi șterse permanent.</string>
     <string name="stats_settings_retention_snapshots_label">Instantanee de stocare</string>
     <string name="stats_settings_retention_snapshots_desc">Numărul de zile pentru păstrarea instantaneelor spațiului de stocare.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-ru/strings.xml
+++ b/app-common-stats/src/main/res/values-ru/strings.xml
@@ -50,6 +50,8 @@
     <string name="stats_storage_type_primary">Основное хранилище</string>
     <string name="stats_storage_type_secondary">Дополнительное хранилище</string>
     <string name="stats_storage_type_portable">Съёмный накопитель</string>
+    <string name="stats_space_history_delete_storage_title">Удалить историю хранилища?</string>
+    <string name="stats_space_history_delete_storage_desc">Все данные об этом хранилище будут окончательно удалены.</string>
     <string name="stats_settings_retention_snapshots_label">Снимки состояния хранилища</string>
     <string name="stats_settings_retention_snapshots_desc">Количество дней для хранения снимков состояния памяти.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-sc-rIT/strings.xml
+++ b/app-common-stats/src/main/res/values-sc-rIT/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">Archìviu primàriu</string>
     <string name="stats_storage_type_secondary">Archìviu secundàriu</string>
     <string name="stats_storage_type_portable">Archìviu portàbile</string>
+    <string name="stats_space_history_delete_storage_title">Cantzellare sa crònaca de su depòsitu?</string>
+    <string name="stats_space_history_delete_storage_desc">Totu is datos de tendentzia de custu depòsitu serant cantzellados permanentemente.</string>
     <string name="stats_settings_retention_snapshots_label">Instantàneas de memorizamentu</string>
     <string name="stats_settings_retention_snapshots_desc">Número de dies pro mantenni sas instantàneas de s’ispatziu de memorizamentu.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-si-rLK/strings.xml
+++ b/app-common-stats/src/main/res/values-si-rLK/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">මුලික ආචයනය</string>
     <string name="stats_storage_type_secondary">ද්විතීය ආචයනය</string>
     <string name="stats_storage_type_portable">ජංගම ආචයනය</string>
+    <string name="stats_space_history_delete_storage_title">ගබඩා ඉතිහාසය මකන්නද?</string>
+    <string name="stats_space_history_delete_storage_desc">මෙම ගබඩාව සඳහා සියලු ප්‍රවණතා දත්ත ස්ථිරවම මකා දැමෙනු ඇත.</string>
     <string name="stats_settings_retention_snapshots_label">ගබඩා ස්නැප්ශොට්</string>
     <string name="stats_settings_retention_snapshots_desc">ගබඩා අවකාශ ස්නැප්ශොට් තබා ගත යුතු දින ගණන.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-sk/strings.xml
+++ b/app-common-stats/src/main/res/values-sk/strings.xml
@@ -50,6 +50,8 @@
     <string name="stats_storage_type_primary">Primárne úložisko</string>
     <string name="stats_storage_type_secondary">Sekundárne úložisko</string>
     <string name="stats_storage_type_portable">Prenosné úložisko</string>
+    <string name="stats_space_history_delete_storage_title">Odstrániť históriu úloziška?</string>
+    <string name="stats_space_history_delete_storage_desc">Všetky údaje trendov pre toto úloziško budú natrvalo odstránené.</string>
     <string name="stats_settings_retention_snapshots_label">Snímky úložiska</string>
     <string name="stats_settings_retention_snapshots_desc">Počet dní na uchovanie snímok úložného priestoru.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-sl/strings.xml
+++ b/app-common-stats/src/main/res/values-sl/strings.xml
@@ -50,6 +50,8 @@
     <string name="stats_storage_type_primary">Primarna pomnilniška naprava</string>
     <string name="stats_storage_type_secondary">Sekundarna pomnilniška naprava</string>
     <string name="stats_storage_type_portable">Prenosna pomnilniška naprava</string>
+    <string name="stats_space_history_delete_storage_title">Izbriši zgodovino pomnilnika?</string>
+    <string name="stats_space_history_delete_storage_desc">Vsi podatki o trendih za ta pomnilnik bodo trajno izbrisani.</string>
     <string name="stats_settings_retention_snapshots_label">Posnetki stanja pomnilnika</string>
     <string name="stats_settings_retention_snapshots_desc">Število dni za shranjevanje posnetkov stanja pomnilniškega prostora.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-sq-rAL/strings.xml
+++ b/app-common-stats/src/main/res/values-sq-rAL/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">Magazina primare</string>
     <string name="stats_storage_type_secondary">Magazina sekondare</string>
     <string name="stats_storage_type_portable">Ruajtja e lëvizshme</string>
+    <string name="stats_space_history_delete_storage_title">Fshi historikun e ruajtjes?</string>
+    <string name="stats_space_history_delete_storage_desc">Të gjitha të dhënat e trendit për këtë hapësirë ruaëtëse do të fshihen përgjithmonë.</string>
     <string name="stats_settings_retention_snapshots_label">Fotografi të hapësirës ruajtëse</string>
     <string name="stats_settings_retention_snapshots_desc">Numri i ditëve për të ruajtur fotografitë e hapësirës ruajtëse.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-sr/strings.xml
+++ b/app-common-stats/src/main/res/values-sr/strings.xml
@@ -47,6 +47,8 @@
     <string name="stats_storage_type_primary">Примарно складиште</string>
     <string name="stats_storage_type_secondary">Секундарно складиште</string>
     <string name="stats_storage_type_portable">Преносиво складиште</string>
+    <string name="stats_space_history_delete_storage_title">Обрисати историју складиштења?</string>
+    <string name="stats_space_history_delete_storage_desc">Сви подаци о трендовима за ово складиште биће трајно обрисани.</string>
     <string name="stats_settings_retention_snapshots_label">Снимци складишта</string>
     <string name="stats_settings_retention_snapshots_desc">Број дана чувања снимака простора за складиштење.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-sv/strings.xml
+++ b/app-common-stats/src/main/res/values-sv/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">Primär lagring</string>
     <string name="stats_storage_type_secondary">Sekundär lagring</string>
     <string name="stats_storage_type_portable">Portabel lagring</string>
+    <string name="stats_space_history_delete_storage_title">Ta bort lagringshistorik?</string>
+    <string name="stats_space_history_delete_storage_desc">All trenddata för detta lagringsutrymme kommer att raderas permanent.</string>
     <string name="stats_settings_retention_snapshots_label">Lagringsögonblicksbilder</string>
     <string name="stats_settings_retention_snapshots_desc">Antal dagar att behålla ögonblicksbilder av lagringsutrymme.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-sw/strings.xml
+++ b/app-common-stats/src/main/res/values-sw/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">Hifadhi ya msingi</string>
     <string name="stats_storage_type_secondary">Hifadhi ya pili</string>
     <string name="stats_storage_type_portable">Hifadhi ya kubeba</string>
+    <string name="stats_space_history_delete_storage_title">Futa historia ya hifadhi?</string>
+    <string name="stats_space_history_delete_storage_desc">Data yote ya mwelekeo kwa hifadhi hii itafutwa kabisa.</string>
     <string name="stats_settings_retention_snapshots_label">Picha za hifadhi ya nafasi</string>
     <string name="stats_settings_retention_snapshots_desc">Idadi ya siku za kuhifadhi picha za nafasi ya hifadhi.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-ta-rIN/strings.xml
+++ b/app-common-stats/src/main/res/values-ta-rIN/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">முதன்மை சேமிப்பு</string>
     <string name="stats_storage_type_secondary">இரண்டாம் நிலை சேமிப்பு</string>
     <string name="stats_storage_type_portable">கையடக்க சேமிப்பு</string>
+    <string name="stats_space_history_delete_storage_title">சேமிப்பக வரலாற்றை நீக்கவா?</string>
+    <string name="stats_space_history_delete_storage_desc">இந்த சேமிப்பகத்திற்கான அனைத்து போக்கு தரவும் நிரந்தரமாக நீக்கப்படும்.</string>
     <string name="stats_settings_retention_snapshots_label">சேமிப்பக ஸ்னாப்ஷாட்கள்</string>
     <string name="stats_settings_retention_snapshots_desc">சேமிப்பக இடத்தின் ஸ்னாப்ஷாட்களை வைத்திருக்க வேண்டிய நாட்களின் எண்ணிக்கை.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-te-rIN/strings.xml
+++ b/app-common-stats/src/main/res/values-te-rIN/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">ముఖ్య స్టోరేజీ</string>
     <string name="stats_storage_type_secondary">ద్వితీయ స్టోరేజీ</string>
     <string name="stats_storage_type_portable">పోర్టేబుల్ స్టోరేజీ</string>
+    <string name="stats_space_history_delete_storage_title">స్టోరేజ్ చరిత్రను తొలగించాలా?</string>
+    <string name="stats_space_history_delete_storage_desc">ఈ స్టోరేజ్ కోసం అన్ని ట్రెండ్ డేటా శాశ్వతంగా తొలగించబడతాయి.</string>
     <string name="stats_settings_retention_snapshots_label">స్టోరేజ్ స్నాప్‌షాట్లు</string>
     <string name="stats_settings_retention_snapshots_desc">స్టోరేజ్ స్నాప్‌షాట్లను ఉంచుకోవాలసిన రోజుల సంఖ్య.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-th/strings.xml
+++ b/app-common-stats/src/main/res/values-th/strings.xml
@@ -41,6 +41,8 @@
     <string name="stats_storage_type_primary">พื้นที่จัดเก็บหลัก</string>
     <string name="stats_storage_type_secondary">พื้นที่จัดเก็บรอง</string>
     <string name="stats_storage_type_portable">พื้นที่จัดเก็บแบบพกพา</string>
+    <string name="stats_space_history_delete_storage_title">ลบประวัติพื้นที่จัดเก็บ?</string>
+    <string name="stats_space_history_delete_storage_desc">ข้อมูลแนวโน้มทั้งหมดสำหรับพื้นที่จัดเก็บนี้จะถูกลบถาวร</string>
     <string name="stats_settings_retention_snapshots_label">สแนปช็อตพื้นที่เก็บข้อมูล</string>
     <string name="stats_settings_retention_snapshots_desc">จำนวนวันที่จะเก็บสแนปช็อตพื้นที่เก็บข้อมูล</string>
 </resources>

--- a/app-common-stats/src/main/res/values-tr/strings.xml
+++ b/app-common-stats/src/main/res/values-tr/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">Birincil depolama</string>
     <string name="stats_storage_type_secondary">İkincil depolama</string>
     <string name="stats_storage_type_portable">Taşınabilir depolama</string>
+    <string name="stats_space_history_delete_storage_title">Depolama geçmişi silinsin mi?</string>
+    <string name="stats_space_history_delete_storage_desc">Bu depolama alanına ait tüm trend verileri kalıcı olarak silinecek.</string>
     <string name="stats_settings_retention_snapshots_label">Depolama anlık görüntüleri</string>
     <string name="stats_settings_retention_snapshots_desc">Depolama alanı anlık görüntülerini saklamak için gün sayısı.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-uk/strings.xml
+++ b/app-common-stats/src/main/res/values-uk/strings.xml
@@ -50,6 +50,8 @@
     <string name="stats_storage_type_primary">Основне сховище</string>
     <string name="stats_storage_type_secondary">Додаткове сховище</string>
     <string name="stats_storage_type_portable">Портативне сховище</string>
+    <string name="stats_space_history_delete_storage_title">Видалити історію сховища?</string>
+    <string name="stats_space_history_delete_storage_desc">Усі дані тенденцій для цього сховища буде остаточно видалено.</string>
     <string name="stats_settings_retention_snapshots_label">Знімки сховища</string>
     <string name="stats_settings_retention_snapshots_desc">Кількість днів, протягом яких зберігаються знімки стану сховища.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-ur-rIN/strings.xml
+++ b/app-common-stats/src/main/res/values-ur-rIN/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">بنیادی اسٹوریج</string>
     <string name="stats_storage_type_secondary">ثانوی اسٹوریج</string>
     <string name="stats_storage_type_portable">پورٹابل اسٹوریج</string>
+    <string name="stats_space_history_delete_storage_title">اسٹوریج کی تاریخ حذف کریں؟</string>
+    <string name="stats_space_history_delete_storage_desc">اس اسٹوریج کا تمام رجحان کا ڈیٹا مستقل طور پر حذف ہو جائے گا۔</string>
     <string name="stats_settings_retention_snapshots_label">اسٹوریج اسنیپ شاٹس</string>
     <string name="stats_settings_retention_snapshots_desc">اسٹوریج اسپیس اسنیپ شاٹس کو رکھنے کے دنوں کی تعداد۔</string>
 </resources>

--- a/app-common-stats/src/main/res/values-uz/strings.xml
+++ b/app-common-stats/src/main/res/values-uz/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">Asosiy xotira</string>
     <string name="stats_storage_type_secondary">Ikkilamchi xotira</string>
     <string name="stats_storage_type_portable">Ko\'chma xotira</string>
+    <string name="stats_space_history_delete_storage_title">Saqlash tarixini o\'chirishmi?</string>
+    <string name="stats_space_history_delete_storage_desc">Ushbu saqlash uchun barcha trend ma\'lumotlari butunlay o\'chiriladi.</string>
     <string name="stats_settings_retention_snapshots_label">Xotira snapshotlari</string>
     <string name="stats_settings_retention_snapshots_desc">Xotira bo\'shligi snapshotlarini saqlash kunlari soni.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-vi/strings.xml
+++ b/app-common-stats/src/main/res/values-vi/strings.xml
@@ -41,6 +41,8 @@
     <string name="stats_storage_type_primary">Bộ nhớ chính</string>
     <string name="stats_storage_type_secondary">Bộ nhớ thứ cấp</string>
     <string name="stats_storage_type_portable">Bộ lưu trữ di động</string>
+    <string name="stats_space_history_delete_storage_title">Xóa lịch sử bộ nhớ?</string>
+    <string name="stats_space_history_delete_storage_desc">Tất cả dữ liệu xu hướng cho bộ nhớ này sẽ bị xóa vĩnh viễn.</string>
     <string name="stats_settings_retention_snapshots_label">Ảnh chụp nhanh bộ nhớ</string>
     <string name="stats_settings_retention_snapshots_desc">Số ngày lưu giữ ảnh chụp nhanh dung lượng bộ nhớ.</string>
 </resources>

--- a/app-common-stats/src/main/res/values-zh-rCN/strings.xml
+++ b/app-common-stats/src/main/res/values-zh-rCN/strings.xml
@@ -41,6 +41,8 @@
     <string name="stats_storage_type_primary">内部存储</string>
     <string name="stats_storage_type_secondary">外部存储</string>
     <string name="stats_storage_type_portable">外置存储</string>
+    <string name="stats_space_history_delete_storage_title">删除存储历史记录？</string>
+    <string name="stats_space_history_delete_storage_desc">此存储的所有趋势数据将被永久删除。</string>
     <string name="stats_settings_retention_snapshots_label">存储快照</string>
     <string name="stats_settings_retention_snapshots_desc">保留存储空间快照的天数。</string>
 </resources>

--- a/app-common-stats/src/main/res/values-zh-rHK/strings.xml
+++ b/app-common-stats/src/main/res/values-zh-rHK/strings.xml
@@ -41,6 +41,8 @@
     <string name="stats_storage_type_primary">主要儲存空間</string>
     <string name="stats_storage_type_secondary">次要儲存空間</string>
     <string name="stats_storage_type_portable">可攜式儲存空間</string>
+    <string name="stats_space_history_delete_storage_title">刪除儲存空間歷史記錄？</string>
+    <string name="stats_space_history_delete_storage_desc">此儲存空間的所有趨勢資料將被永久刪除。</string>
     <string name="stats_settings_retention_snapshots_label">儲存空間快照</string>
     <string name="stats_settings_retention_snapshots_desc">保留儲存空間快照的天數。</string>
 </resources>

--- a/app-common-stats/src/main/res/values-zh-rTW/strings.xml
+++ b/app-common-stats/src/main/res/values-zh-rTW/strings.xml
@@ -41,6 +41,8 @@
     <string name="stats_storage_type_primary">主要儲存空間</string>
     <string name="stats_storage_type_secondary">次要儲存空間</string>
     <string name="stats_storage_type_portable">可攜式儲存空間</string>
+    <string name="stats_space_history_delete_storage_title">刪除儲存空間歷史記錄？</string>
+    <string name="stats_space_history_delete_storage_desc">此儲存空間的所有趨勢資料將被永久刪除。</string>
     <string name="stats_settings_retention_snapshots_label">儲存空間快照</string>
     <string name="stats_settings_retention_snapshots_desc">保留儲存空間快照的天數。</string>
 </resources>

--- a/app-common-stats/src/main/res/values-zu/strings.xml
+++ b/app-common-stats/src/main/res/values-zu/strings.xml
@@ -44,6 +44,8 @@
     <string name="stats_storage_type_primary">Isitoreji esiyinhloko</string>
     <string name="stats_storage_type_secondary">Isitoreji sesibili</string>
     <string name="stats_storage_type_portable">Isitoreji esiphathekayo</string>
+    <string name="stats_space_history_delete_storage_title">Susa umlando wendawo yokugcina?</string>
+    <string name="stats_space_history_delete_storage_desc">Yonke imininingwane yezindlela zale ndawo yokugcina izosuswa ngokuphelelele.</string>
     <string name="stats_settings_retention_snapshots_label">Izithombe zesitoreji</string>
-    <string name="stats_settings_retention_snapshots_desc">Inani lezinsuku yokugcina izithombe zendawo yesitoreji.</string>
+    <string name="stats_settings_retention_snapshots_desc">Inani lamanga okugcina izithombe zendawo yokugcina.</string>
 </resources>

--- a/app-common/src/main/res/values-af-rZA/strings.xml
+++ b/app-common/src/main/res/values-af-rZA/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">In tou</string>
     <string name="general_progress_deleting">Skrap</string>
     <string name="general_progress_deleting_x">Skrap %s</string>
+    <string name="general_sort_action">Sorteer</string>
+    <string name="general_sort_by_title">Sorteer volgens</string>
     <string name="general_sort_options_label">Sorteer opsies</string>
     <string name="general_sort_reverse_action">Keer sorteer modus om</string>
+    <string name="general_sort_oldest_first">Oudste eerste</string>
+    <string name="general_sort_newest_first">Nuutste eerste</string>
+    <string name="general_sort_name_asc">Naam (A → Z)</string>
+    <string name="general_sort_size_desc">Grootste eerste</string>
     <string name="general_tag_filter_label">Filter volgens etikette</string>
     <string name="general_tag_system">Stelsel</string>
     <string name="general_result_success_message">Operasie suksesvol</string>

--- a/app-common/src/main/res/values-am/strings.xml
+++ b/app-common/src/main/res/values-am/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">በወረፋ ውስጥ</string>
     <string name="general_progress_deleting">መሰረዝ</string>
     <string name="general_progress_deleting_x">%s መሰረዝ</string>
+    <string name="general_sort_action">ደርድር</string>
+    <string name="general_sort_by_title">በምን ይደርደር</string>
     <string name="general_sort_options_label">የአደባባይ አማራጮች</string>
     <string name="general_sort_reverse_action">የእድገት ሁነታ ማሽከርከር</string>
+    <string name="general_sort_oldest_first">ቀድሞ የተፈጠረ አስቀድሞ</string>
+    <string name="general_sort_newest_first">በቅርብ ጊዜ የተፈጠረ አስቀድሞ</string>
+    <string name="general_sort_name_asc">ስም (ሀ → ፐ)</string>
+    <string name="general_sort_size_desc">ትልቁ አስቀድሞ</string>
     <string name="general_tag_filter_label">በመለያዎች ማጣራት</string>
     <string name="general_tag_system">ሲስተም</string>
     <string name="general_result_success_message">ክንዋኔ ተሳክቷል</string>

--- a/app-common/src/main/res/values-ar/strings.xml
+++ b/app-common/src/main/res/values-ar/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">قيد الانتظار</string>
     <string name="general_progress_deleting">جار الحذف</string>
     <string name="general_progress_deleting_x">جار حذف %s</string>
+    <string name="general_sort_action">ترتيب</string>
+    <string name="general_sort_by_title">ترتيب حسب</string>
     <string name="general_sort_options_label">خيارات الفرز</string>
     <string name="general_sort_reverse_action">وضع الفرز العكسي</string>
+    <string name="general_sort_oldest_first">الأقدم أولاً</string>
+    <string name="general_sort_newest_first">الأحدث أولاً</string>
+    <string name="general_sort_name_asc">الاسم (أ ← ي)</string>
+    <string name="general_sort_size_desc">الأكبر أولاً</string>
     <string name="general_tag_filter_label">تصفية حسب العلامات</string>
     <string name="general_tag_system">النظام</string>
     <string name="general_result_success_message">تمت المهمة بنجاح</string>

--- a/app-common/src/main/res/values-az/strings.xml
+++ b/app-common/src/main/res/values-az/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">Növbədə</string>
     <string name="general_progress_deleting">Silinir</string>
     <string name="general_progress_deleting_x">%s silinir</string>
+    <string name="general_sort_action">Sırala</string>
+    <string name="general_sort_by_title">Sıralama üzrə</string>
     <string name="general_sort_options_label">Sıralama seçimləri</string>
     <string name="general_sort_reverse_action">Tərsinə sıralama rejimi</string>
+    <string name="general_sort_oldest_first">Əvvəl köhnələr</string>
+    <string name="general_sort_newest_first">Əvvəl yenilər</string>
+    <string name="general_sort_name_asc">Ad (A → Z)</string>
+    <string name="general_sort_size_desc">Əvvəl böyüklər</string>
     <string name="general_tag_filter_label">Etiketlərə görə filtr</string>
     <string name="general_tag_system">Sistem</string>
     <string name="general_result_success_message">Əməliyyat uğurlu oldu</string>

--- a/app-common/src/main/res/values-be/strings.xml
+++ b/app-common/src/main/res/values-be/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">У чарзе</string>
     <string name="general_progress_deleting">Выдаленне</string>
     <string name="general_progress_deleting_x">Выдаленне %s</string>
+    <string name="general_sort_action">Сартаваць</string>
+    <string name="general_sort_by_title">Сартаваць па</string>
     <string name="general_sort_options_label">Опцыі сартавання</string>
     <string name="general_sort_reverse_action">Адваротны парадак сартавання</string>
+    <string name="general_sort_oldest_first">Спачатку старыя</string>
+    <string name="general_sort_newest_first">Спачатку новыя</string>
+    <string name="general_sort_name_asc">Назва (А → Я)</string>
+    <string name="general_sort_size_desc">Спачатку найбольшыя</string>
     <string name="general_tag_filter_label">Фільтраваць паводле тэгаў</string>
     <string name="general_tag_system">Сістэма</string>
     <string name="general_result_success_message">Аперацыя выканана</string>

--- a/app-common/src/main/res/values-bg/strings.xml
+++ b/app-common/src/main/res/values-bg/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">В опашката</string>
     <string name="general_progress_deleting">Изтриване</string>
     <string name="general_progress_deleting_x">Изтриване на %s</string>
+    <string name="general_sort_action">Сортиране</string>
+    <string name="general_sort_by_title">Сортиране по</string>
     <string name="general_sort_options_label">Опции за сортиране</string>
     <string name="general_sort_reverse_action">Обратен режим на сортиране</string>
+    <string name="general_sort_oldest_first">Най-старите първи</string>
+    <string name="general_sort_newest_first">Най-новите първи</string>
+    <string name="general_sort_name_asc">Име (А → Я)</string>
+    <string name="general_sort_size_desc">Най-големите първи</string>
     <string name="general_tag_filter_label">Филтриране по тагове</string>
     <string name="general_tag_system">Система</string>
     <string name="general_result_success_message">Операцията е успешна</string>

--- a/app-common/src/main/res/values-bn-rBD/strings.xml
+++ b/app-common/src/main/res/values-bn-rBD/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">লাইনে আছে</string>
     <string name="general_progress_deleting">মুছে ফেলা হচ্ছে</string>
     <string name="general_progress_deleting_x">%s মুছে ফেলা হচ্ছে</string>
+    <string name="general_sort_action">বাছাই করুন</string>
+    <string name="general_sort_by_title">এর ভিত্তিতে বাছাই করুন</string>
     <string name="general_sort_options_label">সাজানোর বিকল্প</string>
     <string name="general_sort_reverse_action">বিপরীত সাজানোর মোড</string>
+    <string name="general_sort_oldest_first">পুরনো আগে</string>
+    <string name="general_sort_newest_first">নতুন আগে</string>
+    <string name="general_sort_name_asc">নাম (অ → জ)</string>
+    <string name="general_sort_size_desc">বড় আগে</string>
     <string name="general_tag_filter_label">ট্যাগ দ্বারা ফিল্টার</string>
     <string name="general_tag_system">সিস্টেম</string>
     <string name="general_result_success_message">কাজটি সফল হয়েছে</string>

--- a/app-common/src/main/res/values-ca/strings.xml
+++ b/app-common/src/main/res/values-ca/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">A la cua</string>
     <string name="general_progress_deleting">S\'està eliminant</string>
     <string name="general_progress_deleting_x">S\'està suprimint %s</string>
+    <string name="general_sort_action">Ordena</string>
+    <string name="general_sort_by_title">Ordena per</string>
     <string name="general_sort_options_label">Opcions d\'ordenació</string>
     <string name="general_sort_reverse_action">Mode d\'ordenació inversa</string>
+    <string name="general_sort_oldest_first">Primer els més antics</string>
+    <string name="general_sort_newest_first">Primer els més actuals</string>
+    <string name="general_sort_name_asc">Nom (A → Z)</string>
+    <string name="general_sort_size_desc">Els més grans primer</string>
     <string name="general_tag_filter_label">Filtra per etiquetes</string>
     <string name="general_tag_system">Sistema</string>
     <string name="general_result_success_message">Operació realitzada amb èxit</string>

--- a/app-common/src/main/res/values-ckb-rIR/strings.xml
+++ b/app-common/src/main/res/values-ckb-rIR/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">لە ڕیزدا</string>
     <string name="general_progress_deleting">سڕینەوە</string>
     <string name="general_progress_deleting_x">سڕینەوەی %s</string>
+    <string name="general_sort_action">رێزکردن</string>
+    <string name="general_sort_by_title">رێزکردن بەڕێی</string>
     <string name="general_sort_options_label">بژاردەکانی ڕێکخستن</string>
     <string name="general_sort_reverse_action">شێوازی ڕێکخستنی پێچەوانە</string>
+    <string name="general_sort_oldest_first">کۆنترین ھەروێی</string>
+    <string name="general_sort_newest_first">نەوترین ھەروێی</string>
+    <string name="general_sort_name_asc">ناو (آ ← یائ)(ئەلێفبە بەرەو)</string>
+    <string name="general_sort_size_desc">بزورترین ھەروێی</string>
     <string name="general_tag_filter_label">پاڵاوتن بەپێی تاگەکان</string>
     <string name="general_tag_system">سیستەم</string>
     <string name="general_result_success_message">کارپێکردن سەرکەوتوو بوو</string>

--- a/app-common/src/main/res/values-cs/strings.xml
+++ b/app-common/src/main/res/values-cs/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">Ve frontě</string>
     <string name="general_progress_deleting">Mazání</string>
     <string name="general_progress_deleting_x">Mazání %s</string>
+    <string name="general_sort_action">Třídit</string>
+    <string name="general_sort_by_title">Seřadit podle</string>
     <string name="general_sort_options_label">Možnosti řazení</string>
     <string name="general_sort_reverse_action">Obrátit režim řazení</string>
+    <string name="general_sort_oldest_first">Od nejstarších</string>
+    <string name="general_sort_newest_first">Od nejnovějších</string>
+    <string name="general_sort_name_asc">Název (A → Z)</string>
+    <string name="general_sort_size_desc">Od největších</string>
     <string name="general_tag_filter_label">Filtrovat podle štítků</string>
     <string name="general_tag_system">Systém</string>
     <string name="general_result_success_message">Operace úspěšně dokončena</string>

--- a/app-common/src/main/res/values-da/strings.xml
+++ b/app-common/src/main/res/values-da/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">I kø</string>
     <string name="general_progress_deleting">Sletter</string>
     <string name="general_progress_deleting_x">Sletter %s</string>
+    <string name="general_sort_action">Sortér</string>
+    <string name="general_sort_by_title">Sortér efter</string>
     <string name="general_sort_options_label">Sorteringsindstillinger</string>
     <string name="general_sort_reverse_action">Omvendt sorteringstilstand</string>
+    <string name="general_sort_oldest_first">Ældste først</string>
+    <string name="general_sort_newest_first">Nyeste først</string>
+    <string name="general_sort_name_asc">Navn (A → Z)</string>
+    <string name="general_sort_size_desc">Størst først</string>
     <string name="general_tag_filter_label">Filtrér efter tags</string>
     <string name="general_tag_system">System</string>
     <string name="general_result_success_message">Operation lykkedes</string>

--- a/app-common/src/main/res/values-de/strings.xml
+++ b/app-common/src/main/res/values-de/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">In der Warteschlange</string>
     <string name="general_progress_deleting">Am Löschen</string>
     <string name="general_progress_deleting_x">%s wird gelöscht</string>
+    <string name="general_sort_action">Sortieren</string>
+    <string name="general_sort_by_title">Sortieren nach</string>
     <string name="general_sort_options_label">Sortier-Optionen</string>
     <string name="general_sort_reverse_action">Sortiermodus umkehren</string>
+    <string name="general_sort_oldest_first">Älteste zuerst</string>
+    <string name="general_sort_newest_first">Neueste zuerst</string>
+    <string name="general_sort_name_asc">Name (A → Z)</string>
+    <string name="general_sort_size_desc">Größte zuerst</string>
     <string name="general_tag_filter_label">Nach Tags filtern</string>
     <string name="general_tag_system">System</string>
     <string name="general_result_success_message">Operation erfolgreich</string>

--- a/app-common/src/main/res/values-el/strings.xml
+++ b/app-common/src/main/res/values-el/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">Σε αναμονή</string>
     <string name="general_progress_deleting">Διαγραφή</string>
     <string name="general_progress_deleting_x">Διαγραφή %s</string>
+    <string name="general_sort_action">Ταξινόμηση</string>
+    <string name="general_sort_by_title">Ταξινόμηση κατά</string>
     <string name="general_sort_options_label">Επιλογές ταξινόμησης</string>
     <string name="general_sort_reverse_action">Αντιστροφή λειτουργίας ταξινόμησης</string>
+    <string name="general_sort_oldest_first">Παλαιότερα πρώτα</string>
+    <string name="general_sort_newest_first">Νεότερα πρώτα</string>
+    <string name="general_sort_name_asc">Όνομα (Α → Ω)</string>
+    <string name="general_sort_size_desc">Μεγαλύτερα πρώτα</string>
     <string name="general_tag_filter_label">Φιλτράρισμα με ετικέτες</string>
     <string name="general_tag_system">Σύστημα</string>
     <string name="general_result_success_message">Λειτουργία επιτυχής</string>

--- a/app-common/src/main/res/values-es-rAR/strings.xml
+++ b/app-common/src/main/res/values-es-rAR/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">En espera</string>
     <string name="general_progress_deleting">Eliminando</string>
     <string name="general_progress_deleting_x">Eliminando %s</string>
+    <string name="general_sort_action">Ordenar</string>
+    <string name="general_sort_by_title">Ordenar por</string>
     <string name="general_sort_options_label">Ordenar opciones</string>
     <string name="general_sort_reverse_action">Modo de clasificación inversa</string>
+    <string name="general_sort_oldest_first">Más antiguos primero</string>
+    <string name="general_sort_newest_first">Más nuevos primero</string>
+    <string name="general_sort_name_asc">Nombre (A → Z)</string>
+    <string name="general_sort_size_desc">Más grandes primero</string>
     <string name="general_tag_filter_label">Filtrar por etiquetas</string>
     <string name="general_tag_system">Sistema</string>
     <string name="general_result_success_message">Operación exitosa</string>

--- a/app-common/src/main/res/values-es-rMX/strings.xml
+++ b/app-common/src/main/res/values-es-rMX/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">En espera</string>
     <string name="general_progress_deleting">Borrando</string>
     <string name="general_progress_deleting_x">Borrando %s</string>
+    <string name="general_sort_action">Ordenar</string>
+    <string name="general_sort_by_title">Ordenar por</string>
     <string name="general_sort_options_label">Ordenar opciones</string>
     <string name="general_sort_reverse_action">Invertir el modo de ordenación</string>
+    <string name="general_sort_oldest_first">Más antiguos primero</string>
+    <string name="general_sort_newest_first">Más recientes primero</string>
+    <string name="general_sort_name_asc">Nombre (A → Z)</string>
+    <string name="general_sort_size_desc">Más grandes primero</string>
     <string name="general_tag_filter_label">Filtrar por etiquetas</string>
     <string name="general_tag_system">Sistema</string>
     <string name="general_result_success_message">Operación exitosa</string>

--- a/app-common/src/main/res/values-es/strings.xml
+++ b/app-common/src/main/res/values-es/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">En espera</string>
     <string name="general_progress_deleting">Borrando</string>
     <string name="general_progress_deleting_x">Borrando %s</string>
+    <string name="general_sort_action">Ordenar</string>
+    <string name="general_sort_by_title">Ordenar por</string>
     <string name="general_sort_options_label">Ordenar las opciones</string>
     <string name="general_sort_reverse_action">Modo de ordenación inversa</string>
+    <string name="general_sort_oldest_first">Más antiguos primero</string>
+    <string name="general_sort_newest_first">Más recientes primero</string>
+    <string name="general_sort_name_asc">Nombre (A → Z)</string>
+    <string name="general_sort_size_desc">Más grandes primero</string>
     <string name="general_tag_filter_label">Filtrar por las etiquetas</string>
     <string name="general_tag_system">Sistema</string>
     <string name="general_result_success_message">Operación exitosa</string>

--- a/app-common/src/main/res/values-et-rEE/strings.xml
+++ b/app-common/src/main/res/values-et-rEE/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">Järjekorras</string>
     <string name="general_progress_deleting">Kustutan</string>
     <string name="general_progress_deleting_x">%s kustutamine</string>
+    <string name="general_sort_action">Sordi</string>
+    <string name="general_sort_by_title">Sordi järgi</string>
     <string name="general_sort_options_label">Sortimise sätted</string>
     <string name="general_sort_reverse_action">Pööra järjestamisreziim pahupidi</string>
+    <string name="general_sort_oldest_first">Vanemad ees</string>
+    <string name="general_sort_newest_first">Uuemad ees</string>
+    <string name="general_sort_name_asc">Nimi (A → Z)</string>
+    <string name="general_sort_size_desc">Suurimad ees</string>
     <string name="general_tag_filter_label">Filtreeri siltide järgi</string>
     <string name="general_tag_system">Süsteem</string>
     <string name="general_result_success_message">Edukas toiming</string>

--- a/app-common/src/main/res/values-eu-rES/strings.xml
+++ b/app-common/src/main/res/values-eu-rES/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">Ilaran</string>
     <string name="general_progress_deleting">Ezabatzen</string>
     <string name="general_progress_deleting_x">%s ezabatzen</string>
+    <string name="general_sort_action">Ordenatu</string>
+    <string name="general_sort_by_title">Ordenatu honen arabera</string>
     <string name="general_sort_options_label">Ordenatzeko aukerak</string>
     <string name="general_sort_reverse_action">Alderantzizko ordenazio modua</string>
+    <string name="general_sort_oldest_first">Zaharrenak lehenik</string>
+    <string name="general_sort_newest_first">Berrienak lehenik</string>
+    <string name="general_sort_name_asc">Izena (A → Z)</string>
+    <string name="general_sort_size_desc">Handienak lehenik</string>
     <string name="general_tag_filter_label">Etiketez iragazki</string>
     <string name="general_tag_system">Sistema</string>
     <string name="general_result_success_message">Eragiketa arrakastatsua</string>

--- a/app-common/src/main/res/values-fa/strings.xml
+++ b/app-common/src/main/res/values-fa/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">در صف</string>
     <string name="general_progress_deleting">درحال حذف</string>
     <string name="general_progress_deleting_x">درحال حذف %s</string>
+    <string name="general_sort_action">مرتب‌سازی</string>
+    <string name="general_sort_by_title">مرتب‌سازی بر اساس</string>
     <string name="general_sort_options_label">گزینه‌های مرتب‌سازی</string>
     <string name="general_sort_reverse_action">حالت مرتب سازی معکوس</string>
+    <string name="general_sort_oldest_first">قدیمی‌ترین اول</string>
+    <string name="general_sort_newest_first">جدیدترین اول</string>
+    <string name="general_sort_name_asc">نام (الف ← ی)</string>
+    <string name="general_sort_size_desc">بزرگ‌ترین اول</string>
     <string name="general_tag_filter_label">فیلتر بر اساس برچسب</string>
     <string name="general_tag_system">سیستم</string>
     <string name="general_result_success_message">عملیات موفق</string>

--- a/app-common/src/main/res/values-fi/strings.xml
+++ b/app-common/src/main/res/values-fi/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">Jonossa</string>
     <string name="general_progress_deleting">Poistetaan</string>
     <string name="general_progress_deleting_x">Poistetaan %s</string>
+    <string name="general_sort_action">Lajittele</string>
+    <string name="general_sort_by_title">Lajitteluperuste</string>
     <string name="general_sort_options_label">Lajitteluasetukset</string>
     <string name="general_sort_reverse_action">Käänteinen lajittelutila</string>
+    <string name="general_sort_oldest_first">Vanhin ensin</string>
+    <string name="general_sort_newest_first">Uusin ensin</string>
+    <string name="general_sort_name_asc">Nimi (A → Ö)</string>
+    <string name="general_sort_size_desc">Suurin ensin</string>
     <string name="general_tag_filter_label">Suodata tunnisteiden mukaan</string>
     <string name="general_tag_system">Järjestelmä</string>
     <string name="general_result_success_message">Toiminto onnistui</string>

--- a/app-common/src/main/res/values-fil/strings.xml
+++ b/app-common/src/main/res/values-fil/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">Nakapila</string>
     <string name="general_progress_deleting">Binubura</string>
     <string name="general_progress_deleting_x">Binubura ang %s</string>
+    <string name="general_sort_action">Pagbukud-bukurin</string>
+    <string name="general_sort_by_title">Pagbukud-bukurin ayon sa</string>
     <string name="general_sort_options_label">Mga opsyon sa pagkakasunod-sunod</string>
     <string name="general_sort_reverse_action">Baligtarin ang pagkakaayos</string>
+    <string name="general_sort_oldest_first">Pinakamatanda muna</string>
+    <string name="general_sort_newest_first">Pinakabago muna</string>
+    <string name="general_sort_name_asc">Pangalan (A → Z)</string>
+    <string name="general_sort_size_desc">Pinakamalaki muna</string>
     <string name="general_tag_filter_label">Salain ayon sa tag</string>
     <string name="general_tag_system">Sistema</string>
     <string name="general_result_success_message">Matagumpay ang operasyon</string>

--- a/app-common/src/main/res/values-fr/strings.xml
+++ b/app-common/src/main/res/values-fr/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">En attente</string>
     <string name="general_progress_deleting">Suppression</string>
     <string name="general_progress_deleting_x">Suppression de %s</string>
+    <string name="general_sort_action">Trier</string>
+    <string name="general_sort_by_title">Trier par</string>
     <string name="general_sort_options_label">Options de tri</string>
     <string name="general_sort_reverse_action">Mode de tri inversé</string>
+    <string name="general_sort_oldest_first">Plus anciens en premier</string>
+    <string name="general_sort_newest_first">Plus récents en premier</string>
+    <string name="general_sort_name_asc">Nom (A → Z)</string>
+    <string name="general_sort_size_desc">Plus grands en premier</string>
     <string name="general_tag_filter_label">Filtrer par étiquettes</string>
     <string name="general_tag_system">Système</string>
     <string name="general_result_success_message">L’opération est réussie</string>

--- a/app-common/src/main/res/values-gl-rES/strings.xml
+++ b/app-common/src/main/res/values-gl-rES/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">Na cola</string>
     <string name="general_progress_deleting">Eliminando</string>
     <string name="general_progress_deleting_x">Eliminando %s</string>
+    <string name="general_sort_action">Ordenar</string>
+    <string name="general_sort_by_title">Ordenar por</string>
     <string name="general_sort_options_label">Opcións de ordenación</string>
     <string name="general_sort_reverse_action">Modo de ordenación inversa</string>
+    <string name="general_sort_oldest_first">Os máis antigos primeiro</string>
+    <string name="general_sort_newest_first">Os máis novos primeiro</string>
+    <string name="general_sort_name_asc">Nome (A → Z)</string>
+    <string name="general_sort_size_desc">Os máis grandes primeiro</string>
     <string name="general_tag_filter_label">Filtrar por etiquetas</string>
     <string name="general_tag_system">Sistema</string>
     <string name="general_result_success_message">Operación exitosa</string>

--- a/app-common/src/main/res/values-hi-rIN/strings.xml
+++ b/app-common/src/main/res/values-hi-rIN/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">पंक्ति में</string>
     <string name="general_progress_deleting">डिलीट कर रहा है</string>
     <string name="general_progress_deleting_x">डिलीट कर रहा है %s</string>
+    <string name="general_sort_action">क्रमबद्ध करें</string>
+    <string name="general_sort_by_title">इसके अनुसार क्रमबद्ध करें</string>
     <string name="general_sort_options_label">क्रमबद्ध विकल्प</string>
     <string name="general_sort_reverse_action">रिवर्स क्रम मोड</string>
+    <string name="general_sort_oldest_first">पहले पुराने</string>
+    <string name="general_sort_newest_first">पहले नए</string>
+    <string name="general_sort_name_asc">नाम (A → Z)</string>
+    <string name="general_sort_size_desc">पहले सबसे बड़े</string>
     <string name="general_tag_filter_label">टैग द्वारा फ़िल्टर करें</string>
     <string name="general_tag_system">सिस्टम</string>
     <string name="general_result_success_message">ऑपरेशन सफल रहा</string>

--- a/app-common/src/main/res/values-hr/strings.xml
+++ b/app-common/src/main/res/values-hr/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">U redu čekanja</string>
     <string name="general_progress_deleting">Brisanje</string>
     <string name="general_progress_deleting_x">Brisanje %s</string>
+    <string name="general_sort_action">Sortiraj</string>
+    <string name="general_sort_by_title">Sortiraj po</string>
     <string name="general_sort_options_label">Mogućnosti sortiranja</string>
     <string name="general_sort_reverse_action">Obrnuti način sortiranja</string>
+    <string name="general_sort_oldest_first">Najstariji prvo</string>
+    <string name="general_sort_newest_first">Najnoviji prvo</string>
+    <string name="general_sort_name_asc">Naziv (A → Z)</string>
+    <string name="general_sort_size_desc">Najveći prvo</string>
     <string name="general_tag_filter_label">Filtriraj po oznakama</string>
     <string name="general_tag_system">Sustav</string>
     <string name="general_result_success_message">Operacija uspješna</string>

--- a/app-common/src/main/res/values-hu/strings.xml
+++ b/app-common/src/main/res/values-hu/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">Sorban</string>
     <string name="general_progress_deleting">Törlés</string>
     <string name="general_progress_deleting_x">%s törlése</string>
+    <string name="general_sort_action">Rendezés</string>
+    <string name="general_sort_by_title">Rendezés alapja</string>
     <string name="general_sort_options_label">Rendezési lehetőségek</string>
     <string name="general_sort_reverse_action">Fordított rendezési mód</string>
+    <string name="general_sort_oldest_first">Legrégebbi először</string>
+    <string name="general_sort_newest_first">Legújabb először</string>
+    <string name="general_sort_name_asc">Név (A → Z)</string>
+    <string name="general_sort_size_desc">Legnagyobb először</string>
     <string name="general_tag_filter_label">Szűrés címkék szerint</string>
     <string name="general_tag_system">Rendszer</string>
     <string name="general_result_success_message">A művelet sikeres</string>

--- a/app-common/src/main/res/values-in/strings.xml
+++ b/app-common/src/main/res/values-in/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">Dalam antrean</string>
     <string name="general_progress_deleting">Menghapus</string>
     <string name="general_progress_deleting_x">Menghapus %s</string>
+    <string name="general_sort_action">Urutkan</string>
+    <string name="general_sort_by_title">Urutkan berdasarkan</string>
     <string name="general_sort_options_label">Pilihan pengurutan</string>
     <string name="general_sort_reverse_action">Mode penyortiran terbalik</string>
+    <string name="general_sort_oldest_first">Terlama dahulu</string>
+    <string name="general_sort_newest_first">Terbaru dahulu</string>
+    <string name="general_sort_name_asc">Nama (A → Z)</string>
+    <string name="general_sort_size_desc">Terbesar dahulu</string>
     <string name="general_tag_filter_label">Saring berdasarkan tag</string>
     <string name="general_tag_system">Sistem</string>
     <string name="general_result_success_message">Pekerjaan selesai</string>

--- a/app-common/src/main/res/values-is/strings.xml
+++ b/app-common/src/main/res/values-is/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">Í biðröð</string>
     <string name="general_progress_deleting">Eyðir</string>
     <string name="general_progress_deleting_x">Eyðir %s</string>
+    <string name="general_sort_action">Raða</string>
+    <string name="general_sort_by_title">Raða eftir</string>
     <string name="general_sort_options_label">Röðunarvalkostir</string>
     <string name="general_sort_reverse_action">Öfug röðunarham</string>
+    <string name="general_sort_oldest_first">Elsta fyrst</string>
+    <string name="general_sort_newest_first">Nýjasta fyrst</string>
+    <string name="general_sort_name_asc">Nafn (A → Ö)</string>
+    <string name="general_sort_size_desc">Stærsta fyrst</string>
     <string name="general_tag_filter_label">Sía eftir merkjum</string>
     <string name="general_tag_system">Kerfi</string>
     <string name="general_result_success_message">Aðgerð tókst</string>

--- a/app-common/src/main/res/values-it/strings.xml
+++ b/app-common/src/main/res/values-it/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">In coda</string>
     <string name="general_progress_deleting">Eliminazione</string>
     <string name="general_progress_deleting_x">Eliminazione di %s</string>
+    <string name="general_sort_action">Ordina</string>
+    <string name="general_sort_by_title">Ordina per</string>
     <string name="general_sort_options_label">Opzioni di ordinamento</string>
     <string name="general_sort_reverse_action">Inverti modalità di ordinamento</string>
+    <string name="general_sort_oldest_first">Prima i più vecchi</string>
+    <string name="general_sort_newest_first">Prima i più recenti</string>
+    <string name="general_sort_name_asc">Nome (A → Z)</string>
+    <string name="general_sort_size_desc">Prima i più grandi</string>
     <string name="general_tag_filter_label">Filtra per tags</string>
     <string name="general_tag_system">Sistema</string>
     <string name="general_result_success_message">Operazione riuscita</string>

--- a/app-common/src/main/res/values-iw/strings.xml
+++ b/app-common/src/main/res/values-iw/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">בתור</string>
     <string name="general_progress_deleting">מוחק</string>
     <string name="general_progress_deleting_x">מוחק %s</string>
+    <string name="general_sort_action">מיין</string>
+    <string name="general_sort_by_title">מיין לפי</string>
     <string name="general_sort_options_label">אפשרויות מיון</string>
     <string name="general_sort_reverse_action">מצב סידור הפוך</string>
+    <string name="general_sort_oldest_first">הישנים ביותר תחילה</string>
+    <string name="general_sort_newest_first">החדשים ביותר תחילה</string>
+    <string name="general_sort_name_asc">שם (א → ת)</string>
+    <string name="general_sort_size_desc">הגדולים ביותר תחילה</string>
     <string name="general_tag_filter_label">סנן לפי תגיות</string>
     <string name="general_tag_system">מערכת</string>
     <string name="general_result_success_message">הפעולה בוצעה בהצלחה</string>

--- a/app-common/src/main/res/values-ja/strings.xml
+++ b/app-common/src/main/res/values-ja/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">待機中</string>
     <string name="general_progress_deleting">削除中</string>
     <string name="general_progress_deleting_x">%sを削除中</string>
+    <string name="general_sort_action">並べ替え</string>
+    <string name="general_sort_by_title">並べ替え基準</string>
     <string name="general_sort_options_label">並び替えオプション</string>
     <string name="general_sort_reverse_action">降順モード</string>
+    <string name="general_sort_oldest_first">古い順</string>
+    <string name="general_sort_newest_first">新しい順</string>
+    <string name="general_sort_name_asc">名前 (A → Z)</string>
+    <string name="general_sort_size_desc">大きい順</string>
     <string name="general_tag_filter_label">タグによるフィルタリング</string>
     <string name="general_tag_system">システム</string>
     <string name="general_result_success_message">実行成功</string>

--- a/app-common/src/main/res/values-ka-rGE/strings.xml
+++ b/app-common/src/main/res/values-ka-rGE/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">რიგში</string>
     <string name="general_progress_deleting">წაშლა</string>
     <string name="general_progress_deleting_x">%s-ის წაშლა</string>
+    <string name="general_sort_action">დალაგება</string>
+    <string name="general_sort_by_title">დალაგება კრიტერიუმით</string>
     <string name="general_sort_options_label">დალაგების ვარიანტები</string>
     <string name="general_sort_reverse_action">დალაგების რევერსიული რეჟიმი</string>
+    <string name="general_sort_oldest_first">ძველი პირველი</string>
+    <string name="general_sort_newest_first">ახალი პირველი</string>
+    <string name="general_sort_name_asc">სახელი (A → Z)</string>
+    <string name="general_sort_size_desc">უდიდესი პირველი</string>
     <string name="general_tag_filter_label">ტეგების მიხედვით ფილტრაცია</string>
     <string name="general_tag_system">სისტემა</string>
     <string name="general_result_success_message">ოპერაცია წარმატებული</string>

--- a/app-common/src/main/res/values-kaa/strings.xml
+++ b/app-common/src/main/res/values-kaa/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">Gezekte</string>
     <string name="general_progress_deleting">Óshiriw</string>
     <string name="general_progress_deleting_x">%s óshiriw</string>
+    <string name="general_sort_action">Сортлаў</string>
+    <string name="general_sort_by_title">Сортлаў тәртиби</string>
     <string name="general_sort_options_label">Tartıplew tańlawları</string>
     <string name="general_sort_reverse_action">Tartıplew modesin teskers etew</string>
+    <string name="general_sort_oldest_first">Ең ески биринши</string>
+    <string name="general_sort_newest_first">Ең жаңа биринши</string>
+    <string name="general_sort_name_asc">Ат (А → Я)</string>
+    <string name="general_sort_size_desc">Ең үлкен биринши</string>
     <string name="general_tag_filter_label">Teglar boyınsha filtrlew</string>
     <string name="general_tag_system">Sistema</string>
     <string name="general_result_success_message">Amal jetiskerli</string>

--- a/app-common/src/main/res/values-km-rKH/strings.xml
+++ b/app-common/src/main/res/values-km-rKH/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">កំពុងចាំជួរ</string>
     <string name="general_progress_deleting">កំពុងលុប</string>
     <string name="general_progress_deleting_x">កំពុងលុប %s</string>
+    <string name="general_sort_action">តម្រៀប</string>
+    <string name="general_sort_by_title">តម្រៀបតាម</string>
     <string name="general_sort_options_label">ជម្រើសនៃតម្រៀប</string>
     <string name="general_sort_reverse_action">ម៉ូតតម្រៀបបញ្ច្រាស</string>
+    <string name="general_sort_oldest_first">ចាស់ជាងមុន</string>
+    <string name="general_sort_newest_first">ថ្មីជាងគេ</string>
+    <string name="general_sort_name_asc">ឈ្មោះ (A → Z)</string>
+    <string name="general_sort_size_desc">ធំជាងគេ</string>
     <string name="general_tag_filter_label">តម្រងតាមស្លាក</string>
     <string name="general_tag_system">ប្រព័ន្ធ</string>
     <string name="general_result_success_message">ប្រតិបត្តិការជោគជ័យ</string>

--- a/app-common/src/main/res/values-ko/strings.xml
+++ b/app-common/src/main/res/values-ko/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">대기 중</string>
     <string name="general_progress_deleting">삭제 중</string>
     <string name="general_progress_deleting_x">%s 삭제중</string>
+    <string name="general_sort_action">정렬</string>
+    <string name="general_sort_by_title">정렬 기준</string>
     <string name="general_sort_options_label">정렬 기준</string>
     <string name="general_sort_reverse_action">역정렬 모드</string>
+    <string name="general_sort_oldest_first">오래된 것 먼저</string>
+    <string name="general_sort_newest_first">최신 것 먼저</string>
+    <string name="general_sort_name_asc">이름 (A → Z)</string>
+    <string name="general_sort_size_desc">큰 것 먼저</string>
     <string name="general_tag_filter_label">태그별로 필터</string>
     <string name="general_tag_system">시스템</string>
     <string name="general_result_success_message">작업 성공</string>

--- a/app-common/src/main/res/values-lo-rLA/strings.xml
+++ b/app-common/src/main/res/values-lo-rLA/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">ຢູ່ໃນແຖວ</string>
     <string name="general_progress_deleting">ກຳລັງລຶບ</string>
     <string name="general_progress_deleting_x">ກຳລັງລຶບ %s</string>
+    <string name="general_sort_action">ຈັດລຽງ</string>
+    <string name="general_sort_by_title">ຈັດລຽງຕາມ</string>
     <string name="general_sort_options_label">ຕົວເລືອກການຈັດລຽງ</string>
     <string name="general_sort_reverse_action">ປີ້ນກັບໂໝດການຈັດລຽງ</string>
+    <string name="general_sort_oldest_first">ເກົ່າທີ່ສຸດກ່ອນ</string>
+    <string name="general_sort_newest_first">ໃໝ່ທີ່ສຸດກ່ອນ</string>
+    <string name="general_sort_name_asc">ຊື່ (ກ → ຮ)</string>
+    <string name="general_sort_size_desc">ໃຫຍ່ທີ່ສຸດກ່ອນ</string>
     <string name="general_tag_filter_label">ຕອງຕາມແທັກ</string>
     <string name="general_tag_system">ລະບົບ</string>
     <string name="general_result_success_message">ການດຳເນີນງານສຳເລັດ</string>

--- a/app-common/src/main/res/values-lt/strings.xml
+++ b/app-common/src/main/res/values-lt/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">Eilėje</string>
     <string name="general_progress_deleting">Trinamas</string>
     <string name="general_progress_deleting_x">Trinamas %s</string>
+    <string name="general_sort_action">Rūšiuoti</string>
+    <string name="general_sort_by_title">Rūšiuoti pagal</string>
     <string name="general_sort_options_label">Rūšiavimo parinktys</string>
     <string name="general_sort_reverse_action">Atvirkštinis rūšiavimo režimas</string>
+    <string name="general_sort_oldest_first">Seniausias pirmas</string>
+    <string name="general_sort_newest_first">Naujausias pirmas</string>
+    <string name="general_sort_name_asc">Pavadinimas (A → Z)</string>
+    <string name="general_sort_size_desc">Didžiausias pirmas</string>
     <string name="general_tag_filter_label">Filtruoti pagal žymes</string>
     <string name="general_tag_system">Sistema</string>
     <string name="general_result_success_message">Operacija sėkminga</string>

--- a/app-common/src/main/res/values-lv/strings.xml
+++ b/app-common/src/main/res/values-lv/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">Rindā</string>
     <string name="general_progress_deleting">Dzēšana</string>
     <string name="general_progress_deleting_x">Dzēš %s</string>
+    <string name="general_sort_action">Kārtot</string>
+    <string name="general_sort_by_title">Kārtot pēc</string>
     <string name="general_sort_options_label">Kārtošanas opcijas</string>
     <string name="general_sort_reverse_action">Apgrieztais kārtošanas režīms</string>
+    <string name="general_sort_oldest_first">Vispirms vecākie</string>
+    <string name="general_sort_newest_first">Vispirms jaunākie</string>
+    <string name="general_sort_name_asc">Nosaukums (A → Z)</string>
+    <string name="general_sort_size_desc">Vispirms lielākie</string>
     <string name="general_tag_filter_label">Filtrēt pēc atzīmēm</string>
     <string name="general_tag_system">Sistēma</string>
     <string name="general_result_success_message">Operācija veiksmīga</string>

--- a/app-common/src/main/res/values-mk-rMK/strings.xml
+++ b/app-common/src/main/res/values-mk-rMK/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">Во редица</string>
     <string name="general_progress_deleting">Бришење</string>
     <string name="general_progress_deleting_x">Се брише %s</string>
+    <string name="general_sort_action">Сортирај</string>
+    <string name="general_sort_by_title">Сортирај по</string>
     <string name="general_sort_options_label">Опции за подредување</string>
     <string name="general_sort_reverse_action">Режим на обратно сортирање</string>
+    <string name="general_sort_oldest_first">Прво најстарите</string>
+    <string name="general_sort_newest_first">Прво најновите</string>
+    <string name="general_sort_name_asc">Име (А → Ш)</string>
+    <string name="general_sort_size_desc">Прво најголемите</string>
     <string name="general_tag_filter_label">Филтрирајте по ознаки</string>
     <string name="general_tag_system">Систем</string>
     <string name="general_result_success_message">Operation successful</string>

--- a/app-common/src/main/res/values-ml-rIN/strings.xml
+++ b/app-common/src/main/res/values-ml-rIN/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">ക്യൂവിൽ</string>
     <string name="general_progress_deleting">ഡിലീറ്റ് ചെയ്യുന്നു</string>
     <string name="general_progress_deleting_x">%s ഡിലീറ്റ് ചെയ്യുന്നു</string>
+    <string name="general_sort_action">അടുക്കുക</string>
+    <string name="general_sort_by_title">അടുക്കുക ഇതനുസരിച്ച്</string>
     <string name="general_sort_options_label">ഓപ്‌ഷനുകൾ അടുക്കുക</string>
     <string name="general_sort_reverse_action">റിവേഴ്സ് സോർട്ട് മോഡ്</string>
+    <string name="general_sort_oldest_first">പഴയത് ആദ്യം</string>
+    <string name="general_sort_newest_first">പുതിയത് ആദ്യം</string>
+    <string name="general_sort_name_asc">പേര് (A → Z)</string>
+    <string name="general_sort_size_desc">ഏറ്റവും വലുത് ആദ്യം</string>
     <string name="general_tag_filter_label">ടാഗുകൾ പ്രകാരം ഫിൽട്ടർ ചെയ്യുക</string>
     <string name="general_tag_system">സിസ്റ്റം</string>
     <string name="general_result_success_message">ഓപ്പറേഷൻ വിജയിച്ചു</string>

--- a/app-common/src/main/res/values-mn-rMN/strings.xml
+++ b/app-common/src/main/res/values-mn-rMN/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">Дарааллд</string>
     <string name="general_progress_deleting">Устгаж байна</string>
     <string name="general_progress_deleting_x">%s устгаж байна</string>
+    <string name="general_sort_action">Эрэмбэлэх</string>
+    <string name="general_sort_by_title">Эрэмбэлэх шалгуур</string>
     <string name="general_sort_options_label">Эрэмбэлэх сонголтууд</string>
     <string name="general_sort_reverse_action">Урвуу эрэмбэлэх горим</string>
+    <string name="general_sort_oldest_first">Эхэлсэн огноогоор</string>
+    <string name="general_sort_newest_first">Шинэ эхэлж</string>
+    <string name="general_sort_name_asc">Нэр (А → Я)</string>
+    <string name="general_sort_size_desc">Хамгийн том эхэлж</string>
     <string name="general_tag_filter_label">Шошгоор шүүх</string>
     <string name="general_tag_system">Систем</string>
     <string name="general_result_success_message">Амжилттай гүйцэтгэгдсэн</string>

--- a/app-common/src/main/res/values-ms/strings.xml
+++ b/app-common/src/main/res/values-ms/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">Dalam barisan</string>
     <string name="general_progress_deleting">Memadam</string>
     <string name="general_progress_deleting_x">Memadam %s</string>
+    <string name="general_sort_action">Susun</string>
+    <string name="general_sort_by_title">Susun mengikut</string>
     <string name="general_sort_options_label">Isih pilihan</string>
     <string name="general_sort_reverse_action">Mod isihan terbalik</string>
+    <string name="general_sort_oldest_first">Terlama dahulu</string>
+    <string name="general_sort_newest_first">Terbaru dahulu</string>
+    <string name="general_sort_name_asc">Nama (A → Z)</string>
+    <string name="general_sort_size_desc">Terbesar dahulu</string>
     <string name="general_tag_filter_label">Tapis mengikut tag</string>
     <string name="general_tag_system">Sistem</string>
     <string name="general_result_success_message">Operasi berjaya</string>

--- a/app-common/src/main/res/values-my-rMM/strings.xml
+++ b/app-common/src/main/res/values-my-rMM/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">အစီအစဉ်တွင်</string>
     <string name="general_progress_deleting">ဖျက်နေပါသည်</string>
     <string name="general_progress_deleting_x">%s ကိုဖျက်နေပါသည်</string>
+    <string name="general_sort_action">စီရင်ရန်</string>
+    <string name="general_sort_by_title">စီရင်မည့် အခြေခံ</string>
     <string name="general_sort_options_label">စီစဉ်ရန်ရွေးချယ်မှုများ</string>
     <string name="general_sort_reverse_action">ပြောင်းပြန်စီစဉ်ရန်မုဒ်</string>
+    <string name="general_sort_oldest_first">အဟောင်းဆုံးကို ဦးစွာ</string>
+    <string name="general_sort_newest_first">အသစ်ဆုံးကို ဦးစွာ</string>
+    <string name="general_sort_name_asc">နာမည် (A → Z)</string>
+    <string name="general_sort_size_desc">အကြီးဆုံးကို ဦးစွာ</string>
     <string name="general_tag_filter_label">အမှတ်အသားများဖြင့် စစ်ထုတ်ပါ</string>
     <string name="general_tag_system">စနစ်</string>
     <string name="general_result_success_message">အောင်မြင်စွာ လုပ်ဆောင်ပြီးပါပြီ</string>

--- a/app-common/src/main/res/values-nb/strings.xml
+++ b/app-common/src/main/res/values-nb/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">I kø</string>
     <string name="general_progress_deleting">Sletter</string>
     <string name="general_progress_deleting_x">Sletter %s</string>
+    <string name="general_sort_action">Sorter</string>
+    <string name="general_sort_by_title">Sorter etter</string>
     <string name="general_sort_options_label">Sorteringsalternativer</string>
     <string name="general_sort_reverse_action">Inverter sorteringsmodus</string>
+    <string name="general_sort_oldest_first">Eldste først</string>
+    <string name="general_sort_newest_first">Nyeste først</string>
+    <string name="general_sort_name_asc">Navn (A → Å)</string>
+    <string name="general_sort_size_desc">Største først</string>
     <string name="general_tag_filter_label">Filtrer etter etiketter</string>
     <string name="general_tag_system">System</string>
     <string name="general_result_success_message">Operasjonen var vellykket</string>

--- a/app-common/src/main/res/values-ne-rNP/strings.xml
+++ b/app-common/src/main/res/values-ne-rNP/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">लाइनमा</string>
     <string name="general_progress_deleting">मेटाउँदै</string>
     <string name="general_progress_deleting_x">%s मेटाउँदै</string>
+    <string name="general_sort_action">क्रमबद्ध गर्नुहोस्</string>
+    <string name="general_sort_by_title">यसद्वारा क्रमबद्ध गर्नुहोस्</string>
     <string name="general_sort_options_label">क्रमबद्ध विकल्पहरू</string>
     <string name="general_sort_reverse_action">उल्टो क्रमबद्ध मोड</string>
+    <string name="general_sort_oldest_first">पुरानो पहिले</string>
+    <string name="general_sort_newest_first">नयाँ पहिले</string>
+    <string name="general_sort_name_asc">नाम (अ → ज्ञ)</string>
+    <string name="general_sort_size_desc">सबैभन्दा ठूलो पहिले</string>
     <string name="general_tag_filter_label">ट्यागहरूद्वारा फिल्टर गर्नुहोस्</string>
     <string name="general_tag_system">सिस्टम</string>
     <string name="general_result_success_message">सफलतापूर्वक सम्पन्न</string>

--- a/app-common/src/main/res/values-nl/strings.xml
+++ b/app-common/src/main/res/values-nl/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">In de wachtrij</string>
     <string name="general_progress_deleting">Verwijderen</string>
     <string name="general_progress_deleting_x">Verwijderen %s</string>
+    <string name="general_sort_action">Sorteren</string>
+    <string name="general_sort_by_title">Sorteren op</string>
     <string name="general_sort_options_label">Sorteer opties</string>
     <string name="general_sort_reverse_action">Omgekeerde sorteermodus</string>
+    <string name="general_sort_oldest_first">Oudste eerst</string>
+    <string name="general_sort_newest_first">Nieuwste eerst</string>
+    <string name="general_sort_name_asc">Naam (A → Z)</string>
+    <string name="general_sort_size_desc">Grootste eerst</string>
     <string name="general_tag_filter_label">Filteren op tags</string>
     <string name="general_tag_system">Systeem</string>
     <string name="general_result_success_message">Bewerking geslaagd</string>

--- a/app-common/src/main/res/values-or-rIN/strings.xml
+++ b/app-common/src/main/res/values-or-rIN/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">ଧାଡ଼ିରେ</string>
     <string name="general_progress_deleting">ବିଲୋପ କରାଯାଉଛି</string>
     <string name="general_progress_deleting_x">%s ବିଲୋପ କରାଯାଉଛି</string>
+    <string name="general_sort_action">ସଜାଇବେ</string>
+    <string name="general_sort_by_title">ଏହା ଦ୍ୱାରା ସଜାଇବେ</string>
     <string name="general_sort_options_label">ସର୍ଟ୍ ବିକଳ୍ପ</string>
     <string name="general_sort_reverse_action">ରିଭର୍ସ ସର୍ଟ୍ ମୋଡ୍</string>
+    <string name="general_sort_oldest_first">ସବୁଠୁ ପୁରୁଣା ପ୍ରଥମ</string>
+    <string name="general_sort_newest_first">ସବୁଠୁ ନୂଆ ପ୍ରଥମ</string>
+    <string name="general_sort_name_asc">ନାମ (A → Z)</string>
+    <string name="general_sort_size_desc">ସବୁଠୁ ବଡ଼ ପ୍ରଥମ</string>
     <string name="general_tag_filter_label">ଟ୍ୟାଗ ଦ୍ୱାରା ଫିଲ୍ଟର୍ କରିବା</string>
     <string name="general_tag_system">ସିଷ୍ଟମ୍</string>
     <string name="general_result_success_message">ପ୍ରକ୍ରିୟା ସଫଳ ହୋଇଛି</string>

--- a/app-common/src/main/res/values-pa-rIN/strings.xml
+++ b/app-common/src/main/res/values-pa-rIN/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">ਕਤਾਰ ਵਿੱਚ</string>
     <string name="general_progress_deleting">ਮਿਟਾ ਰਿਹਾ ਹੈ</string>
     <string name="general_progress_deleting_x">%s ਮਿਟਾ ਰਿਹਾ ਹੈ</string>
+    <string name="general_sort_action">ਕ੍ਰਮਬੱਧ ਕਰੋ</string>
+    <string name="general_sort_by_title">ਇਸ ਅਨੁਸਾਰ ਕ੍ਰਮਬੱਧ ਕਰੋ</string>
     <string name="general_sort_options_label">ਸੰਧਿ ਵਿਕਲਪ</string>
     <string name="general_sort_reverse_action">ਰਿਵਰਸ ਸੰਧਿ ਮੋਡ</string>
+    <string name="general_sort_oldest_first">ਪੁਰਾਣੇ ਪਹਿਲਾਂ</string>
+    <string name="general_sort_newest_first">ਨਵੇਂ ਪਹਿਲਾਂ</string>
+    <string name="general_sort_name_asc">ਨਾਮ (A → Z)</string>
+    <string name="general_sort_size_desc">ਸਭ ਤੋਂ ਵੱਡੇ ਪਹਿਲਾਂ</string>
     <string name="general_tag_filter_label">ਟੈਗਾਂ ਦੁਆਰਾ ਫਿਲਟਰ ਕਰੋ</string>
     <string name="general_tag_system">ਸਿਸਟਮ</string>
     <string name="general_result_success_message">ਕਾਰਵਾਈ ਸਫਲ ਹੋਈ</string>

--- a/app-common/src/main/res/values-pl/strings.xml
+++ b/app-common/src/main/res/values-pl/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">W kolejce</string>
     <string name="general_progress_deleting">Usuwanie</string>
     <string name="general_progress_deleting_x">Usuwanie %s</string>
+    <string name="general_sort_action">Sortuj</string>
+    <string name="general_sort_by_title">Sortuj według</string>
     <string name="general_sort_options_label">Opcje sortowania</string>
     <string name="general_sort_reverse_action">Odwróć kolejność sortowania</string>
+    <string name="general_sort_oldest_first">Najpierw najstarsze</string>
+    <string name="general_sort_newest_first">Najpierw najnowsze</string>
+    <string name="general_sort_name_asc">Nazwa (A - Z)</string>
+    <string name="general_sort_size_desc">Najpierw największe</string>
     <string name="general_tag_filter_label">Filtruj według tagów</string>
     <string name="general_tag_system">Systemowy</string>
     <string name="general_result_success_message">Operacja zakończona sukcesem</string>

--- a/app-common/src/main/res/values-pt-rBR/strings.xml
+++ b/app-common/src/main/res/values-pt-rBR/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">Na fila</string>
     <string name="general_progress_deleting">Apagando</string>
     <string name="general_progress_deleting_x">Apagando %s</string>
+    <string name="general_sort_action">Ordenar</string>
+    <string name="general_sort_by_title">Ordenar por</string>
     <string name="general_sort_options_label">Opções de classificação</string>
     <string name="general_sort_reverse_action">Modo de classificação inversa</string>
+    <string name="general_sort_oldest_first">Mais antigos primeiro</string>
+    <string name="general_sort_newest_first">Mais recentes primeiro</string>
+    <string name="general_sort_name_asc">Nome (A → Z)</string>
+    <string name="general_sort_size_desc">Maiores primeiro</string>
     <string name="general_tag_filter_label">Filtrar por tags</string>
     <string name="general_tag_system">Sistema</string>
     <string name="general_result_success_message">Operação bem sucedida</string>

--- a/app-common/src/main/res/values-pt/strings.xml
+++ b/app-common/src/main/res/values-pt/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">Em espera</string>
     <string name="general_progress_deleting">A apagar</string>
     <string name="general_progress_deleting_x">A eliminar %s</string>
+    <string name="general_sort_action">Ordenar</string>
+    <string name="general_sort_by_title">Ordenar por</string>
     <string name="general_sort_options_label">Opções de ordenação</string>
     <string name="general_sort_reverse_action">Inverter critério de ordenação</string>
+    <string name="general_sort_oldest_first">Mais antigos primeiro</string>
+    <string name="general_sort_newest_first">Mais recentes primeiro</string>
+    <string name="general_sort_name_asc">Nome (A → Z)</string>
+    <string name="general_sort_size_desc">Maior primeiro</string>
     <string name="general_tag_filter_label">Filtrar por etiqueta</string>
     <string name="general_tag_system">Sistema</string>
     <string name="general_result_success_message">Operação bem sucedida</string>

--- a/app-common/src/main/res/values-ro/strings.xml
+++ b/app-common/src/main/res/values-ro/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">În coadă</string>
     <string name="general_progress_deleting">Se sterge</string>
     <string name="general_progress_deleting_x">Se șterge %s</string>
+    <string name="general_sort_action">Sortare</string>
+    <string name="general_sort_by_title">Sortare după</string>
     <string name="general_sort_options_label">Opțiuni pentru sortare</string>
     <string name="general_sort_reverse_action">Modul de sortare inversă</string>
+    <string name="general_sort_oldest_first">Cele mai vechi primele</string>
+    <string name="general_sort_newest_first">Cele mai noi primele</string>
+    <string name="general_sort_name_asc">Nume (A → Z)</string>
+    <string name="general_sort_size_desc">Cele mai mari primele</string>
     <string name="general_tag_filter_label">Filtrează după etichete</string>
     <string name="general_tag_system">Sistem</string>
     <string name="general_result_success_message">Operațiune cu succes</string>

--- a/app-common/src/main/res/values-ru/strings.xml
+++ b/app-common/src/main/res/values-ru/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">В очереди</string>
     <string name="general_progress_deleting">Удаление</string>
     <string name="general_progress_deleting_x">Удаление %s</string>
+    <string name="general_sort_action">Сортировка</string>
+    <string name="general_sort_by_title">Порядок сортировки</string>
     <string name="general_sort_options_label">Опции сортировки</string>
     <string name="general_sort_reverse_action">Обратный порядок сортировки</string>
+    <string name="general_sort_oldest_first">Сначала старые</string>
+    <string name="general_sort_newest_first">Сначала новые</string>
+    <string name="general_sort_name_asc">По имени (A - Z)</string>
+    <string name="general_sort_size_desc">Сначала большие</string>
     <string name="general_tag_filter_label">Фильтр по тегам</string>
     <string name="general_tag_system">Системная</string>
     <string name="general_result_success_message">Операция выполнена</string>

--- a/app-common/src/main/res/values-sc-rIT/strings.xml
+++ b/app-common/src/main/res/values-sc-rIT/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">In fila</string>
     <string name="general_progress_deleting">Iscancellende</string>
     <string name="general_progress_deleting_x">Iscancellende %s</string>
+    <string name="general_sort_action">Ordinamentu</string>
+    <string name="general_sort_by_title">Ordina po</string>
     <string name="general_sort_options_label">Optzionis de ordinamentu</string>
     <string name="general_sort_reverse_action">Modalidade de ordinamentu inversu</string>
+    <string name="general_sort_oldest_first">Pius antigus primmu</string>
+    <string name="general_sort_newest_first">Pius nous primmu</string>
+    <string name="general_sort_name_asc">Nòmine (A → Z)</string>
+    <string name="general_sort_size_desc">Pius mannu primmu</string>
     <string name="general_tag_filter_label">Filtrare pro etichetas</string>
     <string name="general_tag_system">Sistema</string>
     <string name="general_result_success_message">Operatzione cumpletada cun èsitu</string>

--- a/app-common/src/main/res/values-si-rLK/strings.xml
+++ b/app-common/src/main/res/values-si-rLK/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">පෙළගස්සා</string>
     <string name="general_progress_deleting">මකමින්</string>
     <string name="general_progress_deleting_x">%s මකමින්</string>
+    <string name="general_sort_action">වර්ගීකරණය</string>
+    <string name="general_sort_by_title">අනුව වර්ගීකරණය</string>
     <string name="general_sort_options_label">වර්ග විකල්ප</string>
     <string name="general_sort_reverse_action">ප්‍රතිලෝම වර්ග ක්‍රමය</string>
+    <string name="general_sort_oldest_first">පැරණිතම මුලින්</string>
+    <string name="general_sort_newest_first">නවතම මුලින්</string>
+    <string name="general_sort_name_asc">නම (A → Z)</string>
+    <string name="general_sort_size_desc">විශාලතම මුලින්</string>
     <string name="general_tag_filter_label">ටැග අනුව පෙරන්න</string>
     <string name="general_tag_system">පද්ධතිය</string>
     <string name="general_result_success_message">සාර්ථකව සම්පූර්ණ කළා</string>

--- a/app-common/src/main/res/values-sk/strings.xml
+++ b/app-common/src/main/res/values-sk/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">V poradí</string>
     <string name="general_progress_deleting">Vymazávanie</string>
     <string name="general_progress_deleting_x">Odstraňuje sa %s</string>
+    <string name="general_sort_action">Zoradiť</string>
+    <string name="general_sort_by_title">Zoradiť podľa</string>
     <string name="general_sort_options_label">Možnosti zoradenia</string>
     <string name="general_sort_reverse_action">Obrátený režim triedenia</string>
+    <string name="general_sort_oldest_first">Najstaršie ako prvé</string>
+    <string name="general_sort_newest_first">Najnovšie ako prvé</string>
+    <string name="general_sort_name_asc">Názov (A → Z)</string>
+    <string name="general_sort_size_desc">Najväčšie ako prvé</string>
     <string name="general_tag_filter_label">Filtrujte podľa štítkov</string>
     <string name="general_tag_system">Systém</string>
     <string name="general_result_success_message">Operácia úspešná</string>

--- a/app-common/src/main/res/values-sl/strings.xml
+++ b/app-common/src/main/res/values-sl/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">V čakalni vrsti</string>
     <string name="general_progress_deleting">Brisanje</string>
     <string name="general_progress_deleting_x">Brisanje %s</string>
+    <string name="general_sort_action">Razvrsti</string>
+    <string name="general_sort_by_title">Razvrsti po</string>
     <string name="general_sort_options_label">Možnosti razvrščanja</string>
     <string name="general_sort_reverse_action">Obratni vrstni red razvrščanja</string>
+    <string name="general_sort_oldest_first">Najprej najstarejše</string>
+    <string name="general_sort_newest_first">Najprej najnovejše</string>
+    <string name="general_sort_name_asc">Ime (A → Ž)</string>
+    <string name="general_sort_size_desc">Najprej največje</string>
     <string name="general_tag_filter_label">Filtriraj po oznakah</string>
     <string name="general_tag_system">Sistem</string>
     <string name="general_result_success_message">Opravilo je bilo uspešno.</string>

--- a/app-common/src/main/res/values-sq-rAL/strings.xml
+++ b/app-common/src/main/res/values-sq-rAL/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">Në radhë</string>
     <string name="general_progress_deleting">Po fshihet</string>
     <string name="general_progress_deleting_x">Po fshihet %s</string>
+    <string name="general_sort_action">Rendit</string>
+    <string name="general_sort_by_title">Rendit sipas</string>
     <string name="general_sort_options_label">Opsionet e renditjes</string>
     <string name="general_sort_reverse_action">Modaliteti i renditjes së kundërt</string>
+    <string name="general_sort_oldest_first">Më të vjetrat fillimisht</string>
+    <string name="general_sort_newest_first">Më të rejat fillimisht</string>
+    <string name="general_sort_name_asc">Emri (A → Z)</string>
+    <string name="general_sort_size_desc">Më të mëdhatë fillimisht</string>
     <string name="general_tag_filter_label">Filtro sipas etiketave</string>
     <string name="general_tag_system">Sistemi</string>
     <string name="general_result_success_message">Operation successful</string>

--- a/app-common/src/main/res/values-sr/strings.xml
+++ b/app-common/src/main/res/values-sr/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">У реду</string>
     <string name="general_progress_deleting">Брисање</string>
     <string name="general_progress_deleting_x">Брисање %s</string>
+    <string name="general_sort_action">Сортирај</string>
+    <string name="general_sort_by_title">Сортирај по</string>
     <string name="general_sort_options_label">Опције сортирања</string>
     <string name="general_sort_reverse_action">Обрнути режим сортирања</string>
+    <string name="general_sort_oldest_first">Најстарији прво</string>
+    <string name="general_sort_newest_first">Најновији прво</string>
+    <string name="general_sort_name_asc">Назив (А → Ж)</string>
+    <string name="general_sort_size_desc">Највећи прво</string>
     <string name="general_tag_filter_label">Филтрирај по таговима</string>
     <string name="general_tag_system">Систем</string>
     <string name="general_result_success_message">Операција успешна</string>

--- a/app-common/src/main/res/values-sv/strings.xml
+++ b/app-common/src/main/res/values-sv/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">I kö</string>
     <string name="general_progress_deleting">Tar bort</string>
     <string name="general_progress_deleting_x">Tar bort %s</string>
+    <string name="general_sort_action">Sortera</string>
+    <string name="general_sort_by_title">Sortera efter</string>
     <string name="general_sort_options_label">Sorteringsalternativ</string>
     <string name="general_sort_reverse_action">Omvänt sorteringsläge</string>
+    <string name="general_sort_oldest_first">Äldst först</string>
+    <string name="general_sort_newest_first">Nyast först</string>
+    <string name="general_sort_name_asc">Namn (A → Ö)</string>
+    <string name="general_sort_size_desc">Störst först</string>
     <string name="general_tag_filter_label">Filtrera efter taggar</string>
     <string name="general_tag_system">System</string>
     <string name="general_result_success_message">Operationen lyckades</string>

--- a/app-common/src/main/res/values-sw/strings.xml
+++ b/app-common/src/main/res/values-sw/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">Kwenye foleni</string>
     <string name="general_progress_deleting">Kufuta</string>
     <string name="general_progress_deleting_x">Kufuta %s</string>
+    <string name="general_sort_action">Panga</string>
+    <string name="general_sort_by_title">Panga kulingana na</string>
     <string name="general_sort_options_label">Chaguo za kupanga</string>
     <string name="general_sort_reverse_action">Hali ya kupanga kinyume</string>
+    <string name="general_sort_oldest_first">La zamani kwanza</string>
+    <string name="general_sort_newest_first">Jipya kwanza</string>
+    <string name="general_sort_name_asc">Jina (A → Z)</string>
+    <string name="general_sort_size_desc">Kubwa kwanza</string>
     <string name="general_tag_filter_label">Chuja kwa lebo</string>
     <string name="general_tag_system">Mfumo</string>
     <string name="general_result_success_message">Imekamilika kwa mafanikio</string>

--- a/app-common/src/main/res/values-ta-rIN/strings.xml
+++ b/app-common/src/main/res/values-ta-rIN/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">வரிசையில்</string>
     <string name="general_progress_deleting">நீக்குகிறது</string>
     <string name="general_progress_deleting_x">%s ஐ நீக்குகிறது</string>
+    <string name="general_sort_action">வரிசைப்படுத்து</string>
+    <string name="general_sort_by_title">இதன்படி வரிசைப்படுத்து</string>
     <string name="general_sort_options_label">வரிசைப்படுத்தும் விருப்பங்கள்</string>
     <string name="general_sort_reverse_action">வெல்-வரிசைப்படுத்தும் பயன்முறை</string>
+    <string name="general_sort_oldest_first">பழையது முதலில்</string>
+    <string name="general_sort_newest_first">புதியது முதலில்</string>
+    <string name="general_sort_name_asc">பெயர் (அ → ஆ)</string>
+    <string name="general_sort_size_desc">பெரியது முதலில்</string>
     <string name="general_tag_filter_label">குறிகளால் வடிகட்டு</string>
     <string name="general_tag_system">கணினி</string>
     <string name="general_result_success_message">வெற்றிகரமாக முடிக்கப்பட்டது</string>

--- a/app-common/src/main/res/values-te-rIN/strings.xml
+++ b/app-common/src/main/res/values-te-rIN/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">వరుసలో</string>
     <string name="general_progress_deleting">తొలగిస్తుంది</string>
     <string name="general_progress_deleting_x">%s తొలగిస్తుంది</string>
+    <string name="general_sort_action">క్రమబద్ధీకరించు</string>
+    <string name="general_sort_by_title">దీని ద్వారా క్రమబద్ధీకరించు</string>
     <string name="general_sort_options_label">క్రమబద్ధీకరణ ఎంపికలు</string>
     <string name="general_sort_reverse_action">రివర్స్ సార్ట్ మోడ్</string>
+    <string name="general_sort_oldest_first">పాతవి ముందు</string>
+    <string name="general_sort_newest_first">కొత్తవి ముందు</string>
+    <string name="general_sort_name_asc">పేరు (A → Z)</string>
+    <string name="general_sort_size_desc">పెద్దవి ముందు</string>
     <string name="general_tag_filter_label">ట్యాగ్‌ల ద్వారా ఫిల్టర్ చేయండి</string>
     <string name="general_tag_system">సిస్టం</string>
     <string name="general_result_success_message">విజయవంతంగా పూర్తయింది</string>

--- a/app-common/src/main/res/values-th/strings.xml
+++ b/app-common/src/main/res/values-th/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">อยู่ในคิว</string>
     <string name="general_progress_deleting">กำลังลบ</string>
     <string name="general_progress_deleting_x">กำลังลบ %s</string>
+    <string name="general_sort_action">เรียงลำดับ</string>
+    <string name="general_sort_by_title">เรียงตาม</string>
     <string name="general_sort_options_label">ตัวเลือกการเรียงลำดับ</string>
     <string name="general_sort_reverse_action">โหมดเรียงลำดับแบบกลับด้าน</string>
+    <string name="general_sort_oldest_first">เก่าที่สุดก่อน</string>
+    <string name="general_sort_newest_first">ใหม่ที่สุดก่อน</string>
+    <string name="general_sort_name_asc">ชื่อ (ก → ฮ)</string>
+    <string name="general_sort_size_desc">ใหญ่ที่สุดก่อน</string>
     <string name="general_tag_filter_label">กรองตามแท็ก</string>
     <string name="general_tag_system">ระบบ</string>
     <string name="general_result_success_message">การดำเนินการสำเร็จ</string>

--- a/app-common/src/main/res/values-tr/strings.xml
+++ b/app-common/src/main/res/values-tr/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">Sırada</string>
     <string name="general_progress_deleting">Siliniyor</string>
     <string name="general_progress_deleting_x">%s siliniyor</string>
+    <string name="general_sort_action">Sırala</string>
+    <string name="general_sort_by_title">Sıralama ölçütü</string>
     <string name="general_sort_options_label">Sıralama seçenekleri</string>
     <string name="general_sort_reverse_action">Ters sıralama modu</string>
+    <string name="general_sort_oldest_first">Önce en eski</string>
+    <string name="general_sort_newest_first">Önce en yeni</string>
+    <string name="general_sort_name_asc">Ad (A → Z)</string>
+    <string name="general_sort_size_desc">Önce en büyük</string>
     <string name="general_tag_filter_label">Etiketlere göre filtrele</string>
     <string name="general_tag_system">Sistem</string>
     <string name="general_result_success_message">İşlem başarılı</string>

--- a/app-common/src/main/res/values-uk/strings.xml
+++ b/app-common/src/main/res/values-uk/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">У черзі</string>
     <string name="general_progress_deleting">Видалення</string>
     <string name="general_progress_deleting_x">Видалення %s</string>
+    <string name="general_sort_action">Сортувати</string>
+    <string name="general_sort_by_title">Сортувати за</string>
     <string name="general_sort_options_label">Параметри сортування</string>
     <string name="general_sort_reverse_action">Зворотне сортування</string>
+    <string name="general_sort_oldest_first">Спочатку найстаріші</string>
+    <string name="general_sort_newest_first">Спочатку найновіші</string>
+    <string name="general_sort_name_asc">Ім\'я (А → Я)</string>
+    <string name="general_sort_size_desc">Спочатку найбільші</string>
     <string name="general_tag_filter_label">Фільтрувати за тегами</string>
     <string name="general_tag_system">Система</string>
     <string name="general_result_success_message">Операція успішна</string>

--- a/app-common/src/main/res/values-ur-rIN/strings.xml
+++ b/app-common/src/main/res/values-ur-rIN/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">قطار میں</string>
     <string name="general_progress_deleting">حذف کر رہا ہے</string>
     <string name="general_progress_deleting_x">%s حذف کر رہا ہے</string>
+    <string name="general_sort_action">ترتیب دیں</string>
+    <string name="general_sort_by_title">ترتیب بذریعہ</string>
     <string name="general_sort_options_label">ترتیب کے اختیارات</string>
     <string name="general_sort_reverse_action">ریورس سارٹ موڈ</string>
+    <string name="general_sort_oldest_first">پرانا پہلے</string>
+    <string name="general_sort_newest_first">نیا پہلے</string>
+    <string name="general_sort_name_asc">نام (الف → ے)</string>
+    <string name="general_sort_size_desc">سب سے بڑا پہلے</string>
     <string name="general_tag_filter_label">ٹیگز کے ذریعے فلٹر کریں</string>
     <string name="general_tag_system">سسٹم</string>
     <string name="general_result_success_message">کامیابی سے مکمل</string>

--- a/app-common/src/main/res/values-uz/strings.xml
+++ b/app-common/src/main/res/values-uz/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">Navbatda</string>
     <string name="general_progress_deleting">O\'chirilmoqda</string>
     <string name="general_progress_deleting_x">%s o\'chirilmoqda</string>
+    <string name="general_sort_action">Saralash</string>
+    <string name="general_sort_by_title">Saralash mezoni</string>
     <string name="general_sort_options_label">Saralash variantlari</string>
     <string name="general_sort_reverse_action">Teskari saralash rejimi</string>
+    <string name="general_sort_oldest_first">Avval eng eskisi</string>
+    <string name="general_sort_newest_first">Avval eng yangi</string>
+    <string name="general_sort_name_asc">Nom (A → Z)</string>
+    <string name="general_sort_size_desc">Avval eng kattasi</string>
     <string name="general_tag_filter_label">Teglar bo\'yicha filtrlash</string>
     <string name="general_tag_system">Tizim</string>
     <string name="general_result_success_message">Muvaffaqiyatli bajarildi</string>

--- a/app-common/src/main/res/values-vi/strings.xml
+++ b/app-common/src/main/res/values-vi/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">Đang chờ</string>
     <string name="general_progress_deleting">Đang xóa</string>
     <string name="general_progress_deleting_x">Đang xoá %s</string>
+    <string name="general_sort_action">Sắp xếp</string>
+    <string name="general_sort_by_title">Sắp xếp theo</string>
     <string name="general_sort_options_label">Tùy chọn sắp xếp</string>
     <string name="general_sort_reverse_action">Chế độ sắp xếp ngược</string>
+    <string name="general_sort_oldest_first">Cũ nhất trước</string>
+    <string name="general_sort_newest_first">Mới nhất trước</string>
+    <string name="general_sort_name_asc">Tên (A → Z)</string>
+    <string name="general_sort_size_desc">Lớn nhất trước</string>
     <string name="general_tag_filter_label">Bộ lọc theo thẻ</string>
     <string name="general_tag_system">Hệ thống</string>
     <string name="general_result_success_message">Thao tác thành công</string>

--- a/app-common/src/main/res/values-zh-rCN/strings.xml
+++ b/app-common/src/main/res/values-zh-rCN/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">排队中</string>
     <string name="general_progress_deleting">正在删除</string>
     <string name="general_progress_deleting_x">正在删除 %s</string>
+    <string name="general_sort_action">排序</string>
+    <string name="general_sort_by_title">排序方式</string>
     <string name="general_sort_options_label">排序选项</string>
     <string name="general_sort_reverse_action">反向排序模式</string>
+    <string name="general_sort_oldest_first">最旧优先</string>
+    <string name="general_sort_newest_first">最新优先</string>
+    <string name="general_sort_name_asc">名称（A → Z）</string>
+    <string name="general_sort_size_desc">最大优先</string>
     <string name="general_tag_filter_label">按标签排序</string>
     <string name="general_tag_system">系统</string>
     <string name="general_result_success_message">操作成功</string>

--- a/app-common/src/main/res/values-zh-rHK/strings.xml
+++ b/app-common/src/main/res/values-zh-rHK/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">在佇列中</string>
     <string name="general_progress_deleting">正在刪除</string>
     <string name="general_progress_deleting_x">正在刪除 %s</string>
+    <string name="general_sort_action">排序</string>
+    <string name="general_sort_by_title">排序方式</string>
     <string name="general_sort_options_label">排序選項</string>
     <string name="general_sort_reverse_action">反向排序模式</string>
+    <string name="general_sort_oldest_first">最舊優先</string>
+    <string name="general_sort_newest_first">最新優先</string>
+    <string name="general_sort_name_asc">名稱（A → Z）</string>
+    <string name="general_sort_size_desc">最大優先</string>
     <string name="general_tag_filter_label">依標籤過濾</string>
     <string name="general_tag_system">系統</string>
     <string name="general_result_success_message">作業成功</string>

--- a/app-common/src/main/res/values-zh-rTW/strings.xml
+++ b/app-common/src/main/res/values-zh-rTW/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">在佇列中</string>
     <string name="general_progress_deleting">正在刪除</string>
     <string name="general_progress_deleting_x">正在刪除 %s</string>
+    <string name="general_sort_action">排序</string>
+    <string name="general_sort_by_title">排序方式</string>
     <string name="general_sort_options_label">排序選項</string>
     <string name="general_sort_reverse_action">反向排序模式</string>
+    <string name="general_sort_oldest_first">最舊的優先</string>
+    <string name="general_sort_newest_first">最新的優先</string>
+    <string name="general_sort_name_asc">名稱（A → Z）</string>
+    <string name="general_sort_size_desc">最大的優先</string>
     <string name="general_tag_filter_label">依標籤過濾</string>
     <string name="general_tag_system">系統</string>
     <string name="general_result_success_message">作業成功</string>

--- a/app-common/src/main/res/values-zu/strings.xml
+++ b/app-common/src/main/res/values-zu/strings.xml
@@ -71,8 +71,14 @@
     <string name="general_progress_queued">Emgqeni</string>
     <string name="general_progress_deleting">Iyasusa</string>
     <string name="general_progress_deleting_x">Susa %s</string>
+    <string name="general_sort_action">Hlunga</string>
+    <string name="general_sort_by_title">Hlunga ngo</string>
     <string name="general_sort_options_label">Izinketho zokuhlunga</string>
     <string name="general_sort_reverse_action">Imodi yokuhlungana okuphambene</string>
+    <string name="general_sort_oldest_first">Omdala kuqala</string>
+    <string name="general_sort_newest_first">Omusha kuqala</string>
+    <string name="general_sort_name_asc">Igama (A → Z)</string>
+    <string name="general_sort_size_desc">Olukhulu kuqala</string>
     <string name="general_tag_filter_label">Hlola ngama-tag</string>
     <string name="general_tag_system">Uhlelo</string>
     <string name="general_result_success_message">Kuqedwe ngempumelelo</string>

--- a/app-tool-analyzer/src/main/res/values-af-rZA/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-af-rZA/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">Gevangde foto\'s, opgenome video\'s of afgelaai data. Enige data wat nie aan \'n spesifieke toepassing behoort nie.</string>
     <string name="analyzer_storage_content_type_system_label">Stelsel data</string>
     <string name="analyzer_storage_content_type_system_description">Stelsel toepassings en stelsel data. Toepassings en data van ander gebruikers, as verskeie gebruiker rekeninge op hierdie toestel gestel is.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Ander</string>
+    <string name="analyzer_storage_content_type_system_info">Lêers wat nie in die Programme- of Gebruikerslêers-kategorieë pas nie. Slegs blaai — verwydering word nie ondersteun nie. Sommige areas kan onvolledig wees weens toegangsbeperkings.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">Stelsellêers en ander data waartoe SD Maid nie toegang gehad het of kon kategoriseer nie. Die bedryfstelsel beperk die lys van die inhoud van sommige areas.</string>
     <string name="analyzer_storage_content_app_code_label">Toepassing kode</string>
     <string name="analyzer_storage_content_app_code_description">Toepassing lêers, biblioteke en hulpbronne. Hierdie ruimte kan bevry word deur die toepassing te deïnstalleer of dit te argiveer (beskikbaar op nuwer Android weergawe).</string>
     <string name="analyzer_storage_content_app_data_label">Toepassing data</string>

--- a/app-tool-analyzer/src/main/res/values-am/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-am/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">የተወሰዱ ምስሎች፣ የተቀዱ ቪዲዮዎች ወይም የተወረዱ ውሂቦች። ለተወሰነ መተግበሪያ የማያመሩ ማንኛቸውም ውሂቦች።</string>
     <string name="analyzer_storage_content_type_system_label">የሲስተም ውሂብ</string>
     <string name="analyzer_storage_content_type_system_description">የሲስተም መተግበሪያዎችና የሲስተም ውሂብ። ብዙ የተጠቃሚ መለያዎች በዚህ መሣሪያ ላይ ከተሰናዱ የሌሎች ተጠቃሚዎች መተግበሪያዎችና ውሂብ።</string>
+    <string name="analyzer_storage_content_type_system_other_label">ሌላ</string>
+    <string name="analyzer_storage_content_type_system_info">ከመተግበሪያዎች ወይም ከተጠቃሚ ፋይሎች ምድቦች ውጭ የሆኑ ፋይሎች። ማሰስ ብቻ — ሰርዛ አይደገፍም። አንዳንድ ቦታዎች ባለው ፍቃድ ገደብ ምክንያት ሙሉ ላይሆኑ ይችላሉ።</string>
+    <string name="analyzer_storage_content_type_system_other_desc">SD Maid መድረስ ወይም መመደብ ያልቻለ የስርዓት ፋይሎች እና ሌሎች ውሂቦች። ስርዓተ ክወናው አንዳንድ ቦታዎች ይዘት ዝርዝር መዘርዘርን ይገድባል።</string>
     <string name="analyzer_storage_content_app_code_label">የመተግበሪያ ኮድ</string>
     <string name="analyzer_storage_content_app_code_description">የመተግበሪያ ፋይሎች፣ ቤተ-መጻሕፍትና ሀብቶች። ይህ ቦታ መተግበሪያውን በማጥፋት ወይም በማከማቸት (በአዲሶቹ አንድሮይድ ስሪቶች ላይ ይገኛል) ሊለቀቅ ይችላል።</string>
     <string name="analyzer_storage_content_app_data_label">የመተግበሪያ ውሂብ</string>

--- a/app-tool-analyzer/src/main/res/values-ar/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-ar/strings.xml
@@ -47,6 +47,9 @@
     <string name="analyzer_storage_content_type_media_description">الصور الملتقطة أو مقاطع الفيديو المسجلة أو البيانات التي تم تنزيلها. أي بيانات لا تنتمي إلى تطبيق محدد.</string>
     <string name="analyzer_storage_content_type_system_label">بيانات النظام</string>
     <string name="analyzer_storage_content_type_system_description">تطبيقات النظام وبيانات النظام. التطبيقات والبيانات من المستخدمين الآخرين، إذا تم تعيين عدة حسابات للمستخدمين على هذا الجهاز.</string>
+    <string name="analyzer_storage_content_type_system_other_label">أخرى</string>
+    <string name="analyzer_storage_content_type_system_info">الملفات التي لا تنتمي إلى فئتَي التطبيقات أو ملفات المستخدم. للاستعراض فقط — الحذف غير مدعوم. قد تكون بعض المناطق غير مكتملة بسبب قيود الوصول.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">ملفات النظام والبيانات الأخرى التي تعذّر على SD Maid الوصول إليها أو تصنيفها. يقيّد نظام التشغيل إمكانية سرد محتويات بعض المناطق.</string>
     <string name="analyzer_storage_content_app_code_label">كود التطبيق</string>
     <string name="analyzer_storage_content_app_code_description">ملفات التطبيق، المكتبات والموارد. يمكن تحرير هذه المساحة عن طريق إلغاء تثبيت التطبيق أو أرشفته (متاحة على إصدارات أندرويد الأحدث).</string>
     <string name="analyzer_storage_content_app_data_label">بيانات التطبيق</string>

--- a/app-tool-analyzer/src/main/res/values-az/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-az/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">Çəkilmiş şəkillər, qeydə alınmış videolar və ya yüklənmiş məlumatlar. Xüsusi tətbiqə aid olmayan istənilən məlumat.</string>
     <string name="analyzer_storage_content_type_system_label">Sistem məlumatları</string>
     <string name="analyzer_storage_content_type_system_description">Sistem tətbiqləri və sistem məlumatları. Bu cihazda bir neçə istifadəçi hesabı qurulubsa, digər istifadəçilərin tətbiqləri və məlumatları.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Digər</string>
+    <string name="analyzer_storage_content_type_system_info">Tətbiqliər və ya İstifadəçi faylları kateqoriyalarına uyğun olmayan fayllar. Yalnız baxış — silinmə dəstəklənmir. Giriş məhdudiyyətləri səbəbindən bəzi sahələr natamam ola bilər.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">SD Maid-in daxil ola bilmədiyi və ya kateqoriyalaşdıra bilmədiyi sistem faylları və digər məlumatlar. Əməliyyat sistemi bəzi sahələrin məzmununu siyahıya almaqı məhdudlaşdırır.</string>
     <string name="analyzer_storage_content_app_code_label">Tətbiq kodu</string>
     <string name="analyzer_storage_content_app_code_description">Tətbiq faylları, kitabxanalar və resurslar. Bu yer tətbiqi silərek və ya arxivləyərək (yeni Android versiyalarında mövcuddur) azad edilə bilər.</string>
     <string name="analyzer_storage_content_app_data_label">Tətbiq məlumatları</string>

--- a/app-tool-analyzer/src/main/res/values-be/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-be/strings.xml
@@ -41,6 +41,9 @@
     <string name="analyzer_storage_content_type_media_description">Фатаграфіі, відэа ці спампаваныя даныя. Любыя даныя, якія не адносяцца да пэўных праграм.</string>
     <string name="analyzer_storage_content_type_system_label">Сістэмныя даныя</string>
     <string name="analyzer_storage_content_type_system_description">Сістэмныя праграмы і сістэмныя даныя. Праграмы і даныя іншых карыстальнікаў, калі на гэтай прыладзе маецца некалькі ўліковых запісаў.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Іншае</string>
+    <string name="analyzer_storage_content_type_system_info">Файлы, якія не адносяцца да катэгорый «Праграмы» або «Файлы карыстальніка». Толькі прагляд — выдаленне не падтрымліваецца. Некаторыя вобласці могуць быць няпоўнымі з-за абмежаванняў доступу.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">Сістэмныя файлы і іншыя даныя, да якіх SD Maid не мог атрымаць доступ або катэгарызаваць. Аперацыйная сістэма абмяжоўвае пералічэнне змесціва некаторых вобласцей.</string>
     <string name="analyzer_storage_content_app_code_label">Праграмы код</string>
     <string name="analyzer_storage_content_app_code_description">Файлы праграм, бібліятэкі і рэсурсы. Гэта месца можна вызваліць, выдаліўшы праграму або перамясціць яе ў архіў (даступна ў навейшых версіях Android).</string>
     <string name="analyzer_storage_content_app_data_label">Праграмныя даныя</string>

--- a/app-tool-analyzer/src/main/res/values-bg/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-bg/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">Заснети снимки, записани видеа или изтеглени данни. Всякакви данни, които не принадлежат на конкретно приложение.</string>
     <string name="analyzer_storage_content_type_system_label">Системни данни</string>
     <string name="analyzer_storage_content_type_system_description">Системни приложения и системни данни. Приложения и данни от други потребители, ако са настроени няколко потребителски акаунта на това устройство.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Друго</string>
+    <string name="analyzer_storage_content_type_system_info">Файлове, които не попадат в категориите Приложения или Потребителски файлове. Само преглеждане — изтриването не се поддържа. Някои области може да са непълни поради ограничения достъп.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">Системни файлове и други данни, до които SD Maid не може да получи достъп или да категоризира. Операционната система ограничава изброяването на съдържанието на някои области.</string>
     <string name="analyzer_storage_content_app_code_label">Код на приложение</string>
     <string name="analyzer_storage_content_app_code_description">Файлове на приложения, библиотеки и ресурси. Това място може да бъде освободено чрез деинсталиране на приложението или архивирането му (налично в по-нови версии на Android).</string>
     <string name="analyzer_storage_content_app_data_label">Данни на приложение</string>

--- a/app-tool-analyzer/src/main/res/values-bn-rBD/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-bn-rBD/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">ক্যাপচার করা ছবি, রেকর্ড করা ভিডিও বা ডাউনলোড করা ডেটা। কোনো নির্দিষ্ট অ্যাপের অন্তর্গত নয় এমন কোনো ডেটা।</string>
     <string name="analyzer_storage_content_type_system_label">সিস্টেম ডেটা</string>
     <string name="analyzer_storage_content_type_system_description">সিস্টেম অ্যাপস এবং সিস্টেম ডেটা। এই ডিভাইসে একাধিক ব্যবহারকারীর অ্যাকাউন্ট সেট করা থাকলে অন্যান্য ব্যবহারকারীর অ্যাপ এবং ডেটা।</string>
+    <string name="analyzer_storage_content_type_system_other_label">অন্যান্য</string>
+    <string name="analyzer_storage_content_type_system_info">ফাইলগুলি যা Apps বা User files বিভাগে পড়ে না। শুধুমাত্র ব্রাউজ করুন — মুছে ফেলা সমর্থিত নয়। অ্যাক্সেস সীমাবদ্ধতার কারণে কিছু এলাকা অসম্পূর্ণ হতে পারে।</string>
+    <string name="analyzer_storage_content_type_system_other_desc">সিস্টেম ফাইল এবং অন্যান্য ডেটা যা SD Maid অ্যাক্সেস করতে বা শ্রেণীবদ্ধ করতে পারেনি। অপারেটিং সিস্টেম কিছু এলাকার বিষয়বস্তু তালিকাভুক্ত করা সীমাবদ্ধ করে।</string>
     <string name="analyzer_storage_content_app_code_label">অ্যাপ কোড</string>
     <string name="analyzer_storage_content_app_code_description">অ্যাপ্লিকেশন ফাইল, লাইব্রেরি এবং সম্পদ. অ্যাপটি আনইনস্টল করে বা আর্কাইভ করে (নতুন Android সংস্করণে উপলব্ধ) এই স্থানটি খালি করা যেতে পারে।</string>
     <string name="analyzer_storage_content_app_data_label">অ্যাপ ডেটা</string>

--- a/app-tool-analyzer/src/main/res/values-ca/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-ca/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">Imatges capturades, vídeos gravats o dades baixades. Qualsevol dada que no pertanyi a una aplicació específica.</string>
     <string name="analyzer_storage_content_type_system_label">Dades del sistema</string>
     <string name="analyzer_storage_content_type_system_description">Aplicacions del sistema i dades del sistema. Aplicacions i dades d\'altres usuaris, si hi ha diversos comptes d\'usuari configurats en aquest dispositiu.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Altres</string>
+    <string name="analyzer_storage_content_type_system_info">Fitxers que no pertanyen a les categories d\'aplicacions o fitxers d\'usuari. Només es permet la visualització; no s\'admet l\'eliminació. Algunes àrees poden estar incompletes per restriccions d\'accés.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">Fitxers del sistema i altres dades a les quals l\'SD Maid no ha pogut accedir o classificar. El sistema operatiu restringeix la llista del contingut d\'algunes àrees.</string>
     <string name="analyzer_storage_content_app_code_label">Codi de l\'aplicació</string>
     <string name="analyzer_storage_content_app_code_description">Fitxers d\'aplicacions, biblioteques i recursos. Aquest espai es pot alliberar desinstal·lant l\'aplicació o arxivant-la (disponible a la versió d\'Android més recent).</string>
     <string name="analyzer_storage_content_app_data_label">Dades de l\'aplicació</string>

--- a/app-tool-analyzer/src/main/res/values-ckb-rIR/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-ckb-rIR/strings.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="analyzer_explanation_short">بزانە چی شوێن دەگێرێت لە ئامێرەکەتدا.</string>
+    <string name="analyzer_progress_scanning_device">گەڕان بەدوای ئامێرەکانی حەزداری</string>
+    <string name="analyzer_progress_scanning_storage">سکانکردنی حەزداری</string>
+    <string name="analyzer_progress_scanning_apps">سکانکردنی بەرنامەکان</string>
+    <string name="analyzer_progress_scanning_userfiles">گەڕان بەدوای فایلەکانی بەکارهێنەر</string>
+    <string name="analyzer_progress_scanning_system">سکانکردنی داتای سیستەم</string>
+    <string name="analyzer_device_storage_title">حەزداری ئامێر</string>
     <plurals name="analyzer_space_available">
         <item quantity="one">%s بەردەستە</item>
         <item quantity="other">%s بەردەستە</item>
@@ -9,6 +15,7 @@
         <item quantity="one">%s بەکاردەهێنرێت</item>
         <item quantity="other">%s بەکاردەهێنرێت</item>
     </plurals>
+    <string name="analyzer_content_access_opaque">دەسترسی ڕاستەوخۆ بەردەست نییە</string>
     <string name="analyzer_content_create_swiper_session_action">دروستکردنی سێشنی Swiper</string>
     <plurals name="analyzer_content_swiper_session_created_x_items">
         <item quantity="one">سێشنی Swiper دروستکرا بە %d بابەت</item>
@@ -17,11 +24,27 @@
     <string name="analyzer_storage_type_primary_title">ئەمبارەکردنی سەرەکی</string>
     <string name="analyzer_storage_type_primary_description">ئەمبارەکردنی سەرەکی ئامێرەکەت. کارتی SD ناوخۆیی، ئەمبارەکردنی تایبەت بۆ ئەپەکان و داتای سیستەم دەگێرێتەوە.</string>
     <string name="analyzer_storage_type_secondary_title">ئەمبارەکردنی دووەم</string>
+    <string name="analyzer_storage_type_secondary_description">حەزداریەکی دووەم، بەمعمولا کارتی SD کە دەرهێنرێت. فایلە میدیاکان و داتای بەرنامەکانی پشتیوانیکەرەوەی تێدایە.</string>
     <string name="analyzer_storage_type_tertiary_title">ئەمبارەی گواستراوە</string>
     <string name="analyzer_storage_type_tertiary_description">ئەمبارەی گواستراوە، بۆ نموونە فلاش درایڤ کراوتەناو پۆرتی USB.</string>
+    <string name="analyzer_storage_content_title">ناوەڕۆکی حەزداری</string>
     <string name="analyzer_storage_content_type_app_label">ئەپەکان</string>
+    <string name="analyzer_storage_content_type_app_description">شوێنی داگیرکراو بەرنامە دامەزراوەکان و داتاکانیان (بەوانەش فایلی بەرنامە، داتا و کاچێکان).</string>
+    <string name="analyzer_storage_content_type_app_setup_incomplete_hint">مۆڵەتەکان کەمن</string>
+    <string name="analyzer_storage_content_type_media_label">فایلەکانی بەکارهێنەر</string>
     <string name="analyzer_storage_content_type_media_description">وێنەی وێنەگیراو، ڤیدیۆی تۆمارکراو یان داتای داونلۆدکراو. هەر داتاییکە بەلونگی ئەپێکی دیاریکراو نابێت.</string>
+    <string name="analyzer_storage_content_type_system_label">داتای سیستەم</string>
+    <string name="analyzer_storage_content_type_system_description">بەرنامە و داتاکانی سیستەم. بەرنامە و داتای بەکارهێنەرانی تر، ئەگەر چەندین هەژمار لەسەر ئەم ئامێرە ڕێکخراوبێن.</string>
+    <string name="analyzer_storage_content_type_system_other_label">تر</string>
+    <string name="analyzer_storage_content_type_system_info">فایلەکانی کە لە سەردەستەی بەرنامەکان یان فایلەکانی بەکارهێنەر ناگنجنەن. بێنین تەنھا ― سماچکردن پشتیوانیکرینیکەوە نییە. هەندێکێ ناحێگەکانی ھەندێکەکان لە هەگیری دەسترسی ناتەواو دەبێت.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">فایلەکانی سیستەم و داتای ترەکە SD Maid دەسترسیی پێنێوابوو یان بەخشبەندیكردنییمن. سیستەمەکەی ڤەرمانروایی کۆمساییکێش ناوەكانی هەندێکێ ناحێگەکان بیست.</string>
+    <string name="analyzer_storage_content_app_code_label">کۆدی بەرنامە</string>
+    <string name="analyzer_storage_content_app_code_description">فایلەکانی بەرنامە، کتێبخانەکان و سەرچاوەکان. ئەم شوێنە دەتوانرێت بە لابردنی بەرنامەکە یان ئەرشیفکردنی ئازاد بکرێتەوە (بەردەستە لە وەرزیانی نویتری ئەندرۆید).</string>
+    <string name="analyzer_storage_content_app_data_label">داتای بەرنامە</string>
+    <string name="analyzer_storage_content_app_data_description">داتا، ڕێکخستنەکان و کاچێکان.</string>
     <string name="analyzer_storage_content_app_media_label">ئەپ media</string>
+    <string name="analyzer_storage_content_app_media_description">فایلە میدیاکانی ئەم بەرنامەیە، بۆ نموونە وێنەکانی WhatsApp کە وەرگیراون.</string>
+    <string name="analyzer_storage_content_app_extra_label">فایلە زیادەکانی بەرنامە</string>
     <string name="analyzer_storage_content_app_extra_description">داتای زیادە کە ئەم ئەپە لە دەرەوەی ڕێگاکانی بنەڕەتی داناوە، بۆ نموونە وێنەکان یان داونلۆدەکان.</string>
     <string name="analyzer_app_details_app_occupies_x_on_y">ئەم ئەپە %1$s لەسەر \"%2$s\" دەیگێرێت.</string>
     <string name="analyzer_app_details_app_is_archived">ئەم ئەپە ئەرشیفکراوە.</string>

--- a/app-tool-analyzer/src/main/res/values-cs/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-cs/strings.xml
@@ -41,6 +41,9 @@
     <string name="analyzer_storage_content_type_media_description">Pořízené fotky, nahraná videa nebo stažená data. Jakákoliv data, která nepatří ke konkrétní aplikaci.</string>
     <string name="analyzer_storage_content_type_system_label">Systémová data</string>
     <string name="analyzer_storage_content_type_system_description">Systémové aplikace a systémová data. Aplikace a data od jiných uživatelů, pokud je v tomto zařízení nastaveno více uživatelských účtů.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Ostatní</string>
+    <string name="analyzer_storage_content_type_system_info">Soubory, které nespadají do kategorií Aplikace nebo Uživatelské soubory. Pouze procházení — mazání není podporováno. Některé oblasti mohou být neúplné z důvodu omezení přístupu.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">Systémové soubory a další data, ke kterým SD Maid nemohl přistupovat nebo je zařadit. Operační systém omezuje výpis obsahu některých oblastí.</string>
     <string name="analyzer_storage_content_app_code_label">Kód aplikace</string>
     <string name="analyzer_storage_content_app_code_description">Soubory aplikace, knihovny a prostředky. Tento prostor může být uvolněn odinstalováním aplikace nebo její archivací (dostupné v novějších verzích Android).</string>
     <string name="analyzer_storage_content_app_data_label">Data aplikace</string>

--- a/app-tool-analyzer/src/main/res/values-da/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-da/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">Billeder, videooptagelser eller downloadede data. Al data, der ikke hører til en bestemt app.</string>
     <string name="analyzer_storage_content_type_system_label">Systemdata</string>
     <string name="analyzer_storage_content_type_system_description">Systemapps og -data. Apps og data fra andre brugere, hvis enheden har flere brugerkonti.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Andet</string>
+    <string name="analyzer_storage_content_type_system_info">Filer der ikke passer ind i kategorierne Apps eller Brugerfiler. Gennemse kun — sletning understøttes ikke. Nogle områder kan være ufuldstændige på grund af adgangsbegrænsninger.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">Systemfiler og andre data, som SD Maid ikke kunne få adgang til eller kategorisere. Operativsystemet begrænser visningen af indholdet i nogle områder.</string>
     <string name="analyzer_storage_content_app_code_label">Appkode</string>
     <string name="analyzer_storage_content_app_code_description">Programfiler, biblioteker og ressourcer. Denne plads kan frigøres ved at afinstallere eller arkivere appen (tilgængelig på nyere Android-versioner).</string>
     <string name="analyzer_storage_content_app_data_label">Appdata</string>

--- a/app-tool-analyzer/src/main/res/values-de/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-de/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">Aufgenommene Bilder und Videos oder heruntergeladene Daten. Alle Daten, die nicht zu einer bestimmten App gehören.</string>
     <string name="analyzer_storage_content_type_system_label">Systemdaten</string>
     <string name="analyzer_storage_content_type_system_description">System-Apps und Systemdaten. Apps und Daten von anderen Benutzern, falls mehrere Benutzerkonten auf diesem Gerät eingerichtet sind.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Andere</string>
+    <string name="analyzer_storage_content_type_system_info">Dateien, die nicht in die Kategorien „Apps“ oder „Benutzerdateien“ passen. Nur durchsuchen — Löschen wird nicht unterstützt. Einige Bereiche können aufgrund von Zugriffsbeschränkungen unvollständig sein.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">Systemdateien und andere Daten, auf die SD Maid nicht zugreifen oder die es nicht kategorisieren konnte. Das Betriebssystem schränkt das Auflisten der Inhalte einiger Bereiche ein.</string>
     <string name="analyzer_storage_content_app_code_label">App-Code</string>
     <string name="analyzer_storage_content_app_code_description">Anwendungsdateien, Bibliotheken und Ressourcen. Dieser Speicherplatz kann freigegeben werden, indem die App deinstalliert oder archiviert wird (verfügbar bei neueren Android-Versionen).</string>
     <string name="analyzer_storage_content_app_data_label">App-Daten</string>

--- a/app-tool-analyzer/src/main/res/values-el/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-el/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">Συλληφθείσες εικόνες, εγγεγραμμένα βίντεο ή ληφθέντα δεδομένα. Οποιαδήποτε δεδομένα που δεν ανήκουν σε μια συγκεκριμένη εφαρμογή.</string>
     <string name="analyzer_storage_content_type_system_label">Δεδομένα συστήματος</string>
     <string name="analyzer_storage_content_type_system_description">Εφαρμογές συστήματος και δεδομένα συστήματος. Εφαρμογές και δεδομένα από άλλους χρήστες, εάν έχουν οριστεί πολλοί λογαριασμοί χρηστών σε αυτήν τη συσκευή.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Άλλο</string>
+    <string name="analyzer_storage_content_type_system_info">Αρχεία που δεν ανήκουν στις κατηγορίες Εφαρμογές ή Αρχεία χρήστη. Μόνο περιήγηση — η διαγραφή δεν υποστηρίζεται. Ορισμένες περιοχές ενδέχεται να είναι ελλιπείς λόγω περιορισμών πρόσβασης.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">Αρχεία συστήματος και άλλα δεδομένα που το SD Maid δεν μπόρεσε να αποκτήσει πρόσβαση ή να κατηγοριοποιήσει. Το λειτουργικό σύστημα περιορίζει την εμφάνιση των περιεχομένων ορισμένων περιοχών.</string>
     <string name="analyzer_storage_content_app_code_label">Κώδικας εφαρμογής</string>
     <string name="analyzer_storage_content_app_code_description">Αρχεία εφαρμογών, βιβλιοθήκες και πόροι. Αυτός ο χώρος μπορεί να ελευθερωθεί με την απεγκατάσταση της εφαρμογής ή την αρχειοθέτησή της (διατίθεται σε νεότερη έκδοση Android).</string>
     <string name="analyzer_storage_content_app_data_label">Δεδομένα εφαρμογών</string>

--- a/app-tool-analyzer/src/main/res/values-es-rAR/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-es-rAR/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">Imágenes capturadas, videos grabados o datos descargados. Cualquier dato que no pertenezca a una aplicación específica.</string>
     <string name="analyzer_storage_content_type_system_label">Datos del sistema</string>
     <string name="analyzer_storage_content_type_system_description">Aplicaciones y datos del sistema. Aplicaciones y datos de otros usuarios, si hay varias cuentas de usuario configuradas en este dispositivo.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Otros</string>
+    <string name="analyzer_storage_content_type_system_info">Archivos que no encajan en las categorías Apps o Archivos de usuario. Solo navegación — no se admite la eliminación. Algunas áreas pueden estar incompletas debido a restricciones de acceso.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">Archivos del sistema y otros datos a los que SD Maid no pudo acceder ni categorizar. El sistema operativo restringe el listado del contenido de algunas áreas.</string>
     <string name="analyzer_storage_content_app_code_label">Código de la aplicación</string>
     <string name="analyzer_storage_content_app_code_description">Archivos, bibliotecas y recursos de la aplicación. Este espacio puede liberarse desinstalando la aplicación o archivándola (disponible en las versiones más recientes de Android).</string>
     <string name="analyzer_storage_content_app_data_label">Datos de la aplicación</string>

--- a/app-tool-analyzer/src/main/res/values-es-rMX/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-es-rMX/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">Fotos capturadas, videos grabados o datos descargados. Cualquier dato que no pertenezca a una aplicación específica.</string>
     <string name="analyzer_storage_content_type_system_label">Datos del sistema</string>
     <string name="analyzer_storage_content_type_system_description">Aplicaciones del sistema y datos del sistema. Aplicaciones y datos de otros usuarios, si hay varias cuentas de usuario configuradas en este dispositivo.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Otros</string>
+    <string name="analyzer_storage_content_type_system_info">Archivos que no encajan en las categorías de Apps o Archivos de usuario. Solo navegación — la eliminación no es compatible. Algunas áreas pueden estar incompletas debido a restricciones de acceso.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">Archivos del sistema y otros datos a los que SD Maid no pudo acceder o categorizar. El sistema operativo restringe el listado del contenido de algunas áreas.</string>
     <string name="analyzer_storage_content_app_code_label">Código de aplicación</string>
     <string name="analyzer_storage_content_app_code_description">Archivos de aplicación, bibliotecas y recursos. Este espacio se puede liberar desinstalando la aplicación o archivándola (disponible en versiones más nuevas de Android).</string>
     <string name="analyzer_storage_content_app_data_label">Datos de aplicación</string>

--- a/app-tool-analyzer/src/main/res/values-es/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-es/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">Imágenes capturadas, videos grabados o datos descargados. Cualquier dato que no pertenezca a una aplicación específica.</string>
     <string name="analyzer_storage_content_type_system_label">Datos del sistema</string>
     <string name="analyzer_storage_content_type_system_description">Las aplicaciones y los datos del sistema. Las aplicaciones y los datos de otros usuarios, si hay varias cuentas de usuario configuradas en este dispositivo.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Otros</string>
+    <string name="analyzer_storage_content_type_system_info">Archivos que no encajan en las categorías Aplicaciones o Archivos de usuario. Solo navegación — la eliminación no está disponible. Algunas áreas pueden estar incompletas debido a restricciones de acceso.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">Archivos del sistema y otros datos a los que SD Maid no pudo acceder o categorizar. El sistema operativo restringe el listado de contenidos de algunas áreas.</string>
     <string name="analyzer_storage_content_app_code_label">Código de la aplicación</string>
     <string name="analyzer_storage_content_app_code_description">Archivos, bibliotecas y recursos de la aplicación. Este espacio puede liberarse desinstalando la aplicación o archivándola (disponible en las versiones más recientes de Android).</string>
     <string name="analyzer_storage_content_app_data_label">Datos de la aplicación</string>

--- a/app-tool-analyzer/src/main/res/values-et-rEE/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-et-rEE/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">Jäädvustatud pildid, salvestatud videod või alla laaditud andmed. Kõik kindlale rakendusele mitte kuuluvad andmed.</string>
     <string name="analyzer_storage_content_type_system_label">Süsteemi andmed</string>
     <string name="analyzer_storage_content_type_system_description">Süsteemi rakendused ja andmed. Muude kasutajate rakendused ja andmed, kui seadmes on seadistatud mitu kasutajakontot.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Muu</string>
+    <string name="analyzer_storage_content_type_system_info">Failid, mis ei kuulu rakenduste ega kasutajafailide kategooriatesse. Ainult sirvimine — kustutamine pole toetatud. Mõned alad võivad olla mittetäielikud juurdepääsupiirangute tõttu.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">Süsteemifailid ja muud andmed, millele SD Maid ei saanud juurde pääseda ega kategoriseerida. Operatsioonisüsteem piirab mõnede alade sisu loetlemist.</string>
     <string name="analyzer_storage_content_app_code_label">Rakenduse kood</string>
     <string name="analyzer_storage_content_app_code_description">Rakenduse failid, teegid ja allikad. Sellle ruumi vabastamiseks eemaldage rakendus või arhiveerige see (saadaval uusimas Androidi versioonis).</string>
     <string name="analyzer_storage_content_app_data_label">Rakenduse andmed</string>

--- a/app-tool-analyzer/src/main/res/values-eu-rES/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-eu-rES/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">Ateratako argazkiak, grabatutako bideoak edo deskargatutako datuak. Aplikazio zehatz bati ez dagokion edozein datu.</string>
     <string name="analyzer_storage_content_type_system_label">Sistema-datuak</string>
     <string name="analyzer_storage_content_type_system_description">Sistema-aplikazioak eta sistema-datuak. Beste erabiltzaileen aplikazioak eta datuak, gailu honetan hainbat erabiltzaile-kontu konfiguratuta badaude.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Bestelakoak</string>
+    <string name="analyzer_storage_content_type_system_info">Aplikazio edo Erabiltzaile fitxategien kategorietara egokitzen ez diren fitxategiak. Arakatu soilik — ezabatzea ez da onartzen. Zenbait area ez da osoa sarbide mugapenak direla eta.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">Sistema-fitxategiak eta SD Maid-ek atzitu edo sailkatu ezin dituen beste datu batzuk. Eragiketa-sistemak zenbait arearen edukia zerrendatzea mugatzen du.</string>
     <string name="analyzer_storage_content_app_code_label">Aplikazioaren kodea</string>
     <string name="analyzer_storage_content_app_code_description">Aplikazio-fitxategiak, liburutegiak eta baliabideak. Leku hau askatu daiteke aplikazioa desinstalatu edo artxibatuz (Android bertsio berrietan erabilgarri).</string>
     <string name="analyzer_storage_content_app_data_label">Aplikazioaren datuak</string>

--- a/app-tool-analyzer/src/main/res/values-fa/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-fa/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">تصاویر گرفته شده، ویدئوهای ضبط شده یا داده‌های دانلود شده. هر داده‌ای که به یک برنامه خاص تعلق ندارد.</string>
     <string name="analyzer_storage_content_type_system_label">داده های سیستم</string>
     <string name="analyzer_storage_content_type_system_description">برنامه های سیستم و داده های سیستم و سایر کاربران، در صورتی که چندین حساب کاربری در این دستگاه تنظیم شده باشد.</string>
+    <string name="analyzer_storage_content_type_system_other_label">بقیه</string>
+    <string name="analyzer_storage_content_type_system_info">فایل‌هایی که در دسته‌بندی برنامه‌ها یا فایل‌های کاربر جای نمی‌گیرند. فقط مرور — حذف پشتیبانی نمی‌شود. برخی بخش‌ها ممکن است به دلیل محدودیت دسترسی ناقص باشند.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">فایل‌های سیستمی و سایر داده‌هایی که SD Maid قادر به دسترسی یا دسته‌بندی آن‌ها نبود. سیستم‌عامل فهرست‌کردن محتوای برخی بخش‌ها را محدود می‌کند.</string>
     <string name="analyzer_storage_content_app_code_label">کد برنامه</string>
     <string name="analyzer_storage_content_app_code_description">فایل‌های برنامه، کتابخانه‌ها و منابع. این فضا را می‌توان با حذف برنامه یا بایگانی آن آزاد کرد (این امکان در نسخه‌های جدیدتر اندروید وجود دارد).</string>
     <string name="analyzer_storage_content_app_data_label">داده برنامه</string>

--- a/app-tool-analyzer/src/main/res/values-fi/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-fi/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">Kuvat, videot, äänet ja muut mediatiedostot.</string>
     <string name="analyzer_storage_content_type_system_label">Järjestelmä</string>
     <string name="analyzer_storage_content_type_system_description">Käyttöjärjestelmä ja järjestelmäsovellukset.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Muut</string>
+    <string name="analyzer_storage_content_type_system_info">Tiedostot, jotka eivät sovi Sovellukset- tai Käyttäjätiedostot-luokkiin. Vain selaus — poistamista ei tueta. Jotkin alueet saattavat olla puutteellisia käyttörajoitusten vuoksi.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">Järjestelmätiedostot ja muut tiedot, joihin SD Maid ei päässyt käsiksi tai joita se ei pystynyt luokittelemaan. Käyttöjärjestelmä rajoittaa joidenkin alueiden sisällön listaamista.</string>
     <string name="analyzer_storage_content_app_code_label">Koodi</string>
     <string name="analyzer_storage_content_app_code_description">Sovelluksen asennustiedostot (APK ja muut välimuistiin tallennetut tiedostot).</string>
     <string name="analyzer_storage_content_app_data_label">Tiedot</string>

--- a/app-tool-analyzer/src/main/res/values-fil/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-fil/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">Mga nakuhang larawan, naka-record na video o na-download na data. Anumang data na hindi kabilang sa isang tukoy na app.</string>
     <string name="analyzer_storage_content_type_system_label">Data ng sistema</string>
     <string name="analyzer_storage_content_type_system_description">Mga system app at system data. Mga app at data mula sa ibang mga user, kung may mga user account na naka-set sa device na ito.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Iba</string>
+    <string name="analyzer_storage_content_type_system_info">Mga file na hindi akma sa kategorya ng Apps o User files. Browse lamang — hindi sinusuportahan ang pagtanggal. Maaaring hindi kumpleto ang ilang lugar dahil sa mga paghihigpit sa access.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">Mga system file at iba pang data na hindi ma-access o ma-kategorya ng SD Maid. Nililimitahan ng operating system ang paglilista ng mga nilalaman ng ilang lugar.</string>
     <string name="analyzer_storage_content_app_code_label">Code ng app</string>
     <string name="analyzer_storage_content_app_code_description">Mga application file, library at resource. Ang space na ito ay maaaring ma-free sa pamamagitan ng pag-uninstall ng app o pag-archive nito (available sa mas bagong Android version).</string>
     <string name="analyzer_storage_content_app_data_label">Data ng app</string>

--- a/app-tool-analyzer/src/main/res/values-fr/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-fr/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">Captation d’images, vidéos enregistrées et données téléchargées. Toutes les données qui n\'appartiennent pas à une appli particulière.</string>
     <string name="analyzer_storage_content_type_system_label">Données système</string>
     <string name="analyzer_storage_content_type_system_description">Applications système et données système. Applis et données d’autres utilisateurs, si plusieurs comptes utilisateur sont configurés sur cet appareil.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Autres</string>
+    <string name="analyzer_storage_content_type_system_info">Fichiers qui ne correspondent pas aux catégories Applications ou Fichiers utilisateur. Navigation uniquement — la suppression n’est pas prise en charge. Certaines zones peuvent être incomplètes en raison de restrictions d’accès.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">Fichiers système et autres données auxquels SD Maid n’a pas pu accéder ou catégoriser. Le système d’exploitation restreint l’affichage du contenu de certaines zones.</string>
     <string name="analyzer_storage_content_app_code_label">Code de l’appli</string>
     <string name="analyzer_storage_content_app_code_description">Fichiers, bibliothèques et ressources de l’appli. Cet espace peut être libéré en la désinstallant ou en l’archivant (proposé sur les versions d’Android les plus récentes).</string>
     <string name="analyzer_storage_content_app_data_label">Données de l’appli</string>

--- a/app-tool-analyzer/src/main/res/values-gl-rES/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-gl-rES/strings.xml
@@ -35,8 +35,11 @@
     <string name="analyzer_storage_content_type_media_description">Imaxes capturadas, vídeos gravados ou datos descargados. Calquera dato que non pertenza a unha aplicación específica.</string>
     <string name="analyzer_storage_content_type_system_label">Datos do sistema</string>
     <string name="analyzer_storage_content_type_system_description">Aplicacións e datos do sistema. Aplicacións e datos doutros usuarios, se hai varias contas de usuario configuradas neste dispositivo.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Outros</string>
+    <string name="analyzer_storage_content_type_system_info">Ficheiros que non se axustan ás categorías de Aplicacións ou Ficheiros de usuario. Só navegación — non se admite a eliminación. Algunhas áreas poden estar incompletas debido a restricións de acceso.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">Ficheiros do sistema e outros datos aos que SD Maid non puido acceder ou clasificar. O sistema operativo restrinxe a lista dos contidos dalgunhas áreas.</string>
     <string name="analyzer_storage_content_app_code_label">Código da aplicación</string>
-    <string name="analyzer_storage_content_app_code_description">Ficheiros de aplicación, bibliotecas e recursos. Este espazo pode liberarse desinstalando a aplicación ou arquivándoa (dispoñible en versións máis recentes de Android).</string>
+    <string name="analyzer_storage_content_app_code_description">Ficheiros de aplicación, bibliotecas e recursos. Este espazo pódese liberar desinstalando a aplicación ou arquivándoa (dispoñible en versións máis recentes de Android).</string>
     <string name="analyzer_storage_content_app_data_label">Datos da aplicación</string>
     <string name="analyzer_storage_content_app_data_description">Datos, configuración e cachés.</string>
     <string name="analyzer_storage_content_app_media_label">Multimedia da aplicación</string>

--- a/app-tool-analyzer/src/main/res/values-hi-rIN/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-hi-rIN/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">कैप्चर की गई तस्वीरें, रिकॉर्ड किए गए वीडियो या डाउनलोड किए गए डेटा है। कोई भी डेटा जो किसी विशिष्ट ऐप से संबंधित नहीं है।</string>
     <string name="analyzer_storage_content_type_system_label">सिस्टम डेटा</string>
     <string name="analyzer_storage_content_type_system_description">सिस्टम ऐप्स और सिस्टम डेटा। अन्य उपयोगकर्ताओं के ऐप्स और डेटा, यदि इस डिवाइस पर कई उपयोगकर्ता खाते सेट हैं।</string>
+    <string name="analyzer_storage_content_type_system_other_label">अन्य</string>
+    <string name="analyzer_storage_content_type_system_info">वे फ़ाइलें जो एप्स या उपयोगकर्ता फ़ाइलें श्रेणियों में फिट नहीं होतीं। केवल ब्राउज़ करें — हटाना समर्थित नहीं है। कुछ क्षेत्र पहुंच प्रतिबंधों के कारण अधूरे हो सकते हैं।</string>
+    <string name="analyzer_storage_content_type_system_other_desc">सिस्टम फ़ाइलें और अन्य डेटा जिन्हें SD Maid एक्सेस या वर्गीकृत नहीं कर सका। ऑपरेटिंग सिस्टम कुछ क्षेत्रों की सामग्री सूचीबद्ध करने पर प्रतिबंध लगाता है।</string>
     <string name="analyzer_storage_content_app_code_label">ऐप कोड</string>
     <string name="analyzer_storage_content_app_code_description">एप्लिकेशन फ़ाइलें, लाइब्रेरी और संसाधन। ऐप को अनइंस्टॉल करके या संग्रहीत करके (नए Android संस्करण पर उपलब्ध) इस स्थान को मुक्त किया जा सकता है।</string>
     <string name="analyzer_storage_content_app_data_label">ऐप डेटा</string>

--- a/app-tool-analyzer/src/main/res/values-hr/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-hr/strings.xml
@@ -38,6 +38,9 @@
     <string name="analyzer_storage_content_type_media_description">Snimljene slike, videozapisi ili preuzeti podaci. Svi podaci koji ne pripadaju određenoj aplikaciji.</string>
     <string name="analyzer_storage_content_type_system_label">Sistemski podaci</string>
     <string name="analyzer_storage_content_type_system_description">Aplikacije sustava i sistemski podaci. Aplikacije i podaci drugih korisnika, ako je na ovom uređaju postavljeno više korisničkih računa.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Ostalo</string>
+    <string name="analyzer_storage_content_type_system_info">Datoteke koje ne odgovaraju kategorijama Aplikacije ili Korisničke datoteke. Samo pregled — brisanje nije podržano. Neka područja mogu biti nepotpuna zbog ograničenja pristupa.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">Sistemske datoteke i drugi podaci kojima SD Maid nije mogao pristupiti ili ih kategorizirati. Operativni sustav ograničava popis sadržaja nekih područja.</string>
     <string name="analyzer_storage_content_app_code_label">Kod aplikacije</string>
     <string name="analyzer_storage_content_app_code_description">Datoteke aplikacije, biblioteke i resursi. Ovaj se prostor može osloboditi deinstaliranjem aplikacije ili njenim arhiviranjem (dostupno u novijim verzijama Androida).</string>
     <string name="analyzer_storage_content_app_data_label">Podaci aplikacije</string>

--- a/app-tool-analyzer/src/main/res/values-hu/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-hu/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">Felvett képek, rögzített videók vagy letöltött adatok. Minden olyan adat, amely nem tartozik egy adott alkalmazáshoz.</string>
     <string name="analyzer_storage_content_type_system_label">Rendszeradatok</string>
     <string name="analyzer_storage_content_type_system_description">Rendszeralkalmazások és rendszeradatok.  Alkalmazások és adatok más felhasználóktól, ha több felhasználói fiók van beállítva ezen az eszközön.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Egyéb</string>
+    <string name="analyzer_storage_content_type_system_info">Az Alkalmazások vagy Felhasználói fájlok kategóriákba nem illő fájlok. Csak böngészés — a törlés nem támogatott. Egyes területek hozzáférési korlátok miatt hiányosak lehetnek.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">Rendszerfájlok és egyéb adatok, amelyekhez az SD Maid nem fért hozzá, vagy nem tudta kategórizálni. Az operációs rendszer korlátozza egyes területek tartalomának listázását.</string>
     <string name="analyzer_storage_content_app_code_label">App kód</string>
     <string name="analyzer_storage_content_app_code_description">Alkalmazási fájlok, könyvtárak és erőforrások. Ez a hely felszabadítható az alkalmazás eltávolításával vagy archiválásával (az újabb Android-verziókban elérhető).</string>
     <string name="analyzer_storage_content_app_data_label">App adatok</string>

--- a/app-tool-analyzer/src/main/res/values-in/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-in/strings.xml
@@ -32,6 +32,9 @@
     <string name="analyzer_storage_content_type_media_description">Gambar yang diambil, video yang direkam, atau data yang diunduh. Semua data yang bukan milik aplikasi tertentu.</string>
     <string name="analyzer_storage_content_type_system_label">Data sistem</string>
     <string name="analyzer_storage_content_type_system_description">Aplikasi sistem dan data sistem. Aplikasi dan data dari pengguna lain, jika beberapa akun pengguna lain ada di perangkat ini.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Lainnya</string>
+    <string name="analyzer_storage_content_type_system_info">File yang tidak sesuai dengan kategori Aplikasi atau File Pengguna. Jelajahi saja — penghapusan tidak didukung. Beberapa area mungkin tidak lengkap karena pembatasan akses.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">File sistem dan data lain yang tidak dapat diakses atau dikategorikan oleh SD Maid. Sistem operasi membatasi pencantuman isi beberapa area.</string>
     <string name="analyzer_storage_content_app_code_label">Kode aplikasi</string>
     <string name="analyzer_storage_content_app_code_description">File aplikasi, pustaka, dan sumber daya. Ruang ini dapat dibebaskan dengan mencopot pemasangan aplikasi atau mengarsipkannya (tersedia pada versi Android yang lebih baru).</string>
     <string name="analyzer_storage_content_app_data_label">Data aplikasi</string>

--- a/app-tool-analyzer/src/main/res/values-is/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-is/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">Teknar myndir, tekin myndbönd eða sótt gögn. Öll gögn sem tilheyra ekki ákveðnu forriti.</string>
     <string name="analyzer_storage_content_type_system_label">Kerfisgögn</string>
     <string name="analyzer_storage_content_type_system_description">Kerfisforrit og kerfisgögn. Forrit og gögn frá öðrum notendum, ef fleiri en einn reikningur er settur upp á þessu tæki.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Annað</string>
+    <string name="analyzer_storage_content_type_system_info">Skrár sem passa ekki í flokka Forrita eða Notendaskráa. Aðeins vafra — eyðing er ekki studd. Sumar svæðum getur verið ábótavant vegna aðgangstakmarkana.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">Kerfaskrár og önnur gögn sem SD Maid gat ekki nálgast eða flokkað. Stýrikerfi takmarkar skráningu á innihaldi sumra svæða.</string>
     <string name="analyzer_storage_content_app_code_label">Kóði forrits</string>
     <string name="analyzer_storage_content_app_code_description">Forritaskrár, söfn og auðlindir. Hægt er að losa um þetta pláss með því að fjarlægja forritið eða safnvista það.</string>
     <string name="analyzer_storage_content_app_data_label">Forritagögn</string>

--- a/app-tool-analyzer/src/main/res/values-it/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-it/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">Foto e video dalla fotocamera o dati scaricati. Tutti i dati che non appartengono a una specifica app.</string>
     <string name="analyzer_storage_content_type_system_label">Dati di sistema</string>
     <string name="analyzer_storage_content_type_system_description">App di sistema e dati di sistema. Applicazioni e dati di altri utenti, se ci sono più account utente in questo dispositivo.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Altro</string>
+    <string name="analyzer_storage_content_type_system_info">File che non rientrano nelle categorie App o File utente. Solo navigazione — l\'eliminazione non è supportata. Alcune aree potrebbero essere incomplete a causa di restrizioni di accesso.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">File di sistema e altri dati a cui SD Maid non ha potuto accedere o categorizzare. Il sistema operativo limita l\'elenco dei contenuti di alcune aree.</string>
     <string name="analyzer_storage_content_app_code_label">Codice app</string>
     <string name="analyzer_storage_content_app_code_description">File di applicazioni, librerie e risorse. Questo spazio può essere liberato disinstallando l\'app oppure archiviandola (disponibile nella versione di android più recente).</string>
     <string name="analyzer_storage_content_app_data_label">Dati app</string>

--- a/app-tool-analyzer/src/main/res/values-iw/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-iw/strings.xml
@@ -41,6 +41,9 @@
     <string name="analyzer_storage_content_type_media_description">תמונות שצולמו, סרטונים מוקלטים או נתונים שהורדו. כל נתונים שאינם שייכים לאפליקציה מסוימת.</string>
     <string name="analyzer_storage_content_type_system_label">נתוני מערכת</string>
     <string name="analyzer_storage_content_type_system_description">אפליקציות מערכת ונתוני מערכת. אפליקציות ונתונים ממשתמשים אחרים, אם מוגדרים מספר חשבונות משתמש במכשיר זה.</string>
+    <string name="analyzer_storage_content_type_system_other_label">אחר</string>
+    <string name="analyzer_storage_content_type_system_info">קבצים שאינם מתאימים לקטגוריות אפליקציות או קבצי משתמש. עיון בלבד — מחיקה אינה נתמכת. ייתכן שחלק מהאזורים אינם שלמים עקב הגבלות גישה.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">קבצי מערכת ונתונים אחרים ש-SD Maid לא יכלה לגשת אליהם או לסווג. מערכת ההפעלה מגבילה את רישום תכולת חלק מהאזורים.</string>
     <string name="analyzer_storage_content_app_code_label">קוד אפליקציה</string>
     <string name="analyzer_storage_content_app_code_description">קבצי אפליקציות, ספריות ומשאבים. מקום זה יכול להתפנות על ידי הסרת האפליקציה או אירכובה (זמין בגירסאות אנדרואיד חדשות).</string>
     <string name="analyzer_storage_content_app_data_label">נתוני יישום</string>

--- a/app-tool-analyzer/src/main/res/values-ja/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-ja/strings.xml
@@ -32,6 +32,9 @@
     <string name="analyzer_storage_content_type_media_description">キャプチャされた写真、記録されたビデオ、またはダウンロードしたデータ。特定のアプリに属さないデータ。</string>
     <string name="analyzer_storage_content_type_system_label">システムデータ</string>
     <string name="analyzer_storage_content_type_system_description">システムアプリとシステムデータ。この端末で複数のユーザーアカウントが設定されている場合、他のユーザーからのアプリとデータ。</string>
+    <string name="analyzer_storage_content_type_system_other_label">その他</string>
+    <string name="analyzer_storage_content_type_system_info">「アプリ」または「ユーザーファイル」カテゴリに該当しないファイルです。閲覧のみ可能 — 削除はサポートされていません。アクセス制限により一部のエリアが不完全な場合があります。</string>
+    <string name="analyzer_storage_content_type_system_other_desc">SD Maid がアクセスまたは分類できなかったシステムファイルやその他のデータです。オペレーティングシステムにより、一部のエリアの内容一覧はアクセスが制限されています。</string>
     <string name="analyzer_storage_content_app_code_label">アプリコード</string>
     <string name="analyzer_storage_content_app_code_description">アプリのファイル、ライブラリ、リソースが含まれます。この領域は、アプリをアンインストールするか、アーカイブ（新しいAndroidバージョンで利用可能）することで解放できます。</string>
     <string name="analyzer_storage_content_app_data_label">アプリのデータ</string>

--- a/app-tool-analyzer/src/main/res/values-ka-rGE/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-ka-rGE/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">გადაღებული სურათები, ჩაწერილი ვიდეოები ან ჩამოტვირთული მონაცემები. ნებისმიერი მონაცემი, რომელიც არ ეკუთვნის კონკრეტულ აპს.</string>
     <string name="analyzer_storage_content_type_system_label">სისტემური მონაცემები</string>
     <string name="analyzer_storage_content_type_system_description">სისტემური აპები და სისტემური მონაცემები. აპები და მონაცემები სხვა მომხმარებლებისგან, თუ ამ მოწყობილობაზე დაყენებულია რამდენიმე მომხმარებლის ანგარიში.</string>
+    <string name="analyzer_storage_content_type_system_other_label">სხვა</string>
+    <string name="analyzer_storage_content_type_system_info">ფაილები, რომლებიც არ შეესაბამება აპლიკაციების ან მომხმარებლის ფაილების კატეგორიებს. მხოლოდ დათვალიერება — წაშლა არ არის მხარდაჭერილი. ზოგიერთი სფერო შეიძლება არასრული იყოს წვდომის შეზღუდვების გამო.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">სისტემური ფაილები და სხვა მონაცემები, რომლებზეც SD Maid-ს არ ჰქონდა წვდომა ან ვერ დაახარისეთ. ოპერაციული სისტემა ზღუდავს ზოგიერთი სფეროს შინაარსის ჩამოთვლას.</string>
     <string name="analyzer_storage_content_app_code_label">აპის კოდი</string>
     <string name="analyzer_storage_content_app_code_description">აპლიკაციის ფაილები, ბიბლიოთეკები და რესურსები. ეს ადგილი შეიძლება განთავისუფლდეს აპის წაშლით ან დაარქივებით (ხელმისაწვდომია Android-ის ახალ ვერსიებზე).</string>
     <string name="analyzer_storage_content_app_data_label">აპის მონაცემები</string>

--- a/app-tool-analyzer/src/main/res/values-kaa/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-kaa/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">Túsirilgen súwretler, jazılǵan videolar yamasa júklengen maǵlıwmatlar. Qandayda bir anıq baǵdarlamaǵa tiyisli bolmaǵan hár qanday maǵlıwmat.</string>
     <string name="analyzer_storage_content_type_system_label">Sistema maǵlıwmatları</string>
     <string name="analyzer_storage_content_type_system_description">Sistema baǵdarlamaları hám sistema maǵlıwmatları. Eger bul qurılmada bir neshe paydalanıwshı akkauntı ornatılǵan bolsa, basqa paydalanıwshılardıń baǵdarlamaları hám maǵlıwmatları.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Басқа</string>
+    <string name="analyzer_storage_content_type_system_info">Қолланбалар яки Пайдаланыўшы файллары категорияларына тиймейтуғын файллар. Тек қараў мүмкин — өширіў қолланбайды. Кириў шекленгенлиги себепли кейбир аймақлар толық болмауы мүмкин.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">SD Maid кириў яки категорияға бөле алмаған системалық файллар ҳәм басқа мәліметлер. Операциялық система кейбир аймақлардың мазмунын тизимлеўди шеклейди.</string>
     <string name="analyzer_storage_content_app_code_label">Qosımsha kodı</string>
     <string name="analyzer_storage_content_app_code_description">Baǵdarlama faylları, kitapxanalar hám resurslar. Bul orındı baǵdarlamanı óshiriw yamasa arxivlew arqalı bosatıw múmkin (jańa Android nusqalarında bar).</string>
     <string name="analyzer_storage_content_app_data_label">Qosımsha maǵlıwmatları</string>

--- a/app-tool-analyzer/src/main/res/values-km-rKH/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-km-rKH/strings.xml
@@ -32,6 +32,9 @@
     <string name="analyzer_storage_content_type_media_description">រូបត្សរេកែលបានថត់ វិឌិឥដែលបានថត់ អ្វីទិន្នន័យដែលបានដញ្ចូល។ តិន្នន័យណាតាញដែលមិនស្នាហ់ដល់កម្មវិធីបន្នឹក្រូមណា។</string>
     <string name="analyzer_storage_content_type_system_label">តិន្នន័យប្រព័ន្ធ</string>
     <string name="analyzer_storage_content_type_system_description">កម្មវិធីប្រព័ន្ធ និងតិន្នន័យប្រព័ន្ធ។ កម្មវិធី និងតិន្នន័យពីអ្នកប្រើផសេងតីតែ ប័ត័បានកំណត់គណនីអ្នកប្រើជាច្រើននៅឧបករណ៍នេ។</string>
+    <string name="analyzer_storage_content_type_system_other_label">ដទៃ</string>
+    <string name="analyzer_storage_content_type_system_info">ឯកសារ​ដែល​មិន​សម​នឹង​ប្រភេទ​កម្មវិធី​ឬ​ឯកសារ​អ្នក​ប្រើ​ប្រាស់។ ចូលមើល​ប៉ុណ្ណោះ — មិន​គាំទ្រ​ការ​លុប​ទេ។ តំបន់​ខ្លះ​អាច​មិន​ពេញ​លេញ​ដោយ​សារ​ការ​កំណត់​ការ​ចូល​ប្រើ​ប្រាស់។</string>
+    <string name="analyzer_storage_content_type_system_other_desc">ឯកសារ​ប្រព័ន្ធ​និង​ទិន្នន័យ​ផ្សេង​ទៀត​ដែល SD Maid មិន​អាច​ចូល​ប្រើ​ឬ​វិភាគ​បាន។ ប្រព័ន្ធ​ប្រតិបត្តិការ​រឹត​ត្បិត​ការ​រាយ​ឈ្មោះ​មាតិកា​នៃ​តំបន់​ខ្លះ។</string>
     <string name="analyzer_storage_content_app_code_label">សង្កើតកម្មវិធី</string>
     <string name="analyzer_storage_content_app_code_description">ឯកសារកម្មវិធី ប័ន្ទាក និងសម្ភអ្ល។ ស្ថានទែនេហើឡ់ឯនល័យដោយការដកតិត្តាក់កម្មវិធី អ្វីដកទែនក្រឹត់វា អ្ល័នង់ឯកសារវា បន្ថែមនៅវៀរសន់ Android ថ្មីប័ត។</string>
     <string name="analyzer_storage_content_app_data_label">តិន្នន័យកម្មវិធី</string>

--- a/app-tool-analyzer/src/main/res/values-ko/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-ko/strings.xml
@@ -32,6 +32,9 @@
     <string name="analyzer_storage_content_type_media_description">스크린샷, 녹화한 영상, 다운로드 파일 등의 특정 앱에 속하지 않은 파일이 차지하는 공간입니다.</string>
     <string name="analyzer_storage_content_type_system_label">시스템 데이터</string>
     <string name="analyzer_storage_content_type_system_description">시스템 앱 및 데이터. 여러 유저가 추가되어 있다면 다른 유저의 앱과 데이터를 포함합니다.</string>
+    <string name="analyzer_storage_content_type_system_other_label">기타</string>
+    <string name="analyzer_storage_content_type_system_info">앱 또는 사용자 파일 카테고리에 맞지 않는 파일입니다. 탐색만 가능하며 삭제는 지원되지 않습니다. 접근 제한으로 인해 일부 영역이 불완전할 수 있습니다.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">SD Maid가 접근하거나 분류할 수 없었던 시스템 파일 및 기타 데이터입니다. 운영 체제가 일부 영역의 내용 목록을 제한합니다.</string>
     <string name="analyzer_storage_content_app_code_label">앱 소스</string>
     <string name="analyzer_storage_content_app_code_description">APK 파일 및 기타 설치 관련 파일</string>
     <string name="analyzer_storage_content_app_data_label">앱 데이터</string>

--- a/app-tool-analyzer/src/main/res/values-lo-rLA/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-lo-rLA/strings.xml
@@ -32,6 +32,9 @@
     <string name="analyzer_storage_content_type_media_description">ພາບຖ່າຍຮູປ, ວິດີໂອທີ່ຊຶກໞ່ ຫຣືອຂ້ອມູນທີ່ດາວນໄອດ້. ຂ້ອມູນໃດໆທີ່ໄມ່ວ່າລະກັບແອບທີ່ເຈາະຈອງ.</string>
     <string name="analyzer_storage_content_type_system_label">ຂ້ອມູນລະບົ</string>
     <string name="analyzer_storage_content_type_system_description">ແອບລະບົ ແລະຂ້ອມູນລະບົ. ແອບ ແລະຂ້ອມູນຈາກຜູ້ໃຊ້ອື່ນ, ຖ້າມີບັນຊີຜູ້ໃຊ້ຫລາຍບັຍຊີຖືກຕັ້ງແຕ່ງໃນອຸປະກອນນີ້.</string>
+    <string name="analyzer_storage_content_type_system_other_label">ອື່ນໆ</string>
+    <string name="analyzer_storage_content_type_system_info">ໄຟລ໌ທີ່ບໍ່ເໝາະກັບໝວດໝູ່ Apps ຫຼື ໄຟລ໌ຜູ້ໃຊ້. ເລີ່ຍດູເທົ່ານັ້ນ — ການລົບໄຟລ໌ບໍ່ຮອງຮັບ. ບາງພື້ນທີ່ອາດຈະບໍ່ຄົບຖ້ວນ ເນື່ອງຈາກຂໍ້ຈຳກັດການເຂົ້າເຖິງ.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">ໄຟລ໌ລະບົບ ແລະ ຂໍ້ມູນອື່ນໆ ທີ່ SD Maid ບໍ່ສາມາດເຂົ້າເຖິງ ຫຼື ຈັດໝວດໝູ່ໄດ້. ລະບົບປະຕິບັດການຈຳກັດການສະແດງລາຍການເນື້ອຫາໃນບາງພື້ນທີ່.</string>
     <string name="analyzer_storage_content_app_code_label">ໂຄດໂປໂກລແອບ</string>
     <string name="analyzer_storage_content_app_code_description">ໄຟລ໌ແອບ, ໄລບຣະລີ ແລະທລະພາກອະ. ພື້ນທີ່ນີ່ສາມາຖຖືກຄືນເດຟດ້ວຍການຖອນຕິດຕັ້ງແອບ ຫຣືອເກັບໄວ້ໃນຕຸ (Android ວັນໃໝ່ຮອງຮັບ).</string>
     <string name="analyzer_storage_content_app_data_label">ຂ້ອມູນແອບ</string>

--- a/app-tool-analyzer/src/main/res/values-lt/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-lt/strings.xml
@@ -41,6 +41,9 @@
     <string name="analyzer_storage_content_type_media_description">Užfiksuotos nuotraukos, įrašyti vaizdo įrašai ar atsisiųsti duomenys. Visi duomenys, nepriklausantys konkreiai programai.</string>
     <string name="analyzer_storage_content_type_system_label">Sistemos duomenys</string>
     <string name="analyzer_storage_content_type_system_description">Sistemos programos ir sistemos duomenys. Programos ir duomenys iš kitų vartotojų, jei šiame įrenginyje nustatytos kelios vartotojų paskyros.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Kita</string>
+    <string name="analyzer_storage_content_type_system_info">Failai, kurie netinka programų ar vartotojo failų kategorijoms. Tik naršymas — ištrynimas nepalaikomas. Kai kurios sritys gali būti neišsamios dėl prieigos apribojimų.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">Sisteminiai failai ir kiti duomenys, kurių SD Maid negalėjo pasiekti ar suskirstyti į kategorijas. Operatė sistema riboja kai kurių sričių turinio peržiūrą.</string>
     <string name="analyzer_storage_content_app_code_label">Programos kodas</string>
     <string name="analyzer_storage_content_app_code_description">Programos failai, bibliotekos ir ištekliai. Ši vieta gali būti atlaisvinta išdiegiant programą arba ją archyvuojant (galima naujesnose Android versijose).</string>
     <string name="analyzer_storage_content_app_data_label">Programos duomenys</string>

--- a/app-tool-analyzer/src/main/res/values-lv/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-lv/strings.xml
@@ -38,6 +38,9 @@
     <string name="analyzer_storage_content_type_media_description">Uzfotografēti attēli, ieņemti video vai lejupielādēti dati. Jebkuri dati, kas nepieder konkrētai lietotnei.</string>
     <string name="analyzer_storage_content_type_system_label">Sistēmas dati</string>
     <string name="analyzer_storage_content_type_system_description">Sistēmas lietotnes un sistēmas dati. Citu lietotāju lietotnes un dati, ja šajā ierīcē ir uzstādīti vairāki lietotāja konti.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Cits</string>
+    <string name="analyzer_storage_content_type_system_info">Faili, kas neietilpst kategorijās Lietotnes vai Lietotāja faili. Tikai pārlūkošana — dzēšana netiek atbalstīta. Dažas jomas var būt nepilnīgas piekļušanas ierobežojumu dēļ.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">Sistēmas faili un citi dati, kuriem SD Maid nevarēja piekļūt vai tos kategorizēt. Operētājsistēma ierobežo dažu apgabalu satura uzskaitīšanu.</string>
     <string name="analyzer_storage_content_app_code_label">Lietotnes kods</string>
     <string name="analyzer_storage_content_app_code_description">Lietotnes faili, bibliotēkas un resursi. Šo vietu var atbrīvot, atinstalējot lietotni vai arhivējot to (pieejams jaunākās Android versijās).</string>
     <string name="analyzer_storage_content_app_data_label">Lietotnes dati</string>

--- a/app-tool-analyzer/src/main/res/values-mk-rMK/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-mk-rMK/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">Сликани фотографии, снимени видеа или преземени податоци. Сите податоци кои не припаѓаат на конкретна апликација.</string>
     <string name="analyzer_storage_content_type_system_label">Системски податоци</string>
     <string name="analyzer_storage_content_type_system_description">Системски апликации и системски податоци. Апликации и податоци од други корисници, ако на уредот има повеќе кориснички сметки.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Друго</string>
+    <string name="analyzer_storage_content_type_system_info">Датотеки кои не се вклопуваат во категориите Апликации или Кориснички датотеки. Само прелистување — бришењето не е поддржано. Некои области може да бидат нецелосни поради ограничувања на пристапот.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">Системски датотеки и други податоци до кои SD Maid не можеше да пристапи или да ги категоризира. Оперативниот систем ги ограничува листите со содржини на некои области.</string>
     <string name="analyzer_storage_content_app_code_label">Код на апликација</string>
     <string name="analyzer_storage_content_app_code_description">Датотеки, библиотеки и ресурси на апликацијата. Овој простор може да се ослободи со деинсталирање или архивирање на апликацијата (достапно на понови верзии на Android).</string>
     <string name="analyzer_storage_content_app_data_label">Податоци на апликација</string>

--- a/app-tool-analyzer/src/main/res/values-ml-rIN/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-ml-rIN/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">ക്യാപ്ചർ ചെയ്ത ചിത്രങ്ങൾ, റെക്കർഡ് ചെയ്ത വീഡിയോകൾ അഥവാ ഡൗൺലോഡ് ചെയ്ത ഡേറ്റ. ഓരോ ഉൾപ്പ് നിർദിഷ്ട ആപ്പിന് സ്വന്തമല്ലാത്ത ഡേറ്റ.</string>
     <string name="analyzer_storage_content_type_system_label">സിസ്റ്റം ഡേറ്റ</string>
     <string name="analyzer_storage_content_type_system_description">സിസ്റ്റം ആപ്പുകൾം സിസ്റ്റം ഡേറ്റയും. ഈ ഉപകരണത്തിൽ പല ഉപയോക്തൃ അക്കൗണ്ടുകൾ സെറ്റ് ചെയ്തിട്ടുണ്ടെങ്കിൽ, മറ്റ ഉപയോക്താകളിൽ നിന്നുള്ള ആപ്പുകൾം ഡേറ്റയും.</string>
+    <string name="analyzer_storage_content_type_system_other_label">മറ്റുള്ളവ</string>
+    <string name="analyzer_storage_content_type_system_info">ആപ്പുകൾ അല്ലെങ്കിൽ ഉപയോക്തൃ ഫയൽ വിഭാഗങ്ങളിൽ പെടാത്ത ഫയലുകൾ. ബ്രൗസ് മാത്രം — ഇല്ലാതാക്കൽ പിന്തുണയ്ക്കുന്നില്ല. ആക്സസ് നിയന്ത്രണങ്ങൾ കാരണം ചില മേഖലകൾ അപൂർണ്ണമായിരിക്കാം.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">SD Maid-ന് ആക്സസ് ചെയ്യാനോ വർഗ്ഗീകരിക്കാനോ കഴിയാത്ത സിസ്റ്റം ഫയലുകളും മറ്റ് ഡേറ്റയും. ചില മേഖലകളുടെ ഉള്ളടക്കങ്ങൾ ലിസ്റ്റ് ചെയ്യുന്നത് ഓപ്പറേറ്റിംഗ് സിസ്റ്റം നിയന്ത്രിക്കുന്നു.</string>
     <string name="analyzer_storage_content_app_code_label">ആപ്പ് കോഡ്</string>
     <string name="analyzer_storage_content_app_code_description">ആപ്ലിക്കേഷൻ ഫയലുകൾ, ലൈബ്രറികൾ, റിസോർസുകൾ. ആപ്പ് അനിന്സ്റ്റോൾ ചെയ്ത് അഥവാ ആർക്കൈവ് ചെയ്ത് ഈ സ്ഥലം ശൂന്യമാക്കാം (പുതിയ Android പതിപ്പിൽ ലഭ്യം).</string>
     <string name="analyzer_storage_content_app_data_label">ആപ്പ് ഡേറ്റ</string>

--- a/app-tool-analyzer/src/main/res/values-mn-rMN/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-mn-rMN/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">Бүртгэсэн зураг, бичлэгдсэн видео эсвэл татаж авсан өгөгдөл. Тухайлагдсан аппд харьяагүй огн өгөгдөл.</string>
     <string name="analyzer_storage_content_type_system_label">Системийн өгөгдөл</string>
     <string name="analyzer_storage_content_type_system_description">Системийн аппууд болон өгөгдөл. Энэ төхөөрөмжт олон харилцааны аппууд болон өгөгдөл, энэ төхөөрөмжт олон хэрэглэгчдийн бүлтгүүд хэрэглэгчийн бүртгэс өгөгдөлдэх аппууд болон өгөгдөл.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Бусад</string>
+    <string name="analyzer_storage_content_type_system_info">Аппууд эсвэл Хэрэглэгчийн файлуудын ангилалд багтахгүй файлууд. Зөвхөн харах боломжтой — устгах дэмжигдэхгүй. Хандалтын хязгаарлалтаас шалтгаалан зарим хэсэг дутуу байж болно.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">SD Maid хандаж чадаагүй буюу ангилж чадаагүй системийн файлууд болон бусад өгөгдөл. Үйлдлийн систем зарим хэсгийн агуулгыг жагсаахыг хязгаарладаг.</string>
     <string name="analyzer_storage_content_app_code_label">Аппын код</string>
     <string name="analyzer_storage_content_app_code_description">Аппликацийн файл, номдаллагууд болон нөөц. Аппыг устгах эсвэл архивлахад (шинэ Android хувилбарт боломжтой) зайг чөлөөлж болно.</string>
     <string name="analyzer_storage_content_app_data_label">Аппын өгөгдөл</string>

--- a/app-tool-analyzer/src/main/res/values-ms/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-ms/strings.xml
@@ -32,6 +32,9 @@
     <string name="analyzer_storage_content_type_media_description">Gambar yang ditangkap, video yang dirakam atau data yang dimuat turun. Sebarang data yang bukan milik aplikasi tertentu.</string>
     <string name="analyzer_storage_content_type_system_label">Data sistem</string>
     <string name="analyzer_storage_content_type_system_description">Aplikasi sistem dan data sistem. Aplikasi dan data dari pengguna lain, jika beberapa akaun pengguna ditetapkan pada peranti ini.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Lain-lain</string>
+    <string name="analyzer_storage_content_type_system_info">Fail yang tidak sesuai dalam kategori Aplikasi atau fail Pengguna. Layar sahaja — pemadaman tidak disokong. Sesetengah kawasan mungkin tidak lengkap disebabkan sekatan akses.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">Fail sistem dan data lain yang tidak dapat diakses atau dikategorikan oleh SD Maid. Sistem pengendalian menyekat penyenaraian kandungan sesetengah kawasan.</string>
     <string name="analyzer_storage_content_app_code_label">Kod aplikasi</string>
     <string name="analyzer_storage_content_app_code_description">Fail aplikasi, perpustakaan dan sumber. Ruang ini boleh dibebaskan dengan menyahpasang aplikasi atau mengarkibkannya (tersedia pada versi Android yang lebih baharu).</string>
     <string name="analyzer_storage_content_app_data_label">Data aplikasi</string>

--- a/app-tool-analyzer/src/main/res/values-my-rMM/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-my-rMM/strings.xml
@@ -32,6 +32,9 @@
     <string name="analyzer_storage_content_type_media_description">ရိုကူးထားသော ပုံများ၊ ဗီဒီယာများ သို့မဟုတ် ဒော်င်လုဒ်ဆွဲးထားသော ဒေတာ။ တိကျသောအပ်ပ်တစ်ခုနှင့် မဆက်နွှေသော မည်သည့့်ဒေတာမဆို။</string>
     <string name="analyzer_storage_content_type_system_label">စနစ်ဒေတာ</string>
     <string name="analyzer_storage_content_type_system_description">စနစ်အပ်ပ်များနှင့် စနစ်ဒေတာ။ ဤကိရိယာတွင် အသုံးပြု အကောင်အည်းများစွာ သတ်မှတ်ထားလျှင် အခြားအသုံးပြုသူများမှ အပ်ပ်များနှင့် ဒေတာ။</string>
+    <string name="analyzer_storage_content_type_system_other_label">အခြား</string>
+    <string name="analyzer_storage_content_type_system_info">Apps သို့မဟုတ် အသုံးပြုသူဖိုင်များ အမျိုးအစားများတွင် မကိုက်ညီသော ဖိုင်များ။ ကြည့်ရှုရန်သာ — ဖျက်ခြင်းကို ပံ့ပိုးမထားပါ။ ဝင်ရောက်ခွင့် ကန့်သတ်ချက်များကြောင့် အချို့နေရာများ မပြည့်စုံနိုင်ပါ။</string>
+    <string name="analyzer_storage_content_type_system_other_desc">SD Maid ဝင်ရောက်၍ မရသော သို့မဟုတ် အမျိုးအစားခွဲ၍ မရသော စနစ်ဖိုင်များနှင့် အခြားဒေတာ။ ကွန်ပျူတာ စစ်ဆင်ရေး စနစ်သည် အချို့နေရာများ၏ အကြောင်းအရာများကို ကြည့်ရှုခွင့် ကန့်သတ်ထားသည်။</string>
     <string name="analyzer_storage_content_app_code_label">အပ်ပ် ကုဒ်</string>
     <string name="analyzer_storage_content_app_code_description">Application ဖိုင်များ၊ library များနှင့် အရင်းအမြစ်များ။ ဤနေရာကို အပ်ပ်ကို ဖြုတ်ချပြီး သို့မဟုတ် မြှုပ်သိမ်းခြင်းဖြင့် (Android ဗားရှင်းအသစ်တွင် ရနိုင်သည်) ရှင်းလင်းနိုင်သည်။</string>
     <string name="analyzer_storage_content_app_data_label">အပ်ပ် ဒေတာ</string>

--- a/app-tool-analyzer/src/main/res/values-nb/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-nb/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">Tatt bilder, innspilte videoer eller nedlastet data. Alle data som ikke tilhører en bestemt app.</string>
     <string name="analyzer_storage_content_type_system_label">Systemdata</string>
     <string name="analyzer_storage_content_type_system_description">Systemapper og systemdata. Apper og data fra andre brukere, hvis flere brukerkontoer er angitt på denne enheten.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Andre</string>
+    <string name="analyzer_storage_content_type_system_info">Filer som ikke passer inn i kategoriene Apper eller Brukerfiler. Bla gjennom bare — sletting støttes ikke. Noen områder kan være ufullstendige på grunn av tilgangsbegrensninger.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">Systemfiler og andre data som SD Maid ikke kunne få tilgang til eller kategorisere. Operativsystemet begrenser opplistingen av innholdet i noen områder.</string>
     <string name="analyzer_storage_content_app_code_label">App-kode</string>
     <string name="analyzer_storage_content_app_code_description">Applikasjonsfiler, biblioteker og ressurser. Denne plassen kan frigjøres ved å avinstallere appen eller arkivere den (tilgjengelig på nyere Android-versjon).</string>
     <string name="analyzer_storage_content_app_data_label">App-data</string>

--- a/app-tool-analyzer/src/main/res/values-ne-rNP/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-ne-rNP/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">खिचिएका तस्बिरहरू, रेकर्ड गरिएका भिडियोहरू वा डाउनलोड गरिएका डेटा। कुनै विशेष app को नभएको कुनै पनि डेटा।</string>
     <string name="analyzer_storage_content_type_system_label">सिस्टम डेटा</string>
     <string name="analyzer_storage_content_type_system_description">सिस्टम apps र सिस्टम डेटा। यदि यस उपकरणमा धेरै प्रयोगकर्ता खाताहरू सेट छन् भने अन्य प्रयोगकर्ताहरूका Apps र डेटा।</string>
+    <string name="analyzer_storage_content_type_system_other_label">अन्य</string>
+    <string name="analyzer_storage_content_type_system_info">एप्स वा प्रयोगकर्ता फाइलहरू श्रेणीमा नफिट्ने फाइलहरू। ब्राउज मात्र — मेटाउने कार्य समर्थित छैन। पहुँच प्रतिबन्धहरूका कारण केही क्षेत्रहरू अपूर्ण हुन सक्छन्।</string>
+    <string name="analyzer_storage_content_type_system_other_desc">SD Maid ले पहुँच गर्न वा वर्गीकृत गर्न नसकेका प्रणाली फाइलहरू र अन्य डेटा। अपरेटिङ प्रणालीले केही क्षेत्रहरूको सामग्री सूचीबद्ध गर्न प्रतिबन्ध लगाउँछ।</string>
     <string name="analyzer_storage_content_app_code_label">App कोड</string>
     <string name="analyzer_storage_content_app_code_description">Application फाइलहरू, libraries र संसाधनहरू। यो ठाउँ app हटाएर वा archive गरेर (नयाँ Android version मा उपलब्ध) फ्री गर्न सकिन्छ।</string>
     <string name="analyzer_storage_content_app_data_label">App डेटा</string>

--- a/app-tool-analyzer/src/main/res/values-nl/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-nl/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">Gemaakte foto\'s, opgenomen video\'s of gedownloade gegevens. Alle gegevens die niet bij een specifieke app horen.</string>
     <string name="analyzer_storage_content_type_system_label">Systeem gegevens</string>
     <string name="analyzer_storage_content_type_system_description">Systeem-apps en systeemgegevens. Apps en gegevens van andere gebruikers, als er meerdere gebruikersaccounts op dit apparaat zijn ingesteld.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Andere</string>
+    <string name="analyzer_storage_content_type_system_info">Bestanden die niet in de categorieën Apps of Gebruikersbestanden passen. Alleen bladeren — verwijderen wordt niet ondersteund. Sommige gebieden zijn mogelijk onvolledig vanwege toegangsbeperkingen.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">Systeembestanden en andere gegevens waartoe SD Maid geen toegang had of die niet gecategoriseerd konden worden. Het besturingssysteem beperkt het weergeven van de inhoud van sommige gebieden.</string>
     <string name="analyzer_storage_content_app_code_label">App code</string>
     <string name="analyzer_storage_content_app_code_description">Applicatiebestanden, bibliotheken en bronnen. Deze ruimte kan vrijgemaakt worden door de app te verwijderen of te archiveren (beschikbaar op nieuwere Android-versie).</string>
     <string name="analyzer_storage_content_app_data_label">App gegevens</string>

--- a/app-tool-analyzer/src/main/res/values-or-rIN/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-or-rIN/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">କ୍ୟାପଚର୍ ହୋଇଥିବା ଛବି, ରେକର୍ଡ ହୋଇଥିବା ଭିଡିଓ କିମ୍ବା ଡାଉନଲୋଡ୍ ହୋଇଥିବା ଡାଟା। କୌଣସି ନିର୍ଦ୍ଦିଷ୍ଟ ଆପ୍ର ନଥିବା ଯେକୌଣସି ଡାଟା।</string>
     <string name="analyzer_storage_content_type_system_label">ସିଷ୍ଟମ୍ ତଥ୍ୟ</string>
     <string name="analyzer_storage_content_type_system_description">ସିଷ୍ଟମ୍ ଆପ୍ସ ଏବଂ ସିଷ୍ଟମ୍ ଡାଟା। ଅନ୍ୟ ଉପଭୋକ୍ତାମାନଙ୍କ ଆପ୍ସ ଏବଂ ଡାଟା, ଯଦି ଏହି ଉପକରଣରେ ଅନେକ ଉପଭୋକ୍ତା ଆକାଉଣ୍ଟ ସେଟ୍ ହୋଇଛି।</string>
+    <string name="analyzer_storage_content_type_system_other_label">ଅନ୍ୟ</string>
+    <string name="analyzer_storage_content_type_system_info">ଯେଉଁ ଫାଇଲଗୁଡ଼ିକ Apps ବା User files ବର୍ଗରେ ପଡ଼େ ନାହିଁ। କେବଳ ଦେଖିହେବ — ବିଲୋପ ସମର୍ଥିତ ନୁହେଁ। ପ୍ରବେଶ ସୀମାବଦ୍ଧତା ହେତୁ କିଛି କ୍ଷେତ୍ର ଅସମ୍ପୂର୍ଣ୍ଣ ହୋଇ ପାରେ।</string>
+    <string name="analyzer_storage_content_type_system_other_desc">ସିଷ୍ଟମ ଫାଇଲ ଓ ଅନ୍ୟ ତଥ୍ୟ ଯାହା SD Maid ଆକ୍ସେସ ବା ବର୍ଗ ନିର୍ଣ୍ଣୟ କରି ପାରି ନାହିଁ। ଅପରେଟିଂ ସିଷ୍ଟମ କିଛି କ୍ଷେତ୍ରର ବିଷୟ ତାଲିକା ଉପରେ ସୀମା ଲଗାଏ।</string>
     <string name="analyzer_storage_content_app_code_label">ଆପ୍ କୋଡ୍</string>
     <string name="analyzer_storage_content_app_code_description">ଆପ୍ଲିକେସନ୍ ଫାଇଲ, ଲାଇବ୍ରେରୀ ଏବଂ ରିସୋର୍ସ। ଆପ୍କୁ ଅନ୍‌ଇନ୍‌ଷ୍ଟଲ୍ କରି କିମ୍ବା ଆର୍କାଇଭ୍ କରି (ନୂତନ Android ସଂସ୍କରଣରେ ଉପଲବ୍ଧ) ଏହି ସ୍ଥାନ ମୁକ୍ତ କରାଯାଇପାରିବ।</string>
     <string name="analyzer_storage_content_app_data_label">ଆପ୍ ତଥ୍ୟ</string>

--- a/app-tool-analyzer/src/main/res/values-pa-rIN/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-pa-rIN/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">ਖਿੱਚੀਆਂ ਗਈਆਂ ਤਸਵੀਰਾਂ, ਰਿਕਾਰਡ ਕੀਤੇ ਵੀਡੀਓ ਜਾਂ ਡਾਊਨਲੋਡ ਕੀਤਾ ਡਾਟਾ। ਕੋਈ ਵੀ ਡਾਟਾ ਜੋ ਕਿਸੇ ਖਾਸ ਐਪ ਨਾਲ ਸਬੰਧਤ ਨਹੀਂ ਹੈ।</string>
     <string name="analyzer_storage_content_type_system_label">ਸਿਸਟਮ ਡਾਟਾ</string>
     <string name="analyzer_storage_content_type_system_description">ਸਿਸਟਮ ਐਪਾਂ ਅਤੇ ਸਿਸਟਮ ਡਾਟਾ। ਜੇ ਇਸ ਡਿਵਾਈਸ \'ਤੇ ਕਈ ਵਰਤੋਂਕਾਰ ਖਾਤੇ ਸੈੱਟ ਹਨ ਤਾਂ ਹੋਰ ਵਰਤੋਂਕਾਰਾਂ ਦੀਆਂ ਐਪਾਂ ਅਤੇ ਡਾਟਾ।</string>
+    <string name="analyzer_storage_content_type_system_other_label">ਹੋਰ</string>
+    <string name="analyzer_storage_content_type_system_info">ਉਹ ਫਾਈਲਾਂ ਜੋ ਐਪਸ ਜਾਂ ਯੂਜ਼ਰ ਫਾਈਲਾਂ ਦੀਆਂ ਸ਼੍ਰੇਣੀਆਂ ਵਿੱਚ ਫਿੱਟ ਨਹੀਂ ਬੈਠਦੀਆਂ। ਸਿਰਫ਼ ਬ੍ਰਾਊਜ਼ ਕਰੋ — ਮਿਟਾਉਣਾ ਸਮਰਥਿਤ ਨਹੀਂ ਹੈ। ਪਹੁੰਚ ਪਾਬੰਦੀਆਂ ਕਾਰਨ ਕੁਝ ਖੇਤਰ ਅਧੂਰੇ ਹੋ ਸਕਦੇ ਹਨ।</string>
+    <string name="analyzer_storage_content_type_system_other_desc">ਸਿਸਟਮ ਫਾਈਲਾਂ ਅਤੇ ਹੋਰ ਡੇਟਾ ਜਿਸ ਤੱਕ SD Maid ਪਹੁੰਚ ਨਹੀਂ ਕਰ ਸਕਿਆ ਜਾਂ ਵਰਗੀਕਰਨ ਨਹੀਂ ਕਰ ਸਕਿਆ। ਓਪਰੇਟਿੰਗ ਸਿਸਟਮ ਕੁਝ ਖੇਤਰਾਂ ਦੀ ਸਮੱਗਰੀ ਦੀ ਸੂਚੀਬੱਧਤਾ ਤੇ ਪਾਬੰਦੀ ਲਗਾਉਂਦਾ ਹੈ।</string>
     <string name="analyzer_storage_content_app_code_label">ਐਪ ਕੋਡ</string>
     <string name="analyzer_storage_content_app_code_description">ਐਪਲੀਕੇਸ਼ਨ ਫਾਈਲਾਂ, ਲਾਇਬ੍ਰੇਰੀਆਂ ਅਤੇ ਸਰੋਤ। ਇਹ ਜਗ੍ਹਾ ਐਪ ਨੂੰ ਅਣਸਥਾਪਿਤ ਕਰਕੇ ਜਾਂ ਇਸਨੂੰ ਸੰਗ੍ਰਹਿਤ ਕਰਕੇ (ਨਵੇਂ Android ਵਰਜਨ \'ਤੇ ਉਪਲਬਧ) ਮੁਕਤ ਕੀਤੀ ਜਾ ਸਕਦੀ ਹੈ।</string>
     <string name="analyzer_storage_content_app_data_label">ਐਪ ਡਾਟਾ</string>

--- a/app-tool-analyzer/src/main/res/values-pl/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-pl/strings.xml
@@ -41,6 +41,9 @@
     <string name="analyzer_storage_content_type_media_description">Przechwycone zdjęcia, nagrane filmy lub pobrane dane. Wszelkie dane, które nie należą do konkretnej aplikacji.</string>
     <string name="analyzer_storage_content_type_system_label">Dane systemowe</string>
     <string name="analyzer_storage_content_type_system_description">Aplikacje systemowe i dane systemowe. Aplikacje i dane od innych użytkowników, jeśli na tym urządzeniu ustawiono kilka kont użytkowników.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Inne</string>
+    <string name="analyzer_storage_content_type_system_info">Pliki, które nie pasują do kategorii Aplikacje ani Pliki użytkownika. Tylko przeglądanie — usuwanie nie jest obsługiwane. Niektóre obszary mogą być niepełne z powodu ograniczeń dostępu.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">Pliki systemowe i inne dane, do których SD Maid nie miał dostępu ani nie mógł ich sklasyfikować. System operacyjny ogranicza możliwość wyświetlania zawartości niektórych obszarów.</string>
     <string name="analyzer_storage_content_app_code_label">Kod aplikacji</string>
     <string name="analyzer_storage_content_app_code_description">Pliki aplikacji, biblioteki i zasoby. Przestrzeń, która może zostać uwolniona przez odinstalowanie aplikacji lub jej archiwizację (dostępne w nowszej wersji Androida).</string>
     <string name="analyzer_storage_content_app_data_label">Dane aplikacji</string>

--- a/app-tool-analyzer/src/main/res/values-pt-rBR/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-pt-rBR/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">Imagens capturadas, vídeos gravados ou dados baixados. Quaisquer dados que não pertençam a um aplicativo específico.</string>
     <string name="analyzer_storage_content_type_system_label">Dados do sistema</string>
     <string name="analyzer_storage_content_type_system_description">Apps do sistema e dados do sistema. Apps e dados de outros usuários, se várias contas de usuário estiverem definidas neste dispositivo.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Outros</string>
+    <string name="analyzer_storage_content_type_system_info">Arquivos que não se encaixam nas categorias de Aplicativos ou Arquivos do usuário. Somente navegação — exclusão não é suportada. Algumas áreas podem estar incompletas devido a restrições de acesso.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">Arquivos do sistema e outros dados que o SD Maid não conseguiu acessar ou categorizar. O sistema operacional restringe a listagem do conteúdo de algumas áreas.</string>
     <string name="analyzer_storage_content_app_code_label">Código da aplicação</string>
     <string name="analyzer_storage_content_app_code_description">Arquivos de aplicativos, bibliotecas e recursos. Este espaço pode ser liberado desinstalando o aplicativo ou arquivando-o (disponível na versão mais recente do Android).</string>
     <string name="analyzer_storage_content_app_data_label">Dados do aplicativo</string>

--- a/app-tool-analyzer/src/main/res/values-pt/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-pt/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">Imagens capturadas, vídeos gravados ou dados baixados. Quaisquer dados que não pertençam a um aplicativo específico.</string>
     <string name="analyzer_storage_content_type_system_label">Dados de sistema</string>
     <string name="analyzer_storage_content_type_system_description">Apps do sistema e dados do sistema. Apps e dados de outros utilizadores, se várias contas de utilizador estiverem definidas neste dispositivo.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Outro</string>
+    <string name="analyzer_storage_content_type_system_info">Ficheiros que não se enquadram nas categorias Aplicações ou Ficheiros de utilizador. Apenas navegação — a eliminação não é suportada. Algumas áreas podem estar incompletas devido a restrições de acesso.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">Ficheiros do sistema e outros dados aos quais o SD Maid não conseguiu aceder ou categorizar. O sistema operativo restringe a listagem do conteúdo de algumas áreas.</string>
     <string name="analyzer_storage_content_app_code_label">Código da aplicação</string>
     <string name="analyzer_storage_content_app_code_description">Arquivos de aplicações, bibliotecas e recursos. Este espaço pode ser liberto desinstalando a aplicação ou arquivando-a (disponível na versão mais recente do Android).</string>
     <string name="analyzer_storage_content_app_data_label">Dados das aplicações</string>

--- a/app-tool-analyzer/src/main/res/values-ro/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-ro/strings.xml
@@ -38,6 +38,9 @@
     <string name="analyzer_storage_content_type_media_description">Fotografii înregistrate, videoclipuri înregistrate sau date descărcate. Orice date care nu aparțin unei anumite aplicații.</string>
     <string name="analyzer_storage_content_type_system_label">Date de sistem</string>
     <string name="analyzer_storage_content_type_system_description">Aplicații de sistem și date de sistem. Aplicații și date de la alți utilizatori, dacă pe acest dispozitiv sunt setate mai multe conturi de utilizatori.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Altele</string>
+    <string name="analyzer_storage_content_type_system_info">Fișiere care nu se încadrează în categoriile Aplicații sau Fișiere utilizator. Numai navigare — ștergerea nu este acceptată. Unele zone pot fi incomplete din cauza restricțiilor de acces.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">Fișiere de sistem și alte date la care SD Maid nu a putut accesa sau categoriza. Sistemul de operare restricționează listarea conținutului unor zone.</string>
     <string name="analyzer_storage_content_app_code_label">Codul aplicației</string>
     <string name="analyzer_storage_content_app_code_description">Fișiere de aplicații, biblioteci și resurse. Acest spațiu poate fi eliberat dezinstalând aplicația sau arhivând-o (disponibil pe versiunea Android mai nouă).</string>
     <string name="analyzer_storage_content_app_data_label">Date aplicație</string>

--- a/app-tool-analyzer/src/main/res/values-ru/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-ru/strings.xml
@@ -41,6 +41,9 @@
     <string name="analyzer_storage_content_type_media_description">Сохраненные изображения, видео или загруженные данные. Любые данные, которые не принадлежат определенному приложению.</string>
     <string name="analyzer_storage_content_type_system_label">Системные данные</string>
     <string name="analyzer_storage_content_type_system_description">Системные приложения и системные данные. Приложения и данные других пользователей, если на этом устройстве установлено несколько учетных записей.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Прочее</string>
+    <string name="analyzer_storage_content_type_system_info">Файлы, которые не соответствуют категориям приложений или пользовательских файлов. Только просмотр — удаление не поддерживается. Некоторые области могут быть неполными из-за ограничений доступа.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">Системные файлы и другие данные, недоступные и некатегоризируемые SD Maid. Операционная система ограничивает отображение содержимого некоторых областей.</string>
     <string name="analyzer_storage_content_app_code_label">Код приложения</string>
     <string name="analyzer_storage_content_app_code_description">Файлы приложений, библиотеки и ресурсы. Это место можно освободить, удаляя приложение или архивируя его (доступно на новой версии Android).</string>
     <string name="analyzer_storage_content_app_data_label">Данные приложений</string>

--- a/app-tool-analyzer/src/main/res/values-sc-rIT/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-sc-rIT/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">Imàgines pigadas, vídeos registrados o datos iscarrigados. Cale si siat datu chi no apertenet a una aplicatzione ispetzìfica.</string>
     <string name="analyzer_storage_content_type_system_label">Datos de sistema</string>
     <string name="analyzer_storage_content_type_system_description">Aplicatziones de sistema e datos de sistema. Aplicatziones e datos dae àteros usuàrios, si tàntos contos de usuàriu sunt cunfigurrados in custu dispositivu.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Àteru</string>
+    <string name="analyzer_storage_content_type_system_info">Archìvios chi no antòniant in is categorias Aplicatziones o Archìvios de s\'utilizadore. Solu navigatzione — sa cancellatzione no est supportada. Calicuna àrea podet essere incumpleta pro via de is limitatziones de accesso.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">Archìvios de sistema e datos àteros chi SD Maid no at podiù accedere o categorizare. Su sistema operativu restringhet sa lista de is cuntenutos de calicuna àrea.</string>
     <string name="analyzer_storage_content_app_code_label">Còdighe de aplicatzione</string>
     <string name="analyzer_storage_content_app_code_description">Documentos de aplicatzione, bibliotecas e risursas. Custu ispàtziu podet èssere liberadu disinstalende s\'aplicatzione o archiviende·la (a disponimentu in versiones de Android più noas).</string>
     <string name="analyzer_storage_content_app_data_label">Datos de aplicatzione</string>

--- a/app-tool-analyzer/src/main/res/values-si-rLK/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-si-rLK/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">වින්යාස කු ෆායාකෘට, රේකෝඩ් කු විඩියෝ හෝ ඩೞවන්ලෝඩ් කු දත්ත. විශේෂ යෙදුමකට ආවණික නොවන එනිම දත්ත.</string>
     <string name="analyzer_storage_content_type_system_label">පද්ධති දත්ත</string>
     <string name="analyzer_storage_content_type_system_description">පද්ධති යෙදුම් සහ පද්ධති දත්ත. මෙම පිකරණයම බොහෝ පරිශීලක නියෝජන සැකසා ඇත නම් ඉතර පරිශීලකයන්ගෙ යෙදුම් සහ දත්ත.</string>
+    <string name="analyzer_storage_content_type_system_other_label">වෙනත්</string>
+    <string name="analyzer_storage_content_type_system_info">යෙදුම් හෝ පරිශීලක ගොනු ප්‍රවර්ගවලට නොගැළපෙන ගොනු. පිරිසැලසුම් පමණයි — මකාදැමීම සහාය නොදක්වයි. ප්‍රවේශ සීමාවන් හේතුවෙන් සමහර ප්‍රදේශ අසම්පූර්ණ විය හැකිය.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">SD Maid ප්‍රවේශ වීමට හෝ වර්ගීකරණය කිරීමට නොහැකි වූ පද්ධති ගොනු සහ වෙනත් දත්ත. මෙහෙයුම් පද්ධතිය සමහර ප්‍රදේශවල අන්තර්ගතය ලැයිස්තු කිරීම සීමා කරයි.</string>
     <string name="analyzer_storage_content_app_code_label">යෙදුමේ කෝඩය</string>
     <string name="analyzer_storage_content_app_code_description">යෙදුම් ගොනු, ඵානදාර සහ සම්පත්. යෙදුම ඉවත් කිරීමෙන් හෝ එය ආරකිව කිරීමෙන් (නව Android අනුවාදම නිවාපු) මෙම හීම මුක්ත් කරන්න පුළුවාන්.</string>
     <string name="analyzer_storage_content_app_data_label">යෙදුමේ දත්ත</string>

--- a/app-tool-analyzer/src/main/res/values-sk/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-sk/strings.xml
@@ -41,6 +41,9 @@
     <string name="analyzer_storage_content_type_media_description">Nasnímané obrázky, nahrané videá alebo stiahnuté dáta. Akékoľvek údaje, ktoré nepatria do konkrétnej aplikácie.</string>
     <string name="analyzer_storage_content_type_system_label">Systémové údaje</string>
     <string name="analyzer_storage_content_type_system_description">Systémové aplikácie a systémové údaje. Aplikácie a údaje od iných používateľov, ak je na tomto zariadení nastavených niekoľko používateľských účtov.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Iné</string>
+    <string name="analyzer_storage_content_type_system_info">Súbory, ktoré nepatria do kategórií Aplikácie alebo Používateľské súbory. Len prezeranie — mazanie nie je podporované. Niektoré oblasti môžu byť neúplné z dôvodu obmedzení prístupu.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">Systémové súbory a iné dáta, ku ktorým SD Maid nemohol pristupovať ani ich kategorizovať. Operačný systém obmedzuje zobrazenie obsahu niektorých oblastí.</string>
     <string name="analyzer_storage_content_app_code_label">Kód aplikácie</string>
     <string name="analyzer_storage_content_app_code_description">Aplikačné súbory, knižnice a zdroje. Tento priestor je možné uvoľniť odinštalovaním aplikácie alebo jej archiváciou (k dispozícii v novšej verzii Androidu).</string>
     <string name="analyzer_storage_content_app_data_label">Dáta aplikácie</string>

--- a/app-tool-analyzer/src/main/res/values-sl/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-sl/strings.xml
@@ -41,6 +41,9 @@
     <string name="analyzer_storage_content_type_media_description">Posnete slike, videoposnetki in prejeti podatki.  Vsi podatki, ki ne pripadajo nobenemu določenemu programu.</string>
     <string name="analyzer_storage_content_type_system_label">Sistemski podatki</string>
     <string name="analyzer_storage_content_type_system_description">Sistemski programi in podatki.  Programi in podatki drugih uporabnikov, če je na napravi več uporabniških računov.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Drugo</string>
+    <string name="analyzer_storage_content_type_system_info">Datoteke, ki ne spadajo v kategoriji Aplikacije ali Uporabniške datoteke. Samo brskanje — brisanje ni podprto. Nekatera področja so morda nepopolna zaradi omejitev dostopa.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">Sistemske datoteke in drugi podatki, do katerih SD Maid ni mogel dostopati ali jih razvrstiti. Operacijski sistem omejuje izpisovanje vsebine nekaterih področij.</string>
     <string name="analyzer_storage_content_app_code_label">Programska koda</string>
     <string name="analyzer_storage_content_app_code_description">Programske datoteke, knjižnice in viri.  Ta prostor lahko sprostite z odstranitvijo ali arhiviranjem (na voljo v novejših različicah Androida) programa.</string>
     <string name="analyzer_storage_content_app_data_label">Programski podatki</string>

--- a/app-tool-analyzer/src/main/res/values-sq-rAL/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-sq-rAL/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">Fotografi të shkrepura, video të regjistruara ose të dhëna të shkarkuara. Çdo të dhënë që nuk i përket një aplikacioni specifik.</string>
     <string name="analyzer_storage_content_type_system_label">Të dhënat e sistemit</string>
     <string name="analyzer_storage_content_type_system_description">Aplikacionet e sistemit dhe të dhënat e sistemit. Aplikacionet dhe të dhënat nga përdoruesit e tjerë, nëse në këtë pajisje janë caktuar disa llogari përdoruesish.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Tjetër</string>
+    <string name="analyzer_storage_content_type_system_info">Skedarë që nuk i përshtaten kategorive Aplikacione ose Skedarë të përdoruesit. Shfletim i vetëm — fshirja nuk mbështet. Disa zona mund të jenë të paplotë për shkak të kufizimeve të aksesit.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">Skedarë të sistemit dhe të dhëna të tjera që SD Maid nuk mund t’i aksesojë ose kategorizojë. Sistemi operativ kufizon listimin e përbajtjes në disa zona.</string>
     <string name="analyzer_storage_content_app_code_label">Kodi i aplikacionit</string>
     <string name="analyzer_storage_content_app_code_description">Skedarët e aplikacionit, bibliotekat dhe burimet. Kjo hapësirë ​​mund të lirohet duke çinstaluar aplikacionin ose duke e arkivuar atë (e disponueshme në versionin më të ri të Android).</string>
     <string name="analyzer_storage_content_app_data_label">Të dhenat e programit</string>

--- a/app-tool-analyzer/src/main/res/values-sr/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-sr/strings.xml
@@ -38,6 +38,9 @@
     <string name="analyzer_storage_content_type_media_description">Снимљене слике, снимљени видео записи или преузети подаци. Било који подаци који не припадају одређеној апликацији.</string>
     <string name="analyzer_storage_content_type_system_label">Системски подаци</string>
     <string name="analyzer_storage_content_type_system_description">Системске апликације и системски подаци. Апликације и подаци осталих корисника, ако је на овом уређају подешено више корисничких налога.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Остало</string>
+    <string name="analyzer_storage_content_type_system_info">Датотеке које не припадају категоријама Апликације или Кориснички фајлови. Само прегледање — брисање није подржано. Неке области могу бити непотпуне услед ограничења приступа.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">Системске датотеке и остали подаци којима SD Maid није могао приступити или их категорисати. Оперативни систем ограничава листање садржаја неких области.</string>
     <string name="analyzer_storage_content_app_code_label">Код апликације</string>
     <string name="analyzer_storage_content_app_code_description">Датотеке апликације, библиотеке и ресурси. Овај простор се може ослободити деинсталирањем апликације или архивирањем (доступно на новијим Андроид верзијама).</string>
     <string name="analyzer_storage_content_app_data_label">Подаци апликације</string>

--- a/app-tool-analyzer/src/main/res/values-sv/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-sv/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">Tagna bilder, inspelade videor eller nedladdad data. All data som inte tillhör en specifik app.</string>
     <string name="analyzer_storage_content_type_system_label">Systemdata</string>
     <string name="analyzer_storage_content_type_system_description">Systemappar och systemdata. Appar och data från andra användare, om flera användarkonton är inställda på denna enhet.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Övriga</string>
+    <string name="analyzer_storage_content_type_system_info">Filer som inte passar in i kategorierna Appar eller Användarfiler. Bläddra endast — borttagning stöds inte. Vissa områden kan vara ofullständiga på grund av åtkomstbegränsningar.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">Systemfiler och andra data som SD Maid inte kunde komma åt eller kategorisera. Operativsystemet begränsar listning av innehållet i vissa områden.</string>
     <string name="analyzer_storage_content_app_code_label">Appkod</string>
     <string name="analyzer_storage_content_app_code_description">Applikationsfiler, bibliotek och resurser. Detta utrymme kan frigöras genom att avinstallera appen eller arkivera den (tillgängligt på nyare Android-versioner).</string>
     <string name="analyzer_storage_content_app_data_label">Appdata</string>

--- a/app-tool-analyzer/src/main/res/values-sw/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-sw/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">Picha zilizochukuliwa, video zilizoandikwa au data zilizopakuliwa. Data yoyote ambayo haimilikiwi na programu maalum.</string>
     <string name="analyzer_storage_content_type_system_label">Data ya mfumo</string>
     <string name="analyzer_storage_content_type_system_description">Programu za mfumo na data ya mfumo. Programu na data kutoka watumiaji wengine, ikiwa akaunti nyingi za watumiaji zimewekwa kwenye kifaa hiki.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Nyingine</string>
+    <string name="analyzer_storage_content_type_system_info">Faili ambazo hazifai katika kategoria za Programu au faili za Mtumiaji. Vinjari tu — kufuta hakusaidiwi. Baadhi ya maeneo yanaweza kuwa hayakamiliki kwa sababu ya vikwazo vya ufikiaji.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">Faili za mfumo na data nyingine ambayo SD Maid haikuweza kufikia au kuainisha. Mfumo wa uendeshaji unazuia kuorodhesha maudhui ya baadhi ya maeneo.</string>
     <string name="analyzer_storage_content_app_code_label">Msimbo wa programu</string>
     <string name="analyzer_storage_content_app_code_description">Faili za programu, maktaba na rasilimali. Nafasi hii inaweza kufunguliwa kwa kuondoa programu au kuihifadhi (inapatikana kwenye toleo jipya la Android).</string>
     <string name="analyzer_storage_content_app_data_label">Data ya programu</string>

--- a/app-tool-analyzer/src/main/res/values-ta-rIN/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-ta-rIN/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">பிடிக்கப்பட்ட படங்கள், பதிவு செய்யப்பட்ட வீடியோகள் அல்லது இறங்கப்பட்ட தரவு. குறிப்பிட்ட பயன்பாட்டுக்கு சொந்தமில்லாத எந்த தரவும்.</string>
     <string name="analyzer_storage_content_type_system_label">கணினி தரவு</string>
     <string name="analyzer_storage_content_type_system_description">கணினி பயன்பாடுகள் மற்றும் கணினி தரவு. இந்த சாதனத்தில் பல பயனர் கணக்குகள் அமைக்கப்பட்டிருந்தால், மற்ற பயனர்களின் பயன்பாடுகள் மற்றும் தரவு.</string>
+    <string name="analyzer_storage_content_type_system_other_label">மற்றவை</string>
+    <string name="analyzer_storage_content_type_system_info">ஆப்ஸ் அல்லது பயனர் கோப்புகள் வகைகளில் பொருந்தாத கோப்புகள். உலாவல் மட்டுமே — நீக்குதல் ஆதரிக்கப்படவில்லை. அணுகல் கட்டுப்பாடுகள் காரணமாக சில பகுதிகள் முழுமையற்றதாக இருக்கலாம்.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">SD Maid அணுக அல்லது வகைப்படுத்த முடியாத கணினி கோப்புகள் மற்றும் பிற தரவு. இயக்க முறைமை சில பகுதிகளின் உள்ளடக்கங்களை பட்டியலிடுவதை கட்டுப்படுத்துகிறது.</string>
     <string name="analyzer_storage_content_app_code_label">பயன்பாட்டு கோட்</string>
     <string name="analyzer_storage_content_app_code_description">பயன்பாட்டு கோப்புகள், நூலகங்கள் மற்றும் வளங்கள். பயன்பாடை அன்இன்ஸ்டால் செய்வதன் மூலம் அல்லது அர்கைவ் செய்வதன் மூலம் (புதிய Android வெர்ஷன்களில் கிடைக்கும்) இந்த இடத்தை விடுவிக்க முடியும்.</string>
     <string name="analyzer_storage_content_app_data_label">பயன்பாட்டு தரவு</string>

--- a/app-tool-analyzer/src/main/res/values-te-rIN/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-te-rIN/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">తీసిన చిత్రాలు, రికార్డ్ చేసిన వీడియోలు లేదా డౌన్‌లోడ్ చేసిన డేటా. నిర్దిష్ట యాప్‌కు సంబంధించని డేటా.</string>
     <string name="analyzer_storage_content_type_system_label">సిస్టం డేటా</string>
     <string name="analyzer_storage_content_type_system_description">సిస్టం యాప్‌లు మరియు సిస్టం డేటా. ఈ పరికరంలో ఎక్కువ వినియోగదారు ఖాతాలు సెట్ చేసి ఉంటే, ఇతర వినియోగదారుల నుంచి యాప్‌లు మరియు డేటా.</string>
+    <string name="analyzer_storage_content_type_system_other_label">ఇతర</string>
+    <string name="analyzer_storage_content_type_system_info">Apps లేదా వినియోగదారు ఫైళ్ళ వర్గాలలో సరిపోని ఫైళ్ళు. బ్రౌజ్ మాత్రమే — తొలగింపు మద్దతు లేదు. యాక్సెస్ పరిమితుల కారణంగా కొన్ని ప్రాంతాలు అసంపూర్ణంగా ఉండవచ్చు.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">SD Maid యాక్సెస్ చేయలేకపోయిన లేదా వర్గీకరించలేకపోయిన సిస్టమ్ ఫైళ్ళు మరియు ఇతర డేటా. ఆపరేటింగ్ సిస్టమ్ కొన్ని ప్రాంతాల కంటెంట్‌లను జాబితా చేయడాన్ని నిరోధిస్తుంది.</string>
     <string name="analyzer_storage_content_app_code_label">యాప్ కోడ్</string>
     <string name="analyzer_storage_content_app_code_description">అప్లికేషన్ ఫైల్‌లు, లైబ్రరీలు మరియు రిసోర్సెస్. యాప్‌ను అనిన్‌స్టాల్ చేయడం లేదా ఆర్కైవ్ చేయడం (కొత్త Android వెర్షన్‌లో అనుపలబ్ధం) ద్వారా ఈ స్థలాన్ని విడుదల చేయవచ్చు.</string>
     <string name="analyzer_storage_content_app_data_label">యాప్ డేటా</string>

--- a/app-tool-analyzer/src/main/res/values-th/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-th/strings.xml
@@ -32,6 +32,9 @@
     <string name="analyzer_storage_content_type_media_description">รูปภาพที่ถ่าย, วิดีโอที่บันทึก, หรือข้อมูลที่ดาวน์โหลด ข้อมูลใดๆ ที่ไม่ได้เป็นของแอพใดโดยเฉพาะ</string>
     <string name="analyzer_storage_content_type_system_label">ข้อมูลระบบ</string>
     <string name="analyzer_storage_content_type_system_description">แอพระบบและข้อมูลระบบ แอพและข้อมูลจากผู้ใช้คนอื่น หากมีบัญชีผู้ใช้หลายบัญชีบนอุปกรณ์นี้</string>
+    <string name="analyzer_storage_content_type_system_other_label">อื่นๆ</string>
+    <string name="analyzer_storage_content_type_system_info">ไฟล์ที่ไม่เข้าหมวดหมู่แอปหรือไฟล์ผู้ใช้ เรียกดูเท่านั้น — ไม่รองรับการลบ บางพื้นที่อาจไม่ครบถ้วนเนื่องจากข้อจำกัดในการเข้าถึง</string>
+    <string name="analyzer_storage_content_type_system_other_desc">ไฟล์ระบบและข้อมูลอื่นๆ ที่ SD Maid ไม่สามารถเข้าถึงหรือจัดหมวดหมู่ได้ ระบบปฏิบัติการจำกัดการแสดงรายการเนื้อหาของบางพื้นที่</string>
     <string name="analyzer_storage_content_app_code_label">โค้ดแอพ</string>
     <string name="analyzer_storage_content_app_code_description">ไฟล์แอพพลิเคชัน, ไลบรารี และทรัพยากร สามารถลบพื้นที่นี้ได้โดยถอนการติดตั้งแอพหรือเก็บแอพไว้ (ใช้ได้ใน Android รุ่นใหม่)</string>
     <string name="analyzer_storage_content_app_data_label">ข้อมูลแอพ</string>

--- a/app-tool-analyzer/src/main/res/values-tr/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-tr/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">Çekilen resimler, kaydedilen videolar veya indirilen veriler. Belirli bir uygulamaya ait olmayan tüm veriler.</string>
     <string name="analyzer_storage_content_type_system_label">Sistem verileri</string>
     <string name="analyzer_storage_content_type_system_description">Sistem uygulamaları ve sistem verileri. Bu cihazda birden fazla kullanıcı hesabı ayarlanmışsa, diğer kullanıcılara ait uygulamalar ve veriler.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Diğer</string>
+    <string name="analyzer_storage_content_type_system_info">Uygulamalar veya Kullanıcı dosyaları kategorilerine uymayan dosyalar. Yalnızca göz atma — silme desteklenmez. Bazı alanlar, erişim kısıtlamaları nedeniyle eksik olabilir.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">SD Maid\'in erişemediği veya kategorize edemediği sistem dosyaları ve diğer veriler. İşletim sistemi, bazı alanların içeriğini listelemeyi kısıtlar.</string>
     <string name="analyzer_storage_content_app_code_label">Uygulama kodu</string>
     <string name="analyzer_storage_content_app_code_description">Uygulama dosyaları, kütüphaneler ve kaynaklar. Bu alan, uygulamayı kaldırarak veya arşivleyerek (daha yeni Android sürümlerinde mevcuttur) boşaltılabilir.</string>
     <string name="analyzer_storage_content_app_data_label">Uygulama verileri</string>

--- a/app-tool-analyzer/src/main/res/values-uk/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-uk/strings.xml
@@ -41,6 +41,9 @@
     <string name="analyzer_storage_content_type_media_description">Зроблені фотографії, записані відео або завантажені дані. Будь-які дані, що не належать конкретній програмі.</string>
     <string name="analyzer_storage_content_type_system_label">Системні дані</string>
     <string name="analyzer_storage_content_type_system_description">Системні додатки та системні дані. Додатки та дані інших користувачів, якщо на пристрої встановлено кілька облікових записів.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Інше</string>
+    <string name="analyzer_storage_content_type_system_info">Файли, які не належать до категорій «Додатки» або «Файли користувача». Тільки перегляд — видалення не підтримується. Деякі розділи можуть бути неповними через обмеження доступу.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">Системні файли та інші дані, до яких SD Maid не зміг отримати доступ або класифікувати. Операційна система обмежує відображення вмісту деяких розділів.</string>
     <string name="analyzer_storage_content_app_code_label">Код додатка</string>
     <string name="analyzer_storage_content_app_code_description">Файли додатка, бібліотеки та ресурси. Цей простір можна звільнити, видаливши додатки або заархівувавши їх (доступно на нових версіях Android).</string>
     <string name="analyzer_storage_content_app_data_label">Дані додатка</string>

--- a/app-tool-analyzer/src/main/res/values-ur-rIN/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-ur-rIN/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">کیپچر شدہ تصاویر، ریکارڈ شدہ ویڈیوز یا ڈاؤن لوڈ شدہ ڈیٹا۔ کوئی بھی ڈیٹا جو کسی مخصوص ایپ سے تعلق نہیں رکھتا۔</string>
     <string name="analyzer_storage_content_type_system_label">سسٹم ڈیٹا</string>
     <string name="analyzer_storage_content_type_system_description">سسٹم ایپس اور سسٹم ڈیٹا۔ دوسرے صارفین کے ایپس اور ڈیٹا، اگر اس ڈیوائس پر کئی صارف اکاؤنٹس سیٹ ہیں۔</string>
+    <string name="analyzer_storage_content_type_system_other_label">دیگر</string>
+    <string name="analyzer_storage_content_type_system_info">وہ فائلیں جو ایپس یا صارف کی فائلوں کے زمروں میں فٹ نہیں ہوتیں۔ صرف براؤز کریں — حذف کرنا سپورٹ نہیں ہے۔ رسائی کی پابندیوں کی وجہ سے کچھ علاقے نامکمل ہو سکتے ہیں۔</string>
+    <string name="analyzer_storage_content_type_system_other_desc">سسٹم فائلیں اور دیگر ڈیٹا جن تک SD Maid رسائی یا درجہ بندی نہیں کر سکا۔ آپریٹنگ سسٹم کچھ علاقوں کے مواد کی فہرست کو محدود کرتا ہے۔</string>
     <string name="analyzer_storage_content_app_code_label">ایپ کوڈ</string>
     <string name="analyzer_storage_content_app_code_description">ایپلیکیشن فائلیں، لائبریریز اور ریسورسز۔ یہ جگہ ایپ کو ان انسٹال کرنے یا آرکائیو کرنے سے آزاد کی جا سکتی ہے (نئے Android ورژن پر دستیاب)۔</string>
     <string name="analyzer_storage_content_app_data_label">ایپ ڈیٹا</string>

--- a/app-tool-analyzer/src/main/res/values-uz/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-uz/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">Olingan rasmlar, yozilgan videolar yoki yuklab olingan ma\'lumotlar. Muayyan ilovaga tegishli bo\'lmagan har qanday ma\'lumot.</string>
     <string name="analyzer_storage_content_type_system_label">Tizim ma\'lumotlari</string>
     <string name="analyzer_storage_content_type_system_description">Tizim ilovalari va tizim ma\'lumotlari. Agar ushbu qurilmada bir nechta foydalanuvchi hisobi o\'rnatilgan bo\'lsa, boshqa foydalanuvchilarning ilovalari va ma\'lumotlari.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Boshqa</string>
+    <string name="analyzer_storage_content_type_system_info">Ilovalar yoki Foydalanuvchi fayllari toifalariga mos kelmaydigan fayllar. Faqat ko\'rish — o\'chirish qo\'llab-quvvatlanmaydi. Ba\'zi bo\'limlar kirish cheklovlari sababli to\'liq bo\'lmasligi mumkin.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">SD Maid kira olmagan yoki toifalay olmagan tizim fayllari va boshqa ma\'lumotlar. Operatsion tizim ba\'zi bo\'limlar mazmunini ko\'rsatishni cheklaydi.</string>
     <string name="analyzer_storage_content_app_code_label">Ilova kodi</string>
     <string name="analyzer_storage_content_app_code_description">Ilova fayllari, kutubxonalar va resurslar. Bu joyni ilovani o\'chirish yoki arxivlash orqali bo\'shatish mumkin (yangi Android versiyalarida mavjud).</string>
     <string name="analyzer_storage_content_app_data_label">Ilova ma\'lumotlari</string>

--- a/app-tool-analyzer/src/main/res/values-vi/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-vi/strings.xml
@@ -32,6 +32,9 @@
     <string name="analyzer_storage_content_type_media_description">Ảnh đã chụp, video đã ghi hoặc dữ liệu đã tải xuống. Bất kỳ dữ liệu nào không thuộc về một ứng dụng cụ thể.</string>
     <string name="analyzer_storage_content_type_system_label">Dữ liệu hệ thống</string>
     <string name="analyzer_storage_content_type_system_description">Ứng dụng hệ thống và dữ liệu hệ thống. Ứng dụng và dữ liệu từ những người dùng khác nếu có nhiều tài khoản người dùng được đặt trên thiết bị này.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Khác</string>
+    <string name="analyzer_storage_content_type_system_info">Các tệp không thuộc danh mục Ứng dụng hoặc Tệp người dùng. Chỉ duyệt — không hỗ trợ xóa. Một số khu vực có thể không đầy đủ do hạn chế truy cập.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">Tệp hệ thống và dữ liệu khác mà SD Maid không thể truy cập hoặc phân loại. Hệ điều hành hạn chế việc liệt kê nội dung của một số khu vực.</string>
     <string name="analyzer_storage_content_app_code_label">Mã ứng dụng</string>
     <string name="analyzer_storage_content_app_code_description">Các tập tin ứng dụng, thư viện và tài nguyên. Không gian này có thể được giải phóng bằng cách gỡ cài đặt ứng dụng hoặc lưu trữ nó (có sẵn trên phiên bản Android mới hơn).</string>
     <string name="analyzer_storage_content_app_data_label">Dữ liệu ứng dụng</string>

--- a/app-tool-analyzer/src/main/res/values-zh-rCN/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-zh-rCN/strings.xml
@@ -32,6 +32,9 @@
     <string name="analyzer_storage_content_type_media_description">截取的图片、录制的视频或下载的数据，不属于特定应用的任何数据</string>
     <string name="analyzer_storage_content_type_system_label">系统数据</string>
     <string name="analyzer_storage_content_type_system_description">系统应用和系统数据。如果在此设备上设置了其他用户账户，则这也将清除其他用户的应用和数据。</string>
+    <string name="analyzer_storage_content_type_system_other_label">其他</string>
+    <string name="analyzer_storage_content_type_system_info">不属于应用或用户文件类别的文件。仅供浏览——不支持删除。由于访问限制，某些区域可能不完整。</string>
+    <string name="analyzer_storage_content_type_system_other_desc">SD Maid 无法访问或分类的系统文件和其他数据。操作系统限制了对某些区域内容的列出。</string>
     <string name="analyzer_storage_content_app_code_label">应用代码</string>
     <string name="analyzer_storage_content_app_code_description">应用程序的文件、依赖库和资源。此空间可以通过卸载应用程序或将其存档（在较新的安卓版本上）从而释放。</string>
     <string name="analyzer_storage_content_app_data_label">应用数据</string>

--- a/app-tool-analyzer/src/main/res/values-zh-rHK/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-zh-rHK/strings.xml
@@ -32,6 +32,9 @@
     <string name="analyzer_storage_content_type_media_description">擷取的圖片、錄製的影片或已下載的資料，任何不屬於特定應用程式的資料。</string>
     <string name="analyzer_storage_content_type_system_label">系統資料</string>
     <string name="analyzer_storage_content_type_system_description">系統應用程式和系統資料，即來自其他使用者的應用程式和資料 (如果此裝置上有多位使用者)。</string>
+    <string name="analyzer_storage_content_type_system_other_label">其他</string>
+    <string name="analyzer_storage_content_type_system_info">不屬於「應用程式」或「使用者檔案」類別的檔案。僅供瀏覽——不支援刪除。由於存取限制，部分區域內容可能不完整。</string>
+    <string name="analyzer_storage_content_type_system_other_desc">SD Maid 無法存取或分類的系統檔案及其他資料。作業系統限制列出某些區域的內容。</string>
     <string name="analyzer_storage_content_app_code_label">應用程式程式碼</string>
     <string name="analyzer_storage_content_app_code_description">APK 檔案和其他安裝相關檔案</string>
     <string name="analyzer_storage_content_app_data_label">應用程式資料</string>

--- a/app-tool-analyzer/src/main/res/values-zh-rTW/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-zh-rTW/strings.xml
@@ -32,6 +32,9 @@
     <string name="analyzer_storage_content_type_media_description">擷取的圖片、錄製的影片或已下載的資料，任何不屬於特定應用程式的資料。</string>
     <string name="analyzer_storage_content_type_system_label">系統資料</string>
     <string name="analyzer_storage_content_type_system_description">系統應用程式和系統資料，即來自其他使用者的應用程式和資料 (如果此裝置上有多位使用者)。</string>
+    <string name="analyzer_storage_content_type_system_other_label">其他</string>
+    <string name="analyzer_storage_content_type_system_info">不屬於應用程式或使用者檔案類別的檔案。僅供瀏覽——不支援刪除。由於存取限制，部分區域可能不完整。</string>
+    <string name="analyzer_storage_content_type_system_other_desc">SD Maid 無法存取或分類的系統檔案和其他資料。作業系統限制列出某些區域的內容。</string>
     <string name="analyzer_storage_content_app_code_label">應用程式程式碼</string>
     <string name="analyzer_storage_content_app_code_description">應用程式的檔案、函式庫和資源。可以透過解除安裝應用程式或將其封存（適用於較新版的 Android 系統）來釋放這些空間。</string>
     <string name="analyzer_storage_content_app_data_label">應用程式資料</string>

--- a/app-tool-analyzer/src/main/res/values-zu/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-zu/strings.xml
@@ -35,6 +35,9 @@
     <string name="analyzer_storage_content_type_media_description">Izithombe ezithathiwe, amavidiyo arekhotiwe noma idatha elandiwe. Noma iyiphi idatha engeyona eyinhlelo lokusebenza elithile.</string>
     <string name="analyzer_storage_content_type_system_label">Idatha yesistimu</string>
     <string name="analyzer_storage_content_type_system_description">Izinhlelo zokusebenza zesistimu nedatha yesistimu. Izinhlelo zokusebenza nedatha kwabanye abasebenzisi, uma ama-akhawunti abasebenzisi ambalwa esetiwe kule divayisi.</string>
+    <string name="analyzer_storage_content_type_system_other_label">Okunye</string>
+    <string name="analyzer_storage_content_type_system_info">Amafayela angafaneli izigaba ze-Apps noma izifayela zomsebenzisi. Bhrowza kuphela — ukususa akusekelelwa. Ezinye izindawo zingaba nekhona okuswelekayo ngenxa yemikhawulo yokungena.</string>
+    <string name="analyzer_storage_content_type_system_other_desc">Amafayela esikhungo namanye idatha i-SD Maid engakwazi ukungena noma ukuhlukanisa. Uhlelo lwokusebenza luvimba ukubhaliswa kwamazwi ezindaweni ezithile.</string>
     <string name="analyzer_storage_content_app_code_label">Ikhodi yohlelo</string>
     <string name="analyzer_storage_content_app_code_description">Amafayela ohlelo, amathala ezincwadi nezinsiza. Lesi sikhala singakhululwa ngokususa uhlelo noma ngokusibekela (sitholakala kwinguqulo entsha ye-Android).</string>
     <string name="analyzer_storage_content_app_data_label">Idatha yohlelo</string>

--- a/app-tool-deduplicator/src/main/res/values-af-rZA/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-af-rZA/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Bepaal duplikate deur checksums vir lêers te bereken. Lêers met passende checksums het presies dieselfde inhoud.</string>
     <string name="deduplicator_detection_method_phash_title">Perceptuele hash</string>
     <string name="deduplicator_detection_method_phash_summary">Vind soortgelyke lêers deur inhoudkenmerke te ontleed en perseptuele hash-waardes te vergelyk. ⚠️ Ooreenkoms-gebaseerde opsporing kan vals positiewes insluit wat handmatige verifikasie vereis.</string>
+    <string name="deduplicator_detection_method_media_title">Media-vingerafdruk</string>
+    <string name="deduplicator_detection_method_media_summary">Vind soortgelyke video- en oudiolêers deur oudio-vingerafdrukke te ontleed. ⚠️ Gelykenisgebaseerde opsporing kan vals positiewe insluit wat handmatige verifikasie vereis.</string>
+    <string name="deduplicator_matches_media_label">Soortgelyke media</string>
+    <string name="deduplicator_media_match_audio">Oudiogebaseerde ooreenkoms</string>
+    <string name="deduplicator_media_match_visual">Video-gebaseerde ooreenkoms</string>
+    <string name="deduplicator_media_match_audio_visual">Oudio- en video-gebaseerde ooreenkoms</string>
     <string name="deduplicator_occupied_space_label">Besette berging</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s word deur duplikate beset</item>

--- a/app-tool-deduplicator/src/main/res/values-am/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-am/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">ለፋይሎች ማረጋገጫ ድምሮችን በማስላት ተመሳሳዮችን ወስን። ተመሳሳይ ማረጋገጫ ድምሮች ያላቸው ፋይሎች ፍጹም ተመሳሳይ ይዘት አላቸው።</string>
     <string name="deduplicator_detection_method_phash_title">የእይታ ሃሽ</string>
     <string name="deduplicator_detection_method_phash_summary">የይዘት ባህሪያትን በመተንተንና የማስተዋል ሃሽ ዋጋዎችን በማነጻጸር ተመሳሳይ ፋይሎችን ያግኙ። ⚠️ በተመሳሳይነት ላይ የተመሰረተ ግኝት በእጅ ማረጋገጫ የሚያስፈልጋቸውን የሐሰት አዎንታዊ ውጤቶች ሊያካትት ይችላል።</string>
+    <string name="deduplicator_detection_method_media_title">የሚዲያ ጣት አሻራ</string>
+    <string name="deduplicator_detection_method_media_summary">የድምፅ ጣት አሻራዎችን በመተንተን ተመሳሳይ ቪዲዮ እና ድምፅ ፋይሎችን ያግኙ። ⚠️ ተመሳሳይነት ላይ የተመሰረተ ማወቅ የሐሰት አዎንታዊ ውጤቶችን ሊያካትት ይችላል፣ ይህም ከእጅ ማረጋገጥ ያስፈልጋል።</string>
+    <string name="deduplicator_matches_media_label">ተመሳሳይ ሚዲያ</string>
+    <string name="deduplicator_media_match_audio">በድምፅ ላይ የተመሰረተ ተዛምዶ</string>
+    <string name="deduplicator_media_match_visual">በቪዲዮ ላይ የተመሰረተ ተዛምዶ</string>
+    <string name="deduplicator_media_match_audio_visual">በድምፅ እና ቪዲዮ ላይ የተመሰረተ ተዛምዶ</string>
     <string name="deduplicator_occupied_space_label">የተያዘ ማጠራቀሚያ</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s በተመሳሳዮች ተይዟል</item>

--- a/app-tool-deduplicator/src/main/res/values-ar/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-ar/strings.xml
@@ -33,6 +33,12 @@
     <string name="deduplicator_detection_method_checksum_summary">تحديد التكرارات عن طريق حساب مقادير الاختبار للملفات. الملفات مع مقاييس الاختبار المطابقة لها نفس المحتوى بالضبط.</string>
     <string name="deduplicator_detection_method_phash_title">التجزئة المفهومة</string>
     <string name="deduplicator_detection_method_phash_summary">البحث عن ملفات مشابهة عن طريق تحليل ميزات المحتوى ومقارنة قيم التجزئة الإدراكية. ⚠️ قد يتضمن الكشف القائم على المماثلة إيجابيات خاطئة تتطلب التحقق اليدوي.</string>
+    <string name="deduplicator_detection_method_media_title">بصمة الوسائط</string>
+    <string name="deduplicator_detection_method_media_summary">البحث عن ملفات الفيديو والصوت المتشابهة عن طريق تحليل البصمات الصوتية. ⚠️ قد يتضمن الكشف القائم على التشابه نتائج إيجابية كاذبة تتطلب التحقق اليدوي.</string>
+    <string name="deduplicator_matches_media_label">وسائط متشابهة</string>
+    <string name="deduplicator_media_match_audio">تطابق قائم على الصوت</string>
+    <string name="deduplicator_media_match_visual">تطابق قائم على الفيديو</string>
+    <string name="deduplicator_media_match_audio_visual">تطابق قائم على الصوت والفيديو</string>
     <string name="deduplicator_occupied_space_label">المساحة المستخدمة</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="zero">%s مشغولة بالنسخ المكررة</item>

--- a/app-tool-deduplicator/src/main/res/values-az/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-az/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Fayllar üçün checksumları hesablayaraq dublikatları müəyyən et. Uyğun checksumları olan fayllar eyni məzmuna sahibdir.</string>
     <string name="deduplicator_detection_method_phash_title">Qavrayış hash-ı</string>
     <string name="deduplicator_detection_method_phash_summary">Məzmun xüsusiyyətlərini təhlil edərək və qavrayış həş perceptual hash dəyərlərini müqayisə edərək bənzər faylları tapın. ⚠️ Bənzərlik əsaslı aşkarlama əl ilə yoxlama tələb edən yanlış müsbət false positive nəticələr verə bilər.</string>
+    <string name="deduplicator_detection_method_media_title">Media barmaq izi</string>
+    <string name="deduplicator_detection_method_media_summary">Səs barmaq izlərini analiz edərək oxşar video və audio faylları tapın. ⚠️ Oxşarlığa əsaslanan aşkarlama, əl ilə yoxlama tələb edən yanlış müsbət nəticələr verə bilər.</string>
+    <string name="deduplicator_matches_media_label">Oxşar media</string>
+    <string name="deduplicator_media_match_audio">Səsə əsaslanan uyğunluq</string>
+    <string name="deduplicator_media_match_visual">Videoya əsaslanan uyğunluq</string>
+    <string name="deduplicator_media_match_audio_visual">Səs və videoya əsaslanan uyğunluq</string>
     <string name="deduplicator_occupied_space_label">Tutulan yaddaş</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s dublikatlar tərəfindən tutulub</item>

--- a/app-tool-deduplicator/src/main/res/values-be/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-be/strings.xml
@@ -29,6 +29,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Вызначэнне дублікатаў шляхам разліку кантрольных сум для файлаў. Файлы з супадаючымі кантрольнымі сумамі маюць аднолькавы змест.</string>
     <string name="deduplicator_detection_method_phash_title">Падобныя ўласцівасці</string>
     <string name="deduplicator_detection_method_phash_summary">Пошук падобных файлаў з дапамогай аналізу асаблівасцей і параўнання падобных уласцівасцей. ⚠️ Выяўленне на аснове падабенства можа змяшчаць памылковыя вынікі, якія патрабуюць ручнога выяўлення.</string>
+    <string name="deduplicator_detection_method_media_title">Медыяадбітак</string>
+    <string name="deduplicator_detection_method_media_summary">Знайсці падобныя відэа- і аўдыяфайлы шляхам аналізу аўдыяадбіткаў. ⚠️ Выяўленне на аснове падабенства можа ўключаць ілжывыя спрацоўванні, якія патрабуюць ручной праверкі.</string>
+    <string name="deduplicator_matches_media_label">Падобныя медыяфайлы</string>
+    <string name="deduplicator_media_match_audio">Супадзенне па аўдыя</string>
+    <string name="deduplicator_media_match_visual">Супадзенне па відэа</string>
+    <string name="deduplicator_media_match_audio_visual">Супадзенне па аўдыя і відэа</string>
     <string name="deduplicator_occupied_space_label">Занятае сховішча</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s занята дублікатамі</item>

--- a/app-tool-deduplicator/src/main/res/values-bg/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-bg/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Определяне на дубликати чрез изчисляване на контролни суми за файлове. Файлове със съвпадащи контролни суми имат точно същото съдържание.</string>
     <string name="deduplicator_detection_method_phash_title">Перцептуален хеш</string>
     <string name="deduplicator_detection_method_phash_summary">Намиране на подобни файлове чрез анализ на характеристиките на съдържанието и сравняване на перцептуални хеш стойности. ⚠️ Базираното на подобие откриване може да включва фалшиви положителни резултати, изискващи ръчна проверка.</string>
+    <string name="deduplicator_detection_method_media_title">Медиен пръстов отпечатък</string>
+    <string name="deduplicator_detection_method_media_summary">Намерете подобни видео и аудио файлове чрез анализ на аудио пръстови отпечатъци. ⚠️ Базираното на сходство откриване може да включва фалшиви позитиви, изискващи ръчна проверка.</string>
+    <string name="deduplicator_matches_media_label">Подобни медии</string>
+    <string name="deduplicator_media_match_audio">Съвпадение по аудио</string>
+    <string name="deduplicator_media_match_visual">Съвпадение по видео</string>
+    <string name="deduplicator_media_match_audio_visual">Съвпадение по аудио и видео</string>
     <string name="deduplicator_occupied_space_label">Заето хранилище</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s е заето от дубликати</item>

--- a/app-tool-deduplicator/src/main/res/values-bn-rBD/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-bn-rBD/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">ফাইলের জন্য চেকসাম গণনা করে ডুপ্লিকেট নির্ধারণ করুন। ম্যাচিং চেকসাম সহ ফাইলগুলিতে একই কন্টেন্ট রয়েছে৷</string>
     <string name="deduplicator_detection_method_phash_title">উপলব্ধিগত হ্যাশ</string>
     <string name="deduplicator_detection_method_phash_summary">কন্টেন্ট বৈশিষ্ট্য বিশ্লেষণ করে এবং পারসেপচুয়াল হ্যাশ মান তুলনা করে অনুরূপ ফাইল খুঁজুন। ⚠️ সাদৃশ্য-ভিত্তিক সনাক্তকরণে ম্যানুয়াল যাচাইয়ের প্রয়োজন এমন মিথ্যা পজিটিভ অন্তর্ভুক্ত থাকতে পারে।</string>
+    <string name="deduplicator_detection_method_media_title">মিডিয়া ফিঙ্গারপ্রিন্ট</string>
+    <string name="deduplicator_detection_method_media_summary">অডিও ফিঙ্গারপ্রিন্ট বিশ্লেষণ করে একই ধরনের ভিডিও এবং অডিও ফাইল খুঁজুন। ⚠️ সাদৃশ্য-ভিত্তিক সনাক্তকরণে মিথ্যা ইতিবাচক ফলাফল থাকতে পারে যার জন্য ম্যানুয়াল যাচাইয়ের প্রয়োজন।</string>
+    <string name="deduplicator_matches_media_label">একই ধরনের মিডিয়া</string>
+    <string name="deduplicator_media_match_audio">অডিও-ভিত্তিক মিল</string>
+    <string name="deduplicator_media_match_visual">ভিডিও-ভিত্তিক মিল</string>
+    <string name="deduplicator_media_match_audio_visual">অডিও এবং ভিডিও-ভিত্তিক মিল</string>
     <string name="deduplicator_occupied_space_label">সঞ্চয়স্থান দখল</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s ডুপ্লিকেট দ্বারা দখল করা আছে</item>

--- a/app-tool-deduplicator/src/main/res/values-ca/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-ca/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Determina els duplicats calculant les sumes de control dels fitxers. Els fitxers amb sumes de comprovació coincidents tenen exactament el mateix contingut.</string>
     <string name="deduplicator_detection_method_phash_title">Hash perceptiu</string>
     <string name="deduplicator_detection_method_phash_summary">Troba fitxers similars analitzant les característiques del contingut i comparant els valors hash perceptuals. ⚠️ La detecció basada en la similitud pot incloure falsos positius que requereixen verificació manual.</string>
+    <string name="deduplicator_detection_method_media_title">Empremta digital multimèdia</string>
+    <string name="deduplicator_detection_method_media_summary">Trobeu fitxers de vídeo i àudio similars analitzant les empremtes d\'àudio. ⚠️ La detecció basada en la similitud pot incloure falsos positius que requereixen verificació manual.</string>
+    <string name="deduplicator_matches_media_label">Multimèdia similar</string>
+    <string name="deduplicator_media_match_audio">Coincidència basada en àudio</string>
+    <string name="deduplicator_media_match_visual">Coincidència basada en vídeo</string>
+    <string name="deduplicator_media_match_audio_visual">Coincidència basada en àudio i vídeo</string>
     <string name="deduplicator_occupied_space_label">Emmagatzematge ocupat</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s està ocupat per duplicats</item>

--- a/app-tool-deduplicator/src/main/res/values-ckb-rIR/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-ckb-rIR/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Determine duplicates by calculating checksums for files. فایلs with matching checksums have the exact same content.</string>
     <string name="deduplicator_detection_method_phash_title">هاشی هەستبردنی</string>
     <string name="deduplicator_detection_method_phash_summary">فایلی هاوشێوە بدۆزەرەوە بە شیکردنەوەی تایبەتمەندییەکانی ناوەڕۆک و بەراوردکردنی بەهاکانی هاشی هەستبردنی. ⚠️ دۆزینەوەی بنەماتی هاوشێوەیی لەوانەیە هەڵەی دروستی تێدابێت کە پشکنینی دەستی پێویستە.</string>
+    <string name="deduplicator_detection_method_media_title">نیشانەی میدیا</string>
+    <string name="deduplicator_detection_method_media_summary">فایلە کاریکانی کورتە و دەنگ ھەمان بە تالیلکردنی نیشانەی دەنگ بدەستبێنە. ⚠️ کاشفکردنی لە سەر هاوبەندی لەوانی ھەبیهەی شاشە راست نییە کە چەککردنی دەست دەخەی بەکارھێنەر دەبێتەوە.</string>
+    <string name="deduplicator_matches_media_label">میدیای هاوبێش</string>
+    <string name="deduplicator_media_match_audio">هاوبێشی لەسەر دەنگ</string>
+    <string name="deduplicator_media_match_visual">هاوبێشی لەسەر ڤیدیۆ</string>
+    <string name="deduplicator_media_match_audio_visual">هاوبێشی لەسەر دەنگ و ڤیدیۆ</string>
     <string name="deduplicator_occupied_space_label">ئەمبارەی پڕکراو</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s لەلایەن دووبارەکانەوە پڕکراوە</item>

--- a/app-tool-deduplicator/src/main/res/values-cs/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-cs/strings.xml
@@ -29,6 +29,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Určení duplikátů pomocí výpočtu kontrolních součtů souborů. Soubory se shodnými kontrolními součty mají naprosto stejný obsah.</string>
     <string name="deduplicator_detection_method_phash_title">Percepční hash</string>
     <string name="deduplicator_detection_method_phash_summary">Vyhledejte podobné soubory pomocí analýzy vlastností obsahu a porovnání hodnot percepčního hash. ⚠️ Detekce na základě podobnosti může zahrnovat falešné pozitivní výsledky, které vyžadují ruční ověření.</string>
+    <string name="deduplicator_detection_method_media_title">Otisk média</string>
+    <string name="deduplicator_detection_method_media_summary">Najde podobné video a audio soubory analýzou zvukových otisků. ⚠️ Detekce na základě podobnosti může zahrnovat falešné poplachy vyžadující ruční ověření.</string>
+    <string name="deduplicator_matches_media_label">Podobná média</string>
+    <string name="deduplicator_media_match_audio">Shoda na základě zvuku</string>
+    <string name="deduplicator_media_match_visual">Shoda na základě videa</string>
+    <string name="deduplicator_media_match_audio_visual">Shoda na základě zvuku a videa</string>
     <string name="deduplicator_occupied_space_label">Obsazené úložiště</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">Obsazeno duplikáty je %s</item>

--- a/app-tool-deduplicator/src/main/res/values-da/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-da/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Find duplikater ved at beregne kontrolsummer for filer. Filer med ens kontrolsum har nøjagtigt det samme indhold.</string>
     <string name="deduplicator_detection_method_phash_title">Perceptuel hash</string>
     <string name="deduplicator_detection_method_phash_summary">Find lignende filer ved at analysere indholdsegenskaber og sammenligne perceptuelle hashværdier. Lighedsbaseret detektion kan inkludere falske positiver der kræver manuel verifikation.</string>
+    <string name="deduplicator_detection_method_media_title">Mediefingeraftryk</string>
+    <string name="deduplicator_detection_method_media_summary">Find lignende video- og lydfiler ved at analysere lydfingeraftryk. ⚠️ Lighedsbaseret registrering kan indeholde falske positiver, der kræver manuel bekræftelse.</string>
+    <string name="deduplicator_matches_media_label">Lignende medier</string>
+    <string name="deduplicator_media_match_audio">Lydbaseret match</string>
+    <string name="deduplicator_media_match_visual">Videobaseret match</string>
+    <string name="deduplicator_media_match_audio_visual">Lyd- og videobaseret match</string>
     <string name="deduplicator_occupied_space_label">Optaget lagerplads</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s er optaget af duplikater</item>

--- a/app-tool-deduplicator/src/main/res/values-de/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-de/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Ermittele Duplikate durch die Berechnung von Prüfsummen für Dateien. Dateien mit übereinstimmenden Prüfsummen haben genau den gleichen Inhalt.</string>
     <string name="deduplicator_detection_method_phash_title">Wahrnehmungshash</string>
     <string name="deduplicator_detection_method_phash_summary">Findet ähnliche Dateien, indem Inhaltsmerkmale analysiert und perzeptive Hashwerte vergleichen werden. ⚠️ Die ähnlichkeitsbasierte Erkennung kann Fehler beinhalten, die manuelle Überprüfung erfordern.</string>
+    <string name="deduplicator_detection_method_media_title">Medien-Fingerabdruck</string>
+    <string name="deduplicator_detection_method_media_summary">Ähnliche Video- und Audiodateien durch Analyse von Audio-Fingerabdrücken finden. ⚠️ Ähnlichkeitsbasierte Erkennung kann Fehlalarme enthalten und erfordert eine manuelle Überprüfung.</string>
+    <string name="deduplicator_matches_media_label">Ähnliche Medien</string>
+    <string name="deduplicator_media_match_audio">Audio-basierte Übereinstimmung</string>
+    <string name="deduplicator_media_match_visual">Video-basierte Übereinstimmung</string>
+    <string name="deduplicator_media_match_audio_visual">Audio- und videobasierte Übereinstimmung</string>
     <string name="deduplicator_occupied_space_label">Belegter Speicher</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s ist von Duplikaten belegt</item>

--- a/app-tool-deduplicator/src/main/res/values-el/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-el/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Προσδιορισμός διπλότυπων υπολογίζοντας τα checksum των αρχείων. Τα αρχεία με ίσα checksums έχουν ακριβώς το ίδιο περιεχόμενο.</string>
     <string name="deduplicator_detection_method_phash_title">Ομοιότητες εικόνων</string>
     <string name="deduplicator_detection_method_phash_summary">Βρείτε παρόμοια αρχεία αναλύοντας χαρακτηριστικά περιεχομένου και συγκρίνοντας τιμές hash που βασίζονται στην αντίληψη. ⚠️ Η ανίχνευση βάσει ομοιότητας μπορεί να περιλαμβάνει ψευδώς θετικά αποτελέσματα που απαιτούν χειροκίνητη επαλήθευση.</string>
+    <string name="deduplicator_detection_method_media_title">Αποτύπωμα πολυμέσων</string>
+    <string name="deduplicator_detection_method_media_summary">Εύρεση παρόμοιων βίντεο και αρχείων ήχου με ανάλυση ακουστικών αποτυπωμάτων. ⚠️ Η ανίχνευση βάσει ομοιότητας ενδέχεται να περιλαμβάνει ψευδώς θετικά που απαιτούν χειροκίνητη επαλήθευση.</string>
+    <string name="deduplicator_matches_media_label">Παρόμοια πολυμέσα</string>
+    <string name="deduplicator_media_match_audio">Αντιστοιχία βάσει ήχου</string>
+    <string name="deduplicator_media_match_visual">Αντιστοιχία βάσει βίντεο</string>
+    <string name="deduplicator_media_match_audio_visual">Αντιστοιχία βάσει ήχου και βίντεο</string>
     <string name="deduplicator_occupied_space_label">Αποθηκευτικός χώρος που χρησιμοποιείται</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s καταλαμβάνεται από διπλότυπα</item>

--- a/app-tool-deduplicator/src/main/res/values-es-rAR/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-es-rAR/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Determina los duplicados calculando las sumas de verificación para los archivos. Los archivos con las sumas de comprobación coincidentes tienen exactamente el mismo contenido.</string>
     <string name="deduplicator_detection_method_phash_title">Hash conceptual</string>
     <string name="deduplicator_detection_method_phash_summary">Encontrar archivos similares analizando características del contenido y comparando valores de hash perceptual. La detección basada en similitud puede incluir falsos positivos que requieren verificación manual.</string>
+    <string name="deduplicator_detection_method_media_title">Huella digital de medios</string>
+    <string name="deduplicator_detection_method_media_summary">Buscá archivos de video y audio similares analizando huellas digitales de audio. ⚠️ La detección basada en similitudes puede incluir falsos positivos que requieren verificación manual.</string>
+    <string name="deduplicator_matches_media_label">Medios similares</string>
+    <string name="deduplicator_media_match_audio">Coincidencia basada en audio</string>
+    <string name="deduplicator_media_match_visual">Coincidencia basada en video</string>
+    <string name="deduplicator_media_match_audio_visual">Coincidencia basada en audio y video</string>
     <string name="deduplicator_occupied_space_label">Almacenamiento ocupado</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s está ocupado por duplicados</item>

--- a/app-tool-deduplicator/src/main/res/values-es-rMX/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-es-rMX/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Determinar duplicados calculando sumas de verificación para archivos. Los archivos con sumas de verificación coincidentes tienen exactamente el mismo contenido.</string>
     <string name="deduplicator_detection_method_phash_title">Hash perceptual</string>
     <string name="deduplicator_detection_method_phash_summary">Encuentra archivos similares analizando el contenido y comparando los valores hash perceptuales. ⚠️ La detección basada en similitudes puede incluir falsos positivos que requieran una verificación manual.</string>
+    <string name="deduplicator_detection_method_media_title">Huella digital de medios</string>
+    <string name="deduplicator_detection_method_media_summary">Encuentra archivos de video y audio similares analizando huellas digitales de audio. ⚠️ La detección basada en similitud puede incluir falsos positivos que requieren verificación manual.</string>
+    <string name="deduplicator_matches_media_label">Medios similares</string>
+    <string name="deduplicator_media_match_audio">Coincidencia basada en audio</string>
+    <string name="deduplicator_media_match_visual">Coincidencia basada en video</string>
+    <string name="deduplicator_media_match_audio_visual">Coincidencia basada en audio y video</string>
     <string name="deduplicator_occupied_space_label">Almacenamiento ocupado</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s está ocupado por duplicados</item>

--- a/app-tool-deduplicator/src/main/res/values-es/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-es/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Determina los duplicados calculando las sumas de verificación para los archivos. Los archivos con las sumas de comprobación coincidentes tienen exactamente el mismo contenido.</string>
     <string name="deduplicator_detection_method_phash_title">Hash perceptual</string>
     <string name="deduplicator_detection_method_phash_summary">Encuentra archivos similares analizando el contenido y comparando los valores hash perceptuales. ⚠️ La detección basada en similitudes puede incluir falsos positivos que requieran una verificación manual.</string>
+    <string name="deduplicator_detection_method_media_title">Huella digital de medios</string>
+    <string name="deduplicator_detection_method_media_summary">Encuentra archivos de vídeo y audio similares analizando huellas de audio. ⚠️ La detección basada en similitud puede incluir falsos positivos que requieren verificación manual.</string>
+    <string name="deduplicator_matches_media_label">Medios similares</string>
+    <string name="deduplicator_media_match_audio">Coincidencia basada en audio</string>
+    <string name="deduplicator_media_match_visual">Coincidencia basada en vídeo</string>
+    <string name="deduplicator_media_match_audio_visual">Coincidencia basada en audio y vídeo</string>
     <string name="deduplicator_occupied_space_label">Almacenamiento ocupado</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s está ocupado por duplicados</item>

--- a/app-tool-deduplicator/src/main/res/values-et-rEE/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-et-rEE/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Tuvasta koopiad failide kontrollsummade arvutamisel. Kattuvate kontrollsummadega failide sisu on sama.</string>
     <string name="deduplicator_detection_method_phash_title">Tajuräsi</string>
     <string name="deduplicator_detection_method_phash_summary">Leidke sarnaseid faile, analüüsides sisu võimalusi ja võrreldes tajuräsi väärtusi. ⚠️ Sarnasusel põhinev tuvastus võib sisaldada valeteateid, mis vajavad inimese kontrolli.</string>
+    <string name="deduplicator_detection_method_media_title">Meedia sõrmejälg</string>
+    <string name="deduplicator_detection_method_media_summary">Leia sarnaseid video- ja helifaile heli sõrmejälgede analüüsi abil. ⚠️ Sarnasusepõhine tuvastamine võib sisaldada valepositiivseid tulemusi, mis nõuavad käsitsi kontrollimist.</string>
+    <string name="deduplicator_matches_media_label">Sarnane meedia</string>
+    <string name="deduplicator_media_match_audio">Heliõhine vaste</string>
+    <string name="deduplicator_media_match_visual">Videopõhine vaste</string>
+    <string name="deduplicator_media_match_audio_visual">Heli- ja videopõhine vaste</string>
     <string name="deduplicator_occupied_space_label">Kasutatud salvestusruum</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s kasutab koopiad</item>

--- a/app-tool-deduplicator/src/main/res/values-eu-rES/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-eu-rES/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Zehaztu bikoiztuak fitxategien egiaztapen-batuak kalkulatuz. Egiaztapen-batu berdinak dituzten fitxategiek eduki berdina dute.</string>
     <string name="deduplicator_detection_method_phash_title">Hash pertzeptuala</string>
     <string name="deduplicator_detection_method_phash_summary">Bilatu antzeko fitxategiak edukiaren ezaugarriak aztertuz eta hash pertzeptualak alderatuz. ⚠️ Antzekotasunean oinarritutako detekzioak faltsuki positiboak sar ditzake eskuzko egiaztapena behar dutenak.</string>
+    <string name="deduplicator_detection_method_media_title">Media hatz-marka</string>
+    <string name="deduplicator_detection_method_media_summary">Bilatu antzeko bideo eta audio fitxategiak audio hatz-markak aztertuz. ⚠️ Antzekotasunean oinarritutako detekzioak faltsu positiboak sor ditzake eskuzko egiaztapena eskatuz.</string>
+    <string name="deduplicator_matches_media_label">Antzeko multimedia</string>
+    <string name="deduplicator_media_match_audio">Audio-oinarritutako bat etortzea</string>
+    <string name="deduplicator_media_match_visual">Bideo-oinarritutako bat etortzea</string>
+    <string name="deduplicator_media_match_audio_visual">Audio eta bideo-oinarritutako bat etortzea</string>
     <string name="deduplicator_occupied_space_label">Erabilitako biltegiratzea</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s bikoiztuek hartuta dago</item>

--- a/app-tool-deduplicator/src/main/res/values-fa/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-fa/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">تشخیص تکراری‌ها با محاسبه مجموع چکیده برای فایل‌ها. فایل‌هایی که مجموع چکیده یکسان دارند، محتوای دقیقا یکسانی دارند.</string>
     <string name="deduplicator_detection_method_phash_title">چکیده ادراکی</string>
     <string name="deduplicator_detection_method_phash_summary">با تجزیه و تحلیل ویژگی‌های محتوا و مقایسه مقادیر هش ادراکی، فایل‌های مشابه را پیدا کنید. ⚠️ تشخیص مبتنی بر شباهت ممکن است شامل موارد مثبت کاذب باشد که نیاز به تأیید دستی دارند.</string>
+    <string name="deduplicator_detection_method_media_title">اثر انگشت رسانه</string>
+    <string name="deduplicator_detection_method_media_summary">یافتن فایل‌های ویدیویی و صوتی مشابه با تحلیل اثر انگشت صوتی. ⚠️ تشخیص مبتنی بر شباهت ممکن است شامل موارد مثبت کاذب باشد که نیاز به تأیید دستی دارند.</string>
+    <string name="deduplicator_matches_media_label">رسانه‌های مشابه</string>
+    <string name="deduplicator_media_match_audio">تطابق مبتنی بر صدا</string>
+    <string name="deduplicator_media_match_visual">تطابق مبتنی بر ویدیو</string>
+    <string name="deduplicator_media_match_audio_visual">تطابق مبتنی بر صدا و ویدیو</string>
     <string name="deduplicator_occupied_space_label">حافظه اشغال شده</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s توسط فایل‌های تکراری اشغال شده</item>

--- a/app-tool-deduplicator/src/main/res/values-fi/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-fi/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Määritä kaksoiskappaleet laskemalla tiedostojen tarkistussummat. Tiedostot, joilla on vastaavat tarkistussummat, sisältävät täsmälleen saman sisällön.</string>
     <string name="deduplicator_detection_method_phash_title">Havainnollinen hash</string>
     <string name="deduplicator_detection_method_phash_summary">Löydä samankaltaisia ​​tiedostoja analysoimalla sisällön ominaisuuksia ja vertaamalla tiivistearvoja. ⚠️ Samankaltaisuuteen perustuva tunnistus voi sisältää vääriä positiivisia tuloksia, jotka vaativat manuaalisen vahvistuksen.</string>
+    <string name="deduplicator_detection_method_media_title">Median sormenjälki</string>
+    <string name="deduplicator_detection_method_media_summary">Etsi samankaltaisia video- ja äänitiedostoja analysoimalla äänen sormenjälkiä. ⚠️ Samankaltaisuuteen perustuva tunnistus saattaa sisältää vääriä positiivisia, jotka vaativat manuaalista tarkistusta.</string>
+    <string name="deduplicator_matches_media_label">Samankaltainen media</string>
+    <string name="deduplicator_media_match_audio">Äänipohjainen vastaavuus</string>
+    <string name="deduplicator_media_match_visual">Videopohjainen vastaavuus</string>
+    <string name="deduplicator_media_match_audio_visual">Ääni- ja videopohjainen vastaavuus</string>
     <string name="deduplicator_occupied_space_label">Käytetty tallennustila</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s on kaksoiskappaleiden käyttämää</item>

--- a/app-tool-deduplicator/src/main/res/values-fil/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-fil/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Tukuyin ang mga duplicate sa pamamagitan ng pagkakalkula ng mga checksum para sa mga file. Ang mga file na may magkatugang checksum ay may eksaktong magkaparehong nilalaman.</string>
     <string name="deduplicator_detection_method_phash_title">Perceptual hash</string>
     <string name="deduplicator_detection_method_phash_summary">Hanapin ang mga katulad na file sa pamamagitan ng pagsusuri ng mga content feature at paghahambing ng perceptual hash values. ⚠️ Ang similarity-based detection ay maaaring magsama ng mga false positive na nangangailangan ng manu-manong verification.</string>
+    <string name="deduplicator_detection_method_media_title">Media fingerprint</string>
+    <string name="deduplicator_detection_method_media_summary">Hanapin ang mga katulad na video at audio file sa pamamagitan ng pagsusuri ng mga audio fingerprint. ⚠️ Maaaring maglaman ng mga maling positibo ang pagtuklas batay sa pagkakatulad na nangangailangan ng manu-manong pag-verify.</string>
+    <string name="deduplicator_matches_media_label">Katulad na media</string>
+    <string name="deduplicator_media_match_audio">Tugma batay sa audio</string>
+    <string name="deduplicator_media_match_visual">Tugma batay sa video</string>
+    <string name="deduplicator_media_match_audio_visual">Tugma batay sa audio at video</string>
     <string name="deduplicator_occupied_space_label">Ginamit na storage</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s ay ginagamit ng mga duplicate</item>

--- a/app-tool-deduplicator/src/main/res/values-fr/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-fr/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Déterminer les doublons en calculant les sommes de contrôle des fichiers. Le contenu des fichiers dont les sommes de contrôle correspondent est identique.</string>
     <string name="deduplicator_detection_method_phash_title">Hachage perceptuel</string>
     <string name="deduplicator_detection_method_phash_summary">Trouvez des fichiers similaires en analysant les caractéristiques du contenu et en comparant les valeurs perceptuelles de hachage. ⚠️ La détection fondée sur la similitude peut comporter de faux positifs qui nécessitent une vérification manuelle.</string>
+    <string name="deduplicator_detection_method_media_title">Empreinte multimédia</string>
+    <string name="deduplicator_detection_method_media_summary">Trouver des fichiers vidéo et audio similaires en analysant les empreintes audio. ⚠️ La détection basée sur la similarité peut inclure des faux positifs nécessitant une vérification manuelle.</string>
+    <string name="deduplicator_matches_media_label">Médias similaires</string>
+    <string name="deduplicator_media_match_audio">Correspondance audio</string>
+    <string name="deduplicator_media_match_visual">Correspondance vidéo</string>
+    <string name="deduplicator_media_match_audio_visual">Correspondance audio et vidéo</string>
     <string name="deduplicator_occupied_space_label">Mémoire occupée</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s est occupé par des doublons</item>

--- a/app-tool-deduplicator/src/main/res/values-gl-rES/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-gl-rES/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Determinar duplicados calculando sumas de verificación para ficheiros. Os ficheiros con sumas de verificación coincidentes teñen o mesmo contido exacto.</string>
     <string name="deduplicator_detection_method_phash_title">Hash perceptual</string>
     <string name="deduplicator_detection_method_phash_summary">Atopar ficheiros similares analizando características do contido e comparando valores de hash perceptual. ⚠️ A detección baseada en similitude pode incluír falsos positivos que requiren verificación manual.</string>
+    <string name="deduplicator_detection_method_media_title">Pegada dixital de medios</string>
+    <string name="deduplicator_detection_method_media_summary">Atopa ficheiros de vídeo e audio similares analizando as pegadas dixitais de audio. ⚠️ A detección baseada en similitude pode incluír falsos positivos que requiren verificación manual.</string>
+    <string name="deduplicator_matches_media_label">Medios similares</string>
+    <string name="deduplicator_media_match_audio">Coincidencia baseada en audio</string>
+    <string name="deduplicator_media_match_visual">Coincidencia baseada en vídeo</string>
+    <string name="deduplicator_media_match_audio_visual">Coincidencia baseada en audio e vídeo</string>
     <string name="deduplicator_occupied_space_label">Almacenamento ocupado</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s está ocupado por duplicados</item>

--- a/app-tool-deduplicator/src/main/res/values-hi-rIN/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-hi-rIN/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">फ़ाइल सामग्री की तुलना करने के लिए चेकसम का उपयोग करें। अधिक सटीक लेकिन धीमा।</string>
     <string name="deduplicator_detection_method_phash_title">पर्सेप्चुअल हैश</string>
     <string name="deduplicator_detection_method_phash_summary">सामग्री विशेषताओं का विश्लेषण करके और अवधारणात्मक हैश मूल्यों की तुलना करके समान फ़ाइलें ढूंढें। ⚠️ समानता-आधारित पहचान में गलत परिणाम हो सकते हैं जिन्हें मैन्युअल सत्यापन की आवश्यकता होती है।</string>
+    <string name="deduplicator_detection_method_media_title">मीडिया फिंगरप्रिंट</string>
+    <string name="deduplicator_detection_method_media_summary">ऑडियो फिंगरप्रिंट विश्लेषण करके समान वीडियो और ऑडियो फ़ाइलें खोजें। ⚠️ समानता-आधारित पहचान में गलत परिणाम शामिल हो सकते हैं जिन्हें मैन्युअल सत्यापन की आवश्यकता है।</string>
+    <string name="deduplicator_matches_media_label">समान मीडिया</string>
+    <string name="deduplicator_media_match_audio">ऑडियो-आधारित मिलान</string>
+    <string name="deduplicator_media_match_visual">वीडियो-आधारित मिलान</string>
+    <string name="deduplicator_media_match_audio_visual">ऑडियो और वीडियो-आधारित मिलान</string>
     <string name="deduplicator_occupied_space_label">कब्जाया गया स्थान</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s डुप्लिकेट्स द्वारा कब्जा किया गया है</item>

--- a/app-tool-deduplicator/src/main/res/values-hr/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-hr/strings.xml
@@ -27,6 +27,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Odredite duplikate izračunavanjem kontrolnih zbrojeva za datoteke. Datoteke s podudarajućim kontrolnim zbrojevima imaju potpuno isti sadržaj.</string>
     <string name="deduplicator_detection_method_phash_title">Perceptualni hash</string>
     <string name="deduplicator_detection_method_phash_summary">Pronađite slične datoteke analizom značajki sadržaja i usporedbom perceptivnih hash vrijednosti. ⚠️ Detekcija na temelju sličnosti može uključivati ​​lažno pozitivne rezultate koji zahtijevaju ručnu provjeru.</string>
+    <string name="deduplicator_detection_method_media_title">Medijski otisak prsta</string>
+    <string name="deduplicator_detection_method_media_summary">Pronađi slične video i audio datoteke analizom audio otisaka prstiju. ⚠️ Detekcija temeljena na sličnosti može sadržavati lažno pozitivne rezultate koji zahtijevaju ručnu provjeru.</string>
+    <string name="deduplicator_matches_media_label">Slični mediji</string>
+    <string name="deduplicator_media_match_audio">Podudaranje temeljeno na zvuku</string>
+    <string name="deduplicator_media_match_visual">Podudaranje temeljeno na videu</string>
+    <string name="deduplicator_media_match_audio_visual">Podudaranje temeljeno na zvuku i videu</string>
     <string name="deduplicator_occupied_space_label">Zauzeta pohrana</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s je zauzet duplikatima</item>

--- a/app-tool-deduplicator/src/main/res/values-hu/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-hu/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Duplikátumok meghatározása a fájlok ellenőrző összegének kiszámításával. Az egyező ellenőrzőösszegű fájlok tartalma pontosan megegyezik.</string>
     <string name="deduplicator_detection_method_phash_title">Hasonló hash</string>
     <string name="deduplicator_detection_method_phash_summary">Hasonló fájlok keresése tartalmi jellemzők elemzésével és perceptuális hash értékek összehasonlításával. ⚠️ A hasonlóság alapú felismerés téves találatokat is tartalmazhat, amelyek kézi ellenőrzést igényelnek.</string>
+    <string name="deduplicator_detection_method_media_title">Médiaujjlenyomat</string>
+    <string name="deduplicator_detection_method_media_summary">Hasonló videó- és hangfájlok keresése hangujjlenyomatok elemzésével. ⚠️ A hasonlóságalapú észlelés fals pozitív találatokat is tartalmazhat, amelyek manuális ellenőrzést igényelnek.</string>
+    <string name="deduplicator_matches_media_label">Hasonló média</string>
+    <string name="deduplicator_media_match_audio">Hangalapú egyezés</string>
+    <string name="deduplicator_media_match_visual">Videóalapú egyezés</string>
+    <string name="deduplicator_media_match_audio_visual">Hang- és videóalapú egyezés</string>
     <string name="deduplicator_occupied_space_label">Foglalt tároló</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s duplikátummal elfoglalva</item>

--- a/app-tool-deduplicator/src/main/res/values-in/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-in/strings.xml
@@ -23,6 +23,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Tentukan duplikat dengan menghitung checksum untuk file. File dengan checksum yang cocok memiliki konten yang persis sama.</string>
     <string name="deduplicator_detection_method_phash_title">Hash persepsual</string>
     <string name="deduplicator_detection_method_phash_summary">Temukan file serupa dengan menganalisis fitur konten dan membandingkan nilai hash perseptual. ⚠️ Deteksi berbasis kesamaan dapat mencakup positif palsu yang memerlukan verifikasi manual.</string>
+    <string name="deduplicator_detection_method_media_title">Sidik jari media</string>
+    <string name="deduplicator_detection_method_media_summary">Temukan file video dan audio serupa dengan menganalisis sidik jari audio. ⚠️ Deteksi berbasis kemiripan dapat mencakup positif palsu yang memerlukan verifikasi manual.</string>
+    <string name="deduplicator_matches_media_label">Media serupa</string>
+    <string name="deduplicator_media_match_audio">Kecocokan berbasis audio</string>
+    <string name="deduplicator_media_match_visual">Kecocokan berbasis video</string>
+    <string name="deduplicator_media_match_audio_visual">Kecocokan berbasis audio dan video</string>
     <string name="deduplicator_occupied_space_label">Penyimpanan terpakai</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="other">%s ditempati oleh duplikat</item>

--- a/app-tool-deduplicator/src/main/res/values-is/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-is/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Ákvarða tvítekningu með því að reikna efnisskoðun skráa. Skrár með samsvarandi skoðun hafa nákvæmlega sama efni.</string>
     <string name="deduplicator_detection_method_phash_title">Skynjunarhassh</string>
     <string name="deduplicator_detection_method_phash_summary">Finna svipaðar skrár með því að greina efniseiginleika og bera saman skynjunarhassh gildi. ⚠️ Greining byggð á líkingu gæti falið í sér falska jákvæðninga sem krefjast handvirkrar staðfestingar.</string>
+    <string name="deduplicator_detection_method_media_title">Fjölmiðlafingraför</string>
+    <string name="deduplicator_detection_method_media_summary">Finna svipað myndband og hljóðskrár með greiningu á hljóðfingraförum. ⚠️ Líkindargreining getur falið í sér ranga jákvæða sem krefjast handvirkrar staðfestingar.</string>
+    <string name="deduplicator_matches_media_label">Svipuð fjölmiðlaskrár</string>
+    <string name="deduplicator_media_match_audio">Samsvörun byggð á hljóði</string>
+    <string name="deduplicator_media_match_visual">Samsvörun byggð á myndbandi</string>
+    <string name="deduplicator_media_match_audio_visual">Samsvörun byggð á hljóði og myndbandi</string>
     <string name="deduplicator_occupied_space_label">Upptekið geymslupláss</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s er tekið af tvítekningum</item>

--- a/app-tool-deduplicator/src/main/res/values-it/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-it/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Determina i duplicati calcolando il checksum dei file. I file con checksum corrispondenti hanno lo stesso identico contenuto.</string>
     <string name="deduplicator_detection_method_phash_title">Hash percettivo</string>
     <string name="deduplicator_detection_method_phash_summary">Trova file simili analizzando le caratteristiche del contenuto e confrontando i valori di hash percettivo. ⚠️ Il rilevamento basato sulla somiglianza potrebbe includere falsi positivi che richiedono verifica manuale.</string>
+    <string name="deduplicator_detection_method_media_title">Impronta multimediale</string>
+    <string name="deduplicator_detection_method_media_summary">Trova file video e audio simili analizzando le impronte audio. ⚠️ Il rilevamento basato sulla somiglianza potrebbe includere falsi positivi che richiedono verifica manuale.</string>
+    <string name="deduplicator_matches_media_label">Media simili</string>
+    <string name="deduplicator_media_match_audio">Corrispondenza basata sull\'audio</string>
+    <string name="deduplicator_media_match_visual">Corrispondenza basata sul video</string>
+    <string name="deduplicator_media_match_audio_visual">Corrispondenza basata su audio e video</string>
     <string name="deduplicator_occupied_space_label">Spazio occupato</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s è occupato da duplicati</item>

--- a/app-tool-deduplicator/src/main/res/values-iw/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-iw/strings.xml
@@ -29,6 +29,12 @@
     <string name="deduplicator_detection_method_checksum_summary">קבע כפילויות על ידי חישוב סכומי ביקורת עבור קבצים. לקבצים עם סכומי ביקורת תואמים יש את אותו תוכן בדיוק.</string>
     <string name="deduplicator_detection_method_phash_title">זיהוי גיבוב</string>
     <string name="deduplicator_detection_method_phash_summary">מציאת קבצים דומים על ידי ניתוח מאפייני תוכן והשוואת ערכי גיבוב תפיסתיים. ⚠️ זיהוי מבוסס דמיון עשוי לכלול תוצאות חיוביות שגויות הדורשות אימות ידני.</string>
+    <string name="deduplicator_detection_method_media_title">טביעת אצבע מדיה</string>
+    <string name="deduplicator_detection_method_media_summary">מצא קבצי וידאו ואודיו דומים על ידי ניתוח טביעות אצבע אודיו. ⚠️ זיהוי מבוסס-דמיון עשוי לכלול תוצאות חיוביות שגויות הדורשות אימות ידני.</string>
+    <string name="deduplicator_matches_media_label">מדיה דומה</string>
+    <string name="deduplicator_media_match_audio">התאמה מבוססת-אודיו</string>
+    <string name="deduplicator_media_match_visual">התאמה מבוססת-וידאו</string>
+    <string name="deduplicator_media_match_audio_visual">התאמה מבוססת-אודיו ווידאו</string>
     <string name="deduplicator_occupied_space_label">נפח אחסון תפוס</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s תפוס על ידי כפילויות</item>

--- a/app-tool-deduplicator/src/main/res/values-ja/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-ja/strings.xml
@@ -23,6 +23,12 @@
     <string name="deduplicator_detection_method_checksum_summary">ファイルのチェックサムを計算することで重複を決定します。チェックサムに一致するファイルは全く同じ内容を持ちます。</string>
     <string name="deduplicator_detection_method_phash_title">概念ハッシュ</string>
     <string name="deduplicator_detection_method_phash_summary">コンテンツの特徴を分析し知覚ハッシュ値を比較して類似ファイルを検出します。⚠️ 類似性に基づく検出では誤検出が含まれる場合があり、手動確認が必要です。</string>
+    <string name="deduplicator_detection_method_media_title">メディアフィンガープリント</string>
+    <string name="deduplicator_detection_method_media_summary">オーディオフィンガープリントを解析して類似した動画・音声ファイルを検索します。⚠️ 類似性ベースの検出には誤検知が含まれる場合があり、手動での確認が必要です。</string>
+    <string name="deduplicator_matches_media_label">類似メディア</string>
+    <string name="deduplicator_media_match_audio">音声ベースの一致</string>
+    <string name="deduplicator_media_match_visual">映像ベースの一致</string>
+    <string name="deduplicator_media_match_audio_visual">音声・映像ベースの一致</string>
     <string name="deduplicator_occupied_space_label">占拠されたストレージ</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="other">%sが重複により占有されています</item>

--- a/app-tool-deduplicator/src/main/res/values-ka-rGE/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-ka-rGE/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">დუბლიკატების განსაზღვრა ფაილებისთვის კონტროლური ჯამების გამოთვლით. ფაილები შესაბამისი კონტროლური ჯამებით აქვთ ზუსტად იგივე შინაარსი.</string>
     <string name="deduplicator_detection_method_phash_title">პერცეპტუალური ჰეში</string>
     <string name="deduplicator_detection_method_phash_summary">მსგავსი ფაილების პოვნა კონტენტის მახასიათებლების ანალიზითა და პერცეპტუალური ჰეშის მნიშვნელობების შედარებით. ⚠️ მსგავსებაზე დაფუძნებულმა ამოცნობამ შეიძლება მოიცვას ცრუ პოზიტივები, რომლებიც ხელით შემოწმებას საჭიროებს.</string>
+    <string name="deduplicator_detection_method_media_title">მედიის თითის ანაბეჭდი</string>
+    <string name="deduplicator_detection_method_media_summary">იპოვეთ მსგავსი ვიდეო და აუდიო ფაილები აუდიო თითის ანაბეჭდების ანალიზით. ⚠️ მსგავსებაზე დაფუძნებული გამოვლენა შეიძლება შეიცავდეს ყალბ დადებით შედეგებს, რომლებიც საჭიროებს ხელით გადამოწმებას.</string>
+    <string name="deduplicator_matches_media_label">მსგავსი მედია</string>
+    <string name="deduplicator_media_match_audio">აუდიოზე დაფუძნებული დამთხვევა</string>
+    <string name="deduplicator_media_match_visual">ვიდეოზე დაფუძნებული დამთხვევა</string>
+    <string name="deduplicator_media_match_audio_visual">აუდიო და ვიდეოზე დაფუძნებული დამთხვევა</string>
     <string name="deduplicator_occupied_space_label">დაკავებული მეხსიერება</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s დაკავებულია დუბლიკატებით</item>

--- a/app-tool-deduplicator/src/main/res/values-kaa/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-kaa/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Fayllar ushın tekseriw jıyındıların esaplaw arqalı dublikatlardı anıqlaw. Sáykes tekseriw jıyındısına iye fayllar tap sol mazmunǵa iye.</string>
     <string name="deduplicator_detection_method_phash_title">Qabıllaw xeshi</string>
     <string name="deduplicator_detection_method_phash_summary">Mazmun o\'zgesheliklerdi taldaw ha\'m perseptual xesh qıymatların salıstırıw arqalı uqsas faylları tabın\'. ⚠️ Uqsaslıqqa tiykarlanǵan anıqlaw jalǵan pozitiflerdı o\'z ishine alıwı mu\'mkin, qoldan tekseriwdi talap etedi.</string>
+    <string name="deduplicator_detection_method_media_title">Медиа саусақ изи</string>
+    <string name="deduplicator_detection_method_media_summary">Аудио саусақ излери арқалы усыс видео ҳәм аудио файлларды табыў. ⚠️ Усыслыққа тийкарланған анықлаў нәтийжесинде қол менен тексериўди талап ететуғын жалған позитивлер болыўы мүмкин.</string>
+    <string name="deduplicator_matches_media_label">Усыс медиа</string>
+    <string name="deduplicator_media_match_audio">Аудиоға тийкарланған сәйкеслик</string>
+    <string name="deduplicator_media_match_visual">Видеоға тийкарланған сәйкеслик</string>
+    <string name="deduplicator_media_match_audio_visual">Аудио ҳәм видеоға тийкарланған сәйкеслик</string>
     <string name="deduplicator_occupied_space_label">Bándelgen saqlawsh</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s dublikatlları iyelep turır</item>

--- a/app-tool-deduplicator/src/main/res/values-km-rKH/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-km-rKH/strings.xml
@@ -23,6 +23,12 @@
     <string name="deduplicator_detection_method_checksum_summary">កំណត់​សែសែ​ដោយ​ការ​ឡើ​ចន្ល​ម៉ួល​ប៉័ដ​សម្រួល​កំពិល័។ កំពិល័​ដែល​មាន​ចន្ល​​ម៉ួល​ប៉័ដ​ដឹក​គ្នា​មាន​និយម​ដឹក​គ្នា។</string>
     <string name="deduplicator_detection_method_phash_title">ឡើ​ហាស​​ប៉័ដ​ក្នុង​ចន្ល​</string>
     <string name="deduplicator_detection_method_phash_summary">រក​កំពិល័​ដែល​​ស័ក់ញ្ញ​ដោយ​ការ​វិជ័យ​ព័ត័​ នឹង​ប្រើប្រាស់​ហាស​​ប៉័ដ​ក្នុង​ចន្ល​។ ⚠️ ការស័ក់​ដោយ​᠀អិន​អាច​មាន​កំហុស​ប៉ុន្តែ​ត្រូវការ​បញ្ជាក់​ដែល​ត្រូវ​ការ​បញ្ជាក់​ដោយ​ដែលឯបនើ។</string>
+    <string name="deduplicator_detection_method_media_title">រូបមន្តប្រព័ន្ធផ្សព្វផ្សាយ</string>
+    <string name="deduplicator_detection_method_media_summary">រក​ឯកសារ​វីដេអូ​និង​អូឌីយ៉ូ​ស្រដៀង​គ្នា​ដោយ​វិភាគ​ស្នាម​ម្រាមដៃ​អូឌីយ៉ូ។ ⚠️ ការ​រក​ឃើញ​ដែល​ផ្អែក​លើ​ភាព​ស្រដៀង​គ្នា​អាច​រួម​បញ្ចូល​ការ​រក​ឃើញ​មិន​ត្រឹម​ត្រូវ​ដែល​ត្រូវ​ការ​ការ​ផ្ទៀង​ផ្ទាត់​ដោយ​ដៃ។</string>
+    <string name="deduplicator_matches_media_label">ប្រព័ន្ធផ្សព្វផ្សាយស្រដៀងគ្នា</string>
+    <string name="deduplicator_media_match_audio">ការ​ផ្គូផ្គង​ផ្អែក​លើ​សំឡេង</string>
+    <string name="deduplicator_media_match_visual">ការ​ផ្គូផ្គង​ផ្អែក​លើ​វីដេអូ</string>
+    <string name="deduplicator_media_match_audio_visual">ការ​ផ្គូផ្គង​ផ្អែក​លើ​សំឡេង​និង​វីដេអូ</string>
     <string name="deduplicator_occupied_space_label">ទាក​ស្តោរេជ​បាន​ប្រើ​ប្រាស់</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="other">%s ត្រួវ​បាន​ប្រើ​ប្រាស់​ដោយ​សែសែ</item>

--- a/app-tool-deduplicator/src/main/res/values-ko/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-ko/strings.xml
@@ -23,6 +23,12 @@
     <string name="deduplicator_detection_method_checksum_summary">파일에 대한 체크썸을 계산하여 중복 여부를 확인합니다. 체크썸이 일치하는 파일은 콘텐츠가 완전히 동일합니다.</string>
     <string name="deduplicator_detection_method_phash_title">인식 해시</string>
     <string name="deduplicator_detection_method_phash_summary">콘텐츠 특성을 분석하고 인식 해시 값을 비교하여 유사한 파일을 찾습니다. ⚠️ 유사도 기반 탐지에는 수동 확인이 필요한 오탐이 포함될 수 있습니다.</string>
+    <string name="deduplicator_detection_method_media_title">미디어 지문</string>
+    <string name="deduplicator_detection_method_media_summary">오디오 지문을 분석하여 유사한 동영상 및 오디오 파일을 찾습니다. ⚠️ 유사성 기반 감지는 수동 확인이 필요한 오탐지를 포함할 수 있습니다.</string>
+    <string name="deduplicator_matches_media_label">유사 미디어</string>
+    <string name="deduplicator_media_match_audio">오디오 기반 일치</string>
+    <string name="deduplicator_media_match_visual">동영상 기반 일치</string>
+    <string name="deduplicator_media_match_audio_visual">오디오 및 동영상 기반 일치</string>
     <string name="deduplicator_occupied_space_label">사용 중인 저장공간</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="other">%s가 중복 파일로 점유되고 있습니다</item>

--- a/app-tool-deduplicator/src/main/res/values-lo-rLA/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-lo-rLA/strings.xml
@@ -23,6 +23,12 @@
     <string name="deduplicator_detection_method_checksum_summary">ກຳນົດສຳເນົາทີ່ຊ້າກັນໂດຍການຄຳນວນ checksum ຂອງໄຟລ໌. ໄຟລ໌ທີ່ checksum ກົງກັນມີເນື້ຫາດຽວກັນ.</string>
     <string name="deduplicator_detection_method_phash_title">Perceptual hash</string>
     <string name="deduplicator_detection_method_phash_summary">ຊອກຫາໄຟລ໌ທີ່ຄ້າຍກັນໂດຍການວິເຄາະຄຸນລັກຂອງເນື້ຫາ ແລະປຽບທຽຍຄ່າ perceptual hash. ⚠️ ການກວດຫາທີ່ອ້າງໃສ່ຄວາມຄ້າຍກັນ ອາດລວມຜົນບວກທີ່ຜິດຕ້ອງການກວດສອບດ້ວຍຕົນເອງ.</string>
+    <string name="deduplicator_detection_method_media_title">ລາຍນິ້ວມືສື່</string>
+    <string name="deduplicator_detection_method_media_summary">ຊອກຫາໄຟລ໌ວິດີໂອ ແລະ ສຽງທີ່ຄ້າຍຄືກັນໂດຍການວິເຄາະລາຍນິ້ວມືສຽງ. ⚠️ ການກວດຫາທີ່ອ້າງອິງຈາກຄວາມຄ້າຍຄືກັນອາດລວມມີຜົນບວກຜິດພາດທີ່ຕ້ອງການກວດສອບດ້ວຍຕົນເອງ.</string>
+    <string name="deduplicator_matches_media_label">ສື່ທີ່ຄ້າຍຄືກັນ</string>
+    <string name="deduplicator_media_match_audio">ກົງກັນໂດຍອ້າງອີງສຽງ</string>
+    <string name="deduplicator_media_match_visual">ກົງກັນໂດຍອ້າງອີງວິດີໂອ</string>
+    <string name="deduplicator_media_match_audio_visual">ກົງກັນໂດຍອ້າງອີງສຽງ ແລະ ວິດີໂອ</string>
     <string name="deduplicator_occupied_space_label">ຫນ່ວຍເກັບຂໍ້ມູລທີ່ຖືກໃຊ້</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="other">%s ຖືກໃຊ້ໂດຍສຳເນົາທີ່ຊ້າ</item>

--- a/app-tool-deduplicator/src/main/res/values-lt/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-lt/strings.xml
@@ -29,6 +29,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Nustatyti dublikatus skaičiuojant failų kontrolines sumas. Failai su sutampančiomis kontrolinėmis sumomis turi tiksliai toki patut turinį.</string>
     <string name="deduplicator_detection_method_phash_title">Suvokimo maistėlis</string>
     <string name="deduplicator_detection_method_phash_summary">Rasti panašius failus analizuojant turinio požymius ir lyginant suvokimo maštėlio reikšmes. ⚠️ Panaumo pagrindu aptikimas gali apimti klaidingų rezultatų, reikalaujančių rankinio tikrinimo.</string>
+    <string name="deduplicator_detection_method_media_title">Medijų pirštų atspaudas</string>
+    <string name="deduplicator_detection_method_media_summary">Raskite panašius vaizdo ir garso failus analizuodami garso pirštų atspaudus. ⚠️ Panašumu pagrįstas aptikimas gali apimti klaidingus teigiamus atvejus, reikalaujančius rankinio patikrinimo.</string>
+    <string name="deduplicator_matches_media_label">Panašios medijos</string>
+    <string name="deduplicator_media_match_audio">Atitiktis pagal garsą</string>
+    <string name="deduplicator_media_match_visual">Atitiktis pagal vaizdą</string>
+    <string name="deduplicator_media_match_audio_visual">Atitiktis pagal garsą ir vaizdą</string>
     <string name="deduplicator_occupied_space_label">Užimta atmintis</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s užimama dublikatų</item>

--- a/app-tool-deduplicator/src/main/res/values-lv/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-lv/strings.xml
@@ -27,6 +27,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Noteikt dublikātus, apreķinot failu kontrolsummas. Failiem ar sakristošām kontrolsummām ir precizīgi tadās pašas saturs.</string>
     <string name="deduplicator_detection_method_phash_title">Uztveres jūkls</string>
     <string name="deduplicator_detection_method_phash_summary">Atrast līdzīgus failus, analīzējot satura pazīmes un salīdzinot uztveres jūkla vērtības. ⚠️ Līdzībās bazēta noteikšana var iekļaut neprecizitātes, kas prasa manuālu pārbaudi.</string>
+    <string name="deduplicator_detection_method_media_title">Multivides pirkstspiediens</string>
+    <string name="deduplicator_detection_method_media_summary">Atrast līdzīgus video un audio failus, analizējot audio pirkstspiedienus. ⚠️ Uz līdzību balstīta noteikšana var ietvert viltus pozitīvus rezultātus, kuriem nepieciešama manuāla pārbaude.</string>
+    <string name="deduplicator_matches_media_label">Līdzīga multivide</string>
+    <string name="deduplicator_media_match_audio">Uz audio balstīta atbilstība</string>
+    <string name="deduplicator_media_match_visual">Uz video balstīta atbilstība</string>
+    <string name="deduplicator_media_match_audio_visual">Uz audio un video balstīta atbilstība</string>
     <string name="deduplicator_occupied_space_label">Aizņemtais krātuves apjoms</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="zero">%s ir aizņemti ar dublikātiem</item>

--- a/app-tool-deduplicator/src/main/res/values-mk-rMK/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-mk-rMK/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Одредете дупликати со пресметување контролни зборови за датотеки. Датотеки со совпаднати контролни зборови имаат потполно иста содржина.</string>
     <string name="deduplicator_detection_method_phash_title">Перцептуален хеш</string>
     <string name="deduplicator_detection_method_phash_summary">Најдете слични датотеки со анализа на карактеристики на содржината и споредба на перцептуални хеш вредности. ⚠️ Откривањето базирано на сличност може да вклучи лажни позитивни резултати кои бараат рачна верификација.</string>
+    <string name="deduplicator_detection_method_media_title">Медиумски отпечаток</string>
+    <string name="deduplicator_detection_method_media_summary">Пронајди слични видео и аудио датотеки со анализа на аудио отпечатоци. ⚠️ Откривањето засновано на сличност може да вклучи лажни позитиви кои бараат рачна верификација.</string>
+    <string name="deduplicator_matches_media_label">Слични медиуми</string>
+    <string name="deduplicator_media_match_audio">Совпаѓање засновано на аудио</string>
+    <string name="deduplicator_media_match_visual">Совпаѓање засновано на видео</string>
+    <string name="deduplicator_media_match_audio_visual">Совпаѓање засновано на аудио и видео</string>
     <string name="deduplicator_occupied_space_label">Зафатено складирање</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s е зафатено од дупликати</item>

--- a/app-tool-deduplicator/src/main/res/values-ml-rIN/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-ml-rIN/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">ഫയലുകൾക്കായി ചെക്ക്സം കണക്കാക്കി ഡ്യൂപ്ലിക്കേറ്റുകൾ നിർണ്ണയിക്കുക. ഒരേ ചെക്ക്സം ഉള്ള ഫയലുകൾക്ക് ഒരേ ഉള്ളടക്കമാണ്.</string>
     <string name="deduplicator_detection_method_phash_title">പെർസെപ്ച്വൽ ഹാഷ്</string>
     <string name="deduplicator_detection_method_phash_summary">ഉള്ളടക്ക സവിശേഷതകൾ വിശകലനം ചെയ്ത് പെർസെപ്ച്വൽ ഹാഷ് മൂല്യങ്ങൾ താരതമ്യം ചെയ്ത് സമാന ഫയലുകൾ കണ്ടെത്തുക. ⚠️ സമാനത അടിസ്ഥാനത്തിലുള്ള കണ്ടെത്തൽ തെറ്റായ ഫലങ്ങൾ നൽകിയേക്കാം, അതിന് സ്വമേധയായ പരിശോധന ആവശ്യമായി വരും.</string>
+    <string name="deduplicator_detection_method_media_title">മീഡിയ ഫിംഗർപ്രിന്റ്</string>
+    <string name="deduplicator_detection_method_media_summary">ഓഡിയോ ഫിംഗർപ്രിന്റുകൾ വിശകലനം ചെയ്ത് സമാനമായ വീഡിയോ, ഓഡിയോ ഫയലുകൾ കണ്ടെത്തുക. ⚠️ സാദൃശ്യ അടിസ്ഥാനത്തിലുള്ള കണ്ടെത്തൽ തെറ്റായ ഫലങ്ങൾ ഉൾക്കൊള്ളാം, അതിനാൽ സ്വമേധയാ പരിശോധന ആവശ്യമാണ്.</string>
+    <string name="deduplicator_matches_media_label">സമാന മീഡിയ</string>
+    <string name="deduplicator_media_match_audio">ഓഡിയോ അടിസ്ഥാനത്തിലുള്ള പൊരുത്തം</string>
+    <string name="deduplicator_media_match_visual">വീഡിയോ അടിസ്ഥാനത്തിലുള്ള പൊരുത്തം</string>
+    <string name="deduplicator_media_match_audio_visual">ഓഡിയോ, വീഡിയോ അടിസ്ഥാനത്തിലുള്ള പൊരുത്തം</string>
     <string name="deduplicator_occupied_space_label">ഉപയോഗിക്കുന്ന സ്റ്റോറേജ്</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s ഡ്യൂപ്ലിക്കേറ്റ് ഉപയോഗിക്കുന്നു</item>

--- a/app-tool-deduplicator/src/main/res/values-mn-rMN/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-mn-rMN/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Файлуудад хяналтын нийлбэр тооцоолж давхардлыг тодорхойлох. Тааралдсан хяналтын нийлбэртэй файлууд яг ижил агуулгатай.</string>
     <string name="deduplicator_detection_method_phash_title">Хүртэхүйн хэш</string>
     <string name="deduplicator_detection_method_phash_summary">Агуулгын шинж чанарыг дүн шинжилгээ хийж, хүртэхүйн хэш утгуудыг харьцуулж ижил файлуудыг олох.</string>
+    <string name="deduplicator_detection_method_media_title">Медиа хурууны хээ</string>
+    <string name="deduplicator_detection_method_media_summary">Аудио хурууны хээг шинжлэн төстэй видео болон аудио файлуудыг олох. ⚠️ Төстэй байдалд суурилсан илрүүлэлт нь гараар баталгаажуулалт шаардах худал эерэг үр дүнг агуулж болно.</string>
+    <string name="deduplicator_matches_media_label">Төстэй медиа</string>
+    <string name="deduplicator_media_match_audio">Аудиод суурилсан тохирц</string>
+    <string name="deduplicator_media_match_visual">Видеод суурилсан тохирц</string>
+    <string name="deduplicator_media_match_audio_visual">Аудио болон видеод суурилсан тохирц</string>
     <string name="deduplicator_occupied_space_label">Езлэгдсэн санах</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s давхардах файлууд эзлаад байна</item>

--- a/app-tool-deduplicator/src/main/res/values-ms/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-ms/strings.xml
@@ -23,6 +23,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Tentukan pendua dengan mengira checksum untuk fail. Fail dengan checksum yang sepadan mempunyai kandungan yang sama persis.</string>
     <string name="deduplicator_detection_method_phash_title">Hash persepsi</string>
     <string name="deduplicator_detection_method_phash_summary">Cari fail yang serupa dengan menganalisis ciri kandungan dan membandingkan nilai hash persepsi. ⚠️ Pengesanan berasaskan keserupaan mungkin termasuk positif palsu yang memerlukan pengesahan manual.</string>
+    <string name="deduplicator_detection_method_media_title">Cap jari media</string>
+    <string name="deduplicator_detection_method_media_summary">Cari fail video dan audio yang serupa dengan menganalisis cap jari audio. ⚠️ Pengesanan berasaskan persamaan mungkin termasuk positif palsu yang memerlukan pengesahan manual.</string>
+    <string name="deduplicator_matches_media_label">Media yang serupa</string>
+    <string name="deduplicator_media_match_audio">Padanan berasaskan audio</string>
+    <string name="deduplicator_media_match_visual">Padanan berasaskan video</string>
+    <string name="deduplicator_media_match_audio_visual">Padanan berasaskan audio dan video</string>
     <string name="deduplicator_occupied_space_label">Storan yang digunakan</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="other">%s diduduki oleh pendua</item>

--- a/app-tool-deduplicator/src/main/res/values-my-rMM/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-my-rMM/strings.xml
@@ -23,6 +23,12 @@
     <string name="deduplicator_detection_method_checksum_summary">ဖိုင်များတာ် အမှား checksum တွက်ချက်ခြင်းဖြင့် ထပ်တူများ ဆုံးဖြစ်ပါ။ ကိုက်ညိသော checksum ရှိသော ဖိုင်များသည် အတိအကျ တူညီသော အကြောင်အရာ ရှိသည်။</string>
     <string name="deduplicator_detection_method_phash_title">Perceptual hash</string>
     <string name="deduplicator_detection_method_phash_summary">အကြောင်အရာ လက္ခနာများ ခွဲခြမ်းစိတ်ဖြာပြီး perceptual hash တန်ဖိုးများ နှိုးယှေစ်ကာ ဆင်တူသော ဖိုင်များ ရှာပါ။ ⚠️ ဆင်တူမှုအပေါ် အခှပြု သစ်ဆေးခြင်းတွင် လက်ဖြင့် သစ်ဆေးရမည့်သော မှားယွင်းသော ရလဒ်များ ပါဝင်နိုင်သည်။</string>
+    <string name="deduplicator_detection_method_media_title">မီဒီယာ လက်ဗွေ</string>
+    <string name="deduplicator_detection_method_media_summary">အသံ လက်ဗွေများကို ခွဲခြမ်းစိတ်ဖြာ၍ ဗီဒီယိုနှင့် အသံဖိုင်များ ကို ရှာဖွေပါ။ ⚠️ တူညီမှုအပေါ် အခြေပြု စစ်ဆေးခြင်းသည် ကိုယ်တိုင် စစ်ဆေးမှု လိုအပ်သော မှားယွင်းသော ကိုက်ညီမှုများ ပါဝင်နိုင်သည်။</string>
+    <string name="deduplicator_matches_media_label">ဆင်တူသော မီဒီယာ</string>
+    <string name="deduplicator_media_match_audio">အသံအပေါ် အခြေပြုသော ကိုက်ညီမှု</string>
+    <string name="deduplicator_media_match_visual">ဗီဒီယိုအပေါ် အခြေပြုသော ကိုက်ညီမှု</string>
+    <string name="deduplicator_media_match_audio_visual">အသံနှင့် ဗီဒီယိုအပေါ် အခြေပြုသော ကိုက်ညီမှု</string>
     <string name="deduplicator_occupied_space_label">လွှမ်းမိုးထားသော သိုလှောင့်မှု</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="other">%s ကို ထပ်တူများက လွှမ်းမိုးထေသည်</item>

--- a/app-tool-deduplicator/src/main/res/values-nb/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-nb/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Bestem duplikater ved å beregne sjekksummer for filer. Filer med samsvarende sjekksum har nøyaktig samme innhold.</string>
     <string name="deduplicator_detection_method_phash_title">Perseptuell hasj</string>
     <string name="deduplicator_detection_method_phash_summary">Finn lignende filer ved å analysere innholdsfunksjoner og sammenligne perseptuelle hashverdier. ⚠️ Likhetsbasert deteksjon kan inkludere falske positiver som krever manuell verifisering.</string>
+    <string name="deduplicator_detection_method_media_title">Mediefingeravtrykk</string>
+    <string name="deduplicator_detection_method_media_summary">Finn lignende video- og lydfiler ved å analysere lydfingeravtrykk. ⚠️ Likhetbasert gjenkjenning kan inkludere falske positiver som krever manuell verifisering.</string>
+    <string name="deduplicator_matches_media_label">Lignende medier</string>
+    <string name="deduplicator_media_match_audio">Lydbasert treff</string>
+    <string name="deduplicator_media_match_visual">Videobasert treff</string>
+    <string name="deduplicator_media_match_audio_visual">Lyd- og videobasert treff</string>
     <string name="deduplicator_occupied_space_label">Brukt lagringsplass</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s er brukt av duplikater</item>

--- a/app-tool-deduplicator/src/main/res/values-ne-rNP/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-ne-rNP/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">फाइलहरूका लागि checksum गणना गरेर डुप्लिकेटहरू पत्ता लगाउनुहोस्। मिल्दो checksum भएका फाइलहरूमा एकदमै उस्तै सामग्री हुन्छ।</string>
     <string name="deduplicator_detection_method_phash_title">पर्सेप्चुअल ह्यास</string>
     <string name="deduplicator_detection_method_phash_summary">सामग्री विशेषताहरू विश्लेषण गरेर र पर्सेप्चुअल ह्यास मानहरू तुलना गरेर मिल्दोजुल्दो फाइलहरू फेला पार्नुहोस्। ⚠️ समानता-आधारित पहिचानमा म्यानुअल सत्यापन आवश्यक पर्ने गलत सकारात्मक परिणामहरू समावेश हुन सक्छ।</string>
+    <string name="deduplicator_detection_method_media_title">मिडिया फिंगरप्रिन्ट</string>
+    <string name="deduplicator_detection_method_media_summary">अडियो फिंगरप्रिन्ट विश्लेषण गरेर मिल्दो भिडियो र अडियो फाइलहरू खोज्नुहोस्। ⚠️ समानता-आधारित पहिचानमा गलत परिणामहरू समावेश हुन सक्छन् जसलाई म्यानुअल प्रमाणीकरण आवश्यक छ।</string>
+    <string name="deduplicator_matches_media_label">मिल्दो मिडिया</string>
+    <string name="deduplicator_media_match_audio">अडियो-आधारित मिलान</string>
+    <string name="deduplicator_media_match_visual">भिडियो-आधारित मिलान</string>
+    <string name="deduplicator_media_match_audio_visual">अडियो र भिडियो-आधारित मिलान</string>
     <string name="deduplicator_occupied_space_label">कब्जा गरिएको भण्डारण</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s डुप्लिकेटले ओगटेको छ</item>

--- a/app-tool-deduplicator/src/main/res/values-nl/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-nl/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Bepaal dubbele bestanden door controlesommen voor bestanden te berekenen. Bestanden met overeenkomende controlesommen hebben exact dezelfde inhoud.</string>
     <string name="deduplicator_detection_method_phash_title">Perceptie-hash</string>
     <string name="deduplicator_detection_method_phash_summary">Vind vergelijkbare bestanden door inhoudskenmerken te analyseren en perceptuele hashwaarden te vergelijken. ⚠️ Detectie op basis van gelijkenis kan vals-positieve resultaten opleveren, waarvoor handmatige verificatie vereist is.</string>
+    <string name="deduplicator_detection_method_media_title">Media-vingerafdruk</string>
+    <string name="deduplicator_detection_method_media_summary">Vind vergelijkbare video- en audiobestanden door audio-vingerafdrukken te analyseren. ⚠️ Detectie op basis van gelijkenis kan valse positieven opleveren die handmatige verificatie vereisen.</string>
+    <string name="deduplicator_matches_media_label">Vergelijkbare media</string>
+    <string name="deduplicator_media_match_audio">Op audio gebaseerde overeenkomst</string>
+    <string name="deduplicator_media_match_visual">Op video gebaseerde overeenkomst</string>
+    <string name="deduplicator_media_match_audio_visual">Op audio en video gebaseerde overeenkomst</string>
     <string name="deduplicator_occupied_space_label">Gebruikte opslag</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s wordt ingenomen door duplicaten</item>

--- a/app-tool-deduplicator/src/main/res/values-or-rIN/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-or-rIN/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">ଫାଇଲଗୁଡ଼ିକ ପାଇଁ ଚେକସମ୍ ଗଣନା କରି ନକଲ ନିର୍ଣ୍ଣୟ କରନ୍ତୁ। ମେଳ ଖାଉଥିବା ଚେକସମ୍ ଥିବା ଫାଇଲଗୁଡ଼ିକର ଏକେ ସମାନ ବିଷୟବସ୍ତୁ ରହିଛି।</string>
     <string name="deduplicator_detection_method_phash_title">ପର୍ସେପଚୁଆଲ ହ୍ୟାସ୍</string>
     <string name="deduplicator_detection_method_phash_summary">ବିଷୟବସ୍ତୁ ବୈଶିଷ୍ଟ୍ୟ ବିଶ୍ଳେଷଣ ଏବଂ ଅନୁଭୂତିମୂଳକ ହ୍ୟାସ୍ ମୂଲ୍ୟ ତୁଳନା କରି ସମାନ ଫାଇଲ୍ ଖୋଜନ୍ତୁ। ⚠️ ସମାନତା-ଆଧାରିତ ଚିହ୍ନଟ ମିଥ୍ୟା ସକରାତ୍ମକ ଅନ୍ତର୍ଭୁକ୍ତ କରିପାରେ ଯାହା ହାତରେ ଯାଞ୍ଚ ଆବଶ୍ୟକ କରେ।</string>
+    <string name="deduplicator_detection_method_media_title">ମିଡ଼ିଆ ଫିଙ୍ଗର୍‌ପ୍ରିଣ୍ଟ</string>
+    <string name="deduplicator_detection_method_media_summary">ଅଡ଼ିଓ ଫିଙ୍ଗର୍‌ପ୍ରିଣ୍ଟ ବିଶ୍ଳେଷଣ କରି ସମାନ ଭିଡ଼ିଓ ଓ ଅଡ଼ିଓ ଫାଇଲ ଖୋଜନ୍ତୁ। ⚠️ ସମାନତା ଆଧାରିତ ଚିହ୍ନଟ ପ୍ରଣାଳୀ ଭୁଲ ଫଳ ଦେଇ ପାରେ, ତେଣୁ ହସ୍ତ ଯାଞ୍ଚ ଆବଶ୍ୟକ।</string>
+    <string name="deduplicator_matches_media_label">ସମାନ ମିଡ଼ିଆ</string>
+    <string name="deduplicator_media_match_audio">ଅଡ଼ିଓ ଆଧାରିତ ମିଳାଣ</string>
+    <string name="deduplicator_media_match_visual">ଭିଡ଼ିଓ ଆଧାରିତ ମିଳାଣ</string>
+    <string name="deduplicator_media_match_audio_visual">ଅଡ଼ିଓ ଓ ଭିଡ଼ିଓ ଆଧାରିତ ମିଳାଣ</string>
     <string name="deduplicator_occupied_space_label">ଅଧିକୃତ ଷ୍ଟୋରେଜ୍</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s ନକଲ ଦ୍ୱାରା ଦଖଲ ହୋଇଛି</item>

--- a/app-tool-deduplicator/src/main/res/values-pa-rIN/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-pa-rIN/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">ਫਾਈਲਾਂ ਲਈ ਚੈਕਸਮ ਗਿਣਤੀ ਕਰਕੇ ਡੁਪਲੀਕੇਟ ਨਿਰਧਾਰਤ ਕਰੋ। ਮੇਲ ਖਾਂਦੇ ਚੈਕਸਮ ਵਾਲੀਆਂ ਫਾਈਲਾਂ ਵਿੱਚ ਬਿਲਕੁਲ ਇੱਕੋ ਜਿਹੀ ਸਮੱਗਰੀ ਹੁੰਦੀ ਹੈ।</string>
     <string name="deduplicator_detection_method_phash_title">ਅਨੁਭਵੀ ਹੈਸ਼</string>
     <string name="deduplicator_detection_method_phash_summary">ਸਮੱਗਰੀ ਵਿਸ਼ੇਸ਼ਤਾਵਾਂ ਦਾ ਵਿਸ਼ਲੇਸ਼ਣ ਕਰਕੇ ਅਤੇ ਅਨੁਭਵੀ ਹੈਸ਼ ਮੁੱਲਾਂ ਦੀ ਤੁਲਨਾ ਕਰਕੇ ਸਮਾਨ ਫਾਈਲਾਂ ਲੱਭੋ। ⚠️ ਸਮਾਨਤਾ-ਅਧਾਰਤ ਖੋਜ ਵਿੱਚ ਗਲਤ ਨਤੀਜੇ ਸ਼ਾਮਲ ਹੋ ਸਕਦੇ ਹਨ ਜਿਨ੍ਹਾਂ ਲਈ ਹੱਥੀਂ ਤਸਦੀਕ ਦੀ ਲੋੜ ਹੈ।</string>
+    <string name="deduplicator_detection_method_media_title">ਮੀਡੀਆ ਫਿੰਗਰਪ੍ਰਿੰਟ</string>
+    <string name="deduplicator_detection_method_media_summary">ਆਡੀਓ ਫਿੰਗਰਪ੍ਰਿੰਟਸ ਦਾ ਵਿਸ਼ਲੇਸ਼ਣ ਕਰਕੇ ਸਮਾਨ ਵੀਡੀਓ ਅਤੇ ਆਡੀਓ ਫਾਈਲਾਂ ਲੱਭੋ। ⚠️ ਸਮਾਨਤਾ-ਆਧਾਰਿਤ ਖੋਜ ਵਿੱਚ ਝੂਠੇ ਸਕਾਰਾਤਮਕ ਨਤੀਜੇ ਹੋ ਸਕਦੇ ਹਨ ਜਿਨ੍ਹਾਂ ਲਈ ਦਸਤੀ ਪੁਸ਼ਟੀ ਦੀ ਲੋੜ ਹੈ।</string>
+    <string name="deduplicator_matches_media_label">ਸਮਾਨ ਮੀਡੀਆ</string>
+    <string name="deduplicator_media_match_audio">ਆਡੀਓ-ਆਧਾਰਿਤ ਮੇਲ</string>
+    <string name="deduplicator_media_match_visual">ਵੀਡੀਓ-ਆਧਾਰਿਤ ਮੇਲ</string>
+    <string name="deduplicator_media_match_audio_visual">ਆਡੀਓ ਅਤੇ ਵੀਡੀਓ-ਆਧਾਰਿਤ ਮੇਲ</string>
     <string name="deduplicator_occupied_space_label">ਵਰਤੀ ਗਈ ਸਟੋਰੇਜ</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s ਡੁਪਲੀਕੇਟਸ ਦੁਆਰਾ ਲਿਆ ਗਿਆ ਹੈ</item>

--- a/app-tool-deduplicator/src/main/res/values-pl/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-pl/strings.xml
@@ -29,6 +29,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Określ duplikaty, obliczając sumy kontrolne dla plików. Pliki z pasującymi sumami kontrolnymi mają dokładnie taką samą zawartość.</string>
     <string name="deduplicator_detection_method_phash_title">Percepcyjny skrót</string>
     <string name="deduplicator_detection_method_phash_summary">Znajdź podobne pliki, analizując cechy treści i porównując percepcyjne wartości skrótów. ⚠️ Wykrywanie na podstawie podobieństwa może obejmować fałszywe alarmy wymagające ręcznej weryfikacji.</string>
+    <string name="deduplicator_detection_method_media_title">Sygnatury multimediów</string>
+    <string name="deduplicator_detection_method_media_summary">Znajdź podobne pliki wideo i audio poprzez analizę sygnatur audio. ⚠️ Wykrywanie oparte na podobieństwie może zawierać fałszywe trafienia wymagające ręcznej weryfikacji.</string>
+    <string name="deduplicator_matches_media_label">Podobne multimedia</string>
+    <string name="deduplicator_media_match_audio">Dopasowanie na podstawie dźwięku</string>
+    <string name="deduplicator_media_match_visual">Dopasowanie na podstawie wideo</string>
+    <string name="deduplicator_media_match_audio_visual">Dopasowanie na podstawie dźwięku i wideo</string>
     <string name="deduplicator_occupied_space_label">Zajęta pamięć</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s jest zajęty przez duplikaty</item>

--- a/app-tool-deduplicator/src/main/res/values-pt-rBR/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-pt-rBR/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Determinar os duplicados calculando as somas de verificação dos arquivos. Os arquivos com as somas de verificação correspondentes têm exatamente o mesmo conteúdo.</string>
     <string name="deduplicator_detection_method_phash_title">Hash perceptivo</string>
     <string name="deduplicator_detection_method_phash_summary">Encontre arquivos similares, analisando recursos de conteúdo e comparando valores hash perceptuais. ⚠️ Detecção baseada em similar pode incluir falsos positivos que requerem verificação manual.</string>
+    <string name="deduplicator_detection_method_media_title">Impressão digital de mídia</string>
+    <string name="deduplicator_detection_method_media_summary">Encontre arquivos de vídeo e áudio semelhantes analisando impressões digitais de áudio. ⚠️ A detecção baseada em similaridade pode incluir falsos positivos que requerem verificação manual.</string>
+    <string name="deduplicator_matches_media_label">Mídia semelhante</string>
+    <string name="deduplicator_media_match_audio">Correspondência baseada em áudio</string>
+    <string name="deduplicator_media_match_visual">Correspondência baseada em vídeo</string>
+    <string name="deduplicator_media_match_audio_visual">Correspondência baseada em áudio e vídeo</string>
     <string name="deduplicator_occupied_space_label">Armazenamento ocupado</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s está ocupado por duplicados</item>

--- a/app-tool-deduplicator/src/main/res/values-pt/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-pt/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Encontre duplicados calculando as verificações de ficheiros. Arquivos com valores de verificação correspondentes têm exatamente o mesmo conteúdo.</string>
     <string name="deduplicator_detection_method_phash_title">Hash perceptual</string>
     <string name="deduplicator_detection_method_phash_summary">Encontre arquivos similares, analisando recursos de conteúdo e comparando valores hash perceptuais. ⚠️ Detecção baseada em similaridade pode incluir falsos positivos que requerem verificação manual.</string>
+    <string name="deduplicator_detection_method_media_title">Impressão digital de multimédia</string>
+    <string name="deduplicator_detection_method_media_summary">Encontrar ficheiros de vídeo e áudio semelhantes através da análise de impressões digitais de áudio. ⚠️ A deteção baseada em semelhança pode incluir falsos positivos que requerem verificação manual.</string>
+    <string name="deduplicator_matches_media_label">Multimédia semelhante</string>
+    <string name="deduplicator_media_match_audio">Correspondência baseada em áudio</string>
+    <string name="deduplicator_media_match_visual">Correspondência baseada em vídeo</string>
+    <string name="deduplicator_media_match_audio_visual">Correspondência baseada em áudio e vídeo</string>
     <string name="deduplicator_occupied_space_label">Armazenamento Ocupado</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s está ocupado por duplicados </item>

--- a/app-tool-deduplicator/src/main/res/values-ro/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-ro/strings.xml
@@ -27,6 +27,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Determinați duplicate prin calcularea sumelor de verificare pentru fișiere. Fișierele cu sumele corespunzătoare de verificare au exact același conținut.</string>
     <string name="deduplicator_detection_method_phash_title">Hash veșnic</string>
     <string name="deduplicator_detection_method_phash_summary">Găsiți fișiere similare analizând caracteristicile de conținut și comparând valorile hash perceptuale. ⚠️ Detectarea bazată pe similitudine poate include rezultate fals pozitive care necesită verificare manuală.</string>
+    <string name="deduplicator_detection_method_media_title">Amprentă media</string>
+    <string name="deduplicator_detection_method_media_summary">Găsește fișiere video și audio similare analizând amprentele audio. ⚠️ Detecția bazată pe similitudine poate include fals pozitive care necesită verificare manuală.</string>
+    <string name="deduplicator_matches_media_label">Media similară</string>
+    <string name="deduplicator_media_match_audio">Potrivire bazată pe audio</string>
+    <string name="deduplicator_media_match_visual">Potrivire bazată pe video</string>
+    <string name="deduplicator_media_match_audio_visual">Potrivire bazată pe audio și video</string>
     <string name="deduplicator_occupied_space_label">Spațiu de stocare ocupat</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s este ocupat de duplicate</item>

--- a/app-tool-deduplicator/src/main/res/values-ru/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-ru/strings.xml
@@ -29,6 +29,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Выявлять дубликаты вычислением контрольной суммы файлов. Файлы с одинаковой контрольной суммой идентичны по содержимому.</string>
     <string name="deduplicator_detection_method_phash_title">Похожее содержимое</string>
     <string name="deduplicator_detection_method_phash_summary">Поиск похожих файлов посредством анализа свойств содержимого и сравнения значений хэша. ⚠️ Обнаружение на основе схожести может включать неверные позиции, требующие ручной проверки.</string>
+    <string name="deduplicator_detection_method_media_title">Отпечаток медиа</string>
+    <string name="deduplicator_detection_method_media_summary">Находите похожие видео и аудио файлы, анализируя аудио отпечатки. ⚠️ Обнаружение на основе схожих признаков может включать ложные срабатывания, требующие ручной проверки.</string>
+    <string name="deduplicator_matches_media_label">Похожие медиа</string>
+    <string name="deduplicator_media_match_audio">Совпадение на основе аудио</string>
+    <string name="deduplicator_media_match_visual">Совпадение на основе видео</string>
+    <string name="deduplicator_media_match_audio_visual">Совпадение на основе аудио и видео</string>
     <string name="deduplicator_occupied_space_label">Используемая память</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">Дубликатами занято: %s</item>

--- a/app-tool-deduplicator/src/main/res/values-sc-rIT/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-sc-rIT/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Determinare duplicados calculende checksums pro documentos. Documentos cun checksums chi currispondent tenent su stessu cuntentu isatu.</string>
     <string name="deduplicator_detection_method_phash_title">Hash percettivu</string>
     <string name="deduplicator_detection_method_phash_summary">Agatza archìvios simìliles analizende is caraterìsticas de su cuntenutu e paragonende is valores de hash pertzettivos. ⚠️ Sa rilevadura basada in sa similitùdine podet inclùere positivos falsos chi ant a bisongiare de verìfica manuale.</string>
+    <string name="deduplicator_detection_method_media_title">Imprenta digitale multimediale</string>
+    <string name="deduplicator_detection_method_media_summary">Acata archìvios de vìdeo e àudio simìlares analizende is imprentas digitales de s\'àudio. ⚠️ Sa detecione basada in sa similitùdine podet incluire falsos positivos chi cherent verificatzione manuale.</string>
+    <string name="deduplicator_matches_media_label">Mèdia simìlare</string>
+    <string name="deduplicator_media_match_audio">Cumbinadura basada in s\'àudio</string>
+    <string name="deduplicator_media_match_visual">Cumbinadura basada in su vìdeo</string>
+    <string name="deduplicator_media_match_audio_visual">Cumbinadura basada in àudio e vìdeo</string>
     <string name="deduplicator_occupied_space_label">Archìviu ocupadu</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s est ocupadu dae duplicados</item>

--- a/app-tool-deduplicator/src/main/res/values-si-rLK/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-si-rLK/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">ගොනු සඳහා මගොස්තන ගණනය කිරීමෙන් බහුපත නිර්ණය කරන්න. සමාන මගොස්තන හෛය ගොනුවල නිවැරදිව එකම අන්තර්ගතය හැදේ.</string>
     <string name="deduplicator_detection_method_phash_title">ඇන්දරිය හැශ්</string>
     <string name="deduplicator_detection_method_phash_summary">අන්තර්ගත විශේෂාංග විශ්ලේෂණය කර සහ සංකල්පමය හැෂ් අගයන් සැසඳීමෙන් සමාන ගොනු සොයන්න. ⚠️ සමානත්ව පාදක හඳුනාගැනීමේදී අතින් සත්‍යාපනය අවශ්‍ය ව්‍යාජ ධනාත්මක ඇතුළත් විය හැක.</string>
+    <string name="deduplicator_detection_method_media_title">මාධ්‍ය ඇඟිලි සලකුණ</string>
+    <string name="deduplicator_detection_method_media_summary">ශ්‍රව්‍ය ඇඟිලි සලකුණු විශ්ලේෂණය කිරීමෙන් සමාන වීඩියෝ සහ ශ්‍රව්‍ය ගොනු සොයන්න. ⚠️ සමානත්ව-පදනම් කළ හඳුනාගැනීමට අත්පිටපත් සත්‍යාපනය අවශ්‍ය වන අසත්‍ය ධනාත්මක ප්‍රතිඵල ඇතුළත් විය හැකිය.</string>
+    <string name="deduplicator_matches_media_label">සමාන මාධ්‍ය</string>
+    <string name="deduplicator_media_match_audio">ශ්‍රව්‍ය-පදනම් ගැළපීම</string>
+    <string name="deduplicator_media_match_visual">වීඩියෝ-පදනම් ගැළපීම</string>
+    <string name="deduplicator_media_match_audio_visual">ශ්‍රව්‍ය සහ වීඩියෝ-පදනම් ගැළපීම</string>
     <string name="deduplicator_occupied_space_label">අවවන් න් ඇත ආචයනය</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s බහුපත විසින් අවවන් න් වෙ</item>

--- a/app-tool-deduplicator/src/main/res/values-sk/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-sk/strings.xml
@@ -29,6 +29,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Určte duplikáty výpočtom kontrolných súčtov pre súbory. Súbory so zodpovedajúcimi kontrolnými súčtami majú presne rovnaký obsah.</string>
     <string name="deduplicator_detection_method_phash_title">Percepčný hash</string>
     <string name="deduplicator_detection_method_phash_summary">Nájdite podobné súbory analýzou vlastností obsahu a porovnaním percepčných hash hodnôt. ⚠️ Detekcia na základe podobnosti môže zahŕňať falošne pozitívne výsledky vyžadujúce manuálne overenie.</string>
+    <string name="deduplicator_detection_method_media_title">Mediálny odtlačok</string>
+    <string name="deduplicator_detection_method_media_summary">Nájdite podobné video a audio súbory analýzou zvukových odtlačkov. ⚠️ Detekcia na základe podobnosti môže zahŕňať falošné pozitíva vyžadujúce manuálne overenie.</string>
+    <string name="deduplicator_matches_media_label">Podobné médiá</string>
+    <string name="deduplicator_media_match_audio">Zhoda na základe zvuku</string>
+    <string name="deduplicator_media_match_visual">Zhoda na základe videa</string>
+    <string name="deduplicator_media_match_audio_visual">Zhoda na základe zvuku a videa</string>
     <string name="deduplicator_occupied_space_label">Obsadené úložisko</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s je obsadené duplikátmi</item>

--- a/app-tool-deduplicator/src/main/res/values-sl/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-sl/strings.xml
@@ -29,6 +29,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Zaznaj dvojnike z izračunom nadzornih vsot datotek.  Datoteke, katerih nadzorne vsote se ujemajo, imajo enako vsebino.</string>
     <string name="deduplicator_detection_method_phash_title">Zaznavno razpršilo</string>
     <string name="deduplicator_detection_method_phash_summary">Poišči podobne datoteke s preučevanjem značilnosti vsebine in primerjavo zaznavnih zgoščenih vrednosti. ⚠️ Zaznavanje podobnosti lahko poda lažne podobnosti, kar zahteva ročno preverjanje.</string>
+    <string name="deduplicator_detection_method_media_title">Medijski prstni odtis</string>
+    <string name="deduplicator_detection_method_media_summary">Poišči podobne video in avdio datoteke z analizo zvočnih prstnih odtisov. ⚠️ Zaznavanje na podlagi podobnosti lahko vključuje lažne zadetke, ki zahtevajo ročno preverjanje.</string>
+    <string name="deduplicator_matches_media_label">Podobni mediji</string>
+    <string name="deduplicator_media_match_audio">Ujemanje na podlagi zvoka</string>
+    <string name="deduplicator_media_match_visual">Ujemanje na podlagi videa</string>
+    <string name="deduplicator_media_match_audio_visual">Ujemanje na podlagi zvoka in videa</string>
     <string name="deduplicator_occupied_space_label">Zaseden prostor</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s zasedajo dvojniki.</item>

--- a/app-tool-deduplicator/src/main/res/values-sq-rAL/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-sq-rAL/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Përcaktoni dublikatat duke llogaritur shumat e kontrollit për skedarët. Skedarët me shuma kontrolli që përputhen kanë të njëjtën përmbajtje.</string>
     <string name="deduplicator_detection_method_phash_title">Hash perceptues</string>
     <string name="deduplicator_detection_method_phash_summary">Gjeni skedarë të ngjashëm duke analizuar veçoritë e përmbajtjes dhe duke krahasuar vlerat e perceptuara të hash-it. ⚠️ Zbulimi i bazuar në ngjashmëri mund të përfshijë rezultate pozitive të rreme që kërkojnë verifikim manual.</string>
+    <string name="deduplicator_detection_method_media_title">Gjurmë dixhitale e medias</string>
+    <string name="deduplicator_detection_method_media_summary">Gjej video dhe skedarë audio të ngjashëm duke analizuar gjurmët audio. ⚠️ Zbulimi i bazuar në ngjashmëri mund të përfshijë pozitive të rreme që kërkojnë verifikim manual.</string>
+    <string name="deduplicator_matches_media_label">Media të ngjashme</string>
+    <string name="deduplicator_media_match_audio">Përputhje e bazuar në audio</string>
+    <string name="deduplicator_media_match_visual">Përputhje e bazuar në video</string>
+    <string name="deduplicator_media_match_audio_visual">Përputhje e bazuar në audio dhe video</string>
     <string name="deduplicator_occupied_space_label">Magazina e zënë</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s është zënë nga dublikata</item>

--- a/app-tool-deduplicator/src/main/res/values-sr/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-sr/strings.xml
@@ -27,6 +27,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Одреди дупликате израчунавањем контролних сума за датотеке. Датотеке са поклапајућим контролним сумама имају потпуно исти садржај.</string>
     <string name="deduplicator_detection_method_phash_title">Перцептуални хеш</string>
     <string name="deduplicator_detection_method_phash_summary">Пронађите сличне датотеке анализирањем карактеристика садржаја и поређењем перцептуалних хеш вредности. ⚠️ Детекција заснована на сличности може укључити лажне позитивне резултате који захтевају ручну верификацију.</string>
+    <string name="deduplicator_detection_method_media_title">Медијски отисак</string>
+    <string name="deduplicator_detection_method_media_summary">Пронађите сличне видео и аудио датотеке анализом аудио отисака. ⚠️ Детекција заснована на сличности може укључивати лажне позитиве који захтевају ручну верификацију.</string>
+    <string name="deduplicator_matches_media_label">Слични медији</string>
+    <string name="deduplicator_media_match_audio">Подударање засновано на аудио</string>
+    <string name="deduplicator_media_match_visual">Подударање засновано на видео</string>
+    <string name="deduplicator_media_match_audio_visual">Подударање засновано на аудио и видео</string>
     <string name="deduplicator_occupied_space_label">Заузето складиште</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s је заузет дупликатима</item>

--- a/app-tool-deduplicator/src/main/res/values-sv/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-sv/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Bestäm dubbletter genom att beräkna kontrollsummor för filer. Filer med matchande kontrollsummor har exakt samma innehåll.</string>
     <string name="deduplicator_detection_method_phash_title">Perceptuell hash</string>
     <string name="deduplicator_detection_method_phash_summary">Hitta liknande filer genom att analysera innehållsfunktioner och jämföra perceptuella hashvärden. Likhetsbaserad detektering kan inkludera falska positiva som kräver manuell verifiering.</string>
+    <string name="deduplicator_detection_method_media_title">Mediefingeravtryck</string>
+    <string name="deduplicator_detection_method_media_summary">Hitta liknande video- och ljudfiler genom att analysera ljudfingeravtryck. ⚠️ Likhetbaserad identifiering kan inkludera falskt positiva fynd som kräver manuell verifiering.</string>
+    <string name="deduplicator_matches_media_label">Liknande media</string>
+    <string name="deduplicator_media_match_audio">Ljudbaserad matchning</string>
+    <string name="deduplicator_media_match_visual">Videobaserad matchning</string>
+    <string name="deduplicator_media_match_audio_visual">Ljud- och videobaserad matchning</string>
     <string name="deduplicator_occupied_space_label">Upptagen lagring</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s upptas av dubbletter</item>

--- a/app-tool-deduplicator/src/main/res/values-sw/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-sw/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Tambua nakala kwa kukokotoa jumla za kuangalia za faili. Faili zenye jumla za kuangalia zinazofanana zina maudhui sawa kabisa.</string>
     <string name="deduplicator_detection_method_phash_title">Hash ya utambuzi</string>
     <string name="deduplicator_detection_method_phash_summary">Pata mafaili yanayofanana kwa kuchanganua vipengele vya maudhui na kulinganisha thamani za hash ya mtazamo. ⚠️ Ugunduzi unaotegemea ufanano unaweza kujumuisha matokeo ya uongo yanayohitaji uthibitisho wa mikono.</string>
+    <string name="deduplicator_detection_method_media_title">Alama ya kidole ya midia</string>
+    <string name="deduplicator_detection_method_media_summary">Tafuta video na faili za sauti zinazofanana kwa kuchambua alama za kidole za sauti. ⚠️ Ugunduzi unaotegemea ufanani unaweza kujumuisha matokeo ya uwongo yanayohitaji uthibitisho wa mkono.</string>
+    <string name="deduplicator_matches_media_label">Midia inayofanana</string>
+    <string name="deduplicator_media_match_audio">Mechi inayotegemea sauti</string>
+    <string name="deduplicator_media_match_visual">Mechi inayotegemea video</string>
+    <string name="deduplicator_media_match_audio_visual">Mechi inayotegemea sauti na video</string>
     <string name="deduplicator_occupied_space_label">Hifadhi iliyotumika</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s inatumika na nakala</item>

--- a/app-tool-deduplicator/src/main/res/values-ta-rIN/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-ta-rIN/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">கோப்புகளுக்கான செக்சம்களை கணக்கீடு செய்வதன் மூலம் நகல்களை நிர்ணயிக்கவும். பொருந்தும் செக்சம்களை கொண்ட கோப்புகள் சரியான அதே விஷயத்தை கொண்டிருக்கும்.</string>
     <string name="deduplicator_detection_method_phash_title">உணர்வு ஹாஷ்</string>
     <string name="deduplicator_detection_method_phash_summary">உள்ளடக்க அம்சங்களை பகுப்பாய்வு செய்து புலனுணர்வு ஹாஷ் மதிப்புகளை ஒப்பிட்டு ஒத்த கோப்புகளைக் கண்டறியவும். ⚠️ ஒற்றுமை அடிப்படையிலான கண்டறிதலில் கைமுறை சரிபார்ப்பு தேவைப்படும் தவறான நேர்மறைகள் இருக்கலாம்.</string>
+    <string name="deduplicator_detection_method_media_title">மீடியா கைரேகை</string>
+    <string name="deduplicator_detection_method_media_summary">ஆடியோ கைரேகைகளை பகுப்பாய்வு செய்வதன் மூலம் ஒத்த வீடியோ மற்றும் ஆடியோ கோப்புகளைக் கண்டறியவும். ⚠️ ஒற்றுமை அடிப்படையிலான கண்டறிதல் தவறான நேர்மறைகளை உள்ளடக்கியிருக்கலாம், கைமுறை சரிபார்ப்பு தேவை.</string>
+    <string name="deduplicator_matches_media_label">ஒத்த மீடியா</string>
+    <string name="deduplicator_media_match_audio">ஆடியோ அடிப்படையிலான பொருத்தம்</string>
+    <string name="deduplicator_media_match_visual">வீடியோ அடிப்படையிலான பொருத்தம்</string>
+    <string name="deduplicator_media_match_audio_visual">ஆடியோ மற்றும் வீடியோ அடிப்படையிலான பொருத்தம்</string>
     <string name="deduplicator_occupied_space_label">ஆக்ரமிக்கப்பட்ட சேமிப்பு</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s நகல்களால் ஆக்ரமிக்கப்பட்டுள்ளது</item>

--- a/app-tool-deduplicator/src/main/res/values-te-rIN/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-te-rIN/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">ఫైల్‌ల కోసం చెక్‌సమ్‌లను లెక్కించి డుప్లికేట్‌లను నిర్ణయించండి. సరిపోలిక చెక్‌సమ్‌ల ఉన్న ఫైల్‌లు సరియాగా అను కంటెంట్ ఉంటాయి.</string>
     <string name="deduplicator_detection_method_phash_title">పర్సెప్చుఅల్ హాష్</string>
     <string name="deduplicator_detection_method_phash_summary">కంటెంట్ ఫీచర్‌లను విశ్లేషించడం మరియు పర్సెప్చువల్ హాష్ విలువలను పోల్చడం ద్వారా సారూప్య ఫైల్‌లను కనుగొనండి. ⚠️ సారూప్యత-ఆధారిత గుర్తింపులో తప్పుడు పాజిటివ్‌లు ఉండవచ్చు, మాన్యువల్ ధృవీకరణ అవసరం.</string>
+    <string name="deduplicator_detection_method_media_title">మీడియా వేలిముద్ర</string>
+    <string name="deduplicator_detection_method_media_summary">ఆడియో వేలిముద్రలను విశ్లేషించడం ద్వారా సారూప్య వీడియో మరియు ఆడియో ఫైళ్ళను కనుగొనండి. ⚠️ సారూప్యత-ఆధారిత గుర్తింపులో తప్పుడు ఫలితాలు ఉండవచ్చు, వాటికి మాన్యువల్ ధృవీకరణ అవసరం.</string>
+    <string name="deduplicator_matches_media_label">సారూప్య మీడియా</string>
+    <string name="deduplicator_media_match_audio">ఆడియో-ఆధారిత సరిపోలిక</string>
+    <string name="deduplicator_media_match_visual">వీడియో-ఆధారిత సరిపోలిక</string>
+    <string name="deduplicator_media_match_audio_visual">ఆడియో మరియు వీడియో-ఆధారిత సరిపోలిక</string>
     <string name="deduplicator_occupied_space_label">ఆక్రమించిన స్టోరేజీ</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s డుప్లికేట్‌లు ఆక్రమించాయి</item>

--- a/app-tool-deduplicator/src/main/res/values-th/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-th/strings.xml
@@ -23,6 +23,12 @@
     <string name="deduplicator_detection_method_checksum_summary">กำหนดไฟล์ซ้ำโดยการคำนวณค่าตรวจสอบสำหรับไฟล์ ไฟล์ที่มีค่าตรวจสอบตรงกันจะมีเนื้อหาเหมือนกันทุกประการ</string>
     <string name="deduplicator_detection_method_phash_title">แฮชการรับรู้</string>
     <string name="deduplicator_detection_method_phash_summary">ค้นหาไฟล์ที่คล้ายกันโดยวิเคราะห์คุณลักษณะเนื้อหาและเปรียบเทียบค่าแฮชเชิงรับรู้ ⚠️ การตรวจจับตามความคล้ายคลึงอาจรวมผลบวกปลอมที่ต้องตรวจสอบด้วยตนเอง</string>
+    <string name="deduplicator_detection_method_media_title">ลายนิ้วมือสื่อ</string>
+    <string name="deduplicator_detection_method_media_summary">ค้นหาไฟล์วิดีโอและเสียงที่คล้ายกันโดยวิเคราะห์ลายนิ้วมือเสียง ⚠️ การตรวจจับตามความคล้ายคลึงอาจรวมถึงผลบวกเท็จที่ต้องการการยืนยันด้วยตนเอง</string>
+    <string name="deduplicator_matches_media_label">สื่อที่คล้ายกัน</string>
+    <string name="deduplicator_media_match_audio">การจับคู่ตามเสียง</string>
+    <string name="deduplicator_media_match_visual">การจับคู่ตามวิดีโอ</string>
+    <string name="deduplicator_media_match_audio_visual">การจับคู่ตามเสียงและวิดีโอ</string>
     <string name="deduplicator_occupied_space_label">พื้นที่ที่ถูกใช้งาน</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="other">%s ถูกใช้งานโดยไฟล์ซ้ำ</item>

--- a/app-tool-deduplicator/src/main/res/values-tr/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-tr/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Dosyalar için sağlama toplamlarını hesaplayarak kopyaları belirleyin. Eşleşen sağlama toplamlarına sahip dosyalar tamamen aynı içeriğe sahiptir.</string>
     <string name="deduplicator_detection_method_phash_title">Algısal hash</string>
     <string name="deduplicator_detection_method_phash_summary">İçerik özelliklerini analiz ederek ve algısal karma değerleri karşılaştırarak benzer dosyaları bulun. ⚠️ Benzerlik tabanlı algılama, manuel doğrulama gerektiren yanlış pozitif sonuçlar içerebilir.</string>
+    <string name="deduplicator_detection_method_media_title">Medya parmak izi</string>
+    <string name="deduplicator_detection_method_media_summary">Ses parmak izlerini analiz ederek benzer video ve ses dosyalarını bulur. ⚠️ Benzerlik tabanlı algılama, manuel doğrulama gerektiren yanlış pozitifler içerebilir.</string>
+    <string name="deduplicator_matches_media_label">Benzer medya</string>
+    <string name="deduplicator_media_match_audio">Ses tabanlı eşleşme</string>
+    <string name="deduplicator_media_match_visual">Video tabanlı eşleşme</string>
+    <string name="deduplicator_media_match_audio_visual">Ses ve video tabanlı eşleşme</string>
     <string name="deduplicator_occupied_space_label">Kullanılan depolama</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s kopyalar tarafından işgal edilmiş</item>

--- a/app-tool-deduplicator/src/main/res/values-uk/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-uk/strings.xml
@@ -29,6 +29,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Визначте дублікати, обчисливши контрольні суми для файлів. Файли з однаковими контрольними сумами мають однаковий вміст.</string>
     <string name="deduplicator_detection_method_phash_title">Хеш сприйняття</string>
     <string name="deduplicator_detection_method_phash_summary">Знаходьте схожі файли, аналізуючи особливості вмісту та порівнюючи сприйнятливі хеш-значення. ⚠️ Виявлення на основі подібності може містити помилкові спрацьовування, які потребують ручної перевірки.</string>
+    <string name="deduplicator_detection_method_media_title">Медіа-відбиток</string>
+    <string name="deduplicator_detection_method_media_summary">Знаходьте схожі відео та аудіофайли за допомогою аналізу аудіовідбитків. ⚠️ Виявлення на основі схожості може супроводжуватися помилковими спрацьовуваннями, які потребують ручної перевірки.</string>
+    <string name="deduplicator_matches_media_label">Схожі медіа</string>
+    <string name="deduplicator_media_match_audio">Збіг на основі аудіо</string>
+    <string name="deduplicator_media_match_visual">Збіг на основі відео</string>
+    <string name="deduplicator_media_match_audio_visual">Збіг на основі аудіо та відео</string>
     <string name="deduplicator_occupied_space_label">Зайняте сховище</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s зайнято дублікатами</item>

--- a/app-tool-deduplicator/src/main/res/values-ur-rIN/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-ur-rIN/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">فائلوں کے لیے چیک سم کی گنتی کرکے ڈپلیکیٹس کا تعین کریں۔ میچنگ چیک سم والی فائلوں میں بالکل وہی مواد ہوتا ہے۔</string>
     <string name="deduplicator_detection_method_phash_title">ادراکی ہیش</string>
     <string name="deduplicator_detection_method_phash_summary">مواد کی خصوصیات کا تجزیہ کر کے اور ادراکی ہیش اقدار کا موازنہ کر کے ملتی جلتی فائلیں تلاش کریں۔ ⚠️ مماثلت پر مبنی شناخت میں غلط مثبت نتائج شامل ہو سکتے ہیں جن کی دستی تصدیق ضروری ہے۔</string>
+    <string name="deduplicator_detection_method_media_title">میڈیا فنگر پرنٹ</string>
+    <string name="deduplicator_detection_method_media_summary">آڈیو فنگر پرنٹس کا تجزیہ کر کے ملتی جلتی ویڈیو اور آڈیو فائلیں تلاش کریں۔ ⚠️ مماثلت پر مبنی پتہ لگانے میں غلط نتائج شامل ہو سکتے ہیں جن کی دستی تصدیق ضروری ہے۔</string>
+    <string name="deduplicator_matches_media_label">ملتا جلتا میڈیا</string>
+    <string name="deduplicator_media_match_audio">آڈیو پر مبنی مماثلت</string>
+    <string name="deduplicator_media_match_visual">ویڈیو پر مبنی مماثلت</string>
+    <string name="deduplicator_media_match_audio_visual">آڈیو اور ویڈیو پر مبنی مماثلت</string>
     <string name="deduplicator_occupied_space_label">قبضہ شدہ سٹوریج</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s ڈپلیکیٹس کے ذریعے قبضہ میں ہے</item>

--- a/app-tool-deduplicator/src/main/res/values-uz/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-uz/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Fayllar uchun nazorat yig\'indilarini hisoblash orqali takrorlanganlarni aniqlash. Mos nazorat yig\'indili fayllar aynan bir xil kontentga ega.</string>
     <string name="deduplicator_detection_method_phash_title">Sezgi hash</string>
     <string name="deduplicator_detection_method_phash_summary">Kontent xususiyatlarini tahlil qilib va perseptual xesh qiymatlarini solishtirish orqali o\'xshash fayllarni topish. ⚠️ O\'xshashlikka asoslangan aniqlash qo\'lda tekshirishni talab qiladigan noto\'g\'ri natijalarni o\'z ichiga olishi mumkin.</string>
+    <string name="deduplicator_detection_method_media_title">Media barmoq izi</string>
+    <string name="deduplicator_detection_method_media_summary">Audio barmoq izlarini tahlil qilib o\'xshash video va audio fayllarni toping. ⚠️ O\'xshashlikka asoslangan aniqlash noto\'g\'ri natijalarni o\'z ichiga olishi mumkin, bu qo\'lda tekshirishni talab qiladi.</string>
+    <string name="deduplicator_matches_media_label">O\'xshash media</string>
+    <string name="deduplicator_media_match_audio">Audioga asoslangan moslik</string>
+    <string name="deduplicator_media_match_visual">Videoga asoslangan moslik</string>
+    <string name="deduplicator_media_match_audio_visual">Audio va videoga asoslangan moslik</string>
     <string name="deduplicator_occupied_space_label">Band xotira</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s takrorlanganlar tomonidan band qilingan</item>

--- a/app-tool-deduplicator/src/main/res/values-vi/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-vi/strings.xml
@@ -23,6 +23,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Xác định các bản sao bằng cách tính tổng kiểm tra cho các tập tin. Các tệp có tổng kiểm tra phù hợp có nội dung giống hệt nhau.</string>
     <string name="deduplicator_detection_method_phash_title">Perceptual hash</string>
     <string name="deduplicator_detection_method_phash_summary">Tìm các tệp tương tự bằng cách phân tích các tính năng nội dung và so sánh các giá trị Hash. ⚠️ Phát hiện dựa trên sự tương đồng có thể bao gồm các kết qủa không chính xác, cần xác minh thủ công.</string>
+    <string name="deduplicator_detection_method_media_title">Dấu ấn Media</string>
+    <string name="deduplicator_detection_method_media_summary">Tìm các tệp video và âm thanh tương tự bằng cách phân tích Dấu ấn âm thanh. ⚠️ Phát hiện dựa trên sự tương đồng có thể bao gồm các kết qủa không chính xác, cần được xác minh thủ công.</string>
+    <string name="deduplicator_matches_media_label">Media tương tự</string>
+    <string name="deduplicator_media_match_audio">Khớp dựa trên âm thanh</string>
+    <string name="deduplicator_media_match_visual">Khớp dựa trên video</string>
+    <string name="deduplicator_media_match_audio_visual">Khớp dựa trên âm thanh và video</string>
     <string name="deduplicator_occupied_space_label">Bộ nhớ bị chiếm dụng</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="other">%s bị chiếm bởi các bản sao</item>

--- a/app-tool-deduplicator/src/main/res/values-zh-rCN/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-zh-rCN/strings.xml
@@ -23,6 +23,12 @@
     <string name="deduplicator_detection_method_checksum_summary">通过计算文件的校验和来确定重复项，校验和匹配的文件具有「完全相同」的内容</string>
     <string name="deduplicator_detection_method_phash_title">感知哈希</string>
     <string name="deduplicator_detection_method_phash_summary">通过分析内容特征并比较感知哈希值来查找相似文件。⚠️ 基于相似度的检测可能包含需要人工验证的误报。</string>
+    <string name="deduplicator_detection_method_media_title">媒体指纹</string>
+    <string name="deduplicator_detection_method_media_summary">通过分析音频指纹查找相似的视频和音频文件。⚠️ 基于相似度的检测可能包含误报，需要手动验证。</string>
+    <string name="deduplicator_matches_media_label">相似媒体</string>
+    <string name="deduplicator_media_match_audio">基于音频的匹配</string>
+    <string name="deduplicator_media_match_visual">基于视频的匹配</string>
+    <string name="deduplicator_media_match_audio_visual">基于音频和视频的匹配</string>
     <string name="deduplicator_occupied_space_label">占用的存储空间</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="other">重复项占用 %s</item>

--- a/app-tool-deduplicator/src/main/res/values-zh-rHK/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-zh-rHK/strings.xml
@@ -23,6 +23,12 @@
     <string name="deduplicator_detection_method_checksum_summary">通過計算文件校驗和以確定重複文件。校驗和相同的文件具有完全相同的內容。</string>
     <string name="deduplicator_detection_method_phash_title">感知哈希值</string>
     <string name="deduplicator_detection_method_phash_summary">透過分析內容特徵和比較感知雜湊值來尋找相似檔案。⚠️ 基於相似度的偵測可能會包含誤判結果，需要手動驗證。</string>
+    <string name="deduplicator_detection_method_media_title">媒體指紋</string>
+    <string name="deduplicator_detection_method_media_summary">透過分析音訊指紋尋找相似的影片和音訊檔案。⚠️ 基於相似度的偵測可能包含需要手動驗證的誤報。</string>
+    <string name="deduplicator_matches_media_label">相似媒體</string>
+    <string name="deduplicator_media_match_audio">基於音訊的匹配</string>
+    <string name="deduplicator_media_match_visual">基於影片的匹配</string>
+    <string name="deduplicator_media_match_audio_visual">基於音訊和影片的匹配</string>
     <string name="deduplicator_occupied_space_label">已佔用空間</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="other">%s 被重複項佔用</item>

--- a/app-tool-deduplicator/src/main/res/values-zh-rTW/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-zh-rTW/strings.xml
@@ -23,6 +23,12 @@
     <string name="deduplicator_detection_method_checksum_summary">透過計算檔案的總和檢查碼來確定重複項目，總和檢查碼相符的檔案具有完全相同的內容。</string>
     <string name="deduplicator_detection_method_phash_title">感知雜湊</string>
     <string name="deduplicator_detection_method_phash_summary">透過分析內容特徵與比對感知雜湊值（Perceptual Hash）來找出相似檔案。⚠️ 基於相似度的偵測可能會出現誤判，請務必進行人工確認。</string>
+    <string name="deduplicator_detection_method_media_title">媒體指紋</string>
+    <string name="deduplicator_detection_method_media_summary">透過分析音訊指紋找出相似的影片和音訊檔案。⚠️ 基於相似性的偵測可能包含誤報，需要手動驗證。</string>
+    <string name="deduplicator_matches_media_label">相似媒體</string>
+    <string name="deduplicator_media_match_audio">基於音訊的配對</string>
+    <string name="deduplicator_media_match_visual">基於影片的配對</string>
+    <string name="deduplicator_media_match_audio_visual">基於音訊和影片的配對</string>
     <string name="deduplicator_occupied_space_label">佔用儲存空間</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="other">%s 被重複項目佔用</item>

--- a/app-tool-deduplicator/src/main/res/values-zu/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-zu/strings.xml
@@ -25,6 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Nquma okukhophisiwe ngokubala ama-checksum wamafayela. Amafayela ama-checksum afanayo anokuqukethwe okufanayo ngqo.</string>
     <string name="deduplicator_detection_method_phash_title">I-hash yokubona</string>
     <string name="deduplicator_detection_method_phash_summary">Thola amafayela afanayo ngokuhlaziya izici zokuqukethwe nokuqhathanisa amagugu e-hash okuqonda. ⚠️ Ukutholwa okungesokunembile okusekelwe kufanayo kungafaka imiphumela engalona iqiniso edinga ukuqinisekiswa ngesandla.</string>
+    <string name="deduplicator_detection_method_media_title">Uphawu lwemidiya</string>
+    <string name="deduplicator_detection_method_media_summary">Thola amafayela efuziwe evidiyo namazwi ngokuhlaziya izimpawu zamazwi. ⚠️ Ukutholwa okusekelwe okulunganayo kungahlanganisa izinto ezingeyizo ezidinga ukuqinisekiswa ngesandla.</string>
+    <string name="deduplicator_matches_media_label">Imidiya efanayo</string>
+    <string name="deduplicator_media_match_audio">Ukufanana okusekelwe kumazwi</string>
+    <string name="deduplicator_media_match_visual">Ukufanana okusekelwe evidiyo</string>
+    <string name="deduplicator_media_match_audio_visual">Ukufanana okusekelwe kumazwi nasevidiyo</string>
     <string name="deduplicator_occupied_space_label">Isitoreji esihleli</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">I-%s ihleli okukhophisiwe</item>

--- a/app-tool-scheduler/src/main/res/values-af-rZA/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-af-rZA/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">Skeduleerder</string>
     <string name="scheduler_notification_title">Geskeduleerde taak</string>
     <string name="scheduler_notification_message">Voer uit: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Skeduleerderresultate</string>
     <string name="scheduler_notification_result_title">Skeduleerder klaar</string>
     <string name="scheduler_notification_result_success_message">Alle geskeduleerde take het suksesvol geloop.</string>
     <string name="scheduler_notification_result_failure_message">Sommige geskeduleerde take het gefaal of foute ondervind. Probeer om hulle handmatig te loop.</string>

--- a/app-tool-scheduler/src/main/res/values-am/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-am/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">መርሃ ግብር አዘጋጅ</string>
     <string name="scheduler_notification_title">የታቀደ ተግባር</string>
     <string name="scheduler_notification_message">በአፈጻጸም ላይ: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">የጊዜ ሰሌዳ ውጤቶች</string>
     <string name="scheduler_notification_result_title">መርሃ ግብር አዘጋጅ ተጠናቅቋል</string>
     <string name="scheduler_notification_result_success_message">ሁሉም የታቀዱ ተግባራት በተሳካ ሁኔታ ተሠርተዋል።</string>
     <string name="scheduler_notification_result_failure_message">አንዳንድ የታቀዱ ተግባራት ተሳሽተዋል ወይም ስህተቶች አጋጥመዋቸዋል። በእጅ ማስኬድ ይሞክሩ።</string>

--- a/app-tool-scheduler/src/main/res/values-ar/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-ar/strings.xml
@@ -36,6 +36,7 @@
     <string name="scheduler_notification_channel_label">الجدولة</string>
     <string name="scheduler_notification_title">المهام المجدولة</string>
     <string name="scheduler_notification_message">جارٍ التنفيذ: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">نتائج جدولة المهام</string>
     <string name="scheduler_notification_result_title">انتهت الجدولة</string>
     <string name="scheduler_notification_result_success_message">تمت جميع المهام المجدولة بنجاح.</string>
     <string name="scheduler_notification_result_failure_message">بعض المهام المجدولة فشلت أو واجهت أخطاء. حاول تشغيلها يدويا.</string>

--- a/app-tool-scheduler/src/main/res/values-az/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-az/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">Planlayıcı</string>
     <string name="scheduler_notification_title">Planlaşdırılmış tapşırıq</string>
     <string name="scheduler_notification_message">İcra edilir: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Planlaşdırıcı nəticələri</string>
     <string name="scheduler_notification_result_title">Planlayıcı tamamlandı</string>
     <string name="scheduler_notification_result_success_message">Bütün planlaşdırılmış tapşırıqlar uğurla işlədi.</string>
     <string name="scheduler_notification_result_failure_message">Bəzi planlaşdırılmış tapşırıqlar uğursuz oldu və ya xətalarla qarşılaşdı. Onları əl ilə işlətməyi cəhd edin.</string>

--- a/app-tool-scheduler/src/main/res/values-be/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-be/strings.xml
@@ -34,6 +34,7 @@
     <string name="scheduler_notification_channel_label">Планіроўшчык</string>
     <string name="scheduler_notification_title">Запланаванае заданне</string>
     <string name="scheduler_notification_message">Выкананне: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Вынікі планавальніка</string>
     <string name="scheduler_notification_result_title">Планіроўшчык завяршыў працу</string>
     <string name="scheduler_notification_result_success_message">Усе запланаваныя задачы паспяхова выкананы.</string>
     <string name="scheduler_notification_result_failure_message">Некаторыя запланаваныя задачы не выкананы або пры іх выкананні ўзніклі памылкі. Паспрабуйце запусціць іх уручную.</string>

--- a/app-tool-scheduler/src/main/res/values-bg/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-bg/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">Планировчик</string>
     <string name="scheduler_notification_title">Планирана задача</string>
     <string name="scheduler_notification_message">Изпълнява се: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Резултати от планировчика</string>
     <string name="scheduler_notification_result_title">Планировчикът завърши</string>
     <string name="scheduler_notification_result_success_message">Всички планирани задачи се изпълниха успешно.</string>
     <string name="scheduler_notification_result_failure_message">Някои планирани задачи се провалиха или срещнаха грешки. Опитайте да ги стартирате ръчно.</string>

--- a/app-tool-scheduler/src/main/res/values-bn-rBD/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-bn-rBD/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">সময়সূচী</string>
     <string name="scheduler_notification_title">সূচীভুক্ত কাজ</string>
     <string name="scheduler_notification_message">কার্যকর করা হচ্ছে: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">শিডিউলারের ফলাফল</string>
     <string name="scheduler_notification_result_title">সময়সূচী সমাপ্ত</string>
     <string name="scheduler_notification_result_success_message">সমস্ত নির্ধারিত কাজ সফলভাবে চালিত হয়েছে৷</string>
     <string name="scheduler_notification_result_failure_message">কিছু নির্ধারিত কাজ ব্যর্থ হয়েছে বা ত্রুটির সম্মুখীন হয়েছে। এগুলোকে নিজে নিজে চালানোর চেষ্টা করুন।</string>

--- a/app-tool-scheduler/src/main/res/values-ca/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-ca/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">Programador</string>
     <string name="scheduler_notification_title">Tasca programada</string>
     <string name="scheduler_notification_message">Executant: «%s»</string>
+    <string name="scheduler_notification_result_channel_label">Resultats del programador</string>
     <string name="scheduler_notification_result_title">El programador ha finalitat</string>
     <string name="scheduler_notification_result_success_message">Totes les tasques programades s\'han executat correctament.</string>
     <string name="scheduler_notification_result_failure_message">Algunes tasques programades han fallat o han trobat errors. Proveu d\'executar-les manualment.</string>

--- a/app-tool-scheduler/src/main/res/values-ckb-rIR/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-ckb-rIR/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">زامانبەست</string>
     <string name="scheduler_notification_title">کاری زامانکراو</string>
     <string name="scheduler_notification_message">ئەنجامدان: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">ڕیکئەکانی ڤەرمانبەری</string>
     <string name="scheduler_notification_result_title">زامانبەست تەواو بوو</string>
     <string name="scheduler_notification_result_success_message">هەموو کارە زامانکراوەکان بە سەرکەوتوویی ئەنجامدران.</string>
     <string name="scheduler_notification_result_failure_message">Some scheduled tasks failed or encountered هەڵەs. Try running them manually.</string>

--- a/app-tool-scheduler/src/main/res/values-cs/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-cs/strings.xml
@@ -34,6 +34,7 @@
     <string name="scheduler_notification_channel_label">Plánovač</string>
     <string name="scheduler_notification_title">Naplánovaná úloha</string>
     <string name="scheduler_notification_message">Spouštím: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Výsledky plánovače</string>
     <string name="scheduler_notification_result_title">Plánování dokončeno</string>
     <string name="scheduler_notification_result_success_message">Všechny naplánované úlohy proběhly úspěšně.</string>
     <string name="scheduler_notification_result_failure_message">Některé naplánované úlohy selhaly nebo došlo k chybám. Zkuste je spustit ručně.</string>

--- a/app-tool-scheduler/src/main/res/values-da/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-da/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">Planlægger</string>
     <string name="scheduler_notification_title">Planlagt opgave</string>
     <string name="scheduler_notification_message">Udfører: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Planlæggerresultater</string>
     <string name="scheduler_notification_result_title">Planlæggeren er færdig</string>
     <string name="scheduler_notification_result_success_message">Alle planlagte opgaver blev kørt.</string>
     <string name="scheduler_notification_result_failure_message">Nogle planlagte opgaver mislykkedes eller stødte på fejl. Prøv at køre dem manuelt.</string>

--- a/app-tool-scheduler/src/main/res/values-de/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-de/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">Zeitplaner</string>
     <string name="scheduler_notification_title">Geplante Aufgabe</string>
     <string name="scheduler_notification_message">Ausführen: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Zeitplan-Ergebnisse</string>
     <string name="scheduler_notification_result_title">Planer beendet</string>
     <string name="scheduler_notification_result_success_message">Alle geplanten Aufgaben wurden erfolgreich ausgeführt.</string>
     <string name="scheduler_notification_result_failure_message">Einige geplante Aufgaben sind fehlgeschlagen oder es sind Fehler aufgetreten. Versuchen Sie, sie manuell auszuführen.</string>

--- a/app-tool-scheduler/src/main/res/values-el/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-el/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">Χρονοδιάγραμμα</string>
     <string name="scheduler_notification_title">Προγραμματισμένες εργασίες</string>
     <string name="scheduler_notification_message">Εκτελείται: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Αποτελέσματα προγραμματιστή</string>
     <string name="scheduler_notification_result_title">Ο προγραμματισμός ολοκληρώθηκε</string>
     <string name="scheduler_notification_result_success_message">Όλες οι προγραμματισμένες εργασίες εκτελέστηκαν με επιτυχία.</string>
     <string name="scheduler_notification_result_failure_message">Ορισμένες προγραμματισμένες εργασίες απέτυχαν ή αντιμετώπισαν σφάλματα. Δοκιμάστε να τις εκτελέσετε χειροκίνητα.</string>

--- a/app-tool-scheduler/src/main/res/values-es-rAR/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-es-rAR/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">Planificador</string>
     <string name="scheduler_notification_title">Tarea programada</string>
     <string name="scheduler_notification_message">Ejecutando: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Resultados del programador</string>
     <string name="scheduler_notification_result_title">Planificador terminado</string>
     <string name="scheduler_notification_result_success_message">Todas las tareas programadas se han ejecutado correctamente.</string>
     <string name="scheduler_notification_result_failure_message">Algunas tareas programadas fallaron o encontraron errores. Intente ejecutarlas manualmente.</string>

--- a/app-tool-scheduler/src/main/res/values-es-rMX/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-es-rMX/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">Programador</string>
     <string name="scheduler_notification_title">Tarea programada</string>
     <string name="scheduler_notification_message">Ejecutando: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Resultados del programador</string>
     <string name="scheduler_notification_result_title">El programador ha terminado</string>
     <string name="scheduler_notification_result_success_message">Todas las tareas programadas se han ejecutado correctamente.</string>
     <string name="scheduler_notification_result_failure_message">Algunas tareas programadas fallaron o encontraron errores. Intente ejecutarlas manualmente.</string>

--- a/app-tool-scheduler/src/main/res/values-es/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-es/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">Programador</string>
     <string name="scheduler_notification_title">Tarea programada</string>
     <string name="scheduler_notification_message">Ejecutando: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Resultados del programador</string>
     <string name="scheduler_notification_result_title">El programador ha terminado</string>
     <string name="scheduler_notification_result_success_message">Todas las tareas programadas se han ejecutado correctamente.</string>
     <string name="scheduler_notification_result_failure_message">Algunas tareas programadas fallaron o encontraron errores. Intente ejecutarlas manualmente.</string>

--- a/app-tool-scheduler/src/main/res/values-et-rEE/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-et-rEE/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">Ajastaja</string>
     <string name="scheduler_notification_title">Ajastatud ülesanne</string>
     <string name="scheduler_notification_message">Käivitub: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Ajastaja tulemused</string>
     <string name="scheduler_notification_result_title">Ajastatu lõppes</string>
     <string name="scheduler_notification_result_success_message">Kõik ajastatud ülesanded lõppesid edukalt.</string>
     <string name="scheduler_notification_result_failure_message">Osad ajastatud ülesanded nurjusid või sattusid vea otsa. Üritage neid ise teha.</string>

--- a/app-tool-scheduler/src/main/res/values-eu-rES/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-eu-rES/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">Ordutegia</string>
     <string name="scheduler_notification_title">Planifikatutako ataza</string>
     <string name="scheduler_notification_message">Exekutatzen: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Programatzailearen emaitzak</string>
     <string name="scheduler_notification_result_title">Ordutegia amaituta</string>
     <string name="scheduler_notification_result_success_message">Planifikatutako ataza guztiak arrakastaz exekutatu dira.</string>
     <string name="scheduler_notification_result_failure_message">Planifikatutako ataza batzuek huts egin dute edo erroreak jaso dituzte. Saiatu eskuz exekutatzen.</string>

--- a/app-tool-scheduler/src/main/res/values-fa/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-fa/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">برنامه ریز</string>
     <string name="scheduler_notification_title">وظیفه زمان‌بندی شده</string>
     <string name="scheduler_notification_message">اجرایی: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">نتایج زمان‌بند</string>
     <string name="scheduler_notification_result_title">برنامه‌ زمان‌بندی به پایان رسید.</string>
     <string name="scheduler_notification_result_success_message">تمام وظایف زمان‌بندی شده با موفقیت اجرا شدند.</string>
     <string name="scheduler_notification_result_failure_message">برخی از وظایف زمان‌بندی شده با خطا مواجه شدند یا شکست خوردند. سعی کنید آنها را به صورت دستی اجرا کنید.</string>

--- a/app-tool-scheduler/src/main/res/values-fi/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-fi/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">Ajastin</string>
     <string name="scheduler_notification_title">Ajoitettu tehtävä</string>
     <string name="scheduler_notification_message">Suoritetaan: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Ajastimen tulokset</string>
     <string name="scheduler_notification_result_title">Ajastin valmis</string>
     <string name="scheduler_notification_result_success_message">Kaikki ajoitetut tehtävät suoritettiin onnistuneesti.</string>
     <string name="scheduler_notification_result_failure_message">Jotkut ajoitetut tehtävät epäonnistuivat tai kohtasivat virheitä. Kokeile suorittaa ne manuaalisesti.</string>

--- a/app-tool-scheduler/src/main/res/values-fil/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-fil/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">Taga-iskedyul</string>
     <string name="scheduler_notification_title">Naka-schedule na task</string>
     <string name="scheduler_notification_message">Ine-execute: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Mga resulta ng Scheduler</string>
     <string name="scheduler_notification_result_title">Tapos na ang scheduler</string>
     <string name="scheduler_notification_result_success_message">Lahat ng naka-schedule na task ay matagumpay na nag-run.</string>
     <string name="scheduler_notification_result_failure_message">Ang ilang naka-schedule na task ay nabigo o nakatagpo ng mga error. Subukang patakbuhin ito nang mano-mano.</string>

--- a/app-tool-scheduler/src/main/res/values-fr/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-fr/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">Programmateur</string>
     <string name="scheduler_notification_title">Tâche programmée</string>
     <string name="scheduler_notification_message">Exécution : %s</string>
+    <string name="scheduler_notification_result_channel_label">Résultats du planificateur</string>
     <string name="scheduler_notification_result_title">Le programmateur a terminé</string>
     <string name="scheduler_notification_result_success_message">Toutes vos tâches programmées ont été effectuées correctement.</string>
     <string name="scheduler_notification_result_failure_message">Certaines tâches ont échoué ou des erreurs sont survenues. Tentez de les effectuer manuellement.</string>

--- a/app-tool-scheduler/src/main/res/values-gl-rES/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-gl-rES/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">Programador</string>
     <string name="scheduler_notification_title">Tarefa programada</string>
     <string name="scheduler_notification_message">Executando: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Resultados do programador</string>
     <string name="scheduler_notification_result_title">Programador finalizado</string>
     <string name="scheduler_notification_result_success_message">Todas as tarefas programadas executáronse correctamente.</string>
     <string name="scheduler_notification_result_failure_message">Algunhas tarefas programadas fallaron ou atoparon erros. Probe a executalas manualmente.</string>

--- a/app-tool-scheduler/src/main/res/values-hi-rIN/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-hi-rIN/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">शेड्यूलर</string>
     <string name="scheduler_notification_title">शेड्यूल किया गया कार्य</string>
     <string name="scheduler_notification_message">निष्पादित किया जा रहा है: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">शेड्यूलर परिणाम</string>
     <string name="scheduler_notification_result_title">शेड्यूलर समाप्त</string>
     <string name="scheduler_notification_result_success_message">सभी शेड्यूल किए गए कार्य सफलतापूर्वक चले।</string>
     <string name="scheduler_notification_result_failure_message">कुछ शेड्यूल किए गए कार्य असफल हुए या त्रुटियों का सामना करना पड़ा। उन्हें मैन्युअल रूप से चलाने का प्रयास करें।</string>

--- a/app-tool-scheduler/src/main/res/values-hr/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-hr/strings.xml
@@ -33,6 +33,7 @@
     <string name="scheduler_notification_channel_label">Planer</string>
     <string name="scheduler_notification_title">Zakazani zadatak</string>
     <string name="scheduler_notification_message">Izvršavanje: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Rezultati planera</string>
     <string name="scheduler_notification_result_title">Planer završen</string>
     <string name="scheduler_notification_result_success_message">Svi zakazani zadaci su uspješno izvršeni.</string>
     <string name="scheduler_notification_result_failure_message">Neki zakazani zadaci nisu uspješni ili su naišli na greške. Pokušajte ih pokrenuti ručno.</string>

--- a/app-tool-scheduler/src/main/res/values-hu/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-hu/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">Ütemező</string>
     <string name="scheduler_notification_title">Ütemezett terv</string>
     <string name="scheduler_notification_message">Végrehajtás: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Ütemező eredmények</string>
     <string name="scheduler_notification_result_title">Az ütemező végzett</string>
     <string name="scheduler_notification_result_success_message">Minden ütemezett feladat sikeresen futtatva.</string>
     <string name="scheduler_notification_result_failure_message">Néhány ütemezett feladat meghiúsult vagy hibákat észlelt. Próbálja meg manuálisan futtatni őket.</string>

--- a/app-tool-scheduler/src/main/res/values-in/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-in/strings.xml
@@ -31,6 +31,7 @@
     <string name="scheduler_notification_channel_label">Penjadwal</string>
     <string name="scheduler_notification_title">Tugas terjadwal</string>
     <string name="scheduler_notification_message">Menjalankan: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Hasil penjadwal</string>
     <string name="scheduler_notification_result_title">Penjadwal selesai</string>
     <string name="scheduler_notification_result_success_message">Semua tugas yang dijadwalkan berhasil dijalankan.</string>
     <string name="scheduler_notification_result_failure_message">Beberapa tugas terjadwal gagal atau mengalami kesalahan. Cobalah menjalankannya secara manual.</string>

--- a/app-tool-scheduler/src/main/res/values-is/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-is/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">Tímasetjari</string>
     <string name="scheduler_notification_title">Áætlað verkefni</string>
     <string name="scheduler_notification_message">Keyri: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Niðurstöður tímasetningar</string>
     <string name="scheduler_notification_result_title">Tímasetjari kláraður</string>
     <string name="scheduler_notification_result_success_message">Öll áætluð verkefni voru keyrð.</string>
     <string name="scheduler_notification_result_failure_message">Sum áætluð verkefni mistókust eða lentu í villum. Prófaðu að keyra þau handvirkt.</string>

--- a/app-tool-scheduler/src/main/res/values-it/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-it/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">Pianificatore</string>
     <string name="scheduler_notification_title">Attività pianificata</string>
     <string name="scheduler_notification_message">Esecuzione di: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Risultati dello scheduler</string>
     <string name="scheduler_notification_result_title">Pianificazione completata</string>
     <string name="scheduler_notification_result_success_message">Tutte le attività pianificate sono state eseguite con successo.</string>
     <string name="scheduler_notification_result_failure_message">Alcune attività pianificate sono fallite o hanno riscontrato errori. Provare ad eseguirle manualmente.</string>

--- a/app-tool-scheduler/src/main/res/values-iw/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-iw/strings.xml
@@ -34,6 +34,7 @@
     <string name="scheduler_notification_channel_label">מתזמן</string>
     <string name="scheduler_notification_title">משימה מתוזמנת</string>
     <string name="scheduler_notification_message">מבצע: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">תוצאות מתזמן</string>
     <string name="scheduler_notification_result_title">תזמון הסתיים</string>
     <string name="scheduler_notification_result_success_message">כל המשימות המתוזמנות פעלו בהצלחה.</string>
     <string name="scheduler_notification_result_failure_message">חלק מהמשימות המתוזמנות נכשלו או נתקלו בשגיאות. נסה להפעיל אותם ידנית.</string>

--- a/app-tool-scheduler/src/main/res/values-ja/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-ja/strings.xml
@@ -31,6 +31,7 @@
     <string name="scheduler_notification_channel_label">スケジューラー</string>
     <string name="scheduler_notification_title">スケジュールされたタスク</string>
     <string name="scheduler_notification_message">実行中: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">スケジューラーの結果</string>
     <string name="scheduler_notification_result_title">スケジューラが完了しました</string>
     <string name="scheduler_notification_result_success_message">すべてのスケジュールされたタスクが正常に実行されました。</string>
     <string name="scheduler_notification_result_failure_message">スケジュールされたタスクの一部で失敗またはエラーが発生しました。手動で実行してください。</string>

--- a/app-tool-scheduler/src/main/res/values-ka-rGE/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-ka-rGE/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">მგეგმავი</string>
     <string name="scheduler_notification_title">დაგეგმილი ამოცანა</string>
     <string name="scheduler_notification_message">შესრულება: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">გამრიგებლის შედეგები</string>
     <string name="scheduler_notification_result_title">მგეგმავი დასრულდა</string>
     <string name="scheduler_notification_result_success_message">ყველა დაგეგმილი ამოცანა წარმატებით შესრულდა.</string>
     <string name="scheduler_notification_result_failure_message">ზოგიერთი დაგეგმილი ამოცანა ვერ შესრულდა ან წააწყდა შეცდომებს. სცადეთ მათი მანუალური გაშვება.</string>

--- a/app-tool-scheduler/src/main/res/values-kaa/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-kaa/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">Keste</string>
     <string name="scheduler_notification_title">Josparlangan tapshırw</string>
     <string name="scheduler_notification_message">Orınlang̱an: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Режелестириўши нәтийжелери</string>
     <string name="scheduler_notification_result_title">Josparlaushı tamamlandı</string>
     <string name="scheduler_notification_result_success_message">Barlıq josparlangan tapshırıqlar tabıslı orınlandı.</string>
     <string name="scheduler_notification_result_failure_message">Bazi josparlangan tapshırıqlar sátsiz bolıp yáki qateler keszikti. Olarıń qoldan orınlag̱anıŋızın sinag̱ıŋ.</string>

--- a/app-tool-scheduler/src/main/res/values-km-rKH/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-km-rKH/strings.xml
@@ -31,6 +31,7 @@
     <string name="scheduler_notification_channel_label">ការកំណត់ការរង្វាំ</string>
     <string name="scheduler_notification_title">ការងារត័ត្រូវបានកំណត់</string>
     <string name="scheduler_notification_message">កំពុងដំឡើរ: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">លទ្ធផល​កម្មវិធីកំណត់ពេលវេលា</string>
     <string name="scheduler_notification_result_title">ការរង្វាំបានប័រចប់</string>
     <string name="scheduler_notification_result_success_message">ការងារត័ត្រូទាំងនាំត្រូវបានជៅកជ័យ។</string>
     <string name="scheduler_notification_result_failure_message">ការងារខ្ឡើនមួយបានប័កស្ខាល ឬប័ត្រងកៀស។ ស្វែងដែលប័រើរត្រងដ្តី។</string>

--- a/app-tool-scheduler/src/main/res/values-ko/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-ko/strings.xml
@@ -31,6 +31,7 @@
     <string name="scheduler_notification_channel_label">예약관리자</string>
     <string name="scheduler_notification_title">예약 작</string>
     <string name="scheduler_notification_message">실행 : \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">스케줄러 결과</string>
     <string name="scheduler_notification_result_title">스케쥴 완료</string>
     <string name="scheduler_notification_result_success_message">스케줄된 모든 작업을 성공적으로 완료했습니다.</string>
     <string name="scheduler_notification_result_failure_message">일부 예약된 작업이 실패했거나 오류가 발생했습니다. 수동으로 실행해 보세요.</string>

--- a/app-tool-scheduler/src/main/res/values-lo-rLA/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-lo-rLA/strings.xml
@@ -31,6 +31,7 @@
     <string name="scheduler_notification_channel_label">ຕັວຈັດຕາຣາງເວລາ</string>
     <string name="scheduler_notification_title">ງານທີ່ຖືກວາງເວລາ</string>
     <string name="scheduler_notification_message">ກຳລັງທໍາງານ: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">ຜົນໄດ້ຮັບຂອງຕາຕະລາງ</string>
     <string name="scheduler_notification_result_title">ຕັວຈັດຕາຣາງເວລາສຳເລີດແລ້ວ</string>
     <string name="scheduler_notification_result_success_message">ງານຕາຣາງເວລາທັງຫມົດທໍາງານສຳເລີດ.</string>
     <string name="scheduler_notification_result_failure_message">ງານຕາຣາງເວລາບາງอັນລ້ວເຫລວ ຫຼືພົບຂໍ້ຜິດພາດ. ລອງທໍາງານດ້ວຍຕນເອງ.</string>

--- a/app-tool-scheduler/src/main/res/values-lt/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-lt/strings.xml
@@ -34,6 +34,7 @@
     <string name="scheduler_notification_channel_label">Planuotuvas</string>
     <string name="scheduler_notification_title">Planuojama užduotis</string>
     <string name="scheduler_notification_message">Vykdoma: „%s“</string>
+    <string name="scheduler_notification_result_channel_label">Planuoklio rezultatai</string>
     <string name="scheduler_notification_result_title">Planuotuvas baigė</string>
     <string name="scheduler_notification_result_success_message">Visos planuotos užduotys įvykdytos sėkmingai.</string>
     <string name="scheduler_notification_result_failure_message">Kai kurios planuotos užduotys nepavyko arba susidarė klaidų. Pabandykite jas vykdyti rankiniu būdu.</string>

--- a/app-tool-scheduler/src/main/res/values-lv/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-lv/strings.xml
@@ -33,6 +33,7 @@
     <string name="scheduler_notification_channel_label">Plānotājs</string>
     <string name="scheduler_notification_title">Plānotais uzdevums</string>
     <string name="scheduler_notification_message">Izpilda: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Plānotāja rezultāti</string>
     <string name="scheduler_notification_result_title">Grafiks pabeigts</string>
     <string name="scheduler_notification_result_success_message">Visi plānotie uzdevumi tika izpildīti veiksmgi.</string>
     <string name="scheduler_notification_result_failure_message">Daži plānotić uzdevumi neizdevās vai saskara ar kļūdām. Mēģiniet tos izpildīt manuāli.</string>

--- a/app-tool-scheduler/src/main/res/values-mk-rMK/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-mk-rMK/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">Распоредувач</string>
     <string name="scheduler_notification_title">Закажана задача</string>
     <string name="scheduler_notification_message">Извршување: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Резултати на распоредувачот</string>
     <string name="scheduler_notification_result_title">Распоредувачот заврши</string>
     <string name="scheduler_notification_result_success_message">Сите закажани задачи се извршија успешно.</string>
     <string name="scheduler_notification_result_failure_message">Некои закажани задачи не успеаја или наидоа на грешки. Обидете се да ги извршите рачно.</string>

--- a/app-tool-scheduler/src/main/res/values-ml-rIN/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-ml-rIN/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">ഷെഡ്യൂർ</string>
     <string name="scheduler_notification_title">ഷെഡ്യൂർ ചെയ്ത ടാസ്ക്</string>
     <string name="scheduler_notification_message">നടപ്പിലാക്കുന്നു: “%s”</string>
+    <string name="scheduler_notification_result_channel_label">ഷെഡ്യൂളർ ഫലങ്ങൾ</string>
     <string name="scheduler_notification_result_title">ഷെഡ്യൂർ പൂർത്തിയായി</string>
     <string name="scheduler_notification_result_success_message">ഷെഡ്യൂർ ചെയ്ത എല്ലാ ടാസ്ക്കുകളും വിജയകരമായി പൂർത്തിയായി.</string>
     <string name="scheduler_notification_result_failure_message">ചില ഷെഡ്യൂർ ടാസ്ക്കുകൾ പരാജയപ്പെടുകയോ പിശകുകൾ നേരിടുകയോ ചെയ്തു. അവ കൈയാർ നടത്തി പരീക്ഷിക്കുക.</string>

--- a/app-tool-scheduler/src/main/res/values-mn-rMN/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-mn-rMN/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">Төлөвлөгч</string>
     <string name="scheduler_notification_title">Төлөвлөгдсөн даалгавар</string>
     <string name="scheduler_notification_message">Гүйцэтгэж байна: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Хуваарьлагчийн үр дүнгүүд</string>
     <string name="scheduler_notification_result_title">Төлөвлөгч дууссан</string>
     <string name="scheduler_notification_result_success_message">Бүх төлөвлөгдсөн даалгаврууд амжилттай гүйцэтгэгдсэн.</string>
     <string name="scheduler_notification_result_failure_message">Зарим төлөвлөгдсөн даалгаврууд амжилтгүй болсон эсвэл алдаатай тулгарсан. Гар аргаар ажиллуулж үзнэ үү.</string>

--- a/app-tool-scheduler/src/main/res/values-ms/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-ms/strings.xml
@@ -31,6 +31,7 @@
     <string name="scheduler_notification_channel_label">Penjadual</string>
     <string name="scheduler_notification_title">Tugas berjadual</string>
     <string name="scheduler_notification_message">Melaksanakan: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Keputusan penjadual</string>
     <string name="scheduler_notification_result_title">Penjadual selesai</string>
     <string name="scheduler_notification_result_success_message">Semua tugas berjadual berjalan dengan jayanya.</string>
     <string name="scheduler_notification_result_failure_message">Beberapa tugas berjadual gagal atau menghadapi ralat. Cuba jalankan secara manual.</string>

--- a/app-tool-scheduler/src/main/res/values-my-rMM/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-my-rMM/strings.xml
@@ -31,6 +31,7 @@
     <string name="scheduler_notification_channel_label">အချိန်ဇယား ချိန်ညှိမှု</string>
     <string name="scheduler_notification_title">ဆုံးဆေးခြယ်စိုး</string>
     <string name="scheduler_notification_message">အလုပ်ဆောင်ချနေစ်သည်: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">အချိန်ဇယား ရလဒ်များ</string>
     <string name="scheduler_notification_result_title">ဆုံးဆေးပြီးသောသည်</string>
     <string name="scheduler_notification_result_success_message">ဆုံးဆေးခြယ်စိုးများအားလုံး အအကြေးများ ပြမည့်ပြမည့် အလုပ်ဆောင်ချပြီးသည်။</string>
     <string name="scheduler_notification_result_failure_message">ဆုံးဆေးခြယ်စိုးများအချား အချားများ မအစားတွေနေရာပြီးသည် သိုမရှိပါ။ ကိုယ်ကိုယ် အလုပ်ဆောင်ချပြမည့်တွက်အသုံးချသည်။</string>

--- a/app-tool-scheduler/src/main/res/values-nb/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-nb/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">Planlegger</string>
     <string name="scheduler_notification_title">Planlagt oppgave</string>
     <string name="scheduler_notification_message">Utfører: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Planleggerresultater</string>
     <string name="scheduler_notification_result_title">Planlegger ferdig</string>
     <string name="scheduler_notification_result_success_message">Alle planlagte oppgaver kjørte vellykket.</string>
     <string name="scheduler_notification_result_failure_message">Noen planlagte oppgaver mislyktes eller møtte feil. Prøv å kjøre dem manuelt.</string>

--- a/app-tool-scheduler/src/main/res/values-ne-rNP/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-ne-rNP/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">शेड्युलर</string>
     <string name="scheduler_notification_title">अनुसूचित कार्य</string>
     <string name="scheduler_notification_message">कार्यान्वयन गरिँदैछ: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">शेड्युलर परिणामहरू</string>
     <string name="scheduler_notification_result_title">शेड्युलर सम्पन्न भयो</string>
     <string name="scheduler_notification_result_success_message">सबै अनुसूचित कार्यहरू सफलतापूर्वक चलाइए।</string>
     <string name="scheduler_notification_result_failure_message">केही अनुसूचित कार्यहरू विफल भयो वा त्रुटिहरूको सामना गरियो। तिनलाई म्यानुअली चलाउने प्रयास गर्नुहोस्।</string>

--- a/app-tool-scheduler/src/main/res/values-nl/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-nl/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">Planner</string>
     <string name="scheduler_notification_title">Geplande taak</string>
     <string name="scheduler_notification_message">Wordt uitgevoerd: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Planner-resultaten</string>
     <string name="scheduler_notification_result_title">Planner is klaar</string>
     <string name="scheduler_notification_result_success_message">Alle geplande taken werden succesvol uitgevoerd.</string>
     <string name="scheduler_notification_result_failure_message">Sommige geplande taken zijn mislukt of er zijn fouten opgetreden. Probeer ze handmatig uit te voeren.</string>

--- a/app-tool-scheduler/src/main/res/values-or-rIN/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-or-rIN/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">ନିର୍ଦ୍ଧାରଣକାରୀ</string>
     <string name="scheduler_notification_title">ନିର୍ଦ୍ଧାରିତ କାର୍ଯ୍ୟ</string>
     <string name="scheduler_notification_message">କାର୍ଯ୍ୟକାରୀ କରୁଛି: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">ସ୍କ୍ୟାଡ୍ୟୁଲର ଫଳାଫଳ</string>
     <string name="scheduler_notification_result_title">ନିର୍ଦ୍ଧାରଣକାରୀ ସମାପ୍ତ ହୋଇଛି</string>
     <string name="scheduler_notification_result_success_message">ସମସ୍ତ ନିର୍ଦ୍ଧାରିତ କାର୍ଯ୍ୟ ସଫଳତାର ସହିତ ଚାଲିଛି।</string>
     <string name="scheduler_notification_result_failure_message">କିଛି ନିର୍ଦ୍ଧାରିତ କାର୍ଯ୍ୟ ବିଫଳ ହୋଇଛି କିମ୍ବା ତ୍ରୁଟିର ସମ୍ମୁଖୀନ ହୋଇଛି। ସେଗୁଡ଼ିକୁ ହସ୍ତକୃତ ଭାବରେ ଚଲାଇବାକୁ ଚେଷ୍ଟା କରନ୍ତୁ।</string>

--- a/app-tool-scheduler/src/main/res/values-pa-rIN/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-pa-rIN/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">ਸ਼ੈਡਿਊਲਰ</string>
     <string name="scheduler_notification_title">ਸ਼ੈਡਿਊਲਡ ਟਾਸਕ</string>
     <string name="scheduler_notification_message">ਐਕਜ਼ੀਕਿਊਟ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">ਸ਼ਡਿਊਲਰ ਨਤੀਜੇ</string>
     <string name="scheduler_notification_result_title">ਸ਼ੈਡਿਊਲਰ ਪੂਰਾ ਹੋਇਆ</string>
     <string name="scheduler_notification_result_success_message">ਸਾਰੇ ਸ਼ੈਡਿਊਲਡ ਟਾਸਕ ਸਫਲਤਾਪੂਰਵਕ ਚੱਲੇ।</string>
     <string name="scheduler_notification_result_failure_message">ਕੁਝ ਸ਼ੈਡਿਊਲਡ ਟਾਸਕ ਅਸਫਲ ਹੋਏ ਜਾਂ ਗਲਤੀਆਂ ਆਈਆਂ। ਇਹਨਾਂ ਨੂੰ ਮੈਨੁਅਲੀ ਚਲਾਉਣ ਦੀ ਕੋਸ਼ਿਸ਼ ਕਰੋ।</string>

--- a/app-tool-scheduler/src/main/res/values-pl/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-pl/strings.xml
@@ -34,6 +34,7 @@
     <string name="scheduler_notification_channel_label">Harmonogram</string>
     <string name="scheduler_notification_title">Zaplanowane zadanie</string>
     <string name="scheduler_notification_message">Wykonywanie: „%s”</string>
+    <string name="scheduler_notification_result_channel_label">Wyniki harmonogramu</string>
     <string name="scheduler_notification_result_title">Harmonogram zakończony</string>
     <string name="scheduler_notification_result_success_message">Wszystkie zaplanowane zadania zostały pomyślnie uruchomione.</string>
     <string name="scheduler_notification_result_failure_message">Niektóre zaplanowane zadania nie powiodły się lub wystąpiły błędy. Spróbuj uruchomić je ręcznie.</string>

--- a/app-tool-scheduler/src/main/res/values-pt-rBR/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-pt-rBR/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">Agendador</string>
     <string name="scheduler_notification_title">Tarefa agendada</string>
     <string name="scheduler_notification_message">Executando: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Resultados do agendador</string>
     <string name="scheduler_notification_result_title">Agendador finalizado</string>
     <string name="scheduler_notification_result_success_message">Todas as tarefas agendadas foram executadas com sucesso.</string>
     <string name="scheduler_notification_result_failure_message">Algumas tarefas agendadas falharam ou encontraram erros. Tente executá-las manualmente.</string>

--- a/app-tool-scheduler/src/main/res/values-pt/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-pt/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">Agenda</string>
     <string name="scheduler_notification_title">Tarefa agendada</string>
     <string name="scheduler_notification_message">Executando: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Resultados do agendador</string>
     <string name="scheduler_notification_result_title">Tarefa agendada finalizada</string>
     <string name="scheduler_notification_result_success_message">Todas as tarefas agendadas foram executadas com sucesso.</string>
     <string name="scheduler_notification_result_failure_message">Algumas tarefas agendadas falharam ou encontraram erros. Tente executá-las manualmente.</string>

--- a/app-tool-scheduler/src/main/res/values-ro/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-ro/strings.xml
@@ -33,6 +33,7 @@
     <string name="scheduler_notification_channel_label">Programator</string>
     <string name="scheduler_notification_title">Sarcina programată</string>
     <string name="scheduler_notification_message">Executare: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Rezultate programator</string>
     <string name="scheduler_notification_result_title">Programator terminat</string>
     <string name="scheduler_notification_result_success_message">Toate sarcinile programate au fost rulate cu succes.</string>
     <string name="scheduler_notification_result_failure_message">Unele sarcini programate au eșuat sau au întâmpinat erori. Încercați să le rulați manual.</string>

--- a/app-tool-scheduler/src/main/res/values-ru/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-ru/strings.xml
@@ -34,6 +34,7 @@
     <string name="scheduler_notification_channel_label">Расписание</string>
     <string name="scheduler_notification_title">Запланированное задание</string>
     <string name="scheduler_notification_message">Выполнение: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Результаты расписания</string>
     <string name="scheduler_notification_result_title">Планировщик завершен</string>
     <string name="scheduler_notification_result_success_message">Все запланированные задачи выполнены.</string>
     <string name="scheduler_notification_result_failure_message">Некоторые запланированные задачи не выполнены или выполнены с ошибками. Попробуйте запустить их вручную.</string>

--- a/app-tool-scheduler/src/main/res/values-sc-rIT/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-sc-rIT/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">Programmadore</string>
     <string name="scheduler_notification_title">Tarea programmada</string>
     <string name="scheduler_notification_message">Eseguende: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Resultados de su pianificadore</string>
     <string name="scheduler_notification_result_title">Programmadore finidu</string>
     <string name="scheduler_notification_result_success_message">Totu is tareas programmadas sunt eseguidas cun sutzessu.</string>
     <string name="scheduler_notification_result_failure_message">Calchìzas tareas programmadas sunt falladas o ant agatadu errores. Prova a is eseguire manualmente.</string>

--- a/app-tool-scheduler/src/main/res/values-si-rLK/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-si-rLK/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">වේලාව නිර්ණායක</string>
     <string name="scheduler_notification_title">වේලාව කාර්ය</string>
     <string name="scheduler_notification_message">කාර්යාන්විත කරමින්: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">කාලසටහන් ප්‍රතිඵල</string>
     <string name="scheduler_notification_result_title">වේලාව නිර්ණායක සමාප්ත විය</string>
     <string name="scheduler_notification_result_success_message">සියලු වේලාව කාර්ය ඪාවිතාවෙන් කාර්යාන්විත විය.</string>
     <string name="scheduler_notification_result_failure_message">කදාචර වේලාව කාර්ය ඉඤාඵර විය හෝ ගැට්ටු ආහ්වාන කරෑය. එවා හස්තින් චාවිත කිරීමට උත්සාහ කරන්න.</string>

--- a/app-tool-scheduler/src/main/res/values-sk/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-sk/strings.xml
@@ -34,6 +34,7 @@
     <string name="scheduler_notification_channel_label">Plánovač</string>
     <string name="scheduler_notification_title">Naplánovaná úloha</string>
     <string name="scheduler_notification_message">Prebieha: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Výsledky plánovača</string>
     <string name="scheduler_notification_result_title">Plánovač skončil</string>
     <string name="scheduler_notification_result_success_message">Všetky naplánované úlohy prebehli úspešne.</string>
     <string name="scheduler_notification_result_failure_message">Niektoré naplánované úlohy zlyhali alebo sa vyskytli chyby. Skúste ich spustiť manuálne.</string>

--- a/app-tool-scheduler/src/main/res/values-sl/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-sl/strings.xml
@@ -34,6 +34,7 @@
     <string name="scheduler_notification_channel_label">Urejevalec urnikov</string>
     <string name="scheduler_notification_title">Načrtovano opravilo</string>
     <string name="scheduler_notification_message">Izvajanje: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Rezultati razporejevalnika</string>
     <string name="scheduler_notification_result_title">Urnik je končan.</string>
     <string name="scheduler_notification_result_success_message">Vsa načrtovana opravila so se uspešno izvedla.</string>
     <string name="scheduler_notification_result_failure_message">Nekatera načrtovana opravila se niso uspešno končala ali so naletela na napake.  Poizkusite jih ročno zagnati.</string>

--- a/app-tool-scheduler/src/main/res/values-sq-rAL/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-sq-rAL/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">Programuesi</string>
     <string name="scheduler_notification_title">Detyrë e planifikuar</string>
     <string name="scheduler_notification_message">Ekzekutimi: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Rezultatet e planifikuesit</string>
     <string name="scheduler_notification_result_title">Programuesi përfundoi</string>
     <string name="scheduler_notification_result_success_message">Të gjitha detyrat e planifikuara u kryen me sukses.</string>
     <string name="scheduler_notification_result_failure_message">Disa detyra të planifikuara dështuan ose hasën në gabime. Provoni t\'i ekzekutoni ato manualisht.</string>

--- a/app-tool-scheduler/src/main/res/values-sr/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-sr/strings.xml
@@ -33,6 +33,7 @@
     <string name="scheduler_notification_channel_label">Распоређивач</string>
     <string name="scheduler_notification_title">Заказан задатак</string>
     <string name="scheduler_notification_message">Извршавање: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Резултати планера</string>
     <string name="scheduler_notification_result_title">Распоређивач завршен</string>
     <string name="scheduler_notification_result_success_message">Сви заказани задаци су успешно покренути.</string>
     <string name="scheduler_notification_result_failure_message">Неки заказани задаци су неуспешни или су наишли на грешке. Покушајте их покренути ручно.</string>

--- a/app-tool-scheduler/src/main/res/values-sv/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-sv/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">Schemaläggare</string>
     <string name="scheduler_notification_title">Schemalagd uppgift</string>
     <string name="scheduler_notification_message">Kör: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Schemaläggningsresultat</string>
     <string name="scheduler_notification_result_title">Schemaläggaren slutförd</string>
     <string name="scheduler_notification_result_success_message">Alla schemalagda uppgifter kördes framgångsrikt.</string>
     <string name="scheduler_notification_result_failure_message">Vissa schemalagda uppgifter misslyckades eller påträffade fel. Försök köra dem manuellt.</string>

--- a/app-tool-scheduler/src/main/res/values-sw/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-sw/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">Mpangaji</string>
     <string name="scheduler_notification_title">Kazi iliyopangwa</string>
     <string name="scheduler_notification_message">Inatekeleza: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Matokeo ya mpanga ratiba</string>
     <string name="scheduler_notification_result_title">Mpangaji umemaliza</string>
     <string name="scheduler_notification_result_success_message">Kazi zote zilizopangwa zimetekelezwa kwa mafanikio.</string>
     <string name="scheduler_notification_result_failure_message">Baadhi ya kazi zilizopangwa zimeshindwa au zimekutana na makosa. Jaribu kuzitekeleza kwa mkono.</string>

--- a/app-tool-scheduler/src/main/res/values-ta-rIN/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-ta-rIN/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">தேதி நிர்ணாயகர்</string>
     <string name="scheduler_notification_title">திட்டமிடப்பட்ட பணி</string>
     <string name="scheduler_notification_message">நிறைவேற்றுகிறது: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">திட்டமிடல் முடிவுகள்</string>
     <string name="scheduler_notification_result_title">தேதி நிர்ணாயகர் முடிந்தது</string>
     <string name="scheduler_notification_result_success_message">அனைத்து திட்டமிடப்பட்ட பணிகளும் வெற்றிகரமாக இயங்கின.</string>
     <string name="scheduler_notification_result_failure_message">சில திட்டமிடப்பட்ட பணிகள் தோல்வியடைந்தன அல்லது பிழைகளைச் சந்தித்தன. அவற்றை கையால் இயக்க முயற்சிக்கவும்.</string>

--- a/app-tool-scheduler/src/main/res/values-te-rIN/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-te-rIN/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">శెడ్యూలర్</string>
     <string name="scheduler_notification_title">శెడ్యూల్ చేయబడిన కార్యం</string>
     <string name="scheduler_notification_message">క్రియాన్వయం చేస్తోంది: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">షెడ్యూలర్ ఫలితాలు</string>
     <string name="scheduler_notification_result_title">శెడ్యూలర్ పూర్తి అయింది</string>
     <string name="scheduler_notification_result_success_message">అన్ని శెడ్యూల్ చేయబడిన కార్యాలు విజయవంతంగా పూర్తి అయినాయి.</string>
     <string name="scheduler_notification_result_failure_message">కొన్ని శెడ్యూల్ చేయబడిన కార్యాలు విఫలమైనాయి లేదా లోపాలను ఎదుర్కొన్నాయి. వాటిని మానువల్‌గా చాలానికి ప్రయత్నించండి.</string>

--- a/app-tool-scheduler/src/main/res/values-th/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-th/strings.xml
@@ -31,6 +31,7 @@
     <string name="scheduler_notification_channel_label">ตัวจัดตารางเวลา</string>
     <string name="scheduler_notification_title">งานตามตาราง</string>
     <string name="scheduler_notification_message">กำลังทำงาน: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">ผลลัพธ์ตัวกำหนดเวลา</string>
     <string name="scheduler_notification_result_title">ตัวจัดตารางเวลาเสร็จสิ้น</string>
     <string name="scheduler_notification_result_success_message">งานตามตารางทั้งหมดทำงานสำเร็จ</string>
     <string name="scheduler_notification_result_failure_message">งานตามตารางบางงานล้มเหลวหรือพบข้อผิดพลาด ลองทำงานด้วยตนเอง</string>

--- a/app-tool-scheduler/src/main/res/values-tr/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-tr/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">Zamanlayıcı</string>
     <string name="scheduler_notification_title">Planlanmış görev</string>
     <string name="scheduler_notification_message">Yürütülüyor: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Zamanlayıcı sonuçları</string>
     <string name="scheduler_notification_result_title">Zamanlayıcı tamamlandı</string>
     <string name="scheduler_notification_result_success_message">Tüm zamanlanmış görevler başarıyla çalıştı.</string>
     <string name="scheduler_notification_result_failure_message">Bazı zamanlanmış görevler başarısız oldu veya hatalarla karşılaştı. Bunları manuel olarak çalıştırmayı deneyin.</string>

--- a/app-tool-scheduler/src/main/res/values-uk/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-uk/strings.xml
@@ -34,6 +34,7 @@
     <string name="scheduler_notification_channel_label">Планувальник</string>
     <string name="scheduler_notification_title">Заплановане завдання</string>
     <string name="scheduler_notification_message">Виконую: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Результати планувальника</string>
     <string name="scheduler_notification_result_title">Планувальник завершив роботу</string>
     <string name="scheduler_notification_result_success_message">Всі заплановані завдання успішно виконані.</string>
     <string name="scheduler_notification_result_failure_message">Деякі заплановані завдання не вдалося виконати або виникли помилки. Спробуйте запустити їх вручну.</string>

--- a/app-tool-scheduler/src/main/res/values-ur-rIN/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-ur-rIN/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">شیڈیولر</string>
     <string name="scheduler_notification_title">مقررہ کام</string>
     <string name="scheduler_notification_message">عمل کر رہے ہیں: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">شیڈیولر کے نتائج</string>
     <string name="scheduler_notification_result_title">شیڈیولر مکمل</string>
     <string name="scheduler_notification_result_success_message">تمام شیڈیول شدہ کام کامیابی سے چلے۔</string>
     <string name="scheduler_notification_result_failure_message">کچھ شیڈیول شدہ کام ناکام ہوئے یا خرابی کا سامنا کیا۔ انھیں دستی طور پر چلانے کی کوشش کریں۔</string>

--- a/app-tool-scheduler/src/main/res/values-uz/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-uz/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">Rejalashtiruvchi</string>
     <string name="scheduler_notification_title">Rejalashtirilgan vazifa</string>
     <string name="scheduler_notification_message">Bajarilmoqda: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Rejalashtiruvchi natijalari</string>
     <string name="scheduler_notification_result_title">Rejalashtiruvchi tugallandi</string>
     <string name="scheduler_notification_result_success_message">Barcha rejalashtirilgan vazifalar muvaffaqiyatli bajarildi.</string>
     <string name="scheduler_notification_result_failure_message">Ba\'zi rejalashtirilgan vazifalar muvaffaqiyatsiz tugadi yoki xatolarga duch keldi. Ularni qo\'lda ishga tushirishga harakat qiling.</string>

--- a/app-tool-scheduler/src/main/res/values-vi/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-vi/strings.xml
@@ -31,6 +31,7 @@
     <string name="scheduler_notification_channel_label">Lịch trình</string>
     <string name="scheduler_notification_title">Hoạt động theo lịch trình</string>
     <string name="scheduler_notification_message">Đang thực thi: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Kết quả lịch trình</string>
     <string name="scheduler_notification_result_title">Lch trình đã hoàn tất</string>
     <string name="scheduler_notification_result_success_message">Tất cả các tác vụ theo lịch trình đã chạy thành công.</string>
     <string name="scheduler_notification_result_failure_message">Một số tác vụ đã lên lịch không thành công hoặc gặp lỗi. Hãy thử chạy chúng bằng tay.</string>

--- a/app-tool-scheduler/src/main/res/values-zh-rCN/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-zh-rCN/strings.xml
@@ -31,6 +31,7 @@
     <string name="scheduler_notification_channel_label">计划任务</string>
     <string name="scheduler_notification_title">计划任务</string>
     <string name="scheduler_notification_message">正在执行: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">计划任务结果</string>
     <string name="scheduler_notification_result_title">计划任务已完成</string>
     <string name="scheduler_notification_result_success_message">所有计划任务均成功运行。</string>
     <string name="scheduler_notification_result_failure_message">部分计划任务运行失败或遇到错误。请尝试手动运行。</string>

--- a/app-tool-scheduler/src/main/res/values-zh-rHK/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-zh-rHK/strings.xml
@@ -31,6 +31,7 @@
     <string name="scheduler_notification_channel_label">時間表</string>
     <string name="scheduler_notification_title">已編排的工作</string>
     <string name="scheduler_notification_message">正在執行：%s</string>
+    <string name="scheduler_notification_result_channel_label">排程器結果</string>
     <string name="scheduler_notification_result_title">計劃任務已完成</string>
     <string name="scheduler_notification_result_success_message">所有計劃任務已成功運行。</string>
     <string name="scheduler_notification_result_failure_message">部分計劃任務失敗或遇到錯誤。請嘗試手動執行它們。</string>

--- a/app-tool-scheduler/src/main/res/values-zh-rTW/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-zh-rTW/strings.xml
@@ -31,6 +31,7 @@
     <string name="scheduler_notification_channel_label">排程器</string>
     <string name="scheduler_notification_title">已排程的工作</string>
     <string name="scheduler_notification_message">正在執行：%s</string>
+    <string name="scheduler_notification_result_channel_label">排程器結果</string>
     <string name="scheduler_notification_result_title">排程器已完成</string>
     <string name="scheduler_notification_result_success_message">所有排程的工作已成功執行。</string>
     <string name="scheduler_notification_result_failure_message">部分排程的工作失敗或發生錯誤，請嘗試手動執行。</string>

--- a/app-tool-scheduler/src/main/res/values-zu/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-zu/strings.xml
@@ -32,6 +32,7 @@
     <string name="scheduler_notification_channel_label">Isihlelakuthi</string>
     <string name="scheduler_notification_title">Umsebenzi ohleliwe</string>
     <string name="scheduler_notification_message">Kuyenziwa: \"%s\"</string>
+    <string name="scheduler_notification_result_channel_label">Imiphumela ye-Scheduler</string>
     <string name="scheduler_notification_result_title">Isihlelakuthi siqediwe</string>
     <string name="scheduler_notification_result_success_message">Yonke imisebenzi ehleliwe iqhubekile ngempumelelo.</string>
     <string name="scheduler_notification_result_failure_message">Eminye imisebenzi ehleliwe yehlulekile noma yahlangabezana namaphutha. Zama ukuyiqhuba mathupha.</string>

--- a/app-tool-squeezer/src/main/res/values-af-rZA/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-af-rZA/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Komprimeer beelde om bergingsruimte te bespaar.</string>
+    <string name="squeezer_explanation_short">Komprimeer beelde en videos om bergingspasie te bespaar.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d beeld gevind</item>
-        <item quantity="other">%d beelde gevind</item>
+        <item quantity="one">%d item gevind</item>
+        <item quantity="other">%d items gevind</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s kan bespaar word</item>
         <item quantity="other">~%s kan bespaar word</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d beeld gekomprimeer</item>
-        <item quantity="other">%d beelde gekomprimeer</item>
+        <item quantity="one">%d item gekomprimeer</item>
+        <item quantity="other">%d items gekomprimeer</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d misluk</item>
+        <item quantity="other">%d misluk</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d lêer oorgeslaan (nie toeganklik nie)</item>
+        <item quantity="other">%d lêers oorgeslaan (nie toeganklik nie)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d beeld gekies</item>
-        <item quantity="other">%d beelde gekies</item>
+        <item quantity="one">%d item gekies</item>
+        <item quantity="other">%d items gekies</item>
     </plurals>
     <string name="squeezer_search_locations_title">Soek liggings</string>
     <string name="squeezer_search_locations_default_summary">Kameravouers (verstek)</string>
     <string name="squeezer_min_size_title">Minimum lêergrootte</string>
-    <string name="squeezer_min_size_description">Slaan beelde kleiner as hierdie grootte oor.</string>
+    <string name="squeezer_min_size_description">Slaan lêers kleiner as hierdie grootte oor.</string>
     <string name="squeezer_min_age_title">Minimum lêerouderdom</string>
-    <string name="squeezer_min_age_description">Sluit slegs beelde ouer as hierdie ouderdom in.</string>
-    <string name="squeezer_compression_settings_label">Kompressieinstellings</string>
+    <string name="squeezer_min_age_description">Sluit slegs lêers in wat ouer is as hierdie ouderdom.</string>
+    <string name="squeezer_compression_settings_label">Algemeen</string>
     <string name="squeezer_quality_label">Kwaliteit</string>
     <string name="squeezer_quality_title">Kompressiekwaliteit</string>
-    <string name="squeezer_quality_description">Laer kwaliteit beteken kleiner lêergrootte maar verminderde beeldkwaliteit.</string>
+    <string name="squeezer_quality_description">Laer kwaliteit beteken \'n kleiner lêergrootte maar verminderde visuele kwaliteit.</string>
     <string name="squeezer_quality_example_format">Voorbeeld: %1$s beeld → bespaar ~%2$s teen %3$d%% kwaliteit</string>
     <string name="squeezer_quality_warning_low">Laer kwaliteite kan sigbare artefakte veroorsaak.</string>
     <string name="squeezer_quality_warning_high">Baie hoë kwaliteit bied minimale ruimtebesparings.</string>
-    <string name="squeezer_types_category_label">Beeldtipes</string>
+    <string name="squeezer_types_category_label">Beeldinstellings</string>
+    <string name="squeezer_video_settings_category_label">Video-instellings</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">Sluit JPEG-beelde in (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">Sluit WebP-beelde in (.webp).</string>
+    <string name="squeezer_type_video_title">MP4 Video</string>
+    <string name="squeezer_type_video_description">Sluit MP4-videolêers (.mp4) in.</string>
     <string name="squeezer_skip_compressed_title">Slaan voorheen gekomprimeerdes oor</string>
-    <string name="squeezer_skip_compressed_description">Slaan beelde oor wat reeds deur SD Maid gekomprimeer is.</string>
+    <string name="squeezer_skip_compressed_description">Slaan lêers oor wat reeds deur SD Maid gekomprimeer is.</string>
     <string name="squeezer_exif_marker_title">Skryf EXIF-merker</string>
     <string name="squeezer_exif_marker_description">Voeg \'n merker by die beeld se EXIF-gebruikerkommentaarveld om herkompressie te voorkom selfs as die kompressiegeskiedenis uitgevee word.</string>
     <string name="squeezer_estimated_savings_format">~%s besparing</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">Bevestig kompressie</string>
     <string name="squeezer_preview_total_size">Totale grootte</string>
     <string name="squeezer_preview_estimated_savings">Beraamde besparing</string>
-    <string name="squeezer_compress_confirmation_title">Beelde komprimeer?</string>
-    <string name="squeezer_compress_confirmation_message">Dit sal oorspronklike beelde met gekomprimeerde weergawes vervang. Hierdie aksie kan nie ongedaan gemaak word nie.</string>
+    <string name="squeezer_compress_confirmation_title">Gekose items komprimeer?</string>
+    <string name="squeezer_compress_confirmation_message">Dit sal oorspronklike lêers vervang met gekomprimeerde weergawes. Hierdie aksie kan nie ongedaan gemaak word nie.</string>
     <string name="squeezer_history_title">Kompressiegeskiedenis</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d item (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">Geen kompressiegeskiedenis nie</string>
     <string name="squeezer_history_clear_title">Vee kompressiegeskiedenis uit</string>
-    <string name="squeezer_history_clear_message">Dit sal toelaat dat voorheen gekomprimeerde beelde weer gekomprimeer kan word. Die beelde self word nie geaffekteer nie.</string>
+    <string name="squeezer_history_clear_message">Dit sal toelaat dat voorheen gekomprimeerde lêers weer gekomprimeer word. Die lêers self word nie geraak nie.</string>
     <string name="squeezer_onboarding_title">Oor beeldkompressie</string>
     <string name="squeezer_onboarding_message">Beeldkompressie verminder lêergrootte deur visuele detail te verwyder. Hierdie proses is onomkeerbaar - die oorspronklike kwaliteit kan nie herstel word nie.\n\nHier is \'n voorskou van hoe jou beelde sal lyk:</string>
     <string name="squeezer_onboarding_original_label">Oorspronklik</string>
     <string name="squeezer_onboarding_compressed_label">Na kompressie</string>
+    <string name="squeezer_onboarding_video_original_label">Videoraam</string>
+    <string name="squeezer_onboarding_video_compressed_label">Voorskou (benaderd)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">Werklike videokwaliteit kan verskil</string>
     <string name="squeezer_onboarding_quality_label">Kwaliteit: %d%%</string>
     <string name="squeezer_compare_action">Bekyk vergelyking</string>
     <string name="squeezer_no_example_found">Geen beelde gevind in gekose paaie nie.</string>
-    <string name="squeezer_result_empty_message">Geen komprimeerbare beelde gevind nie.</string>
-    <string name="squeezer_setup_warning">Kompressie verminder beeldkwaliteit permanent om bergingsruimte te bespaar. Dit kan nie ongedaan gemaak word nie. Hersien jou instellings noukeurig voor jy begin.</string>
-    <string name="squeezer_setup_explanation">Media Squeeze verminder die lêergrootte van beelde om bergingsruimte vry te maak. Dit verminder beeldkwaliteit permanent en kan nie ongedaan gemaak word nie. Hersien jou instellings noukeurig voor jy begin.</string>
+    <string name="squeezer_result_empty_message">Geen komprimeerbare media gevind nie.</string>
+    <string name="squeezer_setup_warning">Kompressie verminder kwaliteit permanent om bergingspasie te bespaar. Dit kan nie ongedaan gemaak word nie. Hersien jou instellings noukeurig voor jy begin.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d ligging kan nie vir kompressie gebruik word nie en is verwyder. Kompressie vereis direkte toegang tot interne berging.</item>
+        <item quantity="other">%d liggings kan nie vir kompressie gebruik word nie en is verwyder. Kompressie vereis direkte toegang tot interne berging.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze verminder die lêergrootte van beelde en videos om bergingspasie vry te stel. Dit verminder kwaliteit permanent en kan nie ongedaan gemaak word nie. Hersien jou instellings noukeurig voor jy begin.</string>
     <string name="squeezer_setup_paths_title">Soek liggings</string>
     <string name="squeezer_setup_paths_default">Kies vouers om te soek</string>
     <string name="squeezer_setup_quality_title">Kompressiekwaliteit</string>
@@ -81,6 +99,6 @@
         <item quantity="one">Ten minste %d dag oud</item>
         <item quantity="other">Ten minste %d dae oud</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">Beraamde ~%d%% besparing vir JPEG-lêers</string>
+    <string name="squeezer_estimated_savings_percent">Geskatte ~%d%% besparing vir beelde</string>
     <string name="squeezer_onboarding_got_it">Verstaan</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-am/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-am/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">የማከማቻ ቦታ ለመቆጠብ ምስሎችን ይጨምቁ።</string>
+    <string name="squeezer_explanation_short">ምስሎችን እና ቪዲዮዎችን በማቀናበር የማከማቻ ቦታ ቆጥቡ።</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d ምስል ተገኝቷል</item>
-        <item quantity="other">%d ምስሎች ተገኝተዋል</item>
+        <item quantity="one">%d ንጥል ተገኝቷል</item>
+        <item quantity="other">%d ንጥሎች ተገኝተዋል</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s ሊቆጠብ ይችላል</item>
         <item quantity="other">~%s ሊቆጠቡ ይችላሉ</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d ምስል ተጨምቋል</item>
-        <item quantity="other">%d ምስሎች ተጨምቀዋል</item>
+        <item quantity="one">%d ንጥል ተጨናንቋል</item>
+        <item quantity="other">%d ንጥሎች ተጨናንቀዋል</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d አልተሳካም</item>
+        <item quantity="other">%d አልተሳኩም</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d ፋይል ተዘልሏል (ሊደረስበት አልተቻለም)</item>
+        <item quantity="other">%d ፋይሎች ተዘልለዋል (ሊደረስባቸው አልተቻለም)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d ምስል ተመርጧል</item>
-        <item quantity="other">%d ምስሎች ተመርጠዋል</item>
+        <item quantity="one">%d ንጥል ተመርጧል</item>
+        <item quantity="other">%d ንጥሎች ተመርጠዋል</item>
     </plurals>
     <string name="squeezer_search_locations_title">የፍለጋ ቦታዎች</string>
     <string name="squeezer_search_locations_default_summary">የካሜራ ማህደሮች (ነባሪ)</string>
     <string name="squeezer_min_size_title">ዝቅተኛ የፋይል መጠን</string>
-    <string name="squeezer_min_size_description">ከዚህ መጠን ያነሱ ምስሎችን ይዝለሉ።</string>
+    <string name="squeezer_min_size_description">ከዚህ መጠን ያነሱ ፋይሎችን ዝለል።</string>
     <string name="squeezer_min_age_title">ዝቅተኛ የፋይል ዕድሜ</string>
-    <string name="squeezer_min_age_description">ከዚህ ዕድሜ የቆዩ ምስሎችን ብቻ ያካትቱ።</string>
-    <string name="squeezer_compression_settings_label">የመጨመቅ ቅንብሮች</string>
+    <string name="squeezer_min_age_description">ከዚህ ዕድሜ በላይ ያሉ ፋይሎችን ብቻ አካትት።</string>
+    <string name="squeezer_compression_settings_label">አጠቃላይ</string>
     <string name="squeezer_quality_label">ጥራት</string>
     <string name="squeezer_quality_title">የመጨመቅ ጥራት</string>
-    <string name="squeezer_quality_description">ዝቅ ያለ ጥራት ትንሽ የፋይል መጠን ማለት ነው ግን የቀነሰ የምስል ጥራት።</string>
+    <string name="squeezer_quality_description">ዝቅተኛ ጥራት ማለት ትንሽ የፋይል መጠን ነው፣ ነገር ግን የምስሉ ጥራት ይቀንሳል።</string>
     <string name="squeezer_quality_example_format">ምሳሌ: %1$s ምስል → በ%3$d%% ጥራት ~%2$s ይቆጥባል</string>
     <string name="squeezer_quality_warning_low">ዝቅ ያሉ ጥራቶች የሚታዩ ጉድለቶች ሊያስከትሉ ይችላሉ።</string>
     <string name="squeezer_quality_warning_high">በጣም ከፍተኛ ጥራት ዝቅተኛ ቦታ ቁጠባ ይሰጣል።</string>
-    <string name="squeezer_types_category_label">የምስል ዓይነቶች</string>
+    <string name="squeezer_types_category_label">የምስል ቅንብሮች</string>
+    <string name="squeezer_video_settings_category_label">የቪዲዮ ቅንብሮች</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">JPEG ምስሎችን (.jpg, .jpeg) ያካትቱ።</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">WebP ምስሎችን (.webp) ያካትቱ።</string>
+    <string name="squeezer_type_video_title">MP4 ቪዲዮ</string>
+    <string name="squeezer_type_video_description">የ MP4 ቪዲዮ ፋይሎችን (.mp4) አካትት።</string>
     <string name="squeezer_skip_compressed_title">ቀድሞ የተጨመቁትን ይዝለሉ</string>
-    <string name="squeezer_skip_compressed_description">በSD Maid ቀድሞ የተጨመቁ ምስሎችን ይዝለሉ።</string>
+    <string name="squeezer_skip_compressed_description">በ SD Maid አስቀድሞ የተጨናነቁ ፋይሎችን ዝለል።</string>
     <string name="squeezer_exif_marker_title">EXIF ምልክት ይፃፉ</string>
     <string name="squeezer_exif_marker_description">የመጨመቅ ታሪክ ቢጸዳ እንኳን እንደገና መጨመቅን ለመከላከል በምስሉ EXIF የተጠቃሚ አስተያየት መስክ ውስጥ ምልክት ያክሉ።</string>
     <string name="squeezer_estimated_savings_format">~%s ቁጠባ</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">መጨመቅ ያረጋግጡ</string>
     <string name="squeezer_preview_total_size">ጠቅላላ መጠን</string>
     <string name="squeezer_preview_estimated_savings">የተገመተ ቁጠባ</string>
-    <string name="squeezer_compress_confirmation_title">ምስሎችን ይጨምቁ?</string>
-    <string name="squeezer_compress_confirmation_message">ይህ ዋና ምስሎችን በተጨመቁ ስሪቶች ይተካል። ይህ ድርጊት ሊሰረዝ አይችልም።</string>
+    <string name="squeezer_compress_confirmation_title">የተመረጡ ንጥሎችን ትጨናንቃለህ?</string>
+    <string name="squeezer_compress_confirmation_message">ይህ ዋናዎቹን ፋይሎች በተጨናነቁ ስሪቶች ይተካቸዋል። ይህ እርምጃ ሊቀለበስ አይችልም።</string>
     <string name="squeezer_history_title">የመጨመቅ ታሪክ</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d ንጥል (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">ምንም የመጨመቅ ታሪክ የለም</string>
     <string name="squeezer_history_clear_title">የመጨመቅ ታሪክ ያጽዱ</string>
-    <string name="squeezer_history_clear_message">ይህ ቀድሞ የተጨመቁ ምስሎች እንደገና እንዲጨመቁ ያስችላል። ምስሎቹ ራሳቸው አይነኩም።</string>
+    <string name="squeezer_history_clear_message">ይህ ቀደም ሲል የተጨናነቁ ፋይሎች እንደገና እንዲጨናነቁ ያስችላል። ፋይሎቹ ራሳቸው አይጎዳም።</string>
     <string name="squeezer_onboarding_title">ስለ ምስል መጨመቅ</string>
     <string name="squeezer_onboarding_message">የምስል መጨመቅ ምስላዊ ዝርዝርን በማስወገድ የፋይል መጠንን ይቀንሳል። ይህ ሂደት ሊቀለበስ አይችልም - ዋናው ጥራት ሊመለስ አይችልም።\n\nምስሎችዎ እንዴት እንደሚታዩ ቅድመ-ዕይታ ይኸውና:</string>
     <string name="squeezer_onboarding_original_label">ዋና</string>
     <string name="squeezer_onboarding_compressed_label">ከመጨመቅ በኋላ</string>
+    <string name="squeezer_onboarding_video_original_label">የቪዲዮ ፍሬም</string>
+    <string name="squeezer_onboarding_video_compressed_label">ቅድመ እይታ (ግምታዊ)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">ትክክለኛው የቪዲዮ ጥራት ሊለያይ ይችላል</string>
     <string name="squeezer_onboarding_quality_label">ጥራት: %d%%</string>
     <string name="squeezer_compare_action">ንጽጽር ይመልከቱ</string>
     <string name="squeezer_no_example_found">በተመረጡ ዱካዎች ውስጥ ምንም ምስሎች አልተገኙም።</string>
-    <string name="squeezer_result_empty_message">ሊጨመቁ የሚችሉ ምስሎች አልተገኙም።</string>
-    <string name="squeezer_setup_warning">መጨመቅ የማከማቻ ቦታ ለመቆጠብ የምስል ጥራትን በቋሚነት ይቀንሳል። ይህ ሊሰረዝ አይችልም። ከመጀመርዎ በፊት ቅንብሮችዎን በጥንቃቄ ይገምግሙ።</string>
-    <string name="squeezer_setup_explanation">ሚዲያ መጨመቂያ የማከማቻ ቦታ ለማስለቀቅ የምስል ፋይል መጠንን ይቀንሳል። ይህ የምስል ጥራትን በቋሚነት ይቀንሳልና ሊሰረዝ አይችልም። ከመጀመርዎ በፊት ቅንብሮችዎን በጥንቃቄ ይገምግሙ።</string>
+    <string name="squeezer_result_empty_message">ሊጨናነቅ የሚችል ሚዲያ አልተገኘም።</string>
+    <string name="squeezer_setup_warning">መጨናነቅ የማከማቻ ቦታ ለመቆጠብ ጥራቱን ቋሚ በሆነ ሁኔታ ይቀንሳል። ይህ ሊቀለበስ አይችልም። ከመጀመርዎ በፊት ቅንብሮቻቸውን በጥንቃቄ ይገምግሙ።</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d ቦታ ለመጨናነቅ ጥቅም ላይ ሊውል አይችልም እና ተወግዷል። መጨናነቅ ወደ ውስጣዊ ማከማቻ ቀጥተኛ ፍቃድ ያስፈልጋል።</item>
+        <item quantity="other">%d ቦታዎች ለመጨናነቅ ጥቅም ላይ ሊውሉ አይችሉም እና ተወግደዋል። መጨናነቅ ወደ ውስጣዊ ማከማቻ ቀጥተኛ ፍቃድ ያስፈልጋል።</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze የምስሎችን እና ቪዲዮዎችን ፋይል መጠን ቀንሶ የማከማቻ ቦታ ይለቃል። ይህ ጥራቱን ቋሚ በሆነ ሁኔታ ይቀንሳል እና ሊቀለበስ አይችልም። ከመጀመርዎ በፊት ቅንብሮቻቸውን በጥንቃቄ ይገምግሙ።</string>
     <string name="squeezer_setup_paths_title">የፍለጋ ቦታዎች</string>
     <string name="squeezer_setup_paths_default">ለመፈለግ ማህደሮችን ይምረጡ</string>
     <string name="squeezer_setup_quality_title">የመጨመቅ ጥራት</string>
@@ -81,6 +99,6 @@
         <item quantity="one">ቢያንስ %d ቀን የቆየ</item>
         <item quantity="other">ቢያንስ %d ቀናት የቆየ</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">ለJPEG ፋይሎች የሚገመት ~%d%% ቁጠባ</string>
+    <string name="squeezer_estimated_savings_percent">ለምስሎች ግምታዊ ~%d%% ቁጠባ</string>
     <string name="squeezer_onboarding_got_it">ገባኝ</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-ar/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-ar/strings.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">ضغط الصور لتوفير مساحة التخزين.</string>
+    <string name="squeezer_explanation_short">ضغط الصور ومقاطع الفيديو لتوفير مساحة التخزين.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="zero">تم العثور على %d صور</item>
-        <item quantity="one">تم العثور على صورة %d</item>
-        <item quantity="two">تم العثور على صورتين %d</item>
-        <item quantity="few">تم العثور على %d صور</item>
-        <item quantity="many">تم العثور على %d صورة</item>
-        <item quantity="other">تم العثور على %d صورة</item>
+        <item quantity="zero">لم يتم العثور على عناصر</item>
+        <item quantity="one">تم العثور على عنصر واحد</item>
+        <item quantity="two">تم العثور على عنصرين</item>
+        <item quantity="few">تم العثور على %d عناصر</item>
+        <item quantity="many">تم العثور على %d عنصرًا</item>
+        <item quantity="other">تم العثور على %d عنصر</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="zero">يمكن توفير ~%s</item>
@@ -18,41 +18,60 @@
         <item quantity="other">يمكن توفير ~%s</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="zero">تم ضغط %d صور</item>
-        <item quantity="one">تم ضغط صورة %d</item>
-        <item quantity="two">تم ضغط صورتين %d</item>
-        <item quantity="few">تم ضغط %d صور</item>
-        <item quantity="many">تم ضغط %d صورة</item>
-        <item quantity="other">تم ضغط %d صورة</item>
+        <item quantity="zero">لم يتم ضغط أي عنصر</item>
+        <item quantity="one">تم ضغط عنصر واحد</item>
+        <item quantity="two">تم ضغط عنصرين</item>
+        <item quantity="few">تم ضغط %d عناصر</item>
+        <item quantity="many">تم ضغط %d عنصرًا</item>
+        <item quantity="other">تم ضغط %d عنصر</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="zero">لم يفشل أي عنصر</item>
+        <item quantity="one">فشل عنصر واحد</item>
+        <item quantity="two">فشل عنصران</item>
+        <item quantity="few">فشل %d عناصر</item>
+        <item quantity="many">فشل %d عنصرًا</item>
+        <item quantity="other">فشل %d عنصر</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="zero">لم يتم تخطي أي ملف (غير متاح)</item>
+        <item quantity="one">تم تخطي ملف واحد (غير متاح)</item>
+        <item quantity="two">تم تخطي ملفين (غير متاحين)</item>
+        <item quantity="few">تم تخطي %d ملفات (غير متاحة)</item>
+        <item quantity="many">تم تخطي %d ملفًا (غير متاح)</item>
+        <item quantity="other">تم تخطي %d ملف (غير متاح)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="zero">تم تحديد %d صور</item>
-        <item quantity="one">تم تحديد صورة %d</item>
-        <item quantity="two">تم تحديد صورتين %d</item>
-        <item quantity="few">تم تحديد %d صور</item>
-        <item quantity="many">تم تحديد %d صورة</item>
-        <item quantity="other">تم تحديد %d صورة</item>
+        <item quantity="zero">لم يتم تحديد أي عنصر</item>
+        <item quantity="one">تم تحديد عنصر واحد</item>
+        <item quantity="two">تم تحديد عنصرين</item>
+        <item quantity="few">تم تحديد %d عناصر</item>
+        <item quantity="many">تم تحديد %d عنصرًا</item>
+        <item quantity="other">تم تحديد %d عنصر</item>
     </plurals>
     <string name="squeezer_search_locations_title">أماكن البحث</string>
     <string name="squeezer_search_locations_default_summary">مجلدات الكاميرا (افتراضي)</string>
     <string name="squeezer_min_size_title">الحد الأدنى لحجم الملف</string>
-    <string name="squeezer_min_size_description">تخطي الصور الأصغر من هذا الحجم.</string>
+    <string name="squeezer_min_size_description">تخطي الملفات الأصغر من هذا الحجم.</string>
     <string name="squeezer_min_age_title">الحد الأدنى لعمر الملف</string>
-    <string name="squeezer_min_age_description">تضمين الصور الأقدم من هذا العمر فقط.</string>
-    <string name="squeezer_compression_settings_label">إعدادات الضغط</string>
+    <string name="squeezer_min_age_description">تضمين الملفات الأقدم من هذا العمر فقط.</string>
+    <string name="squeezer_compression_settings_label">عام</string>
     <string name="squeezer_quality_label">الجودة</string>
     <string name="squeezer_quality_title">جودة الضغط</string>
-    <string name="squeezer_quality_description">جودة أقل تعني حجم ملف أصغر لكن جودة صورة أقل.</string>
+    <string name="squeezer_quality_description">الجودة المنخفضة تعني حجم ملف أصغر ولكن جودة بصرية أقل.</string>
     <string name="squeezer_quality_example_format">مثال: صورة %1$s → توفير ~%2$s بجودة %3$d%%</string>
     <string name="squeezer_quality_warning_low">الجودة المنخفضة قد تسبب تشوهات مرئية.</string>
     <string name="squeezer_quality_warning_high">الجودة العالية جدًا توفر مساحة قليلة.</string>
-    <string name="squeezer_types_category_label">أنواع الصور</string>
+    <string name="squeezer_types_category_label">إعدادات الصورة</string>
+    <string name="squeezer_video_settings_category_label">إعدادات الفيديو</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">تضمين صور JPEG (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">تضمين صور WebP (.webp).</string>
+    <string name="squeezer_type_video_title">فيديو MP4</string>
+    <string name="squeezer_type_video_description">تضمين ملفات الفيديو بصيغة MP4 (.mp4).</string>
     <string name="squeezer_skip_compressed_title">تخطي المضغوطة سابقًا</string>
-    <string name="squeezer_skip_compressed_description">تخطي الصور التي تم ضغطها بالفعل بواسطة SD Maid.</string>
+    <string name="squeezer_skip_compressed_description">تخطي الملفات التي سبق ضغطها بواسطة SD Maid.</string>
     <string name="squeezer_exif_marker_title">كتابة علامة EXIF</string>
     <string name="squeezer_exif_marker_description">إضافة علامة إلى حقل تعليق مستخدم EXIF للصورة لمنع إعادة الضغط حتى لو تم مسح سجل الضغط.</string>
     <string name="squeezer_estimated_savings_format">~%s توفير</string>
@@ -63,8 +82,8 @@
     <string name="squeezer_preview_dialog_title">تأكيد الضغط</string>
     <string name="squeezer_preview_total_size">الحجم الإجمالي</string>
     <string name="squeezer_preview_estimated_savings">التوفير المقدر</string>
-    <string name="squeezer_compress_confirmation_title">ضغط الصور؟</string>
-    <string name="squeezer_compress_confirmation_message">سيتم استبدال الصور الأصلية بنسخ مضغوطة. لا يمكن التراجع عن هذا الإجراء.</string>
+    <string name="squeezer_compress_confirmation_title">ضغط العناصر المحددة؟</string>
+    <string name="squeezer_compress_confirmation_message">سيتم استبدال الملفات الأصلية بنسخ مضغوطة. لا يمكن التراجع عن هذا الإجراء.</string>
     <string name="squeezer_history_title">سجل الضغط</string>
     <plurals name="squeezer_history_summary">
         <item quantity="zero">%1$d عناصر (%2$s)</item>
@@ -76,17 +95,28 @@
     </plurals>
     <string name="squeezer_history_empty">لا يوجد سجل ضغط</string>
     <string name="squeezer_history_clear_title">مسح سجل الضغط</string>
-    <string name="squeezer_history_clear_message">سيسمح هذا بإعادة ضغط الصور المضغوطة سابقًا. الصور نفسها لن تتأثر.</string>
+    <string name="squeezer_history_clear_message">سيسمح هذا بضغط الملفات المضغوطة سابقًا مرة أخرى. الملفات نفسها لن تتأثر.</string>
     <string name="squeezer_onboarding_title">حول ضغط الصور</string>
     <string name="squeezer_onboarding_message">ضغط الصور يقلل حجم الملف عن طريق إزالة التفاصيل المرئية. هذه العملية لا رجعة فيها - لا يمكن استعادة الجودة الأصلية.\n\nإليك معاينة لكيفية ظهور صورك:</string>
     <string name="squeezer_onboarding_original_label">الأصلية</string>
     <string name="squeezer_onboarding_compressed_label">بعد الضغط</string>
+    <string name="squeezer_onboarding_video_original_label">إطار الفيديو</string>
+    <string name="squeezer_onboarding_video_compressed_label">معاينة (تقريبية)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">قد تختلف جودة الفيديو الفعلية</string>
     <string name="squeezer_onboarding_quality_label">الجودة: %d%%</string>
     <string name="squeezer_compare_action">عرض المقارنة</string>
     <string name="squeezer_no_example_found">لم يتم العثور على صور في المسارات المحددة.</string>
-    <string name="squeezer_result_empty_message">لم يتم العثور على صور قابلة للضغط.</string>
-    <string name="squeezer_setup_warning">الضغط يقلل جودة الصورة بشكل دائم لتوفير مساحة التخزين. لا يمكن التراجع عن ذلك. راجع إعداداتك بعناية قبل البدء.</string>
-    <string name="squeezer_setup_explanation">ضغط الوسائط يقلل حجم ملفات الصور لتحرير مساحة التخزين. هذا يقلل جودة الصورة بشكل دائم ولا يمكن التراجع عنه. راجع إعداداتك بعناية قبل البدء.</string>
+    <string name="squeezer_result_empty_message">لم يتم العثور على وسائط قابلة للضغط.</string>
+    <string name="squeezer_setup_warning">يُقلّل الضغط من الجودة بشكل دائم لتوفير مساحة التخزين. لا يمكن التراجع عن ذلك. راجع إعداداتك بعناية قبل البدء.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="zero">لا توجد مواقع يمكن استخدامها للضغط وتمت إزالتها. يتطلب الضغط وصولاً مباشرًا إلى التخزين الداخلي.</item>
+        <item quantity="one">لا يمكن استخدام موقع واحد للضغط وتمت إزالته. يتطلب الضغط وصولاً مباشرًا إلى التخزين الداخلي.</item>
+        <item quantity="two">لا يمكن استخدام موقعين للضغط وتمت إزالتهما. يتطلب الضغط وصولاً مباشرًا إلى التخزين الداخلي.</item>
+        <item quantity="few">لا يمكن استخدام %d مواقع للضغط وتمت إزالتها. يتطلب الضغط وصولاً مباشرًا إلى التخزين الداخلي.</item>
+        <item quantity="many">لا يمكن استخدام %d موقعًا للضغط وتمت إزالتها. يتطلب الضغط وصولاً مباشرًا إلى التخزين الداخلي.</item>
+        <item quantity="other">لا يمكن استخدام %d موقع للضغط وتمت إزالتها. يتطلب الضغط وصولاً مباشرًا إلى التخزين الداخلي.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">يُقلّل Media Squeeze من حجم ملفات الصور ومقاطع الفيديو لتحرير مساحة التخزين. يُقلّل هذا من الجودة بشكل دائم ولا يمكن التراجع عنه. راجع إعداداتك بعناية قبل البدء.</string>
     <string name="squeezer_setup_paths_title">أماكن البحث</string>
     <string name="squeezer_setup_paths_default">اختر المجلدات للبحث</string>
     <string name="squeezer_setup_quality_title">جودة الضغط</string>
@@ -105,6 +135,6 @@
         <item quantity="many">عمرها %d يومًا على الأقل</item>
         <item quantity="other">عمرها %d يوم على الأقل</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">توفير مقدر ~%d%% لملفات JPEG</string>
+    <string name="squeezer_estimated_savings_percent">توفير تقديري ~%d%% للصور</string>
     <string name="squeezer_onboarding_got_it">عُلم</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-az/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-az/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Yaddaş yerindən qənaət etmək üçün şəkilləri sıxışdırın.</string>
+    <string name="squeezer_explanation_short">Yaddaş sahəsinə qənaət etmək üçün şəkilləri və videoları sıxışdırın.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d şəkil tapıldı</item>
-        <item quantity="other">%d şəkil tapıldı</item>
+        <item quantity="one">%d element tapıldı</item>
+        <item quantity="other">%d element tapıldı</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s qənaət edilə bilər</item>
         <item quantity="other">~%s qənaət edilə bilər</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d şəkil sıxışdırıldı</item>
-        <item quantity="other">%d şəkil sıxışdırıldı</item>
+        <item quantity="one">%d element sıxışdırıldı</item>
+        <item quantity="other">%d element sıxışdırıldı</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d uğursuz</item>
+        <item quantity="other">%d uğursuz</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d fayl atlandı (əlçatmaz)</item>
+        <item quantity="other">%d fayl atlandı (əlçatmaz)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d şəkil seçildi</item>
-        <item quantity="other">%d şəkil seçildi</item>
+        <item quantity="one">%d element seçildi</item>
+        <item quantity="other">%d element seçildi</item>
     </plurals>
     <string name="squeezer_search_locations_title">Axtarış yerləri</string>
     <string name="squeezer_search_locations_default_summary">Kamera qovluqları (standart)</string>
     <string name="squeezer_min_size_title">Minimum fayl ölçüsü</string>
-    <string name="squeezer_min_size_description">Bu ölçüdən kiçik şəkilləri keçin.</string>
+    <string name="squeezer_min_size_description">Bu ölçüdən kiçik faylları atlayın.</string>
     <string name="squeezer_min_age_title">Minimum fayl yaşı</string>
-    <string name="squeezer_min_age_description">Yalnız bu yaşdan köhnə şəkilləri daxil edin.</string>
-    <string name="squeezer_compression_settings_label">Sıxışdırma parametrləri</string>
+    <string name="squeezer_min_age_description">Yalnız bu yaşdan köhnə faylları daxil edin.</string>
+    <string name="squeezer_compression_settings_label">Ümumi</string>
     <string name="squeezer_quality_label">Keyfiyyət</string>
     <string name="squeezer_quality_title">Sıxışdırma keyfiyyəti</string>
-    <string name="squeezer_quality_description">Aşağı keyfiyyət daha kiçik fayl ölçüsü deməkdir, lakin şəkil keyfiyyəti azalır.</string>
+    <string name="squeezer_quality_description">Aşağı keyfiyyət daha kiçik fayl ölçüsü deməkdir, lakin vizual keyfiyyəti azaldır.</string>
     <string name="squeezer_quality_example_format">Nümunə: %1$s şəkil → %3$d%% keyfiyyətdə ~%2$s qənaət</string>
     <string name="squeezer_quality_warning_low">Aşağı keyfiyyət görünən artefaktlara səbəb ola bilər.</string>
     <string name="squeezer_quality_warning_high">Çox yüksək keyfiyyət minimum yer qənaəti təmin edir.</string>
-    <string name="squeezer_types_category_label">Şəkil növləri</string>
+    <string name="squeezer_types_category_label">Şəkil parametrləri</string>
+    <string name="squeezer_video_settings_category_label">Video parametrləri</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">JPEG şəkillərini daxil et (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">WebP şəkillərini daxil et (.webp).</string>
+    <string name="squeezer_type_video_title">MP4 Video</string>
+    <string name="squeezer_type_video_description">MP4 video fayllarını (.mp4) daxil edin.</string>
     <string name="squeezer_skip_compressed_title">Əvvəl sıxışdırılmışları keç</string>
-    <string name="squeezer_skip_compressed_description">SD Maid tərəfindən artıq sıxışdırılmış şəkilləri keçin.</string>
+    <string name="squeezer_skip_compressed_description">SD Maid tərəfindən artıq sıxışdırılmış faylları atlayın.</string>
     <string name="squeezer_exif_marker_title">EXIF işarəsi yaz</string>
     <string name="squeezer_exif_marker_description">Sıxışdırma tarixçəsi silinsa belə təkrar sıxışdırmanın qarşısını almaq üçün şəklin EXIF istifadəçi şərhi sahəsinə işarə əlavə edin.</string>
     <string name="squeezer_estimated_savings_format">~%s qənaət</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">Sıxışdırmanı təsdiqləyin</string>
     <string name="squeezer_preview_total_size">Ümumi ölçü</string>
     <string name="squeezer_preview_estimated_savings">Təxmini qənaət</string>
-    <string name="squeezer_compress_confirmation_title">Şəkillər sıxışdırılsın?</string>
-    <string name="squeezer_compress_confirmation_message">Bu orijinal şəkilləri sıxışdırılmış versiyalarla əvəz edəcək. Bu əməliyyat geri qaytarıla bilməz.</string>
+    <string name="squeezer_compress_confirmation_title">Seçilmiş elementləri sıxışdırılsın?</string>
+    <string name="squeezer_compress_confirmation_message">Bu, orijinal faylları sıxışdırılmış versiyalarla əvəz edəcək. Bu əməliyyat geri qaytarrla biləməz.</string>
     <string name="squeezer_history_title">Sıxışdırma tarixçəsi</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d element (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">Sıxışdırma tarixçəsi yoxdur</string>
     <string name="squeezer_history_clear_title">Sıxışdırma tarixçəsini təmizlə</string>
-    <string name="squeezer_history_clear_message">Bu əvvəl sıxışdırılmış şəkillərin yenidən sıxışdırılmasına icazə verəcək. Şəkillərin özü təsirlənmir.</string>
+    <string name="squeezer_history_clear_message">Bu, əvvəllər sıxışdırılmış faylların yenidən sıxışdırılmasına icəazə verəcək. Faylların özlərinə təsir edilmir.</string>
     <string name="squeezer_onboarding_title">Şəkil sıxışdırma haqqında</string>
     <string name="squeezer_onboarding_message">Şəkil sıxışdırma vizual detalları silməklə fayl ölçüsünü azaldır. Bu proses geri dönməzdir - orijinal keyfiyyət bərpa edilə bilməz.\n\nŞəkillərinizin necə görünəcəyinin ön baxışı:</string>
     <string name="squeezer_onboarding_original_label">Orijinal</string>
     <string name="squeezer_onboarding_compressed_label">Sıxışdırmadan sonra</string>
+    <string name="squeezer_onboarding_video_original_label">Video kadrı</string>
+    <string name="squeezer_onboarding_video_compressed_label">Önizləmə (təxmini)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">Faktiki video keyfiyyəti fərqlənə bilər</string>
     <string name="squeezer_onboarding_quality_label">Keyfiyyət: %d%%</string>
     <string name="squeezer_compare_action">Müqayisəyə bax</string>
     <string name="squeezer_no_example_found">Seçilmiş yollarda şəkil tapılmadı.</string>
-    <string name="squeezer_result_empty_message">Sıxışdırıla bilən şəkil tapılmadı.</string>
-    <string name="squeezer_setup_warning">Sıxışdırma yer qənaəti üçün şəkil keyfiyyətini daimi olaraq azaldır. Bu geri qaytarıla bilməz. Başlamadan əvvəl parametrlərinizi diqqətlə nəzərdən keçirin.</string>
-    <string name="squeezer_setup_explanation">Media Squeeze yaddaş yeri azad etmək üçün şəkil fayl ölçüsünü azaldır. Bu şəkil keyfiyyətini daimi olaraq azaldır və geri qaytarıla bilməz. Başlamadan əvvəl parametrlərinizi diqqətlə nəzərdən keçirin.</string>
+    <string name="squeezer_result_empty_message">Sıxışdırıla bilən media tapılmadı.</string>
+    <string name="squeezer_setup_warning">Sıxışdırma, yaddaş sahəsinə qənaət etmək üçün keyfiyyəti daimi olaraq azaldır. Bu geri qaytarrla biləməz. Başlamadan əvvəl parametrlərinizi diqqətlə nəzardən keçirin.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d yer sıxışdırma üçün istifadə edilə bilməz və silindi. Sıxışdırma daxili yaddaşa birbirə giriş tələb edir.</item>
+        <item quantity="other">%d yer sıxışdırma üçün istifadə edilə bilməz və silindi. Sıxışdırma daxili yaddaşa birbirə giriş tələb edir.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze, yaddaş sahəsini azad etmək üçün şəkil və videoların fayl ölçüsünü azaldır. Bu, keyfiyyəti daimi olaraq azaldır və geri qaytarrla biləməz. Başlamadan əvvəl parametrlərinizi diqqətlə nəzardən keçirin.</string>
     <string name="squeezer_setup_paths_title">Axtarış yerləri</string>
     <string name="squeezer_setup_paths_default">Axtarış üçün qovluqları seçin</string>
     <string name="squeezer_setup_quality_title">Sıxışdırma keyfiyyəti</string>
@@ -81,6 +99,6 @@
         <item quantity="one">Ən azı %d gün köhnə</item>
         <item quantity="other">Ən azı %d gün köhnə</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">JPEG faylları üçün təxmini ~%d%% qənaət</string>
+    <string name="squeezer_estimated_savings_percent">Şəkillər üçün təxmini ~%d%% qənaət</string>
     <string name="squeezer_onboarding_got_it">Başa düşdüm</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-bg/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-bg/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Компресиране на изображения за спестяване на място за съхранение.</string>
+    <string name="squeezer_explanation_short">Компресирайте изображения и видеоклипове, за да спестите място за съхранение.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d изображение намерено</item>
-        <item quantity="other">%d изображения намерени</item>
+        <item quantity="one">%d намерен елемент</item>
+        <item quantity="other">%d намерени елемента</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s може да се спести</item>
         <item quantity="other">~%s могат да се спестят</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d изображение компресирано</item>
-        <item quantity="other">%d изображения компресирани</item>
+        <item quantity="one">%d компресиран елемент</item>
+        <item quantity="other">%d компресирани елемента</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d неуспешен</item>
+        <item quantity="other">%d неуспешни</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d файл пропуснат (недостъпен)</item>
+        <item quantity="other">%d файла пропуснати (недостъпни)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d изображение избрано</item>
-        <item quantity="other">%d изображения избрани</item>
+        <item quantity="one">%d избран елемент</item>
+        <item quantity="other">%d избрани елемента</item>
     </plurals>
     <string name="squeezer_search_locations_title">Места за търсене</string>
     <string name="squeezer_search_locations_default_summary">Папки на камерата (по подразбиране)</string>
     <string name="squeezer_min_size_title">Минимален размер на файла</string>
-    <string name="squeezer_min_size_description">Пропускане на изображения по-малки от този размер.</string>
+    <string name="squeezer_min_size_description">Пропускайте файлове, по-малки от този размер.</string>
     <string name="squeezer_min_age_title">Минимална възраст на файла</string>
-    <string name="squeezer_min_age_description">Включване само на изображения по-стари от тази възраст.</string>
-    <string name="squeezer_compression_settings_label">Настройки за компресия</string>
+    <string name="squeezer_min_age_description">Включвайте само файлове, по-стари от тази възраст.</string>
+    <string name="squeezer_compression_settings_label">Общи</string>
     <string name="squeezer_quality_label">Качество</string>
     <string name="squeezer_quality_title">Качество на компресия</string>
-    <string name="squeezer_quality_description">По-ниско качество означава по-малък размер на файла, но намалено качество на изображението.</string>
+    <string name="squeezer_quality_description">По-ниското качество означава по-малък размер на файла, но намалено визуално качество.</string>
     <string name="squeezer_quality_example_format">Пример: %1$s изображение → спестява ~%2$s при %3$d%% качество</string>
     <string name="squeezer_quality_warning_low">По-ниските качества могат да причинят видими артефакти.</string>
     <string name="squeezer_quality_warning_high">Много високото качество осигурява минимални спестявания на място.</string>
-    <string name="squeezer_types_category_label">Типове изображения</string>
+    <string name="squeezer_types_category_label">Настройки за изображения</string>
+    <string name="squeezer_video_settings_category_label">Настройки за видео</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">Включване на JPEG изображения (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">Включване на WebP изображения (.webp).</string>
+    <string name="squeezer_type_video_title">MP4 видео</string>
+    <string name="squeezer_type_video_description">Включвайте MP4 видео файлове (.mp4).</string>
     <string name="squeezer_skip_compressed_title">Пропускане на вече компресирани</string>
-    <string name="squeezer_skip_compressed_description">Пропускане на изображения, които вече са компресирани от SD Maid.</string>
+    <string name="squeezer_skip_compressed_description">Пропускайте файлове, които вече са компресирани от SD Maid.</string>
     <string name="squeezer_exif_marker_title">Записване на EXIF маркер</string>
     <string name="squeezer_exif_marker_description">Добавяне на маркер в полето за EXIF потребителски коментар на изображението, за да се предотврати повторна компресия, дори ако историята на компресията бъде изчистена.</string>
     <string name="squeezer_estimated_savings_format">~%s спестявания</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">Потвърждаване на компресията</string>
     <string name="squeezer_preview_total_size">Общ размер</string>
     <string name="squeezer_preview_estimated_savings">Очаквани спестявания</string>
-    <string name="squeezer_compress_confirmation_title">Компресиране на изображенията?</string>
-    <string name="squeezer_compress_confirmation_message">Това ще замени оригиналните изображения с компресирани версии. Това действие не може да бъде отменено.</string>
+    <string name="squeezer_compress_confirmation_title">Компресиране на избраните елементи?</string>
+    <string name="squeezer_compress_confirmation_message">Това ще замени оригиналните файлове с компресирани версии. Това действие не може да бъде отменено.</string>
     <string name="squeezer_history_title">История на компресията</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d елемент (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">Няма история на компресията</string>
     <string name="squeezer_history_clear_title">Изчистване на историята на компресията</string>
-    <string name="squeezer_history_clear_message">Това ще позволи на вече компресираните изображения да бъдат компресирани отново. Самите изображения не са засегнати.</string>
+    <string name="squeezer_history_clear_message">Това ще позволи на вече компресираните файлове да бъдат компресирани отново. Самите файлове не са засегнати.</string>
     <string name="squeezer_onboarding_title">За компресията на изображения</string>
     <string name="squeezer_onboarding_message">Компресията на изображения намалява размера на файла чрез премахване на визуални детайли. Този процес е необратим - оригиналното качество не може да бъде възстановено.\n\nЕто предварителен преглед на това как ще изглеждат вашите изображения:</string>
     <string name="squeezer_onboarding_original_label">Оригинал</string>
     <string name="squeezer_onboarding_compressed_label">След компресия</string>
+    <string name="squeezer_onboarding_video_original_label">Видео кадър</string>
+    <string name="squeezer_onboarding_video_compressed_label">Преглед (приблизителен)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">Действителното качество на видеото може да се различава</string>
     <string name="squeezer_onboarding_quality_label">Качество: %d%%</string>
     <string name="squeezer_compare_action">Преглед на сравнение</string>
     <string name="squeezer_no_example_found">Не са намерени изображения в избраните пътища.</string>
-    <string name="squeezer_result_empty_message">Не са намерени компресируеми изображения.</string>
-    <string name="squeezer_setup_warning">Компресията трайно намалява качеството на изображенията, за да спести място за съхранение. Това не може да бъде отменено. Прегледайте внимателно настройките си преди да започнете.</string>
-    <string name="squeezer_setup_explanation">Media Squeeze намалява размера на файловете с изображения, за да освободи място за съхранение. Това трайно намалява качеството на изображенията и не може да бъде отменено. Прегледайте внимателно настройките си преди да започнете.</string>
+    <string name="squeezer_result_empty_message">Няма намерени медии за компресиране.</string>
+    <string name="squeezer_setup_warning">Компресирането намалява качеството завинаги, за да спести място за съхранение. Това не може да бъде отменено. Прегледайте внимателно настройките си, преди да започнете.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d местоположение не може да се използва за компресиране и беше премахнато. Компресирането изисква директен достъп до вътрешната памет.</item>
+        <item quantity="other">%d местоположения не могат да се използват за компресиране и бяха премахнати. Компресирането изисква директен достъп до вътрешната памет.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze намалява размера на файловете с изображения и видеоклипове, за да освободи място за съхранение. Това постоянно намалява качеството и не може да бъде отменено. Прегледайте внимателно настройките си, преди да започнете.</string>
     <string name="squeezer_setup_paths_title">Места за търсене</string>
     <string name="squeezer_setup_paths_default">Изберете папки за търсене</string>
     <string name="squeezer_setup_quality_title">Качество на компресия</string>
@@ -81,6 +99,6 @@
         <item quantity="one">Поне %d ден стар</item>
         <item quantity="other">Поне %d дни стар</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">Очаквани ~%d%% спестявания за JPEG файлове</string>
+    <string name="squeezer_estimated_savings_percent">Очаквана спестяване ~%d%% за изображения</string>
     <string name="squeezer_onboarding_got_it">Разбрах</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-bn-rBD/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-bn-rBD/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">স্টোরেজ স্পেস বাঁচাতে ছবি সংকুচিত করুন।</string>
+    <string name="squeezer_explanation_short">স্টোরেজ স্থান বাঁচাতে ছবি এবং ভিডিও সংকুচিত করুন।</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d ছবি পাওয়া গেছে</item>
-        <item quantity="other">%d ছবি পাওয়া গেছে</item>
+        <item quantity="one">%dটি আইটেম পাওয়া গেছে</item>
+        <item quantity="other">%dটি আইটেম পাওয়া গেছে</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s সাশ্রয় করা যাবে</item>
         <item quantity="other">~%s সাশ্রয় করা যাবে</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d ছবি সংকুচিত হয়েছে</item>
-        <item quantity="other">%d ছবি সংকুচিত হয়েছে</item>
+        <item quantity="one">%dটি আইটেম সংকুচিত হয়েছে</item>
+        <item quantity="other">%dটি আইটেম সংকুচিত হয়েছে</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d ব্যর্থ</item>
+        <item quantity="other">%d ব্যর্থ</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%dটি ফাইল এড়িয়ে যাওয়া হয়েছে (অ্যাক্সেসযোগ্য নয়)</item>
+        <item quantity="other">%dটি ফাইল এড়িয়ে যাওয়া হয়েছে (অ্যাক্সেসযোগ্য নয়)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d ছবি নির্বাচিত</item>
-        <item quantity="other">%d ছবি নির্বাচিত</item>
+        <item quantity="one">%dটি আইটেম নির্বাচিত</item>
+        <item quantity="other">%dটি আইটেম নির্বাচিত</item>
     </plurals>
     <string name="squeezer_search_locations_title">অনুসন্ধান অবস্থান</string>
     <string name="squeezer_search_locations_default_summary">ক্যামেরা ফোল্ডার (ডিফল্ট)</string>
     <string name="squeezer_min_size_title">সর্বনিম্ন ফাইল আকার</string>
-    <string name="squeezer_min_size_description">এই আকারের চেয়ে ছোট ছবি এড়িয়ে যান।</string>
+    <string name="squeezer_min_size_description">এই আকারের চেয়ে ছোট ফাইলগুলি এড়িয়ে যান।</string>
     <string name="squeezer_min_age_title">সর্বনিম্ন ফাইল বয়স</string>
-    <string name="squeezer_min_age_description">শুধুমাত্র এই বয়সের চেয়ে পুরনো ছবি অন্তর্ভুক্ত করুন।</string>
-    <string name="squeezer_compression_settings_label">সংকোচন সেটিংস</string>
+    <string name="squeezer_min_age_description">কেবল এই বয়সের চেয়ে পুরানো ফাইলগুলি অন্তর্ভুক্ত করুন।</string>
+    <string name="squeezer_compression_settings_label">সাধারণ</string>
     <string name="squeezer_quality_label">গুণমান</string>
     <string name="squeezer_quality_title">সংকোচনের গুণমান</string>
-    <string name="squeezer_quality_description">নিম্ন গুণমান মানে ছোট ফাইল আকার কিন্তু হ্রাসকৃত ছবির গুণমান।</string>
+    <string name="squeezer_quality_description">কম মান মানে ছোট ফাইলের আকার কিন্তু কম দৃশ্যমান মান।</string>
     <string name="squeezer_quality_example_format">উদাহরণ: %1$s ছবি → %3$d%% গুণমানে ~%2$s সাশ্রয়</string>
     <string name="squeezer_quality_warning_low">নিম্ন গুণমান দৃশ্যমান আর্টিফ্যাক্ট তৈরি করতে পারে।</string>
     <string name="squeezer_quality_warning_high">অত্যন্ত উচ্চ গুণমান ন্যূনতম স্থান সাশ্রয় প্রদান করে।</string>
-    <string name="squeezer_types_category_label">ছবির ধরন</string>
+    <string name="squeezer_types_category_label">ছবির সেটিংস</string>
+    <string name="squeezer_video_settings_category_label">ভিডিও সেটিংস</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">JPEG ছবি (.jpg, .jpeg) অন্তর্ভুক্ত করুন।</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">WebP ছবি (.webp) অন্তর্ভুক্ত করুন।</string>
+    <string name="squeezer_type_video_title">MP4 ভিডিও</string>
+    <string name="squeezer_type_video_description">MP4 ভিডিও ফাইল (.mp4) অন্তর্ভুক্ত করুন।</string>
     <string name="squeezer_skip_compressed_title">আগে সংকুচিত এড়িয়ে যান</string>
-    <string name="squeezer_skip_compressed_description">SD Maid দ্বারা আগে সংকুচিত ছবি এড়িয়ে যান।</string>
+    <string name="squeezer_skip_compressed_description">SD Maid দ্বারা ইতিমধ্যে সংকুচিত ফাইলগুলি এড়িয়ে যান।</string>
     <string name="squeezer_exif_marker_title">EXIF মার্কার লিখুন</string>
     <string name="squeezer_exif_marker_description">সংকোচন ইতিহাস মুছে ফেলা হলেও পুনরায় সংকোচন রোধ করতে ছবির EXIF ব্যবহারকারী মন্তব্য ক্ষেত্রে একটি মার্কার যোগ করুন।</string>
     <string name="squeezer_estimated_savings_format">~%s সাশ্রয়</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">সংকোচন নিশ্চিত করুন</string>
     <string name="squeezer_preview_total_size">মোট আকার</string>
     <string name="squeezer_preview_estimated_savings">আনুমানিক সাশ্রয়</string>
-    <string name="squeezer_compress_confirmation_title">ছবি সংকুচিত করবেন?</string>
-    <string name="squeezer_compress_confirmation_message">এটি মূল ছবিগুলিকে সংকুচিত সংস্করণ দিয়ে প্রতিস্থাপন করবে। এই ক্রিয়া পূর্বাবস্থায় ফেরানো যাবে না।</string>
+    <string name="squeezer_compress_confirmation_title">নির্বাচিত আইটেমগুলি সংকুচিত করবেন?</string>
+    <string name="squeezer_compress_confirmation_message">এটি মূল ফাইলগুলিকে সংকুচিত সংস্করণ দিয়ে প্রতিস্থাপন করবে। এই ক্রিয়াটি পূর্বাবস্থায় ফেরানো যাবে না।</string>
     <string name="squeezer_history_title">সংকোচন ইতিহাস</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d আইটেম (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">কোন সংকোচন ইতিহাস নেই</string>
     <string name="squeezer_history_clear_title">সংকোচন ইতিহাস মুছুন</string>
-    <string name="squeezer_history_clear_message">এটি আগে সংকুচিত ছবিগুলিকে আবার সংকুচিত করার অনুমতি দেবে। ছবিগুলি নিজেরা প্রভাবিত হবে না।</string>
+    <string name="squeezer_history_clear_message">এটি পূর্বে সংকুচিত ফাইলগুলিকে আবার সংকুচিত করার অনুমতি দেবে। ফাইলগুলি নিজেই প্রভাবিত হয় না।</string>
     <string name="squeezer_onboarding_title">ছবি সংকোচন সম্পর্কে</string>
     <string name="squeezer_onboarding_message">ছবি সংকোচন ভিজ্যুয়াল বিশদ অপসারণ করে ফাইলের আকার কমায়। এই প্রক্রিয়া অপরিবর্তনীয় - আসল গুণমান পুনরুদ্ধার করা যাবে না।\n\nআপনার ছবিগুলি কেমন দেখাবে তার একটি প্রিভিউ এখানে:</string>
     <string name="squeezer_onboarding_original_label">আসল</string>
     <string name="squeezer_onboarding_compressed_label">সংকোচনের পর</string>
+    <string name="squeezer_onboarding_video_original_label">ভিডিও ফ্রেম</string>
+    <string name="squeezer_onboarding_video_compressed_label">প্রিভিউ (আনুমানিক)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">প্রকৃত ভিডিও মান ভিন্ন হতে পারে</string>
     <string name="squeezer_onboarding_quality_label">গুণমান: %d%%</string>
     <string name="squeezer_compare_action">তুলনা দেখুন</string>
     <string name="squeezer_no_example_found">নির্বাচিত পাথে কোনো ছবি পাওয়া যায়নি।</string>
-    <string name="squeezer_result_empty_message">সংকোচনযোগ্য কোনো ছবি পাওয়া যায়নি।</string>
-    <string name="squeezer_setup_warning">সংকোচন স্টোরেজ স্পেস বাঁচাতে স্থায়ীভাবে ছবির গুণমান হ্রাস করে। এটি পূর্বাবস্থায় ফেরানো যাবে না। শুরু করার আগে আপনার সেটিংস সাবধানে পর্যালোচনা করুন।</string>
-    <string name="squeezer_setup_explanation">মিডিয়া স্কুইজ স্টোরেজ স্পেস খালি করতে ছবির ফাইলের আকার কমায়। এটি স্থায়ীভাবে ছবির গুণমান হ্রাস করে এবং পূর্বাবস্থায় ফেরানো যাবে না। শুরু করার আগে আপনার সেটিংস সাবধানে পর্যালোচনা করুন।</string>
+    <string name="squeezer_result_empty_message">কোনো সংকোচনযোগ্য মিডিয়া পাওয়া যায়নি।</string>
+    <string name="squeezer_setup_warning">সংকোচন স্থায়ীভাবে স্টোরেজ স্থান বাঁচাতে মান কমিয়ে দেয়। এটি পূর্বাবস্থায় ফেরানো যাবে না। শুরু করার আগে আপনার সেটিংস সাবধানে পর্যালোচনা করুন।</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%dটি অবস্থান সংকোচনের জন্য ব্যবহার করা যাবে না এবং সরানো হয়েছে। সংকোচনের জন্য অভ্যন্তরীণ স্টোরেজে সরাসরি অ্যাক্সেস প্রয়োজন।</item>
+        <item quantity="other">%dটি অবস্থান সংকোচনের জন্য ব্যবহার করা যাবে না এবং সরানো হয়েছে। সংকোচনের জন্য অভ্যন্তরীণ স্টোরেজে সরাসরি অ্যাক্সেস প্রয়োজন।</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">মিডিয়া স্কুইজ স্টোরেজ স্থান খালি করতে ছবি ও ভিডিওর ফাইলের আকার কমায়। এটি স্থায়ীভাবে মান কমিয়ে দেয় এবং পূর্বাবস্থায় ফেরানো যাবে না। শুরু করার আগে আপনার সেটিংস সাবধানে পর্যালোচনা করুন।</string>
     <string name="squeezer_setup_paths_title">অনুসন্ধান অবস্থান</string>
     <string name="squeezer_setup_paths_default">অনুসন্ধানের জন্য ফোল্ডার নির্বাচন করুন</string>
     <string name="squeezer_setup_quality_title">সংকোচনের গুণমান</string>
@@ -81,6 +99,6 @@
         <item quantity="one">অন্তত %d দিন পুরনো</item>
         <item quantity="other">অন্তত %d দিন পুরনো</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">JPEG ফাইলের জন্য আনুমানিক ~%d%% সাশ্রয়</string>
+    <string name="squeezer_estimated_savings_percent">ছবির জন্য আনুমানিক ~%d%% সাশ্রয়</string>
     <string name="squeezer_onboarding_got_it">বুঝেছি</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-ca/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-ca/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Comprimiu imatges per estalviar espai d\'emmagatzematge.</string>
+    <string name="squeezer_explanation_short">Comprimiu imatges i vídeos per estalviar espai d\'emmagatzematge.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">S\'ha trobat %d imatge</item>
-        <item quantity="other">S\'han trobat %d imatges</item>
+        <item quantity="one">S\'ha trobat %d element</item>
+        <item quantity="other">S\'han trobat %d elements</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">Es pot estalviar ~%s</item>
         <item quantity="other">Es poden estalviar ~%s</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">S\'ha comprimit %d imatge</item>
-        <item quantity="other">S\'han comprimit %d imatges</item>
+        <item quantity="one">S\'ha comprimit %d element</item>
+        <item quantity="other">S\'han comprimit %d elements</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d ha fallat</item>
+        <item quantity="other">%d han fallat</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">S\'ha omès %d fitxer (no accessible)</item>
+        <item quantity="other">S\'han omès %d fitxers (no accessibles)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">S\'ha seleccionat %d imatge</item>
-        <item quantity="other">S\'han seleccionat %d imatges</item>
+        <item quantity="one">%d element seleccionat</item>
+        <item quantity="other">%d elements seleccionats</item>
     </plurals>
     <string name="squeezer_search_locations_title">Cerca ubicacions</string>
     <string name="squeezer_search_locations_default_summary">Carpetes de càmera (per defecte)</string>
     <string name="squeezer_min_size_title">Mida mínima del fitxer</string>
-    <string name="squeezer_min_size_description">Omet les imatges més petites que aquesta mida.</string>
+    <string name="squeezer_min_size_description">Omet els fitxers més petits que aquesta mida.</string>
     <string name="squeezer_min_age_title">Antiguitat mínima del fitxer</string>
-    <string name="squeezer_min_age_description">Només inclou imatges anteriors a aquesta antiguitat.</string>
-    <string name="squeezer_compression_settings_label">Configuració de la compressió</string>
+    <string name="squeezer_min_age_description">Només inclou fitxers anteriors a aquesta antiguitat.</string>
+    <string name="squeezer_compression_settings_label">General</string>
     <string name="squeezer_quality_label">Qualitat</string>
     <string name="squeezer_quality_title">Qualitat de compressió</string>
-    <string name="squeezer_quality_description">Una qualitat més baixa significa una mida de fitxer més petita però una qualitat d\'imatge reduïda.</string>
+    <string name="squeezer_quality_description">Una qualitat més baixa significa una mida de fitxer més petita però una qualitat visual reduïda.</string>
     <string name="squeezer_quality_example_format">Exemple: %1$s imatge → estalvia ~%2$s amb una qualitat del %3$d%%</string>
     <string name="squeezer_quality_warning_low">Les qualitats inferiors poden causar artefactes visibles.</string>
     <string name="squeezer_quality_warning_high">La qualitat molt alta proporciona un estalvi mínim d\'espai.</string>
-    <string name="squeezer_types_category_label">Tipus d\'imatge</string>
+    <string name="squeezer_types_category_label">Configuració d\'imatges</string>
+    <string name="squeezer_video_settings_category_label">Configuració de vídeo</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">Inclou imatges JPEG (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">Inclou imatges WebP (.webp).</string>
+    <string name="squeezer_type_video_title">Vídeo MP4</string>
+    <string name="squeezer_type_video_description">Inclou fitxers de vídeo MP4 (.mp4).</string>
     <string name="squeezer_skip_compressed_title">Omet els elements comprimits anteriorment</string>
-    <string name="squeezer_skip_compressed_description">Omet les imatges que ja han estat comprimides per l\'SD Maid.</string>
+    <string name="squeezer_skip_compressed_description">Omet els fitxers que ja han estat comprimits per l\'SD Maid.</string>
     <string name="squeezer_exif_marker_title">Escriu el marcador EXIF</string>
     <string name="squeezer_exif_marker_description">Afegeix un marcador al camp de comentaris de l\'usuari EXIF ​​de la imatge per evitar la recompressió fins i tot si s\'esborra l\'historial de compressió.</string>
     <string name="squeezer_estimated_savings_format">~%s estalviats</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">Confirmeu la compressió</string>
     <string name="squeezer_preview_total_size">Mida total</string>
     <string name="squeezer_preview_estimated_savings">Estalvi estimat</string>
-    <string name="squeezer_compress_confirmation_title">Voleu comprimir les imatges?</string>
-    <string name="squeezer_compress_confirmation_message">Això substituirà les imatges originals per versions comprimides. Aquesta acció no es pot desfer.</string>
+    <string name="squeezer_compress_confirmation_title">Voleu comprimir els elements seleccionats?</string>
+    <string name="squeezer_compress_confirmation_message">Això substituïrà els fitxers originals per versions comprimides. Aquesta acció no es pot desfer.</string>
     <string name="squeezer_history_title">Historial de compressió</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d element (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">Sense historial de compressió</string>
     <string name="squeezer_history_clear_title">Esborra l\'historial de compressió</string>
-    <string name="squeezer_history_clear_message">Això permetrà que les imatges prèviament comprimides es tornin a comprimir. Les imatges en si no es veuen afectades.</string>
+    <string name="squeezer_history_clear_message">Això permetrà que els fitxers prèviament comprimits es tornin a comprimir. Els fitxers en si no es veuen afectats.</string>
     <string name="squeezer_onboarding_title">Quant a la compressió d\'imatges</string>
     <string name="squeezer_onboarding_message">La compressió d\'imatges redueix la mida del fitxer eliminant detalls visuals. Aquest procés és irreversible: la qualitat original no es pot restaurar.\n\nAquí teniu una vista prèvia de com quedaran les vostres imatges:</string>
     <string name="squeezer_onboarding_original_label">Original</string>
     <string name="squeezer_onboarding_compressed_label">Després de la compressió</string>
+    <string name="squeezer_onboarding_video_original_label">Fotograma de vídeo</string>
+    <string name="squeezer_onboarding_video_compressed_label">Previsualització (aproximada)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">La qualitat real del vídeo pot variar</string>
     <string name="squeezer_onboarding_quality_label">Qualitat: %d%%</string>
     <string name="squeezer_compare_action">Mostra la comparació</string>
     <string name="squeezer_no_example_found">No s\'han trobat imatges a les rutes seleccionades.</string>
-    <string name="squeezer_result_empty_message">No s\'han trobat imatges comprimibles.</string>
-    <string name="squeezer_setup_warning">La compressió redueix permanentment la qualitat de la imatge per estalviar espai d\'emmagatzematge. Això no es pot desfer. Reviseu la configuració acuradament abans de començar.</string>
-    <string name="squeezer_setup_explanation">La compressió multimèdia redueix la mida dels fitxers d\'imatges per alliberar espai d\'emmagatzematge. Això redueix permanentment la qualitat de la imatge i no es pot desfer. Reviseu la configuració acuradament abans de començar.</string>
+    <string name="squeezer_result_empty_message">No s\'han trobat fitxers multimèdia comprimibles.</string>
+    <string name="squeezer_setup_warning">La compressió reduïx permanentment la qualitat per estalviar espai d\'emmagatzematge. Això no es pot desfer. Reviseu la configuració acuradament abans de començar.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d ubicació no es pot utilitzar per a la compressió i s\'ha eliminat. La compressió requereix accés directe a l\'emmagatzematge intern.</item>
+        <item quantity="other">%d ubicacions no es poden utilitzar per a la compressió i s\'han eliminat. La compressió requereix accés directe a l\'emmagatzematge intern.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">La compressió de fitxers multimèdia reduïx la mida dels fitxers d\'imatges i vídeos per alliberar espai d\'emmagatzematge. Això reduïx permanentment la qualitat i no es pot desfer. Reviseu la configuració acuradament abans de començar.</string>
     <string name="squeezer_setup_paths_title">Cerca ubicacions</string>
     <string name="squeezer_setup_paths_default">Seleccioneu les carpetes per cercar</string>
     <string name="squeezer_setup_quality_title">Qualitat de compressió</string>
@@ -81,6 +99,6 @@
         <item quantity="one">Almenys %d dia d\'antiguitat</item>
         <item quantity="other">Almenys %d dies d\'antiguitat</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">Estalvi estimat d\'un %d%% per a fitxers JPEG</string>
+    <string name="squeezer_estimated_savings_percent">Estalvi estimat d\'un ~%d%% per a imatges</string>
     <string name="squeezer_onboarding_got_it">Entesos</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-ckb-rIR/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-ckb-rIR/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">وێنەکان بپەکێنە بۆ زیادکردنی شوێنی ئەمبارکردن.</string>
+    <string name="squeezer_explanation_short">وێنە و ڤیدیۆ بچووک بکەرەوە بۆ خەزن کردنی شوێنی ساردەرگە.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d وێنە دۆزرایەوە</item>
-        <item quantity="other">%d وێنە دۆزرایەوە</item>
+        <item quantity="one">%d دانە دۆزرایەوە</item>
+        <item quantity="other">%d دانە دۆزرایەوە</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s دەکرێت خەزن بکرێت</item>
         <item quantity="other">~%s دەکرێت خەزن بکرێت</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d وێنە پەکاندرا</item>
-        <item quantity="other">%d وێنە پەکاندرا</item>
+        <item quantity="one">%d دانە بچووک کرایەوە</item>
+        <item quantity="other">%d دانە بچووک کرایەوە</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d شکستی هێنا</item>
+        <item quantity="other">%d شکستی هێنا</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d فایل تێپەڕا (دەستنەگەی)</item>
+        <item quantity="other">%d فایل تێپەڕا (دەستنەگەی)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d وێنە هەڵبژێردرا</item>
-        <item quantity="other">%d وێنە هەڵبژێردرا</item>
+        <item quantity="one">%d دانە هەڵبژێردرا</item>
+        <item quantity="other">%d دانە هەڵبژێردرا</item>
     </plurals>
     <string name="squeezer_search_locations_title">گەڕان locations</string>
     <string name="squeezer_search_locations_default_summary">فۆڵدەرەکانی کامێرا (بنەڕەت)</string>
     <string name="squeezer_min_size_title">کەمترین قەبارەی فایل</string>
-    <string name="squeezer_min_size_description">وێنەکانی بچووکتر لەم قەبارەیە بگوێزرێنەوە.</string>
+    <string name="squeezer_min_size_description">فایلەکانی بچووکتر لەم قەبارەیە تێپەڕ بکە.</string>
     <string name="squeezer_min_age_title">کەمترین تەمەنی فایل</string>
-    <string name="squeezer_min_age_description">تەنها وێنەکانی کۆنتر لەم تەمەنە تێبگرە.</string>
-    <string name="squeezer_compression_settings_label">ڕێکخستنەکانی پەکاندن</string>
+    <string name="squeezer_min_age_description">تەنها فایلەکانی کۆنتر لەم تەمەنە لەخۆ بگرە.</string>
+    <string name="squeezer_compression_settings_label">گشتی</string>
     <string name="squeezer_quality_label">کوالیتی</string>
     <string name="squeezer_quality_title">کوالیتی پەکاندن</string>
-    <string name="squeezer_quality_description">کوالیتی کەمتر یانی قەبارەی فایلی بچووکتر بەڵام کوالیتی وێنەی کەمتر.</string>
+    <string name="squeezer_quality_description">کوالیتی نزم یانی قەبارەی فایل بچووکتر دەبێت بەڵام کوالیتی دیداری کەمتر دەبێت.</string>
     <string name="squeezer_quality_example_format">نموونە: وێنەی %1$s → ~%2$s خەزن دەکات لە %3$d%% کوالیتیدا</string>
     <string name="squeezer_quality_warning_low">کوالیتی کەمتر لەوانەیە بکاتە هۆی ئارتیفاکتی دیاریکراو.</string>
     <string name="squeezer_quality_warning_high">کوالیتی زۆر بەرز کەمترین خەزنکردنی شوێن دابین دەکات.</string>
-    <string name="squeezer_types_category_label">جۆرەکانی وێنە</string>
+    <string name="squeezer_types_category_label">ڕێکخستنەکانی وێنە</string>
+    <string name="squeezer_video_settings_category_label">ڕێکخستنەکانی ڤیدیۆ</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">وێنەکانی JPEG تێبگرە (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">وێنەکانی WebP تێبگرە (.webp).</string>
+    <string name="squeezer_type_video_title">ڤیدیۆی MP4</string>
+    <string name="squeezer_type_video_description">فایلەکانی ڤیدیۆی MP4 لەخۆ بگرە (.mp4).</string>
     <string name="squeezer_skip_compressed_title">یەکانی پێشووی پەکاندراو بگوێزرێنەوە</string>
-    <string name="squeezer_skip_compressed_description">وێنەکانی پێشووی پەکاندراو لەلایەن SD Maidەوە بگوێزرێنەوە.</string>
+    <string name="squeezer_skip_compressed_description">فایلەکانی کە پێشتر لەلایەن SD Maid بچووک کراوەتەوە تێپەڕ بکە.</string>
     <string name="squeezer_exif_marker_title">نیشانەی EXIF بنووسە</string>
     <string name="squeezer_exif_marker_description">نیشانەیەک لە خانەی کۆمێنتی بەکارهێنەری EXIF ی وێنەکە زیاد بکە بۆ ئەوەی دووبارە پەکاندن جێگیر بکات تەوەکو مێژووی پەکاندن پاک بکرێتەوە.</string>
     <string name="squeezer_estimated_savings_format">~%s خەزن</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">پشتڕاستکردنەوەی پەکاندن</string>
     <string name="squeezer_preview_total_size">قەبارەی سەرجەم</string>
     <string name="squeezer_preview_estimated_savings">خەزنکردنی خەمڵاندراو</string>
-    <string name="squeezer_compress_confirmation_title">وێنەکان بپەکێنیت؟</string>
-    <string name="squeezer_compress_confirmation_message">ئەمە وێنەی ڕەسەنەکان بە گۆڕینی وێنەکانی پەکاندراو جێگگوژمێر دەکات. ئەم کردارە نابێتەوە.</string>
+    <string name="squeezer_compress_confirmation_title">دانەبژێردراوەکان بچووک بکرێتەوە؟</string>
+    <string name="squeezer_compress_confirmation_message">ئەمە فایلە بنەڕەتیەکان بە گەڕانەوەیەکی بچووک کراو دەگۆڕێت. ئەم کاری پێچەوانەی نابێت.</string>
     <string name="squeezer_history_title">مێژووی پەکاندن</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d بابەت (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">هیچ مێژووی پەکاندنێک نییە</string>
     <string name="squeezer_history_clear_title">مێژووی پەکاندن پاک بکەرەوە</string>
-    <string name="squeezer_history_clear_message">ئەمە ڕێ دەدات بە وێنەکانی پێشووی پەکاندراو کە دووبارە پەکاندرێن. وێنەکانی خۆیان کاریگەر نابن.</string>
+    <string name="squeezer_history_clear_message">ئەمە ڕێ دەدات فایلەکانی کە پێشتر بچووک کراوەتەوە دووبارە بچووک بکرێتەوە. فایلەکان خۆیان کاریگەریان لێ نابێت.</string>
     <string name="squeezer_onboarding_title">دەربارەی پەکاندنی وێنە</string>
     <string name="squeezer_onboarding_message">پەکاندنی وێنە قەبارەی فایل کەم دەکاتەوە بە لابردنی وردەکاری بینراو. ئەم پرۆسەیە گەڕاندنەوەی نییە - کوالیتی ڕەسەن نابێتەوە.\n\nئەمێتە پێشبینییەک لەوەی وێنەکانت چۆن دەبێتەوە:</string>
     <string name="squeezer_onboarding_original_label">ڕەسەن</string>
     <string name="squeezer_onboarding_compressed_label">پاش پەکاندن</string>
+    <string name="squeezer_onboarding_video_original_label">فریمی ڤیدیۆ</string>
+    <string name="squeezer_onboarding_video_compressed_label">پێشبینی (بە نزیکەیی)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">کوالیتی ڤیدیۆی ڕاستەقینە لەوانەیە جیاواز بێت</string>
     <string name="squeezer_onboarding_quality_label">کوالیتی: %d%%</string>
     <string name="squeezer_compare_action">بەراوردکردن ببینە</string>
     <string name="squeezer_no_example_found">هیچ وێنەیەک لە ڕێگاکانی دیاریکراودا نەدۆزرایەوە.</string>
-    <string name="squeezer_result_empty_message">هیچ وێنەی پەکاندنەپەزیریوو نەدۆزرایەوە.</string>
-    <string name="squeezer_setup_warning">پەکاندن بە جێگیری کوالیتی وێنە کەم دەکاتەوە بۆ خەزنکردنی شوێنی ئەمبارکردن. ئەمە نابێتەوە. ڕێکخستنەکانت بە وریاییەوە بپشکنە پێش دەستپێکردن.</string>
-    <string name="squeezer_setup_explanation">Media Squeeze قەبارەی فایلی وێنەکان کەم دەکاتەوە بۆ ئازادکردنی شوێنی ئەمبارکردن. ئەمە کوالیتی وێنە بە جێگیری کەم دەکاتەوە و نابێتەوە. ڕێکخستنەکانت بە وریاییەوە بپشکنە پێش دەستپێکردن.</string>
+    <string name="squeezer_result_empty_message">هیچ میدیایەکی بچووک کراوەپەذیر نەدۆزرایەوە.</string>
+    <string name="squeezer_setup_warning">بچووک کردنەوە بەردەوام کوالیتی کەم دەکاتەوە بۆ خەزن کردنی شوێنی ساردەرگە. ئەمە پێچەوانەی نابێت. ڕێکخستنەکانت بە باشی پێش دەستپێکردن بکولێنەوە.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d شوێن ناتوانرێت بۆ بچووک کردنەوە بەکار بهێنرێت و لابرا. بچووک کردنەوە پێویستی بە دەستڕاگەیشتنی ڕاستەوخۆ بە ساردەرگەی ناوەکی هەیە.</item>
+        <item quantity="other">%d شوێن ناتوانرێت بۆ بچووک کردنەوە بەکار بهێنرێت و لابرا. بچووک کردنەوە پێویستی بە دەستڕاگەیشتنی ڕاستەوخۆ بە ساردەرگەی ناوەکی هەیە.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze قەبارەی فایلی وێنە و ڤیدیۆ کەم دەکاتەوە بۆ ئازاد کردنی شوێنی ساردەرگە. ئەمە بەردەوام کوالیتی کەم دەکاتەوە و پێچەوانەی نابێت. ڕێکخستنەکانت بە باشی پێش دەستپێکردن بکولێنەوە.</string>
     <string name="squeezer_setup_paths_title">گەڕان locations</string>
     <string name="squeezer_setup_paths_default">فۆڵدەرەکان بۆ گەڕان هەڵبژێرە</string>
     <string name="squeezer_setup_quality_title">کوالیتی پەکاندن</string>
@@ -81,6 +99,6 @@
         <item quantity="one">لانی کەم %d ڕۆژ کۆنە</item>
         <item quantity="other">لانی کەم %d ڕۆژ کۆنن</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">خەمڵاندراوی ~%d%% خەزنکردن بۆ فایلەکانی JPEG</string>
+    <string name="squeezer_estimated_savings_percent">~%d%% تەخمینی پاشەکەوتی بۆ وێنەکان</string>
     <string name="squeezer_onboarding_got_it">تێگەیشتم</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-cs/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-cs/strings.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Komprese obrázků pro ušetření místa v úložišti.</string>
+    <string name="squeezer_explanation_short">Komprese obrázků a videí pro ušetření místa v úložišti.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d obrázek nalezen</item>
-        <item quantity="few">%d obrázky nalezeny</item>
-        <item quantity="many">%d obrázků nalezeno</item>
-        <item quantity="other">%d obrázků nalezeno</item>
+        <item quantity="one">%d položka nalezena</item>
+        <item quantity="few">%d položky nalezeny</item>
+        <item quantity="many">%d položek nalezeno</item>
+        <item quantity="other">%d položek nalezeno</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s může být uvolněno</item>
@@ -14,37 +14,52 @@
         <item quantity="other">~%s může být uvolněno</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d obrázek komprimován</item>
-        <item quantity="few">%d obrázky komprimovány</item>
-        <item quantity="many">%d obrázků komprimováno</item>
-        <item quantity="other">%d obrázků komprimováno</item>
+        <item quantity="one">%d položka komprimována</item>
+        <item quantity="few">%d položky komprímovány</item>
+        <item quantity="many">%d položek komprimováno</item>
+        <item quantity="other">%d položek komprimováno</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d selhala</item>
+        <item quantity="few">%d selhaly</item>
+        <item quantity="many">%d selhalo</item>
+        <item quantity="other">%d selhalo</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d soubor přeskočen (nepřístupný)</item>
+        <item quantity="few">%d soubory přeskočeny (nepřístupné)</item>
+        <item quantity="many">%d souborů přeskočeno (nepřístupné)</item>
+        <item quantity="other">%d souborů přeskočeno (nepřístupné)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d obrázek vybrán</item>
-        <item quantity="few">%d obrázky vybrány</item>
-        <item quantity="many">%d obrázků vybráno</item>
-        <item quantity="other">%d obrázků vybráno</item>
+        <item quantity="one">%d položka vybrána</item>
+        <item quantity="few">%d položky vybrány</item>
+        <item quantity="many">%d položek vybráno</item>
+        <item quantity="other">%d položek vybráno</item>
     </plurals>
     <string name="squeezer_search_locations_title">Místa k prohledání</string>
     <string name="squeezer_search_locations_default_summary">Složky kamery (výchozí)</string>
     <string name="squeezer_min_size_title">Minimální velikost souboru</string>
-    <string name="squeezer_min_size_description">Přeskočit obrázky menší než tato velikost.</string>
+    <string name="squeezer_min_size_description">Přeskočit soubory menší než tato velikost.</string>
     <string name="squeezer_min_age_title">Minimální stáří souboru</string>
-    <string name="squeezer_min_age_description">Zahrnout pouze obrázky, které jsou starší.</string>
-    <string name="squeezer_compression_settings_label">Nastavení komprese</string>
+    <string name="squeezer_min_age_description">Zahrnout pouze soubory, které jsou starší.</string>
+    <string name="squeezer_compression_settings_label">Obecné</string>
     <string name="squeezer_quality_label">Kvalita</string>
     <string name="squeezer_quality_title">Kvalita komprese</string>
-    <string name="squeezer_quality_description">Nižší kvalita znamená menší velikost souboru, ale sníží kvalitu obrázku.</string>
+    <string name="squeezer_quality_description">Nižší kvalita znamená menší velikost souboru, ale sníženou vizuální kvalitu.</string>
     <string name="squeezer_quality_example_format">Příklad: obrázek %1$s → ušetří ~%2$s v kvalitě %3$d %%</string>
     <string name="squeezer_quality_warning_low">Nižší kvalita může způsobit viditelné artefakty.</string>
     <string name="squeezer_quality_warning_high">Velmi vysoká kvalita nabídne minimální úspory prostoru.</string>
-    <string name="squeezer_types_category_label">Typy obrázků</string>
+    <string name="squeezer_types_category_label">Nastavení obrázků</string>
+    <string name="squeezer_video_settings_category_label">Nastavení videa</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">Zahrnout JPEG obrázky (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">Zahrnout obrázky WebP (.webp).</string>
+    <string name="squeezer_type_video_title">Video MP4</string>
+    <string name="squeezer_type_video_description">Zahrnout videosoubory MP4 (.mp4).</string>
     <string name="squeezer_skip_compressed_title">Přeskočit dříve zkomprimované</string>
-    <string name="squeezer_skip_compressed_description">Přeskočit obrázky, které již byly komprimovány SD Maid.</string>
+    <string name="squeezer_skip_compressed_description">Přeskočit soubory, které již byly komprimovány SD Maid.</string>
     <string name="squeezer_exif_marker_title">Vložit EXIF značku</string>
     <string name="squeezer_exif_marker_description">Připojí značku do pole komentáře v EXIF obrázku, aby se zamezilo rekompresi v případě vyčištění historie kompresí.</string>
     <string name="squeezer_estimated_savings_format">~%s ušetřeno</string>
@@ -55,8 +70,8 @@
     <string name="squeezer_preview_dialog_title">Potvrdit kompresi</string>
     <string name="squeezer_preview_total_size">Celková velikost</string>
     <string name="squeezer_preview_estimated_savings">Odhadované úspory</string>
-    <string name="squeezer_compress_confirmation_title">Komprimovat obrázky?</string>
-    <string name="squeezer_compress_confirmation_message">Toto nahradí původní obrázky komprimovanými verzemi. Tuto akci nelze vrátit zpět.</string>
+    <string name="squeezer_compress_confirmation_title">Komprimovat vybrané položky?</string>
+    <string name="squeezer_compress_confirmation_message">Tato akce nahradí původní soubory zkomprimovanými verzemi. Tuto akci nelze vrátit zpět.</string>
     <string name="squeezer_history_title">Historie komprese</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d položka (%2$s)</item>
@@ -66,17 +81,26 @@
     </plurals>
     <string name="squeezer_history_empty">Žádná historie komprese</string>
     <string name="squeezer_history_clear_title">Vyčistit historii kompresí</string>
-    <string name="squeezer_history_clear_message">Toto umožní znovu zkomprimovat dříve zkomprimované obrázky. Samotné obrázky nejsou dotčené.</string>
+    <string name="squeezer_history_clear_message">Toto umožní znovu zkomprimovat dříve zkomprimované soubory. Samotné soubory nejsou ovlivněny.</string>
     <string name="squeezer_onboarding_title">O kompresi obrázků</string>
     <string name="squeezer_onboarding_message">Komprese obrázků snižuje velikost souboru odstraněním vizuálních detailů. Tento proces je nevratný - původní kvalita nemůže být obnovena.\n\nZde je náhled, jak budou vaše obrázky vypadat:</string>
     <string name="squeezer_onboarding_original_label">Originál</string>
     <string name="squeezer_onboarding_compressed_label">Po kompresi</string>
+    <string name="squeezer_onboarding_video_original_label">Snímek videa</string>
+    <string name="squeezer_onboarding_video_compressed_label">Náhled (přibližný)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">Skutečná kvalita videa se může lišit</string>
     <string name="squeezer_onboarding_quality_label">Kvalita: %d%%</string>
     <string name="squeezer_compare_action">Zobrazit porovnání</string>
     <string name="squeezer_no_example_found">Nenalezeny obrázky ve vybraných cestách.</string>
-    <string name="squeezer_result_empty_message">Nenalezeny obrázky ke kompresi.</string>
-    <string name="squeezer_setup_warning">Komprese trvale snižuje kvalitu obrázku, aby se ušetřil prostor v úložišti. Tuto akci nelze vrátit zpět. Před spuštěním pečlivě zkontrolujte nastavení.</string>
-    <string name="squeezer_setup_explanation">Zmáčknutí médií zmenšuje velikost souboru obrázků, čímž uvolní úložný prostor. To trvale snižuje kvalitu obrázku a nelze to vrátit zpět. Před spuštěním pečlivě zkontrolujte nastavení.</string>
+    <string name="squeezer_result_empty_message">Nebyla nalezena žádná komprimovatelná média.</string>
+    <string name="squeezer_setup_warning">Komprese trvale snižuje kvalitu souboru, aby se ušetřil prostor v úložišti. Tuto akci nelze vrátit zpět. Před spuštěním pečlivě zkontrolujte nastavení.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d umístění nelze použít pro kompresi a bylo odstraněno. Komprese vyžaduje přímý přístup k internímu úložišti.</item>
+        <item quantity="few">%d umístění nelze použít pro kompresi a byla odstraněna. Komprese vyžaduje přímý přístup k internímu úložišti.</item>
+        <item quantity="many">%d umístění nelze použít pro kompresi a bylo odstraněno. Komprese vyžaduje přímý přístup k internímu úložišti.</item>
+        <item quantity="other">%d umístění nelze použít pro kompresi a bylo odstraněno. Komprese vyžaduje přímý přístup k internímu úložišti.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Zmáčknutí médií zmenšuje velikost souboru obrázkůa videí, čímž uvolní úložný prostor. To trvale snižuje kvalitu a nelze to vrátit zpět. Před spuštěním pečlivě zkontrolujte nastavení.</string>
     <string name="squeezer_setup_paths_title">Místa k prohledání</string>
     <string name="squeezer_setup_paths_default">Vyberte složky k prohledání</string>
     <string name="squeezer_setup_quality_title">Kvalita komprese</string>
@@ -93,6 +117,6 @@
         <item quantity="many">Alespoň %d dnů staré</item>
         <item quantity="other">Alespoň %d dnů staré</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">Odhadovaná úspora ~%d%% pro JPEG soubory</string>
+    <string name="squeezer_estimated_savings_percent">Odhadovaná úspora ~%d %% pro obrázky</string>
     <string name="squeezer_onboarding_got_it">Rozumím</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-da/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-da/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Komprimér billeder for at spare lagerplads.</string>
+    <string name="squeezer_explanation_short">Komprimer billeder og videoer for at spare lagerplads.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d billede fundet</item>
-        <item quantity="other">%d billeder fundet</item>
+        <item quantity="one">%d element fundet</item>
+        <item quantity="other">%d elementer fundet</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s kan spares</item>
         <item quantity="other">~%s kan spares</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d billede komprimeret</item>
-        <item quantity="other">%d billeder komprimeret</item>
+        <item quantity="one">%d element komprimeret</item>
+        <item quantity="other">%d elementer komprimeret</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d mislykkedes</item>
+        <item quantity="other">%d mislykkedes</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d fil sprunget over (ikke tilgængelig)</item>
+        <item quantity="other">%d filer sprunget over (ikke tilgængelige)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d billede valgt</item>
-        <item quantity="other">%d billeder valgt</item>
+        <item quantity="one">%d element valgt</item>
+        <item quantity="other">%d elementer valgt</item>
     </plurals>
     <string name="squeezer_search_locations_title">Søgeplaceringer</string>
     <string name="squeezer_search_locations_default_summary">Kameramapper (standard)</string>
     <string name="squeezer_min_size_title">Minimum filstørrelse</string>
-    <string name="squeezer_min_size_description">Spring billeder over, der er mindre end denne størrelse.</string>
+    <string name="squeezer_min_size_description">Spring filer over, der er mindre end denne størrelse.</string>
     <string name="squeezer_min_age_title">Minimum fil alder</string>
-    <string name="squeezer_min_age_description">Inkludér kun billeder ældre end denne alder.</string>
-    <string name="squeezer_compression_settings_label">Komprimering indstillinger</string>
+    <string name="squeezer_min_age_description">Medtag kun filer, der er ældre end denne alder.</string>
+    <string name="squeezer_compression_settings_label">Generelt</string>
     <string name="squeezer_quality_label">Kvalitet</string>
     <string name="squeezer_quality_title">Kompressions kvalitet</string>
-    <string name="squeezer_quality_description">Lavere kvalitet betyder mindre filstørrelse, men reduceret billedkvalitet.</string>
+    <string name="squeezer_quality_description">Lavere kvalitet betyder mindre filstørrelse, men reduceret visuel kvalitet.</string>
     <string name="squeezer_quality_example_format">Eksempel: %1$s billede → sparer ~%2$s ved %3$d%% kvalitet</string>
     <string name="squeezer_quality_warning_low">Lavere kvaliteter kan forårsage synlige artefakter.</string>
     <string name="squeezer_quality_warning_high">Meget høj kvalitet giver minimal pladsbesparelser.</string>
-    <string name="squeezer_types_category_label">Billedtyper</string>
+    <string name="squeezer_types_category_label">Billedindstillinger</string>
+    <string name="squeezer_video_settings_category_label">Videoindstillinger</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">Inkluder JPEG-billeder (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">Inkludér WebP-billeder (.Webp).</string>
+    <string name="squeezer_type_video_title">MP4 Video</string>
+    <string name="squeezer_type_video_description">Medtag MP4-videofiler (.mp4).</string>
     <string name="squeezer_skip_compressed_title">Spring tidligere komprimerede over</string>
-    <string name="squeezer_skip_compressed_description">Spring billeder over, der allerede er komprimeret af SD Maid.</string>
+    <string name="squeezer_skip_compressed_description">Spring filer over, der allerede er komprimeret af SD Maid.</string>
     <string name="squeezer_exif_marker_title">Skriv EXIF-markør</string>
     <string name="squeezer_exif_marker_description">Tilføj en markør til billedets EXIF-brugerkommentarfelt for at forhindre genkomprimering, selvom komprimeringshistorikken ryddes.</string>
     <string name="squeezer_estimated_savings_format">~%s besparelse</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">Bekræft komprimering</string>
     <string name="squeezer_preview_total_size">Total størrelse</string>
     <string name="squeezer_preview_estimated_savings">Estimeret besparelse</string>
-    <string name="squeezer_compress_confirmation_title">Komprimer billeder?</string>
-    <string name="squeezer_compress_confirmation_message">Dette vil erstatte originale billeder med komprimerede versioner. Denne handling kan ikke fortrydes.</string>
+    <string name="squeezer_compress_confirmation_title">Komprimer valgte elementer?</string>
+    <string name="squeezer_compress_confirmation_message">Dette vil erstatte de originale filer med komprimerede versioner. Denne handling kan ikke fortrydes.</string>
     <string name="squeezer_history_title">Komprimeringshistorik</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d element (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">Ingen komprimeringshistorik</string>
     <string name="squeezer_history_clear_title">Ryd komprimeringshistorik</string>
-    <string name="squeezer_history_clear_message">Dette vil tillade, at tidligere komprimerede billeder kan komprimeres igen. Selve billederne påvirkes ikke.</string>
+    <string name="squeezer_history_clear_message">Dette vil tillade tidligere komprimerede filer at blive komprimeret igen. Filerne selv påvirkes ikke.</string>
     <string name="squeezer_onboarding_title">Om Billedkomprimering</string>
     <string name="squeezer_onboarding_message">Billedkomprimering reducerer filstørrelsen ved at fjerne visuelle detaljer. Denne proces er irreversibel - den originale kvalitet kan ikke genskabes.\n\nHer er en forhåndsvisning af, hvordan dine billeder vil se ud:</string>
     <string name="squeezer_onboarding_original_label">Oprindelig</string>
     <string name="squeezer_onboarding_compressed_label">Efter komprimering</string>
+    <string name="squeezer_onboarding_video_original_label">Videobillede</string>
+    <string name="squeezer_onboarding_video_compressed_label">Forhåndsvisning (omtrentlig)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">Den faktiske videokvalitet kan variere</string>
     <string name="squeezer_onboarding_quality_label">Kvalitet: %d%%</string>
     <string name="squeezer_compare_action">Vis sammenligning</string>
     <string name="squeezer_no_example_found">Ingen billeder fundet i valgte stier.</string>
-    <string name="squeezer_result_empty_message">Ingen komprimerbare billeder fundet.</string>
-    <string name="squeezer_setup_warning">Komprimering reducerer permanent billedkvaliteten for at spare lagerplads. Dette kan ikke fortrydes. Gennemgå dine indstillinger omhyggeligt, før du starter.</string>
-    <string name="squeezer_setup_explanation">Media Squeeze reducerer filstørrelsen af billeder for at frigøre lagerplads. Dette reducerer permanent billedkvaliteten og kan ikke fortrydes. Gennemgå dine indstillinger omhyggeligt, før du starter.</string>
+    <string name="squeezer_result_empty_message">Ingen komprimerbart medie fundet.</string>
+    <string name="squeezer_setup_warning">Komprimering reducerer kvaliteten permanent for at spare lagerplads. Dette kan ikke fortrydes. Gennemgå dine indstillinger omhyggeligt, før du starter.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d placering kan ikke bruges til komprimering og blev fjernet. Komprimering kræver direkte adgang til det interne lager.</item>
+        <item quantity="other">%d placeringer kan ikke bruges til komprimering og blev fjernet. Komprimering kræver direkte adgang til det interne lager.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze reducerer filstørrelsen på billeder og videoer for at frigøre lagerplads. Dette reducerer kvaliteten permanent og kan ikke fortrydes. Gennemgå dine indstillinger omhyggeligt, før du starter.</string>
     <string name="squeezer_setup_paths_title">Søgeplaceringer</string>
     <string name="squeezer_setup_paths_default">Vælg mapper at søge i</string>
     <string name="squeezer_setup_quality_title">Komprimeringskvalitet</string>
@@ -81,6 +99,6 @@
         <item quantity="one">Mindst %d dag gammel</item>
         <item quantity="other">Mindst %d dage gammel</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">Estimeret ~%d%% besparelse for JPEG-filer</string>
+    <string name="squeezer_estimated_savings_percent">Anslået ~%d%% besparelse for billeder</string>
     <string name="squeezer_onboarding_got_it">Forstået</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-de/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-de/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Bilder komprimieren, um Speicherplatz zu sparen.</string>
+    <string name="squeezer_explanation_short">Bilder und Videos komprimieren, um Speicherplatz zu sparen.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d Bild gefunden</item>
-        <item quantity="other">%d Bilder gefunden</item>
+        <item quantity="one">%d Element gefunden</item>
+        <item quantity="other">%d Elemente gefunden</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s kann gespart werden</item>
         <item quantity="other">~%s können gespart werden</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d Bild komprimiert</item>
-        <item quantity="other">%d Bilder komprimiert</item>
+        <item quantity="one">%d Element komprimiert</item>
+        <item quantity="other">%d Elemente komprimiert</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d fehlgeschlagen</item>
+        <item quantity="other">%d fehlgeschlagen</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d Datei übersprungen (nicht zugänglich)</item>
+        <item quantity="other">%d Dateien übersprungen (nicht zugänglich)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d Bild ausgewählt</item>
-        <item quantity="other">%d Bilder ausgewählt</item>
+        <item quantity="one">%d Element ausgewählt</item>
+        <item quantity="other">%d Elemente ausgewählt</item>
     </plurals>
     <string name="squeezer_search_locations_title">Suchorte</string>
     <string name="squeezer_search_locations_default_summary">Kameraordner (Standard)</string>
     <string name="squeezer_min_size_title">Mindestdateigröße</string>
-    <string name="squeezer_min_size_description">Bilder kleiner als diese Größe überspringen.</string>
+    <string name="squeezer_min_size_description">Dateien kleiner als diese Größe überspringen.</string>
     <string name="squeezer_min_age_title">Mindestdateialter</string>
-    <string name="squeezer_min_age_description">Nur Bilder einbeziehen, die älter als dieses Alter sind.</string>
-    <string name="squeezer_compression_settings_label">Komprimierungseinstellungen</string>
+    <string name="squeezer_min_age_description">Nur Dateien einschließen, die älter als dieses Alter sind.</string>
+    <string name="squeezer_compression_settings_label">Allgemein</string>
     <string name="squeezer_quality_label">Qualität</string>
     <string name="squeezer_quality_title">Komprimierungsqualität</string>
-    <string name="squeezer_quality_description">Niedrigere Qualität bedeutet kleinere Dateigröße, aber reduzierte Bildqualität.</string>
+    <string name="squeezer_quality_description">Niedrigere Qualität bedeutet kleinere Dateigröße, aber reduzierte visuelle Qualität.</string>
     <string name="squeezer_quality_example_format">Beispiel: %1$s Bild → spart ~%2$s bei %3$d%% Qualität</string>
     <string name="squeezer_quality_warning_low">Niedrigere Qualitäten können sichtbare Artefakte verursachen.</string>
     <string name="squeezer_quality_warning_high">Sehr hohe Qualität bietet minimale Platzersparnis.</string>
-    <string name="squeezer_types_category_label">Bildtypen</string>
+    <string name="squeezer_types_category_label">Bildeinstellungen</string>
+    <string name="squeezer_video_settings_category_label">Videoeinstellungen</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">JPEG-Bilder einbeziehen (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">WebP-Bilder einbeziehen (.webp).</string>
+    <string name="squeezer_type_video_title">MP4 Video</string>
+    <string name="squeezer_type_video_description">MP4-Videodateien einschließen (.mp4).</string>
     <string name="squeezer_skip_compressed_title">Bereits komprimierte überspringen</string>
-    <string name="squeezer_skip_compressed_description">Bilder überspringen, die bereits von SD Maid komprimiert wurden.</string>
+    <string name="squeezer_skip_compressed_description">Dateien überspringen, die bereits von SD Maid komprimiert wurden.</string>
     <string name="squeezer_exif_marker_title">EXIF-Marker schreiben</string>
     <string name="squeezer_exif_marker_description">Einen Marker an das EXIF-Benutzerkommentarfeld des Bildes anhängen, um eine erneute Komprimierung zu verhindern, auch wenn der Komprimierungsverlauf gelöscht wird.</string>
     <string name="squeezer_estimated_savings_format">~%s Ersparnis</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">Komprimierung bestätigen</string>
     <string name="squeezer_preview_total_size">Gesamtgröße</string>
     <string name="squeezer_preview_estimated_savings">Geschätzte Ersparnis</string>
-    <string name="squeezer_compress_confirmation_title">Bilder komprimieren?</string>
-    <string name="squeezer_compress_confirmation_message">Dies ersetzt die Originalbilder durch komprimierte Versionen. Diese Aktion kann nicht rückgängig gemacht werden.</string>
+    <string name="squeezer_compress_confirmation_title">Ausgewählte Elemente komprimieren?</string>
+    <string name="squeezer_compress_confirmation_message">Dadurch werden Originaldateien durch komprimierte Versionen ersetzt. Diese Aktion kann nicht rükgängig gemacht werden.</string>
     <string name="squeezer_history_title">Komprimierungsverlauf</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d Element (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">Kein Komprimierungsverlauf</string>
     <string name="squeezer_history_clear_title">Komprimierungsverlauf löschen</string>
-    <string name="squeezer_history_clear_message">Dies ermöglicht es, zuvor komprimierte Bilder erneut zu komprimieren. Die Bilder selbst werden nicht beeinflusst.</string>
+    <string name="squeezer_history_clear_message">Dadurch können zuvor komprimierte Dateien erneut komprimiert werden. Die Dateien selbst sind davon nicht betroffen.</string>
     <string name="squeezer_onboarding_title">Über Bildkomprimierung</string>
     <string name="squeezer_onboarding_message">Bildkomprimierung reduziert die Dateigröße durch Entfernen visueller Details. Dieser Vorgang ist irreversibel - die Originalqualität kann nicht wiederhergestellt werden.\n\nHier ist eine Vorschau, wie deine Bilder aussehen werden:</string>
     <string name="squeezer_onboarding_original_label">Original</string>
     <string name="squeezer_onboarding_compressed_label">Nach Komprimierung</string>
+    <string name="squeezer_onboarding_video_original_label">Videoframe</string>
+    <string name="squeezer_onboarding_video_compressed_label">Vorschau (ungefähr)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">Tatsächliche Videoqualität kann abweichen</string>
     <string name="squeezer_onboarding_quality_label">Qualität: %d%%</string>
     <string name="squeezer_compare_action">Vergleich anzeigen</string>
     <string name="squeezer_no_example_found">Keine Bilder in den ausgewählten Pfaden gefunden.</string>
-    <string name="squeezer_result_empty_message">Keine komprimierbaren Bilder gefunden.</string>
-    <string name="squeezer_setup_warning">Komprimierung reduziert dauerhaft die Bildqualität, um Speicherplatz zu sparen. Dies kann nicht rückgängig gemacht werden. Überprüfe deine Einstellungen sorgfältig vor dem Start.</string>
-    <string name="squeezer_setup_explanation">Medienkomprimierung reduziert die Dateigröße von Bildern, um Speicherplatz freizugeben. Dies reduziert dauerhaft die Bildqualität und kann nicht rückgängig gemacht werden. Überprüfe deine Einstellungen sorgfältig vor dem Start.</string>
+    <string name="squeezer_result_empty_message">Keine komprimierbaren Medien gefunden.</string>
+    <string name="squeezer_setup_warning">Komprimierung reduziert die Qualität dauerhaft, um Speicherplatz zu sparen. Dies kann nicht rükgängig gemacht werden. Überprüfe deine Einstellungen sorgfältig, bevor du beginnst.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d Speicherort kann nicht für die Komprimierung verwendet werden und wurde entfernt. Die Komprimierung erfordert direkten Zugriff auf den internen Speicher.</item>
+        <item quantity="other">%d Speicherorte können nicht für die Komprimierung verwendet werden und wurden entfernt. Die Komprimierung erfordert direkten Zugriff auf den internen Speicher.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze reduziert die Dateigröße von Bildern und Videos, um Speicherplatz freizugeben. Dies reduziert die Qualität dauerhaft und kann nicht rükgängig gemacht werden. Überprüfe deine Einstellungen sorgfältig, bevor du beginnst.</string>
     <string name="squeezer_setup_paths_title">Suchorte</string>
     <string name="squeezer_setup_paths_default">Ordner zum Durchsuchen auswählen</string>
     <string name="squeezer_setup_quality_title">Komprimierungsqualität</string>
@@ -81,6 +99,6 @@
         <item quantity="one">Mindestens %d Tag alt</item>
         <item quantity="other">Mindestens %d Tage alt</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">Geschätzte ~%d%% Ersparnis für JPEG-Dateien</string>
+    <string name="squeezer_estimated_savings_percent">Geschätzte ~%d%% Einsparungen bei Bildern</string>
     <string name="squeezer_onboarding_got_it">Verstanden</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-el/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-el/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Συμπίεση εικόνων για εξοικονόμηση αποθηκευτικού χώρου.</string>
+    <string name="squeezer_explanation_short">Συμπίεση εικόνων και βίντεο για εξοικονόμηση αποθηκευτικού χώρου.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">Βρέθηκε %d εικόνα</item>
-        <item quantity="other">Βρέθηκαν %d εικόνες</item>
+        <item quantity="one">Βρέθηκε %d στοιχείο</item>
+        <item quantity="other">Βρέθηκαν %d στοιχεία</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s μπορεί να εξοικονομηθεί</item>
         <item quantity="other">~%s μπορούν να εξοικονομηθούν</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d εικόνα συμπιέστηκε</item>
-        <item quantity="other">%d εικόνες συμπιέστηκαν</item>
+        <item quantity="one">%d στοιχείο συμπιέστηκε</item>
+        <item quantity="other">%d στοιχεία συμπιέστηκαν</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d απέτυχε</item>
+        <item quantity="other">%d απέτυχαν</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d αρχείο παραλείφθηκε (μη προσβάσιμο)</item>
+        <item quantity="other">%d αρχεία παραλείφθηκαν (μη προσβάσιμα)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d εικόνα επιλεγμένη</item>
-        <item quantity="other">%d εικόνες επιλεγμένες</item>
+        <item quantity="one">%d στοιχείο επιλεγμένο</item>
+        <item quantity="other">%d στοιχεία επιλεγμένα</item>
     </plurals>
     <string name="squeezer_search_locations_title">Τοποθεσίες αναζήτησης</string>
     <string name="squeezer_search_locations_default_summary">Φάκελοι κάμερας (προεπιλογή)</string>
     <string name="squeezer_min_size_title">Ελάχιστο μέγεθος αρχείου</string>
-    <string name="squeezer_min_size_description">Παράλειψη εικόνων μικρότερων από αυτό το μέγεθος.</string>
+    <string name="squeezer_min_size_description">Παράλειψη αρχείων μικρότερων από αυτό το μέγεθος.</string>
     <string name="squeezer_min_age_title">Ελάχιστη ηλικία αρχείου</string>
-    <string name="squeezer_min_age_description">Συμπερίληψη μόνο εικόνων παλαιότερων από αυτή την ηλικία.</string>
-    <string name="squeezer_compression_settings_label">Ρυθμίσεις συμπίεσης</string>
+    <string name="squeezer_min_age_description">Συμπερίληψη μόνο αρχείων παλαιότερων από αυτή την ηλικία.</string>
+    <string name="squeezer_compression_settings_label">Γενικά</string>
     <string name="squeezer_quality_label">Ποιότητα</string>
     <string name="squeezer_quality_title">Ποιότητα συμπίεσης</string>
-    <string name="squeezer_quality_description">Χαμηλότερη ποιότητα σημαίνει μικρότερο μέγεθος αρχείου αλλά μειωμένη ποιότητα εικόνας.</string>
+    <string name="squeezer_quality_description">Χαμηλότερη ποιότητα σημαίνει μικρότερο μέγεθος αρχείου αλλά μειωμένη οπτική ποιότητα.</string>
     <string name="squeezer_quality_example_format">Παράδειγμα: %1$s εικόνα → εξοικονομεί ~%2$s σε %3$d%% ποιότητα</string>
     <string name="squeezer_quality_warning_low">Χαμηλότερες ποιότητες μπορεί να προκαλέσουν ορατά τεχνουργήματα.</string>
     <string name="squeezer_quality_warning_high">Πολύ υψηλή ποιότητα παρέχει ελάχιστη εξοικονόμηση χώρου.</string>
-    <string name="squeezer_types_category_label">Τύποι εικόνων</string>
+    <string name="squeezer_types_category_label">Ρυθμίσεις εικόνας</string>
+    <string name="squeezer_video_settings_category_label">Ρυθμίσεις βίντεο</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">Συμπερίληψη εικόνων JPEG (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">Συμπερίληψη εικόνων WebP (.webp).</string>
+    <string name="squeezer_type_video_title">MP4 Video</string>
+    <string name="squeezer_type_video_description">Συμπερίληψη αρχείων βίντεο MP4 (.mp4).</string>
     <string name="squeezer_skip_compressed_title">Παράλειψη ήδη συμπιεσμένων</string>
-    <string name="squeezer_skip_compressed_description">Παράλειψη εικόνων που έχουν ήδη συμπιεστεί από το SD Maid.</string>
+    <string name="squeezer_skip_compressed_description">Παράλειψη αρχείων που έχουν ήδη συμπιεστεί από το SD Maid.</string>
     <string name="squeezer_exif_marker_title">Εγγραφή δείκτη EXIF</string>
     <string name="squeezer_exif_marker_description">Προσάρτηση ενός δείκτη στο πεδίο σχολίων χρήστη EXIF της εικόνας για την αποτροπή επανασυμπίεσης ακόμη και αν εκκαθαριστεί το ιστορικό συμπίεσης.</string>
     <string name="squeezer_estimated_savings_format">~%s εξοικονόμηση</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">Επιβεβαίωση συμπίεσης</string>
     <string name="squeezer_preview_total_size">Συνολικό μέγεθος</string>
     <string name="squeezer_preview_estimated_savings">Εκτιμώμενη εξοικονόμηση</string>
-    <string name="squeezer_compress_confirmation_title">Συμπίεση εικόνων;</string>
-    <string name="squeezer_compress_confirmation_message">Αυτό θα αντικαταστήσει τις αρχικές εικόνες με συμπιεσμένες εκδόσεις. Αυτή η ενέργεια δεν μπορεί να αναιρεθεί.</string>
+    <string name="squeezer_compress_confirmation_title">Συμπίεση επιλεγμένων στοιχείων;</string>
+    <string name="squeezer_compress_confirmation_message">Αυτό θα αντικαταστήσει τα αρχικά αρχεία με συμπιεσμένες εκδόσεις. Αυτή η ενέργεια δεν μπορεί να αναιρεθεί.</string>
     <string name="squeezer_history_title">Ιστορικό συμπίεσης</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d στοιχείο (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">Κανένα ιστορικό συμπίεσης</string>
     <string name="squeezer_history_clear_title">Εκκαθάριση ιστορικού συμπίεσης</string>
-    <string name="squeezer_history_clear_message">Αυτό θα επιτρέψει σε εικόνες που έχουν ήδη συμπιεστεί να συμπιεστούν ξανά. Οι ίδιες οι εικόνες δεν επηρεάζονται.</string>
+    <string name="squeezer_history_clear_message">Αυτό θα επιτρέψει σε αρχεία που έχουν ήδη συμπιεστεί να συμπιεστούν ξανά. Τα ίδια τα αρχεία δεν επηρεάζονται.</string>
     <string name="squeezer_onboarding_title">Σχετικά με τη Συμπίεση Εικόνων</string>
     <string name="squeezer_onboarding_message">Η συμπίεση εικόνων μειώνει το μέγεθος αρχείου αφαιρώντας οπτική λεπτομέρεια. Αυτή η διαδικασία είναι μη αναστρέψιμη - η αρχική ποιότητα δεν μπορεί να αποκατασταθεί.\n\nΑκολουθεί μια προεπισκόπηση του πώς θα μοιάζουν οι εικόνες σας:</string>
     <string name="squeezer_onboarding_original_label">Πρωτότυπο</string>
     <string name="squeezer_onboarding_compressed_label">Μετά τη συμπίεση</string>
+    <string name="squeezer_onboarding_video_original_label">Καρέ βίντεο</string>
+    <string name="squeezer_onboarding_video_compressed_label">Προεπισκόπηση (κατά προσέγγιση)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">Η πραγματική ποιότητα βίντεο μπορεί να διαφέρει</string>
     <string name="squeezer_onboarding_quality_label">Ποιότητα: %d%%</string>
     <string name="squeezer_compare_action">Προβολή σύγκρισης</string>
     <string name="squeezer_no_example_found">Δεν βρέθηκαν εικόνες στις επιλεγμένες διαδρομές.</string>
-    <string name="squeezer_result_empty_message">Δεν βρέθηκαν συμπιέσιμες εικόνες.</string>
-    <string name="squeezer_setup_warning">Η συμπίεση μειώνει μόνιμα την ποιότητα εικόνας για εξοικονόμηση αποθηκευτικού χώρου. Αυτό δεν μπορεί να αναιρεθεί. Ελέγξτε προσεκτικά τις ρυθμίσεις σας πριν ξεκινήσετε.</string>
-    <string name="squeezer_setup_explanation">Το Media Squeeze μειώνει το μέγεθος αρχείου εικόνων για εξοικονόμηση αποθηκευτικού χώρου. Αυτό μειώνει μόνιμα την ποιότητα εικόνας και δεν μπορεί να αναιρεθεί. Ελέγξτε προσεκτικά τις ρυθμίσεις σας πριν ξεκινήσετε.</string>
+    <string name="squeezer_result_empty_message">Δεν βρέθηκαν συμπιέσιμα αρχεία πολυμέσων.</string>
+    <string name="squeezer_setup_warning">Η συμπίεση μειώνει μόνιμα την ποιότητα για εξοικονόμηση αποθηκευτικού χώρου. Αυτό δεν μπορεί να αναιρεθεί. Ελέγξτε προσεκτικά τις ρυθμίσεις σας πριν ξεκινήσετε.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d τοποθεσία δεν μπορεί να χρησιμοποιηθεί για συμπίεση και αφαιρέθηκε. Η συμπίεση απαιτεί απευθείας πρόσβαση στον εσωτερικό χώρο αποθήκευσης.</item>
+        <item quantity="other">%d τοποθεσίες δεν μπορούν να χρησιμοποιηθούν για συμπίεση και αφαιρέθηκαν. Η συμπίεση απαιτεί απευθείας πρόσβαση στον εσωτερικό χώρο αποθήκευσης.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Το Media Squeeze μειώνει το μέγεθος αρχείου εικόνων και βίντεο για εξοικονόμηση αποθηκευτικού χώρου. Αυτό μειώνει μόνιμα την ποιότητα και δεν μπορεί να αναιρεθεί. Ελέγξτε προσεκτικά τις ρυθμίσεις σας πριν ξεκινήσετε.</string>
     <string name="squeezer_setup_paths_title">Τοποθεσίες αναζήτησης</string>
     <string name="squeezer_setup_paths_default">Επιλέξτε φακέλους για αναζήτηση</string>
     <string name="squeezer_setup_quality_title">Ποιότητα συμπίεσης</string>
@@ -81,6 +99,6 @@
         <item quantity="one">Τουλάχιστον %d ημέρα παλιό</item>
         <item quantity="other">Τουλάχιστον %d ημέρες παλιό</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">Εκτιμώμενη ~%d%% εξοικονόμηση για αρχεία JPEG</string>
+    <string name="squeezer_estimated_savings_percent">Εκτιμώμενη ~%d%% εξοικονόμηση για εικόνες</string>
     <string name="squeezer_onboarding_got_it">Το κατάλαβα</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-es-rAR/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-es-rAR/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Comprimir imágenes para ahorrar espacio de almacenamiento.</string>
+    <string name="squeezer_explanation_short">Comprimir imágenes y videos para ahorrar espacio de almacenamiento.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d imagen encontrada</item>
-        <item quantity="other">%d imágenes encontradas</item>
+        <item quantity="one">%d elemento encontrado</item>
+        <item quantity="other">%d elementos encontrados</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s de ahorro estimado</item>
         <item quantity="other">~%s de ahorro estimado</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d imagen comprimida</item>
-        <item quantity="other">%d imágenes comprimidas</item>
+        <item quantity="one">%d elemento comprimido</item>
+        <item quantity="other">%d elementos comprimidos</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d ha fallado</item>
+        <item quantity="other">%d ha fallado</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d archivo omitido (no accesible)</item>
+        <item quantity="other">%d archivos omitidos (no accesibles)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d imagen</item>
-        <item quantity="other">%d imágenes</item>
+        <item quantity="one">%d elemento seleccionado</item>
+        <item quantity="other">%d elementos seleccionados</item>
     </plurals>
     <string name="squeezer_search_locations_title">Ubicaciones de búsqueda</string>
     <string name="squeezer_search_locations_default_summary">Carpetas de cámara (predeterminado)</string>
     <string name="squeezer_min_size_title">Tamaño mínimo de archivo</string>
-    <string name="squeezer_min_size_description">Omitir imágenes más chicas que este tamaño.</string>
+    <string name="squeezer_min_size_description">Omitir archivos más pequeños que este tamaño.</string>
     <string name="squeezer_min_age_title">Antigüedad mínima del archivo</string>
-    <string name="squeezer_min_age_description">Solo incluir imágenes más viejas que esta antigüedad.</string>
-    <string name="squeezer_compression_settings_label">Configuración de compresión</string>
+    <string name="squeezer_min_age_description">Solo incluir archivos más antiguos que esta edad.</string>
+    <string name="squeezer_compression_settings_label">General</string>
     <string name="squeezer_quality_label">Calidad</string>
     <string name="squeezer_quality_title">Calidad de compresión</string>
-    <string name="squeezer_quality_description">Menor calidad significa menor tamaño de archivo pero menor calidad de imagen.</string>
+    <string name="squeezer_quality_description">Una calidad más baja significa un tamaño de archivo menor pero una calidad visual reducida.</string>
     <string name="squeezer_quality_example_format">Ejemplo: imagen %1$s → ahorra ~%2$s al %3$d%% de calidad</string>
     <string name="squeezer_quality_warning_low">Las calidades más bajas pueden causar artefactos visibles.</string>
     <string name="squeezer_quality_warning_high">La calidad muy alta proporciona un ahorro mínimo de espacio.</string>
-    <string name="squeezer_types_category_label">Tipos de imagen</string>
+    <string name="squeezer_types_category_label">Configuración de imágenes</string>
+    <string name="squeezer_video_settings_category_label">Configuración de video</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">Incluir imágenes JPEG (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">Incluir imágenes WebP (.webp).</string>
+    <string name="squeezer_type_video_title">Video MP4</string>
+    <string name="squeezer_type_video_description">Incluir archivos de video MP4 (.mp4).</string>
     <string name="squeezer_skip_compressed_title">Omitir previamente comprimidas</string>
-    <string name="squeezer_skip_compressed_description">Omitir imágenes que ya fueron comprimidas por SD Maid.</string>
+    <string name="squeezer_skip_compressed_description">Omitir archivos que ya han sido comprimidos por SD Maid.</string>
     <string name="squeezer_exif_marker_title">Escribir marcador EXIF</string>
     <string name="squeezer_exif_marker_description">Agregar un marcador al campo de comentario EXIF de la imagen para evitar la recompresión incluso si se borra el historial de compresión.</string>
     <string name="squeezer_estimated_savings_format">~%s de ahorro</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">Confirmar compresión</string>
     <string name="squeezer_preview_total_size">Tamaño total</string>
     <string name="squeezer_preview_estimated_savings">Ahorro estimado</string>
-    <string name="squeezer_compress_confirmation_title">¿Comprimir imágenes?</string>
-    <string name="squeezer_compress_confirmation_message">Esto reemplazará las imágenes originales con versiones comprimidas. Esta acción no se puede deshacer.</string>
+    <string name="squeezer_compress_confirmation_title">¿Comprimir los elementos seleccionados?</string>
+    <string name="squeezer_compress_confirmation_message">Esto reemplazará los archivos originales con versiones comprimidas. Esta acción no se puede deshacer.</string>
     <string name="squeezer_history_title">Historial de compresión</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%d imagen comprimida previamente</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">Sin historial de compresión</string>
     <string name="squeezer_history_clear_title">Borrar historial de compresión</string>
-    <string name="squeezer_history_clear_message">Esto permitirá que las imágenes previamente comprimidas sean comprimidas de nuevo. Las imágenes en sí no se ven afectadas.</string>
+    <string name="squeezer_history_clear_message">Esto permitirá que los archivos previamente comprimidos vuelvan a comprimirse. Los archivos en sí no se ven afectados.</string>
     <string name="squeezer_onboarding_title">Acerca de la compresión de imágenes</string>
     <string name="squeezer_onboarding_message">La compresión de imágenes reduce el tamaño del archivo eliminando detalles visuales. Este proceso es irreversible - la calidad original no se puede restaurar.\n\nAcá tenés una vista previa de cómo se verán tus imágenes:</string>
     <string name="squeezer_onboarding_original_label">Original</string>
     <string name="squeezer_onboarding_compressed_label">Después de la compresión</string>
+    <string name="squeezer_onboarding_video_original_label">Fotograma de video</string>
+    <string name="squeezer_onboarding_video_compressed_label">Vista previa (aproximada)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">La calidad real del video puede variar</string>
     <string name="squeezer_onboarding_quality_label">Calidad: %d%%</string>
     <string name="squeezer_compare_action">Ver comparación</string>
     <string name="squeezer_no_example_found">No se encontraron imágenes en las rutas seleccionadas.</string>
-    <string name="squeezer_result_empty_message">No se encontraron imágenes comprimibles.</string>
-    <string name="squeezer_setup_warning">La compresión reduce permanentemente la calidad de las imágenes para ahorrar espacio. No se puede deshacer. Revisá cuidadosamente la configuración antes de comenzar.</string>
-    <string name="squeezer_setup_explanation">Media Squeeze reduce el tamaño de los archivos de imagen para liberar espacio. Esto reduce permanentemente la calidad de las imágenes y no se puede deshacer. Revisá cuidadosamente la configuración antes de comenzar.</string>
+    <string name="squeezer_result_empty_message">No se encontraron medios comprimibles.</string>
+    <string name="squeezer_setup_warning">La compresión reduce permanentemente la calidad para ahorrar espacio de almacenamiento. Esto no se puede deshacer. Revise su configuración cuidadosamente antes de comenzar.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d ubicación no se puede usar para compresión y fue eliminada. La compresión requiere acceso directo al almacenamiento interno.</item>
+        <item quantity="other">%d ubicaciones no se pueden usar para compresión y fueron eliminadas. La compresión requiere acceso directo al almacenamiento interno.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze reduce el tamaño de archivo de imágenes y videos para liberar espacio de almacenamiento. Esto reduce permanentemente la calidad y no se puede deshacer. Revise su configuración cuidadosamente antes de comenzar.</string>
     <string name="squeezer_setup_paths_title">Ubicaciones de búsqueda</string>
     <string name="squeezer_setup_paths_default">Seleccioná carpetas para buscar</string>
     <string name="squeezer_setup_quality_title">Calidad de compresión</string>
@@ -81,6 +99,6 @@
         <item quantity="one">Al menos %d día de antigüedad</item>
         <item quantity="other">Al menos %d días de antigüedad</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">Ahorro estimado de ~%d%% para archivos JPEG</string>
+    <string name="squeezer_estimated_savings_percent">Ahorro estimado de ~%d%% para imágenes</string>
     <string name="squeezer_onboarding_got_it">Entendido</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-es-rMX/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-es-rMX/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Comprimir imágenes para ahorrar espacio de almacenamiento.</string>
+    <string name="squeezer_explanation_short">Comprime imágenes y videos para ahorrar espacio de almacenamiento.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d imagen encontrada</item>
-        <item quantity="other">%d imágenes encontradas</item>
+        <item quantity="one">%d elemento encontrado</item>
+        <item quantity="other">%d elementos encontrados</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s se puede ahorrar</item>
         <item quantity="other">~%s se pueden ahorrar</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d imagen comprimida</item>
-        <item quantity="other">%d imágenes comprimidas</item>
+        <item quantity="one">%d elemento comprimido</item>
+        <item quantity="other">%d elementos comprimidos</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d falló</item>
+        <item quantity="other">%d fallaron</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d archivo omitido (no accesible)</item>
+        <item quantity="other">%d archivos omitidos (no accesibles)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d imagen seleccionada</item>
-        <item quantity="other">%d imágenes seleccionadas</item>
+        <item quantity="one">%d elemento seleccionado</item>
+        <item quantity="other">%d elementos seleccionados</item>
     </plurals>
     <string name="squeezer_search_locations_title">Ubicaciones de búsqueda</string>
     <string name="squeezer_search_locations_default_summary">Carpetas de cámara (predeterminado)</string>
     <string name="squeezer_min_size_title">Tamaño mínimo de archivo</string>
-    <string name="squeezer_min_size_description">Omitir imágenes más pequeñas que este tamaño.</string>
+    <string name="squeezer_min_size_description">Omitir archivos más pequeños que este tamaño.</string>
     <string name="squeezer_min_age_title">Antigüedad mínima del archivo</string>
-    <string name="squeezer_min_age_description">Solo incluir imágenes más antiguas que esta edad.</string>
-    <string name="squeezer_compression_settings_label">Ajustes de compresión</string>
+    <string name="squeezer_min_age_description">Incluir solo archivos con más antigüedad que esta.</string>
+    <string name="squeezer_compression_settings_label">General</string>
     <string name="squeezer_quality_label">Calidad</string>
     <string name="squeezer_quality_title">Calidad de compresión</string>
-    <string name="squeezer_quality_description">Menor calidad significa menor tamaño de archivo pero menor calidad de imagen.</string>
+    <string name="squeezer_quality_description">Una calidad más baja significa un tamaño de archivo menor, pero con menor calidad visual.</string>
     <string name="squeezer_quality_example_format">Ejemplo: imagen %1$s → ahorra ~%2$s al %3$d%% de calidad</string>
     <string name="squeezer_quality_warning_low">Calidades más bajas pueden causar artefactos visibles.</string>
     <string name="squeezer_quality_warning_high">Calidad muy alta proporciona un ahorro de espacio mínimo.</string>
-    <string name="squeezer_types_category_label">Tipos de imagen</string>
+    <string name="squeezer_types_category_label">Configuración de imágenes</string>
+    <string name="squeezer_video_settings_category_label">Configuración de video</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">Incluir imágenes JPEG (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">Incluir imágenes WebP (.webp).</string>
+    <string name="squeezer_type_video_title">MP4 Video</string>
+    <string name="squeezer_type_video_description">Incluir archivos de video MP4 (.mp4).</string>
     <string name="squeezer_skip_compressed_title">Omitir previamente comprimidas</string>
-    <string name="squeezer_skip_compressed_description">Omitir imágenes que ya han sido comprimidas por SD Maid.</string>
+    <string name="squeezer_skip_compressed_description">Omitir archivos que ya hayan sido comprimidos por SD Maid.</string>
     <string name="squeezer_exif_marker_title">Escribir marcador EXIF</string>
     <string name="squeezer_exif_marker_description">Agregar un marcador al campo de comentario de usuario EXIF de la imagen para evitar la recompresión incluso si se borra el historial de compresión.</string>
     <string name="squeezer_estimated_savings_format">~%s de ahorro</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">Confirmar compresión</string>
     <string name="squeezer_preview_total_size">Tamaño total</string>
     <string name="squeezer_preview_estimated_savings">Ahorro estimado</string>
-    <string name="squeezer_compress_confirmation_title">¿Comprimir imágenes?</string>
-    <string name="squeezer_compress_confirmation_message">Esto reemplazará las imágenes originales con versiones comprimidas. Esta acción no se puede deshacer.</string>
+    <string name="squeezer_compress_confirmation_title">¿Comprimir elementos seleccionados?</string>
+    <string name="squeezer_compress_confirmation_message">Esto reemplazará los archivos originales con versiones comprimidas. Esta acción no se puede deshacer.</string>
     <string name="squeezer_history_title">Historial de compresión</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d elemento (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">Sin historial de compresión</string>
     <string name="squeezer_history_clear_title">Borrar historial de compresión</string>
-    <string name="squeezer_history_clear_message">Esto permitirá que las imágenes previamente comprimidas se compriman de nuevo. Las imágenes en sí no se ven afectadas.</string>
+    <string name="squeezer_history_clear_message">Esto permitirá que los archivos comprimidos anteriormente puedan comprimirse nuevamente. Los archivos en sí no se ven afectados.</string>
     <string name="squeezer_onboarding_title">Acerca de la Compresión de Imágenes</string>
     <string name="squeezer_onboarding_message">La compresión de imágenes reduce el tamaño del archivo eliminando detalles visuales. Este proceso es irreversible - la calidad original no se puede restaurar.\n\nAquí tienes una vista previa de cómo se verán tus imágenes:</string>
     <string name="squeezer_onboarding_original_label">Original</string>
     <string name="squeezer_onboarding_compressed_label">Después de la compresión</string>
+    <string name="squeezer_onboarding_video_original_label">Fotograma de video</string>
+    <string name="squeezer_onboarding_video_compressed_label">Vista previa (aproximada)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">La calidad real del video puede variar</string>
     <string name="squeezer_onboarding_quality_label">Calidad: %d%%</string>
     <string name="squeezer_compare_action">Ver comparación</string>
     <string name="squeezer_no_example_found">No se encontraron imágenes en las rutas seleccionadas.</string>
-    <string name="squeezer_result_empty_message">No se encontraron imágenes comprimibles.</string>
-    <string name="squeezer_setup_warning">La compresión reduce permanentemente la calidad de imagen para ahorrar espacio. No se puede deshacer. Revisa tus ajustes cuidadosamente antes de comenzar.</string>
-    <string name="squeezer_setup_explanation">El Compresor de Medios reduce el tamaño de archivo de las imágenes para liberar espacio. Esto reduce permanentemente la calidad de imagen y no se puede deshacer. Revisa tus ajustes cuidadosamente antes de comenzar.</string>
+    <string name="squeezer_result_empty_message">No se encontraron medios comprimibles.</string>
+    <string name="squeezer_setup_warning">La compresión reduce permanentemente la calidad para ahorrar espacio de almacenamiento. Esto no se puede deshacer. Revisa tu configuración cuidadosamente antes de comenzar.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d ubicación no se puede usar para la compresión y fue eliminada. La compresión requiere acceso directo al almacenamiento interno.</item>
+        <item quantity="other">%d ubicaciones no se pueden usar para la compresión y fueron eliminadas. La compresión requiere acceso directo al almacenamiento interno.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze reduce el tamaño de archivo de imágenes y videos para liberar espacio de almacenamiento. Esto reduce permanentemente la calidad y no se puede deshacer. Revisa tu configuración cuidadosamente antes de comenzar.</string>
     <string name="squeezer_setup_paths_title">Ubicaciones de búsqueda</string>
     <string name="squeezer_setup_paths_default">Seleccionar carpetas para buscar</string>
     <string name="squeezer_setup_quality_title">Calidad de compresión</string>
@@ -81,6 +99,6 @@
         <item quantity="one">Al menos %d día de antigüedad</item>
         <item quantity="other">Al menos %d días de antigüedad</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">Ahorro estimado de ~%d%% para archivos JPEG</string>
+    <string name="squeezer_estimated_savings_percent">Ahorro estimado de ~%d%% para imágenes</string>
     <string name="squeezer_onboarding_got_it">Entendido</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-es/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-es/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Comprimir imágenes para ahorrar espacio de almacenamiento.</string>
+    <string name="squeezer_explanation_short">Comprime imágenes y vídeos para ahorrar espacio de almacenamiento.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d imagen encontrada</item>
-        <item quantity="other">%d imágenes encontradas</item>
+        <item quantity="one">%d elemento encontrado</item>
+        <item quantity="other">%d elementos encontrados</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s puede ahorrarse</item>
         <item quantity="other">~%s pueden ahorrarse</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d imagen comprimida</item>
-        <item quantity="other">%d imágenes comprimidas</item>
+        <item quantity="one">%d elemento comprimido</item>
+        <item quantity="other">%d elementos comprimidos</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d ha fallado</item>
+        <item quantity="other">%d han fallado</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d archivo omitido (no accesible)</item>
+        <item quantity="other">%d archivos omitidos (no accesibles)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d imagen seleccionada</item>
-        <item quantity="other">%d imágenes seleccionadas</item>
+        <item quantity="one">%d elemento seleccionado</item>
+        <item quantity="other">%d elementos seleccionados</item>
     </plurals>
     <string name="squeezer_search_locations_title">Buscar ubicaciones</string>
     <string name="squeezer_search_locations_default_summary">Carpetas de cámara (predeterminado)</string>
     <string name="squeezer_min_size_title">Tamaño mínimo del archivo</string>
-    <string name="squeezer_min_size_description">Omitir imágenes más pequeñas que este tamaño.</string>
+    <string name="squeezer_min_size_description">Omitir archivos más pequeños que este tamaño.</string>
     <string name="squeezer_min_age_title">Antigüedad mínima del archivo</string>
-    <string name="squeezer_min_age_description">Solo incluir imágenes más antiguas que esta edad.</string>
-    <string name="squeezer_compression_settings_label">Ajustes de compresión</string>
+    <string name="squeezer_min_age_description">Incluir solo archivos más antiguos que esta edad.</string>
+    <string name="squeezer_compression_settings_label">General</string>
     <string name="squeezer_quality_label">Calidad</string>
     <string name="squeezer_quality_title">Calidad de compresión</string>
-    <string name="squeezer_quality_description">Menor calidad significa menor tamaño de archivo pero menor calidad de imagen.</string>
+    <string name="squeezer_quality_description">Una calidad menor significa un tamaño de archivo más pequeño pero una calidad visual reducida.</string>
     <string name="squeezer_quality_example_format">Ejemplo: imagen %1$s → ahorra ~%2$s al %3$d%% de calidad</string>
     <string name="squeezer_quality_warning_low">Calidades más bajas pueden causar artefactos visibles.</string>
     <string name="squeezer_quality_warning_high">Calidad muy alta proporciona ahorros mínimos de espacio.</string>
-    <string name="squeezer_types_category_label">Tipos de imagen</string>
+    <string name="squeezer_types_category_label">Configuración de imágenes</string>
+    <string name="squeezer_video_settings_category_label">Configuración de vídeo</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">Incluir imágenes JPEG (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">Incluir imágenes WebP (.webp).</string>
+    <string name="squeezer_type_video_title">MP4 Video</string>
+    <string name="squeezer_type_video_description">Incluir archivos de vídeo MP4 (.mp4).</string>
     <string name="squeezer_skip_compressed_title">Omitir previamente comprimidas</string>
-    <string name="squeezer_skip_compressed_description">Omitir imágenes que ya han sido comprimidas por SD Maid.</string>
+    <string name="squeezer_skip_compressed_description">Omitir archivos que ya han sido comprimidos por SD Maid.</string>
     <string name="squeezer_exif_marker_title">Escribir marcador EXIF</string>
     <string name="squeezer_exif_marker_description">Añadir un marcador al campo de comentario de usuario EXIF de la imagen para evitar la recompresión incluso si se borra el historial de compresión.</string>
     <string name="squeezer_estimated_savings_format">~%s de ahorro</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">Confirmar compresión</string>
     <string name="squeezer_preview_total_size">Tamaño total</string>
     <string name="squeezer_preview_estimated_savings">Ahorro estimado</string>
-    <string name="squeezer_compress_confirmation_title">¿Comprimir imágenes?</string>
-    <string name="squeezer_compress_confirmation_message">Esto reemplazará las imágenes originales con versiones comprimidas. Esta acción no se puede deshacer.</string>
+    <string name="squeezer_compress_confirmation_title">¿Comprimir los elementos seleccionados?</string>
+    <string name="squeezer_compress_confirmation_message">Esto reemplazará los archivos originales con versiones comprimidas. Esta acción no se puede deshacer.</string>
     <string name="squeezer_history_title">Historial de compresión</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d elemento (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">Sin historial de compresión</string>
     <string name="squeezer_history_clear_title">Borrar historial de compresión</string>
-    <string name="squeezer_history_clear_message">Esto permitirá comprimir de nuevo imágenes previamente comprimidas. Las imágenes en sí no se ven afectadas.</string>
+    <string name="squeezer_history_clear_message">Esto permitirá que los archivos previamente comprimidos se compriman de nuevo. Los archivos en sí no se ven afectados.</string>
     <string name="squeezer_onboarding_title">Acerca de la compresión de imágenes</string>
     <string name="squeezer_onboarding_message">La compresión de imágenes reduce el tamaño del archivo eliminando detalle visual. Este proceso es irreversible: la calidad original no puede restaurarse.\n\nAquí tienes una vista previa de cómo se verán tus imágenes:</string>
     <string name="squeezer_onboarding_original_label">Original</string>
     <string name="squeezer_onboarding_compressed_label">Después de la compresión</string>
+    <string name="squeezer_onboarding_video_original_label">Fotograma de vídeo</string>
+    <string name="squeezer_onboarding_video_compressed_label">Vista previa (aproximada)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">La calidad real del vídeo puede variar</string>
     <string name="squeezer_onboarding_quality_label">Calidad: %d%%</string>
     <string name="squeezer_compare_action">Ver comparación</string>
     <string name="squeezer_no_example_found">No se encontraron imágenes en las rutas seleccionadas.</string>
-    <string name="squeezer_result_empty_message">No se encontraron imágenes comprimibles.</string>
-    <string name="squeezer_setup_warning">La compresión reduce permanentemente la calidad de imagen para ahorrar espacio. No se puede deshacer. Revisa tus ajustes cuidadosamente antes de comenzar.</string>
-    <string name="squeezer_setup_explanation">La compresión de medios reduce el tamaño de las imágenes para liberar espacio. Esto reduce permanentemente la calidad y no se puede deshacer. Revisa tus ajustes cuidadosamente antes de comenzar.</string>
+    <string name="squeezer_result_empty_message">No se encontraron archivos multimedia comprimibles.</string>
+    <string name="squeezer_setup_warning">La compresión reduce permanentemente la calidad para ahorrar espacio de almacenamiento. Esta acción no se puede deshacer. Revisa tu configuración detenidamente antes de comenzar.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d ubicación no se puede usar para la compresión y fue eliminada. La compresión requiere acceso directo al almacenamiento interno.</item>
+        <item quantity="other">%d ubicaciones no se pueden usar para la compresión y fueron eliminadas. La compresión requiere acceso directo al almacenamiento interno.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze reduce el tamaño de archivo de imágenes y vídeos para liberar espacio de almacenamiento. Esto reduce permanentemente la calidad y no se puede deshacer. Revisa tu configuración detenidamente antes de comenzar.</string>
     <string name="squeezer_setup_paths_title">Buscar ubicaciones</string>
     <string name="squeezer_setup_paths_default">Seleccionar carpetas a buscar</string>
     <string name="squeezer_setup_quality_title">Calidad de compresión</string>
@@ -81,6 +99,6 @@
         <item quantity="one">Al menos %d día de antigüedad</item>
         <item quantity="other">Al menos %d días de antigüedad</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">Ahorro estimado de ~%d%% para archivos JPEG</string>
+    <string name="squeezer_estimated_savings_percent">Ahorro estimado de ~%d%% para imágenes</string>
     <string name="squeezer_onboarding_got_it">Entiendo</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-et-rEE/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-et-rEE/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Ruumi tekitamiseks paki pilte.</string>
+    <string name="squeezer_explanation_short">Ruumi säästmiseks paki pilte ja videoid.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">Leiti %d pilt</item>
-        <item quantity="other">Leiti %d pilti</item>
+        <item quantity="one">%d leiti</item>
+        <item quantity="other">%d leiti</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s saab säästa</item>
         <item quantity="other">~%s saab säästa</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d pilt kokkupakitud</item>
-        <item quantity="other">%d pilti kokkupakitud</item>
+        <item quantity="one">%d kokkupakitud</item>
+        <item quantity="other">%d kokkupakitud</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d nurjus</item>
+        <item quantity="other">%d nurjus</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d fail jäeti vahele (pole ligipääsetav)</item>
+        <item quantity="other">%d faili jäeti vahele (pole ligipääsetav)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d pilt valitud</item>
-        <item quantity="other">%d pilti valitud</item>
+        <item quantity="one">%d valitud</item>
+        <item quantity="other">%d valitud</item>
     </plurals>
     <string name="squeezer_search_locations_title">Otsi asukohti</string>
     <string name="squeezer_search_locations_default_summary">Kaamera kaustad (tavaline)</string>
     <string name="squeezer_min_size_title">Väikseim faili maht</string>
-    <string name="squeezer_min_size_description">Eira sellest mahust väiksemaid pilte.</string>
+    <string name="squeezer_min_size_description">Eira sellest mahust väiksemaid faile.</string>
     <string name="squeezer_min_age_title">Faili noorim vanus</string>
-    <string name="squeezer_min_age_description">Kaasa pilte, mis vanemad sellest east.</string>
-    <string name="squeezer_compression_settings_label">Kokkupakkimise seaded</string>
+    <string name="squeezer_min_age_description">Kaasa ainult sellest east vanemad failid.</string>
+    <string name="squeezer_compression_settings_label">Üldine</string>
     <string name="squeezer_quality_label">Kvaliteet</string>
     <string name="squeezer_quality_title">Kokkupakkimise kvaliteet</string>
-    <string name="squeezer_quality_description">Madal kvaliteet tähendab väiksemat faili mahtu, ent kehvemat pildikvaliteeti.</string>
+    <string name="squeezer_quality_description">Madal kvaliteet tähendab väiksemat faili mahtu, ent kehvemat visuaalset kvaliteeti.</string>
     <string name="squeezer_quality_example_format">Näiteks: %1$s pilt → säästab ~%2$s %3$d%% kvaliteedi puhul</string>
     <string name="squeezer_quality_warning_low">Kehvem kvaliteet võib põhjustada nähtavaid segajaid.</string>
     <string name="squeezer_quality_warning_high">Väga kõrge kvaliteet ei paku eriti mälu säästmist.</string>
-    <string name="squeezer_types_category_label">Pildi tüübid</string>
+    <string name="squeezer_types_category_label">Pildi seaded</string>
+    <string name="squeezer_video_settings_category_label">Video seaded</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">Kaasa JPEG pilte (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">Kaasa WebP pilte (.webp).</string>
+    <string name="squeezer_type_video_title">MP4 Video</string>
+    <string name="squeezer_type_video_description">Kaasa MP4 videofailid (.mp4).</string>
     <string name="squeezer_skip_compressed_title">Eira varem kokkupakitut</string>
-    <string name="squeezer_skip_compressed_description">Eira SD Maidi juba kokkupakitud pildid.</string>
+    <string name="squeezer_skip_compressed_description">Eira SD Maidi juba kokkupakitud failid.</string>
     <string name="squeezer_exif_marker_title">Kirjuta EXIF märkus</string>
     <string name="squeezer_exif_marker_description">Tee märge pildi EXIFi kasutaja kommentaari väljale, et ennetada uuesti kokkupakkimist isegi pärast kokkupakkimise ajaloo tühjenemist.</string>
     <string name="squeezer_estimated_savings_format">~%s sääst</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">Kinnita kokkupakkimine</string>
     <string name="squeezer_preview_total_size">Kogumaht</string>
     <string name="squeezer_preview_estimated_savings">Hinnanguline sääst</string>
-    <string name="squeezer_compress_confirmation_title">Pildid kokku pakkida?</string>
-    <string name="squeezer_compress_confirmation_message">See asendab algpildid kokkupakitutega. Seda ei saa tühistada.</string>
+    <string name="squeezer_compress_confirmation_title">Pakkida valitud üksused kokku?</string>
+    <string name="squeezer_compress_confirmation_message">See asendab originaalfailid kokkupakitud versioonidega. Seda toimingut ei saa tagasi võtta.</string>
     <string name="squeezer_history_title">Kokkupakkimise ajalugu</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d kirje (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">Kokkupakkimise ajalugu puudub</string>
     <string name="squeezer_history_clear_title">Tühjenda kokkupakkimise ajalugu</string>
-    <string name="squeezer_history_clear_message">Pärast seda saab taas kokku pakkida varem kokkupakitud pilte. Pildid jäävad alles.</string>
+    <string name="squeezer_history_clear_message">See võimaldab eelnevalt kokkupakitud faile uuesti kokku pakkida. Failid ise ei muutu.</string>
     <string name="squeezer_onboarding_title">Piltide kokkupakkimisest</string>
     <string name="squeezer_onboarding_message">Pildi kokkupakkimine vähendab faili mahtu, eemaldades nähtavad osad. Toiming on lõplik ehk algkvaliteeti pole võimalik taastada.\n\nPildid muutuvad sellisteks:</string>
     <string name="squeezer_onboarding_original_label">Algne</string>
     <string name="squeezer_onboarding_compressed_label">Pärast kokkupakkimist</string>
+    <string name="squeezer_onboarding_video_original_label">Videokaader</string>
+    <string name="squeezer_onboarding_video_compressed_label">Eelvaade (ligikaudne)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">Tegelik videokvaliteet võib erineda</string>
     <string name="squeezer_onboarding_quality_label">Kvaliteet: %d%%</string>
     <string name="squeezer_compare_action">Vaata võrdlust</string>
     <string name="squeezer_no_example_found">Valitud asukohtadest ei leitud ühtki pilti.</string>
-    <string name="squeezer_result_empty_message">Ühtki kokkupakitud pilti ei leitud.</string>
-    <string name="squeezer_setup_warning">Kokkupakkimine vähendab igaveseks pildi kvaliteeti, et hoida kokku mälu arvelt. Seda ei saa ennistada. Enne alustamist kontrollige seadeid hoolikalt.</string>
-    <string name="squeezer_setup_explanation">Meedia kokkupakkija vähendab pildifaili mahtu, et tekitada juurde mäluruumi. See vähendab pildi kvaliteeti jäädavalt ja seda ei saa ennistada. Enne alustamist kontrollige seadeid hoolikalt.</string>
+    <string name="squeezer_result_empty_message">Kokkupakitavat meediat ei leitud.</string>
+    <string name="squeezer_setup_warning">Tihendamine vähendab kvaliteeti püsiavlt, et säästa salvestusruumi. Seda ei saa tagasi võtta. Vaata seaded enne alustamist hoolikalt üle.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d asukohta ei saa tihendamiseks kasutada ja eemaldati. Tihendamine nõuab otsest juurdepääsu sisemälule.</item>
+        <item quantity="other">%d asukohta ei saa tihendamiseks kasutada ja eemaldati. Tihendamine nõuab otsest juurdepääsu sisemälule.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze vähendab piltide ja videote failimaht, et vabastada salvestusruumi. See vähendab kvaliteeti püsiavlt ja seda ei saa tagasi võtta. Vaata seaded enne alustamist hoolikalt üle.</string>
     <string name="squeezer_setup_paths_title">Otsi asukohti</string>
     <string name="squeezer_setup_paths_default">Vali otsitavad kaustad</string>
     <string name="squeezer_setup_quality_title">Kokkupakkimise kvaliteet</string>
@@ -81,6 +99,6 @@
         <item quantity="one">Vähemalt %d päev vana</item>
         <item quantity="other">Vähemalt %d päeva vana</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">Umbes %d%% sääst JPEG failide puhul</string>
+    <string name="squeezer_estimated_savings_percent">Hinnanguliselt ~%d%% sääst piltide puhul</string>
     <string name="squeezer_onboarding_got_it">Selge!</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-eu-rES/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-eu-rES/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Konprimatu irudiak biltegiratzeko lekua aurrezteko.</string>
+    <string name="squeezer_explanation_short">Irudiak eta bideoak konprimatu biltegiratze-espazioa aurrezteko.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d irudi aurkitu da</item>
-        <item quantity="other">%d irudi aurkitu dira</item>
+        <item quantity="one">%d elementu aurkitu da</item>
+        <item quantity="other">%d elementu aurkitu dira</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s aurreztu daiteke</item>
         <item quantity="other">~%s aurreztu daiteke</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d irudi konprimatu da</item>
-        <item quantity="other">%d irudi konprimatu dira</item>
+        <item quantity="one">%d elementu konprimatu da</item>
+        <item quantity="other">%d elementu konprimatu dira</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d huts egin du</item>
+        <item quantity="other">%d huts egin dute</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d fitxategi saltatu da (ez dago eskuragarri)</item>
+        <item quantity="other">%d fitxategi saltatu dira (ez daude eskuragarri)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d irudi hautatuta</item>
-        <item quantity="other">%d irudi hautatuta</item>
+        <item quantity="one">%d elementu hautatuta</item>
+        <item quantity="other">%d elementu hautatuta</item>
     </plurals>
     <string name="squeezer_search_locations_title">Bilaketa-kokalekuak</string>
     <string name="squeezer_search_locations_default_summary">Kamera-karpetak (lehenetsiak)</string>
     <string name="squeezer_min_size_title">Fitxategiaren gutxieneko tamaina</string>
-    <string name="squeezer_min_size_description">Saltatu tamaina hau baino txikiagoak diren irudiak.</string>
+    <string name="squeezer_min_size_description">Tamaina hau baino txikiagoak diren fitxategiak saltatu.</string>
     <string name="squeezer_min_age_title">Fitxategiaren gutxieneko adina</string>
-    <string name="squeezer_min_age_description">Sartu adin hau baino zaharragoak diren irudiak soilik.</string>
-    <string name="squeezer_compression_settings_label">Konpresio-ezarpenak</string>
+    <string name="squeezer_min_age_description">Adina hau baino zaharragoak diren fitxategiak soilik sartu.</string>
+    <string name="squeezer_compression_settings_label">Orokorra</string>
     <string name="squeezer_quality_label">Kalitatea</string>
     <string name="squeezer_quality_title">Konpresio-kalitatea</string>
-    <string name="squeezer_quality_description">Kalitate baxuagoak fitxategi txikiagoak esan nahi du baina irudi-kalitate txikiagoa ere bai.</string>
+    <string name="squeezer_quality_description">Kalitate txikiagoak fitxategi-tamaina txikiagoa esan nahi du, baina ikusmen-kalitatea murrizten du.</string>
     <string name="squeezer_quality_example_format">Adibidea: %1$s irudia → ~%2$s aurrezten du %3$d%% kalitatean</string>
     <string name="squeezer_quality_warning_low">Kalitate baxuagoek ikusgai dauden artifaktuak sor ditzakete.</string>
     <string name="squeezer_quality_warning_high">Kalitate oso altuak leku-aurrezpen minimoa ematen du.</string>
-    <string name="squeezer_types_category_label">Irudi-motak</string>
+    <string name="squeezer_types_category_label">Irudien ezarpenak</string>
+    <string name="squeezer_video_settings_category_label">Bideoen ezarpenak</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">Sartu JPEG irudiak (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">Sartu WebP irudiak (.webp).</string>
+    <string name="squeezer_type_video_title">MP4 Bideoa</string>
+    <string name="squeezer_type_video_description">MP4 bideo fitxategiak sartu (.mp4).</string>
     <string name="squeezer_skip_compressed_title">Saltatu aurrez konprimatutakoak</string>
-    <string name="squeezer_skip_compressed_description">Saltatu SD Maid-ek jada konprimatu dituen irudiak.</string>
+    <string name="squeezer_skip_compressed_description">SD Maid-ek dagoeneko konprimatu dituen fitxategiak saltatu.</string>
     <string name="squeezer_exif_marker_title">Idatzi EXIF marka</string>
     <string name="squeezer_exif_marker_description">Gehitu marka bat irudiaren EXIF erabiltzaile-iruzkin eremura berriro konprimatzea saihesteko, nahiz eta konpresio-historia garbitu.</string>
     <string name="squeezer_estimated_savings_format">~%s aurrezpen</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">Berretsi konpresioa</string>
     <string name="squeezer_preview_total_size">Tamaina osoa</string>
     <string name="squeezer_preview_estimated_savings">Aurreikusitako aurrezpena</string>
-    <string name="squeezer_compress_confirmation_title">Konprimatu irudiak?</string>
-    <string name="squeezer_compress_confirmation_message">Honek jatorrizko irudiak konprimatutako bertsioez ordezkatuko ditu. Ekintza hau ezin da desegin.</string>
+    <string name="squeezer_compress_confirmation_title">Hautatutako elementuak konprimatu?</string>
+    <string name="squeezer_compress_confirmation_message">Honek jatorrizko fitxategiak bertsio konprimatuekin ordezkatuko ditu. Ekintza hau ezin da desegin.</string>
     <string name="squeezer_history_title">Konpresio-historia</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d elementu (%2$s)</item>
@@ -56,19 +67,26 @@
     </plurals>
     <string name="squeezer_history_empty">Ez dago konpresio-historiarik</string>
     <string name="squeezer_history_clear_title">Garbitu konpresio-historia</string>
-    <string name="squeezer_history_clear_message">Honek aurrez konprimatutako irudiak berriro konprima daitezen utziko du. Irudiak berrak ez dira kaltetuko.</string>
+    <string name="squeezer_history_clear_message">Honek aurretik konprimatutako fitxategiak berriro konprimatzea ahalbidetuko du. Fitxategiek beraiek ez dute eraginik jasaten.</string>
     <string name="squeezer_onboarding_title">Irudi-konpresioa buruz</string>
     <string name="squeezer_onboarding_message">Irudi-konpresioak fitxategi-tamaina murrizten du xehetasun bisuala kenduz. Prozesu hau itzulezina da - jatorrizko kalitatea ezin da berreskuratu.
 
 Hona hemen zure irudiak nola ikusiko diren aurrebista:</string>
     <string name="squeezer_onboarding_original_label">Jatorrizkoa</string>
     <string name="squeezer_onboarding_compressed_label">Konpresio ondoren</string>
+    <string name="squeezer_onboarding_video_original_label">Bideo-fotograma</string>
+    <string name="squeezer_onboarding_video_compressed_label">Aurrebista (gutxi gorabeherakoa)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">Benetako bideo-kalitatea alda daiteke</string>
     <string name="squeezer_onboarding_quality_label">Kalitatea: %d%%</string>
     <string name="squeezer_compare_action">Ikusi konparazioa</string>
     <string name="squeezer_no_example_found">Ez da irudirik aurkitu hautatutako bideetan.</string>
-    <string name="squeezer_result_empty_message">Ez da konprimatu daitezkeen irudirik aurkitu.</string>
-    <string name="squeezer_setup_warning">Konpresioak behin betiko murrizten du irudi-kalitatea biltegiratzeko lekua aurrezteko. Hau ezin da desegin. Berrikusi zure ezarpenak arretaz hasi baino lehen.</string>
-    <string name="squeezer_setup_explanation">Media Squeeze-k irudien fitxategi-tamaina murrizten du biltegiratzeko lekua askatzeko. Honek behin betiko murrizten du irudi-kalitatea eta ezin da desegin. Berrikusi zure ezarpenak arretaz hasi baino lehen.</string>
+    <string name="squeezer_result_empty_message">Ez da konprimatu daitekeen multimedia aurkitu.</string>
+    <string name="squeezer_setup_warning">Konprimatzeak kalitatea betirako murrizten du biltegiratze-espazioa aurrezteko. Hau ezin da desegin. Berrikusi zure ezarpenak arretaz hasi aurretik.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d kokapen ezin da konprimatzeko erabili eta ezabatu da. Konprimatzeak barne-biltegiratze zuzeneko sarbidea behar du.</item>
+        <item quantity="other">%d kokapen ezin dira konprimatzeko erabili eta ezabatu dira. Konprimatzeak barne-biltegiratze zuzeneko sarbidea behar du.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze-k irudien eta bideoen fitxategi-tamaina murrizten du biltegiratze-espazioa askatzeko. Honek betirako murrizten du kalitatea eta ezin da desegin. Berrikusi zure ezarpenak arretaz hasi aurretik.</string>
     <string name="squeezer_setup_paths_title">Bilaketa-kokalekuak</string>
     <string name="squeezer_setup_paths_default">Hautatu bilatzeko karpetak</string>
     <string name="squeezer_setup_quality_title">Konpresio-kalitatea</string>
@@ -83,6 +101,6 @@ Hona hemen zure irudiak nola ikusiko diren aurrebista:</string>
         <item quantity="one">Gutxienez %d egun zaharra</item>
         <item quantity="other">Gutxienez %d egun zaharrak</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">JPEG fitxategientzako ~%d%% aurrezpen estimatua</string>
+    <string name="squeezer_estimated_savings_percent">~%d%% aurrezte estimatua irudientzat</string>
     <string name="squeezer_onboarding_got_it">Ulertuta</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-fa/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-fa/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">فشرده‌سازی تصاویر برای صرفه‌جویی در فضای ذخیره‌سازی.</string>
+    <string name="squeezer_explanation_short">تصاویر و ویدیوها را فشرده کنید تا فضای ذخیره‌سازی آزاد شود.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d تصویر یافت شد</item>
-        <item quantity="other">%d تصویر یافت شد</item>
+        <item quantity="one">%d مورد پیدا شد</item>
+        <item quantity="other">%d مورد پیدا شد</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s قابل صرفه‌جویی است</item>
         <item quantity="other">~%s قابل صرفه‌جویی است</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d تصویر فشرده شد</item>
-        <item quantity="other">%d تصویر فشرده شد</item>
+        <item quantity="one">%d مورد فشرده شد</item>
+        <item quantity="other">%d مورد فشرده شد</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d شکست خورد</item>
+        <item quantity="other">%d شکست خورد</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d فایل رد شد (قابل دسترس نیست)</item>
+        <item quantity="other">%d فایل رد شد (قابل دسترس نیست)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d تصویر انتخاب شد</item>
-        <item quantity="other">%d تصویر انتخاب شد</item>
+        <item quantity="one">%d مورد انتخاب شد</item>
+        <item quantity="other">%d مورد انتخاب شد</item>
     </plurals>
     <string name="squeezer_search_locations_title">جستجوی مکان‌ها</string>
     <string name="squeezer_search_locations_default_summary">پوشه‌های دوربین (پیش‌فرض)</string>
     <string name="squeezer_min_size_title">حداقل اندازه فایل</string>
     <string name="squeezer_min_size_description">فایل‌های کوچک‌تر از این اندازه را رد کنید.</string>
     <string name="squeezer_min_age_title">حداقل سن فایل</string>
-    <string name="squeezer_min_age_description">فقط تصاویر قدیمی‌تر از این سن را شامل کنید.</string>
-    <string name="squeezer_compression_settings_label">تنظیمات فشرده‌سازی</string>
+    <string name="squeezer_min_age_description">فقط فایل‌هایی که قدیمی‌تر از این سن هستند را شامل شوید.</string>
+    <string name="squeezer_compression_settings_label">عمومی</string>
     <string name="squeezer_quality_label">کیفیت</string>
     <string name="squeezer_quality_title">کیفیت فشرده‌سازی</string>
-    <string name="squeezer_quality_description">کیفیت پایین‌تر به معنای اندازه فایل کوچک‌تر اما کاهش کیفیت تصویر است.</string>
+    <string name="squeezer_quality_description">کیفیت پایین‌تر به معنای حجم فایل کمتر اما کیفیت بصری کاهش‌یافته است.</string>
     <string name="squeezer_quality_example_format">مثال: تصویر %1$s → صرفه‌جویی ~%2$s در کیفیت %3$d%%</string>
     <string name="squeezer_quality_warning_low">کیفیت‌های پایین‌تر ممکن است آثار قابل مشاهده‌ای ایجاد کنند.</string>
     <string name="squeezer_quality_warning_high">کیفیت بسیار بالا صرفه‌جویی حداقلی در فضا ارائه می‌دهد.</string>
-    <string name="squeezer_types_category_label">انواع تصاویر</string>
+    <string name="squeezer_types_category_label">تنظیمات تصویر</string>
+    <string name="squeezer_video_settings_category_label">تنظیمات ویدیو</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">شامل تصاویر JPEG (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">شامل تصاویر WebP (.webp).</string>
+    <string name="squeezer_type_video_title">ویدیوی MP4</string>
+    <string name="squeezer_type_video_description">فایل‌های ویدیویی MP4 (‎.mp4) را شامل شوید.</string>
     <string name="squeezer_skip_compressed_title">رد کردن فایل‌های قبلاً فشرده شده</string>
-    <string name="squeezer_skip_compressed_description">رد کردن تصاویری که قبلاً توسط SD Maid فشرده شده‌اند.</string>
+    <string name="squeezer_skip_compressed_description">فایل‌هایی که قبلاً توسط SD Maid فشرده شده‌اند را رد کنید.</string>
     <string name="squeezer_exif_marker_title">نوشتن نشانگر EXIF</string>
     <string name="squeezer_exif_marker_description">افزودن نشانگر به فیلد نظر کاربر EXIF تصویر برای جلوگیری از فشرده‌سازی مجدد حتی اگر تاریخچه فشرده‌سازی پاک شود.</string>
     <string name="squeezer_estimated_savings_format">~%s صرفه‌جویی</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">تأیید فشرده‌سازی</string>
     <string name="squeezer_preview_total_size">اندازه کل</string>
     <string name="squeezer_preview_estimated_savings">صرفه‌جویی تخمینی</string>
-    <string name="squeezer_compress_confirmation_title">تصاویر فشرده شوند؟</string>
-    <string name="squeezer_compress_confirmation_message">این عمل تصاویر اصلی را با نسخه‌های فشرده جایگزین می‌کند. این عمل قابل بازگشت نیست.</string>
+    <string name="squeezer_compress_confirmation_title">موارد انتخاب‌شده فشرده شوند؟</string>
+    <string name="squeezer_compress_confirmation_message">این کار فایل‌های اصلی را با نسخه‌های فشرده‌شده جایگزین می‌کند. این عمل قابل بازگشت نیست.</string>
     <string name="squeezer_history_title">تاریخچه فشرده‌سازی</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d مورد (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">تاریخچه فشرده‌سازی خالی است</string>
     <string name="squeezer_history_clear_title">پاک کردن تاریخچه فشرده‌سازی</string>
-    <string name="squeezer_history_clear_message">این اجازه می‌دهد تصاویر قبلاً فشرده شده دوباره فشرده شوند. خود تصاویر تحت تأثیر قرار نمی‌گیرند.</string>
+    <string name="squeezer_history_clear_message">این کار اجازه می‌دهد فایل‌هایی که قبلاً فشرده شده‌اند دوباره فشرده شوند. خود فایل‌ها تحت تأثیر قرار نمی‌گیرند.</string>
     <string name="squeezer_onboarding_title">درباره فشرده‌سازی تصاویر</string>
     <string name="squeezer_onboarding_message">فشرده‌سازی تصاویر اندازه فایل را با حذف جزئیات بصری کاهش می‌دهد. این فرآیند غیرقابل بازگشت است - کیفیت اصلی قابل بازیابی نیست.\n\nدر اینجا پیش‌نمایشی از ظاهر تصاویر شما آمده است:</string>
     <string name="squeezer_onboarding_original_label">اصلی</string>
     <string name="squeezer_onboarding_compressed_label">پس از فشرده‌سازی</string>
+    <string name="squeezer_onboarding_video_original_label">فریم ویدیو</string>
+    <string name="squeezer_onboarding_video_compressed_label">پیش‌نمایش (تقریبی)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">کیفیت واقعی ویدیو ممکن است متفاوت باشد</string>
     <string name="squeezer_onboarding_quality_label">کیفیت: %d%%</string>
     <string name="squeezer_compare_action">مشاهده مقایسه</string>
     <string name="squeezer_no_example_found">تصویری در مسیرهای انتخابی یافت نشد.</string>
-    <string name="squeezer_result_empty_message">تصویر قابل فشرده‌سازی یافت نشد.</string>
-    <string name="squeezer_setup_warning">فشرده‌سازی به طور دائم کیفیت تصاویر را برای صرفه‌جویی در فضا کاهش می‌دهد. این عمل قابل بازگشت نیست. تنظیمات خود را قبل از شروع با دقت بررسی کنید.</string>
-    <string name="squeezer_setup_explanation">فشرده‌سازی رسانه اندازه فایل تصاویر را برای آزادسازی فضا کاهش می‌دهد. این عمل به طور دائم کیفیت تصویر را کاهش می‌دهد و قابل بازگشت نیست. تنظیمات خود را قبل از شروع با دقت بررسی کنید.</string>
+    <string name="squeezer_result_empty_message">هیچ رسانه‌ای قابل فشرده‌سازی پیدا نشد.</string>
+    <string name="squeezer_setup_warning">فشرده‌سازی کیفیت را به‌طور دائمی کاهش می‌دهد تا فضای ذخیره‌سازی آزاد شود. این عمل قابل بازگشت نیست. قبل از شروع، تنظیمات خود را با دقت بررسی کنید.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d مکان قابل استفاده برای فشرده‌سازی نیست و حذف شد. فشرده‌سازی نیاز به دسترسی مستقیم به حافظه داخلی دارد.</item>
+        <item quantity="other">%d مکان قابل استفاده برای فشرده‌سازی نیستند و حذف شدند. فشرده‌سازی نیاز به دسترسی مستقیم به حافظه داخلی دارد.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze حجم فایل تصاویر و ویدیوها را برای آزاد کردن فضای ذخیره‌سازی کاهش می‌دهد. این به‌طور دائمی کیفیت را کاهش می‌دهد و قابل بازگشت نیست. قبل از شروع، تنظیمات خود را با دقت بررسی کنید.</string>
     <string name="squeezer_setup_paths_title">جستجوی مکان‌ها</string>
     <string name="squeezer_setup_paths_default">انتخاب پوشه‌ها برای جستجو</string>
     <string name="squeezer_setup_quality_title">کیفیت فشرده‌سازی</string>
@@ -81,6 +99,6 @@
         <item quantity="one">حداقل %d روزه</item>
         <item quantity="other">حداقل %d روزه</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">صرفه‌جویی تخمینی ~%d%% برای فایل‌های JPEG</string>
+    <string name="squeezer_estimated_savings_percent">صرفه‌جویی تخمینی ~%d%% برای تصاویر</string>
     <string name="squeezer_onboarding_got_it">فهمیدم</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-fi/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-fi/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Pakkaa kuvia tallennustilan säästämiseksi.</string>
+    <string name="squeezer_explanation_short">Pakkaa kuvat ja videot tallennustilan säästämiseksi.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d kuva löydetty</item>
-        <item quantity="other">%d kuvaa löydetty</item>
+        <item quantity="one">%d kohde löydetty</item>
+        <item quantity="other">%d kohdetta löydetty</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s voidaan säästää</item>
         <item quantity="other">~%s voidaan säästää</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d kuva pakattu</item>
-        <item quantity="other">%d kuvaa pakattu</item>
+        <item quantity="one">%d kohde pakattu</item>
+        <item quantity="other">%d kohdetta pakattu</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d epäonnistui</item>
+        <item quantity="other">%d epäonnistui</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d tiedosto ohitettu (ei pääsyä)</item>
+        <item quantity="other">%d tiedostoa ohitettu (ei pääsyä)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d kuva valittu</item>
-        <item quantity="other">%d kuvaa valittu</item>
+        <item quantity="one">%d kohde valittu</item>
+        <item quantity="other">%d kohdetta valittu</item>
     </plurals>
     <string name="squeezer_search_locations_title">Hakusijainnit</string>
     <string name="squeezer_search_locations_default_summary">Kamerakansiot (oletus)</string>
     <string name="squeezer_min_size_title">Tiedoston vähimmäiskoko</string>
-    <string name="squeezer_min_size_description">Ohita kuvia jotka ovat pienempiä kuin tämä koko.</string>
+    <string name="squeezer_min_size_description">Ohita tiedostot, jotka ovat pienempiä kuin tämä koko.</string>
     <string name="squeezer_min_age_title">Tiedoston vähimmäisikä</string>
-    <string name="squeezer_min_age_description">Sisällytä vain tätä ikää vanhemmat kuvat.</string>
-    <string name="squeezer_compression_settings_label">Pakkausasetukset</string>
+    <string name="squeezer_min_age_description">Sisällytä vain tätä ikää vanhemmat tiedostot.</string>
+    <string name="squeezer_compression_settings_label">Yleiset</string>
     <string name="squeezer_quality_label">Laatu</string>
     <string name="squeezer_quality_title">Pakkauksen laatu</string>
-    <string name="squeezer_quality_description">Matalampi laatu tarkoittaa pienempää tiedostokokoa mutta heikompaa kuvanlaatua.</string>
+    <string name="squeezer_quality_description">Alempi laatu tarkoittaa pienempiä tiedostokokoja, mutta heikentynytä kuvanlaatua.</string>
     <string name="squeezer_quality_example_format">Esimerkki: %1$s kuva → säästä ~%2$s laadulla %3$d%%</string>
     <string name="squeezer_quality_warning_low">Matalampi laatu voi aiheuttaa näkyviä artefakteja.</string>
     <string name="squeezer_quality_warning_high">Erittäin korkea laatu tarjoaa minimaalisia tilansäästöjä.</string>
-    <string name="squeezer_types_category_label">Kuvatyypit</string>
+    <string name="squeezer_types_category_label">Kuva-asetukset</string>
+    <string name="squeezer_video_settings_category_label">Videoasetukset</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">Sisällytä JPEG-kuvat (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">Sisällytä WebP-kuvat (.webp).</string>
+    <string name="squeezer_type_video_title">MP4-video</string>
+    <string name="squeezer_type_video_description">Sisällytä MP4-videotiedostot (.mp4).</string>
     <string name="squeezer_skip_compressed_title">Ohita aiemmin pakatut</string>
-    <string name="squeezer_skip_compressed_description">Ohita kuvat jotka SD Maid on jo pakkannut.</string>
+    <string name="squeezer_skip_compressed_description">Ohita tiedostot, jotka SD Maid on jo pakannut.</string>
     <string name="squeezer_exif_marker_title">Kirjoita EXIF-merkintä</string>
     <string name="squeezer_exif_marker_description">Lisää merkintä kuvan EXIF-käyttäjäkommenttikenttään estääksesi uudelleenpakkauksen vaikka pakkaushistoria tyhjennettäisiin.</string>
     <string name="squeezer_estimated_savings_format">~%s säästöä</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">Vahvista pakkaus</string>
     <string name="squeezer_preview_total_size">Kokonaiskoko</string>
     <string name="squeezer_preview_estimated_savings">Arvioitu säästö</string>
-    <string name="squeezer_compress_confirmation_title">Pakataan kuvat?</string>
-    <string name="squeezer_compress_confirmation_message">Tämä korvaa alkuperäiset kuvat pakatuilla versioilla. Tätä toimintoa ei voi kumota.</string>
+    <string name="squeezer_compress_confirmation_title">Pakataan valitut kohteet?</string>
+    <string name="squeezer_compress_confirmation_message">Tämä korvaa alkuperäiset tiedostot pakatuilla versioilla. Tätä toimintoa ei voi kumota.</string>
     <string name="squeezer_history_title">Pakkaushistoria</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d kohde (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">Ei pakkaushistoriaa</string>
     <string name="squeezer_history_clear_title">Tyhjennä pakkaushistoria</string>
-    <string name="squeezer_history_clear_message">Tämä mahdollistaa aiemmin pakattujen kuvien pakkaamisen uudelleen. Itse kuviin ei vaikuteta.</string>
+    <string name="squeezer_history_clear_message">Tämä sallii aiemmin pakattujen tiedostojen pakkaamisen uudelleen. Tiedostoihin itseensä ei vaikuteta.</string>
     <string name="squeezer_onboarding_title">Tietoa kuvien pakkaamisesta</string>
     <string name="squeezer_onboarding_message">Kuvien pakkaaminen pienentää tiedostokokoa poistamalla visuaalisia yksityiskohtia. Prosessi on peruuttamaton - alkuperäistä laatua ei voi palauttaa.\n\nTässä esikatselu miltä kuvasi näyttävät:</string>
     <string name="squeezer_onboarding_original_label">Alkuperäinen</string>
     <string name="squeezer_onboarding_compressed_label">Pakkauksen jälkeen</string>
+    <string name="squeezer_onboarding_video_original_label">Videokuva</string>
+    <string name="squeezer_onboarding_video_compressed_label">Esikatselu (likimääräinen)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">Todellinen videokuvanlaatu voi poiketa</string>
     <string name="squeezer_onboarding_quality_label">Laatu: %d%%</string>
     <string name="squeezer_compare_action">Näytä vertailu</string>
     <string name="squeezer_no_example_found">Kuvia ei löytynyt valituista poluista.</string>
-    <string name="squeezer_result_empty_message">Pakattavia kuvia ei löytynyt.</string>
-    <string name="squeezer_setup_warning">Pakkaus pienentää pysyvästi kuvanlaatua säästääkseen tallennustilaa. Tätä ei voi kumota. Tarkista asetuksesi huolellisesti ennen aloittamista.</string>
-    <string name="squeezer_setup_explanation">Median tiivistys pienentää kuvatiedostojen kokoa vapauttaakseen tallennustilaa. Tämä pienentää pysyvästi kuvanlaatua eikä sitä voi kumota. Tarkista asetuksesi huolellisesti ennen aloittamista.</string>
+    <string name="squeezer_result_empty_message">Pakattavaa mediaa ei löydetty.</string>
+    <string name="squeezer_setup_warning">Pakkaus heikentää pysyvästi laatua tallennustilan säästämiseksi. Tätä ei voi kumota. Tarkista asetukset huolellisesti ennen aloittamista.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d sijaintia ei voi käyttää pakkaamiseen ja se poistettiin. Pakkaaminen vaatii suoran pääsyn sisäiseen tallennustilaan.</item>
+        <item quantity="other">%d sijaintia ei voi käyttää pakkaamiseen ja ne poistettiin. Pakkaaminen vaatii suoran pääsyn sisäiseen tallennustilaan.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze pienentää kuvien ja videoiden tiedostokokoa vapauttaakseen tallennustilaa. Tämä heikentää pysyvästi laatua eikä sitä voi kumota. Tarkista asetukset huolellisesti ennen aloittamista.</string>
     <string name="squeezer_setup_paths_title">Hakusijainnit</string>
     <string name="squeezer_setup_paths_default">Valitse kansiot haettavaksi</string>
     <string name="squeezer_setup_quality_title">Pakkauksen laatu</string>
@@ -81,6 +99,6 @@
         <item quantity="one">Vähintään %d päivä vanha</item>
         <item quantity="other">Vähintään %d päivää vanha</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">Arvioitu ~%d%% säästö JPEG-tiedostoille</string>
+    <string name="squeezer_estimated_savings_percent">Arvioitu säästö ~%d%% kuville</string>
     <string name="squeezer_onboarding_got_it">Selvä</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-fil/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-fil/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">I-compress ang mga larawan upang makatipid ng storage space.</string>
+    <string name="squeezer_explanation_short">I-compress ang mga larawan at video upang makatipid ng espasyo sa storage.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d larawang nahanap</item>
-        <item quantity="other">%d mga larawang nahanap</item>
+        <item quantity="one">%d item ang natagpuan</item>
+        <item quantity="other">%d mga item ang natagpuan</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s ang maaaring matipid</item>
         <item quantity="other">~%s ang maaaring matipid</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d larawang na-compress</item>
-        <item quantity="other">%d mga larawang na-compress</item>
+        <item quantity="one">%d item ang na-compress</item>
+        <item quantity="other">%d mga item ang na-compress</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d nabigo</item>
+        <item quantity="other">%d nabigo</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d file ang nilaktawan (hindi naa-access)</item>
+        <item quantity="other">%d mga file ang nilaktawan (hindi naa-access)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d larawang napili</item>
-        <item quantity="other">%d mga larawang napili</item>
+        <item quantity="one">%d item ang napili</item>
+        <item quantity="other">%d mga item ang napili</item>
     </plurals>
     <string name="squeezer_search_locations_title">Mga lokasyon ng paghahanap</string>
     <string name="squeezer_search_locations_default_summary">Mga camera folder (default)</string>
     <string name="squeezer_min_size_title">Pinakamaliit na sukat ng file</string>
-    <string name="squeezer_min_size_description">Laktawan ang mga larawang mas maliit sa sukat na ito.</string>
+    <string name="squeezer_min_size_description">Laktawan ang mga file na mas maliit kaysa sa sukat na ito.</string>
     <string name="squeezer_min_age_title">Pinakamababang edad ng file</string>
-    <string name="squeezer_min_age_description">Isama lang ang mga larawang mas matanda sa edad na ito.</string>
-    <string name="squeezer_compression_settings_label">Mga setting ng compression</string>
+    <string name="squeezer_min_age_description">Isama lamang ang mga file na mas matanda kaysa sa edad na ito.</string>
+    <string name="squeezer_compression_settings_label">Pangkalahatan</string>
     <string name="squeezer_quality_label">Kalidad</string>
     <string name="squeezer_quality_title">Kalidad ng compression</string>
-    <string name="squeezer_quality_description">Mas mababang kalidad ay nangangahulugang mas maliit na file subalit mas mababang kalidad ng larawan.</string>
+    <string name="squeezer_quality_description">Ang mas mababang kalidad ay nangangahulugang mas maliit na laki ng file ngunit nabawasan ang visual na kalidad.</string>
     <string name="squeezer_quality_example_format">Halimbawa: %1$s na larawan → ~%2$s na matitipid sa %3$d%% na kalidad</string>
     <string name="squeezer_quality_warning_low">Ang mas mababang kalidad ay maaaring magdulot ng nakikitang artifact.</string>
     <string name="squeezer_quality_warning_high">Ang napakataas na kalidad ay nagbibigay ng kaunting matitipid na espasyo.</string>
-    <string name="squeezer_types_category_label">Mga uri ng larawan</string>
+    <string name="squeezer_types_category_label">Mga setting ng larawan</string>
+    <string name="squeezer_video_settings_category_label">Mga setting ng video</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">Isama ang mga JPEG na larawan (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">Isama ang mga WebP na larawan (.webp).</string>
+    <string name="squeezer_type_video_title">MP4 Video</string>
+    <string name="squeezer_type_video_description">Isama ang mga MP4 video file (.mp4).</string>
     <string name="squeezer_skip_compressed_title">Laktawan ang mga dating na-compress</string>
-    <string name="squeezer_skip_compressed_description">Laktawan ang mga larawang na-compress na ng SD Maid.</string>
+    <string name="squeezer_skip_compressed_description">Laktawan ang mga file na na-compress na ng SD Maid.</string>
     <string name="squeezer_exif_marker_title">Isulat ang EXIF marker</string>
     <string name="squeezer_exif_marker_description">Magdagdag ng marker sa EXIF user comment field ng larawan upang maiwasan ang muling pag-compress kahit na-clear ang compression history.</string>
     <string name="squeezer_estimated_savings_format">~%s na matitipid</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">Kumpirmahin ang compression</string>
     <string name="squeezer_preview_total_size">Kabuuang sukat</string>
     <string name="squeezer_preview_estimated_savings">Tinatayang matitipid</string>
-    <string name="squeezer_compress_confirmation_title">I-compress ang mga larawan?</string>
-    <string name="squeezer_compress_confirmation_message">Papalitan nito ang mga orihinal na larawan ng mga na-compress na bersyon. Hindi na maaaring ibalik ang aksyon na ito.</string>
+    <string name="squeezer_compress_confirmation_title">I-compress ang mga napiling item?</string>
+    <string name="squeezer_compress_confirmation_message">Papalitan nito ang mga orihinal na file ng mga compressed na bersyon. Hindi maaaring i-undo ang aksyong ito.</string>
     <string name="squeezer_history_title">History ng compression</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d item (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">Walang history ng compression</string>
     <string name="squeezer_history_clear_title">I-clear ang history ng compression</string>
-    <string name="squeezer_history_clear_message">Papayagan nitong ma-compress muli ang mga dating na-compress na larawan. Hindi maaapektuhan ang mga larawan mismo.</string>
+    <string name="squeezer_history_clear_message">Papayagan nito na ma-compress muli ang mga dating na-compress na file. Ang mga file mismo ay hindi apektado.</string>
     <string name="squeezer_onboarding_title">Tungkol sa Image Compression</string>
     <string name="squeezer_onboarding_message">Binabawasan ng image compression ang sukat ng file sa pamamagitan ng pag-alis ng visual detail. Ang prosesong ito ay hindi na maaaring ibalik - hindi na maibabalik ang orihinal na kalidad.\n\nNarito ang preview kung paano magiging hitsura ng iyong mga larawan:</string>
     <string name="squeezer_onboarding_original_label">Orihinal</string>
     <string name="squeezer_onboarding_compressed_label">Pagkatapos ng compression</string>
+    <string name="squeezer_onboarding_video_original_label">Frame ng video</string>
+    <string name="squeezer_onboarding_video_compressed_label">Preview (tinatayang)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">Maaaring mag-iba ang aktwal na kalidad ng video</string>
     <string name="squeezer_onboarding_quality_label">Kalidad: %d%%</string>
     <string name="squeezer_compare_action">Tingnan ang paghahambing</string>
     <string name="squeezer_no_example_found">Walang nahanap na larawan sa mga napiling path.</string>
-    <string name="squeezer_result_empty_message">Walang nahanap na maaaring i-compress na larawan.</string>
-    <string name="squeezer_setup_warning">Permanenteng binabawasan ng compression ang kalidad ng larawan upang makatipid ng storage space. Hindi na ito maaaring ibalik. Suriin nang mabuti ang iyong mga setting bago magsimula.</string>
-    <string name="squeezer_setup_explanation">Binabawasan ng Media Squeeze ang sukat ng file ng mga larawan upang magpalaya ng storage space. Permanente nitong binabawasan ang kalidad ng larawan at hindi na maaaring ibalik. Suriin nang mabuti ang iyong mga setting bago magsimula.</string>
+    <string name="squeezer_result_empty_message">Walang nahanap na compressible na media.</string>
+    <string name="squeezer_setup_warning">Ang compression ay permanenteng nagbabawas ng kalidad upang makatipid ng espasyo sa storage. Hindi ito maaaring i-undo. Suriin nang maingat ang iyong mga setting bago magsimula.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d lokasyon ay hindi magagamit para sa compression at inalis. Ang compression ay nangangailangan ng direktang access sa panloob na storage.</item>
+        <item quantity="other">%d mga lokasyon ay hindi magagamit para sa compression at inalis. Ang compression ay nangangailangan ng direktang access sa panloob na storage.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Binabawasan ng Media Squeeze ang laki ng file ng mga larawan at video upang palayain ang espasyo sa storage. Permanente itong nagbabawas ng kalidad at hindi maaaring i-undo. Suriin nang maingat ang iyong mga setting bago magsimula.</string>
     <string name="squeezer_setup_paths_title">Mga lokasyon ng paghahanap</string>
     <string name="squeezer_setup_paths_default">Pumili ng mga folder na hahanapin</string>
     <string name="squeezer_setup_quality_title">Kalidad ng compression</string>
@@ -81,6 +99,6 @@
         <item quantity="one">Hindi bababa sa %d araw na edad</item>
         <item quantity="other">Hindi bababa sa %d araw na edad</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">Tinatayang ~%d%% na matitipid para sa mga JPEG file</string>
+    <string name="squeezer_estimated_savings_percent">Tinatayang ~%d%% ang matitipid para sa mga larawan</string>
     <string name="squeezer_onboarding_got_it">Kuha ko</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-fr/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-fr/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Compresser les images pour réduire l’espace utilisé.</string>
+    <string name="squeezer_explanation_short">Compresser les images et vidéos pour réduire l\'espace utilisé.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d image trouvée</item>
-        <item quantity="other">%d images trouvées</item>
+        <item quantity="one">%d élément a été trouvé</item>
+        <item quantity="other">%d éléments ont été trouvés</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s en moins</item>
         <item quantity="other">~%s en moins</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d image compressée</item>
-        <item quantity="other">%d images compressées</item>
+        <item quantity="one">%d élément compressé</item>
+        <item quantity="other">%d éléments compressés</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d en échec</item>
+        <item quantity="other">%d en échec</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d fichier ignoré (non accessible)</item>
+        <item quantity="other">%d fichiers ignorés (non accessibles)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d image sélectionnée</item>
-        <item quantity="other">%d images sélectionnées</item>
+        <item quantity="one">%d élément sélectionné</item>
+        <item quantity="other">%d éléments sélectionnés</item>
     </plurals>
     <string name="squeezer_search_locations_title">Emplacements de recherche</string>
     <string name="squeezer_search_locations_default_summary">Dossiers de l’appareil photo (par défaut)</string>
     <string name="squeezer_min_size_title">Taille minimale des fichiers</string>
-    <string name="squeezer_min_size_description">Ignorer les images plus petites que cette taille.</string>
+    <string name="squeezer_min_size_description">Ignorer les fichiers plus petits que cette taille.</string>
     <string name="squeezer_min_age_title">Âge minimal des fichiers</string>
-    <string name="squeezer_min_age_description">N’inclure que les images plus anciennes que cet âge.</string>
-    <string name="squeezer_compression_settings_label">Paramètres de compression</string>
+    <string name="squeezer_min_age_description">N\'inclure que les fichiers plus anciens que cet âge.</string>
+    <string name="squeezer_compression_settings_label">Général</string>
     <string name="squeezer_quality_label">Qualité</string>
     <string name="squeezer_quality_title">Qualité de la compression</string>
-    <string name="squeezer_quality_description">Une qualité inférieure implique une taille de fichier plus petite, mais une qualité d’image moindre.</string>
+    <string name="squeezer_quality_description">Une qualité inférieure implique une taille de fichier plus petite, mais une qualité visuelle moindre.</string>
     <string name="squeezer_quality_example_format">Exemple : %1$s image → économise ~%2$s avec une qualité de %3$d %%</string>
     <string name="squeezer_quality_warning_low">Les qualités inférieures peuvent entraîner des distortions visuelles.</string>
     <string name="squeezer_quality_warning_high">Une qualité très élevée réduit peu la taille du fichier.</string>
-    <string name="squeezer_types_category_label">Types d’images</string>
+    <string name="squeezer_types_category_label">Paramètres d\'image</string>
+    <string name="squeezer_video_settings_category_label">Paramètres vidéo</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">Inclure les images JPEG (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">Inclure les images WebP (.webp).</string>
+    <string name="squeezer_type_video_title">Vidéo MP4</string>
+    <string name="squeezer_type_video_description">Inclure les fichiers vidéo MP4 (.mp4).</string>
     <string name="squeezer_skip_compressed_title">Ignorer les images déjà compressées</string>
-    <string name="squeezer_skip_compressed_description">Ignorer les images déjà compressées par SD Maid.</string>
+    <string name="squeezer_skip_compressed_description">Ignorer les fichiers déjà compressés par SD Maid.</string>
     <string name="squeezer_exif_marker_title">Écrire le marqueur EXIF</string>
     <string name="squeezer_exif_marker_description">Ajouter un marqueur au champ de commentaire utilisateur EXIF de l’image pour empêcher la recompression, même si l’historique de compression est effacé.</string>
     <string name="squeezer_estimated_savings_format">~%s en moins</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">Confirmer la compression</string>
     <string name="squeezer_preview_total_size">Taille totale</string>
     <string name="squeezer_preview_estimated_savings">Économies probables</string>
-    <string name="squeezer_compress_confirmation_title">Compresser les images ?</string>
-    <string name="squeezer_compress_confirmation_message">Les images originales seront remplacées par les versions compressées. Cette action est irréversible.</string>
+    <string name="squeezer_compress_confirmation_title">Compresser les éléments sélectionnés ?</string>
+    <string name="squeezer_compress_confirmation_message">Les fichiers originaux seront remplacés par les versions compressées. Cette action est irréversible.</string>
     <string name="squeezer_history_title">Historique de compression</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d élément (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">Aucun historique de compression</string>
     <string name="squeezer_history_clear_title">Effacer l’historique de compression</string>
-    <string name="squeezer_history_clear_message">Les images déjà compressées pourront être compressées de nouveau. Les images mêmes ne sont pas affectées.</string>
+    <string name="squeezer_history_clear_message">Les fichiers déjà compressés pourront être compressés de nouveau. Les fichiers eux-mêmes ne sont pas affectés.</string>
     <string name="squeezer_onboarding_title">À propos de la compression des images</string>
     <string name="squeezer_onboarding_message">La compression des images réduit la taille des fichiers en supprimant certains détails visuels. Ce processus est irréversible ; la qualité originale ne peut pas être restaurée.\n\nVoici un aperçu du rendu final de vos images :</string>
     <string name="squeezer_onboarding_original_label">Originale</string>
     <string name="squeezer_onboarding_compressed_label">Après compression</string>
+    <string name="squeezer_onboarding_video_original_label">Image vidéo</string>
+    <string name="squeezer_onboarding_video_compressed_label">Aperçu (approximatif)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">La qualité réelle de la vidéo peut différer</string>
     <string name="squeezer_onboarding_quality_label">Qualité : %d %%</string>
     <string name="squeezer_compare_action">Afficher la comparaison</string>
     <string name="squeezer_no_example_found">Aucune image n’a été trouvée dans les chemins définis.</string>
-    <string name="squeezer_result_empty_message">Aucune image compressible n’a été trouvée.</string>
-    <string name="squeezer_setup_warning">La compression réduit irrémédiablement la qualité des images pour économiser l’espace de stockage. Cette opération est irréversible. Confirmez vos paramètres avant de commencer.</string>
-    <string name="squeezer_setup_explanation">La compression des médias réduit la taille des images afin de libérer l’espace de stockage. Cela réduit irrémédiablement la qualité des images. Cette opération est irréversible. Confirmez vos paramètres avant de commencer.</string>
+    <string name="squeezer_result_empty_message">Aucun média compressible n\'a été trouvé.</string>
+    <string name="squeezer_setup_warning">La compression réduit irrémédiablement la qualité pour économiser l\'espace de stockage. Cette opération est irréversible. Confirmez vos paramètres avant de commencer.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d emplacement ne peut pas être utilisé pour la compression et a été supprimé. La compression nécessite un accès direct au stockage interne.</item>
+        <item quantity="other">%d emplacements ne peuvent pas être utilisés pour la compression et ont été supprimés. La compression nécessite un accès direct au stockage interne.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">La compression des médias réduit la taille des images et des vidéos afin de libérer l\'espace de stockage. Cela réduit irrémédiablement la qualité. Cette opération est irréversible. Confirmez vos paramètres avant de commencer.</string>
     <string name="squeezer_setup_paths_title">Emplacements de recherche</string>
     <string name="squeezer_setup_paths_default">Choisir les dossiers à explorer</string>
     <string name="squeezer_setup_quality_title">Qualité de compression</string>
@@ -81,6 +99,6 @@
         <item quantity="one">Au moins %d jour</item>
         <item quantity="other">Au moins %d jours</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">Économie probable de %d %% pour les fichiers JPEG</string>
+    <string name="squeezer_estimated_savings_percent">Économie estimée de ~%d %% pour les images</string>
     <string name="squeezer_onboarding_got_it">J’ai compris</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-gl-rES/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-gl-rES/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Comprimir imaxes para aforrar espazo de almacenamento.</string>
+    <string name="squeezer_explanation_short">Comprime imaxes e vídeos para aforrar espazo de almacenamento.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d imaxe atopada</item>
-        <item quantity="other">%d imaxes atopadas</item>
+        <item quantity="one">%d elemento atopado</item>
+        <item quantity="other">%d elementos atopados</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s pode aforrarse</item>
         <item quantity="other">~%s poden aforrarse</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d imaxe comprimida</item>
-        <item quantity="other">%d imaxes comprimidas</item>
+        <item quantity="one">%d elemento comprimido</item>
+        <item quantity="other">%d elementos comprimidos</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d fallou</item>
+        <item quantity="other">%d fallaron</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d ficheiro omitido (non accesible)</item>
+        <item quantity="other">%d ficheiros omitidos (non accesibles)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d imaxe seleccionada</item>
-        <item quantity="other">%d imaxes seleccionadas</item>
+        <item quantity="one">%d elemento seleccionado</item>
+        <item quantity="other">%d elementos seleccionados</item>
     </plurals>
     <string name="squeezer_search_locations_title">Ubicacións de busca</string>
     <string name="squeezer_search_locations_default_summary">Cartafoles da cámara (predeterminado)</string>
     <string name="squeezer_min_size_title">Tamaño mínimo de ficheiro</string>
-    <string name="squeezer_min_size_description">Omitir imaxes máis pequenas que este tamaño.</string>
+    <string name="squeezer_min_size_description">Omitir ficheiros máis pequenos que este tamaño.</string>
     <string name="squeezer_min_age_title">Antigüidade mínima do ficheiro</string>
-    <string name="squeezer_min_age_description">Incluír só imaxes máis antigas que esta antigüidade.</string>
-    <string name="squeezer_compression_settings_label">Axustes de compresión</string>
+    <string name="squeezer_min_age_description">Incluír só ficheiros máis antigos que esta antigüidade.</string>
+    <string name="squeezer_compression_settings_label">Xeral</string>
     <string name="squeezer_quality_label">Calidade</string>
     <string name="squeezer_quality_title">Calidade de compresión</string>
-    <string name="squeezer_quality_description">Menor calidade significa menor tamaño de ficheiro pero calidade de imaxe reducida.</string>
+    <string name="squeezer_quality_description">Unha calidade inferior significa un tamaño de ficheiro menor pero unha calidade visual reducida.</string>
     <string name="squeezer_quality_example_format">Exemplo: imaxe de %1$s → aforra ~%2$s ao %3$d%% de calidade</string>
     <string name="squeezer_quality_warning_low">Calidades máis baixas poden causar artefactos visibles.</string>
     <string name="squeezer_quality_warning_high">Calidade moi alta proporciona un aforro mínimo de espazo.</string>
-    <string name="squeezer_types_category_label">Tipos de imaxe</string>
+    <string name="squeezer_types_category_label">Configuración de imaxes</string>
+    <string name="squeezer_video_settings_category_label">Configuración de vídeo</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">Incluír imaxes JPEG (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">Incluír imaxes WebP (.webp).</string>
+    <string name="squeezer_type_video_title">Vídeo MP4</string>
+    <string name="squeezer_type_video_description">Incluír ficheiros de vídeo MP4 (.mp4).</string>
     <string name="squeezer_skip_compressed_title">Omitir previamente comprimidas</string>
-    <string name="squeezer_skip_compressed_description">Omitir imaxes que xa foron comprimidas por SD Maid.</string>
+    <string name="squeezer_skip_compressed_description">Omitir ficheiros que xa foron comprimidos por SD Maid.</string>
     <string name="squeezer_exif_marker_title">Escribir marcador EXIF</string>
     <string name="squeezer_exif_marker_description">Engadir un marcador ao campo de comentario de usuario EXIF da imaxe para evitar a recompresión aínda que se borre o historial de compresión.</string>
     <string name="squeezer_estimated_savings_format">~%s de aforro</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">Confirmar compresión</string>
     <string name="squeezer_preview_total_size">Tamaño total</string>
     <string name="squeezer_preview_estimated_savings">Aforro estimado</string>
-    <string name="squeezer_compress_confirmation_title">Comprimir imaxes?</string>
-    <string name="squeezer_compress_confirmation_message">Isto substituirá as imaxes orixinais con versións comprimidas. Esta acción non se pode desfacer.</string>
+    <string name="squeezer_compress_confirmation_title">Comprimir os elementos seleccionados?</string>
+    <string name="squeezer_compress_confirmation_message">Isto substituírá os ficheiros orixinais por versións comprimidas. Esta acción non se pode desfacer.</string>
     <string name="squeezer_history_title">Historial de compresión</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d elemento (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">Sen historial de compresión</string>
     <string name="squeezer_history_clear_title">Borrar historial de compresión</string>
-    <string name="squeezer_history_clear_message">Isto permitirá que as imaxes previamente comprimidas sexan comprimidas de novo. As imaxes en si non se ven afectadas.</string>
+    <string name="squeezer_history_clear_message">Isto permitirá que os ficheiros comprimidos anteriormente poñan comprimirse de novo. Os propios ficheiros non se ven afectados.</string>
     <string name="squeezer_onboarding_title">Sobre a compresión de imaxes</string>
     <string name="squeezer_onboarding_message">A compresión de imaxes reduce o tamaño do ficheiro eliminando detalle visual. Este proceso é irreversible - a calidade orixinal non se pode restaurar.\n\nAquí tes unha vista previa de como se verán as túas imaxes:</string>
     <string name="squeezer_onboarding_original_label">Orixinal</string>
     <string name="squeezer_onboarding_compressed_label">Despois da compresión</string>
+    <string name="squeezer_onboarding_video_original_label">Fotograma de vídeo</string>
+    <string name="squeezer_onboarding_video_compressed_label">Vista previa (aproximada)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">A calidade real do vídeo pode variar</string>
     <string name="squeezer_onboarding_quality_label">Calidade: %d%%</string>
     <string name="squeezer_compare_action">Ver comparación</string>
     <string name="squeezer_no_example_found">Non se atoparon imaxes nas rutas seleccionadas.</string>
-    <string name="squeezer_result_empty_message">Non se atoparon imaxes comprimibles.</string>
-    <string name="squeezer_setup_warning">A compresión reduce permanentemente a calidade da imaxe para aforrar espazo. Isto non se pode desfacer. Revisa a túa configuración coidadosamente antes de comezar.</string>
-    <string name="squeezer_setup_explanation">Media Squeeze reduce o tamaño das imaxes para liberar espazo de almacenamento. Isto reduce permanentemente a calidade da imaxe e non se pode desfacer. Revisa a túa configuración coidadosamente antes de comezar.</string>
+    <string name="squeezer_result_empty_message">Non se atoparon medios comprimibles.</string>
+    <string name="squeezer_setup_warning">A compresión reduce permanentemente a calidade para aforrar espazo de almacenamento. Isto non se pode desfacer. Revisa a túa configuración coidadosamente antes de comezar.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d localización non se pode usar para a compresión e foi eliminada. A compresión require acceso directo ao almacenamento interno.</item>
+        <item quantity="other">%d localizacións non se poden usar para a compresión e foron eliminadas. A compresión require acceso directo ao almacenamento interno.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze reduce o tamaño dos ficheiros de imaxes e vídeos para liberar espazo de almacenamento. Isto reduce permanentemente a calidade e non se pode desfacer. Revisa a túa configuración coidadosamente antes de comezar.</string>
     <string name="squeezer_setup_paths_title">Ubicacións de busca</string>
     <string name="squeezer_setup_paths_default">Seleccionar cartafoles para buscar</string>
     <string name="squeezer_setup_quality_title">Calidade de compresión</string>
@@ -81,6 +99,6 @@
         <item quantity="one">Polo menos %d día de antigüidade</item>
         <item quantity="other">Polo menos %d días de antigüidade</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">Aforro estimado de ~%d%% para ficheiros JPEG</string>
+    <string name="squeezer_estimated_savings_percent">Aforros estimados de ~%d%% para imaxes</string>
     <string name="squeezer_onboarding_got_it">Entendido</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-hi-rIN/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-hi-rIN/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">स्टोरेज स्थान बचाने के लिए छवियों को संपीड़ित करें।</string>
+    <string name="squeezer_explanation_short">स्टोरेज स्पेस बचाने के लिए छवियों और वीडियो को संपीड़ित करें।</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d छवि मिली</item>
-        <item quantity="other">%d छवियाँ मिलीं</item>
+        <item quantity="one">%d आइटम मिला</item>
+        <item quantity="other">%d आइटम मिले</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s बचाया जा सकता है</item>
         <item quantity="other">~%s बचाया जा सकता है</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d छवि संपीड़ित की गई</item>
-        <item quantity="other">%d छवियाँ संपीड़ित की गईं</item>
+        <item quantity="one">%d आइटम संपीड़ित</item>
+        <item quantity="other">%d आइटम संपीड़ित</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d विफल</item>
+        <item quantity="other">%d विफल</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d फ़ाइल छोड़ी गई (पहुँच योग्य नहीं)</item>
+        <item quantity="other">%d फ़ाइलें छोड़ी गईं (पहुँच योग्य नहीं)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d छवि चुनी गई</item>
-        <item quantity="other">%d छवियाँ चुनी गईं</item>
+        <item quantity="one">%d आइटम चयनित</item>
+        <item quantity="other">%d आइटम चयनित</item>
     </plurals>
     <string name="squeezer_search_locations_title">खोज स्थान</string>
     <string name="squeezer_search_locations_default_summary">कैमरा फ़ोल्डर (डिफ़ॉल्ट)</string>
     <string name="squeezer_min_size_title">न्यूनतम फ़ाइल आकार</string>
-    <string name="squeezer_min_size_description">इस आकार से छोटी छवियों को छोड़ें।</string>
+    <string name="squeezer_min_size_description">इस आकार से छोटी फ़ाइलें छोड़ें।</string>
     <string name="squeezer_min_age_title">न्यूनतम फ़ाइल आयु</string>
-    <string name="squeezer_min_age_description">केवल इस आयु से पुरानी छवियों को शामिल करें।</string>
-    <string name="squeezer_compression_settings_label">संपीड़न सेटिंग</string>
+    <string name="squeezer_min_age_description">केवल इस आयु से पुरानी फ़ाइलें शामिल करें।</string>
+    <string name="squeezer_compression_settings_label">सामान्य</string>
     <string name="squeezer_quality_label">गुणवत्ता</string>
     <string name="squeezer_quality_title">संपीड़न गुणवत्ता</string>
-    <string name="squeezer_quality_description">कम गुणवत्ता का मतलब छोटा फ़ाइल आकार है लेकिन छवि गुणवत्ता कम होती है।</string>
+    <string name="squeezer_quality_description">कम गुणवत्ता का अर्थ है छोटा फ़ाइल आकार लेकिन दृश्य गुणवत्ता कम होगी।</string>
     <string name="squeezer_quality_example_format">उदाहरण: %1$s छवि → %3$d%% गुणवत्ता पर ~%2$s बचाता है</string>
     <string name="squeezer_quality_warning_low">कम गुणवत्ता में दृश्य आर्टिफ़ैक्ट हो सकते हैं।</string>
     <string name="squeezer_quality_warning_high">बहुत उच्च गुणवत्ता से स्थान की बचत न्यूनतम होती है।</string>
-    <string name="squeezer_types_category_label">छवि प्रकार</string>
+    <string name="squeezer_types_category_label">छवि सेटिंग</string>
+    <string name="squeezer_video_settings_category_label">वीडियो सेटिंग</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">JPEG छवियाँ शामिल करें (.jpg, .jpeg)।</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">WebP छवियाँ शामिल करें (.webp)।</string>
+    <string name="squeezer_type_video_title">MP4 वीडियो</string>
+    <string name="squeezer_type_video_description">MP4 वीडियो फ़ाइलें (.mp4) शामिल करें।</string>
     <string name="squeezer_skip_compressed_title">पहले से संपीड़ित को छोड़ें</string>
-    <string name="squeezer_skip_compressed_description">उन छवियों को छोड़ें जो पहले से SD Maid द्वारा संपीड़ित की जा चुकी हैं।</string>
+    <string name="squeezer_skip_compressed_description">उन फ़ाइलों को छोड़ें जो पहले से SD Maid द्वारा संपीड़ित की जा चुकी हैं।</string>
     <string name="squeezer_exif_marker_title">EXIF मार्कर लिखें</string>
     <string name="squeezer_exif_marker_description">संपीड़न इतिहास साफ़ होने पर भी पुनः-संपीड़न रोकने के लिए छवि के EXIF उपयोगकर्ता टिप्पणी फ़ील्ड में एक मार्कर जोड़ें।</string>
     <string name="squeezer_estimated_savings_format">~%s की बचत</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">संपीड़न की पुष्टि करें</string>
     <string name="squeezer_preview_total_size">कुल आकार</string>
     <string name="squeezer_preview_estimated_savings">अनुमानित बचत</string>
-    <string name="squeezer_compress_confirmation_title">छवियाँ संपीड़ित करें?</string>
-    <string name="squeezer_compress_confirmation_message">यह मूल छवियों को संपीड़ित संस्करणों से बदल देगा। यह क्रिया पूर्ववत नहीं की जा सकती।</string>
+    <string name="squeezer_compress_confirmation_title">चयनित आइटम संपीड़ित करें?</string>
+    <string name="squeezer_compress_confirmation_message">यह मूल फ़ाइलों को संपीड़ित संस्करणों से बदल देगा। यह क्रिया पूर्ववत नहीं की जा सकती।</string>
     <string name="squeezer_history_title">संपीड़न इतिहास</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d आइटम (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">कोई संपीड़न इतिहास नहीं</string>
     <string name="squeezer_history_clear_title">संपीड़न इतिहास साफ़ करें</string>
-    <string name="squeezer_history_clear_message">यह पहले से संपीड़ित छवियों को फिर से संपीड़ित करने की अनुमति देगा। छवियाँ स्वयं प्रभावित नहीं होती हैं।</string>
+    <string name="squeezer_history_clear_message">यह पहले से संपीड़ित फ़ाइलों को दोबारा संपीड़ित करने की अनुमति देगा। फ़ाइलें स्वयं प्रभावित नहीं होती हैं।</string>
     <string name="squeezer_onboarding_title">छवि संपीड़न के बारे में</string>
     <string name="squeezer_onboarding_message">छवि संपीड़न दृश्य विवरण हटाकर फ़ाइल आकार कम करता है। यह प्रक्रिया अपरिवर्तनीय है - मूल गुणवत्ता पुनर्स्थापित नहीं की जा सकती।\n\nयहां आपकी छवियों का पूर्वावलोकन है:</string>
     <string name="squeezer_onboarding_original_label">मूल</string>
     <string name="squeezer_onboarding_compressed_label">संपीड़न के बाद</string>
+    <string name="squeezer_onboarding_video_original_label">वीडियो फ्रेम</string>
+    <string name="squeezer_onboarding_video_compressed_label">पूर्वावलोकन (अनुमानित)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">वास्तविक वीडियो गुणवत्ता भिन्न हो सकती है</string>
     <string name="squeezer_onboarding_quality_label">गुणवत्ता: %d%%</string>
     <string name="squeezer_compare_action">तुलना देखें</string>
     <string name="squeezer_no_example_found">चयनित पथों में कोई छवि नहीं मिली।</string>
-    <string name="squeezer_result_empty_message">कोई संपीड़न योग्य छवि नहीं मिली।</string>
-    <string name="squeezer_setup_warning">संपीड़न संग्रहण स्थान बचाने के लिए छवि गुणवत्ता को स्थायी रूप से कम करता है। इसे पूर्ववत नहीं किया जा सकता। शुरू करने से पहले अपनी सेटिंग्स की सावधानीपूर्वक समीक्षा करें।</string>
-    <string name="squeezer_setup_explanation">Media Squeeze संग्रहण स्थान खाली करने के लिए छवि फ़ाइल आकार कम करता है। यह छवि गुणवत्ता को स्थायी रूप से कम करता है और इसे पूर्ववत नहीं किया जा सकता। शुरू करने से पहले अपनी सेटिंग्स की सावधानीपूर्वक समीक्षा करें।</string>
+    <string name="squeezer_result_empty_message">कोई संपीड़न योग्य मीडिया नहीं मिला।</string>
+    <string name="squeezer_setup_warning">संपीड़न स्थायी रूप से स्टोरेज स्पेस बचाने के लिए गुणवत्ता कम करता है। यह पूर्ववत नहीं किया जा सकता। शुरू करने से पहले अपनी सेटिंग ध्यानपूर्वक देखें।</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d स्थान संपीड़न के लिए उपयोग नहीं किया जा सकता और हटा दिया गया। संपीड़न के लिए आंतरिक संग्रहण तक सीधी पहुँच आवश्यक है।</item>
+        <item quantity="other">%d स्थान संपीड़न के लिए उपयोग नहीं किए जा सकते और हटा दिए गए। संपीड़न के लिए आंतरिक संग्रहण तक सीधी पहुँच आवश्यक है।</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze छवियों और वीडियो का फ़ाइल आकार कम करके स्टोरेज खाली करता है। यह स्थायी रूप से गुणवत्ता कम करता है और इसे पूर्ववत नहीं किया जा सकता। शुरू करने से पहले अपनी सेटिंग ध्यानपूर्वक देखें।</string>
     <string name="squeezer_setup_paths_title">खोज स्थान</string>
     <string name="squeezer_setup_paths_default">खोजने के लिए फ़ोल्डर चुनें</string>
     <string name="squeezer_setup_quality_title">संपीड़न गुणवत्ता</string>
@@ -81,6 +99,6 @@
         <item quantity="one">कम से कम %d दिन पुरानी</item>
         <item quantity="other">कम से कम %d दिन पुरानी</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">JPEG फ़ाइलों के लिए अनुमानित ~%d%% बचत</string>
+    <string name="squeezer_estimated_savings_percent">छवियों के लिए अनुमानित ~%d%% बचत</string>
     <string name="squeezer_onboarding_got_it">समझ गया</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-hr/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-hr/strings.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Komprimirajte slike kako biste uštedili prostor za pohranu.</string>
+    <string name="squeezer_explanation_short">Komprimiraj slike i videozapise kako biste uštedjeli prostor za pohranu.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d slika pronađena</item>
-        <item quantity="few">%d slike pronađene</item>
-        <item quantity="other">%d slika pronađeno</item>
+        <item quantity="one">%d stavka pronađena</item>
+        <item quantity="few">%d stavke pronađene</item>
+        <item quantity="other">%d stavki pronađeno</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s se može uštedjeti</item>
@@ -12,35 +12,48 @@
         <item quantity="other">~%s se može uštedjeti</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d slika komprimirana</item>
-        <item quantity="few">%d slike komprimirane</item>
-        <item quantity="other">%d slika komprimirano</item>
+        <item quantity="one">%d stavka komprimirana</item>
+        <item quantity="few">%d stavke komprimirane</item>
+        <item quantity="other">%d stavki komprimirano</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d neuspješan</item>
+        <item quantity="few">%d neuspješna</item>
+        <item quantity="other">%d neuspješnih</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d datoteka preskočena (nije dostupna)</item>
+        <item quantity="few">%d datoteke preskočene (nisu dostupne)</item>
+        <item quantity="other">%d datoteka preskočeno (nije dostupno)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d slika odabrana</item>
-        <item quantity="few">%d slike odabrane</item>
-        <item quantity="other">%d slika odabrano</item>
+        <item quantity="one">%d stavka odabrana</item>
+        <item quantity="few">%d stavke odabrane</item>
+        <item quantity="other">%d stavki odabrano</item>
     </plurals>
     <string name="squeezer_search_locations_title">Lokacije pretraživanja</string>
     <string name="squeezer_search_locations_default_summary">Mape kamere (zadano)</string>
     <string name="squeezer_min_size_title">Minimalna veličina datoteke</string>
-    <string name="squeezer_min_size_description">Preskoči slike manje od ove veličine.</string>
+    <string name="squeezer_min_size_description">Preskoči datoteke manje od ove veličine.</string>
     <string name="squeezer_min_age_title">Minimalna starost datoteke</string>
-    <string name="squeezer_min_age_description">Uključi samo slike starije od ove starosti.</string>
-    <string name="squeezer_compression_settings_label">Postavke kompresije</string>
+    <string name="squeezer_min_age_description">Uključi samo datoteke starije od ove dobi.</string>
+    <string name="squeezer_compression_settings_label">Općenito</string>
     <string name="squeezer_quality_label">Kvaliteta</string>
     <string name="squeezer_quality_title">Kvaliteta kompresije</string>
-    <string name="squeezer_quality_description">Niža kvaliteta znači manju veličinu datoteke, ali smanjenu kvalitetu slike.</string>
+    <string name="squeezer_quality_description">Niža kvaliteta znači manju veličinu datoteke, ali smanjenu vizualnu kvalitetu.</string>
     <string name="squeezer_quality_example_format">Primjer: %1$s slika → ušteda ~%2$s pri %3$d%% kvalitete</string>
     <string name="squeezer_quality_warning_low">Niže kvalitete mogu uzrokovati vidljive artefakte.</string>
     <string name="squeezer_quality_warning_high">Vrlo visoka kvaliteta pruža minimalnu uštedu prostora.</string>
-    <string name="squeezer_types_category_label">Vrste slika</string>
+    <string name="squeezer_types_category_label">Postavke slika</string>
+    <string name="squeezer_video_settings_category_label">Postavke videozapisa</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">Uključi JPEG slike (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">Uključi WebP slike (.webp).</string>
+    <string name="squeezer_type_video_title">MP4 videozapis</string>
+    <string name="squeezer_type_video_description">Uključi MP4 videodatoteke (.mp4).</string>
     <string name="squeezer_skip_compressed_title">Preskoči prethodno komprimirane</string>
-    <string name="squeezer_skip_compressed_description">Preskoči slike koje je SD Maid već komprimirao.</string>
+    <string name="squeezer_skip_compressed_description">Preskoči datoteke koje je SD Maid već komprimirao.</string>
     <string name="squeezer_exif_marker_title">Zapiši EXIF marker</string>
     <string name="squeezer_exif_marker_description">Dodaj marker u polje komentara korisnika EXIF slike kako bi se spriječila ponovna kompresija čak i ako se povijest kompresije obriše.</string>
     <string name="squeezer_estimated_savings_format">~%s uštede</string>
@@ -51,8 +64,8 @@
     <string name="squeezer_preview_dialog_title">Potvrdi kompresiju</string>
     <string name="squeezer_preview_total_size">Ukupna veličina</string>
     <string name="squeezer_preview_estimated_savings">Procijenjena ušteda</string>
-    <string name="squeezer_compress_confirmation_title">Komprimirati slike?</string>
-    <string name="squeezer_compress_confirmation_message">Ovo će zamijeniti originalne slike komprimiranim verzijama. Ova radnja se ne može poništiti.</string>
+    <string name="squeezer_compress_confirmation_title">Komprimirati odabrane stavke?</string>
+    <string name="squeezer_compress_confirmation_message">Ovo će zamijeniti originalne datoteke komprimiranim verzijama. Ova radnja se ne može poništiti.</string>
     <string name="squeezer_history_title">Povijest kompresije</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d stavka (%2$s)</item>
@@ -61,17 +74,25 @@
     </plurals>
     <string name="squeezer_history_empty">Nema povijesti kompresije</string>
     <string name="squeezer_history_clear_title">Obriši povijest kompresije</string>
-    <string name="squeezer_history_clear_message">Ovo će omogućiti ponovnu kompresiju prethodno komprimiranih slika. Same slike nisu pogođene.</string>
+    <string name="squeezer_history_clear_message">Ovo će omogućiti ponovnu kompresiju prethodno komprimiranih datoteka. Same datoteke neće biti pogođene.</string>
     <string name="squeezer_onboarding_title">O kompresiji slika</string>
     <string name="squeezer_onboarding_message">Kompresija slika smanjuje veličinu datoteke uklanjanjem vizualnih detalja. Ovaj proces je nepovratan - originalna kvaliteta se ne može vratiti.\n\nEvo pregleda kako će vaše slike izgledati:</string>
     <string name="squeezer_onboarding_original_label">Originalno</string>
     <string name="squeezer_onboarding_compressed_label">Nakon kompresije</string>
+    <string name="squeezer_onboarding_video_original_label">Videosličica</string>
+    <string name="squeezer_onboarding_video_compressed_label">Pregled (približan)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">Stvarna kvaliteta videozapisa može se razlikovati</string>
     <string name="squeezer_onboarding_quality_label">Kvaliteta: %d%%</string>
     <string name="squeezer_compare_action">Pogledaj usporedbu</string>
     <string name="squeezer_no_example_found">Nema slika u odabranim putanjama.</string>
-    <string name="squeezer_result_empty_message">Nema slika za kompresiju.</string>
-    <string name="squeezer_setup_warning">Kompresija trajno smanjuje kvalitetu slike kako bi uštedjela prostor. Ovo se ne može poništiti. Pažljivo pregledajte postavke prije pokretanja.</string>
-    <string name="squeezer_setup_explanation">Kompresija medija smanjuje veličinu datoteka slika kako bi oslobodila prostor. Ovo trajno smanjuje kvalitetu slike i ne može se poništiti. Pažljivo pregledajte postavke prije pokretanja.</string>
+    <string name="squeezer_result_empty_message">Nije pronađen medij koji se može komprimirati.</string>
+    <string name="squeezer_setup_warning">Kompresija trajno smanjuje kvalitetu kako bi uštedjela prostor za pohranu. Ovo se ne može poništiti. Pažljivo pregledajte postavke prije pokretanja.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d lokacija ne može se koristiti za kompresiju i uklonjena je. Kompresija zahtijeva izravan pristup internoj pohrani.</item>
+        <item quantity="few">%d lokacije ne mogu se koristiti za kompresiju i uklonjene su. Kompresija zahtijeva izravan pristup internoj pohrani.</item>
+        <item quantity="other">%d lokacija ne može se koristiti za kompresiju i uklonjene su. Kompresija zahtijeva izravan pristup internoj pohrani.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze smanjuje veličinu datoteka slika i videozapisa kako bi oslobodio prostor za pohranu. Ovo trajno smanjuje kvalitetu i ne može se poništiti. Pažljivo pregledajte postavke prije pokretanja.</string>
     <string name="squeezer_setup_paths_title">Lokacije pretraživanja</string>
     <string name="squeezer_setup_paths_default">Odaberite mape za pretraživanje</string>
     <string name="squeezer_setup_quality_title">Kvaliteta kompresije</string>
@@ -87,6 +108,6 @@
         <item quantity="few">Najmanje %d dana stara</item>
         <item quantity="other">Najmanje %d dana stara</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">Procjenjena ušteda od ~%d%% za JPEG datoteke</string>
+    <string name="squeezer_estimated_savings_percent">Procijenjena uštedina ~%d%% za slike</string>
     <string name="squeezer_onboarding_got_it">U redu</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-hu/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-hu/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Képek tömörítése a tárhely megtakarítása érdekében.</string>
+    <string name="squeezer_explanation_short">Képek és videók tömörítése a tárhely felszabadításához.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d kép találva</item>
-        <item quantity="other">%d kép találva</item>
+        <item quantity="one">%d elem található</item>
+        <item quantity="other">%d elem található</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s megtakarítható</item>
         <item quantity="other">~%s megtakarítható</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d kép tömörítve</item>
-        <item quantity="other">%d kép tömörítve</item>
+        <item quantity="one">%d elem tömörítve</item>
+        <item quantity="other">%d elem tömörítve</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d sikertelen</item>
+        <item quantity="other">%d sikertelen</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d fájl kihagyva (nem elérhető)</item>
+        <item quantity="other">%d fájl kihagyva (nem elérhető)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d kép kiválasztva</item>
-        <item quantity="other">%d kép kiválasztva</item>
+        <item quantity="one">%d elem kiválasztva</item>
+        <item quantity="other">%d elem kiválasztva</item>
     </plurals>
     <string name="squeezer_search_locations_title">Helyek keresése</string>
     <string name="squeezer_search_locations_default_summary">Kamera mappák (alapértelmezett)</string>
     <string name="squeezer_min_size_title">Minimális fájlméret</string>
-    <string name="squeezer_min_size_description">Az ennél kisebb képek kihagyása.</string>
+    <string name="squeezer_min_size_description">Az ennél kisebb fájlok kihagyása.</string>
     <string name="squeezer_min_age_title">Minimális fájlkor</string>
-    <string name="squeezer_min_age_description">Csak az ennél régebbi képek bevonása.</string>
-    <string name="squeezer_compression_settings_label">Tömörítési beállítások</string>
+    <string name="squeezer_min_age_description">Csak az ennél régebbi fájlok szerepeljenek.</string>
+    <string name="squeezer_compression_settings_label">Általános</string>
     <string name="squeezer_quality_label">Minőség</string>
     <string name="squeezer_quality_title">Tömörítési minőség</string>
-    <string name="squeezer_quality_description">Alacsonyabb minőség kisebb fájlméretet jelent, de csökkentett képminőséggel.</string>
+    <string name="squeezer_quality_description">Az alacsonyabb minőség kisebb fájlméretet jelent, de csökkentett vizuális minőséggel.</string>
     <string name="squeezer_quality_example_format">Példa: %1$s kép → ~%2$s megtakarítás %3$d%% minőségnél</string>
     <string name="squeezer_quality_warning_low">Alacsonyabb minőségnél látható műtermékek jelenhetnek meg.</string>
     <string name="squeezer_quality_warning_high">Nagyon magas minőség minimális helytakarékosságot biztosít.</string>
-    <string name="squeezer_types_category_label">Képtípusok</string>
+    <string name="squeezer_types_category_label">Képbeállítások</string>
+    <string name="squeezer_video_settings_category_label">Videóbeállítások</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">JPEG képek (.jpg, .jpeg) bevonása.</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">WebP képek (.webp) bevonása.</string>
+    <string name="squeezer_type_video_title">MP4 videó</string>
+    <string name="squeezer_type_video_description">MP4 videófájlok (.mp4) hozzáadása.</string>
     <string name="squeezer_skip_compressed_title">Már tömörítettek kihagyása</string>
-    <string name="squeezer_skip_compressed_description">Az SD Maid által már tömörített képek kihagyása.</string>
+    <string name="squeezer_skip_compressed_description">Az SD Maid által már tömörített fájlok kihagyása.</string>
     <string name="squeezer_exif_marker_title">EXIF jelölő írása</string>
     <string name="squeezer_exif_marker_description">Jelölő hozzáadása a kép EXIF felhasználói megjegyzés mezőjéhez az újratömörítés megakadályozására még a tömörítési előzmények törlése után is.</string>
     <string name="squeezer_estimated_savings_format">~%s megtakarítás</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">Tömörítés megerősítése</string>
     <string name="squeezer_preview_total_size">Teljes méret</string>
     <string name="squeezer_preview_estimated_savings">Becsült megtakarítás</string>
-    <string name="squeezer_compress_confirmation_title">Képek tömörítése?</string>
-    <string name="squeezer_compress_confirmation_message">Ez az eredeti képeket tömörített verziókkal cseréli le. Ez a művelet nem vonható vissza.</string>
+    <string name="squeezer_compress_confirmation_title">Tömöríti a kiválasztott elemeket?</string>
+    <string name="squeezer_compress_confirmation_message">Ez lecseréli az eredeti fájlokat tömörített verziókra. Ez a művelet nem vonható vissza.</string>
     <string name="squeezer_history_title">Tömörítési előzmények</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d elem (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">Nincs tömörítési előzmény</string>
     <string name="squeezer_history_clear_title">Tömörítési előzmények törlése</string>
-    <string name="squeezer_history_clear_message">Ez lehetővé teszi a korábban tömörített képek újratömörítését. Maguk a képek nem változnak.</string>
+    <string name="squeezer_history_clear_message">Ez lehetővé teszi, hogy a korábban tömörített fájlokat újra tömörítessük. Magukat a fájlokat ez nem érinti.</string>
     <string name="squeezer_onboarding_title">A képtömörítésről</string>
     <string name="squeezer_onboarding_message">A képtömörítés csökkenti a fájlméretet a vizuális részletek eltávolításával. Ez a folyamat visszafordíthatatlan - az eredeti minőség nem állítható vissza.\n\nÍgy fognak kinézni a képeid:</string>
     <string name="squeezer_onboarding_original_label">Eredeti</string>
     <string name="squeezer_onboarding_compressed_label">Tömörítés után</string>
+    <string name="squeezer_onboarding_video_original_label">Videókeret</string>
+    <string name="squeezer_onboarding_video_compressed_label">Előnézet (hozzávetőleges)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">A tényleges videóminőség eltérhet</string>
     <string name="squeezer_onboarding_quality_label">Minőség: %d%%</string>
     <string name="squeezer_compare_action">Összehasonlítás megtekintése</string>
     <string name="squeezer_no_example_found">Nem található kép a kiválasztott útvonalakon.</string>
-    <string name="squeezer_result_empty_message">Nem található tömöríthető kép.</string>
-    <string name="squeezer_setup_warning">A tömörítés véglegesen csökkenti a képminőséget a tárhely megtakarítása érdekében. Ez nem vonható vissza. Gondosan ellenőrizd a beállításokat az indítás előtt.</string>
-    <string name="squeezer_setup_explanation">A Média Squeeze csökkenti a képfájlok méretét a tárhely felszabadításához. Ez véglegesen csökkenti a képminőséget és nem vonható vissza. Gondosan ellenőrizd a beállításokat az indítás előtt.</string>
+    <string name="squeezer_result_empty_message">Nem található tömöríthető média.</string>
+    <string name="squeezer_setup_warning">A tömörítés véglegesen csökkenti a minőséget a tárhely felszabadítása érdekében. Ez nem vonható vissza. Gondosan ellenőrizd a beállításokat indítás előtt.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d helyszín nem használható tömörítésre és eltávolítottuk. A tömörítéshez közvetlen hozzáférés szükséges a belső tárhelyre.</item>
+        <item quantity="other">%d helyszín nem használható tömörítésre és eltávolítottuk. A tömörítéshez közvetlen hozzáférés szükséges a belső tárhelyre.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">A Media Squeeze csökkenti a képek és videók fájlméretét a tárhely felszabadítása érdekében. Ez véglegesen csökkenti a minőséget és nem vonható vissza. Gondosan ellenőrizd a beállításokat indítás előtt.</string>
     <string name="squeezer_setup_paths_title">Helyek keresése</string>
     <string name="squeezer_setup_paths_default">Válassz mappákat a kereséshez</string>
     <string name="squeezer_setup_quality_title">Tömörítési minőség</string>
@@ -81,6 +99,6 @@
         <item quantity="one">Legalább %d napos</item>
         <item quantity="other">Legalább %d napos</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">Becsült ~%d%% megtakarítás JPEG fájlokhoz</string>
+    <string name="squeezer_estimated_savings_percent">Becsült ~%d%% megtakarítás képeknél</string>
     <string name="squeezer_onboarding_got_it">Megvan</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-in/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-in/strings.xml
@@ -1,38 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Perkecil gambar untuk menghemat ruang penyimpanan.</string>
+    <string name="squeezer_explanation_short">Kompres gambar dan video untuk menghemat ruang penyimpanan.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="other">%d gambar ditemukan</item>
+        <item quantity="other">%d item ditemukan</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="other">~%s dapat dihemat</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="other">%d gambar dikompresi</item>
+        <item quantity="other">%d item dikompres</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="other">%d gagal</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="other">%d file dilewati (tidak dapat diakses)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="other">%d gambar dipilih</item>
+        <item quantity="other">%d item dipilih</item>
     </plurals>
     <string name="squeezer_search_locations_title">Lokasi pencarian</string>
     <string name="squeezer_search_locations_default_summary">Folder kamera (bawaan)</string>
     <string name="squeezer_min_size_title">Ukuran file minimum</string>
-    <string name="squeezer_min_size_description">Lewati gambar yang lebih kecil dari ukuran ini.</string>
+    <string name="squeezer_min_size_description">Lewati file yang lebih kecil dari ukuran ini.</string>
     <string name="squeezer_min_age_title">Umur file minimum</string>
-    <string name="squeezer_min_age_description">Hanya sertakan gambar yang lebih lama dari umur ini.</string>
-    <string name="squeezer_compression_settings_label">Pengaturan kompresi</string>
+    <string name="squeezer_min_age_description">Hanya sertakan file yang lebih lama dari usia ini.</string>
+    <string name="squeezer_compression_settings_label">Umum</string>
     <string name="squeezer_quality_label">Kualitas</string>
     <string name="squeezer_quality_title">Kualitas kompresi</string>
-    <string name="squeezer_quality_description">Kualitas yang lebih rendah berarti ukuran file yang lebih kecil tetapi kualitas gambar yang berkurang.</string>
+    <string name="squeezer_quality_description">Kualitas lebih rendah berarti ukuran file lebih kecil tetapi kualitas visual berkurang.</string>
     <string name="squeezer_quality_example_format">Contoh: gambar %1$s → menghemat ~%2$s pada kualitas %3$d%%</string>
     <string name="squeezer_quality_warning_low">Kualitas yang lebih rendah dapat menyebabkan artefak yang terlihat.</string>
     <string name="squeezer_quality_warning_high">Kualitas yang sangat tinggi memberikan penghematan ruang yang minimal.</string>
-    <string name="squeezer_types_category_label">Jenis gambar</string>
+    <string name="squeezer_types_category_label">Pengaturan gambar</string>
+    <string name="squeezer_video_settings_category_label">Pengaturan video</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">Sertakan gambar JPEG (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">Sertakan gambar WebP (.webp).</string>
+    <string name="squeezer_type_video_title">Video MP4</string>
+    <string name="squeezer_type_video_description">Sertakan file video MP4 (.mp4).</string>
     <string name="squeezer_skip_compressed_title">Lewati yang sudah dikompresi</string>
-    <string name="squeezer_skip_compressed_description">Lewati gambar yang sudah dikompresi oleh SD Maid.</string>
+    <string name="squeezer_skip_compressed_description">Lewati file yang sudah dikompresi oleh SD Maid.</string>
     <string name="squeezer_exif_marker_title">Tulis penanda EXIF</string>
     <string name="squeezer_exif_marker_description">Tambahkan penanda pada bidang komentar pengguna EXIF gambar untuk mencegah kompresi ulang meskipun riwayat kompresi dihapus.</string>
     <string name="squeezer_estimated_savings_format">~%s penghematan</string>
@@ -43,25 +52,31 @@
     <string name="squeezer_preview_dialog_title">Konfirmasi kompresi</string>
     <string name="squeezer_preview_total_size">Ukuran total</string>
     <string name="squeezer_preview_estimated_savings">Perkiraan penghematan</string>
-    <string name="squeezer_compress_confirmation_title">Kompres gambar?</string>
-    <string name="squeezer_compress_confirmation_message">Ini akan mengganti gambar asli dengan versi yang dikompresi. Tindakan ini tidak dapat dibatalkan.</string>
+    <string name="squeezer_compress_confirmation_title">Kompres item yang dipilih?</string>
+    <string name="squeezer_compress_confirmation_message">Ini akan menggantikan file asli dengan versi yang dikompresi. Tindakan ini tidak dapat dibatalkan.</string>
     <string name="squeezer_history_title">Riwayat kompresi</string>
     <plurals name="squeezer_history_summary">
         <item quantity="other">%1$d item (%2$s)</item>
     </plurals>
     <string name="squeezer_history_empty">Tidak ada riwayat kompresi</string>
     <string name="squeezer_history_clear_title">Hapus riwayat kompresi</string>
-    <string name="squeezer_history_clear_message">Ini akan memungkinkan gambar yang sudah dikompresi untuk dikompresi lagi. Gambar itu sendiri tidak terpengaruh.</string>
+    <string name="squeezer_history_clear_message">Ini akan memungkinkan file yang sebelumnya dikompresi untuk dikompresi kembali. File itu sendiri tidak terpengaruh.</string>
     <string name="squeezer_onboarding_title">Tentang Kompresi Gambar</string>
     <string name="squeezer_onboarding_message">Kompresi gambar mengurangi ukuran file dengan menghapus detail visual. Proses ini tidak dapat dibalik - kualitas asli tidak dapat dipulihkan.\n\nBerikut pratinjau tampilan gambar Anda:</string>
     <string name="squeezer_onboarding_original_label">Asli</string>
     <string name="squeezer_onboarding_compressed_label">Setelah kompresi</string>
+    <string name="squeezer_onboarding_video_original_label">Bingkai video</string>
+    <string name="squeezer_onboarding_video_compressed_label">Pratinjau (perkiraan)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">Kualitas video aktual mungkin berbeda</string>
     <string name="squeezer_onboarding_quality_label">Kualitas: %d%%</string>
     <string name="squeezer_compare_action">Lihat perbandingan</string>
     <string name="squeezer_no_example_found">Tidak ada gambar ditemukan di jalur yang dipilih.</string>
-    <string name="squeezer_result_empty_message">Tidak ada gambar yang dapat dikompresi ditemukan.</string>
-    <string name="squeezer_setup_warning">Kompresi secara permanen mengurangi kualitas gambar untuk menghemat ruang penyimpanan. Ini tidak dapat dibatalkan. Tinjau pengaturan Anda dengan cermat sebelum memulai.</string>
-    <string name="squeezer_setup_explanation">Optimasi Media mengurangi ukuran file gambar untuk membebaskan ruang penyimpanan. Ini secara permanen mengurangi kualitas gambar dan tidak dapat dibatalkan. Tinjau pengaturan Anda dengan cermat sebelum memulai.</string>
+    <string name="squeezer_result_empty_message">Tidak ada media yang dapat dikompresi ditemukan.</string>
+    <string name="squeezer_setup_warning">Kompresi secara permanen mengurangi kualitas untuk menghemat ruang penyimpanan. Ini tidak dapat dibatalkan. Tinjau pengaturan Anda dengan cermat sebelum memulai.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="other">%d lokasi tidak dapat digunakan untuk kompresi dan telah dihapus. Kompresi memerlukan akses langsung ke penyimpanan internal.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze mengurangi ukuran file gambar dan video untuk membebaskan ruang penyimpanan. Ini secara permanen mengurangi kualitas dan tidak dapat dibatalkan. Tinjau pengaturan Anda dengan cermat sebelum memulai.</string>
     <string name="squeezer_setup_paths_title">Lokasi pencarian</string>
     <string name="squeezer_setup_paths_default">Pilih folder untuk dicari</string>
     <string name="squeezer_setup_quality_title">Kualitas kompresi</string>
@@ -75,6 +90,6 @@
     <plurals name="squeezer_min_age_x_days">
         <item quantity="other">Minimal %d hari</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">Perkiraan ~%d%% penghematan untuk file JPEG</string>
+    <string name="squeezer_estimated_savings_percent">Estimasi ~%d%% penghematan untuk gambar</string>
     <string name="squeezer_onboarding_got_it">Mengerti</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-is/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-is/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Þjappa myndum til að spara geymslupláss.</string>
+    <string name="squeezer_explanation_short">Þjappa myndum og myndböndum til að spara geymslupláss.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d mynd fannst</item>
-        <item quantity="other">%d myndir fundust</item>
+        <item quantity="one">%d atriði fundið</item>
+        <item quantity="other">%d atriðar fundin</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s er hægt að spara</item>
         <item quantity="other">~%s er hægt að spara</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d mynd þjöppuð</item>
-        <item quantity="other">%d myndir þjappaðar</item>
+        <item quantity="one">%d atriði þjappað</item>
+        <item quantity="other">%d atriðar þjöppuð</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d mistókst</item>
+        <item quantity="other">%d mistókust</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d skrá sleppt (ekki aðgengileg)</item>
+        <item quantity="other">%d skrár slepptar (ekki aðgengilegar)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d mynd valin</item>
-        <item quantity="other">%d myndir valdar</item>
+        <item quantity="one">%d atriði valið</item>
+        <item quantity="other">%d atriðar valin</item>
     </plurals>
     <string name="squeezer_search_locations_title">Leitarstaðir</string>
     <string name="squeezer_search_locations_default_summary">Myndavélarmöppur (sjálfgefið)</string>
     <string name="squeezer_min_size_title">Lágmarksstærð skráar</string>
-    <string name="squeezer_min_size_description">Sleppa myndum sem eru minni en þessi stærð.</string>
+    <string name="squeezer_min_size_description">Sleppa skrám sem eru minni en þssi stærð.</string>
     <string name="squeezer_min_age_title">Lágmarksaldur skráar</string>
-    <string name="squeezer_min_age_description">Aðeins taka myndir eldri en þessi aldur.</string>
-    <string name="squeezer_compression_settings_label">Þjöppunarstillingar</string>
+    <string name="squeezer_min_age_description">Taka aðeins með skrár sem eru eldri en þssi aldur.</string>
+    <string name="squeezer_compression_settings_label">Almennt</string>
     <string name="squeezer_quality_label">Gæði</string>
     <string name="squeezer_quality_title">Þjöppunargæði</string>
-    <string name="squeezer_quality_description">Lægri gæði þýðir minni skráarstærð en minni myndgæði.</string>
+    <string name="squeezer_quality_description">Lægri gæði þyðir minni skráarstæð en lakari sjónræn gæði.</string>
     <string name="squeezer_quality_example_format">Dæmi: %1$s mynd → sparar ~%2$s við %3$d%% gæði</string>
     <string name="squeezer_quality_warning_low">Lægri gæði gætu valdið sjáanlegum göllum.</string>
     <string name="squeezer_quality_warning_high">Mjög há gæði veita lágmarks plásssparnað.</string>
-    <string name="squeezer_types_category_label">Myndategundir</string>
+    <string name="squeezer_types_category_label">Myndastillingar</string>
+    <string name="squeezer_video_settings_category_label">Myndbandasstillingar</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">Taka JPEG myndir (.jpg, .jpeg) með.</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">Taka WebP myndir (.webp) með.</string>
+    <string name="squeezer_type_video_title">MP4 myndband</string>
+    <string name="squeezer_type_video_description">Taka með MP4 myndbandsskrár (.mp4).</string>
     <string name="squeezer_skip_compressed_title">Sleppa áður þjöppuðum</string>
-    <string name="squeezer_skip_compressed_description">Sleppa myndum sem SD Maid hefur þegar þjappað.</string>
+    <string name="squeezer_skip_compressed_description">Sleppa skrám sem þgar hafa verið þjappaðar af SD Maid.</string>
     <string name="squeezer_exif_marker_title">Skrifa EXIF merki</string>
     <string name="squeezer_exif_marker_description">Bæta merki við EXIF athugasemdareit myndarinnar til að koma í veg fyrir endurþjöppun jafnvel þótt þjöppunarsaga sé hreinsuð.</string>
     <string name="squeezer_estimated_savings_format">~%s sparnaður</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">Staðfesta þjöppun</string>
     <string name="squeezer_preview_total_size">Heildarstærð</string>
     <string name="squeezer_preview_estimated_savings">Áætlaður sparnaður</string>
-    <string name="squeezer_compress_confirmation_title">Þjappa myndum?</string>
-    <string name="squeezer_compress_confirmation_message">Þetta mun skipta upprunalegu myndunum út fyrir þjappaðar útgáfur. Ekki er hægt að afturkalla þessa aðgerð.</string>
+    <string name="squeezer_compress_confirmation_title">Þjappa völdum atriðum?</string>
+    <string name="squeezer_compress_confirmation_message">Þtta mun skipta upprunalegum skrám út fyrir þjappaðar útgáfur. Ekki er hægt að afturkalla þessa aðgerð.</string>
     <string name="squeezer_history_title">Þjöppunarsaga</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d hlutur (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">Engin þjöppunarsaga</string>
     <string name="squeezer_history_clear_title">Hreinsa þjöppunarsögu</string>
-    <string name="squeezer_history_clear_message">Þetta mun leyfa að þjappa áður þjöppuðum myndum aftur. Myndirnar sjálfar eru ekki breyttar.</string>
+    <string name="squeezer_history_clear_message">Þtta mun leyfa skrám sem þgar hafa verið þjappaðar að verða þjappaðar aftur. Skrárnar sjálfar verða ekki fyrir áhrifum.</string>
     <string name="squeezer_onboarding_title">Um myndaþjöppun</string>
     <string name="squeezer_onboarding_message">Myndaþjöppun minnkar skráarstærð með því að fjarlægja sjónræn smáatriði. Þetta ferli er óafturkræft - upprunaleg gæði er ekki hægt að endurheimta.\n\nHér er forskoðun á hvernig myndirnar þínar munu líta út:</string>
     <string name="squeezer_onboarding_original_label">Upprunalegt</string>
     <string name="squeezer_onboarding_compressed_label">Eftir þjöppun</string>
+    <string name="squeezer_onboarding_video_original_label">Myndbandsrðammi</string>
+    <string name="squeezer_onboarding_video_compressed_label">Forskoðun (áætluð)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">Raunveruleg myndbandsgaæði geta verið frábruggin</string>
     <string name="squeezer_onboarding_quality_label">Gæði: %d%%</string>
     <string name="squeezer_compare_action">Skoða samanburð</string>
     <string name="squeezer_no_example_found">Engar myndir fundust á völdum slóðum.</string>
-    <string name="squeezer_result_empty_message">Engar þjappanlegar myndir fundust.</string>
-    <string name="squeezer_setup_warning">Þjöppun minnkar myndgæði varanlega til að spara geymslupláss. Þetta er ekki hægt að afturkalla. Farðu vandlega yfir stillingarnar áður en þú byrjar.</string>
-    <string name="squeezer_setup_explanation">Media Squeeze minnkar skráarstærð mynda til að losa um geymslupláss. Þetta minnkar myndgæði varanlega og er ekki hægt að afturkalla. Farðu vandlega yfir stillingarnar áður en þú byrjar.</string>
+    <string name="squeezer_result_empty_message">Ekkert þjáppanlegt efni fannst.</string>
+    <string name="squeezer_setup_warning">Þjöppun minnkar gæði varanlega til að spara geymslupláss. Ekki er hægt að afturkalla þtta. Farðu vandlega yfir stillingar þinar áður en þú byrjar.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d staðsetning er ekki hægt að nota til þjöppunar og var fjarlægð. Þjöppun krefst beinnar aðgangis að innri geymslu.</item>
+        <item quantity="other">%d staðsetningar eru ekki hægt að nota til þjöppunar og voru fjarlægðar. Þjöppun krefst beinnar aðgangis að innri geymslu.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze minnkar skráarstærð mynda og myndbanda til að losa um geymslupláss. Þtta minnkar gæði varanlega og er ekki hægt að afturkalla. Farðu vandlega yfir stillingar þinar áður en þú byrjar.</string>
     <string name="squeezer_setup_paths_title">Leitarstaðir</string>
     <string name="squeezer_setup_paths_default">Veldu möppur til að leita í</string>
     <string name="squeezer_setup_quality_title">Þjöppunargæði</string>
@@ -81,6 +99,6 @@
         <item quantity="one">A.m.k. %d dags gamalt</item>
         <item quantity="other">A.m.k. %d daga gamalt</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">Áætlaður ~%d%% sparnaður fyrir JPEG skrár</string>
+    <string name="squeezer_estimated_savings_percent">Áætlaður sparnaður ~%d%% fyrir myndir</string>
     <string name="squeezer_onboarding_got_it">Ég skil</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-it/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-it/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Comprimi le immagini per risparmiare spazio di archiviazione.</string>
+    <string name="squeezer_explanation_short">Comprimi immagini e video per risparmiare spazio di archiviazione.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d immagine trovata</item>
-        <item quantity="other">%d immagini trovate</item>
+        <item quantity="one">%d elemento trovato</item>
+        <item quantity="other">%d elementi trovati</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s può essere risparmiato</item>
         <item quantity="other">~%s possono essere risparmiati</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d immagine compressa</item>
-        <item quantity="other">%d immagini compresse</item>
+        <item quantity="one">%d elemento compresso</item>
+        <item quantity="other">%d elementi compressi</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d fallito</item>
+        <item quantity="other">%d falliti</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d file saltato (non accessibile)</item>
+        <item quantity="other">%d file saltati (non accessibili)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d immagine selezionata</item>
-        <item quantity="other">%d immagini selezionate</item>
+        <item quantity="one">%d elemento selezionato</item>
+        <item quantity="other">%d elementi selezionati</item>
     </plurals>
     <string name="squeezer_search_locations_title">Percorsi di ricerca</string>
     <string name="squeezer_search_locations_default_summary">Cartelle fotocamera (predefinito)</string>
     <string name="squeezer_min_size_title">Dimensione minima del file</string>
-    <string name="squeezer_min_size_description">Ignora le immagini più piccole di questa dimensione.</string>
+    <string name="squeezer_min_size_description">Salta i file più piccoli di questa dimensione.</string>
     <string name="squeezer_min_age_title">Età minima del file</string>
-    <string name="squeezer_min_age_description">Includi solo le immagini più vecchie di questa età.</string>
-    <string name="squeezer_compression_settings_label">Impostazioni di compressione</string>
+    <string name="squeezer_min_age_description">Includi solo i file più vecchi di questa età.</string>
+    <string name="squeezer_compression_settings_label">Generale</string>
     <string name="squeezer_quality_label">Qualità</string>
     <string name="squeezer_quality_title">Qualità di compressione</string>
-    <string name="squeezer_quality_description">Una qualità inferiore significa file più piccoli ma qualità dell\'immagine ridotta.</string>
+    <string name="squeezer_quality_description">Una qualità inferiore significa file di dimensioni minori ma qualità visiva ridotta.</string>
     <string name="squeezer_quality_example_format">Esempio: immagine %1$s → risparmio ~%2$s al %3$d%% di qualità</string>
     <string name="squeezer_quality_warning_low">Qualità inferiori possono causare artefatti visibili.</string>
     <string name="squeezer_quality_warning_high">Una qualità molto alta fornisce risparmi minimi di spazio.</string>
-    <string name="squeezer_types_category_label">Tipi di immagine</string>
+    <string name="squeezer_types_category_label">Impostazioni immagini</string>
+    <string name="squeezer_video_settings_category_label">Impostazioni video</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">Includi immagini JPEG (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">Includi immagini WebP (.webp).</string>
+    <string name="squeezer_type_video_title">Video MP4</string>
+    <string name="squeezer_type_video_description">Includi file video MP4 (.mp4).</string>
     <string name="squeezer_skip_compressed_title">Salta le già compresse</string>
-    <string name="squeezer_skip_compressed_description">Ignora le immagini già compresse da SD Maid.</string>
+    <string name="squeezer_skip_compressed_description">Salta i file già compressi da SD Maid.</string>
     <string name="squeezer_exif_marker_title">Scrivi marcatore EXIF</string>
     <string name="squeezer_exif_marker_description">Aggiungi un marcatore nel campo commento utente EXIF dell\'immagine per impedire la ricompressione anche se la cronologia di compressione viene cancellata.</string>
     <string name="squeezer_estimated_savings_format">~%s di risparmio</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">Conferma compressione</string>
     <string name="squeezer_preview_total_size">Dimensione totale</string>
     <string name="squeezer_preview_estimated_savings">Risparmio stimato</string>
-    <string name="squeezer_compress_confirmation_title">Comprimere le immagini?</string>
-    <string name="squeezer_compress_confirmation_message">Questo sostituirà le immagini originali con versioni compresse. Questa azione non può essere annullata.</string>
+    <string name="squeezer_compress_confirmation_title">Comprimi gli elementi selezionati?</string>
+    <string name="squeezer_compress_confirmation_message">Questo sostituirà i file originali con versioni compresse. Questa azione non può essere annullata.</string>
     <string name="squeezer_history_title">Cronologia compressione</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d elemento (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">Nessuna cronologia di compressione</string>
     <string name="squeezer_history_clear_title">Cancella cronologia compressione</string>
-    <string name="squeezer_history_clear_message">Questo permetterà di comprimere nuovamente le immagini già compresse. Le immagini stesse non vengono modificate.</string>
+    <string name="squeezer_history_clear_message">Questo permetterà ai file precedentemente compressi di essere compressi di nuovo. I file stessi non vengono modificati.</string>
     <string name="squeezer_onboarding_title">Informazioni sulla compressione immagini</string>
     <string name="squeezer_onboarding_message">La compressione riduce la dimensione dei file rimuovendo dettagli visivi. Questo processo è irreversibile - la qualità originale non può essere ripristinata.\n\nEcco un\'anteprima di come appariranno le tue immagini:</string>
     <string name="squeezer_onboarding_original_label">Originale</string>
     <string name="squeezer_onboarding_compressed_label">Dopo la compressione</string>
+    <string name="squeezer_onboarding_video_original_label">Fotogramma video</string>
+    <string name="squeezer_onboarding_video_compressed_label">Anteprima (approssimativa)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">La qualità video effettiva potrebbe variare</string>
     <string name="squeezer_onboarding_quality_label">Qualità: %d%%</string>
     <string name="squeezer_compare_action">Visualizza confronto</string>
     <string name="squeezer_no_example_found">Nessuna immagine trovata nei percorsi selezionati.</string>
-    <string name="squeezer_result_empty_message">Nessuna immagine comprimibile trovata.</string>
-    <string name="squeezer_setup_warning">La compressione riduce permanentemente la qualità delle immagini per risparmiare spazio. Non può essere annullata. Controlla attentamente le impostazioni prima di iniziare.</string>
-    <string name="squeezer_setup_explanation">Media Squeeze riduce la dimensione dei file immagine per liberare spazio. Questo riduce permanentemente la qualità delle immagini e non può essere annullato. Controlla attentamente le impostazioni prima di iniziare.</string>
+    <string name="squeezer_result_empty_message">Nessun file multimediale comprimibile trovato.</string>
+    <string name="squeezer_setup_warning">La compressione riduce permanentemente la qualità per risparmiare spazio di archiviazione. Questa operazione non può essere annullata. Rivedi attentamente le impostazioni prima di iniziare.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d posizione non può essere utilizzata per la compressione ed è stata rimossa. La compressione richiede accesso diretto all\'archivio interno.</item>
+        <item quantity="other">%d posizioni non possono essere utilizzate per la compressione e sono state rimosse. La compressione richiede accesso diretto all\'archivio interno.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze riduce le dimensioni dei file di immagini e video per liberare spazio di archiviazione. Questo riduce permanentemente la qualità e non può essere annullato. Rivedi attentamente le impostazioni prima di iniziare.</string>
     <string name="squeezer_setup_paths_title">Percorsi di ricerca</string>
     <string name="squeezer_setup_paths_default">Seleziona le cartelle da cercare</string>
     <string name="squeezer_setup_quality_title">Qualità di compressione</string>
@@ -81,6 +99,6 @@
         <item quantity="one">Almeno %d giorno</item>
         <item quantity="other">Almeno %d giorni</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">Risparmio stimato ~%d%% per file JPEG</string>
+    <string name="squeezer_estimated_savings_percent">Risparmio stimato ~%d%% per le immagini</string>
     <string name="squeezer_onboarding_got_it">Fatto</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-ja/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-ja/strings.xml
@@ -1,38 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">画像を圧縮してストレージ容量を節約します。</string>
+    <string name="squeezer_explanation_short">画像と動画を圧縮してストレージ容量を節約します。</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="other">%d 枚の画像が見つかりました</item>
+        <item quantity="other">%d件のアイテムが見つかりました</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="other">約 %s 節約可能</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="other">%d 枚の画像を圧縮しました</item>
+        <item quantity="other">%d件のアイテムを圧縮しました</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="other">%d件が失敗しました</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="other">%d件のファイルをスキップしました（アクセス不可）</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="other">%d 枚の画像を選択</item>
+        <item quantity="other">%d件のアイテムが選択されました</item>
     </plurals>
     <string name="squeezer_search_locations_title">検索場所</string>
     <string name="squeezer_search_locations_default_summary">カメラフォルダ（デフォルト）</string>
     <string name="squeezer_min_size_title">最小ファイルサイズ</string>
-    <string name="squeezer_min_size_description">このサイズより小さい画像をスキップします。</string>
+    <string name="squeezer_min_size_description">このサイズより小さいファイルをスキップします。</string>
     <string name="squeezer_min_age_title">最小ファイル年齢</string>
-    <string name="squeezer_min_age_description">この年齢より古い画像のみを含めます。</string>
-    <string name="squeezer_compression_settings_label">圧縮設定</string>
+    <string name="squeezer_min_age_description">この経過時間より古いファイルのみ対象にします。</string>
+    <string name="squeezer_compression_settings_label">一般</string>
     <string name="squeezer_quality_label">品質</string>
     <string name="squeezer_quality_title">圧縮品質</string>
-    <string name="squeezer_quality_description">品質が低いほどファイルサイズは小さくなりますが、画質が低下します。</string>
+    <string name="squeezer_quality_description">品質を下げるとファイルサイズは小さくなりますが、画質が低下します。</string>
     <string name="squeezer_quality_example_format">例：%1$s 画像 → %3$d%% 品質で約 %2$s 節約</string>
     <string name="squeezer_quality_warning_low">品質が低いと目に見えるアーティファクトが発生する場合があります。</string>
     <string name="squeezer_quality_warning_high">非常に高い品質では容量の節約がごくわずかです。</string>
-    <string name="squeezer_types_category_label">画像タイプ</string>
+    <string name="squeezer_types_category_label">画像設定</string>
+    <string name="squeezer_video_settings_category_label">動画設定</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">JPEG画像（.jpg、.jpeg）を含めます。</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">WebP画像（.webp）を含めます。</string>
+    <string name="squeezer_type_video_title">MP4 Video</string>
+    <string name="squeezer_type_video_description">MP4動画ファイル（.mp4）を対象にします。</string>
     <string name="squeezer_skip_compressed_title">圧縮済みをスキップ</string>
-    <string name="squeezer_skip_compressed_description">SD Maidで既に圧縮された画像をスキップします。</string>
+    <string name="squeezer_skip_compressed_description">SD Maidによってすでに圧縮されたファイルをスキップします。</string>
     <string name="squeezer_exif_marker_title">EXIFマーカーを書き込む</string>
     <string name="squeezer_exif_marker_description">圧縮履歴がクリアされても再圧縮を防ぐため、画像のEXIFユーザーコメント欄にマーカーを追加します。</string>
     <string name="squeezer_estimated_savings_format">約 %s 節約</string>
@@ -43,25 +52,31 @@
     <string name="squeezer_preview_dialog_title">圧縮の確認</string>
     <string name="squeezer_preview_total_size">合計サイズ</string>
     <string name="squeezer_preview_estimated_savings">推定節約量</string>
-    <string name="squeezer_compress_confirmation_title">画像を圧縮しますか？</string>
-    <string name="squeezer_compress_confirmation_message">元の画像が圧縮版に置き換えられます。この操作は元に戻せません。</string>
+    <string name="squeezer_compress_confirmation_title">選択したアイテムを圧縮しますか？</string>
+    <string name="squeezer_compress_confirmation_message">元のファイルを圧縮バージョンに置き換えます。この操作は元に戻せません。</string>
     <string name="squeezer_history_title">圧縮履歴</string>
     <plurals name="squeezer_history_summary">
         <item quantity="other">%1$d 項目（%2$s）</item>
     </plurals>
     <string name="squeezer_history_empty">圧縮履歴がありません</string>
     <string name="squeezer_history_clear_title">圧縮履歴をクリア</string>
-    <string name="squeezer_history_clear_message">以前に圧縮された画像を再度圧縮できるようにします。画像自体は影響を受けません。</string>
+    <string name="squeezer_history_clear_message">以前に圧縮されたファイルを再度圧縮できるようになります。ファイル自体には影響しません。</string>
     <string name="squeezer_onboarding_title">画像圧縮について</string>
     <string name="squeezer_onboarding_message">画像圧縮は視覚的な詳細を削除してファイルサイズを縮小します。このプロセスは元に戻せません。元の品質は復元できません。\n\n圧縮後の画像のプレビューはこちらです：</string>
     <string name="squeezer_onboarding_original_label">オリジナル</string>
     <string name="squeezer_onboarding_compressed_label">圧縮後</string>
+    <string name="squeezer_onboarding_video_original_label">動画フレーム</string>
+    <string name="squeezer_onboarding_video_compressed_label">プレビュー（目安）</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">実際の動画品質は異なる場合があります</string>
     <string name="squeezer_onboarding_quality_label">品質：%d%%</string>
     <string name="squeezer_compare_action">比較を表示</string>
     <string name="squeezer_no_example_found">選択したパスに画像が見つかりません。</string>
-    <string name="squeezer_result_empty_message">圧縮可能な画像が見つかりません。</string>
-    <string name="squeezer_setup_warning">圧縮はストレージ容量を節約するために画質を永久に低下させます。元に戻せません。開始前に設定を慎重に確認してください。</string>
-    <string name="squeezer_setup_explanation">メディア圧縮は画像のファイルサイズを縮小してストレージ容量を解放します。画質が永久に低下し、元に戻せません。開始前に設定を慎重に確認してください。</string>
+    <string name="squeezer_result_empty_message">圧縮可能なメディアが見つかりません。</string>
+    <string name="squeezer_setup_warning">圧縮すると品質が恒久的に低下してストレージ容量を節約します。この操作は元に戻せません。開始前に設定を慎重に確認してください。</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="other">%d件の場所は圧縮に使用できないため削除されました。圧縮には内部ストレージへの直接アクセスが必要です。</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">メディアスクイーズは、画像と動画のファイルサイズを縮小してストレージ空き容量を確保します。これにより品質が恒久的に低下し、元に戻すことはできません。開始前に設定を慎重に確認してください。</string>
     <string name="squeezer_setup_paths_title">検索場所</string>
     <string name="squeezer_setup_paths_default">検索するフォルダを選択</string>
     <string name="squeezer_setup_quality_title">圧縮品質</string>
@@ -75,6 +90,6 @@
     <plurals name="squeezer_min_age_x_days">
         <item quantity="other">少なくとも %d 日以上</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">JPEGファイルの推定節約率 約 %d%%</string>
+    <string name="squeezer_estimated_savings_percent">画像の推定節約量 約%d%%</string>
     <string name="squeezer_onboarding_got_it">わかりました。</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-ka-rGE/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-ka-rGE/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">სურათების შეკუმშვა მეხსიერების დაზოგვისთვის.</string>
+    <string name="squeezer_explanation_short">შეკუმშეთ სურათები და ვიდეოები საცავის სივრცის დასაზოგად.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d სურათი ნაპოვნია</item>
-        <item quantity="other">%d სურათი ნაპოვნია</item>
+        <item quantity="one">%d ელემენტი მოიძებნა</item>
+        <item quantity="other">%d ელემენტი მოიძებნა</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s დაზოგვა შესაძლებელია</item>
         <item quantity="other">~%s დაზოგვა შესაძლებელია</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d სურათი შეკუმშულია</item>
-        <item quantity="other">%d სურათი შეკუმშულია</item>
+        <item quantity="one">%d ელემენტი შეკუმშულია</item>
+        <item quantity="other">%d ელემენტი შეკუმშულია</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d ვერ შესრულდა</item>
+        <item quantity="other">%d ვერ შესრულდა</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d ფაილი გამოტოვებულია (მიუწვდომელია)</item>
+        <item quantity="other">%d ფაილი გამოტოვებულია (მიუწვდომელია)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d სურათი არჩეულია</item>
-        <item quantity="other">%d სურათი არჩეულია</item>
+        <item quantity="one">%d ელემენტი არჩეულია</item>
+        <item quantity="other">%d ელემენტი არჩეულია</item>
     </plurals>
     <string name="squeezer_search_locations_title">ძიების ადგილები</string>
     <string name="squeezer_search_locations_default_summary">კამერის საქაღალდეები (ნაგულისხმევი)</string>
     <string name="squeezer_min_size_title">ფაილის მინიმალური ზომა</string>
-    <string name="squeezer_min_size_description">ამ ზომაზე პატარა სურათების გამოტოვება.</string>
+    <string name="squeezer_min_size_description">გამოტოვე ამ ზომაზე პატარა ფაილები.</string>
     <string name="squeezer_min_age_title">ფაილის მინიმალური ასაკი</string>
-    <string name="squeezer_min_age_description">მხოლოდ ამ ასაკზე ძველი სურათების ჩართვა.</string>
-    <string name="squeezer_compression_settings_label">შეკუმშვის პარამეტრები</string>
+    <string name="squeezer_min_age_description">შეიტანე მხოლოდ ამ ასაკზე ძველი ფაილები.</string>
+    <string name="squeezer_compression_settings_label">ზოგადი</string>
     <string name="squeezer_quality_label">ხარისხი</string>
     <string name="squeezer_quality_title">შეკუმშვის ხარისხი</string>
-    <string name="squeezer_quality_description">დაბალი ხარისხი ნიშნავს უფრო მცირე ფაილის ზომას, მაგრამ შემცირებულ სურათის ხარისხს.</string>
+    <string name="squeezer_quality_description">დაბალი ხარისხი ნიშნავს პატარა ფაილის ზომას, მაგრამ მცირდება ვიზუალური ხარისხი.</string>
     <string name="squeezer_quality_example_format">მაგალითი: %1$s სურათი → %3$d%% ხარისხით ~%2$s დაზოგვა</string>
     <string name="squeezer_quality_warning_low">დაბალმა ხარისხმა შეიძლება ხილული არტეფაქტები გამოიწვიოს.</string>
     <string name="squeezer_quality_warning_high">ძალიან მაღალი ხარისხი მინიმალურ დაზოგვას უზრუნველყოფს.</string>
-    <string name="squeezer_types_category_label">სურათების ტიპები</string>
+    <string name="squeezer_types_category_label">სურათის პარამეტრები</string>
+    <string name="squeezer_video_settings_category_label">ვიდეოს პარამეტრები</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">JPEG სურათების ჩართვა (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">WebP სურათების ჩართვა (.webp).</string>
+    <string name="squeezer_type_video_title">MP4 ვიდეო</string>
+    <string name="squeezer_type_video_description">შეიტანე MP4 ვიდეო ფაილები (.mp4).</string>
     <string name="squeezer_skip_compressed_title">ადრე შეკუმშულების გამოტოვება</string>
-    <string name="squeezer_skip_compressed_description">SD Maid-ის მიერ უკვე შეკუმშული სურათების გამოტოვება.</string>
+    <string name="squeezer_skip_compressed_description">გამოტოვე ფაილები, რომლებიც უკვე შეკუმშულია SD Maid-ის მიერ.</string>
     <string name="squeezer_exif_marker_title">EXIF მარკერის ჩაწერა</string>
     <string name="squeezer_exif_marker_description">სურათის EXIF მომხმარებლის კომენტარის ველში მარკერის დამატება ხელახალი შეკუმშვის თავიდან ასაცილებლად, მაშინაც კი, თუ შეკუმშვის ისტორია გასუფთავდა.</string>
     <string name="squeezer_estimated_savings_format">~%s დაზოგვა</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">შეკუმშვის დადასტურება</string>
     <string name="squeezer_preview_total_size">საერთო ზომა</string>
     <string name="squeezer_preview_estimated_savings">სავარაუდო დაზოგვა</string>
-    <string name="squeezer_compress_confirmation_title">სურათების შეკუმშვა?</string>
-    <string name="squeezer_compress_confirmation_message">ეს ჩაანაცვლებს ორიგინალ სურათებს შეკუმშული ვერსიებით. ეს მოქმედება ვერ გაუქმდება.</string>
+    <string name="squeezer_compress_confirmation_title">შეკუმშოთ არჩეული ელემენტები?</string>
+    <string name="squeezer_compress_confirmation_message">ეს შეცვლის ორიგინალ ფაილებს შეკუმშული ვერსიებით. ეს მოქმედება ვერ გაუქმდება.</string>
     <string name="squeezer_history_title">შეკუმშვის ისტორია</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d ელემენტი (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">შეკუმშვის ისტორია არ არის</string>
     <string name="squeezer_history_clear_title">შეკუმშვის ისტორიის გასუფთავება</string>
-    <string name="squeezer_history_clear_message">ეს საშუალებას მისცემს ადრე შეკუმშულ სურათებს ხელახლა შეიკუმშოს. თავად სურათებზე გავლენა არ იქნება.</string>
+    <string name="squeezer_history_clear_message">ეს საშუალებას მისცემს ადრე შეკუმშულ ფაილებს კვლავ შეიკუმშოს. თავად ფაილები არ შეიცვლება.</string>
     <string name="squeezer_onboarding_title">სურათის შეკუმშვის შესახებ</string>
     <string name="squeezer_onboarding_message">სურათის შეკუმშვა ამცირებს ფაილის ზომას ვიზუალური დეტალების წაშლით. ეს პროცესი შეუქცევადია - ორიგინალი ხარისხის აღდგენა შეუძლებელია.\n\nაი, როგორ გამოიყურება თქვენი სურათები:</string>
     <string name="squeezer_onboarding_original_label">ორიგინალი</string>
     <string name="squeezer_onboarding_compressed_label">შეკუმშვის შემდეგ</string>
+    <string name="squeezer_onboarding_video_original_label">ვიდეო კადრი</string>
+    <string name="squeezer_onboarding_video_compressed_label">გადახედვა (სავარაუდო)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">ვიდეოს რეალური ხარისხი შეიძლება განსხვავდებოდეს</string>
     <string name="squeezer_onboarding_quality_label">ხარისხი: %d%%</string>
     <string name="squeezer_compare_action">შედარების ნახვა</string>
     <string name="squeezer_no_example_found">არჩეულ გზებში სურათები ვერ მოიძებნა.</string>
-    <string name="squeezer_result_empty_message">შეკუმშვადი სურათები ვერ მოიძებნა.</string>
-    <string name="squeezer_setup_warning">შეკუმშვა სამუდამოდ ამცირებს სურათის ხარისხს მეხსიერების დაზოგვის მიზნით. ეს ვერ გაუქმდება. დაწყებამდე ყურადღებით გადახედეთ თქვენს პარამეტრებს.</string>
-    <string name="squeezer_setup_explanation">მედია შეკუმშვა ამცირებს სურათების ფაილის ზომას მეხსიერების გასათავისუფლებლად. ეს სამუდამოდ ამცირებს სურათის ხარისხს და ვერ გაუქმდება. დაწყებამდე ყურადღებით გადახედეთ თქვენს პარამეტრებს.</string>
+    <string name="squeezer_result_empty_message">შეკუმშვადი მედია ვერ მოიძებნა.</string>
+    <string name="squeezer_setup_warning">შეკუმშვა მუდმივად ამცირებს ხარისხს საცავის სივრცის დაზოგვის მიზნით. ეს ვერ გაუქმდება. ყურადღებით გადახედე პარამეტრებს დაწყებამდე.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d ლოკაცია ვერ გამოიყენება შეკუმშვისთვის და ამოღებულიყო. შეკუმშვა მოითხოვს პირდაპირ წვდომას შიდა საცავზე.</item>
+        <item quantity="other">%d ლოკაცია ვერ გამოიყენება შეკუმშვისთვის და ამოღებულიყო. შეკუმშვა მოითხოვს პირდაპირ წვდომას შიდა საცავზე.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze ამცირებს სურათების და ვიდეოების ფაილის ზომას საცავის სივრცის გასათავისუფლებლად. ეს მუდმივად ამცირებს ხარისხს და ვერ გაუქმდება. ყურადღებით გადახედე პარამეტრებს დაწყებამდე.</string>
     <string name="squeezer_setup_paths_title">ძიების ადგილები</string>
     <string name="squeezer_setup_paths_default">აირჩიეთ საქაღალდეები საძიებლად</string>
     <string name="squeezer_setup_quality_title">შეკუმშვის ხარისხი</string>
@@ -81,6 +99,6 @@
         <item quantity="one">სულ მცირე %d დღის</item>
         <item quantity="other">სულ მცირე %d დღის</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">JPEG ფაილებისთვის სავარაუდოდ ~%d%% დაზოგვა</string>
+    <string name="squeezer_estimated_savings_percent">სავარაუდო ~%d%% დაზოგვა სურათებისთვის</string>
     <string name="squeezer_onboarding_got_it">Გავიგე</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-kaa/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-kaa/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Saqlash ornın u\'nemlew ushin su\'wretlerdi sıǵıstırıw.</string>
+    <string name="squeezer_explanation_short">Saqlaw orının tejew ushın súwretler hám videolardı sıqıw.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d su\'wret tabıldı</item>
-        <item quantity="other">%d su\'wret tabıldı</item>
+        <item quantity="one">%d element tabıldı</item>
+        <item quantity="other">%d element tabıldı</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s u\'nemleniw mu\'mkin</item>
         <item quantity="other">~%s u\'nemleniw mu\'mkin</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d su\'wret sıǵıstırıldı</item>
-        <item quantity="other">%d su\'wret sıǵıstırıldı</item>
+        <item quantity="one">%d element sıqıldı</item>
+        <item quantity="other">%d element sıqıldı</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d jetiskersiz</item>
+        <item quantity="other">%d jetiskersiz</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d fayl ótkirip jiberildi (qoljetimli emes)</item>
+        <item quantity="other">%d fayl ótkirip jiberildi (qoljetimli emes)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d su\'wret tańlandı</item>
-        <item quantity="other">%d su\'wret tańlandı</item>
+        <item quantity="one">%d element tańlandı</item>
+        <item quantity="other">%d element tańlandı</item>
     </plurals>
     <string name="squeezer_search_locations_title">Izlew orınları</string>
     <string name="squeezer_search_locations_default_summary">Kamera papkası (birden kelgen)</string>
     <string name="squeezer_min_size_title">Minimum fayl o\'lshemi</string>
-    <string name="squeezer_min_size_description">Usı o\'lshemnen kishi su\'wretlerdi atlap o\'tiw.</string>
+    <string name="squeezer_min_size_description">Bul óлшемden kishi fayllardy ótkirip jiberiw.</string>
     <string name="squeezer_min_age_title">Minimum fayl jasılıǵı</string>
-    <string name="squeezer_min_age_description">Tek usı jasılıqtan eski su\'wretlerdi qosıw.</string>
-    <string name="squeezer_compression_settings_label">Sıǵıstırıw sazlamaları</string>
+    <string name="squeezer_min_age_description">Tek bul jasdan úlken fayllardy qosiw.</string>
+    <string name="squeezer_compression_settings_label">Ulıwmalıq</string>
     <string name="squeezer_quality_label">Sapa</string>
     <string name="squeezer_quality_title">Sıǵıstırıw sapası</string>
-    <string name="squeezer_quality_description">To\'men sapa kishi fayl o\'lshemin, biraq kemeytirilgen su\'wret sapasın bildiredi.</string>
+    <string name="squeezer_quality_description">Tómen sapa — fayldıń kishi ólshemin bildiredi, biraq kóriw sapasın azaytadı.</string>
     <string name="squeezer_quality_example_format">Mısal: %1$s su\'wret → %3$d%% sapada ~%2$s u\'nemlew</string>
     <string name="squeezer_quality_warning_low">To\'men sapalarda ko\'rinetug\'ın artefaktlar payda bolıwı mu\'mkin.</string>
     <string name="squeezer_quality_warning_high">Juqarı sapa az orın u\'nemleydi.</string>
-    <string name="squeezer_types_category_label">Su\'wret tu\'rleri</string>
+    <string name="squeezer_types_category_label">Súwret sazlamaları</string>
+    <string name="squeezer_video_settings_category_label">Video sazlamaları</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">JPEG su\'wretlerdi (.jpg, .jpeg) qosıw.</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">WebP su\'wretlerdi (.webp) qosıw.</string>
+    <string name="squeezer_type_video_title">MP4 Video</string>
+    <string name="squeezer_type_video_description">MP4 video fayllardı (.mp4) qosiw.</string>
     <string name="squeezer_skip_compressed_title">Aldın sıǵıstırılǵanlardı atlap o\'tiw</string>
-    <string name="squeezer_skip_compressed_description">SD Maid ta\'repinen aldın sıǵıstırılǵan su\'wretlerdi atlap o\'tiw.</string>
+    <string name="squeezer_skip_compressed_description">SD Maid tárepinen burın sıqılǵan fayllardy ótkirip jiberiw.</string>
     <string name="squeezer_exif_marker_title">EXIF belgini jazıw</string>
     <string name="squeezer_exif_marker_description">Su\'wrettiń EXIF paydalanıwshı ko\'rsetpesi maydan\'ına belgi qosıw, sıǵıstırıw tariyxı tazalanǵan jaǵdayda da qayta sıǵıstırıwdı aldın alıw ushin.</string>
     <string name="squeezer_estimated_savings_format">~%s u\'nemlew</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">Sıǵıstırıwdı tastıyıqlaw</string>
     <string name="squeezer_preview_total_size">Ulıwma o\'lshem</string>
     <string name="squeezer_preview_estimated_savings">Boljamalı u\'nemlew</string>
-    <string name="squeezer_compress_confirmation_title">Su\'wretlerdi sıǵıstırıw?</string>
-    <string name="squeezer_compress_confirmation_message">Bul original su\'wretlerdi sıǵıstırılǵan versiyalar menen almastyradı. Bul a\'meldi qaytarǵa alıw mu\'mkin emes.</string>
+    <string name="squeezer_compress_confirmation_title">Tańlap alınǵan elementlerdı sıqıw?</string>
+    <string name="squeezer_compress_confirmation_message">Bul túpnusqa fayllardı sıqılǵan versiyaları menen almaştıradı. Bul ámeldi qaytarıp bolmaydı.</string>
     <string name="squeezer_history_title">Sıǵıstırıw tariyxı</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d element (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">Sıǵıstırıw tariyxı joq</string>
     <string name="squeezer_history_clear_title">Sıǵıstırıw tariyxın tazalaw</string>
-    <string name="squeezer_history_clear_message">Bul aldın sıǵıstırılǵan su\'wretlerdi qayta sıǵıstırıwǵa mu\'mkinshilik beredi. Su\'wretlerdiń o\'zleri ta\'sir etilmeydi.</string>
+    <string name="squeezer_history_clear_message">Bul burın sıqılǵan fayllardy qaytadan sıqıwǵa múmkinshilik beredi. Fayllardıń ózine tásir etpeydi.</string>
     <string name="squeezer_onboarding_title">Su\'wret sıǵıstırıw haqqında</string>
     <string name="squeezer_onboarding_message">Su\'wret sıǵıstırıw ko\'riniw detallarin alıp taslaw arqalı fayl o\'lshemin kemeyterdi. Bul protsess qaytarılmas - original sapa qayta tikleniwi mu\'mkin emes.\n\nSu\'wretleriniz qalay ko\'rinetuǵının aldın alıw:</string>
     <string name="squeezer_onboarding_original_label">Asliyet</string>
     <string name="squeezer_onboarding_compressed_label">Sıǵıstırılǵannan keyin</string>
+    <string name="squeezer_onboarding_video_original_label">Video kadr</string>
+    <string name="squeezer_onboarding_video_compressed_label">Aldın ala kóriw (taxminiy)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">Haqıyqıy video sapası ózgeshe bolıwı múmkin</string>
     <string name="squeezer_onboarding_quality_label">Sapa: %d%%</string>
     <string name="squeezer_compare_action">Salıstırıwdı ko\'riw</string>
     <string name="squeezer_no_example_found">Tańlanǵan jollarda su\'wretler tabılmadı.</string>
-    <string name="squeezer_result_empty_message">Sıǵıstırılıwshı su\'wretler tabılmadı.</string>
-    <string name="squeezer_setup_warning">Sıǵıstırıw saqlash ornın u\'nemlew ushin su\'wret sapasın biyrden kemeyterdi. Bul qaytarılmas. Baslawdan aldın sazlamalarıńızdı diqqat penen tekserin\'.</string>
-    <string name="squeezer_setup_explanation">Media Squeeze saqlash ornın bosatıw ushin su\'wretlerdiń fayl o\'lshemin kemeyterdi. Bul su\'wret sapasın biyrden kemeyterdi ha\'m qaytarılmas. Baslawdan aldın sazlamalarıńızdı diqqat penen tekserin\'.</string>
+    <string name="squeezer_result_empty_message">Sıqıwǵa jaramlı media tabılmadı.</string>
+    <string name="squeezer_setup_warning">Sıqıw sapanı birotola azaytadı hám saqlaw orınına tejeydi. Bul ámeldi qaytarıp bolmaydı. Baslamastan burın sazlamalardı dıqqat penen qarap shıǵıń.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d orın sıqıw ushın qollanılmaydı hám óshirildi. Sıqıw ishki saqlaw orınına tikkeley qoljetimdi talap etedi.</item>
+        <item quantity="other">%d orın sıqıw ushın qollanılmaydı hám óshirildi. Sıqıw ishki saqlaw orınına tikkeley qoljetimdi talap etedi.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze súwretler hám videolardıń fayl ólshemin azaytıp, saqlaw orının bosatadı. Bul sapanı birotola azaytadı hám qaytarıp bolmaydı. Baslamastan burın sazlamalardı dıqqat penen qarap shıǵıń.</string>
     <string name="squeezer_setup_paths_title">Izlew orınları</string>
     <string name="squeezer_setup_paths_default">Izlew ushin papkalardı tańlan\'</string>
     <string name="squeezer_setup_quality_title">Sıǵıstırıw sapası</string>
@@ -81,6 +99,6 @@
         <item quantity="one">Keminde %d ku\'n eski</item>
         <item quantity="other">Keminde %d ku\'n eski</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">JPEG faylları ushin boljamalı ~%d%% u\'nemlew</string>
+    <string name="squeezer_estimated_savings_percent">Súwretler ushın ~%d%% tejew kútiliwde</string>
     <string name="squeezer_onboarding_got_it">Túsinikli</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-km-rKH/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-km-rKH/strings.xml
@@ -1,38 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">ចុចរូបភាពត់ដើម្បីថ្នូកទំហំផ័ឡក។</string>
+    <string name="squeezer_explanation_short">បង្រួមរូបភាព និងវីដេអូ ដើម្បីសន្សំទំហំផ្ទុក។</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="other">ពាក្ស័ល់ %d រូបត្រូវបានរក</item>
+        <item quantity="other">រកឃើញ %d ធាតុ</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="other">~%s អាចត្រូវសញ្ញអំប័ក</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="other">%d រូបត្រូវបានចុច</item>
+        <item quantity="other">%d ធាតុត្រូវបានបង្រួម</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="other">បរាជ័យចំនួន %d</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="other">%d ឯកសារត្រូវបានរំលង (មិនអាចចូលដំណើរការបាន)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="other">%d រូបត្រូវបានជ្រើស</item>
+        <item quantity="other">%d ធាតុត្រូវបានជ្រើររើស</item>
     </plurals>
     <string name="squeezer_search_locations_title">តំណែស្វែងរក</string>
     <string name="squeezer_search_locations_default_summary">ថតកាមេរា ដែលប័កត្រង់</string>
     <string name="squeezer_min_size_title">ទំហំឯកសារតែចិត្ត</string>
-    <string name="squeezer_min_size_description">លឹចលញរូបត្រចន្តែតែងំហំកន្តែនេ។</string>
+    <string name="squeezer_min_size_description">រំលងឯកសារដើលតូចជាទំហំនេ។</string>
     <string name="squeezer_min_age_title">អាយុឯកសារតែចិត្ត</string>
-    <string name="squeezer_min_age_description">រួមតែរូបត្រចឱន្ត្នែឡប់ជាងអាយុនេ។</string>
-    <string name="squeezer_compression_settings_label">ការកំណត់ការចុច</string>
+    <string name="squeezer_min_age_description">រួមបញ្ចូលតើឯកសារចាសជាងអាយុនេ។</string>
+    <string name="squeezer_compression_settings_label">ជាទូទៅ</string>
     <string name="squeezer_quality_label">គុណភាព</string>
     <string name="squeezer_quality_title">គុណភាពការចុច</string>
-    <string name="squeezer_quality_description">គុណភាពតែចិត្តនាឣតំហំឯកសារតូចជាង តែអាចកំណត់រូប។</string>
+    <string name="squeezer_quality_description">គុណភាពតាបមានន័យថាទំហំឯកសារតូចជាងប៉ុន្តើគុណភាពមើលខើញថយចុ។</string>
     <string name="squeezer_quality_example_format">ត័វរាង %1$s រូប → សញ្ញ ~%2$s នៅគុណភាព %3$d%%</string>
     <string name="squeezer_quality_warning_low">គុណភាពតែចិត្តអាចនាឣទាក់ខុស្សនៅរូបបាន។</string>
     <string name="squeezer_quality_warning_high">គុណភាព័កច្រើនពីក្រោមនិងការសញ្ញតែចិត្តទំហំផ័ឡកតូច។</string>
-    <string name="squeezer_types_category_label">ប្រភេតរូប</string>
+    <string name="squeezer_types_category_label">ការកំណត់រូបភាព</string>
+    <string name="squeezer_video_settings_category_label">ការកំណត់វីដេអូ</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">រួមរូប JPEG (.jpg, .jpeg)។</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">រួមរូប WebP (.webp)។</string>
+    <string name="squeezer_type_video_title">វីដេអូ MP4</string>
+    <string name="squeezer_type_video_description">រួមបញ្ចូលឯកសារវីដេអូ MP4 (.mp4)។</string>
     <string name="squeezer_skip_compressed_title">លឹចលញដែលត្រូវបានចុចហើយ។។។</string>
-    <string name="squeezer_skip_compressed_description">លឹចលញរូបដែលត្រូវបានចុចហើយដោយ SD Maid ហើយ។</string>
+    <string name="squeezer_skip_compressed_description">រំលងឯកសារដែលត្រូវបានបង្រួមរួចហើយដោយ SD Maid។</string>
     <string name="squeezer_exif_marker_title">ស្វែងសញ្ញ្ណា EXIF</string>
     <string name="squeezer_exif_marker_description">បន្ថែមសញ្ញ្ណាទៅក្នុងច្ន័លសម្លឹកបច្ចើនិយនិយម់រូប EXIF ដើម្បីទឹក្កានការចុចម្តង ទៀឧប័វប័តប្រវត្តការចុចត្រូវបានលុប។</string>
     <string name="squeezer_estimated_savings_format">~%s នៅសល់</string>
@@ -43,25 +52,31 @@
     <string name="squeezer_preview_dialog_title">បញ្ជាក់ការចុច</string>
     <string name="squeezer_preview_total_size">ទំហំសរុប</string>
     <string name="squeezer_preview_estimated_savings">ការសញ្ញដែលប័តិម្ឡួត់</string>
-    <string name="squeezer_compress_confirmation_title">ចុចរូបក្រើ?</string>
-    <string name="squeezer_compress_confirmation_message">នេឣនឹងជួលជាករូបដើម្បីនៅវៀរសន់សម្រាប់ចុច។ ការប័ក័វត់នេឣមិនអាចលែត្រលប់វិញបាន។</string>
+    <string name="squeezer_compress_confirmation_title">បង្រួមធាតុដែលបានជ្រើររើស?</string>
+    <string name="squeezer_compress_confirmation_message">វានឹងជំនួសឯកសារដើមដោយកំណែដែលបានបង្រួម។ សកម្មភាពនេ័ហមិនអាចត្រល្បវឹញបានតើ។</string>
     <string name="squeezer_history_title">ប្រវត្តការចុច</string>
     <plurals name="squeezer_history_summary">
         <item quantity="other">%1$d ឯកថន្ទ់ (%2$s)</item>
     </plurals>
     <string name="squeezer_history_empty">មិនមានប្រវត្តការចុច</string>
     <string name="squeezer_history_clear_title">លុបប្រវត្តការចុច</string>
-    <string name="squeezer_history_clear_message">នេឣនឹងអនុញ្ញាតរូបដែលត្រូវបានចុចហើយដើម្បីឡេតឥចុចម្តង។ រូបត្រង់គ័ឡនេមិនត្រូវបានរង់ន័។</string>
+    <string name="squeezer_history_clear_message">វានឹងអនុញ្ញាតអោយឯកសារដែលបានបង្រួមមុននេ័ត្រូវបានបង្រួមម្តងតឹត។ ឯកសារខ្លួនឯងមិនរងផលប៉ែពាលើយ។</string>
     <string name="squeezer_onboarding_title">អានស័ម្ព័ន្ធការចុចរូប</string>
     <string name="squeezer_onboarding_message">ការចុចរូបកំណត់ទំហំឯកសារដោយការលុបសម្ឆាល់វិសួយ។ ដ្វងនេឣមិនអាចដក្កើតវិញបាន–គុណភាពដើម្បីមិនអាចផ័ត់វិញបាន។\n\nនេឣជាការមើលឹករបស់អ្នកនៅក្រើ៖</string>
     <string name="squeezer_onboarding_original_label">ត់បញ់ដើម</string>
     <string name="squeezer_onboarding_compressed_label">ប័កការចុច</string>
+    <string name="squeezer_onboarding_video_original_label">ស្រតាប់វីដេអូ</string>
+    <string name="squeezer_onboarding_video_compressed_label">មើលជាមុន (ប្រហាក់ប្រហែល)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">គុណភាពវីដេអូជាក់ស័ត្តែអាចខុសគ្នា</string>
     <string name="squeezer_onboarding_quality_label">គុណភាព៖ %d%%</string>
     <string name="squeezer_compare_action">មើលការបរន័យប័កគ្នា</string>
     <string name="squeezer_no_example_found">មិនន័ឯកសាររូបនៅផ្លូវដែលបានជ្រើស។</string>
-    <string name="squeezer_result_empty_message">មិនន័រូបដែលអាចចុចបាន។</string>
-    <string name="squeezer_setup_warning">ការចុចកំណត់ធ្វើលគុណភាពរូបដើម្បីសញ្ញទំហំផ័ឡក។ នេឣមិនអាចត្រលប់វិញបាន។ ស្វែងការកំណត់របស់អ្នកយ្វាក់មុនបីបន្ថែមផ័ក។</string>
-    <string name="squeezer_setup_explanation">Media Squeeze កំណត់ទំហំឯកសាររូបដើម្បី័កទំហំផ័ឡក។ នេឣកំណត់ធ្វើលគុណភាពរូប និងមិនអាចត្រលប់វិញបាន។ ស្វែងការកំណត់របស់អ្នកយ្វាក់មុនបីបន្ថែមផ័ក។</string>
+    <string name="squeezer_result_empty_message">រកមិនឃើញមេដីអដែលអាចបង្រួមបាន។</string>
+    <string name="squeezer_setup_warning">ការបង្រួមកាត់បន្ថយគុណភាពជាអចិន្ត្រ័យ៍ ដើម្បីសន្សំទំហំផ្ទុក។ វាមិនអាចត្រល្បវឹញបានតើ។ ពិនិតការកំណត់របស់អ្នកដោយប្រុងប្រយ័ត្តនមុននឹងចាបផ័តើម។</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="other">%d តីតំហងមិនអាចប្រើសសម្រាប់ការបង្រួម ហើយត្រូវបានដកចើញ។ ការបង្រួមតម្រួវអោយចូលដំណើរការផ្តល់ទឹលកន្លងផ្ទុកខាងក្នុង។</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze កាត់បន្ថយទំហំឯកសាររូបភាព និងវីដេអូ ដើម្បីបង្កើតទំហំផ្ទុក។ វាកាត់បន្ថយគុណភាពជាអចិន្ត្រ័យ៍ ហើយមិនអាចត្រល្បវឹញបានតើ។ ពិនិតការកំណត់របស់អ្នកដោយប្រុងប្រយ័ត្តនមុននឹងចាបផ័តើម។</string>
     <string name="squeezer_setup_paths_title">តំណែស្វែងរក</string>
     <string name="squeezer_setup_paths_default">ជ្រើសថតដើម្បីស្វែងរក</string>
     <string name="squeezer_setup_quality_title">គុណភាពការចុច</string>
@@ -75,6 +90,6 @@
     <plurals name="squeezer_min_age_x_days">
         <item quantity="other">អាយុយឹងតិ %d ថ្ង័ឡក្នៅមក</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">ប័តិម្ឡើត ~%d%% សញ្ញសម្រាប់ឯកសារ JPEG</string>
+    <string name="squeezer_estimated_savings_percent">ការសន្សំប្រហែល ~%d%% សម្រាប់រូបភាព</string>
     <string name="squeezer_onboarding_got_it">យល់ហើយ</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-ko/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-ko/strings.xml
@@ -1,38 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">이미지를 압축하여 저장 공간을 절약합니다.</string>
+    <string name="squeezer_explanation_short">이미지와 동영상을 압축하여 저장 공간을 절약합니다.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="other">%d개의 이미지 발견</item>
+        <item quantity="other">%d개 항목 발견됨</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="other">~%s 절약 가능</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="other">%d개의 이미지 압축됨</item>
+        <item quantity="other">%d개 항목 압축됨</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="other">%d개 실패</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="other">%d개 파일 건너뜀 (접근 불가)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="other">%d개의 이미지 선택됨</item>
+        <item quantity="other">%d개 항목 선택됨</item>
     </plurals>
     <string name="squeezer_search_locations_title">검색 위치</string>
     <string name="squeezer_search_locations_default_summary">카메라 폴더 (기본값)</string>
     <string name="squeezer_min_size_title">최소 파일 크기</string>
-    <string name="squeezer_min_size_description">이 크기보다 작은 이미지를 건너뜁니다.</string>
+    <string name="squeezer_min_size_description">이 크기보다 작은 파일은 건너뜁니다.</string>
     <string name="squeezer_min_age_title">최소 파일 기간</string>
-    <string name="squeezer_min_age_description">이 기간보다 최근의 이미지만 포함합니다.</string>
-    <string name="squeezer_compression_settings_label">압축 설정</string>
+    <string name="squeezer_min_age_description">이 기간보다 오래된 파일만 포함합니다.</string>
+    <string name="squeezer_compression_settings_label">일반</string>
     <string name="squeezer_quality_label">품질</string>
     <string name="squeezer_quality_title">압축 품질</string>
-    <string name="squeezer_quality_description">낮은 품질은 파일 크기가 작아지지만 이미지 품질이 저하됩니다.</string>
+    <string name="squeezer_quality_description">낮은 품질은 파일 크기를 줄이지만 시각적 품질도 낮아집니다.</string>
     <string name="squeezer_quality_example_format">예시: %1$s 이미지 → %3$d%% 품질에서 ~%2$s 절약</string>
     <string name="squeezer_quality_warning_low">낮은 품질은 눈에 보이는 아티팩트를 유발할 수 있습니다.</string>
     <string name="squeezer_quality_warning_high">매우 높은 품질은 공간 절약이 거의 없습니다.</string>
-    <string name="squeezer_types_category_label">이미지 유형</string>
+    <string name="squeezer_types_category_label">이미지 설정</string>
+    <string name="squeezer_video_settings_category_label">동영상 설정</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">JPEG 이미지 (.jpg, .jpeg)를 포함합니다.</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">WebP 이미지 (.webp)를 포함합니다.</string>
+    <string name="squeezer_type_video_title">MP4 Video</string>
+    <string name="squeezer_type_video_description">MP4 동영상 파일(.mp4)을 포함합니다.</string>
     <string name="squeezer_skip_compressed_title">이미 압축된 파일 건너뛰기</string>
-    <string name="squeezer_skip_compressed_description">SD Maid에 의해 이미 압축된 이미지를 건너뜁니다.</string>
+    <string name="squeezer_skip_compressed_description">SD Maid에서 이미 압축된 파일은 건너뜁니다.</string>
     <string name="squeezer_exif_marker_title">EXIF 마커 기록</string>
     <string name="squeezer_exif_marker_description">압축 기록이 삭제되더라도 재압축을 방지하기 위해 이미지의 EXIF 사용자 코멘트 필드에 마커를 추가합니다.</string>
     <string name="squeezer_estimated_savings_format">~%s 절약</string>
@@ -43,25 +52,31 @@
     <string name="squeezer_preview_dialog_title">압축 확인</string>
     <string name="squeezer_preview_total_size">총 크기</string>
     <string name="squeezer_preview_estimated_savings">예상 절약량</string>
-    <string name="squeezer_compress_confirmation_title">이미지를 압축하시겠습니까?</string>
-    <string name="squeezer_compress_confirmation_message">원본 이미지가 압축된 버전으로 대체됩니다. 이 작업은 되돌릴 수 없습니다.</string>
+    <string name="squeezer_compress_confirmation_title">선택된 항목을 압축하시겠습니까?</string>
+    <string name="squeezer_compress_confirmation_message">원본 파일이 압축 버전으로 교체됩니다. 이 작업은 취소할 수 없습니다.</string>
     <string name="squeezer_history_title">압축 기록</string>
     <plurals name="squeezer_history_summary">
         <item quantity="other">%1$d개 항목 (%2$s)</item>
     </plurals>
     <string name="squeezer_history_empty">압축 기록 없음</string>
     <string name="squeezer_history_clear_title">압축 기록 삭제</string>
-    <string name="squeezer_history_clear_message">이전에 압축된 이미지를 다시 압축할 수 있게 됩니다. 이미지 자체에는 영향이 없습니다.</string>
+    <string name="squeezer_history_clear_message">이전에 압축된 파일을 다시 압축할 수 있게 됩니다. 파일 자체에는 영향이 없습니다.</string>
     <string name="squeezer_onboarding_title">이미지 압축 소개</string>
     <string name="squeezer_onboarding_message">이미지 압축은 시각적 세부 사항을 제거하여 파일 크기를 줄입니다. 이 과정은 되돌릴 수 없습니다 - 원래 품질을 복원할 수 없습니다.\n\n이미지가 어떻게 보일지 미리보기:</string>
     <string name="squeezer_onboarding_original_label">원본</string>
     <string name="squeezer_onboarding_compressed_label">압축 후</string>
+    <string name="squeezer_onboarding_video_original_label">동영상 프레임</string>
+    <string name="squeezer_onboarding_video_compressed_label">미리보기 (근사치)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">실제 동영상 품질은 다를 수 있습니다</string>
     <string name="squeezer_onboarding_quality_label">품질: %d%%</string>
     <string name="squeezer_compare_action">비교 보기</string>
     <string name="squeezer_no_example_found">선택한 경로에서 이미지를 찾을 수 없습니다.</string>
-    <string name="squeezer_result_empty_message">압축 가능한 이미지를 찾을 수 없습니다.</string>
-    <string name="squeezer_setup_warning">압축은 저장 공간을 절약하기 위해 이미지 품질을 영구적으로 낮춥니다. 이 작업은 되돌릴 수 없습니다. 시작하기 전에 설정을 주의 깊게 확인하세요.</string>
-    <string name="squeezer_setup_explanation">Media Squeeze는 저장 공간을 확보하기 위해 이미지 파일 크기를 줄입니다. 이미지 품질이 영구적으로 저하되며 되돌릴 수 없습니다. 시작하기 전에 설정을 주의 깊게 확인하세요.</string>
+    <string name="squeezer_result_empty_message">압축 가능한 미디어를 찾을 수 없습니다.</string>
+    <string name="squeezer_setup_warning">압축은 저장 공간 절약을 위해 품질을 영구적으로 낙십니다. 이 작업은 취소할 수 없습니다. 시작하기 전에 설정을 주의 깊게 검토하세요.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="other">%d개의 위치는 압축에 사용할 수 없어 제거되었습니다. 압축을 위해서는 내부 저장소에 직접 접근이 필요합니다.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">미디어 스쿈즈는 이미지와 동영상의 파일 크기를 줄여 저장 공간을 확보합니다. 이 작업은 품질을 영구적으로 낙심으며 취소할 수 없습니다. 시작하기 전에 설정을 주의 깊게 검토하세요.</string>
     <string name="squeezer_setup_paths_title">검색 위치</string>
     <string name="squeezer_setup_paths_default">검색할 폴더 선택</string>
     <string name="squeezer_setup_quality_title">압축 품질</string>
@@ -75,6 +90,6 @@
     <plurals name="squeezer_min_age_x_days">
         <item quantity="other">최소 %d일 경과</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">JPEG 파일에 대해 ~%d%% 절약 예상</string>
+    <string name="squeezer_estimated_savings_percent">이미지 약 ~%d%% 절약 예상</string>
     <string name="squeezer_onboarding_got_it">확인</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-lo-rLA/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-lo-rLA/strings.xml
@@ -1,38 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">ບີບອັດຣູບພື່ນພື້ນທີ່ເກັບຂ້ອມູນ.</string>
+    <string name="squeezer_explanation_short">ບີບອັດຮູບພາບ ແລະ ວິດີໂອເພື່ອປະຢັດພື້ນທີ່ເກັບຂໍ້ມູນ.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="other">ພົບ %d ຣູບ</item>
+        <item quantity="other">%d ລາຍການທີ່ພົບ</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="other">~%s ສາມາຖປະຫຍັດໄດ້</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="other">ບີບອັດ %d ຣູບແລ້ວ</item>
+        <item quantity="other">%d ລາຍການທີ່ຖືກບີບອັດ</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="other">%d ລົ້ມເຫຼວ</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="other">%d ໄຟລ໌ທີ່ຖືກຂ້າມ (ບໍ່ສາມາດເຂົ້າເຖິງໄດ້)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="other">ເລືອກ %d ຣູບ</item>
+        <item quantity="other">%d ລາຍການທີ່ເລືອກ</item>
     </plurals>
     <string name="squeezer_search_locations_title">ຕໍ່ແຫນ່ງຄົ້ນຫາ</string>
     <string name="squeezer_search_locations_default_summary">ໂຟນເດີກາແມ່ລາ (ແມ່ພົນຖານ)</string>
     <string name="squeezer_min_size_title">ຂນາດໄຟລ໌ຂັ້ນຕ່ໍາ</string>
-    <string name="squeezer_min_size_description">ຂ້າມຣູບທີ່ໃຫຍ່ກວ່າຂນາດນີ້.</string>
+    <string name="squeezer_min_size_description">ຂ້າມໄຟລ໌ທີ່ນ້ອຍກວ່າຂະໜາດນີ້.</string>
     <string name="squeezer_min_age_title">ອາຍຸໄຟລ໌ຂັ້ນຕໃ఼່ຕ່ໍາ</string>
-    <string name="squeezer_min_age_description">ຮວມເຉພາະຣູບທີ່ເກົ່າກວ່າອາຍຸນີ້ເທ່ານັ້ນ.</string>
-    <string name="squeezer_compression_settings_label">ການຕັ້ງຄ່າການບີບອັດ</string>
+    <string name="squeezer_min_age_description">ລວມສະເພາະໄຟລ໌ທີ່ເກົ່າກວ່າອາຍຸນີ້ເທົ່ານັ້ນ.</string>
+    <string name="squeezer_compression_settings_label">ທົ່ວໄປ</string>
     <string name="squeezer_quality_label">ຄຸນນາພ</string>
     <string name="squeezer_quality_title">ຄຸນນາພການບີບອັດ</string>
-    <string name="squeezer_quality_description">ຄຸນນາພຕ່ໍາຫມາຍຖຶງຂນາດໄຟລ໌ນ້ອຍລງ ແຕ່คຸນນາພຣູບລດລງ.</string>
+    <string name="squeezer_quality_description">ຄຸນນະພາບຕ່ຳໝາຍຄວາມວ່າຂະໜາດໄຟລ໌ນ້ອຍລົງ ແຕ່ຄຸນນະພາບຮູບທີ່ຫຼຸດລົງ.</string>
     <string name="squeezer_quality_example_format">ຕົວອຍ່າງ: ຣູບ %1$s → ປະຫຍັດ ~%2$s ທີ່ຄຸນນາພ %3$d%%</string>
     <string name="squeezer_quality_warning_low">ຄຸນນາພຕໃ່າອາດທຳໃຫ້ເຫັນສິ່ງຜິດປົກກະຕິ.</string>
     <string name="squeezer_quality_warning_high">ຄຸນນາພສູງມາກເກັບພື້ນທີ່ດ້ວຍນ້ອຍນິດ.</string>
-    <string name="squeezer_types_category_label">ປະເພດຣູບ</string>
+    <string name="squeezer_types_category_label">ການຕັ້ງຄ່າຮູບພາບ</string>
+    <string name="squeezer_video_settings_category_label">ການຕັ້ງຄ່າວິດີໂອ</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">ຮວມຣູບ JPEG (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">ຮວມຣູບ WebP (.webp).</string>
+    <string name="squeezer_type_video_title">MP4 Video</string>
+    <string name="squeezer_type_video_description">ລວມໄຟລ໌ວິດີໂອ MP4 (.mp4).</string>
     <string name="squeezer_skip_compressed_title">ຂ້າມຣູບທີ່ບີບອັດແລ້ວ</string>
-    <string name="squeezer_skip_compressed_description">ຂ້າມຣູບທີ່ຖືກບີບອັດໂດຍ SD Maid ແລ້ວ.</string>
+    <string name="squeezer_skip_compressed_description">ຂ້າມໄຟລ໌ທີ່ຖືກບີບອັດໂດຍ SD Maid ແລ້ວ.</string>
     <string name="squeezer_exif_marker_title">ເຂີຍນໄວ້ແນວ EXIF</string>
     <string name="squeezer_exif_marker_description">ເພີ່ມເຕີມແນວໃນຊ່ອງຄອມເມນຕ໌ຜູ້ໃຊ້ EXIF ຂອງຣູບເພື່ອປ້ອງກັນການບີບອັດ຋້ຳ ແມ່ນແຕ່ຊຶ່ນປະຫວັດການບີບອັດຈະຖືກລົບລ້າງ.</string>
     <string name="squeezer_estimated_savings_format">ປະຫຍັດ ~%s</string>
@@ -43,25 +52,31 @@
     <string name="squeezer_preview_dialog_title">ຍືນຍັນການບີບອັດ</string>
     <string name="squeezer_preview_total_size">ຂນາດທັງຫມດ</string>
     <string name="squeezer_preview_estimated_savings">ການປະຫຍັດທີ່ຄາດເດົາ</string>
-    <string name="squeezer_compress_confirmation_title">ບີບອັດຣູບພົ່?</string>
-    <string name="squeezer_compress_confirmation_message">ການນີ້ຈະແທນຣູບຕ້ນພົ້ນດ້ວຍວງຈົນທີ່ບີບອັດ. ການກະທຳນີ້ໄມ່ສາມາຖຍ້ອນຄືນໄດ້.</string>
+    <string name="squeezer_compress_confirmation_title">ບີບອັດລາຍການທີ່ເລືອກ?</string>
+    <string name="squeezer_compress_confirmation_message">ນີ້ຈະແທນທີ່ໄຟລ໌ຕົ້ນສະບັບດ້ວຍສະບັບທີ່ຖືກບີບອັດ. ການກະທຳນີ້ບໍ່ສາມາດຍ້ອນກັບໄດ້.</string>
     <string name="squeezer_history_title">ປະຫວັດການບີບອັດ</string>
     <plurals name="squeezer_history_summary">
         <item quantity="other">%1$d ລາຍການ (%2$s)</item>
     </plurals>
     <string name="squeezer_history_empty">ໄມ່ມີປະຫວັດການບີບອັດ</string>
     <string name="squeezer_history_clear_title">ລົບປະຫວັດການບີບອັດ</string>
-    <string name="squeezer_history_clear_message">ການນີ້ຈະອະນຸຍາດໃຫ້ຣູບທີ່ບີບອັດກ່ອນຫນ້າຖືກບີບອັດອີກ. ຣູບຕົວເອງໄມ່ໄດ້ຮັບຜົນກະທບ.</string>
+    <string name="squeezer_history_clear_message">ນີ້ຈະອະນຸຍາດໃຫ້ໄຟລ໌ທີ່ຖືກບີບອັດກ່ອນໜ້ານີ້ຖືກບີບອັດອີກຄັ້ງ. ໄຟລ໌ເຫຼົ່ານັ້ນເອງບໍ່ໄດ້ຮັບຜົນກະທົບ.</string>
     <string name="squeezer_onboarding_title">ກ່ນການບີບອັດຣູບ</string>
     <string name="squeezer_onboarding_message">ການບີບອັດຣູບລດຂນາດໄຟລ໌ດ້ວຍການລົບລາຍລະເອີຊດ້ານພາບ. ການກະທຳນີ້ໄມ່ສາມາຖກັບຄືນໄດ້ - ຄຸນນາພຕ້ນພົ້ນໄມ່ສາມາຖຖືກຄືນ.\n\nนଵ່ໂປຣຮ້ວຂອງວິຘີທີ່ຣູບຂອງທ່ານຈະປະກົດ:</string>
     <string name="squeezer_onboarding_original_label">ຕ້ນພົ້ນ</string>
     <string name="squeezer_onboarding_compressed_label">ຫລັງການບີບອັດ</string>
+    <string name="squeezer_onboarding_video_original_label">ເຟຣມວິດີໂອ</string>
+    <string name="squeezer_onboarding_video_compressed_label">ຕົວຢ່າງ (ໂດຍປະມານ)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">ຄຸນນະພາບວິດີໂອທີ່ແທ້ຈິງອາດຕ່າງກັນ</string>
     <string name="squeezer_onboarding_quality_label">ຄຸນນາພ: %d%%</string>
     <string name="squeezer_compare_action">ດູການເປົນເທີຍບ</string>
     <string name="squeezer_no_example_found">ໄມ່ພົບຣູບໃນເສ້ນທາງທີ່ເລືອກ.</string>
-    <string name="squeezer_result_empty_message">ໄມ່ພົບຣູບທີ່ສາມາຖບີບອັດໄດ້.</string>
-    <string name="squeezer_setup_warning">ການບີບອັດລດຄຸນນາພຣູບອຍ່າງຖາວນີรະພົ້ນທີ່ເກັບຂ້ອມູນ. ການນີ້ໄມ່ສາມາຖຍ້ອນຄືນໄດ້. ກ້ອຂາດໃຊ້ການຕັ້ງຄ່າອຍ່າງລະອີຊກ່ອນເລີ່ມຕ້ນ.</string>
-    <string name="squeezer_setup_explanation">Media Squeeze ລດຂນາດໄຟລ໌ຂອງຣູບເພື່ອໄຖ່ພື້ນທີ່ເກັບຂ້ອມູນ. ການນີ້ລດຄຸນນາພຣູບອຍ່າງຖາວນີรະພົ ແລະໄມ່ສາມາຖຍ້ອນຄືນໄດ້. ກ້ອຂາດໃຊ້ການຕັ້ງຄ່າອຍ່າງລະອີຊກ່ອນເລີ່ມຕ້ນ.</string>
+    <string name="squeezer_result_empty_message">ບໍ່ພົບສື່ທີ່ສາມາດບີບອັດໄດ້.</string>
+    <string name="squeezer_setup_warning">ການບີບອັດຫຼຸດຄຸນນະພາບຢ່າງຖາວອນເພື່ອປະຢັດພື້ນທີ່ເກັບຂໍ້ມູນ. ນີ້ບໍ່ສາມາດຍ້ອນກັບໄດ້. ກວດສອບການຕັ້ງຄ່າຂອງທ່ານຢ່າງລະມັດລະວັງກ່ອນເລີ່ມ.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="other">%d ສະຖານທີ່ບໍ່ສາມາດໃຊ້ສຳລັບການບີບອັດ ແລະ ຖືກລຶບອອກ. ການບີບອັດຕ້ອງການການເຂົ້າເຖິງໂດຍກົງຕໍ່ບ່ອນເກັບຂໍ້ມູນພາຍໃນ.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze ຫຼຸດຂະໜາດໄຟລ໌ຂອງຮູບພາບ ແວວວິດີໂອເພື່ອໃຫ້ມີພື້ນທີ່ເກັປຂໍ້ມູນ. ນີ້ຫຼຸດຄຸນນະພາບຢ່າງຖາວອນ ແວວບໍ່ສາມາດຍ້ອນກັບໄດ້. ກວດສອບການຕັ້ງຄ່າຂອງທ່ານຢ່າງລະມັດລະວັງກ່ອນເລີ່ມ.</string>
     <string name="squeezer_setup_paths_title">ຕໍ່ແຫນ່ງຄົ້ນຫາ</string>
     <string name="squeezer_setup_paths_default">ເລືອກໂຟນເດີເພື່ອຄົ້ນຫາ</string>
     <string name="squeezer_setup_quality_title">ຄຸນນາພການບີບອັດ</string>
@@ -75,6 +90,6 @@
     <plurals name="squeezer_min_age_x_days">
         <item quantity="other">ອາຍຸອຍ່າງນ້ອຍ %d ວັນ</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">ປະຫຍັດຄາດว່າ ~%d%% ສຳຫລັບໄຟລ໌ JPEG</string>
+    <string name="squeezer_estimated_savings_percent">ຄາດຄະເນ ~%d%% ການປະຢັດສຳລັບຮູບພາບ</string>
     <string name="squeezer_onboarding_got_it">ເຂົ້າໃຈແລ້ວ</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-lt/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-lt/strings.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Suglaudinti vaizdus, kad sutaupytumėte vietos atmintyje.</string>
+    <string name="squeezer_explanation_short">Suglaudinkite vaizdus ir vaizdo įrašus, kad atlaisvintumėte atminties vietos.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">Rasta %d nuotrauka</item>
-        <item quantity="few">Rastos %d nuotraukos</item>
-        <item quantity="many">Rasta %d nuotraukų</item>
-        <item quantity="other">Rasta %d vaizdų</item>
+        <item quantity="one">%d elementas rastas</item>
+        <item quantity="few">%d elementai rasti</item>
+        <item quantity="many">%d elemento rasta</item>
+        <item quantity="other">%d elementų rasta</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s galima sutaupyti</item>
@@ -14,37 +14,52 @@
         <item quantity="other">~%s galima sutaupyti</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d nuotrauka sukompresuota</item>
-        <item quantity="few">%d nuotraukos sukompresuotos</item>
-        <item quantity="many">%d nuotraukų sukompresuota</item>
-        <item quantity="other">Suspausti %d vaizdų</item>
+        <item quantity="one">%d elementas suglaudintas</item>
+        <item quantity="few">%d elementai suglaudinti</item>
+        <item quantity="many">%d elemento suglaudinta</item>
+        <item quantity="other">%d elementų suglaudinta</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d nepavyko</item>
+        <item quantity="few">%d nepavyko</item>
+        <item quantity="many">%d nepavyko</item>
+        <item quantity="other">%d nepavyko</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d failas praleistas (nepasiekiamas)</item>
+        <item quantity="few">%d failai praleisti (nepasiekiami)</item>
+        <item quantity="many">%d failo praleista (nepasiekiama)</item>
+        <item quantity="other">%d failų praleista (nepasiekiama)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d nuotrauka pasirinkta</item>
-        <item quantity="few">%d nuotraukos pasirinktos</item>
-        <item quantity="many">%d nuotraukų pasirinkta</item>
-        <item quantity="other">Pasirinkta %d vaizdų</item>
+        <item quantity="one">%d elementas pasirinktas</item>
+        <item quantity="few">%d elementai pasirinkti</item>
+        <item quantity="many">%d elemento pasirinkta</item>
+        <item quantity="other">%d elementų pasirinkta</item>
     </plurals>
     <string name="squeezer_search_locations_title">Ieškoti vietos</string>
     <string name="squeezer_search_locations_default_summary">Fotoaparato aplankai (numatytasis)</string>
     <string name="squeezer_min_size_title">Minimalus failo dydis</string>
-    <string name="squeezer_min_size_description">Praleisti vaizdus, mažesnius nei šis dydis.</string>
+    <string name="squeezer_min_size_description">Praleisti failus, mažsnius už šį dydį.</string>
     <string name="squeezer_min_age_title">Minimalus failo amžius</string>
-    <string name="squeezer_min_age_description">Įtraukti tik vaizdus senesnius nei šis amžius.</string>
-    <string name="squeezer_compression_settings_label">Suglaudinimo nustatymai</string>
+    <string name="squeezer_min_age_description">Įtraukti tik failus, senesnius už šį amžių.</string>
+    <string name="squeezer_compression_settings_label">Bendrieji</string>
     <string name="squeezer_quality_label">Kokybė</string>
     <string name="squeezer_quality_title">Suglaudinimo kokybė</string>
-    <string name="squeezer_quality_description">Maesnė kokybė reiškia mažesnį failo dydį, bet sumaginą vaizdo kokybę.</string>
+    <string name="squeezer_quality_description">Mažesnė kokybė reiškia mažesnį failo dydį, tačiau blogesnę vaizdinę kokybę.</string>
     <string name="squeezer_quality_example_format">Pavyzdys: %1$s vaizdas → sutaupo ~%2$s prie %3$d%% kokybės</string>
     <string name="squeezer_quality_warning_low">Maesnė kokybė gali sukelti matomus artefaktus.</string>
     <string name="squeezer_quality_warning_high">Labai aukšta kokybė suteikia minimalias vietos sutaupymas.</string>
-    <string name="squeezer_types_category_label">Vaizdų tipai</string>
+    <string name="squeezer_types_category_label">Vaizdo nustatymai</string>
+    <string name="squeezer_video_settings_category_label">Vaizdo įrašų nustatymai</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">Įtraukti JPEG vaizdus (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">Įtraukti WebP vaizdus (.webp).</string>
+    <string name="squeezer_type_video_title">MP4 Video</string>
+    <string name="squeezer_type_video_description">Įtraukti MP4 vaizdo įrašų failus (.mp4).</string>
     <string name="squeezer_skip_compressed_title">Praleisti anksčiau suglaudintus</string>
-    <string name="squeezer_skip_compressed_description">Praleisti vaizdus, kurie jau buvo suglaudinti SD Maid.</string>
+    <string name="squeezer_skip_compressed_description">Praleisti failus, kurie jau buvo suglaudinti SD Maid.</string>
     <string name="squeezer_exif_marker_title">Rašyti EXIF žymė</string>
     <string name="squeezer_exif_marker_description">Prideti žymę prie vaizdo EXIF vartotojo komentaro lauko, kad būtų užkirstas kelias pakartotiniam suglaudinimui net jei suglaudinimo istorija išvaloma.</string>
     <string name="squeezer_estimated_savings_format">~%s sutaupyta</string>
@@ -55,8 +70,8 @@
     <string name="squeezer_preview_dialog_title">Patvirtinti suglaudinimą</string>
     <string name="squeezer_preview_total_size">Bendras dydis</string>
     <string name="squeezer_preview_estimated_savings">Numatomas sutaupymas</string>
-    <string name="squeezer_compress_confirmation_title">Suglaudinti vaizdus?</string>
-    <string name="squeezer_compress_confirmation_message">Tai pakeis originalius vaizdus suglaudintomis versijomis. Šio veiksmo negalima atcofti.</string>
+    <string name="squeezer_compress_confirmation_title">Suglaudinti pasirinktus elementus?</string>
+    <string name="squeezer_compress_confirmation_message">Originalūs failai bus pakeisti suglaudintomis versijomis. Šio veiksmo negalima atšaukti.</string>
     <string name="squeezer_history_title">Suglaudinimo istorija</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d elementas (%2$s)</item>
@@ -66,17 +81,26 @@
     </plurals>
     <string name="squeezer_history_empty">Nėra suglaudinimo istorijos</string>
     <string name="squeezer_history_clear_title">Išvalyti suglaudinimo istoriją</string>
-    <string name="squeezer_history_clear_message">Tai leis anksčiau suglaudintus vaizdus suglaudinti iš naujo. Patys vaizdai neličiami.</string>
+    <string name="squeezer_history_clear_message">Tai leis anksčiau suglaudintus failus suglaudinti dar kartą. Patys failai nebus paveikti.</string>
     <string name="squeezer_onboarding_title">Apie vaizdų suglaudinimą</string>
     <string name="squeezer_onboarding_message">Vaizdų suglaudinimas sumažina failo dydį pašalindamas vizualias detales. Šis procesas yra neatstatomas - originalės kokybės negalima atstatyti.\n\nStai kaip atrodys jūsų vaizdai:</string>
     <string name="squeezer_onboarding_original_label">Originalas</string>
     <string name="squeezer_onboarding_compressed_label">Po suglaudinimo</string>
+    <string name="squeezer_onboarding_video_original_label">Vaizdo kadras</string>
+    <string name="squeezer_onboarding_video_compressed_label">Peržiūra (apytikslė)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">Tikroji vaizdo kokybė gali skirtis</string>
     <string name="squeezer_onboarding_quality_label">Kokybė: %d%%</string>
     <string name="squeezer_compare_action">Peržiūrėti palyginimą</string>
     <string name="squeezer_no_example_found">Pasirinktuose keliuose vaizdai nerasti.</string>
-    <string name="squeezer_result_empty_message">Nerasti jokių suglaudinamo vaizdų.</string>
-    <string name="squeezer_setup_warning">Suglaudinimas neatstatomai sumažina vaizdo kokybę, kad sutaupytų vietos. Tai negali būti atcofta. Atidžiai patikrinkite nustatymus prieš pradėdami.</string>
-    <string name="squeezer_setup_explanation">Media Squeeze sumažina vaizdo failų dydį, kad atlaisvintų vietos atmintyje. Tai neatstatomai sumažina vaizdo kokybę ir negali būti atcofta. Atidžiai patikrinkite nustatymus prieš pradėdami.</string>
+    <string name="squeezer_result_empty_message">Nesurasta jokių suglaudinamų medijų.</string>
+    <string name="squeezer_setup_warning">Suglaudinimas visam laikui sumažina kokybę, kad atlaisvintų atminties vietą. Šio veiksmo negalima atšaukti. Prieš pradėdami atidžiai peržiūrėkite savo nustatymus.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d vieta negali būti naudojama suglaudinimui ir buvo pašalinta. Suglaudinimui reikalinga tiesioginė prieiga prie vidinės atminties.</item>
+        <item quantity="few">%d vietos negali būti naudojamos suglaudinimui ir buvo pašalintos. Suglaudinimui reikalinga tiesioginė prieiga prie vidinės atminties.</item>
+        <item quantity="many">%d vietos negali būti naudojamos suglaudinimui ir buvo pašalintos. Suglaudinimui reikalinga tiesioginė prieiga prie vidinės atminties.</item>
+        <item quantity="other">%d vietų negali būti naudojama suglaudinimui ir buvo pašalinta. Suglaudinimui reikalinga tiesioginė prieiga prie vidinės atminties.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze sumažina vaizdų ir vaizdo įrašų failo dydį, kad atlaisvintų atminties vietą. Tai visam laikui sumažina kokybę ir negali būti atšaukta. Prieš pradėdami atidžiai peržiūrėkite savo nustatymus.</string>
     <string name="squeezer_setup_paths_title">Ieškoti vietos</string>
     <string name="squeezer_setup_paths_default">Pasirinkti aplankus paiieškai</string>
     <string name="squeezer_setup_quality_title">Suglaudinimo kokybė</string>
@@ -93,6 +117,6 @@
         <item quantity="many">Mažigiausiai %d dienų sena</item>
         <item quantity="other">Ne mažiau kaip %d dienų</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">Numatamai ~%d%% sutaupymas JPEG failams</string>
+    <string name="squeezer_estimated_savings_percent">Numatomas ~%d%% sutaupymas vaizdams</string>
     <string name="squeezer_onboarding_got_it">Supratau</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-lv/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-lv/strings.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Saspiediet attēlus, lai ietaupītu krātuves vietu.</string>
+    <string name="squeezer_explanation_short">Saspiež attēlus un video, lai ietaupītu krātuves vietu.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="zero">%d attēlu atrasti</item>
-        <item quantity="one">%d attēls atrasts</item>
-        <item quantity="other">%d attēli atrasti</item>
+        <item quantity="zero">%d vienumu atrasts</item>
+        <item quantity="one">%d vienums atrasts</item>
+        <item quantity="other">%d vienumi atrasti</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="zero">~%s var ietaupīt</item>
@@ -12,35 +12,48 @@
         <item quantity="other">~%s var ietaupīt</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="zero">%d attēli saspiesti</item>
-        <item quantity="one">%d attēls saspists</item>
-        <item quantity="other">%d attēli saspiesti</item>
+        <item quantity="zero">%d vienumu saspiest</item>
+        <item quantity="one">%d vienums saspiest</item>
+        <item quantity="other">%d vienumi saspiesti</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="zero">%d neveiksmīgi</item>
+        <item quantity="one">%d neveiksmīgs</item>
+        <item quantity="other">%d neveiksmīgi</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="zero">%d failu izlaists (nav pieejams)</item>
+        <item quantity="one">%d fails izlaists (nav pieejams)</item>
+        <item quantity="other">%d faili izlaisti (nav pieejami)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="zero">%d attēli atlasīti</item>
-        <item quantity="one">%d attēls atlasīts</item>
-        <item quantity="other">%d attēli atlasīti</item>
+        <item quantity="zero">%d vienumu atlasīts</item>
+        <item quantity="one">%d vienums atlasīts</item>
+        <item quantity="other">%d vienumi atlasīti</item>
     </plurals>
     <string name="squeezer_search_locations_title">Meklēšanas vietas</string>
     <string name="squeezer_search_locations_default_summary">Kameras mapes (noklusējums)</string>
     <string name="squeezer_min_size_title">Minimālais faila izmērs</string>
-    <string name="squeezer_min_size_description">Izlaist attēlus, kas ir mazāki par šo izmēru.</string>
+    <string name="squeezer_min_size_description">Izlaist failus, kas ir mazāki par šo izmēru.</string>
     <string name="squeezer_min_age_title">Minimālais faila vecums</string>
-    <string name="squeezer_min_age_description">Iekļaut tikai attēlus, kas ir vecāki par šo vecumu.</string>
-    <string name="squeezer_compression_settings_label">Kompresijas iestatījumi</string>
+    <string name="squeezer_min_age_description">Iekļaut tikai failus, kas ir vecāki par šo vecumu.</string>
+    <string name="squeezer_compression_settings_label">Vispārīgi</string>
     <string name="squeezer_quality_label">Kvalitāte</string>
     <string name="squeezer_quality_title">Kompresijas kvalitāte</string>
-    <string name="squeezer_quality_description">Zemāka kvalitāte nozīmē mazāku faila izmēru, bet samazinātu attēla kvalitāti.</string>
+    <string name="squeezer_quality_description">Zemāka kvalitāte nozīmē mazāku faila izmēru, bet samazinātu vizuālo kvalitāti.</string>
     <string name="squeezer_quality_example_format">Piemērs: %1$s attēls → ietaupa ~%2$s pie %3$d%% kvalitātes</string>
     <string name="squeezer_quality_warning_low">Zemāka kvalitāte var radīt redzamus artefaktus.</string>
     <string name="squeezer_quality_warning_high">Oti augsta kvalitāte nodrošina minimalu vietas ietaupijumu.</string>
-    <string name="squeezer_types_category_label">Attēlu tipi</string>
+    <string name="squeezer_types_category_label">Attēlu iestatījumi</string>
+    <string name="squeezer_video_settings_category_label">Video iestatījumi</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">Iekļaut JPEG attēlus (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">Iekļaut WebP attēlus (.webp).</string>
+    <string name="squeezer_type_video_title">MP4 Video</string>
+    <string name="squeezer_type_video_description">Iekļaut MP4 video failus (.mp4).</string>
     <string name="squeezer_skip_compressed_title">Izlaist jau saspiestus</string>
-    <string name="squeezer_skip_compressed_description">Izlaist attēlus, kas jau ir saspiesti ar SD Maid.</string>
+    <string name="squeezer_skip_compressed_description">Izlaist failus, kas jau ir saspiesti ar SD Maid.</string>
     <string name="squeezer_exif_marker_title">Rakstīt EXIF atzīmi</string>
     <string name="squeezer_exif_marker_description">Pievienot atzīmi attēla EXIF lietotāja komentāra laukam, lai novērstu atkartotu saspiešanu, pat ja kompresijas vēsture ir notīrīta.</string>
     <string name="squeezer_estimated_savings_format">~%s ietaupijums</string>
@@ -51,8 +64,8 @@
     <string name="squeezer_preview_dialog_title">Apstiprināt kompresiju</string>
     <string name="squeezer_preview_total_size">Kopējais izmērs</string>
     <string name="squeezer_preview_estimated_savings">Paredzamais ietaupijums</string>
-    <string name="squeezer_compress_confirmation_title">Saspiest attēlus?</string>
-    <string name="squeezer_compress_confirmation_message">Tas aizvietōs originālos attēlus ar saspiestajām versijām. Šo darbību nav iespējams atcelt.</string>
+    <string name="squeezer_compress_confirmation_title">Saspiest atlasītos vienumus?</string>
+    <string name="squeezer_compress_confirmation_message">Tas aizstās oriģinālos failus ar saspiestam versijām. Šo darbību nevar atsaukt.</string>
     <string name="squeezer_history_title">Kompresijas vēsture</string>
     <plurals name="squeezer_history_summary">
         <item quantity="zero">%1$d vienības (%2$s)</item>
@@ -61,17 +74,25 @@
     </plurals>
     <string name="squeezer_history_empty">Nav kompresijas vēstures</string>
     <string name="squeezer_history_clear_title">Notīrīt kompresijas vēsturi</string>
-    <string name="squeezer_history_clear_message">Tas ļaujs iepriekš saspiestajiem attēliem tikt saspiestiem atkārtoti. Paši attēli netiek skartī.</string>
+    <string name="squeezer_history_clear_message">Tas ļaus iepriekš saspiestus failus saspiest vēlreiz. Paši faili netiek ietekmēti.</string>
     <string name="squeezer_onboarding_title">Par attēlu kompresiju</string>
     <string name="squeezer_onboarding_message">Attēlu kompresija samazina faila izmēru, noņemot vizuālas detajas. Šis process ir neatgriezenisks — originālo kvalitāti nav iespējams atjaunot.\n\nLot paskats, kā jūsu attēli izskatiesšies:</string>
     <string name="squeezer_onboarding_original_label">Origināls</string>
     <string name="squeezer_onboarding_compressed_label">Pēc kompresijas</string>
+    <string name="squeezer_onboarding_video_original_label">Video rāmis</string>
+    <string name="squeezer_onboarding_video_compressed_label">Priekšskatījums (aptuvens)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">Faktiskā video kvalitāte var atšķirties</string>
     <string name="squeezer_onboarding_quality_label">Kvalitāte: %d%%</string>
     <string name="squeezer_compare_action">Skatīt salīdzīnājumu</string>
     <string name="squeezer_no_example_found">Nav atrasts neviens attēls atlasītajās ceļos.</string>
-    <string name="squeezer_result_empty_message">Nav atrasti saspiešanai piemēroti attēli.</string>
-    <string name="squeezer_setup_warning">Kompresija neatgriezeniski samazina attēla kvalitāti, lai ietaupītu krātuves vietu. To nav iespējams atcelt. Rūpīgi pārskatiet savus iestatījumus pirms sākuma.</string>
-    <string name="squeezer_setup_explanation">Media Squeeze samazina attēlu failu izmēru, lai atbrīvotu krātuves vietu. Tas neatgriezeniski samazina attēlu kvalitāti un to nav iespējams atcelt. Rūpīgi pārskatiet savus iestatījumus pirms sākuma.</string>
+    <string name="squeezer_result_empty_message">Nav atrasts neviens saspiežams multivides fails.</string>
+    <string name="squeezer_setup_warning">Saspiešana neatgriezeniski samazina kvalitāti, lai ietaupītu krātuves vietu. To nevar atsaukt. Pirms sākšanas rūpīgi pārskatiet iestatījumus.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="zero">%d atrašanvietu nevar izmantot saspiešanai un tās tika noņemtas. Saspiešanai nepieciešama tieša piekļuve iekšējai krātuvei.</item>
+        <item quantity="one">%d atrašanvietu nevar izmantot saspiešanai un tā tika noņemta. Saspiešanai nepieciešama tieša piekļuve iekšējai krātuvei.</item>
+        <item quantity="other">%d atrašanvietas nevar izmantot saspiešanai un tās tika noņemtas. Saspiešanai nepieciešama tieša piekļuve iekšējai krātuvei.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze samazina attēlu un video failu izmēru, lai atbrīvotu krātuves vietu. Tas neatgriezeniski samazina kvalitāti un to nevar atsaukt. Pirms sākšanas rūpīgi pārskatiet iestatījumus.</string>
     <string name="squeezer_setup_paths_title">Meklēšanas vietas</string>
     <string name="squeezer_setup_paths_default">Atlasīt meklējamas mapes</string>
     <string name="squeezer_setup_quality_title">Kompresijas kvalitāte</string>
@@ -87,6 +108,6 @@
         <item quantity="one">Vismaz %d dienu vecs</item>
         <item quantity="other">Vismaz %d dienas vecs</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">Paredzamie ~%d%% ietaupijumi JPEG failiem</string>
+    <string name="squeezer_estimated_savings_percent">Parēdzamais ~%d%% ietaupījums attēliem</string>
     <string name="squeezer_onboarding_got_it">Sapratu</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-mk-rMK/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-mk-rMK/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Компресирајте слики за да заштедите простор.</string>
+    <string name="squeezer_explanation_short">Компресирајте слики и видеа за да заштедите простор за складирање.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d слика пронајдена</item>
-        <item quantity="other">%d слики пронајдени</item>
+        <item quantity="one">%d ставка пронајдена</item>
+        <item quantity="other">%d ставки пронајдени</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s може да се заштеди</item>
         <item quantity="other">~%s може да се заштедат</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d слика компресирана</item>
-        <item quantity="other">%d слики компресирани</item>
+        <item quantity="one">%d ставка компресирана</item>
+        <item quantity="other">%d ставки компресирани</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d неуспешно</item>
+        <item quantity="other">%d неуспешни</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d датотека прескокната (не е достапна)</item>
+        <item quantity="other">%d датотеки прескокнати (не се достапни)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d слика избрана</item>
-        <item quantity="other">%d слики избрани</item>
+        <item quantity="one">%d ставка избрана</item>
+        <item quantity="other">%d ставки избрани</item>
     </plurals>
     <string name="squeezer_search_locations_title">Локации за пребарување</string>
     <string name="squeezer_search_locations_default_summary">Папки на камера (стандардно)</string>
     <string name="squeezer_min_size_title">Минимална големина на датотека</string>
-    <string name="squeezer_min_size_description">Прескокни слики помали од оваа големина.</string>
+    <string name="squeezer_min_size_description">Прескокни датотеки помали од оваа големина.</string>
     <string name="squeezer_min_age_title">Минимална старост на датотека</string>
-    <string name="squeezer_min_age_description">Вклучи само слики постари од оваа старост.</string>
-    <string name="squeezer_compression_settings_label">Поставки за компресија</string>
+    <string name="squeezer_min_age_description">Вклучи само датотеки постари од оваа возраст.</string>
+    <string name="squeezer_compression_settings_label">Општо</string>
     <string name="squeezer_quality_label">Квалитет</string>
     <string name="squeezer_quality_title">Квалитет на компресија</string>
-    <string name="squeezer_quality_description">Понизок квалитет значи помала датотека но намален квалитет на сликата.</string>
+    <string name="squeezer_quality_description">Пониски квалитет значи помала големина на датотеката но намален визуелен квалитет.</string>
     <string name="squeezer_quality_example_format">Пример: %1$s слика → заштеда ~%2$s при %3$d%% квалитет</string>
     <string name="squeezer_quality_warning_low">Пониски квалитети може да предизвикаат видливи артефакти.</string>
     <string name="squeezer_quality_warning_high">Многу висок квалитет дава минимална заштеда на простор.</string>
-    <string name="squeezer_types_category_label">Типови на слики</string>
+    <string name="squeezer_types_category_label">Поставки за слики</string>
+    <string name="squeezer_video_settings_category_label">Поставки за видео</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">Вклучи JPEG слики (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">Вклучи WebP слики (.webp).</string>
+    <string name="squeezer_type_video_title">MP4 видео</string>
+    <string name="squeezer_type_video_description">Вклучи MP4 видео датотеки (.mp4).</string>
     <string name="squeezer_skip_compressed_title">Прескокни претходно компресирани</string>
-    <string name="squeezer_skip_compressed_description">Прескокни слики кои веќе се компресирани од SD Maid.</string>
+    <string name="squeezer_skip_compressed_description">Прескокни датотеки кои веќе биле компресирани од SD Maid.</string>
     <string name="squeezer_exif_marker_title">Запиши EXIF ознака</string>
     <string name="squeezer_exif_marker_description">Додај ознака во полето за EXIF кориснички коментар на сликата за да се спречи повторна компресија дури и ако историјата на компресија е избришана.</string>
     <string name="squeezer_estimated_savings_format">~%s заштеда</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">Потврди компресија</string>
     <string name="squeezer_preview_total_size">Вкупна големина</string>
     <string name="squeezer_preview_estimated_savings">Проценета заштеда</string>
-    <string name="squeezer_compress_confirmation_title">Компресирај слики?</string>
-    <string name="squeezer_compress_confirmation_message">Ова ќе ги замени оригиналните слики со компресирани верзии. Оваа акција не може да се поврати.</string>
+    <string name="squeezer_compress_confirmation_title">Да се компресираат избраните ставки?</string>
+    <string name="squeezer_compress_confirmation_message">Ова ќе ги замени оригиналните датотеки со компресирани верзии. Оваа акција не може да се врати.</string>
     <string name="squeezer_history_title">Историја на компресија</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d ставка (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">Нема историја на компресија</string>
     <string name="squeezer_history_clear_title">Избриши историја на компресија</string>
-    <string name="squeezer_history_clear_message">Ова ќе дозволи претходно компресирани слики да бидат компресирани повторно. Самите слики не се засегнати.</string>
+    <string name="squeezer_history_clear_message">Ова ќе дозволи претходно компресирани датотеки да бидат компресирани повторно. Самите датотеки не се засегнати.</string>
     <string name="squeezer_onboarding_title">За компресија на слики</string>
     <string name="squeezer_onboarding_message">Компресијата на слики ја намалува големината на датотеката со отстранување визуелни детали. Овој процес е неповратен - оригиналниот квалитет не може да се врати.\n\nЕве преглед како ќе изгледаат вашите слики:</string>
     <string name="squeezer_onboarding_original_label">Оригинал</string>
     <string name="squeezer_onboarding_compressed_label">По компресија</string>
+    <string name="squeezer_onboarding_video_original_label">Видео рамка</string>
+    <string name="squeezer_onboarding_video_compressed_label">Преглед (приближно)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">Вистинскиот квалитет на видеото може да се разликува</string>
     <string name="squeezer_onboarding_quality_label">Квалитет: %d%%</string>
     <string name="squeezer_compare_action">Прегледај споредба</string>
     <string name="squeezer_no_example_found">Нема пронајдени слики во избраните патеки.</string>
-    <string name="squeezer_result_empty_message">Нема пронајдени слики за компресија.</string>
-    <string name="squeezer_setup_warning">Компресијата трајно го намалува квалитетот на сликите за да заштеди складирање. Ова не може да се поврати. Внимателно прегледајте ги поставките пред да започнете.</string>
-    <string name="squeezer_setup_explanation">Медиа Компресорот ја намалува големината на датотеките на слики за да ослободи складирање. Ова трајно го намалува квалитетот на сликите и не може да се поврати. Внимателно прегледајте ги поставките пред да започнете.</string>
+    <string name="squeezer_result_empty_message">Не е пронајдено компресибилно медиумско содржина.</string>
+    <string name="squeezer_setup_warning">Компресијата трајно го намалува квалитетот за да заштеди простор за складирање. Ова не може да се врати. Внимателно прегледајте ги вашите поставки пред да започнете.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d локација не може да се користи за компресија и беше отстранета. Компресијата бара директен пристап до внатрешниот склад.</item>
+        <item quantity="other">%d локации не можат да се користат за компресија и беа отстранети. Компресијата бара директен пристап до внатрешниот склад.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze ја намалува големината на датотеките на слики и видеа за да ослободи простор за складирање. Ова трајно го намалува квалитетот и не може да се врати. Внимателно прегледајте ги вашите поставки пред да започнете.</string>
     <string name="squeezer_setup_paths_title">Локации за пребарување</string>
     <string name="squeezer_setup_paths_default">Изберете папки за пребарување</string>
     <string name="squeezer_setup_quality_title">Квалитет на компресија</string>
@@ -81,6 +99,6 @@
         <item quantity="one">Најмалку %d ден стара</item>
         <item quantity="other">Најмалку %d дена стара</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">Проценета ~%d%% заштеда за JPEG датотеки</string>
+    <string name="squeezer_estimated_savings_percent">Проценето ~%d%% заштеда за слики</string>
     <string name="squeezer_onboarding_got_it">Разбрав</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-ml-rIN/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-ml-rIN/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">സ്റ്റോറേജ് സ്ഥലം ലാഭിക്കാൻ ചിത്രങ്ങൾ കമ്പ്രസ് ചെയ്യുക.</string>
+    <string name="squeezer_explanation_short">സ്റ്റോറേജ് സ്പേസ് ലാഭിക്കാൻ ചിത്രങ്ങളും വീഡിയോകളും കംപ്രസ്സ് ചെയ്യുക.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d ചിത്രം കണ്ടെത്തി</item>
-        <item quantity="other">%d ചിത്രങ്ങൾ കണ്ടെത്തി</item>
+        <item quantity="one">%d ഇനം കണ്ടെത്തി</item>
+        <item quantity="other">%d ഇനങ്ങൾ കണ്ടെത്തി</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s ലാഭിക്കാം</item>
         <item quantity="other">~%s ലാഭിക്കാം</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d ചിത്രം കമ്പ്രസ് ചെയ്തു</item>
-        <item quantity="other">%d ചിത്രങ്ങൾ കമ്പ്രസ് ചെയ്തു</item>
+        <item quantity="one">%d ഇനം കംപ്രസ്സ് ചെയ്തു</item>
+        <item quantity="other">%d ഇനങ്ങൾ കംപ്രസ്സ് ചെയ്തു</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d പരാജയപ്പെട്ടു</item>
+        <item quantity="other">%d പരാജയപ്പെട്ടു</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d ഫയൽ ഒഴിവാക്കി (ആക്സസ് ചെയ്യാനാവില്ല)</item>
+        <item quantity="other">%d ഫയലുകൾ ഒഴിവാക്കി (ആക്സസ് ചെയ്യാനാവില്ല)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d ചിത്രം തിരഞ്ഞെടുത്തി</item>
-        <item quantity="other">%d ചിത്രങ്ങൾ തിരഞ്ഞെടുത്തി</item>
+        <item quantity="one">%d ഇനം തിരഞ്ഞെടുത്തു</item>
+        <item quantity="other">%d ഇനങ്ങൾ തിരഞ്ഞെടുത്തു</item>
     </plurals>
     <string name="squeezer_search_locations_title">തിരയൽ സ്ഥലങ്ങൾ</string>
     <string name="squeezer_search_locations_default_summary">ക്യാമറ ഫോർഡർുകൾ (ഡിഫോർൽട്)</string>
     <string name="squeezer_min_size_title">കുറഞ്ഞ ഫയൽ വലുപ്പം</string>
-    <string name="squeezer_min_size_description">ഈ വലുപ്പത്തിൽ ചെറുത് ചിത്രങ്ങൾ ഒഴിവാക്കുക.</string>
+    <string name="squeezer_min_size_description">ഈ വലിപ്പത്തിൽ കുറഞ്ഞ ഫയലുകൾ ഒഴിവാക്കുക.</string>
     <string name="squeezer_min_age_title">കുറഞ്ഞ ഫയൽ പഴക്കം</string>
-    <string name="squeezer_min_age_description">ഈ പഴക്കത്തിലധികം പഴയ ചിത്രങ്ങൾ മാത്രം ഉൾപ്പെടുത്തുക.</string>
-    <string name="squeezer_compression_settings_label">കമ്പ്രഷൻ കാർയക്ഷമതാ അടവുകൾ</string>
+    <string name="squeezer_min_age_description">ഈ പഴക്കത്തിൽ കൂടുതൽ പഴയ ഫയലുകൾ മാത്രം ഉൾപ്പെടുത്തുക.</string>
+    <string name="squeezer_compression_settings_label">പൊതുവായ</string>
     <string name="squeezer_quality_label">ഗുണമേൻമ</string>
     <string name="squeezer_quality_title">കമ്പ്രഷൻ ഗുണമേൻമ</string>
-    <string name="squeezer_quality_description">കുറഞ്ഞ ഗുണമേൻമ അര്ഥമാക്കുന്നത് ചെറിയ ഫയൽ വലുപ്പം പക്ഷേ ചിത്ര ഗുണമേൻമ കുറയും.</string>
+    <string name="squeezer_quality_description">കുറഞ്ഞ ഗുണമേൻമ എന്നാൽ ചെറിയ ഫയൽ വലിപ്പം, പക്ഷേ ദൃശ്യ ഗുണമേൻമ കുറയും.</string>
     <string name="squeezer_quality_example_format">ഉദാ: %1$s ചിത്രം → %3$d%% ഗുണമേൻമയിൽ ~%2$s ലാഭിക്കും</string>
     <string name="squeezer_quality_warning_low">കുറഞ്ഞ ഗുണമേൻമ ദൃശ്യമായ തക്രാരുകൾ ഉണ്ടാകാൻ സാധ്യതയുണ്ട്.</string>
     <string name="squeezer_quality_warning_high">വളരെ ഉച്ച ഗുണമേൻമ കുറഞ്ഞ സ്ഥല ലാഭം നൽകുന്നു.</string>
-    <string name="squeezer_types_category_label">ചിത്ര തരങ്ങൾ</string>
+    <string name="squeezer_types_category_label">ചിത്ര ക്രമീകരണങ്ങൾ</string>
+    <string name="squeezer_video_settings_category_label">വീഡിയോ ക്രമീകരണങ്ങൾ</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">JPEG ചിത്രങ്ങൾ (.jpg, .jpeg) ഉൾപ്പെടുത്തുക.</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">WebP ചിത്രങ്ങൾ (.webp) ഉൾപ്പെടുത്തുക.</string>
+    <string name="squeezer_type_video_title">MP4 വീഡിയോ</string>
+    <string name="squeezer_type_video_description">MP4 വീഡിയോ ഫയലുകൾ (.mp4) ഉൾപ്പെടുത്തുക.</string>
     <string name="squeezer_skip_compressed_title">മുൻപൎ കമ്പ്രസ് ചെയ്തവ ഒഴിവാക്കുക</string>
-    <string name="squeezer_skip_compressed_description">SD Maid മുൻപെ കമ്പ്രസ് ചെയ്ത ചിത്രങ്ങൾ ഒഴിവാക്കുക.</string>
+    <string name="squeezer_skip_compressed_description">SD Maid ഇതിനകം കംപ്രസ്സ് ചെയ്ത ഫയലുകൾ ഒഴിവാക്കുക.</string>
     <string name="squeezer_exif_marker_title">EXIF മാർക്കർ എഴുതുക</string>
     <string name="squeezer_exif_marker_description">കമ്പ്രഷൻ ചരിത്രം മാർജിക്കപ്പെട്ടാൽപോലും വീണ്ടും കമ്പ്രഷൻ തടയാൻ, ചിത്രത്തിന്റെ EXIF ഉപയോക്തൃ കമ്മെന്റ് ഫീൽഡിൽ ഒരു മാർക്കർ ചേർക്കുക.</string>
     <string name="squeezer_estimated_savings_format">~%s ലാഭം</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">കമ്പ്രഷൻ സ്ഥിരീകരിക്കുക</string>
     <string name="squeezer_preview_total_size">മൊത്തം വലുപ്പം</string>
     <string name="squeezer_preview_estimated_savings">കണക്കാക്കിയ ലാഭം</string>
-    <string name="squeezer_compress_confirmation_title">ചിത്രങ്ങൾ കമ്പ്രസ് ചെയ്യണോ?</string>
-    <string name="squeezer_compress_confirmation_message">ഇത് യഥാർത്ഥ ചിത്രങ്ങൾ കമ്പ്രസ് ചെയ്ത പതിപ്പുകൾകൊണ്ട് പകർത്തും. ഈ പ്രവർത്തി തിരിച്ചെടുക്കാൻ കഴിയില്ല.</string>
+    <string name="squeezer_compress_confirmation_title">തിരഞ്ഞെടുത്ത ഇനങ്ങൾ കംപ്രസ്സ് ചെയ്യണോ?</string>
+    <string name="squeezer_compress_confirmation_message">ഇത് യഥാർത്ഥ ഫയലുകൾ കംപ്രസ്സ് ചെയ്ത പതിപ്പുകൾ ഉപയോഗിച്ച് മാറ്റിസ്ഥാപിക്കും. ഈ പ്രവൃത്തി പഴേ നിലയിലാക്കാൻ കഴിയില്ല.</string>
     <string name="squeezer_history_title">കമ്പ്രഷൻ ചരിത്രം</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d ഇനം (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">കമ്പ്രഷൻ ചരിത്രം ഇല്ല</string>
     <string name="squeezer_history_clear_title">കമ്പ്രഷൻ ചരിത്രം മാർജിക്കുക</string>
-    <string name="squeezer_history_clear_message">ഇത് മുൻപൎ കമ്പ്രസ് ചെയ്ത ചിത്രങ്ങൾ വീണ്ടും കമ്പ്രസ് ചെയ്യാൻ അനുവദിക്കും. ചിത്രങ്ങൾ തന്നെ ബാധിക്കപ്പെടുന്നില്ല.</string>
+    <string name="squeezer_history_clear_message">ഇത് മുമ്പ് കംപ്രസ്സ് ചെയ്ത ഫയലുകൾ വീണ്ടും കംപ്രസ്സ് ചെയ്യാൻ അനുവദിക്കും. ഫയലുകൾ തന്നെ ബാധിക്കപ്പെടില്ല.</string>
     <string name="squeezer_onboarding_title">ഇമേജ് കമ്പ്രഷൻ കുറിച്ച്</string>
     <string name="squeezer_onboarding_message">ഇമേജ് കമ്പ്രഷൻ ദൃശ്യമാന വിവരങ്ങൾ നീക്കി ഫയൽ വലുപ്പം കുറയ്ക്കുന്നു. ഈ പ്രക്രിയ തിരിച്ചെടുക്കാൻ കഴിയാത്തതാണ് - മൂല ഗുണമേൻമ വില തിരിച്ചെടുക്കാൻ കഴിയില്ല.\n\nനിങ്ങളുടെ ചിത്രങ്ങൾ എപ്പോർ കാണപ്പെടും എന്നതിന്റെ ഒരു മുന്നല്:</string>
     <string name="squeezer_onboarding_original_label">യഥാർത്ഥം</string>
     <string name="squeezer_onboarding_compressed_label">കമ്പ്രഷൻക്കു ശേഷം</string>
+    <string name="squeezer_onboarding_video_original_label">വീഡിയോ ഫ്രെയിം</string>
+    <string name="squeezer_onboarding_video_compressed_label">പ്രിവ്യൂ (ഏകദേശം)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">യഥാർത്ഥ വീഡിയോ ഗുണമേൻമ വ്യത്യാസപ്പെടാം</string>
     <string name="squeezer_onboarding_quality_label">ഗുണമേൻമ: %d%%</string>
     <string name="squeezer_compare_action">താരതമ്യം കാണുക</string>
     <string name="squeezer_no_example_found">തിരഞ്ഞെടുത്ത പാതകളിൽ ചിത്രങ്ങൾ കണ്ടെത്തിയില്ല.</string>
-    <string name="squeezer_result_empty_message">കമ്പ്രസ് ചെയ്യാവുന്ന ചിത്രങ്ങൾ കണ്ടെത്തിയില്ല.</string>
-    <string name="squeezer_setup_warning">കമ്പ്രഷൻ സ്റ്റോറേജ് ലാഭിക്കാൻ ചിത്ര ഗുണമേൻമ സ്ഥിരമായി കുറയ്ക്കുന്നു. ഇത് തിരിച്ചെടുക്കാൻ കഴിയില്ല. തുടങ്ങുനതിന് മുൻപ് നിങ്ങളുടെ കാർയക്ഷമതാ അടവുകൾ ശ്രദ്ധാപൂർവം പരിശോധിക്കുക.</string>
-    <string name="squeezer_setup_explanation">Media Squeeze സ്റ്റോറേജ് സ്ഥലം ശൂന്യമാക്കാൻ ചിത്രങ്ങളുടെ ഫയൽ വലുപ്പം കുറയ്ക്കുന്നു. ഇത് ചിത്ര ഗുണമേൻമ സ്ഥിരമായി കുറയ്ക്കുകയും തിരിച്ചെടുക്കാൻ കഴിയാത്തതുമാണ്. തുടങ്ങുനതിന് മുൻപ് നിങ്ങളുടെ കാർയക്ഷമതാ അടവുകൾ ശ്രദ്ധാപൂർവം പരിശോധിക്കുക.</string>
+    <string name="squeezer_result_empty_message">കംപ്രസ്സ് ചെയ്യാവുന്ന മീഡിയ ഒന്നും കണ്ടെത്തിയില്ല.</string>
+    <string name="squeezer_setup_warning">കംപ്രഷൻ സ്ഥിരമായി ഗുണമേൻമ കുറക്കുന്നു, സ്റ്റോറേജ് സ്പേസ് ലാഭിക്കാൻ. ഇത് പഴേ നിലയിലാക്കാൻ കഴിയില്ല. തുടങ്ങുന്നതിന് മുമ്പ് ക്രമീകരണങ്ങൾ ശ്രദ്ധാപൂർവ്വം പരിശോധിക്കുക.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">കംപ്രഷനായി %d സ്ഥാനം ഉപയോഗിക്കാനാകില്ല, അത് നീക്കം ചെയ്തു. കംപ്രഷന് ആന്തരിക സ്റ്റോറേജിലേക്ക് നേരിട്ടുള്ള ആക്സസ് ആവശ്യമാണ്.</item>
+        <item quantity="other">കംപ്രഷനായി %d സ്ഥാനങ്ങൾ ഉപയോഗിക്കാനാകില്ല, അവ നീക്കം ചെയ്തു. കംപ്രഷന് ആന്തരിക സ്റ്റോറേജിലേക്ക് നേരിട്ടുള്ള ആക്സസ് ആവശ്യമാണ്.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze ചിത്രങ്ങളുടെയും വീഡിയോകളുടെയും ഫയൽ വലിപ്പം കുറക്കുന്നു, സ്റ്റോറേജ് സ്പേസ് മോചിപ്പിക്കാൻ. ഇത് സ്ഥിരമായി ഗുണമേൻമ കുറക്കുകയും പഴേ നിലയിലാക്കാൻ കഴിയാത്തതുമാണ്. തുടങ്ങുന്നതിന് മുമ്പ് ക്രമീകരണങ്ങൾ ശ്രദ്ധാപൂർവ്വം പരിശോധിക്കുക.</string>
     <string name="squeezer_setup_paths_title">തിരയൽ സ്ഥലങ്ങൾ</string>
     <string name="squeezer_setup_paths_default">തിരയാൻ ഫോർഡർുകൾ തിരഞ്ഞെടുക്കുക</string>
     <string name="squeezer_setup_quality_title">കമ്പ്രഷൻ ഗുണമേൻമ</string>
@@ -81,6 +99,6 @@
         <item quantity="one">കുറഞ്ഞത് %d ദിവസം പഴക്കമുള്ളത്</item>
         <item quantity="other">കുറഞ്ഞത് %d ദിവസം പഴക്കമുള്ളത്</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">JPEG ഫയലുകൾക്കായി ~%d%% ലാഭം കണക്കാക്കിയിട്ടുണ്ട്</string>
+    <string name="squeezer_estimated_savings_percent">ചിത്രങ്ങൾക്ക് ഏകദേശം ~%d%% ലാഭം</string>
     <string name="squeezer_onboarding_got_it">മനസ്സിലായി</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-mn-rMN/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-mn-rMN/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Хадгалах зай хэмнэхийн тулд зургийг шахах.</string>
+    <string name="squeezer_explanation_short">Санах ойн зайг хэмнэхийн тулд зураг болон видеог шахна.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d зураг олдсон</item>
-        <item quantity="other">%d зураг олдсон</item>
+        <item quantity="one">%d зүйл олдлоо</item>
+        <item quantity="other">%d зүйл олдлоо</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s хадгалах боломжтой</item>
         <item quantity="other">~%s хадгалах боломжтой</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d зураг шахаагдсан</item>
-        <item quantity="other">%d зураг шахаагдсан</item>
+        <item quantity="one">%d зүйл шахагдлаа</item>
+        <item quantity="other">%d зүйл шахагдлаа</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d амжилтгүй</item>
+        <item quantity="other">%d амжилтгүй</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d файл алгасагдлаа (хандах боломжгүй)</item>
+        <item quantity="other">%d файл алгасагдлаа (хандах боломжгүй)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d зураг сонгосон</item>
-        <item quantity="other">%d зураг сонгосон</item>
+        <item quantity="one">%d зүйл сонгогдлоо</item>
+        <item quantity="other">%d зүйл сонгогдлоо</item>
     </plurals>
     <string name="squeezer_search_locations_title">Хайх газрууд</string>
     <string name="squeezer_search_locations_default_summary">Камерын фолдерууд (үндсэн)</string>
     <string name="squeezer_min_size_title">Файлын деэд хэмжээ</string>
-    <string name="squeezer_min_size_description">Энэ хэмжээас жижиг зурагуудыг алгасах.</string>
+    <string name="squeezer_min_size_description">Энэ хэмжээнээс жижиг файлуудыг алгасана.</string>
     <string name="squeezer_min_age_title">Файлын деэд нас</string>
-    <string name="squeezer_min_age_description">Зөвхөн энэ наснаас өшөө зурагуудыг л хүснээр оруулах.</string>
-    <string name="squeezer_compression_settings_label">Шахалтын тохиргоо</string>
+    <string name="squeezer_min_age_description">Зөвхөн энэ насаас ахмад файлуудыг оруулна.</string>
+    <string name="squeezer_compression_settings_label">Ерөнхий</string>
     <string name="squeezer_quality_label">Чанар</string>
     <string name="squeezer_quality_title">Шахалтын чанар</string>
-    <string name="squeezer_quality_description">Дородуу чанар нь файлын хэмжээг багасгаад зурагны чанарыг бууруулна.</string>
+    <string name="squeezer_quality_description">Чанар бага байх нь файлын хэмжээ жижиг боловч харагдах чанар буурна.</string>
     <string name="squeezer_quality_example_format">Жишээ: %1$s зураг → %3$d%% чанарт ойроор ~%2$s хадгалалана</string>
     <string name="squeezer_quality_warning_low">Дородуу чанар харагдсан алдаа үүсгэх боломжтой.</string>
     <string name="squeezer_quality_warning_high">Маш өндөр чанар нь зайны олзолт хадгалалт цөөн байна.</string>
-    <string name="squeezer_types_category_label">Зурагны төрол</string>
+    <string name="squeezer_types_category_label">Зургийн тохиргоо</string>
+    <string name="squeezer_video_settings_category_label">Видеоны тохиргоо</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">JPEG зураг (.jpg, .jpeg) оруулах.</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">WebP зураг (.webp) оруулах.</string>
+    <string name="squeezer_type_video_title">MP4 Видео</string>
+    <string name="squeezer_type_video_description">MP4 видео файлуудыг (.mp4) оруулна.</string>
     <string name="squeezer_skip_compressed_title">Өмнө шахаагдсаныг алгасах</string>
-    <string name="squeezer_skip_compressed_description">SD Maid-аар аль шахаагдсан зурагуудыг алгасах.</string>
+    <string name="squeezer_skip_compressed_description">SD Maid-аар аль хэдийн шахагдсан файлуудыг алгасана.</string>
     <string name="squeezer_exif_marker_title">EXIF тэмдэглэл бичих</string>
     <string name="squeezer_exif_marker_description">Шахалтын түүх арилга цэвхлэгдсэн ч дахин шахаахаас сэргийлгэхийн тулд зурагны EXIF хэрэглэгчийн сэтгэлт темдэглэл немэх.</string>
     <string name="squeezer_estimated_savings_format">~%s хадгалалт</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">Шахалтыг баталгаажуулах</string>
     <string name="squeezer_preview_total_size">Нийт хэмжээ</string>
     <string name="squeezer_preview_estimated_savings">Төсөөлдсөн хадгалалт</string>
-    <string name="squeezer_compress_confirmation_title">Зурагуудыг шахаах уу?</string>
-    <string name="squeezer_compress_confirmation_message">Энэ эх зурагуудыг шахаагдсан хувилбаруудаар солиуулана. Энэ үйлдлийг буцаах боломжгүй.</string>
+    <string name="squeezer_compress_confirmation_title">Сонгосон зүйлсийг шахах уу?</string>
+    <string name="squeezer_compress_confirmation_message">Энэ нь анхны файлуудыг шахагдсан хувилбараар солих болно. Энэ үйлдлийг буцаах боломжгүй.</string>
     <string name="squeezer_history_title">Шахалтын түүх</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d зүйл (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">Шахалтын түүх байхгүй</string>
     <string name="squeezer_history_clear_title">Шахалтын түүхийг арилгах</string>
-    <string name="squeezer_history_clear_message">Өмнө шахаагдсан зурагуудыг дахин шахаах боломжтой болно. Зураг өөрөө нөлөөлохгүй.</string>
+    <string name="squeezer_history_clear_message">Энэ нь өмнө нь шахагдсан файлуудыг дахин шахах боломжтой болгоно. Файлуудад өөрчлөлт ороогүй.</string>
     <string name="squeezer_onboarding_title">Зураг шахалтын тухай</string>
     <string name="squeezer_onboarding_message">Зураг шахалт нь хараахад дэталгыг арилгаснаар файлын хэмжээг багасгана. Энэ ургшийлах боломжгүй явц — эх чанарыг сэргээх боломжгүй.\n\nТаны зурагууд хэрхэн харагдахыг үзүүлэхэд үз:</string>
     <string name="squeezer_onboarding_original_label">Эх</string>
     <string name="squeezer_onboarding_compressed_label">Шахаасны дараа</string>
+    <string name="squeezer_onboarding_video_original_label">Видео фрэйм</string>
+    <string name="squeezer_onboarding_video_compressed_label">Урьдчилан харах (ойролцоогоор)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">Бодит видеоны чанар өөр байж болно</string>
     <string name="squeezer_onboarding_quality_label">Чанар: %d%%</string>
     <string name="squeezer_compare_action">Харьцуулга үзэх</string>
     <string name="squeezer_no_example_found">Сонгосон замуудаас зураг олдсонгүй.</string>
-    <string name="squeezer_result_empty_message">Шахах боломжтой зураг олдсонгүй.</string>
-    <string name="squeezer_setup_warning">Шахалт нь зай чөлөөлж гэдэг зурагны чанарыг байнга бууруулна. Энэг буцаах боломжгүй. Эхлэлт хийхэхийн өмнө тохиргоогоо анхнылан шалгаагаарай.</string>
-    <string name="squeezer_setup_explanation">Media Squeeze зай чөлөөлжийн тулд зурагуудын файлын хэмжээг багасгана. Энэ зурагны чанарыг байнга бууруулад буцаах боломжгүй. Эхлэлт хийхэхийн өмнө тохиргоогоо анхнылан шалгаагаарай.</string>
+    <string name="squeezer_result_empty_message">Шахах боломжтой медиа олдсонгүй.</string>
+    <string name="squeezer_setup_warning">Шахалт нь санах ойн зайг хэмнэхийн тулд чанарыг байнгын бууруулна. Үүнийг буцаах боломжгүй. Эхлэхийн өмнө тохиргоогоо сайтар хянана уу.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d байршлыг шахахад ашиглах боломжгүй тул устгагдлаа. Шахалт нь дотоод санах ойд шууд хандахыг шаардадаг.</item>
+        <item quantity="other">%d байршлыг шахахад ашиглах боломжгүй тул устгагдлаа. Шахалт нь дотоод санах ойд шууд хандахыг шаардадаг.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze нь санах ойн зайг чөлөөлөхийн тулд зураг болон видеоны файлын хэмжээг бууруулдаг. Энэ нь чанарыг байнгын бууруулдаг бөгөөд буцаах боломжгүй. Эхлэхийн өмнө тохиргоогоо сайтар хянана уу.</string>
     <string name="squeezer_setup_paths_title">Хайх газрууд</string>
     <string name="squeezer_setup_paths_default">Хайх фолдеруудыг сонгох</string>
     <string name="squeezer_setup_quality_title">Шахалтын чанар</string>
@@ -81,6 +99,6 @@
         <item quantity="one">Дорроо %d өдөөсийн</item>
         <item quantity="other">Дорроо %d өдөөсийн</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">JPEG файлуудад ~%d%% хадгалалт төсөөлдөд</string>
+    <string name="squeezer_estimated_savings_percent">Зургийн хувьд ~%d%% хэмнэлт байна гэж тооцоолсон</string>
     <string name="squeezer_onboarding_got_it">Ойлголоо</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-ms/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-ms/strings.xml
@@ -1,38 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Mampatkan imej untuk menjimatkan ruang storan.</string>
+    <string name="squeezer_explanation_short">Mampat imej dan video untuk menjimatkan ruang storan.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="other">%d imej dijumpai</item>
+        <item quantity="other">%d item dijumpai</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="other">~%s boleh dijimatkan</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="other">%d imej dimampatkan</item>
+        <item quantity="other">%d item dimampatkan</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="other">%d gagal</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="other">%d fail dilangkau (tidak boleh diakses)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="other">%d imej dipilih</item>
+        <item quantity="other">%d item dipilih</item>
     </plurals>
     <string name="squeezer_search_locations_title">Lokasi carian</string>
     <string name="squeezer_search_locations_default_summary">Folder kamera (lalai)</string>
     <string name="squeezer_min_size_title">Saiz fail minimum</string>
-    <string name="squeezer_min_size_description">Langkau imej yang lebih kecil daripada saiz ini.</string>
+    <string name="squeezer_min_size_description">Langkau fail yang lebih kecil daripada saiz ini.</string>
     <string name="squeezer_min_age_title">Umur fail minimum</string>
-    <string name="squeezer_min_age_description">Hanya sertakan imej yang lebih lama daripada umur ini.</string>
-    <string name="squeezer_compression_settings_label">Tetapan mampatan</string>
+    <string name="squeezer_min_age_description">Hanya sertakan fail yang lebih lama daripada umur ini.</string>
+    <string name="squeezer_compression_settings_label">Umum</string>
     <string name="squeezer_quality_label">Kualiti</string>
     <string name="squeezer_quality_title">Kualiti mampatan</string>
-    <string name="squeezer_quality_description">Kualiti rendah bermaksud saiz fail lebih kecil tetapi kualiti imej berkurangan.</string>
+    <string name="squeezer_quality_description">Kualiti lebih rendah bermaksud saiz fail lebih kecil tetapi kualiti visual berkurangan.</string>
     <string name="squeezer_quality_example_format">Contoh: %1$s imej → jimat ~%2$s pada kualiti %3$d%%</string>
     <string name="squeezer_quality_warning_low">Kualiti rendah mungkin menyebabkan artifak yang kelihatan.</string>
     <string name="squeezer_quality_warning_high">Kualiti sangat tinggi memberikan penjimatan ruang yang minimum.</string>
-    <string name="squeezer_types_category_label">Jenis imej</string>
+    <string name="squeezer_types_category_label">Tetapan imej</string>
+    <string name="squeezer_video_settings_category_label">Tetapan video</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">Sertakan imej JPEG (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">Sertakan imej WebP (.webp).</string>
+    <string name="squeezer_type_video_title">Video MP4</string>
+    <string name="squeezer_type_video_description">Sertakan fail video MP4 (.mp4).</string>
     <string name="squeezer_skip_compressed_title">Langkau yang telah dimampatkan</string>
-    <string name="squeezer_skip_compressed_description">Langkau imej yang telah dimampatkan oleh SD Maid.</string>
+    <string name="squeezer_skip_compressed_description">Langkau fail yang telah dimampatkan oleh SD Maid.</string>
     <string name="squeezer_exif_marker_title">Tulis penanda EXIF</string>
     <string name="squeezer_exif_marker_description">Tambah penanda pada medan ulasan pengguna EXIF imej untuk mengelakkan pemampatan semula walaupun sejarah pemampatan dikosongkan.</string>
     <string name="squeezer_estimated_savings_format">~%s penjimatan</string>
@@ -43,25 +52,31 @@
     <string name="squeezer_preview_dialog_title">Sahkan pemampatan</string>
     <string name="squeezer_preview_total_size">Jumlah saiz</string>
     <string name="squeezer_preview_estimated_savings">Anggaran penjimatan</string>
-    <string name="squeezer_compress_confirmation_title">Mampat imej?</string>
-    <string name="squeezer_compress_confirmation_message">Ini akan menggantikan imej asal dengan versi yang dimampatkan. Tindakan ini tidak boleh dibatalkan.</string>
+    <string name="squeezer_compress_confirmation_title">Mampatkan item yang dipilih?</string>
+    <string name="squeezer_compress_confirmation_message">Ini akan menggantikan fail asal dengan versi yang dimampatkan. Tindakan ini tidak boleh dibatalkan.</string>
     <string name="squeezer_history_title">Sejarah pemampatan</string>
     <plurals name="squeezer_history_summary">
         <item quantity="other">%1$d item (%2$s)</item>
     </plurals>
     <string name="squeezer_history_empty">Tiada sejarah pemampatan</string>
     <string name="squeezer_history_clear_title">Kosongkan sejarah pemampatan</string>
-    <string name="squeezer_history_clear_message">Ini akan membenarkan imej yang telah dimampatkan sebelum ini untuk dimampatkan semula. Imej itu sendiri tidak terjejas.</string>
+    <string name="squeezer_history_clear_message">Ini akan membenarkan fail yang telah dimampatkan sebelum ini untuk dimampatkan semula. Fail itu sendiri tidak terjejas.</string>
     <string name="squeezer_onboarding_title">Tentang Pemampatan Imej</string>
     <string name="squeezer_onboarding_message">Pemampatan imej mengurangkan saiz fail dengan mengalih keluar butiran visual. Proses ini tidak boleh dibalikkan - kualiti asal tidak boleh dipulihkan.\n\nBerikut ialah pratonton bagaimana imej anda akan kelihatan:</string>
     <string name="squeezer_onboarding_original_label">Asal</string>
     <string name="squeezer_onboarding_compressed_label">Selepas pemampatan</string>
+    <string name="squeezer_onboarding_video_original_label">Bingkai video</string>
+    <string name="squeezer_onboarding_video_compressed_label">Pratonton (anggaran)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">Kualiti video sebenar mungkin berbeza</string>
     <string name="squeezer_onboarding_quality_label">Kualiti: %d%%</string>
     <string name="squeezer_compare_action">Lihat perbandingan</string>
     <string name="squeezer_no_example_found">Tiada imej dijumpai di laluan yang dipilih.</string>
-    <string name="squeezer_result_empty_message">Tiada imej yang boleh dimampatkan dijumpai.</string>
-    <string name="squeezer_setup_warning">Pemampatan mengurangkan kualiti imej secara kekal untuk menjimatkan ruang storan. Ini tidak boleh dibatalkan. Semak tetapan anda dengan teliti sebelum memulakan.</string>
-    <string name="squeezer_setup_explanation">Mampat Media mengurangkan saiz fail imej untuk membebaskan ruang storan. Ini mengurangkan kualiti imej secara kekal dan tidak boleh dibatalkan. Semak tetapan anda dengan teliti sebelum memulakan.</string>
+    <string name="squeezer_result_empty_message">Tiada media yang boleh dimampatkan ditemui.</string>
+    <string name="squeezer_setup_warning">Pemampatan mengurangkan kualiti secara kekal untuk menjimatkan ruang storan. Ini tidak boleh dibatalkan. Semak tetapan anda dengan teliti sebelum memulakan.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="other">%d lokasi tidak boleh digunakan untuk pemampatan dan telah dikeluarkan. Pemampatan memerlukan akses terus ke storan dalaman.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze mengurangkan saiz fail imej dan video untuk membebaskan ruang storan. Ini mengurangkan kualiti secara kekal dan tidak boleh dibatalkan. Semak tetapan anda dengan teliti sebelum memulakan.</string>
     <string name="squeezer_setup_paths_title">Lokasi carian</string>
     <string name="squeezer_setup_paths_default">Pilih folder untuk dicari</string>
     <string name="squeezer_setup_quality_title">Kualiti mampatan</string>
@@ -75,6 +90,6 @@
     <plurals name="squeezer_min_age_x_days">
         <item quantity="other">Sekurang-kurangnya %d hari</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">Anggaran ~%d%% penjimatan untuk fail JPEG</string>
+    <string name="squeezer_estimated_savings_percent">Anggaran ~%d%% penjimatan untuk imej</string>
     <string name="squeezer_onboarding_got_it">Faham</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-my-rMM/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-my-rMM/strings.xml
@@ -1,38 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">သိုလှောင်မှု နေရာချွေတာရန် ပုံများ ချုံ့ပါ။</string>
+    <string name="squeezer_explanation_short">သိုလှောင်မှုနေရာကို သက်သာစေရန် ပုံများနှင့် ဗီဒီယိုများကို ချုံ့ပါ။</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="other">%d ပုံ တွေ့ရှိသည်</item>
+        <item quantity="other">%d ခု တွေ့ရှိသည်</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="other">~%s သိမ်းဆညးပါ</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="other">%d ပုံ ချုံ့ပြီးပြီ</item>
+        <item quantity="other">%d ခု ချုံ့ပြီးသည်</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="other">%d ခု မအောင်မြင်ခဲ့ပါ</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="other">%d ဖိုင် ကျော်သွားသည် (ဝင်ရောက်၍ မရနိုင်)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="other">%d ပုံ ရွေးချယ်ထားသည်</item>
+        <item quantity="other">%d ခု ရွေးချယ်ထားသည်</item>
     </plurals>
     <string name="squeezer_search_locations_title">ရှာဖွေသောနေရာများ</string>
     <string name="squeezer_search_locations_default_summary">ကင်မရာဖိုဒာများ (မူလ)</string>
     <string name="squeezer_min_size_title">အနည်းဆုံး ဖိုင်အရွယ်အစား</string>
-    <string name="squeezer_min_size_description">ဤအရွယ်အစားထက် သေးသောပုံများကို ကျောပါ။</string>
+    <string name="squeezer_min_size_description">ဤအရွယ်အစားထက် သေးသောဖိုင်များကို ကျော်သွားပါ။</string>
     <string name="squeezer_min_age_title">အနည်းဆုံး ဖိုင်သက်တမ်း</string>
-    <string name="squeezer_min_age_description">ဤသက်တမ်းထက် နောက်သောပုံများသာ ထည့်သွင်းပါ။</string>
-    <string name="squeezer_compression_settings_label">ချုံ့မှု ဆက်တင်</string>
+    <string name="squeezer_min_age_description">ဤသက်တမ်းထက် ဟောင်းသောဖိုင်များသာ ထည့်သွင်းပါ။</string>
+    <string name="squeezer_compression_settings_label">ယေဘူယျ</string>
     <string name="squeezer_quality_label">အရည်အသွေး</string>
     <string name="squeezer_quality_title">ချုံ့မှု အရည်အသွေး</string>
-    <string name="squeezer_quality_description">အရည်အသွေး နည်းသည့်က ဖိုင်အရွယ်အစား သေးသော်လည်း ပုံအရည်အသွေး ကျဆင်းသည်။</string>
+    <string name="squeezer_quality_description">အရည်အသွေး နည်းလေ ဖိုင်အရွယ်အစား သေးလေ သို့သော်လည်း မြင်နိုင်သောအရည်အသွေး ကျဆင်းသွားမည်။</string>
     <string name="squeezer_quality_example_format">ဥပမာ - %1$s ပုံ → %3$d%% အရည်အသွေးတွင် ~%2$s ချွေတာနိုင်သည်</string>
     <string name="squeezer_quality_warning_low">အရည်အသွေး နည်းသည့်က မြင်ရနိုင်သော ချို့ပျက်ချက်များ ဖြစ်ပော်နိုင်သည်။</string>
     <string name="squeezer_quality_warning_high">အလွန် မြင့်မားသော အရည်အသွေးသည် နေရာချွေတာမှု အနည်းဆုံးသာသာ ပေးသည်။</string>
-    <string name="squeezer_types_category_label">ပုံအမျိုးအစားများ</string>
+    <string name="squeezer_types_category_label">ပုံဆက်တင်များ</string>
+    <string name="squeezer_video_settings_category_label">ဗီဒီယိုဆက်တင်များ</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">JPEG ပုံများ (.jpg, .jpeg) ထည့်သွင်းရန်။</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">WebP ပုံများ (.webp) ထည့်သွင်းရန်။</string>
+    <string name="squeezer_type_video_title">MP4 Video</string>
+    <string name="squeezer_type_video_description">MP4 ဗီဒီယိုဖိုင်များ (.mp4) ထည့်သွင်းပါ။</string>
     <string name="squeezer_skip_compressed_title">ယခင်က ချုံ့ပြီးသားများ ကျော်ရန်</string>
-    <string name="squeezer_skip_compressed_description">SD Maid မှ ယခင်က ချုံ့ပြီးသားပုံများကို ကျော်သွားမည်။</string>
+    <string name="squeezer_skip_compressed_description">SD Maid မှ ချုံ့ပြီးသောဖိုင်များကို ကျော်သွားပါ။</string>
     <string name="squeezer_exif_marker_title">EXIF အမှတ်အသား ရေးသားရန်</string>
     <string name="squeezer_exif_marker_description">ချုံ့မှုမှတ်တမ်းကို ရှင်းလင်းလင့်ကစား ထပ်မံချုံ့ခြင်းမှ ကာကွယ်ရန် ပုံ၏ EXIF user comment field တွင် အမှတ်အသားတစ်ခု ထည့်သွင်းသည်။</string>
     <string name="squeezer_estimated_savings_format">~%s သက်သာမှု</string>
@@ -43,25 +52,31 @@
     <string name="squeezer_preview_dialog_title">ချုံ့ခြင်း အတည်ပြုရန်</string>
     <string name="squeezer_preview_total_size">စုစုပေါင်း အရွယ်အစား</string>
     <string name="squeezer_preview_estimated_savings">ခန့်မှန်းသော သက်သာမှု</string>
-    <string name="squeezer_compress_confirmation_title">ပုံများ ချုံ့မည်လား?</string>
-    <string name="squeezer_compress_confirmation_message">ဤလုပ်ဆောင်ချက်သည် မူရင်းပုံများကို ချုံ့ထားသောဗားရှင်းများဖြင့် အစားထိုးမည်။ ဤလုပ်ဆောင်ချက်ကို နောက်ပြန်ဆွဲ၍မရနိုင်ပါ။</string>
+    <string name="squeezer_compress_confirmation_title">ရွေးချယ်ထားသောအရာများကို ချုံ့မည်လား?</string>
+    <string name="squeezer_compress_confirmation_message">ဤလုပ်ဆောင်ချက်သည် မူရင်းဖိုင်များကို ချုံ့ထားသောဗားရှင်းများဖြင့် အစားထိုးမည်။ ဤလုပ်ဆောင်ချက်ကို နောက်ကြောင်းပြောင်း၍ မရနိုင်ပါ။</string>
     <string name="squeezer_history_title">ချုံ့ခြင်း မှတ်တမ်း</string>
     <plurals name="squeezer_history_summary">
         <item quantity="other">%1$d ခု (%2$s)</item>
     </plurals>
     <string name="squeezer_history_empty">ချုံ့ခြင်း မှတ်တမ်း မရှိပါ</string>
     <string name="squeezer_history_clear_title">ချုံ့ခြင်း မှတ်တမ်း သန့်သင်းရန်</string>
-    <string name="squeezer_history_clear_message">ဤလုပ်ဆောင်ချက်သည် ယခင်ချုံ့ပြီးသားပုံများကို ချုံ့မှုရန်ပြန်ခွင့်ပေးမည်။ ပုံများကိုယ်တိုင်သည် မထိခိုက်ဘဲသည်။</string>
+    <string name="squeezer_history_clear_message">ဤလုပ်ဆောင်ချက်သည် ယခင်ချုံ့ပြီးသောဖိုင်များကို ထပ်မံချုံ့နိုင်ရန် ခွင့်ပြုမည်။ ဖိုင်များကိုယ်တိုင် မထိခိုက်ပါ။</string>
     <string name="squeezer_onboarding_title">ပုံချုံ့ခြင်း အကြောင်း</string>
     <string name="squeezer_onboarding_message">ပုံချုံ့ခြင်းသည် ဗျင်ပါးချုံ့ခြင်းဖြင့် ပုံဖိုင်အရွယ်အစားကို လျှော့ချသည်။ ဤလုပ်ဆောင်ချက်ကို ပြန်ဆွဲ၍မရ၊ မူရင်းပန်ဆွဲကို ပြန်ယူ၍မရနိုင်ပါ။\n\nသင်လာရပုံများကို မည်သို့မည်သို့:</string>
     <string name="squeezer_onboarding_original_label">မူရင်း</string>
     <string name="squeezer_onboarding_compressed_label">ချုံ့ပြီးသည်နောက်</string>
+    <string name="squeezer_onboarding_video_original_label">ဗီဒီယိုဘောင်</string>
+    <string name="squeezer_onboarding_video_compressed_label">အစမ်းကြည့်ရှုခြင်း (ခန့်မှန်းချက်)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">တကယ့်ဗီဒီယိုအရည်အသွေး ကွဲပြာရနိုင်သည်</string>
     <string name="squeezer_onboarding_quality_label">အစနအစား: %d%%</string>
     <string name="squeezer_compare_action">နှိုင်းယှဉ်ချက် ကြည့်ရန်</string>
     <string name="squeezer_no_example_found">ရွေးချယ်ထားသောလမ်းများတွင် ပုံများ မရှိပါ။</string>
-    <string name="squeezer_result_empty_message">ချုံ့နိုင်သောပုံများ မရှိပါ။</string>
-    <string name="squeezer_setup_warning">ချုံ့ခြင်းသည် သိုလှောင်မှုနေရာချွေတာရန် ပုံအရည်အသွေးကို အမြဲတမ်းလျှော့ချသည်။ ဤလုပ်ဆောင်ချက်ကို နောက်ပြန်ဆွဲ၍မရပါ။ စတင်မတိုင်မီ သင်၏ဆက်တင်များကို သေချာစစ်ဆေးပါ။</string>
-    <string name="squeezer_setup_explanation">Media Squeeze သည် သိုလှောင်မှုနေရာလွတ်ရေးအတွက် ပုံဖိုင်အရွယ်အစားကို လျှော့ချသည်။ ဤလုပ်ဆောင်ချက်သည် ပုံအရည်အသွေးကို အမြဲတမ်းလျှော့ချပြီး နောက်ပြန်ဆွဲ၍မရပါ။ စတင်မတိုင်မီ သင်၏ဆက်တင်များကို သေချာစစ်ဆေးပါ။</string>
+    <string name="squeezer_result_empty_message">ချုံ့နိုင်သောမီဒီယို မတွေ့ရှိပါ။</string>
+    <string name="squeezer_setup_warning">ချုံ့ခြင်းသည် သိုလှောင်မှုနေရာကို သက်သာစေရန် အရည်အသွေးကို ဆက်တိုက်လျှော့ချသည်။ ဤလုပ်ဆောင်ချက်ကို နောက်ကြောင်းပြောင်း၍ မရနိုင်ပါ။ စတင်မတိုင်မအစား သင်သောဆက်တင်များကို သေချားသေးသေးသေခြည့်ပါ။</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="other">%d တည်နေရာ(များ)ကို ချုံ့ရန် အသုံးမပြုသောကြောင် ဖယ်ရှားလိုက်သည်။ ချုံ့ခြင်းသည် အတွင်သိုလှောင်သို့ဆိုသို တိုက်ရိုက်ခွင့်ပြု လိုအပ်သည်။</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze သည် သိုလှောင်မှုနေရာကို လွတ်ကိင်းစေရန် ပုံများနှင့် ဗီဒီယိုများတို့အရွယ်အစားကို လျှော့ချသည်။ ဤလုပ်ဆောင်ချက်သည် အရည်အသွေးကို အမြဲတမ်းအလျှော့ချသော နောက်ကြောင်း၍ မရနိုင်ပါ။ စတင်မတိုင်မအစား သင်သောဆက်တင်များကို သေချားသေးသေးသေခြည့်ပါ။</string>
     <string name="squeezer_setup_paths_title">ရှာဖွေရမည့်နေရာများ</string>
     <string name="squeezer_setup_paths_default">ရှာဖွေမည့်ဖိုင်တွဲများ ရွေးချယ်ပါ</string>
     <string name="squeezer_setup_quality_title">ချုံ့ခြင်းအရည်အသွေး</string>
@@ -75,6 +90,6 @@
     <plurals name="squeezer_min_age_x_days">
         <item quantity="other">အနည်းဆုံး %d ရက် အနည်းဆုံးသား</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">JPEG ဖိုင်များအတွက် ~%d%% သက်သာမှု ခန့်မှန်းတွက်</string>
+    <string name="squeezer_estimated_savings_percent">ပုံများအတွက် ခန့်မှန်းချက် ~%d%% သက်သာမည်</string>
     <string name="squeezer_onboarding_got_it">နား လည်ပါပြီ</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-nb/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-nb/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Komprimer bilder for å spare lagringsplass.</string>
+    <string name="squeezer_explanation_short">Komprimer bilder og videoer for å spare lagringsplass.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d bilde funnet</item>
-        <item quantity="other">%d bilder funnet</item>
+        <item quantity="one">%d element funnet</item>
+        <item quantity="other">%d elementer funnet</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s kan spares</item>
         <item quantity="other">~%s kan spares</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d bilde komprimert</item>
-        <item quantity="other">%d bilder komprimert</item>
+        <item quantity="one">%d element komprimert</item>
+        <item quantity="other">%d elementer komprimert</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d mislyktes</item>
+        <item quantity="other">%d mislyktes</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d fil hoppet over (ikke tilgjengelig)</item>
+        <item quantity="other">%d filer hoppet over (ikke tilgjengelig)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d bilde valgt</item>
-        <item quantity="other">%d bilder valgt</item>
+        <item quantity="one">%d element valgt</item>
+        <item quantity="other">%d elementer valgt</item>
     </plurals>
     <string name="squeezer_search_locations_title">Søkeplasseringer</string>
     <string name="squeezer_search_locations_default_summary">Kameramapper (standard)</string>
     <string name="squeezer_min_size_title">Minste filstørrelse</string>
-    <string name="squeezer_min_size_description">Hopp over bilder mindre enn denne størrelsen.</string>
+    <string name="squeezer_min_size_description">Hopp over filer mindre enn denne størrelsen.</string>
     <string name="squeezer_min_age_title">Minste filens alder</string>
-    <string name="squeezer_min_age_description">Inkluder kun bilder eldre enn denne alderen.</string>
-    <string name="squeezer_compression_settings_label">Komprimeringsinnstillinger</string>
+    <string name="squeezer_min_age_description">Ta bare med filer som er eldre enn denne alderen.</string>
+    <string name="squeezer_compression_settings_label">Generelt</string>
     <string name="squeezer_quality_label">Kvalitet</string>
     <string name="squeezer_quality_title">Komprimeringskvalitet</string>
-    <string name="squeezer_quality_description">Lavere kvalitet betyr mindre filstørrelse, men redusert bildekvalitet.</string>
+    <string name="squeezer_quality_description">Lavere kvalitet betyr mindre filstørrelse, men redusert visuell kvalitet.</string>
     <string name="squeezer_quality_example_format">Eksempel: %1$s-bilde → sparer ~%2$s ved %3$d%% kvalitet</string>
     <string name="squeezer_quality_warning_low">Lavere kvalitet kan forårsake synlige artefakter.</string>
     <string name="squeezer_quality_warning_high">Svært høy kvalitet gir minimal plassbesparelse.</string>
-    <string name="squeezer_types_category_label">Bildetyper</string>
+    <string name="squeezer_types_category_label">Bildeinnstillinger</string>
+    <string name="squeezer_video_settings_category_label">Videoinnstillinger</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">Inkluder JPEG-bilder (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">Inkluder WebP-bilder (.webp).</string>
+    <string name="squeezer_type_video_title">MP4 Video</string>
+    <string name="squeezer_type_video_description">Inkluder MP4-videofiler (.mp4).</string>
     <string name="squeezer_skip_compressed_title">Hopp over allerede komprimerte</string>
-    <string name="squeezer_skip_compressed_description">Hopp over bilder som allerede er komprimert av SD Maid.</string>
+    <string name="squeezer_skip_compressed_description">Hopp over filer som allerede er komprimert av SD Maid.</string>
     <string name="squeezer_exif_marker_title">Skriv EXIF-markør</string>
     <string name="squeezer_exif_marker_description">Legg til en markør i bildets EXIF-brukerkommentarfelt for å forhindre rekomprimering selv om komprimeringshistorikken slettes.</string>
     <string name="squeezer_estimated_savings_format">~%s besparelse</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">Bekreft komprimering</string>
     <string name="squeezer_preview_total_size">Total størrelse</string>
     <string name="squeezer_preview_estimated_savings">Estimert besparelse</string>
-    <string name="squeezer_compress_confirmation_title">Komprimere bilder?</string>
-    <string name="squeezer_compress_confirmation_message">Dette vil erstatte originale bilder med komprimerte versjoner. Denne handlingen kan ikke angres.</string>
+    <string name="squeezer_compress_confirmation_title">Komprimer valgte elementer?</string>
+    <string name="squeezer_compress_confirmation_message">Dette vil erstatte originalfiler med komprimerte versjoner. Denne handlingen kan ikke angres.</string>
     <string name="squeezer_history_title">Komprimeringshistorikk</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d element (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">Ingen komprimeringshistorikk</string>
     <string name="squeezer_history_clear_title">Tøm komprimeringshistorikk</string>
-    <string name="squeezer_history_clear_message">Dette lar tidligere komprimerte bilder bli komprimert igjen. Bildene selv påvirkes ikke.</string>
+    <string name="squeezer_history_clear_message">Dette vil tillate at tidligere komprimerte filer komprimeres på nytt. Selve filene påvirkes ikke.</string>
     <string name="squeezer_onboarding_title">Om bildekomprimering</string>
     <string name="squeezer_onboarding_message">Bildekomprimering reduserer filstørrelsen ved å fjerne visuelle detaljer. Denne prosessen er irreversibel – original kvalitet kan ikke gjenopprettes.\n\nHer er en forhåndsvisning av hvordan bildene dine vil se ut:</string>
     <string name="squeezer_onboarding_original_label">Original</string>
     <string name="squeezer_onboarding_compressed_label">Etter komprimering</string>
+    <string name="squeezer_onboarding_video_original_label">Videoramme</string>
+    <string name="squeezer_onboarding_video_compressed_label">Forhåndsvisning (omtrentlig)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">Faktisk videokvalitet kan variere</string>
     <string name="squeezer_onboarding_quality_label">Kvalitet: %d%%</string>
     <string name="squeezer_compare_action">Vis sammenligning</string>
     <string name="squeezer_no_example_found">Ingen bilder funnet i valgte stier.</string>
-    <string name="squeezer_result_empty_message">Ingen komprimerbare bilder funnet.</string>
-    <string name="squeezer_setup_warning">Komprimering reduserer bildekvaliteten permanent for å spare lagringsplass. Dette kan ikke angres. Gjennomgå innstillingene nøye før du starter.</string>
-    <string name="squeezer_setup_explanation">Mediekomprimering reduserer filstørrelsen på bilder for å frigjøre lagringsplass. Dette reduserer bildekvaliteten permanent og kan ikke angres. Gjennomgå innstillingene nøye før du starter.</string>
+    <string name="squeezer_result_empty_message">Ingen komprimerbare medier funnet.</string>
+    <string name="squeezer_setup_warning">Komprimering reduserer kvaliteten permanent for å spare lagringsplass. Dette kan ikke angres. Gå nøye gjennom innstillingene dine før du starter.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d sted kan ikke brukes til komprimering og ble fjernet. Komprimering krever direkte tilgang til intern lagring.</item>
+        <item quantity="other">%d steder kan ikke brukes til komprimering og ble fjernet. Komprimering krever direkte tilgang til intern lagring.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze reduserer filstørrelsen på bilder og videoer for å frigjøre lagringsplass. Dette reduserer kvaliteten permanent og kan ikke angres. Gå nøye gjennom innstillingene dine før du starter.</string>
     <string name="squeezer_setup_paths_title">Søkeplasseringer</string>
     <string name="squeezer_setup_paths_default">Velg mapper å søke i</string>
     <string name="squeezer_setup_quality_title">Komprimeringskvalitet</string>
@@ -81,6 +99,6 @@
         <item quantity="one">Minst %d dag gammel</item>
         <item quantity="other">Minst %d dager gammel</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">Estimert ~%d%% besparelse for JPEG-filer</string>
+    <string name="squeezer_estimated_savings_percent">Estimert ~%d%% sparing for bilder</string>
     <string name="squeezer_onboarding_got_it">Forstått</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-ne-rNP/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-ne-rNP/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">भण्डारण स्थान बचाउन छविहरू संकुचित गर्नुहोस्।</string>
+    <string name="squeezer_explanation_short">भण्डारण स्थान बचत गर्न छविहरू र भिडियोहरू सम्पीडन गर्नुहोस्।</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d छवि फेला पर्यो</item>
-        <item quantity="other">%d छविहरू फेला परिए</item>
+        <item quantity="one">%d वस्तु फेला परियो</item>
+        <item quantity="other">%d वस्तुहरू फेला परिए</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s बचाउन सकिन्छ</item>
         <item quantity="other">~%s बचाउन सकिन्छ</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d छवि संकुचित गरियो</item>
-        <item quantity="other">%d छविहरू संकुचित गरिए</item>
+        <item quantity="one">%d वस्तु सम्पीडन गरियो</item>
+        <item quantity="other">%d वस्तुहरू सम्पीडन गरिए</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d असफल</item>
+        <item quantity="other">%d असफल</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d फाइल छोडियो (पहुँचयोग्य छैन)</item>
+        <item quantity="other">%d फाइलहरू छोडिए (पहुँचयोग्य छैन)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d छवि चयन गरियो</item>
-        <item quantity="other">%d छविहरू चयन गरिए</item>
+        <item quantity="one">%d वस्तु चयन गरियो</item>
+        <item quantity="other">%d वस्तुहरू चयन गरिए</item>
     </plurals>
     <string name="squeezer_search_locations_title">खोज स्थानहरू</string>
     <string name="squeezer_search_locations_default_summary">क्यामेरा फोल्डरहरू (पूर्वनिर्धारित)</string>
     <string name="squeezer_min_size_title">न्यूनतम फाइल आकार</string>
-    <string name="squeezer_min_size_description">यस आकारभन्दा साना छविहरू छोड्नुहोस्।</string>
+    <string name="squeezer_min_size_description">यो आकारभन्दा साना फाइलहरू छोड्नुहोस्।</string>
     <string name="squeezer_min_age_title">न्यूनतम फाइल उमेर</string>
-    <string name="squeezer_min_age_description">यस उमेरभन्दा पुराना छविहरू मात्र समावेश गर्नुहोस्।</string>
-    <string name="squeezer_compression_settings_label">संकुचन सेटिङ्गहरू</string>
+    <string name="squeezer_min_age_description">यो उमेरभन्दा पुराना फाइलहरू मात्र समावेश गर्नुहोस्।</string>
+    <string name="squeezer_compression_settings_label">सामान्य</string>
     <string name="squeezer_quality_label">गुणस्तर</string>
     <string name="squeezer_quality_title">संकुचन गुणस्तर</string>
-    <string name="squeezer_quality_description">न्यून गुणस्तरको अर्थ सानो फाइल आकार तर घटेको छवि गुणस्तर हो।</string>
+    <string name="squeezer_quality_description">कम गुणस्तरको अर्थ सानो फाइल आकार तर घटेको दृश्य गुणस्तर हो।</string>
     <string name="squeezer_quality_example_format">उदाहरण: %1$s छवि → %3$d%% गुणस्तरमा ~%2$s बचत गर्छ</string>
     <string name="squeezer_quality_warning_low">न्यून गुणस्तरले दृश्यमान कलाकृतिहरू निम्त्याउन सक्छ।</string>
     <string name="squeezer_quality_warning_high">अत्यधिक उच्च गुणस्तरले न्यूनतम स्थान बचत प्रदान गर्छ।</string>
-    <string name="squeezer_types_category_label">छवि प्रकारहरू</string>
+    <string name="squeezer_types_category_label">छवि सेटिङहरू</string>
+    <string name="squeezer_video_settings_category_label">भिडियो सेटिङहरू</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">JPEG छविहरू (.jpg, .jpeg) समावेश गर्नुहोस्।</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">WebP छविहरू (.webp) समावेश गर्नुहोस्।</string>
+    <string name="squeezer_type_video_title">MP4 भिडियो</string>
+    <string name="squeezer_type_video_description">MP4 भिडियो फाइलहरू (.mp4) समावेश गर्नुहोस्।</string>
     <string name="squeezer_skip_compressed_title">पहिले संकुचित गरिएकाहरू छोड्नुहोस्</string>
-    <string name="squeezer_skip_compressed_description">SD Maid द्वारा पहिले नै संकुचित गरिएका छविहरू छोड्नुहोस्।</string>
+    <string name="squeezer_skip_compressed_description">SD Maid द्वारा पहिले नै सम्पीडन गरिएका फाइलहरू छोड्नुहोस्।</string>
     <string name="squeezer_exif_marker_title">EXIF मार्कर लेख्नुहोस्</string>
     <string name="squeezer_exif_marker_description">संकुचन इतिहास सफा गरिएमा पनि पुनः संकुचन हुन नदिन छविको EXIF प्रयोगकर्ता तप्पर क्षेत्रमा मार्कर जोड्नुहोस्।</string>
     <string name="squeezer_estimated_savings_format">~%s बचत</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">संकुचन पुष्टि गर्नुहोस्</string>
     <string name="squeezer_preview_total_size">कुल आकार</string>
     <string name="squeezer_preview_estimated_savings">अनुमानित बचत</string>
-    <string name="squeezer_compress_confirmation_title">छविहरू संकुचित गर्नुहोस्?</string>
-    <string name="squeezer_compress_confirmation_message">यसले मूल छविहरूलाई संकुचित संस्करणहरूसँग प्रतिस्थापन गर्नेछ। यो कार्य पूर्ववत गर्न सकिँदैन।</string>
+    <string name="squeezer_compress_confirmation_title">चयन गरिएका वस्तुहरू सम्पीडन गर्ने?</string>
+    <string name="squeezer_compress_confirmation_message">यसले मूल फाइलहरूलाई सम्पीडन गरिएका संस्करणहरूले प्रतिस्थापन गर्नेछ। यो कार्य पूर्ववत् गर्न सकिँदैन।</string>
     <string name="squeezer_history_title">संकुचन इतिहास</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">1 वस्तु (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">कुनै संकुचन इतिहास छैन</string>
     <string name="squeezer_history_clear_title">संकुचन इतिहास सफा गर्नुहोस्</string>
-    <string name="squeezer_history_clear_message">यसले पहिले संकुचित छविहरूलाई फिरि संकुचित गर्न अनुमति दिनेछ। छविहरू आफैं प्रभावित हुँदैनन्।</string>
+    <string name="squeezer_history_clear_message">यसले पहिले सम्पीडन गरिएका फाइलहरूलाई फेरि सम्पीडन गर्न अनुमति दिनेछ। फाइलहरू आफैंमा प्रभावित हुँदैनन्।</string>
     <string name="squeezer_onboarding_title">छवि संकुचन बारे</string>
     <string name="squeezer_onboarding_message">छवि संकुचनले दृश्य विवरण हटाेर फाइल आकार घटाउँछ। यो प्रक्रिया अपरिवर्तनीय छ - मूल गुणस्तर पुनः स्थापन गर्न सकिँदैन।\n\nतपाईंका छविहरू कस्तो देखिनेछन् भन्ने पूर्वावलोकन:</string>
     <string name="squeezer_onboarding_original_label">मूल</string>
     <string name="squeezer_onboarding_compressed_label">संकुचनपछि</string>
+    <string name="squeezer_onboarding_video_original_label">भिडियो फ्रेम</string>
+    <string name="squeezer_onboarding_video_compressed_label">पूर्वावलोकन (अनुमानित)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">वास्तविक भिडियो गुणस्तर फरक हुन सक्छ</string>
     <string name="squeezer_onboarding_quality_label">गुणस्तर: %d%%</string>
     <string name="squeezer_compare_action">तुलना हेर्नुहोस्</string>
     <string name="squeezer_no_example_found">चयनित पाथहरूमा कुनै छवि फेला परेन।</string>
-    <string name="squeezer_result_empty_message">कुनै संकुचन योग्य छवि फेला परेन।</string>
-    <string name="squeezer_setup_warning">संकुचनले भण्डारण स्थान बचाउन छवि गुणस्तरलाई स्थायी रूपमा घटाउँछ। यो पूर्ववत गर्न सकिँदैन। सुरु गर्नु अगाडि तपाईंको सेटिङ्गहरू सावधानीपूर्वक समीक्षा गर्नुहोस्।</string>
-    <string name="squeezer_setup_explanation">Media Squeeze ले भण्डारण स्थान खाली गर्न छविहरूको फाइल आकार घटाउँछ। यसले छवि गुणस्तरलाई स्थायी रूपमा घटाउँछ र पूर्ववत गर्न सकिँदैन। सुरु गर्नु अगाडि तपाईंको सेटिङ्गहरू सावधानीपूर्वक समीक्षा गर्नुहोस्।</string>
+    <string name="squeezer_result_empty_message">कुनै सम्पीडन गर्न मिल्ने मिडिया फेला परेन।</string>
+    <string name="squeezer_setup_warning">सम्पीडनले भण्डारण स्थान बचत गर्न गुणस्तर स्थायी रूपमा घटाउँछ। यो पूर्ववत् गर्न सकिँदैन। सुरु गर्नुअघि आफ्नो सेटिङहरू ध्यानपूर्वक समीक्षा गर्नुहोस्।</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d स्थान सम्पीडनका लागि प्रयोग गर्न सकिँदैन र हटाइयो। सम्पीडनका लागि आन्तरिक भण्डारणमा प्रत्यक्ष पहुँच आवश्यक छ।</item>
+        <item quantity="other">%d स्थानहरू सम्पीडनका लागि प्रयोग गर्न सकिँदैन र हटाइए। सम्पीडनका लागि आन्तरिक भण्डारणमा प्रत्यक्ष पहुँच आवश्यक छ।</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">मिडिया स्क्वीज भण्डारण स्थान मुक्त गर्न छवि र भिडियोहरूको फाइल आकार घटाउँछ। यसले गुणस्तर स्थायी रूपमा घटाउँछ र यो पूर्ववत् गर्न सकिँदैन। सुरु गर्नुअघि आफ्नो सेटिङहरू ध्यानपूर्वक समीक्षा गर्नुहोस्।</string>
     <string name="squeezer_setup_paths_title">खोज स्थानहरू</string>
     <string name="squeezer_setup_paths_default">खोज गर्नका लागि फोल्डरहरू चयन गर्नुहोस्</string>
     <string name="squeezer_setup_quality_title">संकुचन गुणस्तर</string>
@@ -81,6 +99,6 @@
         <item quantity="one">कम्तिमा %d दिन पुरानो</item>
         <item quantity="other">कम्तिमा %d दिन पुरानो</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">JPEG फाइलहरूको लागि अनुमानित ~%d%% बचत</string>
+    <string name="squeezer_estimated_savings_percent">छविहरूका लागि अनुमानित ~%d%% बचत</string>
     <string name="squeezer_onboarding_got_it">ठिक छ</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-nl/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-nl/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Comprimeer afbeeldingen om opslagruimte te besparen.</string>
+    <string name="squeezer_explanation_short">Comprimeer afbeeldingen en video\'s om opslagruimte te besparen.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d afbeelding gevonden</item>
-        <item quantity="other">%d afbeeldingen gevonden</item>
+        <item quantity="one">%d item gevonden</item>
+        <item quantity="other">%d items gevonden</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s kan worden bespaard</item>
         <item quantity="other">~%s kan worden bespaard</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d afbeelding gecomprimeerd</item>
-        <item quantity="other">%d afbeeldingen gecomprimeerd</item>
+        <item quantity="one">%d item gecomprimeerd</item>
+        <item quantity="other">%d items gecomprimeerd</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d mislukt</item>
+        <item quantity="other">%d mislukt</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d bestand overgeslagen (niet toegankelijk)</item>
+        <item quantity="other">%d bestanden overgeslagen (niet toegankelijk)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d afbeelding geselecteerd</item>
-        <item quantity="other">%d afbeeldingen geselecteerd</item>
+        <item quantity="one">%d item geselecteerd</item>
+        <item quantity="other">%d items geselecteerd</item>
     </plurals>
     <string name="squeezer_search_locations_title">Zoek locaties</string>
     <string name="squeezer_search_locations_default_summary">Cameramappen (standaard)</string>
     <string name="squeezer_min_size_title">Minimale bestandsgrootte</string>
-    <string name="squeezer_min_size_description">Sla afbeeldingen over die kleiner zijn dan deze grootte.</string>
+    <string name="squeezer_min_size_description">Sla bestanden over die kleiner zijn dan deze grootte.</string>
     <string name="squeezer_min_age_title">Minimale bestandsleeftijd</string>
-    <string name="squeezer_min_age_description">Alleen afbeeldingen ouder dan deze leeftijd opnemen.</string>
-    <string name="squeezer_compression_settings_label">Compressie-instellingen</string>
+    <string name="squeezer_min_age_description">Alleen bestanden ouder dan deze leeftijd opnemen.</string>
+    <string name="squeezer_compression_settings_label">Algemeen</string>
     <string name="squeezer_quality_label">Kwaliteit</string>
     <string name="squeezer_quality_title">Compressiekwaliteit</string>
-    <string name="squeezer_quality_description">Lagere kwaliteit betekent kleinere bestandsgrootte maar verminderde beeldkwaliteit.</string>
+    <string name="squeezer_quality_description">Lagere kwaliteit betekent kleinere bestandsgrootte maar verminderde visuele kwaliteit.</string>
     <string name="squeezer_quality_example_format">Voorbeeld: %1$s afbeelding → bespaart ~%2$s bij %3$d%% kwaliteit</string>
     <string name="squeezer_quality_warning_low">Lagere kwaliteiten kunnen zichtbare artefacten veroorzaken.</string>
     <string name="squeezer_quality_warning_high">Zeer hoge kwaliteit biedt minimale ruimtebesparing.</string>
-    <string name="squeezer_types_category_label">Afbeeldingstypen</string>
+    <string name="squeezer_types_category_label">Afbeeldingsinstellingen</string>
+    <string name="squeezer_video_settings_category_label">Video-instellingen</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">Voeg JPEG-afbeeldingen (.jpg, .jpeg) toe.</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">Voeg WebP-afbeeldingen (.webp) toe.</string>
+    <string name="squeezer_type_video_title">MP4 Video</string>
+    <string name="squeezer_type_video_description">Inclusief MP4-videobestanden (.mp4).</string>
     <string name="squeezer_skip_compressed_title">Eerder gecomprimeerd overslaan</string>
-    <string name="squeezer_skip_compressed_description">Sla afbeeldingen over die al door SD Maid zijn gecomprimeerd.</string>
+    <string name="squeezer_skip_compressed_description">Sla bestanden over die al door SD Maid zijn gecomprimeerd.</string>
     <string name="squeezer_exif_marker_title">EXIF-markering schrijven</string>
     <string name="squeezer_exif_marker_description">Voeg een markering toe aan het EXIF-opmerkingenveld van de afbeelding om hercompressie te voorkomen, zelfs als de compressiegeschiedenis wordt gewist.</string>
     <string name="squeezer_estimated_savings_format">~%s besparing</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">Compressie bevestigen</string>
     <string name="squeezer_preview_total_size">Totale grootte</string>
     <string name="squeezer_preview_estimated_savings">Geschatte besparing</string>
-    <string name="squeezer_compress_confirmation_title">Afbeeldingen comprimeren?</string>
-    <string name="squeezer_compress_confirmation_message">Dit vervangt originele afbeeldingen door gecomprimeerde versies. Deze actie kan niet ongedaan worden gemaakt.</string>
+    <string name="squeezer_compress_confirmation_title">Geselecteerde items comprimeren?</string>
+    <string name="squeezer_compress_confirmation_message">Dit vervangt originele bestanden door gecomprimeerde versies. Deze actie kan niet ongedaan worden gemaakt.</string>
     <string name="squeezer_history_title">Compressiegeschiedenis</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d item (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">Geen compressiegeschiedenis</string>
     <string name="squeezer_history_clear_title">Compressiegeschiedenis wissen</string>
-    <string name="squeezer_history_clear_message">Dit maakt het mogelijk om eerder gecomprimeerde afbeeldingen opnieuw te comprimeren. De afbeeldingen zelf worden niet beïnvloed.</string>
+    <string name="squeezer_history_clear_message">Dit maakt het mogelijk om eerder gecomprimeerde bestanden opnieuw te comprimeren. De bestanden zelf worden niet beïnvloed.</string>
     <string name="squeezer_onboarding_title">Over beeldcompressie</string>
     <string name="squeezer_onboarding_message">Beeldcompressie verkleint het bestand door visueel detail te verwijderen. Dit proces is onomkeerbaar - de originele kwaliteit kan niet worden hersteld.\n\nHier is een voorbeeld van hoe je afbeeldingen eruit zullen zien:</string>
     <string name="squeezer_onboarding_original_label">Origineel</string>
     <string name="squeezer_onboarding_compressed_label">Na compressie</string>
+    <string name="squeezer_onboarding_video_original_label">Videoframe</string>
+    <string name="squeezer_onboarding_video_compressed_label">Voorbeeld (bij benadering)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">Werkelijke videokwaliteit kan afwijken</string>
     <string name="squeezer_onboarding_quality_label">Kwaliteit: %d%%</string>
     <string name="squeezer_compare_action">Bekijk de vergelijking</string>
     <string name="squeezer_no_example_found">Geen afbeeldingen gevonden in geselecteerde paden.</string>
-    <string name="squeezer_result_empty_message">Geen comprimeerbare afbeeldingen gevonden.</string>
-    <string name="squeezer_setup_warning">Compressie vermindert permanent de beeldkwaliteit om opslagruimte te besparen. Dit kan niet ongedaan worden gemaakt. Controleer je instellingen zorgvuldig voordat je begint.</string>
-    <string name="squeezer_setup_explanation">Media Squeeze verkleint de bestandsgrootte van afbeeldingen om opslagruimte vrij te maken. Dit vermindert permanent de beeldkwaliteit en kan niet ongedaan worden gemaakt. Controleer je instellingen zorgvuldig voordat je begint.</string>
+    <string name="squeezer_result_empty_message">Geen comprimeerbare media gevonden.</string>
+    <string name="squeezer_setup_warning">Compressie vermindert de kwaliteit permanent om opslagruimte te besparen. Dit kan niet ongedaan worden gemaakt. Controleer uw instellingen zorgvuldig voor u begint.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d locatie kan niet worden gebruikt voor compressie en is verwijderd. Compressie vereist directe toegang tot de interne opslag.</item>
+        <item quantity="other">%d locaties kunnen niet worden gebruikt voor compressie en zijn verwijderd. Compressie vereist directe toegang tot de interne opslag.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze verkleint de bestandsgrootte van afbeeldingen en video\'s om opslagruimte vrij te maken. Dit vermindert de kwaliteit permanent en kan niet ongedaan worden gemaakt. Controleer uw instellingen zorgvuldig voor u begint.</string>
     <string name="squeezer_setup_paths_title">Zoek locaties</string>
     <string name="squeezer_setup_paths_default">Selecteer mappen om te doorzoeken</string>
     <string name="squeezer_setup_quality_title">Compressiekwaliteit</string>
@@ -81,6 +99,6 @@
         <item quantity="one">Minstens %d dag oud</item>
         <item quantity="other">Minstens %d dagen oud</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">Geschatte ~%d%% besparing voor JPEG-bestanden</string>
+    <string name="squeezer_estimated_savings_percent">Geschatte ~%d%% besparing voor afbeeldingen</string>
     <string name="squeezer_onboarding_got_it">Begrepen</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-or-rIN/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-or-rIN/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">ଷ୍ଟୋରେଜ୍ ସ୍ଥାନ ସଞ୍ଚୟ ପାଇଁ ଚିତ୍ର ସଙ୍କୋଚନ କରନ୍ତୁ।</string>
+    <string name="squeezer_explanation_short">ଷ୍ଟୋରେଜ ସ୍ଥାନ ସଞ୍ଚୟ କରିବାକୁ ଚିତ୍ର ଏବଂ ଭିଡ଼ିଓ ସଙ୍କୁଚିତ କରନ୍ତୁ।</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d ଚିତ୍ର ମିଳିଲା</item>
-        <item quantity="other">%d ଚିତ୍ରଗୁଡିକ ମିଳିଲା</item>
+        <item quantity="one">%d ଆଇଟମ ମିଳିଲା</item>
+        <item quantity="other">%d ଆଇଟମ ମିଳିଲା</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s ସଞ୍ଚୟ କରିହେବ</item>
         <item quantity="other">~%s ସଞ୍ଚୟ କରିହେବ</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d ଚିତ୍ର ସଙ୍କୋଚିତ</item>
-        <item quantity="other">%d ଚିତ୍ରଗୁଡିକ ସଙ୍କୋଚିତ</item>
+        <item quantity="one">%d ଆଇଟମ ସଙ୍କୁଚିତ ହେଲା</item>
+        <item quantity="other">%d ଆଇଟମ ସଙ୍କୁଚିତ ହେଲା</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d ବିଫଳ</item>
+        <item quantity="other">%d ବିଫଳ</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d ଫାଇଲ ଛଡ଼ାଇ ଦିଆଗଲା (ଆକ୍ସେସ ଯୋଗ୍ୟ ନୁହେଁ)</item>
+        <item quantity="other">%d ଫାଇଲ ଛଡ଼ାଇ ଦିଆଗଲା (ଆକ୍ସେସ ଯୋଗ୍ୟ ନୁହେଁ)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d ଚିତ୍ର ଚୟନ ହୋଇଛି</item>
-        <item quantity="other">%d ଚିତ୍ରଗୁଡିକ ଚୟନ ହୋଇଛି</item>
+        <item quantity="one">%d ଆଇଟମ ମନୋନୀତ</item>
+        <item quantity="other">%d ଆଇଟମ ମନୋନୀତ</item>
     </plurals>
     <string name="squeezer_search_locations_title">ଖୋଜ ସ୍ଥାନ</string>
     <string name="squeezer_search_locations_default_summary">କ୍ୟାମେରା ଫୋଲ୍ଡର (ଡିଫଲ୍ଟ)</string>
     <string name="squeezer_min_size_title">ସର୍ବନିମ୍ନ ଫାଇଲ୍ ଆକାର</string>
-    <string name="squeezer_min_size_description">ଏହି ଆକାରଠାରୁ ଛୋଟ ଚିତ୍ର ଛାଡନ୍ତୁ।</string>
+    <string name="squeezer_min_size_description">ଏହି ଆକାରରୁ ଛୋଟ ଫାଇଲ ଛଡ଼ାଇ ଦିଅନ୍ତୁ।</string>
     <string name="squeezer_min_age_title">ସର୍ବନିମ୍ନ ଫାଇଲ୍ ବୟସ</string>
-    <string name="squeezer_min_age_description">କେବଳ ଏହି ବୟସଠାରୁ ପୁରୁଣା ଚିତ୍ର ଅନ୍ତର୍ଭୁକ୍ତ କରନ୍ତୁ।</string>
-    <string name="squeezer_compression_settings_label">ସଙ୍କୋଚନ ସେଟିଂସ</string>
+    <string name="squeezer_min_age_description">କେବଳ ଏହି ବୟସରୁ ପୁରୁଣା ଫାଇଲ ଅନ୍ତର୍ଭୁକ୍ତ କରନ୍ତୁ।</string>
+    <string name="squeezer_compression_settings_label">ସାଧାରଣ</string>
     <string name="squeezer_quality_label">ଗୁଣବତ୍ତା</string>
     <string name="squeezer_quality_title">ସଙ୍କୋଚନ ଗୁଣବତ୍ତା</string>
-    <string name="squeezer_quality_description">କମ୍ ଗୁଣବତ୍ତା ମାନେ ଛୋଟ ଫାଇଲ୍ ଆକାର କିନ୍ତୁ ଚିତ୍ର ଗୁଣବତ୍ତା ହ୍ରାସ।</string>
+    <string name="squeezer_quality_description">କମ ଗୁଣମାନ ମାନେ ଛୋଟ ଫାଇଲ ଆକାର କିନ୍ତୁ ଦୃଶ୍ୟ ଗୁଣମାନ ହ୍ରାସ ପାଏ।</string>
     <string name="squeezer_quality_example_format">ଉଦାହରଣ: %1$s ଚିତ୍ର → %3$d%% ଗୁଣବତ୍ତାରେ ~%2$s ସଞ୍ଚୟ</string>
     <string name="squeezer_quality_warning_low">କମ୍ ଗୁଣବତ୍ତା ଦୃଶ୍ୟମାନ ତ୍ରୁଟି ସୃଷ୍ଟି କରିପାରେ।</string>
     <string name="squeezer_quality_warning_high">ଅତ୍ୟଧିକ ଉଚ୍ଚ ଗୁଣବତ୍ତା ସର୍ବନିମ୍ନ ସ୍ଥାନ ସଞ୍ଚୟ ପ୍ରଦାନ କରେ।</string>
-    <string name="squeezer_types_category_label">ଚିତ୍ର ପ୍ରକାର</string>
+    <string name="squeezer_types_category_label">ଚିତ୍ର ସେଟିଂସ</string>
+    <string name="squeezer_video_settings_category_label">ଭିଡ଼ିଓ ସେଟିଂସ</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">JPEG ଚିତ୍ର (.jpg, .jpeg) ଅନ୍ତର୍ଭୁକ୍ତ କରନ୍ତୁ।</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">WebP ଚିତ୍ର (.webp) ଅନ୍ତର୍ଭୁକ୍ତ କରନ୍ତୁ।</string>
+    <string name="squeezer_type_video_title">MP4 ଭିଡ଼ିଓ</string>
+    <string name="squeezer_type_video_description">MP4 ଭିଡ଼ିଓ ଫାଇଲ (.mp4) ଅନ୍ତର୍ଭୁକ୍ତ କରନ୍ତୁ।</string>
     <string name="squeezer_skip_compressed_title">ପୂର୍ବରୁ ସଙ୍କୋଚିତ ଛାଡନ୍ତୁ</string>
-    <string name="squeezer_skip_compressed_description">SD Maid ଦ୍ୱାରା ପୂର୍ବରୁ ସଙ୍କୋଚିତ ହୋଇଥିବା ଚିତ୍ର ଛାଡନ୍ତୁ।</string>
+    <string name="squeezer_skip_compressed_description">SD Maid ଦ୍ଵାରା ଈତିମଧ୍ୟେ ସଙ୍କୁଚିତ ଫାଇଲ ଛଡ଼ାଇ ଦିଅନ୍ତୁ।</string>
     <string name="squeezer_exif_marker_title">EXIF ମାର୍କର ଲେଖନ୍ତୁ</string>
     <string name="squeezer_exif_marker_description">ସଙ୍କୋଚନ ଇତିହାସ ସଫା ହେଲେ ମଧ୍ୟ ପୁନଃ-ସଙ୍କୋଚନ ରୋକିବା ପାଇଁ ଚିତ୍ରର EXIF ବ୍ୟବହାରକାରୀ ମନ୍ତବ୍ୟ କ୍ଷେତ୍ରରେ ଏକ ମାର୍କର ଯୋଡନ୍ତୁ।</string>
     <string name="squeezer_estimated_savings_format">~%s ସଞ୍ଚୟ</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">ସଙ୍କୋଚନ ନିଶ୍ଚିତ କରନ୍ତୁ</string>
     <string name="squeezer_preview_total_size">ମୋଟ ଆକାର</string>
     <string name="squeezer_preview_estimated_savings">ଆନୁମାନିକ ସଞ୍ଚୟ</string>
-    <string name="squeezer_compress_confirmation_title">ଚିତ୍ର ସଙ୍କୋଚନ କରିବେ?</string>
-    <string name="squeezer_compress_confirmation_message">ଏହା ମୂଳ ଚିତ୍ରଗୁଡିକୁ ସଙ୍କୋଚିତ ସଂସ୍କରଣ ସହ ବଦଳାଇବ। ଏହି କାର୍ଯ୍ୟ ପ୍ରତ୍ୟାବର୍ତ୍ତନ ଯୋଗ୍ୟ ନୁହେଁ।</string>
+    <string name="squeezer_compress_confirmation_title">ମନୋନୀତ ଆଇଟମ ସଙ୍କୁଚିତ କରିବେ?</string>
+    <string name="squeezer_compress_confirmation_message">ଏହା ମିଳ ଫାଇଲ ସ୍ଥାନରେ ସଙ୍କୁଚିତ ସଂସ୍କରଣ ରଖିବ। ଏହି କ୍ରିୟା ପୂର୍ବବତ୍ ହୋଇ ପାରିବ ନାହିଁ।</string>
     <string name="squeezer_history_title">ସଙ୍କୋଚନ ଇତିହାସ</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d ଆଇଟମ୍ (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">କୌଣସି ସଙ୍କୋଚନ ଇତିହାସ ନାହିଁ</string>
     <string name="squeezer_history_clear_title">ସଙ୍କୋଚନ ଇତିହାସ ସଫା କରନ୍ତୁ</string>
-    <string name="squeezer_history_clear_message">ଏହା ପୂର୍ବରୁ ସଙ୍କୋଚିତ ଚିତ୍ରଗୁଡିକୁ ପୁନଃ ସଙ୍କୋଚନ ହେବାକୁ ଅନୁମତି ଦେବ। ଚିତ୍ରଗୁଡିକ ନିଜେ ପ୍ରଭାବିତ ହୁଅନ୍ତି ନାହିଁ।</string>
+    <string name="squeezer_history_clear_message">ଏହା ପୂର୍ବରୁ ସଙ୍କୁଚିତ ଫାଇଲ ପୁଣି ସଙ୍କୁଚିତ ହେବାର ସୁୟୋଗ ଦେବ। ଫାଇଲ ନିଜେ ପ୍ରଭାଵିତ ହୁଏ ନାହିଁ।</string>
     <string name="squeezer_onboarding_title">ଚିତ୍ର ସଙ୍କୋଚନ ବିଷୟରେ</string>
     <string name="squeezer_onboarding_message">ଚିତ୍ର ସଙ୍କୋଚନ ଦୃଶ୍ୟ ବିବରଣୀ ଅପସାରଣ କରି ଫାଇଲ୍ ଆକାର ହ୍ରାସ କରେ। ଏହି ପ୍ରକ୍ରିୟା ଅପ୍ରତ୍ୟାବର୍ତ୍ତନୀୟ - ମୂଳ ଗୁଣବତ୍ତା ପୁନଃସ୍ଥାପିତ ହୋଇପାରିବ ନାହିଁ।\n\nଆପଣଙ୍କ ଚିତ୍ରଗୁଡିକ କିପରି ଦେଖାଯିବ ତାହାର ଏକ ପୂର୍ବାବଲୋକନ ଏଠାରେ ଅଛି:</string>
     <string name="squeezer_onboarding_original_label">ମୂଳ</string>
     <string name="squeezer_onboarding_compressed_label">ସଙ୍କୋଚନ ପରେ</string>
+    <string name="squeezer_onboarding_video_original_label">ଭିଡ଼ିଓ ଫ୍ରେମ</string>
+    <string name="squeezer_onboarding_video_compressed_label">ପୂର୍ବାବଲୋକନ (ଆନୁମାନିକ)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">ପ୍ରକୃତ ଭିଡ଼ିଓ ଗୁଣମାନ ଭିନ୍ନ ହୋଇ ପାରେ</string>
     <string name="squeezer_onboarding_quality_label">ଗୁଣବତ୍ତା: %d%%</string>
     <string name="squeezer_compare_action">ତୁଳନା ଦେଖନ୍ତୁ</string>
     <string name="squeezer_no_example_found">ଚୟନ ହୋଇଥିବା ପଥରେ କୌଣସି ଚିତ୍ର ମିଳିଲା ନାହିଁ।</string>
-    <string name="squeezer_result_empty_message">କୌଣସି ସଙ୍କୋଚନଯୋଗ୍ୟ ଚିତ୍ର ମିଳିଲା ନାହିଁ।</string>
-    <string name="squeezer_setup_warning">ସଙ୍କୋଚନ ଷ୍ଟୋରେଜ୍ ସ୍ଥାନ ସଞ୍ଚୟ ପାଇଁ ସ୍ଥାୟୀ ଭାବରେ ଚିତ୍ର ଗୁଣବତ୍ତା ହ୍ରାସ କରେ। ଏହା ପ୍ରତ୍ୟାବର୍ତ୍ତନ ଯୋଗ୍ୟ ନୁହେଁ। ଆରମ୍ଭ କରିବା ପୂର୍ବରୁ ଆପଣଙ୍କ ସେଟିଂସ ଯତ୍ନର ସହ ସମୀକ୍ଷା କରନ୍ତୁ।</string>
-    <string name="squeezer_setup_explanation">ମିଡିଆ ସ୍କ୍ୱିଜ୍ ଷ୍ଟୋରେଜ୍ ସ୍ଥାନ ମୁକ୍ତ କରିବା ପାଇଁ ଚିତ୍ର ଫାଇଲ୍ ଆକାର ହ୍ରାସ କରେ। ଏହା ସ୍ଥାୟୀ ଭାବରେ ଚିତ୍ର ଗୁଣବତ୍ତା ହ୍ରାସ କରେ ଏବଂ ପ୍ରତ୍ୟାବର୍ତ୍ତନ ଯୋଗ୍ୟ ନୁହେଁ। ଆରମ୍ଭ କରିବା ପୂର୍ବରୁ ଆପଣଙ୍କ ସେଟିଂସ ଯତ୍ନର ସହ ସମୀକ୍ଷା କରନ୍ତୁ।</string>
+    <string name="squeezer_result_empty_message">କୌଣସି ସଙ୍କୁଚିତ ଯୋଗ୍ୟ ମିଡ଼ିଆ ମିଳିଲା ନାହିଁ।</string>
+    <string name="squeezer_setup_warning">ସଙ୍କୋଚନ ଷ୍ଟୋରେଜ ସ୍ଥାନ ସଞ୍ଚୟ କରିବାକୁ ଗୁଣମାନ ସ୍ଥାୟୀଭାବେ ହ୍ରାସ କରେ। ଏହା ପୂର୍ବବତ୍ ହୋଇ ପାରିବ ନାହିଁ। ଆରମ୍ଭ କରିବା ପୂର୍ବରୁ ଆପଣଙ୍କ ସେଟିଂସ ୟତ୍ନ ସହ ୟାଞ୍ଚ କରନ୍ତୁ।</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d ଅବସ୍ଥାନ ସଙ୍କୋଚନ ପାଇଁ ବ୍ୟବହାର ହୋଇ ପାରିବ ନାହିଁ ଏବଂ ହଟାଇ ଦିଆଗଲା। ସଙ୍କୋଚନ ପାଇଁ ଆଭ୍ୟନ୍ତରୀଣ ଷ୍ଟୋରେଜରେ ସିଧା ପ୍ରବେଶ ଆବଶ୍ୟକ।</item>
+        <item quantity="other">%d ଅବସ୍ଥାନ ସଙ୍କୋଚନ ପାଇଁ ବ୍ୟବହାର ହୋଇ ପାରିବ ନାହିଁ ଏବଂ ହଟାଇ ଦିଆଗଲା। ସଙ୍କୋଚନ ପାଇଁ ଆଭ୍ୟନ୍ତରୀଣ ଷ୍ଟୋରେଜରେ ସିଧା ପ୍ରବେଶ ଆବଶ୍ୟକ।</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">ମିଡ଼ିଆ ସ୍କ୍ୟୁଇଜ ଷ୍ଟୋରେଜ ସ୍ଥାନ ମୁକ୍ତ କରିବାକୁ ଚିତ୍ର ଏବଂ ଭିଡ଼ିଓ ଫାଇଲ ଆକାର ହ୍ରାସ କରେ। ଏହା ଗୁଣମାନ ସ୍ଥାୟୀଭାବେ ହ୍ରାସ କରେ ଏବଂ ପୂର୍ବବତ୍ ହୋଇ ପାରିବ ନାହିଁ। ଆରମ୍ଭ କରିବା ପୂର୍ବରୁ ଆପଣଙ୍କ ସେଟିଂସ ୟତ୍ନ ସହ ୟାଞ୍ଚ କରନ୍ତୁ।</string>
     <string name="squeezer_setup_paths_title">ଖୋଜ ସ୍ଥାନ</string>
     <string name="squeezer_setup_paths_default">ଖୋଜିବା ପାଇଁ ଫୋଲ୍ଡର ଚୟନ କରନ୍ତୁ</string>
     <string name="squeezer_setup_quality_title">ସଙ୍କୋଚନ ଗୁଣବତ୍ତା</string>
@@ -81,6 +99,6 @@
         <item quantity="one">ଅତିକମରେ %d ଦିନ ପୁରୁଣା</item>
         <item quantity="other">ଅତିକମରେ %d ଦିନ ପୁରୁଣା</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">JPEG ଫାଇଲ୍ ପାଇଁ ଆନୁମାନିକ ~%d%% ସଞ୍ଚୟ</string>
+    <string name="squeezer_estimated_savings_percent">ଚିତ୍ର ପାଇଁ ଅନୁମାନିତ ~%d%% ସଞ୍ଚୟ</string>
     <string name="squeezer_onboarding_got_it">ବୁଝିଗଲି</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-pa-rIN/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-pa-rIN/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">ਸਟੋਰੇਜ ਬਚਾਉਣ ਲਈ ਤਸਵੀਰਾਂ ਨੂੰ ਕੰਪ੍ਰੈਸ ਕਰੋ।</string>
+    <string name="squeezer_explanation_short">ਸਟੋਰੇਜ ਸਪੇਸ ਬਚਾਉਣ ਲਈ ਚਿੱਤਰਾਂ ਅਤੇ ਵੀਡੀਓਜ਼ ਨੂੰ ਕੰਪ੍ਰੈੱਸ ਕਰੋ।</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d ਤਸਵੀਰ ਮਿਲੀ</item>
-        <item quantity="other">%d ਤਸਵੀਰਾਂ ਮਿਲੀਆਂ</item>
+        <item quantity="one">%d ਆਈਟਮ ਮਿਲੀ</item>
+        <item quantity="other">%d ਆਈਟਮਾਂ ਮਿਲੀਆਂ</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s ਬਚਾਈ ਜਾ ਸਕਦੀ ਹੈ</item>
         <item quantity="other">~%s ਬਚਾਈ ਜਾ ਸਕਦੀ ਹੈ</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d ਤਸਵੀਰ ਕੰਪ੍ਰੈਸ ਕੀਤੀ ਗਈ</item>
-        <item quantity="other">%d ਤਸਵੀਰਾਂ ਕੰਪ੍ਰੈਸ ਕੀਤੀਆਂ ਗਈਆਂ</item>
+        <item quantity="one">%d ਆਈਟਮ ਕੰਪ੍ਰੈੱਸ ਕੀਤੀ</item>
+        <item quantity="other">%d ਆਈਟਮਾਂ ਕੰਪ੍ਰੈੱਸ ਕੀਤੀਆਂ</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d ਅਸਫਲ</item>
+        <item quantity="other">%d ਅਸਫਲ</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d ਫਾਈਲ ਛੱਡੀ ਗਈ (ਪਹੁੰਚਯੋਗ ਨਹੀਂ)</item>
+        <item quantity="other">%d ਫਾਈਲਾਂ ਛੱਡੀਆਂ ਗਈਆਂ (ਪਹੁੰਚਯੋਗ ਨਹੀਂ)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d ਤਸਵੀਰ ਚੁਣੀ ਗਈ</item>
-        <item quantity="other">%d ਤਸਵੀਰਾਂ ਚੁਣੀਆਂ ਗਈਆਂ</item>
+        <item quantity="one">%d ਆਈਟਮ ਚੁਣੀ ਗਈ</item>
+        <item quantity="other">%d ਆਈਟਮਾਂ ਚੁਣੀਆਂ ਗਈਆਂ</item>
     </plurals>
     <string name="squeezer_search_locations_title">ਖੋਜ ਸਥਾਨ</string>
     <string name="squeezer_search_locations_default_summary">ਕੈਮਰਾ ਫੋਲਡਰ (ਮੂਲ)</string>
     <string name="squeezer_min_size_title">ਘੱਟੋ-ਘੱਟ ਫਾਈਲ ਆਕਾਰ</string>
-    <string name="squeezer_min_size_description">ਇਸ ਆਕਾਰ ਤੋਂ ਛੋਟੀਆਂ ਤਸਵੀਰਾਂ ਛੱਡੋ।</string>
+    <string name="squeezer_min_size_description">ਇਸ ਆਕਾਰ ਤੋਂ ਛੋਟੀਆਂ ਫਾਈਲਾਂ ਛੱਡੋ।</string>
     <string name="squeezer_min_age_title">ਘੱਟੋ-ਘੱਟ ਫਾਈਲ ਉਮਰ</string>
-    <string name="squeezer_min_age_description">ਸਿਰਫ਼ ਇਸ ਉਮਰ ਤੋਂ ਪੁਰਾਣੀਆਂ ਤਸਵੀਰਾਂ ਸ਼ਾਮਲ ਕਰੋ।</string>
-    <string name="squeezer_compression_settings_label">ਕੰਪ੍ਰੈਸ਼ਨ ਸੈਟਿੰਗਾਂ</string>
+    <string name="squeezer_min_age_description">ਸਿਰਫ਼ ਇਸ ਉਮਰ ਤੋਂ ਪੁਰਾਣੀਆਂ ਫਾਈਲਾਂ ਸ਼ਾਮਲ ਕਰੋ।</string>
+    <string name="squeezer_compression_settings_label">ਆਮ</string>
     <string name="squeezer_quality_label">ਗੁਣਵੱਤਾ</string>
     <string name="squeezer_quality_title">ਕੰਪ੍ਰੈਸ਼ਨ ਗੁਣਵੱਤਾ</string>
-    <string name="squeezer_quality_description">ਘੱਟ ਗੁਣਵੱਤਾ ਦਾ ਮਤਲਬ ਹੈ ਛੋਟਾ ਫਾਈਲ ਆਕਾਰ ਪਰ ਘਟੀ ਹੋਈ ਤਸਵੀਰ ਗੁਣਵੱਤਾ।</string>
+    <string name="squeezer_quality_description">ਘੱਟ ਗੁਣਵੱਤਾ ਦਾ ਮਤਲਬ ਹੈ ਛੋਟਾ ਫਾਈਲ ਆਕਾਰ ਪਰ ਘੱਟ ਵਿਜ਼ੂਅਲ ਗੁਣਵੱਤਾ।</string>
     <string name="squeezer_quality_example_format">ਉਦਾਹਰਨ: %1$s ਤਸਵੀਰ → %3$d%% ਗੁਣਵੱਤਾ \'ਤੇ ~%2$s ਬਚਤ</string>
     <string name="squeezer_quality_warning_low">ਘੱਟ ਗੁਣਵੱਤਾ ਦਿਖਾਈ ਦੇਣ ਵਾਲੀਆਂ ਖਾਮੀਆਂ ਪੈਦਾ ਕਰ ਸਕਦੀ ਹੈ।</string>
     <string name="squeezer_quality_warning_high">ਬਹੁਤ ਉੱਚੀ ਗੁਣਵੱਤਾ ਘੱਟ ਥਾਂ ਬਚਾਉਂਦੀ ਹੈ।</string>
-    <string name="squeezer_types_category_label">ਤਸਵੀਰ ਕਿਸਮਾਂ</string>
+    <string name="squeezer_types_category_label">ਚਿੱਤਰ ਸੈਟਿੰਗਾਂ</string>
+    <string name="squeezer_video_settings_category_label">ਵੀਡੀਓ ਸੈਟਿੰਗਾਂ</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">JPEG ਤਸਵੀਰਾਂ (.jpg, .jpeg) ਸ਼ਾਮਲ ਕਰੋ।</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">WebP ਤਸਵੀਰਾਂ (.webp) ਸ਼ਾਮਲ ਕਰੋ।</string>
+    <string name="squeezer_type_video_title">MP4 ਵੀਡੀਓ</string>
+    <string name="squeezer_type_video_description">MP4 ਵੀਡੀਓ ਫਾਈਲਾਂ (.mp4) ਸ਼ਾਮਲ ਕਰੋ।</string>
     <string name="squeezer_skip_compressed_title">ਪਹਿਲਾਂ ਕੰਪ੍ਰੈਸ ਕੀਤੀਆਂ ਛੱਡੋ</string>
-    <string name="squeezer_skip_compressed_description">SD Maid ਦੁਆਰਾ ਪਹਿਲਾਂ ਹੀ ਕੰਪ੍ਰੈਸ ਕੀਤੀਆਂ ਤਸਵੀਰਾਂ ਛੱਡੋ।</string>
+    <string name="squeezer_skip_compressed_description">ਉਹ ਫਾਈਲਾਂ ਛੱਡੋ ਜੋ SD Maid ਦੁਆਰਾ ਪਹਿਲਾਂ ਹੀ ਕੰਪ੍ਰੈੱਸ ਕੀਤੀਆਂ ਜਾ ਚੁੱਕੀਆਂ ਹਨ।</string>
     <string name="squeezer_exif_marker_title">EXIF ਮਾਰਕਰ ਲਿਖੋ</string>
     <string name="squeezer_exif_marker_description">ਕੰਪ੍ਰੈਸ਼ਨ ਇਤਿਹਾਸ ਸਾਫ਼ ਹੋਣ \'ਤੇ ਵੀ ਦੁਬਾਰਾ ਕੰਪ੍ਰੈਸ਼ਨ ਰੋਕਣ ਲਈ ਤਸਵੀਰ ਦੇ EXIF ਉਪਭੋਗਤਾ ਟਿੱਪਣੀ ਖੇਤਰ ਵਿੱਚ ਮਾਰਕਰ ਜੋੜੋ।</string>
     <string name="squeezer_estimated_savings_format">~%s ਬੱਚਤ</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">ਕੰਪ੍ਰੈਸ਼ਨ ਦੀ ਪੁਸ਼ਟੀ ਕਰੋ</string>
     <string name="squeezer_preview_total_size">ਕੁੱਲ ਆਕਾਰ</string>
     <string name="squeezer_preview_estimated_savings">ਅੰਦਾਜ਼ਨ ਬੱਚਤ</string>
-    <string name="squeezer_compress_confirmation_title">ਤਸਵੀਰਾਂ ਕੰਪ੍ਰੈਸ ਕਰਨੀਆਂ ਹਨ?</string>
-    <string name="squeezer_compress_confirmation_message">ਇਹ ਅਸਲ ਤਸਵੀਰਾਂ ਨੂੰ ਕੰਪ੍ਰੈਸ ਕੀਤੇ ਵਰਜ਼ਨਾਂ ਨਾਲ ਬਦਲ ਦੇਵੇਗਾ। ਇਹ ਕਾਰਵਾਈ ਵਾਪਸ ਨਹੀਂ ਕੀਤੀ ਜਾ ਸਕਦੀ।</string>
+    <string name="squeezer_compress_confirmation_title">ਚੁਣੀਆਂ ਗਈਆਂ ਆਈਟਮਾਂ ਕੰਪ੍ਰੈੱਸ ਕਰੋ?</string>
+    <string name="squeezer_compress_confirmation_message">ਇਹ ਅਸਲੀ ਫਾਈਲਾਂ ਨੂੰ ਕੰਪ੍ਰੈੱਸ ਕੀਤੇ ਸੰਸਕਰਣਾਂ ਨਾਲ ਬਦਲ ਦੇਵੇਗਾ। ਇਹ ਕਿਰਿਆ ਵਾਪਸ ਨਹੀਂ ਕੀਤੀ ਜਾ ਸਕਦੀ।</string>
     <string name="squeezer_history_title">ਕੰਪ੍ਰੈਸ਼ਨ ਇਤਿਹਾਸ</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d ਆਈਟਮ (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">ਕੋਈ ਕੰਪ੍ਰੈਸ਼ਨ ਇਤਿਹਾਸ ਨਹੀਂ</string>
     <string name="squeezer_history_clear_title">ਕੰਪ੍ਰੈਸ਼ਨ ਇਤਿਹਾਸ ਸਾਫ਼ ਕਰੋ</string>
-    <string name="squeezer_history_clear_message">ਇਹ ਪਹਿਲਾਂ ਕੰਪ੍ਰੈਸ ਕੀਤੀਆਂ ਤਸਵੀਰਾਂ ਨੂੰ ਦੁਬਾਰਾ ਕੰਪ੍ਰੈਸ ਕਰਨ ਦੀ ਇਜਾਜ਼ਤ ਦੇਵੇਗਾ। ਤਸਵੀਰਾਂ \'ਤੇ ਕੋਈ ਅਸਰ ਨਹੀਂ ਹੋਵੇਗਾ।</string>
+    <string name="squeezer_history_clear_message">ਇਹ ਪਹਿਲਾਂ ਕੰਪ੍ਰੈੱਸ ਕੀਤੀਆਂ ਫਾਈਲਾਂ ਨੂੰ ਦੁਬਾਰਾ ਕੰਪ੍ਰੈੱਸ ਕਰਨ ਦੇਵੇਗਾ। ਫਾਈਲਾਂ ਆਪ ਪ੍ਰਭਾਵਿਤ ਨਹੀਂ ਹੁੰਦੀਆਂ।</string>
     <string name="squeezer_onboarding_title">ਤਸਵੀਰ ਕੰਪ੍ਰੈਸ਼ਨ ਬਾਰੇ</string>
     <string name="squeezer_onboarding_message">ਤਸਵੀਰ ਕੰਪ੍ਰੈਸ਼ਨ ਦ੍ਰਿਸ਼ਟੀਗਤ ਵੇਰਵੇ ਹਟਾ ਕੇ ਫਾਈਲ ਦਾ ਆਕਾਰ ਘਟਾਉਂਦੀ ਹੈ। ਇਹ ਪ੍ਰਕਿਰਿਆ ਉਲਟਾਈ ਨਹੀਂ ਜਾ ਸਕਦੀ - ਅਸਲ ਗੁਣਵੱਤਾ ਬਹਾਲ ਨਹੀਂ ਕੀਤੀ ਜਾ ਸਕਦੀ।\n\nਇੱਥੇ ਝਲਕ ਹੈ ਕਿ ਤੁਹਾਡੀਆਂ ਤਸਵੀਰਾਂ ਕਿਵੇਂ ਦਿਖਣਗੀਆਂ:</string>
     <string name="squeezer_onboarding_original_label">ਅਸਲ</string>
     <string name="squeezer_onboarding_compressed_label">ਕੰਪ੍ਰੈਸ਼ਨ ਤੋਂ ਬਾਅਦ</string>
+    <string name="squeezer_onboarding_video_original_label">ਵੀਡੀਓ ਫ੍ਰੇਮ</string>
+    <string name="squeezer_onboarding_video_compressed_label">ਝਲਕ (ਅੰਦਾਜ਼ਨ)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">ਅਸਲ ਵੀਡੀਓ ਗੁਣਵੱਤਾ ਵੱਖਰੀ ਹੋ ਸਕਦੀ ਹੈ</string>
     <string name="squeezer_onboarding_quality_label">ਗੁਣਵੱਤਾ: %d%%</string>
     <string name="squeezer_compare_action">ਤੁਲਨਾ ਦੇਖੋ</string>
     <string name="squeezer_no_example_found">ਚੁਣੇ ਮਾਰਗਾਂ ਵਿੱਚ ਕੋਈ ਤਸਵੀਰਾਂ ਨਹੀਂ ਮਿਲੀਆਂ।</string>
-    <string name="squeezer_result_empty_message">ਕੋਈ ਕੰਪ੍ਰੈਸ ਹੋਣ ਯੋਗ ਤਸਵੀਰਾਂ ਨਹੀਂ ਮਿਲੀਆਂ।</string>
-    <string name="squeezer_setup_warning">ਕੰਪ੍ਰੈਸ਼ਨ ਸਟੋਰੇਜ ਬਚਾਉਣ ਲਈ ਤਸਵੀਰ ਦੀ ਗੁਣਵੱਤਾ ਸਥਾਈ ਤੌਰ \'ਤੇ ਘਟਾਉਂਦੀ ਹੈ। ਇਹ ਵਾਪਸ ਨਹੀਂ ਕੀਤੀ ਜਾ ਸਕਦੀ। ਸ਼ੁਰੂ ਕਰਨ ਤੋਂ ਪਹਿਲਾਂ ਆਪਣੀਆਂ ਸੈਟਿੰਗਾਂ ਧਿਆਨ ਨਾਲ ਦੇਖੋ।</string>
-    <string name="squeezer_setup_explanation">ਮੀਡੀਆ ਸਕੁਈਜ਼ ਸਟੋਰੇਜ ਖਾਲੀ ਕਰਨ ਲਈ ਤਸਵੀਰਾਂ ਦਾ ਫਾਈਲ ਆਕਾਰ ਘਟਾਉਂਦਾ ਹੈ। ਇਹ ਸਥਾਈ ਤੌਰ \'ਤੇ ਤਸਵੀਰ ਦੀ ਗੁਣਵੱਤਾ ਘਟਾਉਂਦਾ ਹੈ ਅਤੇ ਵਾਪਸ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਦਾ। ਸ਼ੁਰੂ ਕਰਨ ਤੋਂ ਪਹਿਲਾਂ ਆਪਣੀਆਂ ਸੈਟਿੰਗਾਂ ਧਿਆਨ ਨਾਲ ਦੇਖੋ।</string>
+    <string name="squeezer_result_empty_message">ਕੋਈ ਕੰਪ੍ਰੈੱਸ ਕਰਨਯੋਗ ਮੀਡੀਆ ਨਹੀਂ ਮਿਲਿਆ।</string>
+    <string name="squeezer_setup_warning">ਕੰਪ੍ਰੈਸ਼ਨ ਸਟੋਰੇਜ ਸਪੇਸ ਬਚਾਉਣ ਲਈ ਗੁਣਵੱਤਾ ਨੂੰ ਸਥਾਈ ਤੌਰ \'ਤੇ ਘਟਾਉਂਦਾ ਹੈ। ਇਹ ਵਾਪਸ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਦਾ। ਸ਼ੁਰੂ ਕਰਨ ਤੋਂ ਪਹਿਲਾਂ ਆਪਣੀਆਂ ਸੈਟਿੰਗਾਂ ਧਿਆਨ ਨਾਲ ਜਾਂਚੋ।</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d ਟਿਕਾਣਾ ਕੰਪ੍ਰੈਸ਼ਨ ਲਈ ਵਰਤਿਆ ਨਹੀਂ ਜਾ ਸਕਦਾ ਅਤੇ ਹਟਾ ਦਿੱਤਾ ਗਿਆ। ਕੰਪ੍ਰੈਸ਼ਨ ਲਈ ਅੰਦਰੂਨੀ ਸਟੋਰੇਜ ਤੱਕ ਸਿੱਧੀ ਪਹੁੰਚ ਲੋੜੀਂਦੀ ਹੈ।</item>
+        <item quantity="other">%d ਟਿਕਾਣੇ ਕੰਪ੍ਰੈਸ਼ਨ ਲਈ ਵਰਤੇ ਨਹੀਂ ਜਾ ਸਕਦੇ ਅਤੇ ਹਟਾ ਦਿੱਤੇ ਗਏ। ਕੰਪ੍ਰੈਸ਼ਨ ਲਈ ਅੰਦਰੂਨੀ ਸਟੋਰੇਜ ਤੱਕ ਸਿੱਧੀ ਪਹੁੰਚ ਲੋੜੀਂਦੀ ਹੈ।</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze ਚਿੱਤਰਾਂ ਅਤੇ ਵੀਡੀਓਜ਼ ਦੇ ਫਾਈਲ ਆਕਾਰ ਨੂੰ ਘਟਾ ਕੇ ਸਟੋਰੇਜ ਸਪੇਸ ਖਾਲੀ ਕਰਦਾ ਹੈ। ਇਹ ਗੁਣਵੱਤਾ ਨੂੰ ਸਥਾਈ ਤੌਰ \'ਤੇ ਘਟਾਉਂਦਾ ਹੈ ਅਤੇ ਵਾਪਸ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਦਾ। ਸ਼ੁਰੂ ਕਰਨ ਤੋਂ ਪਹਿਲਾਂ ਆਪਣੀਆਂ ਸੈਟਿੰਗਾਂ ਧਿਆਨ ਨਾਲ ਜਾਂਚੋ।</string>
     <string name="squeezer_setup_paths_title">ਖੋਜ ਸਥਾਨ</string>
     <string name="squeezer_setup_paths_default">ਖੋਜਣ ਲਈ ਫੋਲਡਰ ਚੁਣੋ</string>
     <string name="squeezer_setup_quality_title">ਕੰਪ੍ਰੈਸ਼ਨ ਗੁਣਵੱਤਾ</string>
@@ -81,6 +99,6 @@
         <item quantity="one">ਘੱਟੋ-ਘੱਟ %d ਦਿਨ ਪੁਰਾਣੀ</item>
         <item quantity="other">ਘੱਟੋ-ਘੱਟ %d ਦਿਨ ਪੁਰਾਣੀ</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">JPEG ਫਾਈਲਾਂ ਲਈ ਅੰਦਾਜ਼ਨ ~%d%% ਬੱਚਤ</string>
+    <string name="squeezer_estimated_savings_percent">ਚਿੱਤਰਾਂ ਲਈ ਅੰਦਾਜ਼ਨ ~%d%% ਬੱਚਤ</string>
     <string name="squeezer_onboarding_got_it">ਸਮਝ ਗਿਆਂ/ ਗਈ</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-pl/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-pl/strings.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Kompresuj obrazy, aby zaoszczędzić miejsce.</string>
+    <string name="squeezer_explanation_short">Kompresuj obrazy i filmy, aby zaoszczędzić miejsce na dysku.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">Znaleziono %d obraz</item>
-        <item quantity="few">Znaleziono %d obrazy</item>
-        <item quantity="many">Znaleziono %d obrazów</item>
-        <item quantity="other">Znaleziono %d obrazów</item>
+        <item quantity="one">znaleziono %d element</item>
+        <item quantity="few">znaleziono %d elementy</item>
+        <item quantity="many">znaleziono %d elementów</item>
+        <item quantity="other">znaleziono %d elementów</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s może zostać zwolniony</item>
@@ -14,37 +14,52 @@
         <item quantity="other">~%s może zostać zwolnionych</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d skompresowany obraz</item>
-        <item quantity="few">%d skompresowane obrazy</item>
-        <item quantity="many">%d skompresowanych obrazów</item>
-        <item quantity="other">%d skompresowanych obrazów </item>
+        <item quantity="one">skompresowano %d element</item>
+        <item quantity="few">skompresowano %d elementy</item>
+        <item quantity="many">skompresowano %d elementów</item>
+        <item quantity="other">skompresowano %d elementów</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d nie powiodło się</item>
+        <item quantity="few">%d nie powiodło się</item>
+        <item quantity="many">%d nie powiodło się</item>
+        <item quantity="other">%d nie powiodło się</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">pominięto %d plik (niedostępny)</item>
+        <item quantity="few">pominięto %d pliki (niedostępne)</item>
+        <item quantity="many">pominięto %d plików (niedostępne)</item>
+        <item quantity="other">pominięto %d plików (niedostępne)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">Wybrano %d obraz</item>
-        <item quantity="few">Wybrano %d obrazy</item>
-        <item quantity="many">Wybrano %d obrazów</item>
-        <item quantity="other">Wybrano %d obrazów</item>
+        <item quantity="one">wybrano %d element</item>
+        <item quantity="few">wybrano %d elementy</item>
+        <item quantity="many">wybrano %d elementów</item>
+        <item quantity="other">wybrano %d elementów</item>
     </plurals>
     <string name="squeezer_search_locations_title">Lokalizacje wyszukiwania</string>
     <string name="squeezer_search_locations_default_summary">Foldery aparatu (domyślnie)</string>
     <string name="squeezer_min_size_title">Minimalny rozmiar pliku</string>
     <string name="squeezer_min_size_description">Pomiń obrazy mniejsze niż ten rozmiar.</string>
     <string name="squeezer_min_age_title">Minimalny wiek pliku</string>
-    <string name="squeezer_min_age_description">Uwzględnia tylko obrazy starsze niż ten wiek.</string>
-    <string name="squeezer_compression_settings_label">Ustawienia kompresji</string>
+    <string name="squeezer_min_age_description">Uwzględniaj tylko pliki starsze niż ten wiek.</string>
+    <string name="squeezer_compression_settings_label">Ogólne</string>
     <string name="squeezer_quality_label">Jakość</string>
     <string name="squeezer_quality_title">Kompresja jakości</string>
-    <string name="squeezer_quality_description">Niższa jakość oznacza mniejszy rozmiar pliku, ale mniejszą jakość obrazu.</string>
+    <string name="squeezer_quality_description">Niższa jakość oznacza mniejszy rozmiar pliku, ale gorszą jakość wizualną.</string>
     <string name="squeezer_quality_example_format">Przykład: %1$s obraz → zapisuje ~%2$s przy %3$d%% jakości</string>
     <string name="squeezer_quality_warning_low">Niższa jakość może powodować widoczne artefakty.</string>
     <string name="squeezer_quality_warning_high">Bardzo wysoka jakość zapewnia minimalne oszczędności przestrzeni.</string>
-    <string name="squeezer_types_category_label">Typy obrazów</string>
+    <string name="squeezer_types_category_label">Ustawienia obrazu</string>
+    <string name="squeezer_video_settings_category_label">Ustawienia wideo</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">Dołącz zdjęcia JPEG (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">Dołącz obrazy WebP (.webp).</string>
+    <string name="squeezer_type_video_title">Wideo MP4</string>
+    <string name="squeezer_type_video_description">Dołącz pliki wideo MP4 (.mp4).</string>
     <string name="squeezer_skip_compressed_title">Pomiń poprzednio skompresowane</string>
-    <string name="squeezer_skip_compressed_description">Pomiń obrazy, które zostały już skompresowane przez SD Maid.</string>
+    <string name="squeezer_skip_compressed_description">Pomiń pliki, które zostały już skompresowane przez SD Maid.</string>
     <string name="squeezer_exif_marker_title">Zapisz znacznik EXIF</string>
     <string name="squeezer_exif_marker_description">Dołącz znacznik do pola komentarza użytkownika EXIF obrazu, aby zapobiec ponownemu kompresji, nawet jeśli historia kompresji jest wyczyszczona.</string>
     <string name="squeezer_estimated_savings_format">~%s zaoszczędzone</string>
@@ -55,8 +70,8 @@
     <string name="squeezer_preview_dialog_title">Potwierdź kompresję</string>
     <string name="squeezer_preview_total_size">Całkowity rozmiar</string>
     <string name="squeezer_preview_estimated_savings">Szacowane oszczędności</string>
-    <string name="squeezer_compress_confirmation_title">Kompresować obrazy?</string>
-    <string name="squeezer_compress_confirmation_message">To zastąpi oryginalne obrazy skompresowanymi wersjami. Tej czynności nie można cofnąć.</string>
+    <string name="squeezer_compress_confirmation_title">Skompresować zaznaczone elementy?</string>
+    <string name="squeezer_compress_confirmation_message">Spowoduje to zastąpienie oryginalnych plików wersjami skompresowanymi. Tej czynności nie można cofnąć.</string>
     <string name="squeezer_history_title">Historia kompresji</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d element (%2$s)</item>
@@ -66,16 +81,25 @@
     </plurals>
     <string name="squeezer_history_empty">Brak historii kompresji</string>
     <string name="squeezer_history_clear_title">Wyczyść historię kompresji</string>
-    <string name="squeezer_history_clear_message">Pozwoli to ponownie skompresować wcześniej skompresowane obrazy. Same obrazy nie są naruszone.</string>
+    <string name="squeezer_history_clear_message">Umożliwi to ponowną kompresję wcześniej skompresowanych plików. Same pliki nie zostaną naruszone.</string>
     <string name="squeezer_onboarding_title">O kompresji obrazów</string>
     <string name="squeezer_onboarding_message">Kompresja obrazu zmniejsza rozmiar pliku, usuwając szczegóły wizualne. Ten proces jest nieodwracalny - oryginalna jakość nie może być przywrócona.\n\nOto podgląd jak będą wyglądać twoje obrazy:</string>
     <string name="squeezer_onboarding_original_label">Oryginał</string>
     <string name="squeezer_onboarding_compressed_label">Po kompresji</string>
+    <string name="squeezer_onboarding_video_original_label">Klatka wideo</string>
+    <string name="squeezer_onboarding_video_compressed_label">Podgląd (przybliżony)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">Rzeczywista jakość wideo może się różnić</string>
     <string name="squeezer_onboarding_quality_label">Jakość: %d%%</string>
     <string name="squeezer_compare_action">Zobacz porównanie</string>
     <string name="squeezer_no_example_found">Nie znaleziono obrazów w wybranych ścieżkach.</string>
-    <string name="squeezer_result_empty_message">Nie znaleziono skompresowanych obrazów.</string>
-    <string name="squeezer_setup_warning">Kompresja trwale zmniejsza jakość obrazu, aby zapisać miejsce na dysku. Tej operacji nie można cofnąć. Przejrzyj swoje ustawienia ostrożnie przed rozpoczęciem.</string>
+    <string name="squeezer_result_empty_message">Nie znaleziono kompresowalnych multimediów.</string>
+    <string name="squeezer_setup_warning">Kompresja trwale obniża jakość, oszczędzając miejsce na dysku. Tej operacji nie można cofnąć. Przed rozpoczęciem dokładnie sprawdź ustawienia.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d lokalizacja nie może zostać użyta do kompresji i została usunięta. Kompresja wymaga bezpośredniego dostępu do pamięci wewnętrznej.</item>
+        <item quantity="few">%d lokalizacje nie mogą zostać użyte do kompresji i zostały usunięte. Kompresja wymaga bezpośredniego dostępu do pamięci wewnętrznej.</item>
+        <item quantity="many">%d lokalizacje nie mogą zostać użyte do kompresji i zostały usunięte. Kompresja wymaga bezpośredniego dostępu do pamięci wewnętrznej.</item>
+        <item quantity="other">%d lokalizacje nie mogą zostać użyte do kompresji i zostały usunięte. Kompresja wymaga bezpośredniego dostępu do pamięci wewnętrznej.</item>
+    </plurals>
     <string name="squeezer_setup_explanation">Kompresowanie multimediów zmniejsza rozmiar plików obrazów, aby zwolnić miejsce na dysku. To trwale zmniejsza jakość obrazu i nie może być cofnięte. Przejrzyj swoje ustawienia ostrożnie przed rozpoczęciem.</string>
     <string name="squeezer_setup_paths_title">Lokalizacje wyszukiwania</string>
     <string name="squeezer_setup_paths_default">Wybierz foldery do przeszukania</string>
@@ -93,6 +117,6 @@
         <item quantity="many">Co najmniej %d dni</item>
         <item quantity="other">Co najmniej %d dni</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">Szacowane oszczędności ~%d%% dla plików JPEG</string>
+    <string name="squeezer_estimated_savings_percent">Szacowane ~%d%% oszczędności dla obrazów</string>
     <string name="squeezer_onboarding_got_it">Rozumiem</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-pt-rBR/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-pt-rBR/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Comprima imagens para economizar espaço de armazenamento.</string>
+    <string name="squeezer_explanation_short">Comprimir imagens e vídeos para economizar espaço de armazenamento.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d imagem encontrada</item>
-        <item quantity="other">%d imagens encontradas</item>
+        <item quantity="one">%d item encontrado</item>
+        <item quantity="other">%d itens encontrados</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s pode ser economizado</item>
         <item quantity="other">~%s podem ser economizados</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d imagem comprimida</item>
-        <item quantity="other">%d imagens comprimidas</item>
+        <item quantity="one">%d item comprimido</item>
+        <item quantity="other">%d itens comprimidos</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d falhou</item>
+        <item quantity="other">%d falharam</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d arquivo ignorado (inacessível)</item>
+        <item quantity="other">%d arquivos ignorados (inacessíveis)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d imagem selecionada</item>
-        <item quantity="other">%d imagens selecionadas</item>
+        <item quantity="one">%d item selecionado</item>
+        <item quantity="other">%d itens selecionados</item>
     </plurals>
     <string name="squeezer_search_locations_title">Pesquisar os locais</string>
     <string name="squeezer_search_locations_default_summary">Pastas da câmera (padrão)</string>
     <string name="squeezer_min_size_title">Tamanho mínimo do arquivo</string>
-    <string name="squeezer_min_size_description">Pular imagens menores que este tamanho.</string>
+    <string name="squeezer_min_size_description">Ignorar arquivos menores que este tamanho.</string>
     <string name="squeezer_min_age_title">Idade mínima do arquivo</string>
-    <string name="squeezer_min_age_description">Incluir apenas imagens mais antigas que esta idade.</string>
-    <string name="squeezer_compression_settings_label">Configurações de compressão</string>
+    <string name="squeezer_min_age_description">Incluir apenas arquivos mais antigos que esta idade.</string>
+    <string name="squeezer_compression_settings_label">Gerais</string>
     <string name="squeezer_quality_label">Qualidade</string>
     <string name="squeezer_quality_title">Qualidade de compressão</string>
-    <string name="squeezer_quality_description">Menor qualidade significa menor tamanho de arquivo, mas qualidade de imagem reduzida.</string>
+    <string name="squeezer_quality_description">Qualidade menor significa tamanho de arquivo menor, mas qualidade visual reduzida.</string>
     <string name="squeezer_quality_example_format">Exemplo: imagem %1$s → economiza ~%2$s a %3$d%% de qualidade</string>
     <string name="squeezer_quality_warning_low">Qualidades mais baixas podem causar artefatos visíveis.</string>
     <string name="squeezer_quality_warning_high">Qualidade muito alta oferece economia mínima de espaço.</string>
-    <string name="squeezer_types_category_label">Tipos de imagem</string>
+    <string name="squeezer_types_category_label">Configurações de imagem</string>
+    <string name="squeezer_video_settings_category_label">Configurações de vídeo</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">Incluir imagens JPEG (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">Incluir imagens WebP (.webp).</string>
+    <string name="squeezer_type_video_title">Vídeo MP4</string>
+    <string name="squeezer_type_video_description">Incluir arquivos de vídeo MP4 (.mp4).</string>
     <string name="squeezer_skip_compressed_title">Pular já comprimidas</string>
-    <string name="squeezer_skip_compressed_description">Pular imagens que já foram comprimidas pelo SD Maid.</string>
+    <string name="squeezer_skip_compressed_description">Ignorar arquivos que já foram comprimidos pelo SD Maid.</string>
     <string name="squeezer_exif_marker_title">Gravar marcador EXIF</string>
     <string name="squeezer_exif_marker_description">Adicionar um marcador ao campo de comentário do usuário EXIF da imagem para evitar recompressão mesmo se o histórico de compressão for limpo.</string>
     <string name="squeezer_estimated_savings_format">~%s de economia</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">Confirmar compressão</string>
     <string name="squeezer_preview_total_size">Tamanho total</string>
     <string name="squeezer_preview_estimated_savings">Economia estimada</string>
-    <string name="squeezer_compress_confirmation_title">Comprimir imagens?</string>
-    <string name="squeezer_compress_confirmation_message">Isso substituirá as imagens originais por versões comprimidas. Esta ação não pode ser desfeita.</string>
+    <string name="squeezer_compress_confirmation_title">Comprimir itens selecionados?</string>
+    <string name="squeezer_compress_confirmation_message">Isso substituirá os arquivos originais por versões comprimidas. Esta ação não pode ser desfeita.</string>
     <string name="squeezer_history_title">Histórico de compressão</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d item (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">Sem histórico de compressão</string>
     <string name="squeezer_history_clear_title">Limpar histórico de compressão</string>
-    <string name="squeezer_history_clear_message">Isso permitirá que imagens previamente comprimidas sejam comprimidas novamente. As imagens em si não são afetadas.</string>
+    <string name="squeezer_history_clear_message">Isso permitirá que arquivos previamente comprimidos sejam comprimidos novamente. Os próprios arquivos não são afetados.</string>
     <string name="squeezer_onboarding_title">Sobre a Compressão de Imagens</string>
     <string name="squeezer_onboarding_message">A compressão de imagens reduz o tamanho do arquivo removendo detalhes visuais. Este processo é irreversível - a qualidade original não pode ser restaurada.\n\nVeja como suas imagens ficarão:</string>
     <string name="squeezer_onboarding_original_label">Original</string>
     <string name="squeezer_onboarding_compressed_label">Após compressão</string>
+    <string name="squeezer_onboarding_video_original_label">Quadro de vídeo</string>
+    <string name="squeezer_onboarding_video_compressed_label">Pré-visualização (aproximada)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">A qualidade real do vídeo pode variar</string>
     <string name="squeezer_onboarding_quality_label">Qualidade: %d%%</string>
     <string name="squeezer_compare_action">Ver comparação</string>
     <string name="squeezer_no_example_found">Nenhuma imagem encontrada nos caminhos selecionados.</string>
-    <string name="squeezer_result_empty_message">Nenhuma imagem comprimível encontrada.</string>
-    <string name="squeezer_setup_warning">A compressão reduz permanentemente a qualidade da imagem para economizar espaço de armazenamento. Isto não pode ser desfeito. Revise suas configurações cuidadosamente antes de começar.</string>
-    <string name="squeezer_setup_explanation">O Compressor de Mídia reduz o tamanho de arquivo das imagens para liberar espaço de armazenamento. Isso reduz permanentemente a qualidade da imagem e não pode ser desfeito. Revise suas configurações cuidadosamente antes de começar.</string>
+    <string name="squeezer_result_empty_message">Nenhuma mídia comprimível encontrada.</string>
+    <string name="squeezer_setup_warning">A compressão reduz permanentemente a qualidade para economizar espaço de armazenamento. Isso não pode ser desfeito. Revise suas configurações cuidadosamente antes de começar.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d local não pode ser usado para compressão e foi removido. A compressão requer acesso direto ao armazenamento interno.</item>
+        <item quantity="other">%d locais não podem ser usados para compressão e foram removidos. A compressão requer acesso direto ao armazenamento interno.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">O Media Squeeze reduz o tamanho dos arquivos de imagens e vídeos para liberar espaço de armazenamento. Isso reduz permanentemente a qualidade e não pode ser desfeito. Revise suas configurações cuidadosamente antes de começar.</string>
     <string name="squeezer_setup_paths_title">Pesquisar os locais</string>
     <string name="squeezer_setup_paths_default">Selecionar pastas para buscar</string>
     <string name="squeezer_setup_quality_title">Qualidade de compressão</string>
@@ -81,6 +99,6 @@
         <item quantity="one">Pelo menos %d dia</item>
         <item quantity="other">Pelo menos %d dias</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">Economia estimada de ~%d%% para arquivos JPEG</string>
+    <string name="squeezer_estimated_savings_percent">Economia estimada de ~%d%% para imagens</string>
     <string name="squeezer_onboarding_got_it">Entendi</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-pt/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-pt/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Comprimir imagens para economizar espaço de armazenamento.</string>
+    <string name="squeezer_explanation_short">Comprimir imagens e vídeos para poupar espaço de armazenamento.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d imagem encontrada</item>
-        <item quantity="other">%d imagens encontradas</item>
+        <item quantity="one">%d item encontrado</item>
+        <item quantity="other">%d itens encontrados</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">Pode libertar %s</item>
         <item quantity="other">Pode libertar %s</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d imagem comprimida</item>
-        <item quantity="other">%d imagens comprimidas</item>
+        <item quantity="one">%d item comprimido</item>
+        <item quantity="other">%d itens comprimidos</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d falhou</item>
+        <item quantity="other">%d falharam</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d ficheiro ignorado (não acessível)</item>
+        <item quantity="other">%d ficheiros ignorados (não acessíveis)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d imagem selecionada</item>
-        <item quantity="other">%d imagens selecionadas</item>
+        <item quantity="one">%d item selecionado</item>
+        <item quantity="other">%d itens selecionados</item>
     </plurals>
     <string name="squeezer_search_locations_title">Pesquisar localizações</string>
     <string name="squeezer_search_locations_default_summary">Pastas da câmera (padrão)</string>
     <string name="squeezer_min_size_title">Tamanho mínimo do arquivo</string>
-    <string name="squeezer_min_size_description">Pular imagens menores que este tamanho.</string>
+    <string name="squeezer_min_size_description">Ignorar ficheiros menores do que este tamanho.</string>
     <string name="squeezer_min_age_title">Idade mínima do arquivo</string>
-    <string name="squeezer_min_age_description">Inclua apenas imagens mais antigas que esta idade.</string>
-    <string name="squeezer_compression_settings_label">Configurações de compressão</string>
+    <string name="squeezer_min_age_description">Incluir apenas ficheiros com idade superior a esta.</string>
+    <string name="squeezer_compression_settings_label">Geral</string>
     <string name="squeezer_quality_label">Qualidade</string>
     <string name="squeezer_quality_title">Qualidade da Compressão</string>
-    <string name="squeezer_quality_description">Menor qualidade significa menor tamanho de arquivo, mas redução de qualidade de imagem.</string>
+    <string name="squeezer_quality_description">Qualidade inferior significa tamanho de ficheiro menor, mas qualidade visual reduzida.</string>
     <string name="squeezer_quality_example_format">Exemplo: %1$s imagem → salva ~%2$s a %3$d%% qualidade</string>
     <string name="squeezer_quality_warning_low">Qualidade inferiore pode causar artefatos visíveis.</string>
     <string name="squeezer_quality_warning_high">Alta qualidade não economiza espaço.</string>
-    <string name="squeezer_types_category_label">Tipos de Imagem</string>
+    <string name="squeezer_types_category_label">Definições de imagem</string>
+    <string name="squeezer_video_settings_category_label">Definições de vídeo</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">Incluir imagens JPEG (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">Incluir imagens WebP (.webp).</string>
+    <string name="squeezer_type_video_title">Vídeo MP4</string>
+    <string name="squeezer_type_video_description">Incluir ficheiros de vídeo MP4 (.mp4).</string>
     <string name="squeezer_skip_compressed_title">Pular compactado anteriormente</string>
-    <string name="squeezer_skip_compressed_description">Pular imagens que já foram compactadas pelo SD Maid.</string>
+    <string name="squeezer_skip_compressed_description">Ignorar ficheiros que já foram comprimidos pelo SD Maid.</string>
     <string name="squeezer_exif_marker_title">Escrever marcador EXIF</string>
     <string name="squeezer_exif_marker_description">Acrescentar um marcador ao campo de comentário de usuário EXIF da imagem para evitar a re-compressão mesmo que o histórico de compressão seja apagado.</string>
     <string name="squeezer_estimated_savings_format">~ %s economia</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">Confirmar compressão</string>
     <string name="squeezer_preview_total_size">Tamanho total</string>
     <string name="squeezer_preview_estimated_savings">Poupança estimada</string>
-    <string name="squeezer_compress_confirmation_title">Comprimir imagens?</string>
-    <string name="squeezer_compress_confirmation_message">Isto irá substituir as imagens originais por versões compactadas. Esta ação não pode ser desfeita.</string>
+    <string name="squeezer_compress_confirmation_title">Comprimir os itens selecionados?</string>
+    <string name="squeezer_compress_confirmation_message">Isto irá substituir os ficheiros originais por versões comprimidas. Esta ação não pode ser anulada.</string>
     <string name="squeezer_history_title">Histórico de compressão</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d item (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">Sem histórico de compressão</string>
     <string name="squeezer_history_clear_title">Limpar histórico de compressão</string>
-    <string name="squeezer_history_clear_message">Isto permitirá que imagens compactadas anteriormente sejam comprimidas novamente. As próprias imagens não são afetadas.</string>
+    <string name="squeezer_history_clear_message">Isto permitirá que ficheiros previamente comprimidos sejam comprimidos novamente. Os próprios ficheiros não são afetados.</string>
     <string name="squeezer_onboarding_title">Sobre a compressão de imagens</string>
     <string name="squeezer_onboarding_message">A compressão da imagem reduz o tamanho do arquivo removendo detalhes visuais. Esse processo é irreversível - a qualidade original não pode ser restaurada.\n\nAqui está uma imagem prévia de como as suas imagens ficarão:</string>
     <string name="squeezer_onboarding_original_label">Original</string>
     <string name="squeezer_onboarding_compressed_label">Após compressão</string>
+    <string name="squeezer_onboarding_video_original_label">Fotograma de vídeo</string>
+    <string name="squeezer_onboarding_video_compressed_label">Pré-visualização (aproximada)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">A qualidade real do vídeo pode ser diferente</string>
     <string name="squeezer_onboarding_quality_label">Qualidade: %d%%</string>
     <string name="squeezer_compare_action">Ver comparação</string>
     <string name="squeezer_no_example_found">Nenhuma imagem encontrada nos caminhos selecionados.</string>
-    <string name="squeezer_result_empty_message">Nenhuma imagem comprimida encontrada.</string>
-    <string name="squeezer_setup_warning">Compressão reduz permanentemente a qualidade de imagem para economizar espaço de armazenamento. Isto não pode ser desfeito. Reveja as configurações cuidadosamente antes de iniciar.</string>
-    <string name="squeezer_setup_explanation">Compressão de mídia reduz o tamanho das imagens para liberar espaço de armazenamento. Isto reduz permanentemente a qualidade da imagem e não pode ser desfeito. Reveja as configurações cuidadosamente antes de iniciar.</string>
+    <string name="squeezer_result_empty_message">Nenhum míia compressível encontrado.</string>
+    <string name="squeezer_setup_warning">A compressão reduz permanentemente a qualidade para poupar espaço de armazenamento. Isto não pode ser anulado. Reveja as suas definições com cuidado antes de começar.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d localização não pode ser utilizada para compressão e foi removida. A compressão requer acesso direto ao armazenamento interno.</item>
+        <item quantity="other">%d localizações não podem ser utilizadas para compressão e foram removidas. A compressão requer acesso direto ao armazenamento interno.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">O Media Squeeze reduz o tamanho dos ficheiros de imagens e vídeos para libertar espaço de armazenamento. Isto reduz permanentemente a qualidade e não pode ser anulado. Reveja as suas definições com cuidado antes de começar.</string>
     <string name="squeezer_setup_paths_title">Pesquisar localizações</string>
     <string name="squeezer_setup_paths_default">Selecionar pastas para pesquisar</string>
     <string name="squeezer_setup_quality_title">Qualidade da Compressão</string>
@@ -81,6 +99,6 @@
         <item quantity="one">Pelo menos %d dia de idade</item>
         <item quantity="other">Pelo menos %d dias de idade</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">Estimado ~%d%% poupança para arquivos JPEG</string>
+    <string name="squeezer_estimated_savings_percent">Economia estimada de ~%d%% para imagens</string>
     <string name="squeezer_onboarding_got_it">Entendido</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-ro/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-ro/strings.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Comprimați imaginile pentru a economisi spațiu de stocare.</string>
+    <string name="squeezer_explanation_short">Comprimă imagini și videoclipuri pentru a economisi spațiu de stocare.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d imagine găsită</item>
-        <item quantity="few">%d imagini găsite</item>
-        <item quantity="other">%d imagini găsite</item>
+        <item quantity="one">%d element găsit</item>
+        <item quantity="few">%d elemente găsite</item>
+        <item quantity="other">%d de elemente găsite</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s poate fi eliberat</item>
@@ -12,35 +12,48 @@
         <item quantity="other">~%s pot fi eliberați</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d imagine compresată</item>
-        <item quantity="few">%d imagini compresate</item>
-        <item quantity="other">%d imagini compresate</item>
+        <item quantity="one">%d element comprimat</item>
+        <item quantity="few">%d elemente comprimate</item>
+        <item quantity="other">%d de elemente comprimate</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d eșuat</item>
+        <item quantity="few">%d eșuate</item>
+        <item quantity="other">%d de eșuate</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d fișier omis (inaccesibil)</item>
+        <item quantity="few">%d fișiere omise (inaccesibile)</item>
+        <item quantity="other">%d de fișiere omise (inaccesibile)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d imagine selectată</item>
-        <item quantity="few">%d imagini selectate</item>
-        <item quantity="other">%d imagini selectate</item>
+        <item quantity="one">%d element selectat</item>
+        <item quantity="few">%d elemente selectate</item>
+        <item quantity="other">%d de elemente selectate</item>
     </plurals>
     <string name="squeezer_search_locations_title">Căutați locații</string>
     <string name="squeezer_search_locations_default_summary">Folderul de galerie (implicit)</string>
     <string name="squeezer_min_size_title">Dimensiunea minimă a fișierului</string>
-    <string name="squeezer_min_size_description">Săriți peste imagini mai mici decât această dimensiune.</string>
+    <string name="squeezer_min_size_description">Omite fișierele mai mici decât această dimensiune.</string>
     <string name="squeezer_min_age_title">Vârsta minimă a fișierului</string>
-    <string name="squeezer_min_age_description">Includeți doar imagini mai vechi decât această vârstă.</string>
-    <string name="squeezer_compression_settings_label">Setări de compresie</string>
+    <string name="squeezer_min_age_description">Include doar fișierele mai vechi decât această vârstă.</string>
+    <string name="squeezer_compression_settings_label">General</string>
     <string name="squeezer_quality_label">Calitate</string>
     <string name="squeezer_quality_title">Calitatea de compresie</string>
-    <string name="squeezer_quality_description">Calitate mai scăzută înseamnă o dimensiune mai mică a fișierului, dar o calitate redusă a imaginii.</string>
+    <string name="squeezer_quality_description">Calitate mai scăzută înseamnă dimensiune mai mică a fișierului, dar calitate vizuală redusă.</string>
     <string name="squeezer_quality_example_format">Exemplu: %1$s imagine→ economisește ~%2$s la %3$d%% calitate</string>
     <string name="squeezer_quality_warning_low">Calitățile inferioare pot provoca artefacte vizibile.</string>
     <string name="squeezer_quality_warning_high">Calitatea foarte înaltă oferă economii minime de spațiu.</string>
-    <string name="squeezer_types_category_label">Tipuri de imagini</string>
+    <string name="squeezer_types_category_label">Setări imagine</string>
+    <string name="squeezer_video_settings_category_label">Setări video</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">Includeți imagini JPEG (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">Includeți imagini WebP (.webp).</string>
+    <string name="squeezer_type_video_title">Video MP4</string>
+    <string name="squeezer_type_video_description">Include fișiere video MP4 (.mp4).</string>
     <string name="squeezer_skip_compressed_title">Săriți peste compresiile anterioare</string>
-    <string name="squeezer_skip_compressed_description">Săriți peste imaginile care au fost deja comprimate de SD Maid.</string>
+    <string name="squeezer_skip_compressed_description">Omite fișierele care au fost deja comprimate de SD Maid.</string>
     <string name="squeezer_exif_marker_title">Scrieți marcajul EXIF</string>
     <string name="squeezer_exif_marker_description">Adăugați un marcaj la câmpul de comentarii EXIF al imaginii pentru a preveni recompresia, chiar dacă istoricul de compresie este șters.</string>
     <string name="squeezer_estimated_savings_format">~%s economisite</string>
@@ -51,8 +64,8 @@
     <string name="squeezer_preview_dialog_title">Confirmați compresia</string>
     <string name="squeezer_preview_total_size">Dimensiune totală</string>
     <string name="squeezer_preview_estimated_savings">Economii estimate</string>
-    <string name="squeezer_compress_confirmation_title">Comprimați imaginile?</string>
-    <string name="squeezer_compress_confirmation_message">Acest lucru va înlocui imaginile originale cu versiuni comprimate. Această acțiune nu poate fi anulată.</string>
+    <string name="squeezer_compress_confirmation_title">Comprimați elementele selectate?</string>
+    <string name="squeezer_compress_confirmation_message">Aceasta va înlocui fișierele originale cu versiuni comprimate. Această acțiune nu poate fi anulată.</string>
     <string name="squeezer_history_title">Istoric compresie</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d element (%2$s)</item>
@@ -61,17 +74,25 @@
     </plurals>
     <string name="squeezer_history_empty">Fără istoric de compresie</string>
     <string name="squeezer_history_clear_title">Ștergeți istoricul de compresie</string>
-    <string name="squeezer_history_clear_message">Acest lucru va permite comprimarea din nou a imaginilor comprimate anterior. Imaginile în sine nu sunt afectate.</string>
+    <string name="squeezer_history_clear_message">Aceasta va permite ca fișierele comprimate anterior să fie comprimate din nou. Fișierele în sine nu sunt afectate.</string>
     <string name="squeezer_onboarding_title">Despre compresia imaginii</string>
     <string name="squeezer_onboarding_message">Compresia imaginilor reduce dimensiunea fișierului prin eliminarea detaliilor vizuale. Acest proces este ireversibil - calitatea originală nu poate fi restaurată.\n\nIată o previzualizare a modului în care vor arăta imaginile dvs:</string>
     <string name="squeezer_onboarding_original_label">Original</string>
     <string name="squeezer_onboarding_compressed_label">Dupa compresie</string>
+    <string name="squeezer_onboarding_video_original_label">Cadru video</string>
+    <string name="squeezer_onboarding_video_compressed_label">Previzualizare (aproximativă)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">Calitatea reală a videoclipului poate diferi</string>
     <string name="squeezer_onboarding_quality_label">Calitate: %d%%</string>
     <string name="squeezer_compare_action">Vizualizare comparație</string>
     <string name="squeezer_no_example_found">Nu s-au găsit imagini în căile selectate.</string>
-    <string name="squeezer_result_empty_message">Nu s-au găsit imagini compresibile.</string>
-    <string name="squeezer_setup_warning">Compresia reduce permanent calitatea imaginii pentru a economisi spațiu de stocare. Acest lucru nu poate fi anulat. Examinați cu atenție setările înainte de a începe.</string>
-    <string name="squeezer_setup_explanation">Presarea media reduce dimensiunea fișierului de imagini pentru a elibera spațiul de stocare. Acest lucru reduce permanent calitatea imaginii și nu poate fi anulat. Examinați cu atenție setările înainte de a începe.</string>
+    <string name="squeezer_result_empty_message">Nu s-au găsit fișiere media compresibile.</string>
+    <string name="squeezer_setup_warning">Compresia reduce permanent calitatea pentru a economisi spațiu de stocare. Aceasta nu poate fi anulată. Revizuiți setările cu atenție înainte de a începe.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d locație nu poate fi utilizată pentru comprimare și a fost eliminată. Compresia necesită acces direct la memoria internă.</item>
+        <item quantity="few">%d locații nu pot fi utilizate pentru comprimare și au fost eliminate. Compresia necesită acces direct la memoria internă.</item>
+        <item quantity="other">%d de locații nu pot fi utilizate pentru comprimare și au fost eliminate. Compresia necesită acces direct la memoria internă.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze reduce dimensiunea fișierelor de imagini și videoclipuri pentru a elibera spațiu de stocare. Aceasta reduce permanent calitatea și nu poate fi anulată. Revizuiți setările cu atenție înainte de a începe.</string>
     <string name="squeezer_setup_paths_title">Căutați locații</string>
     <string name="squeezer_setup_paths_default">Selectați foldere pentru căutare</string>
     <string name="squeezer_setup_quality_title">Calitatea compresiei</string>
@@ -87,6 +108,6 @@
         <item quantity="few">Cel puțin %d zile vechime</item>
         <item quantity="other">Cel puțin %d zile vechime</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">Se estimează că ~%d%% economii pentru fișierele JPEG</string>
+    <string name="squeezer_estimated_savings_percent">Economii estimate ~%d%% pentru imagini</string>
     <string name="squeezer_onboarding_got_it">Am înțeles</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-ru/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-ru/strings.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Сжатие изображений для экономии места.</string>
+    <string name="squeezer_explanation_short">Сжатие изображений и видео для экономии места.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">Найдено изображений: %d</item>
-        <item quantity="few">Найдено изображений: %d</item>
-        <item quantity="many">Найдено изображений: %d</item>
-        <item quantity="other">Найдено изображений: %d</item>
+        <item quantity="one">%d элемент найден</item>
+        <item quantity="few">%d элем. найдено</item>
+        <item quantity="many">%d элем. найдено</item>
+        <item quantity="other">%d элем. найдено</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">Можно сохранить: ~%s</item>
@@ -14,37 +14,52 @@
         <item quantity="other">Можно сохранить: ~%s</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">Изображений сжато: %d</item>
-        <item quantity="few">Изображений сжато: %d</item>
-        <item quantity="many">Изображений сжато: %d</item>
-        <item quantity="other">Изображений сжато: %d</item>
+        <item quantity="one">%d элемент сжат</item>
+        <item quantity="few">%d элем. сжато</item>
+        <item quantity="many">%d элем. сжато</item>
+        <item quantity="other">%d элем. сжато</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d - ошибка</item>
+        <item quantity="few">%d - ошибка</item>
+        <item quantity="many">%d - ошибка</item>
+        <item quantity="other">%d - ошибка</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d файл пропущен (недоступен)</item>
+        <item quantity="few">%d - пропущено (недоступны)</item>
+        <item quantity="many">%d - пропущено (недоступны)</item>
+        <item quantity="other">%d - пропущено (недоступны)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">Изображений выбрано: %d</item>
-        <item quantity="few">Изображений выбрано: %d</item>
-        <item quantity="many">Изображений выбрано: %d</item>
-        <item quantity="other">Изображений выбрано: %d</item>
+        <item quantity="one">%d элемент выбран</item>
+        <item quantity="few">%d элем. выбрано</item>
+        <item quantity="many">%d элем. выбрано</item>
+        <item quantity="other">%d элем. выбрано</item>
     </plurals>
     <string name="squeezer_search_locations_title">Поиск расположений</string>
     <string name="squeezer_search_locations_default_summary">Папки камеры (по умолчанию)</string>
     <string name="squeezer_min_size_title">Минимальный размер файла</string>
-    <string name="squeezer_min_size_description">Пропустить изображения меньше, чем этот размер.</string>
+    <string name="squeezer_min_size_description">Пропускать файлы меньше этого размера.</string>
     <string name="squeezer_min_age_title">Минимальный возраст файла</string>
-    <string name="squeezer_min_age_description">Включать изображения только старше этого возраста.</string>
-    <string name="squeezer_compression_settings_label">Настройки сжатия</string>
+    <string name="squeezer_min_age_description">Включать только файлы старше этого возраста.</string>
+    <string name="squeezer_compression_settings_label">Общее</string>
     <string name="squeezer_quality_label">Качество</string>
     <string name="squeezer_quality_title">Качество сжатия</string>
-    <string name="squeezer_quality_description">Меньшее качество означает меньший размер файла, но снижает качество изображения.</string>
+    <string name="squeezer_quality_description">Меньшее качество означает меньший размер файла, но снижение качества изображения.</string>
     <string name="squeezer_quality_example_format">Пример: %1$s изображение → экономия ~%2$s при качестве %3$d%%</string>
     <string name="squeezer_quality_warning_low">Низкое качество может вызывать видимые артефакты.</string>
     <string name="squeezer_quality_warning_high">Очень высокое качество ведет к минимальной экономии места.</string>
-    <string name="squeezer_types_category_label">Типы изображений</string>
+    <string name="squeezer_types_category_label">Настройки изображений</string>
+    <string name="squeezer_video_settings_category_label">Настройки видео</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">Включать изображения JPEG (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">Включать изображения WebP (.webp).</string>
+    <string name="squeezer_type_video_title">MP4 видео</string>
+    <string name="squeezer_type_video_description">Включать видеофайлы MP4 (.mp4).</string>
     <string name="squeezer_skip_compressed_title">Пропустить ранее сжатые</string>
-    <string name="squeezer_skip_compressed_description">Пропустить изображения, которые уже были сжаты SD Maid.</string>
+    <string name="squeezer_skip_compressed_description">Пропускать файлы, которые уже были сжаты SD Maid.</string>
     <string name="squeezer_exif_marker_title">Вписать маркер EXIF</string>
     <string name="squeezer_exif_marker_description">Добавляет маркер к полю комментариев пользователя EXIF для предотвращения повторного сжатия, даже если история сжатия очищается.</string>
     <string name="squeezer_estimated_savings_format">~%s экономия</string>
@@ -55,8 +70,8 @@
     <string name="squeezer_preview_dialog_title">Подтвердите сжатие</string>
     <string name="squeezer_preview_total_size">Общий размер</string>
     <string name="squeezer_preview_estimated_savings">Предполагаемая экономия</string>
-    <string name="squeezer_compress_confirmation_title">Сжать изображения?</string>
-    <string name="squeezer_compress_confirmation_message">Оригинальные изображения будут заменены сжатыми версиями. Это действие не может быть отменено.</string>
+    <string name="squeezer_compress_confirmation_title">Сжать выбранные элементы?</string>
+    <string name="squeezer_compress_confirmation_message">Оригинальные файлы будут заменены сжатыми версиями. Это действие не может быть отменено.</string>
     <string name="squeezer_history_title">История сжатия</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d элем. (%2$s)</item>
@@ -66,17 +81,26 @@
     </plurals>
     <string name="squeezer_history_empty">Нет истории сжатия</string>
     <string name="squeezer_history_clear_title">Очистить историю сжатия</string>
-    <string name="squeezer_history_clear_message">Это позволит снова сжимать ранее сжатые изображения. Сами изображения не будут затронуты.</string>
+    <string name="squeezer_history_clear_message">Это позволит снова сжимать ранее сжатые файлы. Сами файлы не изменяются.</string>
     <string name="squeezer_onboarding_title">О сжатии изображений</string>
     <string name="squeezer_onboarding_message">Сжатие изображений уменьшает размер файла путем удаления деталей. Этот процесс необратим - исходное качество не может быть восстановлено.\n\nВот предпросмотр того, как будут выглядеть Ваши изображения:</string>
     <string name="squeezer_onboarding_original_label">Оригинал</string>
     <string name="squeezer_onboarding_compressed_label">После сжатия</string>
+    <string name="squeezer_onboarding_video_original_label">Кадр видео</string>
+    <string name="squeezer_onboarding_video_compressed_label">Предпросмотр (приблизительно)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">Фактическое качество видео может отличаться</string>
     <string name="squeezer_onboarding_quality_label">Качество: %d%%</string>
     <string name="squeezer_compare_action">Сравнение</string>
     <string name="squeezer_no_example_found">В выбранных путях изображения не найдены.</string>
-    <string name="squeezer_result_empty_message">Не найдено изображений, которые можно сжать.</string>
-    <string name="squeezer_setup_warning">Сжатие навсегда снижает качество изображения для сохранения места. Это не может быть отменено. Перед началом внимательно проверьте настройки.</string>
-    <string name="squeezer_setup_explanation">Media Squeeze уменьшает размер файлов изображений, чтобы освободить место на диске. Это навсегда снижает качество изображения и не может быть отменено. Перед началом внимательно проверьте настройки.</string>
+    <string name="squeezer_result_empty_message">Сжимаемых медиафайлов не найдено.</string>
+    <string name="squeezer_setup_warning">Сжатие навсегда снижает качество для экономии места. Это невозможно отменить. Внимательно проверьте настройки перед началом.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d местоположение нельзя использовать для сжатия, оно было удалено. Для сжатия необходим прямой доступ к внутреннему хранилищу.</item>
+        <item quantity="few">%d местополож. нельзя использовать для сжатия, они были удалены. Для сжатия необходим прямой доступ к внутреннему хранилищу.</item>
+        <item quantity="many">%d местополож. нельзя использовать для сжатия, они были удалены. Для сжатия необходим прямой доступ к внутреннему хранилищу.</item>
+        <item quantity="other">%d местополож. нельзя использовать для сжатия, они были удалены. Для сжатия необходим прямой доступ к внутреннему хранилищу.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Сжатие медиа уменьшает размер файлов изображений и видео для освобождения места на диске. Это навсегда снижает качество и не может быть отменено. Внимательно проверьте настройки перед началом.</string>
     <string name="squeezer_setup_paths_title">Места для поиска</string>
     <string name="squeezer_setup_paths_default">Выберите папки для поиска</string>
     <string name="squeezer_setup_quality_title">Качество сжатия</string>
@@ -93,6 +117,6 @@
         <item quantity="many">По крайней мере %d дн.</item>
         <item quantity="other">По крайней мере %d дн.</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">Приблизительно ~%d%% экономия для JPEG-файлов</string>
+    <string name="squeezer_estimated_savings_percent">Приблизительная экономия ~%d%% для изображений</string>
     <string name="squeezer_onboarding_got_it">Понятно</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-sc-rIT/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-sc-rIT/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Cumprimi is immàgines pro isparagnare ispàtziu de archìviu.</string>
+    <string name="squeezer_explanation_short">Comprimi imàgines e vìdeos pro arrisparmiare ispàtziu de archiviàtzione.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d immàgine agatada</item>
-        <item quantity="other">%d immàgines agatadas</item>
+        <item quantity="one">%d elementu agatadu</item>
+        <item quantity="other">%d elementos agatados</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s si podet isparagnare</item>
         <item quantity="other">~%s si podent isparagnare</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d immàgine cumprimida</item>
-        <item quantity="other">%d immàgines cumprimidas</item>
+        <item quantity="one">%d elementu comprimidu</item>
+        <item quantity="other">%d elementos comprimidos</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d fallidu</item>
+        <item quantity="other">%d fallidos</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d archìviu saltadu (non accessìbile)</item>
+        <item quantity="other">%d archìvios saltados (non accessìbiles)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d immàgine selecionada</item>
-        <item quantity="other">%d immàgines selecionadas</item>
+        <item quantity="one">%d elementu seletzionadu</item>
+        <item quantity="other">%d elementos seletzionados</item>
     </plurals>
     <string name="squeezer_search_locations_title">Logos de chirca</string>
     <string name="squeezer_search_locations_default_summary">Cartellas de sa fotocàmera (predefinidas)</string>
     <string name="squeezer_min_size_title">Mannesa mìnima de s\'archìviu</string>
-    <string name="squeezer_min_size_description">Brinca is immàgines prus piticas de custa mannesa.</string>
+    <string name="squeezer_min_size_description">Salta sos archìvios prus pitchinnos de custa dimensione.</string>
     <string name="squeezer_min_age_title">Edade mìnima de s\'archìviu</string>
-    <string name="squeezer_min_age_description">Inclùe feti is immàgines prus betzas de custa edade.</string>
-    <string name="squeezer_compression_settings_label">Impostatziones de cumpressione</string>
+    <string name="squeezer_min_age_description">Includi ebbia sos archìvios prus bèzios de custa edade.</string>
+    <string name="squeezer_compression_settings_label">Generale</string>
     <string name="squeezer_quality_label">Calidade</string>
     <string name="squeezer_quality_title">Calidade de cumpressione</string>
-    <string name="squeezer_quality_description">Calidade prus bascia cheret nàrrere mannesa de archìviu prus pitica ma calidade de immàgine reduida.</string>
+    <string name="squeezer_quality_description">Una calidàde prus bàscia significat unu archìviu prus pitchinu ma una calidàde visuale reduida.</string>
     <string name="squeezer_quality_example_format">Esèmpiu: %1$s immàgine → isparagnos de ~%2$s a %3$d%% calidade</string>
     <string name="squeezer_quality_warning_low">Calidades prus bascias podent càusare artefatos visìbiles.</string>
     <string name="squeezer_quality_warning_high">Calidade meda arta dat isparagnos mìnimos de ispàtziu.</string>
-    <string name="squeezer_types_category_label">Gèneres de immàgine</string>
+    <string name="squeezer_types_category_label">Cunfiguratziones de imàgines</string>
+    <string name="squeezer_video_settings_category_label">Cunfiguratziones de vìdeo</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">Inclùe immàgines JPEG (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">Inclùe immàgines WebP (.webp).</string>
+    <string name="squeezer_type_video_title">Vìdeo MP4</string>
+    <string name="squeezer_type_video_description">Includi sos archìvios de vìdeo MP4 (.mp4).</string>
     <string name="squeezer_skip_compressed_title">Brinca is cumprimidas in antis</string>
-    <string name="squeezer_skip_compressed_description">Brinca is immàgines chi SD Maid at giai cumprimidu.</string>
+    <string name="squeezer_skip_compressed_description">Salta sos archìvios chi sunt giai istados comprimidos dae SD Maid.</string>
     <string name="squeezer_exif_marker_title">Iscrìe marcadore EXIF</string>
     <string name="squeezer_exif_marker_description">Agiunghe unu marcadore a su campu de comentu EXIF de s\'immàgine pro impedire sa torrada a cumprìmere fintzas si s\'istòria de cumpressione benit limpiada.</string>
     <string name="squeezer_estimated_savings_format">~%s de isparagnu</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">Cunfirma sa cumpressione</string>
     <string name="squeezer_preview_total_size">Mannesa totale</string>
     <string name="squeezer_preview_estimated_savings">Isparagnu istimadu</string>
-    <string name="squeezer_compress_confirmation_title">Cumprimi is immàgines?</string>
-    <string name="squeezer_compress_confirmation_message">Custu at a sostituire is immàgines originales cun versiones cumprimidas. Custa atzione non si podet annullare.</string>
+    <string name="squeezer_compress_confirmation_title">Comprimi sos elementos seletzionados?</string>
+    <string name="squeezer_compress_confirmation_message">Custu ddos remplatzàrà sos archìvios originales cun versiones comprimidas. Custa atzione non podet èssere annullada.</string>
     <string name="squeezer_history_title">Istòria de cumpressione</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d elementu (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">Peruna istòria de cumpressione</string>
     <string name="squeezer_history_clear_title">Lìmpia s\'istòria de cumpressione</string>
-    <string name="squeezer_history_clear_message">Custu at a permìtere de cumprìmere torra is immàgines giai cumprimidas. Is immàgines a sa sola non sunt afetadas.</string>
+    <string name="squeezer_history_clear_message">Custu permettet a sos archìvios comprimidos in antis de bènnere comprimidos ancora. Sos archìvios medesimu no ant a èssere afetados.</string>
     <string name="squeezer_onboarding_title">Informatzione subra sa cumpressione de immàgines</string>
     <string name="squeezer_onboarding_message">Sa cumpressione de immàgines reduet sa mannesa de s\'archìviu boggende detàllios visivos. Custu protzessu est irreversìbile - sa calidade originale non si podet torrare.\n\nEcco comente ant a apàrrere is immàgines tuas:</string>
     <string name="squeezer_onboarding_original_label">Originale</string>
     <string name="squeezer_onboarding_compressed_label">Pustis de sa cumpressione</string>
+    <string name="squeezer_onboarding_video_original_label">Fotogramma de vìdeo</string>
+    <string name="squeezer_onboarding_video_compressed_label">Anteprima (aproximada)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">Sa calidàde reale de vìdeo podet èssere diferente</string>
     <string name="squeezer_onboarding_quality_label">Calidade: %d%%</string>
     <string name="squeezer_compare_action">Bide su paragone</string>
     <string name="squeezer_no_example_found">Peruna immàgine agatada in is caminos selecionados.</string>
-    <string name="squeezer_result_empty_message">Peruna immàgine cumprimìbile agatada.</string>
-    <string name="squeezer_setup_warning">Sa cumpressione reduet in manera permanente sa calidade de s\'immàgine pro isparagnare ispàtziu de archìviu. Non si podet annullare. Revisa is impostatziones tuas cun curu prima de cumintzare.</string>
-    <string name="squeezer_setup_explanation">Media Squeeze reduet sa mannesa de is archìvios de is immàgines pro liberare ispàtziu de archìviu. Custu reduet in manera permanente sa calidade de s\'immàgine e non si podet annullare. Revisa is impostatziones tuas cun curu prima de cumintzare.</string>
+    <string name="squeezer_result_empty_message">Medios comprimìbiles non sunt istados agatados.</string>
+    <string name="squeezer_setup_warning">Sa compressione reduet in manera permanente sa calidàde pro arrisparmiare ispàtziu de archiviàtzione. Custu non podet èssere annulladu. Revisiona cun cuidadu sas tunadas tuas antes de incomintzare.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d logu non podet èssere utilizadu pro sa compressione ed est istadu eliminadu. Sa compressione rechidet atzessu direttu a s\'archìviu internu.</item>
+        <item quantity="other">%d logos non podent èssere utilizados pro sa compressione ed ant a èssere eliminados. Sa compressione rechidet atzessu direttu a s\'archìviu internu.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze reduet sa dimensione de sos archìvios de imàgines e vìdeos pro liberare ispàtziu de archiviàtzione. Custu reduet in manera permanente sa calidàde e non podet èssere annulladu. Revisiona cun cuidadu sas tunadas tuas antes de incomintzare.</string>
     <string name="squeezer_setup_paths_title">Logos de chirca</string>
     <string name="squeezer_setup_paths_default">Sèbera cartellas de chircare</string>
     <string name="squeezer_setup_quality_title">Calidade de cumpressione</string>
@@ -81,6 +99,6 @@
         <item quantity="one">A su mancu %d die de edade</item>
         <item quantity="other">A su mancu %d dies de edade</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">Isparagnu istimadu de ~%d%% pro archìvios JPEG</string>
+    <string name="squeezer_estimated_savings_percent">~%d%% de rispàrmiu istimadu pro imàgines</string>
     <string name="squeezer_onboarding_got_it">Apat cumprèndiu</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-si-rLK/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-si-rLK/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">ගබඩා ඉඩ ඉතිරි කිරීමට රූප සංකෝචනය කරන්න.</string>
+    <string name="squeezer_explanation_short">ගබඩා ඉඩ ඉතිරි කිරීමට රූප සහ වීඩියෝ සම්පීඩනය කරන්න.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">රූපය %d ක් හමු විය</item>
-        <item quantity="other">රූප %d ක් හමු විය</item>
+        <item quantity="one">%d අයිතමය හමු විය</item>
+        <item quantity="other">%d අයිතම හමු විය</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s ඉතිරි කළ හැක</item>
         <item quantity="other">~%s ඉතිරි කළ හැක</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">රූපය %d ක් සංකෝචනය විය</item>
-        <item quantity="other">රූප %d ක් සංකෝචනය විය</item>
+        <item quantity="one">%d අයිතමය සම්පීඩනය කරන ලදි</item>
+        <item quantity="other">%d අයිතම සම්පීඩනය කරන ලදි</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d අසාර්ථක</item>
+        <item quantity="other">%d අසාර්ථක</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d ගොනුව මඟ හැරිණි (ප්‍රවේශ විය නොහැකි)</item>
+        <item quantity="other">%d ගොනු මඟ හැරිණි (ප්‍රවේශ විය නොහැකි)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">රූපය %d ක් තෝරා ඇත</item>
-        <item quantity="other">රූප %d ක් තෝරා ඇත</item>
+        <item quantity="one">%d අයිතමය තෝරා ගන්නා ලදි</item>
+        <item quantity="other">%d අයිතම තෝරා ගන්නා ලදි</item>
     </plurals>
     <string name="squeezer_search_locations_title">සෙවුම් ස්ථාන</string>
     <string name="squeezer_search_locations_default_summary">කැමරා ෆෝල්ඩර (පෙරනිමි)</string>
     <string name="squeezer_min_size_title">අවම ගොනු ප්‍රමාණය</string>
-    <string name="squeezer_min_size_description">මෙම ප්‍රමාණයට වඩා කුඩා රූප මඟ හරින්න.</string>
+    <string name="squeezer_min_size_description">මෙම ප්‍රමාණයට වඩා කුඩා ගොනු මඟ හරින්න.</string>
     <string name="squeezer_min_age_title">අවම ගොනු වයස</string>
-    <string name="squeezer_min_age_description">මෙම වයසට වඩා පැරණි රූප පමණක් ඇතුළත් කරන්න.</string>
-    <string name="squeezer_compression_settings_label">සංකෝචන සැකසුම්</string>
+    <string name="squeezer_min_age_description">මෙම වයසට වඩා පැරණි ගොනු පමණක් ඇතුළත් කරන්න.</string>
+    <string name="squeezer_compression_settings_label">සාමාන්‍ය</string>
     <string name="squeezer_quality_label">ගුණත්වය</string>
     <string name="squeezer_quality_title">සංකෝචන ගුණත්වය</string>
-    <string name="squeezer_quality_description">අඩු ගුණත්වය යනු කුඩා ගොනු ප්‍රමාණය නමුත් අඩු රූප ගුණත්වයයි.</string>
+    <string name="squeezer_quality_description">අඩු ගුණාත්මකභාවය කුඩා ගොනු ප්‍රමාණය අදහස් කරයි නමුත් දෘශ්‍ය ගුණාත්මකභාවය අඩු වේ.</string>
     <string name="squeezer_quality_example_format">උදාහරණ: %1$s රූපය → %3$d%% ගුණත්වයේදී ~%2$s ඉතිරි</string>
     <string name="squeezer_quality_warning_low">අඩු ගුණත්වයන්හි දෘශ්‍ය අවශේෂ ඇති විය හැක.</string>
     <string name="squeezer_quality_warning_high">ඉතා ඉහළ ගුණත්වය අවම ඉඩ ඉතිරිකිරීම් සපයයි.</string>
-    <string name="squeezer_types_category_label">රූප වර්ග</string>
+    <string name="squeezer_types_category_label">රූප සැකසීම්</string>
+    <string name="squeezer_video_settings_category_label">වීඩියෝ සැකසීම්</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">JPEG රූප (.jpg, .jpeg) ඇතුළත් කරන්න.</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">WebP රූප (.webp) ඇතුළත් කරන්න.</string>
+    <string name="squeezer_type_video_title">MP4 Video</string>
+    <string name="squeezer_type_video_description">MP4 වීඩියෝ ගොනු (.mp4) ඇතුළත් කරන්න.</string>
     <string name="squeezer_skip_compressed_title">කලින් සංකෝචනය කළ ඒවා මඟ හරින්න</string>
-    <string name="squeezer_skip_compressed_description">SD Maid විසින් දැනටමත් සංකෝචනය කර ඇති රූප මඟ හරින්න.</string>
+    <string name="squeezer_skip_compressed_description">SD Maid විසින් දැනටමත් සම්පීඩනය කරන ලද ගොනු මඟ හරින්න.</string>
     <string name="squeezer_exif_marker_title">EXIF සලකුණ ලියන්න</string>
     <string name="squeezer_exif_marker_description">සංකෝචන ඉතිහාසය මකා දැමුවද නැවත සංකෝචනය වැළැක්වීමට රූපයේ EXIF පරිශීලක අදහස් ක්‍ෂේත්‍රයට සලකුණක් එකතු කරන්න.</string>
     <string name="squeezer_estimated_savings_format">~%s ඉතිරි</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">සංකෝචනය තහවුරු කරන්න</string>
     <string name="squeezer_preview_total_size">මුළු ප්‍රමාණය</string>
     <string name="squeezer_preview_estimated_savings">ඇස්තමේන්තු ඉතිරි</string>
-    <string name="squeezer_compress_confirmation_title">රූප සංකෝචනය කරන්නද?</string>
-    <string name="squeezer_compress_confirmation_message">මෙය මුල් රූප සංකෝචිත අනුවාද වලින් ප්‍රතිස්ථාපනය කරනු ඇත. මෙම ක්‍රියාව පසුගමනය කළ නොහැක.</string>
+    <string name="squeezer_compress_confirmation_title">තෝරාගත් අයිතම සම්පීඩනය කරන්නද?</string>
+    <string name="squeezer_compress_confirmation_message">මෙය මුල් ගොනු සම්පීඩිත අනුවාද සමඟ ප්‍රතිස්ථාපනය කරනු ඇත. මෙම ක්‍රියාව නිෂ්ප්‍රභ කළ නොහැක.</string>
     <string name="squeezer_history_title">සංකෝචන ඉතිහාසය</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">අයිතම %1$d (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">සංකෝචන ඉතිහාසයක් නැත</string>
     <string name="squeezer_history_clear_title">සංකෝචන ඉතිහාසය මකන්න</string>
-    <string name="squeezer_history_clear_message">මෙය කලින් සංකෝචනය කළ රූප නැවත සංකෝචනය කිරීමට ඉඩ දෙනු ඇත. රූප වලට බලපෑමක් නැත.</string>
+    <string name="squeezer_history_clear_message">මෙය කලින් සම්පීඩනය කරන ලද ගොනු නැවත සම්පීඩනය කිරීමට ඉඩ දෙනු ඇත. ගොනු ම කෙරෙහි බලපෑමක් නොමැත.</string>
     <string name="squeezer_onboarding_title">රූප සංකෝචනය ගැන</string>
     <string name="squeezer_onboarding_message">රූප සංකෝචනය දෘශ්‍ය විස්තර ඉවත් කිරීමෙන් ගොනු ප්‍රමාණය අඩු කරයි. මෙම ක්‍රියාවලිය ආපසු හැරවිය නොහැක - මුල් ගුණත්වය ප්‍රතිසාධනය කළ නොහැක.\n\nඔබේ රූප කෙසේ පෙනෙනු ඇත්දැයි මෙන්න:</string>
     <string name="squeezer_onboarding_original_label">මුල්</string>
     <string name="squeezer_onboarding_compressed_label">සංකෝචනයෙන් පසුව</string>
+    <string name="squeezer_onboarding_video_original_label">වීඩියෝ රාමුව</string>
+    <string name="squeezer_onboarding_video_compressed_label">පූර්වදර්ශනය (ආසන්න)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">සත්‍ය වීඩියෝ ගුණාත්මකභාවය වෙනස් විය හැක</string>
     <string name="squeezer_onboarding_quality_label">ගුණත්වය: %d%%</string>
     <string name="squeezer_compare_action">සැසඳීම බලන්න</string>
     <string name="squeezer_no_example_found">තෝරාගත් මාර්ගවල රූප හමු නොවීය.</string>
-    <string name="squeezer_result_empty_message">සංකෝචනය කළ හැකි රූප හමු නොවීය.</string>
-    <string name="squeezer_setup_warning">සංකෝචනය ගබඩා ඉඩ ඉතිරි කිරීමට රූප ගුණත්වය ස්ථිරවම අඩු කරයි. මෙය පසුගමනය කළ නොහැක. ආරම්භ කිරීමට පෙර ඔබේ සැකසුම් ප්‍රවේශමෙන් සමාලෝචනය කරන්න.</string>
-    <string name="squeezer_setup_explanation">Media Squeeze ගබඩා ඉඩ නිදහස් කිරීමට රූපවල ගොනු ප්‍රමාණය අඩු කරයි. මෙය රූප ගුණත්වය ස්ථිරවම අඩු කරන අතර පසුගමනය කළ නොහැක. ආරම්භ කිරීමට පෙර ඔබේ සැකසුම් ප්‍රවේශමෙන් සමාලෝචනය කරන්න.</string>
+    <string name="squeezer_result_empty_message">සම්පීඩනය කළ හැකි මාධ්‍ය හමු නොවීය.</string>
+    <string name="squeezer_setup_warning">සම්පීඩනය ගබඩා ඉඩ ඉතිරි කිරීමට ගුණාත්මකභාවය ස්ථිරවශයෙන් අඩු කරයි. මෙය නිෂ්ප්‍රභ කළ නොහැක. ආරම්භ කිරීමට පෙර ඔබගේ සැකසීම් ප්‍රවේශමෙන් සමාලෝචනය කරන්න.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d ස්ථානයක් සම්පීඩනය සඳහා භාවිතා කළ නොහැකි අතර ඉවත් කරන ලදි. සම්පීඩනයට අභ්‍යන්තර ගබඩාවට සෘජු ප්‍රවේශය අවශ්‍ය වේ.</item>
+        <item quantity="other">%d ස්ථාන සම්පීඩනය සඳහා භාවිතා කළ නොහැකි අතර ඉවත් කරන ලදි. සම්පීඩනයට අභ්‍යන්තර ගබඩාවට සෘජු ප්‍රවේශය අවශ්‍ය වේ.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze රූප සහ වීඩියෝ ගොනු ප්‍රමාණය අඩු කිරීමෙන් ගබඩා ඉඩ නිදහස් කරයි. මෙය ගුණාත්මකභාවය ස්ථිරවශයෙන් අඩු කරයි, නිෂ්ප්‍රභ කළ නොහැක. ආරම්භ කිරීමට පෙර ඔබගේ සැකසීම් ප්‍රවේශමෙන් සමාලෝචනය කරන්න.</string>
     <string name="squeezer_setup_paths_title">සෙවුම් ස්ථාන</string>
     <string name="squeezer_setup_paths_default">සෙවීමට ෆෝල්ඩර තෝරන්න</string>
     <string name="squeezer_setup_quality_title">සංකෝචන ගුණත්වය</string>
@@ -81,6 +99,6 @@
         <item quantity="one">අවම දින %d ක් පැරණි</item>
         <item quantity="other">අවම දින %d ක් පැරණි</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">JPEG ගොනු සඳහා ඇස්තමේන්තු ~%d%% ඉතිරි</string>
+    <string name="squeezer_estimated_savings_percent">රූප සඳහා ඇස්තමේන්තු ~%d%% ඉතිරිකිරීම්</string>
     <string name="squeezer_onboarding_got_it">තේරුණා</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-sk/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-sk/strings.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Komprimujte obrázky a ušetrite úložný priestor.</string>
+    <string name="squeezer_explanation_short">Komprimujte obrázky a videá, aby ste ušetrili úložný priestor.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d obrázok nájdený</item>
-        <item quantity="few">%d obrázky nájdené</item>
-        <item quantity="many">%d obrázkov nájdených</item>
-        <item quantity="other">%d obrázkov nájdených</item>
+        <item quantity="one">%d položka nájdená</item>
+        <item quantity="few">%d položky nájdené</item>
+        <item quantity="many">%d položiek nájdených</item>
+        <item quantity="other">%d položiek nájdených</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s je možné ušetriť</item>
@@ -14,37 +14,52 @@
         <item quantity="other">~%s je možné ušetriť</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d obrázok komprimovaný</item>
-        <item quantity="few">%d obrázky komprimované</item>
-        <item quantity="many">%d obrázkov komprimovaných</item>
-        <item quantity="other">%d obrázkov komprimovaných</item>
+        <item quantity="one">%d položka skomprimovaná</item>
+        <item quantity="few">%d položky skomprimované</item>
+        <item quantity="many">%d položiek skomprimovaných</item>
+        <item quantity="other">%d položiek skomprimovaných</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d zlyhalo</item>
+        <item quantity="few">%d zlyhalo</item>
+        <item quantity="many">%d zlyhalo</item>
+        <item quantity="other">%d zlyhalo</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d súbor preskočený (nie je prístupný)</item>
+        <item quantity="few">%d súbory preskočené (nie sú prístupné)</item>
+        <item quantity="many">%d súborov preskočených (nie sú prístupné)</item>
+        <item quantity="other">%d súborov preskočených (nie sú prístupné)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d obrázok vybraný</item>
-        <item quantity="few">%d obrázky vybrané</item>
-        <item quantity="many">%d obrázkov vybraných</item>
-        <item quantity="other">%d obrázkov vybraných</item>
+        <item quantity="one">%d položka vybraná</item>
+        <item quantity="few">%d položky vybrané</item>
+        <item quantity="many">%d položiek vybraných</item>
+        <item quantity="other">%d položiek vybraných</item>
     </plurals>
     <string name="squeezer_search_locations_title">Miesta vyhľadávania</string>
     <string name="squeezer_search_locations_default_summary">Priečinky fotoaparátu (predvolené)</string>
     <string name="squeezer_min_size_title">Minimálna veľkosť súboru</string>
-    <string name="squeezer_min_size_description">Preskočiť obrázky menšie ako táto veľkosť.</string>
+    <string name="squeezer_min_size_description">Preskočiť súbory menšie ako táto veľkosť.</string>
     <string name="squeezer_min_age_title">Minimálny vek súboru</string>
-    <string name="squeezer_min_age_description">Zahrnúť iba obrázky staršie ako tento vek.</string>
-    <string name="squeezer_compression_settings_label">Nastavenia kompresie</string>
+    <string name="squeezer_min_age_description">Zahrnúť iba súbory staršie ako tento vek.</string>
+    <string name="squeezer_compression_settings_label">Všeobecné</string>
     <string name="squeezer_quality_label">Kvalita</string>
     <string name="squeezer_quality_title">Kvalita kompresie</string>
-    <string name="squeezer_quality_description">Nižšia kvalita znamená menšiu veľkosť súboru, ale zníženú kvalitu obrázka.</string>
+    <string name="squeezer_quality_description">Nižšia kvalita znamená menšiu veľkosť súboru, ale zníſenú vizuálnu kvalitu.</string>
     <string name="squeezer_quality_example_format">Príklad: %1$s obrázok → úspora ~%2$s pri %3$d%% kvalite</string>
     <string name="squeezer_quality_warning_low">Nižšie kvality môžu spôsobiť viditeľné artefakty.</string>
     <string name="squeezer_quality_warning_high">Veľmi vysoká kvalita poskytuje minimálnu úsporu miesta.</string>
-    <string name="squeezer_types_category_label">Typy obrázkov</string>
+    <string name="squeezer_types_category_label">Nastavenia obrázkov</string>
+    <string name="squeezer_video_settings_category_label">Nastavenia videa</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">Zahrnúť obrázky JPEG (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">Zahrnúť obrázky WebP (.webp).</string>
+    <string name="squeezer_type_video_title">MP4 Video</string>
+    <string name="squeezer_type_video_description">Zahrnúť video súbory MP4 (.mp4).</string>
     <string name="squeezer_skip_compressed_title">Preskočiť predtým komprimované</string>
-    <string name="squeezer_skip_compressed_description">Preskočiť obrázky, ktoré už boli komprimované aplikáciou SD Maid.</string>
+    <string name="squeezer_skip_compressed_description">Preskočiť súbory, ktoré už boli skomprimované aplikaciou SD Maid.</string>
     <string name="squeezer_exif_marker_title">Zapísať EXIF značku</string>
     <string name="squeezer_exif_marker_description">Pridať značku do poľa používateľského komentára EXIF obrázka, aby sa zabránilo opätovnej kompresii, aj keď sa história kompresie vymaže.</string>
     <string name="squeezer_estimated_savings_format">~%s úspora</string>
@@ -55,8 +70,8 @@
     <string name="squeezer_preview_dialog_title">Potvrdiť kompresiu</string>
     <string name="squeezer_preview_total_size">Celková veľkosť</string>
     <string name="squeezer_preview_estimated_savings">Odhadovaná úspora</string>
-    <string name="squeezer_compress_confirmation_title">Komprimovať obrázky?</string>
-    <string name="squeezer_compress_confirmation_message">Toto nahradí pôvodné obrázky komprimovanými verziami. Túto akciu nie je možné vrátiť späť.</string>
+    <string name="squeezer_compress_confirmation_title">Komprimovať vybrané položky?</string>
+    <string name="squeezer_compress_confirmation_message">Tým sa pôvodné súbory nahradia skomprimovanými verziami. Túto akciu nie je možné vrátiť späť.</string>
     <string name="squeezer_history_title">História kompresie</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d položka (%2$s)</item>
@@ -66,17 +81,26 @@
     </plurals>
     <string name="squeezer_history_empty">Žiadna história kompresie</string>
     <string name="squeezer_history_clear_title">Vymazať históriu kompresie</string>
-    <string name="squeezer_history_clear_message">Toto umožní predtým komprimovaným obrázkom byť komprimovaným znova. Samotné obrázky nie sú ovplyvnené.</string>
+    <string name="squeezer_history_clear_message">Tým sa umožní, aby prípadne skomprimované súbory boli skomprimované znova. Samé súbory nie sú ovplyvnené.</string>
     <string name="squeezer_onboarding_title">O kompresii obrázkov</string>
     <string name="squeezer_onboarding_message">Kompresia obrázkov zmenšuje veľkosť súboru odstránením vizuálnych detailov. Tento proces je nezvratný — pôvodnú kvalitu nie je možné obnoviť.\n\nTu je ukážka, ako budú vaše obrázky vyzerať:</string>
     <string name="squeezer_onboarding_original_label">Originál</string>
     <string name="squeezer_onboarding_compressed_label">Po kompresii</string>
+    <string name="squeezer_onboarding_video_original_label">Snímka videa</string>
+    <string name="squeezer_onboarding_video_compressed_label">Náhľad (približný)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">Skutočná kvalita videa sa môže líšiť</string>
     <string name="squeezer_onboarding_quality_label">Kvalita: %d%%</string>
     <string name="squeezer_compare_action">Zobraziť porovnanie</string>
     <string name="squeezer_no_example_found">V zvolených cestách sa nenašli žiadne obrázky.</string>
-    <string name="squeezer_result_empty_message">Nenašli sa žiadne komprimovateľné obrázky.</string>
-    <string name="squeezer_setup_warning">Kompresia natrvalo znižuje kvalitu obrázkov, aby sa ušetril úložný priestor. Túto akciu nie je možné vrátiť späť. Pred spustením si starostlivo skontrolujte nastavenia.</string>
-    <string name="squeezer_setup_explanation">Kompresia médií zmenšuje veľkosť súborov obrázkov, aby sa uvoľnil úložný priestor. Toto natrvalo znižuje kvalitu obrázkov a nie je možné to vrátiť späť. Pred spustením si starostlivo skontrolujte nastavenia.</string>
+    <string name="squeezer_result_empty_message">Nebol nájdený žiadny komprimovateľný mediálny obsáh.</string>
+    <string name="squeezer_setup_warning">Kompresia trvalo znižuje kvalitu, aby ušetrila úložný priestor. Túto akciu nie je možné vrátiť späť. Pred spustením si pozorne prezrite nastavenia.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d miesto nemôže byť použité na kompresiu a bolo odstránené. Kompresia vyžaduje priamy prístup k internému úložisku.</item>
+        <item quantity="few">%d miesta nemôžu byť použité na kompresiu a boli odstránené. Kompresia vyžaduje priamy prístup k internému úložisku.</item>
+        <item quantity="many">%d miest nemôže byť použitých na kompresiu a boli odstránené. Kompresia vyžaduje priamy prístup k internému úložisku.</item>
+        <item quantity="other">%d miest nemôže byť použitých na kompresiu a boli odstránené. Kompresia vyžaduje priamy prístup k internému úložisku.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze zmenšuje veľkosť súborov obrázkov a videí, aby uvoľniiť úložný priestor. Tým sa trvalo znižuje kvalita a túto akciu nie je možné vrátiť späť. Pred spustením si pozorne prezrite nastavenia.</string>
     <string name="squeezer_setup_paths_title">Miesta vyhľadávania</string>
     <string name="squeezer_setup_paths_default">Vyberte priečinky na prehľadávanie</string>
     <string name="squeezer_setup_quality_title">Kvalita kompresie</string>
@@ -93,6 +117,6 @@
         <item quantity="many">Aspoň %d dní starých</item>
         <item quantity="other">Aspoň %d dní starých</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">Odhadovaná úspora ~%d%% pre súbory JPEG</string>
+    <string name="squeezer_estimated_savings_percent">Odhadované úspôr pre obrázky ~%d%%</string>
     <string name="squeezer_onboarding_got_it">Rozumiem</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-sl/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-sl/strings.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Stisnite slike in prihranite prostor.</string>
+    <string name="squeezer_explanation_short">Stisni slike in videoposnetke, da prihranite prostor.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">Najdena je bila %d slika.</item>
-        <item quantity="two">Najdeni sta bili %d sliki.</item>
-        <item quantity="few">Najdene so bile %d slike.</item>
-        <item quantity="other">Najdenih je bilo %d slik.</item>
+        <item quantity="one">%d predmet najden</item>
+        <item quantity="two">%d predmeta najdena</item>
+        <item quantity="few">%d predmeti najdeni</item>
+        <item quantity="other">%d predmetov najdenih</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">Prihranite lahko ~%s.</item>
@@ -14,37 +14,52 @@
         <item quantity="other">Prihranite lahko ~%s.</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">Stisnjena je bila %d slika.</item>
-        <item quantity="two">Stisnjeni sta bili %d sliki.</item>
-        <item quantity="few">Stisnjene so bile %d slike.</item>
-        <item quantity="other">Stisnjenih je bilo %d slik.</item>
+        <item quantity="one">%d predmet stisnjen</item>
+        <item quantity="two">%d predmeta stisnjena</item>
+        <item quantity="few">%d predmeti stisnjeni</item>
+        <item quantity="other">%d predmetov stisnjenih</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">Spodletel: %d</item>
+        <item quantity="two">Spodletela: %d</item>
+        <item quantity="few">Spodleteli: %d</item>
+        <item quantity="other">Spodletelih: %d</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d datoteka preskočena (ni dostopna)</item>
+        <item quantity="two">%d datoteki preskočeni (nista dostopni)</item>
+        <item quantity="few">%d datoteke preskočene (niso dostopne)</item>
+        <item quantity="other">%d datotek preskočenih (niso dostopne)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">Izbrana je %d slika.</item>
-        <item quantity="two">Izbrani sta %d sliki.</item>
-        <item quantity="few">Izbrane so %d slike.</item>
-        <item quantity="other">Izbranih je %d slik.</item>
+        <item quantity="one">%d element izbran</item>
+        <item quantity="two">%d elementa izbrana</item>
+        <item quantity="few">%d elementi izbrani</item>
+        <item quantity="other">%d elementov izbranih</item>
     </plurals>
     <string name="squeezer_search_locations_title">Mesta iskanja</string>
     <string name="squeezer_search_locations_default_summary">Mape fotoaparata (privzeto)</string>
     <string name="squeezer_min_size_title">Najmanjša velikost datoteke</string>
-    <string name="squeezer_min_size_description">Preskoči slike, manjše od te velikosti.</string>
+    <string name="squeezer_min_size_description">Preskoči datoteke, manjše od te velikosti.</string>
     <string name="squeezer_min_age_title">Najmanjša starost datoteke</string>
-    <string name="squeezer_min_age_description">Vključi samo slike, starejše od te vrednosti.</string>
-    <string name="squeezer_compression_settings_label">Nastavitve stiskanja</string>
+    <string name="squeezer_min_age_description">Vključi samo datoteke, starejše od te starosti.</string>
+    <string name="squeezer_compression_settings_label">Splošno</string>
     <string name="squeezer_quality_label">Kakovost</string>
     <string name="squeezer_quality_title">Kakovost stiskanja</string>
-    <string name="squeezer_quality_description">Nižja kakovost pomeni manjšo velikost datoteke, a slabšo kakovost slike.</string>
+    <string name="squeezer_quality_description">Nižja kakovost pomeni manjšo velikost datoteke, vendar slabšo vizualno kakovost.</string>
     <string name="squeezer_quality_example_format">Primer: slika %1$s → prihranite ~%2$s pri %3$d%% kakovosti.</string>
     <string name="squeezer_quality_warning_low">Nižje kakovosti lahko povzročijo vidna popačenja.</string>
     <string name="squeezer_quality_warning_high">Zelo visoka kakovost omogoča le majhen prihranek prostora.</string>
-    <string name="squeezer_types_category_label">Vrste slik</string>
+    <string name="squeezer_types_category_label">Nastavitve slik</string>
+    <string name="squeezer_video_settings_category_label">Nastavitve videa</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">Vključi slike JPEG (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">Vključi slike WebP (.webp).</string>
+    <string name="squeezer_type_video_title">MP4 Video</string>
+    <string name="squeezer_type_video_description">Vključi video datoteke MP4 (.mp4).</string>
     <string name="squeezer_skip_compressed_title">Preskoči že stisnjene</string>
-    <string name="squeezer_skip_compressed_description">Preskoči slike, ki jih je SD Maid že stisnil.</string>
+    <string name="squeezer_skip_compressed_description">Preskoči datoteke, ki jih je SD Maid že stisnilo.</string>
     <string name="squeezer_exif_marker_title">Zapiši oznako EXIF</string>
     <string name="squeezer_exif_marker_description">Dodaj oznako v polje uporabniškega komentarja oznak EXIF, da preprečite ponovno stiskanje, tudi če je bila zgodovina stiskanja izbrisana.</string>
     <string name="squeezer_estimated_savings_format">~%s prihranka</string>
@@ -55,8 +70,8 @@
     <string name="squeezer_preview_dialog_title">Potrdi stiskanje</string>
     <string name="squeezer_preview_total_size">Skupna velikost</string>
     <string name="squeezer_preview_estimated_savings">Predviden prihranek</string>
-    <string name="squeezer_compress_confirmation_title">Stisni slike?</string>
-    <string name="squeezer_compress_confirmation_message">S tem boste zamenjali izvirne slike s stisnjeno različico.  Tega dejanja ni mogoče razveljaviti.</string>
+    <string name="squeezer_compress_confirmation_title">Stisni izbrane elemente?</string>
+    <string name="squeezer_compress_confirmation_message">To bo nadomestilo izvirne datoteke s stisnjenimi različicami. Tega dejanja ni mogoče razveljaviti.</string>
     <string name="squeezer_history_title">Zgodovina stiskanja</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d predmet (%2$s)</item>
@@ -66,17 +81,26 @@
     </plurals>
     <string name="squeezer_history_empty">Ni zgodovine stiskanja.</string>
     <string name="squeezer_history_clear_title">Počisti zgodovino stiskanja</string>
-    <string name="squeezer_history_clear_message">S tem boste omogočili ponovno stiskanje predhodno stisnjenih slik.  To ne vpliva na same slike.</string>
+    <string name="squeezer_history_clear_message">To bo omogočilo, da se predhodno stisnjene datoteke stisnejo znova. Same datoteke niso prizadete.</string>
     <string name="squeezer_onboarding_title">O stiskanju slik</string>
     <string name="squeezer_onboarding_message">Stiskanje slik zmanjša velikost datoteke z odstranitvijo vizualnih podrobnosti.  Ta postopek je nepovraten – izvirne kakovosti ni mogoče obnoviti.\n\nTu je predogled, kako bodo izgledale vaše slike:</string>
     <string name="squeezer_onboarding_original_label">Izvirnik</string>
     <string name="squeezer_onboarding_compressed_label">Po stiskanju</string>
+    <string name="squeezer_onboarding_video_original_label">Sličica videa</string>
+    <string name="squeezer_onboarding_video_compressed_label">Predogled (približno)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">Dejanska kakovost videa se lahko razlikuje</string>
     <string name="squeezer_onboarding_quality_label">Kakovost: %d%%</string>
     <string name="squeezer_compare_action">Pokaži primerjavo</string>
     <string name="squeezer_no_example_found">Na izbranih poteh ni bilo mogoče najti slik.</string>
-    <string name="squeezer_result_empty_message">Slik za stiskanje ni bilo mogoče najti.</string>
-    <string name="squeezer_setup_warning">Stiskanje trajno zmanjša kakovost slike, da prihrani prostor.  Tega ni mogoče razveljaviti.  Pred začetkom skrbno preglejte nastavitve.</string>
-    <string name="squeezer_setup_explanation">Stiskalnik slik zmanjša velikost slikovnih datotek, da sprosti prostor.  To trajno zmanjša kakovost slike in tega ni mogoče razveljaviti.  Pred začetkom skrbno preglejte nastavitve.</string>
+    <string name="squeezer_result_empty_message">Ni stisljive medijske vsebine.</string>
+    <string name="squeezer_setup_warning">Stiskanje trajno zmanjša kakovost za prihranek prostora. Tega ni mogoče razveljaviti. Pred začetkom skrbno preglejte nastavitve.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d lokacije ni mogoče uporabiti za stiskanje in je bila odstranjena. Stiskanje zahteva neposreden dostop do notranjega pomnilnika.</item>
+        <item quantity="two">%d lokaciji ni mogoče uporabiti za stiskanje in sta bili odstranjeni. Stiskanje zahteva neposreden dostop do notranjega pomnilnika.</item>
+        <item quantity="few">%d lokacije ni mogoče uporabiti za stiskanje in so bile odstranjene. Stiskanje zahteva neposreden dostop do notranjega pomnilnika.</item>
+        <item quantity="other">%d lokacij ni mogoče uporabiti za stiskanje in so bile odstranjene. Stiskanje zahteva neposreden dostop do notranjega pomnilnika.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze zmanjša velikost datotek slik in videoposnetkov, da sprosti prostor. To trajno zmanjša kakovost in tega ni mogoče razveljaviti. Pred začetkom skrbno preglejte nastavitve.</string>
     <string name="squeezer_setup_paths_title">Mesta iskanja</string>
     <string name="squeezer_setup_paths_default">Izberite mape za iskanje</string>
     <string name="squeezer_setup_quality_title">Kakovost stiskanja</string>
@@ -93,6 +117,6 @@
         <item quantity="few">Stare vsaj %d dni</item>
         <item quantity="other">Vsaj %d dni</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">Predviden prihranek za datoteke JPEG: ~%d%%.</string>
+    <string name="squeezer_estimated_savings_percent">Ocenjeno ~%d%% prihrankov za slike</string>
     <string name="squeezer_onboarding_got_it">Razumem!</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-sq-rAL/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-sq-rAL/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Kompresoni imazhet për të kursyer hapësirë ​​ruajtëse.</string>
+    <string name="squeezer_explanation_short">Kompreson imazhet dhe videot për të kursyer hapësirë ruajtjeje.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d imazh u gjet</item>
-        <item quantity="other">%d imazhe u gjetën</item>
+        <item quantity="one">%d artikull u gjet</item>
+        <item quantity="other">%d artikuj u gjetën</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s mund të kursehet</item>
         <item quantity="other">~%s mund të kursehen</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d imazh u kompresua</item>
-        <item quantity="other">%d imazhe u kompresuan</item>
+        <item quantity="one">%d artikull u kompresua</item>
+        <item quantity="other">%d artikuj u kompresuan</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d dështoi</item>
+        <item quantity="other">%d dështuan</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d skedar u anashkalua (nuk është i aksesueshëm)</item>
+        <item quantity="other">%d skedarë u anashkaluan (nuk janë të aksesueshëm)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d imazh i zgjedhur</item>
-        <item quantity="other">%d imazhe të zgjedhura</item>
+        <item quantity="one">%d artikull i zgjedhur</item>
+        <item quantity="other">%d artikuj të zgjedhur</item>
     </plurals>
     <string name="squeezer_search_locations_title">Vendet e kërkimit</string>
     <string name="squeezer_search_locations_default_summary">Dosjet e kamerës (parazgjedhur)</string>
     <string name="squeezer_min_size_title">Madhësia minimale e skedarit</string>
-    <string name="squeezer_min_size_description">Kapërce imazhet më të vogla se kjo madhësi.</string>
+    <string name="squeezer_min_size_description">Anashkalo skedarët më të vegjël se kjo madhësi.</string>
     <string name="squeezer_min_age_title">Mosha minimale e skedarit</string>
-    <string name="squeezer_min_age_description">Përfshi vetëm imazhet më të vjetra se kjo moshë.</string>
-    <string name="squeezer_compression_settings_label">Cilësimet e kompresimit</string>
+    <string name="squeezer_min_age_description">Përfshi vetëm skedarët më të vjetër se kjo moshë.</string>
+    <string name="squeezer_compression_settings_label">Gjenerik</string>
     <string name="squeezer_quality_label">Cilësia</string>
     <string name="squeezer_quality_title">Cilësia e kompresimit</string>
-    <string name="squeezer_quality_description">Cilësia më e ulët do të thotë madhësi më e vogël e skedarit por cilësi e ulur e imazhit.</string>
+    <string name="squeezer_quality_description">Cilësia më e ulët nënkupton madhësi më të vogël të skedarit, por cilësi vizuale të reduktuar.</string>
     <string name="squeezer_quality_example_format">Shembull: imazh %1$s → kursen ~%2$s në cilësinë %3$d%%</string>
     <string name="squeezer_quality_warning_low">Cilësi më e ulët mund të shkaktojë artefakte të dukshme.</string>
     <string name="squeezer_quality_warning_high">Cilësia shumë e lartë ofron kursime minimale të hapësirës.</string>
-    <string name="squeezer_types_category_label">Llojet e imazheve</string>
+    <string name="squeezer_types_category_label">Cilësimet e imazhit</string>
+    <string name="squeezer_video_settings_category_label">Cilësimet e videos</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">Përfshi imazhet JPEG (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">Përfshi imazhet WebP (.webp).</string>
+    <string name="squeezer_type_video_title">Video MP4</string>
+    <string name="squeezer_type_video_description">Përfshi skedarët video MP4 (.mp4).</string>
     <string name="squeezer_skip_compressed_title">Kapërce të kompresuarat më parë</string>
-    <string name="squeezer_skip_compressed_description">Kapërce imazhet që janë kompresuar tashmë nga SD Maid.</string>
+    <string name="squeezer_skip_compressed_description">Anashkalo skedarët që janë kompresuar tashmë nga SD Maid.</string>
     <string name="squeezer_exif_marker_title">Shkruaj shënuesin EXIF</string>
     <string name="squeezer_exif_marker_description">Shto një shënues në fushën e komentit EXIF të imazhit për të parandaluar rikompresimin edhe nëse historia e kompresimit pastrohet.</string>
     <string name="squeezer_estimated_savings_format">~%s kursime</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">Konfirmo kompresimin</string>
     <string name="squeezer_preview_total_size">Madhësia totale</string>
     <string name="squeezer_preview_estimated_savings">Kursime të vlerësuara</string>
-    <string name="squeezer_compress_confirmation_title">Kompreso imazhet?</string>
-    <string name="squeezer_compress_confirmation_message">Kjo do të zëvendësojë imazhet origjinale me versione të kompresuara. Ky veprim nuk mund të zhbëhet.</string>
+    <string name="squeezer_compress_confirmation_title">Kompreso artikujt e zgjedhur?</string>
+    <string name="squeezer_compress_confirmation_message">Kjo do t\'i zëvendësojë skedarët origjinalë me versione të kompresuar. Ky veprim nuk mund të zhbëhet.</string>
     <string name="squeezer_history_title">Historia e kompresimit</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d artikull (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">Asnjë histori kompresimi</string>
     <string name="squeezer_history_clear_title">Pastro historinë e kompresimit</string>
-    <string name="squeezer_history_clear_message">Kjo do të lejojë imazhet e kompresuara më parë të kompresohen përsëri. Vetë imazhet nuk preken.</string>
+    <string name="squeezer_history_clear_message">Kjo do të lejojë skedarët e kompresuar më parë të kompresohen përsëri. Vetë skedarët nuk preken.</string>
     <string name="squeezer_onboarding_title">Rreth kompresimit të imazheve</string>
     <string name="squeezer_onboarding_message">Kompresimi i imazheve zvogëlon madhësinë e skedarit duke hequr detajet vizuale. Ky proces është i pakthyeshëm - cilësia origjinale nuk mund të rikthehet.\n\nJa një pamje paraprake se si do të duken imazhet tuaja:</string>
     <string name="squeezer_onboarding_original_label">Origjinale</string>
     <string name="squeezer_onboarding_compressed_label">Pas kompresimit</string>
+    <string name="squeezer_onboarding_video_original_label">Kornizë video</string>
+    <string name="squeezer_onboarding_video_compressed_label">Shikimi paraprak (afërsisht)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">Cilësia aktuale e videos mund të ndryshojë</string>
     <string name="squeezer_onboarding_quality_label">Cilësia: %d%%</string>
     <string name="squeezer_compare_action">Shiko krahasimin</string>
     <string name="squeezer_no_example_found">Nuk u gjetën imazhe në shtegjet e zgjedhura.</string>
-    <string name="squeezer_result_empty_message">Nuk u gjetën imazhe të kompresueshme.</string>
-    <string name="squeezer_setup_warning">Kompresimi zvogëlon përgjithmonë cilësinë e imazhit për të kursyer hapësirë ​​ruajtëse. Kjo nuk mund të zhbëhet. Rishikoni cilësimet tuaja me kujdes para se të filloni.</string>
-    <string name="squeezer_setup_explanation">Media Squeeze zvogëlon madhësinë e skedarëve të imazheve për të liruar hapësirë ​​ruajtëse. Kjo zvogëlon përgjithmonë cilësinë e imazhit dhe nuk mund të zhbëhet. Rishikoni cilësimet tuaja me kujdes para se të filloni.</string>
+    <string name="squeezer_result_empty_message">Nuk u gjet asnjë media e kompresueshme.</string>
+    <string name="squeezer_setup_warning">Kompresimi zvogëlon cilësinë përgjithmonë për të kursyer hapësirë ruajtjeje. Kjo nuk mund të zhbëhet. Rishikoni cilësimet tuaja me kujdes para se të filloni.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d vend nuk mund të përdoret për kompresim dhe u hoq. Kompresimi kërkon qasje të drejtëpërdrejtë në memorien e brendshme.</item>
+        <item quantity="other">%d vende nuk mund të përdoren për kompresim dhe u hoqën. Kompresimi kërkon qasje të drejtëpërdrejtë në memorien e brendshme.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze zvogëlon madhësinë e skedarëve të imazheve dhe videove për të liruar hapësirë ruajtjeje. Kjo zvogëlon cilësinë përgjithmonë dhe nuk mund të zhbëhet. Rishikoni cilësimet tuaja me kujdes para se të filloni.</string>
     <string name="squeezer_setup_paths_title">Vendet e kërkimit</string>
     <string name="squeezer_setup_paths_default">Zgjidhni dosjet për të kërkuar</string>
     <string name="squeezer_setup_quality_title">Cilësia e kompresimit</string>
@@ -81,6 +99,6 @@
         <item quantity="one">Të paktën %d ditë e vjetër</item>
         <item quantity="other">Të paktën %d ditë të vjetra</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">Kursime të vlerësuara ~%d%% për skedarët JPEG</string>
+    <string name="squeezer_estimated_savings_percent">Kursim i vlerësuar ~%d%% për imazhet</string>
     <string name="squeezer_onboarding_got_it">E kuptova</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-sr/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-sr/strings.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Компримујте слике да бисте уштедели простор за складиштење.</string>
+    <string name="squeezer_explanation_short">Компримујте слике и видео записе да бисте уштедели простор за складиштење.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d слика пронађена</item>
-        <item quantity="few">%d слике пронађене</item>
-        <item quantity="other">%d слика пронађено</item>
+        <item quantity="one">%d ставка пронађена</item>
+        <item quantity="few">%d ставке пронађене</item>
+        <item quantity="other">%d ставки пронађено</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s се може уштедети</item>
@@ -12,35 +12,48 @@
         <item quantity="other">~%s се може уштедети</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d слика компримована</item>
-        <item quantity="few">%d слике компримоване</item>
-        <item quantity="other">%d слика компримовано</item>
+        <item quantity="one">%d ставка компримована</item>
+        <item quantity="few">%d ставке компримоване</item>
+        <item quantity="other">%d ставки компримовано</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d неуспешан</item>
+        <item quantity="few">%d неуспешна</item>
+        <item quantity="other">%d неуспешних</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d датотека прескочена (није доступна)</item>
+        <item quantity="few">%d датотеке прескочене (нису доступне)</item>
+        <item quantity="other">%d датотека прескочено (нису доступне)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d слика изабрана</item>
-        <item quantity="few">%d слике изабране</item>
-        <item quantity="other">%d слика изабрано</item>
+        <item quantity="one">%d ставка изабрана</item>
+        <item quantity="few">%d ставке изабране</item>
+        <item quantity="other">%d ставки изабрано</item>
     </plurals>
     <string name="squeezer_search_locations_title">Локације претраге</string>
     <string name="squeezer_search_locations_default_summary">Фасцикле камере (подразумевано)</string>
     <string name="squeezer_min_size_title">Минимална величина датотеке</string>
-    <string name="squeezer_min_size_description">Прескочи слике мање од ове величине.</string>
+    <string name="squeezer_min_size_description">Прескочи датотеке мање од ове величине.</string>
     <string name="squeezer_min_age_title">Минимална старост датотеке</string>
-    <string name="squeezer_min_age_description">Укључи само слике старије од ове старости.</string>
-    <string name="squeezer_compression_settings_label">Подешавања компресије</string>
+    <string name="squeezer_min_age_description">Укључи само датотеке старије од ове старости.</string>
+    <string name="squeezer_compression_settings_label">Опште</string>
     <string name="squeezer_quality_label">Квалитет</string>
     <string name="squeezer_quality_title">Квалитет компресије</string>
-    <string name="squeezer_quality_description">Нижи квалитет значи мању величину датотеке али смањен квалитет слике.</string>
+    <string name="squeezer_quality_description">Нижи квалитет значи мању величину датотеке, али смањен визуелни квалитет.</string>
     <string name="squeezer_quality_example_format">Пример: %1$s слика → штеди ~%2$s при %3$d%% квалитету</string>
     <string name="squeezer_quality_warning_low">Нижи квалитети могу изазвати видљиве артефакте.</string>
     <string name="squeezer_quality_warning_high">Веома висок квалитет пружа минималну уштеду простора.</string>
-    <string name="squeezer_types_category_label">Типови слика</string>
+    <string name="squeezer_types_category_label">Подешавања слике</string>
+    <string name="squeezer_video_settings_category_label">Подешавања видеа</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">Укључи JPEG слике (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">Укључи WebP слике (.webp).</string>
+    <string name="squeezer_type_video_title">MP4 видео</string>
+    <string name="squeezer_type_video_description">Укључи MP4 видео датотеке (.mp4).</string>
     <string name="squeezer_skip_compressed_title">Прескочи претходно компримоване</string>
-    <string name="squeezer_skip_compressed_description">Прескочи слике које су већ компримоване од стране СД Чистача.</string>
+    <string name="squeezer_skip_compressed_description">Прескочи датотеке које је SD Maid већ компримовао.</string>
     <string name="squeezer_exif_marker_title">Упиши EXIF ознаку</string>
     <string name="squeezer_exif_marker_description">Додај ознаку у EXIF поље коментара корисника слике да спречи поновну компресију чак и ако се историја компресије обрише.</string>
     <string name="squeezer_estimated_savings_format">~%s уштеде</string>
@@ -51,8 +64,8 @@
     <string name="squeezer_preview_dialog_title">Потврди компресију</string>
     <string name="squeezer_preview_total_size">Укупна величина</string>
     <string name="squeezer_preview_estimated_savings">Процењена уштеда</string>
-    <string name="squeezer_compress_confirmation_title">Компримовати слике?</string>
-    <string name="squeezer_compress_confirmation_message">Ово ће заменити оригиналне слике компримованим верзијама. Ова акција се не може поништити.</string>
+    <string name="squeezer_compress_confirmation_title">Компримовати изабране ставке?</string>
+    <string name="squeezer_compress_confirmation_message">Ово ће заменити оригиналне датотеке компримованим верзијама. Ова радња не може да се опозове.</string>
     <string name="squeezer_history_title">Историја компресије</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d ставка (%2$s)</item>
@@ -61,17 +74,25 @@
     </plurals>
     <string name="squeezer_history_empty">Нема историје компресије</string>
     <string name="squeezer_history_clear_title">Обриши историју компресије</string>
-    <string name="squeezer_history_clear_message">Ово ће омогућити да се претходно компримоване слике поново компримују. Саме слике нису погођене.</string>
+    <string name="squeezer_history_clear_message">Ово ће омогућити да претходно компримоване датотеке буду поново компримоване. Саме датотеке нису погођене.</string>
     <string name="squeezer_onboarding_title">О компресији слика</string>
     <string name="squeezer_onboarding_message">Компресија слика смањује величину датотеке уклањањем визуелних детаља. Овај процес је неповратан - оригинални квалитет се не може вратити.\n\nЕво прегледа како ће ваше слике изгледати:</string>
     <string name="squeezer_onboarding_original_label">Оригинал</string>
     <string name="squeezer_onboarding_compressed_label">После компресије</string>
+    <string name="squeezer_onboarding_video_original_label">Кадар видеа</string>
+    <string name="squeezer_onboarding_video_compressed_label">Преглед (приближно)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">Стварни квалитет видеа може да се разликује</string>
     <string name="squeezer_onboarding_quality_label">Квалитет: %d%%</string>
     <string name="squeezer_compare_action">Прегледај поређење</string>
     <string name="squeezer_no_example_found">Нису пронађене слике на изабраним путањама.</string>
-    <string name="squeezer_result_empty_message">Нису пронађене слике за компресију.</string>
-    <string name="squeezer_setup_warning">Компресија трајно смањује квалитет слике да би уштедела простор за складиштење. Ово се не може поништити. Пажљиво прегледајте подешавања пре почетка.</string>
-    <string name="squeezer_setup_explanation">Компресија медија смањује величину датотеке слика да ослободи простор за складиштење. Ово трајно смањује квалитет слике и не може се поништити. Пажљиво прегледајте подешавања пре почетка.</string>
+    <string name="squeezer_result_empty_message">Нема медија погодних за компресију.</string>
+    <string name="squeezer_setup_warning">Компресија трајно смањује квалитет да би се уштедео простор за складиштење. Ово не може да се опозове. Пажљиво прегледај подешавања пре него што почнеш.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d локација не може да се користи за компресију и уклоњена је. Компресија захтева директан приступ интерној меморији.</item>
+        <item quantity="few">%d локације не могу да се користе за компресију и уклоњене су. Компресија захтева директан приступ интерној меморији.</item>
+        <item quantity="other">%d локација не може да се користи за компресију и уклоњено је. Компресија захтева директан приступ интерној меморији.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze смањује величину датотека слика и видеа да би се ослободио простор за складиштење. Ово трајно смањује квалитет и не може да се опозове. Пажљиво прегледај подешавања пре него што почнеш.</string>
     <string name="squeezer_setup_paths_title">Локације претраге</string>
     <string name="squeezer_setup_paths_default">Изаберите фасцикле за претрагу</string>
     <string name="squeezer_setup_quality_title">Квалитет компресије</string>
@@ -87,6 +108,6 @@
         <item quantity="few">Најмање %d дана старо</item>
         <item quantity="other">Најмање %d дана старо</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">Процењена ~%d%% уштеда за JPEG датотеке</string>
+    <string name="squeezer_estimated_savings_percent">Процењена уштеда ~%d%% за слике</string>
     <string name="squeezer_onboarding_got_it">Разумем</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-sv/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-sv/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Komprimera bilder för att spara lagringsutrymme.</string>
+    <string name="squeezer_explanation_short">Komprimera bilder och videor för att spara lagringsutrymme.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d bild hittad</item>
-        <item quantity="other">%d bilder hittade</item>
+        <item quantity="one">%d objekt hittades</item>
+        <item quantity="other">%d objekt hittades</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s kan sparas</item>
         <item quantity="other">~%s kan sparas</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d bild komprimerad</item>
-        <item quantity="other">%d bilder komprimerade</item>
+        <item quantity="one">%d objekt komprimerades</item>
+        <item quantity="other">%d objekt komprimerades</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d misslyckades</item>
+        <item quantity="other">%d misslyckades</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d fil hoppades över (inte tillgänglig)</item>
+        <item quantity="other">%d filer hoppades över (inte tillgängliga)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d bild vald</item>
-        <item quantity="other">%d bilder valda</item>
+        <item quantity="one">%d objekt valt</item>
+        <item quantity="other">%d objekt valda</item>
     </plurals>
     <string name="squeezer_search_locations_title">Sökplatser</string>
     <string name="squeezer_search_locations_default_summary">Kameramappar (standard)</string>
     <string name="squeezer_min_size_title">Minsta filstorlek</string>
-    <string name="squeezer_min_size_description">Hoppa över bilder mindre än denna storlek.</string>
+    <string name="squeezer_min_size_description">Hoppa över filer som är mindre än den här storleken.</string>
     <string name="squeezer_min_age_title">Lägsta filålder</string>
-    <string name="squeezer_min_age_description">Inkludera bara bilder äldre än denna ålder.</string>
-    <string name="squeezer_compression_settings_label">Komprimeringsinställningar</string>
+    <string name="squeezer_min_age_description">Inkludera bara filer som är äldre än den här åldern.</string>
+    <string name="squeezer_compression_settings_label">Allmänt</string>
     <string name="squeezer_quality_label">Kvalitet</string>
     <string name="squeezer_quality_title">Komprimeringskvalitet</string>
-    <string name="squeezer_quality_description">Lägre kvalitet innebär mindre filstorlek men sämre bildkvalitet.</string>
+    <string name="squeezer_quality_description">Lägre kvalitet innebär mindre filstorlek men sämre visuell kvalitet.</string>
     <string name="squeezer_quality_example_format">Exempel: %1$s-bild → sparar ~%2$s vid %3$d%% kvalitet</string>
     <string name="squeezer_quality_warning_low">Lägre kvalitet kan orsaka synliga artefakter.</string>
     <string name="squeezer_quality_warning_high">Mycket hög kvalitet ger minimal utrymmebesparing.</string>
-    <string name="squeezer_types_category_label">Bildtyper</string>
+    <string name="squeezer_types_category_label">Bildinstillningar</string>
+    <string name="squeezer_video_settings_category_label">Videoinställningar</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">Inkludera JPEG-bilder (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">Inkludera WebP-bilder (.webp).</string>
+    <string name="squeezer_type_video_title">MP4-video</string>
+    <string name="squeezer_type_video_description">Inkludera MP4-videofiler (.mp4).</string>
     <string name="squeezer_skip_compressed_title">Hoppa över tidigare komprimerade</string>
-    <string name="squeezer_skip_compressed_description">Hoppa över bilder som redan komprimerats av SD Maid.</string>
+    <string name="squeezer_skip_compressed_description">Hoppa över filer som redan har komprimerats av SD Maid.</string>
     <string name="squeezer_exif_marker_title">Skriv EXIF-markör</string>
     <string name="squeezer_exif_marker_description">Lägg till en markör i bildens EXIF-användarkommentarfält för att förhindra omkomprimering även om komprimeringshistoriken rensas.</string>
     <string name="squeezer_estimated_savings_format">~%s besparing</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">Bekräfta komprimering</string>
     <string name="squeezer_preview_total_size">Total storlek</string>
     <string name="squeezer_preview_estimated_savings">Uppskattad besparing</string>
-    <string name="squeezer_compress_confirmation_title">Komprimera bilder?</string>
-    <string name="squeezer_compress_confirmation_message">Detta kommer ersätta originalbilder med komprimerade versioner. Denna åtgärd kan inte ångras.</string>
+    <string name="squeezer_compress_confirmation_title">Komprimera valda objekt?</string>
+    <string name="squeezer_compress_confirmation_message">Detta ersätter originalfilerna med komprimerade versioner. Denna åtgärd kan inte ångras.</string>
     <string name="squeezer_history_title">Komprimeringshistorik</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d objekt (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">Ingen komprimeringshistorik</string>
     <string name="squeezer_history_clear_title">Rensa komprimeringshistorik</string>
-    <string name="squeezer_history_clear_message">Detta gör att tidigare komprimerade bilder kan komprimeras igen. Bilderna själva påverkas inte.</string>
+    <string name="squeezer_history_clear_message">Detta gör det möjligt att komprimera tidigare komprimerade filer igen. Filerna i sig påverkas inte.</string>
     <string name="squeezer_onboarding_title">Om bildkomprimering</string>
     <string name="squeezer_onboarding_message">Bildkomprimering minskar filstorleken genom att ta bort visuella detaljer. Denna process är irreversibel – originalkvaliteten kan inte återställas.\n\nHär är en förhandsgranskning av hur dina bilder kommer se ut:</string>
     <string name="squeezer_onboarding_original_label">Original</string>
     <string name="squeezer_onboarding_compressed_label">Efter komprimering</string>
+    <string name="squeezer_onboarding_video_original_label">Videobildruta</string>
+    <string name="squeezer_onboarding_video_compressed_label">Förhandsgranskning (ungefärlig)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">Faktisk videokvalitet kan variera</string>
     <string name="squeezer_onboarding_quality_label">Kvalitet: %d%%</string>
     <string name="squeezer_compare_action">Visa jämförelse</string>
     <string name="squeezer_no_example_found">Inga bilder hittades i valda sökvägar.</string>
-    <string name="squeezer_result_empty_message">Inga komprimerbara bilder hittades.</string>
-    <string name="squeezer_setup_warning">Komprimering minskar bildkvaliteten permanent för att spara lagringsutrymme. Detta kan inte ångras. Granska dina inställningar noggrant innan du startar.</string>
-    <string name="squeezer_setup_explanation">Mediakomprimering minskar filstorleken på bilder för att frigöra lagringsutrymme. Detta minskar bildkvaliteten permanent och kan inte ångras. Granska dina inställningar noggrant innan du startar.</string>
+    <string name="squeezer_result_empty_message">Ingen komprimeringsbar media hittades.</string>
+    <string name="squeezer_setup_warning">Komprimering minskar kvaliteten permanent för att spara lagringsutrymme. Detta kan inte ångras. Granska dina inställningar noggrant innan du börjar.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d plats kan inte användas för komprimering och togs bort. Komprimering kräver direkt åtkomst till det interna lagringsutrymmet.</item>
+        <item quantity="other">%d platser kan inte användas för komprimering och togs bort. Komprimering kräver direkt åtkomst till det interna lagringsutrymmet.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze minskar filstorleken för bilder och videor för att frigöra lagringsutrymme. Detta minskar kvaliteten permanent och kan inte ångras. Granska dina inställningar noggrant innan du börjar.</string>
     <string name="squeezer_setup_paths_title">Sökplatser</string>
     <string name="squeezer_setup_paths_default">Välj mappar att söka i</string>
     <string name="squeezer_setup_quality_title">Komprimeringskvalitet</string>
@@ -81,6 +99,6 @@
         <item quantity="one">Minst %d dag gammal</item>
         <item quantity="other">Minst %d dagar gammal</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">Uppskattad ~%d%% besparing för JPEG-filer</string>
+    <string name="squeezer_estimated_savings_percent">Beräknad besparing ~%d%% för bilder</string>
     <string name="squeezer_onboarding_got_it">Jag fattar</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-sw/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-sw/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Bana picha ili kuokoa nafasi ya hifadhi.</string>
+    <string name="squeezer_explanation_short">Bana picha na video ili kuokoa nafasi ya hifadhi.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">picha %d imepatikana</item>
-        <item quantity="other">picha %d zimepatikana</item>
+        <item quantity="one">%d kipande kimepatikana</item>
+        <item quantity="other">%d vipande vimepatikana</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s inaweza kuokolewa</item>
         <item quantity="other">~%s zinaweza kuokolewa</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">picha %d imebaniwa</item>
-        <item quantity="other">picha %d zimebaniwa</item>
+        <item quantity="one">%d kipande kimebaniwa</item>
+        <item quantity="other">%d vipande vimebaniwa</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d imeshindwa</item>
+        <item quantity="other">%d zimeshindwa</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d faili imerukwa (haifikiwi)</item>
+        <item quantity="other">%d faili zimerukwa (hazifikiwi)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">picha %d imechaguliwa</item>
-        <item quantity="other">picha %d zimechaguliwa</item>
+        <item quantity="one">%d kipande kimechaguliwa</item>
+        <item quantity="other">%d vipande vimechaguliwa</item>
     </plurals>
     <string name="squeezer_search_locations_title">Maeneo ya kutafuta</string>
     <string name="squeezer_search_locations_default_summary">Folda za kamera (chaguo-msingi)</string>
     <string name="squeezer_min_size_title">Ukubwa wa chini wa faili</string>
-    <string name="squeezer_min_size_description">Ruka picha ndogo kuliko ukubwa huu.</string>
+    <string name="squeezer_min_size_description">Ruka faili ndogo kuliko ukubwa huu.</string>
     <string name="squeezer_min_age_title">Umri wa chini wa faili</string>
-    <string name="squeezer_min_age_description">Jumuisha picha za zamani kuliko umri huu tu.</string>
-    <string name="squeezer_compression_settings_label">Mipangilio ya kubana</string>
+    <string name="squeezer_min_age_description">Jumuisha tu faili za zamani kuliko umri huu.</string>
+    <string name="squeezer_compression_settings_label">Jumla</string>
     <string name="squeezer_quality_label">Ubora</string>
     <string name="squeezer_quality_title">Ubora wa kubana</string>
-    <string name="squeezer_quality_description">Ubora wa chini unamaanisha ukubwa mdogo wa faili lakini ubora uliopunguzwa wa picha.</string>
+    <string name="squeezer_quality_description">Ubora mdogo unamaanisha ukubwa mdogo wa faili lakini ubora wa kuona umepungua.</string>
     <string name="squeezer_quality_example_format">Mfano: picha ya %1$s → inaokoa ~%2$s kwa ubora wa %3$d%%</string>
     <string name="squeezer_quality_warning_low">Ubora wa chini unaweza kusababisha kasoro zinazoonekana.</string>
     <string name="squeezer_quality_warning_high">Ubora wa juu sana unatoa akiba ndogo ya nafasi.</string>
-    <string name="squeezer_types_category_label">Aina za picha</string>
+    <string name="squeezer_types_category_label">Mipangilio ya picha</string>
+    <string name="squeezer_video_settings_category_label">Mipangilio ya video</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">Jumuisha picha za JPEG (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">Jumuisha picha za WebP (.webp).</string>
+    <string name="squeezer_type_video_title">Video ya MP4</string>
+    <string name="squeezer_type_video_description">Jumuisha faili za video za MP4 (.mp4).</string>
     <string name="squeezer_skip_compressed_title">Ruka zilizobaniwa hapo awali</string>
-    <string name="squeezer_skip_compressed_description">Ruka picha ambazo tayari zimebaniwa na SD Maid.</string>
+    <string name="squeezer_skip_compressed_description">Ruka faili ambazo tayari zimebaniwa na SD Maid.</string>
     <string name="squeezer_exif_marker_title">Andika alama ya EXIF</string>
     <string name="squeezer_exif_marker_description">Ongeza alama kwenye sehemu ya maoni ya mtumiaji wa EXIF ya picha ili kuzuia kubaniwa tena hata kama historia ya kubana inafutwa.</string>
     <string name="squeezer_estimated_savings_format">~%s akiba</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">Thibitisha kubana</string>
     <string name="squeezer_preview_total_size">Ukubwa wa jumla</string>
     <string name="squeezer_preview_estimated_savings">Akiba iliyokadiriwa</string>
-    <string name="squeezer_compress_confirmation_title">Bana picha?</string>
-    <string name="squeezer_compress_confirmation_message">Hii itabadilisha picha asili na matoleo yaliyobaniwa. Kitendo hiki hakiwezi kutenduliwa.</string>
+    <string name="squeezer_compress_confirmation_title">Bana vitu vilivyochaguliwa?</string>
+    <string name="squeezer_compress_confirmation_message">Hii itabadilisha faili za asili na matoleo yaliyobanwa. Kitendo hiki hakiwezi kutenduliwa.</string>
     <string name="squeezer_history_title">Historia ya kubana</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">kipengele %1$d (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">Hakuna historia ya kubana</string>
     <string name="squeezer_history_clear_title">Futa historia ya kubana</string>
-    <string name="squeezer_history_clear_message">Hii itaruhusu picha zilizobaniwa hapo awali kubaniwa tena. Picha zenyewe haziathiriwi.</string>
+    <string name="squeezer_history_clear_message">Hii itaruhusu faili zilizobaniwa awali kubaniwa tena. Faili zenyewe hazitaathiriwa.</string>
     <string name="squeezer_onboarding_title">Kuhusu Kubana Picha</string>
     <string name="squeezer_onboarding_message">Kubana picha kunapunguza ukubwa wa faili kwa kuondoa maelezo ya kuona. Mchakato huu hauwezi kutenduliwa - ubora wa asili hauwezi kurejeshwa.\n\nHapa kuna hakikisho la jinsi picha zako zitakavyoonekana:</string>
     <string name="squeezer_onboarding_original_label">Asili</string>
     <string name="squeezer_onboarding_compressed_label">Baada ya kubana</string>
+    <string name="squeezer_onboarding_video_original_label">Fremu ya video</string>
+    <string name="squeezer_onboarding_video_compressed_label">Hakikisho (takriban)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">Ubora halisi wa video unaweza kutofautiana</string>
     <string name="squeezer_onboarding_quality_label">Ubora: %d%%</string>
     <string name="squeezer_compare_action">Tazama kulinganisha</string>
     <string name="squeezer_no_example_found">Hakuna picha zilizopatikana katika njia zilizochaguliwa.</string>
-    <string name="squeezer_result_empty_message">Hakuna picha zinazoweza kubaniwa zilizopatikana.</string>
-    <string name="squeezer_setup_warning">Kubana kunapunguza ubora wa picha kwa kudumu ili kuokoa nafasi ya hifadhi. Hii haiwezi kutenduliwa. Kagua mipangilio yako kwa makini kabla ya kuanza.</string>
-    <string name="squeezer_setup_explanation">Bana Media inapunguza ukubwa wa faili la picha ili kuachilia nafasi ya hifadhi. Hii inapunguza ubora wa picha kwa kudumu na haiwezi kutenduliwa. Kagua mipangilio yako kwa makini kabla ya kuanza.</string>
+    <string name="squeezer_result_empty_message">Hakuna midia inayoweza kubanwa iliyopatikana.</string>
+    <string name="squeezer_setup_warning">Kubana kunapunguza ubora kwa kudumu ili kuokoa nafasi ya hifadhi. Hii haiwezi kutenduliwa. Kagua mipangilio yako kwa makini kabla ya kuanza.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">Mahali %d haliwezi kutumika kwa kubana na limeondolewa. Kubana kunahitaji ufikiaji wa moja kwa moja wa hifadhi ya ndani.</item>
+        <item quantity="other">Maeneo %d hayawezi kutumika kwa kubana na yameondolewa. Kubana kunahitaji ufikiaji wa moja kwa moja wa hifadhi ya ndani.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze inapunguza ukubwa wa faili za picha na video ili kuachilia nafasi ya hifadhi. Hii inapunguza ubora kwa kudumu na haiwezi kutenduliwa. Kagua mipangilio yako kwa makini kabla ya kuanza.</string>
     <string name="squeezer_setup_paths_title">Maeneo ya kutafuta</string>
     <string name="squeezer_setup_paths_default">Chagua folda za kutafuta</string>
     <string name="squeezer_setup_quality_title">Ubora wa kubana</string>
@@ -81,6 +99,6 @@
         <item quantity="one">Angalau siku %d</item>
         <item quantity="other">Angalau siku %d</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">Takriban ~%d%% akiba kwa mafaili ya JPEG</string>
+    <string name="squeezer_estimated_savings_percent">Akiba inayokadiriwa ~%d%% kwa picha</string>
     <string name="squeezer_onboarding_got_it">Nimeelewa</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-ta-rIN/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-ta-rIN/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">சேமிப்பிடத்தை மிச்சப்படுத்த படங்களை சுருக்கவும்.</string>
+    <string name="squeezer_explanation_short">சேமிப்பு இடத்தை மிச்சப்படுத்த படங்கள் மற்றும் வீடியோக்களை சுருக்கவும்.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d படம் கண்டுபிடிக்கப்பட்டது</item>
-        <item quantity="other">%d படங்கள் கண்டுபிடிக்கப்பட்டன</item>
+        <item quantity="one">%d உருப்படி கண்டுபிடிக்கப்பட்டது</item>
+        <item quantity="other">%d உருப்படிகள் கண்டுபிடிக்கப்பட்டன</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s மிச்சப்படுத்தலாம்</item>
         <item quantity="other">~%s மிச்சப்படுத்தலாம்</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d படம் சுருக்கப்பட்டது</item>
-        <item quantity="other">%d படங்கள் சுருக்கப்பட்டன</item>
+        <item quantity="one">%d உருப்படி சுருக்கப்பட்டது</item>
+        <item quantity="other">%d உருப்படிகள் சுருக்கப்பட்டன</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d தோல்வியுற்றது</item>
+        <item quantity="other">%d தோல்வியுற்றன</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d கோப்பு தவிர்க்கப்பட்டது (அணுக இயலவில்லை)</item>
+        <item quantity="other">%d கோப்புகள் தவிர்க்கப்பட்டன (அணுக இயலவில்லை)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d படம் தேர்ந்தெடுக்கப்பட்டது</item>
-        <item quantity="other">%d படங்கள் தேர்ந்தெடுக்கப்பட்டன</item>
+        <item quantity="one">%d உருப்படி தேர்ந்தெடுக்கப்பட்டுள்ளது</item>
+        <item quantity="other">%d உருப்படிகள் தேர்ந்தெடுக்கப்பட்டுள்ளன</item>
     </plurals>
     <string name="squeezer_search_locations_title">தேடல் இடங்கள்</string>
     <string name="squeezer_search_locations_default_summary">கேமரா கோப்புறைகள் (இயல்புநிலை)</string>
     <string name="squeezer_min_size_title">குறைந்தபட்ச கோப்பு அளவு</string>
-    <string name="squeezer_min_size_description">இந்த அளவை விட சிறிய படங்களைத் தவிர்.</string>
+    <string name="squeezer_min_size_description">இந்த அளவை விட சிறிய கோப்புகளை தவிர்க்கவும்.</string>
     <string name="squeezer_min_age_title">குறைந்தபட்ச கோப்பு வயது</string>
-    <string name="squeezer_min_age_description">இந்த வயதை விட பழைய படங்களை மட்டும் சேர்.</string>
-    <string name="squeezer_compression_settings_label">சுருக்க அமைப்புகள்</string>
+    <string name="squeezer_min_age_description">இந்த வயதை விட பழைய கோப்புகளை மட்டும் சேர்க்கவும்.</string>
+    <string name="squeezer_compression_settings_label">போது</string>
     <string name="squeezer_quality_label">தரம்</string>
     <string name="squeezer_quality_title">சுருக்கத் தரம்</string>
-    <string name="squeezer_quality_description">குறைந்த தரம் என்பது சிறிய கோப்பு அளவு ஆனால் குறைந்த படத் தரம்.</string>
+    <string name="squeezer_quality_description">குறைந்த தரம் என்பது சிறிய கோப்பு அளவைக் குறிக்கும், ஆனால் காட்சி தரம் குறையும்.</string>
     <string name="squeezer_quality_example_format">எடுத்துக்காட்டு: %1$s படம் → %3$d%% தரத்தில் ~%2$s மிச்சம்</string>
     <string name="squeezer_quality_warning_low">குறைந்த தரங்களில் கண்ணுக்குத் தெரியும் குறைபாடுகள் ஏற்படலாம்.</string>
     <string name="squeezer_quality_warning_high">மிக உயர் தரம் குறைந்தபட்ச இட மிச்சத்தை வழங்குகிறது.</string>
-    <string name="squeezer_types_category_label">படம் வகைகள்</string>
+    <string name="squeezer_types_category_label">படம் அமைப்புகள்</string>
+    <string name="squeezer_video_settings_category_label">வீடியோ அமைப்புகள்</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">JPEG படங்களைச் (.jpg, .jpeg) சேர்.</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">WebP படங்களைச் (.webp) சேர்.</string>
+    <string name="squeezer_type_video_title">MP4 Video</string>
+    <string name="squeezer_type_video_description">MP4 வீடியோ கோப்புகளை (.mp4) சேர்க்கவும்.</string>
     <string name="squeezer_skip_compressed_title">முன்பு சுருக்கப்பட்டவற்றைத் தவிர்</string>
-    <string name="squeezer_skip_compressed_description">SD Maid ஏற்கனவே சுருக்கிய படங்களைத் தவிர்.</string>
+    <string name="squeezer_skip_compressed_description">SD Maid ஆல் ஏற்கனவே சுருக்கப்பட்ட கோப்புகளை தவிர்க்கவும்.</string>
     <string name="squeezer_exif_marker_title">EXIF குறிப்பான் எழுது</string>
     <string name="squeezer_exif_marker_description">சுருக்க வரலாறு அழிக்கப்பட்டாலும் மீண்டும் சுருக்குவதைத் தடுக்க படத்தின் EXIF பயனர் கருத்து புலத்தில் குறிப்பானை இணை.</string>
     <string name="squeezer_estimated_savings_format">~%s மிச்சம்</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">சுருக்கத்தை உறுதிப்படுத்து</string>
     <string name="squeezer_preview_total_size">மொத்த அளவு</string>
     <string name="squeezer_preview_estimated_savings">மதிப்பிடப்பட்ட மிச்சம்</string>
-    <string name="squeezer_compress_confirmation_title">படங்களை சுருக்கவா?</string>
-    <string name="squeezer_compress_confirmation_message">இது அசல் படங்களை சுருக்கப்பட்ட பதிப்புகளால் மாற்றும். இந்தச் செயலை மீட்க இயலாது.</string>
+    <string name="squeezer_compress_confirmation_title">தேர்ந்தெடுக்கப்பட்ட உருப்படிகளை சுருக்கவா?</string>
+    <string name="squeezer_compress_confirmation_message">இது அசல் கோப்புகளை சுருக்கப்பட்ட பதிப்புகளால் மாற்றும். இந்த செயலை மீட்டெடுக்க முடியாது.</string>
     <string name="squeezer_history_title">சுருக்க வரலாறு</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d உருப்படி (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">சுருக்க வரலாறு இல்லை</string>
     <string name="squeezer_history_clear_title">சுருக்க வரலாற்றை அழி</string>
-    <string name="squeezer_history_clear_message">இது முன்பு சுருக்கப்பட்ட படங்களை மீண்டும் சுருக்க அனுமதிக்கும். படங்கள் பாதிக்கப்படாது.</string>
+    <string name="squeezer_history_clear_message">இது முந்பு சுருக்கப்பட்ட கோப்புகளை மீண்டும் சுருக்க அனுமதிக்கும். கோப்புகளே பாதிக்கப்படாது.</string>
     <string name="squeezer_onboarding_title">பட சுருக்கம் பற்றி</string>
     <string name="squeezer_onboarding_message">பட சுருக்கம் காட்சி விவரங்களை நீக்குவதன் மூலம் கோப்பு அளவைக் குறைக்கிறது. இந்தச் செயல்முறை மீளமுடியாதது - அசல் தரத்தை மீட்டெடுக்க முடியாது.\n\nஉங்கள் படங்கள் எப்படி இருக்கும் என்பதன் முன்னோட்டம்:</string>
     <string name="squeezer_onboarding_original_label">அசல்</string>
     <string name="squeezer_onboarding_compressed_label">சுருக்கத்திற்குப் பிறகு</string>
+    <string name="squeezer_onboarding_video_original_label">வீடியோ சட்டகம்</string>
+    <string name="squeezer_onboarding_video_compressed_label">முன்னோட்டம் (தோராயமான)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">உண்மையான வீடியோ தரம் வேறுபடலாம்</string>
     <string name="squeezer_onboarding_quality_label">தரம்: %d%%</string>
     <string name="squeezer_compare_action">ஒப்பீட்டைக் காண்</string>
     <string name="squeezer_no_example_found">தேர்ந்தெடுக்கப்பட்ட பாதைகளில் படங்கள் காணப்படவில்லை.</string>
-    <string name="squeezer_result_empty_message">சுருக்கக்கூடிய படங்கள் காணப்படவில்லை.</string>
-    <string name="squeezer_setup_warning">சுருக்கம் சேமிப்பிடத்தை மிச்சப்படுத்த படத் தரத்தை நிரந்தரமாகக் குறைக்கிறது. இதை மீட்க முடியாது. தொடங்குவதற்கு முன் உங்கள் அமைப்புகளை கவனமாக மதிப்பாய்வு செய்யவும்.</string>
-    <string name="squeezer_setup_explanation">Media Squeeze சேமிப்பிடத்தை விடுவிக்க படங்களின் கோப்பு அளவைக் குறைக்கிறது. இது படத் தரத்தை நிரந்தரமாகக் குறைக்கிறது, இதை மீட்க முடியாது. தொடங்குவதற்கு முன் உங்கள் அமைப்புகளை கவனமாக மதிப்பாய்வு செய்யவும்.</string>
+    <string name="squeezer_result_empty_message">சுருக்கக்கூடிய ஊடகம் எதுவும் கிடைக்கவில்லை.</string>
+    <string name="squeezer_setup_warning">சுருக்கம் தரத்தை நிரந்தரமாக குறைக்கும், சேமிப்பு இடத்தை மிச்சப்படுத்த. இதை மீட்டெடுக்க முடியாது. தொடங்குவதற்கு முன் உங்கள் அமைப்புகளை கவனமாக சரிபார்க்கவும்.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d இடத்தை சுருக்கத்திற்கு பயன்படுத்த முடியாது மற்றும் அகற்றப்பட்டது. சுருக்கம் உள் சேமிப்பகத்திற்கு நேரடி அணுகல் தேவைப்படுகிறது.</item>
+        <item quantity="other">%d இடங்களை சுருக்கத்திற்கு பயன்படுத்த முடியாது மற்றும் அகற்றப்பட்டன. சுருக்கம் உள் சேமிப்பகத்திற்கு நேரடி அணுகல் தேவைப்படுகிறது.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">மீடியா ஸ்கீஸ் படங்கள் மற்றும் வீடியோக்களின் கோப்பு அளவை சேமிப்பு இடத்தை விடுவிக்க குறைக்கிறது. இது தரத்தை நிரந்தரமாக குறைக்கும், மீட்டெடுக்க முடியாது. தொடங்குவதற்கு முன் உங்கள் அமைப்புகளை கவனமாக சரிபார்க்கவும்.</string>
     <string name="squeezer_setup_paths_title">தேடல் இடங்கள்</string>
     <string name="squeezer_setup_paths_default">தேட கோப்புறைகளைத் தேர்ந்தெடு</string>
     <string name="squeezer_setup_quality_title">சுருக்கத் தரம்</string>
@@ -81,6 +99,6 @@
         <item quantity="one">குறைந்தது %d நாள் பழமையானது</item>
         <item quantity="other">குறைந்தது %d நாட்கள் பழமையானது</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">JPEG கோப்புகளுக்கு மதிப்பிடப்பட்ட ~%d%% மிச்சம்</string>
+    <string name="squeezer_estimated_savings_percent">படங்களுக்கு ~%d%% சேமிப்பு மதிப்பிடப்பட்டுள்ளது</string>
     <string name="squeezer_onboarding_got_it">புரிந்தது</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-te-rIN/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-te-rIN/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">స్టోరేజీ స్థలాన్ని ఆదా చేయడానికి చిత్రాలను కుదించండి.</string>
+    <string name="squeezer_explanation_short">నిల్వ స్థలాన్ని ఆదా చేయడానికి చిత్రాలు మరియు వీడియోలను కంప్రెస్ చేయండి.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d చిత్రం కనుగొనబడింది</item>
-        <item quantity="other">%d చిత్రాలు కనుగొనబడ్డాయి</item>
+        <item quantity="one">%d అంశం కనుగొనబడింది</item>
+        <item quantity="other">%d అంశాలు కనుగొనబడినాయి</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s ఆదా చేయవచ్చు</item>
         <item quantity="other">~%s ఆదా చేయవచ్చు</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d చిత్రం కుదించబడింది</item>
-        <item quantity="other">%d చిత్రాలు కుదించబడ్డాయి</item>
+        <item quantity="one">%d అంశం కంప్రెస్ చేయబడింది</item>
+        <item quantity="other">%d అంశాలు కంప్రెస్ చేయబడినాయి</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d విఫలమైంది</item>
+        <item quantity="other">%d విఫలమైనాయి</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d ఫైల్ దాటవేయబడింది (అందుబాటులో లేదు)</item>
+        <item quantity="other">%d ఫైళ్ళు దాటవేయబడినాయి (అందుబాటులో లేవు)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d చిత్రం ఎంచుకోబడింది</item>
-        <item quantity="other">%d చిత్రాలు ఎంచుకోబడ్డాయి</item>
+        <item quantity="one">%d అంశం ఎంచుకొబడింది</item>
+        <item quantity="other">%d అంశాలు ఎంచుకొబడినాయి</item>
     </plurals>
     <string name="squeezer_search_locations_title">వెతకడానికి స్థానాలు</string>
     <string name="squeezer_search_locations_default_summary">కెమెరా ఫోల్డర్‌లు (డిఫాల్ట్)</string>
     <string name="squeezer_min_size_title">కనిష్ట ఫైల్ పరిమాణం</string>
-    <string name="squeezer_min_size_description">ఈ పరిమాణం కంటే చిన్న చిత్రాలను దాటవేయండి.</string>
+    <string name="squeezer_min_size_description">ఈ పరిమాణం కంటే చిన్న ఫైళ్ళను దాటవేయండి.</string>
     <string name="squeezer_min_age_title">కనిష్ట ఫైల్ వయసు</string>
-    <string name="squeezer_min_age_description">ఈ వయసు కంటే పాత చిత్రాలను మాత్రమే చేర్చండి.</string>
-    <string name="squeezer_compression_settings_label">కుదింపు సెట్టింగ్‌లు</string>
+    <string name="squeezer_min_age_description">ఈ వయసు కంటే పాతవైన ఫైళ్ళను మాత్రమే చేర్చండి.</string>
+    <string name="squeezer_compression_settings_label">సాధారణ</string>
     <string name="squeezer_quality_label">నాణ్యత</string>
     <string name="squeezer_quality_title">కుదింపు నాణ్యత</string>
-    <string name="squeezer_quality_description">తక్కువ నాణ్యత అంటే చిన్న ఫైల్ పరిమాణం కానీ తగ్గిన చిత్ర నాణ్యత.</string>
+    <string name="squeezer_quality_description">తక్కువ నాణ్యత అంటే చిన్న ఫైల్ పరిమాణం కానీ తక్కువ దృశ్య నాణ్యత.</string>
     <string name="squeezer_quality_example_format">ఉదాహరణ: %1$s చిత్రం → %3$d%% నాణ్యతలో ~%2$s ఆదా</string>
     <string name="squeezer_quality_warning_low">తక్కువ నాణ్యతలు కనిపించే ఆర్టిఫాక్ట్‌లకు కారణం కావచ్చు.</string>
     <string name="squeezer_quality_warning_high">చాలా అధిక నాణ్యత కనిష్ట స్థల ఆదాను అందిస్తుంది.</string>
-    <string name="squeezer_types_category_label">చిత్ర రకాలు</string>
+    <string name="squeezer_types_category_label">చిత్రం అమరికలు</string>
+    <string name="squeezer_video_settings_category_label">వీడియో అమరికలు</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">JPEG చిత్రాలను చేర్చండి (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">WebP చిత్రాలను చేర్చండి (.webp).</string>
+    <string name="squeezer_type_video_title">MP4 వీడియో</string>
+    <string name="squeezer_type_video_description">MP4 వీడియో ఫైళ్ళను (.mp4) చేర్చండి.</string>
     <string name="squeezer_skip_compressed_title">గతంలో కుదించినవి దాటవేయండి</string>
-    <string name="squeezer_skip_compressed_description">SD Maid ద్వారా ఇప్పటికే కుదించబడిన చిత్రాలను దాటవేయండి.</string>
+    <string name="squeezer_skip_compressed_description">SD Maid ద్వారా ఇప్పటికే కంప్రెస్ చేయబడిన ఫైళ్ళను దాటవేయండి.</string>
     <string name="squeezer_exif_marker_title">EXIF మార్కర్ వ్రాయండి</string>
     <string name="squeezer_exif_marker_description">కుదింపు చరిత్ర క్లియర్ చేయబడినా మళ్ళీ కుదింపును నిరోధించడానికి చిత్రం యొక్క EXIF వినియోగదారు వ్యాఖ్య ఫీల్డ్‌కు మార్కర్‌ను జోడించండి.</string>
     <string name="squeezer_estimated_savings_format">~%s ఆదా</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">కుదింపును నిర్ధారించండి</string>
     <string name="squeezer_preview_total_size">మొత్తం పరిమాణం</string>
     <string name="squeezer_preview_estimated_savings">అంచనా ఆదా</string>
-    <string name="squeezer_compress_confirmation_title">చిత్రాలను కుదించాలా?</string>
-    <string name="squeezer_compress_confirmation_message">ఇది అసలు చిత్రాలను కుదించిన వెర్షన్‌లతో భర్తీ చేస్తుంది. ఈ చర్యను రద్దు చేయలేరు.</string>
+    <string name="squeezer_compress_confirmation_title">ఎంచుకున్న అంశాలను కంప్రెస్ చేయాలా?</string>
+    <string name="squeezer_compress_confirmation_message">ఇది అసలు ఫైళ్ళను కంప్రెస్ చేయబడిన వెర్షన్‌లతో భర్తీ చేస్తుంది. ఈ చర్యను రద్దు చేయడం సాధ్యం కాదు.</string>
     <string name="squeezer_history_title">కుదింపు చరిత్ర</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d అంశం (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">కుదింపు చరిత్ర లేదు</string>
     <string name="squeezer_history_clear_title">కుదింపు చరిత్రను క్లియర్ చేయండి</string>
-    <string name="squeezer_history_clear_message">ఇది గతంలో కుదించిన చిత్రాలను మళ్ళీ కుదించడానికి అనుమతిస్తుంది. చిత్రాలు ప్రభావితం కావు.</string>
+    <string name="squeezer_history_clear_message">ఇది గతంలో కంప్రెస్ చేయబడిన ఫైళ్ళను మళ్ళీ కంప్రెస్ చేయడానికి అనుమతిస్తుంది. ఫైళ్ళు ప్రభావితం కావు.</string>
     <string name="squeezer_onboarding_title">చిత్ర కుదింపు గురించి</string>
     <string name="squeezer_onboarding_message">చిత్ర కుదింపు విజువల్ వివరాలను తొలగించడం ద్వారా ఫైల్ పరిమాణాన్ని తగ్గిస్తుంది. ఈ ప్రక్రియ తిరుగులేనిది - అసలు నాణ్యతను పునరుద్ధరించలేరు.\n\nమీ చిత్రాలు ఎలా కనిపిస్తాయో ఇక్కడ ప్రివ్యూ ఉంది:</string>
     <string name="squeezer_onboarding_original_label">అసలు</string>
     <string name="squeezer_onboarding_compressed_label">కుదింపు తర్వాత</string>
+    <string name="squeezer_onboarding_video_original_label">వీడియో ఫ్రేమ్</string>
+    <string name="squeezer_onboarding_video_compressed_label">ప్రివ్యూ (సుమారు)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">వాస్తవ వీడియో నాణ్యత భిన్నంగా ఉండవచ్చు</string>
     <string name="squeezer_onboarding_quality_label">నాణ్యత: %d%%</string>
     <string name="squeezer_compare_action">పోలిక చూడండి</string>
     <string name="squeezer_no_example_found">ఎంచుకున్న పాథ్‌లలో చిత్రాలు కనుగొనబడలేదు.</string>
-    <string name="squeezer_result_empty_message">కుదించగల చిత్రాలు కనుగొనబడలేదు.</string>
-    <string name="squeezer_setup_warning">కుదింపు స్టోరేజీ స్థలాన్ని ఆదా చేయడానికి చిత్ర నాణ్యతను శాశ్వతంగా తగ్గిస్తుంది. దీన్ని రద్దు చేయలేరు. ప్రారంభించే ముందు మీ సెట్టింగ్‌లను జాగ్రత్తగా సమీక్షించండి.</string>
-    <string name="squeezer_setup_explanation">Media Squeeze స్టోరేజీ స్థలాన్ని ఖాళీ చేయడానికి చిత్రాల ఫైల్ పరిమాణాన్ని తగ్గిస్తుంది. ఇది చిత్ర నాణ్యతను శాశ్వతంగా తగ్గిస్తుంది మరియు రద్దు చేయలేరు. ప్రారంభించే ముందు మీ సెట్టింగ్‌లను జాగ్రత్తగా సమీక్షించండి.</string>
+    <string name="squeezer_result_empty_message">కంప్రెస్ చేయగలిగే మీడియా ఏదీ కనుగొనబడలేదు.</string>
+    <string name="squeezer_setup_warning">కంప్రెషన్ నిల్వ స్థలాన్ని ఆదా చేయడానికి నాణ్యతను శాశ్వతంగా తగ్గిస్తుంది. ఇది రద్దు చేయడం సాధ్యం కాదు. ప్రారంభించే ముందు మీ అమరికలను జాగ్రత్తగా సమీక్షించండి.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d స్థానాన్ని కంప్రెషన్ కోసం ఉపయోగించలేము మరియు తొలగించబడింది. కంప్రెషన్‌కు అంతర్గత నిల్వకు నేరుగా యాక్సెస్ అవసరం.</item>
+        <item quantity="other">%d స్థానాలను కంప్రెషన్ కోసం ఉపయోగించలేము మరియు తొలగించబడినాయి. కంప్రెషన్‌కు అంతర్గత నిల్వకు నేరుగా యాక్సెస్ అవసరం.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">మీడియా స్క్వీజ్ నిల్వ స్థలాన్ని విముక్తి చేయడానికి చిత్రాలు మరియు వీడియోల ఫైల్ పరిమాణాన్ని తగ్గిస్తుంది. ఇది శాశ్వతంగా నాణ్యతను తగ్గిస్తుంది మరియు రద్దు చేయడం సాధ్యం కాదు. ప్రారంభించే ముందు మీ అమరికలను జాగ్రత్తగా సమీక్షించండి.</string>
     <string name="squeezer_setup_paths_title">వెతకడానికి స్థానాలు</string>
     <string name="squeezer_setup_paths_default">వెతకడానికి ఫోల్డర్‌లను ఎంచుకోండి</string>
     <string name="squeezer_setup_quality_title">కుదింపు నాణ్యత</string>
@@ -81,6 +99,6 @@
         <item quantity="one">కనీసం %d రోజు పాతది</item>
         <item quantity="other">కనీసం %d రోజులు పాతవి</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">JPEG ఫైల్‌లకు అంచనా ~%d%% ఆదా</string>
+    <string name="squeezer_estimated_savings_percent">చిత్రాలకు సుమారు ~%d%% ఆదా అంచనా</string>
     <string name="squeezer_onboarding_got_it">అర్థమైంది</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-th/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-th/strings.xml
@@ -1,38 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">บีบอัดรูปภาพเพื่อประหยัดพื้นที่จัดเก็บ</string>
+    <string name="squeezer_explanation_short">บีบอัดภาพและวิดีโอเพื่อประหยัดพื้นที่จัดเก็บ</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="other">พบ %d รูปภาพ</item>
+        <item quantity="other">พบ %d รายการ</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="other">ประหยัดได้ ~%s</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="other">บีบอัด %d รูปภาพแล้ว</item>
+        <item quantity="other">บีบอัดแล้ว %d รายการ</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="other">%d ล้มเหลว</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="other">ข้ามไปแล้ว %d ไฟล์ (ไม่สามารถเข้าถึงได้)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="other">เลือก %d รูปภาพ</item>
+        <item quantity="other">เลือกแล้ว %d รายการ</item>
     </plurals>
     <string name="squeezer_search_locations_title">ตำแหน่งค้นหา</string>
     <string name="squeezer_search_locations_default_summary">โฟลเดอร์กล้อง (ค่าเริ่มต้น)</string>
     <string name="squeezer_min_size_title">ขนาดไฟล์ขั้นต่ำ</string>
-    <string name="squeezer_min_size_description">ข้ามรูปภาพที่เล็กกว่าขนาดนี้</string>
+    <string name="squeezer_min_size_description">ข้ามไฟล์ที่มีขนาดเล็กกว่านี้</string>
     <string name="squeezer_min_age_title">อายุไฟล์ขั้นต่ำ</string>
-    <string name="squeezer_min_age_description">รวมเฉพาะรูปภาพที่เก่ากว่าอายุนี้</string>
-    <string name="squeezer_compression_settings_label">การตั้งค่าการบีบอัด</string>
+    <string name="squeezer_min_age_description">รวมเฉพาะไฟล์ที่เก่ากว่าอายุนี้เท่านั้น</string>
+    <string name="squeezer_compression_settings_label">ทั่วไป</string>
     <string name="squeezer_quality_label">คุณภาพ</string>
     <string name="squeezer_quality_title">คุณภาพการบีบอัด</string>
-    <string name="squeezer_quality_description">คุณภาพต่ำหมายถึงขนาดไฟล์เล็กลงแต่คุณภาพรูปลดลง</string>
+    <string name="squeezer_quality_description">คุณภาพต่ำกว่าหมายถึงขนาดไฟล์เล็กลงแต่คุณภาพภาพลดลง</string>
     <string name="squeezer_quality_example_format">ตัวอย่าง: รูปภาพ %1$s → ประหยัด ~%2$s ที่คุณภาพ %3$d%%</string>
     <string name="squeezer_quality_warning_low">คุณภาพต่ำอาจทำให้เห็นสิ่งแปลกปลอมได้</string>
     <string name="squeezer_quality_warning_high">คุณภาพสูงมากให้การประหยัดพื้นที่น้อย</string>
-    <string name="squeezer_types_category_label">ประเภทรูปภาพ</string>
+    <string name="squeezer_types_category_label">การตั้งค่าภาพ</string>
+    <string name="squeezer_video_settings_category_label">การตั้งค่าวิดีโอ</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">รวมรูปภาพ JPEG (.jpg, .jpeg)</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">รวมรูปภาพ WebP (.webp)</string>
+    <string name="squeezer_type_video_title">MP4 Video</string>
+    <string name="squeezer_type_video_description">รวมไฟล์วิดีโอ MP4 (.mp4)</string>
     <string name="squeezer_skip_compressed_title">ข้ามที่บีบอัดแล้ว</string>
-    <string name="squeezer_skip_compressed_description">ข้ามรูปภาพที่ SD Maid บีบอัดแล้ว</string>
+    <string name="squeezer_skip_compressed_description">ข้ามไฟล์ที่บีบอัดโดย SD Maid ไปแล้ว</string>
     <string name="squeezer_exif_marker_title">เขียนเครื่องหมาย EXIF</string>
     <string name="squeezer_exif_marker_description">เพิ่มเครื่องหมายในช่องความคิดเห็นผู้ใช้ EXIF ของรูปภาพเพื่อป้องกันการบีบอัดซ้ำแม้ประวัติการบีบอัดจะถูกล้าง</string>
     <string name="squeezer_estimated_savings_format">ประหยัด ~%s</string>
@@ -43,25 +52,31 @@
     <string name="squeezer_preview_dialog_title">ยืนยันการบีบอัด</string>
     <string name="squeezer_preview_total_size">ขนาดรวม</string>
     <string name="squeezer_preview_estimated_savings">ประหยัดโดยประมาณ</string>
-    <string name="squeezer_compress_confirmation_title">บีบอัดรูปภาพ?</string>
-    <string name="squeezer_compress_confirmation_message">สิ่งนี้จะแทนที่รูปภาพต้นฉบับด้วยเวอร์ชันที่บีบอัด ไม่สามารถเลิกทำได้</string>
+    <string name="squeezer_compress_confirmation_title">บีบอัดรายการที่เลือกหรือไม่?</string>
+    <string name="squeezer_compress_confirmation_message">การดำเนินการนี้จะแทนที่ไฟล์ต้นฉบับด้วยเวอร์ชันที่บีบอัดแล้ว ไม่สามารถยกเลิกการดำเนินการนี้ได้</string>
     <string name="squeezer_history_title">ประวัติการบีบอัด</string>
     <plurals name="squeezer_history_summary">
         <item quantity="other">%1$d รายการ (%2$s)</item>
     </plurals>
     <string name="squeezer_history_empty">ไม่มีประวัติการบีบอัด</string>
     <string name="squeezer_history_clear_title">ล้างประวัติการบีบอัด</string>
-    <string name="squeezer_history_clear_message">สิ่งนี้จะอนุญาตให้รูปภาพที่บีบอัดก่อนหน้านี้ถูกบีบอัดอีกครั้ง รูปภาพเองไม่ได้รับผลกระทบ</string>
+    <string name="squeezer_history_clear_message">การดำเนินการนี้จะอนุญาตให้บีบอัดไฟล์ที่เคยบีบอัดแล้วอีกครั้ง ไฟล์เองจะไม่ได้รับผลกระทบ</string>
     <string name="squeezer_onboarding_title">เกี่ยวกับการบีบอัดรูปภาพ</string>
     <string name="squeezer_onboarding_message">การบีบอัดรูปภาพลดขนาดไฟล์โดยการลดรายละเอียดภาพ กระบวนการนี้ไม่สามารถย้อนกลับได้ - คุณภาพต้นฉบับไม่สามารถกู้คืนได้\n\nนี่คือตัวอย่างของรูปภาพของคุณจะมีลักษณะอย่างไร:</string>
     <string name="squeezer_onboarding_original_label">ต้นฉบับ</string>
     <string name="squeezer_onboarding_compressed_label">หลังบีบอัด</string>
+    <string name="squeezer_onboarding_video_original_label">เฟรมวิดีโอ</string>
+    <string name="squeezer_onboarding_video_compressed_label">ตัวอย่าง (โดยประมาณ)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">คุณภาพวิดีโอจริงอาจแตกต่างกัน</string>
     <string name="squeezer_onboarding_quality_label">คุณภาพ: %d%%</string>
     <string name="squeezer_compare_action">ดูการเปรียบเทียบ</string>
     <string name="squeezer_no_example_found">ไม่พบรูปภาพในเส้นทางที่เลือก</string>
-    <string name="squeezer_result_empty_message">ไม่พบรูปภาพที่บีบอัดได้</string>
-    <string name="squeezer_setup_warning">การบีบอัดลดคุณภาพรูปภาพอย่างถาวรเพื่อประหยัดพื้นที่จัดเก็บ ไม่สามารถเลิกทำได้ ตรวจสอบการตั้งค่าของคุณอย่างรอบคอบก่อนเริ่ม</string>
-    <string name="squeezer_setup_explanation">Media Squeeze ลดขนาดไฟล์ของรูปภาพเพื่อเพิ่มพื้นที่จัดเก็บ สิ่งนี้ลดคุณภาพรูปภาพอย่างถาวรและไม่สามารถเลิกทำได้ ตรวจสอบการตั้งค่าของคุณอย่างรอบคอบก่อนเริ่ม</string>
+    <string name="squeezer_result_empty_message">ไม่พบสื่อที่สามารถบีบอัดได้</string>
+    <string name="squeezer_setup_warning">การบีบอัดจะลดคุณภาพอย่างถาวรเพื่อประหยัดพื้นที่จัดเก็บ ไม่สามารถยกเลิกได้ โปรดตรวจสอบการตั้งค่าของคุณอย่างรอบคอบก่อนเริ่ม</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="other">ไม่สามารถใช้ %d ตำแหน่งสำหรับการบีบอัดและถูกลบออกแล้ว การบีบอัดต้องการการเข้าถึงโดยตรงไปยังพื้นที่จัดเก็บภายใน</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze ลดขนาดไฟล์ของภาพและวิดีโอเพื่อเพิ่มพื้นที่จัดเก็บ การดำเนินการนี้จะลดคุณภาพอย่างถาวรและไม่สามารถยกเลิกได้ โปรดตรวจสอบการตั้งค่าของคุณอย่างรอบคอบก่อนเริ่ม</string>
     <string name="squeezer_setup_paths_title">ตำแหน่งค้นหา</string>
     <string name="squeezer_setup_paths_default">เลือกโฟลเดอร์ที่จะค้นหา</string>
     <string name="squeezer_setup_quality_title">คุณภาพการบีบอัด</string>
@@ -75,6 +90,6 @@
     <plurals name="squeezer_min_age_x_days">
         <item quantity="other">อย่างน้อย %d วัน</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">ประมาณ ~%d%% สำหรับไฟล์ JPEG</string>
+    <string name="squeezer_estimated_savings_percent">ประมาณการประหยัด ~%d%% สำหรับภาพ</string>
     <string name="squeezer_onboarding_got_it">เข้าใจแล้ว</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-tr/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-tr/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Depolama alanı kazanmak için resimleri sıkıştırın.</string>
+    <string name="squeezer_explanation_short">Depolama alanı kazanmak için resimleri ve videoları sıkıştırın.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d resim bulundu</item>
-        <item quantity="other">%d resim bulundu</item>
+        <item quantity="one">%d öğe bulundu</item>
+        <item quantity="other">%d öğe bulundu</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s tasarruf edilebilir</item>
         <item quantity="other">~%s tasarruf edilebilir</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d resim sıkıştırıldı</item>
-        <item quantity="other">%d resim sıkıştırıldı</item>
+        <item quantity="one">%d öğe sıkıştırıldı</item>
+        <item quantity="other">%d öğe sıkıştırıldı</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d başarısız</item>
+        <item quantity="other">%d başarısız</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d dosya atlandı (erişilemiyor)</item>
+        <item quantity="other">%d dosya atlandı (erişilemiyor)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d resim seçildi</item>
-        <item quantity="other">%d resim seçildi</item>
+        <item quantity="one">%d öğe seçildi</item>
+        <item quantity="other">%d öğe seçildi</item>
     </plurals>
     <string name="squeezer_search_locations_title">Arama konumları</string>
     <string name="squeezer_search_locations_default_summary">Kamera klasörleri (varsayılan)</string>
     <string name="squeezer_min_size_title">Minimum dosya boyutu</string>
-    <string name="squeezer_min_size_description">Bu boyuttan küçük resimleri atla.</string>
+    <string name="squeezer_min_size_description">Bu boyuttan küçük dosyaları atla.</string>
     <string name="squeezer_min_age_title">Minimum dosya yaşı</string>
-    <string name="squeezer_min_age_description">Yalnızca bu yaştan eski resimleri dahil et.</string>
-    <string name="squeezer_compression_settings_label">Sıkıştırma ayarları</string>
+    <string name="squeezer_min_age_description">Yalnızca bu yaştan eski dosyaları dahil et.</string>
+    <string name="squeezer_compression_settings_label">Genel</string>
     <string name="squeezer_quality_label">Kalite</string>
     <string name="squeezer_quality_title">Sıkıştırma kalitesi</string>
-    <string name="squeezer_quality_description">Düşük kalite, daha küçük dosya boyutu ancak düşük görüntü kalitesi anlamına gelir.</string>
+    <string name="squeezer_quality_description">Daha düşük kalite, daha küçük dosya boyutu ancak azaltılmış görsel kalite anlamına gelir.</string>
     <string name="squeezer_quality_example_format">Örnek: %1$s resim → %3$d%% kalitede ~%2$s tasarruf</string>
     <string name="squeezer_quality_warning_low">Düşük kaliteler görünür bozulmalara neden olabilir.</string>
     <string name="squeezer_quality_warning_high">Çok yüksek kalite minimum alan tasarrufu sağlar.</string>
-    <string name="squeezer_types_category_label">Resim türleri</string>
+    <string name="squeezer_types_category_label">Görsel ayarlar</string>
+    <string name="squeezer_video_settings_category_label">Video ayarları</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">JPEG resimleri dahil et (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">WebP resimleri dahil et (.webp).</string>
+    <string name="squeezer_type_video_title">MP4 Video</string>
+    <string name="squeezer_type_video_description">MP4 video dosyalarını dahil et (.mp4).</string>
     <string name="squeezer_skip_compressed_title">Önceden sıkıştırılmışları atla</string>
-    <string name="squeezer_skip_compressed_description">SD Maid tarafından zaten sıkıştırılmış resimleri atla.</string>
+    <string name="squeezer_skip_compressed_description">SD Maid tarafından zaten sıkıştırılmış dosyaları atla.</string>
     <string name="squeezer_exif_marker_title">EXIF işareti yaz</string>
     <string name="squeezer_exif_marker_description">Sıkıştırma geçmişi temizlense bile yeniden sıkıştırmayı önlemek için resmin EXIF kullanıcı yorum alanına bir işaret ekleyin.</string>
     <string name="squeezer_estimated_savings_format">~%s tasarruf</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">Sıkıştırmayı onayla</string>
     <string name="squeezer_preview_total_size">Toplam boyut</string>
     <string name="squeezer_preview_estimated_savings">Tahmini tasarruf</string>
-    <string name="squeezer_compress_confirmation_title">Resimler sıkıştırılsın mı?</string>
-    <string name="squeezer_compress_confirmation_message">Bu, orijinal resimleri sıkıştırılmış sürümlerle değiştirecektir. Bu işlem geri alınamaz.</string>
+    <string name="squeezer_compress_confirmation_title">Seçili öğeler sıkıştırılsın mı?</string>
+    <string name="squeezer_compress_confirmation_message">Bu işlem orijinal dosyaları sıkıştırılmış sürümleriyle değiştirecektir. Bu işlem geri alınamaz.</string>
     <string name="squeezer_history_title">Sıkıştırma geçmişi</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d öğe (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">Sıkıştırma geçmişi yok</string>
     <string name="squeezer_history_clear_title">Sıkıştırma geçmişini temizle</string>
-    <string name="squeezer_history_clear_message">Bu, daha önce sıkıştırılmış resimlerin tekrar sıkıştırılmasına izin verecektir. Resimlerin kendisi etkilenmez.</string>
+    <string name="squeezer_history_clear_message">Bu, daha önce sıkıştırılmış dosyaların tekrar sıkıştırılabilmesine izin verecektir. Dosyaların kendisi etkilenmez.</string>
     <string name="squeezer_onboarding_title">Resim Sıkıştırma Hakkında</string>
     <string name="squeezer_onboarding_message">Resim sıkıştırma, görsel detayları kaldırarak dosya boyutunu küçültür. Bu işlem geri alınamaz - orijinal kalite geri yüklenemez.\n\nResimlerinizin nasıl görüneceğinin bir önizlemesi:</string>
     <string name="squeezer_onboarding_original_label">Orijinal</string>
     <string name="squeezer_onboarding_compressed_label">Sıkıştırma sonrası</string>
+    <string name="squeezer_onboarding_video_original_label">Video karesi</string>
+    <string name="squeezer_onboarding_video_compressed_label">Önizleme (yaklaşık)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">Gerçek video kalitesi farklılık gösterebilir</string>
     <string name="squeezer_onboarding_quality_label">Kalite: %d%%</string>
     <string name="squeezer_compare_action">Karşılaştırmayı görüntüle</string>
     <string name="squeezer_no_example_found">Seçilen yollarda resim bulunamadı.</string>
-    <string name="squeezer_result_empty_message">Sıkıştırılabilir resim bulunamadı.</string>
-    <string name="squeezer_setup_warning">Sıkıştırma, depolama alanı kazanmak için görüntü kalitesini kalıcı olarak düşürür. Bu geri alınamaz. Başlamadan önce ayarlarınızı dikkatlice gözden geçirin.</string>
-    <string name="squeezer_setup_explanation">Medya Sıkıştırıcı, depolama alanı açmak için resimlerin dosya boyutunu küçültür. Bu, görüntü kalitesini kalıcı olarak düşürür ve geri alınamaz. Başlamadan önce ayarlarınızı dikkatlice gözden geçirin.</string>
+    <string name="squeezer_result_empty_message">Sıkıştırılabilir medya bulunamadı.</string>
+    <string name="squeezer_setup_warning">Sıkıştırma, depolama alanı kazanmak için kaliteyi kalıcı olarak azaltır. Bu geri alınamaz. Başlatmadan önce ayarlarınızı dikkatlice gözden geçirin.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d konum sıkıştırma için kullanılamaz ve kaldırıldı. Sıkıştırma, dahili depolamaya doğrudan erişim gerektirir.</item>
+        <item quantity="other">%d konum sıkıştırma için kullanılamaz ve kaldırıldı. Sıkıştırma, dahili depolamaya doğrudan erişim gerektirir.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Medya Sıkıştırma, depolama alanı boşaltmak için görsel ve videoların dosya boyutunu küçültür. Bu kalıcı olarak kaliteyi azaltır ve geri alınamaz. Başlatmadan önce ayarlarınızı dikkatlice gözden geçirin.</string>
     <string name="squeezer_setup_paths_title">Arama konumları</string>
     <string name="squeezer_setup_paths_default">Aranacak klasörleri seçin</string>
     <string name="squeezer_setup_quality_title">Sıkıştırma kalitesi</string>
@@ -81,6 +99,6 @@
         <item quantity="one">En az %d gün eski</item>
         <item quantity="other">En az %d gün eski</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">JPEG dosyaları için tahmini ~%d%% tasarruf</string>
+    <string name="squeezer_estimated_savings_percent">Görseller için tahmini ~%d%% tasarruf</string>
     <string name="squeezer_onboarding_got_it">Anladım</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-ur-rIN/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-ur-rIN/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">اسٹوریج بچانے کے لیے تصاویر کمپریس کریں۔</string>
+    <string name="squeezer_explanation_short">ذخیرہ کی جگہ بچانے کے لیے تصاویر اور ویڈیوز کو کمپریس کریں۔</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d تصویر ملی</item>
-        <item quantity="other">%d تصاویر ملیں</item>
+        <item quantity="one">%d آئٹم ملا</item>
+        <item quantity="other">%d آئٹمز ملے</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s بچائی جا سکتی ہے</item>
         <item quantity="other">~%s بچائی جا سکتی ہیں</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d تصویر کمپریس ہوئی</item>
-        <item quantity="other">%d تصاویر کمپریس ہوئیں</item>
+        <item quantity="one">%d آئٹم کمپریس ہوا</item>
+        <item quantity="other">%d آئٹمز کمپریس ہوئے</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d ناکام</item>
+        <item quantity="other">%d ناکام</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d فائل چھوڑی گئی (قابل رسائی نہیں)</item>
+        <item quantity="other">%d فائلیں چھوڑی گئیں (قابل رسائی نہیں)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d تصویر منتخب</item>
-        <item quantity="other">%d تصاویر منتخب</item>
+        <item quantity="one">%d آئٹم منتخب</item>
+        <item quantity="other">%d آئٹمز منتخب</item>
     </plurals>
     <string name="squeezer_search_locations_title">تلاش کے مقامات</string>
     <string name="squeezer_search_locations_default_summary">کیمرہ فولڈرز (پہلے سے طے شدہ)</string>
     <string name="squeezer_min_size_title">کم از کم فائل سائز</string>
-    <string name="squeezer_min_size_description">اس سائز سے چھوٹی تصاویر چھوڑ دیں۔</string>
+    <string name="squeezer_min_size_description">اس سائز سے چھوٹی فائلیں چھوڑ دیں۔</string>
     <string name="squeezer_min_age_title">کم از کم فائل عمر</string>
-    <string name="squeezer_min_age_description">صرف اس عمر سے پرانی تصاویر شامل کریں۔</string>
-    <string name="squeezer_compression_settings_label">کمپریشن ترتیبات</string>
+    <string name="squeezer_min_age_description">صرف اس عمر سے پرانی فائلیں شامل کریں۔</string>
+    <string name="squeezer_compression_settings_label">عام</string>
     <string name="squeezer_quality_label">معیار</string>
     <string name="squeezer_quality_title">کمپریشن معیار</string>
-    <string name="squeezer_quality_description">کم معیار کا مطلب چھوٹی فائل سائز لیکن کم تصویر کوالٹی ہے۔</string>
+    <string name="squeezer_quality_description">کم معیار کا مطلب ہے چھوٹا فائل سائز لیکن کم بصری معیار۔</string>
     <string name="squeezer_quality_example_format">مثال: %1$s تصویر → %3$d%% معیار پر ~%2$s بچت</string>
     <string name="squeezer_quality_warning_low">کم معیار میں نظر آنے والی خرابیاں ہو سکتی ہیں۔</string>
     <string name="squeezer_quality_warning_high">بہت زیادہ معیار کم جگہ بچاتا ہے۔</string>
-    <string name="squeezer_types_category_label">تصویر کی اقسام</string>
+    <string name="squeezer_types_category_label">تصویر کی ترتیبات</string>
+    <string name="squeezer_video_settings_category_label">ویڈیو کی ترتیبات</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">JPEG تصاویر (.jpg, .jpeg) شامل کریں۔</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">WebP تصاویر (.webp) شامل کریں۔</string>
+    <string name="squeezer_type_video_title">MP4 ویڈیو</string>
+    <string name="squeezer_type_video_description">MP4 ویڈیو فائلیں (.mp4) شامل کریں۔</string>
     <string name="squeezer_skip_compressed_title">پہلے سے کمپریس شدہ چھوڑیں</string>
-    <string name="squeezer_skip_compressed_description">وہ تصاویر چھوڑیں جو پہلے سے SD Maid نے کمپریس کی ہیں۔</string>
+    <string name="squeezer_skip_compressed_description">وہ فائلیں چھوڑ دیں جو SD Maid نے پہلے ہی کمپریس کی ہیں۔</string>
     <string name="squeezer_exif_marker_title">EXIF مارکر لکھیں</string>
     <string name="squeezer_exif_marker_description">تصویر کے EXIF یوزر کمنٹ فیلڈ میں مارکر شامل کریں تاکہ کمپریشن ہسٹری صاف ہونے پر بھی دوبارہ کمپریشن روکی جائے۔</string>
     <string name="squeezer_estimated_savings_format">~%s بچت</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">کمپریشن کی تصدیق</string>
     <string name="squeezer_preview_total_size">کل سائز</string>
     <string name="squeezer_preview_estimated_savings">تخمینی بچت</string>
-    <string name="squeezer_compress_confirmation_title">تصاویر کمپریس کریں؟</string>
-    <string name="squeezer_compress_confirmation_message">یہ اصل تصاویر کو کمپریس شدہ ورژن سے بدل دے گا۔ یہ عمل واپس نہیں ہو سکتا۔</string>
+    <string name="squeezer_compress_confirmation_title">منتخب آئٹمز کمپریس کریں؟</string>
+    <string name="squeezer_compress_confirmation_message">یہ اصل فائلوں کو کمپریس شدہ ورژنز سے تبدیل کر دے گا۔ یہ عمل واپس نہیں کیا جا سکتا۔</string>
     <string name="squeezer_history_title">کمپریشن ہسٹری</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d آئٹم (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">کوئی کمپریشن ہسٹری نہیں</string>
     <string name="squeezer_history_clear_title">کمپریشن ہسٹری صاف کریں</string>
-    <string name="squeezer_history_clear_message">یہ پہلے سے کمپریس شدہ تصاویر کو دوبارہ کمپریس ہونے دے گا۔ تصاویر خود متاثر نہیں ہوتیں۔</string>
+    <string name="squeezer_history_clear_message">یہ پہلے کمپریس شدہ فائلوں کو دوبارہ کمپریس کرنے کی اجازت دے گا۔ فائلیں خود متاثر نہیں ہوں گی۔</string>
     <string name="squeezer_onboarding_title">تصویر کمپریشن کے بارے میں</string>
     <string name="squeezer_onboarding_message">تصویر کمپریشن بصری تفصیلات ہٹا کر فائل سائز کم کرتی ہے۔ یہ عمل ناقابل واپسی ہے - اصل معیار بحال نہیں ہو سکتا۔\n\nآپ کی تصاویر کیسی نظر آئیں گی اس کا جائزہ:</string>
     <string name="squeezer_onboarding_original_label">اصل</string>
     <string name="squeezer_onboarding_compressed_label">کمپریشن کے بعد</string>
+    <string name="squeezer_onboarding_video_original_label">ویڈیو فریم</string>
+    <string name="squeezer_onboarding_video_compressed_label">پیش نظارہ (تقریبی)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">اصل ویڈیو کا معیار مختلف ہو سکتا ہے</string>
     <string name="squeezer_onboarding_quality_label">معیار: %d%%</string>
     <string name="squeezer_compare_action">موازنہ دیکھیں</string>
     <string name="squeezer_no_example_found">منتخب پاتھز میں کوئی تصاویر نہیں ملیں۔</string>
-    <string name="squeezer_result_empty_message">کوئی کمپریس ہونے والی تصاویر نہیں ملیں۔</string>
-    <string name="squeezer_setup_warning">کمپریشن تصویر کے معیار کو مستقل طور پر کم کر کے اسٹوریج بچاتی ہے۔ یہ واپس نہیں ہو سکتا۔ شروع کرنے سے پہلے اپنی ترتیبات کا بغور جائزہ لیں۔</string>
-    <string name="squeezer_setup_explanation">میڈیا سکویز اسٹوریج خالی کرنے کے لیے تصاویر کا فائل سائز کم کرتا ہے۔ یہ تصویر کا معیار مستقل طور پر کم کرتا ہے اور واپس نہیں ہو سکتا۔ شروع کرنے سے پہلے اپنی ترتیبات کا بغور جائزہ لیں۔</string>
+    <string name="squeezer_result_empty_message">کوئی قابل۔ کمپریس میڈیا نہیں ملا۔</string>
+    <string name="squeezer_setup_warning">کمپریشن مستقل طور پر معیار کو کم کر دیتی ہے تاکہ ذخیرہ کی جگہ بچائی جا سکے۔ یہ واپس نہیں کیا جا سکتا۔ شروع کرنے سے پہلے اپنی ترتیبات کا بغور جائزہ لیں۔</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d مقام کمپریشن کے لیے استعمال نہیں ہو سکتا اور ہٹا دیا گیا۔ کمپریشن کے لیے اندرونی ذخیرے تک براہ راست رسائی درکار ہے۔</item>
+        <item quantity="other">%d مقامات کمپریشن کے لیے استعمال نہیں ہو سکتے اور ہٹا دیے گئے۔ کمپریشن کے لیے اندرونی ذخیرے تک براہ راست رسائی درکار ہے۔</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">میڈیا سکوئیز ذخیرہ کی جگہ خالی کرنے کے لیے تصاویر اور ویڈیوز کا فائل سائز کم کرتا ہے۔ یہ مستقل طور پر معیار کو کم کر دیتا ہے اور واپس نہیں کیا جا سکتا۔ شروع کرنے سے پہلے اپنی ترتیبات کا بغور جائزہ لیں۔</string>
     <string name="squeezer_setup_paths_title">تلاش کے مقامات</string>
     <string name="squeezer_setup_paths_default">تلاش کرنے کے لیے فولڈرز منتخب کریں</string>
     <string name="squeezer_setup_quality_title">کمپریشن معیار</string>
@@ -81,6 +99,6 @@
         <item quantity="one">کم از کم %d دن پرانی</item>
         <item quantity="other">کم از کم %d دن پرانی</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">JPEG فائلوں کے لیے تخمینی ~%d%% بچت</string>
+    <string name="squeezer_estimated_savings_percent">تصاویر کے لیے تخمیناں ~%d%% بچت</string>
     <string name="squeezer_onboarding_got_it">سمجھ گیا</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-uz/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-uz/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Joy tejash uchun rasmlarni siqish.</string>
+    <string name="squeezer_explanation_short">Xotira bo\'shatish uchun rasm va videolarni siqing.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d rasm topildi</item>
-        <item quantity="other">%d rasm topildi</item>
+        <item quantity="one">%d element topildi</item>
+        <item quantity="other">%d element topildi</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s tejash mumkin</item>
         <item quantity="other">~%s tejash mumkin</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d rasm siqildi</item>
-        <item quantity="other">%d rasm siqildi</item>
+        <item quantity="one">%d element siqildi</item>
+        <item quantity="other">%d element siqildi</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d muvaffaqiyatsiz</item>
+        <item quantity="other">%d muvaffaqiyatsiz</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d fayl o\'tkazib yuborildi (mavjud emas)</item>
+        <item quantity="other">%d fayl o\'tkazib yuborildi (mavjud emas)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d rasm tanlandi</item>
-        <item quantity="other">%d rasm tanlandi</item>
+        <item quantity="one">%d element tanlandi</item>
+        <item quantity="other">%d element tanlandi</item>
     </plurals>
     <string name="squeezer_search_locations_title">Qidiruv joylari</string>
     <string name="squeezer_search_locations_default_summary">Kamera papkalari (standart)</string>
     <string name="squeezer_min_size_title">Minimal fayl hajmi</string>
-    <string name="squeezer_min_size_description">Bu hajmdan kichik rasmlarni o\'tkazib yuborish.</string>
+    <string name="squeezer_min_size_description">Ushbu o\'lchamdan kichik fayllarni o\'tkazib yuboring.</string>
     <string name="squeezer_min_age_title">Minimal fayl yoshi</string>
-    <string name="squeezer_min_age_description">Faqat bu yoshdan katta rasmlarni qo\'shish.</string>
-    <string name="squeezer_compression_settings_label">Siqish sozlamalari</string>
+    <string name="squeezer_min_age_description">Faqat ushbu yoshdan katta fayllarni qo\'shing.</string>
+    <string name="squeezer_compression_settings_label">Umumiy</string>
     <string name="squeezer_quality_label">Sifat</string>
     <string name="squeezer_quality_title">Siqish sifati</string>
-    <string name="squeezer_quality_description">Past sifat kichikroq fayl hajmini anglatadi, lekin rasm sifati pasayadi.</string>
+    <string name="squeezer_quality_description">Past sifat fayl hajmini kichraytiradi, lekin ko\'rinish sifatini pasaytiradi.</string>
     <string name="squeezer_quality_example_format">Misol: %1$s rasm → %3$d%% sifatda ~%2$s tejaydi</string>
     <string name="squeezer_quality_warning_low">Past sifat ko\'rinadigan artefaktlarni keltirib chiqarishi mumkin.</string>
     <string name="squeezer_quality_warning_high">Juda yuqori sifat minimal joy tejaydi.</string>
-    <string name="squeezer_types_category_label">Rasm turlari</string>
+    <string name="squeezer_types_category_label">Rasm sozlamalari</string>
+    <string name="squeezer_video_settings_category_label">Video sozlamalari</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">JPEG rasmlarni qo\'shish (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">WebP rasmlarni qo\'shish (.webp).</string>
+    <string name="squeezer_type_video_title">MP4 Video</string>
+    <string name="squeezer_type_video_description">MP4 video fayllarini qo\'shing (.mp4).</string>
     <string name="squeezer_skip_compressed_title">Oldin siqilganlarni o\'tkazib yuborish</string>
-    <string name="squeezer_skip_compressed_description">SD Maid tomonidan allaqachon siqilgan rasmlarni o\'tkazib yuborish.</string>
+    <string name="squeezer_skip_compressed_description">SD Maid tomonidan allaqachon siqilgan fayllarni o\'tkazib yuboring.</string>
     <string name="squeezer_exif_marker_title">EXIF belgisini yozish</string>
     <string name="squeezer_exif_marker_description">Siqish tarixi tozalansa ham qayta siqishni oldini olish uchun rasmning EXIF foydalanuvchi izoh maydoniga belgi qo\'shish.</string>
     <string name="squeezer_estimated_savings_format">~%s tejash</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">Siqishni tasdiqlash</string>
     <string name="squeezer_preview_total_size">Umumiy hajm</string>
     <string name="squeezer_preview_estimated_savings">Taxminiy tejash</string>
-    <string name="squeezer_compress_confirmation_title">Rasmlarni siqish kerakmi?</string>
-    <string name="squeezer_compress_confirmation_message">Bu asl rasmlarni siqilgan versiyalar bilan almashtiradi. Bu amalni qaytarib bo\'lmaydi.</string>
+    <string name="squeezer_compress_confirmation_title">Tanlangan elementlarni siqishmi?</string>
+    <string name="squeezer_compress_confirmation_message">Bu asl fayllarni siqilgan versiyalar bilan almashtiradi. Bu amalni bekor qilib bo\'lmaydi.</string>
     <string name="squeezer_history_title">Siqish tarixi</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d element (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">Siqish tarixi yo\'q</string>
     <string name="squeezer_history_clear_title">Siqish tarixini tozalash</string>
-    <string name="squeezer_history_clear_message">Bu oldin siqilgan rasmlarni qayta siqish imkonini beradi. Rasmlarning o\'zlari ta\'sirlanmaydi.</string>
+    <string name="squeezer_history_clear_message">Bu ilgari siqilgan fayllarni qayta siqish imkonini beradi. Fayllarning o\'zi ta\'sirlanmaydi.</string>
     <string name="squeezer_onboarding_title">Rasmlarni siqish haqida</string>
     <string name="squeezer_onboarding_message">Rasmlarni siqish vizual tafsilotlarni olib tashlash orqali fayl hajmini kamaytiradi. Bu jarayon qaytarib bo\'lmaydi - asl sifatni tiklash mumkin emas.\n\nRasmlaringiz qanday ko\'rinishini ko\'ring:</string>
     <string name="squeezer_onboarding_original_label">Asl</string>
     <string name="squeezer_onboarding_compressed_label">Siqishdan keyin</string>
+    <string name="squeezer_onboarding_video_original_label">Video kadri</string>
+    <string name="squeezer_onboarding_video_compressed_label">Ko\'rinish (taxminiy)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">Haqiqiy video sifati farq qilishi mumkin</string>
     <string name="squeezer_onboarding_quality_label">Sifat: %d%%</string>
     <string name="squeezer_compare_action">Solishtirishni ko\'rish</string>
     <string name="squeezer_no_example_found">Tanlangan yo\'llarda rasmlar topilmadi.</string>
-    <string name="squeezer_result_empty_message">Siqilishi mumkin bo\'lgan rasmlar topilmadi.</string>
-    <string name="squeezer_setup_warning">Siqish rasm sifatini doimiy ravishda kamaytiradi va xotirani tejaydi. Buni qaytarib bo\'lmaydi. Boshlashdan oldin sozlamalaringizni diqqat bilan tekshiring.</string>
-    <string name="squeezer_setup_explanation">Media Siqish rasmlar hajmini kamaytirish orqali xotira joyini bo\'shatadi. Bu rasm sifatini doimiy ravishda kamaytiradi va qaytarib bo\'lmaydi. Boshlashdan oldin sozlamalaringizni diqqat bilan tekshiring.</string>
+    <string name="squeezer_result_empty_message">Siqilishi mumkin bo\'lgan media topilmadi.</string>
+    <string name="squeezer_setup_warning">Siqish xotirani tejash uchun sifatni doimiy ravishda kamaytiradi. Bu amalni bekor qilib bo\'lmaydi. Boshlashdan oldin sozlamalaringizni diqqat bilan ko\'rib chiqing.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">%d manzilni siqish uchun ishlatib bo\'lmadi va olib tashlandi. Siqish ichki xotiraga to\'g\'ridan-to\'g\'ri kirish imkonini talab qiladi.</item>
+        <item quantity="other">%d manzilni siqish uchun ishlatib bo\'lmadi va olib tashlandi. Siqish ichki xotiraga to\'g\'ridan-to\'g\'ri kirish imkonini talab qiladi.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze rasmlar va videolarning fayl hajmini kamaytiradi. Bu sifatni doimiy ravishda kamaytiradi va bekor qilib bo\'lmaydi. Boshlashdan oldin sozlamalaringizni diqqat bilan ko\'rib chiqing.</string>
     <string name="squeezer_setup_paths_title">Qidiruv joylari</string>
     <string name="squeezer_setup_paths_default">Qidirish uchun papkalarni tanlash</string>
     <string name="squeezer_setup_quality_title">Siqish sifati</string>
@@ -81,6 +99,6 @@
         <item quantity="one">Kamida %d kunlik</item>
         <item quantity="other">Kamida %d kunlik</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">JPEG fayllar uchun taxminan ~%d%% tejash</string>
+    <string name="squeezer_estimated_savings_percent">Rasmlar uchun taxminan ~%d%% tejash</string>
     <string name="squeezer_onboarding_got_it">Tushundim</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-vi/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-vi/strings.xml
@@ -1,38 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Nén ảnh để tiết kiệm dung lượng lưu trữ.</string>
+    <string name="squeezer_explanation_short">Nén ảnh và video để tiết kiệm dung lượng lưu trữ.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="other">%d ảnh được tìm thấy</item>
+        <item quantity="other">%d mục được tìm thấy</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="other">~%s có thể được lưu</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="other">%d ảnh được nén</item>
+        <item quantity="other">%d mục được nén</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="other">%d thất bại</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="other">%d tệp bị bỏ qua (không thể truy cập)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="other">%d ảnh đã chọn</item>
+        <item quantity="other">%d mục đã chọn</item>
     </plurals>
     <string name="squeezer_search_locations_title">Vị trí tìm kiếm</string>
     <string name="squeezer_search_locations_default_summary">Thư mục ảnh (mặc định)</string>
     <string name="squeezer_min_size_title">Kích thước tệp tối thiểu</string>
-    <string name="squeezer_min_size_description">Bỏ qua những hình ảnh có kích thước nhỏ hơn kích thước này.</string>
+    <string name="squeezer_min_size_description">Bỏ qua các tệp nhỏ hơn kích thước này.</string>
     <string name="squeezer_min_age_title">Tuổi tối thiểu của tệp</string>
-    <string name="squeezer_min_age_description">Chỉ bao gồm những hình ảnh có tuổi hơn mức này.</string>
-    <string name="squeezer_compression_settings_label">Cài đặt nén</string>
+    <string name="squeezer_min_age_description">Chỉ bao gồm các tệp cũ hơn thời gian này.</string>
+    <string name="squeezer_compression_settings_label">Chung</string>
     <string name="squeezer_quality_label">Chất lượng</string>
     <string name="squeezer_quality_title">Chất lượng nén</string>
     <string name="squeezer_quality_description">Chất lượng thấp hơn có nghĩa là kích thước tệp nhỏ hơn nhưng chất lượng hình ảnh lại giảm.</string>
     <string name="squeezer_quality_example_format">Ví dụ: %1$s ảnh → lưu ~%2$s với %3$d%% chất lượng</string>
     <string name="squeezer_quality_warning_low">Chất lượng thấp hơn có thể gây ra hiện tượng nhiễu có thể nhìn thấy được.</string>
     <string name="squeezer_quality_warning_high">Chất lượng rất cao nhưng lại tiết kiệm không gian tối thiểu.</string>
-    <string name="squeezer_types_category_label">Kiểu hình ảnh</string>
+    <string name="squeezer_types_category_label">Cài đặt hình ảnh</string>
+    <string name="squeezer_video_settings_category_label">Cài đặt video</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">Bao gồm các hình ảnh JPEG (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">Bao gồm các hình ảnh WebP (.webp).</string>
+    <string name="squeezer_type_video_title">Video MP4</string>
+    <string name="squeezer_type_video_description">Bao gồm các tệp video MP4 (.mp4).</string>
     <string name="squeezer_skip_compressed_title">Bỏ qua phần đã nén trước đó</string>
-    <string name="squeezer_skip_compressed_description">Bỏ qua các hình ảnh đã được nén bởi SD Maid.</string>
+    <string name="squeezer_skip_compressed_description">Bỏ qua các tệp đã được nén bởi SD Maid.</string>
     <string name="squeezer_exif_marker_title">Ghi dấu EXIF</string>
     <string name="squeezer_exif_marker_description">Thêm dấu hiệu vào trường chú thích EXIF của hình ảnh để ngăn việc nén lại ngay cả khi lịch sử nén đã bị xóa.</string>
     <string name="squeezer_estimated_savings_format">~%s đang lưu</string>
@@ -43,25 +52,31 @@
     <string name="squeezer_preview_dialog_title">Xác nhận nén</string>
     <string name="squeezer_preview_total_size">Tổng kích thước</string>
     <string name="squeezer_preview_estimated_savings">Tiết kiệm ước tính</string>
-    <string name="squeezer_compress_confirmation_title">Nén ảnh?</string>
-    <string name="squeezer_compress_confirmation_message">Điều này sẽ thay thế hình ảnh gốc bằng phiên bản nén. Không thể hoàn tác thao tác này.</string>
+    <string name="squeezer_compress_confirmation_title">Nén các mục đã chọn?</string>
+    <string name="squeezer_compress_confirmation_message">Thao tác này sẽ thay thế các tệp gốc bằng phiên bản nén. Không thể hoàn tác thao tác này.</string>
     <string name="squeezer_history_title">Lịch sử nén</string>
     <plurals name="squeezer_history_summary">
         <item quantity="other">%1$d mục (%2$s)</item>
     </plurals>
     <string name="squeezer_history_empty">Không có lịch sử nén</string>
     <string name="squeezer_history_clear_title">Xóa lịch sử nén</string>
-    <string name="squeezer_history_clear_message">Điều này sẽ cho phép nén lại các hình ảnh đã được nén trước đó. Bản thân những hình ảnh đó không bị ảnh hưởng.</string>
+    <string name="squeezer_history_clear_message">Thao tác này sẽ cho phép nén lại các tệp đã được nén trước đó. Bản thân những tệp đó không bị ảnh hưởng.</string>
     <string name="squeezer_onboarding_title">Về nén ảnh</string>
     <string name="squeezer_onboarding_message">Nén ảnh làm giảm kích thước tập tin bằng cách loại bỏ các chi tiết hình ảnh. Qúa trình này không thể đảo ngược - chất lượng ban đầu không thể khôi phục được.\n\n Dưới đây là bản xem trước các hình ảnh của bạn sẽ trông như thế nào:</string>
     <string name="squeezer_onboarding_original_label">Bản gốc</string>
     <string name="squeezer_onboarding_compressed_label">Sau khi nén</string>
+    <string name="squeezer_onboarding_video_original_label">Khung hình video</string>
+    <string name="squeezer_onboarding_video_compressed_label">Xem trước (gần đúng)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">Chất lượng video thực tế có thể khác</string>
     <string name="squeezer_onboarding_quality_label">Chất lượng: %d%%</string>
     <string name="squeezer_compare_action">Xem so sánh</string>
     <string name="squeezer_no_example_found">Không tìm thấy hình ảnh nào trong các đường dẫn đã chọn.</string>
-    <string name="squeezer_result_empty_message">Không tìm thấy hình ảnh nén nào.</string>
-    <string name="squeezer_setup_warning">Việc nén ảnh sẽ làm giảm vĩnh viễn chất lượng ảnh để tiết kiệm dung lượng lưu trữ. Điều này không thể hoàn tác được. Hãy kiểm tra kỹ các thiết lập của bạn trước khi bắt đầu.</string>
-    <string name="squeezer_setup_explanation">Chức năng Media Squeeze giảm kích thước tệp hình ảnh để giải phóng dung lượng lưu trữ. Thao tác này sẽ làm giảm chất lượng hình ảnh vĩnh viễn và không thể hoàn tác. Vui lòng xem lại cài đặt cẩn thận trước khi bắt đầu.</string>
+    <string name="squeezer_result_empty_message">Không tìm thấy phương tiện có thể nén.</string>
+    <string name="squeezer_setup_warning">Việc nén sẽ làm giảm vĩnh viễn chất lượng để tiết kiệm dung lượng lưu trữ. Không thể hoàn tác điều này. Hãy kiểm tra kỹ các cài đặt của bạn trước khi bắt đầu.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="other">%d vị trí không thể được sử dụng để nén và đã bị xóa. Việc nén yêu cầu quyền truy cập trực tiếp vào bộ nhớ trong.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze giảm kích thước tệp hình ảnh và video để giải phóng dung lượng lưu trữ. Thao tác này sẽ làm giảm chất lượng vĩnh viễn và không thể hoàn tác. Vui lòng xem lại cài đặt cẩn thận trước khi bắt đầu.</string>
     <string name="squeezer_setup_paths_title">Vị trí tìm kiếm</string>
     <string name="squeezer_setup_paths_default">Chọn thư mục để tìm kiếm</string>
     <string name="squeezer_setup_quality_title">Chất lượng nén</string>
@@ -75,6 +90,6 @@
     <plurals name="squeezer_min_age_x_days">
         <item quantity="other">Ít nhất %d ngày tuổi</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">Ước tính tiết kiệm khoảng %d%% cho các tệp JPEG</string>
+    <string name="squeezer_estimated_savings_percent">Ước tính tiết kiệm ~%d%% cho hình ảnh</string>
     <string name="squeezer_onboarding_got_it">Hiểu rồi</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-zh-rCN/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-zh-rCN/strings.xml
@@ -1,38 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">压缩图片以节省存储空间。</string>
+    <string name="squeezer_explanation_short">压缩图片和视频以节省存储空间。</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="other">找到 %d 张图片</item>
+        <item quantity="other">找到 %d 个项目</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="other">可节省约 %s</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="other">已压缩 %d 张图片</item>
+        <item quantity="other">已压缩 %d 个项目</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="other">%d 失败</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="other">已跳过 %d 个文件（无法访问）</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="other">已选择 %d 张图片</item>
+        <item quantity="other">已选择 %d 个项目</item>
     </plurals>
     <string name="squeezer_search_locations_title">搜索位置</string>
     <string name="squeezer_search_locations_default_summary">相机文件夹（默认）</string>
     <string name="squeezer_min_size_title">最小文件大小</string>
-    <string name="squeezer_min_size_description">跳过小于此大小的图片。</string>
+    <string name="squeezer_min_size_description">跳过小于此大小的文件。</string>
     <string name="squeezer_min_age_title">最小文件年龄</string>
-    <string name="squeezer_min_age_description">仅包含超过此年龄的图片。</string>
-    <string name="squeezer_compression_settings_label">压缩设置</string>
+    <string name="squeezer_min_age_description">仅包含早于此时间的文件。</string>
+    <string name="squeezer_compression_settings_label">常规</string>
     <string name="squeezer_quality_label">质量</string>
     <string name="squeezer_quality_title">压缩质量</string>
-    <string name="squeezer_quality_description">质量越低，文件越小，但图片质量也会降低。</string>
+    <string name="squeezer_quality_description">质量越低，文件越小，但视觉质量也越低。</string>
     <string name="squeezer_quality_example_format">示例：%1$s 图片 → 以 %3$d%% 质量节省约 %2$s</string>
     <string name="squeezer_quality_warning_low">较低的质量可能会导致明显的伪影。</string>
     <string name="squeezer_quality_warning_high">非常高的质量只能节省极少空间。</string>
-    <string name="squeezer_types_category_label">图片类型</string>
+    <string name="squeezer_types_category_label">图片设置</string>
+    <string name="squeezer_video_settings_category_label">视频设置</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">包含 JPEG 图片（.jpg、.jpeg）。</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">包含 WebP 图片（.webp）。</string>
+    <string name="squeezer_type_video_title">MP4 视频</string>
+    <string name="squeezer_type_video_description">包含 MP4 视频文件（.mp4）。</string>
     <string name="squeezer_skip_compressed_title">跳过已压缩的图片</string>
-    <string name="squeezer_skip_compressed_description">跳过已被 SD Maid 压缩过的图片。</string>
+    <string name="squeezer_skip_compressed_description">跳过已被 SD Maid 压缩的文件。</string>
     <string name="squeezer_exif_marker_title">写入 EXIF 标记</string>
     <string name="squeezer_exif_marker_description">在图片的 EXIF 用户备注字段中添加标记，以防止即使压缩记录被清除也不会重新压缩。</string>
     <string name="squeezer_estimated_savings_format">约可节省 %s</string>
@@ -43,25 +52,31 @@
     <string name="squeezer_preview_dialog_title">确认压缩</string>
     <string name="squeezer_preview_total_size">总大小</string>
     <string name="squeezer_preview_estimated_savings">预估节省量</string>
-    <string name="squeezer_compress_confirmation_title">压缩图片？</string>
-    <string name="squeezer_compress_confirmation_message">这将用压缩版本替换原始图片。此操作无法撤消。</string>
+    <string name="squeezer_compress_confirmation_title">压缩所选项目？</string>
+    <string name="squeezer_compress_confirmation_message">这将用压缩版本替换原始文件。此操作无法撤销。</string>
     <string name="squeezer_history_title">压缩历史</string>
     <plurals name="squeezer_history_summary">
         <item quantity="other">%1$d 个项目（%2$s）</item>
     </plurals>
     <string name="squeezer_history_empty">没有压缩历史</string>
     <string name="squeezer_history_clear_title">清除压缩历史</string>
-    <string name="squeezer_history_clear_message">这将允许重新压缩之前已压缩的图片。图片本身不受影响。</string>
+    <string name="squeezer_history_clear_message">这将允许之前压缩的文件再次被压缩。文件本身不受影响。</string>
     <string name="squeezer_onboarding_title">关于图片压缩</string>
     <string name="squeezer_onboarding_message">图片压缩通过移除视觉细节来缩小文件大小。此过程不可逆——原始质量无法恢复。\n\n以下是压缩后图片的预览：</string>
     <string name="squeezer_onboarding_original_label">原始</string>
     <string name="squeezer_onboarding_compressed_label">压缩后</string>
+    <string name="squeezer_onboarding_video_original_label">视频帧</string>
+    <string name="squeezer_onboarding_video_compressed_label">预览（近似）</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">实际视频质量可能有所不同</string>
     <string name="squeezer_onboarding_quality_label">质量：%d%%</string>
     <string name="squeezer_compare_action">查看对比</string>
     <string name="squeezer_no_example_found">在所选路径中未找到图片。</string>
-    <string name="squeezer_result_empty_message">未找到可压缩的图片。</string>
-    <string name="squeezer_setup_warning">压缩会永久降低图片质量以节省存储空间。此操作无法撤消。开始前请仔细检查您的设置。</string>
-    <string name="squeezer_setup_explanation">媒体压缩通过缩小图片文件大小来释放存储空间。这会永久降低图片质量且无法撤消。开始前请仔细检查您的设置。</string>
+    <string name="squeezer_result_empty_message">未找到可压缩的媒体文件。</string>
+    <string name="squeezer_setup_warning">压缩会永久降低质量以节省存储空间。此操作无法撤销。开始前请仔细检查您的设置。</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="other">%d 个位置无法用于压缩，已被移除。压缩需要直接访问内部存储。</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">媒体压缩可缩小图片和视频的文件大小，以释放存储空间。这会永久降低质量且无法撤销。开始前请仔细检查您的设置。</string>
     <string name="squeezer_setup_paths_title">搜索位置</string>
     <string name="squeezer_setup_paths_default">选择要搜索的文件夹</string>
     <string name="squeezer_setup_quality_title">压缩质量</string>
@@ -75,6 +90,6 @@
     <plurals name="squeezer_min_age_x_days">
         <item quantity="other">至少 %d 天前</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">JPEG 文件预估可节省约 %d%%</string>
+    <string name="squeezer_estimated_savings_percent">图片预计节省约 %d%%</string>
     <string name="squeezer_onboarding_got_it">明白</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-zh-rHK/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-zh-rHK/strings.xml
@@ -1,38 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">壓縮圖片以節省儲存空間。</string>
+    <string name="squeezer_explanation_short">壓縮圖片和影片以節省儲存空間。</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="other">找到 %d 張圖片</item>
+        <item quantity="other">找到 %d 個項目</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="other">預計可節省約 %s</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="other">已壓縮 %d 張圖片</item>
+        <item quantity="other">已壓縮 %d 個項目</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="other">%d 個失敗</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="other">%d 個檔案已跳過（無法存取）</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="other">已選取 %d 張圖片</item>
+        <item quantity="other">已選擇 %d 個項目</item>
     </plurals>
     <string name="squeezer_search_locations_title">搜尋位置</string>
     <string name="squeezer_search_locations_default_summary">相機資料夾（預設）</string>
     <string name="squeezer_min_size_title">最小檔案大小</string>
-    <string name="squeezer_min_size_description">略過小於此大小的圖片。</string>
+    <string name="squeezer_min_size_description">跳過小於此大小的檔案。</string>
     <string name="squeezer_min_age_title">最小檔案年齡</string>
-    <string name="squeezer_min_age_description">僅包含超過此年齡的圖片。</string>
-    <string name="squeezer_compression_settings_label">壓縮設定</string>
+    <string name="squeezer_min_age_description">僅包含早於此年齡的檔案。</string>
+    <string name="squeezer_compression_settings_label">一般</string>
     <string name="squeezer_quality_label">品質</string>
     <string name="squeezer_quality_title">壓縮品質</string>
-    <string name="squeezer_quality_description">較低品質表示較小的檔案大小，但圖片品質會降低。</string>
+    <string name="squeezer_quality_description">較低畫質意味著較小的檔案大小，但視覺品質降低。</string>
     <string name="squeezer_quality_example_format">範例：%1$s 圖片 → 以 %3$d%% 品質節省約 %2$s</string>
     <string name="squeezer_quality_warning_low">較低品質可能導致可見瑕疵。</string>
     <string name="squeezer_quality_warning_high">非常高的品質只能提供極少的空間節省。</string>
-    <string name="squeezer_types_category_label">圖片類型</string>
+    <string name="squeezer_types_category_label">圖片設定</string>
+    <string name="squeezer_video_settings_category_label">影片設定</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">包含 JPEG 圖片（.jpg、.jpeg）。</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">包含 WebP 圖片（.webp）。</string>
+    <string name="squeezer_type_video_title">MP4 影片</string>
+    <string name="squeezer_type_video_description">包含 MP4 影片檔案（.mp4）。</string>
     <string name="squeezer_skip_compressed_title">略過已壓縮的檔案</string>
-    <string name="squeezer_skip_compressed_description">略過已被 SD Maid 壓縮過的圖片。</string>
+    <string name="squeezer_skip_compressed_description">跳過已由 SD Maid 壓縮過的檔案。</string>
     <string name="squeezer_exif_marker_title">寫入 EXIF 標記</string>
     <string name="squeezer_exif_marker_description">在圖片的 EXIF 使用者評論欄位附加標記，以防止再次壓縮，即使壓縮歷史記錄被清除。</string>
     <string name="squeezer_estimated_savings_format">預計節省約 %s</string>
@@ -43,25 +52,31 @@
     <string name="squeezer_preview_dialog_title">確認壓縮</string>
     <string name="squeezer_preview_total_size">總大小</string>
     <string name="squeezer_preview_estimated_savings">預計節省</string>
-    <string name="squeezer_compress_confirmation_title">壓縮圖片？</string>
-    <string name="squeezer_compress_confirmation_message">這將以壓縮版本取代原始圖片。此操作無法撤銷。</string>
+    <string name="squeezer_compress_confirmation_title">壓縮已選項目？</string>
+    <string name="squeezer_compress_confirmation_message">此操作將以壓縮版本取代原始檔案。此操作無法撤銷。</string>
     <string name="squeezer_history_title">壓縮歷史記錄</string>
     <plurals name="squeezer_history_summary">
         <item quantity="other">%1$d 個項目（%2$s）</item>
     </plurals>
     <string name="squeezer_history_empty">沒有壓縮歷史記錄</string>
     <string name="squeezer_history_clear_title">清除壓縮歷史記錄</string>
-    <string name="squeezer_history_clear_message">這將允許先前壓縮的圖片再次被壓縮。圖片本身不受影響。</string>
+    <string name="squeezer_history_clear_message">此操作將允許對之前已壓縮的檔案再次進行壓縮。檔案本身不會受到影響。</string>
     <string name="squeezer_onboarding_title">關於圖片壓縮</string>
     <string name="squeezer_onboarding_message">圖片壓縮透過移除視覺細節來縮小檔案大小。此過程不可逆 - 無法恢復原始品質。\n\n以下是壓縮後的預覽效果：</string>
     <string name="squeezer_onboarding_original_label">原圖</string>
     <string name="squeezer_onboarding_compressed_label">壓縮後</string>
+    <string name="squeezer_onboarding_video_original_label">影片畫面</string>
+    <string name="squeezer_onboarding_video_compressed_label">預覽（不就是最終效果）</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">實際影片畫質可能有所不同</string>
     <string name="squeezer_onboarding_quality_label">品質：%d%%</string>
     <string name="squeezer_compare_action">檢視比較</string>
     <string name="squeezer_no_example_found">在所選路徑中找不到圖片。</string>
-    <string name="squeezer_result_empty_message">找不到可壓縮的圖片。</string>
-    <string name="squeezer_setup_warning">壓縮會永久降低圖片品質以節省儲存空間。此操作無法撤銷。開始前請仔細檢查設定。</string>
-    <string name="squeezer_setup_explanation">Media Squeeze 可縮小圖片檔案大小以釋放儲存空間。這會永久降低圖片品質且無法撤銷。開始前請仔細檢查設定。</string>
+    <string name="squeezer_result_empty_message">未找到可壓縮的媒體檔案。</string>
+    <string name="squeezer_setup_warning">壓縮會永久降低畫質以節省儲存空間。此操作無法撤銷。開始前請仔細檢查您的設定。</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="other">%d 個位置無法用於壓縮且已被移除。壓縮需要直接存取內部儲存空間。</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">Media Squeeze 可縮小圖片和影片的檔案大小，以釋放儲存空間。此操作會永久降低畫質，且無法撤銷。開始前請仔細檢查您的設定。</string>
     <string name="squeezer_setup_paths_title">搜尋位置</string>
     <string name="squeezer_setup_paths_default">選擇要搜尋的資料夾</string>
     <string name="squeezer_setup_quality_title">壓縮品質</string>
@@ -75,6 +90,6 @@
     <plurals name="squeezer_min_age_x_days">
         <item quantity="other">至少 %d 天</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">JPEG 檔案預計可節省約 %d%%</string>
+    <string name="squeezer_estimated_savings_percent">預估圖片可節省約 %d%%</string>
     <string name="squeezer_onboarding_got_it">瞭解了</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-zh-rTW/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-zh-rTW/strings.xml
@@ -1,38 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">壓縮圖片以節省儲存空間。</string>
+    <string name="squeezer_explanation_short">壓縮圖片和影片以節省儲存空間。</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="other">找到 %d 張圖片</item>
+        <item quantity="other">找到 %d 個項目</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="other">可節省約 %s</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="other">已壓縮 %d 張圖片</item>
+        <item quantity="other">%d 個項目已壓縮</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="other">%d 個失敗</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="other">%d 個檔案已略過（無法存取）</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="other">已選取 %d 張圖片</item>
+        <item quantity="other">已選取 %d 個項目</item>
     </plurals>
     <string name="squeezer_search_locations_title">搜尋位置</string>
     <string name="squeezer_search_locations_default_summary">相機資料夾（預設）</string>
     <string name="squeezer_min_size_title">最小檔案大小</string>
-    <string name="squeezer_min_size_description">跳過小於此大小的圖片。</string>
+    <string name="squeezer_min_size_description">略過小於此大小的檔案。</string>
     <string name="squeezer_min_age_title">最小檔案年齡</string>
-    <string name="squeezer_min_age_description">僅包含超過此年齡的圖片。</string>
-    <string name="squeezer_compression_settings_label">壓縮設定</string>
+    <string name="squeezer_min_age_description">僅包含早於此時間的檔案。</string>
+    <string name="squeezer_compression_settings_label">一般</string>
     <string name="squeezer_quality_label">品質</string>
     <string name="squeezer_quality_title">壓縮品質</string>
-    <string name="squeezer_quality_description">品質越低，檔案越小，但圖片品質也會降低。</string>
+    <string name="squeezer_quality_description">品質越低，檔案越小，但視覺品質也越差。</string>
     <string name="squeezer_quality_example_format">範例：%1$s 圖片 → 以 %3$d%% 品質節省約 %2$s</string>
     <string name="squeezer_quality_warning_low">較低的品質可能會導致明顯的瑕疵。</string>
     <string name="squeezer_quality_warning_high">非常高的品質只能節省極少空間。</string>
-    <string name="squeezer_types_category_label">圖片類型</string>
+    <string name="squeezer_types_category_label">圖片設定</string>
+    <string name="squeezer_video_settings_category_label">影片設定</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">包含 JPEG 圖片（.jpg、.jpeg）。</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">包含 WebP 圖片（.webp）。</string>
+    <string name="squeezer_type_video_title">MP4 影片</string>
+    <string name="squeezer_type_video_description">包含 MP4 影片檔案（.mp4）。</string>
     <string name="squeezer_skip_compressed_title">跳過已壓縮的圖片</string>
-    <string name="squeezer_skip_compressed_description">跳過已被 SD Maid 壓縮過的圖片。</string>
+    <string name="squeezer_skip_compressed_description">略過已由 SD Maid 壓縮的檔案。</string>
     <string name="squeezer_exif_marker_title">寫入 EXIF 標記</string>
     <string name="squeezer_exif_marker_description">在圖片的 EXIF 使用者註解欄位中附加標記，以防止即使壓縮歷史被清除也不會重新壓縮。</string>
     <string name="squeezer_estimated_savings_format">約可節省 %s</string>
@@ -43,25 +52,31 @@
     <string name="squeezer_preview_dialog_title">確認壓縮</string>
     <string name="squeezer_preview_total_size">總大小</string>
     <string name="squeezer_preview_estimated_savings">預估節省量</string>
-    <string name="squeezer_compress_confirmation_title">壓縮圖片？</string>
-    <string name="squeezer_compress_confirmation_message">這將以壓縮版本取代原始圖片。此操作無法復原。</string>
+    <string name="squeezer_compress_confirmation_title">壓縮所選項目？</string>
+    <string name="squeezer_compress_confirmation_message">這將以壓縮版本取代原始檔案。此操作無法復原。</string>
     <string name="squeezer_history_title">壓縮歷史</string>
     <plurals name="squeezer_history_summary">
         <item quantity="other">%1$d 個項目（%2$s）</item>
     </plurals>
     <string name="squeezer_history_empty">沒有壓縮歷史</string>
     <string name="squeezer_history_clear_title">清除壓縮歷史</string>
-    <string name="squeezer_history_clear_message">這將允許重新壓縮之前已壓縮的圖片。圖片本身不受影響。</string>
+    <string name="squeezer_history_clear_message">這將允許先前壓縮的檔案再次被壓縮。檔案本身不受影響。</string>
     <string name="squeezer_onboarding_title">關於圖片壓縮</string>
     <string name="squeezer_onboarding_message">圖片壓縮透過移除視覺細節來縮小檔案大小。此過程不可逆 - 原始品質無法恢復。\n\n以下是壓縮後圖片的預覽：</string>
     <string name="squeezer_onboarding_original_label">原始</string>
     <string name="squeezer_onboarding_compressed_label">壓縮後</string>
+    <string name="squeezer_onboarding_video_original_label">影片畫格</string>
+    <string name="squeezer_onboarding_video_compressed_label">預覽（近似値）</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">實際影片品質可能有所不同</string>
     <string name="squeezer_onboarding_quality_label">品質：%d%%</string>
     <string name="squeezer_compare_action">檢視比較</string>
     <string name="squeezer_no_example_found">在選取的路徑中找不到圖片。</string>
-    <string name="squeezer_result_empty_message">找不到可壓縮的圖片。</string>
-    <string name="squeezer_setup_warning">壓縮會永久降低圖片品質以節省儲存空間。此操作無法復原。開始前請仔細檢查您的設定。</string>
-    <string name="squeezer_setup_explanation">媒體壓縮透過縮小圖片檔案大小來釋放儲存空間。這會永久降低圖片品質且無法復原。開始前請仔細檢查您的設定。</string>
+    <string name="squeezer_result_empty_message">未找到可壓縮的媒體。</string>
+    <string name="squeezer_setup_warning">壓縮會永久降低品質以節省儲存空間。此操作無法復原。開始前請仔細檢查您的設定。</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="other">%d 個位置無法用於壓縮，已被移除。壓縮需要直接存取內部儲存空間。</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">媒體壓縮器可縮減圖片和影片的檔案大小，以釋放儲存空間。這將永久降低品質且無法復原。開始前請仔細檢查您的設定。</string>
     <string name="squeezer_setup_paths_title">搜尋位置</string>
     <string name="squeezer_setup_paths_default">選取要搜尋的資料夾</string>
     <string name="squeezer_setup_quality_title">壓縮品質</string>
@@ -75,6 +90,6 @@
     <plurals name="squeezer_min_age_x_days">
         <item quantity="other">至少 %d 天前</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">JPEG 檔案預估可節省約 %d%%</string>
+    <string name="squeezer_estimated_savings_percent">圖片預估節省約 %d%%</string>
     <string name="squeezer_onboarding_got_it">瞭解了</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-zu/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-zu/strings.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Cindezela izithombe ukonga isikhala sesitoreji.</string>
+    <string name="squeezer_explanation_short">Goqa izithombe namaviyo ukonga indawo yokugcina.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d isithombe sitholakele</item>
-        <item quantity="other">%d izithombe zitholakele</item>
+        <item quantity="one">%d into etholakele</item>
+        <item quantity="other">%d izinto ezitholakele</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s kungongeka</item>
         <item quantity="other">~%s kungongeka</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d isithombe sicindezelwe</item>
-        <item quantity="other">%d izithombe zicindezelwe</item>
+        <item quantity="one">%d into egoqiwe</item>
+        <item quantity="other">%d izinto ezigoqiwe</item>
+    </plurals>
+    <plurals name="squeezer_result_x_items_failed">
+        <item quantity="one">%d ehlulekile</item>
+        <item quantity="other">%d ezihlulekile</item>
+    </plurals>
+    <plurals name="squeezer_result_x_skipped_inaccessible">
+        <item quantity="one">%d ifayela lishiyiwe (alifikeleleki)</item>
+        <item quantity="other">%d amafayela ashiyiwe (awafikileleki)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d isithombe sikhethiwe</item>
-        <item quantity="other">%d izithombe zikhethiwe</item>
+        <item quantity="one">%d into ekhethiwe</item>
+        <item quantity="other">%d izinto ezikhethiwe</item>
     </plurals>
     <string name="squeezer_search_locations_title">Izindawo zokusesha</string>
     <string name="squeezer_search_locations_default_summary">Amafolda ekhamera (okuzenzakalelayo)</string>
     <string name="squeezer_min_size_title">Usayizi omncane wefayela</string>
-    <string name="squeezer_min_size_description">Yeqa izithombe ezincane kunalo sayizi.</string>
+    <string name="squeezer_min_size_description">Yeqa amafayela amancane kunale ndawo.</string>
     <string name="squeezer_min_age_title">Ubudala obuncane befayela</string>
-    <string name="squeezer_min_age_description">Faka kuphela izithombe ezindala kunobu budala.</string>
-    <string name="squeezer_compression_settings_label">Izilungiselelo zokucindezela</string>
+    <string name="squeezer_min_age_description">Faka kuphela amafayela amadala kunaleli zinga.</string>
+    <string name="squeezer_compression_settings_label">Okujwayelekile</string>
     <string name="squeezer_quality_label">Ikhwalithi</string>
     <string name="squeezer_quality_title">Ikhwalithi yokucindezela</string>
-    <string name="squeezer_quality_description">Ikhwalithi ephansi isho usayizi wefayela omncane kodwa ikhwalithi yesithombe encishisiwe.</string>
+    <string name="squeezer_quality_description">Ikhwalithi ephansi kusho ifayela elincane kodwa ikhwalithi yombono inciphisiwe.</string>
     <string name="squeezer_quality_example_format">Isibonelo: %1$s isithombe → onga ~%2$s ku-%3$d%% ikhwalithi</string>
     <string name="squeezer_quality_warning_low">Amakhwalithi aphansi angabangela izinkinga ezibonakalayo.</string>
     <string name="squeezer_quality_warning_high">Ikhwalithi ephezulu kakhulu ihlinzeka ngokonga kancane.</string>
-    <string name="squeezer_types_category_label">Izinhlobo zezithombe</string>
+    <string name="squeezer_types_category_label">Izilungiselelo zezithombe</string>
+    <string name="squeezer_video_settings_category_label">Izilungiselelo zeviyo</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">Faka izithombe ze-JPEG (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">Faka izithombe ze-WebP (.webp).</string>
+    <string name="squeezer_type_video_title">MP4 Video</string>
+    <string name="squeezer_type_video_description">Faka amafayela eviyo we-MP4 (.mp4).</string>
     <string name="squeezer_skip_compressed_title">Yeqa ezicindezelwe ngaphambilini</string>
-    <string name="squeezer_skip_compressed_description">Yeqa izithombe esezicindezelwe yi-SD Maid.</string>
+    <string name="squeezer_skip_compressed_description">Yeqa amafayela asevele egoqiwe ngu-SD Maid.</string>
     <string name="squeezer_exif_marker_title">Bhala uphawu lwe-EXIF</string>
     <string name="squeezer_exif_marker_description">Engeza uphawu enkundleni yokuphawula komsebenzisi we-EXIF yesithombe ukuvimbela ukucindezelwa kabusha noma umlando wokucindezela usulwe.</string>
     <string name="squeezer_estimated_savings_format">~%s ukonga</string>
@@ -47,8 +58,8 @@
     <string name="squeezer_preview_dialog_title">Qinisekisa ukucindezela</string>
     <string name="squeezer_preview_total_size">Usayizi ophelele</string>
     <string name="squeezer_preview_estimated_savings">Ukonga okulinganisiwe</string>
-    <string name="squeezer_compress_confirmation_title">Cindezela izithombe?</string>
-    <string name="squeezer_compress_confirmation_message">Lokhu kuzoshintsha izithombe zangempela ngezinguqulo ezicindezelwe. Lesi senzo asikwazi ukuhlehliswa.</string>
+    <string name="squeezer_compress_confirmation_title">Goqa izinto ezikhethiwe?</string>
+    <string name="squeezer_compress_confirmation_message">Lokhu kuzobuyisela amafayela asekuqaleni ngamaviyo egoqiwe. Lesi senzo asinakuguqulwa.</string>
     <string name="squeezer_history_title">Umlando wokucindezela</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d into (%2$s)</item>
@@ -56,17 +67,24 @@
     </plurals>
     <string name="squeezer_history_empty">Akukho umlando wokucindezela</string>
     <string name="squeezer_history_clear_title">Sula umlando wokucindezela</string>
-    <string name="squeezer_history_clear_message">Lokhu kuzovumela izithombe ebezicindezelwe ngaphambilini ukuba zicindezelwe futhi. Izithombe ngokwazo azithinteki.</string>
+    <string name="squeezer_history_clear_message">Lokhu kuzovumela amafayela asevele egoqiwe ukuba agoqwe futhi. Amafayela ngokwawo awathinteki.</string>
     <string name="squeezer_onboarding_title">Mayelana Nokucindezela Izithombe</string>
     <string name="squeezer_onboarding_message">Ukucindezela isithombe kunciphisa usayizi wefayela ngokususa imininingwane ebonakalayo. Le nqubo ayihlehliseki - ikhwalithi yokuqala ayikwazi ukubuyiswa.\n\nNansi imboniso yangaphambili yokuthi izithombe zakho zizobukeka kanjani:</string>
     <string name="squeezer_onboarding_original_label">Okwangiempela</string>
     <string name="squeezer_onboarding_compressed_label">Ngemuva kokucindezela</string>
+    <string name="squeezer_onboarding_video_original_label">Uhlaka lweviyo</string>
+    <string name="squeezer_onboarding_video_compressed_label">Iphrevyu (ecatshangwayo)</string>
+    <string name="squeezer_onboarding_video_quality_disclaimer">Ikhwalithi yeviyo yangempela ingahluka</string>
     <string name="squeezer_onboarding_quality_label">Ikhwalithi: %d%%</string>
     <string name="squeezer_compare_action">Buka ukuqhathanisa</string>
     <string name="squeezer_no_example_found">Azikho izithombe ezitholakele ezindleleni ezikhethiwe.</string>
-    <string name="squeezer_result_empty_message">Azikho izithombe ezicindezelekayo ezitholakele.</string>
-    <string name="squeezer_setup_warning">Ukucindezela kunciphisa unomphela ikhwalithi yesithombe ukuze kongeke isikhala sesitoreji. Lokhu akukwazi ukuhlehliswa. Buyekeza izilungiselelo zakho ngokucophelela ngaphambi kokuqala.</string>
-    <string name="squeezer_setup_explanation">Ukucindezela Imidiya kunciphisa usayizi wefayela lezithombe ukukhulula isikhala sesitoreji. Lokhu kunciphisa unomphela ikhwalithi yesithombe futhi akukwazi ukuhlehliswa. Buyekeza izilungiselelo zakho ngokucophelela ngaphambi kokuqala.</string>
+    <string name="squeezer_result_empty_message">Akukho imidiya engoqwa etholakele.</string>
+    <string name="squeezer_setup_warning">Ukugoqwa kwehlisa ikhwalithi ngokunaphakade ukonga indawo yokugcina. Lokhu akunakuguqulwa. Hlola izilungiselelo zakho ngokucophelela ngaphambi kokuqala.</string>
+    <plurals name="squeezer_setup_path_dropped_message">
+        <item quantity="one">Indawo engu-%d ayikwazi ukusetshenziswa ukugoqwa futhi isuswe. Ukugoqwa kudinga ukufinyelela ngokuqondile kwesitoreji sangaphakathi.</item>
+        <item quantity="other">%d izindawo azikwazi ukusetshenziswa ukugoqwa futhi zisuswe. Ukugoqwa kudinga ukufinyelela ngokuqondile kwesitoreji sangaphakathi.</item>
+    </plurals>
+    <string name="squeezer_setup_explanation">I-Media Squeeze inciphisa usayizi wefayela lwezithombe namaviyo ukuze ikhulule indawo yokugcina. Lokhu kwehlisa ikhwalithi ngokunaphakade futhi akunakuguqulwa. Hlola izilungiselelo zakho ngokucophelela ngaphambi kokuqala.</string>
     <string name="squeezer_setup_paths_title">Izindawo zokusesha</string>
     <string name="squeezer_setup_paths_default">Khetha amafolda okuseshwa</string>
     <string name="squeezer_setup_quality_title">Ikhwalithi yokucindezela</string>
@@ -81,6 +99,6 @@
         <item quantity="one">Okungenani usuku olungu-%d</item>
         <item quantity="other">Okungenani izinsuku ezingu-%d</item>
     </plurals>
-    <string name="squeezer_estimated_savings_percent">Kulinganiswa ~%d%% ukonga kwamafayela e-JPEG</string>
+    <string name="squeezer_estimated_savings_percent">Kulinganiselwa ukonga okungama-%d%% kwezithombe</string>
     <string name="squeezer_onboarding_got_it">Ngiyaqonda</string>
 </resources>

--- a/app-tool-swiper/src/main/res/values-pl/strings.xml
+++ b/app-tool-swiper/src/main/res/values-pl/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="swiper_label">Przesuwacz</string>
     <string name="swiper_tool_description">Szybko pozbądź się zbędnych folderów — przeglądaj pliki, aby je zachować, usunąć lub pominąć.</string>
-    <string name="swiper_dashcard_description">Uporządkuj konkretne foldery szybciej niż eksplorator plików — po prostu przesuń każdy plik.</string>
+    <string name="swiper_dashcard_description">Uporządkuj konkretne foldery szybciej niż eksplorator plików. Po prostu przesuń każdy plik.</string>
     <string name="swiper_start_action">Zacznij przesuwać</string>
     <string name="swiper_continue_action">Kontynuuj sesję</string>
     <string name="swiper_sessions_description">Przejrzyj pliki w 3 prostych krokach:\n\n1. Wybierz folder do przeskanowania.\n2. Przesuń palcem po plikach, aby zachować, usunąć lub pominąć.\n3. Przejrzyj swoje wybory i potwierdź.\n\nNic nie zostanie usunięte, dopóki nie klikniesz przycisku usuwania.</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -172,7 +172,7 @@
     <string name="setup_incomplete_card_title">Nastavení dokončena</string>
     <string name="setup_incomplete_card_body">Dokončete nastavení aplikace SD Maid pro dosažení lepších výsledků.</string>
     <string name="setup_incomplete_card_healing_in_progress_body">SD Maid se pokouší opravit problémy s nastavením.</string>
-    <string name="setup_incomplete_card_dismiss_action">Zamítnout</string>
+    <string name="setup_incomplete_card_dismiss_action">Zahodit</string>
     <string name="setup_incomplete_card_continue_action">Pokračovat v nastavení</string>
     <string name="setup_forcedshow_summary">Znovu zobrazit obrazovku nastavení včetně již dokončených položek.</string>
     <string name="setup_checking_card_body">Ověření dokončení nastavení a funkčnosti.</string>
@@ -275,7 +275,7 @@
         <item quantity="one">Již %1$d rok spolu. Děkujeme, že důvěřujete aplikaci SD Maid, aby udržovala váš Android čistý a uklizený. Uvolněné místo: %2$s</item>
         <item quantity="few">%1$d roky bez problémů. Vaše zařízení zůstane čisté a uklizené díky aplikaci SD Maid. Uvolněné místo: %2$s</item>
         <item quantity="many">%1$d let bez problémů. Vaše zařízení zůstane čisté a uklizené díky aplikaci SD Maid. Uvolněné místo: %2$s</item>
-        <item quantity="other">%1$d let bez problémů. Vaše zařízení zůstane čisté a uklizené díky aplikaci SD Maid. Uvolněné místo: %2$s</item>
+        <item quantity="other">%1$d let bez problémů. Vaše zařízení zůstává čisté a uklizené díky aplikaci SD Maid. Uvolněné místo: %2$s</item>
     </plurals>
     <string name="anniversary_share_title">Sdílejte své výročí s aplikací SD Maid</string>
     <plurals name="anniversary_share_text">

--- a/app/src/main/res/values-ne-rNP/strings.xml
+++ b/app/src/main/res/values-ne-rNP/strings.xml
@@ -109,7 +109,7 @@
     <string name="support_debuglog_desc">एपले गरिरहेको सबै कुरा एक टेक्स्ट फाइलमा रेकर्ड गर्नुहोस् जुन तपाईंले साझा गर्न सक्नुहुन्छ।</string>
     <string name="support_debuglog_folder_label">डिबग लग फोल्डर</string>
     <plurals name="support_debuglog_folder_desc">
-        <item quantity="one">1 फाइल %1$s प्रयोग गरिरहेको छ</item>
+        <item quantity="one">%1$d फाइल %2$s प्रयोग गरिरहेको छ</item>
         <item quantity="other">%1$d फाइलहरू %2$s प्रयोग गरिरहेका छन्</item>
     </plurals>
     <string name="support_debuglog_folder_empty_desc">कुनै डिबग लग संग्रहित छैन</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -20,8 +20,8 @@
     <string name="debug_debuglog_screen_session_path_label">Njia ya Kipindi</string>
     <string name="debug_debuglog_screen_log_files_label">Mafaili ya Rekodi</string>
     <plurals name="debug_debuglog_screen_log_files_ready">
-        <item quantity="one">faili %1$d tayari (%2$s) · %3$s</item>
-        <item quantity="other">mafaili %1$d tayari (%2$s) · %3$s</item>
+        <item quantity="one">Faili %1$d tayari (%2$s) · %3$s</item>
+        <item quantity="other">Faili %1$d tayari (%2$s) · %3$s</item>
     </plurals>
     <string name="settings_debuglog_explanation">Kipengele hiki kinarekodi kila kitu programu inachofanya katika faili linaweza kushirikishwa. Faili lililotengenezwa lina maelezo ya siri (k.m. majina ya mafaili na programu zilizosakiniwa). Shiriki tu na wahusika wanaoweza kuaminika (k.m. msanidi programu anayetatua tatizo).</string>
     <string name="debug_debuglog_short_recording_title">Rekodi fupi sana</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -5,6 +5,7 @@
     <string name="dashboard_motd_title">ข้อความจากผู้พัฒนา</string>
     <string name="dashboard_settings_oneclick_title">โหมดแตะครั้งเดียว</string>
     <string name="dashboard_settings_oneclick_summary">เริ่มการสแกนและการลบสำหรับเครื่องมือทั้งหมดด้วยการคลิกปุ่มในแดชบอร์ด โดยไม่มีการยืนยันเพิ่มเติม</string>
+    <string name="dashboard_settings_oneclick_tools_title">เครื่องมือแตะครั้งเดียว</string>
     <string name="dashboard_settings_oneclick_tools_desc">เครื่องมือใดที่ควรรวมอยู่ในการดำเนินการแตะครั้งเดียว?</string>
     <string name="dashboard_card_config_title">การ์ดแดชบอร์ด</string>
     <string name="dashboard_card_config_desc">กำหนดค่าการ์ดที่จะแสดงและลำดับ</string>

--- a/app/src/main/res/values-ur-rIN/strings.xml
+++ b/app/src/main/res/values-ur-rIN/strings.xml
@@ -145,7 +145,7 @@
         <item quantity="other">%1$d / %2$d الفاظ</item>
     </plurals>
     <string name="support_contact_debuglog_label">ڈیبگ لاگ</string>
-    <string name="support_contact_debuglog_zip_error">ڈیبگ لاگ کو کمپریس کرنے میں ناکامی ہوئی</string>
+    <string name="support_contact_debuglog_zip_error">ڈیبگ لاگ کو کمپریس کرنے میں ناکامی</string>
     <string name="support_contact_debuglog_picker_hint">کوئی موجودہ ڈیبگ لاگ منسلک کریں، یا نیا ریکارڈ کریں۔</string>
     <string name="support_contact_debuglog_picker_empty">کوئی ڈیبگ لاگ نہیں ملی۔ پہلے ایک ریکارڈ کریں۔</string>
     <string name="support_contact_send_action">ای میل ایپ کھولیں</string>


### PR DESCRIPTION
## What changed

Updated app string translations pulled from Crowdin across 73 locales (441 files). All fastlane store listing updates were reverted due to quality issues.

## Technical Context

- **Fastlane (7 locales reverted)**: am (mojibake), ja-JP/th/zh-HK (sentence duplication), te-IN (script contamination), zh-CN (corrupted characters), zh-TW (garbled characters + duplication)
- **strings.xml (1 string reverted)**: ne-rNP `support_debuglog_folder_desc` had broken format specifiers (hardcoded `1` instead of `%1$d`, `%1$s` instead of `%2$s`)
- Modules updated: app-common-stats, app-common, app-tool-analyzer, app-tool-deduplicator, app-tool-scheduler, app-tool-squeezer, app-tool-swiper (pl only), app (cs/ne-rNP/sw/th/ur-rIN)
- Pre-existing issue noted: `debug_debuglog_screen_log_files_ready` missing `%3$s` in ~12 locales (not introduced by this pull)
- Build verified: `assembleFossDebug` passes