### PR TITLE
General: Recover gracefully when the system hides installed apps

### DIFF
--- a/app-common-pkgs/src/main/java/eu/darken/sdmse/common/pkgs/PkgInventoryCheck.kt
+++ b/app-common-pkgs/src/main/java/eu/darken/sdmse/common/pkgs/PkgInventoryCheck.kt
@@ -1,0 +1,23 @@
+package eu.darken.sdmse.common.pkgs
+
+object PkgInventoryCheck {
+
+    val SANITY_PKGS = setOf(
+        "android",
+        "com.android.cts.ctsshim",
+    )
+
+    fun check(packageNames: Collection<String>, ownPackage: String): Result = when {
+        packageNames.isEmpty() -> Result.Empty
+        !packageNames.contains(ownPackage) -> Result.MissingOwn
+        packageNames.none { it in SANITY_PKGS } -> Result.MissingCore
+        else -> Result.Valid
+    }
+
+    sealed interface Result {
+        data object Valid : Result
+        data object Empty : Result
+        data object MissingOwn : Result
+        data object MissingCore : Result
+    }
+}

--- a/app-common-pkgs/src/main/java/eu/darken/sdmse/common/pkgs/sources/NormalPkgsSource.kt
+++ b/app-common-pkgs/src/main/java/eu/darken/sdmse/common/pkgs/sources/NormalPkgsSource.kt
@@ -22,6 +22,7 @@ import eu.darken.sdmse.common.hasApiLevel
 import eu.darken.sdmse.common.permissions.Permission
 import eu.darken.sdmse.common.pkgs.InvalidPkgInventoryException
 import eu.darken.sdmse.common.pkgs.PkgDataSource
+import eu.darken.sdmse.common.pkgs.PkgInventoryCheck
 import eu.darken.sdmse.common.pkgs.container.NormalPkg
 import eu.darken.sdmse.common.pkgs.features.Installed
 import eu.darken.sdmse.common.pkgs.features.InstallerInfo
