### PR TITLE
General: Fix rare races in root/ADB/Shizuku access lifecycle

### DIFF
--- a/app-common/src/main/java/eu/darken/sdmse/common/sharedresource/SharedResource.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/sharedresource/SharedResource.kt
@@ -163,13 +163,37 @@ open class SharedResource<T : Any>(
                             if (Bugs.isTrace) log(iTag, DEBUG) { "[${newGen.id}|$lId]-source: Internal cancel, no cleanup" }
                             return@onCompletion
                         }
-                        // Self-completion (error / natural end) of the *active* generation: release leases.
+                        // Self-completion (error / natural end) of the *active* generation: release leases
+                        // and detach. The schedule-time `active === newGen` guard can go stale before the
+                        // launched coroutine runs — a concurrent close()+get() may detach newGen and install
+                        // a fresh generation — so re-validate under coreLock and close-leases + detach in ONE
+                        // atomic hold. Otherwise we'd globally close the *fresh* generation's lease and detach
+                        // it instead.
                         if (active === newGen) {
                             leaseScope.launch(NonCancellable) {
-                                if (Bugs.isTrace) log(iTag, DEBUG) { "[${newGen.id}|$lId]-source: onCompletion calling closeLeases()" }
-                                closeLeases("onCompletion")
-                                if (Bugs.isTrace) log(iTag, VERBOSE) { "[${newGen.id}|$lId]-source: onCompletion calling leaseCheck(forced=true)" }
-                                leaseCheck("onCompletion", forced = true)
+                                // leaseCheckLock -> coreLock: the SAME order leaseCheck() uses, so no deadlock.
+                                leaseCheckLock.withLock {
+                                    val detached = coreLock.withLock("onCompletion-${newGen.id}") {
+                                        if (active !== newGen) {
+                                            if (Bugs.isTrace) log(iTag, DEBUG) { "[${newGen.id}|$lId]-source: onCompletion superseded, skipping teardown" }
+                                            return@withLock false
+                                        }
+                                        if (Bugs.isTrace) log(iTag, DEBUG) { "[${newGen.id}|$lId]-source: onCompletion closing leases + detaching" }
+                                        closeLeasesLocked("onCompletion")
+                                        detachLocked("onCompletion")
+                                        true
+                                    }
+                                    // Only when we actually force-detached newGen: cancel its pending delayed
+                                    // timer (if any) so a stale timer can't later detach a future idle
+                                    // generation early. Done OFF coreLock (the timer body needs it), mirroring
+                                    // leaseCheck()'s own cancel ordering. The superseded path above leaves
+                                    // leaseCheckJob untouched, so it can never cancel a *different*
+                                    // generation's timer.
+                                    if (detached) {
+                                        leaseCheckJob?.cancelAndJoin()
+                                        leaseCheckJob = null
+                                    }
+                                }
                             }
                         }
                         if (Bugs.isTrace) log(iTag, DEBUG) { "[${newGen.id}|$lId]-source: onCompletion done" }
@@ -266,15 +290,25 @@ open class SharedResource<T : Any>(
         }
         if (Bugs.isTrace) log(iTag, DEBUG) { "[$sId|_]-doLeaseCheck()-$tag ZERO leases left" }
 
