### PR TITLE
AppCleaner: Fix slow cleanup on Samsung devices with One UI 1.0

### DIFF
--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/oneui/OneUISpecs.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/oneui/OneUISpecs.kt
@@ -120,7 +120,7 @@ class OneUISpecs @Inject constructor(
                 val target = findNode {
                     when (Bugs.isDryRun) {
                         true -> it.textMatchesAny(cancelLbl)
-                        false -> it.textMatchesAny(okLbl)
+                        false -> it.textMatchesAny(okLbl + forceStopLabels)
                     }
                 } ?: return@action false
                 val mapped = findClickableParent(includeSelf = true, node = target) ?: return@action false
@@ -130,7 +130,7 @@ class OneUISpecs @Inject constructor(
             val step = AutomationStep(
                 source = TAG,
                 descriptionInternal = "Confirm force stop for $pkg",
-                label = eu.darken.sdmse.automation.R.string.automation_progress_find_ok_confirmation.toCaString(titleLbl + okLbl),
+                label = eu.darken.sdmse.automation.R.string.automation_progress_find_ok_confirmation.toCaString(titleLbl + okLbl + forceStopLabels),
                 windowCheck = windowCheck,
                 nodeAction = action,
             )


### PR DESCRIPTION
## What changed

Fixed a bug where AppCleaner would take hours instead of minutes on older Samsung devices running One UI 1.0 (Android 9). The cleanup is now fast again on these devices, and the manual "Force stop" action under App Control works correctly there too.

## Technical Context

- **Symptom from user debug log:** A single AppCleaner run on a Samsung S8 (One UI 1.0) produced 427 force-stop confirmation timeouts and ran for ~3h 45m. The confirm dialog opened correctly, but the click never landed.
- **Root cause:** Samsung's One UI 1.0 / Android 9 labels the AlertDialog's positive button (`android:id/button1`) with the action verb "Force stop" instead of "OK". `OneUISpecs` matched the confirm button by the localized "OK" string only, so `findNode` returned null for the full 15s/30s timeout on every app.
- **Fix:** Extended the confirm-button match in `OneUISpecs.kt:123` to also accept `forceStopLabels` (the same label set the windowCheck already uses). The user-facing progress label was updated in lockstep so the announced keywords actually match what the action searches for.
- **Scope:** The same single-label match pattern exists in AOSP / MIUI / HyperOS / Oukitel specs, but only OneUI is empirically reported failing — leaving those alone unless evidence warrants.
- **No linked issue:** No matching open issue found in the tracker; this surfaced via a support email with debug log.
