### PR TITLE
Analyzer: Show SD cards with exotic fsUuid formats

### DIFF
--- a/app-common-data/src/main/java/eu/darken/sdmse/common/storage/StorageId.kt
+++ b/app-common-data/src/main/java/eu/darken/sdmse/common/storage/StorageId.kt
@@ -18,6 +18,10 @@ data class StorageId(
         // whose fsUuid is a 4+4-hex label (e.g. "EFFD-F4D5") rather than a real 128-bit UUID.
         const val FAT_UUID_PREFIX = "fafafafa-fafa-5afa-8afa-fafa"
 
+        // Returns a deterministic UUID for any non-null fsUuid. Returns null only if fsUuid is null.
+        // Order: real UUID → FAT-synthesised (4+4-hex labels) → hash-synthesised for exotic formats
+        // like 16-hex-char NTFS/exFAT serials (#2418). Hash-synthesised UUIDs won't match any system
+        // UUID, so callers must fall back to the File API for sizing.
         fun parseVolumeUuid(fsUuid: String?): UUID? {
             if (fsUuid == null) return null
             return try {
@@ -26,7 +30,7 @@ data class StorageId(
                 try {
                     UUID.fromString("$FAT_UUID_PREFIX${fsUuid.replace("-", "")}")
                 } catch (_: Exception) {
-                    null
+                    UUID.nameUUIDFromBytes(fsUuid.toByteArray())
                 }
             }
         }

--- a/app-common-data/src/test/java/eu/darken/sdmse/common/storage/StorageIdTest.kt
+++ b/app-common-data/src/test/java/eu/darken/sdmse/common/storage/StorageIdTest.kt
@@ -1,0 +1,51 @@
+package eu.darken.sdmse.common.storage
+
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class StorageIdTest : BaseTest() {
+
+    @Test
+    fun `null fsUuid returns null`() {
+        StorageId.parseVolumeUuid(null).shouldBeNull()
+    }
+
+    @Test
+    fun `real UUID is parsed as-is`() {
+        val real = "12345678-1234-1234-1234-123456789abc"
+        StorageId.parseVolumeUuid(real)!!.toString() shouldBe real
+    }
+
+    @Test
+    fun `FAT 4+4 hex label is FAT-prefixed`() {
+        val u = StorageId.parseVolumeUuid("EFFD-F4D5")
+        u shouldNotBe null
+        u!!.toString().startsWith(StorageId.FAT_UUID_PREFIX) shouldBe true
+        u.toString() shouldBe "${StorageId.FAT_UUID_PREFIX}effdf4d5"
+    }
+
+    @Test
+    fun `exotic 16-hex fsUuid is synthesised deterministically (#2418)`() {
+        val a = StorageId.parseVolumeUuid("1C32C2D032C2AE58")
+        val b = StorageId.parseVolumeUuid("1C32C2D032C2AE58")
+        a shouldNotBe null
+        a shouldBe b
+        // Must not be mis-tagged as FAT, otherwise the size-mismatch heuristic from #2389 fires.
+        a!!.toString().startsWith(StorageId.FAT_UUID_PREFIX) shouldBe false
+    }
+
+    @Test
+    fun `different exotic fsUuids produce different UUIDs`() {
+        val a = StorageId.parseVolumeUuid("1C32C2D032C2AE58")
+        val b = StorageId.parseVolumeUuid("ABCDEF0123456789")
+        a shouldNotBe b
+    }
+
+    @Test
+    fun `garbage fsUuid still produces a UUID rather than null`() {
+        StorageId.parseVolumeUuid("not a uuid at all !!!") shouldNotBe null
+    }
+}

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/device/DeviceStorageScanner.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/device/DeviceStorageScanner.kt
@@ -3,7 +3,6 @@ package eu.darken.sdmse.analyzer.core.device
 import android.os.storage.StorageManager
 import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
-import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.asFile
@@ -90,21 +89,7 @@ class DeviceStorageScanner @Inject constructor(
                     volume.path?.path?.toCaString() ?: eu.darken.sdmse.analyzer.R.string.analyzer_storage_type_secondary_title.toCaString()
                 )
 
-                var volumeId: UUID? = try {
-                    UUID.fromString(volume.fsUuid)
-                } catch (e: IllegalArgumentException) {
-                    null
-                }
-                if (volumeId == null && volume.fsUuid != null) {
-                    try {
-                        volumeId = UUID.fromString(
-                            "${StorageId.FAT_UUID_PREFIX}${volume.fsUuid!!.replace("-", "")}"
-                        )
-                    } catch (e: Exception) {
-                        log(TAG, WARN) { "Failed to construct UUID: ${e.asLog()}" }
-                    }
-                }
-
+                val volumeId = StorageId.parseVolumeUuid(volume.fsUuid)
                 if (volumeId == null) {
                     log(TAG, WARN) { "Failed to determine UUID of $volume" }
                     return@mapNotNull null

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/device/DeviceStorageScannerTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/device/DeviceStorageScannerTest.kt
@@ -158,4 +158,21 @@ class DeviceStorageScannerTest : BaseTest() {
         val synthesised = StorageId.parseVolumeUuid("EFFD-F4D5")
         synthesised!!.toString().startsWith(StorageId.FAT_UUID_PREFIX) shouldBe true
     }
+
+    @Test
+    fun `exotic 16-hex fsUuid is accepted and falls back to File API (reproduces #2418)`() = runTest {
+        // Huawei Mate 40 Pro / Android 12 / NTFS-style SD card serial.
+        val fsUuid = "1C32C2D032C2AE58"
+        val path = mockFile(totalSpace = 250_000_000_000L, freeSpace = 100_000_000_000L)
+        every { storageManager2.volumes } returns listOf(mockVolume(fsUuid = fsUuid, path = path))
+        // System doesn't know the synthesised UUID, so stats calls fail and File API is used.
+        coEvery { statsManager.getTotalBytes(match { it.internalId == fsUuid }) } throws IllegalStateException("unknown volume")
+        coEvery { statsManager.getFreeBytes(match { it.internalId == fsUuid }) } throws IllegalStateException("unknown volume")
+
+        val secondary = createScanner().scan().secondary()
+
+        secondary shouldNotBe null
+        secondary!!.spaceCapacity shouldBe 250_000_000_000L
+        secondary.spaceFree shouldBe 100_000_000_000L
+    }
 }


### PR DESCRIPTION
## What changed

Some memory cards that were formatted on a PC report a non-standard serial (e.g. `1C32C2D032C2AE58`) instead of the usual short card label or a full UUID. In the storage list inside the Analyzer those cards silently disappeared — only internal storage showed up. They now appear correctly, with sizes read from the filesystem.

## Technical Context

- Root cause: `DeviceStorageScanner` tried to build a `UUID` for each volume in two steps — first `UUID.fromString(fsUuid)`, then a FAT fallback that prepends `fafafafa-fafa-5afa-8afa-fafa` to the 4+4 hex label. For a 16-hex-char NTFS/exFAT-style serial the concatenated string has a 20-hex tail (vs. the required 12), `UUID.fromString` calls `Long.decode` on it, and `NumberFormatException` was caught; `volumeId` stayed null and the volume was dropped via `mapNotNull`.
- The same parsing logic already existed in `StorageId.parseVolumeUuid()` and is used correctly by `SpaceTracker` / `SpaceHistoryViewModel`. The scanner had duplicated it. Now reuses the helper.
- `parseVolumeUuid()` gets a final `UUID.nameUUIDFromBytes(fsUuid.toByteArray())` fallback. This is deterministic per fsUuid, so history records stay stable. The synthesised UUID won't match a system UUID, so the existing `StorageStatsManager` `catch` falls back to `volume.path.totalSpace/freeSpace` — exactly what we want for cards the OS won't size for us.
- The new UUIDs do not start with `FAT_UUID_PREFIX`, so the #2389 FAT-size-mismatch heuristic does not fire for them. Correct — they aren't FAT.

Closes #2418
