### PR TITLE
General: Update translations from Crowdin

### DIFF
--- a/app-common-stats/src/main/res/values-fr/strings.xml
+++ b/app-common-stats/src/main/res/values-fr/strings.xml
@@ -33,19 +33,19 @@
     <string name="stats_space_history_range_30d">30 jours</string>
     <string name="stats_space_history_range_90d">90 jours</string>
     <string name="stats_space_history_storage_title">Stockage</string>
-    <string name="stats_space_history_current_used_label">Actuellement utilisé</string>
+    <string name="stats_space_history_current_used_label">Utilisé actuellement</string>
     <string name="stats_space_history_min_label">Minimum utilisé</string>
     <string name="stats_space_history_max_label">Maximum utilisé</string>
     <string name="stats_space_history_delta_label">Delta</string>
     <string name="stats_space_history_delta_in_x">%1$s en %2$s</string>
     <string name="stats_space_history_upgrade_title">L’historique complet est une fonctionnalité Pro</string>
     <string name="stats_space_history_upgrade_body">Passez à la version Pro pour accéder à la vue complète des tendances sur 90 jours pour chaque périphérique de stockage.</string>
-    <string name="stats_space_history_marker_freed">Libéré %1$s</string>
+    <string name="stats_space_history_marker_freed">Espace libéré %1$s</string>
     <string name="stats_storage_type_primary">Mémoire principale</string>
     <string name="stats_storage_type_secondary">Mémoire secondaire</string>
     <string name="stats_storage_type_portable">Unité de stockage amovible</string>
-    <string name="stats_space_history_delete_storage_title">Supprimer l’historique de stockage ?</string>
-    <string name="stats_space_history_delete_storage_desc">Toutes les données de tendance pour ce stockage seront définitivement supprimées.</string>
-    <string name="stats_settings_retention_snapshots_label">Instantanés de stockage</string>
-    <string name="stats_settings_retention_snapshots_desc">Nombre de jours de conservation des instantanés d’espace de stockage.</string>
+    <string name="stats_space_history_delete_storage_title">Supprimer l’historique de stockage ?</string>
+    <string name="stats_space_history_delete_storage_desc">Toutes les données de tendance pour ce stockage seront supprimées irrémédiablement.</string>
+    <string name="stats_settings_retention_snapshots_label">Instantanés de l’espace de stockage</string>
+    <string name="stats_settings_retention_snapshots_desc">Nombre de jours de conservation des instantanés de l’espace de stockage.</string>
 </resources>

--- a/app-common/src/main/res/values-fr/strings.xml
+++ b/app-common/src/main/res/values-fr/strings.xml
@@ -75,10 +75,10 @@
     <string name="general_sort_by_title">Trier par</string>
     <string name="general_sort_options_label">Options de tri</string>
     <string name="general_sort_reverse_action">Mode de tri inversé</string>
-    <string name="general_sort_oldest_first">Plus anciens en premier</string>
-    <string name="general_sort_newest_first">Plus récents en premier</string>
+    <string name="general_sort_oldest_first">Dates plus anciennes en premier</string>
+    <string name="general_sort_newest_first">Dates plus récentes en premier</string>
     <string name="general_sort_name_asc">Nom (A → Z)</string>
-    <string name="general_sort_size_desc">Plus grands en premier</string>
+    <string name="general_sort_size_desc">Plus grandes tailles en premier</string>
     <string name="general_tag_filter_label">Filtrer par étiquettes</string>
     <string name="general_tag_system">Système</string>
     <string name="general_result_success_message">L’opération est réussie</string>

--- a/app-tool-analyzer/src/main/res/values-fr/strings.xml
+++ b/app-tool-analyzer/src/main/res/values-fr/strings.xml
@@ -36,7 +36,7 @@
     <string name="analyzer_storage_content_type_system_label">Données système</string>
     <string name="analyzer_storage_content_type_system_description">Applications système et données système. Applis et données d’autres utilisateurs, si plusieurs comptes utilisateur sont configurés sur cet appareil.</string>
     <string name="analyzer_storage_content_type_system_other_label">Autres</string>
