### PR TITLE
General: Update translations from Crowdin

### DIFF
--- a/app-common/src/main/res/values-lt/strings.xml
+++ b/app-common/src/main/res/values-lt/strings.xml
@@ -7,7 +7,7 @@
     <string name="slogan_message_3">Darome tai, kas būtina.</string>
     <string name="slogan_message_4">Viskas gražiai sutvaryta.</string>
     <string name="slogan_message_5">Nepriekaištingai.</string>
-    <string name="slogan_message_6">Baitai, nykite!</string>
+    <string name="slogan_message_6">Baitai, išnykite!</string>
     <string name="slogan_message_7">Laisva vieta - laiminga vieta.</string>
     <string name="slogan_message_8">Niekada tavęs nepaliksiu.</string>
     <string name="general_thank_you_label">Ačiū</string>

--- a/app-tool-corpsefinder/src/main/res/values-lt/strings.xml
+++ b/app-tool-corpsefinder/src/main/res/values-lt/strings.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="corpsefinder_explanation_short">Duomenys, priklausantys jau pašalintoms programoms.</string>
-    <string name="corpsefinder_settings_summary">Sureguliuokite nuskaitymo filtrus ir rizikos lygius.</string>
-    <string name="corpsefinder_settings_risk_keeper_title">Įtraukti pageidaujamus failus</string>
-    <string name="corpsefinder_settings_risk_keeper_summary">Failus, kuriuos galbūt norėsite išsaugoti, net jei programa bus pašalinta, pvz., padarytas nuotraukas arba sukurtas atsargines kopijas.</string>
+    <string name="corpsefinder_settings_summary">Koreguokite skenavimo filtrus ir rizikos lygius.</string>
+    <string name="corpsefinder_settings_risk_keeper_title">Įtraukti pageidaujamus likučius</string>
+    <string name="corpsefinder_settings_risk_keeper_summary">Failai, kuriuos galbūt norėsite išsaugoti net ir jei programa yra pašalinta, pvz., jūsų padarytos nuotraukos ar sukurtos atsarginės kopijos.</string>
     <string name="corpsefinder_settings_risk_common_title">Įtraukite bendrinius pavadinimus</string>
     <string name="corpsefinder_settings_risk_common_summary">Duomenys su dažnai naudojamais pavadinimais, pvz., aplankas \"Notes\" priklauso per daug nežinomų programų.</string>
     <string name="corpsefinder_watcher_title">Priežiūra po priežįdos</string>

--- a/app-tool-deduplicator/src/main/res/values-lt/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-lt/strings.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="deduplicator_explanation_short">Rasti pasikartojantių duomenų jūsų įrenginyje.</string>
+    <string name="deduplicator_explanation_short">Raskite dubliuotus duomenis savo įrenginyje.</string>
     <plurals name="deduplicator_result_x_clusters_processed">
-        <item quantity="one">%d dublikatas ištrintas</item>
-        <item quantity="few">%d dublikatai ištrinti</item>
-        <item quantity="many">%d dublikatų ištrinta</item>
-        <item quantity="other">Ištrinta %d dublikatų</item>
+        <item quantity="one">%d dublikatas ištrintas.</item>
+        <item quantity="few">%d dublikatai ištrinti.</item>
+        <item quantity="many">%d dublikato ištrinta.</item>
+        <item quantity="other">%d dublikatų ištrinta.</item>
     </plurals>
     <plurals name="deduplicator_result_x_clusters_found">
         <item quantity="one">Rasta %d dublikatų rinkinys</item>
@@ -13,21 +13,21 @@
         <item quantity="many">Rasta %d dublikatų rinkiniai</item>
         <item quantity="other">Rasta %d dublikatų grupių</item>
     </plurals>
