### PR TITLE
SystemCleaner: Handle symlinks consistently in filter matching

### DIFF
--- a/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/core/sieve/SystemCrawlerSieve.kt
+++ b/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/core/sieve/SystemCrawlerSieve.kt
@@ -8,8 +8,7 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APathLookup
-import eu.darken.sdmse.common.files.isDirectory
-import eu.darken.sdmse.common.files.isFile
+import eu.darken.sdmse.common.files.FileType
 import eu.darken.sdmse.common.forensics.AreaInfo
 import eu.darken.sdmse.common.forensics.FileForensics
 import eu.darken.sdmse.common.forensics.identifyArea
@@ -33,13 +32,15 @@ class SystemCrawlerSieve @AssistedInject constructor(
     suspend fun match(subject: APathLookup<*>): Result {
         val nope = { Result(subject, matches = false) }
 
-        // Directory or file?
+        // Directory or file? Symlinks and unknown entries are treated as FILE, mirroring how
+        // CustomFilter maps the configured fileTypes. A symlink is its own node (we only ever
+        // delete the link, never its target), so it must not slip past a directory-only filter.
         config.targetTypes?.takeIf { it.isNotEmpty() }?.let { types ->
-            if (subject.isFile && !types.contains(TypeCriterium.FILE)) {
-                return nope()
-            } else if (subject.isDirectory && !types.contains(TypeCriterium.DIRECTORY)) {
-                return nope()
+            val subjectType = when (subject.fileType) {
+                FileType.DIRECTORY -> TypeCriterium.DIRECTORY
+                FileType.FILE, FileType.SYMBOLIC_LINK, FileType.UNKNOWN -> TypeCriterium.FILE
             }
+            if (!types.contains(subjectType)) return nope()
         }
 
         config.maximumSize?.let {

--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/sieve/SystemCrawlerSieveTest.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/sieve/SystemCrawlerSieveTest.kt
@@ -75,6 +75,21 @@ class SystemCrawlerSieveTest : BaseTest() {
         )
         configForFile.match(aDirectory).matches shouldBe false
         configForDir.match(aDirectory).matches shouldBe true
+
+        // Symlinks are classified as FILE (matching CustomFilter's fileType mapping): they must
+        // match a file-only filter and be rejected by a directory-only one.
+        val aSymlink = baseLookup.copy(
+            fileType = FileType.SYMBOLIC_LINK
+        )
+        configForFile.match(aSymlink).matches shouldBe true
+        configForDir.match(aSymlink).matches shouldBe false
+
+        // Unknown entries (sockets/fifos/...) are likewise treated as non-directory.
+        val anUnknown = baseLookup.copy(
+            fileType = FileType.UNKNOWN
+        )
+        configForFile.match(anUnknown).matches shouldBe true
+        configForDir.match(anUnknown).matches shouldBe false
     }
 
     @Test


### PR DESCRIPTION
## What changed

SystemCleaner filters now treat a symbolic link as a file instead of letting it slip through the file-vs-directory check unclassified. In practice a "directory only" filter no longer matches a symlink, and a symlink is only ever considered as the link itself (SD Maid never follows or deletes a link's target).

## Technical Context

- The sieve's type gate tested `isFile` / `isDirectory`, both of which are strict (`== FILE` / `== DIRECTORY`). A `SYMBOLIC_LINK` (or `UNKNOWN`) entry satisfied neither, so the gate was skipped entirely and the entry fell through to the size/age/path checks. Symlinks do reach the sieve — the crawler walks with `followSymlinks=false` but still emits symlink children (it just doesn't descend them).
- The subject is now classified up front, mirroring `CustomFilter`'s existing `fileType` mapping (`SYMBOLIC_LINK` and `UNKNOWN` → `FILE`), and the gate compares against that. Non-directory entries go through the FILE criteria; `UNKNOWN` (sockets/fifos/device nodes) is therefore now *rejected* by directory-only filters instead of bypassing the gate entirely — strictly more restrictive than before.
- Behavioral note: directory-targeting stock filters (Mac/Linux artifact names such as `.Trashes`, `.Spotlight-V100`, `.Trash-*`) will no longer match a *symlink* that merely carries one of those names — only real directories do. This is intentional: a symlink isn't that directory, and matching it would only delete the user's link.
- Regular-file and directory matching is byte-for-byte unchanged. The exhaustive `when (fileType)` turns a future `FileType` value into a compile error rather than a silent FILE fallthrough.