-    <string name="analyzer_storage_content_type_system_info">Fichiers qui ne correspondent pas aux catégories Applications ou Fichiers utilisateur. Navigation uniquement — la suppression n’est pas prise en charge. Certaines zones peuvent être incomplètes en raison de restrictions d’accès.</string>
+    <string name="analyzer_storage_content_type_system_info">Fichiers qui ne correspondent pas aux catégories Applis ou Fichiers utilisateur. Navigation seulement, la suppression n’est pas prise en charge. Certaines zones peuvent être incomplètes en raison de restrictions d’accès.</string>
     <string name="analyzer_storage_content_type_system_other_desc">Fichiers système et autres données auxquels SD Maid n’a pas pu accéder ou catégoriser. Le système d’exploitation restreint l’affichage du contenu de certaines zones.</string>
     <string name="analyzer_storage_content_app_code_label">Code de l’appli</string>
     <string name="analyzer_storage_content_app_code_description">Fichiers, bibliothèques et ressources de l’appli. Cet espace peut être libéré en la désinstallant ou en l’archivant (proposé sur les versions d’Android les plus récentes).</string>

--- a/app-tool-appcontrol/src/main/res/values-pl/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-pl/strings.xml
@@ -144,7 +144,7 @@
     <string name="appcontrol_item_screentime_x_since_y_label">Czas ekranu: %1$s od %2$s</string>
     <string name="appcontrol_item_lastupdate_x_label">Ostatnia aktualizacja: %s</string>
     <string name="appcontrol_item_installedat_x_label">Zainstalowano: %s</string>
-    <string name="shortcut_appcontrol_short">Kontrola aplikacji</string>
+    <string name="shortcut_appcontrol_short">Aplikacje</string>
     <string name="shortcut_appcontrol_long">Zarządzaj zainstalowanymi aplikacjami</string>
     <string name="appcontrol_automation_loading">Przygotowywanie automatyzacji za pomocą usługi ułatwień dostępu</string>
     <string name="appcontrol_automation_progress_find_ok_confirmation">Próba potwierdzenia poprzedniej akcji (słowa kluczowe: %s)</string>

--- a/app-tool-deduplicator/src/main/res/values-fr/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-fr/strings.xml
@@ -25,12 +25,12 @@
     <string name="deduplicator_detection_method_checksum_summary">Déterminer les doublons en calculant les sommes de contrôle des fichiers. Le contenu des fichiers dont les sommes de contrôle correspondent est identique.</string>
     <string name="deduplicator_detection_method_phash_title">Hachage perceptuel</string>
     <string name="deduplicator_detection_method_phash_summary">Trouvez des fichiers similaires en analysant les caractéristiques du contenu et en comparant les valeurs perceptuelles de hachage. ⚠️ La détection fondée sur la similitude peut comporter de faux positifs qui nécessitent une vérification manuelle.</string>
-    <string name="deduplicator_detection_method_media_title">Empreinte multimédia</string>
-    <string name="deduplicator_detection_method_media_summary">Trouver des fichiers vidéo et audio similaires en analysant les empreintes audio. ⚠️ La détection basée sur la similarité peut inclure des faux positifs nécessitant une vérification manuelle.</string>
+    <string name="deduplicator_detection_method_media_title">Empreinte numérique du média</string>
+    <string name="deduplicator_detection_method_media_summary">Trouver des fichiers vidéo et audio similaires en analysant les empreintes sonores numériques. ⚠️ La détection selon la similitude peut comprendre de faux positifs qui demandent une vérification manuelle.</string>
     <string name="deduplicator_matches_media_label">Médias similaires</string>
