### PR TITLE
CorpseFinder: Avoid false leftovers for data owned by installed apps

### DIFF
--- a/app-common-data/src/main/java/eu/darken/sdmse/common/forensics/FileForensics.kt
+++ b/app-common-data/src/main/java/eu/darken/sdmse/common/forensics/FileForensics.kt
@@ -66,7 +66,10 @@ class FileForensics @Inject constructor(
             }
 
         val installedOwners = result.owners.filter {
-            pkgRepo.isInstalled(it.pkgId, areaInfo.userHandle)
+            // Check each owner against its own user, not the area's: owners normally carry the area's
+            // user, but uid-based attribution (PrivateDataCSI) can resolve an owner in a different user
+            // than the area, and the two must agree for the install check to be meaningful.
+            pkgRepo.isInstalled(it.pkgId, it.userHandle)
         }.toSet()
 
         val ownerInfo = OwnerInfo(

--- a/app-common-data/src/main/java/eu/darken/sdmse/common/forensics/csi/priv/PrivateDataCSI.kt
+++ b/app-common-data/src/main/java/eu/darken/sdmse/common/forensics/csi/priv/PrivateDataCSI.kt
@@ -10,8 +10,12 @@ import eu.darken.sdmse.common.areas.DataArea
 import eu.darken.sdmse.common.areas.DataAreaManager
 import eu.darken.sdmse.common.areas.currentAreas
 import eu.darken.sdmse.common.clutter.ClutterRepo
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.asLog
+import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.isAncestorOf
 import eu.darken.sdmse.common.files.local.LocalPath
 import eu.darken.sdmse.common.forensics.AreaInfo
@@ -20,11 +24,13 @@ import eu.darken.sdmse.common.forensics.Owner
 import eu.darken.sdmse.common.forensics.csi.LocalCSIProcessor
 import eu.darken.sdmse.common.forensics.csi.toOwners
 import eu.darken.sdmse.common.pkgs.PkgRepo
+import eu.darken.sdmse.common.pkgs.getPkgsForUid
 import eu.darken.sdmse.common.pkgs.isInstalled
 import eu.darken.sdmse.common.pkgs.pkgops.PkgOps
 import eu.darken.sdmse.common.pkgs.toPkgId
 import eu.darken.sdmse.common.storage.StorageEnvironment
 import eu.darken.sdmse.common.user.UserManager2
+import kotlinx.coroutines.CancellationException
 import javax.inject.Inject
 
 @Reusable
@@ -35,6 +41,7 @@ class PrivateDataCSI @Inject constructor(
     private val clutterRepo: ClutterRepo,
     private val userManager: UserManager2,
     private val storageEnvironment: StorageEnvironment,
+    private val gatewaySwitch: GatewaySwitch,
 ) : LocalCSIProcessor {
 
     override suspend fun hasJurisdiction(type: DataArea.Type): Boolean = type == DataArea.Type.PRIVATE_DATA
@@ -74,6 +81,7 @@ class PrivateDataCSI @Inject constructor(
         require(hasJurisdiction(areaInfo.type)) { "Wrong jurisdiction: ${areaInfo.type}" }
 
         val owners = mutableSetOf<Owner>()
+        var hasUnknownOwner = false
 
         val userHandle = areaInfo.userHandle
         val dirName = areaInfo.prefixFreeSegments.first()
@@ -95,14 +103,62 @@ class PrivateDataCSI @Inject constructor(
             owners.addAll(matches.map { it.toOwners(areaInfo) }.flatten())
         }
 
+        // No currently-installed owner found by name/clutter (clutter matches are not verified
+        // installed, hence the re-check). The directory may still be actively maintained by a live
+        // package (e.g. a renamed system service writing to its legacy data path, like
+        // com.samsung.android.wifi.intelligence -> com.samsung.android.wifi.ai). Attribute by the
+        // directory's POSIX owner uid before assuming it's a corpse. This costs one extra root stat
+        // per corpse-suspect dir, which is bounded (top-level dirs only).
+        if (owners.none { pkgRepo.isInstalled(it.pkgId, userHandle) }) {
+            when (val resolved = resolveOwnersByUid(areaInfo)) {
+                is UidOwners.Single -> owners.add(resolved.owner)
+                UidOwners.Shared -> hasUnknownOwner = true
+                UidOwners.None -> {}
+            }
+        }
+
         // Fallback, no downside to assuming that dirname=pkgname for PRIVATE_DATA if there are no other owners
-        if (owners.isEmpty()) {
+        if (owners.isEmpty() && !hasUnknownOwner) {
             owners.add(Owner((hiddenPkg ?: dirName).toPkgId(), userHandle))
         }
 
         return CSIProcessor.Result(
-            owners = owners
+            owners = owners,
+            hasKnownUnknownOwner = hasUnknownOwner,
         )
+    }
+
+    /**
+     * Resolves the directory's POSIX owner uid to the live package(s) holding it. A uid (especially a
+     * shared system uid like 1000) can map to many packages; in that case we can't name a single owner
+     * but the data is clearly not orphaned, so we report it as a known-but-unidentified owner.
+     */
+    private suspend fun resolveOwnersByUid(areaInfo: AreaInfo): UidOwners {
+        val localPath = areaInfo.file as? LocalPath ?: return UidOwners.None
+
+        val uid = try {
+            gatewaySwitch.lookupExtended(localPath).ownership?.userId
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, WARN) { "resolveOwnersByUid($areaInfo) failed: ${e.asLog()}" }
+            null
+        } ?: return UidOwners.None
+
+        // A per-app uid maps to exactly one package and its user matches the area; a shared system uid
+        // (e.g. 1000) maps to many, so we can't name a single owner but the data is clearly not orphaned.
+        val livePkgs = pkgRepo.getPkgsForUid(uid)
+        return when {
+            livePkgs.isEmpty() -> UidOwners.None
+            livePkgs.size == 1 -> UidOwners.Single(Owner(livePkgs.first().id, areaInfo.userHandle))
+            else -> UidOwners.Shared
+        }
+    }
+
+    private sealed interface UidOwners {
+        object None : UidOwners
+        data class Single(val owner: Owner) : UidOwners
+        object Shared : UidOwners
     }
 
     private suspend fun tryCleanName(currentName: String): String? {

--- a/app-common-data/src/main/java/eu/darken/sdmse/common/forensics/csi/priv/PrivateDataCSI.kt
+++ b/app-common-data/src/main/java/eu/darken/sdmse/common/forensics/csi/priv/PrivateDataCSI.kt
@@ -113,6 +113,7 @@ class PrivateDataCSI @Inject constructor(
             when (val resolved = resolveOwnersByUid(areaInfo)) {
                 is UidOwners.Single -> owners.add(resolved.owner)
                 UidOwners.Shared -> hasUnknownOwner = true
+                UidOwners.Unknown -> hasUnknownOwner = true
                 UidOwners.None -> {}
             }
         }
@@ -131,7 +132,9 @@ class PrivateDataCSI @Inject constructor(
     /**
      * Resolves the directory's POSIX owner uid to the live package(s) holding it. A uid (especially a
      * shared system uid like 1000) can map to many packages; in that case we can't name a single owner
-     * but the data is clearly not orphaned, so we report it as a known-but-unidentified owner.
+     * but the data is clearly not orphaned, so we report it as a known-but-unidentified owner. If the
+     * lookup fails outright we can't tell either way, so we fail safe and also treat it as owned rather
+     * than risk reporting a live app's data as a corpse.
      */
     private suspend fun resolveOwnersByUid(areaInfo: AreaInfo): UidOwners {
         val localPath = areaInfo.file as? LocalPath ?: return UidOwners.None
@@ -142,23 +145,39 @@ class PrivateDataCSI @Inject constructor(
             throw e
         } catch (e: Exception) {
             log(TAG, WARN) { "resolveOwnersByUid($areaInfo) failed: ${e.asLog()}" }
-            null
-        } ?: return UidOwners.None
+            // A lookup failure is not evidence the owner is gone. Stay conservative and keep the data
+            // protected (known-but-unidentified owner) rather than risk reporting a live app's data as a
+            // corpse because of a transient root/IPC/stat error.
+            return UidOwners.Unknown
+        }
+            // No owner uid despite a successful lookup (e.g. stat couldn't resolve it) is equally
+            // inconclusive, so fail safe rather than fall through to the dirname corpse fallback.
+            ?: return UidOwners.Unknown
 
         // A per-app uid maps to exactly one package and its user matches the area; a shared system uid
         // (e.g. 1000) maps to many, so we can't name a single owner but the data is clearly not orphaned.
         val livePkgs = pkgRepo.getPkgsForUid(uid)
         return when {
             livePkgs.isEmpty() -> UidOwners.None
-            livePkgs.size == 1 -> UidOwners.Single(Owner(livePkgs.first().id, areaInfo.userHandle))
+            // Attribute to the matched package's own user, not the area's: getPkgsForUid resolved the
+            // package from the uid's decomposed user, and the two can differ for cross-user data.
+            livePkgs.size == 1 -> livePkgs.first().let { UidOwners.Single(Owner(it.id, it.userHandle)) }
             else -> UidOwners.Shared
         }
     }
 
     private sealed interface UidOwners {
+        /** A successful lookup whose uid maps to no live package; the dirname corpse fallback may apply. */
         object None : UidOwners
+
+        /** Exactly one live package owns the data. */
         data class Single(val owner: Owner) : UidOwners
+
+        /** A shared uid maps to several live packages: owned, but no single owner can be named. */
         object Shared : UidOwners
+
+        /** The owner uid could not be determined (lookup failure); inconclusive, so fail safe. */
+        object Unknown : UidOwners
     }
 
     private suspend fun tryCleanName(currentName: String): String? {

--- a/app-common-data/src/test/java/eu/darken/sdmse/common/forensics/FileForensicsTest.kt
+++ b/app-common-data/src/test/java/eu/darken/sdmse/common/forensics/FileForensicsTest.kt
@@ -1,13 +1,17 @@
 package eu.darken.sdmse.common.forensics
 
 import android.content.Context
+import eu.darken.sdmse.common.areas.DataArea
 import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.local.LocalPath
 import eu.darken.sdmse.common.pkgs.PkgRepo
+import eu.darken.sdmse.common.pkgs.features.Installed
 import eu.darken.sdmse.common.pkgs.pkgops.PkgOps
+import eu.darken.sdmse.common.pkgs.toPkgId
 import eu.darken.sdmse.common.sharedresource.Resource
 import eu.darken.sdmse.common.sharedresource.SharedResource
 import eu.darken.sdmse.common.shell.ShellOps
+import eu.darken.sdmse.common.user.UserHandle2
 import io.kotest.matchers.shouldBe
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
@@ -75,5 +79,33 @@ class FileForensicsTest : BaseTest() {
         val testPath = LocalPath.build("/test")
         val areaInfo = forensics.identifyArea(testPath)
         areaInfo shouldBe testAreaInfo
+    }
+
+    @Test fun `installed-owner check uses each owner's own user, not the area's`() = runTest2(autoCancel = true) {
+        val forensics = FileForensics(this, context, pkgRepo, processorsProvider, gatewaySwitch, pkgOps)
+
+        val pkgId = "com.some.app".toPkgId()
+        val ownerUser = UserHandle2(10)
+        val areaUser = UserHandle2(0)
+
+        every { testAreaInfo.type } returns DataArea.Type.PRIVATE_DATA
+        every { testAreaInfo.userHandle } returns areaUser
+        every { testAreaInfo.isBlackListLocation } returns true
+        every { testAreaInfo.file } returns LocalPath.build("/data/user/0/com.some.app")
+
+        coEvery { csiProcessor.hasJurisdiction(DataArea.Type.PRIVATE_DATA) } returns true
+        coEvery { csiProcessor.findOwners(testAreaInfo) } returns CSIProcessor.Result(
+            owners = setOf(Owner(pkgId, ownerUser)),
+        )
+
+        // Installed for the owner's own user (10), but not for the area's user (0). The corpse check must
+        // honor the owner's user, otherwise this live app's data is misclassified as a corpse.
+        coEvery { pkgRepo.query(any(), any()) } returns emptySet()
+        coEvery { pkgRepo.query(pkgId, ownerUser) } returns setOf(mockk<Installed>())
+
+        forensics.findOwners(testAreaInfo).apply {
+            installedOwners.map { it.pkgId } shouldBe listOf(pkgId)
+            isCorpse shouldBe false
+        }
     }
 }

--- a/app-common-data/src/test/java/eu/darken/sdmse/common/forensics/csi/priv/PrivateDataCSITest.kt
+++ b/app-common-data/src/test/java/eu/darken/sdmse/common/forensics/csi/priv/PrivateDataCSITest.kt
@@ -1,10 +1,14 @@
 package eu.darken.sdmse.common.forensics.csi.priv
 
+import android.content.pm.ApplicationInfo
 import eu.darken.sdmse.common.areas.DataArea
 import eu.darken.sdmse.common.areas.DataAreaManager
 import eu.darken.sdmse.common.files.local.LocalPath
 import eu.darken.sdmse.common.files.removePrefix
 import eu.darken.sdmse.common.forensics.csi.BaseCSITest
+import eu.darken.sdmse.common.pkgs.Pkg
+import eu.darken.sdmse.common.pkgs.PkgRepo
+import eu.darken.sdmse.common.pkgs.container.NormalPkg
 import eu.darken.sdmse.common.pkgs.container.PkgArchive
 import eu.darken.sdmse.common.pkgs.toPkgId
 import eu.darken.sdmse.common.rngString
@@ -90,6 +94,25 @@ class PrivateDataCSITest : BaseCSITest() {
                 )
             )
         )
+
+        // Default: ownership lookup yields no uid, so UID attribution is a no-op unless a test opts in
+        stubOwnerUid(null)
+    }
+
+    private fun stubOwnerUid(uid: Int?) {
+        coEvery { gatewaySwitch.lookupExtended(any()) } returns mockk {
+            every { ownership } returns uid?.let { value -> mockk { every { userId } returns value.toLong() } }
+        }
+    }
+
+    private fun mockNormalPkg(
+        pkgId: Pkg.Id,
+        uid: Int,
+        userHandle: UserHandle2 = UserHandle2(0),
+    ): NormalPkg = mockk<NormalPkg>().apply {
+        every { id } returns pkgId
+        every { this@apply.userHandle } returns userHandle
+        every { applicationInfo } returns mockk<ApplicationInfo>(relaxed = true).apply { this.uid = uid }
     }
 
     private fun getProcessor() = PrivateDataCSI(
@@ -99,6 +122,7 @@ class PrivateDataCSITest : BaseCSITest() {
         userManager = userManager2,
         storageEnvironment = storageEnvironment,
         pkgOps = pkgOps,
+        gatewaySwitch = gatewaySwitch,
     )
 
     @Test override fun `test jurisdiction`() = runTest {
@@ -191,6 +215,74 @@ class PrivateDataCSITest : BaseCSITest() {
             processor.findOwners(locationInfo).apply {
                 owners.single().pkgId shouldBe testFile1.name.toPkgId()
             }
+        }
+    }
+
+    @Test fun `uid maps to a single installed package - attributed as owner`() = runTest {
+        val processor = getProcessor()
+
+        val wifiAi = "com.samsung.android.wifi.ai".toPkgId()
+        every { pkgRepo.data } returns flowOf(PkgRepo.PkgData.from(setOf(mockNormalPkg(wifiAi, uid = 1000))))
+        stubOwnerUid(1000)
+
+        // Directory named after an uninstalled package, but its data is owned by an installed package's uid
+        val toHit = privData1.path.child("com.samsung.android.wifi.intelligence")
+        val locationInfo = processor.identifyArea(toHit)!!
+
+        processor.findOwners(locationInfo).apply {
+            owners.single().pkgId shouldBe wifiAi
+            hasKnownUnknownOwner shouldBe false
+        }
+    }
+
+    @Test fun `uid shared by multiple installed packages - reported as known unknown owner`() = runTest {
+        val processor = getProcessor()
+
+        every { pkgRepo.data } returns flowOf(
+            PkgRepo.PkgData.from(
+                setOf(
+                    mockNormalPkg("android".toPkgId(), uid = 1000),
+                    mockNormalPkg("com.samsung.android.wifi.ai".toPkgId(), uid = 1000),
+                )
+            )
+        )
+        stubOwnerUid(1000)
+
+        val toHit = privData1.path.child("com.samsung.android.wifi.intelligence")
+        val locationInfo = processor.identifyArea(toHit)!!
+
+        processor.findOwners(locationInfo).apply {
+            owners.isEmpty() shouldBe true
+            hasKnownUnknownOwner shouldBe true
+        }
+    }
+
+    @Test fun `uid resolves to no installed package - still a corpse via fallback`() = runTest {
+        val processor = getProcessor()
+
+        every { pkgRepo.data } returns flowOf(PkgRepo.PkgData.from(emptySet()))
+        stubOwnerUid(12345)
+
+        val toHit = privData1.path.child("com.gone.app")
+        val locationInfo = processor.identifyArea(toHit)!!
+
+        processor.findOwners(locationInfo).apply {
+            owners.single().pkgId shouldBe "com.gone.app".toPkgId()
+            hasKnownUnknownOwner shouldBe false
+        }
+    }
+
+    @Test fun `ownership lookup failure falls through to fallback`() = runTest {
+        val processor = getProcessor()
+
+        coEvery { gatewaySwitch.lookupExtended(any()) } throws IllegalStateException("boom")
+
+        val toHit = privData1.path.child("com.gone.app")
+        val locationInfo = processor.identifyArea(toHit)!!
+
+        processor.findOwners(locationInfo).apply {
+            owners.single().pkgId shouldBe "com.gone.app".toPkgId()
+            hasKnownUnknownOwner shouldBe false
         }
     }
 

--- a/app-common-data/src/test/java/eu/darken/sdmse/common/forensics/csi/priv/PrivateDataCSITest.kt
+++ b/app-common-data/src/test/java/eu/darken/sdmse/common/forensics/csi/priv/PrivateDataCSITest.kt
@@ -13,10 +13,12 @@ import eu.darken.sdmse.common.pkgs.container.PkgArchive
 import eu.darken.sdmse.common.pkgs.toPkgId
 import eu.darken.sdmse.common.rngString
 import eu.darken.sdmse.common.user.UserHandle2
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
@@ -95,8 +97,10 @@ class PrivateDataCSITest : BaseCSITest() {
             )
         )
 
