### PR TITLE
SystemCleaner: Add unit and Compose UI tests, document 9 pre-existing bugs

### DIFF
--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/core/FilterContentTest.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/core/FilterContentTest.kt
@@ -1,0 +1,52 @@
+package eu.darken.sdmse.systemcleaner.core
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class FilterContentTest : BaseTest() {
+
+    @Test
+    fun `FilterContent size sums per-item lookup size`() {
+        val fc = fakeFilterContent(
+            items = listOf(
+                fakeMatch(name = "a", size = 100L),
+                fakeMatch(name = "b", size = 250L),
+                fakeMatch(name = "c", size = 4L),
+            ),
+        )
+        fc.size shouldBe 354L
+    }
+
+    @Test
+    fun `FilterContent size is zero when items is empty`() {
+        fakeFilterContent(items = emptyList()).size shouldBe 0L
+    }
+
+    @Test
+    fun `Data totalSize sums across all filter contents`() {
+        val data = SystemCleaner.Data(
+            filterContents = listOf(
+                fakeFilterContent(identifier = "f1", items = listOf(fakeMatch(name = "a", size = 100L))),
+                fakeFilterContent(identifier = "f2", items = listOf(fakeMatch(name = "b", size = 50L), fakeMatch(name = "c", size = 25L))),
+            ),
+        )
+        data.totalSize shouldBe 175L
+    }
+
+    @Test
+    fun `Data totalCount sums items across all filter contents`() {
+        val data = SystemCleaner.Data(
+            filterContents = listOf(
+                fakeFilterContent(identifier = "f1", items = List(3) { fakeMatch(name = "a$it") }),
+                fakeFilterContent(identifier = "f2", items = List(2) { fakeMatch(name = "b$it") }),
+            ),
+        )
+        data.totalCount shouldBe 5
+    }
+
+    @Test
+    fun `Data totalSize is zero for empty filterContents`() {
+        SystemCleaner.Data(filterContents = emptyList()).totalSize shouldBe 0L
+    }
+}

--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/core/SystemCleanerExclusionTest.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/core/SystemCleanerExclusionTest.kt
@@ -1,0 +1,213 @@
+package eu.darken.sdmse.systemcleaner.core
+
+import eu.darken.sdmse.exclusion.core.types.Exclusion
+import eu.darken.sdmse.exclusion.core.types.PathExclusion
+import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerScanTask
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import io.mockk.coVerify
+import io.mockk.slot
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.plus
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+
+class SystemCleanerExclusionTest : BaseTest() {
+
+    private val keepAliveScope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+
+    @AfterEach
+    fun stopKeepAliveScope() {
+        keepAliveScope.coroutineContext[kotlinx.coroutines.Job]?.cancel()
+    }
+
+    @Test
+    fun `exclude saves PathExclusions tagged SYSTEMCLEANER`() = runTest2 {
+        val match = fakeMatch(name = "to-exclude", size = 100L)
+        val fc = fakeFilterContent(identifier = "f", items = listOf(match))
+        val savedSlot = slot<Set<Exclusion>>()
+        val harness = SystemCleanerHarness(keepAliveScope)
+        val saved = setOf(PathExclusion(path = match.path, tags = setOf(Exclusion.Tag.SYSTEMCLEANER)))
+        val cleaner = harness.build(
+            crawlerResults = listOf(fc),
+            savedExclusions = saved,
+            captureSavedExclusions = savedSlot,
+        )
+        cleaner.submit(SystemCleanerScanTask())
+
+        cleaner.exclude(identifier = "f", exclusionTargets = setOf(match.path))
+
+        savedSlot.captured.size shouldBe 1
+        val excl = savedSlot.captured.single()
+        excl.shouldBe(PathExclusion(path = match.path, tags = setOf(Exclusion.Tag.SYSTEMCLEANER)))
+        // Tag set must contain exactly SYSTEMCLEANER, not GENERAL or any other.
+        excl.tags shouldBe setOf(Exclusion.Tag.SYSTEMCLEANER)
+    }
+
+    @Test
+    fun `exclude returns ExclusionUndo with exclusionIds from save result not from input set size`() = runTest2 {
+        // Analog of CorpseFinder fix #5: the snackbar count comes from
+        // `saved.map { it.id }.toSet()`, NOT the count of input paths. If `save()`
+        // coalesces duplicates, the undo reflects what was actually persisted.
+        val matchA = fakeMatch(name = "a", size = 100L)
+        val matchB = fakeMatch(name = "b", size = 50L)
+        val fc = fakeFilterContent(identifier = "f", items = listOf(matchA, matchB))
+        val harness = SystemCleanerHarness(keepAliveScope)
+        // Caller asked for 2 paths; storage layer coalesced to 1.
+        val saved = setOf(PathExclusion(path = matchA.path, tags = setOf(Exclusion.Tag.SYSTEMCLEANER)))
+        val cleaner = harness.build(
+            crawlerResults = listOf(fc),
+            savedExclusions = saved,
+        )
+        cleaner.submit(SystemCleanerScanTask())
+
+        val undo = cleaner.exclude(identifier = "f", exclusionTargets = setOf(matchA.path, matchB.path))
+
+        undo.exclusionIds.size shouldBe 1
+        undo.exclusionIds shouldBe setOf(PathExclusion.createId(matchA.path))
+    }
+
+    @Test
+    fun `exclude removes matching paths from internalData`() = runTest2 {
+        val matchA = fakeMatch(name = "a", size = 100L)
+        val matchB = fakeMatch(name = "b", size = 50L)
+        val fc = fakeFilterContent(identifier = "f", items = listOf(matchA, matchB))
+        val harness = SystemCleanerHarness(keepAliveScope)
+        val saved = setOf(PathExclusion(path = matchA.path, tags = setOf(Exclusion.Tag.SYSTEMCLEANER)))
+        val cleaner = harness.build(crawlerResults = listOf(fc), savedExclusions = saved)
+        cleaner.submit(SystemCleanerScanTask())
+
+        cleaner.exclude(identifier = "f", exclusionTargets = setOf(matchA.path))
+
+        cleaner.dataFromState()!!.filterContents.single().items.map { it.path } shouldBe listOf(matchB.path)
+    }
+
+    @Test
+    fun `exclude before any scan throws NullPointerException on internalData double-bang`() = runTest2 {
+        // Documents current behavior: SystemCleaner.kt:250 `internalData.value!!` fires when
+        // exclude() is called before any scan has populated data. Real callers don't trigger
+        // this because the UI gates on data presence. The !! is brittle — a future fix would
+        // either no-op or throw IllegalStateException with a clearer message.
+        val harness = SystemCleanerHarness(keepAliveScope)
+        val cleaner = harness.build()
+
+        shouldThrow<NullPointerException> {
+            cleaner.exclude(
+                identifier = "any",
+                exclusionTargets = setOf(fakeMatch(name = "x").path),
+            )
+        }
+    }
+
+    @Test
+    fun `exclude with filterA also removes shared paths from filterB - cross-filter smear`() = runTest2 {
+        // BUG-FIXME-3: exclude(identifier, paths) uses `identifier` only for logging
+        // (SystemCleaner.kt:241). The internalData update at lines 251-254 maps over ALL
+        // filterContents and applies the exclusion list to each. If two filters share a path,
+        // both get pruned — even though only one was named by the caller.
+        //
+        // The fix would scope the prune to `it.identifier == identifier` (or accept that the
+        // current behavior is correct because PathExclusion is persistence-level not
+        // filter-scoped, and document this in the function contract). Flip this test once
+        // the decision is made.
+        val match = fakeMatch(name = "shared.dat", size = 60L)
+        val fcA = fakeFilterContent(identifier = "fA", items = listOf(match))
+        val fcB = fakeFilterContent(identifier = "fB", items = listOf(match))
+        val harness = SystemCleanerHarness(keepAliveScope)
+        val saved = setOf(PathExclusion(path = match.path, tags = setOf(Exclusion.Tag.SYSTEMCLEANER)))
+        val cleaner = harness.build(crawlerResults = listOf(fcA, fcB), savedExclusions = saved)
+        cleaner.submit(SystemCleanerScanTask())
+
+        cleaner.exclude(identifier = "fA", exclusionTargets = setOf(match.path))
+
+        // Both fA and fB have had `match` pruned even though only fA was named. Both
+        // FilterContents become empty and get filtered out, leaving an empty filterContents.
+        cleaner.dataFromState()!!.filterContents shouldBe emptyList()
+    }
+
+    @Test
+    fun `undoExclude calls exclusionManager remove with handle exclusionIds`() = runTest2 {
+        val match = fakeMatch(name = "x", size = 10L)
+        val fc = fakeFilterContent(identifier = "f", items = listOf(match))
+        val harness = SystemCleanerHarness(keepAliveScope)
+        val saved = setOf(PathExclusion(path = match.path, tags = setOf(Exclusion.Tag.SYSTEMCLEANER)))
+        val cleaner = harness.build(crawlerResults = listOf(fc), savedExclusions = saved)
+        cleaner.submit(SystemCleanerScanTask())
+
+        val undo = cleaner.exclude(identifier = "f", exclusionTargets = setOf(match.path))
+        cleaner.undoExclude(undo)
+
+        coVerify(exactly = 1) { harness.exclusionManager.remove(undo.exclusionIds) }
+    }
+
+    @Test
+    fun `undoExclude restores previousData when state has not moved on`() = runTest2 {
+        val matchA = fakeMatch(name = "a", size = 100L)
+        val matchB = fakeMatch(name = "b", size = 50L)
+        val fc = fakeFilterContent(identifier = "f", items = listOf(matchA, matchB))
+        val harness = SystemCleanerHarness(keepAliveScope)
+        val saved = setOf(PathExclusion(path = matchA.path, tags = setOf(Exclusion.Tag.SYSTEMCLEANER)))
+        val cleaner = harness.build(crawlerResults = listOf(fc), savedExclusions = saved)
+        cleaner.submit(SystemCleanerScanTask())
+
+        val undo = cleaner.exclude(identifier = "f", exclusionTargets = setOf(matchA.path))
+        // State now reflects the exclude: only matchB remains.
+        cleaner.dataFromState()!!.filterContents.single().items.map { it.path } shouldBe listOf(matchB.path)
+
+        cleaner.undoExclude(undo)
+
+        // After undo, state restored to pre-exclude (both items present).
+        cleaner.dataFromState()!!.filterContents.single().items.map { it.path } shouldContainExactlyInAnyOrder listOf(matchA.path, matchB.path)
+    }
+
+    @Test
+    fun `undoExclude does not restore previousData when state has moved on`() = runTest2 {
+        // If a new scan replaced internalData between exclude() and undoExclude(), the undo
+        // must only remove exclusions and leave the new state untouched.
+        val matchA = fakeMatch(name = "a", size = 100L)
+        val matchB = fakeMatch(name = "b", size = 50L)
+        val fcInitial = fakeFilterContent(identifier = "f", items = listOf(matchA, matchB))
+        val harness = SystemCleanerHarness(keepAliveScope)
+        val saved = setOf(PathExclusion(path = matchA.path, tags = setOf(Exclusion.Tag.SYSTEMCLEANER)))
+        val cleaner = harness.build(crawlerResults = listOf(fcInitial), savedExclusions = saved)
+        cleaner.submit(SystemCleanerScanTask())
+
+        val undo = cleaner.exclude(identifier = "f", exclusionTargets = setOf(matchA.path))
+
+        // Simulate state moving on: rerun scan with new results.
+        val newMatch = fakeMatch(name = "new", size = 20L)
+        val fcNew = fakeFilterContent(identifier = "g", items = listOf(newMatch))
+        io.mockk.coEvery { harness.crawler.crawl(any()) } returns listOf(fcNew)
+        cleaner.submit(SystemCleanerScanTask())
+
+        cleaner.undoExclude(undo)
+
+        // State unchanged from the new scan; restore did not happen.
+        cleaner.dataFromState()!!.filterContents.map { it.identifier } shouldBe listOf("g")
+        coVerify(exactly = 1) { harness.exclusionManager.remove(undo.exclusionIds) }
+    }
+
+    @Test
+    fun `undoExclude skips exclusionManager remove when exclusionIds is empty`() = runTest2 {
+        // If save() returns an empty set (everything coalesced or storage backed off),
+        // exclusionIds is empty and undoExclude must not call remove() with an empty arg.
+        val match = fakeMatch(name = "x", size = 10L)
+        val fc = fakeFilterContent(identifier = "f", items = listOf(match))
+        val harness = SystemCleanerHarness(keepAliveScope)
+        // Empty saved set → empty exclusionIds.
+        val cleaner = harness.build(crawlerResults = listOf(fc), savedExclusions = emptySet())
+        cleaner.submit(SystemCleanerScanTask())
+
+        val undo = cleaner.exclude(identifier = "f", exclusionTargets = setOf(match.path))
+        undo.exclusionIds shouldBe emptySet()
+
+        cleaner.undoExclude(undo)
+
+        coVerify(exactly = 0) { harness.exclusionManager.remove(any<Set<String>>()) }
+    }
+}

--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/core/SystemCleanerExtensionsTest.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/core/SystemCleanerExtensionsTest.kt
@@ -1,0 +1,26 @@
+package eu.darken.sdmse.systemcleaner.core
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class SystemCleanerExtensionsTest : BaseTest() {
+
+    @Test
+    fun `hasData is false when Data is null`() {
+        val data: SystemCleaner.Data? = null
+        data.hasData shouldBe false
+    }
+
+    @Test
+    fun `hasData is false when filterContents is empty`() {
+        val data = SystemCleaner.Data(filterContents = emptyList())
+        data.hasData shouldBe false
+    }
+
+    @Test
+    fun `hasData is true when filterContents is non-empty`() {
+        val data = SystemCleaner.Data(filterContents = listOf(fakeFilterContent()))
+        data.hasData shouldBe true
+    }
+}

--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/core/SystemCleanerProcessingTest.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/core/SystemCleanerProcessingTest.kt
@@ -1,0 +1,297 @@
+package eu.darken.sdmse.systemcleaner.core
+
+import eu.darken.sdmse.common.files.FileType
+import eu.darken.sdmse.common.files.PathException
+import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.files.local.LocalPathLookup
+import eu.darken.sdmse.systemcleaner.core.filter.SystemCleanerFilter
+import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerProcessingTask
+import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerScanTask
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.plus
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+import java.time.Instant
+
+class SystemCleanerProcessingTest : BaseTest() {
+
+    private val keepAliveScope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+
+    @AfterEach
+    fun stopKeepAliveScope() {
+        keepAliveScope.coroutineContext[kotlinx.coroutines.Job]?.cancel()
+    }
+
+    @Test
+    fun `submit ProcessingTask without prior scan throws IllegalStateException Data is null`() = runTest2 {
+        val cleaner = SystemCleanerHarness(keepAliveScope).build()
+
+        val e = shouldThrow<IllegalStateException> {
+            cleaner.submit(SystemCleanerProcessingTask())
+        }
+        e.message shouldBe "Data is null"
+    }
+
+    @Test
+    fun `submit ProcessingTask with targetFilters null deletes all filters in snapshot`() = runTest2 {
+        val matchA = fakeMatch(name = "a", size = 100L)
+        val matchB = fakeMatch(name = "b", size = 50L)
+        val fcA = fakeFilterContent(identifier = "fA", items = listOf(matchA))
+        val fcB = fakeFilterContent(identifier = "fB", items = listOf(matchB))
+        val filterA = FakeSystemCleanerFilter(identifier = "fA")
+        val filterB = FakeSystemCleanerFilter(identifier = "fB")
+        val cleaner = SystemCleanerHarness(keepAliveScope).build(
+            crawlerResults = listOf(fcA, fcB),
+            filtersForProcess = listOf(filterA, filterB),
+        )
+        cleaner.submit(SystemCleanerScanTask())
+
+        val result = cleaner.submit(SystemCleanerProcessingTask())
+
+        result.shouldBeInstanceOf<SystemCleanerProcessingTask.Success>()
+        result.affectedSpace shouldBe 150L
+        result.affectedPaths shouldContainExactlyInAnyOrder setOf(matchA.path, matchB.path)
+        filterA.processInvocations shouldBe 1
+        filterB.processInvocations shouldBe 1
+        cleaner.dataFromState()!!.filterContents shouldBe emptyList()
+    }
+
+    @Test
+    fun `submit ProcessingTask scopes to one filter when targetFilters is set`() = runTest2 {
+        val matchA = fakeMatch(name = "a", size = 100L)
+        val matchB = fakeMatch(name = "b", size = 50L)
+        val fcA = fakeFilterContent(identifier = "fA", items = listOf(matchA))
+        val fcB = fakeFilterContent(identifier = "fB", items = listOf(matchB))
+        val filterA = FakeSystemCleanerFilter(identifier = "fA")
+        val filterB = FakeSystemCleanerFilter(identifier = "fB")
+        val cleaner = SystemCleanerHarness(keepAliveScope).build(
+            crawlerResults = listOf(fcA, fcB),
+            filtersForProcess = listOf(filterA, filterB),
+        )
+        cleaner.submit(SystemCleanerScanTask())
+
+        val result = cleaner.submit(SystemCleanerProcessingTask(targetFilters = setOf("fA")))
+
+        result.shouldBeInstanceOf<SystemCleanerProcessingTask.Success>()
+        result.affectedPaths shouldBe setOf(matchA.path)
+        filterA.processInvocations shouldBe 1
+        filterB.processInvocations shouldBe 0
+        // fB still present in internalData because it wasn't targeted.
+        cleaner.dataFromState()!!.filterContents.map { it.identifier } shouldBe listOf("fB")
+    }
+
+    @Test
+    fun `submit ProcessingTask with stale targetFilters throws NoSuchElementException`() = runTest2 {
+        val match = fakeMatch(name = "real", size = 100L)
+        val fc = fakeFilterContent(identifier = "real", items = listOf(match))
+        val cleaner = SystemCleanerHarness(keepAliveScope).build(
+            crawlerResults = listOf(fc),
+            filtersForProcess = listOf(FakeSystemCleanerFilter(identifier = "real")),
+        )
+        cleaner.submit(SystemCleanerScanTask())
+
+        // single { it.identifier == targetIdentifier } throws on no-match.
+        shouldThrow<NoSuchElementException> {
+            cleaner.submit(SystemCleanerProcessingTask(targetFilters = setOf("ghost")))
+        }
+    }
+
+    @Test
+    fun `submit ProcessingTask throws IllegalStateException when FilterSource lacks matching filter`() = runTest2 {
+        // Snapshot has FC for "fA" but FilterSource.create(onlyEnabled=false) returns nothing
+        // matching it. Engine throws IllegalStateException("No filter matches $id").
+        val match = fakeMatch(name = "a", size = 100L)
+        val fc = fakeFilterContent(identifier = "fA", items = listOf(match))
+        val cleaner = SystemCleanerHarness(keepAliveScope).build(
+            crawlerResults = listOf(fc),
+            filtersForProcess = emptyList(),
+        )
+        cleaner.submit(SystemCleanerScanTask())
+
+        val e = shouldThrow<IllegalStateException> {
+            cleaner.submit(SystemCleanerProcessingTask(targetFilters = setOf("fA")))
+        }
+        e.message!! shouldBe "No filter matches fA"
+    }
+
+    @Test
+    fun `submit ProcessingTask with targetContent filters per-filter items`() = runTest2 {
+        val matchA = fakeMatch(name = "a", size = 100L)
+        val matchB = fakeMatch(name = "b", size = 50L)
+        val fc = fakeFilterContent(identifier = "f", items = listOf(matchA, matchB))
+        val filter = FakeSystemCleanerFilter(identifier = "f")
+        val cleaner = SystemCleanerHarness(keepAliveScope).build(
+            crawlerResults = listOf(fc),
+            filtersForProcess = listOf(filter),
+        )
+        cleaner.submit(SystemCleanerScanTask())
+
+        val result = cleaner.submit(
+            SystemCleanerProcessingTask(
+                targetFilters = setOf("f"),
+                targetContent = setOf(matchA.path),
+            ),
+        )
+
+        result.shouldBeInstanceOf<SystemCleanerProcessingTask.Success>()
+        // Only matchA processed; matchB stays.
+        result.affectedPaths shouldBe setOf(matchA.path)
+        filter.lastProcessInput shouldBe listOf(matchA)
+        cleaner.dataFromState()!!.filterContents.single().items.map { it.path } shouldBe listOf(matchB.path)
+    }
+
+    @Test
+    fun `submit ProcessingTask retains items whose process result is unsuccessful`() = runTest2 {
+        val matchA = fakeMatch(name = "a", size = 100L)
+        val matchB = fakeMatch(name = "b", size = 50L)
+        val fc = fakeFilterContent(identifier = "f", items = listOf(matchA, matchB))
+        // Filter returns success=false for matchB (error attached).
+        val filter = FakeSystemCleanerFilter(
+            identifier = "f",
+            processResults = { matches ->
+                matches.map { m ->
+                    if (m === matchB) SystemCleanerFilter.Processed(match = m, error = RuntimeException("nope"))
+                    else SystemCleanerFilter.Processed(match = m, error = null)
+                }
+            },
+        )
+        val cleaner = SystemCleanerHarness(keepAliveScope).build(
+            crawlerResults = listOf(fc),
+            filtersForProcess = listOf(filter),
+        )
+        cleaner.submit(SystemCleanerScanTask())
+
+        val result = cleaner.submit(SystemCleanerProcessingTask(targetFilters = setOf("f")))
+
+        result.shouldBeInstanceOf<SystemCleanerProcessingTask.Success>()
+        // Only matchA accounted for; matchB still in state.
+        result.affectedPaths shouldBe setOf(matchA.path)
+        cleaner.dataFromState()!!.filterContents.single().items.map { it.path } shouldBe listOf(matchB.path)
+    }
+
+    @Test
+    fun `submit ProcessingTask swallows PathException from filter and reports zero affected for that filter`() = runTest2 {
+        val matchA = fakeMatch(name = "throws-here", size = 100L)
+        val matchB = fakeMatch(name = "succeeds", size = 50L)
+        val fcA = fakeFilterContent(identifier = "throwing", items = listOf(matchA))
+        val fcB = fakeFilterContent(identifier = "ok", items = listOf(matchB))
+        val throwingFilter = FakeThrowingFilter(
+            identifier = "throwing",
+            toThrow = PathException("simulated path error", path = matchA.path),
+        )
+        val okFilter = FakeSystemCleanerFilter(identifier = "ok")
+        val cleaner = SystemCleanerHarness(keepAliveScope).build(
+            crawlerResults = listOf(fcA, fcB),
+            filtersForProcess = listOf(throwingFilter, okFilter),
+        )
+        cleaner.submit(SystemCleanerScanTask())
+
+        val result = cleaner.submit(SystemCleanerProcessingTask())
+
+        // Throwing filter is swallowed; matchA stays. Ok filter still runs; matchB processed.
+        result.shouldBeInstanceOf<SystemCleanerProcessingTask.Success>()
+        result.affectedPaths shouldBe setOf(matchB.path)
+        result.affectedSpace shouldBe 50L
+        throwingFilter.processInvocations shouldBe 1
+        okFilter.processInvocations shouldBe 1
+        // matchA's filter content stays; matchB's filter content drained.
+        cleaner.dataFromState()!!.filterContents.map { it.identifier } shouldBe listOf("throwing")
+    }
+
+    @Test
+    fun `submit ProcessingTask processed-by-ancestor removes child content and aggregates expectedGain`() = runTest2 {
+        // SystemCleaner.kt:215-225: an item is considered processed when the processed match's
+        // path isAncestorOf the item's path OR matches it. This means a parent path returned
+        // by process() drains all descendants in the same FilterContent.
+        val parentPath = LocalPath.build("storage", "emulated", "0", "parent")
+        val childPath = LocalPath.build("storage", "emulated", "0", "parent", "child.dat")
+        val parentLookup = LocalPathLookup(
+            lookedUp = parentPath,
+            fileType = FileType.DIRECTORY,
+            size = 0L,
+            modifiedAt = Instant.parse("2026-04-01T12:00:00Z"),
+            target = null,
+        )
+        val childLookup = LocalPathLookup(
+            lookedUp = childPath,
+            fileType = FileType.FILE,
+            size = 80L,
+            modifiedAt = Instant.parse("2026-04-01T12:00:00Z"),
+            target = null,
+        )
+        val parentMatch = SystemCleanerFilter.Match.Deletion(parentLookup)
+        val childMatch = SystemCleanerFilter.Match.Deletion(childLookup)
+        val fc = fakeFilterContent(identifier = "f", items = listOf(parentMatch, childMatch))
+        // Filter processes only the parent. Child is drained by isAncestorOf.
+        val filter = FakeSystemCleanerFilter(
+            identifier = "f",
+            processResults = { _ -> listOf(SystemCleanerFilter.Processed(match = parentMatch, error = null)) },
+        )
+        val cleaner = SystemCleanerHarness(keepAliveScope).build(
+            crawlerResults = listOf(fc),
+            filtersForProcess = listOf(filter),
+        )
+        cleaner.submit(SystemCleanerScanTask())
+
+        val result = cleaner.submit(SystemCleanerProcessingTask())
+
+        result.shouldBeInstanceOf<SystemCleanerProcessingTask.Success>()
+        // Both parent and child paths drained; affected size sums their expectedGain.
+        result.affectedPaths shouldContainExactlyInAnyOrder setOf(parentPath, childPath)
+        result.affectedSpace shouldBe 80L // parent has size 0, child has size 80
+        cleaner.dataFromState()!!.filterContents shouldBe emptyList()
+    }
+
+    @Test
+    fun `submit ProcessingTask with targetFilters null and targetContent non-null applies content filter across all filters - cross-filter smear`() = runTest2 {
+        // BUG-FIXME-2: ProcessingTask has no init { require } guard for targetContent !=
+        // null && targetFilters == null. When called this way, targetFilters defaults to
+        // every filter in the snapshot and `task.targetContent.contains(it.path)` is applied
+        // against every filter's items — meaning a path that appears in two filters gets
+        // pruned from both. CorpseFinder analog added the require() guard during its test
+        // pass. Flip this test (and remove the BUG-FIXME comment) once the contract is added.
+        val sharedPath = LocalPath.build("storage", "emulated", "0", "shared.dat")
+        val sharedLookup = LocalPathLookup(
+            lookedUp = sharedPath,
+            fileType = FileType.FILE,
+            size = 60L,
+            modifiedAt = Instant.parse("2026-04-01T12:00:00Z"),
+            target = null,
+        )
+        val sharedMatchA = SystemCleanerFilter.Match.Deletion(sharedLookup)
+        val sharedMatchB = SystemCleanerFilter.Match.Deletion(sharedLookup)
+        val unrelated = fakeMatch(name = "unrelated", size = 30L)
+        val fcA = fakeFilterContent(identifier = "fA", items = listOf(sharedMatchA))
+        val fcB = fakeFilterContent(identifier = "fB", items = listOf(sharedMatchB, unrelated))
+        val filterA = FakeSystemCleanerFilter(identifier = "fA")
+        val filterB = FakeSystemCleanerFilter(identifier = "fB")
+        val cleaner = SystemCleanerHarness(keepAliveScope).build(
+            crawlerResults = listOf(fcA, fcB),
+            filtersForProcess = listOf(filterA, filterB),
+        )
+        cleaner.submit(SystemCleanerScanTask())
+
+        val result = cleaner.submit(
+            SystemCleanerProcessingTask(
+                targetFilters = null,
+                targetContent = setOf(sharedPath),
+            ),
+        )
+
+        result.shouldBeInstanceOf<SystemCleanerProcessingTask.Success>()
+        // Both filters' shared items got processed; filterB's `unrelated` survived because
+        // the targetContent didn't include it.
+        filterA.lastProcessInput shouldBe listOf(sharedMatchA)
+        filterB.lastProcessInput shouldBe listOf(sharedMatchB)
+        cleaner.dataFromState()!!.filterContents.map { it.identifier } shouldBe listOf("fB")
+        cleaner.dataFromState()!!.filterContents.single().items.map { it.path } shouldBe listOf(unrelated.path)
+    }
+}

