### PR TITLE
AppCleaner: Make deleted item count match the scanned count

### DIFF
--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
@@ -159,6 +159,7 @@ class AppCleaner @Inject constructor(
                             AppCleanerSchedulerTask.Success(
                                 affectedSpace = it.affectedSpace,
                                 affectedPaths = it.affectedPaths,
+                                affectedCount = it.affectedCount,
                             )
                         }
                     }
@@ -173,6 +174,7 @@ class AppCleaner @Inject constructor(
                             AppCleanerOneClickTask.Success(
                                 affectedSpace = it.affectedSpace,
                                 affectedPaths = it.affectedPaths,
+                                affectedCount = it.affectedCount,
                             )
                         }
                     }
@@ -377,9 +379,15 @@ class AppCleaner @Inject constructor(
             ?.map { inaccessible -> snapshot.junks.single { it.identifier == inaccessible }.inaccessibleCache!! }
             ?.sumOf { it.totalSize }
             ?: 0L
+        // Count items the same way the scan reported them ("X expendable items found"): the difference between
+        // the pre- and post-deletion scan totals. Deriving it from the snapshot avoids re-deriving the
+        // accessible/inaccessible/public-cache counting rules in a second hand-rolled counter, and it counts ACS
+        // cache clears at scan scale rather than as the <=2 synthetic paths that land in `affectedPaths`.
+        val affectedCount = (snapshot.totalCount - (internalData.value?.totalCount ?: 0)).coerceAtLeast(0)
         return AppCleanerProcessingTask.Success(
             affectedSpace = accessibleDeletionMap.values.sumOf { contents -> contents.sumOf { it.expectedGain } } + automationSize,
             affectedPaths = deleted,
+            affectedCount = affectedCount,
         )
     }
 

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerOneClickTask.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerOneClickTask.kt
@@ -20,6 +20,7 @@ data class AppCleanerOneClickTask(
     data class Success(
         override val affectedSpace: Long,
         override val affectedPaths: Set<APath>,
+        override val affectedCount: Int = affectedPaths.size,
     ) : Result, ReportDetails.AffectedSpace, ReportDetails.AffectedPaths {
 
         override val primaryInfo

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerProcessingTask.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerProcessingTask.kt
@@ -44,6 +44,10 @@ data class AppCleanerProcessingTask(
     data class Success(
         override val affectedSpace: Long,
         override val affectedPaths: Set<APath>,
+        // Explicit item count: `affectedPaths` only holds the paths we can enumerate. Caches cleared via the
+        // accessibility-service "Clear cache" tap contribute just their synthetic dir paths, so the path count
+        // would massively undershoot what the scan reported as "found". This carries the scan-scale count instead.
+        override val affectedCount: Int = affectedPaths.size,
     ) : Result, ReportDetails.AffectedSpace, ReportDetails.AffectedPaths {
 
         override val primaryInfo
@@ -62,7 +66,7 @@ data class AppCleanerProcessingTask(
             }
 
         override fun toString(): String {
-            return "AppCleanerProcessingTask.Success($affectedSpace,${affectedPaths.size} items)"
+            return "AppCleanerProcessingTask.Success($affectedSpace,$affectedCount items,${affectedPaths.size} paths)"
         }
     }
 }

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerSchedulerTask.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerSchedulerTask.kt
@@ -21,6 +21,7 @@ data class AppCleanerSchedulerTask(
     data class Success(
         override val affectedSpace: Long,
         override val affectedPaths: Set<APath>,
+        override val affectedCount: Int = affectedPaths.size,
     ) : Result, ReportDetails.AffectedSpace, ReportDetails.AffectedPaths {
 
         override val primaryInfo

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/AppCleanerTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/AppCleanerTest.kt
@@ -2,6 +2,7 @@ package eu.darken.sdmse.appcleaner.core
 
 import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilter
 import eu.darken.sdmse.appcleaner.core.scanner.AppScanner
+import eu.darken.sdmse.appcleaner.core.scanner.InaccessibleCache
 import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerProcessingTask
 import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerScanTask
 import eu.darken.sdmse.appcleaner.ui.preview.previewAppJunk
@@ -10,6 +11,7 @@ import eu.darken.sdmse.appcleaner.ui.preview.previewInstalled
 import eu.darken.sdmse.common.adb.AdbManager
 import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.files.GatewaySwitch
+import eu.darken.sdmse.common.files.local.LocalPath
 import eu.darken.sdmse.common.forensics.FileForensics
 import eu.darken.sdmse.common.pkgs.Pkg
 import eu.darken.sdmse.common.pkgs.features.InstallId
@@ -568,6 +570,117 @@ class AppCleanerTest : BaseTest() {
             upgradeRepo = mockUpgradeRepo(pro = true),
         )
         return Setup(cleaner, setup.scanner, setup.exclusionManager, inventorySetup)
+    }
+
+    // ─────────────────────────── affectedCount alignment ───────────────────────────
+    // These exercise the inaccessible/ACS deletion path, where the bug lived: a cache the scan
+    // counted as N items is cleared by a single "Clear cache" tap and lands in `affectedPaths` as
+    // only its <=2 synthetic dir paths. The displayed count must follow the scan scale, not the
+    // path-set size. The accessible per-file delete branch needs real filter factories (see NOTE
+    // below) and is left to a follow-up; it already counts per-file, matching the scan.
+
+    private fun inaccJunk(
+        pkgName: String,
+        itemCount: Int,
+        theoreticalPaths: Set<APath>,
+    ): AppJunk = previewAppJunk(
+        pkg = previewInstalled(pkgName = pkgName, label = pkgName),
+        expendables = null,
+        inaccessibleCache = InaccessibleCache(
+            identifier = installId(pkgName),
+            isSystemApp = false,
+            itemCount = itemCount,
+            totalSize = 24L * 1024 * 1024,
+            publicSize = null,
+            theoreticalPaths = theoreticalPaths,
+        ),
+    )
+
+    private fun acsDeleter(succesful: Set<InstallId>): InaccessibleDeleter =
+        mockk<InaccessibleDeleter>(relaxUnitFun = true).apply {
+            every { progress } returns MutableStateFlow<Progress.Data?>(null)
+            every { updateProgress(any()) } just Runs
+            coEvery {
+                deleteInaccessible(any(), any(), any(), any())
+            } returns InaccessibleDeleter.InaccDelResult(succesful = succesful, failed = emptyMap())
+        }
+
+    @Test
+    fun `ProcessingTask reports scan-scale count for ACS-cleared caches, not affectedPaths size`() = runTest2 {
+        val paths = setOf<APath>(LocalPath.build("p", "a"), LocalPath.build("p", "b"))
+        val junk = inaccJunk("com.example.acs", itemCount = 12, theoreticalPaths = paths)
+        val setup = setupCleaner(scanResults = listOf(junk))
+        val rebuilt = rebuildWithDeleter(setup, acsDeleter(succesful = setOf(installId("com.example.acs"))))
+
+        rebuilt.cleaner.submit(AppCleanerScanTask())
+        val result = rebuilt.cleaner.submit(AppCleanerProcessingTask(onlyInaccessible = true))
+
+        result.shouldBeInstanceOf<AppCleanerProcessingTask.Success>()
+        // The cache was scanned as 12 items; clearing it via ACS frees all 12.
+        result.affectedCount shouldBe 12
+        // …but only the 2 synthetic dir paths are individually recordable.
+        result.affectedPaths.size shouldBe 2
+    }
+
+    @Test
+    fun `ProcessingTask does not overcount when ACS clearing fails`() = runTest2 {
+        val junk = inaccJunk("com.example.fail", itemCount = 12, theoreticalPaths = emptySet())
+        val setup = setupCleaner(scanResults = listOf(junk))
+        // Empty `succesful` => the cache was not cleared, so nothing was removed from the scan.
+        val rebuilt = rebuildWithDeleter(setup, acsDeleter(succesful = emptySet()))
+
+        rebuilt.cleaner.submit(AppCleanerScanTask())
+        val result = rebuilt.cleaner.submit(AppCleanerProcessingTask(onlyInaccessible = true))
+
+        result.shouldBeInstanceOf<AppCleanerProcessingTask.Success>()
+        result.affectedCount shouldBe 0
+        result.affectedPaths shouldBe emptySet()
+    }
+
+    @Test
+    fun `ProcessingTask with includeInaccessible false leaves the cache uncounted`() = runTest2 {
+        val junk = inaccJunk("com.example.skip", itemCount = 12, theoreticalPaths = emptySet())
+        // includeInaccessible=false never invokes the deleter, so setupCleaner's erroring provider is fine.
+        val setup = setupCleaner(scanResults = listOf(junk))
+
+        setup.cleaner.submit(AppCleanerScanTask())
+        val result = setup.cleaner.submit(AppCleanerProcessingTask(includeInaccessible = false))
+
+        result.shouldBeInstanceOf<AppCleanerProcessingTask.Success>()
+        result.affectedCount shouldBe 0
+    }
+
+    @Test
+    fun `OneClickTask propagates the scan-scale affectedCount`() = runTest2 {
+        val paths = setOf<APath>(LocalPath.build("p", "a"), LocalPath.build("p", "b"))
+        val junk = inaccJunk("com.example.oneclick", itemCount = 12, theoreticalPaths = paths)
+        val setup = setupCleaner(scanResults = listOf(junk))
+        val rebuilt = rebuildWithDeleter(setup, acsDeleter(succesful = setOf(installId("com.example.oneclick"))))
+
+        val result = rebuilt.cleaner.submit(eu.darken.sdmse.appcleaner.core.tasks.AppCleanerOneClickTask())
+
+        result.shouldBeInstanceOf<eu.darken.sdmse.appcleaner.core.tasks.AppCleanerOneClickTask.Success>()
+        result.affectedCount shouldBe 12
+        result.affectedPaths.size shouldBe 2
+    }
+
+    @Test
+    fun `SchedulerTask propagates the scan-scale affectedCount`() = runTest2 {
+        val paths = setOf<APath>(LocalPath.build("p", "a"), LocalPath.build("p", "b"))
+        val junk = inaccJunk("com.example.scheduler", itemCount = 12, theoreticalPaths = paths)
+        val setup = setupCleaner(scanResults = listOf(junk))
+        val rebuilt = rebuildWithDeleter(setup, acsDeleter(succesful = setOf(installId("com.example.scheduler"))))
+
+        val result = rebuilt.cleaner.submit(
+            eu.darken.sdmse.appcleaner.core.tasks.AppCleanerSchedulerTask(
+                scheduleId = "test-schedule",
+                useAutomation = true,
+            ),
+        )
+
+        result.shouldBeInstanceOf<eu.darken.sdmse.appcleaner.core.tasks.AppCleanerSchedulerTask.Success>()
+        result.affectedCount shouldBe 12
+        result.affectedPaths.size shouldBe 2
     }
 
     // ─────────────────────────── delete-path coverage gap ───────────────────────────


### PR DESCRIPTION
## What changed

After cleaning with AppCleaner, the result could show far fewer "items deleted" than the scan reported as "found" — e.g. a scan finding **4876 items / 2.5 GB** would show **80 items deleted / 2.6 GB freed**. The freed space was correct and nothing was skipped, but the item counts looked wildly inconsistent and read like a bug.

The number now reflects the same thing the scan counted, so the "found" and "deleted" counts line up.

## Technical Context

- Root cause: the scan counts every expendable file individually (`sum of AppJunk.itemCount`), but the post-deletion result reported `affectedPaths.size`. On non-root devices, caches are cleared by the accessibility service tapping "Clear cache" per app — that whole-folder clear contributes only its ≤2 synthetic `theoreticalPaths` to `affectedPaths`, so hundreds of scanned files collapse to ~1–2 counted paths. Two incompatible counting scales, not data loss.
- Fix: derive `affectedCount` from the before/after scan totals (`snapshot.totalCount - internalData.totalCount`) instead of `affectedPaths.size`. This reuses the exact counting the scan already does, so it can't drift from the "found" rules, and it counts ACS cache clears at scan scale. Chosen over a hand-rolled per-item counter (which would have to re-derive the accessible/inaccessible/public-cache rules and risk double-counting).
- `affectedPaths` is left unchanged, so the stats path-record subsystem is unaffected. Side effect: the lifetime "items processed" stat stops undercounting ACS deletions, and the stats detail header now shows the true item count above the (inherently shorter) recordable-path list — accepted, since inaccessible cache files have no enumerable paths.
- Propagated `affectedCount` through the OneClick and Scheduler success wrappers so background/one-tap runs report consistently too.
- Review guidance: the count is a before/after snapshot diff taken under `toolLock`; `coerceAtLeast(0)` guards the (not-expected) negative case. Tests cover the ACS-cleared count, a failed clear (no overcount), `includeInaccessible=false`, and OneClick/Scheduler propagation.
