### PR TITLE
AppCleaner: Fully stop cleaning when cancelling during force-stop

### DIFF
--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/AutomationService.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/AutomationService.kt
@@ -426,7 +426,7 @@ class AutomationService : AccessibilityService(), AutomationHost, AutomationServ
         log(TAG) { "cancelTask()" }
         val (task, job) = currentTask.value ?: return false
         log(TAG, INFO) { "cancelTask(): Canceling $task" }
-        job.cancel()
+        job.cancel(cause = UserCancelledAutomationException())
         return true
     }
 

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleter.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleter.kt
@@ -40,6 +40,7 @@ import eu.darken.sdmse.setup.SetupModule
 import eu.darken.sdmse.setup.isComplete
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asFlow
@@ -171,7 +172,17 @@ class InaccessibleDeleter @Inject constructor(
             } else {
                 // Force-stop apps before clearing cache if enabled
                 if (settings.forceStopBeforeClearing.value()) {
-                    forceStopApps(automationCandidates.map { it.identifier })
+                    try {
+                        forceStopApps(automationCandidates.map { it.identifier })
+                    } catch (e: UserCancelledAutomationException) {
+                        log(TAG, WARN) { "User cancelled during force-stop; skipping cache clear." }
+                        // Honor the cancel as a full stop: don't proceed to clear cache.
+                        successTargets.forEach { failedTargets.remove(it) }
+                        return InaccDelResult(
+                            succesful = successTargets.toSet(),
+                            failed = failedTargets,
+                        )
+                    }
                 }
 
                 val successLive = mutableSetOf<InstallId>()
@@ -225,6 +236,8 @@ class InaccessibleDeleter @Inject constructor(
                     pkgOps.forceStop(installId)
                     log(TAG, VERBOSE) { "Force-stopped $installId" }
                 } catch (e: Exception) {
+                    // Don't swallow cancellation of our own scope (e.g. user cancelled the task).
+                    currentCoroutineContext().ensureActive()
                     log(TAG, WARN) { "Failed to force-stop $installId: ${e.asLog()}" }
                 } finally {
                     increaseProgress()
@@ -236,7 +249,13 @@ class InaccessibleDeleter @Inject constructor(
             val task = ForceStopAutomationTask(targets)
             try {
                 automationManager.submit(task)
+            } catch (e: UserCancelledAutomationException) {
+                // User cancelled => full stop. Propagate so the caller aborts before clearing cache.
+                throw e
             } catch (e: Exception) {
+                // Don't swallow cancellation of our own scope.
+                currentCoroutineContext().ensureActive()
+                // Force-stop is best-effort: log other failures and continue to clear cache.
                 log(TAG, WARN) { "Force-stop automation failed: ${e.asLog()}" }
             }
         } else {

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleterTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleterTest.kt
@@ -4,7 +4,9 @@ import eu.darken.sdmse.appcleaner.core.automation.ClearCacheTask
 import eu.darken.sdmse.appcleaner.core.scanner.InaccessibleCache
 import eu.darken.sdmse.appcleaner.core.scanner.InaccessibleCacheProvider
 import eu.darken.sdmse.automation.core.AutomationSubmitter
+import eu.darken.sdmse.automation.core.ForceStopAutomationTask
 import eu.darken.sdmse.automation.core.errors.NoSettingsWindowException
+import eu.darken.sdmse.automation.core.errors.UserCancelledAutomationException
 import eu.darken.sdmse.common.adb.AdbManager
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.pkgs.NoSettingsDetector
@@ -31,6 +33,7 @@ import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import io.mockk.slot
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -386,5 +389,107 @@ class InaccessibleDeleterTest : BaseTest() {
         result.succesful.size shouldBe 0
         // Empty-batch guard: no submission even though useAutomation=true
         coVerify(exactly = 0) { automationManager.submit(any()) }
+    }
+
+    /**
+     * Drives the automation-based force-stop branch: no root/ADB, automation setup complete,
+     * and force-stop-before-clearing enabled.
+     */
+    private fun enableAutomationForceStop() {
+        every { rootManager.useRoot } returns flowOf(false)
+        every { adbManager.useAdb } returns flowOf(false)
+        every { automationSetupModule.state } returns flowOf(
+            mockk<SetupModule.State.Current> { every { isComplete } returns true }
+        )
+        every { settings.forceStopBeforeClearing } returns mockDataStoreValue(true)
+    }
+
+    @Test
+    fun `user cancel during force-stop aborts before clearing cache and keeps prior successes`() = runTest {
+        val junkMain = createAppJunk("com.example.main", cacheSize = 100000)
+        val junkZero = createAppJunk("com.example.empty", cacheSize = 80000)
+        val snapshot = createSnapshot(junkMain, junkZero)
+
+        enableAutomationForceStop()
+        coEvery { inaccessibleCacheProvider.determineCache(junkMain.pkg) } returns nonZeroCache(junkMain)
+        // junkZero already emptied out -> counts as success before force-stop runs
+        coEvery { inaccessibleCacheProvider.determineCache(junkZero.pkg) } returns InaccessibleCache(
+            identifier = junkZero.identifier,
+            isSystemApp = false,
+            itemCount = 0,
+            totalSize = 0L,
+            publicSize = 0L,
+            theoreticalPaths = emptySet(),
+        )
+
+        coEvery { automationManager.submit(match { it is ForceStopAutomationTask }) } throws UserCancelledAutomationException()
+
+        val result = deleter.deleteInaccessible(
+            snapshot = snapshot,
+            targetPkgs = null,
+            useAutomation = true,
+            isBackground = false,
+        )
+
+        // User cancel == full stop: cache clearing must NOT be attempted.
+        coVerify(exactly = 0) { automationManager.submit(match { it is ClearCacheTask }) }
+        // The actual force-stop target was not cleared.
+        result.succesful shouldNotContain junkMain.identifier
+        // A success that happened before the cancel is still reported (partial result).
+        result.succesful shouldContain junkZero.identifier
+    }
+
+    @Test
+    fun `non-cancel force-stop failure still proceeds to clear cache`() = runTest {
+        val junk = createAppJunk("com.example.main", cacheSize = 100000)
+        val snapshot = createSnapshot(junk)
+
+        enableAutomationForceStop()
+        coEvery { inaccessibleCacheProvider.determineCache(junk.pkg) } returns nonZeroCache(junk)
+
+        coEvery { automationManager.submit(match { it is ForceStopAutomationTask }) } throws RuntimeException("force-stop boom")
+        coEvery { automationManager.submit(match { it is ClearCacheTask }) } returns ClearCacheTask.Result(
+            successful = setOf(junk.identifier),
+            failed = emptyMap(),
+        )
+
+        val result = deleter.deleteInaccessible(
+            snapshot = snapshot,
+            targetPkgs = null,
+            useAutomation = true,
+            isBackground = false,
+        )
+
+        // Force-stop is best-effort: a failure must not block cache clearing.
+        coVerify(exactly = 1) { automationManager.submit(match { it is ClearCacheTask }) }
+        result.succesful shouldContain junk.identifier
+    }
+
+    @Test
+    fun `force-stop internal cancellation with active scope still clears cache`() = runTest {
+        val junk = createAppJunk("com.example.main", cacheSize = 100000)
+        val snapshot = createSnapshot(junk)
+
+        enableAutomationForceStop()
+        coEvery { inaccessibleCacheProvider.determineCache(junk.pkg) } returns nonZeroCache(junk)
+
+        // Simulates retry-exhaustion: the automation processor's own job is cancelled, surfacing as a
+        // plain CancellationException while OUR coroutine scope is still active. Must be treated as a
+        // best-effort failure (continue), NOT as a user cancel (abort).
+        coEvery { automationManager.submit(match { it is ForceStopAutomationTask }) } throws CancellationException("automation job cancelled")
+        coEvery { automationManager.submit(match { it is ClearCacheTask }) } returns ClearCacheTask.Result(
+            successful = setOf(junk.identifier),
+            failed = emptyMap(),
+        )
+
+        val result = deleter.deleteInaccessible(
+            snapshot = snapshot,
+            targetPkgs = null,
+            useAutomation = true,
+            isBackground = false,
+        )
+
+        coVerify(exactly = 1) { automationManager.submit(match { it is ClearCacheTask }) }
+        result.succesful shouldContain junk.identifier
     }
 }

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/automation/AppControlAutomation.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/automation/AppControlAutomation.kt
@@ -53,7 +53,9 @@ import eu.darken.sdmse.common.progress.withProgress
 import eu.darken.sdmse.common.user.UserManager2
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
 import javax.inject.Provider
 
 class AppControlAutomation @AssistedInject constructor(
@@ -222,14 +224,22 @@ class AppControlAutomation @AssistedInject constructor(
                 }
             }
         } finally {
-            delay(250)
+            // Run cleanup even when cancelled, otherwise a user cancel skips the back-navigation
+            // and leaves the user stranded on the system settings screen.
+            withContext(NonCancellable) {
+                delay(250)
 
-            finishAutomation(
-                userCancelled = cancelledByUser,
-            returnToAppIntent = automationReturnHelper.createReturnToAppIntent(context),
-                deviceDetective = deviceDetective,
-            )
+                finishAutomation(
+                    userCancelled = cancelledByUser,
+                    returnToAppIntent = automationReturnHelper.createReturnToAppIntent(context),
+                    deviceDetective = deviceDetective,
+                )
+            }
         }
+
+        // Make the "user cancel => full stop" contract explicit instead of relying on the
+        // cancelled job tripping a suspension point above.
+        if (cancelledByUser) throw UserCancelledAutomationException()
 
         return ForceStopAutomationTask.Result(
             successful = successful,


### PR DESCRIPTION
## What changed

When you cancel an AppCleaner cleanup while it's force-stopping apps (with "force stop apps before cleaning" enabled), it now stops completely and returns you to SD Maid. Previously a single cancel was ignored during the force-stop step — cleaning continued into the cache-clearing phase and the automation overlay reappeared, so you had to press Cancel a second time to actually stop.

## Technical Context

- **Root cause:** `InaccessibleDeleter.forceStopApps()` wrapped the automation call in a generic `catch (Exception)`. `UserCancelledAutomationException` extends `CancellationException`, so the user's cancel was swallowed and execution fell through to submit the `ClearCacheTask` (re-acquiring the accessibility service and re-showing the overlay).
- **Cancel vs failure:** a user cancel now aborts the whole operation before clearing cache, while a genuine force-stop *failure* stays best-effort and still proceeds to clear cache. The force-stop confirm step on some ROMs fails by retry-exhaustion, which surfaces as a plain `JobCancellationException` from the automation's own supervisor job — `ensureActive()` in the catch distinguishes that (deleter scope still active → continue) from a real cancellation of the deleter's own scope (→ propagate). The same guard was added to the root/ADB force-stop catch.
- **Normalized signaling:** `AutomationService.cancelTask()` now cancels with `UserCancelledAutomationException` as the cause, so every user-cancel path emits the same typed exception rather than relying on exception type by accident.
- **Return-to-app on cancel:** `AppControlAutomation.processForceStop()`'s cleanup is wrapped in `NonCancellable` so the back-navigation to SD Maid runs even when the job is cancelled (previously the cancel tripped a suspension point and skipped it; the app only returned incidentally via the later cache-clear phase). It also explicitly rethrows `UserCancelledAutomationException` so the "user cancel = full stop" contract no longer depends on a cancelled job tripping a `delay`.
- **Verified** on a OneUI device (SM-X210): a single cancel during force-stop returns to SD Maid with no further overlay and no cache-clear; force-stop failures still clear cache. New `InaccessibleDeleterTest` cases cover all three branches (user cancel → no clear; failure → clear; internal cancellation with active scope → clear).
- **Review guidance:** focus on the cancel/failure split in `forceStopApps` + the `deleteInaccessible` call site, and the `NonCancellable` + rethrow in `processForceStop`.

## Note

Not addressed here: on this OneUI build the force-stop *confirm dialog* itself isn't tapped reliably (the automation matches the dialog title instead of the OK button), so force-stop usually fails and falls through to cache-clearing. That's a separate issue, fixed in a follow-up.