--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/core/SystemCleanerScanTest.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/core/SystemCleanerScanTest.kt
@@ -1,0 +1,139 @@
+package eu.darken.sdmse.systemcleaner.core
+
+import eu.darken.sdmse.common.pkgs.Pkg
+import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerOneClickTask
+import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerScanTask
+import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerSchedulerTask
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.slot
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.plus
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+
+class SystemCleanerScanTest : BaseTest() {
+
+    // SystemCleaner.submit() wraps work in keepResourceHoldersAlive(...), which calls
+    // addChild(sharedResource) + sharedResource.get(). Wire each dependency to a real
+    // SharedResource.createKeepAlive backed by a long-lived scope.
+    private val keepAliveScope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+
+    @AfterEach
+    fun stopKeepAliveScope() {
+        keepAliveScope.coroutineContext[kotlinx.coroutines.Job]?.cancel()
+    }
+
+    @Test
+    fun `submit ScanTask with empty filter set yields empty Success`() = runTest2 {
+        val cleaner = SystemCleanerHarness(keepAliveScope).build(filtersForScan = emptyList())
+
+        val result = cleaner.submit(SystemCleanerScanTask())
+
+        result.shouldBeInstanceOf<SystemCleanerScanTask.Success>()
+        cleaner.dataFromState()!!.filterContents shouldBe emptyList()
+    }
+
+    @Test
+    fun `submit ScanTask with crawler results populates internalData`() = runTest2 {
+        val f1 = fakeFilterContent(identifier = "f1", items = listOf(fakeMatch(name = "a", size = 100L)))
+        val f2 = fakeFilterContent(identifier = "f2", items = listOf(fakeMatch(name = "b", size = 200L)))
+        val cleaner = SystemCleanerHarness(keepAliveScope).build(crawlerResults = listOf(f1, f2))
+
+        cleaner.submit(SystemCleanerScanTask())
+
+        val data = cleaner.dataFromState()!!
+        data.filterContents.map { it.identifier } shouldContainExactlyInAnyOrder listOf("f1", "f2")
+    }
+
+    @Test
+    fun `submit ScanTask reports itemCount and recoverableSpace from crawler results`() = runTest2 {
+        val f1 = fakeFilterContent(
+            identifier = "f1",
+            items = listOf(fakeMatch(name = "a", size = 100L), fakeMatch(name = "b", size = 50L)),
+        )
+        val f2 = fakeFilterContent(
+            identifier = "f2",
+            items = listOf(fakeMatch(name = "c", size = 25L)),
+        )
+        val cleaner = SystemCleanerHarness(keepAliveScope).build(crawlerResults = listOf(f1, f2))
+
+        val result = cleaner.submit(SystemCleanerScanTask())
+
+        result.shouldBeInstanceOf<SystemCleanerScanTask.Success>()
+        cleaner.dataFromState()!!.totalCount shouldBe 3
+        cleaner.dataFromState()!!.totalSize shouldBe 175L
+    }
+
+    @Test
+    fun `submit ScanTask calls FilterSource with onlyEnabled true`() = runTest2 {
+        val onlyEnabledSlot = slot<Boolean>()
+        val cleaner = SystemCleanerHarness(keepAliveScope).build(
+            crawlerResults = emptyList(),
+            captureOnlyEnabled = onlyEnabledSlot,
+        )
+
+        cleaner.submit(SystemCleanerScanTask())
+
+        onlyEnabledSlot.captured shouldBe true
+    }
+
+    @Test
+    fun `submit ScanTask with non-default pkgIdFilter and isWatcherTask behaves identically to defaults`() = runTest2 {
+        // BUG-FIXME-1: ScanTask.pkgIdFilter and isWatcherTask are accepted but ignored by
+        // performScan (mirror of CorpseFinder's pre-fix dead-code state). Flip this test if
+        // the engine ever starts consuming those fields.
+        val match = fakeMatch(name = "m", size = 100L)
+        val fc = fakeFilterContent(identifier = "f1", items = listOf(match))
+        val cleaner = SystemCleanerHarness(keepAliveScope).build(crawlerResults = listOf(fc))
+
+        val task = SystemCleanerScanTask(
+            pkgIdFilter = setOf(Pkg.Id(name = "com.no.effect")),
+            isWatcherTask = true,
+        )
+        val result = cleaner.submit(task)
+
+        result.shouldBeInstanceOf<SystemCleanerScanTask.Success>()
+        cleaner.dataFromState()!!.filterContents.map { it.identifier } shouldBe listOf("f1")
+    }
+
+    @Test
+    fun `submit SchedulerTask chains scan and processing and returns SchedulerTask Success`() = runTest2 {
+        val match = fakeMatch(name = "scheduled", size = 100L)
+        val fc = fakeFilterContent(identifier = "f1", items = listOf(match))
+        val processingFilter = FakeSystemCleanerFilter(identifier = "f1")
+        val cleaner = SystemCleanerHarness(keepAliveScope).build(
+            crawlerResults = listOf(fc),
+            filtersForProcess = listOf(processingFilter),
+        )
+
+        val result = cleaner.submit(SystemCleanerSchedulerTask(schedulerId = "sched-1"))
+
+        result.shouldBeInstanceOf<SystemCleanerSchedulerTask.Success>()
+        result.affectedSpace shouldBe 100L
+        result.affectedPaths shouldBe setOf(match.path)
+        processingFilter.processInvocations shouldBe 1
+    }
+
+    @Test
+    fun `submit OneClickTask chains scan and processing and returns OneClickTask Success`() = runTest2 {
+        val match = fakeMatch(name = "oneclick", size = 250L)
+        val fc = fakeFilterContent(identifier = "f1", items = listOf(match))
+        val processingFilter = FakeSystemCleanerFilter(identifier = "f1")
+        val cleaner = SystemCleanerHarness(keepAliveScope).build(
+            crawlerResults = listOf(fc),
+            filtersForProcess = listOf(processingFilter),
+        )
+
+        val result = cleaner.submit(SystemCleanerOneClickTask())
+
+        result.shouldBeInstanceOf<SystemCleanerOneClickTask.Success>()
+        result.affectedSpace shouldBe 250L
+        result.affectedPaths shouldBe setOf(match.path)
+    }
+}

--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/core/SystemCleanerTestFixtures.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/core/SystemCleanerTestFixtures.kt
@@ -1,0 +1,203 @@
+package eu.darken.sdmse.systemcleaner.core
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.Delete
+import eu.darken.sdmse.common.areas.DataArea
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.datastore.DataStoreValue
+import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.common.files.FileType
+import eu.darken.sdmse.common.files.GatewaySwitch
+import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.files.local.LocalPathLookup
+import eu.darken.sdmse.common.forensics.FileForensics
+import eu.darken.sdmse.common.pkgs.pkgops.PkgOps
+import eu.darken.sdmse.common.progress.Progress
+import eu.darken.sdmse.common.root.RootManager
+import eu.darken.sdmse.common.sharedresource.SharedResource
+import eu.darken.sdmse.exclusion.core.ExclusionManager
+import eu.darken.sdmse.exclusion.core.types.Exclusion
+import eu.darken.sdmse.systemcleaner.core.filter.BaseSystemCleanerFilter
+import eu.darken.sdmse.systemcleaner.core.filter.FilterIdentifier
+import eu.darken.sdmse.systemcleaner.core.filter.FilterSource
+import eu.darken.sdmse.systemcleaner.core.filter.SystemCleanerFilter
+import io.mockk.CapturingSlot
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import java.time.Instant
+import javax.inject.Provider
+
+/**
+ * Shared fixtures for SystemCleaner tests. Module-local — consolidated because more test files
+ * need them than CorpseFinder's inline-helper approach scales to.
+ */
+
+internal fun fakeMatch(
+    name: String = "file.dat",
+    parent: Array<String> = arrayOf("storage", "emulated", "0", "Android", "data"),
+    size: Long = 1024L,
+    fileType: FileType = FileType.FILE,
+): SystemCleanerFilter.Match.Deletion = SystemCleanerFilter.Match.Deletion(
+    lookup = LocalPathLookup(
+        lookedUp = LocalPath.build(*parent, name),
+        fileType = fileType,
+        size = size,
+        modifiedAt = Instant.parse("2026-04-01T12:00:00Z"),
+        target = null,
+    ),
+)
+
+internal fun fakeFilterContent(
+    identifier: FilterIdentifier = "fake.filter.${FilterContentCounter.next()}",
+    label: String = "Fake filter",
+    description: String = "Fake description",
+    items: Collection<SystemCleanerFilter.Match> = listOf(fakeMatch()),
+): FilterContent = FilterContent(
+    identifier = identifier,
+    icon = Icons.TwoTone.Delete,
+    label = label.toCaString(),
+    description = description.toCaString(),
+    items = items,
+)
+
+private object FilterContentCounter {
+    private var n = 0
+    fun next(): Int = ++n
+}
+
+/**
+ * Counting fake filter — analog of `CountingFactory` in `CorpseFinderTest`. The processed
+ * collection is what `process(matches)` returns; tests can supply failed/successful results.
+ */
+internal class FakeSystemCleanerFilter(
+    override val identifier: FilterIdentifier,
+    private val processResults: (Collection<SystemCleanerFilter.Match>) -> Collection<SystemCleanerFilter.Processed> = { matches ->
+        matches.map { SystemCleanerFilter.Processed(match = it, error = null) }
+    },
+) : BaseSystemCleanerFilter() {
+    var processInvocations: Int = 0
+        private set
+    var lastProcessInput: Collection<SystemCleanerFilter.Match>? = null
+        private set
+
+    override val icon = Icons.TwoTone.Delete
+
+    override suspend fun getLabel() = "Fake $identifier".toCaString()
+    override suspend fun getDescription() = "Fake description for $identifier".toCaString()
+    override suspend fun targetAreas() = emptySet<DataArea.Type>()
+    override suspend fun initialize() = Unit
+    override suspend fun match(item: APathLookup<*>) = null
+    override suspend fun process(matches: Collection<SystemCleanerFilter.Match>): Collection<SystemCleanerFilter.Processed> {
+        processInvocations++
+        lastProcessInput = matches
+        return processResults(matches)
+    }
+}
+
+internal class FakeThrowingFilter(
+    override val identifier: FilterIdentifier,
+    private val toThrow: Throwable,
+) : BaseSystemCleanerFilter() {
+    var processInvocations: Int = 0
+        private set
+
+    override val icon = Icons.TwoTone.Delete
+    override suspend fun getLabel() = "Throwing $identifier".toCaString()
+    override suspend fun getDescription() = "Throws on process".toCaString()
+    override suspend fun targetAreas() = emptySet<DataArea.Type>()
+    override suspend fun initialize() = Unit
+    override suspend fun match(item: APathLookup<*>) = null
+    override suspend fun process(matches: Collection<SystemCleanerFilter.Match>): Collection<SystemCleanerFilter.Processed> {
+        processInvocations++
+        throw toThrow
+    }
+}
+
+internal fun keepAliveSharedResource(tag: String, scope: CoroutineScope) =
+    SharedResource.createKeepAlive(tag, scope)
+
+/**
+ * A writable mocked `DataStoreValue`. The shared `mockDataStoreValue` only stubs `.flow`;
+ * `.value(new)` writes call `DataStoreValue.update(...)` which by default fails in MockK.
+ * This helper also stubs `update` so writes succeed and can be verified by tests.
+ * Mirrors the inline helper at `CorpseFinderSettingsViewModelTest.kt:31-35`.
+ */
+internal fun <T> rwDataStoreValue(
+    initial: T,
+    flow: Flow<T> = flowOf(initial),
+): DataStoreValue<T> = mockk<DataStoreValue<T>>().apply {
+    every { this@apply.flow } returns flow
+    coEvery { update(any()) } returns DataStoreValue.Updated(old = initial, new = initial)
+}
+
+internal suspend fun SystemCleaner.dataFromState(): SystemCleaner.Data? =
+    state.map { it.data }.first()
+
+/**
+ * Shared engine-test harness. Wires the heavy `SharedResource` dependencies (fileForensics,
+ * gatewaySwitch, pkgOps) to real keep-alive resources backed by `keepAliveScope`; mocks the
+ * rest (`crawler`, `FilterSource`, `ExclusionManager`, `RootManager`).
+ *
+ * Used by SystemCleanerScanTest / SystemCleanerProcessingTest / SystemCleanerExclusionTest.
+ */
+internal class SystemCleanerHarness(
+    private val keepAliveScope: CoroutineScope,
+) {
+    val crawler: SystemCrawler = mockk()
+    val exclusionManager: ExclusionManager = mockk()
+    val filterSource: FilterSource = mockk()
+    val rootManager: RootManager = mockk()
+    val fileForensics: FileForensics = mockk()
+    val gatewaySwitch: GatewaySwitch = mockk()
+    val pkgOps: PkgOps = mockk()
+
+    fun build(
+        useRoot: Boolean = false,
+        crawlerResults: Collection<FilterContent> = emptyList(),
+        filtersForScan: List<SystemCleanerFilter> = emptyList(),
+        filtersForProcess: List<SystemCleanerFilter> = emptyList(),
+        captureOnlyEnabled: CapturingSlot<Boolean>? = null,
+        savedExclusions: Collection<Exclusion> = emptyList(),
+        captureSavedExclusions: CapturingSlot<Set<Exclusion>>? = null,
+    ): SystemCleaner {
+        every { fileForensics.sharedResource } returns SharedResource.createKeepAlive("ff", keepAliveScope)
+        every { gatewaySwitch.sharedResource } returns SharedResource.createKeepAlive("gw", keepAliveScope)
+        every { pkgOps.sharedResource } returns SharedResource.createKeepAlive("po", keepAliveScope)
+        every { rootManager.useRoot } returns flowOf(useRoot)
+        every { exclusionManager.exclusions } returns flowOf(emptyList())
+        if (captureSavedExclusions != null) {
+            coEvery { exclusionManager.save(capture(captureSavedExclusions)) } returns savedExclusions
+        } else {
+            coEvery { exclusionManager.save(any()) } returns savedExclusions
+        }
+        coEvery { exclusionManager.remove(any()) } returns Unit
+        if (captureOnlyEnabled != null) {
+            coEvery { filterSource.create(capture(captureOnlyEnabled)) } answers {
+                if (captureOnlyEnabled.captured) filtersForScan.toSet() else filtersForProcess.toSet()
+            }
+        } else {
+            coEvery { filterSource.create(true) } returns filtersForScan.toSet()
+            coEvery { filterSource.create(false) } returns filtersForProcess.toSet()
+        }
+        every { crawler.progress } returns MutableStateFlow<Progress.Data?>(null)
+        coEvery { crawler.crawl(any()) } returns crawlerResults
+
+        return SystemCleaner(
+            appScope = keepAliveScope,
+            fileForensics = fileForensics,
+            gatewaySwitch = gatewaySwitch,
+            crawler = crawler,
+            exclusionManager = exclusionManager,
+            filterSourceProvider = Provider { filterSource },
+            pkgOps = pkgOps,
+            rootManager = rootManager,
+        )
+    }
+}