-    <string name="deduplicator_protection_deleteall_allowed_title">Leisti „Ištrinti visus“</string>
-    <string name="deduplicator_protection_deleteall_allowed_summary">Rodyti parinktis, leidžiančias ištrinti visus failus dublikatų rinkinyje, nepaliekant nė vieno failo.</string>
-    <string name="deduplicator_search_locations_title">Ieškos vietos</string>
+    <string name="deduplicator_protection_deleteall_allowed_title">Įjungti galimybę „Ištrinti viską“</string>
+    <string name="deduplicator_protection_deleteall_allowed_summary">Rodyti parinktis, leidžiančias ištrinti visus failus dublikatų rinkinyje, kad neliktų nė vieno failo.</string>
+    <string name="deduplicator_search_locations_title">Paieškos vietos</string>
     <string name="deduplicator_search_locations_all_summary">Visos pasiekiamos sritys</string>
-    <string name="deduplicator_keep_prefer_paths_title">Pirmenybe išlaikyti</string>
-    <string name="deduplicator_keep_prefer_paths_summary">Nusprendus, kurį dublikatą palikti, pirmenybe teikti failams šiose vietose.</string>
-    <string name="deduplicator_keep_prefer_paths_none_summary">Nėra sukonfigūruotų vietų</string>
+    <string name="deduplicator_keep_prefer_paths_title">Pageidauti išlaikyti</string>
+    <string name="deduplicator_keep_prefer_paths_summary">Sprendžiant, kurį dublikatą išlaikyti, pageidauti išlaikyti failus šiose vietose.</string>
+    <string name="deduplicator_keep_prefer_paths_none_summary">Nėra sukonfigūruotų vietų.</string>
     <string name="deduplicator_skip_minsize_title">Minimalus dydis</string>
-    <string name="deduplicator_skip_minsize_description">Praleisti failus, mažesnius už minimaliu dydį.</string>
-    <string name="deduplicator_skip_uncommon_title">Praleisti nedažnai naudojamus failų tipus</string>
-    <string name="deduplicator_skip_uncommon_description">Įtraukti tik Įprastų media failus, dokumentus ir archyvus.</string>
-    <string name="deduplicator_detection_method_label">Aptikimo metodas</string>
+    <string name="deduplicator_skip_minsize_description">Praleisti failus, kurių mažesnis nei mažiausias dydis.</string>
+    <string name="deduplicator_skip_uncommon_title">Praleisti neįprastus failų tipus</string>
+    <string name="deduplicator_skip_uncommon_description">Įtraukti tik įprastus medijos failus, dokumentus ir archyvus.</string>
+    <string name="deduplicator_detection_method_label">Aptikimo būdas</string>
     <string name="deduplicator_detection_method_checksum_title">Turinio kontrolinė suma</string>
-    <string name="deduplicator_detection_method_checksum_summary">Nustatyti dublikatus skaičiuojant failų kontrolines sumas. Failai su sutampančiomis kontrolinėmis sumomis turi tiksliai toki patut turinį.</string>
-    <string name="deduplicator_detection_method_phash_title">Suvokimo maistėlis</string>
+    <string name="deduplicator_detection_method_checksum_summary">Nustatyti dublikatus apskaičiuojant failų kontrolines sumas. Failai su sutampančiomis kontrolinėmis sumomis turi visiškai tokį patį turinį.</string>
+    <string name="deduplicator_detection_method_phash_title">Suvokimo maiša</string>
     <string name="deduplicator_detection_method_phash_summary">Rasti panašius failus analizuojant turinio požymius ir lyginant suvokimo maštėlio reikšmes. ⚠️ Panaumo pagrindu aptikimas gali apimti klaidingų rezultatų, reikalaujančių rankinio tikrinimo.</string>
     <string name="deduplicator_detection_method_media_title">Medijų pirštų atspaudas</string>
     <string name="deduplicator_detection_method_media_summary">Raskite panašius vaizdo ir garso failus analizuodami garso pirštų atspaudus. ⚠️ Panašumu pagrįstas aptikimas gali apimti klaidingus teigiamus atvejus, reikalaujančius rankinio patikrinimo.</string>
@@ -62,13 +62,13 @@
     <string name="deduplicator_arbiter_configure_paths_action">Sukonfigūruoti kelius…</string>
     <string name="deduplicator_arbiter_criterium_duplicate_type_title">Dublikato tipas</string>
     <string name="deduplicator_arbiter_criterium_duplicate_type_description">Pirmenyė tikslū atitikmenų prieš panašius failus.</string>
