### PR TITLE
Deduplicator: Require Pro for one-tap duplicate deletion

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModel.kt
@@ -821,11 +821,17 @@ class DashboardViewModel @Inject constructor(
                 BottomBarState.Action.SCAN -> submitTask(DeduplicatorScanTask())
                 BottomBarState.Action.WORKING_CANCELABLE -> taskManager.cancel(SDMTool.Type.DEDUPLICATOR)
                 BottomBarState.Action.WORKING -> {}
-                BottomBarState.Action.DELETE -> if (deduplicator.state.first().data != null) {
+                BottomBarState.Action.DELETE -> if (deduplicator.state.first().data != null && upgradeRepo.isPro()) {
                     submitTask(DeduplicatorDeleteTask())
                 }
 
-                BottomBarState.Action.ONECLICK -> submitTask(DeduplicatorOneClickTask())
+                BottomBarState.Action.ONECLICK -> {
+                    if (upgradeRepo.isPro()) {
+                        submitTask(DeduplicatorOneClickTask())
+                    } else if (deduplicator.state.first().data.hasData && !corpseFinder.state.first().data.hasData && !systemCleaner.state.first().data.hasData) {
+                        navigateTo(UpgradeRoute())
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## What changed

Deleting duplicate files is a Pro feature. On the dashboard, deleting duplicates from the Deduplicator's own card already required a Pro upgrade — but the combined **one-tap** button on the bottom bar could trigger a Deduplicator deletion without it, for users who had enabled Deduplicator in the one-tap options. This brings the one-tap button in line with the rest of the app: a non-Pro user is now routed to the upgrade screen instead, exactly like AppCleaner already does.

## Technical Context

- **Root cause:** `DashboardViewModel.mainAction()` submitted `DeduplicatorDeleteTask` / `DeduplicatorOneClickTask` with no `upgradeRepo.isPro()` check, whereas the AppCleaner branch gates the equivalent actions. Pro-gating for cleaning tools lives **only** in the UI layer — the task processors (`Deduplicator.submit()`) don't enforce it — so the missing UI check was a real bypass, not a cosmetic gap.
- **Not a regression:** present since the Deduplicator was first added (#773, Nov 2023). Narrow reach — Deduplicator one-tap defaults to **off**, so only users who explicitly enabled it were affected.
- **Why `DELETE` differs from AppCleaner:** the `ONECLICK` branch mirrors AppCleaner (route to upgrade when Deduplicator is the only actionable tool). `DELETE` only gates the submit and adds no upgrade-nav, because Deduplicator data isn't part of the bottom bar's `DELETE` trigger condition (only CorpseFinder/SystemCleaner/AppCleaner data is) — so a Deduplicator-only `DELETE` state is unreachable, and a second `navigateTo(UpgradeRoute())` there would double-push the upgrade screen (nav events are a buffered channel that AppCleaner's branch already feeds).
- The compose-rewrite branch receives the identical fix separately.