### PR TITLE
General: Read file info in one step; fix symlink size reporting

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/FileExtensionsIO.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/FileExtensionsIO.kt
@@ -1,20 +1,9 @@
 package eu.darken.sdmse.common.files.local
 
 import android.system.Os
-import eu.darken.sdmse.common.files.FileType
 import eu.darken.sdmse.common.files.Ownership
 import eu.darken.sdmse.common.files.Permissions
-import eu.darken.sdmse.common.files.core.local.isSymbolicLink
 import java.io.File
-
-fun File.getAPathFileType(): FileType? = when {
-    // Order matters!
-    isSymbolicLink() -> FileType.SYMBOLIC_LINK
-    isDirectory -> FileType.DIRECTORY
-    isFile -> FileType.FILE
-    exists() -> FileType.UNKNOWN
-    else -> null
-}
 
 fun File.toLocalPath(): LocalPath = LocalPath.build(this)
 

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalPathExtensions.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalPathExtensions.kt
@@ -5,15 +5,19 @@ import android.system.StructStat
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.files.FileType
 import eu.darken.sdmse.common.files.Ownership
 import eu.darken.sdmse.common.files.Permissions
 import eu.darken.sdmse.common.files.ReadException
 import eu.darken.sdmse.common.files.Segments
 import eu.darken.sdmse.common.files.asFile
-import eu.darken.sdmse.common.files.core.local.readLink
 import eu.darken.sdmse.common.funnel.IPCFunnel
 import eu.darken.sdmse.common.pkgs.pkgops.LibcoreTool
 import java.io.File
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.LinkOption
+import java.nio.file.attribute.BasicFileAttributes
 import java.time.Instant
 
 
