### PR TITLE
AppCleaner: Fix wrong screen opened on Samsung when clearing cache

### DIFF
--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/StorageEntryFinder.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/StorageEntryFinder.kt
@@ -155,6 +155,7 @@ class StorageEntryFinder @Inject constructor(
     suspend fun storageFinderAOSP(
         labels: Collection<String>,
         pkg: Installed,
+        antiLabels: Collection<String> = emptySet(),
     ): suspend StepContext.() -> ACSNodeInfo? {
         val matchStorage = createSizeMatcher(pkg) ?: { _: ACSNodeInfo -> false }
         return {
@@ -165,7 +166,7 @@ class StorageEntryFinder @Inject constructor(
                     // Label match: prefer TextViews but also accept other node types (Compose)
                     node.textMatchesAny(labels) -> 0
                     // Size match: only on TextViews to avoid false positives
-                    node.isTextView() && matchStorage(node) -> 1
+                    node.isTextView() && matchStorage(node) && !node.hasRowTitleIn(antiLabels) -> 1
                     else -> null
                 }
             }
@@ -174,7 +175,7 @@ class StorageEntryFinder @Inject constructor(
                 if (!node.isTextView()) return@storageFilter null
                 when {
                     node.idContains("android:id/title") && node.textMatchesAny(labels) -> 0
-                    node.idContains("android:id/summary") && matchStorage(node) -> 1
+                    node.idContains("android:id/summary") && matchStorage(node) && !node.hasRowTitleIn(antiLabels) -> 1
                     else -> null
                 }
             }
@@ -273,4 +274,22 @@ class StorageEntryFinder @Inject constructor(
     companion object {
         private val TAG: String = logTag("AppCleaner", "Automation", "StorageEntryFinder")
     }
+}
+
+private val ANTI_LABEL_TAG = logTag("AppCleaner", "Automation", "StorageEntryFinder", "AntiLabel")
+
+internal fun ACSNodeInfo.hasRowTitleIn(antiLabels: Collection<String>): Boolean {
+    if (antiLabels.isEmpty()) return false
+    val row = this.findParentOrNull(maxNesting = 6) { it.isClickable } ?: return false
+    val match = row.crawl().firstOrNull { walked ->
+        val n = walked.node
+        n.idContains("android:id/title") && n.textMatchesAny(antiLabels)
+    }
+    if (match != null) {
+        log(ANTI_LABEL_TAG, WARN) {
+            "Anti-label rejected size-match: $this (row title=${match.node.text})"
+        }
+        return true
+    }
+    return false
 }

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/oneui/OneUILabels.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/oneui/OneUILabels.kt
@@ -33,6 +33,16 @@ open class OneUILabels @Inject constructor(
         else -> labels14Plus.getClearCacheLabels(acsContext)
     }
 
+    fun getMobileDataAntiDynamic(acsContext: AutomationExplorer.Context): Set<String> = when {
+        hasApiLevel(29) -> labels29Plus.getMobileDataAntiDynamic(acsContext)
+        else -> labels14Plus.getMobileDataAntiDynamic(acsContext)
+    }
+
+    fun getMobileDataAntiLabels(acsContext: AutomationExplorer.Context): Set<String> = when {
+        hasApiLevel(29) -> labels29Plus.getMobileDataAntiLabels(acsContext)
+        else -> labels14Plus.getMobileDataAntiLabels(acsContext)
+    }
+
     companion object {
         private val TAG: String = logTag("AppCleaner", "Automation", "OneUI", "Labels")
     }

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/oneui/OneUILabels14Plus.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/oneui/OneUILabels14Plus.kt
@@ -94,6 +94,14 @@ class OneUILabels14Plus @Inject constructor(
         .append { aospLabels14Plus.getClearCacheStatic(acsContext) }
         .toSet()
 
+    fun getMobileDataAntiDynamic(
+        @Suppress("UNUSED_PARAMETER") acsContext: AutomationExplorer.Context
+    ): Set<String> = emptySet()
+
+    fun getMobileDataAntiLabels(
+        @Suppress("UNUSED_PARAMETER") acsContext: AutomationExplorer.Context
+    ): Set<String> = emptySet()
+
     companion object {
         private val TAG: String = logTag("AppCleaner", "Automation", "OneUI", "Labels", "14Plus")
         val SETTINGS_PKG = "com.android.settings".toPkgId()

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/oneui/OneUILabels29Plus.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/oneui/OneUILabels29Plus.kt
@@ -134,6 +134,44 @@ class OneUILabels29Plus @Inject constructor(
         .append { oneUILabels14Plus.getClearCacheLabels(acsContext) }
         .toSet()
 
+    fun getMobileDataAntiDynamic(
+        acsContext: AutomationExplorer.Context
+    ): Set<String> = acsContext.getStrings(
+        SETTINGS_PKG,
+        setOf(
+            // AOSP App Info "Mobile data" row title
+            "data_usage_app_summary_title",
+            // AOSP older / alternate key
+            "app_data_usage",
+        )
+    )
+
+    fun getMobileDataAntiLabels(
+        acsContext: AutomationExplorer.Context
+    ): Set<String> = acsContext.getLocales()
+        .map { it.language }
+        .mapNotNull { lang ->
+            when {
+                "en".toLang() == lang -> setOf("Mobile data", "Wi-Fi data", "Mobile data usage", "Data usage")
+                "vi".toLang() == lang -> setOf("Dữ liệu di động", "Dữ liệu Wi-Fi", "Sử dụng dữ liệu")
+                "fr".toLang() == lang -> setOf("Données mobiles", "Données Wi-Fi", "Consommation des données")
+                "de".toLang() == lang -> setOf("Mobile Daten", "WLAN-Daten", "Datennutzung")
+                "es".toLang() == lang -> setOf("Datos móviles", "Datos Wi-Fi", "Uso de datos")
+                "pt".toLang() == lang -> setOf("Dados móveis", "Dados Wi-Fi", "Uso de dados")
+                "it".toLang() == lang -> setOf("Dati mobili", "Dati Wi-Fi", "Utilizzo dati")
+                "ru".toLang() == lang -> setOf("Мобильные данные", "Данные Wi-Fi", "Передача данных")
+                "pl".toLang() == lang -> setOf("Dane mobilne", "Dane Wi-Fi", "Wykorzystanie danych")
+                "nl".toLang() == lang -> setOf("Mobiele gegevens", "Wi-Fi-gegevens", "Datagebruik")
+                "tr".toLang() == lang -> setOf("Mobil veri", "Wi-Fi verisi", "Veri kullanımı")
+                "ja".toLang() == lang -> setOf("モバイルデータ", "Wi-Fiデータ", "データ使用量")
+                "ko".toLang() == lang -> setOf("모바일 데이터", "Wi-Fi 데이터", "데이터 사용량")
+                "zh".toLang() == lang -> setOf("移动数据", "Wi-Fi 数据", "数据使用")
+                else -> null
+            }
+        }
+        .flatten()
+        .toSet()
+
     companion object {
         private val TAG: String = logTag("AppCleaner", "Automation", "OneUI", "Labels", "29Plus")
         val SETTINGS_PKG = "com.android.settings".toPkgId()

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/oneui/OneUISpecs.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/oneui/OneUISpecs.kt
@@ -70,7 +70,11 @@ class OneUISpecs @Inject constructor(
                 oneUILabels.getStorageEntryDynamic(this) + oneUILabels.getStorageEntryLabels(this)
             log(TAG) { "storageEntryLabels=${storageEntryLabels.toVisualStrings()}" }
 
-            val storageFinder = storageEntryFinder.storageFinderAOSP(storageEntryLabels, pkg)
+            val antiLabels =
+                oneUILabels.getMobileDataAntiDynamic(this) + oneUILabels.getMobileDataAntiLabels(this)
+            log(TAG) { "antiLabels=${antiLabels.toVisualStrings()}" }
+
+            val storageFinder = storageEntryFinder.storageFinderAOSP(storageEntryLabels, pkg, antiLabels)
 
             val step = AutomationStep(
                 source = TAG,

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/StorageEntryFinderTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/StorageEntryFinderTest.kt
@@ -1,0 +1,158 @@
+package eu.darken.sdmse.appcleaner.core.automation.specs
+
+import eu.darken.sdmse.automation.core.common.ACSNodeInfo
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+/**
+ * Regression coverage for the Samsung One UI 6 Mobile-data false-positive that the
+ * size-based fallback in [StorageEntryFinder.storageFinderAOSP] can produce when the
+ * App Info screen happens to expose a non-Storage row whose summary contains the same
+ * size text as the app's on-disk size.
+ *
+ * The bug: on a Galaxy A52 5G the Storage row is structurally absent from the
+ * accessibility tree, and the Mobile data row's summary "0.97 GB used since Feb 1"
+ * collides with the Threads app's 0.97 GB on-disk size, so the finder taps Mobile data
+ * instead of Storage.
+ *
+ * These tests target the [hasRowTitleIn] anti-label helper, which guards the size
+ * fallback against rows whose title we can prove is not Storage.
+ */
+class StorageEntryFinderTest : BaseTest() {
+
+    /**
+     * Build a mock row: clickable LinearLayout containing two TextView children
+     * (android:id/title with [titleText], android:id/summary with [summaryText]).
+     * Returns (row, titleNode, summaryNode) so the caller can use the summary as the
+     * anti-label query target.
+     */
+    private fun buildRow(
+        titleText: String,
+        summaryText: String,
+        nestTitleExtraLevel: Boolean = false,
+    ): Triple<ACSNodeInfo, ACSNodeInfo, ACSNodeInfo> {
+        val title = mockk<ACSNodeInfo>(relaxed = true).also {
+            every { it.text } returns titleText
+            every { it.viewIdResourceName } returns "android:id/title"
+            every { it.className } returns "android.widget.TextView"
+            every { it.childCount } returns 0
+            every { it.getChild(any()) } returns null
+            every { it.isClickable } returns false
+        }
+        val summary = mockk<ACSNodeInfo>(relaxed = true).also {
+            every { it.text } returns summaryText
+            every { it.viewIdResourceName } returns "android:id/summary"
+            every { it.className } returns "android.widget.TextView"
+            every { it.childCount } returns 0
+            every { it.getChild(any()) } returns null
+            every { it.isClickable } returns false
+        }
+
+        val titleHolder: ACSNodeInfo = if (nestTitleExtraLevel) {
+            mockk<ACSNodeInfo>(relaxed = true).also {
+                every { it.viewIdResourceName } returns null
+                every { it.className } returns "android.widget.LinearLayout"
+                every { it.childCount } returns 1
+                every { it.getChild(0) } returns title
+                every { it.getChild(neq(0)) } returns null
+                every { it.text } returns null
+                every { it.isClickable } returns false
+                every { title.parent } returns it
+            }
+        } else {
+            title
+        }
+
+        val row = mockk<ACSNodeInfo>(relaxed = true).also {
+            every { it.viewIdResourceName } returns null
+            every { it.className } returns "android.widget.LinearLayout"
+            every { it.isClickable } returns true
+            every { it.childCount } returns 2
+            every { it.getChild(0) } returns titleHolder
+            every { it.getChild(1) } returns summary
+            every { it.getChild(match { idx -> idx >= 2 }) } returns null
+            every { it.text } returns null
+            every { titleHolder.parent } returns it
+            every { summary.parent } returns it
+        }
+        return Triple(row, title, summary)
+    }
+
+    @Test
+    fun `anti-label list is empty - size match survives (bug repros for other OEMs)`() {
+        val (_, _, summary) = buildRow(
+            titleText = "Mobile data",
+            summaryText = "0.97 GB used since Feb 1",
+        )
+
+        summary.hasRowTitleIn(emptySet()) shouldBe false
+    }
+
+    @Test
+    fun `mobile data row is rejected when anti-label is configured`() {
+        val (_, _, summary) = buildRow(
+            titleText = "Mobile data",
+            summaryText = "0.97 GB used since Feb 1",
+        )
+
+        summary.hasRowTitleIn(setOf("Mobile data", "Wi-Fi data")) shouldBe true
+    }
+
+    @Test
+    fun `wifi data row is also rejected`() {
+        val (_, _, summary) = buildRow(
+            titleText = "Wi-Fi data",
+            summaryText = "0.97 GB used since Feb 1",
+        )
+
+        summary.hasRowTitleIn(setOf("Mobile data", "Wi-Fi data")) shouldBe true
+    }
+
+    @Test
+    fun `storage row is not rejected even when anti-labels are configured`() {
+        val (_, _, summary) = buildRow(
+            titleText = "Storage",
+            summaryText = "0.97 GB",
+        )
+
+        summary.hasRowTitleIn(setOf("Mobile data", "Wi-Fi data")) shouldBe false
+    }
+
+    @Test
+    fun `nested title still triggers rejection`() {
+        val (_, _, summary) = buildRow(
+            titleText = "Mobile data",
+            summaryText = "0.97 GB used since Feb 1",
+            nestTitleExtraLevel = true,
+        )
+
+        summary.hasRowTitleIn(setOf("Mobile data")) shouldBe true
+    }
+
+    @Test
+    fun `title in unrelated locale is not rejected`() {
+        val (_, _, summary) = buildRow(
+            titleText = "Battery",
+            summaryText = "0.97 GB used since last fully charged",
+        )
+
+        summary.hasRowTitleIn(setOf("Mobile data", "Wi-Fi data")) shouldBe false
+    }
+
+    @Test
+    fun `no clickable ancestor leaves node unaffected`() {
+        val standalone = mockk<ACSNodeInfo>(relaxed = true).also {
+            every { it.text } returns "0.97 GB used since Feb 1"
+            every { it.viewIdResourceName } returns "android:id/summary"
+            every { it.className } returns "android.widget.TextView"
+            every { it.parent } returns null
+            every { it.childCount } returns 0
+            every { it.getChild(any()) } returns null
+        }
+
+        standalone.hasRowTitleIn(setOf("Mobile data")) shouldBe false
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/BaseAppCleanerSpecTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/BaseAppCleanerSpecTest.kt
@@ -105,7 +105,7 @@ abstract class BaseAppCleanerSpecTest<S : AppCleanerSpecGenerator, L : Any> : Ba
         }
 
         // Mock storage finder
-        coEvery { storageEntryFinder.storageFinderAOSP(any(), any()) } returns mockk()
+        coEvery { storageEntryFinder.storageFinderAOSP(any(), any(), any()) } returns mockk()
 
         // Setup default label mocks
         mockLabelDefaults()

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/oneui/OneUISpecsTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/oneui/OneUISpecsTest.kt
@@ -31,6 +31,8 @@ class OneUISpecsTest : BaseAppCleanerSpecTest<OneUISpecs, OneUILabels>() {
         every { labels.getStorageEntryLabels(any()) } returns setOf("Storage")
         every { labels.getClearCacheDynamic(any()) } returns emptySet()
         every { labels.getClearCacheLabels(any()) } returns setOf("Clear cache")
+        every { labels.getMobileDataAntiDynamic(any()) } returns emptySet()
+        every { labels.getMobileDataAntiLabels(any()) } returns emptySet()
     }
 
     // ============================================================


### PR DESCRIPTION
## What changed

Fixes a bug on some Samsung devices (One UI / Android 14) where AppCleaner's automation could open the "Application data usage" screen instead of the app's Storage screen, leaving the cache untouched.

This happened when:
- The app's Storage entry was missing from Samsung's App Info screen for a given app, and
- The app's monthly mobile data usage happened to equal its on-disk size (e.g. both ~0.97 GB).

After this change, AppCleaner ignores rows it can identify as Mobile data / Wi-Fi data and avoids the false positive. If the Storage entry is genuinely absent, the step fails cleanly instead of tapping the wrong row.

## Technical Context

- Root cause: `StorageEntryFinder.storageFinderAOSP` falls back to a size-based match when label matching fails. The fallback accepted any TextView whose text contained the formatted storage size, with no anchoring to its row's title. On the reported Samsung A52 5G the Storage row was structurally absent from the accessibility tree, so the size match landed on the Mobile data row's `android:id/summary` ("0.97 GB used since Feb 1"), and the clickable ancestor was tapped.
- Approach: anti-label denylist scoped to the size-match path. When a size match hits, walk up to the clickable row ancestor and reject if the row's `android:id/title` sibling matches a known non-Storage label. Label-priority matching is untouched.
- Anti-labels are fetched two ways, mirroring how Storage labels work today: dynamically from the Settings APK via AOSP resource keys (`data_usage_app_summary_title`, `app_data_usage`) and from a hardcoded per-locale fallback covering the same languages as the Storage label table.
- Scope: only `OneUISpecs` wires anti-labels through. The new `antiLabels` parameter on `storageFinderAOSP` defaults to empty so the 16 other OEM specs are unchanged — easy to wire later if similar reports arrive.
- Review guidance: the new helper `hasRowTitleIn` (top-level internal in `StorageEntryFinder.kt`) anchors on the clickable row, not on a fixed parent-depth walk, to be resilient to layouts where the title sits one level deeper inside a sub-LinearLayout. Test coverage in `StorageEntryFinderTest` includes the nested-title case, the "Storage row still wins when present" case, and a baseline that the bug repros without anti-labels.
- Not fixed here: why Samsung One UI 6 omits the Storage row for some apps in the first place. That's a separate Samsung-layout question; this change just prevents the false-positive click.
