### PR TITLE
Setup: Show invalid app list warning

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/setup/inventory/InventorySetupCardVH.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/inventory/InventorySetupCardVH.kt
@@ -34,7 +34,7 @@ class InventorySetupCardVH(parent: ViewGroup) :
                 )
             )
             text = when {
-                state.isAccessFaked -> getString(R.string.setup_permission_error_label)
+                state.isAccessFaked -> getString(R.string.setup_inventory_invalid_label)
                 else -> getString(R.string.setup_permission_granted_label)
             }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -216,6 +216,7 @@
     <string name="setup_dismiss_hint">You can find the setup screen again via the settings menu.</string>
     <string name="setup_permission_granted_label">Permission granted</string>
     <string name="setup_permission_error_label">Permission error</string>
+    <string name="setup_inventory_invalid_label">Invalid app list</string>
 
     <string name="setup_usagestats_title">Usage statistics</string>
     <string name="setup_usagestats_body">The usage statistics permission grants access to more app details. SD Maid uses it to determine additional cache sizes.</string>
@@ -246,7 +247,7 @@
     <string name="setup_inventory_card_body">SD Maid needs to know which apps you have to find files that don\'t belong to any installed apps.</string>
     <string name="setup_inventory_card_extra">Look for a permission called \"App list\" or \"Query all packages\".</string>
 
-    <string name="setup_inventory_invalid_message">The system provided an invalid list of installed apps (e.g. too few or some were missing). Go to system settings and allow SD Maid access to \"App list\".</string>
+    <string name="setup_inventory_invalid_message">The system provided an invalid list of installed apps (e.g. too few or some were missing). Check system settings and allow SD Maid access to the full \"App list\".</string>
 
     <string name="dataarea_warningcard_empty_message">SD Maid didn\'t find any data areas that can be scanned. Did you complete the setup?</string>
     <string name="dataarea_warningcard_label">Data areas</string>


### PR DESCRIPTION
## What changed

Shows an invalid app list warning when Android reports an incomplete app inventory, instead of labeling the state as a generic permission error.

## Technical Context

- Root cause: `InventorySetupModule` can now distinguish granted permissions from faked/incomplete package inventory, but the setup card still rendered `isAccessFaked` as `Permission error`
- This keeps the existing setup flow and system-settings action, but gives users a more accurate label when the package list is sandboxed or missing core packages
- The explanatory message now asks users to check full app-list access instead of implying that no permission was granted

Validation:
- `./gradlew :app:compileFossDebugKotlin`
- `./gradlew :app:lintVitalFossRelease`

See #2441