### PR TITLE
General: Explain why Advanced Protection blocks accessibility

### DIFF
--- a/app-common-setup/src/main/java/eu/darken/sdmse/setup/automation/AutomationToolsHelper.kt
+++ b/app-common-setup/src/main/java/eu/darken/sdmse/setup/automation/AutomationToolsHelper.kt
@@ -1,6 +1,8 @@
 package eu.darken.sdmse.setup.automation
 
+import android.annotation.SuppressLint
 import android.content.Context
+import android.security.advancedprotection.AdvancedProtectionManager
 import eu.darken.sdmse.common.hasApiLevel
 import eu.darken.sdmse.common.pkgs.features.InstallerInfo
 import eu.darken.sdmse.common.pkgs.features.getInstallerInfo
@@ -29,3 +31,40 @@ fun Context.mightBeRestrictedDueToSideload(): Boolean {
     // https://cs.android.com/android/platform/superproject/+/master:frameworks/base/services/core/java/com/android/server/pm/InstallPackageHelper.java;l=2180
     return FLAGGED_SOURCE_TYPES.contains(installerInfo.sourceType)
 }
+
+/**
+ * Android 17+ "Advanced Protection" blocks any app that is not a dedicated accessibility tool from
+ * binding an accessibility service (DISALLOW_NON_TOOL_ACCESSIBILITY_SERVICES, enforced by
+ * AccessibilityManagerService). SD Maid is a cleaner, not an accessibility tool, so while Advanced
+ * Protection is active our accessibility service can never be enabled - the bind is rejected, not
+ * just the Settings toggle, so even a root/ADB (Shizuku) secure-settings write does not help.
+ */
+@SuppressLint("NewApi")
+fun Context.isRestrictedByAdvancedProtection(): Boolean {
+    if (!hasApiLevel(37)) return false
+    return runCatching {
+        getSystemService(AdvancedProtectionManager::class.java)?.isAdvancedProtectionEnabled() == true
+    }.getOrDefault(false)
+}
+
+data class AcsRestrictionHints(
+    val showAdvancedProtectionHint: Boolean,
+    val showAppOpsRestrictionHint: Boolean,
+)
+
+/**
+ * Decides which (mutually exclusive) restriction hint the accessibility setup card should surface.
+ *
+ * Advanced Protection takes precedence: while it blocks the service the sideload "restricted
+ * settings" hint is suppressed, because its remedy (lifting per-app app-ops from the system detail
+ * page) cannot lift an Advanced-Protection block.
+ */
+fun decideAcsRestrictionHints(
+    advancedProtectionBlocksAcs: Boolean,
+    hasConsent: Boolean?,
+    isServiceRunning: Boolean,
+    appOpsRestrictionApplies: Boolean,
+): AcsRestrictionHints = AcsRestrictionHints(
+    showAdvancedProtectionHint = advancedProtectionBlocksAcs && hasConsent == true && !isServiceRunning,
+    showAppOpsRestrictionHint = appOpsRestrictionApplies && !advancedProtectionBlocksAcs,
+)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,6 +37,9 @@
         android:name="android.permission.WRITE_SECURE_SETTINGS"
         tools:ignore="ProtectedPermissions" />
 
+    <!--    Android 17+: detect "Advanced Protection" so we can explain why the accessibility service is blocked-->
+    <uses-permission android:name="android.permission.QUERY_ADVANCED_PROTECTION_MODE" />
+
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
 

