### PR TITLE
General: Fix root/Shizuku setup card flickering when reopening app

### DIFF
--- a/app-common-adb/src/main/java/eu/darken/sdmse/common/adb/service/internal/AdbHostLauncher.kt
+++ b/app-common-adb/src/main/java/eu/darken/sdmse/common/adb/service/internal/AdbHostLauncher.kt
@@ -10,6 +10,7 @@ import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.ipc.getInterface
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.channels.trySendBlocking
@@ -30,6 +31,7 @@ class AdbHostLauncher @Inject constructor(
     private val serviceFactory: ShizukuUserServiceFactory,
 ) {
 
+    @OptIn(DelicateCoroutinesApi::class) // isClosedForSend, to skip the close() on intentional teardown
     fun <Service : IInterface, Host : AdbConnection> createConnection(
         serviceClass: KClass<Service>,
         hostClass: KClass<Host>,
@@ -69,6 +71,16 @@ class AdbHostLauncher @Inject constructor(
                 log(TAG) { "onServiceConnected(...) -> $userConnection" }
                 @Suppress("UNCHECKED_CAST")
                 trySendBlocking(ConnectionWrapper(userConnection, baseConnection as Host))
+            },
+            onDisconnected = {
+                // Fires on an UNEXPECTED disconnect (Shizuku/host died outside our own unbind). Close the
+                // flow so the SharedResource generation tears down and the next get() re-binds, instead of
+                // handing out a dead connection during the keep-alive window. On intentional teardown the
+                // channel is already closed (isClosedForSend), so this is a no-op.
+                if (!isClosedForSend) {
+                    log(TAG, WARN) { "Shizuku user service disconnected unexpectedly, closing connection" }
+                    close(AdbException("Shizuku user service disconnected"))
+                }
             },
         )
 

--- a/app-common-adb/src/main/java/eu/darken/sdmse/common/adb/service/internal/AdbHostLauncherSeam.kt
+++ b/app-common-adb/src/main/java/eu/darken/sdmse/common/adb/service/internal/AdbHostLauncherSeam.kt
@@ -40,6 +40,7 @@ interface ShizukuUserServiceFactory {
         hostClass: KClass<Host>,
         options: AdbHostOptions,
         onConnected: (IBinder?) -> Unit,
+        onDisconnected: () -> Unit,
     ): ShizukuUserService
 }
 
@@ -51,6 +52,7 @@ internal class DefaultShizukuUserServiceFactory @Inject constructor() : ShizukuU
         hostClass: KClass<Host>,
         options: AdbHostOptions,
         onConnected: (IBinder?) -> Unit,
