### PR TITLE
Setup: Show root setup card when root is enabled but binder isn't connected

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/setup/root/RootSetupModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/root/RootSetupModule.kt
@@ -105,7 +105,8 @@ class RootSetupModule @Inject constructor(
 
         override val type: SetupModule.Type = SetupModule.Type.ROOT
 
-        override val isComplete: Boolean = useRoot != null
+        override val isComplete: Boolean =
+            useRoot == false || (useRoot == true && (!isInstalled || ourService))
     }
 
     @Module @InstallIn(SingletonComponent::class)


### PR DESCRIPTION
## What changed

Fixed a case where the dashboard wouldn't show the "setup needed" hint card while root access was enabled but the root binder hadn't connected yet. Now the dashboard surfaces the card so the user can see that root isn't currently working and act on it — matching the behavior we already had for Shizuku.

## Technical Context

- Root cause: `RootSetupModule.Result.isComplete` short-circuited to `true` as soon as the user had picked yes/no (`useRoot != null`), ignoring the actual binder state. `ShizukuSetupModule`'s analogous predicate already factored in `ourService`.
- The `State` object has been carrying `isInstalled` and `ourService` since #833 — only the completeness predicate was missed.
- Aligned root's predicate with Shizuku's: `useRoot == false || (useRoot == true && (!isInstalled || ourService))`. Same logic the `compose-rewrite` branch already lands.
- Behavioural change: any transient binder drop will now re-surface the card. Worth keeping an eye on if the binder is flaky under load — appears stable in normal usage.