@@ -77,18 +78,26 @@ class NormalPkgsSource @Inject constructor(
 
         // FYI: MATCH_ALL does not include MATCH_UNINSTALLED_PACKAGES
         val pkgInfos = pkgOps.queryPkgs(PackageManager.MATCH_ALL.toLong())
-        if (pkgInfos.isEmpty()) {
-            throw InvalidPkgInventoryException("Could not retrieve list of installed packages")
-        }
-        if (pkgInfos.none { it.packageName == BuildConfigWrap.APPLICATION_ID }) {
-            throw InvalidPkgInventoryException("Returned package data didn't contain us")
-        }
-        if (pkgInfos.none { SANITY_PKGS.contains(it.packageName) }) {
-            log(TAG, WARN) { "coreList(): ${pkgInfos.size} pkgs returned, missing SANITY_PKGS $SANITY_PKGS" }
-            if (Bugs.isTrace) {
-                log(TAG, WARN) { "coreList(): First 10: ${pkgInfos.take(10).map { it.packageName }}" }
+        when (PkgInventoryCheck.check(pkgInfos.map { it.packageName }, BuildConfigWrap.APPLICATION_ID)) {
+            PkgInventoryCheck.Result.Empty -> {
+                throw InvalidPkgInventoryException("Could not retrieve list of installed packages")
             }
-            throw InvalidPkgInventoryException("Returned package data didn't contain `android` core package")
+
+            PkgInventoryCheck.Result.MissingOwn -> {
+                throw InvalidPkgInventoryException("Returned package data didn't contain us")
+            }
+
+            PkgInventoryCheck.Result.MissingCore -> {
+                val pkgNames = pkgInfos.map { it.packageName }
+                log(TAG, WARN) {
+                    "coreList(): ${pkgInfos.size} pkgs returned, missing SANITY_PKGS ${PkgInventoryCheck.SANITY_PKGS}" +
+                        " (first $PKG_LOG_SAMPLE_SIZE: ${pkgNames.take(PKG_LOG_SAMPLE_SIZE)})"
+                }
+                if (Bugs.isTrace) log(TAG, WARN) { "coreList(): Full list: $pkgNames" }
+                throw InvalidPkgInventoryException("Returned package data didn't contain `android` core package")
+            }
+
+            PkgInventoryCheck.Result.Valid -> Unit
         }
 
         val currentHandle = userManager.currentUser().handle
@@ -148,10 +157,7 @@ class NormalPkgsSource @Inject constructor(
     }
 
     companion object {
-        private val SANITY_PKGS = setOf(
-            "android",
-            "com.android.cts.ctsshim",
-        )
         private val TAG = logTag("Pkg", "Repo", "Source", "NormalPkgs")
+        private const val PKG_LOG_SAMPLE_SIZE = 20
     }
 }

--- a/app-common-pkgs/src/test/java/eu/darken/sdmse/common/pkgs/PkgInventoryCheckTest.kt
+++ b/app-common-pkgs/src/test/java/eu/darken/sdmse/common/pkgs/PkgInventoryCheckTest.kt
@@ -1,0 +1,47 @@
+package eu.darken.sdmse.common.pkgs
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class PkgInventoryCheckTest : BaseTest() {
+
+    private val ownPkg = "eu.darken.sdmse"
+
+    @Test
+    fun `empty list is rejected`() {
+        PkgInventoryCheck.check(emptyList(), ownPkg) shouldBe PkgInventoryCheck.Result.Empty
+    }
+
+    @Test
+    fun `list missing the caller is rejected`() {
+        PkgInventoryCheck.check(listOf("android", "com.android.cts.ctsshim"), ownPkg) shouldBe
+            PkgInventoryCheck.Result.MissingOwn
+    }
+
+    @Test
+    fun `Huawei TAF-sandboxed list with only caller is rejected as MissingCore`() {
+        PkgInventoryCheck.check(listOf(ownPkg, "com.huawei.systemmanager"), ownPkg) shouldBe
+            PkgInventoryCheck.Result.MissingCore
+    }
+
+    @Test
+    fun `list with caller plus android sanity pkg is valid`() {
+        PkgInventoryCheck.check(listOf(ownPkg, "android", "com.huawei.foo"), ownPkg) shouldBe
+            PkgInventoryCheck.Result.Valid
+    }
+
+    @Test
+    fun `list with caller plus ctsshim sanity pkg is valid`() {
+        PkgInventoryCheck.check(listOf(ownPkg, "com.android.cts.ctsshim"), ownPkg) shouldBe
+            PkgInventoryCheck.Result.Valid
+    }
+
+    @Test
+    fun `caller plus single core anchor is intentionally treated as valid`() {
+        // Documents the deliberately permissive heuristic: a single core anchor (android or
+        // ctsshim) is enough. Tightening this risks false positives on minimal AOSP/test images.
+        // See review notes on issue 2419.
+        PkgInventoryCheck.check(listOf(ownPkg, "android"), ownPkg) shouldBe PkgInventoryCheck.Result.Valid
+    }
+}

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/Analyzer.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/Analyzer.kt
@@ -164,10 +164,8 @@ class Analyzer @Inject constructor(
     private suspend fun scanStorageContents(task: StorageScanTask): DeviceStorageScanTask.Result {
         log(TAG, VERBOSE) { "scanStorageContents(): $task" }
 
-        if (!appInventorySetupModule.isComplete()) {
-            log(TAG, WARN) { "SetupModule INVENTORY is not complete" }
-            throw IncompleteSetupException(SetupModule.Type.INVENTORY)
-        }
+        // Inventory completeness is checked per-category inside StorageScanner so that media/system
+        // scans still succeed when the app inventory is unavailable (e.g. Huawei TAF sandbox).
 
         val target = storageDevices.value.singleOrNull { it.id == task.target }
             ?: throw IllegalStateException("Couldn't find ${task.target}")

--- a/app/src/main/java/eu/darken/sdmse/setup/SetupFragment.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/SetupFragment.kt
@@ -196,7 +196,9 @@ class SetupFragment : Fragment3(R.layout.setup_fragment) {
 
                 is SetupEvents.ShowOurDetailsPage -> {
                     try {
-                        startActivity(event.intent)
+                        // Route via specialPermissionLauncher so setup refreshes on return,
+                        // i.e. after the user grants e.g. Huawei's TAF "App list" toggle.
+                        specialPermissionLauncher.launch(event.intent)
                     } catch (e: ActivityNotFoundException) {
                         log(TAG, ERROR) { "Failed to launch app settings for app ops restriction: ${e.asLog()}" }
                         e.asErrorDialogBuilder(requireActivity()).show()

--- a/app/src/main/java/eu/darken/sdmse/setup/inventory/InventorySetupModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/inventory/InventorySetupModule.kt
@@ -10,13 +10,16 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.common.coroutine.AppScope
+import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.flow.replayingShare
 import eu.darken.sdmse.common.hasApiLevel
 import eu.darken.sdmse.common.permissions.Permission
+import eu.darken.sdmse.common.pkgs.PkgInventoryCheck
 import eu.darken.sdmse.common.pkgs.getSettingsIntent
 import eu.darken.sdmse.common.pkgs.pkgops.PkgOps
 import eu.darken.sdmse.common.pkgs.toPkgId
@@ -52,17 +55,31 @@ class InventorySetupModule @Inject constructor(
 
             val isAccessFaked = when {
                 missingPermission.isEmpty() -> {
-                    run {
-                        val pkgs = try {
-                            pkgOps.queryPkgs(PackageManager.MATCH_ALL.toLong()).map { it.packageName }
-                        } catch (e: Exception) {
-                            log(TAG, ERROR) { "Check for fake access failed: ${e.asLog()}" }
-                            null
-                        }
-                        when {
-                            pkgs == null -> false
-                            pkgs.isEmpty() -> true
-                            else -> !pkgs.contains(context.packageName)
+                    val pkgs = try {
+                        pkgOps.queryPkgs(PackageManager.MATCH_ALL.toLong()).map { it.packageName }
+                    } catch (e: Exception) {
+                        log(TAG, ERROR) { "Check for fake access failed: ${e.asLog()}" }
+                        null
+                    }
+                    when (pkgs) {
+                        // Probe failed (binder, SecurityException, OEM PackageManager error). Don't
+                        // pretend setup is complete — tools would later throw a less actionable error.
+                        null -> true
+                        else -> {
+                            val result = PkgInventoryCheck.check(pkgs, context.packageName)
+                            val faked = result != PkgInventoryCheck.Result.Valid
+                            if (faked) {
+                                val sample = pkgs.take(PKG_LOG_SAMPLE_SIZE)
+                                log(TAG, WARN) {
+                                    "Inventory check returned $result for ${pkgs.size} pkgs (first $PKG_LOG_SAMPLE_SIZE: $sample)"
+                                }
+                                if (Bugs.isTrace) {
+                                    log(TAG, WARN) { "Inventory full list: $pkgs" }
+                                }
+                            } else {
+                                log(TAG) { "Inventory check returned $result for ${pkgs.size} pkgs" }
+                            }
+                            faked
                         }
                     }
                 }
@@ -118,5 +135,6 @@ class InventorySetupModule @Inject constructor(
     companion object {
         private val TAG = logTag("Setup", "Inventory", "Module")
         const val INFO_URL = "https://github.com/d4rken-org/sdmaid-se/wiki/Setup#app-inventory"
+        private const val PKG_LOG_SAMPLE_SIZE = 20
     }
 }


### PR DESCRIPTION
## What changed

Some Android builds (notably Huawei devices on EMUI/AOSP 12) hand back a filtered list of installed apps even when the app-inventory permission appears granted. On those devices SD Maid previously failed every tool with a cryptic "Invalid app inventory" error, and the Storage Manager bounced straight back to the dashboard when you tried to open internal storage details.

After this PR:

- The setup card detects the filtered list and shows an actionable error with a direct link to system settings.
- Returning from system settings refreshes the setup state automatically.
- The Storage Manager opens normally even when the inventory is filtered — the "Apps" tile shows a "Setup incomplete — tap to fix" hint, while Media and System tiles work as usual.
- The other tools (AppControl, AppCleaner, CorpseFinder) now route the user to the setup screen instead of erroring out cryptically.

## Technical Context

- **Root cause**: `InventorySetupModule.isAccessFaked` only checked that the caller's own package was in the returned list. Huawei's TAF App-List sandbox includes the caller while filtering out core packages like `android` / `com.android.cts.ctsshim`. `NormalPkgsSource.coreList()` correctly rejected such a list, but the setup module had already reported `isComplete = true`, so tools proceeded into the cryptic `InvalidPkgInventoryException` with no actionable error UI.
- **Shared validator**: pulled the existing sanity check into `PkgInventoryCheck` (`SANITY_PKGS = ["android", "com.android.cts.ctsshim"]`) and used it from both call sites. Tests document the deliberately permissive single-anchor heuristic so it doesn't regress on minimal AOSP/test images.
- **Setup refresh on return**: `SetupEvents.ShowOurDetailsPage` was the only branch using bare `startActivity` instead of `specialPermissionLauncher`, so `setupManager.refresh()` never fired when the user came back from Huawei's app settings. Routed through the launcher to fix that.
- **Probe-failure semantics**: if `pkgOps.queryPkgs` throws (binder failure, `SecurityException`, OEM `PackageManager` errors), `isAccessFaked` is now `true` rather than `false`. Better to surface an inaccurate "setup incomplete" than to leave the card complete and have the tool fail with a less actionable error later.
- **Analyzer graceful degradation**: removed the outer inventory guard in `Analyzer.scanStorageContents`. `StorageScanner.scanForApps` already returned `AppCategory(setupIncomplete = true)` on this path, `AppCategoryVH` already rendered a tap-to-fix hint, and `StorageContentViewModel` already routed the click to `SetupRoute` — the outer guard made that flow unreachable. `deepScanApp` keeps its guard (still legitimately needs the full inventory).
- **Diagnostics**: when the sanity check fails, the first 20 returned package names are logged at WARN, with the full list behind `Bugs.isTrace`. Future support tickets will carry the diagnostic data without users having to enable trace mode.

### Out of scope / known caveats

- This does not grant the App-List permission — the user still has to enable it in Huawei's app settings. The fix replaces a cryptic error with an actionable card.
- On the inventory-incomplete path, the Analyzer's System tile over-reports because it can't subtract app-attributed space. Cosmetic, not a regression.
- `DeviceDetective` Huawei detection still requires `com.miui.securitycenter` (a Xiaomi package). Pre-existing bug, no functional impact here.

Closes #2419
