### PR TITLE
AppCleaner: Fix Realme Android 15 cache cleaning tapping the Home button

### DIFF
--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/common/ACSNodeInfo.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/common/ACSNodeInfo.kt
@@ -40,6 +40,11 @@ interface ACSNodeInfo {
         const val ACTION_SELECT = AccessibilityNodeInfo.ACTION_SELECT
         const val ACTION_SCROLL_FORWARD = AccessibilityNodeInfo.ACTION_SCROLL_FORWARD
         const val ACTION_SCROLL_BACKWARD = AccessibilityNodeInfo.ACTION_SCROLL_BACKWARD
+
+        // Equivalent to AccessibilityAction.ACTION_SHOW_ON_SCREEN.id (API 23+; minSdk is 26).
+        // Referenced via the framework resource id so it stays a plain int constant — the
+        // AccessibilityAction object is null under the unit-test android stub and would NPE.
+        val ACTION_SHOW_ON_SCREEN = android.R.id.accessibilityActionShowOnScreen
         const val ACTION_FOCUS = AccessibilityNodeInfo.ACTION_FOCUS
         const val ACTION_ACCESSIBILITY_FOCUS = AccessibilityNodeInfo.ACTION_ACCESSIBILITY_FOCUS
 

--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/common/ACSNodeInfoExtensions.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/common/ACSNodeInfoExtensions.kt
@@ -146,6 +146,23 @@ fun ACSNodeInfo.scrollNodeBackward(): Boolean {
     }
 }
 
