### PR TITLE
General: Document PR labeling guidelines

### DIFF
--- a/.claude/rules/commit-guidelines.md
+++ b/.claude/rules/commit-guidelines.md
@@ -94,6 +94,24 @@ Fixed a crash that could happen when browsing files on devices without root or A
 - Narrowing `catch(Exception)` to `catch(IOException)` changes behavior: `CancellationException` is no longer silently swallowed, which is correct but may surface previously-hidden cancellation bugs
 ```
 
+## Pull Request Labels
+
+Apply labels that match the change. Run `gh label list` to see what's available — do not invent new labels.
+
+- **Component labels** (`c: AppCleaner`, `c: CorpseFinder`, `c: SystemCleaner`, `c: Deduplicator`, `c: StorageAnalyzer`,
+  `c: AppControl`, `c: Scheduler`, `c: IO`, `c: PKGS`, `c: CSI`, `c: Exclusions`, `c: Setup`, `c: Stats`, `c: Debug`,
+  `c: ClutterDB`): apply for every tool/module the PR touches, not just the one in the title prefix
+- **Type labels**: `bug` for fixes, `enhancement` for new features/improvements, `Chore` for refactors/tests/cleanup,
+  `documentation` for docs-only changes
+- **Platform/scope labels**: `Root`, `ADB`, `SAF`, `Automation`, `FOSS`, `Google Play`, `Translation`, `Build process`,
+  `General UI/UX`, `MOTD` — apply when the PR specifically targets that area
+- **Device-specific labels**: `Device specific` plus the relevant ROM label (`ROM: OneUI`, `ROM: LOS`, `ROM: MIUI`,
+  `ROM: OxygenOS`, `ROM: Android TV`) when fixing manufacturer/ROM-specific behavior
+- **API level labels** (`api: 26 A8.0 (Oreo)` through `api: 35 A15 (Vanilla Ice Cream)`): apply when the change targets
+  behavior specific to certain Android versions
+
+Skip labels that don't fit. A PR with no matching labels is fine — better than wrong labels.
+
 ## Conventions
 
 - **Issue references**: Use "Closes #123", "Fixes #123", or "Resolves #123"


### PR DESCRIPTION
## What changed

No user-facing behavior change. Adds a "Pull Request Labels" section to `.claude/rules/commit-guidelines.md` so contributors (and AI assistants) know which GitHub labels to apply to PRs.

## Technical Context

- The repo has a rich label taxonomy (`c: *` per component, ROM-specific, API levels, `bug`/`Chore`/`enhancement`, etc.) but it was applied inconsistently across recent PRs — some merged PRs had no labels at all.
- The guideline points at `gh label list` as the source of truth instead of enumerating every label inline, so it stays accurate as labels are added/removed.
- Explicit "no labels is fine" clause to discourage forcing wrong labels just to have one.