--- a/app/src/main/java/eu/darken/sdmse/setup/SetupHealer.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/SetupHealer.kt
@@ -168,7 +168,9 @@ class SetupHealer @Inject constructor(
     }
 
     private suspend fun AutomationSetupModule.Result.tryHeal(): Boolean {
-        if (isComplete || hasConsent != true) {
+        // Skips healing while Advanced Protection blocks the ACS bind - a heal attempt would no-op
+        // yet report success and spin this collector in a refresh loop.
+        if (!isAcsHealAttemptViable) {
             return false
         }
 

--- a/app/src/main/java/eu/darken/sdmse/setup/SetupViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/SetupViewModel.kt
@@ -202,6 +202,9 @@ class SetupViewModel @Inject constructor(
                                 onRestrictionsHelp = {
                                     webpageTool.open("https://github.com/d4rken-org/sdmaid-se/wiki/Setup#acs-appops-restrictions")
                                 },
+                                onAdvancedProtectionHelp = {
+                                    webpageTool.open("https://github.com/d4rken-org/sdmaid-se/wiki/Setup#acs-advanced-protection")
+                                },
                             )
 
                             is SetupModule.State.Loading -> SetupLoadingCardItem(state)

--- a/app/src/main/java/eu/darken/sdmse/setup/automation/AutomationSetupCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/automation/AutomationSetupCard.kt
@@ -38,6 +38,7 @@ data class AutomationSetupCardItem(
     val onHelp: () -> Unit,
     val onRestrictionsHelp: () -> Unit,
     val onRestrictionsShow: () -> Unit,
+    val onAdvancedProtectionHelp: () -> Unit,
 ) : SetupCardItem
 
 @Composable
@@ -78,6 +79,12 @@ internal fun AutomationSetupCard(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 32.dp),
+            )
+        }
+
+        if (ui.showAdvancedProtectionHint) {
+            AdvancedProtectionBox(
+                onHelp = item.onAdvancedProtectionHelp,
             )
         }
 
@@ -230,6 +237,49 @@ private fun AppOpsRestrictionBox(
     }
 }
 
+@Composable
+private fun AdvancedProtectionBox(
+    onHelp: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.tertiaryContainer)
+            .padding(horizontal = 32.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Icon(
+                imageVector = Icons.TwoTone.Warning,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.secondary,
+                modifier = Modifier.size(20.dp),
+            )
+            Text(
+                text = stringResource(R.string.setup_acs_advanced_protection_title),
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.secondary,
+            )
+        }
+        Text(
+            text = stringResource(R.string.setup_acs_advanced_protection_body),
+            style = MaterialTheme.typography.bodySmall,
+            color = Color.Unspecified,
+        )
+        Button(
+            onClick = onHelp,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 8.dp),
+        ) {
+            Text(stringResource(CommonR.string.general_help_action))
+        }
+    }
+}
+
 @Preview2
 @Composable
 private fun AutomationSetupCardPreview() {
@@ -246,6 +296,8 @@ private fun AutomationSetupCardPreview() {
                     needsXiaomiAutostart = false,
                     liftRestrictionsIntent = Intent(),
                     showAppOpsRestrictionHint = false,
+                    showAdvancedProtectionHint = false,
+                    isAdvancedProtectionBlocked = false,
                     settingsIntent = Intent(),
                 ),
                 onGrantAction = {},
@@ -253,6 +305,7 @@ private fun AutomationSetupCardPreview() {
                 onHelp = {},
                 onRestrictionsHelp = {},
                 onRestrictionsShow = {},
+                onAdvancedProtectionHelp = {},
             ),
         )
     }

