### PR TITLE
Scheduler: Fix scheduled cleanups failing with error notification

### DIFF
--- a/app-tool-scheduler/src/main/java/eu/darken/sdmse/scheduler/core/SchedulerWorker.kt
+++ b/app-tool-scheduler/src/main/java/eu/darken/sdmse/scheduler/core/SchedulerWorker.kt
@@ -101,7 +101,12 @@ class SchedulerWorker @AssistedInject constructor(
             log(TAG, INFO) { "Executing schedule $schedule" }
             Bugs.leaveBreadCrumb("Executing schedule")
 
-            setForeground(schedulerNotifications.getForegroundInfo(schedule))
+            try {
+                setForeground(schedulerNotifications.getForegroundInfo(schedule))
+            } catch (e: IllegalStateException) {
+                log(TAG, ERROR) { "Can't update foreground info, falling back to notifyState: ${e.asLog()}" }
+                schedulerNotifications.notifyState(schedule)
+            }
 
             doDoWork(schedule)
 


### PR DESCRIPTION
## What changed

Fixes a bug where scheduled cleanups would fail with the notification *"Some scheduled tasks failed or encountered errors. Try running them manually."* — even though nothing was wrong with the setup. The schedule would never actually run the selected tools (CorpseFinder, SystemCleaner, AppCleaner); the run died before any tool was launched.

Affected users whose scheduled cleanup fires while the app has been closed for a while — e.g. an overnight schedule — especially on Android 12+ and most reliably on Android 16. Users who have the app open or recently used, or who run the cleanup manually, were not affected.

## Technical Context

- Root cause: the per-tool-details foreground notification introduced in 96e9b39d2 added a second `setForeground()` call inside `SchedulerWorker.doWork()` without the `IllegalStateException` guard that already wrapped the first `setForeground()`. When the app is past Android's FGS-start allow-window, `WorkForegroundUpdater` raises `ForegroundServiceStartNotAllowedException` / `BackgroundServiceStartNotAllowedException` (both `extends IllegalStateException`). The uncaught exception propagates to the worker's outer `catch (Throwable)`, which logs *"Execution failed"*, calls `notifyError(...)`, and returns `Result.failure` — all before `doDoWork()` gets a chance to run.
- Shipped since `v1.7.0-rc0` (first public release with 96e9b39d2). Happy-path users never hit it because their first `setForeground()` succeeded, which meant the second call was a notification update on an already-live FGS and worked fine. The crash only manifests when the first call also failed (app genuinely backgrounded, no battery-optimisation exemption, schedule fired from an alarm).
- Fix: wrap the second `setForeground()` in the same `IllegalStateException` catch as the first. In the catch branch, fall back to `schedulerNotifications.notifyState(schedule)`, which posts via `NotificationManager.notify(sameId, …)` — the Android-documented way to update an existing notification and not subject to FGS-start restrictions. Happy path is unchanged: `setForeground()` still owns the per-tool-details update while the worker is running foreground.
- Review guidance: single call site in `SchedulerWorker.doWork()`. No API/signatures touched, no new dependencies. The fallback path in the catch is the pre-96e9b39d2 behaviour for the foreground notification, so regression risk is minimal.

Reproduced via support logs from a user on Pixel 8 Pro / Android 16 with a 05:35 daily schedule; device was backgrounded for ~5 min before the alarm fired and both `setForeground()` calls were denied by the OS.
