### PR TITLE
AppControl: Fix force stop getting stuck on Samsung (One UI) devices

### DIFF
--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/oneui/OneUISpecs.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/oneui/OneUISpecs.kt
@@ -8,6 +8,7 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.appcontrol.core.automation.specs.AppControlSpecGenerator
 import eu.darken.sdmse.automation.core.common.crawl
+import eu.darken.sdmse.automation.core.common.isClickyButton
 import eu.darken.sdmse.automation.core.common.pkgId
 import eu.darken.sdmse.automation.core.common.stepper.AutomationStep
 import eu.darken.sdmse.automation.core.common.stepper.StepContext
@@ -117,8 +118,11 @@ class OneUISpecs @Inject constructor(
             }
 
             val action: suspend StepContext.() -> Boolean = action@{
+                // Require a clickable button: the dialog title carries the same "force stop" text
+                // as the button (and appears first in crawl order), so matching on text alone
+                // selects the non-clickable title and the step stalls.
                 val target = findNode {
-                    when (Bugs.isDryRun) {
+                    it.isClickyButton() && when (Bugs.isDryRun) {
                         true -> it.textMatchesAny(cancelLbl)
                         false -> it.textMatchesAny(okLbl + forceStopLabels)
                     }


### PR DESCRIPTION
Fixes #2457

## What changed

On Samsung (One UI) devices, force-stopping apps via the accessibility service — e.g. AppCleaner's "force stop apps before cleaning" — would get stuck on the system "Force stop?" confirmation dialog and never press OK, so the force-stop silently failed (and timed out after a long pause). This is the slowness regression reported in #2457 (v1.7.2 → v1.7.3).

## Technical Context

- **Root cause:** the One UI confirm-dialog step matched the OK button by text (`okLbl + forceStopLabels`). On One UI the dialog's title (`android:id/alertTitle`, a non-clickable `TextView`) carries the *exact same* "force stop" text as the button. `findNode` walks the tree top-down and returns the first match — the title — which has no clickable parent, so the step kept retrying until it timed out. The real OK button (`android:id/button1`) was never reached.
- **Fix:** require the matched node to be a clickable button (`isClickyButton()`) in the `findNode` predicate, so the non-clickable title is skipped and the actual button is selected. This is the same idiom already used across the cleaner specs.
- The `forceStopLabels` are intentionally kept in the matcher (some One UI variants label the confirm button with the force-stop wording); the `isClickyButton()` guard is what resolves the title/button text collision. The dialog-detection `windowCheck` is unchanged.
- **Regression source:** `forceStopLabels` was added to the OK matcher in `bbb355b8a` to fix One UI 1.0 / Android 9 (where the confirm button itself is labelled "Force stop"). That's correct for One UI 1.0 but collides with the title on newer One UI. This change keeps that One UI 1.0 fix intact (the labels stay) and resolves the collision with the `isClickyButton()` guard — it is not a revert.
- Other ROM specs (AOSP/MIUI/HyperOS/Oukitel/Android TV) match `okLbl` only and were never affected — this is scoped to `OneUISpecs`.
- **Verified** on a One UI device (SM-X210): the confirm step now clicks OK and force-stop completes (then cache clearing proceeds and finishes), instead of stalling.
