### PR TITLE
Fix: Service Connection Lost crash and dashboard stuck on Loading

### DIFF
--- a/app-common-io/src/main/aidl/eu/darken/sdmse/common/shell/ipc/ShellOpsConnection.aidl
+++ b/app-common-io/src/main/aidl/eu/darken/sdmse/common/shell/ipc/ShellOpsConnection.aidl
@@ -1,10 +1,13 @@
 package eu.darken.sdmse.common.shell.ipc;
 
+import eu.darken.sdmse.common.ipc.RemoteInputStream;
 import eu.darken.sdmse.common.shell.ipc.ShellOpsCmd;
 import eu.darken.sdmse.common.shell.ipc.ShellOpsResult;
 
 interface ShellOpsConnection {
 
    ShellOpsResult execute(in ShellOpsCmd cmd);
+
+   RemoteInputStream executeStream(in ShellOpsCmd cmd);
 
 }

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/shell/ShellOps.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/shell/ShellOps.kt
@@ -24,7 +24,13 @@ import eu.darken.sdmse.common.sharedresource.keepResourcesAlive
 import eu.darken.sdmse.common.shell.ipc.ShellOpsClient
 import eu.darken.sdmse.common.shell.ipc.ShellOpsCmd
 import eu.darken.sdmse.common.shell.ipc.ShellOpsResult
+import eu.darken.sdmse.common.shell.ipc.ShellOpsStreamEvent
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.withContext
 import java.io.IOException
@@ -85,6 +91,32 @@ class ShellOps @Inject constructor(
             throw ShellOpsException(cmd = cmd, cause = e)
         }
     }
+
+    fun executeStream(cmd: ShellOpsCmd, mode: Mode): Flow<ShellOpsStreamEvent> = flow {
+        when (mode) {
+            Mode.NORMAL -> {
+                log(TAG, VERBOSE) { "executeStream(mode->NORMAL): $cmd" }
+                val result = cmd.toFlowCmd().execute()
+                result.output.forEach { emit(ShellOpsStreamEvent.Stdout(it)) }
+                result.errors.forEach { emit(ShellOpsStreamEvent.Stderr(it)) }
+                emit(ShellOpsStreamEvent.Exit(result.exitCode.value))
+            }
+            Mode.ROOT -> {
+                if (!rootManager.canUseRootNow()) throw RootUnavailableException()
+                log(TAG, VERBOSE) { "executeStream(mode->ROOT): $cmd" }
+                rootOps { client -> emitAll(client.executeStream(cmd)) }
+            }
+            Mode.ADB -> {
+                if (!adbManager.canUseAdbNow()) throw AdbUnavailableException()
+                log(TAG, VERBOSE) { "executeStream(mode->ADB): $cmd" }
+                adbOps { client -> emitAll(client.executeStream(cmd)) }
+            }
+        }
+    }.catch { cause ->
+        log(TAG, WARN) { "executeStream($cmd, $mode) failed: ${cause.asLog()}" }
+        if (cause is IOException) throw ShellOpsException(cmd = cmd, cause = cause)
+        throw cause
+    }.flowOn(dispatcherProvider.IO)
 
     private fun ShellOpsCmd.toFlowCmd() = FlowCmd(cmds)
 

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/shell/ipc/ShellOpsClient.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/shell/ipc/ShellOpsClient.kt
@@ -9,6 +9,10 @@ import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.ipc.IpcClientModule
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.withContext
 
 class ShellOpsClient @AssistedInject constructor(
@@ -25,6 +29,19 @@ class ShellOpsClient @AssistedInject constructor(
             log(TAG, ERROR) { "execute($cmd) failed: ${it.asLog()}" }
         }
     }
