### PR TITLE
Automation: Recover ACS enabling on ROMs that block app-initiated writes

### DIFF
--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/AcsActivator.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/AcsActivator.kt
@@ -78,10 +78,24 @@ class AcsActivator(
         }
     }
 
+    /** How a service-list write should be performed (used for disable / re-toggle). */
+    enum class WriteStrategy { DIRECT, SHELL, SKIP }
+
     companion object {
         private val TAG = logTag("Automation", "AcsActivator")
 
         private const val DEFAULT_BIND_TIMEOUT_MS = 10 * 1000L
+
+        /**
+         * On a build flagged as direct-write-unreliable we must NEVER write via our own process (it can
+         * silently wipe unrelated third-party services). So when no privileged shell is available there,
+         * the only safe option is to [WriteStrategy.SKIP] the write rather than fall back to a direct one.
+         */
+        internal fun writeStrategy(avoidDirectWrite: Boolean, hasShell: Boolean): WriteStrategy = when {
+            !avoidDirectWrite -> WriteStrategy.DIRECT
+            hasShell -> WriteStrategy.SHELL
+            else -> WriteStrategy.SKIP
+        }
 
         /** A write achieves the intent when every intended component is present (extras are fine). */
         internal fun writeMatchesIntent(intent: Set<ComponentName>, actual: Set<ComponentName>): Boolean =

--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/AcsActivator.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/AcsActivator.kt
@@ -1,0 +1,102 @@
+package eu.darken.sdmse.automation.core
+
+import android.content.ComponentName
+import android.provider.Settings
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.shell.ShellOps
+
+/**
+ * Orchestrates enabling our [AutomationService] and waiting for it to actually bind.
+ *
+ * The decision logic lives here (behind the [Io] seam) so it can be unit-tested without the heavy
+ * [AutomationManager] dependency graph. [AutomationManager] provides the real [Io] implementation.
+ *
+ * Two ROM failure modes are handled (both observed on WAIPU TV / Android 14):
+ * - **Mode A**: an app-initiated write to `enabled_accessibility_services` is silently reverted (the
+ *   value never persists, sometimes wiping unrelated third-party services too).
+ * - **Mode B**: the value persists but the system never binds the service.
+ *
+ * Both surface as "the service didn't come up", so the privileged-shell fallback is triggered by the
+ * bind result, not merely by whether the value persisted. At most one direct + one shell attempt.
+ */
+class AcsActivator(
+    private val io: Io,
+    private val bindTimeoutMs: Long = DEFAULT_BIND_TIMEOUT_MS,
+) {
+
+    interface Io {
+        suspend fun shellMode(): ShellOps.Mode?
+        suspend fun isAvoidDirectWrite(): Boolean
+        suspend fun markDirectWriteUnreliable()
+
+        /** Writes the list via our own process and returns the post-write readback. */
+        suspend fun writeDirect(services: Set<ComponentName>): Set<ComponentName>
+
+        /** Writes the list via the privileged shell. Returns whether the intended list persisted. */
+        suspend fun writeShell(services: Set<ComponentName>, mode: ShellOps.Mode): Boolean
+
+        /** Waits up to [timeoutMs] for the service to bind. Returns the handle, or null on timeout. */
+        suspend fun awaitBound(timeoutMs: Long): AutomationServiceHandle?
+    }
+
+    /**
+     * @param intended the full desired service list (incl. any third-party services that were already
+     * enabled), so a Mode A wipe is repaired rather than dropping other apps' services.
+     */
+    suspend fun enable(intended: Set<ComponentName>): AutomationServiceHandle? {
+        val mode = io.shellMode()
+
+        if (io.isAvoidDirectWrite()) {
+            log(TAG, WARN) { "enable(): Direct write known-unreliable for this build, using shell directly" }
+            if (mode == null) {
+                log(TAG, WARN) { "enable(): No privileged shell available, cannot enable" }
+                return null
+            }
+            return if (io.writeShell(intended, mode)) io.awaitBound(bindTimeoutMs) else null
+        }
+
+        val afterDirect = io.writeDirect(intended)
+        if (!writeMatchesIntent(intent = intended, actual = afterDirect)) {
+            // Mode A: the write was reverted (often wiping unrelated third-party services too).
+            log(TAG, WARN) { "enable(): Direct write was reverted (intended=$intended, actual=$afterDirect)" }
+            io.markDirectWriteUnreliable()
+            if (mode == null) return null
+            return if (io.writeShell(intended, mode)) io.awaitBound(bindTimeoutMs) else null
+        }
+
+        io.awaitBound(bindTimeoutMs)?.let { return it }
+
+        // Mode B: the value persisted but the service never bound. Try the shell once.
+        log(TAG, WARN) { "enable(): Direct write persisted but service didn't bind, trying shell" }
+        if (mode == null) return null
+        if (!io.writeShell(intended, mode)) return null
+        return io.awaitBound(bindTimeoutMs)?.also {
+            // Only now is it proven that the shell path was necessary on this build.
+            io.markDirectWriteUnreliable()
+        }
+    }
+
+    companion object {
+        private val TAG = logTag("Automation", "AcsActivator")
+
+        private const val DEFAULT_BIND_TIMEOUT_MS = 10 * 1000L
+
+        /** A write achieves the intent when every intended component is present (extras are fine). */
+        internal fun writeMatchesIntent(intent: Set<ComponentName>, actual: Set<ComponentName>): Boolean =
+            if (intent.isEmpty()) actual.isEmpty() else actual.containsAll(intent)
+
+        internal fun flattenServices(services: Set<ComponentName>): String =
+            services.joinToString(":") { it.flattenToString() }
+
+        /**
+         * Builds the `settings put secure enabled_accessibility_services …` command. The value is
+         * single-quoted so the interactive shell doesn't expand `$` (legal in nested-class component
+         * names of preserved third-party services). Component strings can't contain `'`, so single
+         * quoting needs no further escaping.
+         */
+        internal fun enabledServicesPutCmd(value: String): String =
+            "settings put secure ${Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES} '$value'"
+    }
+}

--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/AcsWriteReliability.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/AcsWriteReliability.kt
@@ -1,0 +1,34 @@
+package eu.darken.sdmse.automation.core
+
+import dagger.Reusable
+import eu.darken.sdmse.common.BuildWrap
+import eu.darken.sdmse.common.datastore.value
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import javax.inject.Inject
+
+/**
+ * Remembers, per OS build, whether writing `enabled_accessibility_services` from our own process is
+ * unreliable (silently reverted, or persisted but never bound). The marker is keyed to
+ * [BuildWrap.FINGERPRINT] so an OTA (which changes the fingerprint) automatically re-probes the direct
+ * path instead of staying stuck on the shell fallback forever. Observed on WAIPU TV (Android 14).
+ */
+@Reusable
+class AcsWriteReliability @Inject constructor(
+    private val settings: AutomationSettings,
+) {
+
+    suspend fun shouldAvoidDirectWrite(): Boolean =
+        settings.acsDirectWriteUnreliableFingerprint.value() == BuildWrap.FINGERPRINT
+
+    suspend fun markDirectWriteUnreliable() {
+        if (shouldAvoidDirectWrite()) return
+        log(TAG, WARN) { "markDirectWriteUnreliable(): Direct ACS write flagged unreliable for ${BuildWrap.FINGERPRINT}" }
+        settings.acsDirectWriteUnreliableFingerprint.value(BuildWrap.FINGERPRINT)
+    }
+
+    companion object {
+        private val TAG = logTag("Automation", "AcsWriteReliability")
+    }
+}

--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/AutomationManager.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/AutomationManager.kt
@@ -2,6 +2,7 @@ package eu.darken.sdmse.automation.core
 
 import android.content.ComponentName
 import android.content.Context
+import android.os.Build
 import android.provider.Settings
 import dagger.Binds
 import dagger.Module
@@ -61,6 +62,7 @@ class AutomationManager @Inject constructor(
     @AppScope private val appScope: CoroutineScope,
     private val setupHelper: SetupHelper,
     private val settingsProvider: SystemSettingsProvider,
+    private val automationSettings: AutomationSettings,
     private val animationTool: AnimationTool,
     private val shellOps: ShellOps,
     private val adbManager: AdbManager,
@@ -113,38 +115,48 @@ class AutomationManager @Inject constructor(
             ?: emptySet()
     }
 
-    private suspend fun setAutomationServices(services: Set<ComponentName>) {
-        val value = services.joinToString(":") { it.flattenToString() }
+    private fun writeMatchesIntent(intent: Set<ComponentName>, actual: Set<ComponentName>): Boolean =
+        if (intent.isEmpty()) actual.isEmpty() else actual.containsAll(intent)
 
+    private suspend fun shellMode(): ShellOps.Mode? = when {
+        adbManager.canUseAdbNow() -> ShellOps.Mode.ADB
+        rootManager.canUseRootNow() -> ShellOps.Mode.ROOT
+        else -> null
+    }
+
+    /**
+     * True when writing ENABLED_ACCESSIBILITY_SERVICES from our own process is known to be unreliable
+     * on the current OS build (see [AutomationSettings.acsDirectWriteUnreliableFingerprint]).
+     */
+    private suspend fun avoidDirectAcsWrite(): Boolean =
+        automationSettings.acsDirectWriteUnreliableFingerprint.value() == Build.FINGERPRINT
+
+    private suspend fun markDirectWriteUnreliable() {
+        if (avoidDirectAcsWrite()) return
+        log(TAG, WARN) { "markDirectWriteUnreliable(): Direct ACS write flagged unreliable for ${Build.FINGERPRINT}" }
+        automationSettings.acsDirectWriteUnreliableFingerprint.value(Build.FINGERPRINT)
+    }
+
+    /** Writes the service list via our own process. Returns the post-write readback. */
+    private suspend fun writeServicesDirect(services: Set<ComponentName>): Set<ComponentName> {
+        val value = services.joinToString(":") { it.flattenToString() }
         settingsProvider.put(
             SystemSettingsProvider.Type.SECURE,
             Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES,
             value
         )
-        val afterDirect = getAutomationServices()
-        log(TAG) { "setAutomationServices($services) -> $afterDirect (direct)" }
-
-        if (writeMatchesIntent(intent = services, actual = afterDirect)) return
-
-        log(TAG, WARN) {
-            "setAutomationServices(): Direct write did not stick (intent=$services, actual=$afterDirect). Trying shell fallback..."
-        }
-        setAutomationServicesViaShell(services, value)
+        val after = getAutomationServices()
+        log(TAG) { "writeServicesDirect($services) -> $after" }
+        return after
     }
 
-    private fun writeMatchesIntent(intent: Set<ComponentName>, actual: Set<ComponentName>): Boolean =
-        if (intent.isEmpty()) actual.isEmpty() else actual.containsAll(intent)
-
-    private suspend fun setAutomationServicesViaShell(services: Set<ComponentName>, value: String) {
-        val mode = when {
-            adbManager.canUseAdbNow() -> ShellOps.Mode.ADB
-            rootManager.canUseRootNow() -> ShellOps.Mode.ROOT
-            else -> null
-        }
-        if (mode == null) {
-            log(TAG, WARN) { "setAutomationServicesViaShell(): No shell available, giving up" }
-            return
-        }
+    /**
+     * Writes the service list via the privileged shell (Shizuku/ADB or root, uid 2000 / root). This is
+     * not subject to the "untrusted app touched a protected setting" rollback some ROMs apply to writes
+     * from our own process. Returns whether the intended list actually persisted.
+     */
+    private suspend fun writeServicesViaShell(services: Set<ComponentName>, mode: ShellOps.Mode): Boolean {
+        val value = services.joinToString(":") { it.flattenToString() }
 
         try {
             pkgOps.setAppOps(
@@ -152,22 +164,91 @@ class AutomationManager @Inject constructor(
                 PkgOps.AppOpsKey.ACCESS_RESTRICTED_SETTINGS,
                 PkgOps.AppOpsValue.ALLOW,
             )
-            log(TAG) { "setAutomationServicesViaShell(): ACCESS_RESTRICTED_SETTINGS=allow OK" }
+            log(TAG) { "writeServicesViaShell(): ACCESS_RESTRICTED_SETTINGS=allow OK" }
         } catch (e: Exception) {
-            log(TAG, WARN) { "setAutomationServicesViaShell(): ACCESS_RESTRICTED_SETTINGS set failed: ${e.asLog()}" }
+            log(TAG, WARN) { "writeServicesViaShell(): ACCESS_RESTRICTED_SETTINGS set failed: ${e.asLog()}" }
         }
 
         val cmd = "settings put secure ${Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES} \"$value\""
         val result = try {
             shellOps.execute(ShellOpsCmd(cmd), mode)
         } catch (e: Exception) {
-            log(TAG, WARN) { "setAutomationServicesViaShell(): shell write failed: ${e.asLog()}" }
-            return
+            log(TAG, WARN) { "writeServicesViaShell(): shell write failed: ${e.asLog()}" }
+            return false
         }
-        log(TAG) { "setAutomationServicesViaShell(): mode=$mode result=$result" }
+        if (!result.isSuccess) {
+            log(TAG, WARN) { "writeServicesViaShell(): shell write unsuccessful: $result" }
+            return false
+        }
 
-        val afterShell = getAutomationServices()
-        log(TAG, INFO) { "setAutomationServices($services) -> $afterShell (shell)" }
+        val after = getAutomationServices()
+        val persisted = writeMatchesIntent(intent = services, actual = after)
+        log(TAG, INFO) { "writeServicesViaShell($services) -> $after (mode=$mode, persisted=$persisted)" }
+        return persisted
+    }
+
+    /**
+     * Strategy-aware write used for disable / re-toggle, where binding is NOT the success signal.
+     * Prefers the shell when direct writes are known unreliable on this build.
+     */
+    private suspend fun writeServices(services: Set<ComponentName>) {
+        val mode = shellMode()
+        if (avoidDirectAcsWrite() && mode != null) {
+            writeServicesViaShell(services, mode)
+        } else {
+            writeServicesDirect(services)
+        }
+    }
+
+    private suspend fun waitForServiceBound(timeoutMs: Long): AutomationServiceHandle? =
+        withTimeoutOrNull(timeoutMs) {
+            while (currentCoroutineContext().isActive) {
+                serviceHolder.value?.let { return@withTimeoutOrNull it }
+                log(TAG, VERBOSE) { "waitForServiceBound(): Waiting for service to start" }
+                delay(500)
+            }
+            null
+        }
+
+    /**
+     * Enables our service (writing [intended], the full desired list incl. any third-party services) and
+     * waits for it to actually bind. Direct write is the primary path; the shell is a bounded fallback,
+     * triggered both when the direct write is reverted (Mode A) and when it persists but never binds
+     * (Mode B). At most one direct + one shell attempt. Returns the bound handle, or null on failure.
+     */
+    private suspend fun enableAndWaitForBind(intended: Set<ComponentName>): AutomationServiceHandle? {
+        val mode = shellMode()
+
+        if (avoidDirectAcsWrite()) {
+            log(TAG, WARN) { "enableAndWaitForBind(): Direct write known-unreliable, using shell directly" }
+            if (mode == null) {
+                log(TAG, WARN) { "enableAndWaitForBind(): No privileged shell available, cannot enable" }
+                return null
+            }
+            return if (writeServicesViaShell(intended, mode)) waitForServiceBound(BIND_TIMEOUT_MS) else null
+        }
+
+        val afterDirect = writeServicesDirect(intended)
+        if (!writeMatchesIntent(intent = intended, actual = afterDirect)) {
+            // Mode A: the write was reverted (often wiping unrelated third-party services too).
+            log(TAG, WARN) {
+                "enableAndWaitForBind(): Direct write was reverted (intended=$intended, actual=$afterDirect)"
+            }
+            markDirectWriteUnreliable()
+            if (mode == null) return null
+            return if (writeServicesViaShell(intended, mode)) waitForServiceBound(BIND_TIMEOUT_MS) else null
+        }
+
+        waitForServiceBound(BIND_TIMEOUT_MS)?.let { return it }
+
+        // Mode B: the value persisted but the service never bound. Try the shell once.
+        log(TAG, WARN) { "enableAndWaitForBind(): Direct write persisted but service didn't bind, trying shell" }
+        if (mode == null) return null
+        if (!writeServicesViaShell(intended, mode)) return null
+        return waitForServiceBound(BIND_TIMEOUT_MS)?.also {
+            // Only now is it proven that the shell path was necessary on this build.
+            markDirectWriteUnreliable()
+        }
     }
 
     suspend fun isServiceEnabled(): Boolean = getAutomationServices().contains(ourServiceComp)
@@ -196,11 +277,9 @@ class AutomationManager @Inject constructor(
 
     private suspend fun startService(): AutomationServiceHandle {
         log(TAG, VERBOSE) { "startService()" }
-        var service = serviceHolder.value
-
-        if (service != null) {
+        serviceHolder.value?.let {
             log(TAG) { "startService(): ACS is already running" }
-            return service
+            return it
         }
 
         if (!setupHelper.hasSecureSettings()) {
@@ -213,31 +292,27 @@ class AutomationManager @Inject constructor(
         val currentServices = getAutomationServices()
         log(TAG) { "startService(): Before writing ACS settings: $currentServices" }
 
+        // Snapshot of the full desired list, preserving any third-party services already enabled.
+        val intended = currentServices + ourServiceComp
+
         if (currentServices.contains(ourServiceComp)) {
             log(TAG, WARN) { "startService(): Service isn't running but we are already enabled? Let's re-toggle" }
-            setAutomationServices(currentServices.minus(ourServiceComp))
-
+            writeServices(currentServices - ourServiceComp)
             // Give the system some time
             delay(3000)
-
-            val afterToggleOff = getAutomationServices()
-            if (afterToggleOff.contains(ourServiceComp)) throw IllegalStateException("Failed to remove our ACS service")
-
-            setAutomationServices(afterToggleOff.plus(ourServiceComp))
-        } else {
-            val newAcsValue = currentServices.plus(ourServiceComp)
-            setAutomationServices(newAcsValue)
         }
 
-        while (currentCoroutineContext().isActive) {
-            service = serviceHolder.value
-            if (service != null) break
-            log(TAG, VERBOSE) { "startService(): Waiting for service to start" }
-            delay(500)
+        val service = enableAndWaitForBind(intended)
+        if (service == null) {
+            if (avoidDirectAcsWrite() && shellMode() == null) {
+                log(TAG, WARN) { "startService(): Direct write disabled for this build and no privileged shell available." }
+                throw AutomationNotEnabledException()
+            }
+            throw AutomationNotRunningException()
         }
 
         log(TAG, INFO) { "startService(): Service started!" }
-        return service!!
+        return service
     }
 
     private suspend fun stopService() {
@@ -253,7 +328,7 @@ class AutomationManager @Inject constructor(
             log(TAG, WARN) { "stopService(): We were not part of the active service components: $currentServices" }
         }
 
-        setAutomationServices(newServices)
+        writeServices(newServices)
 
         log(TAG, VERBOSE) { "stopService(): Waiting for service to stop" }
         serviceHolder.filter { it == null }.first()
@@ -272,13 +347,13 @@ class AutomationManager @Inject constructor(
         val canToggle = setupHelper.hasSecureSettings()
         log(TAG) { "serviceLauncher: canToggle=$canToggle" }
 
+        // startService() owns its own bounded waits (direct + optional shell fallback) and throws on
+        // failure, so it must NOT be wrapped in an outer timeout that could cancel the fallback midway.
         val service = if (canToggle) {
-            withTimeoutOrNull(10 * 1000L) { startService() }
+            startService()
         } else {
-            serviceHolder.value
+            serviceHolder.value ?: throw AutomationNotRunningException()
         }
-
-        if (service == null) throw AutomationNotRunningException()
 
         val wrapper = ServiceWrapper(service = service)
 
@@ -328,6 +403,8 @@ class AutomationManager @Inject constructor(
 
     companion object {
         val TAG: String = logTag("Automation", "Manager")
+
+        private const val BIND_TIMEOUT_MS = 10 * 1000L
 
         internal fun parseAccessibilityTargets(vararg settings: String?): Set<ComponentName> =
             settings.filterNotNull()

--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/AutomationManager.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/AutomationManager.kt
@@ -13,6 +13,8 @@ import eu.darken.sdmse.automation.core.errors.AutomationNoConsentException
 import eu.darken.sdmse.automation.core.errors.AutomationNotEnabledException
 import eu.darken.sdmse.automation.core.errors.AutomationNotRunningException
 import eu.darken.sdmse.common.SystemSettingsProvider
+import eu.darken.sdmse.common.adb.AdbManager
+import eu.darken.sdmse.common.adb.canUseAdbNow
 import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
@@ -24,8 +26,15 @@ import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.flow.setupCommonEventHandlers
 import eu.darken.sdmse.common.flow.shareLatest
 import eu.darken.sdmse.common.permissions.Permission
+import eu.darken.sdmse.common.pkgs.pkgops.PkgOps
+import eu.darken.sdmse.common.root.RootManager
+import eu.darken.sdmse.common.root.canUseRootNow
 import eu.darken.sdmse.common.sharedresource.SharedResource
 import eu.darken.sdmse.common.sharedresource.useRes
+import eu.darken.sdmse.common.shell.ShellOps
+import eu.darken.sdmse.common.shell.ipc.ShellOpsCmd
+import eu.darken.sdmse.common.user.UserManager2
+import eu.darken.sdmse.common.user.ourInstall
 import eu.darken.sdmse.main.core.GeneralSettings
 import eu.darken.sdmse.setup.SetupHelper
 import kotlinx.coroutines.CoroutineScope
@@ -53,6 +62,11 @@ class AutomationManager @Inject constructor(
     private val setupHelper: SetupHelper,
     private val settingsProvider: SystemSettingsProvider,
     private val animationTool: AnimationTool,
+    private val shellOps: ShellOps,
+    private val adbManager: AdbManager,
+    private val rootManager: RootManager,
+    private val pkgOps: PkgOps,
+    private val userManager: UserManager2,
 ) : AutomationSubmitter {
 
     init {
@@ -100,13 +114,60 @@ class AutomationManager @Inject constructor(
     }
 
     private suspend fun setAutomationServices(services: Set<ComponentName>) {
+        val value = services.joinToString(":") { it.flattenToString() }
+
         settingsProvider.put(
             SystemSettingsProvider.Type.SECURE,
             Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES,
-            services.joinToString(":") { it.flattenToString() }
+            value
         )
-        val after = getAutomationServices()
-        log(TAG) { "setAutomationServices($services) -> $after" }
+        val afterDirect = getAutomationServices()
+        log(TAG) { "setAutomationServices($services) -> $afterDirect (direct)" }
+
+        if (writeMatchesIntent(intent = services, actual = afterDirect)) return
+
+        log(TAG, WARN) {
+            "setAutomationServices(): Direct write did not stick (intent=$services, actual=$afterDirect). Trying shell fallback..."
+        }
+        setAutomationServicesViaShell(services, value)
+    }
+
+    private fun writeMatchesIntent(intent: Set<ComponentName>, actual: Set<ComponentName>): Boolean =
+        if (intent.isEmpty()) actual.isEmpty() else actual.containsAll(intent)
+
+    private suspend fun setAutomationServicesViaShell(services: Set<ComponentName>, value: String) {
+        val mode = when {
+            adbManager.canUseAdbNow() -> ShellOps.Mode.ADB
+            rootManager.canUseRootNow() -> ShellOps.Mode.ROOT
+            else -> null
+        }
+        if (mode == null) {
+            log(TAG, WARN) { "setAutomationServicesViaShell(): No shell available, giving up" }
+            return
+        }
+
+        try {
+            pkgOps.setAppOps(
+                userManager.ourInstall(),
+                PkgOps.AppOpsKey.ACCESS_RESTRICTED_SETTINGS,
+                PkgOps.AppOpsValue.ALLOW,
+            )
+            log(TAG) { "setAutomationServicesViaShell(): ACCESS_RESTRICTED_SETTINGS=allow OK" }
+        } catch (e: Exception) {
+            log(TAG, WARN) { "setAutomationServicesViaShell(): ACCESS_RESTRICTED_SETTINGS set failed: ${e.asLog()}" }
+        }
+
+        val cmd = "settings put secure ${Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES} \"$value\""
+        val result = try {
+            shellOps.execute(ShellOpsCmd(cmd), mode)
+        } catch (e: Exception) {
+            log(TAG, WARN) { "setAutomationServicesViaShell(): shell write failed: ${e.asLog()}" }
+            return
+        }
+        log(TAG) { "setAutomationServicesViaShell(): mode=$mode result=$result" }
+
+        val afterShell = getAutomationServices()
+        log(TAG, INFO) { "setAutomationServices($services) -> $afterShell (shell)" }
     }
 
     suspend fun isServiceEnabled(): Boolean = getAutomationServices().contains(ourServiceComp)

--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/AutomationManager.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/AutomationManager.kt
@@ -169,14 +169,30 @@ class AutomationManager @Inject constructor(
 
     /**
      * Strategy-aware write used for disable / re-toggle, where binding is NOT the success signal.
-     * Prefers the shell when direct writes are known unreliable on this build.
+     * On a build flagged direct-write-unreliable we never direct-write (it can wipe third-party
+     * services); if no shell is available there we skip rather than fall back to a destructive write.
+     *
+     * @return true if a write was actually performed.
      */
-    private suspend fun writeServices(services: Set<ComponentName>) {
+    private suspend fun writeServices(services: Set<ComponentName>): Boolean {
         val mode = shellMode()
-        if (acsWriteReliability.shouldAvoidDirectWrite() && mode != null) {
-            writeServicesViaShell(services, mode)
-        } else {
-            writeServicesDirect(services)
+        return when (AcsActivator.writeStrategy(acsWriteReliability.shouldAvoidDirectWrite(), mode != null)) {
+            AcsActivator.WriteStrategy.DIRECT -> {
+                writeServicesDirect(services)
+                true
+            }
+
+            AcsActivator.WriteStrategy.SHELL -> {
+                writeServicesViaShell(services, mode!!)
+                true
+            }
+
+            AcsActivator.WriteStrategy.SKIP -> {
+                log(TAG, WARN) {
+                    "writeServices(): avoid-direct build with no shell; skipping write to avoid destructive direct mutation"
+                }
+                false
+            }
         }
     }
 
@@ -247,9 +263,10 @@ class AutomationManager @Inject constructor(
 
         if (currentServices.contains(ourServiceComp)) {
             log(TAG, WARN) { "startService(): Service isn't running but we are already enabled? Let's re-toggle" }
-            writeServices(currentServices - ourServiceComp)
-            // Give the system some time
-            delay(3000)
+            if (writeServices(currentServices - ourServiceComp)) {
+                // Give the system some time to process the toggle-off
+                delay(3000)
+            }
         }
 
         val service = acsActivator.enable(intended)
@@ -278,7 +295,12 @@ class AutomationManager @Inject constructor(
             log(TAG, WARN) { "stopService(): We were not part of the active service components: $currentServices" }
         }
 
-        writeServices(newServices)
+        if (!writeServices(newServices)) {
+            // avoid-direct build with no shell: skipping is safer than a destructive direct write.
+            // Our service stays enabled; don't wait for an unbind that won't happen.
+            log(TAG, WARN) { "stopService(): Disable write skipped, leaving service enabled" }
+            return
+        }
 
         log(TAG, VERBOSE) { "stopService(): Waiting for service to stop" }
         val stopped = withTimeoutOrNull(STOP_TIMEOUT_MS) {

--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/AutomationManager.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/AutomationManager.kt
@@ -2,7 +2,6 @@ package eu.darken.sdmse.automation.core
 
 import android.content.ComponentName
 import android.content.Context
-import android.os.Build
 import android.provider.Settings
 import dagger.Binds
 import dagger.Module
@@ -62,7 +61,7 @@ class AutomationManager @Inject constructor(
     @AppScope private val appScope: CoroutineScope,
     private val setupHelper: SetupHelper,
     private val settingsProvider: SystemSettingsProvider,
-    private val automationSettings: AutomationSettings,
+    private val acsWriteReliability: AcsWriteReliability,
     private val animationTool: AnimationTool,
     private val shellOps: ShellOps,
     private val adbManager: AdbManager,
@@ -115,35 +114,18 @@ class AutomationManager @Inject constructor(
             ?: emptySet()
     }
 
-    private fun writeMatchesIntent(intent: Set<ComponentName>, actual: Set<ComponentName>): Boolean =
-        if (intent.isEmpty()) actual.isEmpty() else actual.containsAll(intent)
-
     private suspend fun shellMode(): ShellOps.Mode? = when {
         adbManager.canUseAdbNow() -> ShellOps.Mode.ADB
         rootManager.canUseRootNow() -> ShellOps.Mode.ROOT
         else -> null
     }
 
-    /**
-     * True when writing ENABLED_ACCESSIBILITY_SERVICES from our own process is known to be unreliable
-     * on the current OS build (see [AutomationSettings.acsDirectWriteUnreliableFingerprint]).
-     */
-    private suspend fun avoidDirectAcsWrite(): Boolean =
-        automationSettings.acsDirectWriteUnreliableFingerprint.value() == Build.FINGERPRINT
-
-    private suspend fun markDirectWriteUnreliable() {
-        if (avoidDirectAcsWrite()) return
-        log(TAG, WARN) { "markDirectWriteUnreliable(): Direct ACS write flagged unreliable for ${Build.FINGERPRINT}" }
-        automationSettings.acsDirectWriteUnreliableFingerprint.value(Build.FINGERPRINT)
-    }
-
     /** Writes the service list via our own process. Returns the post-write readback. */
     private suspend fun writeServicesDirect(services: Set<ComponentName>): Set<ComponentName> {
-        val value = services.joinToString(":") { it.flattenToString() }
         settingsProvider.put(
             SystemSettingsProvider.Type.SECURE,
             Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES,
-            value
+            AcsActivator.flattenServices(services)
         )
         val after = getAutomationServices()
         log(TAG) { "writeServicesDirect($services) -> $after" }
@@ -156,8 +138,6 @@ class AutomationManager @Inject constructor(
      * from our own process. Returns whether the intended list actually persisted.
      */
     private suspend fun writeServicesViaShell(services: Set<ComponentName>, mode: ShellOps.Mode): Boolean {
-        val value = services.joinToString(":") { it.flattenToString() }
-
         try {
             pkgOps.setAppOps(
                 userManager.ourInstall(),
@@ -169,7 +149,7 @@ class AutomationManager @Inject constructor(
             log(TAG, WARN) { "writeServicesViaShell(): ACCESS_RESTRICTED_SETTINGS set failed: ${e.asLog()}" }
         }
 
-        val cmd = "settings put secure ${Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES} \"$value\""
+        val cmd = AcsActivator.enabledServicesPutCmd(AcsActivator.flattenServices(services))
         val result = try {
             shellOps.execute(ShellOpsCmd(cmd), mode)
         } catch (e: Exception) {
@@ -182,7 +162,7 @@ class AutomationManager @Inject constructor(
         }
 
         val after = getAutomationServices()
-        val persisted = writeMatchesIntent(intent = services, actual = after)
+        val persisted = AcsActivator.writeMatchesIntent(intent = services, actual = after)
         log(TAG, INFO) { "writeServicesViaShell($services) -> $after (mode=$mode, persisted=$persisted)" }
         return persisted
     }
@@ -193,7 +173,7 @@ class AutomationManager @Inject constructor(
      */
     private suspend fun writeServices(services: Set<ComponentName>) {
         val mode = shellMode()
-        if (avoidDirectAcsWrite() && mode != null) {
+        if (acsWriteReliability.shouldAvoidDirectWrite() && mode != null) {
             writeServicesViaShell(services, mode)
         } else {
             writeServicesDirect(services)
@@ -210,46 +190,16 @@ class AutomationManager @Inject constructor(
             null
         }
 
-    /**
-     * Enables our service (writing [intended], the full desired list incl. any third-party services) and
-     * waits for it to actually bind. Direct write is the primary path; the shell is a bounded fallback,
-     * triggered both when the direct write is reverted (Mode A) and when it persists but never binds
-     * (Mode B). At most one direct + one shell attempt. Returns the bound handle, or null on failure.
-     */
-    private suspend fun enableAndWaitForBind(intended: Set<ComponentName>): AutomationServiceHandle? {
-        val mode = shellMode()
+    private val acsActivator = AcsActivator(object : AcsActivator.Io {
+        override suspend fun shellMode(): ShellOps.Mode? = this@AutomationManager.shellMode()
+        override suspend fun isAvoidDirectWrite(): Boolean = acsWriteReliability.shouldAvoidDirectWrite()
+        override suspend fun markDirectWriteUnreliable() = acsWriteReliability.markDirectWriteUnreliable()
+        override suspend fun writeDirect(services: Set<ComponentName>) = writeServicesDirect(services)
+        override suspend fun writeShell(services: Set<ComponentName>, mode: ShellOps.Mode) =
+            writeServicesViaShell(services, mode)
 
-        if (avoidDirectAcsWrite()) {
-            log(TAG, WARN) { "enableAndWaitForBind(): Direct write known-unreliable, using shell directly" }
-            if (mode == null) {
-                log(TAG, WARN) { "enableAndWaitForBind(): No privileged shell available, cannot enable" }
-                return null
-            }
-            return if (writeServicesViaShell(intended, mode)) waitForServiceBound(BIND_TIMEOUT_MS) else null
-        }
-
-        val afterDirect = writeServicesDirect(intended)
-        if (!writeMatchesIntent(intent = intended, actual = afterDirect)) {
-            // Mode A: the write was reverted (often wiping unrelated third-party services too).
-            log(TAG, WARN) {
-                "enableAndWaitForBind(): Direct write was reverted (intended=$intended, actual=$afterDirect)"
-            }
-            markDirectWriteUnreliable()
-            if (mode == null) return null
-            return if (writeServicesViaShell(intended, mode)) waitForServiceBound(BIND_TIMEOUT_MS) else null
-        }
-
-        waitForServiceBound(BIND_TIMEOUT_MS)?.let { return it }
-
-        // Mode B: the value persisted but the service never bound. Try the shell once.
-        log(TAG, WARN) { "enableAndWaitForBind(): Direct write persisted but service didn't bind, trying shell" }
-        if (mode == null) return null
-        if (!writeServicesViaShell(intended, mode)) return null
-        return waitForServiceBound(BIND_TIMEOUT_MS)?.also {
-            // Only now is it proven that the shell path was necessary on this build.
-            markDirectWriteUnreliable()
-        }
-    }
+        override suspend fun awaitBound(timeoutMs: Long) = waitForServiceBound(timeoutMs)
+    })
 
     suspend fun isServiceEnabled(): Boolean = getAutomationServices().contains(ourServiceComp)
 
@@ -302,9 +252,9 @@ class AutomationManager @Inject constructor(
             delay(3000)
         }
 
-        val service = enableAndWaitForBind(intended)
+        val service = acsActivator.enable(intended)
         if (service == null) {
-            if (avoidDirectAcsWrite() && shellMode() == null) {
+            if (acsWriteReliability.shouldAvoidDirectWrite() && shellMode() == null) {
                 log(TAG, WARN) { "startService(): Direct write disabled for this build and no privileged shell available." }
                 throw AutomationNotEnabledException()
             }
@@ -331,8 +281,17 @@ class AutomationManager @Inject constructor(
         writeServices(newServices)
 
         log(TAG, VERBOSE) { "stopService(): Waiting for service to stop" }
-        serviceHolder.filter { it == null }.first()
-        log(TAG, INFO) { "stopService(): Service stopped!" }
+        val stopped = withTimeoutOrNull(STOP_TIMEOUT_MS) {
+            serviceHolder.filter { it == null }.first()
+            true
+        } != null
+        if (stopped) {
+            log(TAG, INFO) { "stopService(): Service stopped!" }
+        } else {
+            // A failed disable write (e.g. shell-first build with the shell unavailable) must not hang
+            // the awaitClose/runBlocking forever waiting for an unbind that won't happen.
+            log(TAG, WARN) { "stopService(): Timed out waiting for the service to unbind" }
+        }
     }
 
     private val serviceLauncher = callbackFlow {
@@ -404,7 +363,7 @@ class AutomationManager @Inject constructor(
     companion object {
         val TAG: String = logTag("Automation", "Manager")
 
-        private const val BIND_TIMEOUT_MS = 10 * 1000L
+        private const val STOP_TIMEOUT_MS = 10 * 1000L
 
         internal fun parseAccessibilityTargets(vararg settings: String?): Set<ComponentName> =
             settings.filterNotNull()

--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/AutomationSettings.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/AutomationSettings.kt
@@ -26,6 +26,16 @@ class AutomationSettings @Inject constructor(
     val animationPendingRestoreState =
         dataStore.createValue<AnimationState?>("animation.pending.restore.state", null, json)
 
+    /**
+     * Build.FINGERPRINT of an OS build on which writing ENABLED_ACCESSIBILITY_SERVICES from our own
+     * process is known to be unreliable (silently reverted, or persisted but the service never binds).
+     * Empty when the direct write is considered reliable. Keyed to the fingerprint so a ROM update
+     * (which changes the fingerprint) automatically re-probes the direct path.
+     * Observed on WAIPU TV (Android 14).
+     */
+    val acsDirectWriteUnreliableFingerprint =
+        dataStore.createValue("acs.directwrite.unreliable.fingerprint", "")
+
     companion object {
         internal val TAG = logTag("Automation", "Settings")
     }

--- a/app-common-automation/src/test/java/eu/darken/sdmse/automation/core/AcsActivatorTest.kt
+++ b/app-common-automation/src/test/java/eu/darken/sdmse/automation/core/AcsActivatorTest.kt
@@ -226,4 +226,17 @@ class AcsActivatorTest : BaseTest() {
         val flat = AcsActivator.flattenServices(setOf(ourComp, thirdParty))
         flat.split(":").toSet() shouldBe setOf(ourComp.flattenToString(), thirdParty.flattenToString())
     }
+
+    @Test fun `writeStrategy - reliable build writes directly regardless of shell`() {
+        AcsActivator.writeStrategy(avoidDirectWrite = false, hasShell = false) shouldBe AcsActivator.WriteStrategy.DIRECT
+        AcsActivator.writeStrategy(avoidDirectWrite = false, hasShell = true) shouldBe AcsActivator.WriteStrategy.DIRECT
+    }
+
+    @Test fun `writeStrategy - flagged build with shell uses shell`() {
+        AcsActivator.writeStrategy(avoidDirectWrite = true, hasShell = true) shouldBe AcsActivator.WriteStrategy.SHELL
+    }
+
+    @Test fun `writeStrategy - flagged build without shell SKIPS (never destructive direct write)`() {
+        AcsActivator.writeStrategy(avoidDirectWrite = true, hasShell = false) shouldBe AcsActivator.WriteStrategy.SKIP
+    }
 }

--- a/app-common-automation/src/test/java/eu/darken/sdmse/automation/core/AcsActivatorTest.kt
+++ b/app-common-automation/src/test/java/eu/darken/sdmse/automation/core/AcsActivatorTest.kt
@@ -1,0 +1,229 @@
+package eu.darken.sdmse.automation.core
+
+import android.content.ComponentName
+import eu.darken.sdmse.common.shell.ShellOps
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+import testhelpers.coroutine.runTest2
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class AcsActivatorTest : BaseTest() {
+
+    private val ourComp = ComponentName("eu.darken.sdmse", "eu.darken.sdmse.automation.core.AutomationService")
+    private val thirdParty = ComponentName("com.eset.etvs.gp", "com.eset.commoncore.core.accessibility.CoreAccessibilityService")
+    private val handle = mockk<AutomationServiceHandle>()
+
+    /**
+     * Fake [AcsActivator.Io] that models the secure-setting + bind state and records the exact call
+     * order, so tests can lock side-effect *timing* (e.g. "mark only after a proven shell bind"), not
+     * just final return values.
+     */
+    private inner class FakeIo(
+        val avoidDirect: Boolean = false,
+        val mode: ShellOps.Mode? = ShellOps.Mode.ADB,
+        val directReverts: Boolean = false,
+        val boundAfterDirect: Boolean = false,
+        val shellWriteSucceeds: Boolean = true,
+        val boundAfterShell: Boolean = true,
+    ) : AcsActivator.Io {
+        val events = mutableListOf<String>()
+        var writeDirectCalls = 0
+        var writeShellCalls = 0
+        var markCalls = 0
+        var lastShellServices: Set<ComponentName>? = null
+        var lastAwaitTimeout: Long? = null
+        private var bound = false
+
+        override suspend fun shellMode(): ShellOps.Mode? {
+            events += "shellMode"
+            return mode
+        }
+
+        override suspend fun isAvoidDirectWrite(): Boolean {
+            events += "isAvoidDirectWrite"
+            return avoidDirect
+        }
+
+        override suspend fun markDirectWriteUnreliable() {
+            events += "mark"
+            markCalls++
+        }
+
+        override suspend fun writeDirect(services: Set<ComponentName>): Set<ComponentName> {
+            events += "writeDirect"
+            writeDirectCalls++
+            if (!directReverts && boundAfterDirect) bound = true
+            return if (directReverts) emptySet() else services
+        }
+
+        override suspend fun writeShell(services: Set<ComponentName>, mode: ShellOps.Mode): Boolean {
+            events += "writeShell"
+            writeShellCalls++
+            lastShellServices = services
+            if (shellWriteSucceeds && boundAfterShell) bound = true
+            return shellWriteSucceeds
+        }
+
+        override suspend fun awaitBound(timeoutMs: Long): AutomationServiceHandle? {
+            events += "awaitBound"
+            lastAwaitTimeout = timeoutMs
+            return if (bound) handle else null
+        }
+    }
+
+    @Test fun `normal device - direct write persists and binds, no shell, no mark`() = runTest2 {
+        val io = FakeIo(directReverts = false, boundAfterDirect = true)
+        AcsActivator(io).enable(setOf(ourComp)) shouldBe handle
+        io.writeShellCalls shouldBe 0
+        io.markCalls shouldBe 0
+        io.events shouldContainExactly listOf("shellMode", "isAvoidDirectWrite", "writeDirect", "awaitBound")
+    }
+
+    @Test fun `mode A - reverted write marks immediately and shell-writes full intended set`() = runTest2 {
+        val io = FakeIo(directReverts = true, shellWriteSucceeds = true, boundAfterShell = true)
+        val intended = setOf(ourComp, thirdParty)
+
+        AcsActivator(io).enable(intended) shouldBe handle
+
+        io.markCalls shouldBe 1
+        io.writeShellCalls shouldBe 1
+        // The full original set (incl. the third-party service the wipe took out) is restored.
+        io.lastShellServices shouldBe intended
+        io.events shouldContainExactly listOf(
+            "shellMode", "isAvoidDirectWrite", "writeDirect", "mark", "writeShell", "awaitBound",
+        )
+    }
+
+    @Test fun `mode B - persisted but no bind falls back to shell and marks only after shell binds`() = runTest2 {
+        val io = FakeIo(directReverts = false, boundAfterDirect = false, shellWriteSucceeds = true, boundAfterShell = true)
+
+        AcsActivator(io).enable(setOf(ourComp)) shouldBe handle
+
+        io.writeShellCalls shouldBe 1
+        io.markCalls shouldBe 1
+        io.events shouldContainExactly listOf(
+            "shellMode", "isAvoidDirectWrite", "writeDirect", "awaitBound", "writeShell", "awaitBound", "mark",
+        )
+    }
+
+    @Test fun `mode B - shell writes but still does not bind returns null and does NOT mark`() = runTest2 {
+        val io = FakeIo(directReverts = false, boundAfterDirect = false, shellWriteSucceeds = true, boundAfterShell = false)
+
+        AcsActivator(io).enable(setOf(ourComp)) shouldBe null
+
+        io.markCalls shouldBe 0
+        io.events shouldContainExactly listOf(
+            "shellMode", "isAvoidDirectWrite", "writeDirect", "awaitBound", "writeShell", "awaitBound",
+        )
+    }
+
+    @Test fun `mode A - shell write fails returns null but still marked (bounded, no extra awaitBound)`() = runTest2 {
+        val io = FakeIo(directReverts = true, shellWriteSucceeds = false)
+
+        AcsActivator(io).enable(setOf(ourComp)) shouldBe null
+
+        io.markCalls shouldBe 1
+        io.writeDirectCalls shouldBe 1
+        io.writeShellCalls shouldBe 1
+        // No awaitBound after a failed shell write.
+        io.events shouldContainExactly listOf(
+            "shellMode", "isAvoidDirectWrite", "writeDirect", "mark", "writeShell",
+        )
+    }
+
+    @Test fun `mode A - no shell marks and returns null without shell write`() = runTest2 {
+        val io = FakeIo(directReverts = true, mode = null)
+
+        AcsActivator(io).enable(setOf(ourComp)) shouldBe null
+
+        io.markCalls shouldBe 1
+        io.writeShellCalls shouldBe 0
+        io.events shouldContainExactly listOf("shellMode", "isAvoidDirectWrite", "writeDirect", "mark")
+    }
+
+    @Test fun `mode B - no shell returns null and does NOT mark (bind timeout alone is insufficient)`() = runTest2 {
+        val io = FakeIo(directReverts = false, boundAfterDirect = false, mode = null)
+
+        AcsActivator(io).enable(setOf(ourComp)) shouldBe null
+
+        io.markCalls shouldBe 0
+        io.writeShellCalls shouldBe 0
+        io.events shouldContainExactly listOf("shellMode", "isAvoidDirectWrite", "writeDirect", "awaitBound")
+    }
+
+    @Test fun `avoid-direct build - skips destructive probe and uses shell`() = runTest2 {
+        val io = FakeIo(avoidDirect = true, shellWriteSucceeds = true, boundAfterShell = true)
+
+        AcsActivator(io).enable(setOf(ourComp)) shouldBe handle
+
+        io.writeDirectCalls shouldBe 0
+        io.markCalls shouldBe 0
+        io.events shouldContainExactly listOf("shellMode", "isAvoidDirectWrite", "writeShell", "awaitBound")
+    }
+
+    @Test fun `avoid-direct build - no shell returns null fast without any writes`() = runTest2 {
+        val io = FakeIo(avoidDirect = true, mode = null)
+
+        AcsActivator(io).enable(setOf(ourComp)) shouldBe null
+
+        io.writeDirectCalls shouldBe 0
+        io.writeShellCalls shouldBe 0
+        io.events shouldContainExactly listOf("shellMode", "isAvoidDirectWrite")
+    }
+
+    @Test fun `bounded retry - at most one direct and one shell attempt`() = runTest2 {
+        val io = FakeIo(directReverts = false, boundAfterDirect = false, shellWriteSucceeds = true, boundAfterShell = true)
+        AcsActivator(io).enable(setOf(ourComp)).shouldNotBeNull()
+        io.writeDirectCalls shouldBe 1
+        io.writeShellCalls shouldBe 1
+    }
+
+    @Test fun `bind timeout is passed through to awaitBound`() = runTest2 {
+        val io = FakeIo(boundAfterDirect = true)
+        AcsActivator(io, bindTimeoutMs = 1234L).enable(setOf(ourComp))
+        io.lastAwaitTimeout shouldBe 1234L
+    }
+
+    // --- pure helpers ---
+
+    @Test fun `writeMatchesIntent - empty intent matches empty actual`() {
+        AcsActivator.writeMatchesIntent(emptySet(), emptySet()) shouldBe true
+    }
+
+    @Test fun `writeMatchesIntent - empty intent does not match non-empty actual`() {
+        AcsActivator.writeMatchesIntent(emptySet(), setOf(ourComp)) shouldBe false
+    }
+
+    @Test fun `writeMatchesIntent - missing component fails`() {
+        AcsActivator.writeMatchesIntent(setOf(ourComp), emptySet()) shouldBe false
+    }
+
+    @Test fun `writeMatchesIntent - exact match`() {
+        AcsActivator.writeMatchesIntent(setOf(ourComp), setOf(ourComp)) shouldBe true
+    }
+
+    @Test fun `writeMatchesIntent - superset is success (third-party preserved alongside)`() {
+        AcsActivator.writeMatchesIntent(setOf(ourComp), setOf(ourComp, thirdParty)) shouldBe true
+    }
+
+    @Test fun `enabledServicesPutCmd - value is single-quoted so the shell will not expand`() {
+        // Nested-class component names contain '$' which a shell would expand inside double quotes.
+        val value = "com.x/com.x.Svc\$Inner"
+        val cmd = AcsActivator.enabledServicesPutCmd(value)
+        cmd shouldBe "settings put secure enabled_accessibility_services 'com.x/com.x.Svc\$Inner'"
+    }
+
+    @Test fun `flattenServices - joins flattened components with colon`() {
+        val flat = AcsActivator.flattenServices(setOf(ourComp, thirdParty))
+        flat.split(":").toSet() shouldBe setOf(ourComp.flattenToString(), thirdParty.flattenToString())
+    }
+}

--- a/app-common-automation/src/test/java/eu/darken/sdmse/automation/core/AcsWriteReliabilityTest.kt
+++ b/app-common-automation/src/test/java/eu/darken/sdmse/automation/core/AcsWriteReliabilityTest.kt
@@ -1,0 +1,62 @@
+package eu.darken.sdmse.automation.core
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.sdmse.common.BuildWrap
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import kotlinx.serialization.json.Json
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+import testhelpers.coroutine.runTest2
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class AcsWriteReliabilityTest : BaseTest() {
+
+    private lateinit var settings: AutomationSettings
+
+    @Before fun setup() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        settings = AutomationSettings(context, Json { })
+        mockkObject(BuildWrap)
+    }
+
+    @After fun teardown() {
+        unmockkObject(BuildWrap)
+    }
+
+    @Test fun `fresh state does not avoid the direct write`() = runTest2 {
+        every { BuildWrap.FINGERPRINT } returns "build/fp-1"
+        AcsWriteReliability(settings).shouldAvoidDirectWrite() shouldBe false
+    }
+
+    @Test fun `marking unreliable makes the same build avoid the direct write`() = runTest2 {
+        every { BuildWrap.FINGERPRINT } returns "build/fp-1"
+        val reliability = AcsWriteReliability(settings)
+
+        reliability.markDirectWriteUnreliable()
+
+        reliability.shouldAvoidDirectWrite() shouldBe true
+    }
+
+    @Test fun `an OTA (changed fingerprint) re-probes the direct write`() = runTest2 {
+        val reliability = AcsWriteReliability(settings)
+
+        every { BuildWrap.FINGERPRINT } returns "build/fp-1"
+        reliability.markDirectWriteUnreliable()
+        reliability.shouldAvoidDirectWrite() shouldBe true
+
+        // OTA: fingerprint changes, so the learned marker no longer applies.
+        every { BuildWrap.FINGERPRINT } returns "build/fp-2"
+        reliability.shouldAvoidDirectWrite() shouldBe false
+    }
+}

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/PkgOps.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/PkgOps.kt
@@ -509,6 +509,7 @@ class PkgOps @Inject constructor(
     enum class AppOpsKey(val raw: String) {
         GET_USAGE_STATS("GET_USAGE_STATS"),
         MANAGE_EXTERNAL_STORAGE("MANAGE_EXTERNAL_STORAGE"),
+        ACCESS_RESTRICTED_SETTINGS("ACCESS_RESTRICTED_SETTINGS"),
         ;
     }
 


### PR DESCRIPTION
## What changed

On some customized ROMs (observed on WAIPU TV / Android 14) SD Maid couldn't turn on its own accessibility service, so AppCleaner's automated cache clearing (and other automation) failed. SD Maid now falls back to enabling the service through its privileged Shizuku/ADB (or root) shell when the normal in-app method doesn't actually start the service, and remembers that a given device needs this so it doesn't repeat a disruptive attempt.

## Technical Context

Enabling our `AccessibilityService` writes `Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES` from our own process. On WAIPU TV two distinct failure modes were captured in real debug logs:

- **Mode A** — the app write returns success but the whole setting is reverted within milliseconds (Android 13+ "restricted settings" rollback). This also wipes *other* apps' already-enabled services (ESET was collateral).
- **Mode B** — the app write persists and our component is present, but the system never binds the service (`onServiceConnected` never fires); `startService` times out and the entry is later purged.

A privileged-shell write (uid 2000 / root) of the same value is not subject to the rollback — a debug log proved it makes the value stick, the service bind, and the cache clear. The shell path does **not** need the `accessibility_enabled` master flag, and a static-manifest event-types change was tested in isolation and did not help (both dropped from this PR).

The original fallback gated on whether the value persisted (`writeMatchesIntent`), which only covers Mode A. This PR changes the trigger to the real signal — **did the service actually bind** — so Mode A and Mode B funnel through the same fallback.

Key points for review:

- **Bind-based detection.** `enableAndWaitForBind` writes the full intended list, waits for the bind, and falls back to the shell on either a reverted write (Mode A) or a persisted-but-no-bind timeout (Mode B). Bounded to one direct + one shell attempt.
- **Timeout relocation.** The bind wait was previously a cancellable `withTimeoutOrNull(10s)` wrapping `startService()` in `serviceLauncher` — that would have cancelled the fallback mid-flight. `startService()` now owns its own bounded waits (`waitForServiceBound`) and throws on failure; the outer timeout is gone.
- **Third-party preservation.** Writes use a pre-write snapshot (`currentServices + ours`), never a post-wipe readback, so a Mode A wipe of ESET et al. is restored by the shell write rather than dropped.
- **Learned, self-healing flag.** `AutomationSettings.acsDirectWriteUnreliableFingerprint` stores `Build.FINGERPRINT` once the shell path proves necessary. Subsequent enable/disable/re-toggle writes skip the destructive app write and go shell-first. Keyed to the fingerprint so an OTA automatically re-probes the direct path. The flag flips only on solid evidence (reverted write, or shell actually fixing a bind failure) — not on a bare bind timeout.
- **Blast radius.** Unaffected devices never flip the flag → byte-identical behavior. Affected devices take exactly one transient destructive probe (auto-repaired), then go shell-first.
- **Shell write hardening.** Result is checked (`isSuccess`) and verified via readback. When the flag is set but no shell is available, enabling fails fast.

Plan reviewed via Codex (second opinion); its findings on the timeout-cancellation bug, third-party preservation, and fingerprint-keyed flag are integrated. Per project-owner decision, eligibility checks stay on `WRITE_SECURE_SETTINGS` (fail-fast when no shell) and the shell command is the proven non-`--user` form.

## Testing

- `:app-common-automation:assembleDebug` passes.
- Mode A + shell-binds path proven on the affected device (cache cleared end-to-end). Mode B path not yet device-verified — next test build needed to confirm the bind-failure trigger fires there.