### PR TITLE
CorpseFinder: Fix false leftover for Samsung Intelligent Wi-Fi

### DIFF
--- a/app-common-data/src/main/assets/clutter/db_clutter_markers.json
+++ b/app-common-data/src/main/assets/clutter/db_clutter_markers.json
@@ -6207,6 +6207,9 @@
   "pkgs": ["com.sec.android.allshare.service.controlshare"],
   "mrks": [{"loc": "PRIVATE_DATA", "path": "com.sec.android.allshare.framework"}]
 }, {
+  "pkgs": ["com.samsung.android.wifi.ai"],
+  "mrks": [{"loc": "PRIVATE_DATA", "path": "com.samsung.android.wifi.intelligence"}]
+}, {
   "pkgs": ["com.glu.deerhunt2"],
   "mrks": [{"loc": "PUBLIC_DATA", "path": "com.glu.android.gwallet"}]
 }, {


### PR DESCRIPTION
## What changed

On rooted Samsung phones running newer One UI / Android versions, CorpseFinder
repeatedly reported a bogus "uninstall leftover" for
`com.samsung.android.wifi.intelligence` — even though nothing was actually
removed. Scanning again always brought it back.

This stops that false positive. The leftover is no longer shown, because the
data actually belongs to a Wi-Fi feature that is still part of the system.

## Technical Context

- Root cause: Samsung's "Intelligent Wi-Fi" subsystem moved from the
  `com.samsung.android.wifi.intelligence` package to `com.samsung.android.wifi.ai`
  (WifiAiService, system UID 1000). On affected devices the old package is gone
  from PackageManager, but its `data_ce` directory is still actively maintained
  by the successor service (the dir was modified minutes before the scan in the
  report).
- CorpseFinder attributes private-data directories by directory name. With no
  installed package matching the name, `PrivateDataCSI` fell through to its
  "dirname == pkgname" fallback, producing an owner that isn't installed → a
  false-positive corpse on every scan.
- Fix: a clutter marker mapping the orphan `PRIVATE_DATA` dir to the installed
  `com.samsung.android.wifi.ai`, mirroring the existing
  `allshare.service.controlshare → allshare.framework` marker.
- Safe across devices: `PrivateDataCSI` checks `isInstalled(dirname)` *before*
  consulting the clutter DB, so the marker only activates when
  `wifi.intelligence` itself is absent. If both packages are removed (full
  debloat), the data is still correctly flagged as a corpse.
- Follow-up (separate): a general UID-ownership attribution step (resolve a
  dir's POSIX owner UID to an installed package) would catch this whole class
  without per-package markers.

Closes #2469