-        // Default: ownership lookup yields no uid, so UID attribution is a no-op unless a test opts in
-        stubOwnerUid(null)
+        // Default: ownership resolves to a uid with no installed package, so UID attribution is a no-op
+        // (behaves as before) unless a test opts in. A null/failed lookup would instead be treated as
+        // inconclusive (see the dedicated tests), so it can't be the default no-op.
+        stubOwnerUid(999999)
     }
 
     private fun stubOwnerUid(uid: Int?) {
@@ -235,6 +239,28 @@ class PrivateDataCSITest : BaseCSITest() {
         }
     }
 
+    @Test fun `single uid owner is attributed to the package's own user, not the area's`() = runTest {
+        val processor = getProcessor()
+
+        // Area is user 0, but the directory's POSIX owner uid decodes to user 10 (uid 1010123).
+        val pkg = "com.samsung.android.wifi.ai".toPkgId()
+        every { pkgRepo.data } returns flowOf(
+            PkgRepo.PkgData.from(setOf(mockNormalPkg(pkg, uid = 1010123, userHandle = UserHandle2(10))))
+        )
+        stubOwnerUid(1010123)
+
+        val toHit = privData1.path.child("com.samsung.android.wifi.intelligence")
+        val locationInfo = processor.identifyArea(toHit)!!
+
+        processor.findOwners(locationInfo).apply {
+            owners.single().apply {
+                pkgId shouldBe pkg
+                userHandle shouldBe UserHandle2(10)
+            }
+            hasKnownUnknownOwner shouldBe false
+        }
+    }
+
     @Test fun `uid shared by multiple installed packages - reported as known unknown owner`() = runTest {
         val processor = getProcessor()
 
@@ -272,7 +298,7 @@ class PrivateDataCSITest : BaseCSITest() {
         }
     }
 
