### PR TITLE
Analyzer: Keep storage overview available with invalid app list

### DIFF
--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/Analyzer.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/Analyzer.kt
@@ -216,6 +216,13 @@ class Analyzer @Inject constructor(
     private suspend fun deleteContent(task: ContentDeleteTask): ContentDeleteTask.Result {
         log(TAG, VERBOSE) { "deleteContent(): $task" }
 
+        val targetCategory = storageCategories.value[task.storageId]
+            ?.singleOrNull { category -> category.groups.any { it.id == task.groupId } }
+        if (targetCategory is MediaCategory && targetCategory.isReadOnly) {
+            log(TAG, WARN) { "deleteContent(): Blocked — media content is read-only" }
+            throw UnsupportedOperationException("Deletion is not supported for read-only media content")
+        }
+
         updateProgressPrimary {
             it.getString(
                 eu.darken.sdmse.common.R.string.general_progress_deleting_x,

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/Analyzer.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/Analyzer.kt
@@ -229,6 +229,18 @@ class Analyzer @Inject constructor(
             throw UnsupportedOperationException("Deletion is not supported for $what")
         }
 
+        // App tasks are rebuilt against their pkgStat after deletion — resolve it now so a malformed task
+        // (missing/wrong targetPkg, foreign group) fails before any file is deleted, not after.
+        val oldPkg = (oldCategory as? AppCategory)?.let { category ->
+            val pkg = category.pkgStats[task.targetPkg]
+                ?: throw IllegalStateException("Can't find pkgStat ${task.targetPkg} for ${task.groupId}")
+            val groups = setOfNotNull(pkg.appCode, pkg.appData, pkg.appMedia, pkg.extraData)
+            if (groups.none { it == oldGroup }) {
+                throw IllegalStateException("${pkg.id} has no content group matching ${task.groupId}")
+            }
+            pkg
+        }
+
         updateProgressPrimary {
             it.getString(
                 eu.darken.sdmse.common.R.string.general_progress_deleting_x,
@@ -259,13 +271,13 @@ class Analyzer @Inject constructor(
 
         val newCategory = when (oldCategory) {
             is AppCategory -> {
-                val oldPkg = oldCategory.pkgStats[task.targetPkg]!!
+                checkNotNull(oldPkg) { "pkgStat was preflight-resolved for app categories" }
                 val newPkg = when {
                     oldPkg.appCode == oldGroup -> oldPkg.copy(appCode = newGroup)
                     oldPkg.appData == oldGroup -> oldPkg.copy(appData = newGroup)
                     oldPkg.appMedia == oldGroup -> oldPkg.copy(appMedia = newGroup)
                     oldPkg.extraData == oldGroup -> oldPkg.copy(extraData = newGroup)
-                    else -> throw IllegalArgumentException("${oldPkg.id} has no matching content group")
+                    else -> error("unreachable: group membership was preflight-validated")
                 }
                 oldCategory.copy(
                     pkgStats = oldCategory.pkgStats.mutate {

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/Analyzer.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/Analyzer.kt
@@ -18,6 +18,8 @@ import eu.darken.sdmse.analyzer.core.storage.categories.AppCategory
 import eu.darken.sdmse.analyzer.core.storage.categories.ContentCategory
 import eu.darken.sdmse.analyzer.core.storage.categories.MediaCategory
 import eu.darken.sdmse.analyzer.core.storage.categories.SystemCategory
+import eu.darken.sdmse.analyzer.core.storage.categories.isContentReadOnly
+import eu.darken.sdmse.analyzer.core.storage.categories.ownsGroup
 import eu.darken.sdmse.analyzer.core.storage.toFlatContent
 import eu.darken.sdmse.analyzer.core.storage.toNestedContent
 import eu.darken.sdmse.common.collections.mutate
@@ -216,11 +218,15 @@ class Analyzer @Inject constructor(
     private suspend fun deleteContent(task: ContentDeleteTask): ContentDeleteTask.Result {
         log(TAG, VERBOSE) { "deleteContent(): $task" }
 
-        val targetCategory = storageCategories.value[task.storageId]
-            ?.singleOrNull { category -> category.groups.any { it.id == task.groupId } }
-        if (targetCategory is MediaCategory && targetCategory.isReadOnly) {
-            log(TAG, WARN) { "deleteContent(): Blocked — media content is read-only" }
-            throw UnsupportedOperationException("Deletion is not supported for read-only media content")
+        val oldCategory: ContentCategory = storageCategories.value[task.storageId]
+            ?.singleOrNull { it.ownsGroup(task.groupId) }
+            ?: throw IllegalStateException("Can't find category and group for ${task.groupId}")
+        val oldGroup = oldCategory.groups.single { it.id == task.groupId }
+
+        if (oldCategory.isContentReadOnly) {
+            val what = if (oldCategory is SystemCategory) "system content" else "read-only media content"
+            log(TAG, WARN) { "deleteContent(): Blocked — $what is read-only" }
+            throw UnsupportedOperationException("Deletion is not supported for $what")
         }
 
         updateProgressPrimary {
@@ -239,14 +245,6 @@ class Analyzer @Inject constructor(
                 (target as? LocalPath)?.let { mediaStoreTool.notifyDeleted(it) }
             }
 
-        // TODO this seems convoluted, can we come up with a better data pattern?
-        var _oldGroup: ContentGroup? = null
-        val oldCategory: ContentCategory = storageCategories.value[task.storageId]!!.singleOrNull { category ->
-            category.groups.singleOrNull { it.id == task.groupId }
-                ?.also { _oldGroup = it }
-                ?.let { true } ?: false
-        } ?: throw IllegalStateException("Can't find category and group for ${task.groupId}")
-        val oldGroup = _oldGroup!!
         var freedSpace = 0L
         val newContents = oldGroup.contents
             .toFlatContent()

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/StorageScanner.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/StorageScanner.kt
@@ -21,6 +21,7 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.files.APathLookup
 import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.ReadException
@@ -141,9 +142,14 @@ class StorageScanner @Inject constructor(
 
                 updateProgressSecondary(eu.darken.sdmse.analyzer.R.string.analyzer_progress_scanning_storage)
 
-                val folders = storageDir?.lookedUp
+                val storageChildren = storageDir?.lookedUp
                     ?.listFiles(gatewaySwitch)
                     ?.filter { storage.type == DeviceStorage.Type.PORTABLE || it.name != "Android" }
+                    ?: emptySet()
+
+                val hasCompleteInventory = inventorySetupModule.isComplete()
+                val folders = storageChildren
+                    .takeIf { hasCompleteInventory }
                     ?.mapNotNull { fileForensics.findOwners(it) }
                     ?.filter { setOf(DataArea.Type.SDCARD, DataArea.Type.PORTABLE).contains(it.areaInfo.type) }
                     ?.onEach { log(TAG) { "Top level dir: $it" } }
@@ -155,7 +161,7 @@ class StorageScanner @Inject constructor(
 
                 updateProgressSecondary("Scanning media files")
                 val media = storageDir
-                    ?.let { scanForMedia(storage, it) }
+                    ?.let { scanForMedia(storage, it, storageChildren, hasCompleteInventory) }
                     ?: MediaCategory(storage.id, emptySet())
 
                 updateProgressSecondary("Scanning system data")
@@ -239,9 +245,46 @@ class StorageScanner @Inject constructor(
         }
     }
 
-    private suspend fun scanForMedia(storage: DeviceStorage, mediaDir: APathLookup<*>): MediaCategory {
+    private suspend fun scanForMedia(
+        storage: DeviceStorage,
+        mediaDir: APathLookup<*>,
+        storageChildren: Collection<APath>,
+        hasCompleteInventory: Boolean,
+    ): MediaCategory {
         log(TAG) { "scanForMedia($storage)" }
         updateProgressPrimary(eu.darken.sdmse.analyzer.R.string.analyzer_progress_scanning_userfiles)
+
+        if (!hasCompleteInventory) {
+            log(TAG, WARN) { "Inventory setup is incomplete, sizing media folders without owner forensics." }
+            updateProgressCount(Progress.Count.Percent(storageChildren.size))
+
+            val topLevelContents: Collection<ContentItem> = storageChildren.mapNotNull { path ->
+                updateProgressSecondary(path.userReadablePath)
+
+                try {
+                    path.sizeContentItem(gatewaySwitch)
+                } catch (e: ReadException) {
+                    log(TAG, ERROR) { "Failed to size top-level dir $path: ${e.asLog()}" }
+                    null
+                } finally {
+                    increaseProgress()
+                }
+            }
+
+            val rootItem = topLevelContents.plus(ContentItem.fromLookup(mediaDir)).toNestedContent().single()
+
+            val group = ContentGroup(
+                label = eu.darken.sdmse.analyzer.R.string.analyzer_storage_content_type_media_label.toCaString(),
+                contents = setOf(rootItem),
+            )
+
+            return MediaCategory(
+                storageId = storage.id,
+                groups = setOf(group),
+                isReadOnly = true,
+            )
+        }
+
         updateProgressCount(Progress.Count.Percent(topLevelDirs.size))
 
         val topLevelContents: Collection<ContentItem> = topLevelDirs.mapNotNull { ownerInfo ->
@@ -285,7 +328,10 @@ class StorageScanner @Inject constructor(
             return null
         }
 
-        val unaccountedFor = storage.spaceUsed - (appCategory?.spaceUsed ?: 0L) - mediaCategory.spaceUsed
+        // In the degraded scan media folders are du-sized (no owner forensics), which can overcount and push this
+        // below zero. Clamp so the system category never reports a negative size.
+        val unaccountedFor = (storage.spaceUsed - (appCategory?.spaceUsed ?: 0L) - mediaCategory.spaceUsed)
+            .coerceAtLeast(0L)
 
         val contentItems = setOf(
             ContentItem.fromInaccessible(LocalPath.build("system")),

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/StorageScanner.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/StorageScanner.kt
@@ -167,11 +167,16 @@ class StorageScanner @Inject constructor(
                     }
                 }
 
-                val ownersResolved = owners != null
                 topLevelDirs.clear()
                 topLevelDirs.addAll(owners ?: emptySet())
 
-                val apps = scanForApps(storage)
+                val appScan = scanForApps(storage)
+                val apps = appScan.category
+
+                // Media stays writable only while owner attribution is trustworthy end to end: top-level forensics
+                // resolved AND the app scan didn't hit an inventory failure (which leaves app-owned top-level dirs
+                // undrained — they must not surface as writable user files).
+                val ownersResolved = owners != null && !appScan.inventoryFailed
 
                 updateProgressSecondary("Scanning media files")
                 val media = storageDir
@@ -190,31 +195,58 @@ class StorageScanner @Inject constructor(
         }
     }
 
-    private suspend fun scanForApps(storage: DeviceStorage): AppCategory? {
+    private data class AppScanResult(
+        val category: AppCategory?,
+        // The pkg inventory threw despite setup reporting complete. Unlike plain setup-incomplete (e.g. missing
+        // usage stats, where owner attribution is still trustworthy), this must also degrade the media scan.
+        val inventoryFailed: Boolean = false,
+    )
+
+    private suspend fun scanForApps(storage: DeviceStorage): AppScanResult {
         log(TAG) { "scanForApps($storage)" }
         if (!inventorySetupModule.isComplete()) {
             log(TAG, WARN) { "Inventory setup is incomplete, can't scan apps." }
-            return AppCategory(
-                storageId = storage.id,
-                setupIncomplete = true,
-                pkgStats = emptyMap()
+            return AppScanResult(
+                AppCategory(
+                    storageId = storage.id,
+                    setupIncomplete = true,
+                    pkgStats = emptyMap()
+                )
             )
         }
 
         if (!usageStatsSetupModule.isComplete()) {
             log(TAG, WARN) { "Usagestats setup is incomplete, can't scan apps." }
-            return AppCategory(
-                storageId = storage.id,
-                setupIncomplete = true,
-                pkgStats = emptyMap()
+            return AppScanResult(
+                AppCategory(
+                    storageId = storage.id,
+                    setupIncomplete = true,
+                    pkgStats = emptyMap()
+                )
             )
         }
 
         updateProgressPrimary(eu.darken.sdmse.analyzer.R.string.analyzer_progress_scanning_apps)
 
-        val targetPkgs = pkgRepo.current()
-            .filter { it.packageName != "android" }
-            .filter { it.applicationInfo != null }
+        // Same failure mode as the top-level owner forensics: setup can report complete while the pkg repo holds a
+        // stale error. Degrade to "setup incomplete" instead of aborting the whole storage scan.
+        val targetPkgs = try {
+            pkgRepo.current()
+                .filter { it.packageName != "android" }
+                .filter { it.applicationInfo != null }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, ERROR) { "App inventory unavailable despite completed setup, degrading app scan: ${e.asLog()}" }
+            return AppScanResult(
+                AppCategory(
+                    storageId = storage.id,
+                    setupIncomplete = true,
+                    pkgStats = emptyMap()
+                ),
+                inventoryFailed = true,
+            )
+        }
 
         updateProgressCount(Progress.Count.Percent(targetPkgs.size))
 
@@ -252,11 +284,13 @@ class StorageScanner @Inject constructor(
             .filter { it.totalSize > 0L }
             .associateBy { it.id }
 
-        return if (pkgStats.isNotEmpty()) {
-            AppCategory(storageId = storage.id, pkgStats = pkgStats)
-        } else {
-            null
-        }
+        return AppScanResult(
+            if (pkgStats.isNotEmpty()) {
+                AppCategory(storageId = storage.id, pkgStats = pkgStats)
+            } else {
+                null
+            }
+        )
     }
 
     private suspend fun scanForMedia(
@@ -285,7 +319,9 @@ class StorageScanner @Inject constructor(
                 }
             }
 
-            val rootItem = topLevelContents.plus(ContentItem.fromLookup(mediaDir)).toNestedContent().single()
+            // All sized items are direct children of the storage root, so build the tree directly instead of
+            // relying on segment-based nesting — a stray non-child path must not abort the degraded scan.
+            val rootItem = ContentItem.fromLookup(mediaDir).copy(children = topLevelContents)
 
             val group = ContentGroup(
                 label = eu.darken.sdmse.analyzer.R.string.analyzer_storage_content_type_media_label.toCaString(),

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/StorageScanner.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/StorageScanner.kt
@@ -46,6 +46,7 @@ import eu.darken.sdmse.common.user.UserManager2
 import eu.darken.sdmse.setup.SetupModule
 import eu.darken.sdmse.setup.isComplete
 import eu.darken.sdmse.setup.SetupBinding
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import javax.inject.Inject
@@ -147,21 +148,34 @@ class StorageScanner @Inject constructor(
                     ?.filter { storage.type == DeviceStorage.Type.PORTABLE || it.name != "Android" }
                     ?: emptySet()
 
-                val hasCompleteInventory = inventorySetupModule.isComplete()
-                val folders = storageChildren
-                    .takeIf { hasCompleteInventory }
-                    ?.mapNotNull { fileForensics.findOwners(it) }
-                    ?.filter { setOf(DataArea.Type.SDCARD, DataArea.Type.PORTABLE).contains(it.areaInfo.type) }
-                    ?.onEach { log(TAG) { "Top level dir: $it" } }
-                    ?: emptySet()
+                // Owner forensics needs a working app inventory. Skip it when setup is incomplete, and treat a
+                // wholesale failure as a degraded scan too: on some OEMs attribution can still throw even when setup
+                // reports complete (e.g. a stale PkgRepo error or a forensics/CSI failure), and that must not abort
+                // the whole storage overview.
+                val owners: Collection<OwnerInfo>? = when {
+                    !inventorySetupModule.isComplete() -> null
+                    else -> try {
+                        storageChildren
+                            .mapNotNull { fileForensics.findOwners(it) }
+                            .filter { setOf(DataArea.Type.SDCARD, DataArea.Type.PORTABLE).contains(it.areaInfo.type) }
+                            .onEach { log(TAG) { "Top level dir: $it" } }
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        log(TAG, ERROR) { "Top-level owner forensics failed, degrading storage scan: ${e.asLog()}" }
+                        null
+                    }
+                }
+
+                val ownersResolved = owners != null
                 topLevelDirs.clear()
-                topLevelDirs.addAll(folders)
+                topLevelDirs.addAll(owners ?: emptySet())
 
                 val apps = scanForApps(storage)
 
                 updateProgressSecondary("Scanning media files")
                 val media = storageDir
-                    ?.let { scanForMedia(storage, it, storageChildren, hasCompleteInventory) }
+                    ?.let { scanForMedia(storage, it, storageChildren, ownersResolved) }
                     ?: MediaCategory(storage.id, emptySet())
 
                 updateProgressSecondary("Scanning system data")
@@ -249,13 +263,13 @@ class StorageScanner @Inject constructor(
         storage: DeviceStorage,
         mediaDir: APathLookup<*>,
         storageChildren: Collection<APath>,
-        hasCompleteInventory: Boolean,
+        ownersResolved: Boolean,
     ): MediaCategory {
         log(TAG) { "scanForMedia($storage)" }
         updateProgressPrimary(eu.darken.sdmse.analyzer.R.string.analyzer_progress_scanning_userfiles)
 
-        if (!hasCompleteInventory) {
-            log(TAG, WARN) { "Inventory setup is incomplete, sizing media folders without owner forensics." }
+        if (!ownersResolved) {
+            log(TAG, WARN) { "Owner forensics unavailable, sizing media folders directly (read-only)." }
             updateProgressCount(Progress.Count.Percent(storageChildren.size))
 
             val topLevelContents: Collection<ContentItem> = storageChildren.mapNotNull { path ->

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/categories/ContentCategory.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/categories/ContentCategory.kt
@@ -8,3 +8,19 @@ sealed interface ContentCategory {
     val spaceUsed: Long
     val groups: Collection<ContentGroup>
 }
+
+fun ContentCategory.ownsGroup(groupId: ContentGroup.Id): Boolean = groups.any { it.id == groupId }
+
+/**
+ * Whether content actions (delete, filter, Swiper) must be blocked for this category.
+ *
+ * System content is always read-only. Media content is read-only only in the degraded scan, i.e. when the app
+ * inventory is unavailable and files can't be matched to their owners. Shared by the UI and the core delete guard so
+ * the two definitions can't drift.
+ */
+val ContentCategory.isContentReadOnly: Boolean
+    get() = when (this) {
+        is SystemCategory -> true
+        is MediaCategory -> isReadOnly
+        is AppCategory -> false
+    }

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/categories/MediaCategory.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/categories/MediaCategory.kt
@@ -7,6 +7,7 @@ data class MediaCategory(
     override val storageId: StorageId,
     override val groups: Collection<ContentGroup>,
     val spaceUsedOverride: Long? = null,
+    val isReadOnly: Boolean = false,
 ) : ContentCategory {
 
     override val spaceUsed: Long

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentInfoBanner.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentInfoBanner.kt
@@ -8,15 +8,18 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import eu.darken.sdmse.analyzer.R
+import eu.darken.sdmse.common.ca.CaString
+import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.compose.preview.Preview2
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 
 @Composable
 internal fun ContentInfoBanner(
     modifier: Modifier = Modifier,
+    text: CaString,
 ) {
     Card(
         modifier = modifier.fillMaxWidth(),
@@ -25,7 +28,7 @@ internal fun ContentInfoBanner(
         ),
     ) {
         Text(
-            text = stringResource(R.string.analyzer_storage_content_type_system_info),
+            text = text.get(LocalContext.current),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.padding(16.dp),
@@ -37,6 +40,6 @@ internal fun ContentInfoBanner(
 @Composable
 private fun ContentInfoBannerPreview() {
     PreviewWrapper {
-        ContentInfoBanner()
+        ContentInfoBanner(text = R.string.analyzer_storage_content_type_system_info.toCaString())
     }
 }

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentInfoBanner.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentInfoBanner.kt
@@ -43,3 +43,11 @@ private fun ContentInfoBannerPreview() {
         ContentInfoBanner(text = R.string.analyzer_storage_content_type_system_info.toCaString())
     }
 }
+
+@Preview2
+@Composable
+private fun ContentInfoBannerMediaReadOnlyPreview() {
+    PreviewWrapper {
+        ContentInfoBanner(text = R.string.analyzer_storage_content_type_media_readonly_info.toCaString())
+    }
+}

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentScreen.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentScreen.kt
@@ -396,9 +396,12 @@ internal fun ContentScreen(
                                 modifier = Modifier.fillMaxSize(),
                                 contentPadding = SdmListDefaults.FullWidthContentPadding,
                             ) {
-                                if (s.showSystemInfoBanner) {
+                                s.infoBanner?.let { banner ->
                                     item(key = "info-banner") {
-                                        ContentInfoBanner(modifier = Modifier.padding(horizontal = 16.dp))
+                                        ContentInfoBanner(
+                                            modifier = Modifier.padding(horizontal = 16.dp),
+                                            text = banner,
+                                        )
                                     }
                                 }
                                 contentRows(s.items, selection, isSelectionMode, onItemClick)
@@ -411,12 +414,12 @@ internal fun ContentScreen(
                                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                                 verticalArrangement = Arrangement.spacedBy(8.dp),
                             ) {
-                                if (s.showSystemInfoBanner) {
+                                s.infoBanner?.let { banner ->
                                     item(
                                         key = "info-banner",
                                         span = { GridItemSpan(maxLineSpan) },
                                     ) {
-                                        ContentInfoBanner()
+                                        ContentInfoBanner(text = banner)
                                     }
                                 }
                                 contentTiles(s.items, selection, isSelectionMode, onItemClick)

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentViewModel.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentViewModel.kt
@@ -2,6 +2,7 @@ package eu.darken.sdmse.analyzer.ui.storage.content
 
 import android.content.Intent
 import dagger.hilt.android.lifecycle.HiltViewModel
+import eu.darken.sdmse.analyzer.R
 import eu.darken.sdmse.analyzer.core.Analyzer
 import eu.darken.sdmse.analyzer.core.AnalyzerSettings
 import eu.darken.sdmse.analyzer.core.content.ContentDeleteTask
@@ -17,6 +18,7 @@ import eu.darken.sdmse.analyzer.ui.ContentRoute
 import eu.darken.sdmse.analyzer.ui.storage.computeSizeBarRatio
 import eu.darken.sdmse.common.ViewIntentTool
 import eu.darken.sdmse.common.ca.CaString
+import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
@@ -137,6 +139,15 @@ class ContentViewModel @Inject constructor(
                     pkgStat?.label == null -> null
                     else -> contentGroup.label
                 }
+                val infoBanner: CaString? = when {
+                    // System content: top-level banner only, mirroring the system category presentation.
+                    isSystemGroup -> R.string.analyzer_storage_content_type_system_info.toCaString()
+                        .takeIf { currentLevel == null }
+                    // Degraded read-only media: keep the banner visible while browsing too, since the group is a
+                    // single storage-root item the user must open before seeing any folders.
+                    isReadOnly -> R.string.analyzer_storage_content_type_media_readonly_info.toCaString()
+                    else -> null
+                }
 
                 // Loading frame: no items yet (progress stamped by the outer combine).
                 emit(
@@ -148,7 +159,7 @@ class ContentViewModel @Inject constructor(
                         layoutMode = layoutMode,
                         progress = null,
                         isReadOnly = isReadOnly,
-                        showSystemInfoBanner = isSystemGroup && currentLevel == null,
+                        infoBanner = infoBanner,
                     ),
                 )
 
@@ -173,7 +184,7 @@ class ContentViewModel @Inject constructor(
                         layoutMode = layoutMode,
                         progress = null,
                         isReadOnly = isReadOnly,
-                        showSystemInfoBanner = isSystemGroup && currentLevel == null,
+                        infoBanner = infoBanner,
                     ),
                 )
             }
@@ -321,7 +332,7 @@ class ContentViewModel @Inject constructor(
             val layoutMode: LayoutMode,
             val progress: Progress.Data?,
             val isReadOnly: Boolean,
-            val showSystemInfoBanner: Boolean,
+            val infoBanner: CaString?,
         ) : State
         data object NotFound : State
     }

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentViewModel.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentViewModel.kt
@@ -10,6 +10,8 @@ import eu.darken.sdmse.analyzer.core.content.ContentItem
 import eu.darken.sdmse.analyzer.core.device.DeviceStorage
 import eu.darken.sdmse.analyzer.core.storage.categories.AppCategory
 import eu.darken.sdmse.analyzer.core.storage.categories.SystemCategory
+import eu.darken.sdmse.analyzer.core.storage.categories.isContentReadOnly
+import eu.darken.sdmse.analyzer.core.storage.categories.ownsGroup
 import eu.darken.sdmse.analyzer.core.storage.findContent
 import eu.darken.sdmse.analyzer.ui.ContentRoute
 import eu.darken.sdmse.analyzer.ui.storage.computeSizeBarRatio
@@ -94,8 +96,13 @@ class ContentViewModel @Inject constructor(
 
     private fun Analyzer.Data.isSystemGroup(route: ContentRoute): Boolean {
         return categories[route.storageId]
-            ?.filterIsInstance<SystemCategory>()
-            ?.any { category -> category.groups.any { it.id == route.groupId } }
+            ?.any { it is SystemCategory && it.ownsGroup(route.groupId) }
+            ?: false
+    }
+
+    private fun Analyzer.Data.isReadOnlyGroup(route: ContentRoute): Boolean {
+        return categories[route.storageId]
+            ?.any { it.ownsGroup(route.groupId) && it.isContentReadOnly }
             ?: false
     }
 
@@ -116,7 +123,8 @@ class ContentViewModel @Inject constructor(
                     emit(State.NotFound)
                     return@combineTransform
                 }
-                val isReadOnly = data.isSystemGroup(route)
+                val isReadOnly = data.isReadOnlyGroup(route)
+                val isSystemGroup = data.isSystemGroup(route)
                 val pkgStat = route.installId?.let { installId ->
                     data.categories[route.storageId]
                         ?.filterIsInstance<AppCategory>()?.singleOrNull()
@@ -140,7 +148,7 @@ class ContentViewModel @Inject constructor(
                         layoutMode = layoutMode,
                         progress = null,
                         isReadOnly = isReadOnly,
-                        showSystemInfoBanner = isReadOnly && currentLevel == null,
+                        showSystemInfoBanner = isSystemGroup && currentLevel == null,
                     ),
                 )
 
@@ -165,7 +173,7 @@ class ContentViewModel @Inject constructor(
                         layoutMode = layoutMode,
                         progress = null,
                         isReadOnly = isReadOnly,
-                        showSystemInfoBanner = isReadOnly && currentLevel == null,
+                        showSystemInfoBanner = isSystemGroup && currentLevel == null,
                     ),
                 )
             }
@@ -217,8 +225,8 @@ class ContentViewModel @Inject constructor(
         val route = routeFlow.value ?: return@launch
         log(TAG) { "onDeleteSelected(): ${items.size}" }
         val data = analyzer.data.first()
-        if (data.isSystemGroup(route)) {
-            log(TAG, WARN) { "delete(): Blocked — system content is read-only" }
+        if (data.isReadOnlyGroup(route)) {
+            log(TAG, WARN) { "delete(): Blocked — content is read-only" }
             return@launch
         }
         val targets = items.map { it.path }.toSet()
@@ -245,8 +253,8 @@ class ContentViewModel @Inject constructor(
     fun onCreateFilter(items: Set<ContentItem>) = launch {
         val route = routeFlow.value ?: return@launch
         log(TAG) { "onCreateFilter(): ${items.size}" }
-        if (analyzer.data.first().isSystemGroup(route)) {
-            log(TAG, WARN) { "createFilter(): Blocked — system content is read-only" }
+        if (analyzer.data.first().isReadOnlyGroup(route)) {
+            log(TAG, WARN) { "createFilter(): Blocked — content is read-only" }
             return@launch
         }
         if (!upgradeRepo.isPro()) {
@@ -263,8 +271,8 @@ class ContentViewModel @Inject constructor(
     fun onCreateSwiperSession(items: Set<ContentItem>) = launch {
         val route = routeFlow.value ?: return@launch
         log(TAG) { "onCreateSwiperSession(): ${items.size}" }
-        if (analyzer.data.first().isSystemGroup(route)) {
-            log(TAG, WARN) { "createSwiperSession(): Blocked — system content is read-only" }
+        if (analyzer.data.first().isReadOnlyGroup(route)) {
+            log(TAG, WARN) { "createSwiperSession(): Blocked — content is read-only" }
             return@launch
         }
         val paths = items

--- a/app-tool-analyzer/src/main/res/values/strings.xml
+++ b/app-tool-analyzer/src/main/res/values/strings.xml
@@ -38,6 +38,7 @@
     <string name="analyzer_storage_content_type_system_description">System apps and system data. Apps and data from other users, if several user accounts are set on this device.</string>
     <string name="analyzer_storage_content_type_system_other_label">Other</string>
     <string name="analyzer_storage_content_type_system_info">Files that don\'t fit the Apps or User files categories. Browse only — deletion is not supported. Some areas may be incomplete due to access restrictions.</string>
+    <string name="analyzer_storage_content_type_media_readonly_info">The app inventory is unavailable, so files can\'t be matched to their owners. Sizes are shown for reference only — deletion, filters and Swiper are disabled.</string>
     <string name="analyzer_storage_content_type_system_other_desc">System files and other data that SD Maid could not access or categorize. The operating system restricts listing the contents of some areas.</string>
     <string name="analyzer_storage_content_app_code_label">App code</string>
     <string name="analyzer_storage_content_app_code_description">Application files, libraries and resources. This space can be freed by uninstalling the app or archiving it (available on newer Android version).</string>

--- a/app-tool-analyzer/src/main/res/values/strings.xml
+++ b/app-tool-analyzer/src/main/res/values/strings.xml
@@ -38,7 +38,7 @@
     <string name="analyzer_storage_content_type_system_description">System apps and system data. Apps and data from other users, if several user accounts are set on this device.</string>
     <string name="analyzer_storage_content_type_system_other_label">Other</string>
     <string name="analyzer_storage_content_type_system_info">Files that don\'t fit the Apps or User files categories. Browse only — deletion is not supported. Some areas may be incomplete due to access restrictions.</string>
-    <string name="analyzer_storage_content_type_media_readonly_info">The app inventory is unavailable, so files can\'t be matched to their owners. Sizes are shown for reference only — deletion, filters and Swiper are disabled.</string>
+    <string name="analyzer_storage_content_type_media_readonly_info">Files can\'t be matched to the apps that own them right now. Sizes are shown for reference only — deletion, filters and Swiper are disabled.</string>
     <string name="analyzer_storage_content_type_system_other_desc">System files and other data that SD Maid could not access or categorize. The operating system restricts listing the contents of some areas.</string>
     <string name="analyzer_storage_content_app_code_label">App code</string>
     <string name="analyzer_storage_content_app_code_description">Application files, libraries and resources. This space can be freed by uninstalling the app or archiving it (available on newer Android version).</string>

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/AnalyzerDeleteGuardTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/AnalyzerDeleteGuardTest.kt
@@ -2,6 +2,7 @@ package eu.darken.sdmse.analyzer.core
 
 import eu.darken.sdmse.analyzer.core.content.ContentDeleteTask
 import eu.darken.sdmse.analyzer.core.content.ContentGroup
+import eu.darken.sdmse.analyzer.core.storage.categories.AppCategory
 import eu.darken.sdmse.analyzer.core.storage.categories.ContentCategory
 import eu.darken.sdmse.analyzer.core.storage.categories.MediaCategory
 import eu.darken.sdmse.analyzer.core.storage.categories.SystemCategory
@@ -10,7 +11,11 @@ import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.MediaStoreTool
 import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.pkgs.Pkg
+import eu.darken.sdmse.common.pkgs.features.InstallId
+import eu.darken.sdmse.common.pkgs.features.Installed
 import eu.darken.sdmse.common.storage.StorageId
+import eu.darken.sdmse.common.user.UserHandle2
 import eu.darken.sdmse.setup.SetupModule
 import io.kotest.assertions.throwables.shouldThrow
 import io.mockk.coVerify
@@ -22,17 +27,18 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
-import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
 import java.util.UUID
 import javax.inject.Provider
 
 /**
  * The safety-critical contract behind #2441: a [ContentDeleteTask] aimed at read-only content (system, or degraded
- * read-only media) must fail before [Analyzer] touches the filesystem. The guard runs before the delete loop, so a
- * thrown [UnsupportedOperationException] proves no deletion happened.
+ * read-only media) must fail before [Analyzer] touches the filesystem, and so must an app task whose pkgStat or
+ * group ownership can't be resolved. All guards run before the delete loop, so a thrown exception proves no
+ * deletion happened.
  */
 class AnalyzerDeleteGuardTest : BaseTest() {
 
@@ -73,14 +79,29 @@ class AnalyzerDeleteGuardTest : BaseTest() {
         return analyzer
     }
 
-    private fun deleteTask() = ContentDeleteTask(
+    private fun deleteTask(targetPkg: InstallId? = null) = ContentDeleteTask(
         storageId = storageId,
         groupId = group.id,
+        targetPkg = targetPkg,
         targets = setOf(LocalPath.build("storage", "emulated", "0", "DCIM") as APath),
     )
 
+    private fun installId(pkgName: String) = InstallId(
+        pkgId = Pkg.Id(pkgName),
+        userHandle = UserHandle2(0),
+    )
+
+    private fun pkgStat(id: InstallId, appData: ContentGroup) = AppCategory.PkgStat(
+        pkg = mockk<Installed>().apply { every { installId } returns id },
+        isShallow = false,
+        appCode = null,
+        appData = appData,
+        appMedia = null,
+        extraData = null,
+    )
+
     @Test
-    fun `read-only media deletion is blocked before any filesystem access`() = runTest {
+    fun `read-only media deletion is blocked before any filesystem access`() = runTest2 {
         val analyzer = buildAnalyzer(setOf(MediaCategory(storageId, setOf(group), isReadOnly = true)))
 
         shouldThrow<UnsupportedOperationException> { analyzer.submit(deleteTask()) }
@@ -90,10 +111,48 @@ class AnalyzerDeleteGuardTest : BaseTest() {
     }
 
     @Test
-    fun `system content deletion is blocked before any filesystem access`() = runTest {
+    fun `system content deletion is blocked before any filesystem access`() = runTest2 {
         val analyzer = buildAnalyzer(setOf(SystemCategory(storageId, setOf(group))))
 
         shouldThrow<UnsupportedOperationException> { analyzer.submit(deleteTask()) }
+
+        coVerify(exactly = 0) { gatewaySwitch.delete(any(), any()) }
+        coVerify(exactly = 0) { mediaStoreTool.notifyDeleted(any()) }
+    }
+
+    @Test
+    fun `app deletion without a resolvable pkgStat is blocked before any filesystem access`() = runTest2 {
+        val owner = installId("com.example.owner")
+        val analyzer = buildAnalyzer(
+            setOf(AppCategory(storageId, pkgStats = mapOf(owner to pkgStat(owner, appData = group)))),
+        )
+
+        // targetPkg missing from the task even though the group exists.
+        shouldThrow<IllegalStateException> { analyzer.submit(deleteTask(targetPkg = null)) }
+
+        coVerify(exactly = 0) { gatewaySwitch.delete(any(), any()) }
+        coVerify(exactly = 0) { mediaStoreTool.notifyDeleted(any()) }
+    }
+
+    @Test
+    fun `app deletion targeting another pkg's group is blocked before any filesystem access`() = runTest2 {
+        val owner = installId("com.example.owner")
+        val bystander = installId("com.example.bystander")
+        val bystanderGroup = ContentGroup(label = "bystander".toCaString())
+        val analyzer = buildAnalyzer(
+            setOf(
+                AppCategory(
+                    storageId,
+                    pkgStats = mapOf(
+                        owner to pkgStat(owner, appData = group),
+                        bystander to pkgStat(bystander, appData = bystanderGroup),
+                    ),
+                ),
+            ),
+        )
+
+        // The group exists, but belongs to `owner`, not the task's targetPkg.
+        shouldThrow<IllegalStateException> { analyzer.submit(deleteTask(targetPkg = bystander)) }
 
         coVerify(exactly = 0) { gatewaySwitch.delete(any(), any()) }
         coVerify(exactly = 0) { mediaStoreTool.notifyDeleted(any()) }

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/AnalyzerDeleteGuardTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/AnalyzerDeleteGuardTest.kt
@@ -1,0 +1,101 @@
+package eu.darken.sdmse.analyzer.core
+
+import eu.darken.sdmse.analyzer.core.content.ContentDeleteTask
+import eu.darken.sdmse.analyzer.core.content.ContentGroup
+import eu.darken.sdmse.analyzer.core.storage.categories.ContentCategory
+import eu.darken.sdmse.analyzer.core.storage.categories.MediaCategory
+import eu.darken.sdmse.analyzer.core.storage.categories.SystemCategory
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.files.GatewaySwitch
+import eu.darken.sdmse.common.files.MediaStoreTool
+import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.storage.StorageId
+import eu.darken.sdmse.setup.SetupModule
+import io.kotest.assertions.throwables.shouldThrow
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.util.UUID
+import javax.inject.Provider
+
+/**
+ * The safety-critical contract behind #2441: a [ContentDeleteTask] aimed at read-only content (system, or degraded
+ * read-only media) must fail before [Analyzer] touches the filesystem. The guard runs before the delete loop, so a
+ * thrown [UnsupportedOperationException] proves no deletion happened.
+ */
+class AnalyzerDeleteGuardTest : BaseTest() {
+
+    // The Analyzer's sharedResource + init collector need a long-lived scope.
+    private val gateScope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+
+    @AfterEach
+    fun cancelGateScope() {
+        gateScope.coroutineContext[Job]?.cancel()
+    }
+
+    private val storageId = StorageId(
+        internalId = null,
+        externalId = UUID.fromString("00000000-0000-0000-0000-000000000001"),
+    )
+    private val group = ContentGroup(label = "group".toCaString())
+    private val mediaStoreTool = mockk<MediaStoreTool>(relaxed = true)
+    private val gatewaySwitch = mockk<GatewaySwitch>(relaxed = true)
+
+    private fun buildAnalyzer(categories: Collection<ContentCategory>): Analyzer {
+        val storageSetup = mockk<SetupModule>(relaxed = true).apply { every { state } returns emptyFlow() }
+        val analyzer = Analyzer(
+            appScope = gateScope,
+            deviceScanner = Provider { mockk(relaxed = true) },
+            storageScanner = Provider { mockk(relaxed = true) },
+            gatewaySwitch = gatewaySwitch,
+            appInventorySetupModule = mockk(relaxed = true),
+            storageSetupModule = storageSetup,
+            mediaStoreTool = mediaStoreTool,
+            spaceTracker = mockk(relaxed = true),
+        )
+
+        val field = Analyzer::class.java.getDeclaredField("storageCategories").apply { isAccessible = true }
+        @Suppress("UNCHECKED_CAST")
+        (field.get(analyzer) as MutableStateFlow<Map<StorageId, Collection<ContentCategory>>>).value =
+            mapOf(storageId to categories)
+
+        return analyzer
+    }
+
+    private fun deleteTask() = ContentDeleteTask(
+        storageId = storageId,
+        groupId = group.id,
+        targets = setOf(LocalPath.build("storage", "emulated", "0", "DCIM") as APath),
+    )
+
+    @Test
+    fun `read-only media deletion is blocked before any filesystem access`() = runTest {
+        val analyzer = buildAnalyzer(setOf(MediaCategory(storageId, setOf(group), isReadOnly = true)))
+
+        shouldThrow<UnsupportedOperationException> { analyzer.submit(deleteTask()) }
+
+        coVerify(exactly = 0) { gatewaySwitch.delete(any(), any()) }
+        coVerify(exactly = 0) { mediaStoreTool.notifyDeleted(any()) }
+    }
+
+    @Test
+    fun `system content deletion is blocked before any filesystem access`() = runTest {
+        val analyzer = buildAnalyzer(setOf(SystemCategory(storageId, setOf(group))))
+
+        shouldThrow<UnsupportedOperationException> { analyzer.submit(deleteTask()) }
+
+        coVerify(exactly = 0) { gatewaySwitch.delete(any(), any()) }
+        coVerify(exactly = 0) { mediaStoreTool.notifyDeleted(any()) }
+    }
+}

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/storage/categories/ContentCategoryTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/storage/categories/ContentCategoryTest.kt
@@ -30,6 +30,15 @@ class ContentCategoryTest : BaseTest() {
     }
 
     @Test
+    fun `media content is writable by default`() {
+        // Most call sites construct MediaCategory without isReadOnly — pin the default so a flipped
+        // default can't silently make normal scans read-only (or degraded scans writable).
+        val category = MediaCategory(storageId = storageId, groups = setOf(group))
+        category.isReadOnly shouldBe false
+        category.isContentReadOnly shouldBe false
+    }
+
+    @Test
     fun `app content is never read-only`() {
         AppCategory(storageId = storageId, pkgStats = emptyMap()).isContentReadOnly shouldBe false
     }

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/storage/categories/ContentCategoryTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/storage/categories/ContentCategoryTest.kt
@@ -1,0 +1,44 @@
+package eu.darken.sdmse.analyzer.core.storage.categories
+
+import eu.darken.sdmse.analyzer.core.content.ContentGroup
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.storage.StorageId
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.util.UUID
+
+class ContentCategoryTest : BaseTest() {
+
+    private val storageId = StorageId(
+        internalId = null,
+        externalId = UUID.fromString("00000000-0000-0000-0000-000000000001"),
+    )
+    private val group = ContentGroup(label = "group".toCaString())
+
+    @Test
+    fun `system content is always read-only`() {
+        SystemCategory(storageId = storageId, groups = setOf(group)).isContentReadOnly shouldBe true
+    }
+
+    @Test
+    fun `media content is read-only only in the degraded scan`() {
+        MediaCategory(storageId = storageId, groups = setOf(group), isReadOnly = true)
+            .isContentReadOnly shouldBe true
+        MediaCategory(storageId = storageId, groups = setOf(group), isReadOnly = false)
+            .isContentReadOnly shouldBe false
+    }
+
+    @Test
+    fun `app content is never read-only`() {
+        AppCategory(storageId = storageId, pkgStats = emptyMap()).isContentReadOnly shouldBe false
+    }
+
+    @Test
+    fun `ownsGroup matches only the owning category`() {
+        val other = ContentGroup(label = "other".toCaString())
+        val category = MediaCategory(storageId = storageId, groups = setOf(group))
+        category.ownsGroup(group.id) shouldBe true
+        category.ownsGroup(other.id) shouldBe false
+    }
+}

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentViewModelTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentViewModelTest.kt
@@ -7,6 +7,7 @@ import eu.darken.sdmse.analyzer.core.AnalyzerSettings
 import eu.darken.sdmse.analyzer.core.content.ContentGroup
 import eu.darken.sdmse.analyzer.core.content.ContentItem
 import eu.darken.sdmse.analyzer.core.device.DeviceStorage
+import eu.darken.sdmse.analyzer.core.storage.categories.AppCategory
 import eu.darken.sdmse.analyzer.core.storage.categories.ContentCategory
 import eu.darken.sdmse.analyzer.core.storage.categories.MediaCategory
 import eu.darken.sdmse.analyzer.core.storage.categories.SystemCategory
@@ -15,8 +16,12 @@ import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.files.FileType
 import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.pkgs.Pkg
+import eu.darken.sdmse.common.pkgs.features.InstallId
+import eu.darken.sdmse.common.pkgs.features.Installed
 import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.common.storage.StorageId
+import eu.darken.sdmse.common.user.UserHandle2
 import eu.darken.sdmse.common.ui.LayoutMode
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
@@ -154,7 +159,7 @@ class ContentViewModelTest : BaseTest() {
     }
 
     @Test
-    fun `system banner hides while browsing into a folder`() = runTest2 {
+    fun `system banner hides while browsing into a folder but stays read-only`() = runTest2 {
         val child = dirItem("Android")
         val group = ContentGroup(label = "System".toCaString(), contents = setOf(child))
         val h = harness(SystemCategory(storageId, setOf(group)), group)
@@ -163,7 +168,30 @@ class ContentViewModelTest : BaseTest() {
         h.vm.onItemClick(ContentViewModel.Item(parent = null, content = child, sizeRatio = null))
         advanceUntilIdle()
 
-        h.vm.readyState().infoBanner.shouldBeNull()
+        val state = h.vm.readyState()
+        state.infoBanner.shouldBeNull()
+        // Only the banner is level-gated — the delete/filter/Swiper guard must not lift mid-browse.
+        state.isReadOnly shouldBe true
+    }
+
+    @Test
+    fun `app group shows no banner and is writable`() = runTest2 {
+        val group = ContentGroup(label = "App data".toCaString())
+        val installId = InstallId(pkgId = Pkg.Id("com.example.app"), userHandle = UserHandle2(0))
+        val pkgStat = AppCategory.PkgStat(
+            pkg = mockk<Installed>().apply { every { this@apply.installId } returns installId },
+            isShallow = false,
+            appCode = null,
+            appData = group,
+            appMedia = null,
+            extraData = null,
+        )
+        val h = harness(AppCategory(storageId, pkgStats = mapOf(installId to pkgStat)), group)
+        advanceUntilIdle()
+
+        val state = h.vm.readyState()
+        state.isReadOnly shouldBe false
+        state.infoBanner.shouldBeNull()
     }
 
     @Test

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentViewModelTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentViewModelTest.kt
@@ -1,0 +1,217 @@
+package eu.darken.sdmse.analyzer.ui.storage.content
+
+import android.content.Context
+import eu.darken.sdmse.analyzer.R
+import eu.darken.sdmse.analyzer.core.Analyzer
+import eu.darken.sdmse.analyzer.core.AnalyzerSettings
+import eu.darken.sdmse.analyzer.core.content.ContentGroup
+import eu.darken.sdmse.analyzer.core.content.ContentItem
+import eu.darken.sdmse.analyzer.core.device.DeviceStorage
+import eu.darken.sdmse.analyzer.core.storage.categories.ContentCategory
+import eu.darken.sdmse.analyzer.core.storage.categories.MediaCategory
+import eu.darken.sdmse.analyzer.core.storage.categories.SystemCategory
+import eu.darken.sdmse.analyzer.ui.ContentRoute
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.files.FileType
+import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.progress.Progress
+import eu.darken.sdmse.common.storage.StorageId
+import eu.darken.sdmse.common.ui.LayoutMode
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import testhelpers.coroutine.runTest2
+import java.util.UUID
+
+class ContentViewModelTest : BaseTest() {
+
+    private val storageId = StorageId(
+        internalId = null,
+        externalId = UUID.fromString("00000000-0000-0000-0000-000000000001"),
+    )
+
+    private val context = mockk<Context>().apply {
+        every { getString(R.string.analyzer_storage_content_type_system_info) } returns "SYSTEM_INFO"
+        every { getString(R.string.analyzer_storage_content_type_media_readonly_info) } returns "MEDIA_READONLY"
+    }
+
+    private fun storage() = DeviceStorage(
+        id = storageId,
+        label = "Internal".toCaString(),
+        type = DeviceStorage.Type.PRIMARY,
+        hardware = DeviceStorage.Hardware.BUILT_IN,
+        spaceCapacity = 100L,
+        spaceFree = 50L,
+        setupIncomplete = false,
+    )
+
+    private fun dirItem(name: String) = ContentItem(
+        path = LocalPath.build("storage", "emulated", "0", name),
+        lookup = null,
+        itemSize = 0L,
+        type = FileType.DIRECTORY,
+        children = emptySet(),
+        inaccessible = false,
+    )
+
+    private class Harness(
+        val vm: ContentViewModel,
+        val analyzer: Analyzer,
+        val swiperSessionCreator: eu.darken.sdmse.common.files.SwiperSessionCreator,
+        val filterEditorOptionsCreator: eu.darken.sdmse.common.files.FilterEditorOptionsCreator,
+    )
+
+    private fun TestScope.harness(
+        category: ContentCategory,
+        group: ContentGroup,
+    ): Harness {
+        val dataFlow = MutableStateFlow(
+            Analyzer.Data(
+                storages = setOf(storage()),
+                categories = mapOf(storageId to listOf(category)),
+                groups = mapOf(group.id to group),
+            ),
+        )
+        val analyzer = mockk<Analyzer>(relaxed = true).apply {
+            every { data } returns dataFlow
+            every { progress } returns MutableStateFlow<Progress.Data?>(null)
+        }
+        val settings = mockk<AnalyzerSettings>().apply {
+            every { contentLayoutMode } returns mockk { every { flow } returns flowOf(LayoutMode.LINEAR) }
+        }
+        val swiperSessionCreator = mockk<eu.darken.sdmse.common.files.SwiperSessionCreator>(relaxed = true)
+        val filterEditorOptionsCreator =
+            mockk<eu.darken.sdmse.common.files.FilterEditorOptionsCreator>(relaxed = true)
+
+        val vm = ContentViewModel(
+            dispatcherProvider = TestDispatcherProvider(),
+            analyzer = analyzer,
+            analyzerSettings = settings,
+            viewIntentTool = mockk(relaxed = true),
+            exclusionManager = mockk(relaxed = true),
+            filterEditorOptionsCreator = filterEditorOptionsCreator,
+            upgradeRepo = mockk(relaxed = true),
+            swiperSessionCreator = swiperSessionCreator,
+        )
+        vm.bindRoute(ContentRoute(storageId = storageId, groupId = group.id))
+
+        // safeStateIn uses WhileSubscribed(5000) — keep a subscriber alive for the test scope's lifetime.
+        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { vm.state.collect { } }
+
+        return Harness(vm, analyzer, swiperSessionCreator, filterEditorOptionsCreator)
+    }
+
+    private fun ContentViewModel.readyState(): ContentViewModel.State.Ready {
+        val state = state.value
+        state.shouldBeInstanceOf<ContentViewModel.State.Ready>()
+        return state
+    }
+
+    @Test
+    fun `system group shows the system info banner at the top level`() = runTest2 {
+        val group = ContentGroup(label = "System".toCaString())
+        val h = harness(SystemCategory(storageId, setOf(group)), group)
+        advanceUntilIdle()
+
+        val state = h.vm.readyState()
+        state.isReadOnly shouldBe true
+        state.infoBanner!!.get(context) shouldBe "SYSTEM_INFO"
+    }
+
+    @Test
+    fun `read-only media shows the media info banner`() = runTest2 {
+        val group = ContentGroup(label = "Media".toCaString())
+        val h = harness(MediaCategory(storageId, setOf(group), isReadOnly = true), group)
+        advanceUntilIdle()
+
+        val state = h.vm.readyState()
+        state.isReadOnly shouldBe true
+        state.infoBanner!!.get(context) shouldBe "MEDIA_READONLY"
+    }
+
+    @Test
+    fun `writable media shows no banner and is not read-only`() = runTest2 {
+        val group = ContentGroup(label = "Media".toCaString())
+        val h = harness(MediaCategory(storageId, setOf(group), isReadOnly = false), group)
+        advanceUntilIdle()
+
+        val state = h.vm.readyState()
+        state.isReadOnly shouldBe false
+        state.infoBanner.shouldBeNull()
+    }
+
+    @Test
+    fun `system banner hides while browsing into a folder`() = runTest2 {
+        val child = dirItem("Android")
+        val group = ContentGroup(label = "System".toCaString(), contents = setOf(child))
+        val h = harness(SystemCategory(storageId, setOf(group)), group)
+        advanceUntilIdle()
+
+        h.vm.onItemClick(ContentViewModel.Item(parent = null, content = child, sizeRatio = null))
+        advanceUntilIdle()
+
+        h.vm.readyState().infoBanner.shouldBeNull()
+    }
+
+    @Test
+    fun `read-only media banner persists while browsing into a folder`() = runTest2 {
+        val child = dirItem("DCIM")
+        val group = ContentGroup(label = "Media".toCaString(), contents = setOf(child))
+        val h = harness(MediaCategory(storageId, setOf(group), isReadOnly = true), group)
+        advanceUntilIdle()
+
+        h.vm.onItemClick(ContentViewModel.Item(parent = null, content = child, sizeRatio = null))
+        advanceUntilIdle()
+
+        h.vm.readyState().infoBanner!!.get(context) shouldBe "MEDIA_READONLY"
+    }
+
+    @Test
+    fun `delete is blocked on read-only media`() = runTest2 {
+        val group = ContentGroup(label = "Media".toCaString())
+        val h = harness(MediaCategory(storageId, setOf(group), isReadOnly = true), group)
+        advanceUntilIdle()
+
+        h.vm.onDeleteSelected(setOf(dirItem("DCIM")))
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { h.analyzer.submit(any()) }
+    }
+
+    @Test
+    fun `filter creation is blocked on read-only media`() = runTest2 {
+        val group = ContentGroup(label = "Media".toCaString())
+        val h = harness(MediaCategory(storageId, setOf(group), isReadOnly = true), group)
+        advanceUntilIdle()
+
+        h.vm.onCreateFilter(setOf(dirItem("DCIM")))
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { h.filterEditorOptionsCreator.createOptions(any()) }
+    }
+
+    @Test
+    fun `swiper session creation is blocked on read-only media`() = runTest2 {
+        val group = ContentGroup(label = "Media".toCaString())
+        val h = harness(MediaCategory(storageId, setOf(group), isReadOnly = true), group)
+        advanceUntilIdle()
+
+        h.vm.onCreateSwiperSession(setOf(dirItem("DCIM")))
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { h.swiperSessionCreator.createSession(any()) }
+    }
+}


### PR DESCRIPTION
## What changed

Storage Analyzer keeps working when Android returns a broken app inventory (e.g. some sandboxed/manufacturer setups). Instead of failing the whole scan, it still shows how much space your storage uses — sizing the top-level user folders directly — and marks that view read-only. An info note explains why, and deletion, filters and Swiper are disabled there so nothing acts on data whose owner couldn't be verified. The system view and the regular app list keep their existing behavior.

## Technical Context

- Root cause: the partial-scan path ran top-level owner forensics before the app-category setup guard, and owner forensics can initialize the package repo, which throws when the app inventory is missing core packages.
- When the app inventory setup is incomplete, the scanner skips package-owner forensics and sizes top-level media folders directly through the filesystem gateway, producing a read-only media category. The app category still reports setup incomplete, preserving the safety behavior cleanup tools (e.g. CorpseFinder) rely on.
- Read-only is enforced at two layers: the UI hides/blocks delete/filter/Swiper, and the delete task layer fails closed *before* any filesystem access. Both share one `ContentCategory.isContentReadOnly` definition (system = always read-only, media = read-only only in the degraded scan) so the two can't drift.
- The degraded view shows a distinct "inventory unavailable" info banner (the system category keeps its own message). Since the degraded media group is a single storage-root item, the media banner stays visible while browsing into it, not just at the top level.
- Defensive: degraded media folders are du-sized and can overcount, so the residual System size is clamped at ≥ 0.
- Scope/review guidance: this only affects the no-app-inventory path; normal scans are unchanged. `/Android` stays grouped under System in degraded mode — same as normal mode, where it is instead recovered under Apps.

### Validation

- `./gradlew :app-tool-analyzer:compileDebugKotlin :app-tool-analyzer:testDebugUnitTest`
- `./gradlew assembleFossDebug lintVitalFossRelease`
- New unit tests: the shared read-only resolver, the core delete guard (deletion blocked before any filesystem access for read-only media and system content), and the ViewModel banner selection + delete/filter/Swiper gating.

Closes #2441