### PR TITLE
SystemCleaner: Log why APKs aren't flagged as superfluous

### DIFF
--- a/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/SuperfluousApksFilter.kt
+++ b/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/SuperfluousApksFilter.kt
@@ -156,7 +156,13 @@ class SuperfluousApksFilter @Inject constructor(
         log(TAG) { "Checking status for ${apkInfo.packageName} (${apkInfo.versionCode})" }
 
         // TODO Multiple profiles can't have different versions of the same APK, right?
-        val installed = pkgRepo.get(apkInfo.id).firstOrNull() ?: return null
+        val installed = pkgRepo.get(apkInfo.id).firstOrNull()
+        if (installed == null) {
+            log(TAG, VERBOSE) {
+                "Not superfluous (not installed): ${apkInfo.packageName} (archive=${apkInfo.versionCode})"
+            }
+            return null
+        }
 
         val superfluos = if (includeSameVersion) {
             installed.versionCode >= apkInfo.versionCode
@@ -166,6 +172,10 @@ class SuperfluousApksFilter @Inject constructor(
         if (superfluos) {
             log(TAG, VERBOSE) {
                 "Superfluos: ${installed.packageName} installed=${installed.versionCode}, archive=${apkInfo.versionCode}"
+            }
+        } else {
+            log(TAG, VERBOSE) {
+                "Not superfluous (archive is newer): ${installed.packageName} installed=${installed.versionCode}, archive=${apkInfo.versionCode}"
             }
         }
         return if (superfluos) SystemCleanerFilter.Match.Deletion(item) else null


### PR DESCRIPTION
## What changed

No user-facing behavior change. The "Superfluous APKs" filter in SystemCleaner now writes an extra line to the debug
log for each APK it parses, explaining why that APK was (or wasn't) flagged. Users who enable a debug scan and share
the log will get a much clearer trace when trying to understand why a given APK wasn't deleted.

## Technical Context

- `SuperfluousApksFilter.match()` had two silent non-match paths: the `pkgRepo.get(...).firstOrNull() ?: return null`
  early-return, and the `installed.versionCode < apkInfo.versionCode` fall-through. Both produced zero log output, so a
  debug log that contained only a `"Checking status for X (Y)"` line gave no way to tell whether the skip was because
  the app wasn't installed or because the archive was newer than the installed version.
- Added a `VERBOSE` line for each: `"Not superfluous (not installed): …"` and `"Not superfluous (archive is newer):
  installed=<i>, archive=<a>"`. Every parsed APK is now followed by one of three outcomes — `Superfluos`,
  `Not superfluous (archive is newer)`, or `Not superfluous (not installed)`.
- Motivated by #2372, where the reporter's log showed only positive-match lines and left the cause of the non-matches
  ambiguous. With these lines in place the same investigation would have been a single `grep` on the log.

Relates to #2372.
