### PR TITLE
General: Keep the dashboard readable at large font sizes

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardBottomBar.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardBottomBar.kt
@@ -127,10 +127,16 @@ internal fun BottomBar(
     val fabBottomInset = DASHBOARD_FAB_BOTTOM_INSET
     val heroBottomInset = DASHBOARD_BAR_HEIGHT + DASHBOARD_HERO_BAR_GAP
 
+    // Hero card + dock reservation grow with the font scale so large text doesn't clip the card's
+    // caption/hint. One read each, reused below for the card height, the dock reservation, the
+    // hidden-offset slide distance, and the swipe-to-dismiss threshold — they must stay in lockstep.
+    val heroCardHeight = dashboardHeroCardHeight
+    val dockHeightWithHero = dashboardDockHeightWithHero
+
     // Reserved layout height drives the Scaffold's content padding. Elements are bottom-anchored, so
     // growing this only reflows the list above — it never moves the bar/FAB.
     val dockHeight by animateDpAsState(
-        targetValue = if (showHero) DASHBOARD_DOCK_HEIGHT_WITH_HERO else DASHBOARD_FAB_SLOT_HEIGHT,
+        targetValue = if (showHero) dockHeightWithHero else DASHBOARD_FAB_SLOT_HEIGHT,
         animationSpec = tween(durationMillis = 300),
         label = "dashboardDockHeight",
     )
@@ -156,7 +162,7 @@ internal fun BottomBar(
         label = "dashboardFabOffset",
     )
     val heroOffsetY by animateDpAsState(
-        targetValue = if (isVisible && showHero) -(navBottom + heroBottomInset) else DASHBOARD_HERO_CARD_HEIGHT,
+        targetValue = if (isVisible && showHero) -(navBottom + heroBottomInset) else heroCardHeight,
         animationSpec = tween(
             durationMillis = 340,
             delayMillis = if (isVisible && showHero) 150 else 0,
@@ -175,7 +181,7 @@ internal fun BottomBar(
     // finish from the dragged position; a short drag springs back. Reset whenever the hero
     // (re)appears so a restored card never starts displaced.
     val density = LocalDensity.current
-    val heroDismissDistancePx = with(density) { DASHBOARD_HERO_CARD_HEIGHT.toPx() }
+    val heroDismissDistancePx = with(density) { heroCardHeight.toPx() }
     val heroDismissThresholdPx = heroDismissDistancePx * 0.35f
     val heroFlingVelocityCutoff = with(density) { 500.dp.toPx() }
     var heroDragPx by remember { mutableFloatStateOf(0f) }
@@ -239,7 +245,7 @@ internal fun BottomBar(
                         alpha = heroAlpha * (1f - heroDragPx / heroDismissDistancePx).coerceIn(0f, 1f)
                     }
                     .fillMaxWidth()
-                    .height(DASHBOARD_HERO_CARD_HEIGHT)
+                    .height(heroCardHeight)
                     .padding(horizontal = DASHBOARD_HERO_HORIZONTAL_MARGIN)
                     .draggable(
                         state = heroDragState,

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardDockGeometry.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardDockGeometry.kt
@@ -1,12 +1,16 @@
 package eu.darken.sdmse.main.ui.dashboard.bottom
 
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Outline
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 
@@ -48,9 +52,10 @@ internal val DASHBOARD_CUTOUT_OUTER_RADIUS = 6.dp
 internal val DASHBOARD_HERO_BAR_GAP = 12.dp
 
 /**
- * Body height of the hero card above its bottom cradle notch. Sized for the worst case: headline
- * (size + inline label) + caption + a [FlowRow] of tool chips wrapping to two rows (all four
- * tools) + the tap-hint wrapping to two lines.
+ * Body height of the hero card above its bottom cradle notch, at font scale 1.0. Sized for the
+ * worst case: headline (size + inline label) + caption + a [FlowRow] of tool chips wrapping to two
+ * rows (all four tools) + the tap-hint wrapping to two lines. At larger font scales the card grows
+ * via [dashboardHeroCardHeight] so the caption/hint don't clip — see that getter.
  */
 internal val DASHBOARD_HERO_CONTENT_HEIGHT = 156.dp
 internal val DASHBOARD_HERO_CARD_HEIGHT = DASHBOARD_HERO_CONTENT_HEIGHT + DASHBOARD_CUTOUT_DEPTH
@@ -59,6 +64,36 @@ internal val DASHBOARD_HERO_HORIZONTAL_MARGIN = 12.dp
 /** Reserved dock height when the hero is shown: bar + gap + hero card (the FAB cradles between). */
 internal val DASHBOARD_DOCK_HEIGHT_WITH_HERO =
     DASHBOARD_BAR_HEIGHT + DASHBOARD_HERO_BAR_GAP + DASHBOARD_HERO_CARD_HEIGHT
+
+/**
+ * Upper bound on how far font scale stretches the hero card. The body height tracks text size so
+ * the caption/hint stay readable; the cap only guards against pathological scales beyond the
+ * platform range. 2.0 matches Android's maximum accessibility font size (200%), so the card still
+ * fully covers the largest real text — the list above just reflows, the bar/FAB never move.
+ */
+private const val HERO_MAX_FONT_SCALE = 2.0f
+
+/**
+ * [DASHBOARD_HERO_CONTENT_HEIGHT] grown for the current font scale. The card's body is text, so its
+ * height has to track the user's font size or the caption and the two-line tap-hint clip. Never
+ * shrinks below the font-scale-1.0 worst-case height (coerced ≥ 1f).
+ */
+val dashboardHeroContentHeight: Dp
+    @Composable
+    @ReadOnlyComposable
+    get() = DASHBOARD_HERO_CONTENT_HEIGHT * LocalDensity.current.fontScale.coerceIn(1f, HERO_MAX_FONT_SCALE)
+
+/** Font-scale-aware counterpart of [DASHBOARD_HERO_CARD_HEIGHT] (content + fixed cradle notch). */
+val dashboardHeroCardHeight: Dp
+    @Composable
+    @ReadOnlyComposable
+    get() = dashboardHeroContentHeight + DASHBOARD_CUTOUT_DEPTH
+
+/** Font-scale-aware counterpart of [DASHBOARD_DOCK_HEIGHT_WITH_HERO]. */
+val dashboardDockHeightWithHero: Dp
+    @Composable
+    @ReadOnlyComposable
+    get() = DASHBOARD_BAR_HEIGHT + DASHBOARD_HERO_BAR_GAP + dashboardHeroCardHeight
 
 /**
  * The bar's shape. The FAB only exists once the dashboard is [isReady]; until then the bar must NOT

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardHeroCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardHeroCard.kt
@@ -159,9 +159,11 @@ private fun HeroBody(
                     summary.itemCount,
                 )
                 Text(
+                    // Two lines so the item-count result reads fully at large font scales (the column
+                    // is narrow next to the dismiss button); the card height grows to make room.
                     text = stringResource(modeRes.caption, itemsText),
                     style = MaterialTheme.typography.bodyMedium,
-                    maxLines = 1,
+                    maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
                 )
             }
@@ -338,7 +340,7 @@ private fun HeroCardPreview(
         DashboardHeroCard(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(DASHBOARD_HERO_CARD_HEIGHT)
+                .height(dashboardHeroCardHeight)
                 .padding(horizontal = DASHBOARD_HERO_HORIZONTAL_MARGIN),
             summary = summary,
             onDiscard = onDiscard,

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/TitleDashboardCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/TitleDashboardCard.kt
@@ -208,6 +208,33 @@ private fun TitleHeaderLayout(
         val inlineSpacing = 12.dp.roundToPx()
         val stackSpacing = 8.dp.roundToPx()
 
+        // Past "Large" system text the mascot-beside-title row + inline badge can't keep the app
+        // name on one line — it collapses into an ugly 2–3 line stack ("SD" / "Maid" / "SE"). Switch
+        // to a clean centered vertical stack instead — mascot on top, the full-width one-line title
+        // below it, then the badge — which reads as a deliberate large-text header, not a cramped
+        // row. The compact horizontal row below is kept verbatim for normal/smaller text.
+        if (constraints.hasBoundedWidth && fontScale > 1.15f) {
+            val w = constraints.maxWidth
+            val titlePlaceable = measurables[1].measure(looseConstraints.copy(maxWidth = w))
+            val contentHeight = mascotPlaceable.height + stackSpacing + titlePlaceable.height +
+                (ribbonPlaceable?.let { stackSpacing + it.height } ?: 0)
+            val layoutHeight = if (constraints.hasBoundedHeight) {
+                contentHeight.coerceIn(constraints.minHeight, constraints.maxHeight)
+            } else {
+                contentHeight.coerceAtLeast(constraints.minHeight)
+            }
+            return@Layout layout(w, layoutHeight) {
+                var y = 0
+                mascotPlaceable.placeRelative((w - mascotPlaceable.width) / 2, y)
+                y += mascotPlaceable.height + stackSpacing
+                titlePlaceable.placeRelative((w - titlePlaceable.width) / 2, y)
+                ribbonPlaceable?.let { ribbon ->
+                    y += titlePlaceable.height + stackSpacing
+                    ribbon.placeRelative((w - ribbon.width) / 2, y)
+                }
+            }
+        }
+
         // When a badge is present, cap the title width so the card-centered title leaves room
         // for the inline badge. A long randomized slogan then ellipsizes instead of pushing the
         // badge onto a second row. Reserve against the badge width only (not the wider mascot),

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardHeroHeightScalingTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardHeroHeightScalingTest.kt
@@ -1,0 +1,65 @@
+package eu.darken.sdmse.main.ui.dashboard.bottom
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+
+/**
+ * Guards the large-font fix for the dashboard hero card: its height must grow with the user's font
+ * scale (so the caption + two-line tap-hint don't clip), clamped so it can't grow unbounded, and
+ * never shrink below the font-scale-1.0 worst-case design height.
+ */
+class DashboardHeroHeightScalingTest : BaseComposeRobolectricTest() {
+
+    private data class Heights(val card: Dp, val dock: Dp)
+
+    /**
+     * Reads the @Composable height getters under each [fontScale] in a single composition —
+     * [androidx.compose.ui.test.junit4.ComposeContentTestRule.setContent] may only be called once
+     * per test, so every scale a test needs is captured here together.
+     */
+    private fun heightsAt(vararg fontScales: Float): Map<Float, Heights> {
+        val out = linkedMapOf<Float, Heights>()
+        composeRule.setContent {
+            fontScales.forEach { scale ->
+                CompositionLocalProvider(LocalDensity provides Density(density = 2.75f, fontScale = scale)) {
+                    out[scale] = Heights(card = dashboardHeroCardHeight, dock = dashboardDockHeightWithHero)
+                }
+            }
+        }
+        composeRule.waitForIdle()
+        return out
+    }
+
+    private val baselineCard = DASHBOARD_HERO_CONTENT_HEIGHT + DASHBOARD_CUTOUT_DEPTH
+
+    @Test
+    fun `card height tracks font scale`() {
+        val h = heightsAt(1.0f, 1.5f)
+        h.getValue(1.0f).card shouldBe baselineCard
+        h.getValue(1.5f).card shouldBe DASHBOARD_HERO_CONTENT_HEIGHT * 1.5f + DASHBOARD_CUTOUT_DEPTH
+    }
+
+    @Test
+    fun `growth is clamped at 2x`() {
+        val h = heightsAt(2.0f, 2.5f)
+        h.getValue(2.0f).card shouldBe DASHBOARD_HERO_CONTENT_HEIGHT * 2.0f + DASHBOARD_CUTOUT_DEPTH
+        // Past the 2.0 ceiling the card stops growing instead of eating the screen.
+        h.getValue(2.5f).card shouldBe h.getValue(2.0f).card
+    }
+
+    @Test
+    fun `never shrinks below the font-scale-1 baseline`() {
+        heightsAt(0.85f).getValue(0.85f).card shouldBe baselineCard
+    }
+
+    @Test
+    fun `dock reservation is bar plus gap plus the scaled card`() {
+        val h = heightsAt(1.5f).getValue(1.5f)
+        h.dock shouldBe DASHBOARD_BAR_HEIGHT + DASHBOARD_HERO_BAR_GAP + h.card
+    }
+}


### PR DESCRIPTION
## What changed

On phones set to large system text — the accessibility "Font size" / "Display size" settings a lot of people (especially older users) rely on — two parts of the dashboard didn't hold up:

- The title at the top squeezed **SD Maid SE** into a cramped two- or three-line stack.
- The one-tap result card cut its own text off — the item count ("180 items can be removed") and the "tap a chip to check first" hint were clipped.

Now, at large text sizes the header reflows into a clean, centered layout (mascot on top, the title on one line, the version badge below it), and the result card grows with the font so nothing is cut off. Normal and small font sizes look exactly as before.

## Technical Context

- **Header:** `TitleHeaderLayout` switches to a centered vertical stack past `fontScale 1.15`; the title measurable is measured exactly once on either layout path. The compact horizontal row is untouched below that threshold (and in release builds, which have no Dev/Beta badge).
- **Hero card:** its content/card/dock heights were fixed dp values sized for `fontScale 1.0`, so the body clipped at larger text. New font-scale-aware getters scale them by `fontScale` (clamped to `[1.0, 2.0]`, 2.0 = Android's max accessibility size); `DashboardBottomBar` reads the scaled values for the card height, dock reservation, hidden-offset slide, and swipe-to-dismiss distance so they stay in lockstep. The result caption may now wrap to two lines.
- **Known minor:** the summary footer timestamp ("0 minutes ago") still ellipsizes at the very largest font — its cell height is locked to the FAB-notch geometry. It's a relative time and the full value stays in its accessibility `contentDescription`.
- **Review guidance:** the custom `Layout` in `TitleDashboardCard` is the trickiest part — confirm the title is measured once per pass on both the vertical and horizontal branches.

## Testing

- Verified on an emulator across font 1.15 / 1.30 / 1.50 with matching display-size bumps (onboarding, dashboard, one-tap scan + summary, upgrade screen).
- Adds `DashboardHeroHeightScalingTest` (height scaling, the 2.0 clamp, the ≥1.0 floor, and the dock = bar + gap + card relationship). All 102 dashboard UI tests pass.
