### PR TITLE
SystemCleaner: Restrict MacFiles filter matches

### DIFF
--- a/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/MacFilesFilter.kt
+++ b/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/MacFilesFilter.kt
@@ -17,7 +17,10 @@ import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APathLookup
 import eu.darken.sdmse.common.files.GatewaySwitch
+import eu.darken.sdmse.common.files.segs
 import eu.darken.sdmse.common.sieve.NameCriterium
+import eu.darken.sdmse.common.sieve.SegmentCriterium
+import eu.darken.sdmse.common.sieve.TypeCriterium
 import eu.darken.sdmse.systemcleaner.core.SystemCleanerSettings
 import eu.darken.sdmse.systemcleaner.core.filter.BaseSystemCleanerFilter
 import eu.darken.sdmse.systemcleaner.core.filter.SystemCleanerFilter
@@ -43,29 +46,40 @@ class MacFilesFilter @Inject constructor(
         DataArea.Type.PORTABLE,
     )
 
-    private lateinit var sieve: SystemCrawlerSieve
+    private lateinit var fileSieve: SystemCrawlerSieve
+    private lateinit var directorySieve: SystemCrawlerSieve
 
     override suspend fun initialize() {
-        val config = SystemCrawlerSieve.Config(
+        val fileConfig = SystemCrawlerSieve.Config(
+            targetTypes = setOf(TypeCriterium.FILE),
             areaTypes = targetAreas(),
             nameCriteria = setOf(
                 NameCriterium("._", mode = NameCriterium.Mode.Start()),
-                NameCriterium(".Trashes", mode = NameCriterium.Mode.Equal()),
-                NameCriterium("._.Trashes", mode = NameCriterium.Mode.Equal()),
-                NameCriterium(".spotlight", mode = NameCriterium.Mode.Equal()),
-                NameCriterium(".Spotlight-V100", mode = NameCriterium.Mode.Equal()),
                 NameCriterium(".DS_Store", mode = NameCriterium.Mode.Equal()),
-                NameCriterium(".fseventsd", mode = NameCriterium.Mode.Equal()),
-                NameCriterium(".TemporaryItems", mode = NameCriterium.Mode.Equal()),
             ),
         )
-        sieve = sieveFactory.create(config)
-        log(TAG) { "initialized() with $config" }
+        val directoryConfig = SystemCrawlerSieve.Config(
+            targetTypes = setOf(TypeCriterium.DIRECTORY),
+            areaTypes = setOf(
+                DataArea.Type.SDCARD,
+                DataArea.Type.PORTABLE,
+            ),
+            pfpCriteria = setOf(
+                SegmentCriterium(segs(".Trashes"), mode = SegmentCriterium.Mode.Equal()),
+                SegmentCriterium(segs(".spotlight"), mode = SegmentCriterium.Mode.Equal()),
+                SegmentCriterium(segs(".Spotlight-V100"), mode = SegmentCriterium.Mode.Equal()),
+                SegmentCriterium(segs(".fseventsd"), mode = SegmentCriterium.Mode.Equal()),
+                SegmentCriterium(segs(".TemporaryItems"), mode = SegmentCriterium.Mode.Equal()),
+            ),
+        )
+        fileSieve = sieveFactory.create(fileConfig)
+        directorySieve = sieveFactory.create(directoryConfig)
+        log(TAG) { "initialized() with $fileConfig and $directoryConfig" }
     }
 
 
     override suspend fun match(item: APathLookup<*>): SystemCleanerFilter.Match? {
-        return sieve.match(item).toDeletion()
+        return fileSieve.match(item).toDeletion() ?: directorySieve.match(item).toDeletion()
     }
 
     override suspend fun process(
@@ -92,6 +106,6 @@ class MacFilesFilter @Inject constructor(
     }
 
     companion object {
-        private val TAG = logTag("SystemCleaner", "Filter", "LostDir")
+        private val TAG = logTag("SystemCleaner", "Filter", "MacFiles")
     }
 }

--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/MacFilesFilterTest.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/MacFilesFilterTest.kt
@@ -11,6 +11,11 @@ import org.junit.jupiter.api.Test
 
 class MacFilesFilterTest : SystemCleanerFilterTest() {
 
+    private val volumeRootAreas = setOf(
+        DataArea.Type.SDCARD,
+        DataArea.Type.PORTABLE,
+    )
+
     @BeforeEach
     override fun setup() {
         super.setup()
@@ -29,37 +34,85 @@ class MacFilesFilterTest : SystemCleanerFilterTest() {
         gatewaySwitch = gatewaySwitch,
     )
 
-    @Test fun testFilter() = runTest {
-        mockDefaults()
+    private suspend fun forEachTargetArea(block: suspend (DataArea.Type) -> Unit) {
         val areas = create().targetAreas()
         areaManager.currentAreas()
             .filter { areas.contains(it.type) }
             .distinctBy { it.type }
-            .forEach {
-                val loc = it.type
-                neg(loc, "folder", Flag.Dir)
-                pos(loc, "._something", Flag.File)
-                pos(loc, "folder/._something", Flag.File)
-                pos(loc, "._rollkuchen#,'Ä", Flag.File)
-                pos(loc, "folder/._rollkuchen#,'Ä", Flag.File)
-                pos(loc, ".Trashes", Flag.File)
-                pos(loc, "folder/.Trashes", Flag.File)
-                pos(loc, "._.Trashes", Flag.File)
-                pos(loc, "folder/._.Trashes", Flag.File)
-                pos(loc, ".spotlight", Flag.File)
-                pos(loc, "folder/.spotlight", Flag.File)
-                pos(loc, ".Spotlight-V100", Flag.File)
-                pos(loc, "folder/.Spotlight-V100", Flag.File)
-                pos(loc, ".DS_Store", Flag.File)
-                pos(loc, "folder/.DS_Store", Flag.File)
-                pos(loc, ".fseventsd", Flag.File)
-                pos(loc, "folder/.fseventsd", Flag.File)
-                pos(loc, ".TemporaryItems", Flag.File)
-                pos(loc, "folder/.TemporaryItems", Flag.File)
-            }
+            .forEach { block(it.type) }
+    }
+
+    @Test fun `matches macOS file artifacts only as files`() = runTest {
+        mockDefaults()
+        forEachTargetArea { loc ->
+            neg(loc, "folder", Flag.Dir)
+            if (loc == DataArea.Type.PUBLIC_MEDIA) neg(loc, "Pictures", Flag.Dir)
+
+            pos(loc, "._something", Flag.File)
+            pos(loc, "folder/._something", Flag.File)
+            pos(loc, "Pictures/._HLE", Flag.File)
+            pos(loc, "._rollkuchen#,'Ä", Flag.File)
+            pos(loc, "folder/._rollkuchen#,'Ä", Flag.File)
+            pos(loc, "._.Trashes", Flag.File)
+            pos(loc, "folder/._.Trashes", Flag.File)
+            pos(loc, ".DS_Store", Flag.File)
+            pos(loc, "folder/.DS_Store", Flag.File)
+
+            neg(loc, ".Trashes", Flag.File)
+            neg(loc, "folder/.Trashes", Flag.File)
+            neg(loc, ".spotlight", Flag.File)
+            neg(loc, "folder/.spotlight", Flag.File)
+            neg(loc, ".Spotlight-V100", Flag.File)
+            neg(loc, "folder/.Spotlight-V100", Flag.File)
+            neg(loc, ".fseventsd", Flag.File)
+            neg(loc, "folder/.fseventsd", Flag.File)
+            neg(loc, ".TemporaryItems", Flag.File)
+            neg(loc, "folder/.TemporaryItems", Flag.File)
+        }
         neg(DataArea.Type.PUBLIC_DATA, "._rollkuchen#,'Ä", Flag.File)
         neg(DataArea.Type.PUBLIC_DATA, "some.pkg", Flag.Dir)
         neg(DataArea.Type.PUBLIC_DATA, "some.pkg/._rollkuchen#,'Ä", Flag.File)
+        confirm(create())
+    }
+
+    @Test fun `matches macOS directory artifacts only as directories`() = runTest {
+        mockDefaults()
+        forEachTargetArea { loc ->
+            neg(loc, "folder", Flag.Dir)
+            if (loc == DataArea.Type.PUBLIC_MEDIA) neg(loc, "Pictures", Flag.Dir)
+
+            if (loc in volumeRootAreas) {
+                pos(loc, ".Trashes", Flag.Dir)
+                pos(loc, ".spotlight", Flag.Dir)
+                pos(loc, ".Spotlight-V100", Flag.Dir)
+                pos(loc, ".fseventsd", Flag.Dir)
+                pos(loc, ".TemporaryItems", Flag.Dir)
+            } else {
+                neg(loc, ".Trashes", Flag.Dir)
+                neg(loc, ".spotlight", Flag.Dir)
+                neg(loc, ".Spotlight-V100", Flag.Dir)
+                neg(loc, ".fseventsd", Flag.Dir)
+                neg(loc, ".TemporaryItems", Flag.Dir)
+            }
+
+            neg(loc, "._something", Flag.Dir)
+            neg(loc, "folder/._something", Flag.Dir)
+            neg(loc, "Pictures/._HLE", Flag.Dir)
+            neg(loc, "._rollkuchen#,'Ä", Flag.Dir)
+            neg(loc, "folder/._rollkuchen#,'Ä", Flag.Dir)
+            neg(loc, "._.Trashes", Flag.Dir)
+            neg(loc, "folder/._.Trashes", Flag.Dir)
+            neg(loc, ".DS_Store", Flag.Dir)
+            neg(loc, "folder/.DS_Store", Flag.Dir)
+            neg(loc, "folder/.Trashes", Flag.Dir)
+            neg(loc, "folder/.spotlight", Flag.Dir)
+            neg(loc, "folder/.Spotlight-V100", Flag.Dir)
+            neg(loc, "folder/.fseventsd", Flag.Dir)
+            neg(loc, "folder/.TemporaryItems", Flag.Dir)
+        }
+        neg(DataArea.Type.PUBLIC_DATA, "._rollkuchen#,'Ä", Flag.Dir)
+        neg(DataArea.Type.PUBLIC_DATA, "some.pkg", Flag.Dir)
+        neg(DataArea.Type.PUBLIC_DATA, "some.pkg/._rollkuchen#,'Ä", Flag.Dir)
         confirm(create())
     }
 }

--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/MacFilesFilterTest.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/MacFilesFilterTest.kt
@@ -115,4 +115,32 @@ class MacFilesFilterTest : SystemCleanerFilterTest() {
         neg(DataArea.Type.PUBLIC_DATA, "some.pkg/._rollkuchen#,'Ä", Flag.Dir)
         confirm(create())
     }
+
+    @Test fun `matches file and directory artifacts in a single filter pass`() = runTest {
+        mockDefaults()
+        // Both sieves must fire within one filter instance: files via fileSieve, dirs via directorySieve
+        neg(DataArea.Type.SDCARD, "folder", Flag.Dir)
+
+        pos(DataArea.Type.SDCARD, "._something", Flag.File)
+        pos(DataArea.Type.SDCARD, "folder/.DS_Store", Flag.File)
+        pos(DataArea.Type.SDCARD, ".Trashes", Flag.Dir)
+        pos(DataArea.Type.SDCARD, ".fseventsd", Flag.Dir)
+
+        neg(DataArea.Type.SDCARD, "folder/.Trashes", Flag.Dir)
+        neg(DataArea.Type.SDCARD, ".Trashes", Flag.File)
+        confirm(create())
+    }
+
+    @Test fun `volume directory artifacts are restricted to SDCARD and PORTABLE`() = runTest {
+        mockDefaults()
+        // Pin the SDCARD/PORTABLE-only restriction so it can't silently widen to PUBLIC_MEDIA
+        pos(DataArea.Type.SDCARD, ".Trashes", Flag.Dir)
+        pos(DataArea.Type.PORTABLE, ".Trashes", Flag.Dir)
+
+        neg(DataArea.Type.PUBLIC_MEDIA, ".Trashes", Flag.Dir)
+        neg(DataArea.Type.PUBLIC_MEDIA, ".Spotlight-V100", Flag.Dir)
+        neg(DataArea.Type.PUBLIC_MEDIA, ".fseventsd", Flag.Dir)
+        neg(DataArea.Type.PUBLIC_MEDIA, ".TemporaryItems", Flag.Dir)
+        confirm(create())
+    }
 }


### PR DESCRIPTION
## What changed

Fixed the Mac files cleanup filter so it no longer reports dot-underscore folders such as `Pictures/._HLE` as cleanup candidates.

The filter now keeps macOS metadata cleanup focused on actual metadata files and top-level macOS volume folders.

## Technical Context

- Root cause: the previous `._` prefix rule matched any file-system entry type, so a real directory whose name started with `._` was treated like an AppleDouble sidecar file.
- The filter now separates file-only metadata (`._*`, `.DS_Store`) from directory-only volume artifacts (`.Trashes`, `.Spotlight-V100`, `.spotlight`, `.fseventsd`, `.TemporaryItems`).
- Volume directory artifacts are limited to `SDCARD` and `PORTABLE` roots; nested folders and `Android/media` roots are excluded to avoid broad recursive cleanup in normal user or app folders.
- Header/magic-byte validation for AppleDouble files was not added in this pass because the current sieve operates on lookup metadata; adding content inspection would be a larger IO-path change.

## Checks

- `./gradlew :app-tool-systemcleaner:testDebugUnitTest` -> 111 passed
- `git diff --check`