@@ -38,15 +42,44 @@ fun LocalPath.toCrumbs(): List<LocalPath> {
 }
 
 fun LocalPath.performLookup(): LocalPathLookup {
-    val type = file.getAPathFileType() ?: throw ReadException("Does not exist or can't be read", this)
+    // One lstat (NOFOLLOW) yields type + size + mtime, replacing ~6 java.io.File syscalls per entry.
+    // NOFOLLOW means a symlink reports its OWN size/mtime (not the target's) — which is correct, since
+    // deletion only ever removes the link, never the target.
+    val attrs = try {
+        Files.readAttributes(file.toPath(), BasicFileAttributes::class.java, LinkOption.NOFOLLOW_LINKS)
+    } catch (e: IOException) {
+        throw ReadException("Does not exist or can't be read", this, e)
+    }
+
+    val type = when {
+        attrs.isSymbolicLink -> FileType.SYMBOLIC_LINK
+        attrs.isDirectory -> FileType.DIRECTORY
+        attrs.isRegularFile -> FileType.FILE
+        else -> FileType.UNKNOWN
+    }
 
     return LocalPathLookup(
         fileType = type,
         lookedUp = this,
-        size = file.length(),
-        modifiedAt = Instant.ofEpochMilli(file.lastModified()),
-        target = file.readLink()?.let { LocalPath.build(it) }
+        size = attrs.size(),
+        modifiedAt = Instant.ofEpochMilli(attrs.lastModifiedTime().toMillis()),
+        target = if (type == FileType.SYMBOLIC_LINK) file.resolveSymlinkTarget() else null,
     )
+}
+
+/**
+ * Resolves a symlink's target to an absolute [LocalPath]. Uses NIO so it works in JVM tests (unlike
+ * `Os.readlink`), and resolves a relative target against the link's parent (the old
+ * `LocalPath.build(rawTarget)` turned `../x` into a bogus `/../x`).
+ */
+private fun File.resolveSymlinkTarget(): LocalPath? {
+    val raw = try {
+        Files.readSymbolicLink(toPath())
+    } catch (e: Exception) {
+        return null
+    }
+    val resolved = if (raw.isAbsolute) raw else (toPath().parent?.resolve(raw) ?: raw)
+    return LocalPath.build(resolved.toString())
 }
 
 fun LocalPath.performLookupExtended(

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalPathExtensions.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalPathExtensions.kt
@@ -16,6 +16,7 @@ import eu.darken.sdmse.common.pkgs.pkgops.LibcoreTool
 import java.io.File
 import java.io.IOException
 import java.nio.file.Files
+import java.nio.file.InvalidPathException
 import java.nio.file.LinkOption
 import java.nio.file.attribute.BasicFileAttributes
 import java.time.Instant
@@ -49,6 +50,10 @@ fun LocalPath.performLookup(): LocalPathLookup {
         Files.readAttributes(file.toPath(), BasicFileAttributes::class.java, LinkOption.NOFOLLOW_LINKS)
     } catch (e: IOException) {
         throw ReadException("Does not exist or can't be read", this, e)
+    } catch (e: InvalidPathException) {
+        // file.toPath() rejects paths with illegal chars (e.g. an embedded NUL). The old
+        // java.io.File-based lookup returned null here, which became a ReadException — keep that contract.
+        throw ReadException("Does not exist or can't be read", this, e)
     }
 
     val type = when {
@@ -70,7 +75,8 @@ fun LocalPath.performLookup(): LocalPathLookup {
 /**
  * Resolves a symlink's target to an absolute [LocalPath]. Uses NIO so it works in JVM tests (unlike
  * `Os.readlink`), and resolves a relative target against the link's parent (the old
- * `LocalPath.build(rawTarget)` turned `../x` into a bogus `/../x`).
+ * `LocalPath.build(rawTarget)` turned `../x` into a bogus `/../x`). The result is lexically
+ * normalized (collapses `.`/`..`); it is informational only and not used for deletion.
  */
 private fun File.resolveSymlinkTarget(): LocalPath? {
     val raw = try {
@@ -79,7 +85,7 @@ private fun File.resolveSymlinkTarget(): LocalPath? {
         return null
     }
     val resolved = if (raw.isAbsolute) raw else (toPath().parent?.resolve(raw) ?: raw)
-    return LocalPath.build(resolved.toString())
+    return LocalPath.build(resolved.normalize().toString())
 }
 
 fun LocalPath.performLookupExtended(

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/LocalPathExtensionsTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/LocalPathExtensionsTest.kt
@@ -6,8 +6,16 @@ import eu.darken.sdmse.common.files.local.*
 import eu.darken.sdmse.common.files.startsWith
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.LinkOption
+import java.nio.file.Paths
+import java.nio.file.attribute.BasicFileAttributes
 import java.time.Instant
 
 class LocalPathExtensionsTest : BaseTest() {
@@ -359,6 +367,75 @@ class LocalPathExtensionsTest : BaseTest() {
 
     @Test fun `isUncommonAndroidDir - Android is last segment`() {
         LocalPath.build("storage", "emulated", "0", "Android").isUncommonAndroidDir shouldBe false
+    }
+
+    private lateinit var fsDir: File
+
+    @BeforeEach fun setupFs() {
+        fsDir = Files.createTempDirectory("performLookup").toFile()
+    }
+
+    @AfterEach fun cleanupFs() {
+        fsDir.deleteRecursively()
+    }
+
+    @Test fun `performLookup - regular file matches java io File`() {
+        val f = File(fsDir, "file.txt").apply { writeText("hello!") } // 6 bytes
+        val lookup = LocalPath.build(f).performLookup()
+        lookup.fileType shouldBe FileType.FILE
+        lookup.size shouldBe 6L
+        lookup.size shouldBe f.length()
+        lookup.modifiedAt.toEpochMilli() shouldBe f.lastModified()
+        lookup.target shouldBe null
+    }
+
+    @Test fun `performLookup - directory size equals File length (totals must not shift)`() {
+        val d = File(fsDir, "sub").apply { mkdirs(); File(this, "a").writeText("x") }
+        val lookup = LocalPath.build(d).performLookup()
+        lookup.fileType shouldBe FileType.DIRECTORY
+        // Critical parity: a directory's reported size must stay identical to the old File.length(),
+        // or every FilterContent/Corpse/AppJunk size total would shift.
+        lookup.size shouldBe d.length()
+        val nofollow = Files.readAttributes(d.toPath(), BasicFileAttributes::class.java, LinkOption.NOFOLLOW_LINKS)
+        lookup.size shouldBe nofollow.size()
+        lookup.target shouldBe null
+    }
+
+    @Test fun `performLookup - symlink reports its own size, not the target's`() {
+        val target = File(fsDir, "target.bin").apply { writeBytes(ByteArray(5000)) }
+        val link = File(fsDir, "link")
+        Files.createSymbolicLink(link.toPath(), target.toPath())
+
+        val lookup = LocalPath.build(link).performLookup()
+        lookup.fileType shouldBe FileType.SYMBOLIC_LINK
+        // The link node, NOT the 5000-byte target — deletion only removes the link.
+        lookup.size shouldNotBe 5000L
+        val linkAttrs = Files.readAttributes(link.toPath(), BasicFileAttributes::class.java, LinkOption.NOFOLLOW_LINKS)
+        lookup.size shouldBe linkAttrs.size()
+        lookup.target shouldBe LocalPath.build(target.path)
+    }
+
+    @Test fun `performLookup - relative symlink target is resolved against the link's parent`() {
+        File(fsDir, "realfile").apply { writeText("x") }
+        val link = File(fsDir, "rellink")
+        Files.createSymbolicLink(link.toPath(), Paths.get("realfile")) // relative target
+
+        val lookup = LocalPath.build(link).performLookup()
+        lookup.fileType shouldBe FileType.SYMBOLIC_LINK
+        // Resolved to <parent>/realfile, not the old bogus "/realfile".
+        lookup.target shouldBe LocalPath.build(File(fsDir, "realfile").path)
+    }
+
+    @Test fun `performLookup - broken symlink is still a SYMBOLIC_LINK`() {
+        val link = File(fsDir, "broken")
+        Files.createSymbolicLink(link.toPath(), File(fsDir, "does-not-exist").toPath())
+
+        val lookup = LocalPath.build(link).performLookup()
+        lookup.fileType shouldBe FileType.SYMBOLIC_LINK
+    }
+
+    @Test fun `performLookup - non-existent path throws ReadException`() {
+        shouldThrow<ReadException> { LocalPath.build(File(fsDir, "nope")).performLookup() }
     }
 
     @Test fun `remove prefix with overlap`() {

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/LocalPathExtensionsTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/LocalPathExtensionsTest.kt
@@ -6,7 +6,6 @@ import eu.darken.sdmse.common.files.local.*
 import eu.darken.sdmse.common.files.startsWith
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -409,7 +408,6 @@ class LocalPathExtensionsTest : BaseTest() {
         val lookup = LocalPath.build(link).performLookup()
         lookup.fileType shouldBe FileType.SYMBOLIC_LINK
         // The link node, NOT the 5000-byte target — deletion only removes the link.
-        lookup.size shouldNotBe 5000L
         val linkAttrs = Files.readAttributes(link.toPath(), BasicFileAttributes::class.java, LinkOption.NOFOLLOW_LINKS)
         lookup.size shouldBe linkAttrs.size()
         lookup.target shouldBe LocalPath.build(target.path)
@@ -426,6 +424,18 @@ class LocalPathExtensionsTest : BaseTest() {
         lookup.target shouldBe LocalPath.build(File(fsDir, "realfile").path)
     }
 
+    @Test fun `performLookup - relative symlink target with parent traversal is normalized`() {
+        File(fsDir, "realfile").apply { writeText("x") }
+        val sub = File(fsDir, "sub").apply { mkdirs() }
+        val link = File(sub, "uplink")
+        Files.createSymbolicLink(link.toPath(), Paths.get("../realfile")) // relative, traverses up
+
+        val lookup = LocalPath.build(link).performLookup()
+        lookup.fileType shouldBe FileType.SYMBOLIC_LINK
+        // <sub>/../realfile is lexically normalized to <fsDir>/realfile, not left as "/sub/../realfile".
+        lookup.target shouldBe LocalPath.build(File(fsDir, "realfile").path)
+    }
+
     @Test fun `performLookup - broken symlink is still a SYMBOLIC_LINK`() {
         val link = File(fsDir, "broken")
         Files.createSymbolicLink(link.toPath(), File(fsDir, "does-not-exist").toPath())
@@ -436,6 +446,11 @@ class LocalPathExtensionsTest : BaseTest() {
 
     @Test fun `performLookup - non-existent path throws ReadException`() {
         shouldThrow<ReadException> { LocalPath.build(File(fsDir, "nope")).performLookup() }
+    }
+
+    @Test fun `performLookup - path with illegal characters throws ReadException`() {
+        // file.toPath() throws InvalidPathException on an embedded NUL; it must surface as ReadException.
+        shouldThrow<ReadException> { LocalPath.build(File(fsDir, "bad\u0000name")).performLookup() }
     }
 
     @Test fun `remove prefix with overlap`() {


### PR DESCRIPTION
## What changed

No user-facing change for normal files. Two internal improvements to how file metadata is read:

- A file's type, size and modified-time are now read in **one** filesystem call instead of ~6. An on-device benchmark over 100,000 files measured the per-file lookup (which dominates large scans) ~3.5× faster.
- **Symlinks now report their own size**, not the size of whatever they point at. SD Maid only ever deletes the symlink itself (never the target), so AppCleaner/CorpseFinder previously *overstated* the recoverable space for any symlink they listed — this makes that number accurate.

## Technical Context

- `performLookup()` replaced ~6 `java.io.File` syscalls (`isSymbolicLink` + `isDirectory` + `isFile` + `length` + `lastModified` + `readLink`) with one `java.nio` `Files.readAttributes(NOFOLLOW_LINKS)` lstat (type + size + mtime). Benchmarked ~3.5× faster (4.4 s → 1.25 s over 100k files); directory *enumeration* is ~neutral, so the win is the per-file attribute read.
- `NOFOLLOW` changes symlink size/mtime from the followed target's to the link node's own — correct, since deletion removes only the link. The Analyzer already nulls symlink size; this aligns AppCleaner/CorpseFinder/SystemCleaner with that. **Directory and regular-file sizes are unchanged** (a unit test guards `dir size == File.length()`, and the on-device SystemCleaner total is byte-identical to baseline).
- Relative symlink targets are now resolved against the link's parent (the old code produced a bogus `/../x`).
- `performLookup` is now pure-JVM (no `android.system.Os`), so it's unit-tested directly (broken symlinks now classify correctly in tests too). The dead `getAPathFileType()` is removed.
- **Reviewer note — deliberately out of scope (follow-up PRs):** `SystemCrawlerSieve` lets symlinks bypass the FILE/DIR type gate; `LocalGateway.lookup()` gates on `canRead()` which follows symlinks; the walkers' symlink-root handling. None are regressions.

## Verification

- Unit tests: directory-size parity (`== File.length()`), symlink-reports-own-size, relative-target resolution, broken-symlink classification, non-existent → `ReadException`; existing walker/path tests unchanged.
- Rooted Pixel 7a: a full multi-tool scan produces **identical** results (SystemCleaner recoverable space byte-identical to baseline) with no errors.
