### PR TITLE
General: Fix setup card still flashing on launch for root users

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModel.kt
@@ -470,7 +470,7 @@ class DashboardViewModel @Inject constructor(
                 onContinue = { navigateTo(SetupRoute()) }
             )
 
-            if (setupState.isIncomplete) return@flatMapLatest flowOf(item)
+            if (setupState.isIncompleteSettled) return@flatMapLatest flowOf(item)
 
             if (!setupState.isLoading) return@flatMapLatest flowOf(null)
 

--- a/app/src/main/java/eu/darken/sdmse/setup/SetupManager.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/SetupManager.kt
@@ -62,6 +62,13 @@ class SetupManager @Inject constructor(
         val isIncomplete: Boolean = moduleStates.filterIsInstance<SetupModule.State.Current>().any { !it.isComplete }
         val isLoading: Boolean = moduleStates.any { it is SetupModule.State.Loading }
         val isWorking: Boolean = isHealerWorking || isLoading
+
+        // Incomplete only once module probing has settled (isLoading=false). While a module is still
+        // probing, a privileged check (e.g. the root service handshake on rooted devices) can briefly
+        // report a settled incomplete Result, which previously flashed the dashboard setup card on
+        // every launch. The healer may still be working here - that's a deliberately visible card
+        // state, so it is not excluded.
+        val isIncompleteSettled: Boolean = !isLoading && isIncomplete
     }
 
     companion object {

--- a/app/src/test/java/eu/darken/sdmse/setup/SetupManagerStateTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/setup/SetupManagerStateTest.kt
@@ -1,0 +1,93 @@
+package eu.darken.sdmse.setup
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.time.Instant
+
+class SetupManagerStateTest : BaseTest() {
+
+    private fun loading(at: Instant = Instant.EPOCH) = object : SetupModule.State.Loading {
+        override val startAt: Instant = at
+        override val type: SetupModule.Type = SetupModule.Type.ROOT
+    }
+
+    private fun current(complete: Boolean) = object : SetupModule.State.Current {
+        override val isComplete: Boolean = complete
+        override val type: SetupModule.Type = SetupModule.Type.ROOT
+    }
+
+    private fun state(
+        moduleStates: List<SetupModule.State>,
+        isDismissed: Boolean = false,
+        isHealerWorking: Boolean = false,
+    ) = SetupManager.State(
+        moduleStates = moduleStates,
+        isDismissed = isDismissed,
+        isHealerWorking = isHealerWorking,
+    )
+
+    @Test fun `incomplete module while another is still loading is not settled-incomplete`() {
+        // Reproduces the dashboard flash: the root module reports a settled incomplete Result during
+        // the cold-start handshake while other modules are still probing. isIncomplete is true, but
+        // the card must NOT be shown immediately - so isIncompleteSettled must be false.
+        val state = state(
+            moduleStates = listOf(
+                loading(),
+                current(complete = false),
+                current(complete = true),
+            ),
+        )
+
+        state.isIncomplete shouldBe true
+        state.isLoading shouldBe true
+        state.isIncompleteSettled shouldBe false
+        state.isDone shouldBe false
+    }
+
+    @Test fun `incomplete module once all modules have settled is settled-incomplete`() {
+        val state = state(
+            moduleStates = listOf(
+                current(complete = true),
+                current(complete = false),
+                current(complete = true),
+            ),
+        )
+
+        state.isIncomplete shouldBe true
+        state.isLoading shouldBe false
+        state.isIncompleteSettled shouldBe true
+        state.isDone shouldBe false
+    }
+
+    @Test fun `all modules complete is done and not settled-incomplete`() {
+        val state = state(
+            moduleStates = listOf(
+                current(complete = true),
+                current(complete = true),
+            ),
+        )
+
+        state.isIncomplete shouldBe false
+        state.isLoading shouldBe false
+        state.isIncompleteSettled shouldBe false
+        state.isDone shouldBe true
+    }
+
+    @Test fun `healer working keeps an incomplete card visible even though setup has settled`() {
+        // The healer running is a deliberately visible card state, so isIncompleteSettled stays true
+        // when a settled module is incomplete and the healer is still working.
+        val state = state(
+            moduleStates = listOf(
+                current(complete = true),
+                current(complete = false),
+            ),
+            isHealerWorking = true,
+        )
+
+        state.isWorking shouldBe true
+        state.isLoading shouldBe false
+        state.isIncompleteSettled shouldBe true
+        state.isDone shouldBe false
+    }
+}


### PR DESCRIPTION
## What changed

On rooted devices, a "Setup Incomplete" card still flashed at the top of the dashboard for about a second on every cold launch, then disappeared before it could be tapped — even after the previous fix. Setup was actually fine; the card was a false alarm. It no longer appears during the brief root check at startup.

This follows up on "Fix setup card flashing on every launch for root users", which addressed one path but not the case some rooted devices hit.

## Technical Context

- Root cause: on cold start the root service is re-verified (~1.2s). During that window `RootManager.binder` emits a transient `null`, which `RootSetupModule` maps to a settled `Result(ourService=false)`. That flips `SetupManager.State.isIncomplete` to `true` while other modules are still `Loading`.
- `DashboardViewModel.setupCardItem` short-circuited on raw `isIncomplete` **before** the existing 5s loading-grace debounce, so the card rendered immediately and then vanished once the root check completed. Confirmed against a user debug log: the aggregate setup state toggles incomplete→complete over ~1.24s, matching the visible flash.
- Fix: added `State.isIncompleteSettled` (`!isLoading && isIncomplete`) and gate the immediate card display on it. Transient incomplete states during module probing now fall through to the debounce instead of flashing. A genuinely incomplete setup still surfaces immediately once probing settles, and the healer-in-progress card state stays visible (gating is on `!isLoading`, not `!isWorking`).
- `RootSetupModule` is intentionally left unchanged: a `null` binder emission also represents a genuine root-acquisition failure that must surface as incomplete, and the module cannot distinguish that from the transient cold-start `null` — so the fix belongs at the dashboard gating layer.
- Review guidance: the behavior change is the branch reordering in `setupCardItem` and the new predicate. `SetupManagerStateTest` locks the invariant (loading + incomplete ⇒ not settled-incomplete; healer-working stays visible).