-    <string name="deduplicator_arbiter_criterium_media_provider_title">Media indeksavimas</string>
+    <string name="deduplicator_arbiter_criterium_media_provider_title">Medijos indeksavimas</string>
     <string name="deduplicator_arbiter_criterium_media_provider_description">Apsvarstyti, ar failai yra indeksuoti media teikėjo.</string>
     <string name="deduplicator_arbiter_criterium_location_title">Atminties vieta</string>
     <string name="deduplicator_arbiter_criterium_location_description">Pirmenyė failams vidinėje arba išorenėje atmintyje.</string>
     <string name="deduplicator_arbiter_criterium_nesting_title">Aplanko gylis</string>
-    <string name="deduplicator_arbiter_criterium_nesting_description">Pirmenyė failams seklėsnėse arba gilesĖse aplanko struktūrose.</string>
-    <string name="deduplicator_arbiter_criterium_modified_title">Keitimo data</string>
+    <string name="deduplicator_arbiter_criterium_nesting_description">Pageidauti failus seklesnėse arba gilesnėse aplankų struktūrose.</string>
+    <string name="deduplicator_arbiter_criterium_modified_title">Modifikacijos data</string>
     <string name="deduplicator_arbiter_criterium_modified_description">Pirmenyė senesniems arba naujesniems failams pagal keitimo laiką.</string>
     <string name="deduplicator_arbiter_criterium_size_title">Failo dydis</string>
     <string name="deduplicator_arbiter_criterium_size_description">Pirmenyė didesniems arba mažesniems failams, kai dydiai skiriasi.</string>
@@ -84,8 +84,8 @@
     <string name="deduplicator_arbiter_mode_prefer_deeper">Pirmenyė gilesniems aplankams</string>
     <string name="deduplicator_arbiter_mode_prefer_older">Pirmenyė senesniems failams</string>
     <string name="deduplicator_arbiter_mode_prefer_newer">Pirmenyė naujesniems failams</string>
-    <string name="deduplicator_arbiter_mode_prefer_larger">Pirmenyė didesniems failams</string>
-    <string name="deduplicator_arbiter_mode_prefer_smaller">Pirmenyė mažesniems failams</string>
+    <string name="deduplicator_arbiter_mode_prefer_larger">Pageidauti didesnius failus</string>
+    <string name="deduplicator_arbiter_mode_prefer_smaller">Pageidauti mažesnius failus</string>
     <string name="deduplicator_view_mode_groups_label">Grupės</string>
     <string name="deduplicator_view_mode_directories_label">Aplankai</string>
 </resources>

--- a/app-tool-squeezer/src/main/res/values-sl/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-sl/strings.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="squeezer_explanation_short">Stisni slike in videoposnetke, da prihranite prostor.</string>
+    <string name="squeezer_explanation_short">Stisnite slike in videoposnetke, da prihranite prostor.</string>
     <plurals name="squeezer_result_x_images_found">
         <item quantity="one">%d predmet najden</item>
         <item quantity="two">%d predmeta najdena</item>
         <item quantity="few">%d predmeti najdeni</item>
-        <item quantity="other">%d predmetov najdenih</item>
+        <item quantity="other">Najdenih je bilo %d predmetov.</item>
     </plurals>
     <plurals name="squeezer_result_x_estimated_savings">
         <item quantity="one">Prihranite lahko ~%s.</item>
@@ -17,25 +17,25 @@
         <item quantity="one">%d predmet stisnjen</item>
         <item quantity="two">%d predmeta stisnjena</item>
         <item quantity="few">%d predmeti stisnjeni</item>
-        <item quantity="other">%d predmetov stisnjenih</item>
+        <item quantity="other">Stisnjenih je bilo %d predmetov.</item>
     </plurals>
     <plurals name="squeezer_result_x_items_failed">
         <item quantity="one">Spodletel: %d</item>
         <item quantity="two">Spodletela: %d</item>
         <item quantity="few">Spodleteli: %d</item>