--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/FilterSourceTest.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/FilterSourceTest.kt
@@ -1,0 +1,128 @@
+package eu.darken.sdmse.systemcleaner.core.filter
+
+import eu.darken.sdmse.systemcleaner.core.filter.custom.CustomFilterConfig
+import eu.darken.sdmse.systemcleaner.core.filter.custom.CustomFilterLoader
+import eu.darken.sdmse.systemcleaner.core.filter.custom.CustomFilterRepo
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+
+class FilterSourceTest : BaseTest() {
+
+    private fun stubFactory(
+        identifier: String,
+        enabled: Boolean,
+    ): SystemCleanerFilter.Factory {
+        val filter = mockk<SystemCleanerFilter>(relaxed = true).apply {
+            every { this@apply.identifier } returns identifier
+        }
+        return mockk<SystemCleanerFilter.Factory>().apply {
+            coEvery { isEnabled() } returns enabled
+            coEvery { create() } returns filter
+        }
+    }
+
+    private suspend fun build(
+        factories: Set<SystemCleanerFilter.Factory>,
+        customConfigs: List<CustomFilterConfig> = emptyList(),
+        customFactoryProvider: (CustomFilterConfig) -> SystemCleanerFilter.Factory = { stubFactory("custom-${it.identifier}", true) },
+    ): FilterSource {
+        val repo = mockk<CustomFilterRepo>().apply {
+            every { configs } returns flowOf(customConfigs)
+        }
+        // Pre-create loaders per config so the factory itself is synchronous.
+        val loadersByConfig = customConfigs.associateWith { cfg ->
+            val underlying = customFactoryProvider(cfg)
+            mockk<CustomFilterLoader>().apply {
+                coEvery { isEnabled() } returns underlying.isEnabled()
+                coEvery { create() } returns underlying.create()
+            }
+        }
+        val loaderFactory = mockk<CustomFilterLoader.Factory>().apply {
+            every { create(any()) } answers {
+                loadersByConfig[firstArg<CustomFilterConfig>()]!!
+            }
+        }
+        return FilterSource(
+            filterFactories = factories,
+            customFilterRepo = repo,
+            customFilterLoader = loaderFactory,
+        )
+    }
+
+    @Test
+    fun `create onlyEnabled true skips disabled factories`() = runTest2 {
+        val source = build(
+            factories = setOf(
+                stubFactory("enabled", enabled = true),
+                stubFactory("disabled", enabled = false),
+            ),
+        )
+
+        val filters = source.create(onlyEnabled = true)
+
+        filters.map { it.identifier } shouldBe listOf("enabled")
+    }
+
+    @Test
+    fun `create onlyEnabled false includes disabled factories`() = runTest2 {
+        val source = build(
+            factories = setOf(
+                stubFactory("enabled", enabled = true),
+                stubFactory("disabled", enabled = false),
+            ),
+        )
+
+        val filters = source.create(onlyEnabled = false)
+
+        filters.map { it.identifier } shouldContainExactlyInAnyOrder listOf("enabled", "disabled")
+    }
+
+    @Test
+    fun `create calls initialize on every returned filter`() = runTest2 {
+        val filterA = mockk<SystemCleanerFilter>(relaxed = true).apply {
+            every { identifier } returns "a"
+        }
+        val filterB = mockk<SystemCleanerFilter>(relaxed = true).apply {
+            every { identifier } returns "b"
+        }
+        val factoryA = mockk<SystemCleanerFilter.Factory>().apply {
+            coEvery { isEnabled() } returns true
+            coEvery { create() } returns filterA
+        }
+        val factoryB = mockk<SystemCleanerFilter.Factory>().apply {
+            coEvery { isEnabled() } returns true
+            coEvery { create() } returns filterB
+        }
+        val source = build(factories = setOf(factoryA, factoryB))
+
+        source.create(onlyEnabled = true)
+
+        coVerify(exactly = 1) { filterA.initialize() }
+        coVerify(exactly = 1) { filterB.initialize() }
+    }
+
+    @Test
+    fun `create mixes built-in and custom filters`() = runTest2 {
+        val builtIn = stubFactory("builtin", enabled = true)
+        val customConfig = CustomFilterConfig(
+            identifier = "cf1",
+            label = "Custom 1",
+        )
+        val source = build(
+            factories = setOf(builtIn),
+            customConfigs = listOf(customConfig),
+        )
+
+        val filters = source.create(onlyEnabled = true)
+
+        filters.map { it.identifier } shouldContainExactlyInAnyOrder listOf("builtin", "custom-cf1")
+    }
+}

--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/custom/CustomFilterExtensionsTest.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/custom/CustomFilterExtensionsTest.kt
@@ -1,0 +1,101 @@
+package eu.darken.sdmse.systemcleaner.core.filter.custom
+
+import eu.darken.sdmse.systemcleaner.core.SystemCleanerSettings
+import eu.darken.sdmse.systemcleaner.core.rwDataStoreValue
+import io.kotest.matchers.shouldBe
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+
+class CustomFilterExtensionsTest : BaseTest() {
+
+    private class Harness(
+        val settings: SystemCleanerSettings,
+        val enabledValue: eu.darken.sdmse.common.datastore.DataStoreValue<Set<String>>,
+    )
+
+    private fun harness(initial: Set<String> = emptySet()): Harness {
+        val enabledValue = rwDataStoreValue(initial)
+        val settings = mockk<SystemCleanerSettings>().apply {
+            every { enabledCustomFilter } returns enabledValue
+        }
+        return Harness(settings, enabledValue)
+    }
+
+    @Test
+    fun `toggleCustomFilter with enabled true adds the id when absent`() = runTest2 {
+        val h = harness(initial = emptySet())
+        val updater = slot<(Set<String>) -> Set<String>?>()
+        io.mockk.coEvery {
+            h.enabledValue.update(capture(updater))
+        } returns eu.darken.sdmse.common.datastore.DataStoreValue.Updated(old = emptySet(), new = setOf("x"))
+
+        h.settings.toggleCustomFilter("x", enabled = true)
+
+        // The lambda's behavior is "add when absent OR enabled==false → remove. Otherwise add."
+        // For `enabled=true` and absent id, the lambda must produce a set containing the id.
+        updater.captured(emptySet()) shouldBe setOf("x")
+    }
+
+    @Test
+    fun `toggleCustomFilter with enabled false always removes the id`() = runTest2 {
+        // The actual code: `if (it.contains(filterId) || enabled == false) it - filterId else it + filterId`
+        // So enabled=false → unconditionally removes (or no-op if absent).
+        val h = harness(initial = setOf("present"))
+        val updater = slot<(Set<String>) -> Set<String>?>()
+        io.mockk.coEvery { h.enabledValue.update(capture(updater)) } returns
+            eu.darken.sdmse.common.datastore.DataStoreValue.Updated(old = setOf("present"), new = emptySet())
+
+        h.settings.toggleCustomFilter("present", enabled = false)
+
+        updater.captured(setOf("present")) shouldBe emptySet()
+    }
+
+    @Test
+    fun `toggleCustomFilter with enabled null toggles - removes when present`() = runTest2 {
+        val h = harness(initial = setOf("toggle"))
+        val updater = slot<(Set<String>) -> Set<String>?>()
+        io.mockk.coEvery { h.enabledValue.update(capture(updater)) } returns
+            eu.darken.sdmse.common.datastore.DataStoreValue.Updated(old = setOf("toggle"), new = emptySet())
+
+        h.settings.toggleCustomFilter("toggle", enabled = null)
+
+        updater.captured(setOf("toggle")) shouldBe emptySet()
+    }
+
+    @Test
+    fun `toggleCustomFilter with enabled null toggles - adds when absent`() = runTest2 {
+        val h = harness(initial = emptySet())
+        val updater = slot<(Set<String>) -> Set<String>?>()
+        io.mockk.coEvery { h.enabledValue.update(capture(updater)) } returns
+            eu.darken.sdmse.common.datastore.DataStoreValue.Updated(old = emptySet(), new = setOf("new"))
+
+        h.settings.toggleCustomFilter("new", enabled = null)
+
+        updater.captured(emptySet()) shouldBe setOf("new")
+    }
+
+    @Test
+    fun `clearCustomFilter removes the id from the set`() = runTest2 {
+        val h = harness(initial = setOf("to-clear", "keep"))
+        val updater = slot<(Set<String>) -> Set<String>?>()
+        io.mockk.coEvery { h.enabledValue.update(capture(updater)) } returns
+            eu.darken.sdmse.common.datastore.DataStoreValue.Updated(old = setOf("to-clear", "keep"), new = setOf("keep"))
+
+        h.settings.clearCustomFilter("to-clear")
+
+        updater.captured(setOf("to-clear", "keep")) shouldBe setOf("keep")
+    }
+
+    @Test
+    fun `isCustomFilterEnabled reads from value`() = runTest2 {
+        val h = harness(initial = setOf("enabled-id"))
+
+        h.settings.isCustomFilterEnabled("enabled-id") shouldBe true
+        h.settings.isCustomFilterEnabled("not-in-set") shouldBe false
+    }
+}

--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/custom/CustomFilterRepoTest.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/custom/CustomFilterRepoTest.kt
@@ -1,0 +1,227 @@
+package eu.darken.sdmse.systemcleaner.core.filter.custom
+
+import android.content.Context
+import eu.darken.sdmse.systemcleaner.core.SystemCleanerSettings
+import eu.darken.sdmse.systemcleaner.core.rwDataStoreValue
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.first
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+import java.io.File
+import java.nio.file.Files
+import java.time.Instant
+import java.util.UUID
+
+class CustomFilterRepoTest : BaseTest() {
+
+    private lateinit var tempDir: File
+
+    @BeforeEach
+    fun setupTemp() {
+        tempDir = Files.createTempDirectory("systemcleaner-repo-test-").toFile()
+    }
+
+    @AfterEach
+    fun cleanupTemp() {
+        tempDir.deleteRecursively()
+    }
+
+    private fun config(
+        id: String = UUID.randomUUID().toString(),
+        label: String = "Test Filter",
+    ): CustomFilterConfig = CustomFilterConfig(
+        identifier = id,
+        label = label,
+        createdAt = Instant.parse("2026-01-01T00:00:00Z"),
+        modifiedAt = Instant.parse("2026-01-01T00:00:00Z"),
+    )
+
+    private class Harness(
+        val repo: CustomFilterRepo,
+        val settings: SystemCleanerSettings,
+        val enabledValue: eu.darken.sdmse.common.datastore.DataStoreValue<Set<String>>,
+        val legacy: LegacyFilterSupport,
+        val filterDir: File,
+    )
+
+    private fun harness(
+        contextFilesDir: File = tempDir,
+        initialEnabled: Set<String> = emptySet(),
+    ): Harness {
+        val context = mockk<Context>().apply {
+            every { filesDir } returns contextFilesDir
+        }
+        val enabledValue = rwDataStoreValue(initialEnabled)
+        val settings = mockk<SystemCleanerSettings>(relaxed = true).apply {
+            every { enabledCustomFilter } returns enabledValue
+        }
+        val legacy = mockk<LegacyFilterSupport>(relaxed = true)
+        val repo = CustomFilterRepo(
+            context = context,
+            json = Json,
+            settings = settings,
+            legacyImporter = legacy,
+        )
+        // Realized filter directory:
+        return Harness(repo, settings, enabledValue, legacy, File(contextFilesDir, "systemcleaner/customfilter2"))
+    }
+
+    @Test
+    fun `configs flow emits empty list when no files exist`() = runTest2 {
+        val h = harness()
+        h.repo.configs.first() shouldBe emptyList()
+    }
+
+    @Test
+    fun `save writes JSON file under filesDir customfilter2 directory`() = runTest2 {
+        val h = harness()
+        val cfg = config(id = "abc", label = "Saved one")
+
+        h.repo.save(setOf(cfg))
+
+        val onDisk = File(h.filterDir, "abc.json")
+        onDisk.exists() shouldBe true
+        onDisk.readText().contains("Saved one") shouldBe true
+    }
+
+    @Test
+    fun `configs re-emits after save - new config appears`() = runTest2 {
+        val h = harness()
+        h.repo.configs.first() shouldBe emptyList()
+        val cfg = config(id = "new")
+
+        h.repo.save(setOf(cfg))
+
+        val emitted = h.repo.configs.first().toList()
+        emitted.map { it.identifier } shouldBe listOf("new")
+    }
+
+    @Test
+    fun `remove deletes the file and clears settings entry`() = runTest2 {
+        val h = harness()
+        val cfg = config(id = "to-remove")
+        h.repo.save(setOf(cfg))
+        val onDisk = File(h.filterDir, "to-remove.json")
+        onDisk.exists() shouldBe true
+
+        h.repo.remove(setOf("to-remove"))
+
+        onDisk.exists() shouldBe false
+        // settings.clearCustomFilter triggers an update on enabledCustomFilter.
+        io.mockk.coVerify(atLeast = 1) { h.enabledValue.update(any()) }
+    }
+
+    @Test
+    fun `configs crashes on malformed JSON file - BUG-FIXME-6 documents current behavior`() = runTest2 {
+        // BUG-FIXME-6: CustomFilterRepo.kt:61 calls `json.decodeFromString` without try/catch.
+        // A single corrupt config file kills the entire `configs` flow until refresh() is
+        // called again. This locks in the crash behavior — flip the test once decode is
+        // wrapped in try/catch and corrupt files are silently skipped (or logged + skipped).
+        val h = harness()
+        // Plant a malformed JSON file directly in the filter directory.
+        h.filterDir.mkdirs()
+        File(h.filterDir, "corrupt.json").writeText("{ this is not valid json")
+
+        shouldThrow<Exception> {
+            h.repo.configs.first()
+        }
+    }
+
+    @Test
+    fun `configs throws NPE when filter directory cannot be created - BUG-FIXME-7 documents listFiles double-bang`() = runTest2 {
+        // BUG-FIXME-7: CustomFilterRepo.kt:36-38 lazy-creates the filter directory via
+        // mkdirs() but ignores the return value. Line 49 then calls `filterDir.listFiles()!!`
+        // — if mkdirs() failed (because filesDir is a regular file, not a directory), the
+        // !! throws NullPointerException when `configs` is collected.
+        // Construct a filesDir that's actually a regular file so mkdirs cannot create a
+        // subdirectory under it.
+        val bogusFilesDir = File(tempDir, "files-as-file")
+        bogusFilesDir.writeText("I am a file, not a directory")
+        val h = harness(contextFilesDir = bogusFilesDir)
+
+        shouldThrow<NullPointerException> {
+            h.repo.configs.first()
+        }
+    }
+
+    @Test
+    fun `importFilter saves a config from modern JSON format`() = runTest2 {
+        val h = harness()
+        val cfg = config(id = "imported", label = "Imported filter")
+        val json = Json.encodeToString(CustomFilterConfig.serializer(), cfg)
+
+        h.repo.importFilter(listOf(RawFilter(name = "import.json", payload = json)))
+
+        val emitted = h.repo.configs.first().toList()
+        emitted.map { it.identifier } shouldBe listOf("imported")
+    }
+
+    @Test
+    fun `importFilter falls back to legacy parser when modern decode fails`() = runTest2 {
+        val h = harness()
+        val legacyPayload = "<some legacy format>"
+        val cfg = config(id = "legacy-id", label = "Legacy imported")
+        coEvery { h.legacy.import(legacyPayload) } returns cfg
+
+        h.repo.importFilter(listOf(RawFilter(name = "legacy.xml", payload = legacyPayload)))
+
+        val emitted = h.repo.configs.first().toList()
+        emitted.map { it.identifier } shouldBe listOf("legacy-id")
+    }
+
+    @Test
+    fun `importFilter rethrows original error when both modern and legacy parsers fail`() = runTest2 {
+        val h = harness()
+        coEvery { h.legacy.import(any()) } returns null
+
+        shouldThrow<Exception> {
+            h.repo.importFilter(listOf(RawFilter(name = "bad.json", payload = "garbage")))
+        }
+    }
+
+    @Test
+    fun `exportFilters produces RawFilter with label and id-tail in name`() = runTest2 {
+        val h = harness()
+        val identifier = "0123456789abcdef-extra-tail"
+        val cfg = config(id = identifier, label = "Exported")
+        h.repo.save(setOf(cfg))
+
+        val exported = h.repo.exportFilters(setOf(identifier))
+
+        exported.size shouldBe 1
+        val raw = exported.single()
+        // RawFilter.name format: "<label> - <last 10 chars of id>.json"
+        raw.name shouldBe "Exported - ${identifier.takeLast(10)}.json"
+        raw.payload.contains("Exported") shouldBe true
+    }
+
+    @Test
+    fun `generateIdentifier returns parseable UUID`() {
+        val h = harness()
+        val id = h.repo.generateIdentifier()
+
+        // Should not throw on UUID parse.
+        UUID.fromString(id)
+    }
+
+    @Test
+    fun `configs clears orphan settings entries with no matching file on disk`() = runTest2 {
+        // settings has IDs for filters that no longer have a config file on disk; loading
+        // configs triggers cleanup of those orphan entries via clearCustomFilter.
+        val h = harness(initialEnabled = setOf("orphan-id"))
+        // No config file for "orphan-id" on disk.
+
+        h.repo.configs.first()
+
+        // settings.clearCustomFilter("orphan-id") was called, which updates enabledCustomFilter.
+        io.mockk.coVerify(atLeast = 1) { h.enabledValue.update(any()) }
+    }
+}

--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/custom/CustomFilterTest.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/custom/CustomFilterTest.kt
@@ -1,0 +1,144 @@
+package eu.darken.sdmse.systemcleaner.core.filter.custom
+
+import eu.darken.sdmse.common.areas.DataArea
+import eu.darken.sdmse.common.files.FileType
+import eu.darken.sdmse.common.files.GatewaySwitch
+import eu.darken.sdmse.common.sieve.SegmentCriterium
+import eu.darken.sdmse.systemcleaner.core.filter.SystemCleanerFilter
+import eu.darken.sdmse.systemcleaner.core.fakeMatch
+import eu.darken.sdmse.systemcleaner.core.sieve.SystemCrawlerSieve
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+import java.time.Instant
+
+class CustomFilterTest : BaseTest() {
+
+    private fun config(
+        identifier: String = "test-filter",
+        label: String = "Test filter",
+        pathCriteria: Set<SegmentCriterium>? = setOf(
+            SegmentCriterium(listOf("Downloads"), SegmentCriterium.Mode.Start()),
+        ),
+        areas: Set<DataArea.Type>? = null,
+        fileTypes: Set<FileType>? = null,
+        pathRegexes: Set<Regex>? = null,
+    ): CustomFilterConfig = CustomFilterConfig(
+        identifier = identifier,
+        label = label,
+        createdAt = Instant.parse("2026-01-01T00:00:00Z"),
+        modifiedAt = Instant.parse("2026-01-01T00:00:00Z"),
+        pathCriteria = pathCriteria,
+        areas = areas,
+        fileTypes = fileTypes,
+        pathRegexes = pathRegexes,
+    )
+
+    private fun customFilter(
+        cfg: CustomFilterConfig,
+        sieve: SystemCrawlerSieve,
+    ): CustomFilter {
+        val sieveFactory = mockk<SystemCrawlerSieve.Factory>().apply {
+            every { create(any()) } returns sieve
+        }
+        val gatewaySwitch = mockk<GatewaySwitch>(relaxed = true)
+        return CustomFilter(
+            filterConfig = cfg,
+            systemCrawlerSieveFactory = sieveFactory,
+            gatewaySwitch = gatewaySwitch,
+        )
+    }
+
+    @Test
+    fun `initialize forwards config fields to sieve config`() = runTest2 {
+        val cfg = config(
+            areas = setOf(DataArea.Type.SDCARD),
+            fileTypes = setOf(FileType.FILE, FileType.DIRECTORY),
+            pathCriteria = setOf(SegmentCriterium(listOf("Downloads"), SegmentCriterium.Mode.Start())),
+        )
+        val sieve = mockk<SystemCrawlerSieve>(relaxed = true)
+        val sieveFactory = mockk<SystemCrawlerSieve.Factory>().apply {
+            every { create(any()) } returns sieve
+        }
+        val captured = slot<SystemCrawlerSieve.Config>()
+        every { sieveFactory.create(capture(captured)) } returns sieve
+
+        val filter = CustomFilter(
+            filterConfig = cfg,
+            systemCrawlerSieveFactory = sieveFactory,
+            gatewaySwitch = mockk(relaxed = true),
+        )
+        filter.initialize()
+
+        captured.captured.areaTypes shouldBe setOf(DataArea.Type.SDCARD)
+        captured.captured.pathCriteria shouldBe cfg.pathCriteria
+    }
+
+    @Test
+    fun `targetAreas returns all DataArea types when config areas is null`() = runTest2 {
+        val cfg = config(areas = null)
+        val sieve = mockk<SystemCrawlerSieve>(relaxed = true)
+        val filter = customFilter(cfg, sieve)
+
+        filter.targetAreas() shouldBe DataArea.Type.entries.toSet()
+    }
+
+    @Test
+    fun `targetAreas returns configured areas when non-null`() = runTest2 {
+        val cfg = config(areas = setOf(DataArea.Type.SDCARD, DataArea.Type.PUBLIC_MEDIA))
+        val sieve = mockk<SystemCrawlerSieve>(relaxed = true)
+        val filter = customFilter(cfg, sieve)
+
+        filter.targetAreas() shouldBe setOf(DataArea.Type.SDCARD, DataArea.Type.PUBLIC_MEDIA)
+    }
+
+    @Test
+    fun `match returns Match Deletion when sieve matches`() = runTest2 {
+        val cfg = config()
+        val hit = fakeMatch(name = "hit.dat", size = 100L)
+        val sieve = mockk<SystemCrawlerSieve>().apply {
+            coEvery { match(any<eu.darken.sdmse.common.files.APathLookup<*>>()) } returns SystemCrawlerSieve.Result(item = hit.lookup, matches = true)
+        }
+        val filter = customFilter(cfg, sieve)
+        filter.initialize()
+
+        val result = filter.match(hit.lookup)
+
+        result.shouldBeInstanceOf<SystemCleanerFilter.Match.Deletion>()
+        result.lookup shouldBe hit.lookup
+    }
+
+    @Test
+    fun `match returns null when sieve does not match`() = runTest2 {
+        val cfg = config()
+        val miss = fakeMatch(name = "miss.dat")
+        val sieve = mockk<SystemCrawlerSieve>().apply {
+            coEvery { match(any<eu.darken.sdmse.common.files.APathLookup<*>>()) } returns SystemCrawlerSieve.Result(item = miss.lookup, matches = false)
+        }
+        val filter = customFilter(cfg, sieve)
+        filter.initialize()
+
+        filter.match(miss.lookup) shouldBe null
+    }
+
+    @Test
+    fun `isUnderdefined is true for regex-only config - BUG-FIXME-8 documents current behavior`() = runTest2 {
+        // BUG-FIXME-8: CustomFilterConfig.isUnderdefined checks only pathCriteria and
+        // nameCriteria. A config with ONLY pathRegexes set is still considered underdefined
+        // even though the sieve can match against pathRegexes. This means the editor's
+        // canSave check rejects regex-only filters, and the user cannot save them.
+        // Flip this test if isUnderdefined is updated to also consider pathRegexes.
+        val cfg = config(
+            pathCriteria = null,
+            pathRegexes = setOf(Regex(".*\\.tmp\$")),
+        )
+
+        cfg.isUnderdefined shouldBe true
+    }
+}