+
+    fun executeStream(cmd: ShellOpsCmd): Flow<ShellOpsStreamEvent> = flow {
+        val remote = connection.executeStream(cmd)
+        remote.toShellOpsEventFlow().collect { event ->
+            when (event) {
+                is ShellOpsStreamEvent.Error -> throw Exception(event.message)
+                else -> emit(event)
+            }
+        }
+    }.catch { cause ->
+        log(TAG, ERROR) { "executeStream($cmd) failed: ${cause.asLog()}" }
+        throw cause.refineException()
+    }.flowOn(dispatcherProvider.IO)
 
     @AssistedFactory
     interface Factory {

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/shell/ipc/ShellOpsEventsIPCWrapper.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/shell/ipc/ShellOpsEventsIPCWrapper.kt
@@ -1,0 +1,27 @@
+package eu.darken.sdmse.common.shell.ipc
+
+import android.os.Parcel
+import android.os.Parcelable
+
+data class ShellOpsEventsIPCWrapper(
+    val payload: List<ShellOpsStreamEvent>,
+) : Parcelable {
+    @Suppress("DEPRECATION", "UNCHECKED_CAST")
+    constructor(parcel: Parcel) : this(
+        parcel.readParcelableArray(ShellOpsStreamEvent::class.java.classLoader)!!
+            .toList() as List<ShellOpsStreamEvent>
+    )
+
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        parcel.writeParcelableArray(payload.toTypedArray(), flags)
+    }
+
+    override fun describeContents(): Int = 0
+
+    companion object CREATOR : Parcelable.Creator<ShellOpsEventsIPCWrapper> {
+        override fun createFromParcel(parcel: Parcel): ShellOpsEventsIPCWrapper =
+            ShellOpsEventsIPCWrapper(parcel)
+
+        override fun newArray(size: Int): Array<ShellOpsEventsIPCWrapper?> = arrayOfNulls(size)
+    }
+}

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/shell/ipc/ShellOpsHost.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/shell/ipc/ShellOpsHost.kt
@@ -6,22 +6,27 @@ import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.ipc.IpcHostModule
+import eu.darken.sdmse.common.ipc.RemoteInputStream
 import eu.darken.sdmse.common.shell.SharedShell
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 
 
 class ShellOpsHost @Inject constructor(
-    @AppScope scope: CoroutineScope,
-    dispatcherProvider: DispatcherProvider,
+    @AppScope private val appScope: CoroutineScope,
+    private val dispatcherProvider: DispatcherProvider,
 ) : ShellOpsConnection.Stub(), IpcHostModule {
 
-    private val sharedShell = SharedShell(TAG, scope + dispatcherProvider.Default)
+    private val sharedShell = SharedShell(TAG, appScope + dispatcherProvider.Default)
 
     override fun execute(cmd: ShellOpsCmd): ShellOpsResult = try {
         runBlocking {
@@ -37,6 +42,25 @@ class ShellOpsHost @Inject constructor(
     } catch (e: Exception) {
         log(TAG, ERROR) { "execute(cmd=$cmd) failed." }
         throw e.wrapToPropagate()
+    }
+
+    override fun executeStream(cmd: ShellOpsCmd): RemoteInputStream {
+        if (Bugs.isTrace) log(TAG, VERBOSE) { "executeStream(cmd=$cmd)" }
+        val eventFlow: Flow<ShellOpsStreamEvent> = flow {
+            try {
+                val result = sharedShell.useRes {
+                    FlowCmd(cmd.cmds).execute(it)
+                }
+                result.output.forEach { emit(ShellOpsStreamEvent.Stdout(it)) }
+                result.errors.forEach { emit(ShellOpsStreamEvent.Stderr(it)) }
+                emit(ShellOpsStreamEvent.Exit(result.exitCode.value))
+            } catch (e: Exception) {
+                log(TAG, ERROR) { "executeStream(cmd=$cmd) failed: ${e.asLog()}" }
+                val wrapped = e.wrapToPropagate()
+                emit(ShellOpsStreamEvent.Error(wrapped.message ?: e.toString()))
+            }
+        }
+        return eventFlow.toRemoteInputStream(appScope + dispatcherProvider.Default)
     }
 
     companion object {

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/shell/ipc/ShellOpsIPCFlow.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/shell/ipc/ShellOpsIPCFlow.kt
@@ -1,0 +1,135 @@
+package eu.darken.sdmse.common.shell.ipc
+
+import android.os.Parcel
+import eu.darken.sdmse.common.debug.Bugs
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.asLog
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.ipc.RemoteInputStream
+import eu.darken.sdmse.common.ipc.inputStream
+import eu.darken.sdmse.common.ipc.remoteInputStream
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.isActive
+import okio.ByteString.Companion.decodeBase64
+import okio.ByteString.Companion.toByteString
+import java.io.IOException
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+
+private val TAG = logTag("ShellOps", "IPC", "Flow")
+
+// Conservatively well below the ~1 MB Android binder buffer.
+// Base64 expands payload by ~33%, so an encoded chunk is ~85 KB max per AIDL read.
+private const val CHUNK_BYTE_LIMIT = 64 * 1024
+private const val PIPE_BUFFER_SIZE = 2 * CHUNK_BYTE_LIMIT
+private const val WRITER_BUFFER_SIZE = CHUNK_BYTE_LIMIT
+
+fun RemoteInputStream.toShellOpsEventFlow(): Flow<ShellOpsStreamEvent> = flow {
+    if (Bugs.isTrace) log(TAG, VERBOSE) { "toShellOpsEventFlow() starting..." }
+
+    val reader = this@toShellOpsEventFlow.inputStream().reader().buffered(WRITER_BUFFER_SIZE)
+    var sawTerminal = false
+    try {
+        while (currentCoroutineContext().isActive) {
+            val line = reader.readLine() ?: break
+
+            val decoded = line.decodeBase64()
+                ?: throw IOException("ShellOps stream: invalid base64 frame")
+            val parcel = Parcel.obtain().apply {
+                unmarshall(decoded.toByteArray(), 0, decoded.size)
+                setDataPosition(0)
+            }
+            val wrapper = try {
+                ShellOpsEventsIPCWrapper.createFromParcel(parcel)
+            } finally {
+                parcel.recycle()
+            }
+            if (Bugs.isTrace) {
+                log(TAG, VERBOSE) { "READCHUNK: ${decoded.size}B to ${wrapper.payload.size} events" }
+            }
+            for (event in wrapper.payload) {
+                if (event is ShellOpsStreamEvent.Exit || event is ShellOpsStreamEvent.Error) {
+                    sawTerminal = true
+                }
+                emit(event)
+            }
+        }
+        if (!sawTerminal) {
+            throw IOException("ShellOps stream ended without Exit or Error event")
+        }
+    } finally {
+        try {
+            this@toShellOpsEventFlow.close()
+        } catch (e: Exception) {
+            log(TAG, ERROR) { "Failed to close RemoteInputStream: ${e.asLog()}" }
+        }
+    }
+}
+
+fun Flow<ShellOpsStreamEvent>.toRemoteInputStream(scope: CoroutineScope): RemoteInputStream {
+    if (Bugs.isTrace) log(TAG, VERBOSE) { "Flow<ShellOpsStreamEvent>.toRemoteInputStream()..." }
+
+    val inputStream = PipedInputStream(PIPE_BUFFER_SIZE)
+    val outputStream = PipedOutputStream()
+    inputStream.connect(outputStream)
+
+    val writer = outputStream.writer().buffered(WRITER_BUFFER_SIZE)
+
+    val pending = mutableListOf<ShellOpsStreamEvent>()
+    var pendingBytes = 0
+
+    fun flushChunk() {
+        if (pending.isEmpty()) return
+        val parcel = Parcel.obtain().apply {
+            ShellOpsEventsIPCWrapper(pending.toList()).writeToParcel(this, 0)
+        }
+        val encoded = parcel.marshall().toByteString().base64()
+        parcel.recycle()
+        writer.apply {
+            write(encoded)
+            write('\n'.code)
+            flush()
+        }
+        if (Bugs.isTrace) {
+            log(TAG, VERBOSE) { "WRITECHUNK: ${pending.size} events to ${encoded.length}B" }
+        }
+        pending.clear()
+        pendingBytes = 0
+    }
+
+    this@toRemoteInputStream
+        .onEach { event ->
+            pending.add(event)
+            pendingBytes += event.estimatedParcelSize
+            if (pendingBytes >= CHUNK_BYTE_LIMIT) flushChunk()
+        }
+        .catch { error ->
+            log(TAG, ERROR) { "Source flow failed before terminal event: ${error.asLog()}" }
+            pending.add(ShellOpsStreamEvent.Error(error.toString()))
+            pendingBytes += pending.last().estimatedParcelSize
+        }
+        .onCompletion {
+            try {
+                flushChunk()
+            } catch (e: Exception) {
+                log(TAG, ERROR) { "Flush on completion failed: ${e.asLog()}" }
+            } finally {
+                try {
+                    writer.close()
+                } catch (_: Exception) {
+                }
+            }
+        }
+        .launchIn(scope)
+
+    return inputStream.remoteInputStream()
+}

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/shell/ipc/ShellOpsStreamEvent.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/shell/ipc/ShellOpsStreamEvent.kt
@@ -1,0 +1,117 @@
+package eu.darken.sdmse.common.shell.ipc
+
+import android.os.Parcel
+import android.os.Parcelable
+
+sealed class ShellOpsStreamEvent : Parcelable {
+
+    abstract val estimatedParcelSize: Int
+
+    data class Stdout(val line: String) : ShellOpsStreamEvent() {
+        constructor(parcel: Parcel) : this(parcel.readString()!!)
+
+        override val estimatedParcelSize: Int get() = OVERHEAD + line.length * 2
+
+        override fun writeToParcel(parcel: Parcel, flags: Int) {
+            parcel.writeString(line)
+        }
+
+        override fun describeContents(): Int = 0
+
+        companion object CREATOR : Parcelable.Creator<Stdout> {
+            override fun createFromParcel(parcel: Parcel): Stdout = Stdout(parcel)
+            override fun newArray(size: Int): Array<Stdout?> = arrayOfNulls(size)
+        }
+    }
+
+    data class Stderr(val line: String) : ShellOpsStreamEvent() {
+        constructor(parcel: Parcel) : this(parcel.readString()!!)
+
+        override val estimatedParcelSize: Int get() = OVERHEAD + line.length * 2
+
+        override fun writeToParcel(parcel: Parcel, flags: Int) {
+            parcel.writeString(line)
+        }
+
+        override fun describeContents(): Int = 0
+
+        companion object CREATOR : Parcelable.Creator<Stderr> {
+            override fun createFromParcel(parcel: Parcel): Stderr = Stderr(parcel)
+            override fun newArray(size: Int): Array<Stderr?> = arrayOfNulls(size)
+        }
+    }
+
+    data class Exit(val exitCode: Int) : ShellOpsStreamEvent() {
+        constructor(parcel: Parcel) : this(parcel.readInt())
+
+        override val estimatedParcelSize: Int get() = OVERHEAD
+
+        override fun writeToParcel(parcel: Parcel, flags: Int) {
+            parcel.writeInt(exitCode)
+        }
+
+        override fun describeContents(): Int = 0
+
+        companion object CREATOR : Parcelable.Creator<Exit> {
+            override fun createFromParcel(parcel: Parcel): Exit = Exit(parcel)
+            override fun newArray(size: Int): Array<Exit?> = arrayOfNulls(size)
+        }
+    }
+
+    data class Error(val message: String) : ShellOpsStreamEvent() {
+        constructor(parcel: Parcel) : this(parcel.readString()!!)
+
+        override val estimatedParcelSize: Int get() = OVERHEAD + message.length * 2
+
+        override fun writeToParcel(parcel: Parcel, flags: Int) {
+            parcel.writeString(message)
+        }
+
+        override fun describeContents(): Int = 0
+
+        companion object CREATOR : Parcelable.Creator<Error> {
+            override fun createFromParcel(parcel: Parcel): Error = Error(parcel)
+            override fun newArray(size: Int): Array<Error?> = arrayOfNulls(size)
+        }
+    }
+
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        when (this) {
+            is Stdout -> {
+                parcel.writeInt(TYPE_STDOUT)
+                writeToParcel(parcel, flags)
+            }
+            is Stderr -> {
+                parcel.writeInt(TYPE_STDERR)
+                writeToParcel(parcel, flags)
+            }
+            is Exit -> {
+                parcel.writeInt(TYPE_EXIT)
+                writeToParcel(parcel, flags)
+            }
+            is Error -> {
+                parcel.writeInt(TYPE_ERROR)
+                writeToParcel(parcel, flags)
+            }
+        }
+    }
+
+    companion object CREATOR : Parcelable.Creator<ShellOpsStreamEvent> {
+        private const val TYPE_STDOUT = 0
+        private const val TYPE_STDERR = 1
+        private const val TYPE_EXIT = 2
+        private const val TYPE_ERROR = 3
+
+        private const val OVERHEAD = 16
+
+        override fun createFromParcel(parcel: Parcel): ShellOpsStreamEvent = when (parcel.readInt()) {
+            TYPE_STDOUT -> Stdout.createFromParcel(parcel)
+            TYPE_STDERR -> Stderr.createFromParcel(parcel)
+            TYPE_EXIT -> Exit.createFromParcel(parcel)
+            TYPE_ERROR -> Error.createFromParcel(parcel)
+            else -> throw IllegalArgumentException("Unknown ShellOpsStreamEvent type")
+        }
+
+        override fun newArray(size: Int): Array<ShellOpsStreamEvent?> = arrayOfNulls(size)
+    }
+}

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/shell/ipc/ShellOpsIPCFlowTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/shell/ipc/ShellOpsIPCFlowTest.kt
@@ -1,0 +1,187 @@
+package eu.darken.sdmse.common.shell.ipc
+
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+import java.io.IOException
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class ShellOpsIPCFlowTest : BaseTest() {
+
+    private fun makeScope() = CoroutineScope(Job() + Dispatchers.IO)
+
+    @Test
+    fun `round trip preserves all event types`() {
+        val events = listOf<ShellOpsStreamEvent>(
+            ShellOpsStreamEvent.Stdout("hello"),
+            ShellOpsStreamEvent.Stdout("world"),
+            ShellOpsStreamEvent.Stderr("warning"),
+            ShellOpsStreamEvent.Exit(0),
+        )
+        val scope = makeScope()
+        try {
+            runBlocking {
+                val remote = events.asFlow().toRemoteInputStream(scope)
+                val collected = remote.toShellOpsEventFlow().toList()
+                collected shouldContainExactly events
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `non-zero exit code preserved`() {
+        val events = listOf<ShellOpsStreamEvent>(
+            ShellOpsStreamEvent.Stdout("oops"),
+            ShellOpsStreamEvent.Exit(127),
+        )
+        val scope = makeScope()
+        try {
+            runBlocking {
+                val collected = events.asFlow().toRemoteInputStream(scope).toShellOpsEventFlow().toList()
+                collected shouldContainExactly events
+                (collected.last() as ShellOpsStreamEvent.Exit).exitCode shouldBe 127
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `error event with message round-trips`() {
+        val events = listOf<ShellOpsStreamEvent>(
+            ShellOpsStreamEvent.Stdout("partial"),
+            ShellOpsStreamEvent.Error("java.io.IOException: pipe closed"),
+        )
+        val scope = makeScope()
+        try {
+            runBlocking {
+                val collected = events.asFlow().toRemoteInputStream(scope).toShellOpsEventFlow().toList()
+                collected shouldContainExactly events
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `large stdout payload streams across multiple chunks`() {
+        // 4500 lines * ~150 chars = ~675 KB raw; parceled UTF-16 would be ~1.3 MB
+        // — comfortably above one binder transaction. With chunking it streams cleanly.
+        val lineCount = 4500
+        val line = "package:/data/app/~~hashabcdefghijk==/com.example.app${"x".repeat(70)}=com.example.app"
+        val source: Flow<ShellOpsStreamEvent> = flow {
+            repeat(lineCount) { emit(ShellOpsStreamEvent.Stdout(line)) }
+            emit(ShellOpsStreamEvent.Exit(0))
+        }
+        val scope = makeScope()
+        try {
+            runBlocking {
+                val collected = source.toRemoteInputStream(scope).toShellOpsEventFlow().toList()
+                collected.size shouldBe lineCount + 1
+                collected.first().shouldBeInstanceOf<ShellOpsStreamEvent.Stdout>()
+                (collected.first() as ShellOpsStreamEvent.Stdout).line shouldBe line
+                collected.last() shouldBe ShellOpsStreamEvent.Exit(0)
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `single event larger than chunk limit still fits in its own chunk`() {
+        // A single Stdout line of ~128 KB (way above the 64 KB chunk target) must still be deliverable.
+        val hugeLine = "x".repeat(128 * 1024)
+        val events = listOf<ShellOpsStreamEvent>(
+            ShellOpsStreamEvent.Stdout(hugeLine),
+            ShellOpsStreamEvent.Exit(0),
+        )
+        val scope = makeScope()
+        try {
+            runBlocking {
+                val collected = events.asFlow().toRemoteInputStream(scope).toShellOpsEventFlow().toList()
+                collected.size shouldBe 2
+                (collected[0] as ShellOpsStreamEvent.Stdout).line.length shouldBe hugeLine.length
+                collected[1] shouldBe ShellOpsStreamEvent.Exit(0)
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `EOF before terminal event is a protocol failure`() {
+        val events = listOf<ShellOpsStreamEvent>(
+            ShellOpsStreamEvent.Stdout("interrupted"),
+            // No Exit or Error — host died mid-stream.
+        )
+        val scope = makeScope()
+        try {
+            runBlocking {
+                val flow = events.asFlow().toRemoteInputStream(scope).toShellOpsEventFlow()
+                val thrown = runCatching { flow.toList() }.exceptionOrNull()
+                thrown.shouldBeInstanceOf<IOException>()
+                (thrown.message ?: "") shouldBe "ShellOps stream ended without Exit or Error event"
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `source flow error is converted to terminal Error event`() {
+        val source: Flow<ShellOpsStreamEvent> = flow {
+            emit(ShellOpsStreamEvent.Stdout("before failure"))
+            throw IllegalStateException("host crashed")
+        }
+        val scope = makeScope()
+        try {
+            runBlocking {
+                val collected = source.toRemoteInputStream(scope).toShellOpsEventFlow().toList()
+                collected.size shouldBe 2
+                (collected[0] as ShellOpsStreamEvent.Stdout).line shouldBe "before failure"
+                collected[1].shouldBeInstanceOf<ShellOpsStreamEvent.Error>()
+                (collected[1] as ShellOpsStreamEvent.Error).message shouldBe "java.lang.IllegalStateException: host crashed"
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `mixed stdout and stderr preserve order`() {
+        val events = listOf<ShellOpsStreamEvent>(
+            ShellOpsStreamEvent.Stdout("out1"),
+            ShellOpsStreamEvent.Stderr("err1"),
+            ShellOpsStreamEvent.Stdout("out2"),
+            ShellOpsStreamEvent.Stderr("err2"),
+            ShellOpsStreamEvent.Exit(0),
+        )
+        val scope = makeScope()
+        try {
+            runBlocking {
+                val collected = events.asFlow().toRemoteInputStream(scope).toShellOpsEventFlow().toList()
+                collected shouldContainExactly events
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+}

--- a/app-common-pkgs/src/main/java/eu/darken/sdmse/common/pkgs/sources/ShellLookUpPkgsSource.kt
+++ b/app-common-pkgs/src/main/java/eu/darken/sdmse/common/pkgs/sources/ShellLookUpPkgsSource.kt
@@ -22,6 +22,7 @@ import eu.darken.sdmse.common.root.RootManager
 import eu.darken.sdmse.common.root.canUseRootNow
 import eu.darken.sdmse.common.shell.ShellOps
 import eu.darken.sdmse.common.shell.ipc.ShellOpsCmd
+import eu.darken.sdmse.common.shell.ipc.ShellOpsStreamEvent
 import eu.darken.sdmse.common.user.UserManager2
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -61,12 +62,21 @@ class ShellLookUpPkgsSource @Inject constructor(
 
         userManager.allUsers()
             .mapNotNull { user ->
-                val result = shellOps.execute(
+                val output = mutableListOf<String>()
+                var exitCode = -1
+                shellOps.executeStream(
                     ShellOpsCmd("pm list packages -f -u --user ${user.handle.handleId}"),
                     mode,
-                )
-                if (!result.isSuccess) return@mapNotNull null
-                user to result.output
+                ).collect { event ->
+                    when (event) {
+                        is ShellOpsStreamEvent.Stdout -> output.add(event.line)
+                        is ShellOpsStreamEvent.Exit -> exitCode = event.exitCode
+                        is ShellOpsStreamEvent.Stderr -> Unit
+                        is ShellOpsStreamEvent.Error -> Unit
+                    }
+                }
+                if (exitCode != 0) return@mapNotNull null
+                user to output.toList()
             }
             .map { (user, lines) ->
                 log(TAG, VERBOSE) { "${lines.size} entries for $user" }

--- a/app-common-root/src/main/java/eu/darken/sdmse/common/root/service/internal/RootHostLauncher.kt
+++ b/app-common-root/src/main/java/eu/darken/sdmse/common/root/service/internal/RootHostLauncher.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeoutOrNull
 import java.util.UUID
+import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 import kotlin.reflect.KClass
 
@@ -50,6 +51,7 @@ class RootHostLauncher @Inject constructor(
         log(iTag, INFO) { "createConnection($serviceClass, $hostClass, $useMountMaster, $options)" }
 
         val pairingCode = UUID.randomUUID().toString()
+        val connected = AtomicBoolean(false)
 
         val ipcReceiver = object : RootConnectionReceiver(pairingCode) {
             override fun onConnect(connection: RootConnection) {
@@ -63,6 +65,7 @@ class RootHostLauncher @Inject constructor(
                 }
 
                 log(iTag, INFO) { "onServiceConnected(...) got our interface: $userConnection" }
+                connected.set(true)
                 trySendBlocking(ConnectionWrapper(userConnection, connection))
             }
 
@@ -93,52 +96,56 @@ class RootHostLauncher @Inject constructor(
             }
         }
 
+        val initArgs = RootHostInitArgs(
+            pairingCode = pairingCode,
+            packageName = context.packageName,
+            waitForDebugger = options.isTrace && Debug.isDebuggerConnected(),
+            isDebug = options.isDebug,
+            isTrace = options.isTrace,
+            isDryRun = options.isDryRun,
+            recorderPath = options.recorderPath
+        )
+
+        val cmdBuilder = RootHostCmdBuilder(context, hostClass)
+
+        // Attempt 1: direct exec. May either block until the root host process exits
+        // (success path, with onConnect having fired in the meantime) or fail fast on
+        // a broken pipe / unsupported exec. Use `connected` rather than the throw/
+        // return result to decide whether the host actually bound.
         try {
-            val initArgs = RootHostInitArgs(
-                pairingCode = pairingCode,
-                packageName = context.packageName,
-                waitForDebugger = options.isTrace && Debug.isDebuggerConnected(),
-                isDebug = options.isDebug,
-                isTrace = options.isTrace,
-                isDryRun = options.isDryRun,
-                recorderPath = options.recorderPath
-            )
+            val cmd = cmdBuilder.build(withRelocation = false, initialOptions = initArgs)
+            log(iTag) { "Launching root host with command: $cmd" }
+            cmd.execute(rootSession).also {
+                log(iTag) { "Session (no-relocation) ended: $it" }
+            }
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            log(iTag, WARN) { "Launch without relocation failed: ${e.asLog()}" }
+        }
 
-            val cmdBuilder = RootHostCmdBuilder(context, hostClass)
-            var retryWithRelocation = false
-
+        // Attempt 2: relocation. Only needed when the direct exec didn't actually
+        // bring up the binder (some Android versions/SELinux policies refuse to
+        // execute /proc/<pid>/exe in-place).
+        if (!connected.get()) {
+            log(iTag, INFO) { "No binder yet, retrying root host launch with relocation" }
             try {
-                val cmd = cmdBuilder.build(withRelocation = false, initialOptions = initArgs)
-                log(iTag) { "Launching root host with command: $cmd" }
-                // Doesn't return until root host has quit
+                val cmd = cmdBuilder.build(withRelocation = true, initialOptions = initArgs)
+                log(iTag) { "Launching root host (relocation) with command: $cmd" }
                 cmd.execute(rootSession).also {
-                    log(iTag) { "Session (WITH-relocation) has ended: $it" }
+                    log(iTag) { "Session (relocation) ended: $it" }
                 }
             } catch (e: Exception) {
                 if (e is CancellationException) throw e
-                log(iTag, WARN) { "Launch without relocation failed: ${e.asLog()}" }
-                retryWithRelocation = true
+                log(iTag, WARN) { "Launch WITH relocation failed too: ${e.asLog()}" }
             }
+        }
 
-            if (retryWithRelocation) {
-                try {
-                    val cmd = cmdBuilder.build(withRelocation = true, initialOptions = initArgs)
-                    log(iTag) { "Launching root host (relocation) with command: $cmd" }
-                    // Doesn't return until root host has quit
-                    cmd.execute(rootSession).also {
-                        log(iTag) { "Session (without-relocation) has ended: $it" }
-                    }
-                } catch (e: Exception) {
-                    log(iTag, WARN) { "Launch WITH relocation failed too: ${e.asLog()}" }
-                    throw e
-                }
-            }
-        } catch (e: Exception) {
-            if (e is CancellationException) {
-                log(iTag) { "Root host launcher was cancelled: ${e.asLog()}" }
-            } else {
-                log(iTag, WARN) { "All launch attempts failed: ${e.asLog()}" }
-            }
+        // If neither attempt produced a binder connection, fail the callbackFlow so
+        // downstream SharedResource consumers (e.g. RootManager.isRooted via
+        // AutomationSetupModule.state) stop waiting on the Loading state forever.
+        if (!connected.get()) {
+            log(iTag, WARN) { "All launch attempts finished without a binder connection" }
+            close(RootException("Root host did not bind after exec/relocation attempts"))
         }
 
         log(iTag, VERBOSE) { "Reached awaitClose" }

--- a/app-common-shell/src/main/java/eu/darken/flowshell/core/cmd/FlowCmdShell.kt
+++ b/app-common-shell/src/main/java/eu/darken/flowshell/core/cmd/FlowCmdShell.kt
@@ -18,6 +18,9 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.dropWhile
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion
@@ -129,6 +132,19 @@ class FlowCmdShell(
                     .onCompletion { if (isDebug) log(_tag, VERBOSE) { "Error monitor finished ($id)" } }
                     .launchIn(this + Dispatchers.IO)
 
+                // `sharedOutput`/`sharedErrors` are `shareIn(Eagerly)` SharedFlows — they
+                // do NOT propagate upstream completion to subscribers. If the shell
+                // process dies (typically because cmd contained `exec ...` which
+                // replaced the shell), `takeWhile` would suspend forever waiting for an
+                // idEnd marker that will never arrive. Watch for the underlying process
+                // exiting and cancel the harvesters so joinAll() can return.
+                val deathWatcher = launch(this.coroutineContext + Dispatchers.IO) {
+                    session.exitCode.filterNotNull().first()
+                    if (isDebug) log(_tag, VERBOSE) { "Shell session died, cancelling harvesters ($id)" }
+                    outputJob.cancel()
+                    errorJob.cancel()
+                }
+
                 listOf(outputReady, errorReady).awaitAll()
 
                 if (isDebug) log(_tag, VERBOSE) { "Harvesters are ready, writing commands... ($id)" }
@@ -142,15 +158,33 @@ class FlowCmdShell(
                 if (isDebug) log(_tag, VERBOSE) { "Commands are written, waiting... ($id)" }
 
                 listOf(outputJob, errorJob).joinAll()
+                deathWatcher.cancel()
 
                 if (isDebug) log(_tag, VERBOSE) { "Determining exitcode ($id)" }
-                val rawExitCodeRow = output.removeAt(output.lastIndex)
 
-                val exitCode = rawExitCodeRow
-                    .split(" ")
-                    .let { it[1].toIntOrNull() }
-                    ?.let { FlowProcess.ExitCode(it) }
-                    ?: throw IllegalArgumentException("Failed to determine exitcode from $rawExitCodeRow")
+                val lastLine = output.lastOrNull()
+                val sawEndMarker = lastLine != null && lastLine.startsWith(idEnd)
+                val exitCode = when {
+                    sawEndMarker -> {
+                        output.removeAt(output.lastIndex)
+                        lastLine.split(" ")
+                            .let { it.getOrNull(1)?.toIntOrNull() }
+                            ?.let { FlowProcess.ExitCode(it) }
+                            ?: throw IllegalArgumentException("Failed to determine exitcode from $lastLine")
+                    }
+
+                    cmd.instructions.any { EXEC_REGEX.containsMatchIn(it) } -> {
+                        // The caller asked the shell to `exec ...` something that replaces
+                        // the shell process — no idEnd marker will ever be echoed. Surface
+                        // a sentinel exit code so callers observe completion cleanly.
+                        if (isDebug) log(_tag, VERBOSE) { "No end marker after exec-replacement ($id)" }
+                        FlowProcess.ExitCode(-1)
+                    }
+
+                    else -> throw IllegalStateException(
+                        "Command $cmd ended without exit-code marker; shell session likely died externally"
+                    )
+                }
 
                 FlowCmd.Result(
                     original = cmd,
@@ -164,5 +198,11 @@ class FlowCmdShell(
 
     companion object {
         private val TAG = "${FlowShellDebug.tag}:FlowCmdShell"
+
+        // Detects a top-level `exec ...` directive (anchored after optional whitespace and
+        // env var assignments). Used to recognise commands where the shell intentionally
+        // replaces itself with another process — no `echo idEnd` will be emitted in that
+        // case, so execute() must surface completion as ExitCode(-1) instead of throwing.
+        private val EXEC_REGEX = Regex("""(^|;|&&|\|\|)\s*(\w+=\S+\s+)*exec\s""")
     }
 }

--- a/app-common-shell/src/test/java/eu/darken/flowshell/core/cmd/FlowCmdShellTest.kt
+++ b/app-common-shell/src/test/java/eu/darken/flowshell/core/cmd/FlowCmdShellTest.kt
@@ -185,4 +185,22 @@ class FlowCmdShellTest : BaseTest() {
         (System.currentTimeMillis() - start) shouldBeGreaterThanOrEqual 1000
     }
 
+    @Test fun `exec command replacing shell blocks until replacement exits and does not throw`(): Unit = runBlocking {
+        // RootHostLauncher writes an `exec /proc/<pid>/exe ...` line to swap the shell with
+        // the root host process. The final `echo idEnd >&2` flush can race against the pipe
+        // being torn down, producing IOException("Stream closed"). execute() must absorb
+        // that race so the launcher stays blocked until the replacement process exits, and
+        // must not propagate the IOException — otherwise the binder connection callback
+        // never reaches the SharedResource consumer.
+        val start = System.currentTimeMillis()
+        val result = FlowCmd("exec sleep 1").execute()
+        val elapsed = System.currentTimeMillis() - start
+
+        // joinAll must have blocked until sleep exited (~1s) instead of returning early.
+        elapsed shouldBeGreaterThanOrEqual 900
+        // No end marker was emitted because sleep replaced the shell; we expose -1 instead
+        // of throwing so callers like RootHostLauncher can observe normal completion.
+        result.exitCode shouldBe FlowProcess.ExitCode(-1)
+    }
+
 }


### PR DESCRIPTION
## What changed

- Fixes the "Service Connection Lost" crash that hit users on devices with a large number of installed packages (~4000+). Scans would fail immediately with an error dialog referencing `BinderProxy.transact` and no cleaning tool could complete.
- Fixes a dashboard that could get stuck on "Loading" with the Scan buttons disabled when root access was enabled in setup but the root host failed to start — for example when root was denied in Magisk, or when SELinux refused the direct exec on certain Android versions. The dashboard now resolves to a usable state regardless of whether root binds.

## Technical Context

- **Binder overflow**: `pm list packages -f -u --user 0` on a device with thousands of packages produces a `ShellOpsResult` parcel whose UTF-16-encoded `List<String>` payload exceeds the per-process binder buffer (~1 MB). The kernel rejects the transaction with `DEAD_OBJECT`, which `IpcClientModule.refineException` surfaces as `ServiceConnectionLostException`.
- **Streaming fix**: `ShellOpsConnection` now exposes an `executeStream` AIDL method that streams sealed `ShellOpsStreamEvent`s (Stdout/Stderr/Exit/Error) through a `RemoteInputStream`, chunked into byte-size-bounded parcels — mirroring the existing `FileOpsConnection.walkStream` / `LocalPathLookupIPCFlow` pattern. The original `execute` is kept for callers that need a buffered `ShellOpsResult`. `ShellLookUpPkgsSource` is the first caller switched over.
- **`FlowCmdShell` deadlock**: `sharedOutput`/`sharedErrors` use `shareIn(Eagerly)` SharedFlows, which do not propagate upstream completion to subscribers. When a command's `exec …` line replaced the shell, the `takeWhile` harvesters would never observe the `idEnd` marker and `joinAll` could suspend indefinitely. A `deathWatcher` observes `FlowShell.Session.exitCode` and cancels the harvesters when the underlying process exits. When no `idEnd` marker arrived but the command contained a top-level `exec`, `execute()` now returns `ExitCode(-1)` instead of throwing — preserving the existing throw-on-abort contract for external close/cancel (verified by the `closing session aborts command` test).
- **Dashboard hang**: `RootHostLauncher.createConnection` previously decided whether to retry-with-relocation based on whether the first `execute()` threw. With `FlowCmdShell` now reliably returning `ExitCode(-1)` for exec-replaced shells, the no-relocation attempt no longer threw, the relocation retry never fired, and the `callbackFlow` sat in `awaitClose` forever — leaving any module that depended on `RootManager.useRoot` (e.g. `AutomationSetupModule`) stuck in Loading. The launcher now uses an `AtomicBoolean` set by `onConnect` as the success criterion for both the relocation retry and the overall outcome, and closes the `callbackFlow` with `RootException` when neither attempt produces a binder connection.
- **Review guidance**:
  - `ShellOpsIPCFlow.kt` is a near copy of `LocalPathLookupIPCFlow.kt` — review for pattern consistency.
  - `FlowCmdShell.kt` is hot path; the 1000-command sequential/concurrent stress tests still pass at the same wall-clock as before.
  - `RootHostLauncher.kt` change shifts the success criterion from "did `execute` throw?" to "did the binder bind?". Verified end-to-end on a rooted Pixel 7a (Android 16, Magisk) where direct `exec /proc/<pid>/exe` is rejected — relocation retry now actually fires, and AppCleaner reports 7256 items / 309 MB via the root path instead of 28 / 306 MB without root.

Refs #1821, Refs #1816
