### PR TITLE
CI: Skip release bump-only workflow runs

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -3,6 +3,9 @@ name: Code tests & eval
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - VERSION
+      - version.properties
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - VERSION
+      - version.properties
   pull_request:
     branches:
       - main

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,6 +3,14 @@ name: Deploy GitHub Pages
 on:
   push:
     branches: [ main ]
+    paths:
+      - _config.yml
+      - _layouts/**
+      - README.md
+      - CHANGELOG.md
+      - PRIVACY_POLICY.md
+      - CNAME
+      - .github/workflows/pages.yml
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- skip main-branch CI and Gradle wrapper validation when a release bump only changes `VERSION` and `version.properties`
- limit automatic Pages deployments on `main` to site-relevant files
- keep PR triggers unchanged so required checks still run for pull requests

## Validation
- `git diff --check`
- parsed edited workflow YAML files with Ruby `YAML.load_file`