-        <item quantity="other">Spodletelih: %d</item>
+        <item quantity="other">%d predmetov je spodletelo.</item>
     </plurals>
     <plurals name="squeezer_result_x_skipped_inaccessible">
         <item quantity="one">%d datoteka preskočena (ni dostopna)</item>
         <item quantity="two">%d datoteki preskočeni (nista dostopni)</item>
         <item quantity="few">%d datoteke preskočene (niso dostopne)</item>
-        <item quantity="other">%d datotek preskočenih (niso dostopne)</item>
+        <item quantity="other">%d datotek je bilo preskočenih (niso dostopne).</item>
     </plurals>
     <plurals name="squeezer_preview_x_images">
         <item quantity="one">%d element izbran</item>
         <item quantity="two">%d elementa izbrana</item>
         <item quantity="few">%d elementi izbrani</item>
-        <item quantity="other">%d elementov izbranih</item>
+        <item quantity="other">Izbranih je bilo %d predmetov.</item>
     </plurals>
     <string name="squeezer_search_locations_title">Mesta iskanja</string>
     <string name="squeezer_search_locations_default_summary">Mape fotoaparata (privzeto)</string>
@@ -51,17 +51,17 @@
     <string name="squeezer_quality_warning_low">Nižje kakovosti lahko povzročijo vidna popačenja.</string>
     <string name="squeezer_quality_warning_high">Zelo visoka kakovost omogoča le majhen prihranek prostora.</string>
     <string name="squeezer_types_category_label">Nastavitve slik</string>
-    <string name="squeezer_video_settings_category_label">Nastavitve videa</string>
+    <string name="squeezer_video_settings_category_label">Nastavitve videoposnetkov</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
     <string name="squeezer_type_jpeg_description">Vključi slike JPEG (.jpg, .jpeg).</string>
     <string name="squeezer_type_webp_title">WebP</string>
     <string name="squeezer_type_webp_description">Vključi slike WebP (.webp).</string>
-    <string name="squeezer_type_video_title">MP4 Video</string>
+    <string name="squeezer_type_video_title">Videoposnetki MP4</string>
     <string name="squeezer_type_video_description">Vključi video datoteke MP4 (.mp4).</string>
     <string name="squeezer_skip_compressed_title">Preskoči že stisnjene</string>
-    <string name="squeezer_skip_compressed_description">Preskoči datoteke, ki jih je SD Maid že stisnilo.</string>
+    <string name="squeezer_skip_compressed_description">Preskoči datoteke, ki jih je SD Maid že stisnil.</string>
     <string name="squeezer_exif_marker_title">Zapiši oznako EXIF</string>
-    <string name="squeezer_exif_marker_description">Dodaj oznako v polje uporabniškega komentarja oznak EXIF, da preprečite ponovno stiskanje, tudi če je bila zgodovina stiskanja izbrisana.</string>
+    <string name="squeezer_exif_marker_description">Dodaj oznako v polje uporabniškega komentarja oznak EXIF, da se prepreči ponovno stiskanje, tudi če je bila zgodovina stiskanja izbrisana.</string>
     <string name="squeezer_estimated_savings_format">~%s prihranka</string>
     <string name="squeezer_no_savings_expected">Omejen prihranek</string>
     <string name="squeezer_current_size_format">Velikost: %s</string>
@@ -70,7 +70,7 @@
     <string name="squeezer_preview_dialog_title">Potrdi stiskanje</string>
     <string name="squeezer_preview_total_size">Skupna velikost</string>
     <string name="squeezer_preview_estimated_savings">Predviden prihranek</string>
-    <string name="squeezer_compress_confirmation_title">Stisni izbrane elemente?</string>
+    <string name="squeezer_compress_confirmation_title">Stisni izbrane predmete?</string>
     <string name="squeezer_compress_confirmation_message">To bo nadomestilo izvirne datoteke s stisnjenimi različicami. Tega dejanja ni mogoče razveljaviti.</string>
     <string name="squeezer_history_title">Zgodovina stiskanja</string>
     <plurals name="squeezer_history_summary">
@@ -81,7 +81,7 @@
     </plurals>
     <string name="squeezer_history_empty">Ni zgodovine stiskanja.</string>
     <string name="squeezer_history_clear_title">Počisti zgodovino stiskanja</string>
