### PR TITLE
General: Expand ShellOps streaming test coverage

### DIFF
--- a/app-common-io/src/test/java/eu/darken/sdmse/common/shell/ipc/ShellOpsClientStreamingTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/shell/ipc/ShellOpsClientStreamingTest.kt
@@ -1,0 +1,130 @@
+package eu.darken.sdmse.common.shell.ipc
+
+import android.os.IBinder
+import eu.darken.sdmse.common.ipc.RemoteInputStream
+import eu.darken.sdmse.common.ipc.ServiceConnectionLostException
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+import testhelpers.coroutine.TestDispatcherProvider
+import java.io.IOException
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class ShellOpsClientStreamingTest : BaseTest() {
+
+    private fun makeScope() = CoroutineScope(Job() + Dispatchers.IO)
+
+    /** Stub that pretends to be an AIDL ShellOpsConnection, returning a pre-built RemoteInputStream. */
+    private class FakeConnection(
+        private val streamFactory: () -> RemoteInputStream,
+    ) : ShellOpsConnection {
+        override fun execute(cmd: ShellOpsCmd?): ShellOpsResult =
+            throw UnsupportedOperationException("not used in streaming tests")
+
+        override fun executeStream(cmd: ShellOpsCmd?): RemoteInputStream = streamFactory()
+
+        override fun asBinder(): IBinder? = null
+    }
+
+    @Test
+    fun `executeStream forwards normal events as a Flow`() {
+        val scope = makeScope()
+        try {
+            runBlocking {
+                val events = listOf(
+                    ShellOpsStreamEvent.Stdout("hello"),
+                    ShellOpsStreamEvent.Stdout("world"),
+                    ShellOpsStreamEvent.Stderr("warn!"),
+                    ShellOpsStreamEvent.Exit(0),
+                )
+                val client = ShellOpsClient(
+                    connection = FakeConnection { events.asFlow().toRemoteInputStream(scope) },
+                    dispatcherProvider = TestDispatcherProvider(),
+                )
+
+                val collected = client.executeStream(ShellOpsCmd("ignored")).toList()
+                collected shouldContainExactly events
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `executeStream unwraps IOException from wrapped Error event`() {
+        // The host's IpcHostModule.wrapToPropagate() formats the exception as:
+        //     "<exception-class>: <message>"
+        // The client must round-trip that back to the original exception type via
+        // IpcClientModule.refineException -> unwrapPropagation. Otherwise callers catching
+        // specific exception types (e.g. RootHostLauncher catching IOException) silently
+        // start seeing generic Exception and miss the handler.
+        val wrappedMessage = "java.io.IOException: Stream closed"
+        val scope = makeScope()
+        try {
+            runBlocking {
+                val client = ShellOpsClient(
+                    connection = FakeConnection {
+                        flow<ShellOpsStreamEvent> {
+                            emit(ShellOpsStreamEvent.Stdout("partial output"))
+                            emit(ShellOpsStreamEvent.Error(wrappedMessage))
+                        }.toRemoteInputStream(scope)
+                    },
+                    dispatcherProvider = TestDispatcherProvider(),
+                )
+
+                val thrown = runCatching { client.executeStream(ShellOpsCmd("ignored")).toList() }
+                    .exceptionOrNull()
+                thrown.shouldBeInstanceOf<IOException>()
+                thrown!!.message shouldBe "Stream closed"
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `executeStream surfaces ServiceConnectionLostException via DeadObject path`() {
+        // When the AIDL call itself raises DeadObjectException (binder went away before
+        // we even got a RemoteInputStream), refineException must promote it to
+        // ServiceConnectionLostException. This is the path that drives the "Service
+        // Connection Lost" dialog — without this mapping, the dashboard would treat the
+        // failure as a generic crash.
+        val scope = makeScope()
+        try {
+            runBlocking {
+                val client = ShellOpsClient(
+                    connection = object : ShellOpsConnection {
+                        override fun execute(cmd: ShellOpsCmd?): ShellOpsResult =
+                            throw UnsupportedOperationException()
+                        override fun executeStream(cmd: ShellOpsCmd?): RemoteInputStream =
+                            throw android.os.DeadObjectException("binder died")
+                        override fun asBinder(): IBinder? = null
+                    },
+                    dispatcherProvider = TestDispatcherProvider(),
+                )
+
+                val thrown = runCatching { client.executeStream(ShellOpsCmd("ignored")).toList() }
+                    .exceptionOrNull()
+                thrown.shouldBeInstanceOf<ServiceConnectionLostException>()
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+}

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/shell/ipc/ShellOpsIPCFlowTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/shell/ipc/ShellOpsIPCFlowTest.kt
@@ -7,11 +7,13 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -179,6 +181,36 @@ class ShellOpsIPCFlowTest : BaseTest() {
             runBlocking {
                 val collected = events.asFlow().toRemoteInputStream(scope).toShellOpsEventFlow().toList()
                 collected shouldContainExactly events
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `consumer cancellation closes the RemoteInputStream and stops emission`() {
+        // When the client-side Flow collector cancels mid-stream (e.g. user backs out of
+        // a scan), toShellOpsEventFlow's finally block must close the RemoteInputStream
+        // so the host writer detects the broken pipe and the producer scope can wind down.
+        // The first event is sized > CHUNK_BYTE_LIMIT (64 KB) so it forces an immediate
+        // chunk flush — otherwise the byte-bounded chunker would buffer the small first
+        // event and the collector would see nothing before the cancellation timeout.
+        val firstLine = "x".repeat(40_000)
+        val source: Flow<ShellOpsStreamEvent> = flow {
+            emit(ShellOpsStreamEvent.Stdout(firstLine))
+            delay(2_000)
+            emit(ShellOpsStreamEvent.Stdout("should-not-arrive"))
+            emit(ShellOpsStreamEvent.Exit(0))
+        }
+        val scope = makeScope()
+        try {
+            runBlocking {
+                val seen = mutableListOf<ShellOpsStreamEvent>()
+                withTimeoutOrNull(500) {
+                    source.toRemoteInputStream(scope).toShellOpsEventFlow().collect { seen.add(it) }
+                }
+                seen.size shouldBe 1
+                (seen[0] as ShellOpsStreamEvent.Stdout).line.length shouldBe firstLine.length
             }
         } finally {
             scope.cancel()


### PR DESCRIPTION
## What changed

No user-facing behavior change. Follow-up to #2420 adding four unit tests that pin paths the initial change exercised only manually on-device.

## Technical Context

- **`ShellOpsClientStreamingTest.executeStream forwards normal events as a Flow`** — happy-path Stdout/Stderr/Exit forwarding through a fake `ShellOpsConnection` stub. Pins the basic client wiring.
- **`ShellOpsClientStreamingTest.executeStream unwraps IOException from wrapped Error event`** — pins the `IpcHostModule.wrapToPropagate` → `IpcClientModule.refineException` → `unwrapPropagation` round trip. Without this, a host-side `IOException` emitted as a wire `Error` event would surface to the client as a generic `Exception`, silently breaking callers that catch specific exception types (e.g. `RootHostLauncher`'s `IOException` retry path).
- **`ShellOpsClientStreamingTest.executeStream surfaces ServiceConnectionLostException via DeadObject path`** — pins the `DeadObjectException` → `ServiceConnectionLostException` promotion that drives the user-facing "Service Connection Lost" dialog. Without this, a binder transaction failure during `executeStream` would propagate as a generic crash instead of the friendly dialog.
- **`ShellOpsIPCFlowTest.consumer cancellation closes the RemoteInputStream and stops emission`** — pins cooperative shutdown when the client-side collector cancels mid-stream (e.g. user backs out of a scan). Uses a first event sized above the 64 KB chunk threshold to force an immediate chunk flush so the collector observes progress before the cancellation timeout.

All four pass alongside the existing 8 IPC-flow tests; full `:app-common-io:testFossDebugUnitTest` suite is green.

## Review guidance

The fake `ShellOpsConnection` in `ShellOpsClientStreamingTest` is the smallest viable stub that lets the test exercise `ShellOpsClient.executeStream` without standing up the full Hilt graph — it returns a pre-built `RemoteInputStream` produced by the same `toRemoteInputStream` helper the host uses, so the wire format is identical to a real binder round-trip minus the AIDL marshalling.

Refs #2420