--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/custom/EditorOptionsCreatorTest.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/custom/EditorOptionsCreatorTest.kt
@@ -1,0 +1,182 @@
+package eu.darken.sdmse.systemcleaner.core.filter.custom
+
+import android.content.Context
+import eu.darken.sdmse.common.areas.DataArea
+import eu.darken.sdmse.common.ca.CaString
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.common.files.FileType
+import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.files.local.LocalPathLookup
+import eu.darken.sdmse.common.filter.CustomFilterEditorOptions
+import eu.darken.sdmse.common.forensics.AreaInfo
+import eu.darken.sdmse.common.forensics.FileForensics
+import eu.darken.sdmse.common.sieve.SegmentCriterium
+import eu.darken.sdmse.common.user.UserHandle2
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+import java.time.Instant
+
+class EditorOptionsCreatorTest : BaseTest() {
+
+    private fun lookup(
+        segments: Array<String>,
+        type: FileType = FileType.FILE,
+    ): APathLookup<*> = LocalPathLookup(
+        lookedUp = LocalPath.build(*segments),
+        fileType = type,
+        size = 0L,
+        modifiedAt = Instant.parse("2026-04-01T12:00:00Z"),
+        target = null,
+    )
+
+    private fun areaInfo(
+        prefix: APath,
+        type: DataArea.Type,
+        prefixLabel: CaString = "Prefix".toCaString(),
+    ): AreaInfo = AreaInfo(
+        file = prefix,
+        prefix = prefix,
+        dataArea = DataArea(
+            path = prefix,
+            type = type,
+            label = "Area".toCaString(),
+            userHandle = UserHandle2(handleId = 0),
+        ),
+        isBlackListLocation = false,
+    )
+
+    private fun mockForensics(
+        responses: Map<APath, AreaInfo?>,
+    ): FileForensics = mockk<FileForensics>().apply {
+        coEvery { identifyArea(any<APath>()) } answers {
+            val path = it.invocation.args[0] as APath
+            responses[path]
+        }
+    }
+
+    private fun mockContext(): Context = mockk<Context>(relaxed = true).apply {
+        every { resources } returns mockk(relaxed = true)
+    }
+
+    @Test
+    fun `creator produces SegmentCriterium with Equal mode for FILE targets`() = runTest2 {
+        val fileLookup = lookup(arrayOf("storage", "emulated", "0", "Downloads", "file.dat"), FileType.FILE)
+        val prefixPath = LocalPath.build("storage", "emulated", "0")
+        val creator = EditorOptionsCreator(
+            context = mockContext(),
+            fileForensics = mockForensics(
+                mapOf(fileLookup.lookedUp to areaInfo(prefixPath, DataArea.Type.SDCARD)),
+            ),
+        )
+
+        val options = creator.createOptions(setOf(fileLookup))
+
+        options.shouldBeInstanceOf<CustomFilterEditorOptions>()
+        val criterium = options.pathCriteria!!.single()
+        criterium.mode.shouldBeInstanceOf<SegmentCriterium.Mode.Equal>()
+        criterium.segments shouldBe fileLookup.segments
+    }
+
+    @Test
+    fun `creator produces SegmentCriterium with Start mode and trailing-slash segment for DIRECTORY targets`() = runTest2 {
+        val dirLookup = lookup(arrayOf("storage", "emulated", "0", "Downloads", "subdir"), FileType.DIRECTORY)
+        val prefixPath = LocalPath.build("storage", "emulated", "0")
+        val creator = EditorOptionsCreator(
+            context = mockContext(),
+            fileForensics = mockForensics(
+                mapOf(dirLookup.lookedUp to areaInfo(prefixPath, DataArea.Type.SDCARD)),
+            ),
+        )
+
+        val options = creator.createOptions(setOf(dirLookup))
+
+        options.shouldBeInstanceOf<CustomFilterEditorOptions>()
+        val criterium = options.pathCriteria!!.single()
+        criterium.mode.shouldBeInstanceOf<SegmentCriterium.Mode.Start>()
+        // Trailing empty segment marks directory boundary.
+        criterium.segments.last() shouldBe ""
+    }
+
+    @Test
+    fun `creator targetAreas contains DataArea types from identifyArea results`() = runTest2 {
+        val a = lookup(arrayOf("storage", "emulated", "0", "Downloads", "a.dat"))
+        val b = lookup(arrayOf("storage", "emulated", "0", "Movies", "b.dat"))
+        val prefixPath = LocalPath.build("storage", "emulated", "0")
+        val creator = EditorOptionsCreator(
+            context = mockContext(),
+            fileForensics = mockForensics(
+                mapOf(
+                    a.lookedUp to areaInfo(prefixPath, DataArea.Type.SDCARD),
+                    b.lookedUp to areaInfo(prefixPath, DataArea.Type.PUBLIC_MEDIA),
+                ),
+            ),
+        )
+
+        val options = creator.createOptions(setOf(a, b))
+
+        options.shouldBeInstanceOf<CustomFilterEditorOptions>()
+        options.areas shouldBe setOf(DataArea.Type.SDCARD, DataArea.Type.PUBLIC_MEDIA)
+    }
+
+    @Test
+    fun `creator label is null when targets identify to different prefixes`() = runTest2 {
+        val a = lookup(arrayOf("storage", "emulated", "0", "Downloads", "a.dat"))
+        val b = lookup(arrayOf("storage", "emulated", "0", "Movies", "b.dat"))
+        val prefixA = LocalPath.build("storage", "emulated", "0", "Downloads")
+        val prefixB = LocalPath.build("storage", "emulated", "0", "Movies")
+        val creator = EditorOptionsCreator(
+            context = mockContext(),
+            fileForensics = mockForensics(
+                mapOf(
+                    a.lookedUp to areaInfo(prefixA, DataArea.Type.SDCARD),
+                    b.lookedUp to areaInfo(prefixB, DataArea.Type.SDCARD),
+                ),
+            ),
+        )
+
+        val options = creator.createOptions(setOf(a, b))
+
+        options.shouldBeInstanceOf<CustomFilterEditorOptions>()
+        options.label shouldBe null
+    }
+
+    @Test
+    fun `creator label is null and areas empty when identifyArea returns null for all targets`() = runTest2 {
+        val orphan = lookup(arrayOf("some", "unknown", "path"))
+        val creator = EditorOptionsCreator(
+            context = mockContext(),
+            fileForensics = mockForensics(mapOf(orphan.lookedUp to null)),
+        )
+
+        val options = creator.createOptions(setOf(orphan))
+
+        options.shouldBeInstanceOf<CustomFilterEditorOptions>()
+        options.label shouldBe null
+        options.areas shouldBe emptySet()
+    }
+
+    @Test
+    fun `creator saveAsEnabled is always true`() = runTest2 {
+        val file = lookup(arrayOf("path", "x"), FileType.FILE)
+        val prefixPath = LocalPath.build("path")
+        val creator = EditorOptionsCreator(
+            context = mockContext(),
+            fileForensics = mockForensics(
+                mapOf(file.lookedUp to areaInfo(prefixPath, DataArea.Type.SDCARD)),
+            ),
+        )
+
+        val options = creator.createOptions(setOf(file))
+
+        options.shouldBeInstanceOf<CustomFilterEditorOptions>()
+        options.saveAsEnabled shouldBe true
+    }
+}

--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/CustomFilterEditorScreenTest.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/CustomFilterEditorScreenTest.kt
@@ -5,6 +5,8 @@ import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import eu.darken.sdmse.common.sieve.SegmentCriterium
 import eu.darken.sdmse.systemcleaner.core.filter.custom.CustomFilterConfig
@@ -78,6 +80,70 @@ class CustomFilterEditorScreenTest : BaseComposeRobolectricTest() {
         }
         composeRule.onAllNodesWithContentDescription("Remove").assertCountEquals(0)
         composeRule.onAllNodesWithContentDescription("Save").assertCountEquals(0)
+    }
+
+    @Test
+    fun `tapping Save invokes onSave when canSave is true`() {
+        var saveClicks = 0
+        val basePath = SegmentCriterium(
+            segments = listOf("Downloads"),
+            mode = SegmentCriterium.Mode.Contain(allowPartial = true),
+        )
+        val state = CustomFilterEditorViewModel.State(
+            original = CustomFilterConfig(identifier = "abc", label = "old", pathCriteria = setOf(basePath)),
+            current = CustomFilterConfig(identifier = "abc", label = "new", pathCriteria = setOf(basePath)),
+        )
+        composeRule.setEditorContent {
+            CustomFilterEditorScreen(
+                stateSource = MutableStateFlow(state),
+                onSave = { saveClicks++ },
+            )
+        }
+
+        composeRule.onNodeWithContentDescription("Save").performClick()
+
+        if (saveClicks != 1) throw AssertionError("Expected onSave to fire once, got $saveClicks")
+    }
+
+    @Test
+    fun `tapping Remove invokes onRemove when canRemove is true`() {
+        var removeClicks = 0
+        val basePath = SegmentCriterium(
+            segments = listOf("Downloads"),
+            mode = SegmentCriterium.Mode.Contain(allowPartial = true),
+        )
+        val state = CustomFilterEditorViewModel.State(
+            original = CustomFilterConfig(identifier = "abc", label = "old", pathCriteria = setOf(basePath)),
+            current = CustomFilterConfig(identifier = "abc", label = "old", pathCriteria = setOf(basePath)),
+        )
+        composeRule.setEditorContent {
+            CustomFilterEditorScreen(
+                stateSource = MutableStateFlow(state),
+                onRemove = { removeClicks++ },
+            )
+        }
+
+        composeRule.onNodeWithContentDescription("Remove").performClick()
+
+        if (removeClicks != 1) throw AssertionError("Expected onRemove to fire once, got $removeClicks")
+    }
+
+    @Test
+    fun `current config label renders as toolbar subtitle when non-blank for new filter too`() {
+        // Documents that the subtitle gating is on `current.label.isNotBlank()`, regardless
+        // of whether this is an edit-existing (original != null) or new (original == null) flow.
+        val state = CustomFilterEditorViewModel.State(
+            original = null,
+            current = CustomFilterConfig(identifier = "new-filter", label = "Typed name"),
+        )
+        composeRule.setEditorContent {
+            CustomFilterEditorScreen(stateSource = MutableStateFlow(state))
+        }
+
+        // The label appears as the toolbar subtitle.
+        composeRule.onAllNodesWithText("Typed name").fetchSemanticsNodes().size.let {
+            if (it == 0) throw AssertionError("Expected typed label visible as subtitle for new filter")
+        }
     }
 }
 

--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/CustomFilterEditorViewModelTest.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/CustomFilterEditorViewModelTest.kt
@@ -1,0 +1,504 @@
+package eu.darken.sdmse.systemcleaner.ui.customfilter.editor
+
+import androidx.lifecycle.SavedStateHandle
+import eu.darken.sdmse.common.areas.DataArea
+import eu.darken.sdmse.common.areas.DataAreaManager
+import eu.darken.sdmse.common.files.FileType
+import eu.darken.sdmse.common.filter.CustomFilterEditorOptions
+import eu.darken.sdmse.common.filter.CustomFilterEditorRoute
+import eu.darken.sdmse.common.navigation.NavEvent
+import eu.darken.sdmse.common.sieve.NameCriterium
+import eu.darken.sdmse.common.sieve.SegmentCriterium
+import eu.darken.sdmse.systemcleaner.core.SystemCleanerSettings
+import eu.darken.sdmse.systemcleaner.core.SystemCrawler
+import eu.darken.sdmse.systemcleaner.core.filter.custom.CustomFilter
+import eu.darken.sdmse.systemcleaner.core.filter.custom.CustomFilterConfig
+import eu.darken.sdmse.systemcleaner.core.filter.custom.CustomFilterRepo
+import eu.darken.sdmse.systemcleaner.core.rwDataStoreValue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import testhelpers.coroutine.runTest2
+import java.time.Duration
+import java.time.Instant
+
+class CustomFilterEditorViewModelTest : BaseTest() {
+
+    @AfterEach
+    fun teardownRouteMock() {
+        unmockkObject(CustomFilterEditorRoute.Companion)
+    }
+
+    private fun config(
+        id: String = "filter-1",
+        label: String = "Filter Label",
+        pathCriteria: Set<SegmentCriterium>? = setOf(
+            SegmentCriterium(segments = listOf("Downloads"), mode = SegmentCriterium.Mode.Start()),
+        ),
+    ): CustomFilterConfig = CustomFilterConfig(
+        identifier = id,
+        label = label,
+        createdAt = Instant.parse("2026-01-01T00:00:00Z"),
+        modifiedAt = Instant.parse("2026-01-01T00:00:00Z"),
+        pathCriteria = pathCriteria,
+    )
+
+    private class Harness(
+        val vm: CustomFilterEditorViewModel,
+        val repo: CustomFilterRepo,
+        val settings: SystemCleanerSettings,
+        val enabledFilterValue: eu.darken.sdmse.common.datastore.DataStoreValue<Set<String>>,
+        val crawler: SystemCrawler,
+        val filterFactory: CustomFilter.Factory,
+        val dataAreaState: MutableSharedFlow<DataAreaManager.State>,
+    )
+
+    /**
+     * Mocks `CustomFilterEditorRoute.from(handle)` to bypass `SavedStateHandle.toRoute()`
+     * which requires real Android Bundle support (Robolectric) — the Navigation library's
+     * `SavedStateHandleArgStore` calls `bundleOf()` internally and crashes on JVM mocks.
+     */
+    private fun mockRoute(identifier: String?, initial: CustomFilterEditorOptions?) {
+        mockkObject(CustomFilterEditorRoute.Companion)
+        every { CustomFilterEditorRoute.from(any()) } returns CustomFilterEditorRoute(
+            identifier = identifier,
+            initial = initial,
+        )
+    }
+
+    private fun buildHarness(
+        identifier: String? = null,
+        initial: CustomFilterEditorOptions? = null,
+        existingConfigs: List<CustomFilterConfig> = emptyList(),
+        availableAreas: Set<DataArea.Type> = emptySet(),
+    ): Harness {
+        mockRoute(identifier, initial)
+        val repo = mockk<CustomFilterRepo>(relaxed = true).apply {
+            every { configs } returns flowOf(existingConfigs)
+            every { generateIdentifier() } returns "generated-id-${System.nanoTime()}"
+        }
+        val enabledFilterValue = rwDataStoreValue(emptySet<String>())
+        val settings = mockk<SystemCleanerSettings>(relaxed = true).apply {
+            every { enabledCustomFilter } returns enabledFilterValue
+        }
+        val dataAreaState = MutableSharedFlow<DataAreaManager.State>(replay = 1).apply {
+            tryEmit(
+                DataAreaManager.State(
+                    areas = availableAreas.map {
+                        mockk<DataArea>(relaxed = true).apply { every { type } returns it }
+                    }.toSet(),
+                ),
+            )
+        }
+        val dataAreaManager = mockk<DataAreaManager>().apply {
+            every { state } returns dataAreaState
+        }
+        val crawler = mockk<SystemCrawler>(relaxed = true).apply {
+            every { progress } returns flowOf(null)
+            every { matchEvents } returns MutableSharedFlow()
+        }
+        val filterFactory = mockk<CustomFilter.Factory>(relaxed = true)
+        val vm = CustomFilterEditorViewModel(
+            handle = SavedStateHandle(),
+            dispatcherProvider = TestDispatcherProvider(),
+            filterRepo = repo,
+            dataAreaManager = dataAreaManager,
+            crawler = crawler,
+            filterFactory = filterFactory,
+            settings = settings,
+        )
+        return Harness(vm, repo, settings, enabledFilterValue, crawler, filterFactory, dataAreaState)
+    }
+
+    /**
+     * The editor VM's `state` is `DynamicStateFlow.shareIn(..., started = Lazily)`. Until
+     * something subscribes, the upstream's `startValueProvider` is never invoked and
+     * `state.value` stays at `null`. With `SharingStarted.Lazily`, ONE subscription is enough
+     * to start the upstream — after that, `replay = 1` keeps the value cached even when no
+     * subscriber is active. Use `first { it != null }` instead of an infinite `collect` so
+     * `runTest2`'s `UncompletedCoroutinesError` check passes.
+     */
+    private fun CoroutineScope.keepStateAlive(vm: CustomFilterEditorViewModel) {
+        launch(start = CoroutineStart.UNDISPATCHED) {
+            vm.state.first { it != null }
+        }
+    }
+
+    // ──────────────────────────── initial state ────────────────────────────
+
+    @Test
+    fun `initial state for edit-existing has original non-null and canRemove true`() = runTest2 {
+        val existing = config(id = "abc", label = "Old", pathCriteria = setOf(SegmentCriterium(listOf("Downloads"), SegmentCriterium.Mode.Start())))
+        val h = buildHarness(identifier = "abc", existingConfigs = listOf(existing))
+        keepStateAlive(h.vm)
+        advanceUntilIdle()
+
+        val state = h.vm.state.value!!
+        state.original shouldBe existing
+        state.canRemove shouldBe true
+    }
+
+    @Test
+    fun `initial state for new filter has original null and canRemove false`() = runTest2 {
+        val h = buildHarness(identifier = null, initial = CustomFilterEditorOptions(label = "New filter"))
+        keepStateAlive(h.vm)
+        advanceUntilIdle()
+
+        val state = h.vm.state.value!!
+        state.original shouldBe null
+        state.canRemove shouldBe false
+    }
+
+    @Test
+    fun `phantom filter path emits IllegalStateException and navs up`() = runTest2 {
+        val h = buildHarness(identifier = "missing", initial = null, existingConfigs = emptyList())
+        keepStateAlive(h.vm)
+        val navEvents = mutableListOf<NavEvent>()
+        val job = launch(start = CoroutineStart.UNDISPATCHED) {
+            h.vm.navEvents.collect { navEvents.add(it) }
+        }
+        advanceUntilIdle()
+        job.cancel()
+
+        navEvents.contains(NavEvent.Up) shouldBe true
+    }
+
+    // ──────────────────────────── computed properties ────────────────────────────
+
+    @Test
+    fun `canSave is false when current is underdefined - no path or name criteria`() = runTest2 {
+        val existingPath = SegmentCriterium(listOf("X"), SegmentCriterium.Mode.Start())
+        val existing = config(id = "abc", pathCriteria = setOf(existingPath))
+        val h = buildHarness(identifier = "abc", existingConfigs = listOf(existing))
+        keepStateAlive(h.vm)
+        advanceUntilIdle()
+
+        h.vm.removePath(existingPath)
+        advanceUntilIdle()
+
+        val state = h.vm.state.value!!
+        state.current.isUnderdefined shouldBe true
+        state.canSave shouldBe false
+    }
+
+    @Test
+    fun `canSave is false when label is empty`() = runTest2 {
+        val existing = config(id = "abc", label = "Has label")
+        val h = buildHarness(identifier = "abc", existingConfigs = listOf(existing))
+        keepStateAlive(h.vm)
+        advanceUntilIdle()
+
+        h.vm.updateLabel("")
+        advanceUntilIdle()
+
+        h.vm.state.value!!.canSave shouldBe false
+    }
+
+    @Test
+    fun `canSave is true when label set and at least one path criterium and original differs`() = runTest2 {
+        val existing = config(id = "abc", label = "Old")
+        val h = buildHarness(identifier = "abc", existingConfigs = listOf(existing))
+        keepStateAlive(h.vm)
+        advanceUntilIdle()
+
+        h.vm.updateLabel("New name")
+        advanceUntilIdle()
+
+        h.vm.state.value!!.canSave shouldBe true
+    }
+
+    // ──────────────────────────── criteria mutators ────────────────────────────
+
+    @Test
+    fun `addPath then removePath round-trips through state`() = runTest2 {
+        val existing = config(id = "abc")
+        val h = buildHarness(identifier = "abc", existingConfigs = listOf(existing))
+        keepStateAlive(h.vm)
+        advanceUntilIdle()
+        val newPath = SegmentCriterium(listOf("Cache"), SegmentCriterium.Mode.Contain())
+
+        h.vm.addPath(newPath)
+        advanceUntilIdle()
+        h.vm.state.value!!.current.pathCriteria!!.contains(newPath) shouldBe true
+
+        h.vm.removePath(newPath)
+        advanceUntilIdle()
+        (h.vm.state.value!!.current.pathCriteria?.contains(newPath) ?: false) shouldBe false
+    }
+
+    @Test
+    fun `addNameContains then removeNameContains round-trips through state`() = runTest2 {
+        val existing = config(id = "abc")
+        val h = buildHarness(identifier = "abc", existingConfigs = listOf(existing))
+        keepStateAlive(h.vm)
+        advanceUntilIdle()
+        val n = NameCriterium(name = "thumb", mode = NameCriterium.Mode.Contain())
+
+        h.vm.addNameContains(n)
+        advanceUntilIdle()
+        h.vm.state.value!!.current.nameCriteria!!.contains(n) shouldBe true
+
+        h.vm.removeNameContains(n)
+        advanceUntilIdle()
+        (h.vm.state.value!!.current.nameCriteria?.contains(n) ?: false) shouldBe false
+    }
+
+    @Test
+    fun `addExclusion then removeExclusion round-trips through state`() = runTest2 {
+        val existing = config(id = "abc")
+        val h = buildHarness(identifier = "abc", existingConfigs = listOf(existing))
+        keepStateAlive(h.vm)
+        advanceUntilIdle()
+        val ex = SegmentCriterium(listOf("keep"), SegmentCriterium.Mode.Contain())
+
+        h.vm.addExclusion(ex)
+        advanceUntilIdle()
+        h.vm.state.value!!.current.exclusionCriteria!!.contains(ex) shouldBe true
+
+        h.vm.removeExclusion(ex)
+        advanceUntilIdle()
+        (h.vm.state.value!!.current.exclusionCriteria?.contains(ex) ?: false) shouldBe false
+    }
+
+    @Test
+    fun `toggleArea adds when not in set and removes when in set`() = runTest2 {
+        val existing = config(id = "abc")
+        val h = buildHarness(identifier = "abc", existingConfigs = listOf(existing))
+        keepStateAlive(h.vm)
+        advanceUntilIdle()
+
+        h.vm.toggleArea(DataArea.Type.SDCARD, checked = true)
+        advanceUntilIdle()
+        h.vm.state.value!!.current.areas!!.contains(DataArea.Type.SDCARD) shouldBe true
+
+        h.vm.toggleArea(DataArea.Type.SDCARD, checked = false)
+        advanceUntilIdle()
+        (h.vm.state.value!!.current.areas?.contains(DataArea.Type.SDCARD) ?: false) shouldBe false
+    }
+
+    @Test
+    fun `toggleFileType from null bootstraps singleton then adds and removes`() = runTest2 {
+        val existing = config(id = "abc")
+        val h = buildHarness(identifier = "abc", existingConfigs = listOf(existing))
+        keepStateAlive(h.vm)
+        advanceUntilIdle()
+
+        h.vm.toggleFileType(FileType.FILE)
+        advanceUntilIdle()
+        h.vm.state.value!!.current.fileTypes shouldBe setOf(FileType.FILE)
+
+        h.vm.toggleFileType(FileType.DIRECTORY)
+        advanceUntilIdle()
+        h.vm.state.value!!.current.fileTypes shouldBe setOf(FileType.FILE, FileType.DIRECTORY)
+
+        h.vm.toggleFileType(FileType.FILE)
+        advanceUntilIdle()
+        h.vm.state.value!!.current.fileTypes shouldBe setOf(FileType.DIRECTORY)
+    }
+
+    @Test
+    fun `updateSizeMinimum and updateSizeMaximum and updateAgeMinimum and updateAgeMaximum propagate`() = runTest2 {
+        val existing = config(id = "abc")
+        val h = buildHarness(identifier = "abc", existingConfigs = listOf(existing))
+        keepStateAlive(h.vm)
+        advanceUntilIdle()
+
+        h.vm.updateSizeMinimum(100L)
+        h.vm.updateSizeMaximum(1000L)
+        h.vm.updateAgeMinimum(Duration.ofDays(1))
+        h.vm.updateAgeMaximum(Duration.ofDays(30))
+        advanceUntilIdle()
+
+        val cur = h.vm.state.value!!.current
+        cur.sizeMinimum shouldBe 100L
+        cur.sizeMaximum shouldBe 1000L
+        cur.ageMinimum shouldBe Duration.ofDays(1)
+        cur.ageMaximum shouldBe Duration.ofDays(30)
+    }
+
+    // ──────────────────────────── save / remove / cancel ────────────────────────────
+
+    @Test
+    fun `save persists current config and navs up`() = runTest2 {
+        val existing = config(id = "abc")
+        val h = buildHarness(identifier = "abc", existingConfigs = listOf(existing))
+        keepStateAlive(h.vm)
+        advanceUntilIdle()
+
+        h.vm.updateLabel("Updated")
+        advanceUntilIdle()
+        h.vm.save()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { h.repo.save(any()) }
+    }
+
+    @Test
+    fun `save with saveAsEnabled true also enables filter via settings`() = runTest2 {
+        val h = buildHarness(
+            identifier = null,
+            initial = CustomFilterEditorOptions(label = "Init", saveAsEnabled = true),
+        )
+        keepStateAlive(h.vm)
+        advanceUntilIdle()
+
+        h.vm.addPath(SegmentCriterium(listOf("X"), SegmentCriterium.Mode.Start()))
+        advanceUntilIdle()
+        h.vm.save()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { h.repo.save(any()) }
+        coVerify(atLeast = 1) { h.enabledFilterValue.update(any()) }
+    }
+
+    @Test
+    fun `save bypasses canSave gating - BUG-FIXME-5 documents current behavior`() = runTest2 {
+        // BUG-FIXME-5: save() does NOT check canSave. A direct call saves the current config
+        // even if canSave is false (empty label, underdefined criteria). The Compose screen
+        // gates the Save action behind canSave but the VM method itself is unguarded. Flip
+        // this test once a canSave guard is added inside save().
+        val existing = config(id = "abc")
+        val h = buildHarness(identifier = "abc", existingConfigs = listOf(existing))
+        keepStateAlive(h.vm)
+        advanceUntilIdle()
+
+        h.vm.updateLabel("") // canSave = false
+        advanceUntilIdle()
+        h.vm.state.value!!.canSave shouldBe false
+
+        h.vm.save()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { h.repo.save(any()) } // Saved anyway.
+    }
+
+    @Test
+    fun `remove with confirmed false emits RemoveConfirmation event`() = runTest2 {
+        val existing = config(id = "abc")
+        val h = buildHarness(identifier = "abc", existingConfigs = listOf(existing))
+        keepStateAlive(h.vm)
+        advanceUntilIdle()
+
+        val events = mutableListOf<CustomFilterEditorViewModel.Event>()
+        val job = launch(start = CoroutineStart.UNDISPATCHED) {
+            h.vm.events.collect { events.add(it) }
+        }
+        h.vm.remove(confirmed = false)
+        advanceUntilIdle()
+        job.cancel()
+
+        events.any { it is CustomFilterEditorViewModel.Event.RemoveConfirmation } shouldBe true
+    }
+
+    @Test
+    fun `remove with confirmed true calls repo remove and navs up`() = runTest2 {
+        val existing = config(id = "abc")
+        val h = buildHarness(identifier = "abc", existingConfigs = listOf(existing))
+        keepStateAlive(h.vm)
+        advanceUntilIdle()
+
+        h.vm.remove(confirmed = true)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { h.repo.remove(setOf("abc")) }
+    }
+
+    @Test
+    fun `remove on new filter is a no-op because canRemove is false`() = runTest2 {
+        val h = buildHarness(identifier = null, initial = CustomFilterEditorOptions(label = "x"))
+        keepStateAlive(h.vm)
+        advanceUntilIdle()
+
+        h.vm.remove(confirmed = false)
+        h.vm.remove(confirmed = true)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { h.repo.remove(any()) }
+    }
+
+    @Test
+    fun `cancel on modified filter emits UnsavedChangesConfirmation`() = runTest2 {
+        val existing = config(id = "abc", label = "Old")
+        val h = buildHarness(identifier = "abc", existingConfigs = listOf(existing))
+        keepStateAlive(h.vm)
+        advanceUntilIdle()
+
+        val events = mutableListOf<CustomFilterEditorViewModel.Event>()
+        val job = launch(start = CoroutineStart.UNDISPATCHED) {
+            h.vm.events.collect { events.add(it) }
+        }
+        h.vm.updateLabel("Changed")
+        advanceUntilIdle()
+        h.vm.cancel(confirmed = false)
+        advanceUntilIdle()
+        job.cancel()
+
+        events.any { it is CustomFilterEditorViewModel.Event.UnsavedChangesConfirmation } shouldBe true
+    }
+
+    @Test
+    fun `cancel on unchanged filter navs up directly`() = runTest2 {
+        val existing = config(id = "abc")
+        val h = buildHarness(identifier = "abc", existingConfigs = listOf(existing))
+        keepStateAlive(h.vm)
+        advanceUntilIdle()
+
+        val navEvents = mutableListOf<NavEvent>()
+        val job = launch(start = CoroutineStart.UNDISPATCHED) {
+            h.vm.navEvents.collect { navEvents.add(it) }
+        }
+        h.vm.cancel(confirmed = false)
+        advanceUntilIdle()
+        job.cancel()
+
+        navEvents.contains(NavEvent.Up) shouldBe true
+    }
+
+    @Test
+    fun `cancel confirmed always navs up regardless of unsaved state`() = runTest2 {
+        val existing = config(id = "abc")
+        val h = buildHarness(identifier = "abc", existingConfigs = listOf(existing))
+        keepStateAlive(h.vm)
+        advanceUntilIdle()
+
+        val navEvents = mutableListOf<NavEvent>()
+        val job = launch(start = CoroutineStart.UNDISPATCHED) {
+            h.vm.navEvents.collect { navEvents.add(it) }
+        }
+        h.vm.updateLabel("Some changes")
+        advanceUntilIdle()
+        h.vm.cancel(confirmed = true)
+        advanceUntilIdle()
+        job.cancel()
+
+        navEvents.contains(NavEvent.Up) shouldBe true
+    }
+
+    @Test
+    fun `availableAreas propagates from dataAreaManager state`() = runTest2 {
+        val h = buildHarness(
+            identifier = null,
+            initial = CustomFilterEditorOptions(label = "x"),
+            availableAreas = setOf(DataArea.Type.SDCARD, DataArea.Type.PUBLIC_MEDIA),
+        )
+        keepStateAlive(h.vm)
+        advanceUntilIdle()
+
+        h.vm.state.value!!.availableAreas shouldBe setOf(DataArea.Type.SDCARD, DataArea.Type.PUBLIC_MEDIA)
+    }
+}

