### PR TITLE
Squeezer: Preserve original creation date for compressed videos

### DIFF
--- a/app-tool-squeezer/build.gradle.kts
+++ b/app-tool-squeezer/build.gradle.kts
@@ -72,6 +72,8 @@ dependencies {
     implementation("io.github.panpf.zoomimage:zoomimage-view-coil2:1.4.0")
 
     implementation("androidx.media3:media3-transformer:${Versions.AndroidX.Media3.core}")
+    implementation("androidx.media3:media3-muxer:${Versions.AndroidX.Media3.core}")
+    implementation("androidx.media3:media3-container:${Versions.AndroidX.Media3.core}")
 
     addTesting()
     testImplementation(project(":app-common-test"))

--- a/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/processor/VideoTimestampPreserver.kt
+++ b/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/processor/VideoTimestampPreserver.kt
@@ -1,0 +1,217 @@
+package eu.darken.sdmse.squeezer.core.processor
+
+import android.media.MediaMetadataRetriever
+import dagger.Reusable
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import java.io.File
+import java.io.IOException
+import java.io.RandomAccessFile
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+import javax.inject.Inject
+
+/**
+ * Reads the source video's `mvhd` `creation_time` + `modification_time` so the same
+ * values can be injected into the Media3 `Transformer` output. Without this, gallery
+ * apps reorder compressed videos: `MediaStore.DATE_TAKEN` is sourced from `mvhd`
+ * `creation_time`, and Media3's muxer writes "now" by default.
+ *
+ * Two extraction paths in priority order:
+ * 1. Atom walker on the source MP4 — gives both `creation_time` and `modification_time` directly.
+ * 2. `MediaMetadataRetriever.METADATA_KEY_DATE` fallback — only exposes one date, so
+ *    `modification_time` is set equal to `creation_time` for that path.
+ *
+ * Best-effort: extraction failures return `null` and the caller skips preservation.
+ */
+@Reusable
+class VideoTimestampPreserver @Inject constructor() {
+
+    data class TimestampData(
+        val creationTimeMp4Seconds: Long,
+        val modificationTimeMp4Seconds: Long,
+    )
+
+    fun extract(file: File): TimestampData? {
+        extractFromMvhd(file)?.let { return it }
+        return extractFromMmr(file)
+    }
+
+    internal fun parseMetadataDate(value: String?): Instant? {
+        // AOSP returns ISO 8601 *basic* format (no separators):
+        // e.g. "20260510T123456.000Z". `Instant.parse()` requires the extended format
+        // and would throw, so we use a dedicated formatter.
+        if (value.isNullOrBlank()) return null
+        return try {
+            BASIC_ISO_FORMATTER.parse(value, Instant::from)
+        } catch (e: DateTimeParseException) {
+            null
+        }
+    }
+
+    internal fun extractFromMvhd(file: File): TimestampData? {
+        return try {
+            RandomAccessFile(file, "r").use { raf ->
+                val fileSize = raf.length()
+                val moov = findTopLevelBox(raf, 0L, fileSize, BOX_MOOV) ?: return null
+                val mvhd = findChildBox(raf, moov, BOX_MVHD) ?: return null
+                readMvhdTimes(raf, mvhd)
+            }
+        } catch (e: IOException) {
+            log(TAG, WARN) { "mvhd extraction failed for ${file.path}: ${e.message}" }
+            null
+        } catch (e: Exception) {
+            log(TAG, WARN) { "mvhd extraction failed for ${file.path}: ${e.message}" }
+            null
+        }
+    }
+
+    private fun extractFromMmr(file: File): TimestampData? {
+        return try {
+            val retriever = MediaMetadataRetriever()
+            try {
+                retriever.setDataSource(file.absolutePath)
+                val date = parseMetadataDate(
+                    retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DATE)
+                ) ?: return null
+                val mp4 = date.epochSecond + MP4_EPOCH_OFFSET_SECONDS
+                if (!isPlausible(mp4)) return null
+                TimestampData(creationTimeMp4Seconds = mp4, modificationTimeMp4Seconds = mp4)
+            } finally {
+                retriever.release()
+            }
+        } catch (e: Exception) {
+            log(TAG, WARN) { "MMR extraction failed for ${file.path}: ${e.message}" }
+            null
+        }
+    }
+
+    private data class BoxRange(val payloadStart: Long, val payloadEnd: Long)
+
+    private data class BoxHeader(val type: Int, val payloadStart: Long, val boxEnd: Long)
+
+    private fun findTopLevelBox(raf: RandomAccessFile, start: Long, end: Long, type: Int): BoxRange? {
+        var pos = start
+        while (pos < end) {
+            val header = readBoxHeader(raf, pos, end, allowExtendsToEof = true) ?: return null
+            if (header.type == type) {
+                return BoxRange(payloadStart = header.payloadStart, payloadEnd = header.boxEnd)
+            }
+            pos = header.boxEnd
+        }
+        return null
+    }
+
+    private fun findChildBox(raf: RandomAccessFile, parent: BoxRange, type: Int): BoxRange? {
+        var pos = parent.payloadStart
+        while (pos < parent.payloadEnd) {
+            val header = readBoxHeader(raf, pos, parent.payloadEnd, allowExtendsToEof = false) ?: return null
+            if (header.type == type) {
+                return BoxRange(payloadStart = header.payloadStart, payloadEnd = header.boxEnd)
+            }
+            pos = header.boxEnd
+        }
+        return null
+    }
+
+    private fun readBoxHeader(
+        raf: RandomAccessFile,
+        offset: Long,
+        parentEnd: Long,
+        allowExtendsToEof: Boolean,
+    ): BoxHeader? {
+        if (offset + MIN_HEADER_SIZE > parentEnd) return null
+
+        raf.seek(offset)
+        val sizeRaw = raf.readInt().toLong() and 0xffffffffL
+        val type = raf.readInt()
+
+        val payloadStart: Long
+        val boxEnd: Long
+        when {
+            sizeRaw == 1L -> {
+                if (offset + LARGESIZE_HEADER_SIZE > parentEnd) return null
+                val largesize = raf.readLong()
+                if (largesize < LARGESIZE_HEADER_SIZE) return null
+                payloadStart = offset + LARGESIZE_HEADER_SIZE
+                boxEnd = offset + largesize
+            }
+            sizeRaw == 0L -> {
+                // "extends to EOF" is only valid at top level per ISO/IEC 14496-12.
+                if (!allowExtendsToEof) return null
+                payloadStart = offset + MIN_HEADER_SIZE
+                boxEnd = parentEnd
+            }
+            sizeRaw < MIN_HEADER_SIZE -> return null
+            else -> {
+                payloadStart = offset + MIN_HEADER_SIZE
+                boxEnd = offset + sizeRaw
+            }
+        }
+
+        if (boxEnd > parentEnd) return null
+        if (payloadStart > boxEnd) return null
+
+        return BoxHeader(type = type, payloadStart = payloadStart, boxEnd = boxEnd)
+    }
+
+    private fun readMvhdTimes(raf: RandomAccessFile, mvhd: BoxRange): TimestampData? {
+        val payloadSize = mvhd.payloadEnd - mvhd.payloadStart
+        if (payloadSize < FULLBOX_HEADER_SIZE) return null
+
+        raf.seek(mvhd.payloadStart)
+        val versionAndFlags = raf.readInt()
+        val version = (versionAndFlags ushr 24) and 0xff
+
+        val creation: Long
+        val modification: Long
+        when (version) {
+            0 -> {
+                if (payloadSize < FULLBOX_HEADER_SIZE + 8) return null
+                creation = raf.readInt().toLong() and 0xffffffffL
+                modification = raf.readInt().toLong() and 0xffffffffL
+            }
+            1 -> {
+                if (payloadSize < FULLBOX_HEADER_SIZE + 16) return null
+                creation = raf.readLong()
+                modification = raf.readLong()
+            }
+            else -> return null
+        }
+
+        if (!isPlausible(creation)) return null
+        return TimestampData(
+            creationTimeMp4Seconds = creation,
+            modificationTimeMp4Seconds = modification,
+        )
+    }
+
+    private fun isPlausible(mp4Seconds: Long): Boolean = mp4Seconds > PLAUSIBILITY_FLOOR_SECONDS
+
+    companion object {
+        internal const val MP4_EPOCH_OFFSET_SECONDS = 2_082_844_800L
+        private const val PLAUSIBILITY_FLOOR_SECONDS = 86_400L
+        private const val MIN_HEADER_SIZE = 8L
+        private const val LARGESIZE_HEADER_SIZE = 16L
+        private const val FULLBOX_HEADER_SIZE = 4
+        private val TAG = logTag("Squeezer", "VideoTimestampPreserver")
+
+        private val BASIC_ISO_FORMATTER: DateTimeFormatter =
+            DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss[.SSS]X")
+                .withZone(ZoneOffset.UTC)
+
+        private fun fourcc(s: String): Int {
+            require(s.length == 4)
+            return ((s[0].code and 0xff) shl 24) or
+                ((s[1].code and 0xff) shl 16) or
+                ((s[2].code and 0xff) shl 8) or
+                (s[3].code and 0xff)
+        }
+
+        private val BOX_MOOV = fourcc("moov")
+        private val BOX_MVHD = fourcc("mvhd")
+    }
+}

