### PR TITLE
AppControl: Log active filter and result count for the app list

### DIFF
--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListViewModel.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListViewModel.kt
@@ -25,6 +25,7 @@ import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.appcontrol.ui.AppActionRoute
 import eu.darken.sdmse.common.navigation.routes.UpgradeRoute
 import eu.darken.sdmse.common.datastore.value
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.formatDuration
@@ -267,6 +268,11 @@ class AppControlListViewModel @Inject constructor(
                     )
                 }
                 ?.toList()
+
+            log(TAG, INFO) {
+                "Filtered ${cur.data?.apps?.size} → ${appInfos?.size} apps " +
+                    "(tags=${listFilter.tags}, sort=${listSort.mode}, query='$queryNormalized')"
+            }
 
             delay(250)
 


### PR DESCRIPTION
## What changed

No user-facing behavior change. Adds an internal debug-log line to the App Control screen.

When a support log reports "App Control shows 0 apps", it was previously impossible to tell from the log whether the package scan found nothing or whether a saved filter simply hid everything — the per-tool filter setting isn't part of the debug-log dump. This logs the active filter plus the before/after app count so those reports can be diagnosed directly.

## Technical Context

- The app list applies a saved tag-filter (USER/SYSTEM/ENABLED/DISABLED/ACTIVE/NOT_INSTALLED) on top of the scanned package set. A filter that matches nothing renders an empty list with a "0" subtitle — indistinguishable in logs from a failed package scan.
- Added one INFO-level log line where the filter is applied in `AppControlListViewModel`, recording before→after counts plus active tags, sort mode, and search query (e.g. `Filtered 686 → 0 apps (tags=[DISABLED], sort=NAME, query='')`). INFO so it survives non-trace logs.
- Logs on every state recompute (search keystrokes, sort/filter changes) — acceptable noise at INFO; the message is compact.
- Motivated by a real support case (Samsung One UI 8.5 / Android 16) where the log proved 686 apps were scanned but a saved filter reduced the visible list to 0.
