### PR TITLE
Swiper: Warn before scanning an entire storage volume

### DIFF
--- a/app-common-data/src/main/java/eu/darken/sdmse/common/areas/DataAreaExtensions.kt
+++ b/app-common-data/src/main/java/eu/darken/sdmse/common/areas/DataAreaExtensions.kt
@@ -23,6 +23,17 @@ fun DataArea.hasFlags(vararg lookup: DataArea.Flag): Boolean = flags.containsAll
 
 suspend fun DataAreaManager.currentAreas(): Collection<DataArea> = state.first().areas
 
+/**
+ * The area roots users see as a whole storage volume (SD card, emulated shared storage, Android/data, Android/media,
+ * Android/obb, OTG/portable). Selecting these as the source of a destructive scan effectively targets every file on
+ * that volume — worth surfacing to the user before we start iterating.
+ */
+val DataArea.Type.isSensitiveRoot: Boolean
+    get() = this in DataArea.Type.PUBLIC_LOCATIONS
+
+val DataArea.isSensitiveRoot: Boolean
+    get() = type.isSensitiveRoot
+
 val DataArea.Type.label: CaString
     get() = when (this) {
         DataArea.Type.SDCARD -> R.string.area_type_sdcard_label.toCaString()

--- a/app-common-data/src/test/java/eu/darken/sdmse/common/areas/DataAreaExtensionsTest.kt
+++ b/app-common-data/src/test/java/eu/darken/sdmse/common/areas/DataAreaExtensionsTest.kt
@@ -1,0 +1,26 @@
+package eu.darken.sdmse.common.areas
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class DataAreaExtensionsTest : BaseTest() {
+
+    @Test
+    fun `isSensitiveRoot covers all public storage locations`() {
+        val sensitive = listOf(
+            DataArea.Type.SDCARD,
+            DataArea.Type.PUBLIC_DATA,
+            DataArea.Type.PUBLIC_OBB,
+            DataArea.Type.PUBLIC_MEDIA,
+            DataArea.Type.PORTABLE,
+        )
+        sensitive.forEach { it.isSensitiveRoot shouldBe true }
+    }
+
+    @Test
+    fun `isSensitiveRoot is false for system and app-private locations`() {
+        val benign = DataArea.Type.entries.filter { it !in DataArea.Type.PUBLIC_LOCATIONS }
+        benign.forEach { it.isSensitiveRoot shouldBe false }
+    }
+}

--- a/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/sessions/SwiperSessionsFragment.kt
+++ b/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/sessions/SwiperSessionsFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.ui.setupWithNavController
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -18,6 +19,7 @@ import eu.darken.sdmse.common.picker.PickerRoute
 import eu.darken.sdmse.common.EdgeToEdgeHelper
 import eu.darken.sdmse.common.areas.DataArea
 import eu.darken.sdmse.common.files.APath
+import kotlinx.coroutines.launch
 import eu.darken.sdmse.common.lists.differ.update
 import eu.darken.sdmse.swiper.core.FileTypeCategory
 import eu.darken.sdmse.swiper.core.FileTypeFilter
@@ -110,6 +112,7 @@ class SwiperSessionsFragment : Fragment3(R.layout.swiper_sessions_fragment) {
                 val sessionId = sessionWithStats.session.sessionId
                 val displayLabel = sessionWithStats.session.label
                     ?: getString(eu.darken.sdmse.swiper.R.string.swiper_session_default_label, position)
+                val isRisky = state.isSessionRisky(sessionId)
                 items.add(
                     SwiperSessionsSessionVH.Item(
                         sessionWithStats = sessionWithStats,
@@ -117,7 +120,8 @@ class SwiperSessionsFragment : Fragment3(R.layout.swiper_sessions_fragment) {
                         isScanning = state.isSessionScanning(sessionId),
                         isCancelling = state.isSessionCancelling(sessionId),
                         isRefreshing = state.isSessionRefreshing(sessionId),
-                        onScan = { vm.scanSession(sessionId) },
+                        isRisky = isRisky,
+                        onScan = { confirmAndScan(sessionWithStats.session.sessionId, sessionWithStats.session.sourcePaths) },
                         onContinue = { vm.continueSession(sessionId) },
                         onRemove = { showDiscardConfirmation(sessionId) },
                         onCancel = { vm.cancelScan() },
@@ -164,6 +168,28 @@ class SwiperSessionsFragment : Fragment3(R.layout.swiper_sessions_fragment) {
                 )
             )
         )
+    }
+
+    private fun confirmAndScan(sessionId: String, sourcePaths: List<APath>) {
+        viewLifecycleOwner.lifecycleScope.launch {
+            val sensitive = vm.findSensitiveRoots(sourcePaths)
+            if (sensitive.isEmpty()) {
+                vm.scanSession(sessionId)
+            } else {
+                showSensitiveRootDialog(sensitive) { vm.scanSession(sessionId) }
+            }
+        }
+    }
+
+    private fun showSensitiveRootDialog(sensitivePaths: List<APath>, onContinue: () -> Unit) {
+        val context = requireContext()
+        val pathsLabel = sensitivePaths.joinToString("\n") { it.userReadablePath.get(context) }
+        MaterialAlertDialogBuilder(context)
+            .setTitle(R.string.swiper_sensitive_root_warning_title)
+            .setMessage(getString(R.string.swiper_sensitive_root_warning_message, pathsLabel))
+            .setPositiveButton(R.string.swiper_sensitive_root_warning_continue_action) { _, _ -> onContinue() }
+            .setNegativeButton(eu.darken.sdmse.common.R.string.general_cancel_action, null)
+            .show()
     }
 
     private fun showDiscardConfirmation(sessionId: String) {

--- a/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/sessions/SwiperSessionsViewModel.kt
+++ b/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/sessions/SwiperSessionsViewModel.kt
@@ -2,11 +2,15 @@ package eu.darken.sdmse.swiper.ui.sessions
 
 import androidx.lifecycle.SavedStateHandle
 import dagger.hilt.android.lifecycle.HiltViewModel
+import eu.darken.sdmse.common.areas.DataAreaManager
+import eu.darken.sdmse.common.areas.currentAreas
+import eu.darken.sdmse.common.areas.isSensitiveRoot
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.*
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.files.matches
 import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.common.uix.ViewModel3
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
@@ -29,6 +33,7 @@ class SwiperSessionsViewModel @Inject constructor(
     private val swiper: Swiper,
     private val taskSubmitter: TaskSubmitter,
     private val upgradeRepo: UpgradeRepo,
+    private val dataAreaManager: DataAreaManager,
 ) : ViewModel3(dispatcherProvider = dispatcherProvider) {
 
     private val selectedPaths = MutableStateFlow<Set<APath>>(emptySet())
@@ -44,7 +49,12 @@ class SwiperSessionsViewModel @Inject constructor(
         scanningSessionId,
         cancellingSessionId,
         refreshingSessionId,
-    ) { sessionsWithStats, progress, paths, isPro, scanningId, cancellingId, refreshingId ->
+        dataAreaManager.state,
+    ) { sessionsWithStats, progress, paths, isPro, scanningId, cancellingId, refreshingId, areaState ->
+        val riskySessionIds = sessionsWithStats
+            .filter { it.session.sourcePaths.any { p -> p.isSensitiveRootIn(areaState.areas) } }
+            .map { it.session.sessionId }
+            .toSet()
         State(
             sessionsWithStats = sessionsWithStats,
             selectedPaths = paths,
@@ -54,8 +64,17 @@ class SwiperSessionsViewModel @Inject constructor(
             scanningSessionId = scanningId,
             cancellingSessionId = cancellingId,
             refreshingSessionId = refreshingId,
+            riskySessionIds = riskySessionIds,
         )
     }.asLiveData2()
+
+    suspend fun findSensitiveRoots(paths: Collection<APath>): List<APath> {
+        val areas = dataAreaManager.currentAreas()
+        return paths.filter { it.isSensitiveRootIn(areas) }
+    }
+
+    private fun APath.isSensitiveRootIn(areas: Collection<eu.darken.sdmse.common.areas.DataArea>): Boolean =
+        areas.any { it.isSensitiveRoot && this.matches(it.path) }
 
     fun setSelectedPaths(paths: Set<APath>) {
         log(TAG, INFO) { "setSelectedPaths: $paths" }
@@ -136,6 +155,7 @@ class SwiperSessionsViewModel @Inject constructor(
         val scanningSessionId: String?,
         val cancellingSessionId: String?,
         val refreshingSessionId: String?,
+        val riskySessionIds: Set<String> = emptySet(),
     ) {
         val canCreateNewSession: Boolean = isPro || sessionsWithStats.size < SwiperSettings.FREE_VERSION_SESSION_LIMIT
         val freeVersionLimit: Int = SwiperSettings.FREE_VERSION_LIMIT
@@ -144,6 +164,7 @@ class SwiperSessionsViewModel @Inject constructor(
         fun isSessionScanning(sessionId: String): Boolean = scanningSessionId == sessionId
         fun isSessionCancelling(sessionId: String): Boolean = cancellingSessionId == sessionId
         fun isSessionRefreshing(sessionId: String): Boolean = refreshingSessionId == sessionId
+        fun isSessionRisky(sessionId: String): Boolean = sessionId in riskySessionIds
     }
 
     companion object {

--- a/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/sessions/items/SwiperSessionsSessionVH.kt
+++ b/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/sessions/items/SwiperSessionsSessionVH.kt
@@ -67,6 +67,21 @@ class SwiperSessionsSessionVH(parent: ViewGroup) :
             pathsContainer.addView(pathView)
         }
 
+        // Risky (whole-storage) warning.
+        // When the user has narrowed the session with a file-type filter, tone the chip down from error red to
+        // tertiary — they've consciously scoped the scan, so the warning becomes informational rather than alarming.
+        riskyWarning.isVisible = item.isRisky
+        if (item.isRisky) {
+            val tintAttr = if (session.fileTypeFilter.isEmpty) {
+                androidx.appcompat.R.attr.colorError
+            } else {
+                com.google.android.material.R.attr.colorTertiary
+            }
+            val tint = android.content.res.ColorStateList.valueOf(context.getColorForAttr(tintAttr))
+            riskyWarningIcon.imageTintList = tint
+            riskyWarningText.setTextColor(tint)
+        }
+
         // Filter summary
         val filter = session.fileTypeFilter
         if (!filter.isEmpty) {
@@ -217,6 +232,7 @@ class SwiperSessionsSessionVH(parent: ViewGroup) :
         val isScanning: Boolean,
         val isCancelling: Boolean,
         val isRefreshing: Boolean,
+        val isRisky: Boolean,
         val onScan: () -> Unit,
         val onContinue: () -> Unit,
         val onRemove: () -> Unit,

--- a/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/status/DeletionPreview.kt
+++ b/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/status/DeletionPreview.kt
@@ -1,0 +1,58 @@
+package eu.darken.sdmse.swiper.ui.status
+
+import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.files.isAncestorOf
+import eu.darken.sdmse.swiper.core.SwipeDecision
+import eu.darken.sdmse.swiper.core.SwipeItem
+
+/**
+ * Aggregated preview of where the deletion reaches. Shown in the finalize confirmation dialog so users can see which
+ * top-level folders are affected before committing, rather than only an aggregate count + size. Items that aren't
+ * under any source path, or that sit directly in the source root, are intentionally omitted from the preview — the
+ * dialog header still reports the full count and size.
+ */
+data class DeletionPreview(
+    val buckets: List<DeletionBucket>,
+    val moreFolders: Int,
+) {
+    data class DeletionBucket(
+        val label: String,
+        val count: Int,
+        val size: Long,
+    )
+
+    companion object {
+        const val MAX_BUCKETS = 5
+
+        fun from(items: List<SwipeItem>, sourcePaths: Collection<APath>): DeletionPreview {
+            val pending = items.filter {
+                it.decision == SwipeDecision.DELETE || it.decision == SwipeDecision.DELETE_FAILED
+            }
+            if (pending.isEmpty()) return DeletionPreview(emptyList(), 0)
+
+            val sourceSegments = sourcePaths.map { it.segments }
+            val counts = mutableMapOf<String, Int>()
+            val sizes = mutableMapOf<String, Long>()
+
+            pending.forEach { item ->
+                val itemSegs = item.lookup.segments
+                val bestSource = sourceSegments
+                    .filter { it.isAncestorOf(itemSegs) }
+                    .maxByOrNull { it.size } ?: return@forEach
+                val relative = itemSegs.drop(bestSource.size)
+                if (relative.size < 2) return@forEach
+                val key = relative.first()
+                counts.merge(key, 1) { a, b -> a + b }
+                sizes.merge(key, item.lookup.size) { a, b -> a + b }
+            }
+
+            val buckets = counts.keys
+                .map { key -> DeletionBucket(label = key, count = counts.getValue(key), size = sizes.getValue(key)) }
+                .sortedByDescending { it.size }
+
+            val top = buckets.take(MAX_BUCKETS)
+            val more = (buckets.size - MAX_BUCKETS).coerceAtLeast(0)
+            return DeletionPreview(top, more)
+        }
+    }
+}

--- a/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/status/SwiperStatusFragment.kt
+++ b/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/status/SwiperStatusFragment.kt
@@ -1,14 +1,18 @@
 package eu.darken.sdmse.swiper.ui.status
 
+import android.content.DialogInterface
 import android.content.res.ColorStateList
 import android.os.Bundle
+import android.view.LayoutInflater
 import android.view.MenuItem
 import android.view.View
+import android.widget.TextView
 import androidx.core.view.ViewCompat
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.ui.setupWithNavController
 import androidx.recyclerview.selection.SelectionTracker
+import com.google.android.material.checkbox.MaterialCheckBox
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.appbar.AppBarLayout
 import dagger.hilt.android.AndroidEntryPoint
@@ -341,35 +345,96 @@ class SwiperStatusFragment : Fragment3(R.layout.swiper_status_fragment) {
             return
         }
 
-        // Show confirmation for delete items
-        val (sizeFormatted, _) = ByteFormatter.formatSize(requireContext(), state.deleteSize)
+        val context = requireContext()
+        val (sizeFormatted, _) = ByteFormatter.formatSize(context, state.deleteSize)
 
         val deleteMessage = resources.getQuantityString(
-            eu.darken.sdmse.swiper.R.plurals.swiper_delete_confirmation_message,
+            R.plurals.swiper_delete_confirmation_message,
             state.deleteCount,
             state.deleteCount,
             sizeFormatted,
         )
-        val message = if (state.undecidedCount > 0) {
-            val undecidedMessage = resources.getQuantityString(
-                eu.darken.sdmse.swiper.R.plurals.swiper_delete_confirmation_message_partial_undecided,
+        val undecidedMessage = if (state.undecidedCount > 0) {
+            resources.getQuantityString(
+                R.plurals.swiper_delete_confirmation_message_partial_undecided,
                 state.undecidedCount,
                 state.undecidedCount,
             )
-            "$deleteMessage\n\n$undecidedMessage"
-        } else {
-            deleteMessage
+        } else null
+
+        val requiresExplicitConfirm = state.hasSensitiveRoot
+
+        val dialogView = LayoutInflater.from(context)
+            .inflate(R.layout.swiper_delete_confirmation_dialog, null)
+
+        dialogView.findViewById<TextView>(R.id.message_text).text = deleteMessage
+
+        dialogView.findViewById<TextView>(R.id.undecided_text).apply {
+            if (undecidedMessage != null) {
+                text = undecidedMessage
+                visibility = View.VISIBLE
+            } else {
+                visibility = View.GONE
+            }
         }
 
-        MaterialAlertDialogBuilder(requireContext()).apply {
-            setTitle(eu.darken.sdmse.swiper.R.string.swiper_delete_confirmation_title)
-            setMessage(message)
-            setPositiveButton(eu.darken.sdmse.common.R.string.general_delete_action) { _, _ ->
-                vm.retryAllFailed()  // Always call - no-op if no failed items
+        dialogView.findViewById<TextView>(R.id.sensitive_root_warning).apply {
+            visibility = if (state.hasSensitiveRoot) View.VISIBLE else View.GONE
+        }
+
+        val bucketsText = buildBucketsText(state.deletionPreview)
+        dialogView.findViewById<TextView>(R.id.buckets_text).apply {
+            if (bucketsText != null) {
+                text = bucketsText
+                visibility = View.VISIBLE
+            } else {
+                visibility = View.GONE
+            }
+        }
+
+        val checkbox = dialogView.findViewById<MaterialCheckBox>(R.id.confirm_checkbox)
+        checkbox.visibility = if (requiresExplicitConfirm) View.VISIBLE else View.GONE
+        checkbox.isChecked = false
+
+        val dialog = MaterialAlertDialogBuilder(context)
+            .setTitle(R.string.swiper_delete_confirmation_title)
+            .setView(dialogView)
+            .setPositiveButton(eu.darken.sdmse.common.R.string.general_delete_action) { _, _ ->
+                vm.retryAllFailed()
                 vm.finalize()
             }
-            setNegativeButton(eu.darken.sdmse.common.R.string.general_cancel_action, null)
-        }.show()
+            .setNegativeButton(eu.darken.sdmse.common.R.string.general_cancel_action, null)
+            .show()
+
+        if (requiresExplicitConfirm) {
+            val positiveButton = dialog.getButton(DialogInterface.BUTTON_POSITIVE)
+            positiveButton.isEnabled = false
+            checkbox.setOnCheckedChangeListener { _, checked ->
+                positiveButton.isEnabled = checked
+            }
+        }
+    }
+
+    private fun buildBucketsText(preview: DeletionPreview): CharSequence? {
+        if (preview.buckets.isEmpty()) return null
+        val context = requireContext()
+        val lines = preview.buckets.map { bucket ->
+            val itemsStr = resources.getQuantityString(
+                eu.darken.sdmse.common.R.plurals.result_x_items,
+                bucket.count,
+                bucket.count,
+            )
+            val (sizeStr, _) = ByteFormatter.formatSize(context, bucket.size)
+            "• ${bucket.label} — $itemsStr ($sizeStr)"
+        }
+        val moreLine = if (preview.moreFolders > 0) {
+            resources.getQuantityString(
+                R.plurals.swiper_delete_confirmation_more_folders,
+                preview.moreFolders,
+                preview.moreFolders,
+            )
+        } else null
+        return (lines + listOfNotNull(moreLine)).joinToString("\n")
     }
 
 }

--- a/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/status/SwiperStatusViewModel.kt
+++ b/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/status/SwiperStatusViewModel.kt
@@ -3,12 +3,16 @@ package eu.darken.sdmse.swiper.ui.status
 import androidx.lifecycle.SavedStateHandle
 import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.sdmse.common.SingleLiveEvent
+import eu.darken.sdmse.common.areas.DataAreaManager
+import eu.darken.sdmse.common.areas.isSensitiveRoot
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.*
 import eu.darken.sdmse.common.debug.logging.log
 import androidx.navigation.navOptions
 import androidx.navigation.toRoute
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.files.matches
 import eu.darken.sdmse.common.uix.ViewModel3
 import eu.darken.sdmse.exclusion.core.ExclusionManager
 import eu.darken.sdmse.swiper.ui.SwiperStatusRoute
@@ -22,7 +26,7 @@ import eu.darken.sdmse.swiper.core.SwipeItem
 import eu.darken.sdmse.swiper.core.SwipeSession
 import eu.darken.sdmse.swiper.core.Swiper
 import eu.darken.sdmse.swiper.core.tasks.SwiperDeleteTask
-import eu.darken.sdmse.common.flow.combine
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import javax.inject.Inject
 
@@ -33,6 +37,7 @@ class SwiperStatusViewModel @Inject constructor(
     private val swiper: Swiper,
     private val taskSubmitter: TaskSubmitter,
     private val exclusionManager: ExclusionManager,
+    private val dataAreaManager: DataAreaManager,
 ) : ViewModel3(dispatcherProvider = dispatcherProvider) {
 
     private val sessionId: String = SwiperStatusRoute.from(handle).sessionId
@@ -43,7 +48,8 @@ class SwiperStatusViewModel @Inject constructor(
         swiper.getSession(sessionId),
         swiper.getItemsForSession(sessionId),
         swiper.progress,
-    ) { session: SwipeSession?, items: List<SwipeItem>, progress ->
+        dataAreaManager.state,
+    ) { session: SwipeSession?, items: List<SwipeItem>, progress, areaState ->
         val keepCount = items.count { it.decision == SwipeDecision.KEEP }
         val deleteCount = items.count { it.decision == SwipeDecision.DELETE || it.decision == SwipeDecision.DELETE_FAILED }
         val undecidedCount = items.count { it.decision == SwipeDecision.UNDECIDED }
@@ -51,6 +57,12 @@ class SwiperStatusViewModel @Inject constructor(
         val keepSize = items.filter { it.decision == SwipeDecision.KEEP }.sumOf { it.lookup.size }
         val deleteSize = items.filter { it.decision == SwipeDecision.DELETE || it.decision == SwipeDecision.DELETE_FAILED }.sumOf { it.lookup.size }
         val undecidedSize = items.filter { it.decision == SwipeDecision.UNDECIDED }.sumOf { it.lookup.size }
+
+        val sourcePaths = session?.sourcePaths.orEmpty()
+        val hasSensitiveRoot = sourcePaths.any { source ->
+            areaState.areas.any { it.isSensitiveRoot && source.matches(it.path) }
+        }
+        val deletionPreview = DeletionPreview.from(items, sourcePaths)
 
         State(
             items = items,
@@ -64,6 +76,9 @@ class SwiperStatusViewModel @Inject constructor(
             isProcessing = progress != null,
             alreadyKeptCount = session?.keptCount ?: 0,
             alreadyDeletedCount = session?.deletedCount ?: 0,
+            sourcePaths = sourcePaths,
+            hasSensitiveRoot = hasSensitiveRoot,
+            deletionPreview = deletionPreview,
         )
     }.asLiveData2()
 
@@ -154,6 +169,9 @@ class SwiperStatusViewModel @Inject constructor(
         val isProcessing: Boolean,
         val alreadyKeptCount: Int,
         val alreadyDeletedCount: Int,
+        val sourcePaths: List<APath> = emptyList(),
+        val hasSensitiveRoot: Boolean = false,
+        val deletionPreview: DeletionPreview = DeletionPreview(emptyList(), 0),
     ) {
         // Can finalize at any time, even with undecided items (partial finalization)
         val canFinalize: Boolean = !isProcessing

--- a/app-tool-swiper/src/main/res/layout/swiper_delete_confirmation_dialog.xml
+++ b/app-tool-swiper/src/main/res/layout/swiper_delete_confirmation_dialog.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingHorizontal="24dp"
+    android:paddingTop="8dp"
+    android:paddingBottom="8dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/message_text"
+            style="?attr/textAppearanceBodyMedium"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            tools:text="This will permanently delete 123 files (456 MB). This action cannot be undone." />
+
+        <TextView
+            android:id="@+id/undecided_text"
+            style="?attr/textAppearanceBodyMedium"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:visibility="gone"
+            tools:text="5 undecided items will remain for later review."
+            tools:visibility="visible" />
+
+        <TextView
+            android:id="@+id/sensitive_root_warning"
+            style="?attr/textAppearanceBodyMedium"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:textColor="?attr/colorError"
+            android:visibility="gone"
+            tools:text="This session targets a whole storage volume — deleting here affects many apps and folders."
+            tools:visibility="visible" />
+
+        <TextView
+            android:id="@+id/buckets_text"
+            style="?attr/textAppearanceBodySmall"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:lineSpacingExtra="2dp"
+            android:visibility="gone"
+            tools:text="• DCIM — 134 items (480 MB)\n• WhatsApp/Media — 812 items (1.2 GB)\n…and 3 more folders"
+            tools:visibility="visible" />
+
+        <com.google.android.material.checkbox.MaterialCheckBox
+            android:id="@+id/confirm_checkbox"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/swiper_delete_confirmation_checkbox"
+            android:visibility="gone"
+            tools:visibility="visible" />
+
+    </LinearLayout>
+
+</androidx.core.widget.NestedScrollView>

--- a/app-tool-swiper/src/main/res/layout/swiper_sessions_session_item.xml
+++ b/app-tool-swiper/src/main/res/layout/swiper_sessions_session_item.xml
@@ -93,6 +93,39 @@
 
         </LinearLayout>
 
+        <!-- Risky (whole-storage) warning -->
+        <LinearLayout
+            android:id="@+id/risky_warning"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:visibility="gone"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/paths_container"
+            tools:visibility="visible">
+
+            <ImageView
+                android:id="@+id/risky_warning_icon"
+                android:layout_width="16dp"
+                android:layout_height="16dp"
+                android:src="@drawable/ic_baseline_warning_24"
+                android:contentDescription="@string/swiper_session_risky_label"
+                app:tint="?attr/colorError" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/risky_warning_text"
+                style="@style/TextAppearance.Material3.BodySmall"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:text="@string/swiper_session_risky_label"
+                android:textColor="?attr/colorError" />
+
+        </LinearLayout>
+
         <!-- Filter summary -->
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/filter_summary"
@@ -104,7 +137,7 @@
             android:visibility="gone"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/paths_container"
+            app:layout_constraintTop_toBottomOf="@id/risky_warning"
             tools:text="Filtered: Images, Videos"
             tools:visibility="visible" />
 

--- a/app-tool-swiper/src/main/res/values/strings.xml
+++ b/app-tool-swiper/src/main/res/values/strings.xml
@@ -39,6 +39,16 @@
         <item quantity="one">%d undecided item will remain for later review.</item>
         <item quantity="other">%d undecided items will remain for later review.</item>
     </plurals>
+    <string name="swiper_delete_confirmation_sensitive_root_warning">This session targets a whole storage volume — deleting here spans every folder on that storage.</string>
+    <plurals name="swiper_delete_confirmation_more_folders">
+        <item quantity="one">…and %d more folder</item>
+        <item quantity="other">…and %d more folders</item>
+    </plurals>
+    <string name="swiper_delete_confirmation_checkbox">I understand these files will be permanently deleted.</string>
+    <string name="swiper_sensitive_root_warning_title">Scan entire storage?</string>
+    <string name="swiper_sensitive_root_warning_message">Scanning %1$s includes every file on this storage — photos, documents, downloads, app media, and more. Continue?</string>
+    <string name="swiper_sensitive_root_warning_continue_action">Continue anyway</string>
+    <string name="swiper_session_risky_label">Whole-storage scan</string>
     <string name="swiper_delete_x_action">Delete %1$d</string>
     <string name="swiper_settings_swap_directions_title">Swap swipe directions</string>
     <string name="swiper_settings_swap_directions_summary">Swipe left to keep, right to delete.</string>

--- a/app-tool-swiper/src/test/java/eu/darken/sdmse/swiper/ui/status/DeletionPreviewTest.kt
+++ b/app-tool-swiper/src/test/java/eu/darken/sdmse/swiper/ui/status/DeletionPreviewTest.kt
@@ -1,0 +1,108 @@
+package eu.darken.sdmse.swiper.ui.status
+
+import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.swiper.core.SwipeDecision
+import eu.darken.sdmse.swiper.core.SwipeItem
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class DeletionPreviewTest : BaseTest() {
+
+    private fun lookup(path: APath, size: Long): APathLookup<APath> = mockk(relaxed = true) {
+        every { segments } returns path.segments
+        every { this@mockk.size } returns size
+        every { lookedUp } returns path
+    }
+
+    private fun item(id: Long, path: APath, size: Long, decision: SwipeDecision): SwipeItem =
+        SwipeItem(id = id, sessionId = "s", itemIndex = id.toInt(), lookup = lookup(path, size), decision = decision)
+
+    @Test
+    fun `empty items produces empty preview`() {
+        val preview = DeletionPreview.from(emptyList(), listOf(LocalPath.build("storage", "emulated", "0")))
+        preview.buckets shouldBe emptyList()
+        preview.moreFolders shouldBe 0
+    }
+
+    @Test
+    fun `groups items by first relative segment under source`() {
+        val source = LocalPath.build("storage", "emulated", "0")
+        val items = listOf(
+            item(1, LocalPath.build("storage", "emulated", "0", "DCIM", "a.jpg"), 100, SwipeDecision.DELETE),
+            item(2, LocalPath.build("storage", "emulated", "0", "DCIM", "sub", "b.jpg"), 200, SwipeDecision.DELETE),
+            item(3, LocalPath.build("storage", "emulated", "0", "Download", "c.pdf"), 50, SwipeDecision.DELETE),
+        )
+        val preview = DeletionPreview.from(items, listOf(source))
+        preview.buckets.map { it.label } shouldBe listOf("DCIM", "Download")
+        preview.buckets.first { it.label == "DCIM" }.count shouldBe 2
+        preview.buckets.first { it.label == "DCIM" }.size shouldBe 300
+        preview.buckets.first { it.label == "Download" }.count shouldBe 1
+        preview.moreFolders shouldBe 0
+    }
+
+    @Test
+    fun `includes DELETE_FAILED alongside DELETE`() {
+        val source = LocalPath.build("root")
+        val items = listOf(
+            item(1, LocalPath.build("root", "A", "file"), 10, SwipeDecision.DELETE),
+            item(2, LocalPath.build("root", "A", "file2"), 20, SwipeDecision.DELETE_FAILED),
+            item(3, LocalPath.build("root", "A", "file3"), 30, SwipeDecision.KEEP),
+            item(4, LocalPath.build("root", "A", "file4"), 40, SwipeDecision.DELETED),
+            item(5, LocalPath.build("root", "A", "file5"), 50, SwipeDecision.UNDECIDED),
+        )
+        val preview = DeletionPreview.from(items, listOf(source))
+        preview.buckets.single().count shouldBe 2
+        preview.buckets.single().size shouldBe 30
+    }
+
+    @Test
+    fun `sorts buckets by size descending and caps at 5`() {
+        val source = LocalPath.build("root")
+        val items = (1..7).map { i ->
+            item(i.toLong(), LocalPath.build("root", "folder$i", "file"), i * 100L, SwipeDecision.DELETE)
+        }
+        val preview = DeletionPreview.from(items, listOf(source))
+        preview.buckets.map { it.label } shouldBe listOf("folder7", "folder6", "folder5", "folder4", "folder3")
+        preview.moreFolders shouldBe 2
+    }
+
+    @Test
+    fun `multi-root session picks longest matching source path`() {
+        val broad = LocalPath.build("storage")
+        val narrow = LocalPath.build("storage", "emulated", "0")
+        val items = listOf(
+            item(1, LocalPath.build("storage", "emulated", "0", "Downloads", "a"), 10, SwipeDecision.DELETE),
+            item(2, LocalPath.build("storage", "other", "Pictures", "a"), 20, SwipeDecision.DELETE),
+        )
+        val preview = DeletionPreview.from(items, listOf(broad, narrow))
+        val labels = preview.buckets.map { it.label }.toSet()
+        labels shouldBe setOf("Downloads", "other")
+    }
+
+    @Test
+    fun `items directly under source are omitted — only folder buckets appear`() {
+        val source = LocalPath.build("root")
+        val items = listOf(
+            item(1, LocalPath.build("root", "direct.txt"), 10, SwipeDecision.DELETE),
+            item(2, LocalPath.build("root", "Folder", "x"), 20, SwipeDecision.DELETE),
+        )
+        val preview = DeletionPreview.from(items, listOf(source))
+        preview.buckets.map { it.label } shouldBe listOf("Folder")
+        preview.buckets.single().count shouldBe 1
+    }
+
+    @Test
+    fun `items outside any source are omitted`() {
+        val source = LocalPath.build("root")
+        val items = listOf(
+            item(1, LocalPath.build("unrelated", "thing"), 10, SwipeDecision.DELETE),
+        )
+        val preview = DeletionPreview.from(items, listOf(source))
+        preview.buckets shouldBe emptyList()
+    }
+}


### PR DESCRIPTION
## What changed

Selecting an entire storage volume in Swiper (like `/storage/emulated/0`, an SD card root, `Android/data`, or `Android/obb`) now shows an extra confirmation before the scan starts, and the session card gets a small "Whole-storage scan" reminder so it stays obvious afterwards. If you've also set a file-type filter on the session, the reminder tones down from red to tertiary because you've narrowed the scope on purpose.

The final "Delete files?" dialog now previews which top-level folders will be affected (e.g. `DCIM — 134 items (480 MB)`), so you can spot surprises before committing. When the session targets a whole storage volume, that dialog also requires a tick-box before the Delete button enables — other scopes keep the single-tap confirm like the rest of the app.

## Technical Context

- Motivated by a Discord support report of a user who batch-deleted important data after picking the storage root, going to the review screen, and tapping Select All → Delete. Nothing was technically broken, but there was zero friction against accidental whole-storage sweeps.
- The "sensitive root" signal is a single helper in `DataAreaExtensions` that checks whether a given `APath.matches()` any `DataArea` of a `PUBLIC_LOCATIONS` type. It's kept in `app-common-data` because the check can apply anywhere a path is picked, not just Swiper.
- The checkbox on the delete dialog is **scope-gated**, not scale-gated — earlier iterations threshold-gated on count (≥100) and size (≥1 GB), but those were hedges that made Swiper heavier than other tools for normal cases. Now the extra friction only kicks in when the session's scope itself is dangerous; all other deletions behave like CorpseFinder/SystemCleaner/AppCleaner.
- Deliberately **no default exclusions** were added for `Android/data` / `Android/obb` — users may legitimately want to swipe through those.
- The bucket preview is built in `DeletionPreview.from()` as a pure function over items + source paths (longest-ancestor match, top 5 by size, rest rolled into a "…and N more folders" count). Items that aren't under any source path, or that sit directly in a source root, are intentionally omitted from the preview — the dialog header still reports the full count and size. Covered by `DeletionPreviewTest`.
- Review guidance: the `combine(…)` call in `SwiperStatusViewModel` now has 4 flows (added `dataAreaManager.state`), which crossed the project's `FlowCombineExtensions` gap for 4-arg combine. Switched that one call site to `kotlinx.coroutines.flow.combine` directly.
