### PR TITLE
General: Fix the beta badge wrapping below the dashboard title

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/TitleDashboardCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/TitleDashboardCard.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import eu.darken.sdmse.R
@@ -156,6 +157,8 @@ internal fun TitleDashboardCard(item: TitleDashboardCardItem) {
                     Text(
                         text = sloganText,
                         style = MaterialTheme.typography.bodySmall,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
                         modifier = if (slogan == CommonR.string.slogan_message_8) {
                             Modifier.pointerInput(item.webpageTool) {
                                 detectTapGestures(
@@ -200,8 +203,26 @@ private fun TitleHeaderLayout(
     ) { measurables, constraints ->
         val looseConstraints = constraints.copy(minWidth = 0, minHeight = 0)
         val mascotPlaceable = measurables[0].measure(looseConstraints)
-        val titlePlaceable = measurables[1].measure(looseConstraints)
         val ribbonPlaceable = measurables.getOrNull(2)?.measure(looseConstraints)
+
+        val inlineSpacing = 12.dp.roundToPx()
+        val stackSpacing = 8.dp.roundToPx()
+
+        // When a badge is present, cap the title width so the card-centered title leaves room
+        // for the inline badge. A long randomized slogan then ellipsizes instead of pushing the
+        // badge onto a second row. Reserve against the badge width only (not the wider mascot),
+        // keeping the slot wide enough that most slogans still fit on one line.
+        val titleConstraints = if (constraints.hasBoundedWidth && ribbonPlaceable != null) {
+            val minTitleWidth = 96.dp.roundToPx()
+            val reserved = 2 * (inlineSpacing + ribbonPlaceable.width)
+            val maxTitleWidth = (constraints.maxWidth - reserved)
+                .coerceAtLeast(minTitleWidth)
+                .coerceAtMost(constraints.maxWidth)
+            looseConstraints.copy(maxWidth = maxTitleWidth)
+        } else {
+            looseConstraints
+        }
+        val titlePlaceable = measurables[1].measure(titleConstraints)
 
         val width = if (constraints.hasBoundedWidth) {
             constraints.maxWidth
@@ -212,8 +233,6 @@ private fun TitleHeaderLayout(
                 ribbonPlaceable?.width,
             ).maxOrNull() ?: 0
         }
-        val inlineSpacing = 12.dp.roundToPx()
-        val stackSpacing = 8.dp.roundToPx()
 
         val titleX = ((width - titlePlaceable.width) / 2).coerceAtLeast(0)
         val titleRight = titleX + titlePlaceable.width


### PR DESCRIPTION
## What changed

On the dashboard, beta/dev builds show a small version badge next to the app title. When the randomly-picked slogan under the title happened to be long, that badge got bumped down onto its own row below the title. Now the badge always stays on the title row, and an overly long slogan is shortened with an ellipsis instead.

This is only visible in beta/dev builds — release builds don't show the badge and are unaffected.

## Technical Context

- The title card uses a custom `Layout` that card-centers the title column (app name + slogan) and places the badge inline to its right. A wide slogan grew that column until the badge no longer fit, so it fell to a second, centered row.
- Fix caps the title column's measured width when a badge is present, reserving room for the inline badge. The reservation is computed against the **badge** width, not the wider mascot, so the title slot stays generous and most slogans still render in full — only the genuinely long ones ellipsize.
- The slogan is now single-line + `TextOverflow.Ellipsis`; `maxLines = 1` alone wouldn't help, since the column would still measure at full single-line width — the width cap is what actually keeps the badge inline.
- Release builds (`ribbon == null`) keep the original unconstrained measurement — no layout change there.
- The pre-existing inline/wrap fallback is retained as a safety net for pathological widths (tiny card, large accessibility font scale), degrading to the old behavior only in those extremes.
- Not unit-tested: the slogan is randomized at composition time, so there's no deterministic way to force the long-slogan case in a Compose preview/test. Verified via compile.