-    <string name="squeezer_history_clear_message">To bo omogočilo, da se predhodno stisnjene datoteke stisnejo znova. Same datoteke niso prizadete.</string>
+    <string name="squeezer_history_clear_message">To bo omogočilo, da se predhodno stisnjene datoteke stisnejo znova. Same datoteke ne bodo prizadete.</string>
     <string name="squeezer_onboarding_title">O stiskanju slik</string>
     <string name="squeezer_onboarding_message">Stiskanje slik zmanjša velikost datoteke z odstranitvijo vizualnih podrobnosti.  Ta postopek je nepovraten – izvirne kakovosti ni mogoče obnoviti.\n\nTu je predogled, kako bodo izgledale vaše slike:</string>
     <string name="squeezer_onboarding_original_label">Izvirnik</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -20,9 +20,9 @@
     <string name="debug_debuglog_screen_session_path_label">Putanja sesije</string>
     <string name="debug_debuglog_screen_log_files_label">Datoteke zapisnika</string>
     <plurals name="debug_debuglog_screen_log_files_ready">
-        <item quantity="one">%1$d datoteka spremna (%2$s)</item>
-        <item quantity="few">%1$d datoteke spremne (%2$s)</item>
-        <item quantity="other">%1$d datoteka spremno (%2$s)</item>
+        <item quantity="one">%1$d datoteka spremna (%2$s) · %3$s</item>
+        <item quantity="few">%1$d datoteke spremne (%2$s) · %3$s</item>
+        <item quantity="other">%1$d datoteka spremno (%2$s) · %3$s</item>
     </plurals>
     <string name="settings_debuglog_explanation">Ova značajka bilježi sve što aplikacija radi u datoteku koja se može dijeliti. Generirana datoteka sadrži osjetljive informacije (npr. nazive datoteka i instalirane aplikacije). Dijelite je samo s pouzdanim stranama (npr. programerom koji rješava problem).</string>
     <string name="debug_debuglog_short_recording_title">Vrlo kratko snimanje</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -135,7 +135,7 @@
     <string name="support_contact_category_question_label">Klausimas</string>
     <string name="support_contact_tool_label">Susijęs įrankis</string>
     <string name="support_contact_tool_appcleaner_label">AppCleaner</string>
-    <string name="support_contact_tool_corpsefinder_label">CorpseFinder</string>
+    <string name="support_contact_tool_corpsefinder_label">Pamirštųjų ieškiklis</string>
     <string name="support_contact_tool_systemcleaner_label">SystemCleaner</string>
     <string name="support_contact_tool_deduplicator_label">Deduplicator</string>
     <string name="support_contact_tool_analyzer_label">Analizatorius</string>

--- a/fastlane/metadata/android/lv/short_description.txt
+++ b/fastlane/metadata/android/lv/short_description.txt
@@ -1,1 +1,1 @@
-Uzticama asistente jūsu Android, lai tas būtu tīrs un kārtīgs.
+Uzticama palīdze Tavam Android, lai tas būtu tīrs un kārtīgs.


### PR DESCRIPTION
## What changed

Updated translations pulled from Crowdin for several languages:

- App interface text for Lithuanian, Slovenian, and Croatian
- Play Store short description for Latvian

Each pulled translation was validated before inclusion. A number of contributions were rejected and not merged because they were broken (e.g. duplicated sentences in store descriptions, a title exceeding the store length limit, a quote-escaping issue that would break the app, and a couple of incorrect translations).

## Technical Context

No user-facing behavior change beyond the translated text itself.

- Validation reverted problematic entries: the known Crowdin store-description export duplication affected most `full_description.txt` pulls (ja-JP, th, zh-CN, zh-HK, zh-TW), which were dropped; `lv/title.txt` exceeded the 30-char store limit; individual strings were reverted in `sl` (inconsistent plural abbreviation), `hr` (semantic mistranslation), and `km-rKH` (unescaped quotes that broke the resource compiler).
- Net result is a small, clean set of changes: Lithuanian/Slovenian/Croatian app strings plus one Latvian store string.
- `assembleFossDebug` passes.
