### PR TITLE
General: Action buttons hide on scroll and stop covering the last item

### DIFF
--- a/app-common-exclusion/src/main/java/eu/darken/sdmse/exclusion/ui/list/ExclusionListScreen.kt
+++ b/app-common-exclusion/src/main/java/eu/darken/sdmse/exclusion/ui/list/ExclusionListScreen.kt
@@ -6,11 +6,13 @@ import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.Add
 import androidx.compose.material.icons.twotone.Check
@@ -51,6 +53,8 @@ import eu.darken.sdmse.common.R as CommonR
 import eu.darken.sdmse.common.compose.SdmModalBottomSheet
 import eu.darken.sdmse.common.compose.layout.SdmDeleteAction
 import eu.darken.sdmse.common.compose.layout.SdmEmptyState
+import eu.darken.sdmse.common.compose.layout.ScrollAwareFab
+import eu.darken.sdmse.common.compose.layout.SdmListDefaults
 import eu.darken.sdmse.common.compose.layout.SdmLoadingState
 import eu.darken.sdmse.common.compose.layout.SdmSelectAllAction
 import eu.darken.sdmse.common.compose.layout.SdmSelectionTopAppBar
@@ -200,6 +204,7 @@ internal fun ExclusionListScreen(
     // Prune stale IDs when the underlying list changes.
     LaunchedEffect(currentIds) { selection.retainAll(currentIds) }
     val selectionActive = selection.isActive
+    val listState = rememberLazyListState()
 
     var overflowExpanded by remember { mutableStateOf(false) }
     var infoOpen by rememberSaveable { mutableStateOf(false) }
@@ -292,8 +297,10 @@ internal fun ExclusionListScreen(
         },
         floatingActionButton = {
             if (!selectionActive) {
-                FloatingActionButton(onClick = onAddExclusion) {
-                    Icon(Icons.TwoTone.Add, contentDescription = stringResource(R.string.exclusion_create_action))
+                ScrollAwareFab(scrollState = listState, scrollHideEnabled = !rows.isNullOrEmpty()) {
+                    FloatingActionButton(onClick = onAddExclusion) {
+                        Icon(Icons.TwoTone.Add, contentDescription = stringResource(R.string.exclusion_create_action))
+                    }
                 }
             }
         },
@@ -310,7 +317,11 @@ internal fun ExclusionListScreen(
                     modifier = Modifier.fillMaxSize(),
                 )
 
-                else -> LazyColumn(modifier = Modifier.fillMaxSize()) {
+                else -> LazyColumn(
+                    state = listState,
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(bottom = SdmListDefaults.FabClearance),
+                ) {
                     items(rows, key = { it.stableId }) { row ->
                         val isSelected = selection.isSelected(row.stableId)
                         val onRowTap = {

--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/layout/ScrollAwareFab.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/layout/ScrollAwareFab.kt
@@ -1,0 +1,74 @@
+package eu.darken.sdmse.common.compose.layout
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.foundation.gestures.ScrollableState
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.Add
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import eu.darken.sdmse.common.compose.preview.Preview2
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+
+/**
+ * Wraps a floating action button so it hides while scrolling down a list and reappears when
+ * scrolling up or at the top.
+ *
+ * Material 3's [androidx.compose.material3.Scaffold] floats the FAB over the content and does NOT
+ * reserve space for it, so the host list must also add [SdmListDefaults.FabClearance] to its bottom
+ * content padding — otherwise the FAB covers the last item.
+ *
+ * The scroll signal uses [ScrollableState.lastScrolledBackward] / [ScrollableState.canScrollBackward]
+ * so a single helper covers both [androidx.compose.foundation.lazy.LazyListState] and
+ * [androidx.compose.foundation.lazy.grid.LazyGridState].
+ *
+ * @param visible An animated visibility gate ANDed with the scroll signal. Use it for gates that
+ *   should themselves animate (e.g. a scan-in-progress state). Hard gates that must remove the FAB
+ *   instantly and unconditionally (e.g. selection mode) belong OUTSIDE this composable as a plain
+ *   `if`, so the FAB can't be tapped while animating out.
+ * @param scrollHideEnabled When the host swaps its scrollable container out (empty / loading state),
+ *   the remembered scroll state keeps reporting its last "scrolled down" value, which would wrongly
+ *   keep the FAB hidden. Pass `false` in those branches (e.g. `rows.isNotEmpty()`) to force the FAB
+ *   visible regardless of the stale scroll signal.
+ */
+@Composable
+fun ScrollAwareFab(
+    modifier: Modifier = Modifier,
+    scrollState: ScrollableState,
+    visible: Boolean = true,
+    scrollHideEnabled: Boolean = true,
+    fab: @Composable () -> Unit,
+) {
+    val scrollVisible by remember(scrollState) {
+        derivedStateOf { !scrollState.canScrollBackward || scrollState.lastScrolledBackward }
+    }
+    AnimatedVisibility(
+        visible = visible && (!scrollHideEnabled || scrollVisible),
+        modifier = modifier,
+        enter = scaleIn() + fadeIn(),
+        exit = scaleOut() + fadeOut(),
+    ) {
+        fab()
+    }
+}
+
+@Preview2
+@Composable
+private fun ScrollAwareFabPreview() {
+    PreviewWrapper {
+        ScrollAwareFab(scrollState = rememberLazyListState()) {
+            FloatingActionButton(onClick = {}) {
+                Icon(Icons.TwoTone.Add, contentDescription = null)
+            }
+        }
+    }
+}

--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/layout/SdmListDefaults.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/layout/SdmListDefaults.kt
@@ -1,6 +1,10 @@
 package eu.darken.sdmse.common.compose.layout
 
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
@@ -11,4 +15,23 @@ object SdmListDefaults {
     val EmptyStatePadding: Dp = 32.dp
     val ToolGridMinWidth: Dp = 410.dp
     val DetailGridMinWidth: Dp = 390.dp
+
+    /**
+     * Extra bottom space a scrollable list needs so a floating action button doesn't cover its
+     * last item ([androidx.compose.material3.Scaffold] floats the FAB over content without
+     * reserving room). FAB height (56dp) + scaffold FAB margin (16dp) + breathing room (16dp).
+     */
+    val FabClearance: Dp = 88.dp
+}
+
+/** Returns a copy of these [PaddingValues] with [extra] added to the bottom. */
+@Composable
+fun PaddingValues.plusBottom(extra: Dp): PaddingValues {
+    val layoutDirection = LocalLayoutDirection.current
+    return PaddingValues(
+        start = calculateStartPadding(layoutDirection),
+        top = calculateTopPadding(),
+        end = calculateEndPadding(layoutDirection),
+        bottom = calculateBottomPadding() + extra,
+    )
 }

--- a/app-common-ui/src/test/java/eu/darken/sdmse/common/compose/layout/ScrollAwareFabTest.kt
+++ b/app-common-ui/src/test/java/eu/darken/sdmse/common/compose/layout/ScrollAwareFabTest.kt
@@ -1,0 +1,113 @@
+package eu.darken.sdmse.common.compose.layout
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performScrollToIndex
+import androidx.compose.ui.unit.dp
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+
+class ScrollAwareFabTest : BaseComposeRobolectricTest() {
+
+    @Composable
+    private fun TestContent(
+        listState: LazyListState,
+        itemCount: Int = 30,
+        visible: Boolean = true,
+        scrollHideEnabled: Boolean = true,
+    ) {
+        PreviewWrapper {
+            Box(modifier = Modifier.fillMaxSize()) {
+                LazyColumn(
+                    state = listState,
+                    modifier = Modifier
+                        .testTag("list")
+                        .fillMaxSize(),
+                ) {
+                    items((0 until itemCount).toList()) { i ->
+                        Text(text = "Item $i", modifier = Modifier.height(80.dp))
+                    }
+                }
+                ScrollAwareFab(
+                    scrollState = listState,
+                    visible = visible,
+                    scrollHideEnabled = scrollHideEnabled,
+                ) {
+                    Box(modifier = Modifier.testTag("fab").size(56.dp))
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `visible at the top of the list`() {
+        val listState = LazyListState()
+        composeRule.setContent { TestContent(listState) }
+
+        composeRule.onNodeWithTag("fab").assertExists()
+    }
+
+    @Test
+    fun `hides after scrolling down and reappears after scrolling up`() {
+        val listState = LazyListState()
+        composeRule.setContent { TestContent(listState) }
+
+        composeRule.onNodeWithTag("list").performScrollToIndex(25)
+        composeRule.waitForIdle()
+        composeRule.onNodeWithTag("fab").assertDoesNotExist()
+
+        composeRule.onNodeWithTag("list").performScrollToIndex(0)
+        composeRule.waitForIdle()
+        composeRule.onNodeWithTag("fab").assertExists()
+    }
+
+    @Test
+    fun `visible=false hides the fab regardless of scroll`() {
+        val listState = LazyListState()
+        composeRule.setContent { TestContent(listState, visible = false) }
+
+        composeRule.onNodeWithTag("fab").assertDoesNotExist()
+    }
+
+    @Test
+    fun `scrollHideEnabled=false keeps the fab visible while scrolled down`() {
+        val listState = LazyListState()
+        composeRule.setContent { TestContent(listState, scrollHideEnabled = false) }
+
+        composeRule.onNodeWithTag("list").performScrollToIndex(25)
+        composeRule.waitForIdle()
+        composeRule.onNodeWithTag("fab").assertExists()
+    }
+
+    @Test
+    fun `fab reappears when the list empties after being scrolled down`() {
+        // Regression for the detached-list path: a scrolled-down list keeps reporting a stale
+        // "scrolled down" signal after its content is swapped out. Hosts gate that off via
+        // scrollHideEnabled (e.g. rows.isNotEmpty()), so the FAB must come back.
+        val listState = LazyListState()
+        val count = mutableStateOf(30)
+        composeRule.setContent {
+            TestContent(listState, itemCount = count.value, scrollHideEnabled = count.value > 0)
+        }
+
+        composeRule.onNodeWithTag("list").performScrollToIndex(25)
+        composeRule.waitForIdle()
+        composeRule.onNodeWithTag("fab").assertDoesNotExist()
+
+        composeRule.runOnIdle { count.value = 0 }
+        composeRule.waitForIdle()
+        composeRule.onNodeWithTag("fab").assertExists()
+    }
+}

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/device/DeviceStorageScreen.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/device/DeviceStorageScreen.kt
@@ -1,8 +1,5 @@
 package eu.darken.sdmse.analyzer.ui.storage.device
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -11,6 +8,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.itemsIndexed
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.ArrowBack
 import androidx.compose.material.icons.twotone.Refresh
@@ -35,7 +33,10 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import eu.darken.sdmse.analyzer.R
 import eu.darken.sdmse.analyzer.ui.storage.device.tour.AnalyzerStorageTour
 import eu.darken.sdmse.common.R as CommonR
+import eu.darken.sdmse.common.compose.layout.ScrollAwareFab
+import eu.darken.sdmse.common.compose.layout.SdmListDefaults
 import eu.darken.sdmse.common.compose.layout.SdmTooltipIconButton
+import eu.darken.sdmse.common.compose.layout.plusBottom
 import eu.darken.sdmse.common.compose.preview.Preview2
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import eu.darken.sdmse.common.compose.progress.ProgressOverlay
@@ -73,6 +74,7 @@ internal fun DeviceStorageScreen(
 ) {
     val state by stateSource.collectAsStateWithLifecycle(initialValue = DeviceStorageViewModel.State())
     val context = LocalContext.current
+    val gridState = rememberLazyGridState()
 
     val tourController = LocalGuidedTourController.current
     val tourDef = remember { AnalyzerStorageTour.definition() }
@@ -111,11 +113,7 @@ internal fun DeviceStorageScreen(
             )
         },
         floatingActionButton = {
-            AnimatedVisibility(
-                visible = state.progress == null,
-                enter = fadeIn(),
-                exit = fadeOut(),
-            ) {
+            ScrollAwareFab(scrollState = gridState, visible = state.progress == null) {
                 FloatingActionButton(onClick = onRefresh) {
                     Icon(
                         Icons.TwoTone.Refresh,
@@ -133,8 +131,10 @@ internal fun DeviceStorageScreen(
         ) {
             LazyVerticalGrid(
                 columns = GridCells.Fixed(context.getSpanCount(widthDp = 360)),
+                state = gridState,
                 modifier = Modifier.fillMaxSize(),
-                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
+                    .plusBottom(SdmListDefaults.FabClearance),
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/storage/StorageContentScreen.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/storage/StorageContentScreen.kt
@@ -1,9 +1,6 @@
 package eu.darken.sdmse.analyzer.ui.storage.storage
 
 import androidx.activity.compose.BackHandler
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -12,6 +9,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.ArrowBack
 import androidx.compose.material.icons.twotone.Refresh
@@ -35,7 +33,10 @@ import eu.darken.sdmse.analyzer.ui.StorageContentRoute
 import eu.darken.sdmse.analyzer.ui.storage.storage.categories.AppCategoryCard
 import eu.darken.sdmse.analyzer.ui.storage.storage.categories.MediaCategoryCard
 import eu.darken.sdmse.analyzer.ui.storage.storage.categories.SystemCategoryCard
+import eu.darken.sdmse.common.compose.layout.ScrollAwareFab
+import eu.darken.sdmse.common.compose.layout.SdmListDefaults
 import eu.darken.sdmse.common.compose.layout.SdmTooltipIconButton
+import eu.darken.sdmse.common.compose.layout.plusBottom
 import eu.darken.sdmse.common.compose.preview.Preview2
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import eu.darken.sdmse.common.compose.progress.ProgressOverlay
@@ -74,6 +75,7 @@ internal fun StorageContentScreen(
 ) {
     val state by stateSource.collectAsStateWithLifecycle(initialValue = StorageContentViewModel.State.Loading)
     val context = LocalContext.current
+    val gridState = rememberLazyGridState()
 
     BackHandler(enabled = true) { onNavigateBack() }
 
@@ -143,11 +145,7 @@ internal fun StorageContentScreen(
                     )
                 },
                 floatingActionButton = {
-                    AnimatedVisibility(
-                        visible = s.progress == null,
-                        enter = fadeIn(),
-                        exit = fadeOut(),
-                    ) {
+                    ScrollAwareFab(scrollState = gridState, visible = s.progress == null) {
                         FloatingActionButton(onClick = onRefresh) {
                             Icon(
                                 Icons.TwoTone.Refresh,
@@ -165,8 +163,10 @@ internal fun StorageContentScreen(
                 ) {
                     LazyVerticalGrid(
                         columns = GridCells.Fixed(context.getSpanCount()),
+                        state = gridState,
                         modifier = Modifier.fillMaxSize(),
-                        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
+                            .plusBottom(SdmListDefaults.FabClearance),
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
                         verticalArrangement = Arrangement.spacedBy(8.dp),
                     ) {

--- a/app-tool-scheduler/src/main/java/eu/darken/sdmse/scheduler/ui/manager/SchedulerManagerScreen.kt
+++ b/app-tool-scheduler/src/main/java/eu/darken/sdmse/scheduler/ui/manager/SchedulerManagerScreen.kt
@@ -1,12 +1,13 @@
 package eu.darken.sdmse.scheduler.ui.manager
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.ArrowBack
 import androidx.compose.material.icons.automirrored.twotone.HelpOutline
@@ -32,6 +33,8 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import eu.darken.sdmse.common.R as CommonR
+import eu.darken.sdmse.common.compose.layout.ScrollAwareFab
+import eu.darken.sdmse.common.compose.layout.SdmListDefaults
 import eu.darken.sdmse.common.compose.layout.SdmTooltipIconButton
 import eu.darken.sdmse.common.compose.preview.Preview2
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
@@ -137,6 +140,7 @@ internal fun SchedulerManagerScreen(
     onDismissBattery: () -> Unit = {},
 ) {
     val state by stateSource.collectAsStateWithLifecycle(initialValue = SchedulerManagerViewModel.State())
+    val listState = rememberLazyListState()
 
     val tourController = LocalGuidedTourController.current
     val tourDef = remember { SchedulerManagerTour.definition() }
@@ -180,14 +184,16 @@ internal fun SchedulerManagerScreen(
             )
         },
         floatingActionButton = {
-            FloatingActionButton(
-                onClick = onCreateNew,
-                modifier = Modifier.guidedTourTarget(SchedulerManagerTour.ADD_TARGET),
-            ) {
-                Icon(
-                    Icons.TwoTone.Add,
-                    contentDescription = stringResource(R.string.scheduler_new_schedule_action),
-                )
+            ScrollAwareFab(scrollState = listState) {
+                FloatingActionButton(
+                    onClick = onCreateNew,
+                    modifier = Modifier.guidedTourTarget(SchedulerManagerTour.ADD_TARGET),
+                ) {
+                    Icon(
+                        Icons.TwoTone.Add,
+                        contentDescription = stringResource(R.string.scheduler_new_schedule_action),
+                    )
+                }
             }
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },
@@ -200,7 +206,8 @@ internal fun SchedulerManagerScreen(
         ) {
             ScheduleListContent(
                 state = state,
-                contentPadding = PaddingValues(vertical = 8.dp),
+                listState = listState,
+                contentPadding = PaddingValues(top = 8.dp, bottom = 8.dp + SdmListDefaults.FabClearance),
                 onEditSchedule = onEditSchedule,
                 onToggleSchedule = onToggleSchedule,
                 onRemoveSchedule = onRemoveSchedule,
@@ -218,6 +225,7 @@ internal fun SchedulerManagerScreen(
 @Composable
 private fun ScheduleListContent(
     state: SchedulerManagerViewModel.State,
+    listState: LazyListState,
     contentPadding: PaddingValues,
     onEditSchedule: (ScheduleId) -> Unit,
     onToggleSchedule: (ScheduleId) -> Unit,
@@ -230,6 +238,7 @@ private fun ScheduleListContent(
     onDismissBattery: () -> Unit,
 ) {
     LazyColumn(
+        state = listState,
         modifier = Modifier.fillMaxSize(),
         contentPadding = contentPadding,
         verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -263,9 +272,6 @@ private fun ScheduleListContent(
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
                 )
             }
-        }
-        item("spacer") {
-            Box(modifier = Modifier.padding(40.dp))
         }
     }
 }

--- a/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/ui/list/SqueezerListScreen.kt
+++ b/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/ui/list/SqueezerListScreen.kt
@@ -11,11 +11,15 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.gestures.ScrollableState
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.ListAlt
 import androidx.compose.material.icons.twotone.Compress
@@ -48,7 +52,9 @@ import eu.darken.sdmse.common.compose.dialog.SdmDialogAction
 import eu.darken.sdmse.common.compose.dialog.SdmDialogButtonBar
 import eu.darken.sdmse.common.compose.layout.SdmEmptyState
 import eu.darken.sdmse.common.compose.layout.SdmExcludeAction
+import eu.darken.sdmse.common.compose.layout.ScrollAwareFab
 import eu.darken.sdmse.common.compose.layout.SdmListDefaults
+import eu.darken.sdmse.common.compose.layout.plusBottom
 import eu.darken.sdmse.common.compose.layout.SdmSelectAllAction
 import eu.darken.sdmse.common.compose.layout.SdmSelectionTopAppBar
 import eu.darken.sdmse.common.compose.layout.SdmTooltipIconButton
@@ -187,6 +193,11 @@ internal fun SqueezerListScreen(
 
     BackHandler(enabled = selection.isActive) { selection.clear() }
 
+    val listState = rememberLazyListState()
+    val gridState = rememberLazyGridState()
+    val activeScroll: ScrollableState =
+        if (state.layoutMode == LayoutMode.GRID) gridState else listState
+
     // remember keyed on the stable inputs so these O(n) passes don't re-run on unrelated
     // recompositions (media ref is stable across progress ticks now that progress is decoupled).
     val totalSavings = remember(media) { media.sumOf { it.estimatedSavings ?: 0L } }
@@ -233,20 +244,22 @@ internal fun SqueezerListScreen(
         },
         floatingActionButton = {
             if (state.progress == null && media.isNotEmpty() && !selection.isActive) {
-                ExtendedFloatingActionButton(
-                    onClick = onCompressAll,
-                    modifier = Modifier.guidedTourTarget(SqueezerListTour.COMPRESS_ALL_TARGET),
-                    icon = {
-                        Icon(
-                            imageVector = Icons.TwoTone.Compress,
-                            contentDescription = null,
-                        )
-                    },
-                    text = { Text(stringResource(R.string.squeezer_compress_all_action)) },
-                    containerColor = MaterialTheme.colorScheme.errorContainer,
-                    contentColor = MaterialTheme.colorScheme.onErrorContainer,
-                    elevation = FloatingActionButtonDefaults.elevation(),
-                )
+                ScrollAwareFab(scrollState = activeScroll) {
+                    ExtendedFloatingActionButton(
+                        onClick = onCompressAll,
+                        modifier = Modifier.guidedTourTarget(SqueezerListTour.COMPRESS_ALL_TARGET),
+                        icon = {
+                            Icon(
+                                imageVector = Icons.TwoTone.Compress,
+                                contentDescription = null,
+                            )
+                        },
+                        text = { Text(stringResource(R.string.squeezer_compress_all_action)) },
+                        containerColor = MaterialTheme.colorScheme.errorContainer,
+                        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                        elevation = FloatingActionButtonDefaults.elevation(),
+                    )
+                }
             }
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },
@@ -265,7 +278,11 @@ internal fun SqueezerListScreen(
 
                     media.isEmpty() -> SdmEmptyState()
 
-                    state.layoutMode == LayoutMode.LINEAR -> LazyColumn(modifier = Modifier.fillMaxSize()) {
+                    state.layoutMode == LayoutMode.LINEAR -> LazyColumn(
+                        state = listState,
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = PaddingValues(bottom = SdmListDefaults.FabClearance),
+                    ) {
                         items(media, key = { it.identifier.value }) { item ->
                             SqueezerListLinearRow(
                                 media = item,
@@ -289,8 +306,9 @@ internal fun SqueezerListScreen(
 
                     state.layoutMode == LayoutMode.GRID -> LazyVerticalGrid(
                         columns = GridCells.Adaptive(144.dp),
+                        state = gridState,
                         modifier = Modifier.fillMaxSize(),
-                        contentPadding = SdmListDefaults.GridTileContentPadding,
+                        contentPadding = SdmListDefaults.GridTileContentPadding.plusBottom(SdmListDefaults.FabClearance),
                     ) {
                         items(media, key = { it.identifier.value }) { item ->
                             SqueezerListGridCard(

--- a/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/sessions/SwiperSessionsScreen.kt
+++ b/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/sessions/SwiperSessionsScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.ArrowBack
@@ -21,6 +22,8 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
+import eu.darken.sdmse.common.compose.layout.ScrollAwareFab
+import eu.darken.sdmse.common.compose.layout.SdmListDefaults
 import eu.darken.sdmse.common.compose.layout.SdmScaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -101,6 +104,7 @@ internal fun SwiperSessionsScreen(
 ) {
     val state by stateSource.collectAsStateWithLifecycle()
     val context = LocalContext.current
+    val listState = rememberLazyListState()
 
     var pendingRename by remember { mutableStateOf<PendingRename?>(null) }
     var pendingFilter by remember { mutableStateOf<PendingFilter?>(null) }
@@ -135,20 +139,23 @@ internal fun SwiperSessionsScreen(
         floatingActionButton = {
             // Free-tier users at the session limit have canCreateNewSession=false; the FAB collapses
             // to icon-only AND must not trigger the picker (legacy disabled the FAB outright).
-            ExtendedFloatingActionButton(
-                onClick = { if (state.canCreateNewSession) onOpenPicker() },
-                icon = { Icon(Icons.TwoTone.Add, contentDescription = null) },
-                text = { Text(stringResource(R.string.swiper_select_folders_action)) },
-                expanded = state.canCreateNewSession,
-                modifier = Modifier.alpha(if (state.canCreateNewSession) 1f else 0.38f),
-            )
+            ScrollAwareFab(scrollState = listState) {
+                ExtendedFloatingActionButton(
+                    onClick = { if (state.canCreateNewSession) onOpenPicker() },
+                    icon = { Icon(Icons.TwoTone.Add, contentDescription = null) },
+                    text = { Text(stringResource(R.string.swiper_select_folders_action)) },
+                    expanded = state.canCreateNewSession,
+                    modifier = Modifier.alpha(if (state.canCreateNewSession) 1f else 0.38f),
+                )
+            }
         },
     ) { paddingValues ->
         LazyColumn(
+            state = listState,
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues),
-            contentPadding = PaddingValues(vertical = 8.dp),
+            contentPadding = PaddingValues(top = 8.dp, bottom = 8.dp + SdmListDefaults.FabClearance),
         ) {
             if (state.sessionsWithStats.isEmpty()) {
                 item(key = "header") { SwiperSessionsHeaderCard() }

--- a/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/swipe/items/SwiperActionBar.kt
+++ b/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/swipe/items/SwiperActionBar.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -50,6 +51,9 @@ internal fun SwiperActionBar(
     Row(
         modifier = modifier
             .fillMaxWidth()
+            // Scaffold's bottomBar slot is NOT auto-padded for the nav bar inset; with
+            // edge-to-edge enabled the bar would otherwise draw under the system nav bar.
+            .navigationBarsPadding()
             .padding(horizontal = 32.dp)
             .padding(top = 8.dp, bottom = 24.dp),
         verticalAlignment = Alignment.Top,

--- a/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/list/CustomFilterListScreen.kt
+++ b/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/list/CustomFilterListScreen.kt
@@ -9,10 +9,12 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.ArrowBack
 import androidx.compose.material.icons.twotone.Add
@@ -48,6 +50,8 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import eu.darken.sdmse.common.R as CommonR
+import eu.darken.sdmse.common.compose.layout.ScrollAwareFab
+import eu.darken.sdmse.common.compose.layout.SdmListDefaults
 import eu.darken.sdmse.common.compose.layout.SdmTooltipIconButton
 import eu.darken.sdmse.common.compose.preview.Preview2
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
@@ -171,6 +175,7 @@ internal fun CustomFilterListScreen(
 ) {
     val state by stateSource.collectAsStateWithLifecycle()
     val selection = rememberSelectionState<String>()
+    val listState = rememberLazyListState()
 
     BackHandler(enabled = selection.isActive) { selection.clear() }
 
@@ -255,11 +260,13 @@ internal fun CustomFilterListScreen(
         },
         floatingActionButton = {
             if (!selection.isActive && state.isPro != null) {
-                ExtendedFloatingActionButton(
-                    onClick = onCreate,
-                    icon = { Icon(Icons.TwoTone.Add, contentDescription = null) },
-                    text = { Text(stringResource(R.string.systemcleaner_customfilter_label)) },
-                )
+                ScrollAwareFab(scrollState = listState, scrollHideEnabled = state.rows.isNotEmpty()) {
+                    ExtendedFloatingActionButton(
+                        onClick = onCreate,
+                        icon = { Icon(Icons.TwoTone.Add, contentDescription = null) },
+                        text = { Text(stringResource(R.string.systemcleaner_customfilter_label)) },
+                    )
+                }
             }
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },
@@ -279,7 +286,11 @@ internal fun CustomFilterListScreen(
 
                 else -> {
                     val selectionActive = selection.isActive
-                    LazyColumn(modifier = Modifier.fillMaxSize()) {
+                    LazyColumn(
+                        state = listState,
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = PaddingValues(bottom = SdmListDefaults.FabClearance),
+                    ) {
                         items(state.rows, key = { it.id }) { row ->
                             val isSelected = selection.isSelected(row.id)
                             CustomFilterRow(

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardScreen.kt
@@ -234,7 +234,11 @@ internal fun DashboardScreen(
             isBottomBarVisible = true
             return@LaunchedEffect
         }
-        var previousPos = 0
+        // Seed from the restored scroll position: returning from a pushed screen recreates this
+        // composable (grid offset restored via its Saver) and restarts this effect. With
+        // previousPos=0, the first emission of a restored non-zero offset reads as one large
+        // downward scroll and wrongly hides the dock. Seeding makes that first delta ~0.
+        var previousPos = gridState.firstVisibleItemIndex * 10_000 + gridState.firstVisibleItemScrollOffset
         snapshotFlow { gridState.firstVisibleItemIndex * 10_000 + gridState.firstVisibleItemScrollOffset }
             .collect { currentPos ->
                 when {


### PR DESCRIPTION
## What changed

On screens with a long list and a floating action button — Swiper sessions, Media Squeeze, SystemCleaner custom filters, Exclusions, Scheduler and the Storage Analyzer — the button used to sit permanently on top of the list and cover the last item, and you couldn't scroll far enough to get it out of the way.

Now:
- The floating button slides and fades out of the way as you scroll down a list, and comes back when you scroll up or reach the top.
- Lists reserve enough room at the bottom so the last item is never hidden behind the button.

This branch also pads the Swiper "swipe" action bar above the system navigation bar so it no longer draws underneath it.

## Technical Context

- **Root cause:** Material 3's `Scaffold` floats the FAB over the body and does not include the FAB's height in the `contentPadding` it hands the content, so lists never reserved space for it and nothing hid the FAB on scroll.
- New shared **`ScrollAwareFab`** (`app-common-ui`) wraps a FAB in `AnimatedVisibility` driven by `ScrollableState.lastScrolledBackward` / `canScrollBackward` — a single scroll signal that works for both `LazyColumn` and `LazyVerticalGrid`. `scrollHideEnabled` keeps the FAB visible when a host swaps its list out (empty/loading) and the remembered scroll state goes stale; hard gates such as selection mode stay as outer `if`s so a FAB can't be tapped while it animates out.
- New `SdmListDefaults.FabClearance` (88dp) + a `PaddingValues.plusBottom()` extension are applied as bottom content padding on every affected list/grid. The Scheduler's brittle hardcoded 40dp spacer item is removed.
- The Storage Analyzer grids fold their existing scan-progress visibility gate into the helper's `visible` param (their FAB animation shifts from fade to scale+fade as a result).
- Covered by a `ScrollAwareFab` Robolectric test (visible at top, hides on scroll down, returns on scroll up, respects the `visible` and `scrollHideEnabled` gates, plus the detached-list regression). Manually verified on-device: hide-on-scroll, reappear-on-scroll-up, last-card clearance, and the existing free-tier icon-only collapse all work.
- The swipe-action-bar navigation-bar padding is an independent edge-to-edge fix that rides along in this branch.

---

### Also in this PR: dashboard bottom bar stays put when returning from a sub-screen

**What:** Scroll the dashboard down, open a tool (e.g. Swiper), then press back — the bottom action dock used to animate away as if you'd scrolled down, even though you hadn't.

**Why:** The dock auto-hides based on scroll *direction*. Returning from a pushed screen recreates the dashboard and restarts the scroll listener with its baseline reset to `0`, while the grid's scroll offset is restored from its `Saver`. The first emission of that restored non-zero offset was read as one large downward scroll. Fix: seed the baseline from the restored scroll position so the first delta is ~0.