--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/customfilter/list/CustomFilterListScreenTest.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/customfilter/list/CustomFilterListScreenTest.kt
@@ -1,0 +1,118 @@
+package eu.darken.sdmse.systemcleaner.ui.customfilter.list
+
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTouchInput
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.systemcleaner.core.filter.custom.CustomFilterConfig
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+import java.time.Instant
+
+class CustomFilterListScreenTest : BaseComposeRobolectricTest() {
+
+    private fun row(id: String, label: String): CustomFilterListViewModel.FilterRow =
+        CustomFilterListViewModel.FilterRow(
+            config = CustomFilterConfig(
+                identifier = id,
+                label = label,
+                createdAt = Instant.parse("2026-01-01T00:00:00Z"),
+                modifiedAt = Instant.parse("2026-01-01T00:00:00Z"),
+            ),
+            isEnabled = false,
+        )
+
+    private fun ComposeContentTestRule.setListScreen(state: CustomFilterListViewModel.State) {
+        setContent {
+            PreviewWrapper {
+                CustomFilterListScreen(stateSource = MutableStateFlow(state))
+            }
+        }
+    }
+
+    @Test
+    fun `loading state shows progress indicator and no rows`() {
+        composeRule.setListScreen(
+            CustomFilterListViewModel.State(rows = emptyList(), loading = true, isPro = null),
+        )
+
+        // The custom-filter create-hint text from EmptyStateBody must NOT render during loading.
+        composeRule.onAllNodesWithText("Create a custom filter to delete extra files that are unique to your device and use-cases.").assertCountEquals(0)
+        composeRule.onNodeWithText("Custom filter").assertExists() // top bar title is always visible
+    }
+
+    @Test
+    fun `empty state shows the create-hint text`() {
+        composeRule.setListScreen(
+            CustomFilterListViewModel.State(rows = emptyList(), loading = false, isPro = true),
+        )
+
+        composeRule.onNodeWithText("Create a custom filter to delete extra files that are unique to your device and use-cases.").assertExists()
+    }
+
+    @Test
+    fun `populated state renders each row by its config label`() {
+        composeRule.setListScreen(
+            CustomFilterListViewModel.State(
+                rows = listOf(row("a", "Alpha filter"), row("b", "Beta filter")),
+                loading = false,
+                isPro = true,
+            ),
+        )
+
+        composeRule.onNodeWithText("Alpha filter").assertExists()
+        composeRule.onNodeWithText("Beta filter").assertExists()
+    }
+
+    @Test
+    fun `FAB hidden when isPro is null - loading branch`() {
+        // The Create FAB is gated on `selection.isEmpty() && state.isPro != null`. With
+        // isPro=null it must not appear regardless of the loading flag.
+        composeRule.setListScreen(
+            CustomFilterListViewModel.State(rows = emptyList(), loading = true, isPro = null),
+        )
+
+        // The FAB renders the "Custom filter" label too. Since the top bar also has that text,
+        // we count occurrences — top bar gives 1, FAB would add a second.
+        composeRule.onAllNodesWithText("Custom filter").assertCountEquals(1)
+    }
+
+    @Test
+    fun `top bar title rendered for both loading and ready states`() {
+        // The Scaffold FAB doesn't render reliably under Robolectric so we cannot directly
+        // assert FAB visibility. Instead, verify the top bar title is always visible — both
+        // the FAB-hidden (isPro=null) and FAB-eligible (isPro=true) states share the same
+        // top bar, which proves the screen composes without crashing in either state.
+        composeRule.setListScreen(
+            CustomFilterListViewModel.State(rows = emptyList(), loading = false, isPro = true),
+        )
+
+        composeRule.onNodeWithText("Custom filter").assertExists()
+    }
+
+    @Test
+    fun `selection mode shows export and delete actions but no edit unless single`() {
+        composeRule.setListScreen(
+            CustomFilterListViewModel.State(
+                rows = listOf(row("a", "Alpha"), row("b", "Beta")),
+                loading = false,
+                isPro = true,
+            ),
+        )
+
+        // Long-press both rows to make a multi-selection.
+        composeRule.onNodeWithText("Alpha").performTouchInput { longClick() }
+        composeRule.onNodeWithText("Beta").performTouchInput { longClick() }
+
+        // Export action surfaces a content description.
+        composeRule.onAllNodesWithContentDescription("Export selected filter")
+            .fetchSemanticsNodes().size.let {
+                if (it == 0) throw AssertionError("Expected Export action visible after selection")
+            }
+    }
+}

--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/customfilter/list/CustomFilterListViewModelTest.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/customfilter/list/CustomFilterListViewModelTest.kt
@@ -1,0 +1,253 @@
+package eu.darken.sdmse.systemcleaner.ui.customfilter.list
+
+import android.content.Context
+import eu.darken.sdmse.common.WebpageTool
+import eu.darken.sdmse.common.filter.CustomFilterEditorRoute
+import eu.darken.sdmse.common.navigation.NavEvent
+import eu.darken.sdmse.common.navigation.routes.UpgradeRoute
+import eu.darken.sdmse.common.upgrade.UpgradeRepo
+import eu.darken.sdmse.systemcleaner.core.SystemCleanerSettings
+import eu.darken.sdmse.systemcleaner.core.filter.custom.CustomFilterConfig
+import eu.darken.sdmse.systemcleaner.core.filter.custom.CustomFilterRepo
+import eu.darken.sdmse.systemcleaner.core.rwDataStoreValue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import testhelpers.coroutine.runTest2
+import java.time.Instant
+
+class CustomFilterListViewModelTest : BaseTest() {
+
+    private fun config(id: String, label: String): CustomFilterConfig = CustomFilterConfig(
+        identifier = id,
+        label = label,
+        createdAt = Instant.parse("2026-01-01T00:00:00Z"),
+        modifiedAt = Instant.parse("2026-01-01T00:00:00Z"),
+    )
+
+    private class Harness(
+        val vm: CustomFilterListViewModel,
+        val repo: CustomFilterRepo,
+        val settings: SystemCleanerSettings,
+        val enabledFilterValue: eu.darken.sdmse.common.datastore.DataStoreValue<Set<String>>,
+        val upgradeRepo: UpgradeRepo,
+        val webpageTool: WebpageTool,
+        val configsFlow: MutableStateFlow<Collection<CustomFilterConfig>>,
+        val upgradeFlow: MutableSharedFlow<UpgradeRepo.Info>,
+    )
+
+    private fun buildHarness(
+        configs: Collection<CustomFilterConfig> = emptyList(),
+        enabled: Set<String> = emptySet(),
+        emitUpgradeInfo: Boolean = true,
+        isPro: Boolean = false,
+    ): Harness {
+        val configsFlow = MutableStateFlow(configs)
+        val upgradeFlow = MutableSharedFlow<UpgradeRepo.Info>(replay = if (emitUpgradeInfo) 1 else 0)
+        if (emitUpgradeInfo) {
+            upgradeFlow.tryEmit(mockk<UpgradeRepo.Info>().apply { every { this@apply.isPro } returns isPro })
+        }
+        val repo = mockk<CustomFilterRepo>(relaxed = true).apply {
+            every { this@apply.configs } returns configsFlow
+        }
+        val enabledFilterValue = rwDataStoreValue(enabled)
+        val settings = mockk<SystemCleanerSettings>().apply {
+            every { enabledCustomFilter } returns enabledFilterValue
+        }
+        val upgradeRepo = mockk<UpgradeRepo>().apply {
+            every { upgradeInfo } returns upgradeFlow
+        }
+        val webpageTool = mockk<WebpageTool>(relaxed = true)
+        val context = mockk<Context>(relaxed = true)
+        val vm = CustomFilterListViewModel(
+            dispatcherProvider = TestDispatcherProvider(),
+            context = context,
+            customFilterRepo = repo,
+            systemCleanerSettings = settings,
+            upgradeRepo = upgradeRepo,
+            webpageTool = webpageTool,
+        )
+        return Harness(vm, repo, settings, enabledFilterValue, upgradeRepo, webpageTool, configsFlow, upgradeFlow)
+    }
+
+    @Test
+    fun `state rows are sorted alphabetically by label`() = runTest2 {
+        val h = buildHarness(
+            configs = listOf(
+                config("z", "Zebra filter"),
+                config("a", "Alpha filter"),
+                config("m", "Middle filter"),
+            ),
+        )
+        h.vm.state.first().rows.map { it.config.identifier } shouldBe listOf("a", "m", "z")
+    }
+
+    @Test
+    fun `state isPro is null while upgradeInfo has not emitted yet`() = runTest2 {
+        // Before upgradeInfo emits, the `onStart { emit(null) }` shim emits null.
+        val h = buildHarness(emitUpgradeInfo = false)
+        h.vm.state.first().isPro shouldBe null
+    }
+
+    @Test
+    fun `state isPro becomes true after upgradeInfo emits pro user`() = runTest2 {
+        val h = buildHarness(isPro = true)
+        h.vm.state.first().isPro shouldBe true
+    }
+
+    @Test
+    fun `state rows isEnabled reflects enabledCustomFilter setting`() = runTest2 {
+        val a = config("a", "A")
+        val b = config("b", "B")
+        val h = buildHarness(configs = listOf(a, b), enabled = setOf("a"))
+
+        val rows = h.vm.state.first().rows
+        rows.single { it.config.identifier == "a" }.isEnabled shouldBe true
+        rows.single { it.config.identifier == "b" }.isEnabled shouldBe false
+    }
+
+    @Test
+    fun `onToggleRow calls toggleCustomFilter via settings`() = runTest2 {
+        val a = config("a", "A")
+        val h = buildHarness(configs = listOf(a))
+
+        h.vm.onToggleRow(CustomFilterListViewModel.FilterRow(config = a, isEnabled = false))
+        advanceUntilIdle()
+
+        // toggleCustomFilter is an extension that calls update on enabledCustomFilter.
+        coVerify(atLeast = 1) { h.enabledFilterValue.update(any()) }
+    }
+
+    @Test
+    fun `onEditClick when not pro navigates to UpgradeRoute`() = runTest2 {
+        val a = config("a", "A")
+        val h = buildHarness(configs = listOf(a), isPro = false)
+
+        h.vm.onEditClick(CustomFilterListViewModel.FilterRow(config = a, isEnabled = false))
+        advanceUntilIdle()
+
+        val event = h.vm.navEvents.first()
+        event.shouldBeInstanceOf<NavEvent.GoTo>()
+        event.destination.shouldBeInstanceOf<UpgradeRoute>()
+    }
+
+    @Test
+    fun `onEditClick when pro navigates to CustomFilterEditorRoute`() = runTest2 {
+        val a = config("a", "A")
+        val h = buildHarness(configs = listOf(a), isPro = true)
+
+        h.vm.onEditClick(CustomFilterListViewModel.FilterRow(config = a, isEnabled = false))
+        advanceUntilIdle()
+
+        val event = h.vm.navEvents.first()
+        event.shouldBeInstanceOf<NavEvent.GoTo>()
+        val dest = event.destination
+        dest.shouldBeInstanceOf<CustomFilterEditorRoute>()
+        dest.identifier shouldBe "a"
+    }
+
+    @Test
+    fun `onCreateClick when not pro navigates to UpgradeRoute`() = runTest2 {
+        val h = buildHarness(isPro = false)
+
+        h.vm.onCreateClick()
+        advanceUntilIdle()
+
+        val event = h.vm.navEvents.first()
+        event.shouldBeInstanceOf<NavEvent.GoTo>()
+        event.destination.shouldBeInstanceOf<UpgradeRoute>()
+    }
+
+    @Test
+    fun `onCreateClick when pro navigates to CustomFilterEditorRoute with initial options and null identifier`() = runTest2 {
+        val h = buildHarness(isPro = true)
+
+        h.vm.onCreateClick()
+        advanceUntilIdle()
+
+        val event = h.vm.navEvents.first()
+        event.shouldBeInstanceOf<NavEvent.GoTo>()
+        val dest = event.destination
+        dest.shouldBeInstanceOf<CustomFilterEditorRoute>()
+        dest.identifier shouldBe null
+        (dest.initial != null) shouldBe true
+    }
+
+    @Test
+    fun `removeRows calls repo remove with identifiers and emits UndoRemove event`() = runTest2 {
+        val a = config("a", "A")
+        val b = config("b", "B")
+        val h = buildHarness(configs = listOf(a, b))
+        val rows = listOf(
+            CustomFilterListViewModel.FilterRow(config = a, isEnabled = false),
+            CustomFilterListViewModel.FilterRow(config = b, isEnabled = false),
+        )
+
+        h.vm.removeRows(rows)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { h.repo.remove(setOf("a", "b")) }
+        val event = h.vm.events.first()
+        event.shouldBeInstanceOf<CustomFilterListViewModel.Event.UndoRemove>()
+        event.configs shouldBe setOf(a, b)
+    }
+
+    @Test
+    fun `restore calls repo save with the given configs`() = runTest2 {
+        val a = config("a", "A")
+        val h = buildHarness()
+
+        h.vm.restore(setOf(a))
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { h.repo.save(setOf(a)) }
+    }
+
+    @Test
+    fun `exportRows when not pro navigates to UpgradeRoute`() = runTest2 {
+        val a = config("a", "A")
+        val h = buildHarness(configs = listOf(a), isPro = false)
+
+        h.vm.exportRows(listOf(CustomFilterListViewModel.FilterRow(config = a, isEnabled = false)))
+        advanceUntilIdle()
+
+        val event = h.vm.navEvents.first()
+        event.shouldBeInstanceOf<NavEvent.GoTo>()
+        event.destination.shouldBeInstanceOf<UpgradeRoute>()
+    }
+
+    @Test
+    fun `exportRows when pro emits LaunchExport event after staging`() = runTest2 {
+        val a = config("a", "A")
+        val h = buildHarness(configs = listOf(a), isPro = true)
+        coEvery { h.repo.exportFilters(any()) } returns emptyList()
+
+        h.vm.exportRows(listOf(CustomFilterListViewModel.FilterRow(config = a, isEnabled = false)))
+        advanceUntilIdle()
+
+        val event = h.vm.events.first()
+        event.shouldBeInstanceOf<CustomFilterListViewModel.Event.LaunchExport>()
+        // exportFilters must have been called before LaunchExport was emitted (otherwise the
+        // staged payload wouldn't be ready for performExport).
+        coVerify(exactly = 1) { h.repo.exportFilters(listOf("a")) }
+    }
+
+    @Test
+    fun `onHelpClick opens help URL via webpage tool`() = runTest2 {
+        val h = buildHarness()
+        h.vm.onHelpClick()
+        advanceUntilIdle()
+        io.mockk.verify(exactly = 1) { h.webpageTool.open(any<String>()) }
+    }
+}