-        val generation = active
-        if (generation == null) {
+        if (active == null) {
             if (Bugs.isTrace) log(iTag, DEBUG) { "[$sId|_]-doLeaseCheck()-$tag active was already null" }
             return@withLock
         }
+        detachLocked(tag)
+    }
+
+    /**
+     * Detach the active generation and schedule its (possibly slow) teardown off-lock.
+     *
+     * Caller MUST hold [coreLock]. Intentionally non-suspend: its body performs no suspending calls,
+     * so it can run inside any coreLock hold (doLeaseCheck, or the onCompletion self-teardown).
+     */
+    private fun detachLocked(tag: String) {
+        val generation = active ?: return
 
         // Detach the generation: clear the active slot *now*, under the lock, so a subsequent get()
         // starts a fresh source immediately instead of waiting for this (potentially slow) teardown.
-        if (Bugs.isTrace) log(iTag, DEBUG) { "[${generation.id}|_]-doLeaseCheck()-$tag Detaching generation" }
+        if (Bugs.isTrace) log(iTag, DEBUG) { "[${generation.id}|_]-detach()-$tag Detaching generation" }
         active = null
         val detachedJob = generation.job
         val detachedChildren = children.toMap()
@@ -286,46 +320,59 @@ open class SharedResource<T : Any>(
         // No-op when a value was already produced (the common detach-after-use case).
         if (!generation.ready.isCompleted) {
             generation.ready.completeExceptionally(
-                IllegalStateException("[${generation.id}|_]-doLeaseCheck()-$tag detached before a value was produced")
+                IllegalStateException("[${generation.id}|_]-detach()-$tag detached before a value was produced")
             )
+        }
+
+        // Schedule the source-job cancel+join FIRST, so a throwing child.close() below can never strand
+        // it (which would leak e.g. a root host that is never disconnected). The cancel+join can itself
+        // be slow, so run it off BOTH coreLock and leaseCheckLock — a wedged source close must never
+        // block a future get() or leaseCheck().
+        leaseScope.launch(NonCancellable) {
+            detachedJob?.cancel(InternalCancelationException("[${generation.id}|_]-detach()-$tag ZERO leases left"))
+            detachedJob?.join() // Waits till source.onComplete is done
+            if (Bugs.isTrace) log(iTag, VERBOSE) { "[${generation.id}|_]-detach()-$tag teardown complete" }
         }
 
         // Close children synchronously — this only releases the leases we hold on them and is fast;
         // callers (and tests) rely on children being closed by the time the parent reads as closed.
+        // Guard each close so one misbehaving child can't abort the rest of the cleanup.
         detachedChildren.values.forEachIndexed { index, child ->
-            if (Bugs.isTrace) log(iTag, VERBOSE) { "[${generation.id}|_]-doLeaseCheck()-$tag Closing child #$index $child" }
-            child.close()
-        }
-
-        // The source-job cancel+join can be slow (e.g. a root host slow to disconnect). Run it off
-        // BOTH coreLock and leaseCheckLock so a wedged source close can never block a future get()
-        // or leaseCheck().
-        leaseScope.launch(NonCancellable) {
-            detachedJob?.cancel(InternalCancelationException("[${generation.id}|_]-doLeaseCheck()-$tag ZERO leases left"))
-            detachedJob?.join() // Waits till source.onComplete is done
-            if (Bugs.isTrace) log(iTag, VERBOSE) { "[${generation.id}|_]-doLeaseCheck()-$tag teardown complete" }
+            if (Bugs.isTrace) log(iTag, VERBOSE) { "[${generation.id}|_]-detach()-$tag Closing child #$index $child" }
+            runCatching { child.close() }.onFailure {
+                log(iTag, WARN) { "[${generation.id}|_]-detach()-$tag Child close failed for $child: ${it.asLog()}" }
+            }
         }
     }
 
     override fun close() {
-        if (isClosed) {
-            if (Bugs.isTrace) log(iTag) { "[$sId|_]-close() already closed" }
-            return
-        } else {
-            if (Bugs.isTrace) log(iTag) { "[$sId|_]-close() via ${Exception().asLog()}" }
-        }
-
         runBlocking(NonCancellable) {
-            if (Bugs.isTrace) log(iTag) { "[$sId|_]-close() calling closeLeases()" }
-            closeLeases("close()")
-            leaseCheck("close", forced = false)
+            // Decide AND close leases under a single coreLock hold. A cold get() registers its lease and
+            // publishes `active` atomically under coreLock; an unsynchronized isClosed (== active == null)
+            // fast-path could observe null while such a get() holds the lock about to set it, return early,
+            // and leak the just-created lease/source. Reading the decision under the lock closes that window.
+            val hadState = coreLock.withLock("close()") {
+                if (active == null && leases.isEmpty()) {
+                    if (Bugs.isTrace) log(iTag) { "[$sId|_]-close() already closed" }
+                    return@withLock false
+                }
+                if (Bugs.isTrace) log(iTag) { "[$sId|_]-close() via ${Exception().asLog()}" }
+                if (Bugs.isTrace) log(iTag) { "[$sId|_]-close() calling closeLeases()" }
+                closeLeasesLocked("close()")
+                true
+            }
+            // leaseCheck must run OFF coreLock (it takes leaseCheckLock -> coreLock via doLeaseCheck). A
+            // get() that starts after the locked decision is a legitimate new acquisition; doLeaseCheck
+            // keeps it if its lease survives, detaches it otherwise — both correct.
+            if (hadState) leaseCheck("close", forced = false)
         }
     }
 
-    private suspend fun closeLeases(tag: String) = coreLock.withLock("closeLeases()-$tag") {
+    // Caller MUST hold coreLock.
+    private suspend fun closeLeasesLocked(tag: String) {
         if (leases.isEmpty()) {
             if (Bugs.isTrace) log(iTag, VERBOSE) { "[$sId|_]-closeLeases()-$tag No leases to close" }
-            return@withLock
+            return
         }
 
         if (Bugs.isTrace) log(iTag, VERBOSE) { "[$sId|_]-closeLeases()-$tag Current leases=${leases.size}" }
@@ -386,6 +433,15 @@ open class SharedResource<T : Any>(
             }
         }
     }
+
+    /**
+     * Test-only seam (module-internal): inject a raw [KeepAlive] under [key] directly into the
+     * children map, bypassing the normal [addChild] adoption flow. Lets tests drive [detachLocked]'s
+     * child-close loop with a child whose `close()` misbehaves (throws), to verify one bad child can
+     * neither abort the rest of the cleanup nor strand the off-lock source teardown. Not for production.
+     */
+    internal suspend fun injectChildForTest(key: SharedResource<*>, child: KeepAlive) =
+        coreLock.withLock("injectChildForTest") { children[key] = child }
 
     override fun toString(): String =
         "SharedResource(tag=$iTag, sId=$sId, leases=${leases.size}, children=${children.size})"

--- a/app-common/src/test/java/eu/darken/sdmse/common/sharedresource/SharedResourceTest.kt
+++ b/app-common/src/test/java/eu/darken/sdmse/common/sharedresource/SharedResourceTest.kt
@@ -779,4 +779,102 @@ class SharedResourceTest : BaseTest() {
 
         releaseTeardown.complete(Unit) // let the off-lock teardown finish so the scope can wind down
     }
+
+    @Test fun `a superseded generation's self-teardown never clobbers the live generation`(): Unit = runBlocking {
+        repeat(300) {
+            val gen1Gate = CompletableDeferred<Unit>()
+            var starts = 0
+            val sr = SharedResource<Int>(
+                tag = "supersede",
+                parentScope = this + Dispatchers.IO,
+                stopTimeout = Duration.ZERO,
+                source = callbackFlow {
+                    val g = ++starts
+                    send(g)
+                    if (g == 1) {
+                        gen1Gate.await()
+                        throw IllegalStateException("gen-1 spontaneous death")
+                    } else {
+                        awaitClose()
+                    }
+                },
+            )
+            val r1 = sr.get()
+            r1.item shouldBe 1
+            // Let gen-1 die spontaneously while we install gen-2; its stale onCompletion must NOT tear
+            // down the fresh generation.
+            val killer = launch(Dispatchers.IO) { gen1Gate.complete(Unit) }
+            r1.close()
+            val r2 = withTimeout(5_000) {
+                var r = sr.get()
+                var guard = 0
+                while (r.item == 1 && guard++ < 1000) {
+                    r.close()
+                    r = sr.get()
+                }
+                r
+            }
+            r2.item shouldBe 2
+            killer.join()
+            delay(15)
+            r2.isClosed shouldBe false
+            sr.isClosed shouldBe false
+            r2.close()
+            sr.close()
+        }
+    }
+
+    @Test fun `close() decided under lock converges with a racing cold get()`(): Unit = runBlocking {
+        repeat(300) {
+            val sr = SharedResource.createKeepAlive("coldclose", this + Dispatchers.Default, Duration.ZERO)
+            var acquired: KeepAlive? = null
+            val getter = launch(Dispatchers.IO) { acquired = runCatching { sr.get() }.getOrNull() }
+            val closer = launch(Dispatchers.IO) { sr.close() }
+            joinAll(getter, closer)
+            acquired?.close()
+            withTimeout(2_000) { while (!sr.isClosed) delay(1) }
+            sr.isClosed shouldBe true
+        }
+    }
+
+    @Test fun `detach is not derailed by a child whose close throws`(): Unit = runBlocking {
+        var sourceTornDown = false
+        val parent = SharedResource<Int>(
+            tag = "throwparent",
+            parentScope = this + Dispatchers.IO,
+            stopTimeout = Duration.ZERO,
+            source = callbackFlow {
+                send(1)
+                awaitClose { sourceTornDown = true } // fires only if the off-lock source teardown runs
+            },
+        )
+        val keepParent = parent.get().apply { item shouldBe 1 } // keep parent active while we inject
+
+        // A misbehaving child (close throws) inserted BEFORE a well-behaved one. Detach must close the
+        // good child despite the bad one, and must still tear the source down.
+        var goodChildClosed = false
+        val throwingChild = object : KeepAlive {
+            override val resourceId = "throwing"
+            override val isClosed = false // detachLocked never reads this; close() just throws
+            override fun close() = throw RuntimeException("boom on child close")
+        }
+        val goodChild = object : KeepAlive {
+            override val resourceId = "good"
+            override val isClosed: Boolean get() = goodChildClosed
+            override fun close() {
+                goodChildClosed = true
+            }
+        }
+        parent.injectChildForTest(SharedResource.createKeepAlive("k1", this + Dispatchers.IO, Duration.ZERO), throwingChild)
+        parent.injectChildForTest(SharedResource.createKeepAlive("k2", this + Dispatchers.IO, Duration.ZERO), goodChild)
+
+        keepParent.close() // drops the only real lease -> detach -> detachLocked closes children
+
+        withTimeout(5_000) {
+            while (!(parent.isClosed && goodChildClosed && sourceTornDown)) delay(1)
+        }
+        parent.isClosed shouldBe true   // detach completed despite the throwing child
+        goodChildClosed shouldBe true   // iteration continued past the thrower (per-child runCatching)
+        sourceTornDown shouldBe true    // source teardown was enqueued before the child loop, not stranded
+    }
 }


