### PR TITLE
AppControl: Add setting to hide the fast scroller on the app list

### DIFF
--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/AppControlSettings.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/AppControlSettings.kt
@@ -28,11 +28,13 @@ class AppControlSettings @Inject constructor(
     val listSort = dataStore.createValue("list.sort.settings", SortSettings(), json)
     val listFilter = dataStore.createValue("list.filter.settings", FilterSettings(), json)
     val ackSizeSortCaveat = dataStore.createValue("list.filter.sizesort.caveat.ack", false)
+    val listFastScrollerEnabled = dataStore.createValue("list.fastscroller.enabled", true)
     val moduleSizingEnabled = dataStore.createValue("module.sizing.enabled", true)
     val moduleActivityEnabled = dataStore.createValue("module.activity.enabled", true)
     val includeMultiUserEnabled = dataStore.createValue("include.multiuser.enabled", false)
 
     override val mapper = PreferenceStoreMapper(
+        listFastScrollerEnabled,
         moduleSizingEnabled,
         moduleActivityEnabled,
         includeMultiUserEnabled,

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListFragment.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListFragment.kt
@@ -262,7 +262,13 @@ class AppControlListFragment : Fragment3(R.layout.appcontrol_list_fragment) {
 
             loadingOverlay.setProgress(state.progress)
             list.isGone = state.progress != null
-            fastscroller.isInvisible = state.progress != null || state.appInfos.isNullOrEmpty()
+            val fastScrollerVisibility = when {
+                !state.fastScrollerEnabled -> View.GONE
+                state.progress != null || state.appInfos.isNullOrEmpty() -> View.INVISIBLE
+                else -> View.VISIBLE
+            }
+            fastscroller.visibility = fastScrollerVisibility
+            fastscrollerThumb.visibility = fastScrollerVisibility
             if (!drawer.isDrawerOpen) refreshAction.isInvisible = state.progress != null
 
             val checkedSortMode = when (state.options.listSort.mode) {

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListViewModel.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListViewModel.kt
@@ -276,7 +276,11 @@ class AppControlListViewModel @Inject constructor(
             )
             emit(finalState)
         }
-    }.asLiveData2()
+    }
+        .combine(settings.listFastScrollerEnabled.flow) { base, fastScrollerEnabled ->
+            base.copy(fastScrollerEnabled = fastScrollerEnabled)
+        }
+        .asLiveData2()
 
     fun updateSearchQuery(query: String) {
         log(TAG) { "updateSearchQuery($query)" }
@@ -515,6 +519,7 @@ class AppControlListViewModel @Inject constructor(
         val allowSortSize: Boolean = false,
         val allowSortScreenTime: Boolean = false,
         val allowFilterActive: Boolean = false,
+        val fastScrollerEnabled: Boolean = true,
     ) {
         val progress: Progress.Data?
             get() = progressWorker ?: progressUI

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/settings/AppControlSettingsFragment.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/settings/AppControlSettingsFragment.kt
@@ -27,6 +27,9 @@ class AppControlSettingsFragment : PreferenceFragment2() {
     override val settings: AppControlSettings by lazy { acSettings }
     override val preferenceFile: Int = R.xml.preferences_appcontrol
 
+    private val fastScroller: BadgedCheckboxPreference
+        get() = findPreference(settings.listFastScrollerEnabled.keyName)!!
+
     private val determineSizes: BadgedCheckboxPreference
         get() = findPreference(settings.moduleSizingEnabled.keyName)!!
 
@@ -39,6 +42,7 @@ class AppControlSettingsFragment : PreferenceFragment2() {
     override fun onPreferencesCreated() {
         super.onPreferencesCreated()
 
+        fastScroller.isRestricted = false
         determineSizes.badgedAction = {
             showSetupHint?.invoke(this@AppControlSettingsFragment, setOf(SetupModule.Type.USAGE_STATS))
         }

--- a/app-tool-appcontrol/src/main/res/values/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values/strings.xml
@@ -86,6 +86,8 @@
         <item quantity="one">%d app was toggled</item>
         <item quantity="other">%d apps were toggled</item>
     </plurals>
+    <string name="appcontrol_settings_fastscroller_enabled_label">Fast scroller</string>
+    <string name="appcontrol_settings_fastscroller_enabled_description">Show the fast scroll index on the right of the app list.</string>
     <string name="appcontrol_settings_module_sizing_enabled_label">Determine sizes</string>
     <string name="appcontrol_settings_module_sizing_enabled_description">Get a rough estimate of each app\'s size.</string>
     <string name="appcontrol_settings_module_activity_enabled_label">Determine activity</string>

--- a/app-tool-appcontrol/src/main/res/xml/preferences_appcontrol.xml
+++ b/app-tool-appcontrol/src/main/res/xml/preferences_appcontrol.xml
@@ -2,6 +2,13 @@
 <PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <eu.darken.sdmse.common.preferences.BadgedCheckboxPreference
+        app:icon="@drawable/ic_drag_vertical_24"
+        app:key="list.fastscroller.enabled"
+        app:singleLineTitle="false"
+        app:summary="@string/appcontrol_settings_fastscroller_enabled_description"
+        app:title="@string/appcontrol_settings_fastscroller_enabled_label" />
+
+    <eu.darken.sdmse.common.preferences.BadgedCheckboxPreference
         app:enabled="false"
         app:icon="@drawable/ic_weight_24"
         app:key="module.sizing.enabled"


### PR DESCRIPTION
## What changed

A new "Fast scroller" toggle has been added to AppControl's settings. When turned off, the index bar on the right edge of the app list (and its bubble that appears while scrubbing) is hidden — so information that was sitting behind it, like the byte-size labels under the "Size" sort, becomes fully visible.

The toggle defaults to on, so nothing changes for existing users until they opt in.

## Technical Context

- The flag is wired into `AppControlListViewModel.State` via an **outer** `combine(settings.listFastScrollerEnabled.flow)` rather than being added to `currentDisplayOptions`. Putting it inside the `flatMapLatest` pipeline would trigger a 250 ms blank-list/progress-overlay re-emission on every toggle.
- Fragment visibility is computed once (`when { !enabled -> GONE; progress-or-empty -> INVISIBLE; else -> VISIBLE }`) and applied to both `fastscroller` and `fastscrollerThumb`. Hiding only the scroller column previously left the thumb reachable via RecyclerView scroll events, so the two views now move in lockstep.
- `BadgedCheckboxPreference.isRestricted` defaults to `true`, so `AppControlSettingsFragment` explicitly unrestricts the new row — without this it would render badge-overlaid and disabled out of the box.
- Scope is AppControl only; other list screens use `zhanghai.FastScroller` via `setupDefaults()`, which is a different component and out of scope for this change.

Closes #2378
