### PR TITLE
General: Fix root/Shizuku access hanging after returning to the app

### DIFF
--- a/app-common-adb/build.gradle.kts
+++ b/app-common-adb/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 }
 
 apply(plugin = "dagger.hilt.android.plugin")
+apply(plugin = "org.jetbrains.kotlinx.kover")
 
 android {
     namespace = "${projectConfig.packageName}.common.adb"

--- a/app-common-adb/src/main/java/eu/darken/sdmse/common/adb/service/internal/AdbHostLauncher.kt
+++ b/app-common-adb/src/main/java/eu/darken/sdmse/common/adb/service/internal/AdbHostLauncher.kt
@@ -1,55 +1,47 @@
 package eu.darken.sdmse.common.adb.service.internal
 
-import android.content.ComponentName
-import android.content.ServiceConnection
 import android.os.IBinder
 import android.os.IInterface
 import dagger.Reusable
-import eu.darken.sdmse.common.BuildConfigWrap
 import eu.darken.sdmse.common.adb.AdbException
 import eu.darken.sdmse.common.adb.service.AdbHostOptions
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.ipc.getInterface
-import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
-import rikka.shizuku.Shizuku
-import rikka.shizuku.Shizuku.UserServiceArgs
 import javax.inject.Inject
 import kotlin.reflect.KClass
 
+/**
+ * The Shizuku touchpoints (version check, bind/unbind, ServiceConnection) are behind an injectable
+ * seam ([ShizukuUserServiceFactory]) so this orchestration — especially the finally-block teardown —
+ * is unit-testable. See AdbHostLauncherSeam.kt.
+ */
 @Reusable
-class AdbHostLauncher @Inject constructor() {
+class AdbHostLauncher @Inject constructor(
+    private val serviceFactory: ShizukuUserServiceFactory,
+) {
 
     fun <Service : IInterface, Host : AdbConnection> createConnection(
         serviceClass: KClass<Service>,
         hostClass: KClass<Host>,
         options: AdbHostOptions,
     ): Flow<ConnectionWrapper<Service, Host>> = callbackFlow {
-        if (Shizuku.getVersion() < 10) throw IllegalStateException("Shizuku API10+ required")
+        if (serviceFactory.apiVersion() < 10) throw IllegalStateException("Shizuku API10+ required")
 
-        val serviceArgs = UserServiceArgs(
-            ComponentName(
-                BuildConfigWrap.APPLICATION_ID,
-                hostClass.qualifiedName!!
-            )
-        ).apply {
-            daemon(false)
-            processNameSuffix(logTag("ADB"))
-            debuggable(options.isDebug)
-            version(BuildConfigWrap.VERSION_CODE.toInt())
-        }
-
-        val awaitDisconnect = CompletableDeferred<Unit>()
-
-        val callback: ServiceConnection = object : ServiceConnection {
-            override fun onServiceConnected(componentName: ComponentName, binder: IBinder?) {
-                log(TAG) { "onServiceConnected($componentName,$binder)" }
+        val service = serviceFactory.create(
+            hostClass = hostClass,
+            options = options,
+            onConnected = fun(binder: IBinder?) {
+                log(TAG) { "onServiceConnected(binder=$binder)" }
 
                 if (binder?.pingBinder() != true) {
                     log(TAG) { "onServiceConnected(...) Invalid binder (ping failed)" }
@@ -77,26 +69,31 @@ class AdbHostLauncher @Inject constructor() {
                 log(TAG) { "onServiceConnected(...) -> $userConnection" }
                 @Suppress("UNCHECKED_CAST")
                 trySendBlocking(ConnectionWrapper(userConnection, baseConnection as Host))
-            }
+            },
+        )
 
-            override fun onServiceDisconnected(componentName: ComponentName) {
-                log(TAG) { "onServiceDisconnected($componentName)" }
-                awaitDisconnect.complete(Unit)
-            }
-        }
-        Shizuku.bindUserService(serviceArgs, callback)
+        var bound = false
+        try {
+            service.bind()
+            bound = true
 
-        log(TAG) { "Waiting for flow to close" }
-        awaitClose {
-            Shizuku.unbindUserService(serviceArgs, callback, true)
-            log(TAG) { "Waiting for disconnect..." }
-            // If we don't wait for the service to actually disconnect,
-            // then quick flow restarts can cause DeadObjectExceptions being thrown by our Shizuku service binder
-            runBlocking {
-                withTimeoutOrNull(500) { awaitDisconnect.await() }
+            log(TAG) { "Waiting for flow to close" }
+            awaitClose { log(TAG) { "awaitClose() reached, flow is closing…" } }
+        } finally {
+            // Runs on cancellation too. Mirrors RootHostLauncher: cleanup lives in the finally (not
+            // only in awaitClose) so a throw between bind and awaitClose can't leak the Shizuku
+            // binding, and unbind is best-effort so a DeadObjectException can't mask the cancellation.
+            if (bound) {
+                log(TAG) { "Unbinding Shizuku user service…" }
+                runCatching { service.unbind() }
+                    .onFailure { log(TAG, WARN) { "unbindUserService() failed: ${it.asLog()}" } }
+                // Bounded wait for the actual disconnect; without it, quick flow restarts can cause
+                // DeadObjectExceptions from our Shizuku service binder.
+                withContext(NonCancellable) {
+                    withTimeoutOrNull(DISCONNECT_TIMEOUT_MS) { service.awaitDisconnect() }
+                }
+                log(TAG) { "Shizuku user service unbound." }
             }
-
-            log(TAG) { "Flow closed." }
         }
     }
 
@@ -107,5 +104,9 @@ class AdbHostLauncher @Inject constructor() {
 
     companion object {
         private val TAG = logTag("ADB", "Host", "Launcher")
+
+        // How long to wait for the Shizuku service to actually disconnect after unbinding before
+        // giving up — bounded so teardown can't hang.
+        private const val DISCONNECT_TIMEOUT_MS = 500L
     }
 }

--- a/app-common-adb/src/main/java/eu/darken/sdmse/common/adb/service/internal/AdbHostLauncherSeam.kt
+++ b/app-common-adb/src/main/java/eu/darken/sdmse/common/adb/service/internal/AdbHostLauncherSeam.kt
@@ -1,0 +1,86 @@
+package eu.darken.sdmse.common.adb.service.internal
+
+import android.content.ComponentName
+import android.content.ServiceConnection
+import android.os.IBinder
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import eu.darken.sdmse.common.BuildConfigWrap
+import eu.darken.sdmse.common.adb.service.AdbHostOptions
+import eu.darken.sdmse.common.debug.logging.logTag
+import kotlinx.coroutines.CompletableDeferred
+import rikka.shizuku.Shizuku
+import rikka.shizuku.Shizuku.UserServiceArgs
+import javax.inject.Inject
+import kotlin.reflect.KClass
+
+/**
+ * Seam that lets [AdbHostLauncher.createConnection] be unit-tested without Shizuku.
+ *
+ * The launcher keeps the bind/unbind ordering, the `bound` guard, and the bounded await-disconnect
+ * (the teardown logic under test). This collaborator is the only thing touching the Shizuku statics
+ * ([Shizuku.getVersion]/[Shizuku.bindUserService]/[Shizuku.unbindUserService]) and the Android
+ * [ServiceConnection]. The real implementation is exercised end-to-end on real devices.
+ */
+interface ShizukuUserService {
+    fun bind()
+
+    fun unbind()
+
+    /** Suspends until the service actually disconnects (onServiceDisconnected). */
+    suspend fun awaitDisconnect()
+}
+
+interface ShizukuUserServiceFactory {
+    fun apiVersion(): Int
+
+    fun <Host : AdbConnection> create(
+        hostClass: KClass<Host>,
+        options: AdbHostOptions,
+        onConnected: (IBinder?) -> Unit,
+    ): ShizukuUserService
+}
+
+internal class DefaultShizukuUserServiceFactory @Inject constructor() : ShizukuUserServiceFactory {
+
+    override fun apiVersion(): Int = Shizuku.getVersion()
+
+    override fun <Host : AdbConnection> create(
+        hostClass: KClass<Host>,
+        options: AdbHostOptions,
+        onConnected: (IBinder?) -> Unit,
+    ): ShizukuUserService {
+        val serviceArgs = UserServiceArgs(
+            ComponentName(BuildConfigWrap.APPLICATION_ID, hostClass.qualifiedName!!)
+        ).apply {
+            daemon(false)
+            processNameSuffix(logTag("ADB"))
+            debuggable(options.isDebug)
+            version(BuildConfigWrap.VERSION_CODE.toInt())
+        }
+
+        val disconnected = CompletableDeferred<Unit>()
+        val callback = object : ServiceConnection {
+            override fun onServiceConnected(name: ComponentName?, binder: IBinder?) = onConnected(binder)
+            override fun onServiceDisconnected(name: ComponentName?) {
+                disconnected.complete(Unit)
+            }
+        }
+
+        return object : ShizukuUserService {
+            override fun bind() = Shizuku.bindUserService(serviceArgs, callback)
+            override fun unbind() = Shizuku.unbindUserService(serviceArgs, callback, true)
+            override suspend fun awaitDisconnect() {
+                disconnected.await()
+            }
+        }
+    }
+}
+
+@InstallIn(SingletonComponent::class)
+@Module
+internal abstract class AdbHostLauncherModule {
+    @Binds abstract fun shizukuUserServiceFactory(impl: DefaultShizukuUserServiceFactory): ShizukuUserServiceFactory
+}

--- a/app-common-adb/src/test/java/eu/darken/sdmse/common/adb/service/internal/AdbHostLauncherTest.kt
+++ b/app-common-adb/src/test/java/eu/darken/sdmse/common/adb/service/internal/AdbHostLauncherTest.kt
@@ -1,0 +1,124 @@
+package eu.darken.sdmse.common.adb.service.internal
+
+import android.os.IBinder
+import eu.darken.sdmse.common.adb.service.AdbHostOptions
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainInOrder
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import kotlin.reflect.KClass
+
+/**
+ * Unit coverage for [AdbHostLauncher.createConnection]'s teardown/orchestration. Shizuku is replaced
+ * with a fake via the injectable seam (AdbHostLauncherSeam.kt).
+ */
+class AdbHostLauncherTest {
+
+    private val events = mutableListOf<String>()
+
+    private inner class FakeService(
+        val onUnbind: () -> Unit = {},
+        val onAwait: suspend () -> Unit = {},
+    ) : ShizukuUserService {
+        override fun bind() {
+            events += "bind"
+        }
+
+        override fun unbind() {
+            events += "unbind"
+            onUnbind()
+        }
+
+        override suspend fun awaitDisconnect() {
+            events += "awaitDisconnect"
+            onAwait()
+        }
+    }
+
+    private inner class FakeFactory(
+        val service: ShizukuUserService = FakeService(),
+        val version: Int = 11,
+        val bindError: Throwable? = null,
+    ) : ShizukuUserServiceFactory {
+        override fun apiVersion(): Int = version
+        override fun <Host : AdbConnection> create(
+            hostClass: KClass<Host>,
+            options: AdbHostOptions,
+            onConnected: (IBinder?) -> Unit,
+        ): ShizukuUserService = if (bindError != null) {
+            object : ShizukuUserService by service {
+                override fun bind() {
+                    events += "bind"
+                    throw bindError
+                }
+            }
+        } else {
+            service
+        }
+    }
+
+    private fun launcher(factory: ShizukuUserServiceFactory) = AdbHostLauncher(factory)
+
+    private fun AdbHostLauncher.connect() = createConnection(
+        serviceClass = AdbConnection::class,
+        hostClass = AdbConnection::class,
+        // Explicit values: AdbHostOptions()'s default isDebug=BuildConfigWrap.DEBUG triggers
+        // BuildConfigWrap's static init, which isn't available on a plain JVM.
+        options = AdbHostOptions(isDebug = false, isTrace = false, isDryRun = false, recorderPath = null),
+    )
+
+    @Test fun `unsupported shizuku version fails before binding`() = runTest {
+        val l = launcher(FakeFactory(version = 9))
+
+        shouldThrow<IllegalStateException> { l.connect().collect { } }
+
+        events.shouldBeEmpty() // never bound
+    }
+
+    @Test fun `cancel unbinds then waits for disconnect`() = runTest {
+        val l = launcher(FakeFactory(FakeService()))
+
+        val job = launch { l.connect().collect { } }
+        advanceUntilIdle() // reach awaitClose (bound)
+        job.cancelAndJoin()
+
+        events shouldContainInOrder listOf("bind", "unbind", "awaitDisconnect")
+    }
+
+    @Test fun `a failing unbind is best-effort and still awaits disconnect`() = runTest {
+        val l = launcher(FakeFactory(FakeService(onUnbind = { throw IllegalStateException("unbind boom") })))
+
+        val job = launch { l.connect().collect { } }
+        advanceUntilIdle()
+        job.cancelAndJoin() // must not throw
+
+        events shouldContainInOrder listOf("bind", "unbind", "awaitDisconnect")
+    }
+
+    @Test fun `a hanging disconnect is bounded`() = runTest {
+        val l = launcher(FakeFactory(FakeService(onAwait = { awaitCancellation() }))) // never disconnects
+
+        val job = launch { l.connect().collect { } }
+        advanceUntilIdle()
+        job.cancelAndJoin() // runTest advances virtual time through the bounded await
+
+        events shouldContainInOrder listOf("bind", "unbind", "awaitDisconnect")
+    }
+
+    @Test fun `a failing bind does not attempt unbind`() = runTest {
+        val l = launcher(FakeFactory(bindError = IllegalStateException("bind boom")))
+
+        shouldThrow<IllegalStateException> { l.connect().collect { } }
+
+        events shouldBe listOf("bind") // bound never became true -> no unbind
+        events shouldNotContain "unbind"
+    }
+}

--- a/app-common-io/build.gradle.kts
+++ b/app-common-io/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 
 apply(plugin = "dagger.hilt.android.plugin")
 apply(plugin = "org.jetbrains.kotlin.plugin.serialization")
+apply(plugin = "org.jetbrains.kotlinx.kover")
 
 android {
     namespace = "${projectConfig.packageName}.common.io"

--- a/app-common-root/build.gradle.kts
+++ b/app-common-root/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 }
 
 apply(plugin = "dagger.hilt.android.plugin")
+apply(plugin = "org.jetbrains.kotlinx.kover")
 
 android {
     namespace = "${projectConfig.packageName}.common.root"

--- a/app-common-root/src/main/java/eu/darken/sdmse/common/root/service/internal/RootHostLauncher.kt
+++ b/app-common-root/src/main/java/eu/darken/sdmse/common/root/service/internal/RootHostLauncher.kt
@@ -1,13 +1,7 @@
 package eu.darken.sdmse.common.root.service.internal
 
-import android.content.Context
-import android.os.Debug
 import android.os.IInterface
-import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.flowshell.core.cmd.FlowCmd
-import eu.darken.flowshell.core.cmd.FlowCmdShell
-import eu.darken.flowshell.core.cmd.execute
-import eu.darken.flowshell.core.cmd.openSession
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
@@ -18,11 +12,12 @@ import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.ipc.getInterface
 import eu.darken.sdmse.common.root.RootException
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicBoolean
@@ -36,9 +31,15 @@ import kotlin.reflect.KClass
  * https://github.com/Chainfire/librootjava/blob/master/librootjava/src/main/java/eu/chainfire/librootjava/AppProcess.java
  * https://github.com/zhanghai/MaterialFiles/tree/71e1e0d50573d5c3645e0fe7ec025e0ec75024ec/app/src/main/java/me/zhanghai/android/files/provider/root
  * https://github.com/RikkaApps/Shizuku/blob/master/starter/src/main/java/moe/shizuku/starter/ServiceStarter.java
+ *
+ * The OS/root touchpoints (session, IPC receiver, command building) are behind injectable seams
+ * ([RootSessionFactory], [RootIpcReceiverFactory], [RootLaunchCommandFactory]) so this orchestration
+ * — especially the finally-block teardown ordering — is unit-testable. See RootHostLauncherSeam.kt.
  */
 class RootHostLauncher @Inject constructor(
-    @ApplicationContext private val context: Context
+    private val sessionFactory: RootSessionFactory,
+    private val receiverFactory: RootIpcReceiverFactory,
+    private val commandFactory: RootLaunchCommandFactory,
 ) {
 
     fun <Service : IInterface, Host : BaseRootHost> createConnection(
@@ -53,8 +54,9 @@ class RootHostLauncher @Inject constructor(
         val pairingCode = UUID.randomUUID().toString()
         val connected = AtomicBoolean(false)
 
-        val ipcReceiver = object : RootConnectionReceiver(pairingCode) {
-            override fun onConnect(connection: RootConnection) {
+        val ipcReceiver = receiverFactory.create(
+            pairingCode = pairingCode,
+            onConnect = fun(connection: RootConnection) {
                 log(iTag) { "onConnect(connection=$connection), getting our interface..." }
                 val userConnection = try {
                     connection.userConnection.getInterface(serviceClass) as Service
@@ -67,97 +69,110 @@ class RootHostLauncher @Inject constructor(
                 log(iTag, INFO) { "onServiceConnected(...) got our interface: $userConnection" }
                 connected.set(true)
                 trySendBlocking(ConnectionWrapper(userConnection, connection))
-            }
-
-            override fun onDisconnect(connection: RootConnection) {
+            },
+            onDisconnect = { connection ->
                 log(iTag, INFO) { "onDisconnect(ipc=$connection), closing channel..." }
                 close()
                 log(iTag, VERBOSE) { "onDisconnect(ipc=$connection), channel closed" }
-            }
-        }
-
-        log(iTag) { "Initiating connection to host($hostClass) via binder($serviceClass)" }
-        ipcReceiver.connect(context)
-
-        val (rootSession, _) = try {
-            FlowCmdShell("su").openSession(this)
-        } catch (e: Exception) {
-            throw RootException("Failed to open root session.", e)
-        }
-
-        if (useMountMaster) {
-            try {
-                log(iTag, INFO) { "Using --mount-master" }
-                val result = FlowCmd("su --mount-master").execute(rootSession)
-                log(iTag) { "--mount-master result: $result" }
-                if (!result.isSuccessful) throw IllegalStateException("--mount-master command was unsuccessful")
-            } catch (e: Exception) {
-                log(iTag) { "Failed to use --mount-master" }
-            }
-        }
-
-        val initArgs = RootHostInitArgs(
-            pairingCode = pairingCode,
-            packageName = context.packageName,
-            waitForDebugger = options.isTrace && Debug.isDebuggerConnected(),
-            isDebug = options.isDebug,
-            isTrace = options.isTrace,
-            isDryRun = options.isDryRun,
-            recorderPath = options.recorderPath
+            },
         )
 
-        val cmdBuilder = RootHostCmdBuilder(context, hostClass)
-
-        // Attempt 1: direct exec. May either block until the root host process exits
-        // (success path, with onConnect having fired in the meantime) or fail fast on
-        // a broken pipe / unsupported exec. Use `connected` rather than the throw/
-        // return result to decide whether the host actually bound.
+        // Everything from receiver registration onwards is inside the try so the finally always runs
+        // the cleanup — even if connect()/open() throws (otherwise the receiver or root session could
+        // leak) or if we're cancelled while parked in execute() below (the common case — see finally).
+        var rootSession: RootSession? = null
         try {
-            val cmd = cmdBuilder.build(withRelocation = false, initialOptions = initArgs)
-            log(iTag) { "Launching root host with command: $cmd" }
-            cmd.execute(rootSession).also {
-                log(iTag) { "Session (no-relocation) ended: $it" }
-            }
-        } catch (e: Exception) {
-            if (e is CancellationException) throw e
-            log(iTag, WARN) { "Launch without relocation failed: ${e.asLog()}" }
-        }
+            log(iTag) { "Initiating connection to host($hostClass) via binder($serviceClass)" }
+            ipcReceiver.connect()
 
-        // Attempt 2: relocation. Only needed when the direct exec didn't actually
-        // bring up the binder (some Android versions/SELinux policies refuse to
-        // execute /proc/<pid>/exe in-place).
-        if (!connected.get()) {
-            log(iTag, INFO) { "No binder yet, retrying root host launch with relocation" }
+            rootSession = try {
+                sessionFactory.open(this)
+            } catch (e: Exception) {
+                throw RootException("Failed to open root session.", e)
+            }
+
+            if (useMountMaster) {
+                try {
+                    log(iTag, INFO) { "Using --mount-master" }
+                    val result = rootSession.execute(FlowCmd("su --mount-master"))
+                    log(iTag) { "--mount-master result: $result" }
+                    if (!result.isSuccessful) throw IllegalStateException("--mount-master command was unsuccessful")
+                } catch (e: Exception) {
+                    log(iTag) { "Failed to use --mount-master" }
+                }
+            }
+
+            val command = commandFactory.create(hostClass, pairingCode, options)
+
+            // Attempt 1: direct exec. May either block until the root host process exits
+            // (success path, with onConnect having fired in the meantime) or fail fast on
+            // a broken pipe / unsupported exec. Use `connected` rather than the throw/
+            // return result to decide whether the host actually bound.
             try {
-                val cmd = cmdBuilder.build(withRelocation = true, initialOptions = initArgs)
-                log(iTag) { "Launching root host (relocation) with command: $cmd" }
-                cmd.execute(rootSession).also {
-                    log(iTag) { "Session (relocation) ended: $it" }
+                val cmd = command.build(withRelocation = false)
+                log(iTag) { "Launching root host with command: $cmd" }
+                rootSession.execute(cmd).also {
+                    log(iTag) { "Session (no-relocation) ended: $it" }
                 }
             } catch (e: Exception) {
                 if (e is CancellationException) throw e
-                log(iTag, WARN) { "Launch WITH relocation failed too: ${e.asLog()}" }
+                log(iTag, WARN) { "Launch without relocation failed: ${e.asLog()}" }
             }
-        }
 
-        // If neither attempt produced a binder connection, fail the callbackFlow so
-        // downstream SharedResource consumers (e.g. RootManager.isRooted via
-        // AutomationSetupModule.state) stop waiting on the Loading state forever.
-        if (!connected.get()) {
-            log(iTag, WARN) { "All launch attempts finished without a binder connection" }
-            close(RootException("Root host did not bind after exec/relocation attempts"))
-        }
-
-        log(iTag, VERBOSE) { "Reached awaitClose" }
-        awaitClose {
-            log(iTag) { "Session is closing..." }
-            ipcReceiver.release()
-
-            runBlocking {
-                withTimeoutOrNull(10 * 1000) { rootSession.close() } ?: run {
-                    log(iTag) { "timeout on rootSession.close(), canceling..." }
-                    rootSession.cancel()
+            // Attempt 2: relocation. Only needed when the direct exec didn't actually
+            // bring up the binder (some Android versions/SELinux policies refuse to
+            // execute /proc/<pid>/exe in-place).
+            if (!connected.get()) {
+                log(iTag, INFO) { "No binder yet, retrying root host launch with relocation" }
+                try {
+                    val cmd = command.build(withRelocation = true)
+                    log(iTag) { "Launching root host (relocation) with command: $cmd" }
+                    rootSession.execute(cmd).also {
+                        log(iTag) { "Session (relocation) ended: $it" }
+                    }
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
+                    log(iTag, WARN) { "Launch WITH relocation failed too: ${e.asLog()}" }
                 }
+            }
+
+            // If neither attempt produced a binder connection, fail the callbackFlow so
+            // downstream SharedResource consumers (e.g. RootManager.isRooted via
+            // AutomationSetupModule.state) stop waiting on the Loading state forever.
+            if (!connected.get()) {
+                log(iTag, WARN) { "All launch attempts finished without a binder connection" }
+                close(RootException("Root host did not bind after exec/relocation attempts"))
+            }
+
+            log(iTag, VERBOSE) { "Reached awaitClose" }
+            awaitClose {
+                log(iTag) { "Session is closing (awaitClose reached)…" }
+            }
+        } finally {
+            // Runs on cancellation too — including when we're cancelled while still parked in
+            // execute() above, which is where the producer spends the whole connection. The previous
+            // teardown lived in awaitClose {}, which is unreachable in that case, so the host never
+            // got told to disconnect and waited (RootIPC.byeWaiter, no timeout) until binder death —
+            // minutes on a frozen-but-alive app.
+            withContext(NonCancellable) {
+                log(iTag) { "Cleaning up root host connection…" }
+                // bye() FIRST so the host's RootIPC.byeWaiter wakes immediately.
+                runCatching { ipcReceiver.release() }
+                    .onFailure { log(iTag, WARN) { "ipcReceiver.release() failed: ${it.asLog()}" } }
+
+                rootSession?.let { session ->
+                    // session.close() writes `exit` and awaits exit (cancellable coroutine wait, so
+                    // the coroutine timeout bounds it). Fall back to a forceful cancel() otherwise.
+                    val closed = withTimeoutOrNull(SESSION_CLOSE_TIMEOUT_MS) {
+                        runCatching { session.close() }.isSuccess
+                    }
+                    if (closed != true) {
+                        log(iTag) { "Graceful session close did not finish, cancelling…" }
+                        runCatching { session.cancel() }
+                            .onFailure { log(iTag, WARN) { "session.cancel() failed: ${it.asLog()}" } }
+                    }
+                }
+                log(iTag, VERBOSE) { "Cleanup done" }
             }
         }
     }
@@ -169,5 +184,9 @@ class RootHostLauncher @Inject constructor(
 
     companion object {
         private val TAG = logTag("Root", "Host", "Launcher")
+
+        // How long to wait for a graceful session close (write `exit` + await) before forcefully
+        // cancelling/killing the root session shell.
+        private const val SESSION_CLOSE_TIMEOUT_MS = 10 * 1000L
     }
 }

--- a/app-common-root/src/main/java/eu/darken/sdmse/common/root/service/internal/RootHostLauncherSeam.kt
+++ b/app-common-root/src/main/java/eu/darken/sdmse/common/root/service/internal/RootHostLauncherSeam.kt
@@ -1,0 +1,140 @@
+package eu.darken.sdmse.common.root.service.internal
+
+import android.content.Context
+import android.os.Debug
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import eu.darken.flowshell.core.cmd.FlowCmd
+import eu.darken.flowshell.core.cmd.FlowCmdShell
+import eu.darken.flowshell.core.cmd.execute
+import eu.darken.flowshell.core.cmd.openSession
+import kotlinx.coroutines.CoroutineScope
+import javax.inject.Inject
+import kotlin.reflect.KClass
+
+/**
+ * Seams that let [RootHostLauncher.createConnection] be unit-tested without an actual rooted device.
+ *
+ * The launcher keeps ALL the orchestration (try/finally teardown ordering, mount-master, direct-vs-
+ * relocation retry, the `connected` flag) — that's the logic under test. These three collaborators
+ * are the only things that touch the OS/root boundary (a `su` shell, a broadcast receiver, and the
+ * Android-only command building via [RootHostCmdBuilder]/[Debug]/Parcel), so tests can replace them
+ * with fakes. The real implementations are exercised end-to-end on real devices.
+ */
+interface RootSession {
+    suspend fun execute(cmd: FlowCmd): FlowCmd.Result
+
+    /** Graceful close — writes `exit` and awaits the shell exiting. */
+    suspend fun close()
+
+    /** Forceful kill of the session. */
+    suspend fun cancel()
+}
+
+interface RootSessionFactory {
+    /** Opens a privileged ("su") session tied to [scope]. */
+    suspend fun open(scope: CoroutineScope): RootSession
+}
+
+interface RootIpcReceiver {
+    fun connect()
+
+    /** Releases the receiver and tells the host we're leaving (sends `bye()`). */
+    fun release()
+}
+
+interface RootIpcReceiverFactory {
+    fun create(
+        pairingCode: String,
+        onConnect: (RootConnection) -> Unit,
+        onDisconnect: (RootConnection) -> Unit,
+    ): RootIpcReceiver
+}
+
+/** A per-connection command builder — created once so its init args (incl. [Debug] state) are frozen. */
+interface RootLaunchCommand {
+    fun build(withRelocation: Boolean): FlowCmd
+}
+
+interface RootLaunchCommandFactory {
+    /**
+     * Creates the per-connection [RootLaunchCommand]. Encapsulates [RootHostInitArgs] construction
+     * (which touches [Debug] and the package name) plus [RootHostCmdBuilder] (which touches Parcel /
+     * reflection), none of which run on a plain JVM — hence the seam. The args are captured ONCE here
+     * so the direct-exec and relocation attempts use identical init args (matching pre-seam behaviour).
+     */
+    fun <Host : BaseRootHost> create(
+        hostClass: KClass<Host>,
+        pairingCode: String,
+        options: RootHostOptions,
+    ): RootLaunchCommand
+}
+
+internal class DefaultRootSessionFactory @Inject constructor() : RootSessionFactory {
+    override suspend fun open(scope: CoroutineScope): RootSession {
+        val session = FlowCmdShell("su").openSession(scope).first
+        return object : RootSession {
+            override suspend fun execute(cmd: FlowCmd): FlowCmd.Result = cmd.execute(session)
+            override suspend fun close() = session.close()
+            override suspend fun cancel() = session.cancel()
+        }
+    }
+}
+
+internal class DefaultRootIpcReceiverFactory @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : RootIpcReceiverFactory {
+    override fun create(
+        pairingCode: String,
+        onConnect: (RootConnection) -> Unit,
+        onDisconnect: (RootConnection) -> Unit,
+    ): RootIpcReceiver {
+        val receiver = object : RootConnectionReceiver(pairingCode) {
+            override fun onConnect(connection: RootConnection) = onConnect(connection)
+            override fun onDisconnect(connection: RootConnection) = onDisconnect(connection)
+        }
+        return object : RootIpcReceiver {
+            override fun connect() = receiver.connect(context)
+            override fun release() = receiver.release()
+        }
+    }
+}
+
+internal class DefaultRootLaunchCommandFactory @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : RootLaunchCommandFactory {
+    override fun <Host : BaseRootHost> create(
+        hostClass: KClass<Host>,
+        pairingCode: String,
+        options: RootHostOptions,
+    ): RootLaunchCommand {
+        // Captured once per connection — both launch attempts reuse these.
+        val initArgs = RootHostInitArgs(
+            pairingCode = pairingCode,
+            packageName = context.packageName,
+            waitForDebugger = options.isTrace && Debug.isDebuggerConnected(),
+            isDebug = options.isDebug,
+            isTrace = options.isTrace,
+            isDryRun = options.isDryRun,
+            recorderPath = options.recorderPath,
+        )
+        val cmdBuilder = RootHostCmdBuilder(context, hostClass)
+        return object : RootLaunchCommand {
+            override fun build(withRelocation: Boolean): FlowCmd =
+                cmdBuilder.build(withRelocation = withRelocation, initialOptions = initArgs)
+        }
+    }
+}
+
+@InstallIn(SingletonComponent::class)
+@Module
+internal abstract class RootHostLauncherModule {
+    @Binds abstract fun sessionFactory(impl: DefaultRootSessionFactory): RootSessionFactory
+
+    @Binds abstract fun receiverFactory(impl: DefaultRootIpcReceiverFactory): RootIpcReceiverFactory
+
+    @Binds abstract fun commandFactory(impl: DefaultRootLaunchCommandFactory): RootLaunchCommandFactory
+}

--- a/app-common-root/src/test/java/eu/darken/sdmse/common/root/service/internal/RootHostLauncherTest.kt
+++ b/app-common-root/src/test/java/eu/darken/sdmse/common/root/service/internal/RootHostLauncherTest.kt
@@ -1,0 +1,217 @@
+package eu.darken.sdmse.common.root.service.internal
+
+import eu.darken.flowshell.core.cmd.FlowCmd
+import eu.darken.flowshell.core.process.FlowProcess
+import eu.darken.sdmse.common.root.RootException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContainInOrder
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit coverage for [RootHostLauncher.createConnection]'s teardown/orchestration — the logic we
+ * rewrote and previously only verified on real devices. The OS/root touchpoints are replaced with
+ * fakes via the injectable seams (RootHostLauncherSeam.kt).
+ */
+class RootHostLauncherTest {
+
+    private val events = mutableListOf<String>()
+
+    private inner class FakeSession(
+        var onExecute: suspend (FlowCmd) -> FlowCmd.Result = { ok(it) },
+        var onClose: suspend () -> Unit = {},
+        var onCancel: suspend () -> Unit = {},
+    ) : RootSession {
+        override suspend fun execute(cmd: FlowCmd): FlowCmd.Result {
+            events += "execute"
+            return onExecute(cmd)
+        }
+
+        override suspend fun close() {
+            events += "close"
+            onClose()
+        }
+
+        override suspend fun cancel() {
+            events += "cancel"
+            onCancel()
+        }
+    }
+
+    private inner class FakeSessionFactory(
+        val session: RootSession = FakeSession(),
+        val openError: Throwable? = null,
+    ) : RootSessionFactory {
+        override suspend fun open(scope: CoroutineScope): RootSession {
+            openError?.let { throw it }
+            return session
+        }
+    }
+
+    private inner class FakeReceiver(val onRelease: () -> Unit = {}) : RootIpcReceiver {
+        /** Captured so a test can simulate the host binding (onConnect firing during execute). */
+        var deliverConnect: ((RootConnection) -> Unit)? = null
+
+        override fun connect() {
+            events += "connect"
+        }
+
+        override fun release() {
+            events += "release"
+            onRelease()
+        }
+    }
+
+    private inner class FakeReceiverFactory(val receiver: FakeReceiver = FakeReceiver()) : RootIpcReceiverFactory {
+        override fun create(
+            pairingCode: String,
+            onConnect: (RootConnection) -> Unit,
+            onDisconnect: (RootConnection) -> Unit,
+        ): RootIpcReceiver = receiver.also { it.deliverConnect = onConnect }
+    }
+
+    private class FakeCommandFactory : RootLaunchCommandFactory {
+        val relocations = mutableListOf<Boolean>()
+        override fun <Host : BaseRootHost> create(
+            hostClass: kotlin.reflect.KClass<Host>,
+            pairingCode: String,
+            options: RootHostOptions,
+        ): RootLaunchCommand = object : RootLaunchCommand {
+            override fun build(withRelocation: Boolean): FlowCmd {
+                relocations += withRelocation
+                return FlowCmd("launch relocate=$withRelocation")
+            }
+        }
+    }
+
+    private fun launcher(
+        sessionFactory: RootSessionFactory,
+        receiverFactory: RootIpcReceiverFactory,
+        commandFactory: RootLaunchCommandFactory = FakeCommandFactory(),
+    ) = RootHostLauncher(sessionFactory, receiverFactory, commandFactory)
+
+    private fun RootHostLauncher.connect() = createConnection(
+        serviceClass = RootConnection::class,
+        hostClass = BaseRootHost::class,
+        options = RootHostOptions(),
+    )
+
+    @Test fun `session open failure still releases the receiver`() = runTest {
+        val l = launcher(
+            sessionFactory = FakeSessionFactory(openError = IllegalStateException("no su")),
+            receiverFactory = FakeReceiverFactory(),
+        )
+
+        shouldThrow<RootException> { l.connect().collect { } }
+
+        // connect happened, the failed open still triggered release, and there was no session to close.
+        events shouldBe listOf("connect", "release")
+    }
+
+    @Test fun `cancel while parked in execute runs cleanup with release before close`() = runTest {
+        val session = FakeSession(onExecute = { awaitCancellation() }) // simulate host running forever
+        val cmds = FakeCommandFactory()
+        val l = launcher(FakeSessionFactory(session), FakeReceiverFactory(), cmds)
+
+        val job = launch { l.connect().collect { } }
+        advanceUntilIdle() // reach the parked execute()
+        job.cancelAndJoin()
+
+        events shouldContainInOrder listOf("connect", "execute", "release", "close")
+        events shouldNotContain "cancel" // graceful close succeeded
+        cmds.relocations shouldBe listOf(false) // cancellation rethrown -> no relocation retry
+    }
+
+    @Test fun `a close that throws falls back to cancel`() = runTest {
+        val session = FakeSession(
+            onExecute = { awaitCancellation() },
+            onClose = { throw IllegalStateException("close boom") },
+        )
+        val l = launcher(FakeSessionFactory(session), FakeReceiverFactory())
+
+        val job = launch { l.connect().collect { } }
+        advanceUntilIdle()
+        job.cancelAndJoin()
+
+        events shouldContainInOrder listOf("release", "close", "cancel")
+    }
+
+    @Test fun `a close that hangs is bounded and falls back to cancel`() = runTest {
+        val session = FakeSession(
+            onExecute = { awaitCancellation() },
+            onClose = { awaitCancellation() }, // close never returns -> must time out
+        )
+        val l = launcher(FakeSessionFactory(session), FakeReceiverFactory())
+
+        val job = launch { l.connect().collect { } }
+        advanceUntilIdle()
+        job.cancelAndJoin() // runTest advances virtual time through the close timeout
+
+        events shouldContainInOrder listOf("release", "close", "cancel")
+    }
+
+    @Test fun `cleanup is best-effort - failing release and close still reach cancel`() = runTest {
+        val session = FakeSession(
+            onExecute = { awaitCancellation() },
+            onClose = { throw IllegalStateException("close boom") },
+            onCancel = { throw IllegalStateException("cancel boom") },
+        )
+        val l = launcher(
+            FakeSessionFactory(session),
+            FakeReceiverFactory(FakeReceiver(onRelease = { throw IllegalStateException("release boom") })),
+        )
+
+        val job = launch { l.connect().collect { } }
+        advanceUntilIdle()
+        job.cancelAndJoin() // must not throw despite every cleanup step throwing
+
+        events shouldContainInOrder listOf("release", "close", "cancel")
+    }
+
+    @Test fun `relocation is retried when the first attempt does not bind, then fails with RootException`() = runTest {
+        // execute returns normally but no connection is ever delivered -> connected stays false.
+        val session = FakeSession(onExecute = { ok(it) })
+        val cmds = FakeCommandFactory()
+        val l = launcher(FakeSessionFactory(session), FakeReceiverFactory(), cmds)
+
+        shouldThrow<RootException> { l.connect().collect { } }
+
+        cmds.relocations shouldBe listOf(false, true) // direct exec, then relocation retry
+        events shouldContainInOrder listOf("connect", "execute", "execute", "release", "close")
+    }
+
+    @Test fun `a connection delivered during the first attempt skips relocation and is emitted`() = runTest {
+        val receiverFactory = FakeReceiverFactory()
+        val cmds = FakeCommandFactory()
+        val connection = mockk<RootConnection> { every { userConnection } returns mockk(relaxed = true) }
+        // The host "binds" during the direct exec: fire the factory-routed onConnect callback.
+        val session = FakeSession(onExecute = {
+            receiverFactory.receiver.deliverConnect?.invoke(connection)
+            ok(it)
+        })
+        val l = launcher(FakeSessionFactory(session), receiverFactory, cmds)
+
+        val emitted = mutableListOf<RootHostLauncher.ConnectionWrapper<RootConnection>>()
+        val job = launch { l.connect().collect { emitted += it } }
+        advanceUntilIdle()
+        job.cancelAndJoin()
+
+        cmds.relocations shouldBe listOf(false) // connected -> relocation retry skipped
+        emitted shouldHaveSize 1 // factory-routed callback sent the connection into the flow
+    }
+
+    companion object {
+        private fun ok(cmd: FlowCmd) = FlowCmd.Result(cmd, FlowProcess.ExitCode.OK, emptyList(), emptyList())
+    }
+}

--- a/app-common-shell/build.gradle.kts
+++ b/app-common-shell/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 }
 
 apply(plugin = "dagger.hilt.android.plugin")
+apply(plugin = "org.jetbrains.kotlinx.kover")
 
 android {
     namespace = "${projectConfig.packageName}.common.shell"

--- a/app-common-shell/src/main/java/eu/darken/flowshell/core/process/FlowProcess.kt
+++ b/app-common-shell/src/main/java/eu/darken/flowshell/core/process/FlowProcess.kt
@@ -22,11 +22,14 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import java.util.UUID
+import java.util.concurrent.TimeUnit
 import kotlin.coroutines.cancellation.CancellationException
 
 class FlowProcess(
     launch: suspend () -> Process,
     kill: suspend (Process) -> Unit = { if (it.isAlive) it.destroyForcibly() },
+    private val terminationTimeoutMs: Long = TERMINATION_TIMEOUT_MS,
+    private val forceTerminationTimeoutMs: Long = FORCE_TERMINATION_TIMEOUT_MS,
 ) {
 
     private val processCreator = callbackFlow {
@@ -77,7 +80,17 @@ class FlowProcess(
             runBlocking {
                 killRoutine()
                 if (isDebug) log(_tag) { "kill() executed, waiting for process to terminate" }
-                process.waitFor()
+                // Bounded wait: a coroutine timeout can't interrupt a blocking JVM waitFor(),
+                // so use the timed Java overload. If the process refuses to die (e.g. a wedged
+                // `su` host on a just-unfrozen process), force-destroy it as a last resort so
+                // teardown can't hang indefinitely.
+                if (!process.waitFor(terminationTimeoutMs, TimeUnit.MILLISECONDS)) {
+                    log(_tag, WARN) { "Process did not terminate within ${terminationTimeoutMs}ms, destroying forcibly" }
+                    process.destroyForcibly()
+                    if (!process.waitFor(forceTerminationTimeoutMs, TimeUnit.MILLISECONDS)) {
+                        log(_tag, WARN) { "Process still alive after destroyForcibly()" }
+                    }
+                }
                 if (isDebug) log(_tag) { "Process has terminated" }
             }
             if (isDebug) log(_tag, VERBOSE) { "Flow is closed!" }
@@ -126,5 +139,10 @@ class FlowProcess(
 
     companion object {
         private val TAG = "${FlowShellDebug.tag}:FlowProcess"
+
+        // How long to wait for a process to exit after the kill routine runs before
+        // resorting to destroyForcibly(), and how long to wait after that.
+        private const val TERMINATION_TIMEOUT_MS = 5000L
+        private const val FORCE_TERMINATION_TIMEOUT_MS = 2000L
     }
 }

--- a/app-common-shell/src/main/java/eu/darken/flowshell/core/process/FlowProcessExtensions.kt
+++ b/app-common-shell/src/main/java/eu/darken/flowshell/core/process/FlowProcessExtensions.kt
@@ -15,9 +15,15 @@ import kotlinx.coroutines.withContext
 import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStreamWriter
+import java.util.concurrent.TimeUnit
 import java.util.regex.Pattern
 
 private val TAG = "${FlowShellDebug.tag}:FlowProcess:Extensions"
+
+// The kill path spawns its own short-lived `su` helper shells. On a wedged/just-unfrozen
+// root environment these can hang; bound how long we wait for them before forcibly destroying,
+// so teardown can never block indefinitely.
+private const val HELPER_SHELL_TIMEOUT_MS = 5000L
 private val PID_PATTERN = Pattern.compile("^.+?pid=(\\d+).+?$")
 private val SPACES_PATTERN = Pattern.compile("\\s+")
 
@@ -55,8 +61,8 @@ internal suspend fun Process.pidFamily(shell: String = "sh"): PidFamily? = withC
         val rawPidLines = coroutineScope {
             val output = mutableListOf<String>()
             val error = mutableListOf<String>()
-            process.errorStream.miniHarvester().onEach { output.add(it) }.launchIn(this)
-            process.inputStream.miniHarvester().onEach { error.add(it) }.launchIn(this)
+            val outJob = process.errorStream.miniHarvester().onEach { output.add(it) }.launchIn(this)
+            val errJob = process.inputStream.miniHarvester().onEach { error.add(it) }.launchIn(this)
 
             OutputStreamWriter(process.outputStream).apply {
                 write("ps -o pid,ppid${System.lineSeparator()}")
@@ -65,8 +71,22 @@ internal suspend fun Process.pidFamily(shell: String = "sh"): PidFamily? = withC
                 close()
             }
 
-            val exitcode = process.waitFor()
-            if (exitcode == 0) output + error else null
+            if (process.waitFor(HELPER_SHELL_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                // Process exited -> streams are at EOF. Join the harvesters BEFORE reading so we don't
+                // copy `output`/`error` while a reader is still draining the last lines (the parsed
+                // `ps` output must be complete).
+                outJob.join()
+                errJob.join()
+                if (process.exitValue() == 0) output + error else null
+            } else {
+                log(TAG, WARN) { "pidFamily helper '$shell' did not exit in ${HELPER_SHELL_TIMEOUT_MS}ms, destroying" }
+                process.destroyForcibly()
+                // destroyForcibly() closes the streams -> harvester reads EOF and unblock; cancel so
+                // the coroutineScope can return even if a read is wedged.
+                outJob.cancel()
+                errJob.cancel()
+                null
+            }
         }
 
         rawPidLines
@@ -109,9 +129,12 @@ internal data class PidFamily(
         try {
             process = ProcessBuilder(shell).start()
 
-            coroutineScope {
-                process.errorStream.miniHarvester().launchIn(this)
-                process.inputStream.miniHarvester().launchIn(this)
+            // waitFor() lives inside the coroutineScope so a bounded, force-destroyable wait can
+            // release the harvester jobs (otherwise the scope blocks forever waiting for EOF if the
+            // helper shell hangs).
+            val killed = coroutineScope {
+                val outJob = process.errorStream.miniHarvester().launchIn(this)
+                val errJob = process.inputStream.miniHarvester().launchIn(this)
 
                 OutputStreamWriter(process.outputStream).apply {
                     pids.forEach { write("kill -9 $it${System.lineSeparator()}") }
@@ -119,11 +142,19 @@ internal data class PidFamily(
                     flush()
                     close()
                 }
-            }
 
-            val exitcode = process.waitFor()
-            if (isDebug) log(TAG, VERBOSE) { "kill(pids=$pids) -> exitcode: $exitcode" }
-            exitcode == 0
+                if (process.waitFor(HELPER_SHELL_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                    process.exitValue() == 0
+                } else {
+                    log(TAG, WARN) { "kill helper '$shell' did not exit in ${HELPER_SHELL_TIMEOUT_MS}ms, destroying" }
+                    process.destroyForcibly()
+                    outJob.cancel()
+                    errJob.cancel()
+                    false
+                }
+            }
+            if (isDebug) log(TAG, VERBOSE) { "kill(pids=$pids) -> success: $killed" }
+            killed
 
         } catch (interrupt: InterruptedException) {
             log(TAG, WARN) { "kill(pids=$pids) Interrupted!" }

--- a/app-common-shell/src/test/java/eu/darken/flowshell/core/process/FlowProcessTest.kt
+++ b/app-common-shell/src/test/java/eu/darken/flowshell/core/process/FlowProcessTest.kt
@@ -244,6 +244,26 @@ class FlowProcessTest : BaseTest() {
         startCount shouldBe 2
     }
 
+    @Test fun `teardown force-destroys a process whose kill routine is a no-op`() = runTest {
+        lateinit var proc: Process
+        val flow = FlowProcess(
+            launch = { ProcessBuilder("sleep", "30").start().also { proc = it } },
+            kill = { /* no-op: simulate a kill that fails to actually terminate the process */ },
+            terminationTimeoutMs = 300,
+            forceTerminationTimeoutMs = 2000,
+        )
+
+        val start = System.currentTimeMillis()
+        // first() opens then closes the flow, running the bounded teardown in awaitClose.
+        flow.session.first()
+        val elapsed = System.currentTimeMillis() - start
+
+        // kill() did nothing, so the graceful waitFor(300ms) elapses and destroyForcibly() reaps it.
+        proc.isAlive shouldBe false
+        elapsed shouldBeGreaterThanOrEqual 300 // we waited the bounded grace period
+        elapsed shouldBeLessThan 3000          // ...but teardown didn't hang
+    }
+
     @Test fun `session is killed via pid`() = runTest {
         var opened = false
         var killed = false

--- a/app-common/build.gradle.kts
+++ b/app-common/build.gradle.kts
@@ -1,3 +1,5 @@
+import kotlinx.kover.gradle.plugin.dsl.KoverProjectExtension
+
 plugins {
     id("com.android.library")
     id("kotlin-parcelize")
@@ -7,6 +9,7 @@ plugins {
 
 apply(plugin = "dagger.hilt.android.plugin")
 apply(plugin = "org.jetbrains.kotlin.plugin.serialization")
+apply(plugin = "org.jetbrains.kotlinx.kover")
 
 android {
     namespace = "${projectConfig.packageName}.common"
@@ -43,4 +46,21 @@ dependencies {
     addTesting()
 
     implementation("io.github.z4kn4fein:semver:3.0.0")
+}
+
+// Kover's verify rules can't filter per-rule (only the report can), so to gate ONLY the
+// well-covered SharedResource concurrency code we scope THIS module's own Kover report to that
+// package and enforce a floor on it. The broad cross-module aggregate lives in the root build and
+// is unaffected (it re-aggregates raw coverage with its own filters).
+configure<KoverProjectExtension> {
+    reports {
+        filters { includes { classes("eu.darken.sdmse.common.sharedresource.*") } }
+        verify {
+            rule("SharedResource line coverage") {
+                // Currently ~86%; floor leaves headroom but still guards against the concurrency
+                // code rotting.
+                minBound(80)
+            }
+        }
+    }
 }

--- a/app-common/src/main/java/eu/darken/sdmse/common/sharedresource/SharedResource.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/sharedresource/SharedResource.kt
@@ -8,6 +8,7 @@ import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.traceCall
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
@@ -29,7 +30,6 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
-import kotlinx.coroutines.yield
 import java.time.Duration
 import java.util.UUID
 
@@ -66,13 +66,35 @@ open class SharedResource<T : Any>(
     private val leases = mutableSetOf<Lease>()
     private val children = mutableMapOf<SharedResource<*>, KeepAlive>()
 
-    private var sId: String? = null
-    private var sourceJob: Job? = null
-    private var sourceValue: T? = null
-    private var sourceError: Throwable? = null
+    /**
+     * The single currently-active source "generation". A new [get] either reuses this or, when it's
+     * null (none yet, or a previous one was detached for teardown), launches a fresh one. When the
+     * last lease is released the generation is *detached* — the slot is cleared immediately under
+     * [coreLock] and the slow teardown runs off-lock — so a new [get] never waits for a closing
+     * generation to finish (which can take minutes if the underlying source, e.g. a root host, is
+     * slow to tear down).
+     */
+    @Volatile
+    private var active: Generation<T>? = null
+    private var generationCounter: Long = 0
+
+    private class Generation<T : Any>(
+        val token: Long,
+        val id: String,
+    ) {
+        /** Completed when the first value arrives; completed exceptionally if the source fails first. */
+        val ready = CompletableDeferred<Unit>()
+        @Volatile var value: T? = null
+        @Volatile var error: Throwable? = null
+        var job: Job? = null
+    }
+
+    /** Id of the active generation, for log breadcrumbs. */
+    private val sId: String?
+        get() = active?.id
 
     override val isClosed: Boolean
-        get() = sourceJob == null
+        get() = active == null
 
     suspend fun get(): Resource<T> {
         val lId = "L:${UUID.randomUUID().toString().takeLast(4)}"
@@ -81,12 +103,8 @@ open class SharedResource<T : Any>(
             log(iTag, VERBOSE) { "[$sId|$lId]-get() ... via $call" }
         }
 
-        if (sourceJob?.isActive == false) {
-            lifecycleLog { "[$sId|$lId]-get() Source is currently closing, waiting..." }
-            while (sourceJob != null) yield()
-        }
-
         var lease: Lease? = null
+        var gen: Generation<T>? = null
 
         coreLock.withLock("[$sId|$lId]-get()-sourcejob") {
             withContext(NonCancellable) {
@@ -108,72 +126,84 @@ open class SharedResource<T : Any>(
                 }
 
                 if (Bugs.isTrace) log(iTag, DEBUG) { "[$sId|$lId]-get() Checking for source job..." }
-                if (sourceJob != null) {
+                active?.let {
                     if (Bugs.isTrace) log(iTag, VERBOSE) { "[$sId|$lId]-get() Source job already exists" }
+                    gen = it
                     return@withContext
                 }
 
-                sId = "S:${UUID.randomUUID().toString().takeLast(4)}"
-                lifecycleLog { "[$sId|$lId]-get() Launching source job..." }
-                sourceError = null
-                sourceJob = source
+                val newGen = Generation<T>(
+                    token = ++generationCounter,
+                    id = "S:${UUID.randomUUID().toString().takeLast(4)}",
+                )
+                active = newGen
+                gen = newGen
+                lifecycleLog { "[${newGen.id}|$lId]-get() Launching source job..." }
+                newGen.job = source
                     .onStart {
-                        lifecycleLog { "[$sId|$lId]-source: Starting source..." }
+                        lifecycleLog { "[${newGen.id}|$lId]-source: Starting source..." }
                     }
                     .onEach {
-                        if (Bugs.isTrace) log(iTag) { "[$sId|$lId]-source: sourceValue=$it" }
-                        sourceValue = it
+                        if (Bugs.isTrace) log(iTag) { "[${newGen.id}|$lId]-source: sourceValue=$it" }
+                        // Only the still-active generation may publish its value; a detached/stale
+                        // generation must never clobber a fresh one's state.
+                        if (active === newGen) newGen.value = it
+                        newGen.ready.complete(Unit)
                     }
                     .onCompletion { reason ->
-                        lifecycleLog { "[$sId|$lId]-source: onCompletion due to $reason" }
-                        sourceError = reason
+                        lifecycleLog { "[${newGen.id}|$lId]-source: onCompletion due to $reason" }
+                        if (active === newGen) newGen.error = reason
+                        // Wake any get() still waiting on the first value.
+                        if (!newGen.ready.isCompleted) {
+                            newGen.ready.completeExceptionally(
+                                reason ?: IllegalStateException("Source completed without a value")
+                            )
+                        }
                         if (reason is InternalCancelationException) {
-                            if (Bugs.isTrace) log(iTag, DEBUG) { "[$sId|$lId]-source: Internal cancel, no cleanup" }
+                            if (Bugs.isTrace) log(iTag, DEBUG) { "[${newGen.id}|$lId]-source: Internal cancel, no cleanup" }
                             return@onCompletion
                         }
-                        leaseScope.launch(NonCancellable) {
-                            if (Bugs.isTrace) {
-                                log(iTag, DEBUG) { "[$sId|$lId]-source: onCompletion calling closeLeases()" }
+                        // Self-completion (error / natural end) of the *active* generation: release leases.
+                        if (active === newGen) {
+                            leaseScope.launch(NonCancellable) {
+                                if (Bugs.isTrace) log(iTag, DEBUG) { "[${newGen.id}|$lId]-source: onCompletion calling closeLeases()" }
+                                closeLeases("onCompletion")
+                                if (Bugs.isTrace) log(iTag, VERBOSE) { "[${newGen.id}|$lId]-source: onCompletion calling leaseCheck(forced=true)" }
+                                leaseCheck("onCompletion", forced = true)
                             }
-                            closeLeases("onCompletion")
-                            if (Bugs.isTrace) {
-                                log(iTag, VERBOSE) {
-                                    "[$sId|$lId]-source: onCompletion calling leaseCheck(forced=true)"
-                                }
-                            }
-                            leaseCheck("onCompletion", forced = true)
                         }
-                        if (Bugs.isTrace) log(iTag, DEBUG) { "[$sId|$lId]-source: onCompletion done" }
+                        if (Bugs.isTrace) log(iTag, DEBUG) { "[${newGen.id}|$lId]-source: onCompletion done" }
                     }
-                    .catch { error -> log(iTag, WARN) { "[$sId|$lId]-source ERROR: ${error.asLog()}" } }
+                    .catch { error -> log(iTag, WARN) { "[${newGen.id}|$lId]-source ERROR: ${error.asLog()}" } }
                     .launchIn(leaseScope)
-                if (Bugs.isTrace) log(iTag, DEBUG) { "[$sId|$lId]-get() ...source job launched $sourceJob" }
+                if (Bugs.isTrace) log(iTag, DEBUG) { "[${newGen.id}|$lId]-get() ...source job launched ${newGen.job}" }
             }
         }
 
-        var value: T? = sourceValue
-        var error: Throwable? = sourceError
-        if (value == null && error == null) {
-            lifecycleLog { "[$sId|$lId]-get() Waiting for source value... (current value=$value, error=$error)" }
+        val generation = gen!!
+        // Await readiness OFF-lock (no busy-loop, no waiting on a closing generation). If we're
+        // cancelled (caller gone) or the source fails before producing a value, release the
+        // provisional lease we registered above so it can't pin the resource open forever.
+        if (!generation.ready.isCompleted) {
+            lifecycleLog { "[${generation.id}|$lId]-get() Waiting for source value..." }
         }
-        while (value == null && error == null) {
-            value = sourceValue?.also {
-                if (Bugs.isTrace) log(iTag, DEBUG) { "[$sId|$lId]-get() sourceValue loop, got $it" }
-            }
-            error = sourceError?.also {
-                if (Bugs.isTrace) log(iTag, DEBUG) { "[$sId|$lId]-get() sourceError loop, got $it" }
-            }
-            yield()
+        try {
+            generation.ready.await()
+        } catch (e: Throwable) {
+            if (Bugs.isTrace) log(iTag, DEBUG) { "[${generation.id}|$lId]-get() await failed (${e.javaClass.simpleName}), releasing provisional lease" }
+            lease!!.close()
+            throw e
         }
 
+        val value = generation.value
         if (value == null) {
-            if (Bugs.isTrace) log(iTag, DEBUG) { "[$sId|$lId]-get() sourceValue failed, waiting for cleanup" }
-            while (sourceJob != null) yield()
-            if (Bugs.isTrace) log(iTag, WARN) { "[$sId|$lId]-get() sourceValue failed, throwing $error" }
-            throw error!!
+            lease!!.close()
+            val error = generation.error ?: IllegalStateException("Source produced no value")
+            if (Bugs.isTrace) log(iTag, WARN) { "[${generation.id}|$lId]-get() no value, throwing $error" }
+            throw error
         }
 
-        if (Bugs.isTrace) log(iTag) { "[$sId|$lId]-get() returning value $value" }
+        if (Bugs.isTrace) log(iTag) { "[${generation.id}|$lId]-get() returning value $value" }
         return Resource(value, lease!!)
     }
 
@@ -236,33 +266,45 @@ open class SharedResource<T : Any>(
         }
         if (Bugs.isTrace) log(iTag, DEBUG) { "[$sId|_]-doLeaseCheck()-$tag ZERO leases left" }
 
-        if (sourceJob == null) {
-            if (Bugs.isTrace) log(iTag, DEBUG) { "[$sId|_]-doLeaseCheck()-$tag sourceJob was already null" }
+        val generation = active
+        if (generation == null) {
+            if (Bugs.isTrace) log(iTag, DEBUG) { "[$sId|_]-doLeaseCheck()-$tag active was already null" }
             return@withLock
         }
 
-        if (Bugs.isTrace) log(iTag, DEBUG) { "[$sId|_]-doLeaseCheck()-$tag Cancelling sourceJob" }
-        sourceJob!!.cancel(InternalCancelationException("[$sId|_]-doLeaseCheck()-$tag ZERO leases left"))
-        sourceJob!!.join() // Waits till source.onComplete is done
-        if (Bugs.isTrace) log(iTag, DEBUG) { "[$sId|_]-doLeaseCheck()-$tag sourceJob has completed" }
+        // Detach the generation: clear the active slot *now*, under the lock, so a subsequent get()
+        // starts a fresh source immediately instead of waiting for this (potentially slow) teardown.
+        if (Bugs.isTrace) log(iTag, DEBUG) { "[${generation.id}|_]-doLeaseCheck()-$tag Detaching generation" }
+        active = null
+        val detachedJob = generation.job
+        val detachedChildren = children.toMap()
+        children.clear()
 
-        children.apply {
-            if (isEmpty()) return@apply
-            onEachIndexed { index, entry ->
-                if (Bugs.isTrace) {
-                    log(iTag, VERBOSE) { "[$sId|_]-doLeaseCheck()-$tag Closing child #$index ${entry.value}" }
-                }
-                entry.value.close()
-            }
-            clear()
-
-            if (Bugs.isTrace) log(iTag, VERBOSE) { "[$sId|_]-doLeaseCheck() Remaining children have been cleared" }
+        // Release any get() that is still parked on this generation's `ready` (e.g. a caller whose
+        // lease was force-closed by close() while it was mid-acquire). It must NOT keep waiting for
+        // the off-lock source teardown below, which may be slow/wedged — that's the very hang we fix.
+        // No-op when a value was already produced (the common detach-after-use case).
+        if (!generation.ready.isCompleted) {
+            generation.ready.completeExceptionally(
+                IllegalStateException("[${generation.id}|_]-doLeaseCheck()-$tag detached before a value was produced")
+            )
         }
 
-        sourceValue = null
-        sourceJob = null
-        if (Bugs.isTrace) log(iTag, VERBOSE) { "[$sId|_]-doLeaseCheck()-$tag Source nulled. fin." }
-        sId = null
+        // Close children synchronously — this only releases the leases we hold on them and is fast;
+        // callers (and tests) rely on children being closed by the time the parent reads as closed.
+        detachedChildren.values.forEachIndexed { index, child ->
+            if (Bugs.isTrace) log(iTag, VERBOSE) { "[${generation.id}|_]-doLeaseCheck()-$tag Closing child #$index $child" }
+            child.close()
+        }
+
+        // The source-job cancel+join can be slow (e.g. a root host slow to disconnect). Run it off
+        // BOTH coreLock and leaseCheckLock so a wedged source close can never block a future get()
+        // or leaseCheck().
+        leaseScope.launch(NonCancellable) {
+            detachedJob?.cancel(InternalCancelationException("[${generation.id}|_]-doLeaseCheck()-$tag ZERO leases left"))
+            detachedJob?.join() // Waits till source.onComplete is done
+            if (Bugs.isTrace) log(iTag, VERBOSE) { "[${generation.id}|_]-doLeaseCheck()-$tag teardown complete" }
+        }
     }
 
     override fun close() {

--- a/app-common/src/test/java/eu/darken/sdmse/common/sharedresource/SharedResourceTest.kt
+++ b/app-common/src/test/java/eu/darken/sdmse/common/sharedresource/SharedResourceTest.kt
@@ -8,16 +8,23 @@ import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import okio.IOException
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -461,6 +468,14 @@ class SharedResourceTest : BaseTest() {
             val lease = srVerbose.get()
             lease.close()
 
+            // The source teardown (and its onCompletion breadcrumb) now runs asynchronously off-lock,
+            // so wait for it before asserting. Runs on real Dispatchers.IO, hence the real-time wait.
+            withContext(Dispatchers.IO) {
+                withTimeoutOrNull(2_000) {
+                    while (captured.none { it.contains("onCompletion due to") }) delay(10)
+                }
+            }
+
             // Lifecycle breadcrumbs should fire even though Bugs.isTrace == false
             captured.any { it.contains("Launching source job") } shouldBe true
             captured.any { it.contains("Starting source") } shouldBe true
@@ -591,5 +606,177 @@ class SharedResourceTest : BaseTest() {
             sr.close()
             sr.isClosed shouldBe true
         }
+    }
+
+    @Test fun `get() does not block on a slow-closing generation`(): Unit = runBlocking {
+        val releaseTeardown = CompletableDeferred<Unit>()
+        var sourceStarts = 0
+        val sr = SharedResource(
+            tag = "slowclose",
+            parentScope = this + Dispatchers.IO,
+            stopTimeout = Duration.ZERO,
+            source = callbackFlow {
+                val generation = ++sourceStarts
+                send(generation)
+                awaitClose {
+                    // The first generation's teardown is deliberately wedged (like a root host that
+                    // refuses to disconnect). It must NOT hold up acquiring a fresh generation.
+                    if (generation == 1) runBlocking { releaseTeardown.await() }
+                }
+            },
+        )
+
+        val r1 = sr.get()
+        r1.item shouldBe 1
+        r1.close() // detaches gen-1; its teardown is now wedged in awaitClose
+
+        // A new get() must start gen-2 and return promptly instead of waiting on gen-1's stuck close.
+        val r2 = withTimeout(5_000) { sr.get() }
+        r2.item shouldBe 2
+        r2.close()
+
+        releaseTeardown.complete(Unit) // let gen-1 finish so the scope can wind down
+    }
+
+    @Test fun `get() cancelled before first value releases its provisional lease`(): Unit = runBlocking {
+        val gate = CompletableDeferred<Unit>()
+        val sr = SharedResource(
+            tag = "cancelgate",
+            parentScope = this + Dispatchers.IO,
+            stopTimeout = Duration.ZERO,
+            source = callbackFlow {
+                gate.await() // never produces a value until released
+                send(Unit)
+                awaitClose { }
+            },
+        )
+
+        val getter = launch(Dispatchers.IO) { sr.get() }
+        // Wait until the source generation is active (provisional lease registered).
+        withTimeout(5_000) { while (sr.isClosed) delay(10) }
+
+        getter.cancelAndJoin() // cancel before any value arrives
+
+        // The provisional lease must have been released, so the resource detaches on its own.
+        withTimeout(5_000) { while (!sr.isClosed) delay(10) }
+        sr.isClosed shouldBe true
+
+        gate.complete(Unit)
+    }
+
+    @Test fun `a stale generation cannot clobber the active one`(): Unit = runBlocking {
+        val releaseGen1 = CompletableDeferred<Unit>()
+        var sourceStarts = 0
+        val sr = SharedResource(
+            tag = "noclobber",
+            parentScope = this + Dispatchers.IO,
+            stopTimeout = Duration.ZERO,
+            source = callbackFlow {
+                val generation = ++sourceStarts
+                send(if (generation == 1) "A" else "B")
+                awaitClose {
+                    // gen-1's teardown is wedged until we release it, so its onCompletion fires
+                    // *after* gen-2 is already the active generation.
+                    if (generation == 1) runBlocking { releaseGen1.await() }
+                }
+            },
+        )
+
+        sr.get().apply { item shouldBe "A" }.close() // detaches gen-1 (teardown wedged)
+        val r2 = withTimeout(5_000) { sr.get() }
+        r2.item shouldBe "B"
+
+        // Let the stale gen-1 finish tearing down; its onEach/onCompletion must not touch gen-2.
+        releaseGen1.complete(Unit)
+        delay(250)
+
+        // gen-2 is still healthy: a fresh get() reuses it and returns "B" without an error.
+        val r3 = sr.get()
+        r3.item shouldBe "B"
+        r2.close()
+        r3.close()
+    }
+
+    @Test fun `source failure is thrown promptly despite a wedged stale teardown`(): Unit = runBlocking {
+        val releaseGen1 = CompletableDeferred<Unit>()
+        var sourceStarts = 0
+        val sr = SharedResource<String>(
+            tag = "failfast",
+            parentScope = this + Dispatchers.IO,
+            stopTimeout = Duration.ZERO,
+            source = callbackFlow {
+                val generation = ++sourceStarts
+                if (generation == 1) {
+                    send("A")
+                    awaitClose { runBlocking { releaseGen1.await() } }
+                } else {
+                    throw IllegalStateException("gen-2 boom")
+                }
+            },
+        )
+
+        sr.get().close() // detaches gen-1 (teardown wedged)
+
+        // gen-2's source fails; get() must surface that promptly rather than waiting on gen-1.
+        val error = withTimeout(5_000) { shouldThrow<IllegalStateException> { sr.get() } }
+        error.message shouldBe "gen-2 boom"
+
+        releaseGen1.complete(Unit)
+    }
+
+    @Test fun `a fresh lease cycle completes while a stale teardown is wedged`(): Unit = runBlocking {
+        val releaseGen1 = CompletableDeferred<Unit>()
+        var sourceStarts = 0
+        val sr = SharedResource(
+            tag = "wedged",
+            parentScope = this + Dispatchers.IO,
+            stopTimeout = Duration.ZERO,
+            source = callbackFlow {
+                val generation = ++sourceStarts
+                send(generation)
+                awaitClose { if (generation == 1) runBlocking { releaseGen1.await() } }
+            },
+        )
+
+        sr.get().close() // gen-1 detached, teardown wedged
+
+        // A full acquire + release of gen-2 (incl. its own detach via leaseCheck/doLeaseCheck) must
+        // complete promptly — the wedged gen-1 teardown must not hold coreLock or leaseCheckLock.
+        withTimeout(5_000) {
+            val r = sr.get()
+            r.item shouldBe 2
+            r.close()
+            while (!sr.isClosed) delay(10)
+        }
+        sr.isClosed shouldBe true
+
+        releaseGen1.complete(Unit)
+    }
+
+    @Test fun `close() releases a get() parked on a generation with a wedged teardown`(): Unit = runBlocking {
+        val releaseTeardown = CompletableDeferred<Unit>()
+        val sr = SharedResource<Int>(
+            tag = "wedgedclose",
+            parentScope = this + Dispatchers.IO,
+            stopTimeout = Duration.ZERO,
+            source = callbackFlow {
+                // Never produces a value, and its teardown wedges until released — so the only way a
+                // parked get() can return is if detach completes `ready`, NOT the source completion.
+                awaitClose { runBlocking { releaseTeardown.await() } }
+            },
+        )
+
+        // A getter parks on the generation's `ready` (source never emits); it holds a lease.
+        val getter = async(Dispatchers.IO) { runCatching { sr.get() } }
+        withTimeout(5_000) { while (sr.isClosed) delay(10) } // wait until the generation is active
+
+        // close() force-closes the lease and detaches. The parked getter must be released promptly,
+        // without waiting for the wedged awaitClose teardown.
+        sr.close()
+
+        val result = withTimeout(5_000) { getter.await() }
+        result.isFailure shouldBe true
+
+        releaseTeardown.complete(Unit) // let the off-lock teardown finish so the scope can wind down
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import kotlinx.kover.gradle.plugin.dsl.KoverProjectExtension
+
 plugins {
     id("projectConfig")
     id("com.google.devtools.ksp") version "2.3.6" apply false
@@ -13,6 +15,7 @@ buildscript {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.Kotlin.core}")
         classpath("com.google.dagger:hilt-android-gradle-plugin:${Versions.Dagger.core}")
         classpath("org.jetbrains.kotlin:kotlin-serialization:${Versions.Kotlin.core}")
+        classpath("org.jetbrains.kotlinx:kover-gradle-plugin:0.9.8")
     }
 }
 
@@ -21,6 +24,46 @@ allprojects {
         google()
         mavenCentral()
         maven { setUrl("https://jitpack.io") }
+    }
+}
+
+// --- Code coverage (Kover) -------------------------------------------------------------------
+// Aggregates unit-test coverage for the core library modules into one merged report. Run:
+//   ./gradlew :koverHtmlReport       (merged HTML, at build/reports/kover/html/index.html)
+//   ./gradlew :koverXmlReport        (merged XML, for CI)
+//   ./gradlew :koverPrintCoverage    (prints the merged % to the console)
+// Per-module reports use the variant-suffixed tasks instead, e.g.
+//   ./gradlew :app-common:koverHtmlReportDebug
+// The package-scoped coverage gate lives in app-common/build.gradle.kts (koverVerifyDebug).
+apply(plugin = "org.jetbrains.kotlinx.kover")
+
+dependencies {
+    "kover"(project(":app-common"))
+    "kover"(project(":app-common-shell"))
+    "kover"(project(":app-common-io"))
+    "kover"(project(":app-common-root"))
+    "kover"(project(":app-common-adb"))
+}
+
+configure<KoverProjectExtension> {
+    reports {
+        filters {
+            excludes {
+                // Generated / boilerplate — not meaningful to measure.
+                annotatedBy(
+                    "dagger.Module",
+                    "dagger.internal.DaggerGenerated",
+                    "javax.annotation.processing.Generated",
+                )
+                classes(
+                    "*_Factory", "*_Factory\$*", "*_MembersInjector",
+                    "Hilt_*", "*.Hilt_*", "*.Dagger*", "hilt_aggregated_deps.*", "*_HiltModules*",
+                    "*.BuildConfig", "*.R", "*.R\$*", "*.databinding.*",
+                    // AIDL-generated binder code (Stub / Stub$Proxy / Default) across all modules.
+                    "*\$Stub", "*\$Stub\$*", "*\$Default",
+                )
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## What changed

Fixes SD Maid sometimes getting stuck on "waiting for root access" (with data areas never finishing loading) after you leave the app and come back — e.g. after opening a private space, switching apps, or spending a while in the background. It could stay stuck for minutes before recovering on its own; now it reconnects immediately. The same fix applies to the Shizuku/ADB access path.

Also adds unit-test coverage for this area (it was previously verified only on real devices) and wires up code-coverage reporting.

## Technical Context

Root cause was two compounding issues, both triggered when the app is backgrounded (often frozen by the ROM) while a privileged connection is live:

- `SharedResource.get()` busy-waited with no timeout while a previous source was mid-close. On return, re-acquiring root wedged every root-dependent caller (dashboard root state, the data-area `canRead`, the SAF setup module's `allUsers()`) until the stale close finally finished.
- `RootHostLauncher`'s cleanup lived in an `awaitClose {}` that is unreachable while the producer is parked in the blocking `cmd.execute()` (where it spends the whole connection). So the host was never told to disconnect (no `bye()`) and waited for binder death — minutes on a frozen-but-alive process.

Fixes:
- **SharedResource** reworked to a single active "generation" holding a `CompletableDeferred`; `get()` awaits it off-lock, and `doLeaseCheck` detaches + tears the generation down off both locks, so a new `get()` never waits on a closing one. A pre-existing provisional-lease leak (a cancelled `get()` leaving its lease registered) is fixed too.
- **RootHostLauncher / AdbHostLauncher** cleanup moved into a `finally` that runs on cancellation: send `bye()` / unbind first so the host disconnects promptly, then a bounded graceful close with a forceful fallback.
- **FlowProcess / FlowProcessExtensions** waits are now bounded (timed `waitFor` + `destroyForcibly` fallback; stream harvesters cancelled on timeout) so a wedged `su` can't hang teardown.

Testability / coverage:
- The launchers' OS touchpoints (su session, IPC receiver, command building, Shizuku) are behind injectable seams so the teardown logic is unit-testable without a rooted device — 12 new launcher tests, plus new SharedResource and FlowProcess cases.
- Kover added for the core library modules: merged report via `./gradlew :koverHtmlReport`, plus a package-scoped coverage gate on the SharedResource concurrency code (`./gradlew :app-common:koverVerifyDebug`).

Review guidance: the SharedResource generation rewrite is the subtle part — the detach-then-teardown ordering and the generation-identity guards on `onEach`/`onCompletion` are what prevent stale state and the wedge. Verified end-to-end on Pixel 2 (A9), 7a and 8 (A14/A15) for both root and Shizuku.