--- a/app/src/main/java/eu/darken/sdmse/setup/automation/AutomationSetupModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/automation/AutomationSetupModule.kt
@@ -54,7 +54,11 @@ class AutomationSetupModule @Inject constructor(
         val isServiceRunning = automationManager.isServiceLaunched()
         log(TAG) { "isServiceRunning=$isServiceRunning" }
 
-        val canSelfEnable = automationManager.canSelfEnable()
+        val aapmBlocksAcs = context.isRestrictedByAdvancedProtection()
+        log(TAG) { "aapmBlocksAcs=$aapmBlocksAcs" }
+
+        // Advanced Protection blocks the service bind entirely, so even root/ADB can't self-enable it
+        val canSelfEnable = automationManager.canSelfEnable() && !aapmBlocksAcs
         log(TAG) { "canSelfEnable=$canSelfEnable" }
 
         val isShortcutOrButtonEnabled = automationManager.isShortcutOrButtonEnabled()
@@ -69,12 +73,20 @@ class AutomationSetupModule @Inject constructor(
         val hasTriggeredRestrictions = generalSettings.hasTriggeredRestrictions.value()
         log(TAG) { "hasTriggeredRestrictions=$hasTriggeredRestrictions" }
 
+        val hasConsent = generalSettings.hasAcsConsent.value()
+
         // https://cs.android.com/android/platform/superproject/+/master:packages/apps/Settings/src/com/android/settings/applications/appinfo/AppInfoDashboardFragment.java;l=520
-        val showAppOpsRestrictionHint = !hasPassedRestrictions
+        val appOpsRestrictionApplies = !hasPassedRestrictions
                 && hasTriggeredRestrictions
                 && mightBeRestricted
                 && !canSelfEnable
-        log(TAG) { "showAppOpsRestrictionHint=$showAppOpsRestrictionHint" }
+        val restrictionHints = decideAcsRestrictionHints(
+            advancedProtectionBlocksAcs = aapmBlocksAcs,
+            hasConsent = hasConsent,
+            isServiceRunning = isServiceRunning,
+            appOpsRestrictionApplies = appOpsRestrictionApplies,
+        )
+        log(TAG) { "restrictionHints=$restrictionHints" }
 
         // Settings details screen needs to have the system UID, not ours, otherwise the appops setting is invisible
         val liftRestrictionsIntent = Intent(Settings.ACTION_APPLICATION_SETTINGS).apply {
@@ -86,14 +98,16 @@ class AutomationSetupModule @Inject constructor(
         @Suppress("USELESS_CAST")
         Result(
             isNotRequired = useRoot,
-            hasConsent = generalSettings.hasAcsConsent.value(),
+            hasConsent = hasConsent,
             canSelfEnable = canSelfEnable,
             isServiceEnabled = isServiceEnabled,
             isServiceRunning = isServiceRunning,
             isShortcutOrButtonEnabled = isShortcutOrButtonEnabled,
             needsXiaomiAutostart = deviceDetective.getROMType() == RomType.MIUI && !canSelfEnable,
             liftRestrictionsIntent = liftRestrictionsIntent,
-            showAppOpsRestrictionHint = showAppOpsRestrictionHint,
+            showAppOpsRestrictionHint = restrictionHints.showAppOpsRestrictionHint,
+            showAdvancedProtectionHint = restrictionHints.showAdvancedProtectionHint,
+            isAdvancedProtectionBlocked = aapmBlocksAcs,
             settingsIntent = when (deviceDetective.getROMType()) {
                 RomType.ANDROID_TV -> Intent(Settings.ACTION_SETTINGS)
                 else -> Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS)
@@ -138,6 +152,8 @@ class AutomationSetupModule @Inject constructor(
         val needsXiaomiAutostart: Boolean,
         val liftRestrictionsIntent: Intent,
         val showAppOpsRestrictionHint: Boolean,
+        val showAdvancedProtectionHint: Boolean,
+        val isAdvancedProtectionBlocked: Boolean,
         val settingsIntent: Intent,
     ) : SetupModule.State.Current {
 
@@ -155,6 +171,14 @@ class AutomationSetupModule @Inject constructor(
             hasConsent == false -> true // User doesn't want ACS
             else -> false // Consent is NULL, need user decision
         }
+
+        /**
+         * Whether trying to self-enable the ACS via secure-settings could plausibly help. While
+         * Advanced Protection blocks the bind, a heal attempt is a no-op that still reports success,
+         * which would spin the SetupHealer in a refresh loop - so it must not be attempted.
+         */
+        val isAcsHealAttemptViable: Boolean
+            get() = !isComplete && hasConsent == true && !isAdvancedProtectionBlocked
     }
 
     @Module @InstallIn(SingletonComponent::class)

--- a/app/src/main/java/eu/darken/sdmse/setup/automation/AutomationUiModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/automation/AutomationUiModel.kt
@@ -12,6 +12,7 @@ internal data class AutomationUiModel(
     val enabledState: StateChip?,
     val showMiuiAutostartHint: Boolean,
     val showAppOpsRestrictionHint: Boolean,
+    val showAdvancedProtectionHint: Boolean,
     val runningState: StateChip?,
     val showRunningStateHint: Boolean,
     val showAllowAction: Boolean,
@@ -78,8 +79,10 @@ internal fun AutomationSetupModule.Result.toUiModel(): AutomationUiModel {
 
     return AutomationUiModel(
         enabledState = enabledChip,
-        showMiuiAutostartHint = !isServiceEnabled && needsXiaomiAutostart,
+        // Advanced Protection takes precedence; the MIUI autostart hint would be a false remedy here.
+        showMiuiAutostartHint = !isServiceEnabled && needsXiaomiAutostart && !isAdvancedProtectionBlocked,
         showAppOpsRestrictionHint = showAppOpsRestrictionHint,
+        showAdvancedProtectionHint = showAdvancedProtectionHint,
         runningState = runningChip,
         showRunningStateHint = !isServiceRunning && isServiceEnabled,
         showAllowAction = showAllow,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -274,6 +274,9 @@
     <string name="setup_acs_appops_restriction_title">Restricted settings</string>
     <string name="setup_acs_appops_restriction_body">Can\'t enable SD Maids accessibility service? Android 13+ may apply restrictions to apps not installed via Google Play. Lift these restrictions from the system\'s detail page for SD Maid. The option is in the context menu in the top right corner.</string>
 
+    <string name="setup_acs_advanced_protection_title">Blocked by Advanced Protection</string>
+    <string name="setup_acs_advanced_protection_body">Android\'s Advanced Protection blocks SD Maid\'s accessibility service on Android 17 and newer, so it can\'t be enabled while Advanced Protection is on. Tap Help for details and alternatives.</string>
+
     <string name="setup_inventory_card_title">App inventory</string>
     <string name="setup_inventory_card_body">SD Maid needs to know which apps you have to find files that don\'t belong to any installed apps.</string>
     <string name="setup_inventory_card_extra">Look for a permission called \"App list\" or \"Query all packages\".</string>

--- a/app/src/test/java/eu/darken/sdmse/setup/SetupScreenTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/setup/SetupScreenTest.kt
@@ -201,6 +201,8 @@ class SetupScreenTest : BaseComposeRobolectricTest() {
                                 needsXiaomiAutostart = false,
                                 liftRestrictionsIntent = Intent(),
                                 showAppOpsRestrictionHint = false,
+                                showAdvancedProtectionHint = false,
+                                isAdvancedProtectionBlocked = false,
                                 settingsIntent = Intent(),
                             ),
                             onGrantAction = {},
@@ -208,6 +210,7 @@ class SetupScreenTest : BaseComposeRobolectricTest() {
                             onHelp = {},
                             onRestrictionsHelp = {},
                             onRestrictionsShow = {},
+                            onAdvancedProtectionHelp = {},
                         ),
                     ),
                 ),
@@ -216,6 +219,44 @@ class SetupScreenTest : BaseComposeRobolectricTest() {
         composeRule.onAllNodesWithText(context.getString(R.string.setup_acs_state_enabled)).assertCountEquals(1)
         composeRule.onAllNodesWithText(context.getString(R.string.setup_acs_state_running)).assertCountEquals(1)
         composeRule.onAllNodesWithText(context.getString(R.string.setup_acs_consent_negative_action)).assertCountEquals(1)
+    }
+
+    @Test
+    fun `automation card advanced protection hint shows help only and no view action`() {
+        composeRule.setSetupContent {
+            SetupScreen(
+                uiState = SetupUiState.Cards(
+                    items = listOf(
+                        AutomationSetupCardItem(
+                            state = AutomationSetupModule.Result(
+                                isNotRequired = false,
+                                hasConsent = true,
+                                canSelfEnable = false,
+                                isServiceEnabled = false,
+                                isServiceRunning = false,
+                                isShortcutOrButtonEnabled = false,
+                                needsXiaomiAutostart = false,
+                                liftRestrictionsIntent = Intent(),
+                                showAppOpsRestrictionHint = false,
+                                showAdvancedProtectionHint = true,
+                                isAdvancedProtectionBlocked = true,
+                                settingsIntent = Intent(),
+                            ),
+                            onGrantAction = {},
+                            onDismiss = {},
+                            onHelp = {},
+                            onRestrictionsHelp = {},
+                            onRestrictionsShow = {},
+                            onAdvancedProtectionHelp = {},
+                        ),
+                    ),
+                ),
+            )
+        }
+        composeRule.onAllNodesWithText(context.getString(R.string.setup_acs_advanced_protection_title)).assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(eu.darken.sdmse.common.R.string.general_help_action)).assertCountEquals(1)
+        // Advanced Protection has no per-app remedy, so the "View" action must not be offered here.
+        composeRule.onAllNodesWithText(context.getString(eu.darken.sdmse.common.R.string.general_view_action)).assertCountEquals(0)
     }
 
     @Test

--- a/app/src/test/java/eu/darken/sdmse/setup/automation/AcsRestrictionHintsTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/setup/automation/AcsRestrictionHintsTest.kt
@@ -1,0 +1,91 @@
+package eu.darken.sdmse.setup.automation
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class AcsRestrictionHintsTest : BaseTest() {
+
+    @Test
+    fun `advanced protection hint requires AAPM, consent and a non-running service`() {
+        decideAcsRestrictionHints(
+            advancedProtectionBlocksAcs = true,
+            hasConsent = true,
+            isServiceRunning = false,
+            appOpsRestrictionApplies = false,
+        ).showAdvancedProtectionHint shouldBe true
+    }
+
+    @Test
+    fun `no advanced protection hint without consent`() {
+        decideAcsRestrictionHints(
+            advancedProtectionBlocksAcs = true,
+            hasConsent = null,
+            isServiceRunning = false,
+            appOpsRestrictionApplies = false,
+        ).showAdvancedProtectionHint shouldBe false
+
+        decideAcsRestrictionHints(
+            advancedProtectionBlocksAcs = true,
+            hasConsent = false,
+            isServiceRunning = false,
+            appOpsRestrictionApplies = false,
+        ).showAdvancedProtectionHint shouldBe false
+    }
+
+    @Test
+    fun `no advanced protection hint while the service is running`() {
+        decideAcsRestrictionHints(
+            advancedProtectionBlocksAcs = true,
+            hasConsent = true,
+            isServiceRunning = true,
+            appOpsRestrictionApplies = false,
+        ).showAdvancedProtectionHint shouldBe false
+    }
+
+    @Test
+    fun `no advanced protection hint when AAPM is off`() {
+        decideAcsRestrictionHints(
+            advancedProtectionBlocksAcs = false,
+            hasConsent = true,
+            isServiceRunning = false,
+            appOpsRestrictionApplies = false,
+        ).showAdvancedProtectionHint shouldBe false
+    }
+
+    @Test
+    fun `advanced protection takes precedence over the sideload appops hint`() {
+        val hints = decideAcsRestrictionHints(
+            advancedProtectionBlocksAcs = true,
+            hasConsent = true,
+            isServiceRunning = false,
+            appOpsRestrictionApplies = true,
+        )
+        hints.showAdvancedProtectionHint shouldBe true
+        hints.showAppOpsRestrictionHint shouldBe false
+    }
+
+    @Test
+    fun `AAPM suppresses the appops hint even when the advanced hint itself is not shown`() {
+        // Privileged user without consent: advanced hint off, but appops must still be suppressed
+        // because its remedy cannot lift an Advanced Protection block.
+        val hints = decideAcsRestrictionHints(
+            advancedProtectionBlocksAcs = true,
+            hasConsent = null,
+            isServiceRunning = false,
+            appOpsRestrictionApplies = true,
+        )
+        hints.showAdvancedProtectionHint shouldBe false
+        hints.showAppOpsRestrictionHint shouldBe false
+    }
+
+    @Test
+    fun `appops hint shows when applicable and AAPM is off`() {
+        decideAcsRestrictionHints(
+            advancedProtectionBlocksAcs = false,
+            hasConsent = true,
+            isServiceRunning = false,
+            appOpsRestrictionApplies = true,
+        ).showAppOpsRestrictionHint shouldBe true
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/setup/automation/AutomationUiModelTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/setup/automation/AutomationUiModelTest.kt
@@ -16,6 +16,8 @@ class AutomationUiModelTest : BaseTest() {
         isShortcutOrButtonEnabled: Boolean = false,
         needsXiaomiAutostart: Boolean = false,
         showAppOpsRestrictionHint: Boolean = false,
+        showAdvancedProtectionHint: Boolean = false,
+        isAdvancedProtectionBlocked: Boolean = false,
     ) = AutomationSetupModule.Result(
         isNotRequired = false,
         hasConsent = hasConsent,
@@ -26,6 +28,8 @@ class AutomationUiModelTest : BaseTest() {
         needsXiaomiAutostart = needsXiaomiAutostart,
         liftRestrictionsIntent = Intent(),
         showAppOpsRestrictionHint = showAppOpsRestrictionHint,
+        showAdvancedProtectionHint = showAdvancedProtectionHint,
+        isAdvancedProtectionBlocked = isAdvancedProtectionBlocked,
         settingsIntent = Intent(),
     )
 
@@ -113,12 +117,48 @@ class AutomationUiModelTest : BaseTest() {
     }
 
     @Test
+    fun `MIUI hint is suppressed while Advanced Protection blocks the service`() {
+        val ui = result(
+            hasConsent = true,
+            isServiceEnabled = false,
+            needsXiaomiAutostart = true,
+            isAdvancedProtectionBlocked = true,
+        ).toUiModel()
+        ui.showMiuiAutostartHint shouldBe false
+    }
+
+    @Test
+    fun `ACS heal is not attempted while Advanced Protection blocks the service`() {
+        // Guards against a SetupHealer refresh loop: heal would no-op yet report success.
+        result(
+            hasConsent = true,
+            isServiceEnabled = false,
+            isAdvancedProtectionBlocked = true,
+        ).isAcsHealAttemptViable shouldBe false
+
+        result(
+            hasConsent = true,
+            isServiceEnabled = false,
+            isAdvancedProtectionBlocked = false,
+        ).isAcsHealAttemptViable shouldBe true
+    }
+
+    @Test
     fun `appops restriction hint propagates directly`() {
         val ui = result(
             hasConsent = true,
             showAppOpsRestrictionHint = true,
         ).toUiModel()
         ui.showAppOpsRestrictionHint shouldBe true
+    }
+
+    @Test
+    fun `advanced protection hint propagates directly`() {
+        val ui = result(
+            hasConsent = true,
+            showAdvancedProtectionHint = true,
+        ).toUiModel()
+        ui.showAdvancedProtectionHint shouldBe true
     }
 
     @Test


### PR DESCRIPTION
## What changed

On Android 17, turning on Google's **Advanced Protection** stops SD Maid's accessibility service from being enabled — Android blocks the accessibility API for any app that isn't a dedicated accessibility tool, and SD Maid (a cleaner) doesn't qualify. Previously the setup screen gave no hint: the toggle simply wouldn't stick.

Now the accessibility setup card shows a clear message explaining that Advanced Protection is blocking the service, with a Help link for details and alternatives. Turning Advanced Protection off (or using root / Shizuku, which clean caches without the accessibility service) remains the way forward — the Help page covers this.

## Technical Context

- **Root cause is platform policy, not a bug.** Advanced Protection enforces `DISALLOW_NON_TOOL_ACCESSIBILITY_SERVICES` at the `AccessibilityManagerService` *bind* layer. Verified on a Pixel 8 / API 37 that even an ADB/Shizuku `WRITE_SECURE_SETTINGS` write (our self-enable path) does **not** bypass it — the service never binds. So this PR explains the situation rather than "fixing" it.
- **Detection:** `AdvancedProtectionManager.isAdvancedProtectionEnabled()` (present in the compileSdk-36 stub) behind `hasApiLevel(37)`, gated by the new `QUERY_ADVANCED_PROTECTION_MODE` permission (a normal permission, auto-granted at install — confirmed on-device). Wrapped in `runCatching` so an OEM `SecurityException` degrades to "not blocked".
- **Trigger / precedence:** hint shows on `Android 17+ && AAPM on && consent given && service not running`. It takes precedence over the existing sideload "restricted settings" hint, whose per-app remedy can't lift an Advanced Protection block. Root users never see it (their card is already "not required"); ADB/Shizuku users do, because selective per-app cleaning still falls back to the accessibility service.
- **Review guidance — the non-obvious bit:** folding the block into `canSelfEnable` (so the card stops reporting the service as on-demand-ready) would otherwise spin `SetupHealer` in a refresh loop, because `setSecureSettings(true)` is a no-op that still returns success once `WRITE_SECURE_SETTINGS` is granted while the card stays incomplete. Guarded via the testable `Result.isAcsHealAttemptViable`. The MIUI autostart hint is also suppressed while Advanced Protection is the real blocker.
- The Help link targets a new wiki page (`Setup#acs-advanced-protection`) that will carry the root/Shizuku guidance — a separate, release-blocking follow-up.

Closes #2475