+        onDisconnected: () -> Unit,
     ): ShizukuUserService {
         val serviceArgs = UserServiceArgs(
             ComponentName(BuildConfigWrap.APPLICATION_ID, hostClass.qualifiedName!!)
@@ -66,6 +68,7 @@ internal class DefaultShizukuUserServiceFactory @Inject constructor() : ShizukuU
             override fun onServiceConnected(name: ComponentName?, binder: IBinder?) = onConnected(binder)
             override fun onServiceDisconnected(name: ComponentName?) {
                 disconnected.complete(Unit)
+                onDisconnected()
             }
         }
 

--- a/app-common-adb/src/test/java/eu/darken/sdmse/common/adb/service/internal/AdbHostLauncherTest.kt
+++ b/app-common-adb/src/test/java/eu/darken/sdmse/common/adb/service/internal/AdbHostLauncherTest.kt
@@ -1,12 +1,15 @@
 package eu.darken.sdmse.common.adb.service.internal
 
 import android.os.IBinder
+import eu.darken.sdmse.common.adb.AdbException
 import eu.darken.sdmse.common.adb.service.AdbHostOptions
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainInOrder
 import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.collect
@@ -48,20 +51,27 @@ class AdbHostLauncherTest {
         val version: Int = 11,
         val bindError: Throwable? = null,
     ) : ShizukuUserServiceFactory {
+        /** Captured so a test can simulate an unexpected onServiceDisconnected. */
+        var disconnectCallback: (() -> Unit)? = null
+
         override fun apiVersion(): Int = version
         override fun <Host : AdbConnection> create(
             hostClass: KClass<Host>,
             options: AdbHostOptions,
             onConnected: (IBinder?) -> Unit,
-        ): ShizukuUserService = if (bindError != null) {
-            object : ShizukuUserService by service {
-                override fun bind() {
-                    events += "bind"
-                    throw bindError
+            onDisconnected: () -> Unit,
+        ): ShizukuUserService {
+            disconnectCallback = onDisconnected
+            return if (bindError != null) {
+                object : ShizukuUserService by service {
+                    override fun bind() {
+                        events += "bind"
+                        throw bindError
+                    }
                 }
+            } else {
+                service
             }
-        } else {
-            service
         }
     }
 
@@ -111,6 +121,28 @@ class AdbHostLauncherTest {
         job.cancelAndJoin() // runTest advances virtual time through the bounded await
 
         events shouldContainInOrder listOf("bind", "unbind", "awaitDisconnect")
+    }
+
+    @Test fun `unexpected disconnect closes the connection and still tears down`() = runTest {
+        val factory = FakeFactory(FakeService())
+        val l = launcher(factory)
+
+        val caught = CompletableDeferred<Throwable>()
+        val job = launch {
+            try {
+                l.connect().collect { }
+            } catch (e: Throwable) {
+                caught.complete(e)
+            }
+        }
+        advanceUntilIdle() // reach awaitClose (bound)
+
+        factory.disconnectCallback!!.invoke() // simulate an unexpected onServiceDisconnected
+        advanceUntilIdle()
+
+        caught.await().shouldBeInstanceOf<AdbException>() // flow closed instead of leaking a dead connection
+        events shouldContainInOrder listOf("bind", "unbind") // finally still unbound
+        job.cancelAndJoin()
     }
 
     @Test fun `a failing bind does not attempt unbind`() = runTest {

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/adb/service/AdbServiceClient.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/adb/service/AdbServiceClient.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
+import java.time.Duration
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -45,6 +46,7 @@ class AdbServiceClient @Inject constructor(
 ) : SharedResource<AdbServiceClient.Connection>(
     tag = TAG,
     parentScope = coroutineScope,
+    stopTimeout = ADB_HOST_KEEPALIVE,
     verboseLifecycle = true,
     source = callbackFlow {
         log(TAG) { "Instantiating ADB launcher..." }
@@ -109,6 +111,13 @@ class AdbServiceClient @Inject constructor(
     )
 
     companion object {
+
+        // Keep the privileged ADB host bound briefly after the last lease is released so in-session
+        // re-acquisition (screen-bouncing between dashboard and tools, back-to-back privileged ops)
+        // reuses the warm host instead of paying the multi-second Shizuku/ADB cold-start. Bounded on
+        // purpose: a uid-2000 host should not linger in the background for long. Teardown still happens
+        // (and is prompt/safe); this only delays its start.
+        private val ADB_HOST_KEEPALIVE: Duration = Duration.ofSeconds(30)
 
         fun AdbHostLauncher.createServiceHostConnection(
             options: AdbHostOptions,

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/adb/shizuku/ShizukuManager.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/adb/shizuku/ShizukuManager.kt
@@ -16,6 +16,7 @@ import eu.darken.sdmse.common.flow.replayingShare
 import eu.darken.sdmse.common.flow.setupCommonEventHandlers
 import eu.darken.sdmse.common.pkgs.Pkg
 import eu.darken.sdmse.common.pkgs.toPkgId
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
@@ -132,9 +133,15 @@ class ShizukuManager @Inject constructor(
 
 
     suspend fun isOurServiceAvailable(): Boolean = withContext(dispatcherProvider.IO) {
+        if (isGranted() != true) {
+            log(TAG, VERBOSE) { "isOurServiceAvailable(): Shizuku permission not granted" }
+            return@withContext false
+        }
         try {
             log(TAG, VERBOSE) { "isOurServiceAvailable(): Requesting service client" }
             serviceClient.get().use { it.item.ipc.checkBase() != null }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             log(TAG, WARN) { "isOurServiceAvailable(): Error during checkBase(): $e" }
             false

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/root/RootManager.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/root/RootManager.kt
@@ -13,6 +13,7 @@ import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.flow.replayingShare
 import eu.darken.sdmse.common.flow.setupCommonEventHandlers
 import eu.darken.sdmse.common.root.service.RootServiceClient
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.channels.awaitClose
@@ -101,6 +102,8 @@ class RootManager @Inject constructor(
 
             val newState = try {
                 serviceClient.get().use { it.item.ipc.checkBase() != null }
+            } catch (e: CancellationException) {
+                throw e // don't cache a cancelled probe as "not rooted"
             } catch (e: Exception) {
                 log(TAG, WARN) { "Error while checking for root: $e" }
                 false

--- a/app/src/main/java/eu/darken/sdmse/setup/root/RootSetupModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/root/RootSetupModule.kt
@@ -16,6 +16,7 @@ import eu.darken.sdmse.common.rngString
 import eu.darken.sdmse.common.root.RootManager
 import eu.darken.sdmse.common.root.RootSettings
 import eu.darken.sdmse.setup.SetupModule
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -41,6 +42,13 @@ class RootSetupModule @Inject constructor(
 ) : SetupModule {
 
     private val refreshTrigger = MutableStateFlow(rngString)
+
+    // Last known concrete Result, kept so re-subscription (e.g. returning to the dashboard) can emit it
+    // immediately instead of regressing to Loading and flickering the setup card while the availability
+    // probe re-runs (acquiring the root host can cold-bind a su session). Only ever holds a real Result.
+    @Volatile
+    private var lastResult: Result? = null
+
     override val state: Flow<SetupModule.State> = combine(refreshTrigger, rootSettings.useRoot.flow) { _, useRoot ->
         val baseState = Result(
             useRoot = useRoot,
@@ -58,6 +66,8 @@ class RootSetupModule @Inject constructor(
                 baseState.copy(
                     ourService = try {
                         connection.ipc.checkBase() != null
+                    } catch (e: CancellationException) {
+                        throw e
                     } catch (e: Exception) {
                         log(TAG, WARN) { "Error while checking for root: $e" }
                         false
@@ -66,7 +76,18 @@ class RootSetupModule @Inject constructor(
             }
     }
         .flatMapLatest { it }
-        .onStart { emit(Loading()) }
+        .onEach { if (it is Result) lastResult = it }
+        .onStart {
+            // Don't regress to Loading if we already know the result: emit the last known state so the
+            // dashboard setup card doesn't flicker while the probe re-runs. Guard against a useRoot
+            // change that happened while we had no subscribers.
+            val cached = lastResult
+            if (cached != null && cached.useRoot == rootSettings.useRoot.value()) {
+                emit(cached)
+            } else {
+                emit(Loading())
+            }
+        }
         .onEach { log(TAG) { "New Root setup state: $it" } }
         .replayingShare(appScope)
 
@@ -77,6 +98,8 @@ class RootSetupModule @Inject constructor(
 
     suspend fun toggleUseRoot(useRoot: Boolean?) {
         log(TAG) { "toggleUseRoot(useRoot=$useRoot)" }
+        // Drop any cached state so we don't replay a stale Result for the previous setting.
+        lastResult = null
         rootSettings.useRoot.value(useRoot)
 
         if (useRoot == true) {

--- a/app/src/main/java/eu/darken/sdmse/setup/shizuku/ShizukuSetupModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/shizuku/ShizukuSetupModule.kt
@@ -47,6 +47,12 @@ class ShizukuSetupModule @Inject constructor(
 
     private val refreshTrigger = MutableStateFlow(rngString)
 
+    // Last known concrete Result, kept so re-subscription (e.g. returning to the dashboard) can emit it
+    // immediately instead of regressing to Loading and flickering the setup card while the availability
+    // probe re-runs (a cold AdbHost bind can take ~10s). Only ever holds a real Result, never Loading.
+    @Volatile
+    private var lastResult: Result? = null
+
     private val permissionRequester = shizukuManager.shizukuBinder
         .onEach {
             if (adbSettings.useShizuku.value() == true && shizukuManager.isGranted() == false) {
@@ -86,7 +92,18 @@ class ShizukuSetupModule @Inject constructor(
         }
     }
         .flatMapLatest { it }
-        .onStart { emit(Loading()) }
+        .onEach { if (it is Result) lastResult = it }
+        .onStart {
+            // Don't regress to Loading if we already know the result: emit the last known state so the
+            // dashboard setup card doesn't flicker while the probe re-runs in the background. Guard
+            // against a useShizuku change that happened while we had no subscribers.
+            val cached = lastResult
+            if (cached != null && cached.useShizuku == adbSettings.useShizuku.value()) {
+                emit(cached)
+            } else {
+                emit(Loading())
+            }
+        }
         .onEach { log(TAG) { "New Shizuku setup state: $it" } }
         .replayingShare(appScope)
 
@@ -97,6 +114,8 @@ class ShizukuSetupModule @Inject constructor(
 
     suspend fun toggleUseShizuku(useShizuku: Boolean?) {
         log(TAG) { "toggleUseShizuku(useShizuku=$useShizuku)" }
+        // Drop any cached state so we don't replay a stale Result for the previous setting.
+        lastResult = null
         val couldUseShizuku = shizukuManager.useShizuku.first()
         if (useShizuku == true && shizukuManager.isGranted() == false) {
             val grantResult = coroutineScope {

--- a/app/src/test/java/eu/darken/sdmse/setup/root/RootSetupModuleTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/setup/root/RootSetupModuleTest.kt
@@ -1,0 +1,127 @@
+package eu.darken.sdmse.setup.root
+
+import eu.darken.sdmse.common.areas.DataAreaManager
+import eu.darken.sdmse.common.datastore.DataStoreValue
+import eu.darken.sdmse.common.root.RootManager
+import eu.darken.sdmse.common.root.RootSettings
+import eu.darken.sdmse.common.root.service.RootServiceClient
+import eu.darken.sdmse.common.root.service.RootServiceConnection
+import eu.darken.sdmse.setup.SetupModule
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.flow.test
+
+class RootSetupModuleTest : BaseTest() {
+
+    private val rootSettings: RootSettings = mockk()
+    private val rootManager: RootManager = mockk()
+    private val dataAreaManager: DataAreaManager = mockk(relaxed = true)
+
+    private val useRootValue: DataStoreValue<Boolean?> = mockk()
+    private lateinit var useRootFlow: MutableStateFlow<Boolean?>
+    private val connection: RootServiceClient.Connection = mockk()
+    private val ipc: RootServiceConnection = mockk()
+    private lateinit var scope: CoroutineScope
+    private var probeCount = 0
+
+    @BeforeEach
+    fun setup() {
+        probeCount = 0
+        useRootFlow = MutableStateFlow(true)
+        scope = CoroutineScope(Dispatchers.Unconfined + SupervisorJob())
+
+        every { rootSettings.useRoot } returns useRootValue
+        every { useRootValue.flow } returns useRootFlow
+
+        coEvery { rootManager.isInstalled() } returns true
+        every { rootManager.binder } returns flowOf(connection)
+        every { connection.ipc } returns ipc
+        every { ipc.checkBase() } answers { probeCount++; "ok" }
+    }
+
+    @AfterEach
+    fun teardown() {
+        scope.cancel()
+    }
+
+    private fun module() = RootSetupModule(scope, rootSettings, rootManager, dataAreaManager)
+
+    @Test fun `first subscription emits Loading then Result`() {
+        val mod = module()
+
+        val collector = mod.state.test(tag = "first", scope = scope)
+        collector.await { values, _ -> values.any { it is RootSetupModule.Result } }
+
+        collector.latestValues.first().shouldBeInstanceOf<RootSetupModule.Loading>()
+        val result = collector.latestValues.last().shouldBeInstanceOf<RootSetupModule.Result>()
+        result.ourService shouldBe true
+
+        runBlocking { collector.cancelAndJoin() }
+    }
+
+    @Test fun `re-subscription emits cached Result instead of Loading`() {
+        val mod = module()
+
+        val first = mod.state.test(tag = "first", scope = scope)
+        first.await { values, _ -> values.any { it is RootSetupModule.Result } }
+        runBlocking { first.cancelAndJoin() }
+        runBlocking { delay(50) }
+
+        val second = mod.state.test(tag = "second", scope = scope)
+        second.await { values, _ -> values.isNotEmpty() }
+
+        second.latestValues.first().shouldBeInstanceOf<RootSetupModule.Result>()
+
+        runBlocking { second.cancelAndJoin() }
+    }
+
+    @Test fun `setting change while unsubscribed does not replay stale cache`() {
+        val mod = module()
+
+        val first = mod.state.test(tag = "first", scope = scope)
+        first.await { values, _ -> values.any { it is RootSetupModule.Result } }
+        runBlocking { first.cancelAndJoin() }
+        runBlocking { delay(50) }
+
+        // User turns root off while nothing observes the module.
+        useRootFlow.value = false
+
+        val second = mod.state.test(tag = "second", scope = scope)
+        second.await { values, _ -> values.isNotEmpty() }
+
+        second.latestValues.first().shouldBeInstanceOf<RootSetupModule.Loading>()
+
+        runBlocking { second.cancelAndJoin() }
+    }
+
+    @Test fun `refresh triggers a fresh probe`() {
+        val mod = module()
+
+        val collector = mod.state.test(tag = "refresh", scope = scope)
+        collector.await { values, _ -> values.any { it is RootSetupModule.Result } }
+        val before = probeCount
+
+        runBlocking { mod.refresh() }
+        collector.await { _, _ -> probeCount > before }
+
+        probeCount shouldBeGreaterThan before
+
+        runBlocking { collector.cancelAndJoin() }
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/setup/shizuku/ShizukuSetupModuleTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/setup/shizuku/ShizukuSetupModuleTest.kt
@@ -1,0 +1,152 @@
+package eu.darken.sdmse.setup.shizuku
+
+import eu.darken.sdmse.common.adb.AdbSettings
+import eu.darken.sdmse.common.adb.shizuku.ShizukuManager
+import eu.darken.sdmse.common.areas.DataAreaManager
+import eu.darken.sdmse.common.datastore.DataStoreValue
+import eu.darken.sdmse.common.pkgs.toPkgId
+import eu.darken.sdmse.common.root.RootManager
+import eu.darken.sdmse.setup.SetupModule
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.flow.test
+
+class ShizukuSetupModuleTest : BaseTest() {
+
+    private val adbSettings: AdbSettings = mockk()
+    private val shizukuManager: ShizukuManager = mockk()
+    private val dataAreaManager: DataAreaManager = mockk(relaxed = true)
+    private val rootManager: RootManager = mockk()
+
+    private val useShizukuValue: DataStoreValue<Boolean?> = mockk()
+    private lateinit var useShizukuFlow: MutableStateFlow<Boolean?>
+    private lateinit var scope: CoroutineScope
+    private var probeCount = 0
+
+    @BeforeEach
+    fun setup() {
+        probeCount = 0
+        useShizukuFlow = MutableStateFlow(true)
+        scope = CoroutineScope(Dispatchers.Unconfined + SupervisorJob())
+
+        every { adbSettings.useShizuku } returns useShizukuValue
+        every { useShizukuValue.flow } returns useShizukuFlow
+
+        every { shizukuManager.shizukuPkgId } returns "moe.shizuku.privileged.api".toPkgId()
+        every { shizukuManager.shizukuBinder } returns flowOf(null)
+        every { shizukuManager.permissionGrantEvents } returns emptyFlow()
+        coEvery { shizukuManager.isInstalled() } returns true
+        coEvery { shizukuManager.isCompatible() } returns true
+        coEvery { shizukuManager.isGranted() } returns true
+        coEvery { shizukuManager.isOurServiceAvailable() } coAnswers { probeCount++; true }
+
+        every { rootManager.useRoot } returns flowOf(false)
+    }
+
+    @AfterEach
+    fun teardown() {
+        scope.cancel()
+    }
+
+    private fun module() = ShizukuSetupModule(scope, adbSettings, shizukuManager, dataAreaManager, rootManager)
+
+    @Test fun `first subscription emits Loading then Result`() {
+        val mod = module()
+
+        val collector = mod.state.test(tag = "first", scope = scope)
+        collector.await { values, _ -> values.any { it is ShizukuSetupModule.Result } }
+
+        collector.latestValues.first().shouldBeInstanceOf<ShizukuSetupModule.Loading>()
+        val result = collector.latestValues.last().shouldBeInstanceOf<ShizukuSetupModule.Result>()
+        result.ourService shouldBe true
+
+        runBlocking { collector.cancelAndJoin() }
+    }
+
+    @Test fun `re-subscription emits cached Result instead of Loading`() {
+        val mod = module()
+
+        val first = mod.state.test(tag = "first", scope = scope)
+        first.await { values, _ -> values.any { it is ShizukuSetupModule.Result } }
+        runBlocking { first.cancelAndJoin() }
+        runBlocking { delay(50) } // let the share fully stop (clears the replay buffer)
+
+        // Returning to the dashboard: the cached Result must come first so the setup card doesn't
+        // flicker to Loading while the probe re-runs.
+        val second = mod.state.test(tag = "second", scope = scope)
+        second.await { values, _ -> values.isNotEmpty() }
+
+        second.latestValues.first().shouldBeInstanceOf<ShizukuSetupModule.Result>()
+
+        runBlocking { second.cancelAndJoin() }
+    }
+
+    @Test fun `re-subscription still re-runs the probe in the background`() {
+        val mod = module()
+
+        val first = mod.state.test(tag = "first", scope = scope)
+        first.await { values, _ -> values.any { it is ShizukuSetupModule.Result } }
+        runBlocking { first.cancelAndJoin() }
+        runBlocking { delay(50) }
+
+        val before = probeCount
+        val second = mod.state.test(tag = "second", scope = scope)
+        second.await { _, _ -> probeCount > before } // doesn't trust the cache blindly
+
+        probeCount shouldBeGreaterThan before
+
+        runBlocking { second.cancelAndJoin() }
+    }
+
+    @Test fun `setting change while unsubscribed does not replay stale cache`() {
+        val mod = module()
+
+        val first = mod.state.test(tag = "first", scope = scope)
+        first.await { values, _ -> values.any { it is ShizukuSetupModule.Result } }
+        runBlocking { first.cancelAndJoin() }
+        runBlocking { delay(50) }
+
+        // User turns Shizuku off while nothing observes the module.
+        useShizukuFlow.value = false
+
+        val second = mod.state.test(tag = "second", scope = scope)
+        second.await { values, _ -> values.isNotEmpty() }
+
+        // Cached Result was for useShizuku=true and must not be replayed for the new setting.
+        second.latestValues.first().shouldBeInstanceOf<ShizukuSetupModule.Loading>()
+
+        runBlocking { second.cancelAndJoin() }
+    }
+
+    @Test fun `refresh triggers a fresh probe`() {
+        val mod = module()
+
+        val collector = mod.state.test(tag = "refresh", scope = scope)
+        collector.await { values, _ -> values.any { it is ShizukuSetupModule.Result } }
+        val before = probeCount
+
+        runBlocking { mod.refresh() }
+        collector.await { _, _ -> probeCount > before }
+
+        probeCount shouldBeGreaterThan before
+
+        runBlocking { collector.cancelAndJoin() }
+    }
+}


### PR DESCRIPTION
## What changed

The root and Shizuku setup card on the dashboard would briefly flash "settings incomplete" and then disappear every time you returned to the app — it looked like access was being lost, even though it wasn't. The card now stays stable and shows the last known state while it re-checks in the background, so it no longer flickers.

Two related improvements come with it:
- Privileged access via Shizuku/ADB reconnects faster when moving between screens, instead of cold-starting each time.
- If the Shizuku connection drops unexpectedly, it's now noticed immediately and re-established on the next use, rather than briefly reusing a dead connection.

## Technical Context

- **Root cause:** the Shizuku and Root setup modules' state flows have no persistent subscriber, so returning to the dashboard restarts them from `Loading` and re-runs the availability probe. That probe cold-binds the privileged host (≈10s through Shizuku on the slow Android TV box this was reported on). The card surfaced after the 5s loading grace, then vanished once the probe resolved — the flicker.
- **Fix:** both setup modules cache the last concrete `Result` and replay it on re-subscription (guarded by the current `useShizuku`/`useRoot` setting) instead of regressing to `Loading`. The probe still re-runs in the background to confirm/correct.
- **Warm-keep:** `AdbServiceClient` keeps the host bound for 30s after the last lease (was the 3s default) so in-session re-acquisition reuses the bind. Bounded deliberately — not applied to the root host (uid 0).
- **Disconnect safety:** `AdbHostLauncher` closes the connection flow on an unexpected Shizuku disconnect (new `onDisconnected` seam callback) so the wider keep-alive window can't hand out a dead connection. The root launcher already did this; this brings ADB to parity.
- **Probe hardening:** `isOurServiceAvailable()` / `isRooted()` rethrow `CancellationException` so a probe cancelled during teardown isn't cached as a false negative — important for `isRooted()`, which caches its result. The Shizuku probe also short-circuits to `false` when permission isn't granted.
- Builds on the teardown rework in #2453; the ACS behavior from #2440 is unaffected.

### Tests

New `ShizukuSetupModuleTest` and `RootSetupModuleTest` (cache replay, background re-probe, stale-setting guard, refresh) plus an `AdbHostLauncher` unexpected-disconnect test.