-    @Test fun `ownership lookup failure falls through to fallback`() = runTest {
+    @Test fun `ownership lookup failure is inconclusive - not reported as a corpse`() = runTest {
         val processor = getProcessor()
 
         coEvery { gatewaySwitch.lookupExtended(any()) } throws IllegalStateException("boom")
@@ -280,9 +306,38 @@ class PrivateDataCSITest : BaseCSITest() {
         val toHit = privData1.path.child("com.gone.app")
         val locationInfo = processor.identifyArea(toHit)!!
 
+        // A transient root/IPC/stat failure must not cause a live app's data to be flagged as a corpse.
         processor.findOwners(locationInfo).apply {
-            owners.single().pkgId shouldBe "com.gone.app".toPkgId()
-            hasKnownUnknownOwner shouldBe false
+            owners.isEmpty() shouldBe true
+            hasKnownUnknownOwner shouldBe true
+        }
+    }
+
+    @Test fun `ownership without a resolvable uid is inconclusive - not reported as a corpse`() = runTest {
+        val processor = getProcessor()
+
+        // Lookup succeeds but carries no POSIX ownership (uid couldn't be resolved) — still inconclusive.
+        stubOwnerUid(null)
+
+        val toHit = privData1.path.child("com.gone.app")
+        val locationInfo = processor.identifyArea(toHit)!!
+
+        processor.findOwners(locationInfo).apply {
+            owners.isEmpty() shouldBe true
+            hasKnownUnknownOwner shouldBe true
+        }
+    }
+
+    @Test fun `ownership lookup cancellation propagates`() = runTest {
+        val processor = getProcessor()
+
+        coEvery { gatewaySwitch.lookupExtended(any()) } throws CancellationException("cancelled")
+
+        val toHit = privData1.path.child("com.gone.app")
+        val locationInfo = processor.identifyArea(toHit)!!
+
+        shouldThrow<CancellationException> {
+            processor.findOwners(locationInfo)
         }
     }
 

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathGateway.kt
@@ -19,6 +19,8 @@ interface APathGateway<
 
     suspend fun lookup(path: P): PLU
 
+    suspend fun lookupExtended(path: P): PLUE
+
     suspend fun lookupFiles(path: P): Collection<PLU>
 
     suspend fun lookupFilesExtended(path: P): Collection<PLUE>

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/GatewaySwitch.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/GatewaySwitch.kt
@@ -91,6 +91,28 @@ class GatewaySwitch @Inject constructor(
         }
     }
 
+    override suspend fun lookupExtended(path: APath): APathLookupExtended<APath> {
+        return lookupExtended(path, Type.CURRENT)
+    }
+
+    suspend fun lookupExtended(path: APath, type: Type): APathLookupExtended<APath> {
+        val mapped = path.toTargetType(type)
+        return try {
+            useGateway(mapped) { lookupExtended(mapped) }
+        } catch (oge: ReadException) {
+            if (type != Type.AUTO) throw oge
+            log(TAG, WARN) { "lookupExtended(...): Original lookup failed, try alternative: ${oge.asLog()}" }
+
+            val fallback = path.toAlternative()
+            try {
+                useGateway(fallback) { lookupExtended(fallback) }
+            } catch (e: ReadException) {
+                log(TAG, WARN) { "lookupExtended(...): Alternative lookup failed either: ${e.asLog()}" }
+                throw oge
+            }
+        }
+    }
+
     override suspend fun lookupFiles(path: APath): Collection<APathLookup<APath>> {
         return lookupFiles(path, Type.CURRENT)
     }

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalGateway.kt
@@ -37,6 +37,7 @@ import eu.darken.sdmse.common.root.service.runModuleAction
 import eu.darken.sdmse.common.sharedresource.SharedResource
 import eu.darken.sdmse.common.sharedresource.adoptChildResource
 import eu.darken.sdmse.common.storage.StorageEnvironment
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.onCompletion
@@ -243,6 +244,48 @@ class LocalGateway @Inject constructor(
         } catch (e: Exception) {
             throw ReadException(path = path, cause = e).also {
                 log(TAG, WARN) { "lookup(path=$path, mode=$mode) failed:\n${it.asLog()}" }
+            }
+        }
+    }
+
+    override suspend fun lookupExtended(path: LocalPath): LocalPathLookupExtended = lookupExtended(path, Mode.AUTO)
+
+    suspend fun lookupExtended(path: LocalPath, mode: Mode = Mode.AUTO): LocalPathLookupExtended = runIO {
+        try {
+            val javaFile = path.asFile()
+            val canRead = if (mode == Mode.ROOT) {
+                false
+            } else {
+                javaFile.canRead()
+            }
+
+            when {
+                mode == Mode.NORMAL || canRead && mode == Mode.AUTO -> {
+                    log(TAG, VERBOSE) { "lookupExtended($mode->NORMAL): $path" }
+                    if (!canRead) throw ReadException(path = path)
+                    path.performLookupExtended(ipcFunnel, libcoreTool)
+                }
+
+                hasRoot() && (mode == Mode.ROOT || !canRead && mode == Mode.AUTO) -> {
+                    log(TAG, VERBOSE) { "lookupExtended($mode->ROOT): $path" }
+                    rootOps { it.lookUpExtended(path) }
+                }
+
+                hasAdb() && (mode == Mode.ADB || !canRead && mode == Mode.AUTO) -> {
+                    log(TAG, VERBOSE) { "lookupExtended($mode->ADB): $path" }
+                    adbOps { it.lookUpExtended(path) }
+                }
+
+                else -> throw IOException("No matching mode available.")
+            }.also {
+                log(TAG, VERBOSE) { "Looked up extended: $it" }
+            }
+
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            throw ReadException(path = path, cause = e).also {
+                log(TAG, WARN) { "lookupExtended(path=$path, mode=$mode) failed:\n${it.asLog()}" }
             }
         }
     }

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/FileOpsClient.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/FileOpsClient.kt
@@ -42,6 +42,14 @@ class FileOpsClient @AssistedInject constructor(
         throw e.refineException()
     }
 
