### PR TITLE
AppCleaner: Explain when an app-lock blocks cache cleaning

### DIFF
--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/errors/AutomationInterferenceException.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/errors/AutomationInterferenceException.kt
@@ -1,0 +1,32 @@
+package eu.darken.sdmse.automation.core.errors
+
+import eu.darken.sdmse.automation.R
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.error.HasLocalizedError
+import eu.darken.sdmse.common.error.LocalizedError
+import eu.darken.sdmse.common.pkgs.Pkg
+
+/**
+ * Thrown when a foreign app (e.g. an app-locker like Avast App Lock) is holding the system
+ * settings window instead of the screen we are trying to automate, preventing us from reaching
+ * the target UI.
+ *
+ * Subclasses [InvalidSystemStateException] so the whole automation run is aborted immediately
+ * (instead of grinding through retries until the generic compatibility/timeout error) and tells
+ * the user which app to adjust.
+ */
+class AutomationInterferenceException(
+    val blockerPkg: Pkg.Id,
+    val blockerLabel: String?,
+) : InvalidSystemStateException(
+    "System settings window is being blocked by $blockerPkg (${blockerLabel ?: "?"})"
+), HasLocalizedError {
+
+    private val displayName: String = blockerLabel ?: blockerPkg.name
+
+    override fun getLocalizedError() = LocalizedError(
+        throwable = this,
+        label = R.string.automation_error_interference_title.toCaString(),
+        description = R.string.automation_error_interference_body.toCaString(displayName),
+    )
+}