### PR DESCRIPTION
## What changed

No user-facing behavior change in practice. This is a robustness follow-up to #2453 (which fixed
root/Shizuku access hanging after returning to the app). It closes two narrow concurrency races in
the shared keep-alive primitive that underpins the root/ADB/Shizuku host lifecycle, plus a related
teardown-robustness gap.

## Technical Context

Ported from the sister project after a review there surfaced two races that existed identically in
our shipped #2453 code (commit `1d2c25e2d`). Both were independently re-validated here and pinned
down with regression tests.

**Race #1 — stale `onCompletion` clobbering a live generation (latent).** The source self-teardown
checked `active === newGen` at *schedule* time. A concurrent `close()` + `get()` could supersede the
generation before the launched cleanup ran, which then globally closed the *fresh* generation's lease
and detached it. Fix: re-validate under `coreLock` and close-leases + detach in one atomic hold. The
pending delayed-detach timer is cancelled only when we actually detach (gated behind the guard, off
`coreLock`), so a stale cleanup can't cancel a *different* generation's timer. Reachable only with
`stopTimeout == ZERO`, which no production resource uses today (Root = 3s, ADB = 30s) — so latent in
shipping configs, but real for the test paths and any future zero-timeout resource.

**Race #2 — cold `get()` vs `close()` (reachable, mostly self-healing).** `close()` read `isClosed`
(`active == null`) without `coreLock` as a fast-path. A cold `get()` publishes its lease and `active`
atomically under `coreLock`; `close()` could observe null mid-`get()`, return early, and leak the
just-created lease/source. Fix: decide and close leases under one `coreLock` hold. `leaseCheck` still
runs off-lock (`forced = false` unchanged — existing tests rely on the delayed-detach grace period).

**Detach hardening.** `detachLocked` now enqueues the source-job cancel+join *before* the child-close
loop and wraps each `child.close()` in `runCatching`, so one misbehaving child can neither abort the
rest of cleanup nor strand a (possibly slow) root-host teardown.

### Review guidance

- Lock order is uniformly `leaseCheckLock → coreLock` everywhere both are held; the new `onCompletion`
  block and `close()` preserve this — no reverse ordering, no new deadlock.
- `detachLocked` is intentionally non-suspend so it can run inside any `coreLock` hold (`doLeaseCheck`
  and the `onCompletion` self-teardown).
- Refactor only, no public API change: extracted `closeLeasesLocked` (caller-holds-lock) and deleted
  the now-dead `closeLeases` wrapper; extracted `detachLocked` from `doLeaseCheck`.
- Test seam `injectChildForTest` is `internal` (the repo uses no `@VisibleForTesting`).
- Tests: 30/30 green. The superseded-generation test was verified to fail on pre-fix code; the
  throwing-child test fails when the detach hardening is reverted.

Refs #2453