--- a/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/processor/VideoTranscoder.kt
+++ b/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/processor/VideoTranscoder.kt
@@ -7,12 +7,14 @@ import android.os.HandlerThread
 import androidx.annotation.OptIn
 import androidx.media3.common.MediaItem
 import androidx.media3.common.util.UnstableApi
+import androidx.media3.container.Mp4TimestampData
 import androidx.media3.transformer.Composition
 import androidx.media3.transformer.DefaultEncoderFactory
 import androidx.media3.transformer.EditedMediaItem
 import androidx.media3.transformer.EditedMediaItemSequence
 import androidx.media3.transformer.ExportException
 import androidx.media3.transformer.ExportResult
+import androidx.media3.transformer.InAppMp4Muxer
 import androidx.media3.transformer.ProgressHolder
 import androidx.media3.transformer.Transformer
 import androidx.media3.transformer.VideoEncoderSettings
@@ -31,6 +33,7 @@ import kotlin.coroutines.resumeWithException
 
 class VideoTranscoder @Inject constructor(
     @ApplicationContext private val context: Context,
+    private val videoTimestampPreserver: VideoTimestampPreserver,
 ) {
 
     /**
@@ -48,6 +51,16 @@ class VideoTranscoder @Inject constructor(
         targetBitrateBps: Long,
         progressListener: ProgressListener? = null,
     ) {
+        // Capture the source mvhd timestamps so we can inject them into the muxer output
+        // (#2388). Best-effort: a failure here just disables date preservation, gallery sort
+        // then falls back to filesystem mtime which FileTransaction already preserves.
+        val sourceTimestamps: VideoTimestampPreserver.TimestampData? = try {
+            videoTimestampPreserver.extract(inputFile)
+        } catch (e: Exception) {
+            log(TAG, WARN) { "Timestamp extract failed for ${inputFile.path}: ${e.message}" }
+            null
+        }
+
         val handlerThread = HandlerThread("sdmaid-transformer").apply { start() }
 
         try {
@@ -85,6 +98,22 @@ class VideoTranscoder @Inject constructor(
                             .setRequestedVideoEncoderSettings(encoderSettings)
                             .build()
 
+                        // MetadataProvider runs at muxer close() time on the muxer thread.
+                        // Strip the default Mp4TimestampData (Media3 seeds it with "now") and
+                        // replace it with the source's mvhd values so gallery DATE_TAKEN sort
+                        // is preserved (#2388).
+                        val muxerFactory = InAppMp4Muxer.Factory { entries ->
+                            sourceTimestamps?.let { ts ->
+                                entries.removeAll { it is Mp4TimestampData }
+                                entries.add(
+                                    Mp4TimestampData(
+                                        ts.creationTimeMp4Seconds,
+                                        ts.modificationTimeMp4Seconds,
+                                    )
+                                )
+                            }
+                        }
+
                         // Audio policy: we pass the input through a Composition with
                         // setTransmuxAudio(true) to force deterministic audio passthrough
                         // regardless of Media3's muxer-support-conditional default. Without
@@ -94,6 +123,7 @@ class VideoTranscoder @Inject constructor(
                         // stable across Media3 versions.
                         val transformer = Transformer.Builder(context)
                             .setEncoderFactory(encoderFactory)
+                            .setMuxerFactory(muxerFactory)
                             .setLooper(handlerThread.looper)
                             .build()
                         transformerRef = transformer

--- a/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/processor/VideoTranscoder.kt
+++ b/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/processor/VideoTranscoder.kt
@@ -134,7 +134,7 @@ class VideoTranscoder @Inject constructor(
 
                         val mediaItem = MediaItem.fromUri(Uri.fromFile(inputFile))
                         val editedItem = EditedMediaItem.Builder(mediaItem).build()
-                        val sequence = EditedMediaItemSequence(listOf(editedItem))
+                        val sequence = EditedMediaItemSequence.Builder(listOf(editedItem)).build()
                         val composition = Composition.Builder(sequence)
                             .setTransmuxAudio(true)
                             .build()

--- a/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/core/processor/VideoTimestampPreserverTest.kt
+++ b/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/core/processor/VideoTimestampPreserverTest.kt
@@ -1,0 +1,326 @@
+package eu.darken.sdmse.squeezer.core.processor
+
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.io.File
+import java.nio.ByteBuffer
+import java.time.Instant
+
+class VideoTimestampPreserverTest : BaseTest() {
+
+    private val testDir = File(IO_TEST_BASEDIR, "VideoTimestampPreserverTest")
+    private lateinit var subject: VideoTimestampPreserver
+
+    @BeforeEach
+    fun setup() {
+        if (testDir.exists()) testDir.deleteRecursively()
+        testDir.mkdirs()
+        subject = VideoTimestampPreserver()
+    }
+
+    @AfterEach
+    fun teardown() {
+        testDir.deleteRecursively()
+    }
+
+    // ----- parseMetadataDate -----
+
+    @Test
+    fun `parseMetadataDate handles AOSP basic format with milliseconds`() {
+        val result = subject.parseMetadataDate("20260510T123456.789Z")
+        result shouldBe Instant.parse("2026-05-10T12:34:56.789Z")
+    }
+
+    @Test
+    fun `parseMetadataDate handles AOSP basic format without milliseconds`() {
+        val result = subject.parseMetadataDate("20260510T123456Z")
+        result shouldBe Instant.parse("2026-05-10T12:34:56Z")
+    }
+
+    @Test
+    fun `parseMetadataDate returns null for malformed input`() {
+        subject.parseMetadataDate("not a date").shouldBeNull()
+        subject.parseMetadataDate("2026-05-10T12:34:56Z").shouldBeNull() // extended format, not AOSP basic
+        subject.parseMetadataDate("20260510").shouldBeNull() // date-only
+    }
+
+    @Test
+    fun `parseMetadataDate returns null for null or blank`() {
+        subject.parseMetadataDate(null).shouldBeNull()
+        subject.parseMetadataDate("").shouldBeNull()
+        subject.parseMetadataDate("   ").shouldBeNull()
+    }
+
+    // ----- extractFromMvhd: happy paths -----
+
+    @Test
+    fun `v0 mvhd with modern post-2026 timestamp survives unsigned-32-bit read`() {
+        // 2026-05-10T12:34:56Z → MP4 seconds = 3_861_606_496 (> Int.MAX_VALUE)
+        val creation = unixToMp4(1_778_761_696L)
+        val modification = creation + 60L
+        val file = writeMp4(testDir, "v0_modern.mp4") {
+            +ftyp()
+            +moov(mvhdV0(creation, modification))
+        }
+
+        val result = subject.extractFromMvhd(file)
+
+        result shouldBe VideoTimestampPreserver.TimestampData(creation, modification)
+        // Sanity: the unsigned-read trap would have produced a negative value.
+        (creation > Int.MAX_VALUE.toLong()) shouldBe true
+    }
+
+    @Test
+    fun `v1 mvhd with modern timestamp roundtrips`() {
+        val creation = unixToMp4(1_778_761_696L)
+        val modification = creation + 120L
+        val file = writeMp4(testDir, "v1_modern.mp4") {
+            +ftyp()
+            +moov(mvhdV1(creation, modification))
+        }
+
+        val result = subject.extractFromMvhd(file)
+
+        result shouldBe VideoTimestampPreserver.TimestampData(creation, modification)
+    }
+
+    @Test
+    fun `v1 mvhd with year-2050 timestamp`() {
+        // 2050-01-01T00:00:00Z → MP4 seconds = 4_607_452_800 (> 32-bit unsigned max)
+        val creation = unixToMp4(2_524_608_000L)
+        val modification = creation
+        val file = writeMp4(testDir, "v1_2050.mp4") {
+            +ftyp()
+            +moov(mvhdV1(creation, modification))
+        }
+
+        val result = subject.extractFromMvhd(file)
+
+        result shouldBe VideoTimestampPreserver.TimestampData(creation, modification)
+    }
+
+    @Test
+    fun `moov after mdat is found by walker`() {
+        val creation = unixToMp4(1_778_761_696L)
+        val file = writeMp4(testDir, "moov_after_mdat.mp4") {
+            +ftyp()
+            +box("mdat", ByteArray(1024) { it.toByte() })
+            +moov(mvhdV0(creation, creation))
+        }
+
+        val result = subject.extractFromMvhd(file)
+
+        result shouldBe VideoTimestampPreserver.TimestampData(creation, creation)
+    }
+
+    @Test
+    fun `top-level largesize moov is parsed correctly`() {
+        val creation = unixToMp4(1_778_761_696L)
+        val file = writeMp4(testDir, "largesize_moov.mp4") {
+            +ftyp()
+            +largesizeBox("moov", mvhdV0(creation, creation))
+        }
+
+        val result = subject.extractFromMvhd(file)
+
+        result shouldBe VideoTimestampPreserver.TimestampData(creation, creation)
+    }
+
+    // ----- extractFromMvhd: rejection paths -----
+
+    @Test
+    fun `largesize less than 16 is rejected`() {
+        // Manually construct a moov box with size==1 and largesize < 16 (header is 16 bytes).
+        val malformedMoov = ByteBuffer.allocate(16).apply {
+            putInt(1) // size = 1 → largesize follows
+            put("moov".toByteArray(Charsets.US_ASCII))
+            putLong(8L) // largesize < 16, malformed
+        }.array()
+        val file = File(testDir, "bad_largesize.mp4").apply { writeBytes(ftyp() + malformedMoov) }
+
+        subject.extractFromMvhd(file).shouldBeNull()
+    }
+
+    @Test
+    fun `box with size less than 8 is rejected`() {
+        val bad = ByteBuffer.allocate(8).apply {
+            putInt(4) // size < MIN_HEADER_SIZE=8
+            put("moov".toByteArray(Charsets.US_ASCII))
+        }.array()
+        val file = File(testDir, "tiny_box.mp4").apply { writeBytes(ftyp() + bad) }
+
+        subject.extractFromMvhd(file).shouldBeNull()
+    }
+
+    @Test
+    fun `child box larger than parent is rejected`() {
+        // mvhd claims a size that overruns the moov payload.
+        val mvhdHeader = ByteBuffer.allocate(8).apply {
+            putInt(9999) // bigger than moov can hold
+            put("mvhd".toByteArray(Charsets.US_ASCII))
+        }.array()
+        val file = writeMp4(testDir, "child_overruns.mp4") {
+            +ftyp()
+            +moov(mvhdHeader)
+        }
+
+        subject.extractFromMvhd(file).shouldBeNull()
+    }
+
+    @Test
+    fun `size equals zero inside moov is rejected`() {
+        // size==0 means "extends to EOF" — only valid at top level.
+        val badChild = ByteBuffer.allocate(12).apply {
+            putInt(0) // size == 0
+            put("mvhd".toByteArray(Charsets.US_ASCII))
+            putInt(0) // would-be version+flags
+        }.array()
+        val file = writeMp4(testDir, "size_zero_in_moov.mp4") {
+            +ftyp()
+            +moov(badChild)
+        }
+
+        subject.extractFromMvhd(file).shouldBeNull()
+    }
+
+    @Test
+    fun `unknown FullBox version is rejected`() {
+        val mvhdV2 = ByteBuffer.allocate(20).apply {
+            putInt(2 shl 24) // version=2, flags=0
+            putLong(0L)
+            putLong(0L)
+        }.array()
+        val file = writeMp4(testDir, "mvhd_v2.mp4") {
+            +ftyp()
+            +moov(box("mvhd", mvhdV2))
+        }
+
+        subject.extractFromMvhd(file).shouldBeNull()
+    }
+
+    @Test
+    fun `creation time of zero is rejected`() {
+        val file = writeMp4(testDir, "zero_creation.mp4") {
+            +ftyp()
+            +moov(mvhdV0(creationMp4Seconds = 0L, modificationMp4Seconds = 0L))
+        }
+
+        subject.extractFromMvhd(file).shouldBeNull()
+    }
+
+    @Test
+    fun `truncated mvhd payload is rejected`() {
+        // mvhd box with payload smaller than required (only version+flags, no times).
+        val truncatedMvhdPayload = ByteArray(4) // FullBox header only
+        val file = writeMp4(testDir, "truncated_mvhd.mp4") {
+            +ftyp()
+            +moov(box("mvhd", truncatedMvhdPayload))
+        }
+
+        subject.extractFromMvhd(file).shouldBeNull()
+    }
+
+    @Test
+    fun `moov without mvhd is rejected`() {
+        val file = writeMp4(testDir, "no_mvhd.mp4") {
+            +ftyp()
+            +moov(box("udta", ByteArray(8))) // sibling box, but no mvhd
+        }
+
+        subject.extractFromMvhd(file).shouldBeNull()
+    }
+
+    @Test
+    fun `file with no moov returns null`() {
+        val file = File(testDir, "no_moov.mp4").apply { writeBytes(ftyp()) }
+
+        subject.extractFromMvhd(file).shouldBeNull()
+    }
+
+    // ----- helpers -----
+
+    private fun unixToMp4(unixSeconds: Long): Long =
+        unixSeconds + VideoTimestampPreserver.MP4_EPOCH_OFFSET_SECONDS
+
+    /** Build an `ftyp` box: type "ftyp" with a minimal payload. */
+    private fun ftyp(): ByteArray = box("ftyp", ByteArray(8) { 0 })
+
+    /** Build a `moov` container box wrapping the given children. */
+    private fun moov(vararg children: ByteArray): ByteArray =
+        box("moov", concat(*children))
+
+    /** Build a v0 `mvhd` box with the given creation and modification times (MP4 seconds). */
+    private fun mvhdV0(creationMp4Seconds: Long, modificationMp4Seconds: Long): ByteArray {
+        val payload = ByteBuffer.allocate(12).apply {
+            putInt(0) // version=0, flags=0
+            putInt((creationMp4Seconds and 0xffffffffL).toInt())
+            putInt((modificationMp4Seconds and 0xffffffffL).toInt())
+        }.array()
+        return box("mvhd", payload)
+    }
+
+    /** Build a v1 `mvhd` box with 64-bit creation and modification times. */
+    private fun mvhdV1(creationMp4Seconds: Long, modificationMp4Seconds: Long): ByteArray {
+        val payload = ByteBuffer.allocate(20).apply {
+            putInt(1 shl 24) // version=1, flags=0
+            putLong(creationMp4Seconds)
+            putLong(modificationMp4Seconds)
+        }.array()
+        return box("mvhd", payload)
+    }
+
+    private fun box(type: String, payload: ByteArray): ByteArray {
+        val totalSize = 8 + payload.size
+        return ByteBuffer.allocate(totalSize).apply {
+            putInt(totalSize)
+            put(type.toByteArray(Charsets.US_ASCII))
+            put(payload)
+        }.array()
+    }
+
+    private fun largesizeBox(type: String, payload: ByteArray): ByteArray {
+        val totalSize = 16 + payload.size
+        return ByteBuffer.allocate(totalSize).apply {
+            putInt(1) // size==1 → largesize follows
+            put(type.toByteArray(Charsets.US_ASCII))
+            putLong(totalSize.toLong())
+            put(payload)
+        }.array()
+    }
+
+    private fun concat(vararg arrays: ByteArray): ByteArray {
+        val total = arrays.sumOf { it.size }
+        val out = ByteArray(total)
+        var off = 0
+        for (a in arrays) {
+            a.copyInto(out, off)
+            off += a.size
+        }
+        return out
+    }
+
+    /** Tiny DSL so the test reads top-down like an MP4 file structure. */
+    private class FileBuilder {
+        val parts = mutableListOf<ByteArray>()
+        operator fun ByteArray.unaryPlus() {
+            parts += this
+        }
+    }
+
+    private fun writeMp4(dir: File, name: String, block: FileBuilder.() -> Unit): File {
+        val builder = FileBuilder().apply(block)
+        val file = File(dir, name)
+        file.outputStream().use { out ->
+            for (part in builder.parts) out.write(part)
+        }
+        return file
+    }
+
+    companion object {
+        private const val IO_TEST_BASEDIR = "build/tmp/unit_tests"
+    }
+}

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -15,7 +15,7 @@ object Versions {
         }
 
         object Media3 {
-            const val core = "1.6.0"
+            const val core = "1.10.0"
         }
     }
 


