### PR TITLE
General: Look up symlinks with broken targets without root/ADB

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalGateway.kt
@@ -23,6 +23,7 @@ import eu.darken.sdmse.common.files.callbacks
 import eu.darken.sdmse.common.files.core.local.createSymlink
 import eu.darken.sdmse.common.files.core.local.deleteRecursivelySafe
 import eu.darken.sdmse.common.files.core.local.isReadable
+import eu.darken.sdmse.common.files.core.local.isSymbolicLink
 import eu.darken.sdmse.common.files.core.local.listFiles2
 import eu.darken.sdmse.common.files.core.local.parentsInclusive
 import eu.darken.sdmse.common.files.local.ipc.FileOpsClient
@@ -215,7 +216,11 @@ class LocalGateway @Inject constructor(
             val canRead = if (mode == Mode.ROOT) {
                 false
             } else {
-                javaFile.canRead()
+                // canRead() follows symlinks, so a valid link with a broken/unreadable target would
+                // report false and force a needless escalation (or fail outright without root).
+                // performLookup() is NOFOLLOW and only needs to lstat the link node, so accept any
+                // symlink we can lstat app-side. Short-circuit keeps readable paths syscall-free.
+                javaFile.canRead() || javaFile.isSymbolicLink()
             }
 
             when {

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/LocalGatewayTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/LocalGatewayTest.kt
@@ -1,0 +1,55 @@
+package eu.darken.sdmse.common.files.local
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import eu.darken.sdmse.common.files.FileType
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import testhelper.EmptyApp
+import testhelpers.coroutine.TestDispatcherProvider
+import testhelpers.coroutine.runTest2
+import java.io.File
+import java.nio.file.Files
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [29], application = EmptyApp::class)
+class LocalGatewayTest {
+
+    private val testDir = Files.createTempDirectory("localgateway-test").toFile()
+
+    @After
+    fun cleanup() {
+        testDir.deleteRecursively()
+    }
+
+    @Test
+    fun `lookup of a broken symlink resolves app-side without privileged escalation`() =
+        runTest2(autoCancel = true) {
+            // rootManager/adbManager are mocked away (no privileged access), so a lookup that
+            // succeeds and classifies the link can only have gone through the app-side NOFOLLOW
+            // path. On the old code canRead() follows the dead target -> false -> NORMAL throws and
+            // AUTO has nowhere to escalate.
+            val gateway = LocalGateway(
+                mockk(),
+                mockk(),
+                this,
+                TestDispatcherProvider(),
+                mockk(),
+                mockk(relaxed = true),
+                mockk(relaxed = true),
+            )
+
+            val link = File(testDir, "broken-link")
+            Files.createSymbolicLink(link.toPath(), File(testDir, "missing-target").toPath())
+            val linkPath = LocalPath.build(link)
+
+            // Precondition: the link is unreadable via canRead() because it follows the dead target.
+            link.canRead() shouldBe false
+
+            gateway.lookup(linkPath, LocalGateway.Mode.NORMAL).fileType shouldBe FileType.SYMBOLIC_LINK
+            gateway.lookup(linkPath, LocalGateway.Mode.AUTO).fileType shouldBe FileType.SYMBOLIC_LINK
+        }
+}

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/LocalGatewayTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/LocalGatewayTest.kt
@@ -1,22 +1,26 @@
 package eu.darken.sdmse.common.files.local
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import eu.darken.sdmse.common.files.FileType
+import eu.darken.sdmse.common.root.RootManager
 import io.kotest.matchers.shouldBe
+import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
 import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import testhelper.EmptyApp
+import testhelpers.BaseTest
 import testhelpers.coroutine.TestDispatcherProvider
 import testhelpers.coroutine.runTest2
 import java.io.File
 import java.nio.file.Files
 
-@RunWith(AndroidJUnit4::class)
+@RunWith(RobolectricTestRunner::class)
 @Config(sdk = [29], application = EmptyApp::class)
-class LocalGatewayTest {
+class LocalGatewayTest : BaseTest() {
 
     private val testDir = Files.createTempDirectory("localgateway-test").toFile()
 
@@ -33,13 +37,13 @@ class LocalGatewayTest {
             // path. On the old code canRead() follows the dead target -> false -> NORMAL throws and
             // AUTO has nowhere to escalate.
             val gateway = LocalGateway(
-                mockk(),
-                mockk(),
-                this,
-                TestDispatcherProvider(),
-                mockk(),
-                mockk(relaxed = true),
-                mockk(relaxed = true),
+                ipcFunnel = mockk(),
+                libcoreTool = mockk(),
+                appScope = this,
+                dispatcherProvider = TestDispatcherProvider(),
+                storageEnvironment = mockk(),
+                rootManager = mockk(relaxed = true),
+                adbManager = mockk(relaxed = true),
             )
 
             val link = File(testDir, "broken-link")
@@ -51,5 +55,29 @@ class LocalGatewayTest {
 
             gateway.lookup(linkPath, LocalGateway.Mode.NORMAL).fileType shouldBe FileType.SYMBOLIC_LINK
             gateway.lookup(linkPath, LocalGateway.Mode.AUTO).fileType shouldBe FileType.SYMBOLIC_LINK
+        }
+
+    @Test
+    fun `AUTO resolves a broken symlink app-side even when root is available`() =
+        runTest2(autoCancel = true) {
+            // canUseRootNow() is an extension over RootManager.useRoot, so stub the flow, not the call.
+            // The root mock is non-relaxed: if the broken symlink were (wrongly) escalated, rootOps
+            // would touch unstubbed members and throw, so a SYMBOLIC_LINK result proves app-side lstat.
+            val rootManager = mockk<RootManager> { every { useRoot } returns flowOf(true) }
+            val gateway = LocalGateway(
+                ipcFunnel = mockk(),
+                libcoreTool = mockk(),
+                appScope = this,
+                dispatcherProvider = TestDispatcherProvider(),
+                storageEnvironment = mockk(),
+                rootManager = rootManager,
+                adbManager = mockk(relaxed = true),
+            )
+
+            val link = File(testDir, "broken-link-rooted")
+            Files.createSymbolicLink(link.toPath(), File(testDir, "missing-target").toPath())
+
+            gateway.hasRoot() shouldBe true // precondition: escalation WAS available
+            gateway.lookup(LocalPath.build(link), LocalGateway.Mode.AUTO).fileType shouldBe FileType.SYMBOLIC_LINK
         }
 }

--- a/app-common/src/main/java/eu/darken/sdmse/common/files/core/local/FileExtensionsBase.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/files/core/local/FileExtensionsBase.kt
@@ -115,8 +115,12 @@ fun File.listFilesStreaming(): Flow<File> = flow {
     }
 }
 
-fun File.isSymbolicLink(): Boolean {
-    return readLink() != null
+// NOFOLLOW lstat: true for any symlink node, including one whose target is missing/unreadable.
+// Fail-safe to false so an unstattable path (e.g. unreadable parent) is treated as "not a symlink".
+fun File.isSymbolicLink(): Boolean = try {
+    Files.isSymbolicLink(toPath())
+} catch (_: Exception) {
+    false
 }
 
 fun File.createSymlink(target: File): Boolean {

--- a/app-common/src/test/java/eu/darken/sdmse/common/files/core/local/FileExtensionsBaseTest.kt
+++ b/app-common/src/test/java/eu/darken/sdmse/common/files/core/local/FileExtensionsBaseTest.kt
@@ -13,12 +13,12 @@ import java.io.IOException
 import java.nio.file.Files
 
 /**
- * Tests the safety property of symlink-aware recursive deletion.
+ * Tests symlink helpers and the safety property of symlink-aware recursive deletion.
  *
- * Since [isSymbolicLink] uses Android's `Os.readlink()` (unavailable on JVM),
- * these tests use `java.nio.file.Files` to create real symlinks and a NIO-based
- * mirror of the same algorithm to verify the core safety property:
- * recursive deletion must NOT follow symlinks into target directories.
+ * [deleteRecursivelySafe] uses Android's `Os.readlink()` (unavailable on JVM), so its recursion
+ * is verified via [deleteRecursivelySafeNio] — a NIO-based mirror of the same algorithm — to
+ * assert the core safety property: recursive deletion must NOT follow symlinks into target
+ * directories. [isSymbolicLink] is NIO-based ([Files.isSymbolicLink]) and is tested directly.
  */
 class FileExtensionsBaseTest : BaseTest() {
 
@@ -157,6 +157,29 @@ class FileExtensionsBaseTest : BaseTest() {
         val names = runBlocking { dir.listFilesStreaming().toList() }.map { it.name }.toSet()
         // The symlink itself is an entry; its target's contents are not enumerated.
         names shouldBe setOf("link", "plain.txt")
+    }
+
+    @Test
+    fun `isSymbolicLink classifies link nodes including broken ones`() {
+        val regularFile = File(testDir, "regular.txt").apply { writeText("data") }
+        val regularDir = File(testDir, "regular-dir").apply { mkdirs() }
+        val nonExistent = File(testDir, "ghost")
+
+        val linkToFile = File(testDir, "link-to-file")
+        Files.createSymbolicLink(linkToFile.toPath(), regularFile.toPath())
+        val linkToDir = File(testDir, "link-to-dir")
+        Files.createSymbolicLink(linkToDir.toPath(), regularDir.toPath())
+        val brokenLink = File(testDir, "broken-link")
+        Files.createSymbolicLink(brokenLink.toPath(), nonExistent.toPath())
+
+        // A symlink node is a symlink regardless of whether its target exists/is readable.
+        linkToFile.isSymbolicLink() shouldBe true
+        linkToDir.isSymbolicLink() shouldBe true
+        brokenLink.isSymbolicLink() shouldBe true
+
+        regularFile.isSymbolicLink() shouldBe false
+        regularDir.isSymbolicLink() shouldBe false
+        nonExistent.isSymbolicLink() shouldBe false
     }
 
     /**


### PR DESCRIPTION
## What changed

Looking up a symbolic link whose target is missing or unreadable now works directly. Previously, on a device with root or ADB access SD Maid would needlessly fall back to the privileged helper for such a link, and on a device without root/ADB the lookup failed outright — even though only the link itself needs to be read.

## Technical Context

- `LocalGateway.lookup()` gated app-side metadata reads on `File.canRead()`, which **follows** symlinks. A valid link with a broken/unreadable target reports `canRead()=false`, so `AUTO` escalated to the root/ADB helper and `NORMAL` on a non-privileged device threw. `performLookup()` is NOFOLLOW and only needs to `lstat` the link node, so the gate now accepts any symlink we can `lstat` app-side: `canRead() || isSymbolicLink()`. The `||` short-circuits, so readable paths pay no extra syscall. Only symlink lookups change; files and directories are unaffected.
- `File.isSymbolicLink()` (previously zero callers) is migrated from `Os.readlink` to `java.nio` `Files.isSymbolicLink` — behavior-equivalent (true for any link node including broken ones, false on error) and now JVM-testable. `deleteRecursivelySafe` uses `readLink()` directly and is untouched.
- **Verification:** `FileExtensionsBaseTest` covers `isSymbolicLink()` over valid/broken/regular nodes; `LocalGatewayTest` asserts a broken-symlink lookup returns `SYMBOLIC_LINK` in `NORMAL` and `AUTO` with root/ADB mocked unavailable (i.e. resolved app-side, no escalation) — it fails on the pre-change code where `NORMAL` throws.
- **Device-verified** on a rooted Pixel 7a against a real broken-target symlink: `isSymbolicLink=true`, `canRead()=false`, and `lookup()` returned `SYMBOLIC_LINK` in both `NORMAL` and `AUTO` (no root escalation) — confirming `java.nio Files.isSymbolicLink` behaves correctly on ART, not just the JVM host.

## Review note

**Draft — builds on #2495's sibling #2493** (the NOFOLLOW `performLookup`). This branch is stacked on top of #2493, so until that merges the diff here also shows #2493's commit — **review only the `Don't follow symlinks when deciding lookup readability` commit**. Once #2493 lands in `main`, this diff collapses to that single commit automatically and it can be marked ready.

Refs #2493.