--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/details/FilterContentDetailsScreenTest.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/details/FilterContentDetailsScreenTest.kt
@@ -1,0 +1,76 @@
+package eu.darken.sdmse.systemcleaner.ui.details
+
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.systemcleaner.ui.preview.previewFilterContent
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+
+// HorizontalPager + ScrollableTabRow are known to interact poorly with Robolectric for
+// multi-page assertions. Tests stay on single-item / empty states.
+class FilterContentDetailsScreenTest : BaseComposeRobolectricTest() {
+
+    private fun ComposeContentTestRule.setDetailsScreen(state: FilterContentDetailsViewModel.State) {
+        setContent {
+            PreviewWrapper {
+                FilterContentDetailsScreen(stateSource = MutableStateFlow(state))
+            }
+        }
+    }
+
+    @Test
+    fun `empty state shows the Empty placeholder`() {
+        composeRule.setDetailsScreen(FilterContentDetailsViewModel.State(items = emptyList()))
+
+        // SystemCleaner top bar title is always visible.
+        composeRule.onNodeWithText("SystemCleaner").assertExists()
+        // Empty placeholder for drained state.
+        composeRule.onNodeWithText("Empty").assertExists()
+    }
+
+    @Test
+    fun `populated state renders the filter content body and tab label`() {
+        val fc = previewFilterContent(
+            identifier = "fc-target",
+            label = "Empty directories",
+            description = "Folders that contain no files.",
+        )
+        composeRule.setDetailsScreen(
+            FilterContentDetailsViewModel.State(
+                items = listOf(fc),
+                target = fc.identifier,
+            ),
+        )
+
+        composeRule.onNodeWithText("SystemCleaner").assertExists()
+        // Empty placeholder must NOT render when items are present.
+        composeRule.onAllNodesWithText("Empty").assertCountEquals(0)
+        // The filter label appears in the tab row.
+        composeRule.onAllNodesWithText("Empty directories").fetchSemanticsNodes().size.let {
+            if (it == 0) throw AssertionError("Expected the filter label visible in tab/title")
+        }
+    }
+
+    @Test
+    fun `populated state renders the filter description in the header card`() {
+        // Filter description text comes from FilterContent.description and renders in the
+        // header card above the file list.
+        val fc = previewFilterContent(
+            identifier = "fc-with-desc",
+            label = "Sample",
+            description = "Custom description text in header.",
+        )
+        composeRule.setDetailsScreen(
+            FilterContentDetailsViewModel.State(
+                items = listOf(fc),
+                target = fc.identifier,
+            ),
+        )
+
+        composeRule.onNodeWithText("Custom description text in header.").assertExists()
+    }
+}

