### PR TITLE
Fix badge links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 [![GitHub release (latest SemVer including pre-releases)](https://img.shields.io/github/v/release/d4rken-org/sdmaid-se?include_prereleases)](https://github.com/d4rken-org/sdmaid-se/releases/latest)
 [![RB Status](https://shields.rbtlog.dev/simple/eu.darken.sdmse)](https://shields.rbtlog.dev/eu.darken.sdmse)
-[![Crowdin](https://badges.crowdin.net/sdmaid-se/localized.svg)](https://crowdin.com/project/sdmaid-se)
-[![Discord](https://img.shields.io/badge/Discord-SDMaid-5865F2?logo=discord&logoColor=white)](https://discord.gg/8Fjy6PTfXu)
 [![Code tests & eval](https://img.shields.io/github/actions/workflow/status/d4rken-org/sdmaid-se/code-checks.yml?logo=githubactions&label=Code%20tests
 )](https://github.com/d4rken-org/sdmaid-se/actions)
-[![Github Downloads](https://img.shields.io/github/downloads/d4rken-org/sdmaid-se/total.svg?label=GitHub%20Downloads&logo=github)](https://github.com/d4rken-org/sdmaid-se/main/README.md#download)
-[![Google Play Downloads](https://img.shields.io/endpoint?color=green&logo=google-play&logoColor=green&url=https%3A%2F%2Fplay.cuzi.workers.dev%2Fplay%3Fi%3Deu.darken.sdmse%26l%3DGoogle%2520Play%26m%3D%24totalinstalls)](https://github.com/d4rken-org/sdmaid-se/main/README.md#download)
-[![⭐](https://img.shields.io/endpoint?url=https%3A%2F%2Fplay.cuzi.workers.dev%2Fplay%3Fi%3Deu.darken.sdmse%26gl%3DUS%26hl%3Den%26l%3D%25E2%25AD%2590%26m%3D%24rating)](https://github.com/d4rken-org/sdmaid-se/main/README.md#download)
+[![Crowdin](https://badges.crowdin.net/sdmaid-se/localized.svg)](https://crowdin.com/project/sdmaid-se)
+
+[![Github Downloads](https://img.shields.io/github/downloads/d4rken-org/sdmaid-se/total.svg?label=GitHub%20Downloads&logo=github)](https://github.com/d4rken-org/sdmaid-se#download)
+[![Google Play Downloads](https://img.shields.io/endpoint?color=green&logo=google-play&logoColor=green&url=https%3A%2F%2Fplay.cuzi.workers.dev%2Fplay%3Fi%3Deu.darken.sdmse%26l%3DGoogle%2520Play%26m%3D%24totalinstalls)](https://github.com/d4rken-org/sdmaid-se#download)
+[![Discord](https://img.shields.io/badge/Discord-SDMaid-5865F2?logo=discord&logoColor=white)](https://discord.gg/8Fjy6PTfXu)
 
 > _**SD Maid 2/SE is actively being worked on and not feature complete. Feature requests are welcome!**_
 


### PR DESCRIPTION
Updated badge links for GitHub Downloads, Google Play Downloads, and Discord.