### PR TITLE
General: Fix flicker when tapping a finished cleanup result

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardToolCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardToolCard.kt
@@ -60,8 +60,11 @@ SDMTool.Type.APPCONTROL, SDMTool.Type.ANALYZER, SDMTool.Type.SQUEEZER, SDMTool.T
         activityContainer.apply {
             isGone = item.progress == null && item.result == null
             setOnClickListener { item.onViewTool() }
-            isFocusable = item.result != null && item.progress == null
-            isClickable = item.result != null && item.progress == null
+            // Only allow opening the tool's live list when there's data to show.
+            // After a clean the result text persists but the live data is empty, so
+            // navigating would open a list that immediately closes itself (flicker).
+            isFocusable = item.result != null && item.progress == null && item.onDelete != null
+            isClickable = item.result != null && item.progress == null && item.onDelete != null
         }
         val resultPrimary = item.result?.primaryInfo?.get(context)
         val resultSecondary = item.result?.secondaryInfo?.get(context)?.takeUnless { it.isBlank() }


### PR DESCRIPTION
## What changed

Fixed a flicker where tapping a finished cleanup result on the dashboard (e.g. "16 items deleted, 258 MB freed") briefly opened a screen that immediately closed itself, instead of showing anything. This affected AppCleaner, CorpseFinder and SystemCleaner.

## Technical Context

- Root cause: the tool card's result area navigated to the tool's live list whenever a task result was present, regardless of whether any scan data remained. After a full clean the live data is empty by design, so the list screen opened and its empty-data guard immediately popped it back — a ~30ms open/close flicker. A user's debug log confirmed the pattern for all three tools: navigate to list → empty data → immediate back.
- The fix gates the result-area tap on live data, the same way the card body is already gated: clickable only when there are items to show (`onDelete != null`, equivalent to `hasData == true`). Post-clean the result now reads as plain status text; after a *partial* delete (items remain) the tap still opens the populated list.
- Chose to gate the navigation source rather than rewrite each list screen's self-close guard. The list is only reachable from this card, so closing the one remaining ungated tap path fixes the flicker for all three tools while leaving the guard to do its legitimate job (close the list when you delete the last item while viewing it).
- Not addressed here: the tap still doesn't show *which* items were deleted after a full clean (the live list intentionally drops cleaned entries). A dedicated "what was deleted" summary would be a separate follow-up.