--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/specs/SettingsInterferenceDetector.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/specs/SettingsInterferenceDetector.kt
@@ -1,0 +1,116 @@
+package eu.darken.sdmse.automation.core.specs
+
+import android.os.SystemClock
+import eu.darken.sdmse.automation.core.common.ACSNodeInfo
+import eu.darken.sdmse.automation.core.errors.AutomationInterferenceException
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.pkgs.Pkg
+import eu.darken.sdmse.common.pkgs.toPkgId
+
+/**
+ * Detects when a foreign app (e.g. an app-locker like Avast App Lock) is holding the active
+ * window instead of the system settings screen we are trying to automate. Without this, such
+ * interference only surfaces as a generic timeout/compatibility error after minutes of retries.
+ *
+ * One instance lives for the lifetime of a single window-check (i.e. one step), so its sightings
+ * accumulate across the stepper's inner retry loop. Benign windows reset the tracker.
+ *
+ * Two confidence levels:
+ * - [knownBlockers]: high confidence, abort on the first sighting (even if it is also the target).
+ * - generic: abort only once the same non-system foreign app has dominated the window for
+ *   [PERSIST_THRESHOLD_MS], so transient windows during the settings launch don't trip it.
+ */
+class SettingsInterferenceDetector(
+    private val expectedPkgs: Set<Pkg.Id>,
+    private val targetPkg: Pkg.Id,
+    private val knownBlockers: Set<Pkg.Id> = KNOWN_INTERFERENCE_PKGS,
+    private val nowMs: () -> Long = { SystemClock.elapsedRealtime() },
+    private val resolveLabel: suspend (Pkg.Id) -> String?,
+    private val isSystemApp: suspend (Pkg.Id) -> Boolean,
+) {
+
+    private var currentForeign: Pkg.Id? = null
+    private var firstSeenAt: Long = 0L
+    private val systemAppCache = mutableMapOf<Pkg.Id, Boolean>()
+
+    /**
+     * Inspect the current window [root]. Throws [AutomationInterferenceException] once we are
+     * confident a foreign app is blocking the settings screen. Safe to call on every observed
+     * root: a matching/benign window just resets the persistence tracker.
+     */
+    suspend fun evaluate(root: ACSNodeInfo, ownPkg: String) {
+        // ACSNodeInfo.pkgId is non-null and maps a missing name to Pkg.Id("null"), so extract manually.
+        val rootPkg = root.packageName?.toString()?.takeIf { it.isNotBlank() }?.toPkgId()
+        if (rootPkg == null) {
+            // Unknown/transient window - don't reset, just wait for the next observation.
+            return
+        }
+
+        // The settings screen (or our own overlay) is up - any prior foreign sighting is stale.
+        if (rootPkg in expectedPkgs || rootPkg.name == ownPkg) {
+            reset()
+            return
+        }
+
+        // Known blockers are high-confidence: fire immediately, even when it is also the target app.
+        if (rootPkg in knownBlockers) {
+            log(TAG, WARN) { "Known interfering app is holding the window: $rootPkg" }
+            throw AutomationInterferenceException(rootPkg, resolveLabel(rootPkg))
+        }
+
+        // The app currently being cleaned may briefly own the window - that's expected.
+        if (rootPkg == targetPkg) {
+            reset()
+            return
+        }
+
+        // System apps (launcher, SystemUI, permission controller, ...) are benign.
+        val system = systemAppCache[rootPkg] ?: isSystemApp(rootPkg).also { systemAppCache[rootPkg] = it }
+        if (system) {
+            reset()
+            return
+        }
+
+        // Generic detection: require the same foreign app to dominate the window for a while.
+        val now = nowMs()
+        if (rootPkg != currentForeign) {
+            currentForeign = rootPkg
+            firstSeenAt = now
+            return
+        }
+        if (now - firstSeenAt >= PERSIST_THRESHOLD_MS) {
+            log(TAG, WARN) { "Foreign app is persistently blocking the window: $rootPkg" }
+            throw AutomationInterferenceException(rootPkg, resolveLabel(rootPkg))
+        }
+    }
+
+    private fun reset() {
+        currentForeign = null
+        firstSeenAt = 0L
+    }
+
+    companion object {
+        private val TAG = logTag("Automation", "InterferenceDetector")
+
+        private const val PERSIST_THRESHOLD_MS = 1500L
+
+        /**
+         * Apps known to lock or overlay the system settings screen. The generic detector covers
+         * unlisted ones too; this list mainly lets us abort instantly with higher confidence.
+         */
+        val KNOWN_INTERFERENCE_PKGS: Set<Pkg.Id> = setOf(
+            "com.avast.android.mobilesecurity", // Avast Mobile Security (App Lock) - originally reported
+            "com.antivirus", // AVG AntiVirus (App Lock)
+            "com.symantec.mobilesecurity", // Norton 360 / Mobile Security
+            "com.symantec.applock", // Norton App Lock
+            "com.wsandroid.suite", // McAfee Security
+            "com.kms.free", // Kaspersky Mobile / Internet Security
+            "com.bitdefender.security", // Bitdefender Mobile Security
+            "com.domobile.applockwatcher", // AppLock (DoMobile)
+            "com.domobile.applock", // AppLock (DoMobile, legacy)
+            "com.sp.protector.free", // Smart AppLock
+        ).map { it.toPkgId() }.toSet()
+    }
+}

--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/specs/SpecGeneratorExtensions.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/specs/SpecGeneratorExtensions.kt
@@ -3,6 +3,7 @@
 package eu.darken.sdmse.automation.core.specs
 
 import android.content.Intent