+/**
+ * Asks the framework to bring this node fully on-screen, scrolling its container in whatever
+ * direction is necessary. Unlike [scrollNode] (blind FORWARD on a scrollable node), this works
+ * for a node that is clipped behind a system bar at the bottom of a list.
+ */
+fun ACSNodeInfo.scrollNodeIntoView(): Boolean =
+    performAction(ACSNodeInfo.ACTION_SHOW_ON_SCREEN).also { success ->
+        log(TAG, VERBOSE) { "scrollNodeIntoView(): success=$success: $this" }
+    }
+
+/**
+ * True when the node's on-screen bounds are empty or degenerate (e.g. clipped behind a system
+ * bar so that `top >= bottom`). A positional gesture computed from such bounds would land on
+ * whatever occupies that screen region (often the navigation bar), so callers must not tap it.
+ */
+fun ACSNodeInfo.ScreenBounds.isEmpty(): Boolean = left >= right || top >= bottom
+
 val AccessibilityEvent.pkgId: Pkg.Id? get() = packageName.takeIf { !it.isNullOrBlank() }?.toString()?.toPkgId()
 
 fun ACSNodeInfo.distanceTo(other: ACSNodeInfo): Double {

--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/common/stepper/StepperExtensions.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/common/stepper/StepperExtensions.kt
@@ -2,7 +2,6 @@ package eu.darken.sdmse.automation.core.common.stepper
 
 import android.accessibilityservice.GestureDescription
 import android.graphics.Path
-import android.graphics.Rect
 import android.view.ViewConfiguration
 import eu.darken.sdmse.automation.core.common.ACSNodeInfo
 import eu.darken.sdmse.automation.core.common.children
@@ -10,6 +9,7 @@ import eu.darken.sdmse.automation.core.common.contentDescMatches
 import eu.darken.sdmse.automation.core.common.crawl
 import eu.darken.sdmse.automation.core.common.distanceTo
 import eu.darken.sdmse.automation.core.common.findParentOrNull
+import eu.darken.sdmse.automation.core.common.isEmpty
 import eu.darken.sdmse.automation.core.common.textMatches
 import eu.darken.sdmse.automation.core.dispatchGesture
 import eu.darken.sdmse.automation.core.errors.DisabledTargetException
@@ -17,9 +17,12 @@ import eu.darken.sdmse.automation.core.errors.UnclickableTargetException
 import eu.darken.sdmse.automation.core.waitForWindowRoot
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.*
 import eu.darken.sdmse.common.debug.logging.log
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 
 
 suspend fun StepContext.findNode(
@@ -203,10 +206,17 @@ suspend fun StepContext.clickGesture(
     isDryRun: Boolean = false,
     node: ACSNodeInfo,
 ): Boolean {
-    val rect = Rect().apply { node.getBoundsInScreen(this) }
-    val x = rect.centerX().toFloat()
-    val y = rect.centerY().toFloat()
-    log(tag, VERBOSE) { "clickGesture(): node=$node, bounds=$rect" }
+    val bounds = node.getScreenBounds()
+    // Empty/degenerate bounds mean the node is clipped (e.g. behind a system bar). The
+    // computed center would land on whatever occupies that region (often the navigation bar's
+    // home button), so refuse the tap and let the step retry via node recovery.
+    if (bounds.isEmpty()) {
+        log(tag, WARN) { "clickGesture(): Refusing tap, node bounds are empty/degenerate: $bounds ($node)" }
+        return false
+    }
+    val x = ((bounds.left + bounds.right) / 2).toFloat()
+    val y = ((bounds.top + bounds.bottom) / 2).toFloat()
+    log(tag, VERBOSE) { "clickGesture(): node=$node, bounds=$bounds" }
     return clickGestureAtCoords(x, y, isDryRun)
 }
 
@@ -219,6 +229,15 @@ suspend fun StepContext.clickGestureAtCoords(
     y: Float,
     isDryRun: Boolean = false,
 ): Boolean {
+    // Defense-in-depth: never dispatch a tap outside the current foreground window (e.g. onto
+    // the navigation/status bar, which belongs to a different window). right/bottom are exclusive.
+    host.windowRoot()?.getScreenBounds()?.let { root ->
+        if (x < root.left || x >= root.right || y < root.top || y >= root.bottom) {
+            log(tag, WARN) { "clickGestureAtCoords(): Refusing tap at X=$x, Y=$y, outside window root $root" }
+            return false
+        }
+    }
+
     val path = Path().apply {
         moveTo(x, y)
         lineTo(x + 1f, y + 1f)
@@ -227,15 +246,20 @@ suspend fun StepContext.clickGestureAtCoords(
         addStroke(GestureDescription.StrokeDescription(path, 0, ViewConfiguration.getTapTimeout().toLong()))
     }.build()
 
-    log(tag, VERBOSE) { "clickGesture(): Waiting for passthrough..." }
-    host.changeOptions { it.copy(passthrough = true) }
-    host.state.filter { it.passthrough }.first()
+    return try {
+        log(tag, VERBOSE) { "clickGesture(): Waiting for passthrough..." }
+        host.changeOptions { it.copy(passthrough = true) }
+        host.state.filter { it.passthrough }.first()
 
-    log(tag) { "clickGestureAtCoords(): Performing CLICK gesture at X=$x, Y=$y" }
-    val success = if (isDryRun) true else host.dispatchGesture(gesture)
-
-    host.changeOptions { it.copy(passthrough = false) }
-    host.state.filter { !it.passthrough }.first()
-
-    return success
+        log(tag) { "clickGestureAtCoords(): Performing CLICK gesture at X=$x, Y=$y" }
+        if (isDryRun) true else host.dispatchGesture(gesture)
+    } finally {
+        // Always restore passthrough, even if enabling/dispatch threw or we're cancelled
+        // mid-gesture; leaving it on would stop the service from intercepting touches. Bounded
+        // so it can never hang past the step timeout if the state never settles.
+        withContext(NonCancellable) {
+            host.changeOptions { it.copy(passthrough = false) }
+            withTimeoutOrNull(1_000L) { host.state.filter { !it.passthrough }.first() }
+        }
+    }
 }

--- a/app-common-automation/src/test/java/eu/darken/sdmse/automation/core/common/ACSNodeInfoExtensionsTest.kt
+++ b/app-common-automation/src/test/java/eu/darken/sdmse/automation/core/common/ACSNodeInfoExtensionsTest.kt
@@ -1,0 +1,32 @@
+package eu.darken.sdmse.automation.core.common
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class ACSNodeInfoExtensionsTest : BaseTest() {
+
+    private fun bounds(left: Int, top: Int, right: Int, bottom: Int) =
+        ACSNodeInfo.ScreenBounds(left = left, top = top, right = right, bottom = bottom)
+
+    @Test
+    fun `screen bounds isEmpty - normal on-screen rect is not empty`() {
+        // git.artdeell.mojo from issue #2464: valid, mid-screen → tappable
+        bounds(64, 801, 560, 839).isEmpty() shouldBe false
+    }
+
+    @Test
+    fun `screen bounds isEmpty - degenerate rect clipped behind nav bar`() {
+        // The 3 failing rows from issue #2464: top >= bottom (clipped at the nav-bar boundary)
+        bounds(64, 1519, 560, 1504).isEmpty() shouldBe true
+        bounds(64, 1650, 560, 1504).isEmpty() shouldBe true
+        bounds(64, 1541, 560, 1504).isEmpty() shouldBe true
+    }
+
+    @Test
+    fun `screen bounds isEmpty - zero height or width is empty`() {
+        bounds(64, 100, 560, 100).isEmpty() shouldBe true
+        bounds(300, 100, 300, 500).isEmpty() shouldBe true
+        bounds(0, 0, 0, 0).isEmpty() shouldBe true
+    }
+}

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/realme/RealmeSpecs.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/realme/RealmeSpecs.kt
@@ -11,7 +11,9 @@ import eu.darken.sdmse.appcleaner.core.automation.specs.AppCleanerSpecGenerator
 import eu.darken.sdmse.appcleaner.core.automation.specs.StorageEntryFinder
 import eu.darken.sdmse.appcleaner.core.automation.specs.clickClearCache
 import eu.darken.sdmse.automation.core.common.isClickyButton
+import eu.darken.sdmse.automation.core.common.isEmpty
 import eu.darken.sdmse.automation.core.common.pkgId
+import eu.darken.sdmse.automation.core.common.scrollNodeIntoView
 import eu.darken.sdmse.automation.core.common.stepper.AutomationStep
 import eu.darken.sdmse.automation.core.common.stepper.StepContext
 import eu.darken.sdmse.automation.core.common.stepper.Stepper
@@ -41,6 +43,7 @@ import eu.darken.sdmse.common.pkgs.features.Installed
 import eu.darken.sdmse.common.pkgs.toPkgId
 import eu.darken.sdmse.common.progress.withProgress
 import eu.darken.sdmse.common.device.RomTypeProvider
+import kotlinx.coroutines.delay
 import javax.inject.Inject
 
 @Reusable
@@ -90,8 +93,26 @@ class RealmeSpecs @Inject constructor(
                         if (mapped != null) {
                             clickNormal(node = mapped)
                         } else {
+                            // No clickable parent (e.g. Compose-based settings): we must tap by
+                            // coordinates. If the row is clipped behind a system bar its bounds are
+                            // degenerate and a tap would hit the navigation bar.
                             log(TAG, WARN) { "Target has no clickable parent, trying gesture..." }
-                            clickGesture(node = target)
+                            if (target.getScreenBounds().isEmpty()) {
+                                // Bring it on-screen, then re-find on a fresh tree. If it's still
+                                // clipped, fail so node recovery scrolls and the step retries —
+                                // never tap degenerate bounds (that lands on the navigation bar).
+                                log(TAG, WARN) { "Target bounds are clipped, scrolling into view: $target" }
+                                target.scrollNodeIntoView()
+                                delay(250)
+                                val refreshed = storageFinder(this) ?: return@action false
+                                if (refreshed.getScreenBounds().isEmpty()) {
+                                    log(TAG, WARN) { "Target still clipped after scroll, retrying: $refreshed" }
+                                    return@action false
+                                }
+                                clickGesture(node = refreshed)
+                            } else {
+                                clickGesture(node = target)
+                            }
                         }
                     }
 

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/BaseAppCleanerSpecTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/BaseAppCleanerSpecTest.kt
@@ -193,6 +193,45 @@ abstract class BaseAppCleanerSpecTest<S : AppCleanerSpecGenerator, L : Any> : Ba
         return actionResult
     }
 
+    /**
+     * Captures and runs the storage-entry step (the first step, "Storage entry for …"), which
+     * navigates from the App Info screen into the storage detail. Returns the nodeAction result.
+     * Runs the action a single time so callers can assert one-shot behaviour (e.g. that a clipped
+     * node is scrolled into view rather than blindly tapped).
+     */
+    protected suspend fun captureAndRunStorageEntryAction(
+        spec: S = createSpec(),
+        pkg: Installed = createTestPkg(),
+    ): Boolean {
+        var actionResult = false
+
+        coEvery { stepper.process(any(), any()) } coAnswers {
+            val step = secondArg<AutomationStep>()
+            if (step.descriptionInternal.contains("storage", ignoreCase = true)) {
+                val stepContext = StepContext(
+                    hostContext = testContext,
+                    tag = "test",
+                    stepAttempts = 0,
+                )
+                val nodeAction = step.nodeAction
+                if (nodeAction != null) {
+                    try {
+                        actionResult = nodeAction.invoke(stepContext)
+                    } catch (_: StepAbortException) {
+                        actionResult = false
+                    }
+                }
+            }
+            Unit
+        }
+
+        val automationSpec = spec.getClearCache(pkg) as AutomationSpec.Explorer
+        val plan = automationSpec.createPlan()
+        plan.invoke(testContext)
+
+        return actionResult
+    }
+
     // ============================================================
     // Generic isResponsible() tests - work for any ROM spec
     // ============================================================

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/realme/RealmeSpecsTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/realme/RealmeSpecsTest.kt
@@ -3,8 +3,11 @@ package eu.darken.sdmse.appcleaner.core.automation.specs.realme
 import eu.darken.sdmse.appcleaner.core.automation.specs.BaseAppCleanerSpecTest
 import eu.darken.sdmse.automation.core.common.ACSNodeInfo
 import eu.darken.sdmse.automation.core.common.crawl
+import eu.darken.sdmse.automation.core.common.stepper.StepContext
 import eu.darken.sdmse.common.device.RomType
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
@@ -114,5 +117,37 @@ class RealmeSpecsTest : BaseAppCleanerSpecTest<RealmeSpecs, RealmeLabels>() {
 
         // Should return true (success) - disabled button with no cache means nothing to clear
         result shouldBe true
+    }
+
+    @Test
+    fun `storage entry - clipped row is scrolled into view, never gesture-tapped - API 35+ - GitHub 2464`() = runTest {
+        // realme C51 / ColorOS A15: the storage row is a Compose node with no clickable ancestor,
+        // and when parked at the bottom of the list it is clipped behind the nav bar so its bounds
+        // are degenerate (top >= bottom). A center-of-bounds gesture would hit the Home button.
+        // The fix: bring it on-screen via ACTION_SHOW_ON_SCREEN and never tap degenerate bounds.
+        // See: https://github.com/d4rken-org/sdmaid-se/issues/2464
+        every { eu.darken.sdmse.common.hasApiLevel(35) } returns true
+
+        val clipped = TestACSNodeInfo(
+            text = "Занято 1,16 ГБ (Внутр. накопитель)",
+            viewIdResourceName = "android:id/summary",
+            className = "android.widget.TextView",
+            isClickable = false,
+            screenBoundsOverride = ACSNodeInfo.ScreenBounds(left = 64, top = 1519, right = 560, bottom = 1504),
+        )
+        // No clickable ancestor anywhere (Compose layout) → forces the gesture branch.
+        val root = TestACSNodeInfo(className = "android.widget.FrameLayout").addChildren(clipped)
+        testHost.setWindowRoot(root)
+
+        val finder: suspend StepContext.() -> ACSNodeInfo? = { clipped }
+        coEvery { storageEntryFinder.storageFinderAOSP(any(), any(), any()) } returns finder
+
+        val result = captureAndRunStorageEntryAction()
+
+        // Scroll-into-view was attempted on the clipped node...
+        clipped.performedActions shouldContain ACSNodeInfo.ACTION_SHOW_ON_SCREEN
+        // ...and because bounds stayed degenerate, no tap was dispatched and the step did not
+        // falsely report success (it will retry / time out instead of pressing Home).
+        result shouldBe false
     }
 }


### PR DESCRIPTION
## What changed

On Realme devices running Android 15, AppCleaner's automated cache cleaning would open the app's settings, then jump to the home screen and do nothing — leaving the cache uncleared. This fixes that: it now reliably opens the "Storage & cache" screen and clears the cache.

## Technical Context

- **Root cause:** On Realme/ColorOS Android 15 the Settings *App Info* screen is rendered with Jetpack Compose, so the "Storage & cache" row exposes **no clickable ancestor** in the accessibility tree — the spec has to tap it by coordinates (this is why the gesture fallback was added for #1912). When the row is scrolled to the bottom of the list it sits behind the 3-button navigation bar, so `getBoundsInScreen` returns **degenerate bounds** (`top >= bottom`). The center-of-bounds tap then lands on the navigation bar's **Home** button → launcher → the clear-cache step runs on the home screen and times out. In the reporter's log the one app whose row was fully on-screen succeeded; the three clipped ones all pressed Home and failed.
- **Why not just raise `findClickableParent` depth:** the debug log shows the row has no `clickable=true` ancestor at *any* depth (Compose), so a deeper search finds nothing. The gesture path is genuinely required; the fix makes it land correctly and fail safely.
- **Safety net is shared:** the empty-bounds guard lives in `clickGesture`, so MIUI/HyperOS clear-cache gestures are also protected. For a real on-screen button the guard never fires, so there's no behavior change there.
- **Incidental hardening:** `clickGestureAtCoords` now restores the touch-passthrough overlay in a `NonCancellable`, timeout-bounded `finally` — previously a thrown or cancelled gesture could leave the service stuck in passthrough.
- **Review guidance:** the interesting files are `StepperExtensions.kt` (guard + passthrough finally) and `RealmeSpecs.kt` (scroll-into-view + re-find). Tests: a pure `ScreenBounds.isEmpty()` test and a `#2464` regression test asserting a clipped row is scrolled into view and never gesture-tapped.

Closes #2464
