### PR TITLE
General: Stop repeated Shizuku checks when Shizuku isn't installed

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/adb/shizuku/ShizukuManager.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/adb/shizuku/ShizukuManager.kt
@@ -51,7 +51,10 @@ class ShizukuManager @Inject constructor(
         .replayingShare(appScope)
 
     val shizukuBinder: Flow<ShizukuBaseServiceBinder?> = settings.useShizuku.flow
-        .flatMapLatest { if (it == true) shizukuWrapper.baseServiceBinder else flowOf(null) }
+        // Only touch the Shizuku binder if the user opted in AND Shizuku is actually installed.
+        // Otherwise (e.g. useShizuku left enabled after uninstalling Shizuku) every subscription would
+        // probe the absent service and spam "binder haven't been received" on each resume.
+        .flatMapLatest { if (it == true && isInstalled()) shizukuWrapper.baseServiceBinder else flowOf(null) }
         .catch { e ->
             log(TAG, WARN) { "Shizuku binder access failed: ${e.asLog()}" }
             emit(null)
@@ -98,21 +101,17 @@ class ShizukuManager @Inject constructor(
     val shizukuPkgId: Pkg.Id
         get() = PKG_ID
 
-    private var isInstalledCache: Boolean? = null
-    private val isInstalledLock = Mutex()
-
-    suspend fun isInstalled(): Boolean = isInstalledLock.withLock {
-        isInstalledCache?.let { return@withLock it }
-
-        try {
+    // Not cached: a stale "not installed" result would keep the binder gate (see shizukuBinder) closed
+    // even after Shizuku gets installed, until the next process restart. The package lookup is cheap.
+    suspend fun isInstalled(): Boolean {
+        val installed = try {
             context.packageManager.getPackageInfo(PKG_ID.name, 0)
             true
         } catch (_: PackageManager.NameNotFoundException) {
             false
-        }.also {
-            isInstalledCache = it
-            log(TAG) { "isInstalled(): $it" }
         }
+        log(TAG) { "isInstalled(): $installed" }
+        return installed
     }
 
     suspend fun isGranted(): Boolean? = shizukuWrapper.isGranted()

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/adb/shizuku/ShizukuManagerTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/adb/shizuku/ShizukuManagerTest.kt
@@ -1,0 +1,133 @@
+package eu.darken.sdmse.common.adb.shizuku
+
+import android.content.Context
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import eu.darken.sdmse.common.adb.AdbSettings
+import eu.darken.sdmse.common.adb.service.AdbServiceClient
+import eu.darken.sdmse.common.datastore.DataStoreValue
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flow
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import testhelpers.flow.test
+
+class ShizukuManagerTest : BaseTest() {
+
+    private val context: Context = mockk()
+    private val packageManager: PackageManager = mockk()
+    private val settings: AdbSettings = mockk()
+    private val shizukuWrapper: ShizukuWrapper = mockk()
+    private val serviceClient: AdbServiceClient = mockk(relaxed = true)
+
+    private val useShizukuValue: DataStoreValue<Boolean?> = mockk()
+    private lateinit var useShizukuFlow: MutableStateFlow<Boolean?>
+    private lateinit var scope: CoroutineScope
+
+    private var binderSubscriptions = 0
+
+    @BeforeEach
+    fun setup() {
+        binderSubscriptions = 0
+        useShizukuFlow = MutableStateFlow(true)
+        scope = CoroutineScope(Dispatchers.Unconfined + SupervisorJob())
+
+        every { context.packageManager } returns packageManager
+        every { settings.useShizuku } returns useShizukuValue
+        every { useShizukuValue.flow } returns useShizukuFlow
+
+        every { shizukuWrapper.permissionGrantEvents } returns emptyFlow()
+
+        // Track whether the underlying Shizuku binder flow is ever collected.
+        every { shizukuWrapper.baseServiceBinder } returns flow {
+            binderSubscriptions++
+            emit(mockk<ShizukuBaseServiceBinder>())
+        }
+    }
+
+    @AfterEach
+    fun teardown() {
+        scope.cancel()
+    }
+
+    private fun manager() = ShizukuManager(
+        context = context,
+        appScope = scope,
+        dispatcherProvider = TestDispatcherProvider(),
+        settings = settings,
+        shizukuWrapper = shizukuWrapper,
+        serviceClient = serviceClient,
+    )
+
+    private fun setShizukuInstalled(installed: Boolean) {
+        if (installed) {
+            every { packageManager.getPackageInfo(ShizukuManager.PKG_ID.name, 0) } returns PackageInfo()
+        } else {
+            every {
+                packageManager.getPackageInfo(ShizukuManager.PKG_ID.name, 0)
+            } throws PackageManager.NameNotFoundException()
+        }
+    }
+
+    @Test fun `binder is not probed when Shizuku is not installed`() {
+        setShizukuInstalled(false)
+        val mgr = manager()
+
+        val collector = mgr.shizukuBinder.test(tag = "binder", scope = scope)
+        collector.await { values, _ -> values.isNotEmpty() }
+
+        collector.latestValues.last() shouldBe null
+        binderSubscriptions shouldBe 0
+
+        kotlinx.coroutines.runBlocking { collector.cancelAndJoin() }
+    }
+
+    @Test fun `binder is probed when Shizuku is installed`() {
+        setShizukuInstalled(true)
+        val mgr = manager()
+
+        val collector = mgr.shizukuBinder.test(tag = "binder", scope = scope)
+        collector.await { values, _ -> values.any { it != null } }
+
+        binderSubscriptions shouldBe 1
+
+        kotlinx.coroutines.runBlocking { collector.cancelAndJoin() }
+    }
+
+    @Test fun `binder stays closed when user opted out even if installed`() {
+        setShizukuInstalled(true)
+        useShizukuFlow.value = false
+        val mgr = manager()
+
+        val collector = mgr.shizukuBinder.test(tag = "binder", scope = scope)
+        collector.await { values, _ -> values.isNotEmpty() }
+
+        collector.latestValues.last() shouldBe null
+        binderSubscriptions shouldBe 0
+
+        kotlinx.coroutines.runBlocking { collector.cancelAndJoin() }
+    }
+
+    @Test fun `isInstalled is not cached and re-evaluates each call`() {
+        val mgr = manager()
+
+        setShizukuInstalled(false)
+        kotlinx.coroutines.runBlocking { mgr.isInstalled() } shouldBe false
+
+        // Shizuku gets installed afterwards: the next call must reflect it (no stale cache).
+        setShizukuInstalled(true)
+        kotlinx.coroutines.runBlocking { mgr.isInstalled() } shouldBe true
+    }
+}


### PR DESCRIPTION
## What changed

Stops SD Maid from repeatedly checking for Shizuku in the background when the "Use Shizuku if available" option is enabled but Shizuku is not installed on the device. Previously this caused wasted work and error log noise on every return to the app, and could contribute to the "Setup is incomplete" card briefly flashing on the dashboard.

No change for users who have Shizuku installed or who have the option turned off.

## Technical Context

- When `useShizuku=true` but the Shizuku package is absent (e.g. the setting was left on after uninstalling Shizuku), every dashboard resume entered the binder-probe branch, spamming `binder haven't been received` and triggering a `SharedResource` "closed parent" race.
- Fix gates `ShizukuManager.shizukuBinder` on `isInstalled()`. Because both the setup module (`permissionRequester` + binder subscription) and `SetupHealer` (via `useAdb` → `useShizuku`) reach the binder through this single flow, gating here silences both paths.
- `isInstalled()` no longer caches its result (the cache was never invalidated, unlike `RootManager`). The package lookup is cheap, and removing the cache lets the new gate self-correct when Shizuku is installed/removed mid-session instead of staying stale until process restart.
- The user-visible setup-card flicker itself was already addressed separately (`lastResult` re-emit + 5s grace window); this is hardening of the underlying probe churn.
- Added `ShizukuManagerTest` covering the install gate and the no-cache behavior.
