### PR TITLE
Swiper: Select individual files, not just whole folders

### DIFF
--- a/app-common-data/src/main/java/eu/darken/sdmse/common/picker/PickerRequest.kt
+++ b/app-common-data/src/main/java/eu/darken/sdmse/common/picker/PickerRequest.kt
@@ -23,5 +23,8 @@ data class PickerRequest(
     enum class PickMode {
         @SerialName("DIR") DIR,
         @SerialName("DIRS") DIRS,
+
+        /** Multi-select like [DIRS], but files are also listed and selectable (folders + files). */
+        @SerialName("FILES_AND_DIRS") FILES_AND_DIRS,
     }
 }

--- a/app-common-data/src/test/java/eu/darken/sdmse/common/picker/PickerRouteSerializationTest.kt
+++ b/app-common-data/src/test/java/eu/darken/sdmse/common/picker/PickerRouteSerializationTest.kt
@@ -45,4 +45,26 @@ class PickerRouteSerializationTest : BaseTest() {
         val deserialized = json.decodeFromString<PickerRoute>(serialized)
         deserialized shouldBe original
     }
+
+    @Test
+    fun `FILES_AND_DIRS mode serializes to its stable name`() {
+        val original = PickerRoute(
+            request = PickerRequest(
+                requestKey = "swiper_sessions_picker",
+                mode = PickerRequest.PickMode.FILES_AND_DIRS,
+            ),
+        )
+
+        val serialized = json.encodeToString(original)
+        serialized.toComparableKotlinxJson() shouldBe """
+            {
+                "request": {
+                    "requestKey": "swiper_sessions_picker",
+                    "mode": "FILES_AND_DIRS"
+                }
+            }
+        """.toComparableKotlinxJson()
+
+        json.decodeFromString<PickerRoute>(serialized) shouldBe original
+    }
 }

--- a/app-common-picker/src/main/java/eu/darken/sdmse/common/picker/PickerViewModel.kt
+++ b/app-common-picker/src/main/java/eu/darken/sdmse/common/picker/PickerViewModel.kt
@@ -14,6 +14,7 @@ import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.isAncestorOf
 import eu.darken.sdmse.common.files.isDescendantOf
 import eu.darken.sdmse.common.files.isDirectory
+import eu.darken.sdmse.common.files.isFile
 import eu.darken.sdmse.common.files.lookup
 import eu.darken.sdmse.common.files.lookupFiles
 import eu.darken.sdmse.common.flow.SingleEventFlow