### PR DESCRIPTION
## What changed

Compressed videos now keep their original date in the gallery. Previously, after Squeezer compressed a video, gallery apps would reorder it to the front of the list — even though the file's modified date was preserved on disk. This PR fixes that by preserving the date stored *inside* the video file (which gallery apps actually use for sorting).

Also bumps Media3 from 1.6.0 to 1.10.0 (latest stable).

## Technical Context

### Why this approach

- `MediaStore.DATE_TAKEN` (what gallery apps sort by) is sourced from `MediaMetadataRetriever.METADATA_KEY_DATE`, which AOSP's `MPEG4Extractor` reads from the MP4's internal `mvhd.creation_time` atom.
- Filesystem `mtime` (preserved by `FileTransaction` since #2388 was first addressed) does **not** drive that sort, so the existing fix didn't help videos.
- Images already preserve EXIF `DateTime` via `ExifPreserver.applyExif()`. This PR is the symmetric piece for videos.

### Why upgrade Media3 in the same PR

- `Mp4TimestampData` exists in 1.6.0 in `media3-container`, and `InAppMp4Muxer.Factory(MetadataProvider)` accepts it — but `InAppMp4Muxer` is opt-in on 1.6 (default is `FrameworkMuxer`/platform `MediaMuxer`).
- Media3 1.9 made `InAppMp4Muxer` the default. Upgrading now means we're not pinning a non-default muxer on a stale dep.
- The upgrade is split into its own commit (`a4f329c8`) so a regression in either piece is bisectable.

### Bug-class avoided in implementation

- `Mp4TimestampData.unixTimeToMp4TimeSeconds(long)` takes Unix **milliseconds**, not seconds — verified via bytecode (`(input / 1000) + 2_082_844_800L`). The atom-walker path uses MP4 seconds directly to avoid the unit ambiguity.
- v0 `mvhd` `creation_time` is `uint32` since 1904. Modern (post-2026) values already exceed `Int.MAX_VALUE`; the parser uses `readInt().toLong() and 0xffffffffL`. There's a regression test for this exact case.
- AOSP returns `METADATA_KEY_DATE` as ISO 8601 *basic* format (`yyyyMMdd'T'HHmmss[.SSS]'Z'`), not extended. `Instant.parse()` would fail; uses a dedicated `DateTimeFormatter`.

### Review guidance

- The highest-risk change is the muxer switch from `FrameworkMuxer` (platform `MediaMuxer`) to `InAppMp4Muxer` (Media3's pure-Kotlin muxer). Different per-device codec edge cases may surface. `da555e3fc` previously hardened the platform-muxer path; this PR moves off it.
- `VideoTimestampPreserver` is best-effort and **fail-open**: a malformed source file, an unknown FullBox version, or a 32-bit-overflow source-into-target-v0 mismatch all log a warning and skip preservation. The transaction still completes; `FileTransaction`'s mtime preservation remains as a second layer.
- The atom walker is read-only — it doesn't write the output file. Output is written entirely by Media3's muxer; we only inject the `Mp4TimestampData` entry into the muxer's metadata set via the `MetadataProvider` callback.

### Manual testing still needed before release

Unit tests cover the parser (16 cases, including modern post-2026 timestamps, year-2050 v1, malformed boxes, AOSP date format, etc.) but the real verification needs a device:

- Compress a camera-captured `.mp4` with a known `DATE_TAKEN`, confirm `MediaStore.Video.Media.DATE_TAKEN` matches after compression.
- Regression sweep across h.264/AAC, h.265/AAC, portrait-rotated, GPS-tagged, long (≥1 min), HEVC, and HDR if the test device supports them.

Closes #2388