### PR TITLE
Fix: Open app even when storage is completely full

### DIFF
--- a/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/TaskStatsCoordinator.kt
+++ b/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/TaskStatsCoordinator.kt
@@ -6,6 +6,7 @@ import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.flow.withPrevious
+import eu.darken.sdmse.common.storage.StorageRescue
 import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -21,6 +22,7 @@ class TaskStatsCoordinator @Inject constructor(
     @AppScope private val appScope: CoroutineScope,
     private val taskSubmitter: TaskSubmitter,
     private val statsRepo: StatsRepo,
+    private val storageRescue: StorageRescue,
 ) {
     private val isStarted = AtomicBoolean(false)
 
@@ -56,6 +58,9 @@ class TaskStatsCoordinator @Inject constructor(
                     } catch (e: Exception) {
                         log(TAG, WARN) { "Failed to record idle snapshot: ${e.asLog()}" }
                     }
+                    // restoreIfPossible() catches all non-cancellation exceptions internally,
+                    // so a wrapper try/catch here would be dead code.
+                    storageRescue.restoreIfPossible()
                 }
             }
             .launchIn(appScope)

--- a/app-common/src/main/java/eu/darken/sdmse/common/storage/StorageRescue.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/storage/StorageRescue.kt
@@ -1,0 +1,130 @@
+package eu.darken.sdmse.common.storage
+
+import android.content.Context
+import android.util.Log
+import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.sdmse.common.coroutine.DispatcherProvider
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.asLog
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileOutputStream
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Pre-allocates a small file (RESCUE_SIZE) in the app's no-backup data dir. When the
+ * device runs out of space, [releaseIfNeeded] frees that file early in app startup so
+ * DataStore / Room / log writes during App init have somewhere to land. After the user
+ * actually frees disk space, [restoreIfPossible] re-allocates the rescue.
+ *
+ * See issue #2401 for the original crash this guards against.
+ */
+@Singleton
+class StorageRescue @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val dispatcherProvider: DispatcherProvider,
+) {
+
+    private val baseDir: File
+        get() = context.noBackupFilesDir
+
+    private val rescueFile: File
+        get() = File(baseDir, RESCUE_FILE_NAME)
+
+    private val mutex = Mutex()
+
+    suspend fun restoreIfPossible() = withContext(dispatcherProvider.IO + NonCancellable) {
+        mutex.withLock {
+            try {
+                if (rescueFile.exists() && rescueFile.length() == RESCUE_SIZE) {
+                    log(TAG) { "restoreIfPossible(): already allocated" }
+                    return@withLock
+                }
+                if (rescueFile.exists()) {
+                    log(TAG) { "restoreIfPossible(): cleaning wrong-size leftover" }
+                    rescueFile.delete()
+                }
+
+                val usable = baseDir.usableSpace
+                if (usable < CREATE_THRESHOLD) {
+                    log(TAG) { "restoreIfPossible(): not enough headroom ($usable), skipping" }
+                    return@withLock
+                }
+
+                // Write actual bytes. RandomAccessFile.setLength() can produce sparse
+                // files on ext4/F2FS where blocks aren't reserved, defeating the rescue.
+                val buf = ByteArray(WRITE_BUFFER_SIZE)
+                FileOutputStream(rescueFile).use { out ->
+                    var written = 0L
+                    while (written < RESCUE_SIZE) {
+                        val n = minOf(buf.size.toLong(), RESCUE_SIZE - written).toInt()
+                        out.write(buf, 0, n)
+                        written += n
+                    }
+                    out.fd.sync()
+                }
+                log(TAG, INFO) { "Allocated rescue file: ${rescueFile.length()} bytes" }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                log(TAG, WARN) { "Failed to allocate rescue file: ${e.asLog()}" }
+                try {
+                    rescueFile.delete()
+                } catch (_: Exception) {
+                }
+            }
+        }
+    }
+
+    companion object {
+        private const val STATIC_TAG = "StorageRescue"
+        private val TAG = logTag(STATIC_TAG)
+        private const val RESCUE_FILE_NAME = "storage_rescue.bin"
+        private const val RESCUE_SIZE = 2L * 1024 * 1024
+        // Release the rescue only when free space is below the rescue's own size:
+        // releasing it gives us back exactly RESCUE_SIZE bytes of headroom.
+        private const val RELEASE_THRESHOLD = RESCUE_SIZE
+        private const val CREATE_THRESHOLD = 10L * 1024 * 1024
+        private const val WRITE_BUFFER_SIZE = 64 * 1024
+
+        /**
+         * Synchronous, dependency-free, callable from [android.app.Application.attachBaseContext]
+         * BEFORE Hilt field-injection runs in `super.onCreate()`. Must not throw under any
+         * condition — this is the very first thing that runs on app launch.
+         *
+         * Hilt-injected singletons can fire DataStore/Room writes from their `init {}` blocks
+         * the moment they're constructed (e.g. RecorderModule.init reads
+         * debugSettings.recorderPath; ReportsDatabase.init runs Room queries). Doing the
+         * release inside onCreate() AFTER super.onCreate() is too late.
+         *
+         * Uses [android.util.Log] directly because the project's Logging system is
+         * installed inside onCreate() and isn't yet configured at attachBaseContext.
+         */
+        fun releaseIfNeeded(context: Context) {
+            try {
+                val baseDir = context.noBackupFilesDir
+                val rescueFile = File(baseDir, RESCUE_FILE_NAME)
+                val usable = baseDir.usableSpace
+
+                if (usable < RELEASE_THRESHOLD && rescueFile.exists()) {
+                    val deleted = rescueFile.delete()
+                    val after = baseDir.usableSpace
+                    Log.w(
+                        STATIC_TAG,
+                        "Released rescue (deleted=$deleted): usable $usable -> $after"
+                    )
+                }
+            } catch (e: Throwable) {
+                Log.e(STATIC_TAG, "releaseIfNeeded failed", e)
+            }
+        }
+    }
+}

