### PR TITLE
General: Fix setup card flashing on every launch for root users

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/setup/root/RootSetupModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/root/RootSetupModule.kt
@@ -58,7 +58,6 @@ class RootSetupModule @Inject constructor(
         if (useRoot != true) return@combine flowOf(baseState)
 
         rootManager.binder
-            .onStart { emit(null) }
             .map { connection ->
                 if (connection == null) return@map baseState
 
@@ -74,6 +73,12 @@ class RootSetupModule @Inject constructor(
                     },
                 ) as SetupModule.State
             }
+            // Stay in Loading while the availability probe cold-binds the su session, instead of emitting
+            // a settled incomplete Result. A synthetic null here used to map to baseState (ourService=false),
+            // briefly flagging setup as incomplete and flashing the dashboard setup card on every launch.
+            // A genuine acquisition failure still surfaces: binder emits null via its catch block (real
+            // failure), which is mapped to baseState above.
+            .onStart { emit(Loading()) }
     }
         .flatMapLatest { it }
         .onEach { if (it is Result) lastResult = it }

--- a/app/src/test/java/eu/darken/sdmse/setup/root/RootSetupModuleTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/setup/root/RootSetupModuleTest.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterEach
@@ -108,6 +109,48 @@ class RootSetupModuleTest : BaseTest() {
         second.latestValues.first().shouldBeInstanceOf<RootSetupModule.Loading>()
 
         runBlocking { second.cancelAndJoin() }
+    }
+
+    @Test fun `cold-start probe stays Loading and never emits a transient incomplete Result`() {
+        // Acquiring the root host cold-binds a su session, so the binder only emits the connection
+        // after a delay. The module must report Loading during that window - never a settled
+        // Result(ourService=false), which previously flagged setup as incomplete and flashed the
+        // dashboard setup card on every launch.
+        every { rootManager.binder } returns flow {
+            delay(100)
+            emit(connection)
+        }
+        val mod = module()
+
+        val collector = mod.state.test(tag = "cold", scope = scope)
+        collector.await { values, _ -> values.any { it is RootSetupModule.Result } }
+
+        // No incomplete Result may appear before the probe resolves.
+        collector.latestValues
+            .filterIsInstance<RootSetupModule.Result>()
+            .forEach { it.isComplete shouldBe true }
+
+        val result = collector.latestValues.last().shouldBeInstanceOf<RootSetupModule.Result>()
+        result.ourService shouldBe true
+
+        runBlocking { collector.cancelAndJoin() }
+    }
+
+    @Test fun `genuine acquisition failure still surfaces an incomplete Result`() {
+        // binder emits null (via its catch block) when root acquisition genuinely fails. That must
+        // map to an incomplete Result so the setup screen shows the real problem - not be swallowed
+        // by the Loading anti-flicker handling.
+        every { rootManager.binder } returns flowOf(null)
+        val mod = module()
+
+        val collector = mod.state.test(tag = "failure", scope = scope)
+        collector.await { values, _ -> values.any { it is RootSetupModule.Result } }
+
+        val result = collector.latestValues.last().shouldBeInstanceOf<RootSetupModule.Result>()
+        result.ourService shouldBe false
+        result.isComplete shouldBe false
+
+        runBlocking { collector.cancelAndJoin() }
     }
 
     @Test fun `refresh triggers a fresh probe`() {


### PR DESCRIPTION
## What changed

Fixes the "Setup is incomplete" card briefly flashing at the top of the home screen every time the app is launched on rooted devices. The card appeared with a button but vanished too fast to tap, even though nothing was actually wrong with the setup.

A previous fix stopped this flicker when *reopening* the app (returning to the dashboard), but the card still flashed on a fresh, cold app start. This covers that remaining case.

## Technical Context

- Root cause: `RootSetupModule` injected a synthetic `null` at the start of its availability probe, which was mapped to a settled `Result(ourService=false)`. While the su session cold-binds (~2s on a fresh process), this transiently reported setup as incomplete. The dashboard's setup-card flow treats an incomplete state as an immediate show signal, bypassing its own anti-flicker grace window (which only covers the pure-`Loading` case).
- Fix: emit `Loading()` during the probe instead of a settled incomplete `Result`, so the dashboard's grace window covers it. A genuine root-acquisition failure still surfaces — the binder emits `null` via its catch block, which remains mapped to an incomplete `Result`.
- Why the earlier `lastResult` cache didn't cover this: on a cold process start `lastResult` is null, so the module still walked `Loading → Result(ourService=false) → Result(ourService=true)` and produced the transient incomplete emission.
- Diagnosis note: this was initially misattributed to the "Use Shizuku if available" toggle re-checking for an uninstalled Shizuku. A user-supplied debug log (rooted Magisk device) ruled that out — toggling/installing Shizuku had no effect — and pointed at the Root module's cold-start probe.
- Tests: added regression coverage for the delayed-probe cold start (no incomplete `Result` before the probe resolves) and for genuine acquisition failure (an incomplete `Result` still surfaces).