-    <string name="deduplicator_media_match_audio">Correspondance audio</string>
-    <string name="deduplicator_media_match_visual">Correspondance vidéo</string>
-    <string name="deduplicator_media_match_audio_visual">Correspondance audio et vidéo</string>
+    <string name="deduplicator_media_match_audio">Correspondance basée sur le son</string>
+    <string name="deduplicator_media_match_visual">Correspondance basée sur la vidéo</string>
+    <string name="deduplicator_media_match_audio_visual">Correspondance basée sur le son et la vidéo</string>
     <string name="deduplicator_occupied_space_label">Mémoire occupée</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s est occupé par des doublons</item>

--- a/app-tool-scheduler/src/main/res/values-fr/strings.xml
+++ b/app-tool-scheduler/src/main/res/values-fr/strings.xml
@@ -32,7 +32,7 @@
     <string name="scheduler_notification_channel_label">Programmateur</string>
     <string name="scheduler_notification_title">Tâche programmée</string>
     <string name="scheduler_notification_message">Exécution : %s</string>
-    <string name="scheduler_notification_result_channel_label">Résultats du planificateur</string>
+    <string name="scheduler_notification_result_channel_label">Résultats du programmateur</string>
     <string name="scheduler_notification_result_title">Le programmateur a terminé</string>
     <string name="scheduler_notification_result_success_message">Toutes vos tâches programmées ont été effectuées correctement.</string>
     <string name="scheduler_notification_result_failure_message">Certaines tâches ont échoué ou des erreurs sont survenues. Tentez de les effectuer manuellement.</string>

--- a/app-tool-squeezer/src/main/res/values-fr/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-fr/strings.xml
@@ -1,29 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Compresser les images et vidéos pour réduire l\'espace utilisé.</string>
+    <string name="squeezer_explanation_short">Compresser les images et vidéos pour réduire l’espace utilisé.</string>
     <plurals name="squeezer_result_x_images_found">
-        <item quantity="one">%d élément a été trouvé</item>
-        <item quantity="other">%d éléments ont été trouvés</item>
+        <item quantity="one">%d élément a été trouvé</item>
+        <item quantity="other">%d éléments ont été trouvés</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">~%s en moins</item>
         <item quantity="other">~%s en moins</item>
     </plurals>
     <plurals name="squeezer_result_x_images_compressed">
-        <item quantity="one">%d élément compressé</item>
-        <item quantity="other">%d éléments compressés</item>
+        <item quantity="one">%d élément a été compressé</item>
+        <item quantity="other">%d éléments ont été compressés</item>
     </plurals>
     <plurals name="squeezer_result_x_items_failed">
         <item quantity="one">%d en échec</item>
         <item quantity="other">%d en échec</item>
     </plurals>
     <plurals name="squeezer_result_x_skipped_inaccessible">
-        <item quantity="one">%d fichier ignoré (non accessible)</item>
-        <item quantity="other">%d fichiers ignorés (non accessibles)</item>
+        <item quantity="one">%d fichier ignoré (non accessible)</item>
+        <item quantity="other">%d fichiers ignorés (non accessibles)</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
-        <item quantity="one">%d élément sélectionné</item>
-        <item quantity="other">%d éléments sélectionnés</item>
+        <item quantity="one">%d élément choisi</item>
+        <item quantity="other">%d éléments choisis</item>
     </plurals>
     <string name="squeezer_search_locations_title">Emplacements de recherche</string>
     <string name="squeezer_search_locations_default_summary">Dossiers de l’appareil photo (par défaut)</string>
@@ -58,7 +58,7 @@
     <string name="squeezer_preview_dialog_title">Confirmer la compression</string>
     <string name="squeezer_preview_total_size">Taille totale</string>
     <string name="squeezer_preview_estimated_savings">Économies probables</string>
-    <string name="squeezer_compress_confirmation_title">Compresser les éléments sélectionnés ?</string>
+    <string name="squeezer_compress_confirmation_title">Compresser les éléments choisis ?</string>
     <string name="squeezer_compress_confirmation_message">Les fichiers originaux seront remplacés par les versions compressées. Cette action est irréversible.</string>
     <string name="squeezer_history_title">Historique de compression</string>
     <plurals name="squeezer_history_summary">