--- a/app-common/src/test/java/eu/darken/sdmse/common/storage/StorageRescueTest.kt
+++ b/app-common/src/test/java/eu/darken/sdmse/common/storage/StorageRescueTest.kt
@@ -1,0 +1,174 @@
+package eu.darken.sdmse.common.storage
+
+import android.content.Context
+import android.util.Log
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.spyk
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import java.io.File
+
+class StorageRescueTest : BaseTest() {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    private lateinit var baseDir: File
+    private lateinit var rescueFile: File
+    private lateinit var context: Context
+    private val dispatcherProvider = TestDispatcherProvider()
+
+    private val rescueSize: Long = 2L * 1024 * 1024
+    private val createThreshold: Long = 10L * 1024 * 1024
+    private val releaseThreshold: Long = 2L * 1024 * 1024
+
+    @BeforeEach
+    fun setup() {
+        // releaseIfNeeded uses android.util.Log directly because it runs before
+        // the project's Logging system is installed. Stub Log in JVM tests.
+        mockkStatic(Log::class)
+        every { Log.w(any<String>(), any<String>()) } returns 0
+        every { Log.e(any<String>(), any<String>(), any()) } returns 0
+
+        baseDir = spyk(File(tempDir, "no_backup").apply { mkdirs() })
+        rescueFile = File(baseDir, "storage_rescue.bin")
+        context = mockk(relaxed = true)
+        every { context.noBackupFilesDir } returns baseDir
+    }
+
+    @AfterEach
+    fun teardown() {
+        rescueFile.delete()
+        baseDir.deleteRecursively()
+        unmockkStatic(Log::class)
+    }
+
+    private fun newRescue() = StorageRescue(context, dispatcherProvider)
+
+    // -------- restoreIfPossible --------
+
+    @Test
+    fun `restoreIfPossible allocates rescue when space is comfortable`() = runTest {
+        every { baseDir.usableSpace } returns 100L * 1024 * 1024
+
+        newRescue().restoreIfPossible()
+
+        rescueFile.exists() shouldBe true
+        rescueFile.length() shouldBe rescueSize
+    }
+
+    @Test
+    fun `restoreIfPossible no-ops when rescue already correct size`() = runTest {
+        every { baseDir.usableSpace } returns 100L * 1024 * 1024
+        rescueFile.writeBytes(ByteArray(rescueSize.toInt()))
+        val originalLastModified = rescueFile.lastModified()
+        Thread.sleep(20)
+
+        newRescue().restoreIfPossible()
+
+        rescueFile.exists() shouldBe true
+        rescueFile.length() shouldBe rescueSize
+        rescueFile.lastModified() shouldBe originalLastModified
+    }
+
+    @Test
+    fun `restoreIfPossible cleans wrong-size leftover and recreates`() = runTest {
+        every { baseDir.usableSpace } returns 100L * 1024 * 1024
+        rescueFile.writeBytes(ByteArray(123))
+
+        newRescue().restoreIfPossible()
+
+        rescueFile.exists() shouldBe true
+        rescueFile.length() shouldBe rescueSize
+    }
+
+    @Test
+    fun `restoreIfPossible skips when usable space well below CREATE_THRESHOLD`() = runTest {
+        every { baseDir.usableSpace } returns 0L
+
+        newRescue().restoreIfPossible()
+
+        rescueFile.exists() shouldBe false
+    }
+
+    @Test
+    fun `restoreIfPossible skips when usable space exactly at CREATE_THRESHOLD - 1`() = runTest {
+        every { baseDir.usableSpace } returns createThreshold - 1
+
+        newRescue().restoreIfPossible()
+
+        rescueFile.exists() shouldBe false
+    }
+
+    @Test
+    fun `restoreIfPossible allocates when usable space exactly at CREATE_THRESHOLD`() = runTest {
+        every { baseDir.usableSpace } returns createThreshold
+
+        newRescue().restoreIfPossible()
+
+        rescueFile.exists() shouldBe true
+        rescueFile.length() shouldBe rescueSize
+    }
+
+    @Test
+    fun `restoreIfPossible is idempotent under repeated invocations`() = runTest {
+        every { baseDir.usableSpace } returns 100L * 1024 * 1024
+        val rescue = newRescue()
+
+        val jobs = (1..5).map { async { rescue.restoreIfPossible() } }
+        jobs.awaitAll()
+
+        rescueFile.exists() shouldBe true
+        rescueFile.length() shouldBe rescueSize
+    }
+
+    // -------- releaseIfNeeded --------
+
+    @Test
+    fun `releaseIfNeeded deletes rescue when usable space below threshold`() {
+        every { baseDir.usableSpace } returns releaseThreshold - 1
+        rescueFile.writeBytes(ByteArray(rescueSize.toInt()))
+
+        StorageRescue.releaseIfNeeded(context)
+
+        rescueFile.exists() shouldBe false
+    }
+
+    @Test
+    fun `releaseIfNeeded keeps rescue when usable space at or above threshold`() {
+        every { baseDir.usableSpace } returns releaseThreshold
+        rescueFile.writeBytes(ByteArray(rescueSize.toInt()))
+
+        StorageRescue.releaseIfNeeded(context)
+
+        rescueFile.exists() shouldBe true
+    }
+
+    @Test
+    fun `releaseIfNeeded is a no-op when no rescue file exists`() {
+        every { baseDir.usableSpace } returns 0L
+        rescueFile.exists() shouldBe false
+
+        StorageRescue.releaseIfNeeded(context)
+
+        rescueFile.exists() shouldBe false
+    }
+
+    @Test
+    fun `releaseIfNeeded swallows exceptions and does not throw`() {
+        every { context.noBackupFilesDir } throws SecurityException("denied")
+
+        StorageRescue.releaseIfNeeded(context) // must not throw
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/App.kt
+++ b/app/src/main/java/eu/darken/sdmse/App.kt
@@ -1,6 +1,7 @@
 package eu.darken.sdmse
 
 import android.app.Application
+import android.content.Context
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
 import coil.Coil
@@ -24,6 +25,7 @@ import eu.darken.sdmse.common.error.installErrorDialogCustomizer
 import eu.darken.sdmse.setup.installShowSetupHint
 import eu.darken.sdmse.common.debug.memory.MemoryMonitor
 import eu.darken.sdmse.common.debug.recorder.core.RecorderModule
+import eu.darken.sdmse.common.storage.StorageRescue
 import eu.darken.sdmse.common.theming.Theming
 import eu.darken.sdmse.common.updater.UpdateService
 import eu.darken.sdmse.main.core.CurriculumVitae
@@ -57,8 +59,17 @@ open class App : Application(), Configuration.Provider {
     @Inject lateinit var shortcutManager: ShortcutManager
     @Inject lateinit var spaceMonitorControl: SpaceMonitorControl
     @Inject lateinit var taskStatsCoordinator: TaskStatsCoordinator
+    @Inject lateinit var storageRescue: StorageRescue
 
     private val logCatLogger = LogCatLogger()
+
+    override fun attachBaseContext(base: Context) {
+        super.attachBaseContext(base)
+        // Runs BEFORE Hilt field-injection in super.onCreate(): release the storage
+        // rescue early so the very first DataStore/Room writes triggered by
+        // singleton init blocks have somewhere to land. See StorageRescue / #2401.
+        StorageRescue.releaseIfNeeded(this)
+    }
 
     override fun onCreate() {
         super.onCreate()
@@ -97,6 +108,7 @@ open class App : Application(), Configuration.Provider {
         memoryMonitor.register()
 
         appScope.launch { coilTempFiles.cleanUp() }
+        appScope.launch { storageRescue.restoreIfPossible() }
         Coil.setImageLoader(imageLoaderFactory)
 
         curriculumVitae.updateAppLaunch()


### PR DESCRIPTION
## What changed

Fixed a crash that prevented opening the app on devices with 0 bytes of free storage — exactly the situation where users want to open SD Maid SE to free up space.

After the fix, the app can be opened and used to scan and delete files even when device storage is completely full.

## Technical Context

- **Root cause**: `App.onCreate` triggers `CurriculumVitae.updateAppLaunch()` which writes 5 keys via DataStore. At 0 bytes free, DataStore cannot create its `.preferences_pb.tmp` file → `IOException: ENOSPC` → uncaught in `appScope` (no `CoroutineExceptionHandler`) → app crash. Other unguarded writes (RecorderModule init, ReportsDatabase init, AnniversaryProvider) compound the failure surface on the same launch.
- **Approach**: `StorageRescue` pre-allocates a 2 MB file in `noBackupFilesDir` when free space is comfortable (≥ 10 MB). On launch when usable space < 2 MB, the static `releaseIfNeeded()` runs from `App.attachBaseContext()` — *before* Hilt field injection in `super.onCreate()` — and deletes the rescue. That gives the very first DataStore/Room writes from injected singleton init blocks (`RecorderModule`, `ReportsDatabase`) and `CurriculumVitae` somewhere to land.
- **Recreation**: hooked into the existing `TaskStatsCoordinator` idle observer — after a task completes and the user has actually freed space, the rescue is reallocated. No new background worker.
- **Why no centralised `try/catch` in `DataStoreValue.update()`**: explicit decision to keep the rescue file as the sole defense rather than silently swallowing `IOException` across every settings write.
- **Sparse-file pitfall**: rescue is written via `FileOutputStream` + `fd.sync()` so blocks are actually reserved on ext4/F2FS — `RandomAccessFile.setLength()` would have produced a sparse file that doesn't free anything when deleted.
- **Manually verified on an emulator**: filled `/data` to 0 bytes free, launched the app — release fired (`usable 224 KB → 2.3 MB`), dashboard rendered, scan found 37 MB / 60 items across CorpseFinder/SystemCleaner/AppCleaner, idle observer reallocated the rescue. Zero FATAL exceptions in logcat.
- **Unhandled edge case**: a user upgrading to this build *while at 0 bytes free for the first time ever* has no rescue file yet, so the original crash still happens on that one launch. After any successful launch with some free space, they're protected.

Closes #2401
