### PR TITLE
General: Handle symlinks consistently in root/ADB file scans

### DIFF
--- a/app-common-io/src/main/aidl/eu/darken/sdmse/common/files/local/ipc/FileOpsConnection.aidl
+++ b/app-common-io/src/main/aidl/eu/darken/sdmse/common/files/local/ipc/FileOpsConnection.aidl
@@ -32,7 +32,7 @@ interface FileOpsConnection {
     List<LocalPathLookupExtended> lookupFilesExtended(in LocalPath path);
     RemoteInputStream lookupFilesExtendedStream(in LocalPath path);
 
-    RemoteInputStream walkStream(in LocalPath path, in List<String> pathDoesNotContain);
+    RemoteInputStream walkStream(in LocalPath path, in List<String> pathDoesNotContain, boolean followSymlinks);
 
     long du(in LocalPath path);
 

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathGateway.kt
@@ -34,8 +34,12 @@ interface APathGateway<
         val onError: (suspend (PLU, Exception) -> Boolean)? = null,
         val followSymlinks: Boolean = false,
     ) {
+        // followSymlinks is intentionally NOT part of this check: symlink following is valid in
+        // every mode. In ROOT/ADB it runs host-side via DirectLocalWalker (privileged process); in
+        // AUTO, EscalatingWalker escalates symlinks it can't resolve app-side. Only onFilter/onError
+        // force the app-side IndirectLocalWalker, since suspend callbacks can't cross the IPC boundary.
         val isDirect: Boolean
-            get() = onFilter == null && onError == null && !followSymlinks
+            get() = onFilter == null && onError == null
     }
 
     suspend fun du(

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/DirectLocalWalker.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/DirectLocalWalker.kt
@@ -32,7 +32,13 @@ class DirectLocalWalker(
         }
 
         val queue = LinkedList(mutableListOf(startLookUp))
-        val visitedCanonical = if (followSymlinks) HashSet<String>() else null
+        // Seed with the start dir's canonical path so a child symlink pointing back to start
+        // doesn't re-walk the root subtree once before its descendants get deduped.
+        val visitedCanonical = if (followSymlinks) {
+            HashSet<String>().apply { runCatching { add(start.asFile().canonicalPath) } }
+        } else {
+            null
+        }
 
         while (!queue.isEmpty()) {
             val lookUp = queue.removeFirst()

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/EscalatingWalker.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/EscalatingWalker.kt
@@ -34,7 +34,13 @@ class EscalatingWalker(
         }
 
         val followSymlinks = options.followSymlinks
-        val visitedCanonical = if (followSymlinks) HashSet<String>() else null
+        // Seed with the start dir's canonical path so a child symlink pointing back to start
+        // doesn't re-walk the root subtree once before its descendants get deduped.
+        val visitedCanonical = if (followSymlinks) {
+            HashSet<String>().apply { runCatching { add(start.asFile().canonicalPath) } }
+        } else {
+            null
+        }
 
         val escalationMode = when {
             gateway.hasRoot() -> LocalGateway.Mode.ROOT
@@ -63,10 +69,24 @@ class EscalatingWalker(
                                 allowed
                             }
                             .forEach { child ->
-                                val shouldDescend = child.isDirectory ||
-                                    (followSymlinks && child.isSymlink && child.lookedUp.asFile().isDirectory)
+                                // For a symlink we can't classify app-side (target can't be stat'd,
+                                // likely privileged), escalate the symlink itself: listing a symlink
+                                // path follows it host-side, so the escalated walk resolves+follows it
+                                // instead of silently under-following. A symlink whose target IS
+                                // app-readable is handled inline (descend if dir, skip if file).
+                                val escalateSymlink = followSymlinks &&
+                                    child.isSymlink &&
+                                    escalationMode != null &&
+                                    !runCatching { child.lookedUp.asFile().exists() }.getOrDefault(false)
 
-                                if (shouldDescend) {
+                                val shouldDescend = child.isDirectory ||
+                                    (followSymlinks && child.isSymlink && !escalateSymlink &&
+                                        runCatching { child.lookedUp.asFile().isDirectory }.getOrDefault(false))
+
+                                if (escalateSymlink) {
+                                    log(tag, VERBOSE) { "Escalating symlink to $escalationMode to follow it: $child" }
+                                    queue.addFirst(QueuedItem(child, escalationMode))
+                                } else if (shouldDescend) {
                                     if (visitedCanonical != null) {
                                         val canonical = try {
                                             child.lookedUp.asFile().canonicalPath

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/IndirectLocalWalker.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/IndirectLocalWalker.kt
@@ -6,10 +6,8 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
-import eu.darken.sdmse.common.files.asFile
 import eu.darken.sdmse.common.files.isDirectory
 import eu.darken.sdmse.common.files.isFile
-import eu.darken.sdmse.common.files.isSymlink
 import kotlinx.coroutines.flow.AbstractFlow
 import kotlinx.coroutines.flow.FlowCollector
 import java.util.LinkedList
@@ -25,6 +23,16 @@ class IndirectLocalWalker(
     private val tag = "$TAG#${hashCode()}"
 
     override suspend fun collectSafely(collector: FlowCollector<LocalPathLookup>) {
+        // followSymlinks is not supported here: resolving a symlink's target type and canonical path
+        // requires stat-ing paths the app process can't reach in ROOT/ADB mode, and the resolution
+        // can't be delegated to the privileged host because this walker only exists to run the
+        // app-side onFilter/onError callbacks (which can't cross the IPC boundary). Callback-free
+        // follow-walks go host-side via DirectLocalWalker (see WalkOptions.isDirect). Here we only
+        // descend real directories — no symlink following, so no traversal cycles are possible.
+        if (followSymlinks) {
+            log(TAG, WARN) { "followSymlinks is not supported for indirect ($mode) walks, nested symlinks won't be followed: $start" }
+        }
+
         val startLookUp = gateway.lookup(start, mode)
 
         if (startLookUp.isFile) {
@@ -33,7 +41,6 @@ class IndirectLocalWalker(
         }
 
         val queue = LinkedList(listOf(startLookUp))
-        val visitedCanonical = if (followSymlinks) HashSet<String>() else null
 
         while (!queue.isEmpty()) {
             val lookUp = queue.removeFirst()
@@ -58,26 +65,9 @@ class IndirectLocalWalker(
                     allowed
                 }
                 .forEach { child ->
-                    val shouldDescend = child.isDirectory ||
-                        (followSymlinks && child.isSymlink && child.lookedUp.asFile().isDirectory)
-
-                    if (shouldDescend) {
-                        if (visitedCanonical != null) {
-                            val canonical = try {
-                                child.lookedUp.asFile().canonicalPath
-                            } catch (e: Exception) {
-                                null
-                            }
-                            if (canonical != null && !visitedCanonical.add(canonical)) {
-                                log(tag, WARN) { "Already visited, skipping: $child -> $canonical" }
-                            } else {
-                                if (Bugs.isTrace) log(tag, VERBOSE) { "Walking: $child" }
-                                queue.addFirst(child)
-                            }
-                        } else {
-                            if (Bugs.isTrace) log(tag, VERBOSE) { "Walking: $child" }
-                            queue.addFirst(child)
-                        }
+                    if (child.isDirectory) {
+                        if (Bugs.isTrace) log(tag, VERBOSE) { "Walking: $child" }
+                        queue.addFirst(child)
                     }
                     collector.emit(child)
                 }

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/FileOpsClient.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/FileOpsClient.kt
@@ -80,6 +80,7 @@ class FileOpsClient @AssistedInject constructor(
             fileOpsConnection.walkStream(
                 path,
                 (options.pathDoesNotContain ?: emptyList()).toMutableList(),
+                options.followSymlinks,
             )
         } catch (e: Exception) {
             throw e.refineException()

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/FileOpsHost.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/FileOpsHost.kt
@@ -104,14 +104,19 @@ class FileOpsHost @Inject constructor(
         throw e.wrapToPropagate()
     }
 
-    override fun walkStream(path: LocalPath, pathDoesNotContain: List<String>): RemoteInputStream = try {
-        if (Bugs.isTrace) log(TAG, VERBOSE) { "walkStream($path)..." }
+    override fun walkStream(
+        path: LocalPath,
+        pathDoesNotContain: List<String>,
+        followSymlinks: Boolean,
+    ): RemoteInputStream = try {
+        if (Bugs.isTrace) log(TAG, VERBOSE) { "walkStream($path, followSymlinks=$followSymlinks)..." }
         runBlocking {
             DirectLocalWalker(
                 start = path,
                 onFilter = { lookup ->
                     pathDoesNotContain.none { lookup.path.contains(it) }
                 },
+                followSymlinks = followSymlinks,
             ).toRemoteInputStream(appScope + dispatcherProvider.IO)
         }
     } catch (e: Exception) {

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/DirectLocalWalkerTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/DirectLocalWalkerTest.kt
@@ -129,6 +129,55 @@ class DirectLocalWalkerTest : BaseTest() {
     }
 
     @Test
+    fun `followSymlinks true descends into a target outside the walked tree`() = runTest {
+        // The symlink target lives OUTSIDE the walked root, so its content is reachable ONLY by
+        // following the symlink — proving the symlink path was actually descended.
+        val walkRoot = File(testDir, "walkRoot").apply { mkdirs() }
+        val outside = File(testDir, "outside").apply { mkdirs() }
+        File(outside, "secret.txt").writeText("data")
+        Files.createSymbolicLink(
+            File(walkRoot, "link").toPath(),
+            outside.toPath(),
+        )
+
+        val walker = DirectLocalWalker(
+            start = LocalPath.build(walkRoot),
+            followSymlinks = true,
+        )
+        val names = walker.toList().names()
+
+        names shouldContain "link"
+        names shouldContain "secret.txt"
+        // 'outside' is a sibling of the walked root and must not be walked directly.
+        names shouldNotContain "outside"
+    }
+
+    @Test
+    fun `followSymlinks true with symlink back to start does not duplicate the root subtree`() = runTest {
+        File(testDir, "sub").mkdirs()
+        File(testDir, "sub/file.txt").writeText("data")
+        // A symlink resolving back to the start directory.
+        Files.createSymbolicLink(
+            File(testDir, "sub/backlink").toPath(),
+            testDir.toPath(),
+        )
+
+        val walker = DirectLocalWalker(
+            start = LocalPath.build(testDir),
+            followSymlinks = true,
+        )
+        val items = walker.toList()
+
+        val names = items.names()
+        names shouldContain "sub"
+        names shouldContain "file.txt"
+        names shouldContain "backlink"
+        // Start dir is seeded into the visited set, so 'backlink' resolves to an already-visited
+        // canonical path and is not descended — 'sub' is emitted exactly once, not duplicated below it.
+        items.count { it.lookedUp.asFile().name == "sub" } shouldBe 1
+    }
+
+    @Test
     fun `deeply nested directories are fully walked`() = runTest {
         var dir = testDir
         for (i in 1..10) {

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/EscalatingWalkerTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/EscalatingWalkerTest.kt
@@ -1,0 +1,111 @@
+package eu.darken.sdmse.common.files.local
+
+import eu.darken.sdmse.common.files.APathGateway
+import eu.darken.sdmse.common.files.FileType
+import io.kotest.matchers.collections.shouldContain
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.io.File
+import java.nio.file.Files
+import java.time.Instant
+
+class EscalatingWalkerTest : BaseTest() {
+
+    private val testDir = File(IO_TEST_BASEDIR, "escalating-walker-test").absoluteFile
+    private val gateway = mockk<LocalGateway>()
+
+    @BeforeEach
+    fun setup() {
+        testDir.deleteRecursively()
+        testDir.mkdirs()
+    }
+
+    private val externalTarget = File(IO_TEST_BASEDIR, "escalating-walker-target.txt").absoluteFile
+
+    @AfterEach
+    fun cleanup() {
+        unmockkAll()
+        testDir.deleteRecursively()
+        externalTarget.delete()
+    }
+
+    private fun lookup(path: LocalPath, fileType: FileType) = LocalPathLookup(
+        lookedUp = path,
+        fileType = fileType,
+        size = 4096L,
+        modifiedAt = Instant.EPOCH,
+        target = null,
+    )
+
+    @Test
+    fun `followSymlinks escalates a symlink whose target the app cannot resolve`() = runTest {
+        val start = LocalPath.build(testDir)
+        // Broken/privileged symlink: its target can't be stat'd by the app process, mirroring a
+        // /system symlink whose target requires root.
+        val symlinkFile = File(testDir, "privlink")
+        Files.createSymbolicLink(symlinkFile.toPath(), File("/nonexistent/privileged/target").toPath())
+        val symlinkPath = LocalPath.build(symlinkFile)
+        val escalatedChild = lookup(LocalPath.build(File(symlinkFile, "found.txt")), FileType.FILE)
+
+        // Os.readlink (symlink classification) is unavailable on the JVM, so stub the child lookup
+        // as a SYMBOLIC_LINK; exists() still runs against the real (unresolvable) symlink on disk.
+        mockkStatic("eu.darken.sdmse.common.files.local.LocalPathExtensionsKt")
+        every { any<LocalPath>().performLookup() } returns lookup(symlinkPath, FileType.SYMBOLIC_LINK)
+
+        coEvery { gateway.lookup(start) } returns lookup(start, FileType.DIRECTORY)
+        coEvery { gateway.hasRoot() } returns true
+        coEvery { gateway.hasAdb() } returns false
+        coEvery {
+            gateway.walk(symlinkPath, any(), LocalGateway.Mode.ROOT)
+        } returns flowOf(escalatedChild)
+
+        val items = EscalatingWalker(
+            gateway = gateway,
+            start = start,
+            options = APathGateway.WalkOptions(followSymlinks = true),
+        ).toList()
+
+        val names = items.map { it.lookedUp.name }.toSet()
+        names shouldContain "privlink"       // the symlink node itself
+        names shouldContain "found.txt"      // resolved host-side via the escalated walk
+        coVerify(exactly = 1) { gateway.walk(symlinkPath, any(), LocalGateway.Mode.ROOT) }
+    }
+
+    @Test
+    fun `followSymlinks does not escalate a symlink whose target the app can resolve`() = runTest {
+        val start = LocalPath.build(testDir)
+        val realFile = externalTarget.apply { writeText("data") }
+        val symlinkFile = File(testDir, "filelink")
+        Files.createSymbolicLink(symlinkFile.toPath(), realFile.toPath())
+        val symlinkPath = LocalPath.build(symlinkFile)
+
+        mockkStatic("eu.darken.sdmse.common.files.local.LocalPathExtensionsKt")
+        every { any<LocalPath>().performLookup() } returns lookup(symlinkPath, FileType.SYMBOLIC_LINK)
+
+        coEvery { gateway.lookup(start) } returns lookup(start, FileType.DIRECTORY)
+        coEvery { gateway.hasRoot() } returns true
+        coEvery { gateway.hasAdb() } returns false
+
+        val items = EscalatingWalker(
+            gateway = gateway,
+            start = start,
+            options = APathGateway.WalkOptions(followSymlinks = true),
+        ).toList()
+
+        val names = items.map { it.lookedUp.name }.toSet()
+        names shouldContain "filelink"
+        // Target (real.txt) is app-readable, so the symlink resolves app-side → no escalation needed.
+        coVerify(exactly = 0) { gateway.walk(any(), any(), LocalGateway.Mode.ROOT) }
+    }
+}

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/IndirectLocalWalkerTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/IndirectLocalWalkerTest.kt
@@ -1,0 +1,73 @@
+package eu.darken.sdmse.common.files.local
+
+import eu.darken.sdmse.common.files.FileType
+import io.kotest.matchers.collections.shouldContainAll
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.time.Instant
+
+class IndirectLocalWalkerTest : BaseTest() {
+
+    private val gateway = mockk<LocalGateway>()
+
+    private fun lookup(
+        path: String,
+        fileType: FileType,
+        target: LocalPath? = null,
+    ) = LocalPathLookup(
+        lookedUp = LocalPath.build(path),
+        fileType = fileType,
+        size = 4096L,
+        modifiedAt = Instant.EPOCH,
+        target = target,
+    )
+
+    private fun List<LocalPathLookup>.names(): Set<String> = map { it.lookedUp.name }.toSet()
+
+    @Test
+    fun `descends into real directories`() = runTest {
+        val mode = LocalGateway.Mode.ROOT
+        val start = LocalPath.build("root")
+        coEvery { gateway.lookup(start, mode) } returns lookup("root", FileType.DIRECTORY)
+        coEvery { gateway.lookupFiles(LocalPath.build("root"), mode) } returns listOf(
+            lookup("root/sub", FileType.DIRECTORY),
+            lookup("root/file.txt", FileType.FILE),
+        )
+        coEvery { gateway.lookupFiles(LocalPath.build("root/sub"), mode) } returns listOf(
+            lookup("root/sub/nested.txt", FileType.FILE),
+        )
+
+        val items = IndirectLocalWalker(gateway = gateway, mode = mode, start = start).toList()
+
+        items.names() shouldContainAll setOf("sub", "file.txt", "nested.txt")
+    }
+
+    @Test
+    fun `followSymlinks does not descend into symlinked directories in indirect mode`() = runTest {
+        // In ROOT/ADB the app process can't stat the symlink target, so this walker intentionally
+        // never follows symlinks (callback-free follow-walks go host-side instead). The symlink is
+        // still emitted, but must NOT be descended into.
+        val mode = LocalGateway.Mode.ROOT
+        val start = LocalPath.build("root")
+        coEvery { gateway.lookup(start, mode) } returns lookup("root", FileType.DIRECTORY)
+        coEvery { gateway.lookupFiles(LocalPath.build("root"), mode) } returns listOf(
+            lookup("root/link", FileType.SYMBOLIC_LINK, target = LocalPath.build("elsewhere")),
+        )
+
+        val items = IndirectLocalWalker(
+            gateway = gateway,
+            mode = mode,
+            start = start,
+            followSymlinks = true,
+        ).toList()
+
+        items.names() shouldContainAll setOf("link")
+        // The symlink target must never be listed through the gateway (no descent).
+        coVerify(exactly = 0) { gateway.lookupFiles(LocalPath.build("root/link"), mode) }
+    }
+}

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/SystemStorageScanner.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/SystemStorageScanner.kt
@@ -64,7 +64,12 @@ class SystemStorageScanner @Inject constructor(
             try {
                 val lookup = gatewaySwitch.lookup(path, type = GatewaySwitch.Type.AUTO)
                 if (lookup.fileType == FileType.DIRECTORY) {
-                    path.walkContentItem(gatewaySwitch, maxItems = WALK_MAX_ITEMS, followSymlinks = true)
+                    // Don't follow symlinks: /system contains cross-partition directory symlinks
+                    // (e.g. /system/vendor -> /vendor, /system/product -> /product) whose targets are
+                    // already walked as separate SYSTEM_PARTITIONS. Following them would walk those
+                    // trees twice as duplicate nodes. Storage is counted once at the target's real
+                    // location; anything only reachable via symlink is absorbed by the addRemainder bucket.
+                    path.walkContentItem(gatewaySwitch, maxItems = WALK_MAX_ITEMS, followSymlinks = false)
                 } else {
                     log(TAG) { "walkSystemPartitions(): /$partition is not a directory (${lookup.fileType}), skipping" }
                     null
@@ -87,7 +92,8 @@ class SystemStorageScanner @Inject constructor(
 
             val walkedChildren = filteredChildren.map { child ->
                 try {
-                    child.walkContentItem(gatewaySwitch, maxItems = WALK_MAX_ITEMS, followSymlinks = true)
+                    // followSymlinks = false: count bytes once at their real location (see walkSystemPartitions).
+                    child.walkContentItem(gatewaySwitch, maxItems = WALK_MAX_ITEMS, followSymlinks = false)
                 } catch (e: ReadException) {
                     log(TAG, WARN) { "walkData(): Failed to walk /data/${child.name}: ${e.asLog()}" }
                     ContentItem.fromInaccessible(child)

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/storage/SystemStorageScannerTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/storage/SystemStorageScannerTest.kt
@@ -3,15 +3,28 @@ package eu.darken.sdmse.analyzer.core.storage
 import eu.darken.sdmse.analyzer.core.content.ContentGroup
 import eu.darken.sdmse.analyzer.core.content.ContentItem
 import eu.darken.sdmse.common.areas.DataArea
+import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.files.APathGateway
+import eu.darken.sdmse.common.files.APathLookup
 import eu.darken.sdmse.common.files.FileType
+import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.files.local.LocalPathLookup
+import eu.darken.sdmse.common.storage.StorageId
 import eu.darken.sdmse.common.user.UserHandle2
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
+import java.time.Instant
+import java.util.UUID
 
 class SystemStorageScannerTest : BaseTest() {
 
@@ -193,5 +206,41 @@ class SystemStorageScannerTest : BaseTest() {
 
         val group = ContentGroup(label = null, contents = items)
         group.groupSize shouldBe override
+    }
+
+    // --- followSymlinks regression ---
+
+    @Test
+    fun `scan never follows symlinks`() = runTest {
+        // Regression guard: following /system's cross-partition directory symlinks (vendor/product/
+        // system_ext) would double-walk content already covered by separate partitions. Every walk
+        // the scanner issues must request followSymlinks = false.
+        val capturedOptions = mutableListOf<APathGateway.WalkOptions<APath, APathLookup<APath>>>()
+
+        val gatewaySwitch = mockk<GatewaySwitch> {
+            coEvery { lookup(any(), type = any()) } answers {
+                val path = firstArg<APath>()
+                mockk<LocalPathLookup> {
+                    coEvery { lookedUp } returns (path as LocalPath)
+                    coEvery { fileType } returns FileType.DIRECTORY
+                    coEvery { size } returns 4096L
+                    coEvery { modifiedAt } returns Instant.EPOCH
+                    coEvery { target } returns null
+                } as APathLookup<APath>
+            }
+            coEvery { listFiles(any()) } returns listOf(LocalPath.build("data", "some_app"))
+            coEvery { walk(any(), capture(capturedOptions)) } returns emptyFlow()
+        }
+
+        SystemStorageScanner(gatewaySwitch).scan(
+            storageId = StorageId(internalId = null, externalId = UUID.randomUUID()),
+            existingGroupId = ContentGroup.Id(),
+            spaceUsedOverride = null,
+            dataAreas = emptySet(),
+        )
+
+        // 5 system partitions + at least one /data child.
+        capturedOptions.size shouldBeGreaterThanOrEqual 6
+        capturedOptions.all { !it.followSymlinks } shouldBe true
     }
 }


### PR DESCRIPTION
## What changed

On rooted / ADB (Shizuku) devices, the file scanners now handle symbolic links consistently no matter how a folder is accessed. Previously, link-following only worked for folders the app could read directly and quietly did nothing once a scan had to fall back to root/ADB.

A side effect of this also cleans up the storage **Analyzer**: the System view no longer risks showing the same content twice. On modern devices `/system` contains links to other partitions it already lists separately (`/system/vendor` → `/vendor`, `/system/product` → `/product`, `/system/system_ext` → `/system_ext`), so following those links would have listed those folders a second time. Storage is now counted once, at its real location.

## Technical Context

Reported by our sibling project **butler**.

- **Root cause**: the local walkers decided symlink descent and loop-breaking via direct `java.io.File` calls (`asFile().isDirectory` / `canonicalPath`) executed in the app process. In ROOT/ADB mode those paths aren't app-accessible, so `followSymlinks` was silently inert — directory *listing* honored the IPC gateway, but symlink *resolution* did not.
- `followSymlinks` is now threaded through the `walkStream` IPC (AIDL + `FileOpsHost` + `FileOpsClient`), and `WalkOptions.isDirect` no longer excludes follow-walks — so callback-free follow-walks run host-side in `DirectLocalWalker`, where the direct `File` calls are valid under root.
- `IndirectLocalWalker` (the callback path that *can't* cross the IPC boundary) no longer makes app-process symlink stat calls. It descends only real directories — which means no traversal cycles are possible, so its canonical cycle-tracking was removed — and logs that nested symlinks aren't followed there.
- `EscalatingWalker` (AUTO mode, partially-readable trees) now escalates a symlink it can't stat app-side to ROOT/ADB instead of silently under-following it; listing a symlink path follows it host-side.
- `visitedCanonical` is seeded with the start directory so a symlink resolving back to the start can't duplicate the root subtree once.
- The Analyzer's `SystemStorageScanner` passes `followSymlinks = false` for both the system-partition and `/data` walks (note: a symlink node reports null size and doesn't propagate its children's sizes, so this never affected totals — only the breakdown granularity / duplicate nodes).

**Review guidance**: the symlink-following capability is correct in every mode now, but after the Analyzer flips to `followSymlinks = false` there is no production caller that sets it `true` — the host-side path is currently exercised only by the new tests. Symlink *classification* depends on Android's `Os.readlink`, which is unavailable in plain JVM tests, so `EscalatingWalkerTest` stubs `performLookup` to classify the child as a symlink while `exists()` runs against a real on-disk link.
