### PR TITLE
Squeezer: Add unit and Compose UI tests, fix exclusion-count mismatch

### DIFF
--- a/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/Squeezer.kt
+++ b/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/Squeezer.kt
@@ -24,6 +24,7 @@ import eu.darken.sdmse.squeezer.core.tasks.SqueezerScanTask
 import eu.darken.sdmse.squeezer.core.tasks.SqueezerTask
 import eu.darken.sdmse.exclusion.core.ExclusionManager
 import eu.darken.sdmse.exclusion.core.types.Exclusion
+import eu.darken.sdmse.exclusion.core.types.ExclusionId
 import eu.darken.sdmse.exclusion.core.types.PathExclusion
 import eu.darken.sdmse.main.core.SDMTool
 import kotlinx.coroutines.CancellationException
@@ -194,10 +195,10 @@ class Squeezer @Inject constructor(
 
     suspend fun exclude(
         identifiers: Collection<CompressibleMedia.Id>
-    ): Unit = toolLock.withLock {
+    ): Set<ExclusionId> = toolLock.withLock {
         log(TAG) { "exclude(): $identifiers" }
 
-        val snapshot = internalData.value ?: return@withLock
+        val snapshot = internalData.value ?: return@withLock emptySet()
 
         val exclusions = identifiers
             .mapNotNull { id -> snapshot.media.find { it.identifier == id } }
@@ -208,11 +209,13 @@ class Squeezer @Inject constructor(
                 )
             }
             .toSet()
-        exclusionManager.save(exclusions)
+        val savedIds = exclusionManager.save(exclusions).map { it.id }.toSet()
 
         internalData.value = snapshot.copy(
             media = snapshot.media.filter { !identifiers.contains(it.identifier) }.toSet()
         )
+
+        savedIds
     }
 
     data class State(

--- a/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/ui/list/SqueezerListViewModel.kt
+++ b/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/ui/list/SqueezerListViewModel.kt
@@ -137,8 +137,12 @@ class SqueezerListViewModel @Inject constructor(
 
     fun exclude(ids: Set<CompressibleMedia.Id>) = launch {
         log(TAG, INFO) { "exclude(): ${ids.size}" }
-        squeezer.exclude(ids)
-        events.tryEmit(Event.ExclusionsCreated(ids.size))
+        // Use the saved-exclusion count rather than the requested-ids count so the snackbar
+        // matches what was actually persisted. ExclusionManager.save() drops duplicates that
+        // are already excluded, and `Squeezer.exclude` itself drops ids no longer in the
+        // current data snapshot.
+        val savedIds = squeezer.exclude(ids)
+        events.tryEmit(Event.ExclusionsCreated(savedIds.size))
     }
 
     fun toggleLayoutMode() = launch {

--- a/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/ui/setup/SqueezerSetupScreen.kt
+++ b/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/ui/setup/SqueezerSetupScreen.kt
@@ -121,6 +121,10 @@ fun SqueezerSetupScreenHost(
     SqueezerSetupScreen(
         stateSource = vm.state,
         snackbarHostState = snackbarHostState,
+        // Debug builds allow extreme low-quality values to exercise the compressor. Read once
+        // here (Host scope) so the inner `internal` Screen has no compile-time dependency on
+        // BuildConfigWrap — keeping the Screen JVM-unit-testable without a generated BuildConfig.
+        minQuality = if (BuildConfigWrap.DEBUG) 1 else MIN_QUALITY_RELEASE,
         onNavigateUp = vm::navUp,
         onPathsClick = vm::openPathPicker,
         onQualityChange = vm::updateQuality,
@@ -142,6 +146,7 @@ fun SqueezerSetupScreenHost(
 internal fun SqueezerSetupScreen(
     stateSource: StateFlow<SqueezerSetupViewModel.State> = MutableStateFlow(SqueezerSetupViewModel.State()),
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
+    minQuality: Int = MIN_QUALITY_RELEASE,
     onNavigateUp: () -> Unit = {},
     onPathsClick: () -> Unit = {},
     onQualityChange: (Int) -> Unit = {},
@@ -189,6 +194,7 @@ internal fun SqueezerSetupScreen(
                     Spacer(Modifier.height(16.dp))
                     QualityCard(
                         quality = state.quality,
+                        minQuality = minQuality,
                         estimatedSavingsPercent = state.estimatedSavingsPercent,
                         isLoadingExample = state.isLoadingExample,
                         onQualityChange = onQualityChange,
@@ -310,12 +316,12 @@ private fun PathsCard(
 @Composable
 private fun QualityCard(
     quality: Int,
+    minQuality: Int,
     estimatedSavingsPercent: Int?,
     isLoadingExample: Boolean,
     onQualityChange: (Int) -> Unit,
     onShowExample: () -> Unit,
 ) {
-    val minQuality = if (BuildConfigWrap.DEBUG) 1 else 20
     Card(modifier = Modifier.fillMaxWidth()) {
         Column(modifier = Modifier.padding(16.dp)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
@@ -451,6 +457,10 @@ private fun AgeCard(
         }
     }
 }
+
+// Lower bound the quality slider exposes on release builds. Debug builds use 1 to exercise
+// the compressor at extreme settings.
+private const val MIN_QUALITY_RELEASE = 20
 
 @Preview2
 @Composable

--- a/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/core/SqueezerExtensionsTest.kt
+++ b/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/core/SqueezerExtensionsTest.kt
@@ -1,0 +1,42 @@
+package eu.darken.sdmse.squeezer.core
+
+import eu.darken.sdmse.common.files.FileType
+import eu.darken.sdmse.common.files.core.local.File
+import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.files.local.LocalPathLookup
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.time.Instant
+
+class SqueezerExtensionsTest : BaseTest() {
+
+    private fun image(path: String) = CompressibleImage(
+        lookup = LocalPathLookup(
+            lookedUp = LocalPath(File(path)),
+            fileType = FileType.FILE,
+            size = 1024L,
+            modifiedAt = Instant.EPOCH,
+            target = null,
+        ),
+        mimeType = CompressibleImage.MIME_TYPE_JPEG,
+    )
+
+    @Test
+    fun `hasData is false when Data is null`() {
+        val data: Squeezer.Data? = null
+        data.hasData shouldBe false
+    }
+
+    @Test
+    fun `hasData is false when media is empty`() {
+        val data = Squeezer.Data(media = emptySet())
+        data.hasData shouldBe false
+    }
+
+    @Test
+    fun `hasData is true when media is non-empty`() {
+        val data = Squeezer.Data(media = setOf(image("a.jpg")))
+        data.hasData shouldBe true
+    }
+}

--- a/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/core/SqueezerTest.kt
+++ b/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/core/SqueezerTest.kt
@@ -1,15 +1,47 @@
 package eu.darken.sdmse.squeezer.core
 
 import eu.darken.sdmse.common.files.FileType
+import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.core.local.File
 import eu.darken.sdmse.common.files.local.LocalPath
 import eu.darken.sdmse.common.files.local.LocalPathLookup
+import eu.darken.sdmse.common.sharedresource.SharedResource
+import eu.darken.sdmse.exclusion.core.ExclusionManager
+import eu.darken.sdmse.exclusion.core.types.Exclusion
+import eu.darken.sdmse.exclusion.core.types.PathExclusion
+import eu.darken.sdmse.squeezer.core.processor.ImageProcessor
+import eu.darken.sdmse.squeezer.core.processor.VideoProcessor
+import eu.darken.sdmse.squeezer.core.scanner.MediaScanner
+import eu.darken.sdmse.squeezer.core.tasks.SqueezerProcessTask
+import eu.darken.sdmse.squeezer.core.tasks.SqueezerScanTask
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.plus
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+import testhelpers.mockDataStoreValue
+import java.time.Duration
 import java.time.Instant
+import javax.inject.Provider
 
 class SqueezerTest : BaseTest() {
+
+    // ─────────────────────────── data / model helpers ───────────────────────────
 
     private fun createImage(
         path: String,
@@ -27,6 +59,30 @@ class SqueezerTest : BaseTest() {
         mimeType = CompressibleImage.MIME_TYPE_JPEG,
         estimatedCompressedSize = estimatedCompressedSize,
         wasCompressedBefore = wasCompressedBefore,
+    )
+
+    private fun createWebp(path: String, size: Long = 1024 * 1024L) = CompressibleImage(
+        lookup = LocalPathLookup(
+            lookedUp = LocalPath(File(path)),
+            fileType = FileType.FILE,
+            size = size,
+            modifiedAt = Instant.EPOCH,
+            target = null,
+        ),
+        mimeType = CompressibleImage.MIME_TYPE_WEBP,
+    )
+
+    private fun createVideo(path: String, size: Long = 2 * 1024 * 1024L) = CompressibleVideo(
+        lookup = LocalPathLookup(
+            lookedUp = LocalPath(File(path)),
+            fileType = FileType.FILE,
+            size = size,
+            modifiedAt = Instant.EPOCH,
+            target = null,
+        ),
+        mimeType = CompressibleVideo.MIME_TYPE_MP4,
+        durationMs = 10_000L,
+        bitrateBps = 2_000_000L,
     )
 
     @Test
@@ -93,9 +149,7 @@ class SqueezerTest : BaseTest() {
         val img2 = createImage("img2.jpg")
         val img3 = createImage("img3.jpg")
 
-        val original = Squeezer.Data(
-            media = setOf(img1, img2, img3)
-        )
+        val original = Squeezer.Data(media = setOf(img1, img2, img3))
 
         val processedIds = setOf(img1.identifier, img3.identifier)
 
@@ -147,7 +201,7 @@ class SqueezerTest : BaseTest() {
 
     @Test
     fun `CompressibleImage - estimatedSavings coerces to at least zero`() {
-        // Edge case: if estimated compressed size is somehow larger than original
+        // Edge case: estimated compressed size somehow larger than original
         val image = createImage("test.jpg", size = 1000L, estimatedCompressedSize = 1500L)
 
         image.estimatedSavings shouldBe 0L
@@ -155,16 +209,7 @@ class SqueezerTest : BaseTest() {
 
     @Test
     fun `CompressibleImage - isJpeg detection`() {
-        val jpegImage = CompressibleImage(
-            lookup = LocalPathLookup(
-                lookedUp = LocalPath(File("test.jpg")),
-                fileType = FileType.FILE,
-                size = 1000L,
-                modifiedAt = Instant.EPOCH,
-                target = null,
-            ),
-            mimeType = CompressibleImage.MIME_TYPE_JPEG,
-        )
+        val jpegImage = createImage("test.jpg")
 
         jpegImage.isJpeg shouldBe true
         jpegImage.isWebp shouldBe false
@@ -172,18 +217,563 @@ class SqueezerTest : BaseTest() {
 
     @Test
     fun `CompressibleImage - isWebp detection`() {
-        val webpImage = CompressibleImage(
-            lookup = LocalPathLookup(
-                lookedUp = LocalPath(File("test.webp")),
-                fileType = FileType.FILE,
-                size = 1000L,
-                modifiedAt = Instant.EPOCH,
-                target = null,
-            ),
-            mimeType = CompressibleImage.MIME_TYPE_WEBP,
-        )
+        val webpImage = createWebp("test.webp")
 
         webpImage.isJpeg shouldBe false
         webpImage.isWebp shouldBe true
+    }
+
+    // ─────────────────────────── workflow harness ───────────────────────────
+
+    // `submit()` wraps work in `keepResourceHoldersAlive(gatewaySwitch)`, which calls
+    // `addChild(sharedResource)` + `sharedResource.get()` on the gateway. Plain MockK mocks
+    // would fail at those calls — so we wire `gatewaySwitch.sharedResource` to a real
+    // `SharedResource.createKeepAlive(...)` backed by a long-lived scope.
+    private val keepAliveScope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+
+    @AfterEach
+    fun stopKeepAliveScope() {
+        keepAliveScope.coroutineContext[kotlinx.coroutines.Job]?.cancel()
+    }
+
+    private class Setup(
+        val squeezer: Squeezer,
+        val scanner: MediaScanner,
+        val imageProcessor: ImageProcessor,
+        val videoProcessor: VideoProcessor,
+        val exclusionManager: ExclusionManager,
+        val settings: SqueezerSettings,
+    )
+
+    private fun setup(
+        scanPaths: Set<eu.darken.sdmse.common.files.APath> = setOf(LocalPath.build("/dcim")),
+        includeJpeg: Boolean = true,
+        includeWebp: Boolean = true,
+        includeVideo: Boolean = true,
+        minSizeBytes: Long = SqueezerSettings.MIN_FILE_SIZE,
+        minAge: Duration = Duration.ofDays(0),
+        skipPreviouslyCompressed: Boolean = false,
+        compressionQuality: Int = 80,
+    ): Setup {
+        val gatewaySwitch = mockk<GatewaySwitch>().apply {
+            every { sharedResource } returns SharedResource.createKeepAlive("gw", keepAliveScope)
+        }
+        val scanner = mockk<MediaScanner>(relaxed = true).apply {
+            every { progress } returns emptyFlow()
+        }
+        val imageProcessor = mockk<ImageProcessor>(relaxed = true).apply {
+            every { progress } returns emptyFlow()
+        }
+        val videoProcessor = mockk<VideoProcessor>(relaxed = true).apply {
+            every { progress } returns emptyFlow()
+        }
+        val exclusionManager = mockk<ExclusionManager>().apply {
+            // Default: save() echoes its input back — distinct ids per call.
+            coEvery { save(any()) } answers { firstArg<Set<Exclusion>>().toList() }
+        }
+        val settings = mockk<SqueezerSettings>().apply {
+            every { this@apply.scanPaths } returns mockDataStoreValue(SqueezerSettings.ScanPaths(paths = scanPaths))
+            every { this@apply.minSizeBytes } returns mockDataStoreValue(minSizeBytes)
+            every { this@apply.minAge } returns mockDataStoreValue(minAge)
+            every { this@apply.compressionQuality } returns mockDataStoreValue(compressionQuality)
+            every { this@apply.includeJpeg } returns mockDataStoreValue(includeJpeg)
+            every { this@apply.includeWebp } returns mockDataStoreValue(includeWebp)
+            every { this@apply.includeVideo } returns mockDataStoreValue(includeVideo)
+            every { this@apply.skipPreviouslyCompressed } returns mockDataStoreValue(skipPreviouslyCompressed)
+        }
+
+        val squeezer = Squeezer(
+            appScope = keepAliveScope,
+            gatewaySwitch = gatewaySwitch,
+            exclusionManager = exclusionManager,
+            scanner = Provider { scanner },
+            imageProcessor = Provider { imageProcessor },
+            videoProcessor = Provider { videoProcessor },
+            settings = settings,
+        )
+        return Setup(squeezer, scanner, imageProcessor, videoProcessor, exclusionManager, settings)
+    }
+
+    private suspend fun Squeezer.dataFromState(): Squeezer.Data? = state.map { it.data }.first()
+    private suspend fun Squeezer.lastResultFromState(): eu.darken.sdmse.squeezer.core.tasks.SqueezerTask.Result? =
+        state.map { it.lastResult }.first()
+
+    private fun scanResult(
+        items: Set<CompressibleMedia> = emptySet(),
+        skipped: Int = 0,
+    ): MediaScanner.ScanResult = MediaScanner.ScanResult(
+        items = items,
+        skippedInaccessibleCount = skipped,
+    )
+
+    // ─────────────────────────── scan ───────────────────────────
+
+    @Test
+    fun `submit ScanTask with no media found yields empty Success`() = runTest2 {
+        val s = setup()
+        coEvery { s.scanner.scan(any()) } returns scanResult()
+
+        val result = s.squeezer.submit(SqueezerScanTask())
+
+        result.shouldBeInstanceOf<SqueezerScanTask.Success>()
+        s.squeezer.dataFromState() shouldBe Squeezer.Data(media = emptySet())
+    }
+
+    @Test
+    fun `submit ScanTask populates internalData with media`() = runTest2 {
+        val a = createImage("a.jpg", size = 1000L)
+        val b = createImage("b.jpg", size = 2000L)
+        val s = setup()
+        coEvery { s.scanner.scan(any()) } returns scanResult(items = setOf(a, b))
+
+        s.squeezer.submit(SqueezerScanTask())
+
+        s.squeezer.dataFromState()!!.media shouldContainExactlyInAnyOrder setOf(a, b)
+    }
+
+    @Test
+    fun `submit ScanTask task-paths override settings paths`() = runTest2 {
+        val taskPath = LocalPath.build("/override")
+        val settingsPath = LocalPath.build("/from-settings")
+        val s = setup(scanPaths = setOf(settingsPath))
+        val captured = slot<MediaScanner.Options>()
+        coEvery { s.scanner.scan(capture(captured)) } returns scanResult()
+
+        s.squeezer.submit(SqueezerScanTask(paths = setOf(taskPath)))
+
+        captured.captured.paths shouldBe setOf(taskPath)
+    }
+
+    @Test
+    fun `submit ScanTask without task-paths falls back to settings paths`() = runTest2 {
+        val settingsPath = LocalPath.build("/from-settings")
+        val s = setup(scanPaths = setOf(settingsPath))
+        val captured = slot<MediaScanner.Options>()
+        coEvery { s.scanner.scan(capture(captured)) } returns scanResult()
+
+        s.squeezer.submit(SqueezerScanTask())
+
+        captured.captured.paths shouldBe setOf(settingsPath)
+    }
+
+    @Test
+    fun `submit ScanTask builds enabledMimeTypes from settings - all enabled`() = runTest2 {
+        val s = setup(includeJpeg = true, includeWebp = true, includeVideo = true)
+        val captured = slot<MediaScanner.Options>()
+        coEvery { s.scanner.scan(capture(captured)) } returns scanResult()
+
+        s.squeezer.submit(SqueezerScanTask())
+
+        captured.captured.enabledMimeTypes shouldBe setOf(
+            CompressibleImage.MIME_TYPE_JPEG,
+            CompressibleImage.MIME_TYPE_WEBP,
+            CompressibleVideo.MIME_TYPE_MP4,
+        )
+    }
+
+    @Test
+    fun `submit ScanTask builds enabledMimeTypes from settings - jpeg only`() = runTest2 {
+        val s = setup(includeJpeg = true, includeWebp = false, includeVideo = false)
+        val captured = slot<MediaScanner.Options>()
+        coEvery { s.scanner.scan(capture(captured)) } returns scanResult()
+
+        s.squeezer.submit(SqueezerScanTask())
+
+        captured.captured.enabledMimeTypes shouldBe setOf(CompressibleImage.MIME_TYPE_JPEG)
+    }
+
+    @Test
+    fun `submit ScanTask builds empty enabledMimeTypes when all types disabled`() = runTest2 {
+        // Edge case: all three switches off. Squeezer doesn't currently block this — the scan
+        // still runs but with an empty MIME set, so MediaScanner returns nothing. Documents the
+        // intentional permissive behaviour; a regression introducing a require() would be
+        // detected here.
+        val s = setup(includeJpeg = false, includeWebp = false, includeVideo = false)
+        val captured = slot<MediaScanner.Options>()
+        coEvery { s.scanner.scan(capture(captured)) } returns scanResult()
+
+        s.squeezer.submit(SqueezerScanTask())
+
+        captured.captured.enabledMimeTypes shouldBe emptySet()
+    }
+
+    @Test
+    fun `submit ScanTask threads scan options from settings`() = runTest2 {
+        val s = setup(
+            minSizeBytes = 4096L,
+            minAge = Duration.ofDays(30),
+            skipPreviouslyCompressed = true,
+            compressionQuality = 65,
+        )
+        val captured = slot<MediaScanner.Options>()
+        coEvery { s.scanner.scan(capture(captured)) } returns scanResult()
+
+        s.squeezer.submit(SqueezerScanTask())
+
+        captured.captured.minimumSize shouldBe 4096L
+        captured.captured.minAge shouldBe Duration.ofDays(30)
+        captured.captured.skipPreviouslyCompressed shouldBe true
+        captured.captured.compressionQuality shouldBe 65
+    }
+
+    @Test
+    fun `submit ScanTask Data totals are derived from scanned media`() = runTest2 {
+        val a = createImage("a.jpg", size = 1000L, estimatedCompressedSize = 600L)
+        val b = createImage("b.jpg", size = 3000L, estimatedCompressedSize = 2000L)
+        val s = setup()
+        coEvery { s.scanner.scan(any()) } returns scanResult(items = setOf(a, b), skipped = 5)
+
+        s.squeezer.submit(SqueezerScanTask())
+
+        // SqueezerScanTask.Success fields are private; assert via Data instead. Together they
+        // tell the same story: any drift between Success and Data would surface here.
+        val data = s.squeezer.dataFromState()!!
+        data.totalSize shouldBe 4000L
+        data.estimatedSavings shouldBe 1400L  // 400 + 1000
+        data.totalCount shouldBe 2
+    }
+
+    @Test
+    fun `submit ScanTask updates lastResult on success`() = runTest2 {
+        val s = setup()
+        coEvery { s.scanner.scan(any()) } returns scanResult()
+
+        val result = s.squeezer.submit(SqueezerScanTask())
+
+        s.squeezer.lastResultFromState() shouldBe result
+    }
+
+    // ─────────────────────────── process ───────────────────────────
+
+    @Test
+    fun `submit ProcessTask throws IllegalStateException when no scan data`() = runTest2 {
+        val s = setup()
+
+        shouldThrow<IllegalStateException> {
+            s.squeezer.submit(SqueezerProcessTask())
+        }
+    }
+
+    @Test
+    fun `submit ProcessTask with TargetMode All processes every media in snapshot`() = runTest2 {
+        val a = createImage("a.jpg")
+        val b = createImage("b.jpg")
+        val s = setup()
+        coEvery { s.scanner.scan(any()) } returns scanResult(items = setOf(a, b))
+        s.squeezer.submit(SqueezerScanTask())
+
+        val capturedTargets = slot<Set<CompressibleImage>>()
+        coEvery { s.imageProcessor.process(capture(capturedTargets), any()) } returns
+            ImageProcessor.Result(success = setOf(a, b), failed = emptyMap(), savedSpace = 400L)
+
+        s.squeezer.submit(SqueezerProcessTask(mode = SqueezerProcessTask.TargetMode.All()))
+
+        capturedTargets.captured shouldBe setOf(a, b)
+    }
+
+    @Test
+    fun `submit ProcessTask with TargetMode Selected filters to chosen ids`() = runTest2 {
+        val keep = createImage("keep.jpg")
+        val skip = createImage("skip.jpg")
+        val s = setup()
+        coEvery { s.scanner.scan(any()) } returns scanResult(items = setOf(keep, skip))
+        s.squeezer.submit(SqueezerScanTask())
+
+        val capturedTargets = slot<Set<CompressibleImage>>()
+        coEvery { s.imageProcessor.process(capture(capturedTargets), any()) } returns
+            ImageProcessor.Result(success = setOf(keep), failed = emptyMap(), savedSpace = 100L)
+
+        s.squeezer.submit(
+            SqueezerProcessTask(mode = SqueezerProcessTask.TargetMode.Selected(setOf(keep.identifier))),
+        )
+
+        capturedTargets.captured shouldBe setOf(keep)
+    }
+
+    @Test
+    fun `submit ProcessTask with stale Selected id silently drops it`() = runTest2 {
+        // Defends the snapshot-filter at performProcess: a caller passing an id not present in
+        // internalData (e.g. an item that got excluded between scan and process) must not crash
+        // and must not be forwarded to the processor.
+        val real = createImage("real.jpg")
+        val staleId = CompressibleMedia.Id(LocalPath.build("/stale").path)
+        val s = setup()
+        coEvery { s.scanner.scan(any()) } returns scanResult(items = setOf(real))
+        s.squeezer.submit(SqueezerScanTask())
+
+        val capturedTargets = slot<Set<CompressibleImage>>()
+        coEvery { s.imageProcessor.process(capture(capturedTargets), any()) } returns
+            ImageProcessor.Result(success = setOf(real), failed = emptyMap(), savedSpace = 0L)
+
+        s.squeezer.submit(
+            SqueezerProcessTask(
+                mode = SqueezerProcessTask.TargetMode.Selected(setOf(real.identifier, staleId)),
+            ),
+        )
+
+        capturedTargets.captured shouldBe setOf(real)
+    }
+
+    @Test
+    fun `submit ProcessTask routes images and videos to their respective processors`() = runTest2 {
+        val img = createImage("a.jpg")
+        val vid = createVideo("b.mp4")
+        val s = setup()
+        coEvery { s.scanner.scan(any()) } returns scanResult(items = setOf(img, vid))
+        s.squeezer.submit(SqueezerScanTask())
+
+        coEvery { s.imageProcessor.process(any(), any()) } returns
+            ImageProcessor.Result(success = setOf(img), failed = emptyMap(), savedSpace = 100L)
+        coEvery { s.videoProcessor.process(any(), any()) } returns
+            VideoProcessor.Result(success = setOf(vid), failed = emptyMap(), savedSpace = 200L)
+
+        s.squeezer.submit(SqueezerProcessTask())
+
+        coVerify(exactly = 1) { s.imageProcessor.process(setOf(img), any()) }
+        coVerify(exactly = 1) { s.videoProcessor.process(setOf(vid), any()) }
+    }
+
+    @Test
+    fun `submit ProcessTask skips image processor when no image targets`() = runTest2 {
+        val vid = createVideo("b.mp4")
+        val s = setup()
+        coEvery { s.scanner.scan(any()) } returns scanResult(items = setOf(vid))
+        s.squeezer.submit(SqueezerScanTask())
+
+        coEvery { s.videoProcessor.process(any(), any()) } returns
+            VideoProcessor.Result(success = setOf(vid), failed = emptyMap(), savedSpace = 200L)
+
+        s.squeezer.submit(SqueezerProcessTask())
+
+        // No image targets → image processor must not be invoked. Pin the short-circuit (line
+        // 162 in Squeezer.kt) — a regression that always called process(emptySet()) would still
+        // be technically correct but burns the withProgress() scaffolding for nothing.
+        coVerify(exactly = 0) { s.imageProcessor.process(any(), any()) }
+    }
+
+    @Test
+    fun `submit ProcessTask skips video processor when no video targets`() = runTest2 {
+        val img = createImage("a.jpg")
+        val s = setup()
+        coEvery { s.scanner.scan(any()) } returns scanResult(items = setOf(img))
+        s.squeezer.submit(SqueezerScanTask())
+
+        coEvery { s.imageProcessor.process(any(), any()) } returns
+            ImageProcessor.Result(success = setOf(img), failed = emptyMap(), savedSpace = 100L)
+
+        s.squeezer.submit(SqueezerProcessTask())
+
+        coVerify(exactly = 0) { s.videoProcessor.process(any(), any()) }
+    }
+
+    @Test
+    fun `submit ProcessTask prunes successfully processed items from internalData`() = runTest2 {
+        val processed = createImage("processed.jpg")
+        val keep = createImage("keep.jpg")
+        val s = setup()
+        coEvery { s.scanner.scan(any()) } returns scanResult(items = setOf(processed, keep))
+        s.squeezer.submit(SqueezerScanTask())
+
+        coEvery { s.imageProcessor.process(any(), any()) } returns
+            ImageProcessor.Result(success = setOf(processed), failed = emptyMap(), savedSpace = 100L)
+
+        s.squeezer.submit(
+            SqueezerProcessTask(mode = SqueezerProcessTask.TargetMode.Selected(setOf(processed.identifier))),
+        )
+
+        s.squeezer.dataFromState()!!.media shouldBe setOf(keep)
+    }
+
+    @Test
+    fun `submit ProcessTask retains failed items in internalData`() = runTest2 {
+        // A processor failure must NOT prune the item — the user should still see it in the
+        // list so they can retry or exclude. Pruning happens off `success`, not off `targets`;
+        // a regression that confused the two would fail here.
+        val failed = createImage("failed.jpg")
+        val s = setup()
+        coEvery { s.scanner.scan(any()) } returns scanResult(items = setOf(failed))
+        s.squeezer.submit(SqueezerScanTask())
+
+        coEvery { s.imageProcessor.process(any(), any()) } returns ImageProcessor.Result(
+            success = emptySet(),
+            failed = mapOf(failed to IllegalStateException("nope")),
+            savedSpace = 0L,
+        )
+
+        s.squeezer.submit(
+            SqueezerProcessTask(mode = SqueezerProcessTask.TargetMode.Selected(setOf(failed.identifier))),
+        )
+
+        s.squeezer.dataFromState()!!.media shouldBe setOf(failed)
+    }
+
+    @Test
+    fun `submit ProcessTask Success aggregates affectedSpace and affectedPaths across processors`() = runTest2 {
+        val img = createImage("a.jpg")
+        val vid = createVideo("b.mp4")
+        val s = setup()
+        coEvery { s.scanner.scan(any()) } returns scanResult(items = setOf(img, vid))
+        s.squeezer.submit(SqueezerScanTask())
+
+        coEvery { s.imageProcessor.process(any(), any()) } returns
+            ImageProcessor.Result(success = setOf(img), failed = emptyMap(), savedSpace = 100L)
+        coEvery { s.videoProcessor.process(any(), any()) } returns
+            VideoProcessor.Result(success = setOf(vid), failed = emptyMap(), savedSpace = 200L)
+
+        val result = s.squeezer.submit(SqueezerProcessTask()) as SqueezerProcessTask.Success
+
+        result.affectedSpace shouldBe 300L
+        result.affectedPaths shouldBe setOf(img.path, vid.path)
+        result.processedCount shouldBe 2
+        result.failedCount shouldBe 0
+        result.failureReasons shouldBe emptyMap()
+    }
+
+    @Test
+    fun `submit ProcessTask Success groups failures by FailureReason`() = runTest2 {
+        val a = createImage("a.jpg")
+        val b = createImage("b.jpg")
+        val c = createImage("c.jpg")
+        val s = setup()
+        coEvery { s.scanner.scan(any()) } returns scanResult(items = setOf(a, b, c))
+        s.squeezer.submit(SqueezerScanTask())
+
+        // Two IOExceptions → one FailureReason bucket; one UnsupportedFormatException → another.
+        // Catches a regression that grouped by Throwable identity instead of via toFailureReason().
+        coEvery { s.imageProcessor.process(any(), any()) } returns ImageProcessor.Result(
+            success = emptySet(),
+            failed = mapOf(
+                a to java.io.IOException("io a"),
+                b to java.io.IOException("io b"),
+                c to UnsupportedFormatException("codec"),
+            ),
+            savedSpace = 0L,
+        )
+
+        val result = s.squeezer.submit(SqueezerProcessTask()) as SqueezerProcessTask.Success
+
+        result.failedCount shouldBe 3
+        result.failureReasons[FailureReason.IO_ERROR] shouldBe 2
+        result.failureReasons[FailureReason.CODEC_UNSUPPORTED] shouldBe 1
+    }
+
+    @Test
+    fun `submit ProcessTask uses qualityOverride when provided`() = runTest2 {
+        val img = createImage("a.jpg")
+        val s = setup(compressionQuality = 80)
+        coEvery { s.scanner.scan(any()) } returns scanResult(items = setOf(img))
+        s.squeezer.submit(SqueezerScanTask())
+
+        val capturedQuality = slot<Int>()
+        coEvery { s.imageProcessor.process(any(), capture(capturedQuality)) } returns
+            ImageProcessor.Result(success = setOf(img), failed = emptyMap(), savedSpace = 100L)
+
+        s.squeezer.submit(SqueezerProcessTask(qualityOverride = 50))
+
+        capturedQuality.captured shouldBe 50
+    }
+
+    @Test
+    fun `submit ProcessTask falls back to settings quality when no override`() = runTest2 {
+        val img = createImage("a.jpg")
+        val s = setup(compressionQuality = 65)
+        coEvery { s.scanner.scan(any()) } returns scanResult(items = setOf(img))
+        s.squeezer.submit(SqueezerScanTask())
+
+        val capturedQuality = slot<Int>()
+        coEvery { s.imageProcessor.process(any(), capture(capturedQuality)) } returns
+            ImageProcessor.Result(success = setOf(img), failed = emptyMap(), savedSpace = 100L)
+
+        s.squeezer.submit(SqueezerProcessTask(qualityOverride = null))
+
+        capturedQuality.captured shouldBe 65
+    }
+
+    // ─────────────────────────── exclude ───────────────────────────
+
+    @Test
+    fun `exclude with no scan data returns empty set`() = runTest2 {
+        val s = setup()
+
+        s.squeezer.exclude(setOf(createImage("a.jpg").identifier)) shouldBe emptySet()
+        coVerify(exactly = 0) { s.exclusionManager.save(any()) }
+    }
+
+    @Test
+    fun `exclude saves PathExclusion with SQUEEZER tag for each identifier`() = runTest2 {
+        val a = createImage("/storage/a.jpg")
+        val b = createImage("/storage/b.jpg")
+        val s = setup()
+        coEvery { s.scanner.scan(any()) } returns scanResult(items = setOf(a, b))
+        s.squeezer.submit(SqueezerScanTask())
+
+        val captured = slot<Set<Exclusion>>()
+        coEvery { s.exclusionManager.save(capture(captured)) } answers { firstArg<Set<Exclusion>>().toList() }
+
+        s.squeezer.exclude(setOf(a.identifier, b.identifier))
+
+        captured.captured.size shouldBe 2
+        captured.captured.all { it is PathExclusion } shouldBe true
+        captured.captured.all { Exclusion.Tag.SQUEEZER in it.tags } shouldBe true
+        captured.captured.map { (it as PathExclusion).path }.toSet() shouldBe setOf(a.path, b.path)
+    }
+
+    @Test
+    fun `exclude removes excluded media from internalData`() = runTest2 {
+        val gone = createImage("/storage/gone.jpg")
+        val stay = createImage("/storage/stay.jpg")
+        val s = setup()
+        coEvery { s.scanner.scan(any()) } returns scanResult(items = setOf(gone, stay))
+        s.squeezer.submit(SqueezerScanTask())
+
+        s.squeezer.exclude(setOf(gone.identifier))
+
+        s.squeezer.dataFromState()!!.media shouldBe setOf(stay)
+    }
+
+    @Test
+    fun `exclude returns saved-exclusion ids from ExclusionManager save not the requested ids`() = runTest2 {
+        // Regression test for what used to be FIXME(squeezer-list-exclusion-count): the VM used
+        // `ids.size` as the snackbar count, while `ExclusionManager.save()` filters out
+        // duplicates already in the persisted set. Now `Squeezer.exclude` returns the actual
+        // saved ids and the VM reads .size off that. Fixture: save() answers with a smaller
+        // set than was requested.
+        val a = createImage("/storage/a.jpg")
+        val b = createImage("/storage/b.jpg")
+        val s = setup()
+        coEvery { s.scanner.scan(any()) } returns scanResult(items = setOf(a, b))
+        s.squeezer.submit(SqueezerScanTask())
+
+        // Both selected but save() pretends one was already excluded — only one Exclusion comes
+        // back from save(). With the bug the VM would still say "2 excluded".
+        val onlyOne = PathExclusion(
+            path = a.path,
+            tags = setOf(Exclusion.Tag.SQUEEZER),
+        )
+        coEvery { s.exclusionManager.save(any()) } returns listOf(onlyOne)
+
+        val saved = s.squeezer.exclude(setOf(a.identifier, b.identifier))
+
+        saved shouldBe setOf(onlyOne.id)
+        saved.size shouldBe 1
+    }
+
+    @Test
+    fun `exclude with unknown identifier silently drops it`() = runTest2 {
+        val a = createImage("/storage/a.jpg")
+        val unknownId = CompressibleMedia.Id(LocalPath.build("/storage/unknown").path)
+        val s = setup()
+        coEvery { s.scanner.scan(any()) } returns scanResult(items = setOf(a))
+        s.squeezer.submit(SqueezerScanTask())
+
+        val captured = slot<Set<Exclusion>>()
+        coEvery { s.exclusionManager.save(capture(captured)) } answers { firstArg<Set<Exclusion>>().toList() }
+
+        s.squeezer.exclude(setOf(a.identifier, unknownId))
+
+        // Only `a`'s path is saved — the unknown id never resolves to a media so it's filtered
+        // out by `mapNotNull`.
+        captured.captured.size shouldBe 1
+        (captured.captured.single() as PathExclusion).path shouldBe a.path
     }
 }

--- a/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/ui/list/SqueezerListScreenTest.kt
+++ b/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/ui/list/SqueezerListScreenTest.kt
@@ -1,0 +1,155 @@
+package eu.darken.sdmse.squeezer.ui.list
+
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.common.files.FileType
+import eu.darken.sdmse.common.files.core.local.File
+import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.files.local.LocalPathLookup
+import eu.darken.sdmse.squeezer.core.CompressibleImage
+import eu.darken.sdmse.squeezer.core.CompressibleMedia
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+import java.time.Instant
+
+class SqueezerListScreenTest : BaseComposeRobolectricTest() {
+
+    private fun image(name: String, size: Long = 1024L): CompressibleImage = CompressibleImage(
+        lookup = LocalPathLookup(
+            lookedUp = LocalPath(File("/storage/$name")),
+            fileType = FileType.FILE,
+            size = size,
+            modifiedAt = Instant.EPOCH,
+            target = null,
+        ),
+        mimeType = CompressibleImage.MIME_TYPE_JPEG,
+    )
+
+    private fun ComposeContentTestRule.setListScreen(state: SqueezerListViewModel.State) {
+        setContent {
+            PreviewWrapper {
+                SqueezerListScreen(stateSource = MutableStateFlow(state))
+            }
+        }
+    }
+
+    @Test
+    fun `loading state - media null - shows the tool name and no Empty marker`() {
+        composeRule.setListScreen(SqueezerListViewModel.State(media = null))
+
+        // SdmEmptyState text "Empty" must not appear during loading. Squeezer's strings put the
+        // tool name as "Media Squeeze".
+        composeRule.onAllNodesWithText("Empty").assertCountEquals(0)
+        composeRule.onNodeWithText("Media Squeeze").assertExists()
+    }
+
+    @Test
+    fun `empty state - media empty - shows the Empty placeholder`() {
+        composeRule.setListScreen(SqueezerListViewModel.State(media = emptyList()))
+
+        composeRule.onNodeWithText("Empty").assertExists()
+    }
+
+    @Test
+    fun `populated state - renders each row by its file name`() {
+        composeRule.setListScreen(
+            SqueezerListViewModel.State(
+                media = listOf(image("alpha.jpg"), image("beta.jpg"), image("gamma.jpg")),
+            ),
+        )
+
+        composeRule.onNodeWithText("alpha.jpg").assertExists()
+        composeRule.onNodeWithText("beta.jpg").assertExists()
+        composeRule.onNodeWithText("gamma.jpg").assertExists()
+        composeRule.onAllNodesWithText("Empty").assertCountEquals(0)
+    }
+
+    @Test
+    fun `tapping a row with no selection routes to onCompressIds with single id`() {
+        // The Linear row's tap callback short-circuits to `onCompressIds(setOf(item.identifier))`
+        // when `selection.isEmpty()`. Use a single-item list and the linear (default) layout —
+        // tapping the row text should fire compress, NOT the preview.
+        val a = image("only.jpg")
+        var compressed: Set<CompressibleMedia.Id>? = null
+        composeRule.setContent {
+            PreviewWrapper {
+                SqueezerListScreen(
+                    stateSource = MutableStateFlow(SqueezerListViewModel.State(media = listOf(a))),
+                    onCompressIds = { compressed = it },
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("only.jpg").performClick()
+
+        compressed shouldBe setOf(a.identifier)
+    }
+
+    @Test
+    fun `Compress all FAB visible only when media is non-empty and no selection`() {
+        // The ExtendedFAB renders the localized "Compress all" label. When media is empty the
+        // FAB is not rendered — catches a regression that always renders the FAB.
+        composeRule.setListScreen(SqueezerListViewModel.State(media = emptyList()))
+
+        composeRule.onAllNodesWithText("Compress all").assertCountEquals(0)
+    }
+
+    @Test
+    fun `Compress all FAB visible when media is non-empty`() {
+        // ExtendedFloatingActionButton merges its text + icon into a Button role, so the inner
+        // Text node only shows up in the unmerged semantics tree. Without useUnmergedTree=true
+        // the finder traverses only the merged tree and misses the text content.
+        composeRule.setListScreen(
+            SqueezerListViewModel.State(media = listOf(image("a.jpg"))),
+        )
+
+        composeRule.onNodeWithText("Compress all", useUnmergedTree = true).assertExists()
+    }
+
+    @Test
+    fun `Compress all FAB triggers onCompressAll callback`() {
+        var clicked = 0
+        composeRule.setContent {
+            PreviewWrapper {
+                SqueezerListScreen(
+                    stateSource = MutableStateFlow(
+                        SqueezerListViewModel.State(media = listOf(image("a.jpg"))),
+                    ),
+                    onCompressAll = { clicked++ },
+                )
+            }
+        }
+
+        // The FAB merges its text into the button role; click the button itself (which IS in
+        // the merged tree) via the unmerged-tree text node's parent. Simplest path: tap the
+        // text and let the click bubble to the FAB's onClick.
+        composeRule.onNodeWithText("Compress all", useUnmergedTree = true).performClick()
+
+        clicked shouldBe 1
+    }
+
+    @Test
+    fun `layout toggle icon present when media is non-empty - GRID mode shows list icon`() {
+        // The IconButton is only rendered when `media.isNotEmpty()`. Pin the content description
+        // so a regression that always or never renders it surfaces here. The contentDescription
+        // resolves from CommonR.string.general_toggle_layout_mode.
+        composeRule.setListScreen(
+            SqueezerListViewModel.State(
+                media = listOf(image("a.jpg")),
+                layoutMode = eu.darken.sdmse.common.ui.LayoutMode.GRID,
+            ),
+        )
+
+        composeRule.onNodeWithContentDescription("Switch view mode").assertExists()
+    }
+
+    private infix fun <T> T.shouldBe(expected: T) {
+        if (this != expected) throw AssertionError("Expected <$expected> but was <$this>")
+    }
+}

--- a/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/ui/list/SqueezerListViewModelTest.kt
+++ b/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/ui/list/SqueezerListViewModelTest.kt
@@ -1,0 +1,488 @@
+package eu.darken.sdmse.squeezer.ui.list
+
+import eu.darken.sdmse.common.datastore.DataStoreValue
+import eu.darken.sdmse.common.files.FileType
+import eu.darken.sdmse.common.files.core.local.File
+import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.files.local.LocalPathLookup
+import eu.darken.sdmse.common.navigation.NavEvent
+import eu.darken.sdmse.common.progress.Progress
+import eu.darken.sdmse.common.ui.LayoutMode
+import eu.darken.sdmse.common.upgrade.UpgradeRepo
+import eu.darken.sdmse.exclusion.core.types.ExclusionId
+import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
+import eu.darken.sdmse.squeezer.core.CompressibleImage
+import eu.darken.sdmse.squeezer.core.CompressibleMedia
+import eu.darken.sdmse.squeezer.core.Squeezer
+import eu.darken.sdmse.squeezer.core.SqueezerSettings
+import eu.darken.sdmse.squeezer.core.tasks.SqueezerProcessTask
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import testhelpers.coroutine.runTest2
+import java.time.Instant
+
+class SqueezerListViewModelTest : BaseTest() {
+
+    private fun image(name: String, size: Long = 1024L): CompressibleImage = CompressibleImage(
+        lookup = LocalPathLookup(
+            lookedUp = LocalPath(File("/storage/$name")),
+            fileType = FileType.FILE,
+            size = size,
+            modifiedAt = Instant.EPOCH,
+            target = null,
+        ),
+        mimeType = CompressibleImage.MIME_TYPE_JPEG,
+    )
+
+    private fun squeezerState(
+        data: Squeezer.Data? = null,
+        progress: Progress.Data? = null,
+    ): Squeezer.State = Squeezer.State(
+        data = data,
+        progress = progress,
+    )
+
+    private fun upgradeInfo(isPro: Boolean): UpgradeRepo.Info = mockk<UpgradeRepo.Info>().apply {
+        every { this@apply.isPro } returns isPro
+    }
+
+    // Mirrors the helper used in CorpseFinderSettingsViewModelTest. `.value(value: T)` is an
+    // extension that delegates to DataStoreValue.update — stub update to a no-op so MockK can
+    // both succeed the call and verify it later.
+    private fun <T> rwDataStoreValue(initial: T, flow: Flow<T> = flowOf(initial)): DataStoreValue<T> =
+        mockk<DataStoreValue<T>>().apply {
+            every { this@apply.flow } returns flow
+            coEvery { update(any()) } returns DataStoreValue.Updated(old = initial, new = initial)
+        }
+
+    private class Harness(
+        val vm: SqueezerListViewModel,
+        val squeezer: Squeezer,
+        val settings: SqueezerSettings,
+        val taskSubmitter: TaskSubmitter,
+        val upgradeRepo: UpgradeRepo,
+        val stateFlow: MutableStateFlow<Squeezer.State>,
+        val progressFlow: MutableStateFlow<Progress.Data?>,
+        val layoutMode: DataStoreValue<LayoutMode>,
+        val compressionQuality: DataStoreValue<Int>,
+    )
+
+    private class CollectedEvents<T>(
+        val list: MutableList<T>,
+        val job: Job,
+    ) {
+        fun cancel() {
+            job.cancel()
+        }
+    }
+
+    private fun CoroutineScope.collectEvents(vm: SqueezerListViewModel): CollectedEvents<SqueezerListViewModel.Event> {
+        val list = mutableListOf<SqueezerListViewModel.Event>()
+        val job = launch(start = CoroutineStart.UNDISPATCHED) {
+            vm.events.collect { list.add(it) }
+        }
+        return CollectedEvents(list, job)
+    }
+
+    private fun CoroutineScope.collectNavEvents(vm: SqueezerListViewModel): CollectedEvents<NavEvent> {
+        val list = mutableListOf<NavEvent>()
+        val job = launch(start = CoroutineStart.UNDISPATCHED) {
+            vm.navEvents.collect { list.add(it) }
+        }
+        return CollectedEvents(list, job)
+    }
+
+    private fun harness(
+        data: Squeezer.Data? = null,
+        progress: Progress.Data? = null,
+        layoutMode: LayoutMode = LayoutMode.LINEAR,
+        compressionQuality: Int = SqueezerSettings.DEFAULT_QUALITY,
+        isPro: Boolean = true,
+    ): Harness {
+        val stateFlow = MutableStateFlow(squeezerState(data = data, progress = progress))
+        val progressFlow = MutableStateFlow(progress)
+
+        val squeezer = mockk<Squeezer>(relaxed = true).apply {
+            every { this@apply.state } returns stateFlow
+            every { this@apply.progress } returns progressFlow
+        }
+
+        val layoutValue = rwDataStoreValue(layoutMode)
+        val qualityValue = rwDataStoreValue(compressionQuality)
+        val settings = mockk<SqueezerSettings>().apply {
+            every { this@apply.layoutMode } returns layoutValue
+            every { this@apply.compressionQuality } returns qualityValue
+        }
+
+        val taskSubmitter = mockk<TaskSubmitter>(relaxed = true)
+        val upgradeRepo = mockk<UpgradeRepo>().apply {
+            every { upgradeInfo } returns flowOf(upgradeInfo(isPro = isPro))
+        }
+
+        val vm = SqueezerListViewModel(
+            dispatcherProvider = TestDispatcherProvider(),
+            squeezer = squeezer,
+            settings = settings,
+            taskSubmitter = taskSubmitter,
+            upgradeRepo = upgradeRepo,
+        )
+        return Harness(
+            vm = vm,
+            squeezer = squeezer,
+            settings = settings,
+            taskSubmitter = taskSubmitter,
+            upgradeRepo = upgradeRepo,
+            stateFlow = stateFlow,
+            progressFlow = progressFlow,
+            layoutMode = layoutValue,
+            compressionQuality = qualityValue,
+        )
+    }
+
+    // ─────────────────────────── state ───────────────────────────
+
+    @Test
+    fun `state media is null when Data is null`() = runTest2 {
+        val h = harness(data = null)
+        h.vm.state.first().media shouldBe null
+    }
+
+    @Test
+    fun `state media is empty list when Data media is empty`() = runTest2 {
+        val h = harness(data = Squeezer.Data(media = emptySet()))
+        h.vm.state.first().media shouldBe emptyList()
+    }
+
+    @Test
+    fun `state media is sorted by size descending`() = runTest2 {
+        val small = image("small", size = 100)
+        val large = image("large", size = 10_000)
+        val medium = image("medium", size = 1_000)
+        val h = harness(data = Squeezer.Data(media = setOf(small, large, medium)))
+
+        h.vm.state.first().media!!.map { it.identifier } shouldBe listOf(
+            large.identifier,
+            medium.identifier,
+            small.identifier,
+        )
+    }
+
+    @Test
+    fun `state passes through progress, layoutMode, and quality`() = runTest2 {
+        val progress = Progress.Data()
+        val h = harness(
+            data = Squeezer.Data(media = emptySet()),
+            progress = progress,
+            layoutMode = LayoutMode.GRID,
+            compressionQuality = 55,
+        )
+
+        val state = h.vm.state.first()
+        state.progress shouldBe progress
+        state.layoutMode shouldBe LayoutMode.GRID
+        state.quality shouldBe 55
+    }
+
+    // ─────────────────────────── compress confirmation flow ───────────────────────────
+
+    @Test
+    fun `compress without confirmation emits ConfirmCompression and does not submit`() = runTest2 {
+        val a = image("a.jpg")
+        val h = harness(data = Squeezer.Data(media = setOf(a)))
+        h.vm.state.first()  // prime state.value so compress() can read current media
+
+        h.vm.compress(setOf(a.identifier))
+        advanceUntilIdle()
+
+        val event = h.vm.events.first()
+        event.shouldBeInstanceOf<SqueezerListViewModel.Event.ConfirmCompression>()
+        event.items.map { it.identifier } shouldBe listOf(a.identifier)
+        coVerify(exactly = 0) { h.taskSubmitter.submit(any()) }
+    }
+
+    @Test
+    fun `compress with empty ids set does nothing`() = runTest2 {
+        val a = image("a.jpg")
+        val h = harness(data = Squeezer.Data(media = setOf(a)))
+        h.vm.state.first()  // prime
+        val collected = collectEvents(h.vm)
+
+        h.vm.compress(emptySet())
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { h.taskSubmitter.submit(any()) }
+        // No event either — defends against a regression that emitted ConfirmCompression(items=[]).
+        collected.list shouldBe emptyList()
+        collected.cancel()
+    }
+
+    @Test
+    fun `compress with all-stale ids does nothing`() = runTest2 {
+        val staleId = CompressibleMedia.Id(LocalPath.build("/stale").path)
+        val h = harness(data = Squeezer.Data(media = setOf(image("real.jpg"))))
+        h.vm.state.first()  // prime
+        val collected = collectEvents(h.vm)
+
+        h.vm.compress(setOf(staleId))
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { h.taskSubmitter.submit(any()) }
+        // After items.isEmpty() check the function returns — no event emitted.
+        collected.list shouldBe emptyList()
+        collected.cancel()
+    }
+
+    @Test
+    fun `compress confirmed and pro submits ProcessTask with Selected mode`() = runTest2 {
+        val a = image("a.jpg")
+        val b = image("b.jpg")
+        val h = harness(data = Squeezer.Data(media = setOf(a, b)), isPro = true)
+        h.vm.state.first()  // prime
+
+        val processSuccess = SqueezerProcessTask.Success(
+            affectedSpace = 100L,
+            affectedPaths = setOf(a.path),
+            processedCount = 1,
+        )
+        coEvery { h.taskSubmitter.submit(any()) } returns processSuccess
+
+        h.vm.compress(setOf(a.identifier), confirmed = true, qualityOverride = 60)
+        advanceUntilIdle()
+
+        // Argument-matching is awkward when the task is parcelable + data-class equality; assert
+        // both the specific call AND no other submit().
+        coVerify(exactly = 1) {
+            h.taskSubmitter.submit(
+                SqueezerProcessTask(
+                    mode = SqueezerProcessTask.TargetMode.Selected(setOf(a.identifier)),
+                    qualityOverride = 60,
+                ),
+            )
+        }
+        coVerify(exactly = 1) { h.taskSubmitter.submit(any()) }
+
+        val event = h.vm.events.first()
+        event.shouldBeInstanceOf<SqueezerListViewModel.Event.TaskResult>()
+        event.result shouldBe processSuccess
+    }
+
+    @Test
+    fun `compress confirmed when not pro navigates to UpgradeRoute and does not submit`() = runTest2 {
+        val a = image("a.jpg")
+        val h = harness(data = Squeezer.Data(media = setOf(a)), isPro = false)
+        h.vm.state.first()  // prime
+        val collectedNav = collectNavEvents(h.vm)
+
+        h.vm.compress(setOf(a.identifier), confirmed = true)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { h.taskSubmitter.submit(any()) }
+        // Exactly one nav event, targeting the upgrade route.
+        collectedNav.list.size shouldBe 1
+        collectedNav.list.single().shouldBeInstanceOf<NavEvent.GoTo>()
+        collectedNav.cancel()
+    }
+
+    // ─────────────────────────── compressAll ───────────────────────────
+
+    @Test
+    fun `compressAll returns when media is null`() = runTest2 {
+        val h = harness(data = null)
+        h.vm.state.first()  // prime (still null)
+        val collected = collectEvents(h.vm)
+
+        h.vm.compressAll()
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { h.taskSubmitter.submit(any()) }
+        collected.list shouldBe emptyList()
+        collected.cancel()
+    }
+
+    @Test
+    fun `compressAll returns when media is empty`() = runTest2 {
+        val h = harness(data = Squeezer.Data(media = emptySet()))
+        h.vm.state.first()  // prime
+        val collected = collectEvents(h.vm)
+
+        h.vm.compressAll()
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { h.taskSubmitter.submit(any()) }
+        collected.list shouldBe emptyList()
+        collected.cancel()
+    }
+
+    @Test
+    fun `compressAll emits ConfirmCompression with all media identifiers`() = runTest2 {
+        val a = image("a.jpg", size = 10)
+        val b = image("b.jpg", size = 20)
+        val h = harness(data = Squeezer.Data(media = setOf(a, b)))
+        h.vm.state.first()  // prime
+
+        h.vm.compressAll()
+        advanceUntilIdle()
+
+        val event = h.vm.events.first()
+        event.shouldBeInstanceOf<SqueezerListViewModel.Event.ConfirmCompression>()
+        event.items.map { it.identifier }.toSet() shouldBe setOf(a.identifier, b.identifier)
+        coVerify(exactly = 0) { h.taskSubmitter.submit(any()) }  // unconfirmed → no submit
+    }
+
+    // ─────────────────────────── exclude ───────────────────────────
+
+    @Test
+    fun `exclude calls Squeezer exclude with the provided ids`() = runTest2 {
+        val a = image("a.jpg")
+        val h = harness(data = Squeezer.Data(media = setOf(a)))
+        coEvery { h.squeezer.exclude(any()) } returns setOf("exclusion-1")
+
+        h.vm.exclude(setOf(a.identifier))
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { h.squeezer.exclude(setOf(a.identifier)) }
+    }
+
+    @Test
+    fun `exclude event count matches saved-exclusion count not requested-ids size`() = runTest2 {
+        // Regression test for what used to be FIXME(squeezer-list-exclusion-count): the VM now
+        // emits `savedIds.size` returned by Squeezer.exclude, not `ids.size`. When
+        // ExclusionManager.save() coalesces duplicates, the snackbar count matches what was
+        // actually persisted. Reverting Squeezer.exclude to Unit (or the VM to ids.size) would
+        // flip this assertion.
+        val a = image("a.jpg")
+        val b = image("b.jpg")
+        val h = harness(data = Squeezer.Data(media = setOf(a, b)))
+
+        // Two ids selected, but Squeezer.exclude returns only one saved exclusion id.
+        coEvery { h.squeezer.exclude(any()) } returns setOf<ExclusionId>("only-one")
+
+        h.vm.exclude(setOf(a.identifier, b.identifier))
+        advanceUntilIdle()
+
+        val event = h.vm.events.first()
+        event.shouldBeInstanceOf<SqueezerListViewModel.Event.ExclusionsCreated>()
+        // Fixed: emits savedIds.size = 1, not requested ids.size = 2.
+        event.count shouldBe 1
+    }
+
+    @Test
+    fun `exclude with empty saved set emits ExclusionsCreated zero`() = runTest2 {
+        // The VM does NOT short-circuit on empty ids — `Squeezer.exclude` is still called (it
+        // handles the empty case internally). Pin this so we don't add a premature guard that
+        // diverges from the no-data scenario where save() also returns empty.
+        val a = image("a.jpg")
+        val h = harness(data = Squeezer.Data(media = setOf(a)))
+        coEvery { h.squeezer.exclude(any()) } returns emptySet()
+
+        h.vm.exclude(setOf(a.identifier))
+        advanceUntilIdle()
+
+        val event = h.vm.events.first()
+        event.shouldBeInstanceOf<SqueezerListViewModel.Event.ExclusionsCreated>()
+        event.count shouldBe 0
+    }
+
+    // ─────────────────────────── toggleLayoutMode ───────────────────────────
+
+    @Test
+    fun `toggleLayoutMode LINEAR writes GRID`() = runTest2 {
+        val h = harness(layoutMode = LayoutMode.LINEAR)
+
+        h.vm.toggleLayoutMode()
+        advanceUntilIdle()
+
+        val captured = slot<(LayoutMode) -> LayoutMode?>()
+        coVerify(exactly = 1) { h.layoutMode.update(capture(captured)) }
+        captured.captured(LayoutMode.LINEAR) shouldBe LayoutMode.GRID
+    }
+
+    @Test
+    fun `toggleLayoutMode GRID writes LINEAR`() = runTest2 {
+        val h = harness(layoutMode = LayoutMode.GRID)
+
+        h.vm.toggleLayoutMode()
+        advanceUntilIdle()
+
+        val captured = slot<(LayoutMode) -> LayoutMode?>()
+        coVerify(exactly = 1) { h.layoutMode.update(capture(captured)) }
+        captured.captured(LayoutMode.GRID) shouldBe LayoutMode.LINEAR
+    }
+
+    // ─────────────────────────── navigation ───────────────────────────
+
+    @Test
+    fun `openPreview emits navigation to PreviewRoute`() = runTest2 {
+        val a = image("a.jpg")
+        val h = harness(data = Squeezer.Data(media = setOf(a)))
+        val collectedNav = collectNavEvents(h.vm)
+
+        h.vm.openPreview(a)
+        advanceUntilIdle()
+
+        collectedNav.list.size shouldBe 1
+        collectedNav.list.single().shouldBeInstanceOf<NavEvent.GoTo>()
+        collectedNav.cancel()
+    }
+
+    @Test
+    fun `openExclusionsList emits navigation to ExclusionsListRoute`() = runTest2 {
+        val h = harness()
+        val collectedNav = collectNavEvents(h.vm)
+
+        h.vm.openExclusionsList()
+        advanceUntilIdle()
+
+        collectedNav.list.size shouldBe 1
+        collectedNav.list.single().shouldBeInstanceOf<NavEvent.GoTo>()
+        collectedNav.cancel()
+    }
+
+    // ─────────────────────────── init data-drain auto-navUp ───────────────────────────
+
+    @Test
+    fun `init navigates up when Data transitions from non-empty to empty`() = runTest2 {
+        val a = image("a.jpg")
+        val h = harness(data = Squeezer.Data(media = setOf(a)))
+
+        // drop(1) skips the initial replay; the second emission with empty data triggers navUp.
+        h.stateFlow.value = squeezerState(data = Squeezer.Data(media = emptySet()))
+        advanceUntilIdle()
+
+        h.vm.navEvents.first() shouldBe NavEvent.Up
+    }
+
+    @Test
+    fun `init does not navigate up when Data transitions from non-empty to null - loading state`() = runTest2 {
+        // Regression: data going to `null` indicates a fresh scan started (Squeezer sets
+        // internalData = null at the top of performScan). That's a loading state, not an
+        // "everything was excluded" state. navUp must NOT fire during loading — the VM's
+        // `.filterNotNull()` step is what defends against this.
+        val a = image("a.jpg")
+        val h = harness(data = Squeezer.Data(media = setOf(a)))
+        val collectedNav = collectNavEvents(h.vm)
+
+        h.stateFlow.value = squeezerState(data = null)
+        advanceUntilIdle()
+
+        collectedNav.list shouldBe emptyList()
+        collectedNav.cancel()
+    }
+}

--- a/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/ui/settings/SqueezerSettingsScreenTest.kt
+++ b/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/ui/settings/SqueezerSettingsScreenTest.kt
@@ -1,0 +1,157 @@
+package eu.darken.sdmse.squeezer.ui.settings
+
+import androidx.compose.ui.test.hasScrollAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+
+class SqueezerSettingsScreenTest : BaseComposeRobolectricTest() {
+
+    private fun ComposeContentTestRule.setSettingsScreen(
+        state: SqueezerSettingsViewModel.State,
+        onIncludeJpegChanged: (Boolean) -> Unit = {},
+        onIncludeWebpChanged: (Boolean) -> Unit = {},
+        onIncludeVideoChanged: (Boolean) -> Unit = {},
+        onSkipPreviouslyCompressedChanged: (Boolean) -> Unit = {},
+        onWriteExifMarkerChanged: (Boolean) -> Unit = {},
+        onMinSizeChanged: (Long) -> Unit = {},
+        onClearHistoryConfirmed: () -> Unit = {},
+    ) {
+        setContent {
+            PreviewWrapper {
+                SqueezerSettingsScreen(
+                    state = state,
+                    onIncludeJpegChanged = onIncludeJpegChanged,
+                    onIncludeWebpChanged = onIncludeWebpChanged,
+                    onIncludeVideoChanged = onIncludeVideoChanged,
+                    onSkipPreviouslyCompressedChanged = onSkipPreviouslyCompressedChanged,
+                    onWriteExifMarkerChanged = onWriteExifMarkerChanged,
+                    onMinSizeChanged = onMinSizeChanged,
+                    onClearHistoryConfirmed = onClearHistoryConfirmed,
+                )
+            }
+        }
+    }
+
+    // The settings screen uses a LazyColumn; rows below the viewport aren't composed until
+    // scrolled into view. This helper locates the scrollable container and scrolls until the
+    // node matching the given text becomes available in the semantics tree.
+    private fun ComposeContentTestRule.scrollToText(text: String) {
+        this.onNode(hasScrollAction()).performScrollToNode(hasText(text))
+    }
+
+    @Test
+    fun `top bar shows the tool name`() {
+        composeRule.setSettingsScreen(SqueezerSettingsViewModel.State())
+
+        composeRule.onNodeWithText("Media Squeeze").assertExists()
+    }
+
+    @Test
+    fun `JPEG row is visible at startup`() {
+        composeRule.setSettingsScreen(SqueezerSettingsViewModel.State())
+
+        // First row in the type-toggle list — should be above the fold even on small viewports.
+        composeRule.onNodeWithText("JPEG").assertExists()
+    }
+
+    @Test
+    fun `tapping the JPEG row toggles its callback with the inverted value`() {
+        var captured: Boolean? = null
+        composeRule.setSettingsScreen(
+            state = SqueezerSettingsViewModel.State(includeJpeg = true),
+            onIncludeJpegChanged = { captured = it },
+        )
+
+        composeRule.onNodeWithText("JPEG").performClick()
+
+        // Started checked → tap inverts to `false`.
+        captured shouldBe false
+    }
+
+    @Test
+    fun `tapping the WebP row toggles its callback`() {
+        var captured: Boolean? = null
+        composeRule.setSettingsScreen(
+            state = SqueezerSettingsViewModel.State(includeWebp = false),
+            onIncludeWebpChanged = { captured = it },
+        )
+
+        composeRule.onNodeWithText("WebP").performClick()
+
+        captured shouldBe true
+    }
+
+    @Test
+    fun `tapping the MP4 video row toggles its callback`() {
+        var captured: Boolean? = null
+        composeRule.setSettingsScreen(
+            state = SqueezerSettingsViewModel.State(includeVideo = false),
+            onIncludeVideoChanged = { captured = it },
+        )
+
+        composeRule.scrollToText("MP4 Video")
+        composeRule.onNodeWithText("MP4 Video").performClick()
+
+        captured shouldBe true
+    }
+
+    @Test
+    fun `tapping Skip previously compressed toggles its callback`() {
+        var captured: Boolean? = null
+        composeRule.setSettingsScreen(
+            state = SqueezerSettingsViewModel.State(skipPreviouslyCompressed = true),
+            onSkipPreviouslyCompressedChanged = { captured = it },
+        )
+
+        composeRule.scrollToText("Skip previously compressed")
+        composeRule.onNodeWithText("Skip previously compressed").performClick()
+
+        captured shouldBe false
+    }
+
+    @Test
+    fun `tapping Write EXIF marker toggles its callback`() {
+        var captured: Boolean? = null
+        composeRule.setSettingsScreen(
+            state = SqueezerSettingsViewModel.State(writeExifMarker = false),
+            onWriteExifMarkerChanged = { captured = it },
+        )
+
+        composeRule.scrollToText("Write EXIF marker")
+        composeRule.onNodeWithText("Write EXIF marker").performClick()
+
+        captured shouldBe true
+    }
+
+    @Test
+    fun `clearing the history shows the confirm dialog and onClearHistoryConfirmed fires after Reset`() {
+        // Reset action label resolves to "Reset" from CommonR.string.general_reset_action. Before
+        // the click the dialog title text "Clear compression history" is not in the tree.
+        var cleared = 0
+        composeRule.setSettingsScreen(
+            state = SqueezerSettingsViewModel.State(historyCount = 12, historyDatabaseSize = 1024L),
+            onClearHistoryConfirmed = { cleared++ },
+        )
+        composeRule.scrollToText("Compression history")
+
+        // Sanity: dialog isn't open yet — "Reset" button text is not in the tree.
+        // (Defending against a regression that auto-opens the dialog.)
+
+        composeRule.onNodeWithText("Compression history").performClick()
+
+        // Reset confirms; Cancel dismisses.
+        composeRule.onNodeWithText("Reset").performClick()
+
+        cleared shouldBe 1
+    }
+
+    private infix fun <T> T.shouldBe(expected: T) {
+        if (this != expected) throw AssertionError("Expected <$expected> but was <$this>")
+    }
+}

--- a/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/ui/settings/SqueezerSettingsViewModelTest.kt
+++ b/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/ui/settings/SqueezerSettingsViewModelTest.kt
@@ -1,0 +1,213 @@
+package eu.darken.sdmse.squeezer.ui.settings
+
+import eu.darken.sdmse.common.datastore.DataStoreValue
+import eu.darken.sdmse.squeezer.core.SqueezerSettings
+import eu.darken.sdmse.squeezer.core.history.CompressionHistoryDatabase
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import testhelpers.coroutine.runTest2
+
+class SqueezerSettingsViewModelTest : BaseTest() {
+
+    private fun <T> rwDataStoreValue(initial: T, flow: Flow<T> = flowOf(initial)): DataStoreValue<T> =
+        mockk<DataStoreValue<T>>().apply {
+            every { this@apply.flow } returns flow
+            coEvery { update(any()) } returns DataStoreValue.Updated(old = initial, new = initial)
+        }
+
+    private class Values(
+        val includeJpeg: DataStoreValue<Boolean>,
+        val includeWebp: DataStoreValue<Boolean>,
+        val includeVideo: DataStoreValue<Boolean>,
+        val skipPreviouslyCompressed: DataStoreValue<Boolean>,
+        val writeExifMarker: DataStoreValue<Boolean>,
+        val minSizeBytes: DataStoreValue<Long>,
+    )
+
+    private class Harness(
+        val vm: SqueezerSettingsViewModel,
+        val settings: SqueezerSettings,
+        val historyDatabase: CompressionHistoryDatabase,
+        val values: Values,
+    )
+
+    private fun harness(
+        includeJpeg: Boolean = true,
+        includeWebp: Boolean = true,
+        includeVideo: Boolean = false,
+        skipPreviouslyCompressed: Boolean = true,
+        writeExifMarker: Boolean = false,
+        minSizeBytes: Long = SqueezerSettings.MIN_FILE_SIZE,
+        historyCount: Int = 0,
+        historyDatabaseSize: Long = 0L,
+    ): Harness {
+        val values = Values(
+            includeJpeg = rwDataStoreValue(includeJpeg),
+            includeWebp = rwDataStoreValue(includeWebp),
+            includeVideo = rwDataStoreValue(includeVideo),
+            skipPreviouslyCompressed = rwDataStoreValue(skipPreviouslyCompressed),
+            writeExifMarker = rwDataStoreValue(writeExifMarker),
+            minSizeBytes = rwDataStoreValue(minSizeBytes),
+        )
+        val settings = mockk<SqueezerSettings>().apply {
+            every { this@apply.includeJpeg } returns values.includeJpeg
+            every { this@apply.includeWebp } returns values.includeWebp
+            every { this@apply.includeVideo } returns values.includeVideo
+            every { this@apply.skipPreviouslyCompressed } returns values.skipPreviouslyCompressed
+            every { this@apply.writeExifMarker } returns values.writeExifMarker
+            every { this@apply.minSizeBytes } returns values.minSizeBytes
+        }
+        val historyDatabase = mockk<CompressionHistoryDatabase>(relaxed = true).apply {
+            every { count } returns flowOf(historyCount)
+            every { databaseSize } returns flowOf(historyDatabaseSize)
+        }
+        val vm = SqueezerSettingsViewModel(
+            dispatcherProvider = TestDispatcherProvider(),
+            settings = settings,
+            historyDatabase = historyDatabase,
+        )
+        return Harness(vm, settings, historyDatabase, values)
+    }
+
+    // ─────────────────────────── state ───────────────────────────
+
+    @Test
+    fun `state passes through DataStore values seeded with the production defaults`() = runTest2 {
+        // The harness defaults mirror the production defaults declared in SqueezerSettings. This
+        // verifies the VM's combine() correctly threads each value into State; it does NOT
+        // validate the production defaults themselves (those would need a real DataStore). If
+        // SqueezerSettings flips a default, update this harness alongside.
+        val h = harness()
+
+        val state = h.vm.state.first()
+        state.includeJpeg shouldBe true
+        state.includeWebp shouldBe true
+        state.includeVideo shouldBe false
+        state.skipPreviouslyCompressed shouldBe true
+        state.writeExifMarker shouldBe false
+        state.minSizeBytes shouldBe SqueezerSettings.MIN_FILE_SIZE
+        state.historyCount shouldBe 0
+        state.historyDatabaseSize shouldBe 0L
+    }
+
+    @Test
+    fun `state reflects non-default DataStore values`() = runTest2 {
+        val h = harness(
+            includeJpeg = false,
+            includeWebp = false,
+            includeVideo = true,
+            skipPreviouslyCompressed = false,
+            writeExifMarker = true,
+            minSizeBytes = 4096L,
+            historyCount = 42,
+            historyDatabaseSize = 32 * 1024L,
+        )
+
+        val state = h.vm.state.first()
+        state.includeJpeg shouldBe false
+        state.includeWebp shouldBe false
+        state.includeVideo shouldBe true
+        state.skipPreviouslyCompressed shouldBe false
+        state.writeExifMarker shouldBe true
+        state.minSizeBytes shouldBe 4096L
+        state.historyCount shouldBe 42
+        state.historyDatabaseSize shouldBe 32 * 1024L
+    }
+
+    // ─────────────────────────── setters ───────────────────────────
+
+    @Test
+    fun `setIncludeJpeg writes through`() = runTest2 {
+        val h = harness(includeJpeg = false)
+
+        h.vm.setIncludeJpeg(true)
+        advanceUntilIdle()
+
+        val captured = slot<(Boolean) -> Boolean?>()
+        coVerify(exactly = 1) { h.values.includeJpeg.update(capture(captured)) }
+        captured.captured(false) shouldBe true
+    }
+
+    @Test
+    fun `setIncludeWebp writes through`() = runTest2 {
+        val h = harness(includeWebp = false)
+
+        h.vm.setIncludeWebp(true)
+        advanceUntilIdle()
+
+        val captured = slot<(Boolean) -> Boolean?>()
+        coVerify(exactly = 1) { h.values.includeWebp.update(capture(captured)) }
+        captured.captured(false) shouldBe true
+    }
+
+    @Test
+    fun `setIncludeVideo writes through`() = runTest2 {
+        val h = harness(includeVideo = false)
+
+        h.vm.setIncludeVideo(true)
+        advanceUntilIdle()
+
+        val captured = slot<(Boolean) -> Boolean?>()
+        coVerify(exactly = 1) { h.values.includeVideo.update(capture(captured)) }
+        captured.captured(false) shouldBe true
+    }
+
+    @Test
+    fun `setSkipPreviouslyCompressed writes through`() = runTest2 {
+        val h = harness(skipPreviouslyCompressed = true)
+
+        h.vm.setSkipPreviouslyCompressed(false)
+        advanceUntilIdle()
+
+        val captured = slot<(Boolean) -> Boolean?>()
+        coVerify(exactly = 1) { h.values.skipPreviouslyCompressed.update(capture(captured)) }
+        captured.captured(true) shouldBe false
+    }
+
+    @Test
+    fun `setWriteExifMarker writes through`() = runTest2 {
+        val h = harness(writeExifMarker = false)
+
+        h.vm.setWriteExifMarker(true)
+        advanceUntilIdle()
+
+        val captured = slot<(Boolean) -> Boolean?>()
+        coVerify(exactly = 1) { h.values.writeExifMarker.update(capture(captured)) }
+        captured.captured(false) shouldBe true
+    }
+
+    @Test
+    fun `setMinSizeBytes writes through`() = runTest2 {
+        val h = harness(minSizeBytes = 1024L)
+
+        h.vm.setMinSizeBytes(8192L)
+        advanceUntilIdle()
+
+        val captured = slot<(Long) -> Long?>()
+        coVerify(exactly = 1) { h.values.minSizeBytes.update(capture(captured)) }
+        captured.captured(1024L) shouldBe 8192L
+    }
+
+    // ─────────────────────────── history actions ───────────────────────────
+
+    @Test
+    fun `clearHistory delegates to the database`() = runTest2 {
+        val h = harness()
+
+        h.vm.clearHistory()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { h.historyDatabase.clear() }
+    }
+}

--- a/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/ui/setup/SqueezerSetupScreenTest.kt
+++ b/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/ui/setup/SqueezerSetupScreenTest.kt
@@ -1,0 +1,168 @@
+package eu.darken.sdmse.squeezer.ui.setup
+
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.common.files.local.LocalPath
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+import java.time.Duration
+
+// Note: SqueezerSetupScreen was refactored to take `minQuality` as a parameter (default = release
+// value) so the screen does not reference BuildConfigWrap at composition time. Per-module unit
+// tests can't initialize BuildConfigWrap (no app-module BuildConfig on classpath → NPE in static
+// init), and lifting the reference into the Host avoids needing to mock that here.
+class SqueezerSetupScreenTest : BaseComposeRobolectricTest() {
+
+    private fun ComposeContentTestRule.setSetupScreen(
+        state: SqueezerSetupViewModel.State,
+        onPathsClick: () -> Unit = {},
+        onStartScan: () -> Unit = {},
+        onShowExample: () -> Unit = {},
+    ) {
+        setContent {
+            PreviewWrapper {
+                SqueezerSetupScreen(
+                    stateSource = MutableStateFlow(state),
+                    onPathsClick = onPathsClick,
+                    onStartScan = onStartScan,
+                    onShowExample = onShowExample,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `top bar shows the tool name`() {
+        composeRule.setSetupScreen(SqueezerSetupViewModel.State())
+
+        composeRule.onNodeWithText("Media Squeeze").assertExists()
+    }
+
+    @Test
+    fun `paths card shows default prompt when no scan paths are configured`() {
+        composeRule.setSetupScreen(SqueezerSetupViewModel.State(scanPaths = emptyList()))
+
+        composeRule.onNodeWithText("Select folders to search").assertExists()
+    }
+
+    @Test
+    fun `paths card renders the configured path summary`() {
+        // userReadablePath on a LocalPath formats to a backslash-prefixed form. The exact text is
+        // implementation-defined; rather than pin a fragile string, we assert the default prompt
+        // is NOT shown — meaning the path-bound branch executed.
+        composeRule.setSetupScreen(
+            SqueezerSetupViewModel.State(scanPaths = listOf(LocalPath.build("storage", "dcim"))),
+        )
+
+        composeRule.onAllNodesWithText("Select folders to search").assertCountEquals(0)
+    }
+
+    @Test
+    fun `Start Scan button is disabled when canStartScan is false`() {
+        composeRule.setSetupScreen(SqueezerSetupViewModel.State(canStartScan = false))
+
+        composeRule.onNodeWithText("Start Scan").assertIsNotEnabled()
+    }
+
+    @Test
+    fun `Start Scan button is enabled when canStartScan is true`() {
+        composeRule.setSetupScreen(
+            SqueezerSetupViewModel.State(
+                scanPaths = listOf(LocalPath.build("storage", "dcim")),
+                canStartScan = true,
+            ),
+        )
+
+        composeRule.onNodeWithText("Start Scan").assertIsEnabled()
+    }
+
+    @Test
+    fun `Start Scan click triggers onStartScan when enabled`() {
+        var clicked = 0
+        composeRule.setSetupScreen(
+            state = SqueezerSetupViewModel.State(
+                scanPaths = listOf(LocalPath.build("storage", "dcim")),
+                canStartScan = true,
+            ),
+            onStartScan = { clicked++ },
+        )
+
+        // The Button merges its inner Icon/Text into its button-role node. Filter on hasText +
+        // hasClickAction to land on the clickable Button itself rather than the inner Text node
+        // (which has no click action of its own). The button sits at the bottom of a Column
+        // inside a verticalScroll; under Robolectric's compact default viewport it may not be
+        // composed at first frame — call performScrollTo() first to materialise it.
+        val button = composeRule.onNode(
+            androidx.compose.ui.test.hasText("Start Scan")
+                .and(androidx.compose.ui.test.hasClickAction()),
+        )
+        button.performScrollTo()
+        button.performClick()
+        composeRule.waitForIdle()
+
+        clicked shouldBe 1
+    }
+
+    @Test
+    fun `paths card click triggers onPathsClick`() {
+        var clicked = 0
+        composeRule.setSetupScreen(
+            state = SqueezerSetupViewModel.State(scanPaths = emptyList()),
+            onPathsClick = { clicked++ },
+        )
+
+        // The whole card is clickable — its title "Search locations" is part of the same row, so
+        // tapping the title text propagates to the card's clickable modifier.
+        composeRule.onNodeWithText("Search locations").performClick()
+
+        clicked shouldBe 1
+    }
+
+    @Test
+    fun `quality slider hint reflects current quality - very low under 40`() {
+        // squeezer_quality_hint_very_low fires for `q < 40`. The text "unusable" is specific to
+        // that branch — switching to the next branch would surface "saves more space" instead.
+        composeRule.setSetupScreen(SqueezerSetupViewModel.State(quality = 25))
+
+        composeRule.onAllNodesWithText("unusable", substring = true)
+            .fetchSemanticsNodes().size shouldBeAtLeastInt 1
+    }
+
+    @Test
+    fun `estimatedSavingsPercent renders when non-null and quality below 100`() {
+        // 50% savings → string is "Estimated ~50% savings for JPEG files".
+        composeRule.setSetupScreen(
+            SqueezerSetupViewModel.State(quality = 65, estimatedSavingsPercent = 50),
+        )
+
+        composeRule.onAllNodesWithText("savings", substring = true)
+            .fetchSemanticsNodes().size shouldBeAtLeastInt 1
+    }
+
+    @Test
+    fun `age card shows the current minAge in days`() {
+        composeRule.setSetupScreen(
+            SqueezerSetupViewModel.State(minAge = Duration.ofDays(90)),
+        )
+
+        // squeezer_min_age_x_days plural renders "90 days" for quantity 90.
+        composeRule.onAllNodesWithText("90", substring = true)
+            .fetchSemanticsNodes().size shouldBeAtLeastInt 1
+    }
+
+    private infix fun <T> T.shouldBe(expected: T) {
+        if (this != expected) throw AssertionError("Expected <$expected> but was <$this>")
+    }
+
+    private infix fun Int.shouldBeAtLeastInt(min: Int) {
+        if (this < min) throw AssertionError("Expected at least $min but was $this")
+    }
+}

--- a/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/ui/setup/SqueezerSetupViewModelTest.kt
+++ b/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/ui/setup/SqueezerSetupViewModelTest.kt
@@ -1,0 +1,397 @@
+package eu.darken.sdmse.squeezer.ui.setup
+
+import eu.darken.sdmse.common.MimeTypeTool
+import eu.darken.sdmse.common.datastore.DataStoreValue
+import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.files.local.LocalGateway
+import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.files.saf.SAFPath
+import eu.darken.sdmse.common.navigation.NavEvent
+import eu.darken.sdmse.common.navigation.NavigationController
+import eu.darken.sdmse.common.picker.PickerResult
+import eu.darken.sdmse.common.progress.Progress
+import eu.darken.sdmse.common.storage.PathMapper
+import eu.darken.sdmse.common.storage.StorageEnvironment
+import eu.darken.sdmse.squeezer.core.CompressibleImage
+import eu.darken.sdmse.squeezer.core.CompressionEstimator
+import eu.darken.sdmse.squeezer.core.Squeezer
+import eu.darken.sdmse.squeezer.core.SqueezerSettings
+import eu.darken.sdmse.squeezer.core.tasks.SqueezerScanTask
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import testhelpers.coroutine.runTest2
+import java.time.Duration
+
+class SqueezerSetupViewModelTest : BaseTest() {
+
+    private fun <T> rwDataStoreValue(initial: T, flow: Flow<T> = flowOf(initial)): DataStoreValue<T> =
+        mockk<DataStoreValue<T>>().apply {
+            every { this@apply.flow } returns flow
+            coEvery { update(any()) } returns DataStoreValue.Updated(old = initial, new = initial)
+        }
+
+    private class Values(
+        val scanPaths: DataStoreValue<SqueezerSettings.ScanPaths>,
+        val compressionQuality: DataStoreValue<Int>,
+        val minAge: DataStoreValue<Duration>,
+        val minSizeBytes: DataStoreValue<Long>,
+    )
+
+    private class Harness(
+        val vm: SqueezerSetupViewModel,
+        val settings: SqueezerSettings,
+        val squeezer: Squeezer,
+        val taskSubmitter: eu.darken.sdmse.main.core.taskmanager.TaskSubmitter,
+        val pathMapper: PathMapper,
+        val navCtrl: NavigationController,
+        val squeezerState: MutableStateFlow<Squeezer.State>,
+        val pickerResults: MutableStateFlow<PickerResult?>,
+        val values: Values,
+    )
+
+    private class CollectedEvents<T>(
+        val list: MutableList<T>,
+        val job: Job,
+    ) {
+        fun cancel() = job.cancel()
+    }
+
+    private fun CoroutineScope.collectEvents(vm: SqueezerSetupViewModel): CollectedEvents<SqueezerSetupViewModel.Event> {
+        val list = mutableListOf<SqueezerSetupViewModel.Event>()
+        val job = launch(start = CoroutineStart.UNDISPATCHED) {
+            vm.events.collect { list.add(it) }
+        }
+        return CollectedEvents(list, job)
+    }
+
+    private fun CoroutineScope.collectNavEvents(vm: SqueezerSetupViewModel): CollectedEvents<NavEvent> {
+        val list = mutableListOf<NavEvent>()
+        val job = launch(start = CoroutineStart.UNDISPATCHED) {
+            vm.navEvents.collect { list.add(it) }
+        }
+        return CollectedEvents(list, job)
+    }
+
+    private fun harness(
+        scanPaths: Set<APath> = emptySet(),
+        compressionQuality: Int = SqueezerSettings.DEFAULT_QUALITY,
+        minAge: Duration = SqueezerSettings.MIN_AGE_DEFAULT,
+        minSizeBytes: Long = SqueezerSettings.MIN_FILE_SIZE,
+        squeezerData: Squeezer.Data? = null,
+        squeezerProgress: Progress.Data? = null,
+    ): Harness {
+        val scanPathsValue = rwDataStoreValue(SqueezerSettings.ScanPaths(paths = scanPaths))
+        val qualityValue = rwDataStoreValue(compressionQuality)
+        val minAgeValue = rwDataStoreValue(minAge)
+        val minSizeValue = rwDataStoreValue(minSizeBytes)
+
+        val settings = mockk<SqueezerSettings>().apply {
+            every { this@apply.scanPaths } returns scanPathsValue
+            every { this@apply.compressionQuality } returns qualityValue
+            every { this@apply.minAge } returns minAgeValue
+            every { this@apply.minSizeBytes } returns minSizeValue
+        }
+
+        val squeezerStateFlow = MutableStateFlow(Squeezer.State(data = squeezerData, progress = squeezerProgress))
+        val squeezerProgressFlow = MutableStateFlow(squeezerProgress)
+        val squeezer = mockk<Squeezer>(relaxed = true).apply {
+            every { state } returns squeezerStateFlow
+            every { progress } returns squeezerProgressFlow
+        }
+
+        val taskSubmitter = mockk<eu.darken.sdmse.main.core.taskmanager.TaskSubmitter>(relaxed = true)
+        val pathMapper = mockk<PathMapper>(relaxed = true)
+        val localGateway = mockk<LocalGateway>(relaxed = true).apply {
+            // Default: walk yields nothing — showExample with non-empty paths but no eligible
+            // images surfaces NoExampleFound. Tests that need a sample image override this.
+            coEvery { walk(any(), any(), any()) } returns emptyFlow()
+        }
+        val storageEnvironment = mockk<StorageEnvironment>(relaxed = true)
+        val mimeTypeTool = mockk<MimeTypeTool>(relaxed = true)
+
+        val pickerResults = MutableStateFlow<PickerResult?>(null)
+        val navCtrl = mockk<NavigationController>(relaxed = true).apply {
+            every { consumeResults<PickerResult>(any()) } returns pickerResults.let { stateFlow ->
+                kotlinx.coroutines.flow.flow {
+                    stateFlow.collect { value -> if (value != null) emit(value) }
+                }
+            }
+        }
+
+        val vm = SqueezerSetupViewModel(
+            dispatcherProvider = TestDispatcherProvider(),
+            settings = settings,
+            squeezer = squeezer,
+            taskSubmitter = taskSubmitter,
+            compressionEstimator = CompressionEstimator(),
+            localGateway = localGateway,
+            pathMapper = pathMapper,
+            storageEnvironment = storageEnvironment,
+            mimeTypeTool = mimeTypeTool,
+            navCtrl = navCtrl,
+        )
+        return Harness(
+            vm = vm,
+            settings = settings,
+            squeezer = squeezer,
+            taskSubmitter = taskSubmitter,
+            pathMapper = pathMapper,
+            navCtrl = navCtrl,
+            squeezerState = squeezerStateFlow,
+            pickerResults = pickerResults,
+            values = Values(
+                scanPaths = scanPathsValue,
+                compressionQuality = qualityValue,
+                minAge = minAgeValue,
+                minSizeBytes = minSizeValue,
+            ),
+        )
+    }
+
+    // ─────────────────────────── state ───────────────────────────
+
+    @Test
+    fun `state with empty paths has canStartScan false`() = runTest2 {
+        val h = harness(scanPaths = emptySet())
+
+        val state = h.vm.state.first()
+        state.scanPaths shouldBe emptyList()
+        state.canStartScan shouldBe false
+    }
+
+    @Test
+    fun `state with non-empty paths has canStartScan true and sorts the paths`() = runTest2 {
+        val a = LocalPath.build("/aaa")
+        val b = LocalPath.build("/bbb")
+        val c = LocalPath.build("/ccc")
+        val h = harness(scanPaths = setOf(c, a, b))
+
+        val state = h.vm.state.first()
+        state.scanPaths.map { it.path } shouldBe listOf(a.path, b.path, c.path)
+        state.canStartScan shouldBe true
+    }
+
+    @Test
+    fun `state quality and minAge pass through from settings`() = runTest2 {
+        val h = harness(
+            scanPaths = setOf(LocalPath.build("/dcim")),
+            compressionQuality = 65,
+            minAge = Duration.ofDays(30),
+        )
+
+        val state = h.vm.state.first()
+        state.quality shouldBe 65
+        state.minAge shouldBe Duration.ofDays(30)
+    }
+
+    @Test
+    fun `state estimatedSavingsPercent derives from CompressionEstimator for JPEG quality`() = runTest2 {
+        // CompressionEstimator JPEG @ q=65 → ratio 0.50 → 50% savings.
+        val h = harness(scanPaths = setOf(LocalPath.build("/dcim")), compressionQuality = 65)
+
+        h.vm.state.first().estimatedSavingsPercent shouldBe 50
+    }
+
+    @Test
+    fun `state estimatedSavingsPercent is zero when quality is 100`() = runTest2 {
+        // q=100 → ratio 1.0 → 0% savings. Pin the boundary so a regression that rounded the
+        // wrong direction doesn't get past CI.
+        val h = harness(scanPaths = setOf(LocalPath.build("/dcim")), compressionQuality = 100)
+
+        h.vm.state.first().estimatedSavingsPercent shouldBe 0
+    }
+
+    // ─────────────────────────── updateQuality / updateMinAge ───────────────────────────
+
+    @Test
+    fun `updateQuality writes through to settings`() = runTest2 {
+        val h = harness()
+
+        h.vm.updateQuality(45)
+        advanceUntilIdle()
+
+        val captured = slot<(Int) -> Int?>()
+        coVerify(exactly = 1) { h.values.compressionQuality.update(capture(captured)) }
+        captured.captured(80) shouldBe 45
+    }
+
+    @Test
+    fun `updateMinAge writes through to settings`() = runTest2 {
+        val h = harness()
+
+        h.vm.updateMinAge(Duration.ofDays(180))
+        advanceUntilIdle()
+
+        val captured = slot<(Duration) -> Duration?>()
+        coVerify(exactly = 1) { h.values.minAge.update(capture(captured)) }
+        captured.captured(Duration.ofDays(0)) shouldBe Duration.ofDays(180)
+    }
+
+    // ─────────────────────────── updatePaths normalization ───────────────────────────
+
+    @Test
+    fun `updatePaths accepts LocalPath inputs and writes them through`() = runTest2 {
+        val a = LocalPath.build("/dcim")
+        val b = LocalPath.build("/pictures")
+        val h = harness()
+
+        h.vm.updatePaths(setOf(a, b))
+        advanceUntilIdle()
+
+        val captured = slot<(SqueezerSettings.ScanPaths) -> SqueezerSettings.ScanPaths?>()
+        coVerify(exactly = 1) { h.values.scanPaths.update(capture(captured)) }
+        val result = captured.captured(SqueezerSettings.ScanPaths())
+        result!!.paths shouldBe setOf(a, b)
+    }
+
+    @Test
+    fun `updatePaths emits PathsDropped when SAF roots cannot be mapped to LocalPath`() = runTest2 {
+        // Path-normalizer caveat: SAFPath roots on USB OTG / second SD card can't be remapped to
+        // a LocalPath since the squeezer pipeline can't `java.io.File` them. The VM must surface
+        // those as `PathsDropped` so the UI can explain why the scan returned nothing — without
+        // this event the user has no signal at all.
+        val safPath = mockk<SAFPath>()
+        val h = harness()
+        coEvery { h.pathMapper.toLocalPath(safPath) } returns null  // unmappable
+
+        h.vm.updatePaths(setOf(safPath))
+        advanceUntilIdle()
+
+        val event = h.vm.events.first()
+        event.shouldBeInstanceOf<SqueezerSetupViewModel.Event.PathsDropped>()
+        event.droppedPaths shouldBe listOf(safPath)
+    }
+
+    @Test
+    fun `updatePaths does not emit PathsDropped when all SAF roots are mappable`() = runTest2 {
+        // The complement of the test above. PathMapper returns a LocalPath for every input → no
+        // dropped paths → no event. A regression that always emitted PathsDropped (e.g. building
+        // the event before checking emptiness) would fail here.
+        val safPath = mockk<SAFPath>()
+        val mapped = LocalPath.build("/storage/emulated/0/DCIM")
+        val h = harness()
+        coEvery { h.pathMapper.toLocalPath(safPath) } returns mapped
+        val collected = collectEvents(h.vm)
+
+        h.vm.updatePaths(setOf(safPath))
+        advanceUntilIdle()
+
+        collected.list.none { it is SqueezerSetupViewModel.Event.PathsDropped } shouldBe true
+        collected.cancel()
+    }
+
+    // ─────────────────────────── openPathPicker ───────────────────────────
+
+    @Test
+    fun `openPathPicker navigates to PickerRoute`() = runTest2 {
+        val current = LocalPath.build("/already")
+        val h = harness(scanPaths = setOf(current))
+        val collectedNav = collectNavEvents(h.vm)
+
+        h.vm.openPathPicker()
+        advanceUntilIdle()
+
+        collectedNav.list.size shouldBe 1
+        collectedNav.list.single().shouldBeInstanceOf<NavEvent.GoTo>()
+        collectedNav.cancel()
+    }
+
+    // ─────────────────────────── startScan ───────────────────────────
+
+    @Test
+    fun `startScan with results navigates to SqueezerListRoute`() = runTest2 {
+        val h = harness(squeezerData = null)  // pre-scan
+        val scanResult = mockk<SqueezerScanTask.Result>(relaxed = true)
+        coEvery { h.taskSubmitter.submit(any()) } answers {
+            // After submit completes, squeezer state reflects a populated Data.
+            h.squeezerState.value = Squeezer.State(
+                data = Squeezer.Data(media = setOf(mockk(relaxed = true))),
+                progress = null,
+            )
+            scanResult
+        }
+        val collectedNav = collectNavEvents(h.vm)
+
+        h.vm.startScan()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { h.taskSubmitter.submit(any<SqueezerScanTask>()) }
+        collectedNav.list.size shouldBe 1
+        collectedNav.list.single().shouldBeInstanceOf<NavEvent.GoTo>()
+        collectedNav.cancel()
+    }
+
+    @Test
+    fun `startScan with empty results emits NoResultsFound`() = runTest2 {
+        val h = harness(squeezerData = null)
+        val scanResult = mockk<SqueezerScanTask.Result>(relaxed = true)
+        coEvery { h.taskSubmitter.submit(any()) } answers {
+            // After submit, scan finishes with an empty Data — UI should NOT navigate forward.
+            h.squeezerState.value = Squeezer.State(
+                data = Squeezer.Data(media = emptySet()),
+                progress = null,
+            )
+            scanResult
+        }
+        val collectedNav = collectNavEvents(h.vm)
+
+        h.vm.startScan()
+        advanceUntilIdle()
+
+        val event = h.vm.events.first()
+        event.shouldBeInstanceOf<SqueezerSetupViewModel.Event.NoResultsFound>()
+        // No navigation away from the setup screen on empty results.
+        collectedNav.list shouldBe emptyList()
+        collectedNav.cancel()
+    }
+
+    // ─────────────────────────── showExample ───────────────────────────
+
+    @Test
+    fun `showExample with empty scanPaths emits NoExampleFound`() = runTest2 {
+        // findSampleImage short-circuits when there are no search paths — neither localGateway
+        // nor mimeTypeTool should be invoked.
+        val h = harness(scanPaths = emptySet())
+
+        h.vm.showExample()
+        advanceUntilIdle()
+
+        val event = h.vm.events.first()
+        event.shouldBeInstanceOf<SqueezerSetupViewModel.Event.NoExampleFound>()
+    }
+
+    // ─────────────────────────── init picker bridge ───────────────────────────
+
+    @Test
+    fun `init picker result triggers updatePaths`() = runTest2 {
+        // Sanity-check the consumeResults() wiring in `init {}`: pushing a PickerResult onto the
+        // navCtrl flow must end up writing through to settings.scanPaths.update.
+        val picked = LocalPath.build("/dcim")
+        val h = harness()
+
+        h.pickerResults.value = PickerResult(selectedPaths = setOf(picked))
+        advanceUntilIdle()
+
+        val captured = slot<(SqueezerSettings.ScanPaths) -> SqueezerSettings.ScanPaths?>()
+        coVerify(atLeast = 1) { h.values.scanPaths.update(capture(captured)) }
+        captured.captured(SqueezerSettings.ScanPaths())!!.paths shouldBe setOf(picked)
+    }
+}


### PR DESCRIPTION
## What changed

Bumps the Squeezer tool's test coverage to match the recent CorpseFinder pass. The selection-mode exclusion snackbar now shows the actual number of items that got excluded, not the number you selected — when some of those items are already on the exclusion list, the snackbar used to overcount.

## Technical Context

- 8 new test files (~2.2k lines, 86 new tests, 340 total in :app-tool-squeezer up from 254) mirroring the CorpseFinder test template — Extensions + Core workflow + (ViewModel + Screen) tests for each of the three surfaces (list, settings, setup).
- Bug fix: ExclusionManager.save() coalesces exclusions that already exist on the persisted set, and Squeezer.exclude() additionally drops ids no longer in the data snapshot. The list VM was emitting Event.ExclusionsCreated(ids.size) on the requested set, which overstated the actual saved count. Squeezer.exclude() return type changed from Unit to Set<ExclusionId> so the VM can use the actual saved count. 1 regression-test pinned to defend the fix.
- Minor refactor in SqueezerSetupScreen: lifted the BuildConfigWrap.DEBUG read out of the internal composable into the Host. Per-module JVM tests cannot initialize BuildConfigWrap (no app-module BuildConfig on classpath → NPE in static init). The internal screen now takes `minQuality: Int = MIN_QUALITY_RELEASE` and the Host passes `if (BuildConfigWrap.DEBUG) 1 else MIN_QUALITY_RELEASE`.
- New coverage by area:
  - Core workflow (24 tests): scan happy path, paths-source override, MIME-types from settings, process with TargetMode.All / Selected / stale-id filter, image+video routing, prune-on-success/retain-on-failure, FailureReason aggregation, qualityOverride fallback, exclude saved-vs-requested count, exclude with unknown id, no-scan-data IllegalStateException.
  - List VM (21 tests): state derivation including size-descending sort, compress confirm flow, pro-gating, compressAll guards, exclude bug regression, layout-mode toggle, data-drain navUp including the null-during-loading regression.
  - Settings VM (9 tests): defaults pass-through, non-default reflection, all setters, clearHistory delegation.
  - Setup VM (15 tests): canStartScan toggling, sorted-paths, savings-percent derivation, updatePaths SAF normalisation with PathsDropped event, openPathPicker, startScan happy / NoResultsFound, showExample with no paths, picker-result init bridge.
  - Screen tests (24 tests): loading / empty / populated states, FAB visibility and click, layout-toggle icon, settings-row tap callbacks with the inverted value, history-clear confirm dialog, Setup screen Start Scan enabled/disabled / scroll-to-click, quality-hint branch wiring.