### PR TITLE
General: Reduce root/adb client log noise during data area scan

### DIFF
--- a/app-common-data/src/main/java/eu/darken/sdmse/common/areas/modules/DataAreaFactory.kt
+++ b/app-common-data/src/main/java/eu/darken/sdmse/common/areas/modules/DataAreaFactory.kt
@@ -12,6 +12,7 @@ import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.pkgs.pkgops.PkgOps
+import eu.darken.sdmse.common.sharedresource.KeepAlive
 import eu.darken.sdmse.common.sharedresource.closeAll
 import eu.darken.sdmse.common.shell.ShellOps
 import javax.inject.Inject
@@ -26,40 +27,43 @@ class DataAreaFactory @Inject constructor(
 
     suspend fun build(): Collection<DataArea> {
         log(TAG) { "build()" }
-        val leases = setOf(pkgOps, gatewaySwitch, shellOps).map { it.sharedResource.get() }
+        val leases = mutableListOf<KeepAlive>()
+        try {
+            setOf(pkgOps, gatewaySwitch, shellOps).forEach { leases.add(it.sharedResource.get()) }
 
-        val firstPass = areaModules.map { it.firstPass() }.flatten()
-        log(TAG, VERBOSE) { "build(): First pass: ${firstPass.joinToString("\n")}" }
+            val firstPass = areaModules.map { it.firstPass() }.flatten()
+            log(TAG, VERBOSE) { "build(): First pass: ${firstPass.joinToString("\n")}" }
 
-        val secondPass = areaModules.map { it.secondPass(firstPass) }.flatten()
-        log(TAG, VERBOSE) { "build(): Second pass:\n${secondPass.joinToString("\n")}" }
+            val secondPass = areaModules.map { it.secondPass(firstPass) }.flatten()
+            log(TAG, VERBOSE) { "build(): Second pass:\n${secondPass.joinToString("\n")}" }
 
-        leases.closeAll()
+            val newAreas = (firstPass + secondPass).toSet()
+            if (firstPass.size + secondPass.size != newAreas.size) {
+                log(TAG, WARN) { "build(): Cleaned areas: ${newAreas.joinToString("\n")}" }
+            }
 
-        val newAreas = (firstPass + secondPass).toSet()
-        if (firstPass.size + secondPass.size != newAreas.size) {
-            log(TAG, WARN) { "build(): Cleaned areas: ${newAreas.joinToString("\n")}" }
+            if (BuildConfigWrap.BUILD_TYPE != RELEASE && firstPass.size + secondPass.size != newAreas.size) {
+                log(TAG, WARN) { "First pass: $firstPass" }
+                log(TAG, WARN) { "Second pass: $secondPass" }
+                log(TAG, WARN) { "Final areas: $newAreas" }
+                throw IllegalStateException("Duplicate data areas")
+            }
+
+            if (BuildConfigWrap.BUILD_TYPE != RELEASE && newAreas.map { it.path }.toSet().size != newAreas.size) {
+                log(TAG, WARN) { "Final areas: $newAreas" }
+                throw IllegalStateException("Duplicate data areas with overlapping paths")
+            }
+
+            if (newAreas.isEmpty()) {
+                log(TAG, ERROR) { "No accessible data areas detected!" }
+            } else {
+                log(TAG, INFO) { "Accessible data areas:\n${newAreas.joinToString("\n")}" }
+            }
+
+            return newAreas
+        } finally {
+            leases.closeAll()
         }
-
-        if (BuildConfigWrap.BUILD_TYPE != RELEASE && firstPass.size + secondPass.size != newAreas.size) {
-            log(TAG, WARN) { "First pass: $firstPass" }
-            log(TAG, WARN) { "Second pass: $secondPass" }
-            log(TAG, WARN) { "Final areas: $newAreas" }
-            throw IllegalStateException("Duplicate data areas")
-        }
-
-        if (BuildConfigWrap.BUILD_TYPE != RELEASE && newAreas.map { it.path }.toSet().size != newAreas.size) {
-            log(TAG, WARN) { "Final areas: $newAreas" }
-            throw IllegalStateException("Duplicate data areas with overlapping paths")
-        }
-
-        if (newAreas.isEmpty()) {
-            log(TAG, ERROR) { "No accessible data areas detected!" }
-        } else {
-            log(TAG, INFO) { "Accessible data areas:\n${newAreas.joinToString("\n")}" }
-        }
-
-        return newAreas
     }
 
     companion object {

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalGateway.kt
@@ -35,7 +35,7 @@ import eu.darken.sdmse.common.root.RootUnavailableException
 import eu.darken.sdmse.common.root.canUseRootNow
 import eu.darken.sdmse.common.root.service.runModuleAction
 import eu.darken.sdmse.common.sharedresource.SharedResource
-import eu.darken.sdmse.common.sharedresource.keepResourcesAlive
+import eu.darken.sdmse.common.sharedresource.adoptChildResource
 import eu.darken.sdmse.common.storage.StorageEnvironment
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
@@ -67,16 +67,14 @@ class LocalGateway @Inject constructor(
 
     private suspend fun <T> rootOps(action: suspend (FileOpsClient) -> T): T {
         if (!rootManager.canUseRootNow()) throw RootUnavailableException()
-        return keepResourcesAlive(rootManager.serviceClient) {
-            rootManager.serviceClient.runModuleAction(FileOpsClient::class.java) { action(it) }
-        }
+        adoptChildResource(rootManager.serviceClient)
+        return rootManager.serviceClient.runModuleAction(FileOpsClient::class.java) { action(it) }
     }
 
     private suspend fun <T> adbOps(action: suspend (FileOpsClient) -> T): T {
         if (!adbManager.canUseAdbNow()) throw AdbUnavailableException()
-        return keepResourcesAlive(adbManager.serviceClient) {
-            adbManager.serviceClient.runModuleAction(FileOpsClient::class.java) { action(it) }
-        }
+        adoptChildResource(adbManager.serviceClient)
+        return adbManager.serviceClient.runModuleAction(FileOpsClient::class.java) { action(it) }
     }
 
     suspend fun hasRoot(): Boolean = rootManager.canUseRootNow()

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/PkgOps.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/PkgOps.kt
@@ -50,7 +50,7 @@ import eu.darken.sdmse.common.root.canUseRootNow
 import eu.darken.sdmse.common.root.service.runModuleAction
 import eu.darken.sdmse.common.sharedresource.HasSharedResource
 import eu.darken.sdmse.common.sharedresource.SharedResource
-import eu.darken.sdmse.common.sharedresource.keepResourcesAlive
+import eu.darken.sdmse.common.sharedresource.adoptChildResource
 import eu.darken.sdmse.common.user.UserHandle2
 import eu.darken.sdmse.common.user.UserManager2
 import kotlinx.coroutines.CoroutineScope
@@ -76,16 +76,14 @@ class PkgOps @Inject constructor(
 
     private suspend fun <T> adbOps(action: suspend (PkgOpsClient) -> T): T {
         if (!adbManager.canUseAdbNow()) throw AdbUnavailableException()
-        return keepResourcesAlive(adbManager.serviceClient) {
-            adbManager.serviceClient.runModuleAction(PkgOpsClient::class.java) { action(it) }
-        }
+        adoptChildResource(adbManager.serviceClient)
+        return adbManager.serviceClient.runModuleAction(PkgOpsClient::class.java) { action(it) }
     }
 
     private suspend fun <T> rootOps(action: suspend (PkgOpsClient) -> T): T {
         if (!rootManager.canUseRootNow()) throw RootUnavailableException()
-        return keepResourcesAlive(rootManager.serviceClient) {
-            rootManager.serviceClient.runModuleAction(PkgOpsClient::class.java) { action(it) }
-        }
+        adoptChildResource(rootManager.serviceClient)
+        return rootManager.serviceClient.runModuleAction(PkgOpsClient::class.java) { action(it) }
     }
 
     suspend fun forceStop(installId: InstallId, mode: Mode = Mode.AUTO): Boolean {

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/shell/ShellOps.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/shell/ShellOps.kt
@@ -20,7 +20,7 @@ import eu.darken.sdmse.common.root.canUseRootNow
 import eu.darken.sdmse.common.root.service.runModuleAction
 import eu.darken.sdmse.common.sharedresource.HasSharedResource
 import eu.darken.sdmse.common.sharedresource.SharedResource
-import eu.darken.sdmse.common.sharedresource.keepResourcesAlive
+import eu.darken.sdmse.common.sharedresource.adoptChildResource
 import eu.darken.sdmse.common.shell.ipc.ShellOpsClient
 import eu.darken.sdmse.common.shell.ipc.ShellOpsCmd
 import eu.darken.sdmse.common.shell.ipc.ShellOpsResult
@@ -49,16 +49,14 @@ class ShellOps @Inject constructor(
 
     private suspend fun <T> adbOps(action: suspend (ShellOpsClient) -> T): T {
         if (!adbManager.canUseAdbNow()) throw AdbUnavailableException()
-        return keepResourcesAlive(adbManager.serviceClient) {
-            adbManager.serviceClient.runModuleAction(ShellOpsClient::class.java) { action(it) }
-        }
+        adoptChildResource(adbManager.serviceClient)
+        return adbManager.serviceClient.runModuleAction(ShellOpsClient::class.java) { action(it) }
     }
 
     private suspend fun <T> rootOps(action: suspend (ShellOpsClient) -> T): T {
         if (!rootManager.canUseRootNow()) throw RootUnavailableException()
-        return keepResourcesAlive(rootManager.serviceClient) {
-            rootManager.serviceClient.runModuleAction(ShellOpsClient::class.java) { action(it) }
-        }
+        adoptChildResource(rootManager.serviceClient)
+        return rootManager.serviceClient.runModuleAction(ShellOpsClient::class.java) { action(it) }
     }
 
     suspend fun execute(cmd: ShellOpsCmd, mode: Mode): ShellOpsResult = withContext(dispatcherProvider.IO) {

--- a/app-common/src/main/java/eu/darken/sdmse/common/sharedresource/SharedResource.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/sharedresource/SharedResource.kt
@@ -109,7 +109,7 @@ open class SharedResource<T : Any>(
 
                 if (Bugs.isTrace) log(iTag, DEBUG) { "[$sId|$lId]-get() Checking for source job..." }
                 if (sourceJob != null) {
-                    lifecycleLog { "[$sId|$lId]-get() Source job already exists" }
+                    if (Bugs.isTrace) log(iTag, VERBOSE) { "[$sId|$lId]-get() Source job already exists" }
                     return@withContext
                 }
 
@@ -153,7 +153,9 @@ open class SharedResource<T : Any>(
 
         var value: T? = sourceValue
         var error: Throwable? = sourceError
-        lifecycleLog { "[$sId|$lId]-get() Waiting for source value... (current value=$value, error=$error)" }
+        if (value == null && error == null) {
+            lifecycleLog { "[$sId|$lId]-get() Waiting for source value... (current value=$value, error=$error)" }
+        }
         while (value == null && error == null) {
             value = sourceValue?.also {
                 if (Bugs.isTrace) log(iTag, DEBUG) { "[$sId|$lId]-get() sourceValue loop, got $it" }
@@ -302,11 +304,19 @@ open class SharedResource<T : Any>(
      * But the backupmodule, while open, keeps the root shell alive.
      */
     suspend fun addChild(child: SharedResource<*>) = coreLock.withLock("addChild-${child.resourceId}") {
-        if (children.contains(child)) {
+        val existing = children[child]
+        if (existing != null && !existing.isClosed) {
             if (Bugs.isTrace) {
                 log(iTag, VERBOSE) { "[$sId|_]-addChild() Already keeping child alive: $child" }
             }
             return@withLock
+        }
+        if (existing != null) {
+            // Stale child entry — drop it and fall through to re-adopt
+            if (Bugs.isTrace) {
+                log(iTag, VERBOSE) { "[$sId|_]-addChild() Replacing stale closed child: $child" }
+            }
+            children.remove(child)
         }
 
         if (isClosed) {

--- a/app-common/src/test/java/eu/darken/sdmse/common/sharedresource/SharedResourceTest.kt
+++ b/app-common/src/test/java/eu/darken/sdmse/common/sharedresource/SharedResourceTest.kt
@@ -450,6 +450,8 @@ class SharedResourceTest : BaseTest() {
                 parentScope = this + Dispatchers.IO,
                 stopTimeout = Duration.ZERO,
                 source = flow {
+                    // Force a real wait so the cold-start "Waiting for source value..." path fires
+                    delay(50)
                     emit(Unit)
                     awaitCancellation()
                 },
@@ -482,6 +484,74 @@ class SharedResourceTest : BaseTest() {
         } finally {
             Logging.remove(capture)
         }
+    }
+
+    @Test fun `warm cache-hit get() does not log Source-job-already-exists or Waiting`() = runTest2(autoCancel = true) {
+        Bugs.isTrace = false
+
+        val captured = mutableListOf<String>()
+        val capture = object : Logging.Logger {
+            override fun log(
+                priority: Logging.Priority,
+                tag: String,
+                message: String,
+                metaData: Map<String, Any>?
+            ) {
+                if (tag.endsWith(":SR")) captured.add(message)
+            }
+        }
+        Logging.install(capture)
+        try {
+            val sr = SharedResource(
+                tag = "warm",
+                parentScope = this + Dispatchers.IO,
+                stopTimeout = Duration.ofSeconds(5),
+                source = flow {
+                    emit(Unit)
+                    awaitCancellation()
+                },
+                verboseLifecycle = true,
+            )
+
+            // First acquisition — cold start, populates the cache
+            val firstLease = sr.get()
+            // Clear logs from the cold-start path
+            captured.clear()
+
+            // Second acquisition — cache hit, must not log either lifecycle breadcrumb
+            val secondLease = sr.get()
+            captured.any { it.contains("Source job already exists") } shouldBe false
+            captured.any { it.contains("Waiting for source value") } shouldBe false
+
+            secondLease.close()
+            firstLease.close()
+        } finally {
+            Logging.remove(capture)
+        }
+    }
+
+    @Test fun `addChild refreshes a stale closed child`() = runTest2(autoCancel = true) {
+        val parent = SharedResource.createKeepAlive("parent", this + Dispatchers.IO, Duration.ZERO)
+        // Keep parent alive across the whole test
+        val parentLease = parent.get()
+
+        val child = SharedResource.createKeepAlive("child", this + Dispatchers.IO, Duration.ZERO)
+
+        // Adopt: parent acquires a keep-alive lease on child
+        parent.addChild(child)
+        child.isClosed shouldBe false
+
+        // Force child to complete: close all direct leases on it. Parent holds the only lease via addChild.
+        child.close()
+        child.isClosed shouldBe true
+
+        // Re-adopt after the child source completed
+        parent.addChild(child)
+
+        // The child must be alive again — proves the stale entry was refreshed, not silently kept
+        child.isClosed shouldBe false
+
+        parentLease.close()
     }
 
     @Test fun `racing global close`(): Unit = runBlocking {


### PR DESCRIPTION
## What changed

No user-facing behavior change. Internal cleanup that quiets the debug log during setup when root or ADB is enabled, and tightens resource management in a few related places.

## Technical Context

- **SharedResource cache-hit logs**: `RootServiceClient`/`AdbServiceClient` set `verboseLifecycle = true` to surface silent-failure diagnostics. The intent was to keep cold-start lifecycle events visible without trace mode, but `get()` also logged `"Source job already exists"` and `"Waiting for source value..."` on every cache hit — producing 4 debug lines per `LocalGateway`/`PkgOps`/`ShellOps` file op. Demoted the cache-hit breadcrumbs to trace-only; cold-start/source-launch/completion breadcrumbs stay visible.
- **Wait-log guard**: `"Waiting for source value..."` now only fires when there is a real wait (`value == null && error == null`), preventing yield-loop spam.
- **Redundant lease per file op**: `rootOps`/`adbOps` in `LocalGateway`, `PkgOps`, `ShellOps` wrapped `runModuleAction` in `keepResourcesAlive(serviceClient) { ... }`. `runModuleAction` already takes a lease via `runSessionAction { get().use { ... } }`. Replaced the wrapper with `adoptChildResource(serviceClient)` to preserve the parent/child relationship without the redundant outer `get()`.
- **Stale child resilience**: `SharedResource.addChild()` short-circuited on `children.contains(child)` without checking if the existing `Child` entry was still alive. After a child source completed mid-life, the parent retained a stale entry and future `adoptChildResource` calls became silent no-ops. Now refreshes stale closed children.
- **DataAreaFactory lease leak**: `build()` only released its `pkgOps`/`gatewaySwitch`/`shellOps` leases on the success path. Wrapped in try/finally with partial-acquisition handling so leases release on exception or coroutine cancellation.

### Verification

- All unit tests pass (`:app-common`, `:app-common-io`, `:app-common-data`).
- New `SharedResourceTest` cases for warm cache-hit silence and stale-child re-adoption.
- Manual test on Pixel 7a with Magisk: setup root toggle off→on produces ~11 `:SR` log lines total (cold-start only) vs dozens previously. CorpseFinder scan across hundreds of root paths produces zero new `:SR` debug lines. Connection reused across >5 s idle gap. Scans complete successfully.

### Side effect surfaced (not fixed)

The reduced noise exposes a pre-existing warning: `W/SDMSE:Pkg:Ops:SR: addChild() We are closed!`. `PkgOps.sharedResource` is closed when `adoptChildResource` is called, so the parent/child keep-alive optimization for PkgOps is silently lost. Operations still succeed via the inner `runModuleAction` lease. The same condition existed with the old `keepResourcesAlive` path — just masked by spam.
