### PR TITLE
General: Fix Pro being lost during temporary Play billing issues

### DIFF
--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/BillingCache.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/BillingCache.kt
@@ -20,5 +20,5 @@ class BillingCache @Inject constructor(
         get() = context.dataStore
 
     val lastProStateAt = dataStore.createValue("gplay.cache.lastProAt", 0L)
-    val lastProStateSku = dataStore.createValue("gplay.cache.lastProAt", "")
+    val lastProStateSku = dataStore.createValue("gplay.cache.lastProSku", "")
 }

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplay.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.time.Duration
 import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -62,7 +63,7 @@ class UpgradeRepoGplay @Inject constructor(
                     Info(billingData = data)
                 }
 
-                (now - lastProStateAt) < 7 * 24 * 60 * 1000L -> { // 7 days
+                (now - lastProStateAt) < GRACE_PERIOD_MS -> {
                     log(TAG, VERBOSE) { "We are not pro, but were recently, did GPlay try annoy us again?" }
                     Info(gracePeriod = true, billingData = null)
                 }
@@ -78,7 +79,7 @@ class UpgradeRepoGplay @Inject constructor(
             val now = System.currentTimeMillis()
             val lastProStateAt = billingCache.lastProStateAt.value()
             log(TAG) { "Catch: now=$now, lastProStateAt=$lastProStateAt, attempt=$attempt, error=$error" }
-            if ((now - lastProStateAt) < 7 * 24 * 60 * 1000L) { // 7 days
+            if ((now - lastProStateAt) < GRACE_PERIOD_MS) {
                 log(TAG, VERBOSE) { "We are not pro, but were recently, and just got an error, what is GPlay doing???" }
                 emit(Info(gracePeriod = true, billingData = null))
             } else {
@@ -151,6 +152,8 @@ class UpgradeRepoGplay @Inject constructor(
         private const val STORE_SITE = "https://play.google.com/store/apps/details?id=eu.darken.sdmse"
         private const val UPGRADE_SITE = "https://play.google.com/store/apps/details?id=eu.darken.sdmse"
         private const val BETA_SITE = "https://play.google.com/apps/testing/eu.darken.sdmse"
+        // Keep paying users Pro through transient empty/failed Play Billing responses
+        val GRACE_PERIOD_MS = Duration.ofDays(7).toMillis()
         val TAG: String = logTag("Upgrade", "Gplay", "Repo")
     }
 }

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplayTest.kt
@@ -54,4 +54,10 @@ class UpgradeRepoGplayTest : BaseTest() {
         info.upgradedAt shouldBe Instant.parse("2023-12-10T00:00:00Z")
         info.type
     }
+
+    @Test fun `grace period is 7 days`() {
+        // Guards against the unit error where 7 * 24 * 60 * 1000 (2.8h) was used instead of 7 days,
+        // which dropped paying users to non-Pro within hours of a transient empty/failed billing response.
+        UpgradeRepoGplay.GRACE_PERIOD_MS shouldBe 604_800_000L
+    }
 }


### PR DESCRIPTION
## What changed

Fixed an issue where users with an active Google Play subscription could be wrongly shown the "Get Pro" upgrade screen — for example when tapping Delete in AppCleaner — even though their subscription was valid. This happened when Google Play briefly failed to report the active purchase to the app.

## Technical Context

- **Root cause:** the Pro grace period in `UpgradeRepoGplay` used `7 * 24 * 60 * 1000L`, which is **2.8 hours, not 7 days** (missing the seconds→minutes factor). The grace period exists to keep a recently-confirmed Pro user on Pro through a transient empty/failed Play Billing response; at 2.8h it effectively didn't bridge normal usage gaps.
- **Fix:** both call sites (the `map` empty-purchase branch and the `retryWhen` error branch) now share `GRACE_PERIOD_MS = Duration.ofDays(7).toMillis()`, with a unit test asserting `604800000L` so the unit error can't silently recur.
- **Trigger vs. cause:** the trigger is device/Play-side (Play returned `code=OK, purchaseData=[]`); the app-side bug is what turned that momentary blip into a paywall.
- **Known residual (intentionally not fixed here):** on a cold start where `lastProStateAt` is `0` (fresh install / cleared data) or older than 7 days, a transient false-negative can still occur until the first successful billing query lands. It self-corrects. A "wait for settled" state was rejected because it risks indefinite hangs when billing is unreachable.
- Also fixed a latent copy-paste bug in `BillingCache`: `lastProStateSku` reused the `"gplay.cache.lastProAt"` key (now `"gplay.cache.lastProSku"`); benign at runtime since the value is unused and Preferences keys are typed.