+import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.content.res.Resources
@@ -79,13 +80,58 @@ fun SpecGenerator.windowCheckDefaultSettings(
     windowPkgId: Pkg.Id,
     ipcFunnel: IPCFunnel,
     pkgInfo: Installed
-): suspend StepContext.() -> ACSNodeInfo = {
-    if (stepAttempts >= 1 && pkgInfo.hasNoSettings) {
-        throw NoSettingsWindowException("${pkgInfo.packageName} has no settings window.")
-    }
-    windowCheck { _, root ->
+): suspend StepContext.() -> ACSNodeInfo {
+    val condition = interferenceAware(
+        expectedPkgs = setOf(windowPkgId),
+        targetPkg = pkgInfo.id,
+        ipcFunnel = ipcFunnel,
+    ) { _, root ->
         root.pkgId == windowPkgId && checkIdentifiers(ipcFunnel, pkgInfo)(root)
-    }()
+    }
+    return {
+        if (stepAttempts >= 1 && pkgInfo.hasNoSettings) {
+            throw NoSettingsWindowException("${pkgInfo.packageName} has no settings window.")
+        }
+        windowCheck(condition)()
+    }
+}
+
+/**
+ * Wraps a window-check [condition] with [SettingsInterferenceDetector]: whenever the condition
+ * does NOT match, the current window is checked for a foreign app (e.g. an app-locker) blocking
+ * the [expectedPkgs] settings screen. One detector is created per call, so it accumulates sightings
+ * across the stepper's inner retry loop. [targetPkg] is the app being processed.
+ */
+fun SpecGenerator.interferenceAware(
+    expectedPkgs: Set<Pkg.Id>,
+    targetPkg: Pkg.Id,
+    ipcFunnel: IPCFunnel,
+    condition: suspend StepContext.(event: AutomationEvent?, root: ACSNodeInfo) -> Boolean,
+): suspend StepContext.(event: AutomationEvent?, root: ACSNodeInfo) -> Boolean {
+    val detector = SettingsInterferenceDetector(
+        expectedPkgs = expectedPkgs,
+        targetPkg = targetPkg,
+        resolveLabel = { pkg -> ipcFunnel.use { packageManager.getLabel2(pkg) } },
+        isSystemApp = { pkg ->
+            ipcFunnel.use {
+                try {
+                    val info = packageManager.getApplicationInfo(pkg.name, 0)
+                    info.flags and ApplicationInfo.FLAG_SYSTEM != 0 ||
+                            info.flags and ApplicationInfo.FLAG_UPDATED_SYSTEM_APP != 0
+                } catch (_: PackageManager.NameNotFoundException) {
+                    // Unknown app - treat as non-system so generic detection can still fire.
+                    false
+                }
+            }
+        },
+    )
+    return { event, root ->
+        // Detection runs before the predicate so an interfering window is caught even if the
+        // predicate would otherwise throw (e.g. NoSettingsWindowException). On a matching or benign
+        // root the detector just resets, so evaluating it first is safe.
+        detector.evaluate(root, androidContext.packageName)
+        condition(event, root)
+    }
 }
 
 suspend fun SpecGenerator.checkIdentifiers(

--- a/app-common-automation/src/main/res/values/strings.xml
+++ b/app-common-automation/src/main/res/values/strings.xml
@@ -21,6 +21,8 @@
     <string name="automation_error_scheduler_body">A scheduled task tried to use the accessibility service, but it was unavailable. If you don\'t need this, disable the \"Accessibility service\" option in the scheduler settings.</string>
     <string name="automation_error_no_settings_title">Settings screen unavailable</string>
     <string name="automation_error_no_settings_body">This system app has no settings screen. Cache clearing via accessibility service is not possible. Exclude it to speed up cache clearing.</string>
+    <string name="automation_error_interference_title">Settings screen blocked</string>
+    <string name="automation_error_interference_body">Another app (%1$s) is blocking the system settings screen, so SD Maid can\'t continue. Disable that app\'s app-lock or screen protection for the system settings, then try again.</string>
     <string name="automation_loading">Preparing automation via accessibility service</string>
     <string name="automation_progress_find_ok_confirmation">Trying to confirm previous action (keywords: %s)</string>
 </resources>

--- a/app-common-automation/src/test/java/eu/darken/sdmse/automation/core/specs/InterferenceDetectionWiringTest.kt
+++ b/app-common-automation/src/test/java/eu/darken/sdmse/automation/core/specs/InterferenceDetectionWiringTest.kt
@@ -1,0 +1,100 @@
+package eu.darken.sdmse.automation.core.specs
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.sdmse.automation.core.AutomationEvent
+import eu.darken.sdmse.automation.core.AutomationHost
+import eu.darken.sdmse.automation.core.common.ACSNodeInfo
+import eu.darken.sdmse.automation.core.common.pkgId
+import eu.darken.sdmse.automation.core.common.stepper.StepContext
+import eu.darken.sdmse.automation.core.errors.AutomationInterferenceException
+import eu.darken.sdmse.common.funnel.IPCFunnel
+import eu.darken.sdmse.common.pkgs.features.Installed
+import eu.darken.sdmse.common.pkgs.toPkgId
+import eu.darken.sdmse.common.progress.Progress
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+import testhelpers.coroutine.TestDispatcherProvider
+
+/**
+ * Exercises the real wiring that the pure detector test skips:
+ * windowCheckDefaultSettings / interferenceAware -> windowCheck flow -> SettingsInterferenceDetector,
+ * driven by a fake [AutomationHost]. Pure-logic / timing cases live in SettingsInterferenceDetectorTest.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class InterferenceDetectionWiringTest : BaseTest() {
+
+    private val appContext: Context = ApplicationProvider.getApplicationContext()
+    private val ipcFunnel = IPCFunnel(appContext, TestDispatcherProvider())
+
+    private val settingsPkg = "com.android.settings".toPkgId()
+    private val targetPkg = "com.example.target".toPkgId()
+    private val avastPkg = "com.avast.android.mobilesecurity".toPkgId()
+
+    private val specGen = object : SpecGenerator {
+        override val tag = "Test"
+        override suspend fun isResponsible(pkg: Installed) = false
+    }
+
+    private fun rootOf(pkg: String): ACSNodeInfo = mockk(relaxed = true) {
+        every { packageName } returns pkg
+    }
+
+    private fun hostWith(root: ACSNodeInfo, eventFlow: Flow<AutomationEvent> = emptyFlow()): AutomationHost =
+        mockk(relaxed = true) {
+            every { events } returns eventFlow
+            coEvery { windowRoot() } returns root
+        }
+
+    private fun stepContextWith(host: AutomationHost): StepContext {
+        val context = object : AutomationExplorer.Context {
+            override val host: AutomationHost = host
+            override val androidContext: Context = appContext
+            override val progress: Flow<Progress.Data?> = emptyFlow()
+            override fun updateProgress(update: (Progress.Data?) -> Progress.Data?) {}
+        }
+        return StepContext(hostContext = context, tag = "Test", stepAttempts = 0)
+    }
+
+    private fun pkgInfo(): Installed = mockk(relaxed = true) {
+        every { id } returns targetPkg
+        every { packageName } returns targetPkg.name
+        every { hasNoSettings } returns false
+    }
+
+    @Test
+    fun `windowCheckDefaultSettings aborts when a known locker holds the settings window`() = runTest {
+        val host = hostWith(rootOf(avastPkg.name))
+        val stepContext = stepContextWith(host)
+        val check = with(specGen) { windowCheckDefaultSettings(settingsPkg, ipcFunnel, pkgInfo()) }
+
+        shouldThrow<AutomationInterferenceException> {
+            check(stepContext)
+        }.blockerPkg shouldBe avastPkg
+    }
+
+    @Test
+    fun `interferenceAware passes the expected settings window through unharmed`() = runTest {
+        val root = rootOf(settingsPkg.name)
+        val stepContext = stepContextWith(hostWith(root))
+        val condition = with(specGen) {
+            interferenceAware(setOf(settingsPkg), targetPkg, ipcFunnel) { _, r -> r.pkgId == settingsPkg }
+        }
+        val check = with(specGen) { windowCheck(condition) }
+
+        check(stepContext) shouldBe root
+    }
+}

--- a/app-common-automation/src/test/java/eu/darken/sdmse/automation/core/specs/SettingsInterferenceDetectorTest.kt
+++ b/app-common-automation/src/test/java/eu/darken/sdmse/automation/core/specs/SettingsInterferenceDetectorTest.kt
@@ -1,0 +1,137 @@
+package eu.darken.sdmse.automation.core.specs
+
+import eu.darken.sdmse.automation.core.common.ACSNodeInfo
+import eu.darken.sdmse.automation.core.errors.AutomationInterferenceException
+import eu.darken.sdmse.common.pkgs.toPkgId
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class SettingsInterferenceDetectorTest : BaseTest() {
+
+    private val settingsPkg = "com.android.settings".toPkgId()
+    private val targetPkg = "com.example.target".toPkgId()
+    private val ownPkg = "eu.darken.sdmse"
+    private val knownBlocker = "com.avast.android.mobilesecurity".toPkgId()
+    private val foreignPkg = "com.some.thirdparty".toPkgId()
+
+    private var clock = 1000L
+
+    private fun rootOf(pkg: String?): ACSNodeInfo = mockk {
+        every { packageName } returns pkg
+    }
+
+    private fun create(
+        systemApps: Set<String> = emptySet(),
+    ) = SettingsInterferenceDetector(
+        expectedPkgs = setOf(settingsPkg),
+        targetPkg = targetPkg,
+        nowMs = { clock },
+        resolveLabel = { "App Label" },
+        isSystemApp = { pkg -> pkg.name in systemApps },
+    )
+
+    @Test
+    fun `known blocker throws immediately`() = runTest {
+        val detector = create()
+        shouldThrow<AutomationInterferenceException> {
+            detector.evaluate(rootOf(knownBlocker.name), ownPkg)
+        }.blockerPkg shouldBe knownBlocker
+    }
+
+    @Test
+    fun `known blocker throws even when it is the target app`() = runTest {
+        val detector = SettingsInterferenceDetector(
+            expectedPkgs = setOf(settingsPkg),
+            targetPkg = knownBlocker,
+            nowMs = { clock },
+            resolveLabel = { null },
+            isSystemApp = { false },
+        )
+        shouldThrow<AutomationInterferenceException> {
+            detector.evaluate(rootOf(knownBlocker.name), ownPkg)
+        }
+    }
+
+    @Test
+    fun `expected settings window does not trigger`() = runTest {
+        val detector = create()
+        detector.evaluate(rootOf(settingsPkg.name), ownPkg)
+    }
+
+    @Test
+    fun `our own window does not trigger`() = runTest {
+        val detector = create()
+        detector.evaluate(rootOf(ownPkg), ownPkg)
+    }
+
+    @Test
+    fun `target app window does not trigger generic detection`() = runTest {
+        val detector = create()
+        // Even seen persistently, the app being cleaned is expected to own the window briefly.
+        detector.evaluate(rootOf(targetPkg.name), ownPkg)
+        clock += 5000
+        detector.evaluate(rootOf(targetPkg.name), ownPkg)
+    }
+
+    @Test
+    fun `system app window does not trigger`() = runTest {
+        val detector = create(systemApps = setOf(foreignPkg.name))
+        detector.evaluate(rootOf(foreignPkg.name), ownPkg)
+        clock += 5000
+        detector.evaluate(rootOf(foreignPkg.name), ownPkg)
+    }
+
+    @Test
+    fun `null or blank package name is ignored`() = runTest {
+        val detector = create()
+        detector.evaluate(rootOf(null), ownPkg)
+        detector.evaluate(rootOf(""), ownPkg)
+        detector.evaluate(rootOf("   "), ownPkg)
+    }
+
+    @Test
+    fun `foreign non-system app throws only after persisting`() = runTest {
+        val detector = create()
+        // First sighting just starts the timer.
+        detector.evaluate(rootOf(foreignPkg.name), ownPkg)
+        // Still within the threshold -> no throw.
+        clock += 1000
+        detector.evaluate(rootOf(foreignPkg.name), ownPkg)
+        // Past the threshold -> throw.
+        clock += 600
+        shouldThrow<AutomationInterferenceException> {
+            detector.evaluate(rootOf(foreignPkg.name), ownPkg)
+        }.blockerPkg shouldBe foreignPkg
+    }
+
+    @Test
+    fun `switching foreign app resets the persistence timer`() = runTest {
+        val detector = create()
+        val otherForeign = "com.other.thirdparty"
+        detector.evaluate(rootOf(foreignPkg.name), ownPkg)
+        clock += 2000
+        // A different foreign app appears -> timer restarts, so this must NOT throw.
+        detector.evaluate(rootOf(otherForeign), ownPkg)
+        // Just under the threshold for the new app -> still no throw.
+        clock += 1400
+        detector.evaluate(rootOf(otherForeign), ownPkg)
+    }
+
+    @Test
+    fun `benign window between sightings resets the timer`() = runTest {
+        val detector = create()
+        detector.evaluate(rootOf(foreignPkg.name), ownPkg)
+        clock += 2000
+        // Settings briefly shows up -> resets.
+        detector.evaluate(rootOf(settingsPkg.name), ownPkg)
+        // Foreign reappears: timer restarts, under threshold -> no throw.
+        detector.evaluate(rootOf(foreignPkg.name), ownPkg)
+        clock += 1400
+        detector.evaluate(rootOf(foreignPkg.name), ownPkg)
+    }
+}

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/hyperos/HyperOsSpecs.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/hyperos/HyperOsSpecs.kt
@@ -43,6 +43,7 @@ import eu.darken.sdmse.automation.core.specs.AutomationSpec
 import eu.darken.sdmse.automation.core.specs.checkIdentifiers
 import eu.darken.sdmse.automation.core.specs.defaultFindAndClick
 import eu.darken.sdmse.automation.core.specs.defaultNodeRecovery
+import eu.darken.sdmse.automation.core.specs.interferenceAware
 import eu.darken.sdmse.automation.core.specs.windowCheck
 import eu.darken.sdmse.automation.core.specs.windowCheckDefaultSettings
 import eu.darken.sdmse.automation.core.specs.windowLauncherDefaultSettings
@@ -113,33 +114,33 @@ class HyperOsSpecs @Inject constructor(
 
         var windowPkg: Pkg.Id? = null
 
-        val windowCheck: suspend StepContext.() -> ACSNodeInfo = {
-            if (stepAttempts >= 1 && pkg.hasNoSettings) {
-                throw NoSettingsWindowException("${pkg.packageName} has no settings window.")
-            }
-            // Wait for correct base window
-            host.events
-                .filter { it.pkgId == SETTINGS_PKG_HYPEROS || it.pkgId == SETTINGS_PKG_AOSP }
-                .mapNotNull { host.windowRoot() }
-                .first { root ->
-                    when {
-                        root.pkgId == SETTINGS_PKG_HYPEROS && checkIdentifiers(ipcFunnel, pkg)(root) -> {
-                            windowPkg = SETTINGS_PKG_HYPEROS
-                            true
-                        }
+        val windowCheck = windowCheck(
+            interferenceAware(
+                expectedPkgs = setOf(SETTINGS_PKG_HYPEROS, SETTINGS_PKG_AOSP),
+                targetPkg = pkg.id,
+                ipcFunnel = ipcFunnel,
+            ) { _, root ->
+                if (stepAttempts >= 1 && pkg.hasNoSettings) {
+                    throw NoSettingsWindowException("${pkg.packageName} has no settings window.")
+                }
+                when {
+                    root.pkgId == SETTINGS_PKG_HYPEROS && checkIdentifiers(ipcFunnel, pkg)(root) -> {
+                        windowPkg = SETTINGS_PKG_HYPEROS
+                        true
+                    }
 
-                        root.pkgId == SETTINGS_PKG_AOSP && checkIdentifiers(ipcFunnel, pkg)(root) -> {
-                            windowPkg = SETTINGS_PKG_AOSP
-                            true
-                        }
+                    root.pkgId == SETTINGS_PKG_AOSP && checkIdentifiers(ipcFunnel, pkg)(root) -> {
+                        windowPkg = SETTINGS_PKG_AOSP
+                        true
+                    }
 
-                        else -> {
-                            log(TAG) { "Unknown window: ${root.pkgId}" }
-                            false
-                        }
+                    else -> {
+                        log(TAG) { "Unknown window: ${root.pkgId}" }
+                        false
                     }
                 }
-        }
+            }
+        )
 
         val step = AutomationStep(
             source = TAG,

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/miui/MIUISpecs.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/miui/MIUISpecs.kt
@@ -42,6 +42,7 @@ import eu.darken.sdmse.automation.core.specs.AutomationSpec
 import eu.darken.sdmse.automation.core.specs.checkIdentifiers
 import eu.darken.sdmse.automation.core.specs.defaultFindAndClick
 import eu.darken.sdmse.automation.core.specs.defaultNodeRecovery
+import eu.darken.sdmse.automation.core.specs.interferenceAware
 import eu.darken.sdmse.automation.core.specs.windowCheck
 import eu.darken.sdmse.automation.core.specs.windowCheckDefaultSettings
 import eu.darken.sdmse.automation.core.specs.windowLauncherDefaultSettings
@@ -110,31 +111,37 @@ class MIUISpecs @Inject constructor(
 
         var windowPkg: Pkg.Id? = null
 
-        val windowCheck = windowCheck { event, root ->
-            if (stepAttempts >= 1 && pkg.hasNoSettings) {
-                throw NoSettingsWindowException("${pkg.packageName} has no settings window.")
-            }
-            // Some MIUI14 devices send the change event for the system settings app
-            val isCorrectWindow = root.pkgId == SETTINGS_PKG_MIUI || root.pkgId == SETTINGS_PKG_AOSP
-                    || event?.pkgId == SETTINGS_PKG_MIUI || event?.pkgId == SETTINGS_PKG_AOSP
-            if (!isCorrectWindow) return@windowCheck false
-            when {
-                root.pkgId == SETTINGS_PKG_MIUI && checkIdentifiers(ipcFunnel, pkg)(root) -> {
-                    windowPkg = SETTINGS_PKG_MIUI
-                    true
+        val windowCheck = windowCheck(
+            interferenceAware(
+                expectedPkgs = setOf(SETTINGS_PKG_MIUI, SETTINGS_PKG_AOSP),
+                targetPkg = pkg.id,
+                ipcFunnel = ipcFunnel,
+            ) { event, root ->
+                if (stepAttempts >= 1 && pkg.hasNoSettings) {
+                    throw NoSettingsWindowException("${pkg.packageName} has no settings window.")
                 }
+                // Some MIUI14 devices send the change event for the system settings app
+                val isCorrectWindow = root.pkgId == SETTINGS_PKG_MIUI || root.pkgId == SETTINGS_PKG_AOSP
+                        || event?.pkgId == SETTINGS_PKG_MIUI || event?.pkgId == SETTINGS_PKG_AOSP
+                if (!isCorrectWindow) return@interferenceAware false
+                when {
+                    root.pkgId == SETTINGS_PKG_MIUI && checkIdentifiers(ipcFunnel, pkg)(root) -> {
+                        windowPkg = SETTINGS_PKG_MIUI
+                        true
+                    }
 
-                root.pkgId == SETTINGS_PKG_AOSP && checkIdentifiers(ipcFunnel, pkg)(root) -> {
-                    windowPkg = SETTINGS_PKG_AOSP
-                    true
-                }
+                    root.pkgId == SETTINGS_PKG_AOSP && checkIdentifiers(ipcFunnel, pkg)(root) -> {
+                        windowPkg = SETTINGS_PKG_AOSP
+                        true
+                    }
 
-                else -> {
-                    log(TAG) { "Unknown window: ${root.pkgId}" }
-                    false
+                    else -> {
+                        log(TAG) { "Unknown window: ${root.pkgId}" }
+                        false
+                    }
                 }
             }
-        }
+        )
 
         val step = AutomationStep(
             source = TAG,

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/realme/RealmeSpecs.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/realme/RealmeSpecs.kt
@@ -22,6 +22,7 @@ import eu.darken.sdmse.automation.core.common.stepper.findNodeByLabel
 import eu.darken.sdmse.automation.core.specs.AutomationExplorer
 import eu.darken.sdmse.automation.core.specs.AutomationSpec
 import eu.darken.sdmse.automation.core.specs.defaultNodeRecovery
+import eu.darken.sdmse.automation.core.specs.interferenceAware
 import eu.darken.sdmse.automation.core.specs.windowCheck
 import eu.darken.sdmse.automation.core.specs.windowCheckDefaultSettings
 import eu.darken.sdmse.automation.core.specs.windowLauncherDefaultSettings
@@ -140,7 +141,13 @@ class RealmeSpecs @Inject constructor(
                 source = TAG,
                 descriptionInternal = "Clear cache for $pkg",
                 label = R.string.appcleaner_automation_progress_find_clear_cache.toCaString(clearCacheButtonLabels),
-                windowCheck = windowCheck { _, root -> root.pkgId == SETTINGS_PKG },
+                windowCheck = windowCheck(
+                    interferenceAware(
+                        expectedPkgs = setOf(SETTINGS_PKG),
+                        targetPkg = pkg.id,
+                        ipcFunnel = ipcFunnel,
+                    ) { _, root -> root.pkgId == SETTINGS_PKG }
+                ),
                 nodeAction = action,
             )
             stepper.withProgress(this) { process(this@plan, step) }


### PR DESCRIPTION
## What changed

Some security/privacy apps (for example Avast Mobile Security's "App Lock") put a PIN/fingerprint lock on the system Settings screen. When SD Maid cleared app caches via the accessibility service, it would open each app's Settings page, get blocked by that lock, and — after retrying for several minutes — fail with a vague "couldn't figure out the screen layout" error that wrongly looked like an SD Maid problem.

Now SD Maid recognises this and stops right away with a clear message naming the app that's in the way (e.g. "Another app (Avast Mobile Security) is blocking the system settings screen…"), telling you to disable its app-lock for Settings and try again.

## Technical Context

- New `SettingsInterferenceDetector` inspects the active window during the settings window-check and throws `AutomationInterferenceException` when a foreign app holds the window. Known lockers (curated list: Avast/AVG/Norton/McAfee/…) abort on first sighting; unknown apps must dominate the window for ≥1.5 s, with system/launcher/own/target windows resetting the tracker to avoid false positives on transient windows.
- `AutomationInterferenceException` extends `InvalidSystemStateException` (already re-thrown by `ClearCacheModule`/`AppControlAutomation` to abort the whole run) and implements `HasLocalizedError`, so the dialog names the app and has no bug-report button.
- Wired once into the shared `windowCheckDefaultSettings` (covers all 17 manufacturer specs + AppControl) via a new `interferenceAware()` wrapper, plus the bespoke MIUI/HyperOS/Realme base-window checks.
- Review guidance: the HyperOS change converts a bespoke event-filtered flow into `windowCheck(interferenceAware(...))`; success is still gated by `checkIdentifiers`, so match behavior is unchanged. Detector persistence relies on the stepper's inner retry loop reusing the same detector within a step.
- Tested: 10 detector unit tests + 2 wiring integration tests; verified end-to-end on an emulator with a stand-in locker app (generic path fired, run aborted, correct dialog shown).

Refs #2439