--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/details/FilterContentDetailsViewModelTest.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/details/FilterContentDetailsViewModelTest.kt
@@ -1,0 +1,406 @@
+package eu.darken.sdmse.systemcleaner.ui.details
+
+import androidx.lifecycle.SavedStateHandle
+import eu.darken.sdmse.common.files.FileType
+import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.files.local.LocalPathLookup
+import eu.darken.sdmse.common.navigation.NavEvent
+import eu.darken.sdmse.common.previews.PreviewRoute
+import eu.darken.sdmse.common.progress.Progress
+import eu.darken.sdmse.main.core.SDMTool
+import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
+import eu.darken.sdmse.systemcleaner.core.FilterContent
+import eu.darken.sdmse.systemcleaner.core.SystemCleaner
+import eu.darken.sdmse.systemcleaner.core.filter.SystemCleanerFilter
+import eu.darken.sdmse.systemcleaner.core.filter.filterIdentifier
+import eu.darken.sdmse.systemcleaner.core.filter.stock.ScreenshotsFilter
+import eu.darken.sdmse.systemcleaner.core.filter.stock.TrashedFilter
+import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerProcessingTask
+import eu.darken.sdmse.systemcleaner.ui.FilterContentDetailsRoute
+import eu.darken.sdmse.systemcleaner.ui.preview.previewFilterContent
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import testhelpers.coroutine.runTest2
+import java.time.Instant
+
+class FilterContentDetailsViewModelTest : BaseTest() {
+
+    private class Harness(
+        val vm: FilterContentDetailsViewModel,
+        val systemCleaner: SystemCleaner,
+        val taskSubmitter: TaskSubmitter,
+        val stateFlow: MutableStateFlow<SystemCleaner.State>,
+        val taskStateFlow: MutableStateFlow<TaskSubmitter.State>,
+    )
+
+    private class CollectedEvents<T>(val list: MutableList<T>, val job: Job) {
+        fun cancel() = job.cancel()
+    }
+
+    private fun CoroutineScope.collectEvents(
+        vm: FilterContentDetailsViewModel,
+    ): CollectedEvents<FilterContentDetailsViewModel.Event> {
+        val list = mutableListOf<FilterContentDetailsViewModel.Event>()
+        val job = launch(start = CoroutineStart.UNDISPATCHED) {
+            vm.events.collect { list.add(it) }
+        }
+        return CollectedEvents(list, job)
+    }
+
+    private fun CoroutineScope.collectNavEvents(
+        vm: FilterContentDetailsViewModel,
+    ): CollectedEvents<NavEvent> {
+        val list = mutableListOf<NavEvent>()
+        val job = launch(start = CoroutineStart.UNDISPATCHED) {
+            vm.navEvents.collect { list.add(it) }
+        }
+        return CollectedEvents(list, job)
+    }
+
+    private fun scState(data: SystemCleaner.Data? = null, progress: Progress.Data? = null) =
+        SystemCleaner.State(
+            data = data,
+            progress = progress,
+            areSystemFilterAvailable = true,
+        )
+
+    private fun match(name: String, parent: String = "f", size: Long = 1024L): SystemCleanerFilter.Match.Deletion =
+        SystemCleanerFilter.Match.Deletion(
+            lookup = LocalPathLookup(
+                lookedUp = LocalPath.build("storage", "emulated", "0", parent, name),
+                fileType = FileType.FILE,
+                size = size,
+                modifiedAt = Instant.parse("2026-04-01T12:00:00Z"),
+                target = null,
+            ),
+        )
+
+    private fun fakeUndo(count: Int): SystemCleaner.ExclusionUndo =
+        mockk<SystemCleaner.ExclusionUndo>().apply {
+            every { exclusionIds } returns (0 until count).map { "ex-$it" }.toSet()
+        }
+
+    private fun harness(
+        filterContents: List<FilterContent> = emptyList(),
+        savedHandle: SavedStateHandle = SavedStateHandle(),
+    ): Harness {
+        val data = SystemCleaner.Data(filterContents = filterContents)
+        val stateFlow = MutableStateFlow(scState(data = data))
+        val progressFlow = MutableStateFlow<Progress.Data?>(null)
+        val taskStateFlow = MutableStateFlow(TaskSubmitter.State(tasks = emptySet()))
+        val systemCleaner = mockk<SystemCleaner>(relaxed = true).apply {
+            every { this@apply.state } returns stateFlow
+            every { this@apply.progress } returns progressFlow
+        }
+        val taskSubmitter = mockk<TaskSubmitter>(relaxed = true).apply {
+            every { this@apply.state } returns taskStateFlow
+        }
+        val vm = FilterContentDetailsViewModel(
+            handle = savedHandle,
+            dispatcherProvider = TestDispatcherProvider(),
+            systemCleaner = systemCleaner,
+            taskSubmitter = taskSubmitter,
+        )
+        return Harness(vm, systemCleaner, taskSubmitter, stateFlow, taskStateFlow)
+    }
+
+    // ──────────────────────────── route + state ────────────────────────────
+
+    @Test
+    fun `bindRoute sets initial target from route filterIdentifier`() = runTest2 {
+        val fc = previewFilterContent(identifier = "f1", items = listOf(match("a")))
+        val h = harness(listOf(fc))
+
+        h.vm.bindRoute(FilterContentDetailsRoute(filterIdentifier = "f1"))
+
+        h.vm.state.first().target shouldBe "f1"
+    }
+
+    @Test
+    fun `bindRoute is idempotent`() = runTest2 {
+        val a = previewFilterContent(identifier = "a", items = listOf(match("a1")))
+        val b = previewFilterContent(identifier = "b", items = listOf(match("b1")))
+        val h = harness(listOf(a, b))
+
+        h.vm.bindRoute(FilterContentDetailsRoute(filterIdentifier = "a"))
+        h.vm.bindRoute(FilterContentDetailsRoute(filterIdentifier = "b"))
+
+        h.vm.state.first().target shouldBe "a"
+    }
+
+    @Test
+    fun `state items are sorted by size descending`() = runTest2 {
+        val small = previewFilterContent(identifier = "small", items = listOf(match("s", size = 100L)))
+        val large = previewFilterContent(identifier = "large", items = listOf(match("l", size = 10_000L)))
+        val medium = previewFilterContent(identifier = "medium", items = listOf(match("m", size = 1_000L)))
+        val h = harness(listOf(small, large, medium))
+        h.vm.bindRoute(FilterContentDetailsRoute(filterIdentifier = "large"))
+
+        h.vm.state.first().items.map { it.identifier } shouldBe listOf("large", "medium", "small")
+    }
+
+    // ──────────────────────────── auto-navUp behaviour ────────────────────────────
+
+    @Test
+    fun `autoNavUpOnEmpty fires navUp when data drains to empty filterContents`() = runTest2 {
+        val fc = previewFilterContent(identifier = "f", items = listOf(match("a")))
+        val h = harness(listOf(fc))
+        h.vm.bindRoute(FilterContentDetailsRoute(filterIdentifier = "f"))
+
+        h.stateFlow.value = scState(data = SystemCleaner.Data(filterContents = emptyList()))
+        advanceUntilIdle()
+
+        h.vm.navEvents.first() shouldBe NavEvent.Up
+    }
+
+    @Test
+    fun `autoNavUpOnEmpty does NOT fire when data transitions to null - mapNotNull fix`() = runTest2 {
+        // Regression test: FilterContentDetailsViewModel uses
+        // `systemCleaner.state.mapNotNull { it.data }` so a null emission during scan-restart
+        // does NOT trigger navUp. Verifies the fix at FilterContentDetailsViewModel.kt:53.
+        val fc = previewFilterContent(identifier = "f", items = listOf(match("a")))
+        val h = harness(listOf(fc))
+        h.vm.bindRoute(FilterContentDetailsRoute(filterIdentifier = "f"))
+        val collected = collectNavEvents(h.vm)
+
+        h.stateFlow.value = scState(data = null)
+        advanceUntilIdle()
+
+        collected.list shouldBe emptyList()
+        collected.cancel()
+    }
+
+    // ──────────────────────────── delete actions ────────────────────────────
+
+    @Test
+    fun `onConfirmDeleteFilter stale id does not submit`() = runTest2 {
+        val fc = previewFilterContent(identifier = "real", items = listOf(match("r")))
+        val h = harness(listOf(fc))
+
+        h.vm.onConfirmDeleteFilter("ghost")
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { h.taskSubmitter.submit(any()) }
+    }
+
+    @Test
+    fun `onConfirmDeleteFilter valid id submits ProcessingTask scoped to that filter`() = runTest2 {
+        val fc = previewFilterContent(identifier = "f", items = listOf(match("a")))
+        val h = harness(listOf(fc))
+
+        h.vm.onConfirmDeleteFilter("f")
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) {
+            h.taskSubmitter.submit(SystemCleanerProcessingTask(targetFilters = setOf("f")))
+        }
+    }
+
+    @Test
+    fun `onConfirmDeleteFiles empty paths does not submit`() = runTest2 {
+        val fc = previewFilterContent(identifier = "f", items = listOf(match("a")))
+        val h = harness(listOf(fc))
+
+        h.vm.onConfirmDeleteFiles("f", emptySet())
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { h.taskSubmitter.submit(any()) }
+    }
+
+    @Test
+    fun `onConfirmDeleteFiles intersects paths with live content`() = runTest2 {
+        val live = match("live")
+        val stalePath = LocalPath.build("storage", "emulated", "0", "f", "stale")
+        val fc = previewFilterContent(identifier = "f", items = listOf(live))
+        val h = harness(listOf(fc))
+
+        h.vm.onConfirmDeleteFiles("f", setOf(live.path, stalePath))
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) {
+            h.taskSubmitter.submit(
+                SystemCleanerProcessingTask(
+                    targetFilters = setOf("f"),
+                    targetContent = setOf(live.path),
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `onConfirmDeleteFiles all-stale paths does not submit`() = runTest2 {
+        val live = match("live")
+        val fc = previewFilterContent(identifier = "f", items = listOf(live))
+        val h = harness(listOf(fc))
+        val stalePath = LocalPath.build("storage", "emulated", "0", "f", "stale")
+
+        h.vm.onConfirmDeleteFiles("f", setOf(stalePath))
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { h.taskSubmitter.submit(any()) }
+    }
+
+    // ──────────────────────────── exclude actions ────────────────────────────
+
+    @Test
+    fun `onExcludeFilter stale id does nothing`() = runTest2 {
+        val fc = previewFilterContent(identifier = "real", items = listOf(match("r")))
+        val h = harness(listOf(fc))
+
+        h.vm.onExcludeFilter("ghost")
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { h.systemCleaner.exclude(any(), any()) }
+    }
+
+    @Test
+    fun `onExcludeFilter empty items does nothing`() = runTest2 {
+        val fc = previewFilterContent(identifier = "f", items = emptyList())
+        val h = harness(listOf(fc))
+
+        h.vm.onExcludeFilter("f")
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { h.systemCleaner.exclude(any(), any()) }
+    }
+
+    @Test
+    fun `onExcludeFilter emits ExclusionsCreated with count from undo not from input set size`() = runTest2 {
+        // Mirrors the CorpseFinder fix: count comes from undo.exclusionIds.size, not the
+        // count of input paths. ExclusionManager.save() may coalesce duplicates.
+        val a = match("a")
+        val b = match("b")
+        val fc = previewFilterContent(identifier = "f", items = listOf(a, b))
+        val h = harness(listOf(fc))
+        coEvery { h.systemCleaner.exclude(eq("f"), any()) } returns fakeUndo(1)
+
+        h.vm.onExcludeFilter("f")
+        advanceUntilIdle()
+
+        val event = h.vm.events.first()
+        event.shouldBeInstanceOf<FilterContentDetailsViewModel.Event.ExclusionsCreated>()
+        event.count shouldBe 1 // not 2 even though we exclude 2 paths
+        event.restoreTarget shouldBe "f"
+    }
+
+    @Test
+    fun `onExcludeFilter emits ExclusionsCreated with count 0 when save returns empty - details VM does not suppress`() = runTest2 {
+        // BUG-FIXME-4: Details VM emits ExclusionsCreated even when undo.exclusionIds is
+        // empty — meaning the snackbar shows "0 exclusions created". List VM has a guard
+        // (`if (totalExclusions == 0) return@launch`); details VM does not. Asymmetric
+        // behaviour. Flip this test if details VM is updated to match list VM.
+        val fc = previewFilterContent(identifier = "f", items = listOf(match("a")))
+        val h = harness(listOf(fc))
+        coEvery { h.systemCleaner.exclude(eq("f"), any()) } returns fakeUndo(0)
+
+        h.vm.onExcludeFilter("f")
+        advanceUntilIdle()
+
+        val event = h.vm.events.first()
+        event.shouldBeInstanceOf<FilterContentDetailsViewModel.Event.ExclusionsCreated>()
+        event.count shouldBe 0
+    }
+
+    @Test
+    fun `onExcludeFiles empty paths does nothing`() = runTest2 {
+        val fc = previewFilterContent(identifier = "f", items = listOf(match("a")))
+        val h = harness(listOf(fc))
+
+        h.vm.onExcludeFiles("f", emptySet())
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { h.systemCleaner.exclude(any(), any()) }
+    }
+
+    @Test
+    fun `onExcludeFiles intersects with live paths and emits SelectionExclusionsCreated`() = runTest2 {
+        val live = match("live")
+        val stalePath = LocalPath.build("storage", "emulated", "0", "f", "stale")
+        val fc = previewFilterContent(identifier = "f", items = listOf(live))
+        val h = harness(listOf(fc))
+        coEvery { h.systemCleaner.exclude(eq("f"), eq(setOf(live.path))) } returns fakeUndo(1)
+
+        h.vm.onExcludeFiles("f", setOf(live.path, stalePath))
+        advanceUntilIdle()
+
+        val event = h.vm.events.first()
+        event.shouldBeInstanceOf<FilterContentDetailsViewModel.Event.SelectionExclusionsCreated>()
+        event.count shouldBe 1
+        coVerify(exactly = 1) { h.systemCleaner.exclude(eq("f"), eq(setOf(live.path))) }
+    }
+
+    @Test
+    fun `onUndoExclude calls systemCleaner undoExclude with the handle`() = runTest2 {
+        val fc = previewFilterContent(identifier = "f", items = listOf(match("a")))
+        val h = harness(listOf(fc))
+        val undo = fakeUndo(2)
+
+        h.vm.onUndoExclude(undo, restoreTarget = "f")
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { h.systemCleaner.undoExclude(undo) }
+    }
+
+    // ──────────────────────────── preview navigation gating ────────────────────────────
+
+    @Test
+    fun `onPreviewFile navigates only for TrashedFilter and ScreenshotsFilter identifiers`() = runTest2 {
+        val trashedId = TrashedFilter::class.filterIdentifier
+        val screenshotsId = ScreenshotsFilter::class.filterIdentifier
+        val otherId = "some.other.filter"
+        val fc = previewFilterContent(identifier = otherId, items = listOf(match("a")))
+        val h = harness(listOf(fc))
+        val collected = collectNavEvents(h.vm)
+
+        h.vm.onPreviewFile(otherId, match("ignored").path)
+        advanceUntilIdle()
+        // No nav event for non-preview filters.
+        collected.list.any { it is NavEvent.GoTo && it.destination is PreviewRoute } shouldBe false
+
+        h.vm.onPreviewFile(trashedId, match("trashed").path)
+        h.vm.onPreviewFile(screenshotsId, match("screenshot").path)
+        advanceUntilIdle()
+
+        val previewNavs = collected.list.count { it is NavEvent.GoTo && it.destination is PreviewRoute }
+        previewNavs shouldBe 2
+        collected.cancel()
+    }
+
+    // ──────────────────────────── TaskResult emission ────────────────────────────
+
+    @Test
+    fun `TaskResult event fires when a SYSTEMCLEANER task completes after init`() = runTest2 {
+        val fc = previewFilterContent(identifier = "f", items = listOf(match("a")))
+        val h = harness(listOf(fc))
+        val collected = collectEvents(h.vm)
+        advanceUntilIdle()
+        val success = SystemCleanerProcessingTask.Success(affectedSpace = 10L, affectedPaths = emptySet())
+        val completed = TaskSubmitter.ManagedTask(
+            id = "t1",
+            toolType = SDMTool.Type.SYSTEMCLEANER,
+            task = SystemCleanerProcessingTask(),
+            completedAt = Instant.now().plusSeconds(1),
+            result = success,
+        )
+        h.taskStateFlow.value = TaskSubmitter.State(tasks = setOf(completed))
+        advanceUntilIdle()
+
+        val taskEvent = collected.list.filterIsInstance<FilterContentDetailsViewModel.Event.TaskResult>().single()
+        taskEvent.result shouldBe success
+        collected.cancel()
+    }
+}

--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/list/SystemCleanerListScreenTest.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/list/SystemCleanerListScreenTest.kt
@@ -1,0 +1,122 @@
+package eu.darken.sdmse.systemcleaner.ui.list
+
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.systemcleaner.ui.preview.previewFilterContent
+import eu.darken.sdmse.systemcleaner.ui.preview.previewSystemCleanerRow
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+
+class SystemCleanerListScreenTest : BaseComposeRobolectricTest() {
+
+    private fun ComposeContentTestRule.setListScreen(state: SystemCleanerListViewModel.State) {
+        setContent {
+            PreviewWrapper {
+                SystemCleanerListScreen(stateSource = MutableStateFlow(state))
+            }
+        }
+    }
+
+    @Test
+    fun `loading state shows no rows or empty marker`() {
+        composeRule.setListScreen(SystemCleanerListViewModel.State(rows = null))
+
+        // "Empty" placeholder must not appear during loading.
+        composeRule.onAllNodesWithText("Empty").assertCountEquals(0)
+        // Tool name from the top bar is always visible.
+        composeRule.onNodeWithText("SystemCleaner").assertExists()
+    }
+
+    @Test
+    fun `empty state shows the Empty placeholder`() {
+        composeRule.setListScreen(SystemCleanerListViewModel.State(rows = emptyList()))
+
+        composeRule.onNodeWithText("Empty").assertExists()
+    }
+
+    @Test
+    fun `populated state renders rows by filter label`() {
+        composeRule.setListScreen(
+            SystemCleanerListViewModel.State(
+                rows = listOf(
+                    previewSystemCleanerRow(content = previewFilterContent(identifier = "alpha", label = "Alpha filter")),
+                    previewSystemCleanerRow(content = previewFilterContent(identifier = "beta", label = "Beta filter")),
+                ),
+            ),
+        )
+
+        composeRule.onNodeWithText("Alpha filter").assertExists()
+        composeRule.onNodeWithText("Beta filter").assertExists()
+        composeRule.onAllNodesWithText("Empty").assertCountEquals(0)
+    }
+
+    @Test
+    fun `long-press on row enters selection mode and shows selection top bar`() {
+        composeRule.setListScreen(
+            SystemCleanerListViewModel.State(
+                rows = listOf(
+                    previewSystemCleanerRow(content = previewFilterContent(identifier = "a", label = "A row")),
+                    previewSystemCleanerRow(content = previewFilterContent(identifier = "b", label = "B row")),
+                ),
+            ),
+        )
+
+        // Before long-press: tool-name top bar visible, no selection top bar.
+        composeRule.onNodeWithText("SystemCleaner").assertExists()
+
+        composeRule.onNodeWithText("A row").performTouchInput { longClick() }
+
+        // After long-press the selection top bar appears. Its actions use stable content
+        // descriptions — "Delete" is the most identifying.
+        composeRule.onAllNodesWithContentDescription("Delete selected").fetchSemanticsNodes().size.let {
+            if (it == 0) throw AssertionError("Expected Delete action visible after long-press")
+        }
+    }
+
+    @Test
+    fun `selection clear action exits selection mode`() {
+        composeRule.setListScreen(
+            SystemCleanerListViewModel.State(
+                rows = listOf(
+                    previewSystemCleanerRow(content = previewFilterContent(identifier = "a", label = "A row")),
+                ),
+            ),
+        )
+        composeRule.onNodeWithText("A row").performTouchInput { longClick() }
+        // Clear-action button is exposed with the "Close" content description from
+        // SdmSelectionTopAppBar.kt:58 (general_close_action).
+        composeRule.onNodeWithContentDescription("Close").performClick()
+
+        // After clearing, the regular top bar with tool name should be back.
+        composeRule.onNodeWithText("SystemCleaner").assertExists()
+        // "Delete selected" action should no longer be visible.
+        composeRule.onAllNodesWithContentDescription("Delete selected").assertCountEquals(0)
+    }
+
+    @Test
+    fun `select-all action visible only with partial selection`() {
+        composeRule.setListScreen(
+            SystemCleanerListViewModel.State(
+                rows = listOf(
+                    previewSystemCleanerRow(content = previewFilterContent(identifier = "a", label = "A row")),
+                    previewSystemCleanerRow(content = previewFilterContent(identifier = "b", label = "B row")),
+                ),
+            ),
+        )
+        // Partial selection: select only A.
+        composeRule.onNodeWithText("A row").performTouchInput { longClick() }
+
+        composeRule.onAllNodesWithContentDescription("Select all").fetchSemanticsNodes().size.let {
+            if (it == 0) throw AssertionError("Expected Select all action visible with partial selection")
+        }
+    }
+}

--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/list/SystemCleanerListViewModelTest.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/list/SystemCleanerListViewModelTest.kt
@@ -3,20 +3,27 @@ package eu.darken.sdmse.systemcleaner.ui.list
 import eu.darken.sdmse.common.files.FileType
 import eu.darken.sdmse.common.files.local.LocalPath
 import eu.darken.sdmse.common.files.local.LocalPathLookup
+import eu.darken.sdmse.common.navigation.NavEvent
 import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
 import eu.darken.sdmse.systemcleaner.core.FilterContent
 import eu.darken.sdmse.systemcleaner.core.SystemCleaner
 import eu.darken.sdmse.systemcleaner.core.filter.SystemCleanerFilter
+import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerProcessingTask
 import eu.darken.sdmse.systemcleaner.ui.preview.previewFilterContent
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
@@ -26,21 +33,61 @@ import java.time.Instant
 
 class SystemCleanerListViewModelTest : BaseTest() {
 
+    private class Harness(
+        val vm: SystemCleanerListViewModel,
+        val systemCleaner: SystemCleaner,
+        val taskSubmitter: TaskSubmitter,
+        val stateFlow: MutableStateFlow<SystemCleaner.State>,
+        val progressFlow: MutableStateFlow<Progress.Data?>,
+    )
+
+    private class CollectedEvents<T>(
+        val list: MutableList<T>,
+        val job: Job,
+    ) {
+        fun cancel() {
+            job.cancel()
+        }
+    }
+
+    private fun CoroutineScope.collectEvents(
+        vm: SystemCleanerListViewModel,
+    ): CollectedEvents<SystemCleanerListViewModel.Event> {
+        val list = mutableListOf<SystemCleanerListViewModel.Event>()
+        val job = launch(start = CoroutineStart.UNDISPATCHED) {
+            vm.events.collect { list.add(it) }
+        }
+        return CollectedEvents(list, job)
+    }
+
+    private fun CoroutineScope.collectNavEvents(
+        vm: SystemCleanerListViewModel,
+    ): CollectedEvents<NavEvent> {
+        val list = mutableListOf<NavEvent>()
+        val job = launch(start = CoroutineStart.UNDISPATCHED) {
+            vm.navEvents.collect { list.add(it) }
+        }
+        return CollectedEvents(list, job)
+    }
+
+    private fun scState(
+        data: SystemCleaner.Data? = null,
+        progress: Progress.Data? = null,
+    ) = SystemCleaner.State(
+        data = data,
+        progress = progress,
+        areSystemFilterAvailable = true,
+    )
+
     private fun harness(
-        filterContents: List<FilterContent>,
-    ): Pair<SystemCleanerListViewModel, SystemCleaner> {
-        val data = SystemCleaner.Data(filterContents = filterContents)
-        val state = MutableStateFlow(
-            SystemCleaner.State(
-                data = data,
-                progress = null,
-                areSystemFilterAvailable = true,
-            ),
-        )
-        val progress = MutableStateFlow<Progress.Data?>(null)
+        filterContents: List<FilterContent>? = emptyList(),
+    ): Harness {
+        val data = filterContents?.let { SystemCleaner.Data(filterContents = it) }
+        val stateFlow = MutableStateFlow(scState(data = data))
+        val progressFlow = MutableStateFlow<Progress.Data?>(null)
         val systemCleaner = mockk<SystemCleaner>(relaxed = true).apply {
-            every { this@apply.state } returns state
-            every { this@apply.progress } returns progress
+            every { this@apply.state } returns stateFlow
+            every { this@apply.progress } returns progressFlow
         }
         val taskSubmitter = mockk<TaskSubmitter>(relaxed = true)
         val vm = SystemCleanerListViewModel(
@@ -48,15 +95,15 @@ class SystemCleanerListViewModelTest : BaseTest() {
             systemCleaner = systemCleaner,
             taskSubmitter = taskSubmitter,
         )
-        return vm to systemCleaner
+        return Harness(vm, systemCleaner, taskSubmitter, stateFlow, progressFlow)
     }
 
-    private fun previewMatch(path: String): SystemCleanerFilter.Match.Deletion =
+    private fun previewMatch(path: String, size: Long = 1024L): SystemCleanerFilter.Match.Deletion =
         SystemCleanerFilter.Match.Deletion(
             lookup = LocalPathLookup(
                 lookedUp = LocalPath.build("storage", "emulated", "0", path),
                 fileType = FileType.FILE,
-                size = 1024L,
+                size = size,
                 modifiedAt = Instant.parse("2026-04-01T12:00:00Z"),
                 target = null,
             ),
@@ -66,6 +113,8 @@ class SystemCleanerListViewModelTest : BaseTest() {
         mockk<SystemCleaner.ExclusionUndo>().apply {
             every { exclusionIds } returns (0 until count).map { "ex-$it" }.toSet()
         }
+
+    // ──────────────────────── exclude tests (existing) ────────────────────────
 
     @Test
     fun `onExcludeSelected aggregates count across multiple live filters`() = runTest2 {
@@ -77,90 +126,202 @@ class SystemCleanerListViewModelTest : BaseTest() {
             identifier = "b",
             items = listOf(previewMatch("b1")),
         )
-        val (vm, systemCleaner) = harness(listOf(filterA, filterB))
+        val h = harness(listOf(filterA, filterB))
 
-        coEvery { systemCleaner.exclude(eq("a"), any()) } returns fakeUndo(2)
-        coEvery { systemCleaner.exclude(eq("b"), any()) } returns fakeUndo(1)
+        coEvery { h.systemCleaner.exclude(eq("a"), any()) } returns fakeUndo(2)
+        coEvery { h.systemCleaner.exclude(eq("b"), any()) } returns fakeUndo(1)
 
-        vm.onExcludeSelected(setOf("a", "b"))
+        h.vm.onExcludeSelected(setOf("a", "b"))
         advanceUntilIdle()
 
-        val event = vm.events.first()
+        val event = h.vm.events.first()
         event.shouldBeInstanceOf<SystemCleanerListViewModel.Event.ExclusionsCreated>()
         event.count shouldBe 3
-        coVerify(exactly = 1) { systemCleaner.exclude(eq("a"), any()) }
-        coVerify(exactly = 1) { systemCleaner.exclude(eq("b"), any()) }
+        coVerify(exactly = 1) { h.systemCleaner.exclude(eq("a"), any()) }
+        coVerify(exactly = 1) { h.systemCleaner.exclude(eq("b"), any()) }
     }
 
     @Test
     fun `onExcludeSelected skips filters that are no longer in state`() = runTest2 {
-        val filterA = previewFilterContent(
-            identifier = "a",
-            items = listOf(previewMatch("a1")),
-        )
-        val (vm, systemCleaner) = harness(listOf(filterA))
+        val filterA = previewFilterContent(identifier = "a", items = listOf(previewMatch("a1")))
+        val h = harness(listOf(filterA))
 
-        coEvery { systemCleaner.exclude(eq("a"), any()) } returns fakeUndo(1)
+        coEvery { h.systemCleaner.exclude(eq("a"), any()) } returns fakeUndo(1)
 
-        vm.onExcludeSelected(setOf("a", "stale"))
+        h.vm.onExcludeSelected(setOf("a", "stale"))
         advanceUntilIdle()
 
-        val event = vm.events.first()
+        val event = h.vm.events.first()
         event.shouldBeInstanceOf<SystemCleanerListViewModel.Event.ExclusionsCreated>()
         event.count shouldBe 1
-        coVerify(exactly = 1) { systemCleaner.exclude(eq("a"), any()) }
-        coVerify(exactly = 0) { systemCleaner.exclude(eq("stale"), any()) }
+        coVerify(exactly = 1) { h.systemCleaner.exclude(eq("a"), any()) }
+        coVerify(exactly = 0) { h.systemCleaner.exclude(eq("stale"), any()) }
     }
 
     @Test
     fun `onExcludeSelected skips filters with no paths`() = runTest2 {
-        val emptyFilter = previewFilterContent(
-            identifier = "empty",
-            items = emptyList(),
-        )
-        val nonEmpty = previewFilterContent(
-            identifier = "non-empty",
-            items = listOf(previewMatch("p1")),
-        )
-        val (vm, systemCleaner) = harness(listOf(emptyFilter, nonEmpty))
+        val emptyFilter = previewFilterContent(identifier = "empty", items = emptyList())
+        val nonEmpty = previewFilterContent(identifier = "non-empty", items = listOf(previewMatch("p1")))
+        val h = harness(listOf(emptyFilter, nonEmpty))
 
-        coEvery { systemCleaner.exclude(eq("non-empty"), any()) } returns fakeUndo(1)
+        coEvery { h.systemCleaner.exclude(eq("non-empty"), any()) } returns fakeUndo(1)
 
-        vm.onExcludeSelected(setOf("empty", "non-empty"))
+        h.vm.onExcludeSelected(setOf("empty", "non-empty"))
         advanceUntilIdle()
 
-        val event = vm.events.first()
+        val event = h.vm.events.first()
         event.shouldBeInstanceOf<SystemCleanerListViewModel.Event.ExclusionsCreated>()
         event.count shouldBe 1
-        coVerify(exactly = 0) { systemCleaner.exclude(eq("empty"), any()) }
-        coVerify(exactly = 1) { systemCleaner.exclude(eq("non-empty"), any()) }
+        coVerify(exactly = 0) { h.systemCleaner.exclude(eq("empty"), any()) }
+        coVerify(exactly = 1) { h.systemCleaner.exclude(eq("non-empty"), any()) }
     }
 
     @Test
     fun `onExcludeSelected does nothing when every selected filter is stale`() = runTest2 {
-        val filterA = previewFilterContent(
-            identifier = "a",
-            items = listOf(previewMatch("a1")),
-        )
-        val (vm, systemCleaner) = harness(listOf(filterA))
-
-        vm.onExcludeSelected(setOf("stale-only"))
+        val h = harness(listOf(previewFilterContent(identifier = "a", items = listOf(previewMatch("a1")))))
+        h.vm.onExcludeSelected(setOf("stale-only"))
         advanceUntilIdle()
-
-        coVerify(exactly = 0) { systemCleaner.exclude(any(), any()) }
+        coVerify(exactly = 0) { h.systemCleaner.exclude(any(), any()) }
     }
 
     @Test
     fun `onExcludeSelected does nothing for an empty selection`() = runTest2 {
-        val filterA = previewFilterContent(
-            identifier = "a",
-            items = listOf(previewMatch("a1")),
-        )
-        val (vm, systemCleaner) = harness(listOf(filterA))
+        val h = harness(listOf(previewFilterContent(identifier = "a", items = listOf(previewMatch("a1")))))
+        h.vm.onExcludeSelected(emptySet())
+        advanceUntilIdle()
+        coVerify(exactly = 0) { h.systemCleaner.exclude(any(), any()) }
+    }
 
-        vm.onExcludeSelected(emptySet())
+    // ──────────────────────── delete + state tests (new) ────────────────────────
+
+    @Test
+    fun `onDeleteSelected does nothing for empty selection`() = runTest2 {
+        val h = harness(listOf(previewFilterContent(identifier = "a", items = listOf(previewMatch("a1")))))
+        val collected = collectEvents(h.vm)
+
+        h.vm.onDeleteSelected(emptySet())
         advanceUntilIdle()
 
-        coVerify(exactly = 0) { systemCleaner.exclude(any(), any()) }
+        collected.list shouldBe emptyList()
+        collected.cancel()
+    }
+
+    @Test
+    fun `onDeleteSelected emits ConfirmDeletion with the selected ids`() = runTest2 {
+        val h = harness(listOf(previewFilterContent(identifier = "a", items = listOf(previewMatch("a1")))))
+
+        h.vm.onDeleteSelected(setOf("a"))
+        advanceUntilIdle()
+
+        val event = h.vm.events.first()
+        event.shouldBeInstanceOf<SystemCleanerListViewModel.Event.ConfirmDeletion>()
+        event.ids shouldBe setOf("a")
+    }
+
+    @Test
+    fun `onRowClick emits ConfirmDeletion with the single row identifier`() = runTest2 {
+        val fc = previewFilterContent(identifier = "row", items = listOf(previewMatch("r1")))
+        val h = harness(listOf(fc))
+        val row = SystemCleanerListViewModel.Row(content = fc)
+
+        h.vm.onRowClick(row)
+        advanceUntilIdle()
+
+        val event = h.vm.events.first()
+        event.shouldBeInstanceOf<SystemCleanerListViewModel.Event.ConfirmDeletion>()
+        event.ids shouldBe setOf("row")
+    }
+
+    @Test
+    fun `onDeleteConfirmed submits ProcessingTask filtered to valid ids only`() = runTest2 {
+        val fc = previewFilterContent(identifier = "valid", items = listOf(previewMatch("v1")))
+        val h = harness(listOf(fc))
+        coEvery {
+            h.taskSubmitter.submit(any<SystemCleanerProcessingTask>())
+        } returns SystemCleanerProcessingTask.Success(affectedSpace = 100L, affectedPaths = emptySet())
+
+        h.vm.onDeleteConfirmed(setOf("valid", "stale"))
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) {
+            h.taskSubmitter.submit(SystemCleanerProcessingTask(targetFilters = setOf("valid")))
+        }
+    }
+
+    @Test
+    fun `onDeleteConfirmed does not submit when no valid ids remain`() = runTest2 {
+        val h = harness(listOf(previewFilterContent(identifier = "live", items = listOf(previewMatch("v1")))))
+
+        h.vm.onDeleteConfirmed(setOf("stale-only"))
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { h.taskSubmitter.submit(any()) }
+    }
+
+    @Test
+    fun `onDeleteConfirmed emits TaskResult event on Success`() = runTest2 {
+        val fc = previewFilterContent(identifier = "tr", items = listOf(previewMatch("t1")))
+        val h = harness(listOf(fc))
+        val success = SystemCleanerProcessingTask.Success(affectedSpace = 250L, affectedPaths = emptySet())
+        coEvery { h.taskSubmitter.submit(any<SystemCleanerProcessingTask>()) } returns success
+
+        h.vm.onDeleteConfirmed(setOf("tr"))
+        advanceUntilIdle()
+
+        val event = h.vm.events.first()
+        event.shouldBeInstanceOf<SystemCleanerListViewModel.Event.TaskResult>()
+        event.result shouldBe success
+    }
+
+    @Test
+    fun `state rows is null when Data is null`() = runTest2 {
+        val h = harness(filterContents = null)
+        h.vm.state.first().rows shouldBe null
+    }
+
+    @Test
+    fun `state rows is empty when filterContents is empty`() = runTest2 {
+        val h = harness(filterContents = emptyList())
+        h.vm.state.first().rows shouldBe emptyList()
+    }
+
+    @Test
+    fun `state rows are sorted by size descending`() = runTest2 {
+        val small = previewFilterContent(identifier = "small", items = listOf(previewMatch("s1", size = 100L)))
+        val large = previewFilterContent(identifier = "large", items = listOf(previewMatch("l1", size = 10_000L)))
+        val medium = previewFilterContent(identifier = "medium", items = listOf(previewMatch("m1", size = 1_000L)))
+        val h = harness(listOf(small, large, medium))
+
+        val rows = h.vm.state.first().rows!!
+
+        rows.map { it.identifier } shouldBe listOf("large", "medium", "small")
+    }
+
+    @Test
+    fun `init navigates up when Data drains from non-empty to empty filterContents`() = runTest2 {
+        val fc = previewFilterContent(identifier = "f", items = listOf(previewMatch("a")))
+        val h = harness(listOf(fc))
+
+        // drop(1) skips replay; second emission with empty filterContents triggers navUp.
+        h.stateFlow.value = scState(data = SystemCleaner.Data(filterContents = emptyList()))
+        advanceUntilIdle()
+
+        h.vm.navEvents.first() shouldBe NavEvent.Up
+    }
+
+    @Test
+    fun `init navigates up when Data transitions from non-empty to null`() = runTest2 {
+        // BUG-FIXME-9: SystemCleanerListViewModel's drain filter at lines 40-45 uses the
+        // `hasData` extension which returns `false` for `null`. That means a fresh scan
+        // (which sets internalData = null) triggers navUp during loading. The fix would be
+        // to use `mapNotNull { it.data }` like FilterContentDetailsViewModel does. Until then
+        // this test locks in current behavior.
+        val fc = previewFilterContent(identifier = "f", items = listOf(previewMatch("a")))
+        val h = harness(listOf(fc))
+
+        h.stateFlow.value = scState(data = null)
+        advanceUntilIdle()
+
+        h.vm.navEvents.first() shouldBe NavEvent.Up
     }
 }

--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/settings/SystemCleanerSettingsScreenTest.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/settings/SystemCleanerSettingsScreenTest.kt
@@ -1,0 +1,125 @@
+package eu.darken.sdmse.systemcleaner.ui.settings
+
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.hasScrollAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+
+class SystemCleanerSettingsScreenTest : BaseComposeRobolectricTest() {
+
+    private fun ComposeContentTestRule.setSettingsScreen(
+        state: SystemCleanerSettingsViewModel.State,
+        onScreenshotsAgeSaved: (java.time.Duration) -> Unit = {},
+        onRootFilterBadgeClick: () -> Unit = {},
+    ) {
+        setContent {
+            PreviewWrapper {
+                SystemCleanerSettingsScreen(
+                    state = state,
+                    onScreenshotsAgeSaved = onScreenshotsAgeSaved,
+                    onRootFilterBadgeClick = onRootFilterBadgeClick,
+                )
+            }
+        }
+    }
+
+    // The settings screen uses a LazyColumn; rows below the viewport aren't composed until
+    // scrolled into view.
+    private fun ComposeContentTestRule.scrollToText(text: String) {
+        this.onNode(hasScrollAction()).performScrollToNode(hasText(text))
+    }
+
+    @Test
+    fun `top bar shows the SystemCleaner title`() {
+        composeRule.setSettingsScreen(SystemCleanerSettingsViewModel.State())
+
+        composeRule.onNodeWithText("SystemCleaner").assertExists()
+    }
+
+    @Test
+    fun `superfluous APKs sub-row hidden when filter is off`() {
+        composeRule.setSettingsScreen(
+            SystemCleanerSettingsViewModel.State(filterSuperfluosApks = false),
+        )
+
+        // The "Include same version" row is conditional on filterSuperfluosApks. When the
+        // parent toggle is off, this row should not be rendered at all.
+        composeRule.onAllNodesWithText("Include same version").assertCountEquals(0)
+    }
+
+    @Test
+    fun `superfluous APKs sub-row visible when filter is on`() {
+        composeRule.setSettingsScreen(
+            SystemCleanerSettingsViewModel.State(filterSuperfluosApks = true),
+        )
+
+        composeRule.scrollToText("Include same version")
+        composeRule.onNodeWithText("Include same version").assertExists()
+    }
+
+    @Test
+    fun `screenshots age row hidden when screenshots filter is off`() {
+        composeRule.setSettingsScreen(
+            SystemCleanerSettingsViewModel.State(filterScreenshots = false),
+        )
+
+        composeRule.onAllNodesWithText("Screenshot Age").assertCountEquals(0)
+    }
+
+    @Test
+    fun `screenshots age row visible when screenshots filter is on`() {
+        composeRule.setSettingsScreen(
+            SystemCleanerSettingsViewModel.State(filterScreenshots = true),
+        )
+
+        composeRule.scrollToText("Screenshot Age")
+        composeRule.onNodeWithText("Screenshot Age").assertExists()
+    }
+
+    @Test
+    fun `root-gated row shows Set up badge when root is unavailable`() {
+        // ANR is the first root-gated filter (first item in the "specific filters" category).
+        // When areSystemFilterAvailable=false, the row renders a "Set up" badge over its switch.
+        composeRule.setSettingsScreen(
+            SystemCleanerSettingsViewModel.State(
+                areSystemFilterAvailable = false,
+                filterAnr = false,
+            ),
+        )
+
+        // Scroll to the ANR row title so it's composed.
+        composeRule.scrollToText("ANR errors")
+        // The badge icon's content description is the localized "Set up" string from
+        // SettingsBadgedSwitchItem. Multiple gated rows render the badge so we expect ≥ 1.
+        composeRule.onAllNodesWithContentDescription("Set up").fetchSemanticsNodes().size.let {
+            if (it == 0) throw AssertionError("Expected at least one Set up badge visible")
+        }
+    }
+
+    @Test
+    fun `root-gated row badge tap invokes onRootFilterBadgeClick callback`() {
+        var badgeClicks = 0
+        composeRule.setSettingsScreen(
+            state = SystemCleanerSettingsViewModel.State(
+                areSystemFilterAvailable = false,
+                filterAnr = false,
+            ),
+            onRootFilterBadgeClick = { badgeClicks++ },
+        )
+
+        // Scroll to and tap the ANR row title — when gated, tapping the row routes to
+        // `onBadgeClick` (badgeClick takes the row click instead of toggling the switch).
+        composeRule.scrollToText("ANR errors")
+        composeRule.onNodeWithText("ANR errors").performClick()
+
+        if (badgeClicks < 1) throw AssertionError("Expected badge click to fire, got $badgeClicks")
+    }
+}

--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/settings/SystemCleanerSettingsViewModelTest.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/settings/SystemCleanerSettingsViewModelTest.kt
@@ -1,0 +1,306 @@
+package eu.darken.sdmse.systemcleaner.ui.settings
+
+import eu.darken.sdmse.common.datastore.DataStoreValue
+import eu.darken.sdmse.common.navigation.NavEvent
+import eu.darken.sdmse.common.navigation.routes.CustomFilterListRoute
+import eu.darken.sdmse.common.progress.Progress
+import eu.darken.sdmse.common.upgrade.UpgradeRepo
+import eu.darken.sdmse.setup.SetupRoute
+import eu.darken.sdmse.systemcleaner.core.SystemCleaner
+import eu.darken.sdmse.systemcleaner.core.SystemCleanerSettings
+import eu.darken.sdmse.systemcleaner.core.rwDataStoreValue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import testhelpers.coroutine.runTest2
+import java.time.Duration
+
+class SystemCleanerSettingsViewModelTest : BaseTest() {
+
+    private class Values(
+        val filterLogFiles: DataStoreValue<Boolean>,
+        val filterAdvertisements: DataStoreValue<Boolean>,
+        val filterEmptyDirectories: DataStoreValue<Boolean>,
+        val filterSuperfluosApks: DataStoreValue<Boolean>,
+        val filterSuperfluosApksIncludeSameVersion: DataStoreValue<Boolean>,
+        val filterTrashed: DataStoreValue<Boolean>,
+        val filterScreenshots: DataStoreValue<Boolean>,
+        val filterLostDir: DataStoreValue<Boolean>,
+        val filterLinuxFiles: DataStoreValue<Boolean>,
+        val filterMacFiles: DataStoreValue<Boolean>,
+        val filterWindowsFiles: DataStoreValue<Boolean>,
+        val filterTempFiles: DataStoreValue<Boolean>,
+        val filterThumbnails: DataStoreValue<Boolean>,
+        val filterAnalytics: DataStoreValue<Boolean>,
+        val filterAnr: DataStoreValue<Boolean>,
+        val filterLocalTmp: DataStoreValue<Boolean>,
+        val filterDownloadCache: DataStoreValue<Boolean>,
+        val filterDataLogger: DataStoreValue<Boolean>,
+        val filterLogDropbox: DataStoreValue<Boolean>,
+        val filterRecentTasks: DataStoreValue<Boolean>,
+        val filterTombstones: DataStoreValue<Boolean>,
+        val filterUsageStats: DataStoreValue<Boolean>,
+        val filterPackageCache: DataStoreValue<Boolean>,
+        val filterScreenshotsAge: DataStoreValue<Duration>,
+    )
+
+    private class Harness(
+        val vm: SystemCleanerSettingsViewModel,
+        val settings: SystemCleanerSettings,
+        val values: Values,
+    )
+
+    private fun buildHarness(
+        rooted: Boolean = false,
+        isPro: Boolean = false,
+        filterLogFiles: Boolean = true,
+        filterAdvertisements: Boolean = true,
+        filterEmptyDirectories: Boolean = true,
+        filterSuperfluosApks: Boolean = false,
+        filterSuperfluosApksIncludeSameVersion: Boolean = true,
+        filterTrashed: Boolean = false,
+        filterScreenshots: Boolean = false,
+        filterLostDir: Boolean = true,
+        filterLinuxFiles: Boolean = true,
+        filterMacFiles: Boolean = true,
+        filterWindowsFiles: Boolean = true,
+        filterTempFiles: Boolean = true,
+        filterThumbnails: Boolean = false,
+        filterAnalytics: Boolean = true,
+        filterAnr: Boolean = true,
+        filterLocalTmp: Boolean = false,
+        filterDownloadCache: Boolean = true,
+        filterDataLogger: Boolean = true,
+        filterLogDropbox: Boolean = true,
+        filterRecentTasks: Boolean = false,
+        filterTombstones: Boolean = false,
+        filterUsageStats: Boolean = false,
+        filterPackageCache: Boolean = false,
+        screenshotsAge: Duration = SystemCleanerSettings.SCREENSHOTS_AGE_DEFAULT,
+    ): Harness {
+        val values = Values(
+            filterLogFiles = rwDataStoreValue(filterLogFiles),
+            filterAdvertisements = rwDataStoreValue(filterAdvertisements),
+            filterEmptyDirectories = rwDataStoreValue(filterEmptyDirectories),
+            filterSuperfluosApks = rwDataStoreValue(filterSuperfluosApks),
+            filterSuperfluosApksIncludeSameVersion = rwDataStoreValue(filterSuperfluosApksIncludeSameVersion),
+            filterTrashed = rwDataStoreValue(filterTrashed),
+            filterScreenshots = rwDataStoreValue(filterScreenshots),
+            filterLostDir = rwDataStoreValue(filterLostDir),
+            filterLinuxFiles = rwDataStoreValue(filterLinuxFiles),
+            filterMacFiles = rwDataStoreValue(filterMacFiles),
+            filterWindowsFiles = rwDataStoreValue(filterWindowsFiles),
+            filterTempFiles = rwDataStoreValue(filterTempFiles),
+            filterThumbnails = rwDataStoreValue(filterThumbnails),
+            filterAnalytics = rwDataStoreValue(filterAnalytics),
+            filterAnr = rwDataStoreValue(filterAnr),
+            filterLocalTmp = rwDataStoreValue(filterLocalTmp),
+            filterDownloadCache = rwDataStoreValue(filterDownloadCache),
+            filterDataLogger = rwDataStoreValue(filterDataLogger),
+            filterLogDropbox = rwDataStoreValue(filterLogDropbox),
+            filterRecentTasks = rwDataStoreValue(filterRecentTasks),
+            filterTombstones = rwDataStoreValue(filterTombstones),
+            filterUsageStats = rwDataStoreValue(filterUsageStats),
+            filterPackageCache = rwDataStoreValue(filterPackageCache),
+            filterScreenshotsAge = rwDataStoreValue(screenshotsAge),
+        )
+        val settings = mockk<SystemCleanerSettings>().apply {
+            every { filterLogFilesEnabled } returns values.filterLogFiles
+            every { filterAdvertisementsEnabled } returns values.filterAdvertisements
+            every { filterEmptyDirectoriesEnabled } returns values.filterEmptyDirectories
+            every { filterSuperfluosApksEnabled } returns values.filterSuperfluosApks
+            every { this@apply.filterSuperfluosApksIncludeSameVersion } returns values.filterSuperfluosApksIncludeSameVersion
+            every { filterTrashedEnabled } returns values.filterTrashed
+            every { filterScreenshotsEnabled } returns values.filterScreenshots
+            every { filterLostDirEnabled } returns values.filterLostDir
+            every { filterLinuxFilesEnabled } returns values.filterLinuxFiles
+            every { filterMacFilesEnabled } returns values.filterMacFiles
+            every { filterWindowsFilesEnabled } returns values.filterWindowsFiles
+            every { filterTempFilesEnabled } returns values.filterTempFiles
+            every { filterThumbnailsEnabled } returns values.filterThumbnails
+            every { filterAnalyticsEnabled } returns values.filterAnalytics
+            every { filterAnrEnabled } returns values.filterAnr
+            every { filterLocalTmpEnabled } returns values.filterLocalTmp
+            every { filterDownloadCacheEnabled } returns values.filterDownloadCache
+            every { filterDataLoggerEnabled } returns values.filterDataLogger
+            every { filterLogDropboxEnabled } returns values.filterLogDropbox
+            every { filterRecentTasksEnabled } returns values.filterRecentTasks
+            every { filterTombstonesEnabled } returns values.filterTombstones
+            every { filterUsageStatsEnabled } returns values.filterUsageStats
+            every { filterPackageCacheEnabled } returns values.filterPackageCache
+            every { this@apply.filterScreenshotsAge } returns values.filterScreenshotsAge
+        }
+        val systemCleaner = mockk<SystemCleaner>(relaxed = true).apply {
+            every { state } returns MutableStateFlow(
+                SystemCleaner.State(
+                    data = null,
+                    progress = null as Progress.Data?,
+                    areSystemFilterAvailable = rooted,
+                ),
+            )
+        }
+        val upgradeRepo = mockk<UpgradeRepo>().apply {
+            every { upgradeInfo } returns flowOf(
+                mockk<UpgradeRepo.Info>().apply { every { this@apply.isPro } returns isPro },
+            )
+        }
+        val vm = SystemCleanerSettingsViewModel(
+            dispatcherProvider = TestDispatcherProvider(),
+            upgradeRepo = upgradeRepo,
+            systemCleaner = systemCleaner,
+            settings = settings,
+        )
+        return Harness(vm, settings, values)
+    }
+
+    @Test
+    fun `state propagates all 23 filter booleans from settings`() = runTest2 {
+        val h = buildHarness(
+            filterLogFiles = false,
+            filterAdvertisements = false,
+            filterEmptyDirectories = false,
+            filterSuperfluosApks = true,
+            filterSuperfluosApksIncludeSameVersion = false,
+            filterTrashed = true,
+            filterScreenshots = true,
+            filterLostDir = false,
+            filterLinuxFiles = false,
+            filterMacFiles = false,
+            filterWindowsFiles = false,
+            filterTempFiles = false,
+            filterThumbnails = true,
+            filterAnalytics = false,
+            filterAnr = false,
+            filterLocalTmp = true,
+            filterDownloadCache = false,
+            filterDataLogger = false,
+            filterLogDropbox = false,
+            filterRecentTasks = true,
+            filterTombstones = true,
+            filterUsageStats = true,
+            filterPackageCache = true,
+        )
+
+        val state = h.vm.state.first()
+
+        state.filterLogFiles shouldBe false
+        state.filterAdvertisements shouldBe false
+        state.filterEmptyDirectories shouldBe false
+        state.filterSuperfluosApks shouldBe true
+        state.filterSuperfluosApksIncludeSameVersion shouldBe false
+        state.filterTrashed shouldBe true
+        state.filterScreenshots shouldBe true
+        state.filterLostDir shouldBe false
+        state.filterLinuxFiles shouldBe false
+        state.filterMacFiles shouldBe false
+        state.filterWindowsFiles shouldBe false
+        state.filterTempFiles shouldBe false
+        state.filterThumbnails shouldBe true
+        state.filterAnalytics shouldBe false
+        state.filterAnr shouldBe false
+        state.filterLocalTmp shouldBe true
+        state.filterDownloadCache shouldBe false
+        state.filterDataLogger shouldBe false
+        state.filterLogDropbox shouldBe false
+        state.filterRecentTasks shouldBe true
+        state.filterTombstones shouldBe true
+        state.filterUsageStats shouldBe true
+        state.filterPackageCache shouldBe true
+    }
+
+    @Test
+    fun `state propagates areSystemFilterAvailable from systemCleaner state`() = runTest2 {
+        buildHarness(rooted = true).vm.state.first().areSystemFilterAvailable shouldBe true
+        buildHarness(rooted = false).vm.state.first().areSystemFilterAvailable shouldBe false
+    }
+
+    @Test
+    fun `state propagates screenshotsAge from settings`() = runTest2 {
+        val customAge = Duration.ofDays(30)
+        buildHarness(screenshotsAge = customAge).vm.state.first().screenshotsAge shouldBe customAge
+    }
+
+    @Test
+    fun `state propagates isPro from upgradeRepo`() = runTest2 {
+        buildHarness(isPro = true).vm.state.first().isPro shouldBe true
+        buildHarness(isPro = false).vm.state.first().isPro shouldBe false
+    }
+
+    @Test
+    fun `setFilterLogFiles writes through to DataStore`() = runTest2 {
+        val h = buildHarness()
+        h.vm.setFilterLogFiles(false)
+        advanceUntilIdle()
+        coVerify(exactly = 1) { h.values.filterLogFiles.update(any()) }
+    }
+
+    @Test
+    fun `setFilterTrashed writes through to DataStore - representative generic toggle`() = runTest2 {
+        val h = buildHarness()
+        h.vm.setFilterTrashed(true)
+        advanceUntilIdle()
+        coVerify(exactly = 1) { h.values.filterTrashed.update(any()) }
+    }
+
+    @Test
+    fun `setFilterAnr writes through to DataStore - representative root-gated toggle`() = runTest2 {
+        val h = buildHarness()
+        h.vm.setFilterAnr(false)
+        advanceUntilIdle()
+        coVerify(exactly = 1) { h.values.filterAnr.update(any()) }
+    }
+
+    @Test
+    fun `setFilterSuperfluosApksIncludeSameVersion writes through to DataStore`() = runTest2 {
+        // Conditional sub-row: only visible in the screen when filterSuperfluosApks is true.
+        val h = buildHarness()
+        h.vm.setFilterSuperfluosApksIncludeSameVersion(false)
+        advanceUntilIdle()
+        coVerify(exactly = 1) { h.values.filterSuperfluosApksIncludeSameVersion.update(any()) }
+    }
+
+    @Test
+    fun `setFilterScreenshotsAge writes through to DataStore`() = runTest2 {
+        val h = buildHarness()
+        h.vm.setFilterScreenshotsAge(Duration.ofDays(7))
+        advanceUntilIdle()
+        coVerify(exactly = 1) { h.values.filterScreenshotsAge.update(any()) }
+    }
+
+    @Test
+    fun `resetFilterScreenshotsAge writes the default through to DataStore`() = runTest2 {
+        val h = buildHarness()
+        h.vm.resetFilterScreenshotsAge()
+        advanceUntilIdle()
+        coVerify(exactly = 1) { h.values.filterScreenshotsAge.update(any()) }
+    }
+
+    @Test
+    fun `onCustomFiltersClick navigates to CustomFilterListRoute`() = runTest2 {
+        val h = buildHarness()
+        h.vm.onCustomFiltersClick()
+        advanceUntilIdle()
+        val event = h.vm.navEvents.first()
+        event.shouldBeInstanceOf<NavEvent.GoTo>()
+        event.destination shouldBe CustomFilterListRoute
+    }
+
+    @Test
+    fun `onRootFilterBadgeClick navigates to SetupRoute with ROOT typeFilter`() = runTest2 {
+        val h = buildHarness()
+        h.vm.onRootFilterBadgeClick()
+        advanceUntilIdle()
+        val event = h.vm.navEvents.first()
+        event.shouldBeInstanceOf<NavEvent.GoTo>()
+        event.destination.shouldBeInstanceOf<SetupRoute>()
+    }
+}


### PR DESCRIPTION
## What changed

Adds comprehensive test coverage to the SystemCleaner tool, mirroring the pattern used in the recent CorpseFinder test pass (#PR for d9901e6dc). 305 module tests in total now (up from ~140), spanning engine orchestration, all five ViewModels, all five Compose screens, and the custom-filter persistence subsystem.

Nine pre-existing bug-smells found during writing are documented as **`BUG-FIXME-N`-tagged regression tests** that lock in current (sometimes buggy) behavior — per scope agreement, fixes are deferred to follow-up PRs. The fix should flip the corresponding test.

No user-facing behavior change in this PR — test-only additions.

## Technical Context

### Coverage added

| Bucket | Files | New tests |
|---|---|---|
| Shared fixtures | `core/SystemCleanerTestFixtures.kt` | (helpers only) |
| Engine | `core/SystemCleanerScanTest` (7), `core/SystemCleanerProcessingTest` (10), `core/SystemCleanerExclusionTest` (9), `core/SystemCleanerExtensionsTest` (3), `core/FilterContentTest` (5), `core/filter/FilterSourceTest` (4) | 38 |
| ViewModel | `ui/list/SystemCleanerListViewModelTest` (5 → 16), `ui/details/FilterContentDetailsViewModelTest` (19), `ui/settings/SystemCleanerSettingsViewModelTest` (12), `ui/customfilter/list/CustomFilterListViewModelTest` (14), `ui/customfilter/editor/CustomFilterEditorViewModelTest` (22) | 83 |
| Compose Screen | `ui/list/SystemCleanerListScreenTest` (6), `ui/details/FilterContentDetailsScreenTest` (3), `ui/settings/SystemCleanerSettingsScreenTest` (7), `ui/customfilter/list/CustomFilterListScreenTest` (6), `ui/customfilter/editor/CustomFilterEditorScreenTest` (4 → 7) | 25 |
| Custom-filter subsystem | `core/filter/custom/CustomFilterTest` (6), `core/filter/custom/EditorOptionsCreatorTest` (6), `core/filter/custom/CustomFilterExtensionsTest` (6), `core/filter/custom/CustomFilterRepoTest` (12) | 30 |

### BUG-FIXME tests (9 pre-existing bugs, all locked in by regression tests)

Each FIXME-tagged test has an in-code comment with the marker. When a fix lands, the corresponding test flips:

1. **BUG-FIXME-1** — `SystemCleanerScanTask.pkgIdFilter` and `isWatcherTask` are accepted but never read by `performScan`. Dead-field state analogous to CorpseFinder's pre-fix #3.
2. **BUG-FIXME-2** — `SystemCleanerProcessingTask` has no `init { require(targetContent == null || targetFilters != null) }` guard. With `targetFilters=null + targetContent=non-null`, `targetContent` smears across every filter in the snapshot, not just the user's selection.
3. **BUG-FIXME-3** — `SystemCleaner.exclude(identifier, paths)` uses the `identifier` param only for logging (`SystemCleaner.kt:241`). The pruning loop at lines 252-254 iterates ALL `filterContents` and removes matching paths from every one. If two filters share a path, both get pruned when only one was named.
4. **BUG-FIXME-4** — `FilterContentDetailsViewModel.onExcludeFilter` emits `ExclusionsCreated(count=0)` when `save()` returns no IDs. List VM has a `if (totalExclusions == 0) return@launch` guard; details VM does not. Asymmetric.
5. **BUG-FIXME-5** — `CustomFilterEditorViewModel.save()` does not check `canSave`. A direct VM call saves underdefined/empty-label configs. The Compose screen gates the Save action behind `canSave`; UI is the only safety net.
6. **BUG-FIXME-6** — `CustomFilterRepo.kt:61` calls `json.decodeFromString` without try/catch. A single corrupt `.json` file kills the entire `configs` flow until `refresh()` is called, silently hiding all filters from the UI.
7. **BUG-FIXME-7** — `CustomFilterRepo.kt:49` does `filterDir.listFiles()!!`. The lazy initializer at lines 36-38 calls `mkdirs()` but ignores its return value — if `filesDir` is a regular file (or the path is otherwise uncreatable), `listFiles()` returns null and `!!` throws NPE on every `configs` collection.
8. **BUG-FIXME-8** — `CustomFilterConfig.isUnderdefined` checks only `pathCriteria` and `nameCriteria`. A regex-only config (`pathRegexes` set, everything else null) is still considered underdefined, which means the editor's `canSave` rejects it. Regex-only filters cannot be saved despite the sieve being able to match them.
9. **BUG-FIXME-9** — `SystemCleanerListViewModel.kt:40-45` uses the `hasData` extension which returns `false` for `null`. A scan-restart that sets `internalData = null` (loading state) triggers `navUp()` mid-scan. `FilterContentDetailsViewModel.kt:53` already has the `mapNotNull { it.data }` fix; the list VM was missed.

### Bottom-up implementation order (each layer green before moving on)

Engine fixtures → trivial pure tests → SystemCleanerScan/Processing/Exclusion + FilterSource → list VM extension → 4 remaining VMs → 4 new + 1 extended Screen test → 3 small custom-filter unit tests → CustomFilterRepoTest. Full module run at the end (305/305 pass).

### Out of scope (intentional)

- **SystemCrawler integration tests** — filter-set first-match race, area orchestration, exclusion second pass require real `APathGateway` / `FileForensics` mocking that exceeds the parity goal. Engine tests mock the crawler.
- **Live-search in `CustomFilterEditorViewModel`** — `callbackFlow` + crawler interaction is genuinely hard to unit-test productively.
- **Bug fixes** — per scope agreement, the 9 BUG-FIXME findings are documented in tests for follow-up, not fixed in this PR.
- **Source changes outside `app-tool-systemcleaner/src/test/`** — zero blast radius outside the module's test source set.

### Review guidance

- The shared `SystemCleanerTestFixtures.kt` `SystemCleanerHarness` is reused by all three engine test files — engine tests are tied together by this harness.
- `CustomFilterEditorViewModelTest` mocks `CustomFilterEditorRoute.Companion.from()` via `mockkObject` because `SavedStateHandle.toRoute<>()` requires real `android.os.Bundle` and crashes in pure JVM tests. `@AfterEach` unmocks.
- The `rwDataStoreValue` helper in shared fixtures stubs both `.flow` (read) and `.update(...)` (write) for `DataStoreValue` mocks. The shared `mockDataStoreValue` stubs only `.flow`; the new helper is documented in the recently-updated `.claude/rules/testing.md`.
- The list VM test for BUG-FIXME-9 is a regression-direction test — if you fix the navUp bug, this test will fail and should be flipped to assert the fixed behavior.