### PR TITLE
Analyzer: Fix wrong secondary storage size on FAT SD cards

### DIFF
--- a/app-common-data/src/main/java/eu/darken/sdmse/common/storage/StorageId.kt
+++ b/app-common-data/src/main/java/eu/darken/sdmse/common/storage/StorageId.kt
@@ -14,14 +14,17 @@ data class StorageId(
 ) : Parcelable {
 
     companion object {
+        // Mirrors android.os.storage.StorageManager.FAT_UUID_PREFIX — synthesised for FAT/exFAT volumes
+        // whose fsUuid is a 4+4-hex label (e.g. "EFFD-F4D5") rather than a real 128-bit UUID.
+        const val FAT_UUID_PREFIX = "fafafafa-fafa-5afa-8afa-fafa"
+
         fun parseVolumeUuid(fsUuid: String?): UUID? {
             if (fsUuid == null) return null
             return try {
                 UUID.fromString(fsUuid)
             } catch (_: IllegalArgumentException) {
                 try {
-                    // StorageManager.FAT_UUID_PREFIX style fallback
-                    UUID.fromString("fafafafa-fafa-5afa-8afa-fafa${fsUuid.replace("-", "")}")
+                    UUID.fromString("$FAT_UUID_PREFIX${fsUuid.replace("-", "")}")
                 } catch (_: Exception) {
                     null
                 }

--- a/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/SpaceTracker.kt
+++ b/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/SpaceTracker.kt
@@ -19,6 +19,7 @@ import java.time.Instant
 import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.math.abs
 
 @Singleton
 class SpaceTracker @Inject constructor(
@@ -140,18 +141,35 @@ class SpaceTracker @Inject constructor(
                     internalId = volume.fsUuid,
                     externalId = volumeUuid,
                 )
+                val isFatUuid = volumeUuid.toString().startsWith(StorageId.FAT_UUID_PREFIX)
+                val fileTotal = volume.path?.totalSpace ?: 0L
+                val fileFree = volume.path?.freeSpace ?: 0L
 
-                val totalBytes = try {
-                    storageStatsManager.getTotalBytes(storageId)
+                val (totalBytes, freeBytes) = try {
+                    val statsTotal = storageStatsManager.getTotalBytes(storageId)
+                    val statsFree = storageStatsManager.getFreeBytes(storageId)
+
+                    // For FAT synthesised UUIDs, StorageStatsManager is unreliable on some devices (#2389).
+                    // If statfs disagrees with the API by >10%, trust the filesystem.
+                    val mismatches = isFatUuid
+                        && fileTotal > 0
+                        && abs(statsTotal - fileTotal) * 10 > fileTotal
+                    if (mismatches) {
+                        log(TAG, WARN) {
+                            "StorageStats total=$statsTotal disagrees with File=$fileTotal for FAT $storageId; using File"
+                        }
+                        fileTotal to fileFree
+                    } else {
+                        statsTotal to statsFree
+                    }
                 } catch (e: Exception) {
-                    log(TAG, WARN) { "Failed to get total bytes for $storageId: ${e.asLog()}" }
-                    volume.path?.totalSpace ?: 0L
+                    log(TAG, WARN) { "StorageStatsManager failed for $storageId, using File API: ${e.asLog()}" }
+                    fileTotal to fileFree
                 }
-                val freeBytes = try {
-                    storageStatsManager.getFreeBytes(storageId)
-                } catch (e: Exception) {
-                    log(TAG, WARN) { "Failed to get free bytes for $storageId: ${e.asLog()}" }
-                    volume.path?.freeSpace ?: 0L
+
+                if (totalBytes <= 0L) {
+                    log(TAG, WARN) { "Secondary volume reports zero capacity, skipping: $volume" }
+                    return@mapNotNull null
                 }
 
                 StorageSnapshot(

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/device/DeviceStorageScanner.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/device/DeviceStorageScanner.kt
@@ -49,9 +49,11 @@ class DeviceStorageScanner @Inject constructor(
 
         val primaryDevice = run {
             updateProgressSecondary(eu.darken.sdmse.analyzer.R.string.analyzer_storage_type_primary_title)
+            val primaryUuid = StorageManager.UUID_DEFAULT
+                ?: UUID.fromString("00000000-0000-0000-0000-000000000000")
             val id = StorageId(
                 internalId = null,
-                externalId = StorageManager.UUID_DEFAULT,
+                externalId = primaryUuid,
             )
 
             val totalBytes = try {
@@ -95,9 +97,8 @@ class DeviceStorageScanner @Inject constructor(
                 }
                 if (volumeId == null && volume.fsUuid != null) {
                     try {
-                        // StorageManager.FAT_UUID_PREFIX
                         volumeId = UUID.fromString(
-                            "fafafafa-fafa-5afa-8afa-fafa" + volume.fsUuid!!.replace("-", "")
+                            "${StorageId.FAT_UUID_PREFIX}${volume.fsUuid!!.replace("-", "")}"
                         )
                     } catch (e: Exception) {
                         log(TAG, WARN) { "Failed to construct UUID: ${e.asLog()}" }
@@ -110,19 +111,37 @@ class DeviceStorageScanner @Inject constructor(
                 }
 
                 val id = StorageId(internalId = volume.fsUuid, externalId = volumeId)
+                val isFatUuid = volumeId.toString().startsWith(StorageId.FAT_UUID_PREFIX)
+                val fileTotal = volume.path?.totalSpace ?: 0L
+                val fileFree = volume.path?.freeSpace ?: 0L
 
-                val totalBytes = try {
-                    // Secondary storage isn't available in on all APIs, (e.g. not on a Redmi 7A @ Android 9)
-                    storageStatsmanager.getTotalBytes(id)
+                val (totalBytes, freeBytes) = try {
+                    // Secondary storage isn't available on all APIs (e.g. not on a Redmi 7A @ Android 9).
+                    // Keep the pair coupled: if either call fails the sentinel guard the other is suspect too (#2389).
+                    val statsTotal = storageStatsmanager.getTotalBytes(id)
+                    val statsFree = storageStatsmanager.getFreeBytes(id)
+
+                    // For FAT synthesised UUIDs, StorageStatsManager is unreliable on some devices (#2389).
+                    // If statfs disagrees with the API by >10%, trust the filesystem.
+                    val mismatches = isFatUuid
+                        && fileTotal > 0
+                        && kotlin.math.abs(statsTotal - fileTotal) * 10 > fileTotal
+                    if (mismatches) {
+                        log(TAG, WARN) {
+                            "StorageStats total=$statsTotal disagrees with File=$fileTotal for FAT $id; using File"
+                        }
+                        fileTotal to fileFree
+                    } else {
+                        statsTotal to statsFree
+                    }
                 } catch (e: Exception) {
-                    log(TAG, WARN) { "Failed to get total bytes for $id" }
-                    volume.path?.totalSpace ?: 0L
+                    log(TAG, WARN) { "StorageStatsManager failed for $id, using File API: ${e.message}" }
+                    fileTotal to fileFree
                 }
-                val freeBytes = try {
-                    storageStatsmanager.getFreeBytes(id)
-                } catch (e: Exception) {
-                    log(TAG, WARN) { "Failed to get free bytes for $id" }
-                    volume.path?.freeSpace ?: 0L
+
+                if (totalBytes <= 0L) {
+                    log(TAG, WARN) { "Secondary volume reports zero capacity, skipping: $volume" }
+                    return@mapNotNull null
                 }
 
                 val type = when {

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/device/DeviceStorageScannerTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/device/DeviceStorageScannerTest.kt
@@ -1,0 +1,161 @@
+package eu.darken.sdmse.analyzer.core.device
+
+import eu.darken.sdmse.common.storage.StorageEnvironment
+import eu.darken.sdmse.common.storage.StorageId
+import eu.darken.sdmse.common.storage.StorageManager2
+import eu.darken.sdmse.common.storage.StorageStatsManager2
+import eu.darken.sdmse.common.storage.VolumeInfoX
+import eu.darken.sdmse.setup.SetupModule
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.io.File
+
+class DeviceStorageScannerTest : BaseTest() {
+
+    private val setupModule = mockk<SetupModule>()
+    private val environment = mockk<StorageEnvironment>(relaxed = true)
+    private val storageManager2 = mockk<StorageManager2>()
+    private val statsManager = mockk<StorageStatsManager2>()
+
+    private fun mockVolume(
+        fsUuid: String?,
+        path: File? = mockFile(totalSpace = 128_000_000_000L, freeSpace = 64_000_000_000L),
+        isUsb: Boolean = false,
+    ) = mockk<VolumeInfoX>().apply {
+        every { this@apply.fsUuid } returns fsUuid
+        every { this@apply.isPrimary } returns false
+        every { this@apply.isMounted } returns true
+        every { this@apply.path } returns path
+        every { this@apply.disk } returns mockk {
+            every { this@mockk.isUsb } returns isUsb
+        }
+    }
+
+    private fun mockFile(totalSpace: Long, freeSpace: Long): File = mockk<File>().apply {
+        every { this@apply.totalSpace } returns totalSpace
+        every { this@apply.freeSpace } returns freeSpace
+        every { this@apply.path } returns "/storage/mocked"
+    }
+
+    @BeforeEach
+    fun setup() {
+        val completeState = mockk<SetupModule.State.Current> {
+            every { isComplete } returns true
+            every { type } returns SetupModule.Type.STORAGE
+        }
+        every { setupModule.state } returns flowOf(completeState)
+        // Primary block: let stats succeed so environment.dataDir fallback is not exercised.
+        coEvery { statsManager.getTotalBytes(match { it.internalId == null }) } returns 128_000_000_000L
+        coEvery { statsManager.getFreeBytes(match { it.internalId == null }) } returns 64_000_000_000L
+    }
+
+    private fun createScanner() = DeviceStorageScanner(
+        storageSetupModule = setupModule,
+        environment = environment,
+        storageManager2 = storageManager2,
+        storageStatsmanager = statsManager,
+    )
+
+    private fun Set<DeviceStorage>.secondary() = firstOrNull { it.type == DeviceStorage.Type.SECONDARY }
+
+    @Test
+    fun `stats succeed on non-FAT UUID uses stats values`() = runTest {
+        val fsUuid = "12345678-1234-1234-1234-123456789abc"
+        every { storageManager2.volumes } returns listOf(mockVolume(fsUuid = fsUuid))
+        coEvery { statsManager.getTotalBytes(match { it.internalId == fsUuid }) } returns 256_000_000_000L
+        coEvery { statsManager.getFreeBytes(match { it.internalId == fsUuid }) } returns 100_000_000_000L
+
+        val secondary = createScanner().scan().secondary()
+
+        secondary shouldNotBe null
+        secondary!!.spaceCapacity shouldBe 256_000_000_000L
+        secondary.spaceFree shouldBe 100_000_000_000L
+    }
+
+    @Test
+    fun `getFreeBytes throws falls back to File for both`() = runTest {
+        val fsUuid = "12345678-1234-1234-1234-123456789abc"
+        val path = mockFile(totalSpace = 128_000_000_000L, freeSpace = 4_300_000_000L)
+        every { storageManager2.volumes } returns listOf(mockVolume(fsUuid = fsUuid, path = path))
+        coEvery { statsManager.getTotalBytes(match { it.internalId == fsUuid }) } returns 256_000_000_000L
+        coEvery { statsManager.getFreeBytes(match { it.internalId == fsUuid }) } throws IllegalStateException("sentinel")
+
+        val secondary = createScanner().scan().secondary()
+
+        secondary!!.spaceCapacity shouldBe 128_000_000_000L
+        secondary.spaceFree shouldBe 4_300_000_000L
+    }
+
+    @Test
+    fun `getTotalBytes throws falls back to File for both`() = runTest {
+        val fsUuid = "12345678-1234-1234-1234-123456789abc"
+        val path = mockFile(totalSpace = 128_000_000_000L, freeSpace = 4_300_000_000L)
+        every { storageManager2.volumes } returns listOf(mockVolume(fsUuid = fsUuid, path = path))
+        coEvery { statsManager.getTotalBytes(match { it.internalId == fsUuid }) } throws IllegalStateException("sentinel")
+        coEvery { statsManager.getFreeBytes(match { it.internalId == fsUuid }) } returns 50_000_000_000L
+
+        val secondary = createScanner().scan().secondary()
+
+        secondary!!.spaceCapacity shouldBe 128_000_000_000L
+        secondary.spaceFree shouldBe 4_300_000_000L
+    }
+
+    @Test
+    fun `FAT UUID with big mismatch prefers File (reproduces #2389)`() = runTest {
+        // Reporter's SD card: 128GB FAT, API says 256GB (2x wrong)
+        val fsUuid = "EFFD-F4D5"
+        val path = mockFile(totalSpace = 128_000_000_000L, freeSpace = 4_658_036_736L)
+        every { storageManager2.volumes } returns listOf(mockVolume(fsUuid = fsUuid, path = path))
+        // Both stats calls succeed with wrong-but-non-sentinel values (hypothetical — in #2389 getFreeBytes
+        // actually threw; this covers the case where it wouldn't have, so pair-coupling alone wouldn't help).
+        coEvery { statsManager.getTotalBytes(match { it.internalId == fsUuid }) } returns 256_000_000_000L
+        coEvery { statsManager.getFreeBytes(match { it.internalId == fsUuid }) } returns 4_658_036_736L
+
+        val secondary = createScanner().scan().secondary()
+
+        secondary!!.spaceCapacity shouldBe 128_000_000_000L
+        secondary.spaceFree shouldBe 4_658_036_736L
+    }
+
+    @Test
+    fun `FAT UUID with small mismatch keeps stats values`() = runTest {
+        // Within the 10% tolerance — don't second-guess the API.
+        val fsUuid = "EFFD-F4D5"
+        val path = mockFile(totalSpace = 128_000_000_000L, freeSpace = 50_000_000_000L)
+        every { storageManager2.volumes } returns listOf(mockVolume(fsUuid = fsUuid, path = path))
+        coEvery { statsManager.getTotalBytes(match { it.internalId == fsUuid }) } returns 130_000_000_000L
+        coEvery { statsManager.getFreeBytes(match { it.internalId == fsUuid }) } returns 52_000_000_000L
+
+        val secondary = createScanner().scan().secondary()
+
+        secondary!!.spaceCapacity shouldBe 130_000_000_000L
+        secondary.spaceFree shouldBe 52_000_000_000L
+    }
+
+    @Test
+    fun `zero capacity from all sources drops the volume`() = runTest {
+        val fsUuid = "12345678-1234-1234-1234-123456789abc"
+        every { storageManager2.volumes } returns listOf(mockVolume(fsUuid = fsUuid, path = null))
+        coEvery { statsManager.getTotalBytes(match { it.internalId == fsUuid }) } throws IllegalStateException("sentinel")
+        coEvery { statsManager.getFreeBytes(match { it.internalId == fsUuid }) } throws IllegalStateException("sentinel")
+
+        val result = createScanner().scan()
+
+        result.secondary() shouldBe null
+    }
+
+    @Test
+    fun `FAT prefix constant matches synthesised UUIDs`() {
+        // Sanity check that the isFatUuid detection key is correct.
+        val synthesised = StorageId.parseVolumeUuid("EFFD-F4D5")
+        synthesised!!.toString().startsWith(StorageId.FAT_UUID_PREFIX) shouldBe true
+    }
+}


### PR DESCRIPTION
## What changed

Fixed the Storage Analyzer showing the wrong capacity for SD cards on some devices. On affected devices (e.g. Xiaomi/Redmi on Android 13), a 128 GB FAT SD card could be reported as 256 GB, making the used-space breakdown nonsensical.

The storage trend chart behind each Analyzer card is recorded separately and had the same bug — it's now fixed too, so history recorded after the update is accurate.

## Technical Context

- **Root cause**: Android's `StorageStatsManager.getTotalBytes/getFreeBytes` can return wrong values for FAT volumes with synthesised UUIDs on some devices. Issue #1575 added sentinel guards for `0` and exactly `1TB`, but "merely wrong" values (in #2389: exactly 2× real) slipped through. The scanner called the two APIs independently, so a failed `getFreeBytes` (File-API fallback) combined with a bogus-but-plausible `getTotalBytes` produced inconsistent pairs — used-space ≈ capacity − free then came out as nonsense.
- **Three layered defences** in the secondary-volume branch (applied to both the Storage Analyzer scanner and the stats snapshot tracker):
  1. **Couple the pair** — if either `StorageStatsManager` call fails, fall back to File API (statfs) for both, so the two values always come from the same source.
  2. **FAT-UUID cross-check** — when the externalId was synthesised via `FAT_UUID_PREFIX`, compare `getTotalBytes` against `volume.path.totalSpace`; if they disagree by >10 %, trust the filesystem. statfs is authoritative for FAT volumes; the Android API is the unreliable leg.
  3. **Drop zero-capacity volumes** — skip secondary volumes whose final capacity resolves to 0 instead of emitting a `DeviceStorage` that produces NaN/Infinity in the percentage render.
- **Primary storage left unchanged** — `UUID_DEFAULT` carries Android's shared-pool semantics and hasn't shown wrong-by-2× reports. If a similar report appears for primary later, the same pattern can be applied separately.
- **`StorageId.FAT_UUID_PREFIX`** extracted as a constant so both the scanner and `SpaceTracker` can consistently detect synthesised UUIDs without duplicating the literal.
- **Review attention**: the 10 % threshold is deliberately loose — worst-case it falls back to statfs, which is what we'd want anyway on a mounted FAT volume. The `fileTotal > 0` guard ensures we never cross-check against a missing `volume.path`.

## Test plan

- [x] `:app-tool-analyzer:testDebugUnitTest` — new `DeviceStorageScannerTest` covers happy path, each sentinel throw, FAT mismatch >10 %, FAT mismatch <10 %, zero-capacity skip, and a FAT-prefix sanity check (7 tests, all passing alongside the existing 48).
- [x] `:app-common-stats:testDebugUnitTest`, `:app-common-data:testDebugUnitTest` — no regressions.
- [x] `:app:assembleFossDebug`, `:app:lintVitalFossRelease` — pass.
- [x] On-device run on a OnePlus Nord (CPH2621) with a 64 GB FAT SD card (label `63A9-9ED4`, same synthesised-UUID shape as the reporter's card). The new `"StorageStatsManager failed ... using File API"` warn fires because `getTotalBytes` returns `0`; the scanner falls back to statfs and the UI renders `7.7 GB / 64 GB` (matches the card and the logged bytes exactly).

Fixes #2389
Related: #1575
