### PR TITLE
AppCleaner: Fix nothing being cleaned on Honor devices in Dutch

### DIFF
--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/honor/HonorLabels.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/honor/HonorLabels.kt
@@ -6,6 +6,7 @@ import eu.darken.sdmse.appcleaner.core.automation.specs.aosp.AOSPLabels
 import eu.darken.sdmse.automation.core.specs.AutomationExplorer
 import eu.darken.sdmse.automation.core.specs.getLocales
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.pkgs.toPkgId
 import javax.inject.Inject
 
 @Reusable
@@ -16,6 +17,10 @@ class HonorLabels @Inject constructor(
     fun getStorageEntryDynamic(
         acsContext: AutomationExplorer.Context
     ): Set<String> = aospLabels.getStorageEntryDynamic(acsContext)
+        // HONOR/PTP-N49EEA/HNPTPX:16/HONORPTP-N49/10.0.0.140C431E6R4P2:user/release-keys
+        // Honor's Settings APK strips `storage_settings_for_app`; fall back to the legacy
+        // `storage_settings` resource which resolves to the same on-screen text on those ROMs.
+        .append { acsContext.getStrings(SETTINGS_PKG, setOf("storage_settings")) }
 
     fun getStorageEntryStatic(acsContext: AutomationExplorer.Context): Set<String> = acsContext.getLocales()
         .map { it.language to it.script }
@@ -24,6 +29,11 @@ class HonorLabels @Inject constructor(
                 "pl".toLang() == lang -> setOf(
                     // HONOR/PGT-N19EEA/HNPGT:13/HONORPGT-N49/7.1.0.176C431E3R2P3:user/release-keys
                     "Pamięć",
+                )
+
+                "nl".toLang() == lang -> setOf(
+                    // HONOR/PTP-N49EEA/HNPTPX:16/HONORPTP-N49/10.0.0.140C431E6R4P2:user/release-keys
+                    "Opslag",
                 )
 
                 else -> null
@@ -45,10 +55,11 @@ class HonorLabels @Inject constructor(
             }
         }
         .flatten()
-        .append { aospLabels.getStorageEntryStatic(acsContext) }
+        .append { aospLabels.getClearCacheStatic(acsContext) }
         .toSet()
 
     companion object {
         private val TAG: String = logTag("AppCleaner", "Automation", "Honor", "Labels")
+        val SETTINGS_PKG = "com.android.settings".toPkgId()
     }
 }


### PR DESCRIPTION
## What changed

Fixes AppCleaner skipping every app without doing anything on Honor devices set to Dutch.

On these devices, the system Settings page shows the storage entry simply as 'Opslag', a label SD Maid did not yet recognize. As a result, the cleaner could not find where to tap to clear the cache, so every app was silently skipped.

## Technical Context

- **Root cause**: Honor's Settings APK ships the legacy 'storage_settings' resource id but not the 'storage_settings_for_app' id that AOSP API 29+ added. `AOSPLabels29Plus.getStorageEntryDynamic` only probes the latter, so on Honor it returned an empty set. The Dutch static label list (`AOSPLabels29Plus` / `AOSPLabels14Plus`) only contained 'Opslag en cache' and 'Opslagruimte' — neither matches the bare 'Opslag' that Honor displays.
- **Scope**: Fix is Honor-only — `HonorLabels.getStorageEntryDynamic` now also probes 'storage_settings' (mirrors the existing `HuaweiLabels` pattern). The AOSP base classes are untouched.
- **Belt-and-braces**: Added Dutch 'Opslag' to `HonorLabels.getStorageEntryStatic` so cleaning still works if the dynamic resource lookup fails.
- **Drive-by**: Fixed a copy-paste bug in `HonorLabels.getClearCacheStatic` — it was appending `aospLabels.getStorageEntryStatic` instead of `aospLabels.getClearCacheStatic`, polluting the clear-cache button matcher with storage-entry labels.
- **Out of scope**: Honor's app-info screen also reports a different size (data only) than `StorageStatsManager` returns (app + data), which defeats the size-based fallback in `StorageEntryFinder`. Not addressed here — this PR fixes the label path only.