### PR TITLE
Squeezer: Preserve original modification date on compressed files

### DIFF
--- a/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/processor/FileOps.kt
+++ b/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/processor/FileOps.kt
@@ -44,6 +44,8 @@ interface FileOps {
     suspend fun createFile(file: File): Boolean
     suspend fun listFiles(dir: File): List<File>
     suspend fun copyFile(from: File, to: File)
+    suspend fun getLastModified(file: File): Long
+    suspend fun setLastModified(file: File, time: Long): Boolean
 }
 
 @Reusable
@@ -89,6 +91,15 @@ class GatewayFileOps @Inject constructor(
         from.inputStream().use { input ->
             to.outputStream().use { output -> input.copyTo(output) }
         }
+    }
+
+    override suspend fun getLastModified(file: File): Long = file.lastModified()
+
+    override suspend fun setLastModified(file: File, time: Long): Boolean = try {
+        file.setLastModified(time)
+    } catch (e: Exception) {
+        log(TAG, WARN) { "setLastModified failed for ${file.path}: ${e.message}" }
+        false
     }
 
     companion object {

--- a/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/processor/FileTransaction.kt
+++ b/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/processor/FileTransaction.kt
@@ -116,6 +116,20 @@ class FileTransaction @Inject constructor(
             }
 
             try {
+                // Preserve the original mtime so gallery apps that sort by date don't reorder
+                // compressed files (issue #2388). Set it on the temp inode before the final
+                // rename: rename preserves inode metadata, so the timestamp carries through.
+                // Doing it post-rename would leave a process-death window where orphan recovery
+                // deletes the backup but target still has the "now" mtime.
+                val originalModifiedAt = fileOps.getLastModified(backupFile)
+                if (originalModifiedAt > 0L) {
+                    if (!fileOps.setLastModified(tempFile, originalModifiedAt)) {
+                        log(TAG, WARN) {
+                            "Failed to preserve modification date for ${target.path}"
+                        }
+                    }
+                }
+
                 // Atomic same-volume rename. The workdir sits next to target so this should
                 // always succeed. If it doesn't, fail closed — a copy fallback would risk
                 // data loss if the app dies mid-copy (orphan recovery can't distinguish a

--- a/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/core/processor/FileTransactionTest.kt
+++ b/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/core/processor/FileTransactionTest.kt
@@ -1,5 +1,6 @@
 package eu.darken.sdmse.squeezer.core.processor
 
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.test.runTest
@@ -22,6 +23,8 @@ class FileTransactionTest : BaseTest() {
     private class FakeFileOps : FileOps {
         var renameBlocker: (from: File, to: File) -> Boolean = { _, _ -> false }
         var copyBlocker: (from: File, to: File) -> Boolean = { _, _ -> false }
+        var setLastModifiedBlocker: (file: File, time: Long) -> Boolean = { _, _ -> false }
+        val setLastModifiedCalls = mutableListOf<Pair<File, Long>>()
 
         override suspend fun exists(file: File): Boolean = file.exists()
         override suspend fun canRead(file: File): Boolean = file.canRead()
@@ -53,6 +56,14 @@ class FileTransactionTest : BaseTest() {
             from.inputStream().use { input ->
                 to.outputStream().use { output -> input.copyTo(output) }
             }
+        }
+
+        override suspend fun getLastModified(file: File): Long = file.lastModified()
+
+        override suspend fun setLastModified(file: File, time: Long): Boolean {
+            setLastModifiedCalls.add(file to time)
+            if (setLastModifiedBlocker(file, time)) return false
+            return file.setLastModified(time)
         }
     }
 
@@ -373,7 +384,64 @@ class FileTransactionTest : BaseTest() {
         tempFile(target).exists() shouldBe false
     }
 
+    // --- Timestamp preservation tests (issue #2388) ---
+
+    @Test
+    fun `target retains original mtime after successful swap`() = runTest {
+        val original = ByteArray(1000) { 0x11 }
+        val target = targetWith(original)
+        val originalMtime = FIXED_MTIME_MILLIS
+        target.setLastModified(originalMtime) shouldBe true
+
+        val outcome = subject.replace(target, dryRun = false) { tempFile ->
+            tempFile.writeBytes(ByteArray(300) { 0x22 })
+        }
+
+        outcome.replaced shouldBe true
+        target.lastModified() shouldBe originalMtime
+    }
+
+    @Test
+    fun `no-savings path does not touch mtime`() = runTest {
+        // Replacement same size → transaction aborts before any rename.
+        val target = targetWith(ByteArray(500) { 0x11 })
+
+        subject.replace(target, dryRun = false) { tempFile ->
+            tempFile.writeBytes(ByteArray(500) { 0x22 })
+        }
+
+        fileOps.setLastModifiedCalls.shouldBeEmpty()
+    }
+
+    @Test
+    fun `dryRun does not touch mtime`() = runTest {
+        val target = targetWith(ByteArray(1000) { 0x11 })
+
+        subject.replace(target, dryRun = true) { tempFile ->
+            tempFile.writeBytes(ByteArray(300) { 0x22 })
+        }
+
+        fileOps.setLastModifiedCalls.shouldBeEmpty()
+    }
+
+    @Test
+    fun `setLastModified failure does not fail the transaction`() = runTest {
+        val target = targetWith(ByteArray(1000) { 0x11 })
+        fileOps.setLastModifiedBlocker = { _, _ -> true }
+
+        val outcome = subject.replace(target, dryRun = false) { tempFile ->
+            tempFile.writeBytes(ByteArray(300) { 0x22 })
+        }
+
+        outcome.replaced shouldBe true
+        target.length() shouldBe 300L
+        backupFile(target).exists() shouldBe false
+        tempFile(target).exists() shouldBe false
+    }
+
     companion object {
         private const val IO_TEST_BASEDIR = "build/tmp/unit_tests"
+
+        private const val FIXED_MTIME_MILLIS = 1_600_000_000_000L
     }
 }


### PR DESCRIPTION
## What changed

Fixed the Media Squeeze tool reordering photos in gallery apps that sort by date. Compressed files now keep their original modification date instead of being stamped with the current time. Verified on a Pixel 7a — compressed test images shrank by ~65% and retained their original mtime bit-exactly.

## Technical Context

- **Root cause**: the atomic swap at the end of compression did `rename(tempFile → target)`, where the temp file was freshly written and carried "now" as its mtime. The filesystem mtime was never restored.
- **Where mtime is captured**: from `backupFile` *after* the `rename(target → backup)` step — this reflects the actual inode being replaced. Capturing at the start of `replace()` would risk restoring a stale value if something touched the file during a long video transcode.
- **Where mtime is applied**: on the temp inode *before* the final rename. POSIX `rename(2)` preserves inode metadata, so the final target inherits the mtime. Writing mtime post-rename would leave a process-death window where orphan recovery sees a valid target + backup and deletes the backup before the mtime write lands, permanently losing the original.
- **Unconditional, no toggle**: this is the behaviour users expect from a "compress in place" tool; the alternative (always-new mtime) has no real use case. A toggle can be added later if someone reports wanting the old behaviour back.
- **Scope**: the Squeezer compression pipeline is `LocalPath`-only (Media3 Transformer and BitmapFactory require raw `File` access), so `File.setLastModified` is sufficient — no gateway escalation needed.
- **Failure handling**: if `File.setLastModified` returns false or throws (read-only filesystem, permission flip), the transaction still succeeds — compression has already happened, mtime drift is a strictly better outcome than rolling back. Covered by a dedicated unit test.

Closes #2388