@@ -241,6 +242,9 @@ class PickerViewModel @Inject constructor(
                     when (req.mode) {
                         PickerRequest.PickMode.DIR,
                         PickerRequest.PickMode.DIRS -> it.isDirectory
+                        // Files + folders. Restrict to plain files/dirs (not symlinks/unknown) so a
+                        // selected source is always something the consumer can walk or read directly.
+                        PickerRequest.PickMode.FILES_AND_DIRS -> it.isDirectory || it.isFile
                     }
                 }
                 .map { lookup ->
@@ -309,6 +313,9 @@ class PickerViewModel @Inject constructor(
 
     fun onRowClick(row: PickerRow) {
         log(TAG) { "onRowClick($row)" }
+        // A file can't be navigated into; the row routes file taps to toggle, but guard here too so
+        // a non-navigable item is never pushed onto the nav stack (lookupFiles on a file would fail).
+        if (!row.navigable) return
         val newNav = (navigationState.value ?: emptyList()) + row.item
         navigationState.value = newNav
         persistNav(newNav)
@@ -385,7 +392,8 @@ class PickerViewModel @Inject constructor(
                 if (alreadySelected) emptyList() else listOf(path)
             }
 
-            PickerRequest.PickMode.DIRS -> current.toMutableList().apply {
+            PickerRequest.PickMode.DIRS,
+            PickerRequest.PickMode.FILES_AND_DIRS -> current.toMutableList().apply {
                 paths.forEach { path ->
                     val removed = removeIf { it.lookedUp == path.lookedUp }
                     if (!removed) {
@@ -418,6 +426,9 @@ class PickerViewModel @Inject constructor(
 
     data class PickerRow(val item: PickerItem) {
         val id: String get() = item.lookup.lookedUp.path
+
+        /** Area roots and directories can be opened; files (the new mode) can only be selected. */
+        val navigable: Boolean get() = item.parent == null || item.lookup.isDirectory
     }
 
     data class SelectedRow(val lookup: APathLookup<*>) {

--- a/app-common-picker/src/main/java/eu/darken/sdmse/common/picker/items/PickerItemRow.kt
+++ b/app-common-picker/src/main/java/eu/darken/sdmse/common/picker/items/PickerItemRow.kt
@@ -51,7 +51,9 @@ fun PickerItemRow(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .clickable(onClick = onClick)
+            // Directories/area-roots open on a body tap; a file has nothing to open into, so its
+            // body tap toggles selection instead (only the checkbox would otherwise select it).
+            .clickable(onClick = { if (row.navigable) onClick() else onToggleSelect() })
             .padding(horizontal = 16.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/app-common-picker/src/test/java/eu/darken/sdmse/common/picker/PickerRowTest.kt
+++ b/app-common-picker/src/test/java/eu/darken/sdmse/common/picker/PickerRowTest.kt
@@ -1,0 +1,44 @@
+package eu.darken.sdmse.common.picker
+
+import eu.darken.sdmse.common.files.FileType
+import eu.darken.sdmse.common.picker.items.previewDataArea
+import eu.darken.sdmse.common.picker.items.previewLocalPathLookup
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class PickerRowTest : BaseTest() {
+
+    private val area = previewDataArea()
+
+    private fun item(fileType: FileType, isRoot: Boolean): PickerItem = PickerItem(
+        lookup = previewLocalPathLookup(fileType = fileType),
+        parent = if (isRoot) null else item(FileType.DIRECTORY, isRoot = true),
+        dataArea = area,
+        selected = false,
+        selectable = true,
+    )
+
+    private fun row(fileType: FileType, isRoot: Boolean): PickerViewModel.PickerRow =
+        PickerViewModel.PickerRow(item(fileType, isRoot))
+
+    @Test
+    fun `area roots are navigable`() {
+        row(FileType.DIRECTORY, isRoot = true).navigable shouldBe true
+    }
+
+    @Test
+    fun `directories are navigable`() {
+        row(FileType.DIRECTORY, isRoot = false).navigable shouldBe true
+    }
+
+    @Test
+    fun `files are not navigable - body tap selects instead of opening`() {
+        row(FileType.FILE, isRoot = false).navigable shouldBe false
+    }
+
+    @Test
+    fun `symlinks are not navigable`() {
+        row(FileType.SYMBOLIC_LINK, isRoot = false).navigable shouldBe false
+    }
+}

--- a/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/core/scanner/SwiperScanner.kt
+++ b/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/core/scanner/SwiperScanner.kt
@@ -2,6 +2,7 @@ package eu.darken.sdmse.swiper.core.scanner
 
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.*
+import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APath
@@ -25,12 +26,14 @@ import eu.darken.sdmse.swiper.core.SessionState
 import eu.darken.sdmse.swiper.core.SortOrder
 import eu.darken.sdmse.swiper.core.db.SwipeItemEntity
 import eu.darken.sdmse.swiper.core.db.SwipeSessionEntity
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.buffer
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flatMapMerge
@@ -80,16 +83,29 @@ class SwiperScanner @Inject constructor(
                     exclusions.none { it.match(toCheck) }
                 }
 
-                val lookup = gatewaySwitch.lookup(path)
-                if (lookup.fileType == FileType.FILE) {
-                    if (filter(lookup)) flowOf(lookup) else emptyFlow()
-                } else {
-                    path.walk(
-                        gatewaySwitch,
-                        options = APathGateway.WalkOptions(
-                            onFilter = filter,
-                        ),
-                    )
+                // A source path can vanish or become unreadable between picking and scanning (more
+                // likely now that sources can be many individually-picked files). Skip a bad source
+                // instead of failing the whole scan — guard both the eager lookup and the lazy walk.
+                try {
+                    val lookup = gatewaySwitch.lookup(path)
+                    if (lookup.fileType == FileType.FILE) {
+                        if (filter(lookup)) flowOf(lookup) else emptyFlow()
+                    } else {
+                        path.walk(
+                            gatewaySwitch,
+                            options = APathGateway.WalkOptions(
+                                onFilter = filter,
+                            ),
+                        ).catch { e ->
+                            if (e is CancellationException) throw e
+                            log(TAG, WARN) { "Source walk failed, skipping remainder: $path\n${e.asLog()}" }
+                        }
+                    }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    log(TAG, WARN) { "Source path no longer accessible, skipping: $path\n${e.asLog()}" }
+                    emptyFlow()
                 }
             }
             .flowOn(dispatcherProvider.IO)

--- a/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/sessions/SwiperSessionsViewModel.kt
+++ b/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/sessions/SwiperSessionsViewModel.kt
@@ -99,7 +99,9 @@ class SwiperSessionsViewModel @Inject constructor(
             PickerRoute(
                 request = PickerRequest(
                     requestKey = PICKER_REQUEST_KEY,
-                    mode = PickerRequest.PickMode.DIRS,
+                    // Files + folders: lets the user pick loose files and whole subfolders, e.g. select
+                    // a folder's contents then deselect a subfolder they don't want to sort.
+                    mode = PickerRequest.PickMode.FILES_AND_DIRS,
                     allowedAreas = setOf(
                         DataArea.Type.PORTABLE,
                         DataArea.Type.SDCARD,

--- a/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/sessions/items/SwiperSessionRow.kt
+++ b/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/sessions/items/SwiperSessionRow.kt
@@ -52,6 +52,8 @@ import eu.darken.sdmse.swiper.core.SessionState
 import eu.darken.sdmse.swiper.core.SortOrder
 import eu.darken.sdmse.swiper.core.Swiper
 
+private const val MAX_VISIBLE_PATHS = 5
+
 @Composable
 fun SwiperSessionRow(
     modifier: Modifier = Modifier,
@@ -136,12 +138,22 @@ fun SwiperSessionRow(
                 style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
-            session.sourcePaths.forEach { path ->
+            // A file selection can hold many individually-picked paths; cap the list so the card
+            // stays compact and summarize the remainder.
+            session.sourcePaths.take(MAX_VISIBLE_PATHS).forEach { path ->
                 Text(
                     text = path.userReadablePath.get(context),
                     style = MaterialTheme.typography.bodySmall,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
+                )
+            }
+            val hiddenPaths = session.sourcePaths.size - MAX_VISIBLE_PATHS
+            if (hiddenPaths > 0) {
+                Text(
+                    text = pluralStringResource(R.plurals.swiper_session_paths_more, hiddenPaths, hiddenPaths),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
 

--- a/app-tool-swiper/src/main/res/values/strings.xml
+++ b/app-tool-swiper/src/main/res/values/strings.xml
@@ -86,6 +86,10 @@
     <string name="swiper_session_rename_hint">Enter a name for this session</string>
     <string name="swiper_sessions_current_sessions">Current sessions</string>
     <string name="swiper_session_paths_label">Paths</string>
+    <plurals name="swiper_session_paths_more">
+        <item quantity="one">…and %d more</item>
+        <item quantity="other">…and %d more</item>
+    </plurals>
     <string name="swiper_session_status_label">Status</string>
     <plurals name="swiper_session_status_to_keep">
         <item quantity="one">%d to keep</item>

--- a/app-tool-swiper/src/test/java/eu/darken/sdmse/swiper/ui/sessions/SwiperSessionsViewModelTest.kt
+++ b/app-tool-swiper/src/test/java/eu/darken/sdmse/swiper/ui/sessions/SwiperSessionsViewModelTest.kt
@@ -5,8 +5,11 @@ import eu.darken.sdmse.common.areas.DataAreaManager
 import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.navigation.NavEvent
 import eu.darken.sdmse.common.navigation.NavigationController
+import eu.darken.sdmse.common.picker.PickerRequest
 import eu.darken.sdmse.common.picker.PickerResult
+import eu.darken.sdmse.common.picker.PickerRoute
 import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
 import eu.darken.sdmse.common.user.UserHandle2
@@ -20,11 +23,14 @@ import eu.darken.sdmse.swiper.core.SwipeSession
 import eu.darken.sdmse.swiper.core.Swiper
 import eu.darken.sdmse.swiper.core.tasks.SwiperScanTask
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
@@ -76,6 +82,18 @@ class SwiperSessionsViewModelTest : BaseTest() {
         val navCtrl: NavigationController,
         val pickerResults: MutableSharedFlow<PickerResult>,
     )
+
+    private class CollectedEvents<T>(val list: MutableList<T>, private val job: Job) {
+        fun cancel() = job.cancel()
+    }
+
+    private fun CoroutineScope.collectNavEvents(vm: SwiperSessionsViewModel): CollectedEvents<NavEvent> {
+        val list = mutableListOf<NavEvent>()
+        val job = launch(start = CoroutineStart.UNDISPATCHED) {
+            vm.navEvents.collect { list.add(it) }
+        }
+        return CollectedEvents(list, job)
+    }
 
     // Extension on TestScope so the harness can launch a state-keep-alive collector inside the test's
     // own scope. safeStateIn uses WhileSubscribed(5000), which means upstream collection only starts
@@ -216,6 +234,22 @@ class SwiperSessionsViewModelTest : BaseTest() {
         // call createSession with an empty set, which crashes (require(paths.isNotEmpty())).
         coVerify(exactly = 0) { h.swiper.createSession(any()) }
         h.vm.state.first().selectedPaths shouldBe emptySet<APath>()
+    }
+
+    @Test
+    fun `openPicker navigates to a files-and-dirs PickerRoute`() = runTest2 {
+        val h = harness()
+        val nav = collectNavEvents(h.vm)
+
+        h.vm.openPicker()
+        advanceUntilIdle()
+
+        val event = nav.list.single().shouldBeInstanceOf<NavEvent.GoTo>()
+        val route = event.destination.shouldBeInstanceOf<PickerRoute>()
+        // Files must be selectable so users can pick loose files and deselect unwanted subfolders.
+        route.request.mode shouldBe PickerRequest.PickMode.FILES_AND_DIRS
+        route.request.requestKey shouldBe SwiperSessionsViewModel.PICKER_REQUEST_KEY
+        nav.cancel()
     }
 
     @Test

--- a/app-tool-swiper/src/test/java/eu/darken/sdmse/swiper/ui/status/DeletionPreviewTest.kt
+++ b/app-tool-swiper/src/test/java/eu/darken/sdmse/swiper/ui/status/DeletionPreviewTest.kt
@@ -97,6 +97,18 @@ class DeletionPreviewTest : BaseTest() {
     }
 
     @Test
+    fun `a file picked as a source path is omitted from buckets - no crash`() {
+        // With FILES_AND_DIRS the user can pick individual files; such a source equals the item path,
+        // so it's never a strict ancestor and is simply omitted from the bucket preview (header count
+        // still covers it). Guards against a crash/odd bucket for direct file sources.
+        val fileSource = LocalPath.build("root", "loose.txt")
+        val items = listOf(item(1, fileSource, 10, SwipeDecision.DELETE))
+        val preview = DeletionPreview.from(items, listOf(fileSource))
+        preview.buckets shouldBe emptyList()
+        preview.moreFolders shouldBe 0
+    }
+
+    @Test
     fun `items outside any source are omitted`() {
         val source = LocalPath.build("root")
         val items = listOf(


### PR DESCRIPTION
## What changed

When you set up a Swiper session, the folder picker now shows **individual files**, not just folders. So you can open a folder, tap **Select all**, and then uncheck any subfolder you don't want to sort. The loose files in that folder plus the subfolders you keep get swiped; the ones you unchecked are skipped entirely.

This came from a support request: when sorting a folder like Downloads, files from subfolders the user didn't want to sort kept showing up in the deck, with no way to leave them out. Now they can pick exactly what goes in.

## Technical Context

- **New opt-in `PickMode.FILES_AND_DIRS`** in the shared picker. The picker previously listed directories only; the new mode lists `isDirectory || isFile` (symlinks/unknown deliberately stay out, so every selected source is something the consumer can walk or read directly). Selection reuses the existing `DIRS` multi-select with ancestor/descendant de-duplication.
- **Only Swiper opts in.** The exclusion editor (`DIR`), Squeezer and Deduplicator (`DIRS`) keep folders-only behavior — no change for them.
- **No data-model change.** The Swiper scanner already accepts mixed file+folder source paths (emits files directly, walks folders). Swiper sessions are one-shot snapshots, so the selection needs nothing persisted beyond the chosen paths — which is why this is a picker-only change with no DB migration.
- **File rows aren't navigable.** A file has nothing to open into, so its body tap toggles selection instead (`PickerRow.navigable`, also guarded in `onRowClick` so a file can never be pushed onto the nav stack).
- **Scanner hardening:** a source that vanishes or becomes unreadable between picking and scanning is now skipped + logged — both the eager lookup and the lazy walk — instead of failing the whole scan. This matters more now that a selection can be many individual files.

### Review guidance
- The behavioral hot-spots are the two `when(mode)` branches in `PickerViewModel` (listing filter + `select()`) and the scanner `try/catch`.
- Verified end-to-end on a device: open a folder → Select all (files + folders) → deselect one subfolder → scan yields exactly the kept files, with the excluded subfolder's contents absent.