@@ -72,17 +72,17 @@
     <string name="squeezer_onboarding_message">La compression des images réduit la taille des fichiers en supprimant certains détails visuels. Ce processus est irréversible ; la qualité originale ne peut pas être restaurée.\n\nVoici un aperçu du rendu final de vos images :</string>
     <string name="squeezer_onboarding_original_label">Originale</string>
     <string name="squeezer_onboarding_compressed_label">Après compression</string>
-    <string name="squeezer_onboarding_video_original_label">Image vidéo</string>
+    <string name="squeezer_onboarding_video_original_label">Image de la vidéo</string>
     <string name="squeezer_onboarding_video_compressed_label">Aperçu (approximatif)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">La qualité réelle de la vidéo peut différer</string>
     <string name="squeezer_onboarding_quality_label">Qualité : %d %%</string>
     <string name="squeezer_compare_action">Afficher la comparaison</string>
     <string name="squeezer_no_example_found">Aucune image n’a été trouvée dans les chemins définis.</string>
-    <string name="squeezer_result_empty_message">Aucun média compressible n\'a été trouvé.</string>
-    <string name="squeezer_setup_warning">La compression réduit irrémédiablement la qualité pour économiser l\'espace de stockage. Cette opération est irréversible. Confirmez vos paramètres avant de commencer.</string>
+    <string name="squeezer_result_empty_message">Aucun média compressible n’a été trouvé.</string>
+    <string name="squeezer_setup_warning">La compression réduit irrémédiablement la qualité pour économiser l’espace de stockage. Cette opération est irréversible. Confirmez vos paramètres avant de commencer.</string>
     <plurals name="squeezer_setup_path_dropped_message">
-        <item quantity="one">%d emplacement ne peut pas être utilisé pour la compression et a été supprimé. La compression nécessite un accès direct au stockage interne.</item>
-        <item quantity="other">%d emplacements ne peuvent pas être utilisés pour la compression et ont été supprimés. La compression nécessite un accès direct au stockage interne.</item>
+        <item quantity="one">%d emplacement ne peut pas être utilisé pour la compression et a été supprimé. La compression nécessite un accès direct à la mémoire interne.</item>
+        <item quantity="other">%d emplacements ne peuvent pas être utilisés pour la compression et ont été supprimés. La compression nécessite un accès direct à la mémoire interne.</item>
     </plurals>
     <string name="squeezer_setup_explanation">La compression des médias réduit la taille des images et des vidéos afin de libérer l\'espace de stockage. Cela réduit irrémédiablement la qualité. Cette opération est irréversible. Confirmez vos paramètres avant de commencer.</string>
     <string name="squeezer_setup_paths_title">Emplacements de recherche</string>


### PR DESCRIPTION
## What changed

Updated translations from Crowdin for French, Polish, Indonesian, and Nepali.

## Technical Context

- 7 strings.xml files updated across `app`, `app-common`, `app-common-stats`, `app-tool-analyzer`, `app-tool-appcontrol`, `app-tool-deduplicator`, `app-tool-scheduler`, `app-tool-squeezer`
- 2 strings reverted during validation:
  - `deduplicator_arbiter_criterium_location_title` (Indonesian): capitalization inconsistent with sibling labels
  - `support_debuglog_folder_desc` quantity=one (Nepali): broken placeholder mapping (`%1$d` removed and `%2$s` renumbered to `%1$s` — would have crashed at runtime)
- 1 string corrected in place: `analyzer_storage_content_type_system_info` (French) — restored a dropped article (`l'`) before `la suppression`
- Fastlane store descriptions were also pulled for `ja-JP`, `th`, `zh-CN`, `zh-HK`, `zh-TW` but all 5 were reverted due to systematic sentence-level duplication (entire sentences/section headers copy-pasted within paragraphs, leaving the descriptions incoherent). Worth flagging upstream — same pattern across all 5 East-Asian locales suggests a TM or MT engine issue.
- `assembleFossDebug` passes cleanly