+    fun lookUpExtended(path: LocalPath): LocalPathLookupExtended = try {
+        fileOpsConnection.lookUpExtended(path).also {
+            if (Bugs.isTrace) log(TAG, VERBOSE) { "lookUpExtended($path): $it" }
+        }
+    } catch (e: Exception) {
+        throw e.refineException()
+    }
+
     /**
      * Doesn't run into IPC buffer overflows on large directories
      */

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/saf/SAFGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/saf/SAFGateway.kt
@@ -242,6 +242,15 @@ class SAFGateway @Inject constructor(
         }
     }
 
+    override suspend fun lookupExtended(path: SAFPath): SAFPathLookupExtended = runIO {
+        try {
+            SAFPathLookupExtended(lookup(path))
+        } catch (e: Exception) {
+            log(TAG, WARN) { "lookupExtended($path) failed." }
+            throw ReadException(path = path, cause = e)
+        }
+    }
+
     override suspend fun lookupFiles(path: SAFPath): List<SAFPathLookup> = runIO {
         try {
             val docFile = findDocFile(path)

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/GatewaySwitchTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/GatewaySwitchTest.kt
@@ -1,0 +1,86 @@
+package eu.darken.sdmse.common.files
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import eu.darken.sdmse.common.files.local.LocalGateway
+import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.files.local.LocalPathLookupExtended
+import eu.darken.sdmse.common.files.saf.SAFGateway
+import eu.darken.sdmse.common.files.saf.SAFPath
+import eu.darken.sdmse.common.files.saf.SAFPathLookupExtended
+import eu.darken.sdmse.common.sharedresource.SharedResource
+import eu.darken.sdmse.common.storage.PathMapper
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import testhelper.EmptyApp
+import testhelpers.coroutine.TestDispatcherProvider
+import testhelpers.coroutine.runTest2
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [29], application = EmptyApp::class)
+class GatewaySwitchTest {
+
+    private val safGateway = mockk<SAFGateway>(relaxed = true)
+    private val localGateway = mockk<LocalGateway>(relaxed = true)
+    private val mapper = mockk<PathMapper>()
+
+    private fun CoroutineScope.createSwitch(): GatewaySwitch {
+        every { localGateway.sharedResource } returns SharedResource.createKeepAlive("local", this)
+        every { safGateway.sharedResource } returns SharedResource.createKeepAlive("saf", this)
+        return GatewaySwitch(
+            appScope = this,
+            dispatcherProvider = TestDispatcherProvider(),
+            safGateway = safGateway,
+            localGateway = localGateway,
+            mapper = mapper,
+        )
+    }
+
+    @Test fun `lookupExtended delegates to the matching gateway`() = runTest2(autoCancel = true) {
+        val switch = createSwitch()
+
+        val path = LocalPath.build("/data/data/com.some.app")
+        val result = mockk<LocalPathLookupExtended>()
+        coEvery { localGateway.lookupExtended(path) } returns result
+
+        switch.lookupExtended(path) shouldBe result
+    }
+
+    @Test fun `lookupExtended AUTO falls back to the alternative gateway`() = runTest2(autoCancel = true) {
+        val switch = createSwitch()
+
+        val localPath = LocalPath.build("/data/data/com.some.app")
+        val safPath = mockk<SAFPath> { every { pathType } returns APath.PathType.SAF }
+        val safResult = mockk<SAFPathLookupExtended>()
+
+        coEvery { localGateway.lookupExtended(localPath) } throws ReadException(path = localPath)
+        coEvery { mapper.toSAFPath(localPath) } returns safPath
+        coEvery { safGateway.lookupExtended(safPath) } returns safResult
+
+        switch.lookupExtended(localPath, GatewaySwitch.Type.AUTO) shouldBe safResult
+    }
+
+    @Test fun `lookupExtended AUTO rethrows the original error when the fallback also fails`() =
+        runTest2(autoCancel = true) {
+            val switch = createSwitch()
+
+            val localPath = LocalPath.build("/data/data/com.some.app")
+            val safPath = mockk<SAFPath> { every { pathType } returns APath.PathType.SAF }
+            val original = ReadException(message = "original", path = localPath)
+
+            coEvery { localGateway.lookupExtended(localPath) } throws original
+            coEvery { mapper.toSAFPath(localPath) } returns safPath
+            coEvery { safGateway.lookupExtended(safPath) } throws ReadException(message = "alternative")
+
+            val thrown = shouldThrow<ReadException> {
+                switch.lookupExtended(localPath, GatewaySwitch.Type.AUTO)
+            }
+            thrown shouldBe original
+        }
+}

--- a/app-common-pkgs/src/main/java/eu/darken/sdmse/common/pkgs/PkgRepoExtensions.kt
+++ b/app-common-pkgs/src/main/java/eu/darken/sdmse/common/pkgs/PkgRepoExtensions.kt
@@ -1,11 +1,15 @@
 package eu.darken.sdmse.common.pkgs
 
+import eu.darken.sdmse.common.pkgs.container.NormalPkg
 import eu.darken.sdmse.common.pkgs.features.InstallId
 import eu.darken.sdmse.common.pkgs.features.Installed
 import eu.darken.sdmse.common.user.UserHandle2
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+
+/** Android's per-user UID range; a POSIX uid encodes `userId * PER_USER_RANGE + appId`. */
+private const val PER_USER_RANGE = 100_000L
 
 fun PkgRepo.pkgs(): Flow<Collection<Installed>> = data.map { it.pkgs }
 
@@ -28,3 +32,27 @@ suspend fun PkgRepo.isInstalled(
     pkgId: Pkg.Id,
     userHandle: UserHandle2? = null,
 ): Boolean = query(pkgId, userHandle).isNotEmpty()
+
+/**
+ * Resolves a POSIX owner uid (e.g. from `stat`) to the currently-installed package(s) that hold it.
+ *
+ * A uid encodes `userId * PER_USER_RANGE + appId`; the appId is shared across users, and multiple
+ * packages can share one appId (e.g. the `android.uid.system` appId 1000). Only live [NormalPkg]
+ * entries are considered, so archived/uninstalled/hidden cache entries with stale uids can't mask a
+ * genuine corpse.
+ */
+suspend fun PkgRepo.getPkgsForUid(uid: Long): Set<Installed> {
+    // uid <= 0 covers root (0) and invalid values; root-owned files have no installed package owner.
+    if (uid <= 0) return emptySet()
+    val appId = uid % PER_USER_RANGE
+    // System uids (< PER_USER_RANGE) decompose to userId 0, which is correct on current Android.
+    val userId = (uid / PER_USER_RANGE).toInt()
+    return current()
+        .filter { it is NormalPkg && it.userHandle.handleId == userId }
+        .filter { pkg ->
+            // applicationInfo.uid is the appId in the package's own user-space, so compare modulo the range.
+            val pkgUid = pkg.applicationInfo?.uid ?: return@filter false
+            pkgUid > 0 && pkgUid % PER_USER_RANGE == appId
+        }
+        .toSet()
+}

--- a/app-common-pkgs/src/test/java/eu/darken/sdmse/common/pkgs/PkgRepoExtensionsTest.kt
+++ b/app-common-pkgs/src/test/java/eu/darken/sdmse/common/pkgs/PkgRepoExtensionsTest.kt
@@ -1,0 +1,86 @@
+package eu.darken.sdmse.common.pkgs
+
+import android.content.pm.ApplicationInfo
+import eu.darken.sdmse.common.pkgs.container.NormalPkg
+import eu.darken.sdmse.common.pkgs.features.Installed
+import eu.darken.sdmse.common.user.UserHandle2
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class PkgRepoExtensionsTest : BaseTest() {
+
+    private fun normalPkg(
+        pkgId: String,
+        uid: Int,
+        userHandle: UserHandle2 = UserHandle2(0),
+    ): NormalPkg = mockk<NormalPkg>().apply {
+        every { id } returns pkgId.toPkgId()
+        every { this@apply.userHandle } returns userHandle
+        every { applicationInfo } returns mockk<ApplicationInfo>(relaxed = true).apply { this.uid = uid }
+    }
+
+    private fun repoOf(vararg pkgs: Installed): PkgRepo = mockk<PkgRepo>().apply {
+        every { data } returns flowOf(PkgRepo.PkgData.from(pkgs.toSet()))
+    }
+
+    @Test fun `resolves a per-user app uid to its package`() = runTest {
+        val repo = repoOf(normalPkg("com.app.one", uid = 10123))
+        repo.getPkgsForUid(10123L).map { it.id } shouldContainExactlyInAnyOrder listOf("com.app.one".toPkgId())
+    }
+
+    @Test fun `shared uid returns all sharing packages`() = runTest {
+        val repo = repoOf(
+            normalPkg("android", uid = 1000),
+            normalPkg("com.samsung.android.wifi.ai", uid = 1000),
+            normalPkg("com.unrelated", uid = 10500),
+        )
+        repo.getPkgsForUid(1000L).map { it.id } shouldContainExactlyInAnyOrder
+            listOf("android".toPkgId(), "com.samsung.android.wifi.ai".toPkgId())
+    }
+
+    @Test fun `decomposes a secondary-user uid - matches only that user`() = runTest {
+        // uid 1012345 => userId 10, appId 12345
+        val repo = repoOf(
+            normalPkg("com.app", uid = 12345, userHandle = UserHandle2(0)),
+            normalPkg("com.app", uid = 1012345, userHandle = UserHandle2(10)),
+        )
+        repo.getPkgsForUid(1012345L).map { it.userHandle } shouldContainExactlyInAnyOrder listOf(UserHandle2(10))
+    }
+
+    @Test fun `uid of zero or below resolves to nothing`() = runTest {
+        val repo = repoOf(normalPkg("android", uid = 0))
+        repo.getPkgsForUid(0L) shouldBe emptySet()
+        repo.getPkgsForUid(-1L) shouldBe emptySet()
+    }
+
+    @Test fun `packages without applicationInfo are ignored`() = runTest {
+        val repo = mockk<PkgRepo>().apply {
+            val pkg = mockk<NormalPkg>().apply {
+                every { id } returns "com.noappinfo".toPkgId()
+                every { userHandle } returns UserHandle2(0)
+                every { applicationInfo } returns null
+            }
+            every { data } returns flowOf(PkgRepo.PkgData.from(setOf(pkg)))
+        }
+        repo.getPkgsForUid(10042L) shouldBe emptySet()
+    }
+
+    @Test fun `non-NormalPkg entries are ignored`() = runTest {
+        // e.g. an archived/uninstalled cache entry with a stale uid must not mask a corpse
+        val stale = mockk<Installed>().apply {
+            every { id } returns "com.stale".toPkgId()
+            every { userHandle } returns UserHandle2(0)
+            every { applicationInfo } returns mockk<ApplicationInfo>(relaxed = true).apply { this.uid = 10777 }
+        }
+        val repo = mockk<PkgRepo>().apply {
+            every { data } returns flowOf(PkgRepo.PkgData.from(setOf(stale)))
+        }
+        repo.getPkgsForUid(10777L) shouldBe emptySet()
+    }
+}


### PR DESCRIPTION
## What changed

CorpseFinder is now less likely to falsely flag leftover data on rooted devices. When a private-data folder is named after an app that isn't installed, but the folder is still actively owned and used by an app that *is* installed (for example after a system app is renamed and keeps writing to its old data folder), CorpseFinder now recognizes the real owner and stops reporting it as uninstall residue.

This is the general fix behind the earlier Samsung "Intelligent Wi-Fi" report (`com.samsung.android.wifi.intelligence` data kept alive by `com.samsung.android.wifi.ai`) — instead of needing a hand-written rule per case.

## Technical Context

- Until now `PrivateDataCSI` decided ownership purely from the directory name. If the name didn't match an installed package (and no clutter rule applied), the folder was reported as a corpse — even when a live, differently-named package owns the data.
- New behaviour: when no installed owner is found by name or clutter rule, the folder's POSIX owner uid is resolved to the currently-installed package(s) holding it:
  - exactly one live package → attributed as the owner (not a corpse)
  - a shared system uid (e.g. 1000) mapping to many packages → reported as a known-but-unidentified owner (`hasKnownUnknownOwner`), so it's not a corpse without flooding `installedOwners`
  - nothing installed → still a corpse via the existing dirname fallback (genuine residue is unaffected)
- `getPkgsForUid` resolves a uid against the in-memory `PkgRepo` cache only (no extra PackageManager/IPC calls); it decomposes `uid = userId * 100000 + appId` and matches live `NormalPkg` entries, so stale archived/uninstalled cache entries can't mask a real corpse.
- A single-path `lookupExtended` was added to the `APath` gateway interface (`LocalGateway`/`SAFGateway`/`GatewaySwitch`); the root/ADB IPC side (`lookUpExtended`) already existed and is now wired through the client.
- Cost is bounded: the extra `stat` only runs for corpse-suspect directories (no installed owner found), which are top-level dirs. Private-data scanning is already root-only, so the uid is authoritative. Lookup failures and cancellation fall through safely (cancellation is re-thrown, not swallowed).
- The curated `wifi.ai` clutter marker from #2471 is kept as belt-and-suspenders.

Refs #2469
