### PR TITLE
Swiper: Fix action buttons hidden behind the navigation bar

### DIFF
--- a/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/swipe/items/SwiperActionBar.kt
+++ b/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/swipe/items/SwiperActionBar.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -50,6 +51,9 @@ internal fun SwiperActionBar(
     Row(
         modifier = modifier
             .fillMaxWidth()
+            // Scaffold's bottomBar slot is NOT auto-padded for the nav bar inset; with
+            // edge-to-edge enabled the bar would otherwise draw under the system nav bar.
+            .navigationBarsPadding()
             .padding(horizontal = 32.dp)
             .padding(top = 8.dp, bottom = 24.dp),
         verticalAlignment = Alignment.Top,


### PR DESCRIPTION
## What changed

On the Swiper swipe screen, the Delete / Skip / Keep buttons were partly hidden behind the system navigation bar on devices with a 3-button nav bar (for example the Pixel 2), so their labels were hard to read. They now sit fully above the navigation bar.

## Technical Context

- **Root cause:** the action bar lives in `Scaffold`'s `bottomBar` slot, which Material3 does *not* auto-pad for the navigation-bar inset — a bottom bar is expected to apply it itself (like M3's own `BottomAppBar`). With edge-to-edge enabled the window extends behind the nav bar, and the bar's only clearance was a hardcoded `bottom = 24.dp`, too little for a ~48dp 3-button nav bar.
- **Fix:** add `navigationBarsPadding()` to the action row so it reserves the inset before its own design padding — the same pattern already used by `RecorderActionBar`.
- **Scope:** only the Swiper swipe screen was affected. The two other `bottomBar`s (dashboard dock, debug recorder) already read the inset, and every other tool screen consumes the scaffold's content padding.
- **Verification:** confirmed on a physical Pixel 2 (Android 9, 3-button nav) — the Delete/Skip/Keep labels now clear the navigation bar.
