### PR TITLE
General: Update translations from Crowdin

### DIFF
--- a/app/src/main/res/values-eu-rES/strings.xml
+++ b/app/src/main/res/values-eu-rES/strings.xml
@@ -6,7 +6,7 @@
     <string name="dashboard_settings_oneclick_title">Tap-bakarreko modua</string>
     <string name="dashboard_settings_oneclick_summary">Has zaitez tresna guztiak eskaneatzen eta ezabatzen paneleko ekintza-botoian ukitu bat emanez, baieztapen gehigarririk gabe.</string>
     <string name="dashboard_settings_oneclick_tools_title">Tap-bakarreko erramintak</string>
-    <string name="dashboard_settings_oneclick_tools_desc">Zer tresna sartu beharko lirateke tap-bakarreko eragiketetan?</string>
+    <string name="dashboard_settings_oneclick_tools_desc">Zer tresna sartu beharko lirateke Tap-bakarreko eragiketetan?</string>
     <string name="dashboard_card_config_title">Paneleko txartelak</string>
     <string name="dashboard_card_config_desc">Konfiguratu zein txartel agertzen diren eta haien ordena</string>
     <string name="dashboard_card_config_header_title">Arrastatu berrordenatzeko, txandakatu erakusteko/ezkutatzeko</string>


### PR DESCRIPTION
## What changed

Updated the Basque (Euskara) translation with the latest reviewed string from Crowdin.

## Technical Context

- Routine Crowdin translation sync. Only one string passed validation this cycle (a capitalization fix in the Basque one-tap tools description); the remaining pulled translations were reverted for quality issues — duplicated/incoherent store descriptions, placeholder mismatches, and number/grammar errors — and the bad source translations were cleared directly on Crowdin so they get retranslated.
- No user-facing behavior change beyond the single translated string.
