### PR TITLE
General: Fix crash when closing the debug log recorder

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/common/debug/recorder/ui/RecorderActivity.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/debug/recorder/ui/RecorderActivity.kt
@@ -40,12 +40,9 @@ class RecorderActivity : Activity2() {
         }
 
         enableEdgeToEdge()
-        vm.navEvents.observe2 {
-            when (it) {
-                null -> finish()
-                else -> throw IllegalArgumentException("Unknown nav event: $it")
-            }
-        }
+        // This is a terminal, single-screen activity: the only navigation the
+        // ViewModel ever requests is popNavStack(), so any nav event means "close".
+        vm.navEvents.observe2 { finish() }
         vm.errorEvents.observe2 { it.asErrorDialogBuilder(this).show() }
 
         ui = DebugRecorderActivityBinding.inflate(layoutInflater)


### PR DESCRIPTION
## What changed

Fixed a crash that happened when closing the debug log recorder — the screen used to record and share diagnostic logs with support. Tapping **Close**, deleting a log, or opening the screen for a log that no longer existed would crash the app instead of simply closing the screen.

## Technical Context

- **Root cause**: The Kotlin nav-graph refactor (`96c75af57`) changed `ViewModel3.popNavStack()` to post `NavCommand.Back` instead of `null`. `Fragment3` was updated to handle the new sealed `NavCommand` type, but `RecorderActivity` (an `Activity2`, not a `Fragment3`) kept its own inline handler that only recognized `null` and threw `IllegalArgumentException` for anything else.
- `RecorderViewModel` only ever navigates via `popNavStack()` (close button, delete, and the session-gone init path) and never calls `navigateTo()`, so **every** nav event hit the throw. The crash was fully reproducible on every close — not Android-16-specific, despite the Play report originating from a Pixel 7a on A16.
- **Fix**: replaced the handler with `finish()`, the only meaningful action for this terminal single-screen activity.
- **Review guidance**: confirmed `MainActivity` (the only other `Activity2` subclass) does not observe `navEvents`, so there is no sibling instance of the same stale-contract bug.
