### PR TITLE
Scheduler: Explain why app cleaning is skipped while locked

### DIFF
--- a/app-common/src/main/java/eu/darken/sdmse/main/core/taskmanager/SchedulerAppCleanerAdvisor.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/main/core/taskmanager/SchedulerAppCleanerAdvisor.kt
@@ -1,0 +1,25 @@
+package eu.darken.sdmse.main.core.taskmanager
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Advises whether a *background* (scheduled) AppCleaner run would currently rely on the accessibility service to
+ * clear inaccessible caches. ACS automation can't run while the screen is off/locked, so such a run would be skipped
+ * during unattended schedules.
+ *
+ * Lives in the app module (composition layer) so the scheduler doesn't need to depend on the AppCleaner tool module.
+ */
+interface SchedulerAppCleanerAdvisor {
+    val acsScheduleRisk: Flow<AcsScheduleRisk>
+}
+
+enum class AcsScheduleRisk {
+    /** No ACS needed for background cleaning (root available, inaccessible cleaning off, or ADB covers everything). */
+    NONE,
+
+    /** All inaccessible caches need ACS (no root, no ADB/Shizuku). */
+    ACS_REQUIRED_ALL,
+
+    /** ADB/Shizuku covers normal apps, but system apps still need ACS because "Include system apps" is enabled. */
+    ACS_REQUIRED_SYSTEM_APPS_ONLY,
+}

--- a/app-tool-scheduler/src/main/java/eu/darken/sdmse/scheduler/core/SchedulerNotifications.kt
+++ b/app-tool-scheduler/src/main/java/eu/darken/sdmse/scheduler/core/SchedulerNotifications.kt
@@ -9,9 +9,11 @@ import android.content.pm.ServiceInfo
 import androidx.core.app.NotificationCompat
 import androidx.work.ForegroundInfo
 import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.sdmse.automation.core.errors.ScreenUnavailableException
 import eu.darken.sdmse.common.BuildConfigWrap
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.error.causes
 import eu.darken.sdmse.common.hasApiLevel
 import eu.darken.sdmse.common.ByteFormatter
 import eu.darken.sdmse.main.core.SDMTool
@@ -159,7 +161,7 @@ class SchedulerNotifications @Inject constructor(
         return results.joinToString("\n") { result ->
             val toolName = context.getString(result.task.type.toToolNameId())
             if (result.error != null) {
-                val errorLabel = context.getString(eu.darken.sdmse.common.R.string.general_error_label)
+                val errorLabel = context.getString(result.error.toSchedulerErrorLabelRes())
                 "$toolName: $errorLabel"
             } else if (result.result != null) {
                 val space = (result.result as? ReportDetails.AffectedSpace)?.affectedSpace
@@ -218,4 +220,18 @@ class SchedulerNotifications @Inject constructor(
         internal const val NOTIFICATION_ID_RANGE_STATE = 1000
         internal const val NOTIFICATION_ID_RANGE_RESULT = 1200
     }
+}
+
+/**
+ * A [ScreenUnavailableException] means the accessibility service couldn't run because the screen was off or locked
+ * (e.g. an unattended scheduled run). That's a by-design limitation, not a genuine failure, so it's worth surfacing
+ * with its own wording instead of the generic error label.
+ */
+internal fun Throwable.isScreenUnavailableSkip(): Boolean =
+    this is ScreenUnavailableException || causes.any { it is ScreenUnavailableException }
+
+internal fun Throwable.toSchedulerErrorLabelRes(): Int = if (isScreenUnavailableSkip()) {
+    R.string.scheduler_notification_result_skipped_screen_unavailable
+} else {
+    eu.darken.sdmse.common.R.string.general_error_label
 }

--- a/app-tool-scheduler/src/main/java/eu/darken/sdmse/scheduler/core/SchedulerSettings.kt
+++ b/app-tool-scheduler/src/main/java/eu/darken/sdmse/scheduler/core/SchedulerSettings.kt
@@ -27,6 +27,7 @@ class SchedulerSettings @Inject constructor(
     val createdDefaultEntry = dataStore.createValue("default.entry.created", false)
 
     val hintBatteryDismissed = dataStore.createValue("hint.battery.optimization.dismissed", false)
+    val hintAcsScreenLockedDismissed = dataStore.createValue("hint.acs.screenlocked.dismissed", false)
 
     companion object {
         internal val TAG = logTag("Scheduler", "Settings")

--- a/app-tool-scheduler/src/main/java/eu/darken/sdmse/scheduler/ui/manager/SchedulerManagerScreen.kt
+++ b/app-tool-scheduler/src/main/java/eu/darken/sdmse/scheduler/ui/manager/SchedulerManagerScreen.kt
@@ -48,9 +48,11 @@ import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.error.ErrorEventHandler
 import eu.darken.sdmse.common.navigation.NavigationEventHandler
 import eu.darken.sdmse.common.progress.Progress
+import eu.darken.sdmse.main.core.taskmanager.AcsScheduleRisk
 import eu.darken.sdmse.scheduler.R
 import eu.darken.sdmse.scheduler.core.Schedule
 import eu.darken.sdmse.scheduler.core.ScheduleId
+import eu.darken.sdmse.scheduler.ui.manager.items.AcsScreenLockedHintRow
 import eu.darken.sdmse.scheduler.ui.manager.items.AlarmHintRow
 import eu.darken.sdmse.scheduler.ui.manager.items.BatteryHintRow
 import eu.darken.sdmse.scheduler.ui.manager.items.CommandsEditDialog
@@ -107,6 +109,7 @@ fun SchedulerManagerScreenHost(
         onEditCommands = vm::requestEditCommands,
         onFixBattery = vm::fixBatteryOptimization,
         onDismissBattery = vm::dismissBatteryHint,
+        onDismissAcsScreenLockedHint = vm::dismissAcsScreenLockedHint,
     )
 
     pendingCommandsEdit?.let { ev ->
@@ -138,6 +141,7 @@ internal fun SchedulerManagerScreen(
     onEditCommands: (ScheduleId) -> Unit = {},
     onFixBattery: () -> Unit = {},
     onDismissBattery: () -> Unit = {},
+    onDismissAcsScreenLockedHint: () -> Unit = {},
 ) {
     val state by stateSource.collectAsStateWithLifecycle(initialValue = SchedulerManagerViewModel.State())
     val listState = rememberLazyListState()
@@ -217,6 +221,7 @@ internal fun SchedulerManagerScreen(
                 onEditCommands = onEditCommands,
                 onFixBattery = onFixBattery,
                 onDismissBattery = onDismissBattery,
+                onDismissAcsScreenLockedHint = onDismissAcsScreenLockedHint,
             )
         }
     }
@@ -236,6 +241,7 @@ private fun ScheduleListContent(
     onEditCommands: (ScheduleId) -> Unit,
     onFixBattery: () -> Unit,
     onDismissBattery: () -> Unit,
+    onDismissAcsScreenLockedHint: () -> Unit,
 ) {
     LazyColumn(
         state = listState,
@@ -248,6 +254,15 @@ private fun ScheduleListContent(
                 BatteryHintRow(
                     onFix = onFixBattery,
                     onDismiss = onDismissBattery,
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                )
+            }
+        }
+        if (state.acsScreenLockedRisk != AcsScheduleRisk.NONE) {
+            item("acs_screenlocked") {
+                AcsScreenLockedHintRow(
+                    risk = state.acsScreenLockedRisk,
+                    onDismiss = onDismissAcsScreenLockedHint,
                     modifier = Modifier.padding(horizontal = 16.dp),
                 )
             }
@@ -307,6 +322,67 @@ private fun SchedulerManagerScreenWithSchedulePreview() {
                         ),
                     ),
                     showAlarmHint = false,
+                    showBatteryHint = false,
+                    showCommands = false,
+                    isLoading = false,
+                ),
+            ),
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun SchedulerManagerScreenWithAcsHintPreview() {
+    PreviewWrapper {
+        SchedulerManagerScreen(
+            stateSource = MutableStateFlow(
+                SchedulerManagerViewModel.State(
+                    schedules = listOf(
+                        Schedule(
+                            id = "preview-1",
+                            label = "Nightly clean",
+                            hour = 1,
+                            minute = 0,
+                            useAppCleaner = true,
+                        ),
+                        Schedule(
+                            id = "preview-2",
+                            label = "Weekend clean",
+                            hour = 23,
+                            minute = 30,
+                            useAppCleaner = true,
+                        ),
+                    ),
+                    acsScreenLockedRisk = AcsScheduleRisk.ACS_REQUIRED_ALL,
+                    showAlarmHint = true,
+                    showBatteryHint = false,
+                    showCommands = false,
+                    isLoading = false,
+                ),
+            ),
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun SchedulerManagerScreenWithAcsSystemAppsHintPreview() {
+    PreviewWrapper {
+        SchedulerManagerScreen(
+            stateSource = MutableStateFlow(
+                SchedulerManagerViewModel.State(
+                    schedules = listOf(
+                        Schedule(
+                            id = "preview-1",
+                            label = "Nightly clean",
+                            hour = 1,
+                            minute = 0,
+                            useAppCleaner = true,
+                        ),
+                    ),
+                    acsScreenLockedRisk = AcsScheduleRisk.ACS_REQUIRED_SYSTEM_APPS_ONLY,
+                    showAlarmHint = true,
                     showBatteryHint = false,
                     showCommands = false,
                     isLoading = false,

--- a/app-tool-scheduler/src/main/java/eu/darken/sdmse/scheduler/ui/manager/SchedulerManagerViewModel.kt
+++ b/app-tool-scheduler/src/main/java/eu/darken/sdmse/scheduler/ui/manager/SchedulerManagerViewModel.kt
@@ -26,6 +26,9 @@ import eu.darken.sdmse.common.shell.ipc.ShellOpsCmd
 import eu.darken.sdmse.common.uix.ViewModel4
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
 import eu.darken.sdmse.common.upgrade.isPro
+import eu.darken.sdmse.main.core.GeneralSettings
+import eu.darken.sdmse.main.core.taskmanager.AcsScheduleRisk
+import eu.darken.sdmse.main.core.taskmanager.SchedulerAppCleanerAdvisor
 import eu.darken.sdmse.scheduler.R
 import eu.darken.sdmse.scheduler.core.Schedule
 import eu.darken.sdmse.scheduler.core.ScheduleId
@@ -35,6 +38,7 @@ import eu.darken.sdmse.scheduler.ui.ScheduleItemRoute
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
@@ -56,6 +60,8 @@ class SchedulerManagerViewModel @Inject constructor(
     dispatcherProvider: DispatcherProvider,
     private val schedulerManager: SchedulerManager,
     private val settings: SchedulerSettings,
+    private val generalSettings: GeneralSettings,
+    private val appCleanerAdvisor: SchedulerAppCleanerAdvisor,
     private val upgradeRepo: UpgradeRepo,
     private val rootManager: RootManager,
     private val adbManager: AdbManager,
@@ -73,6 +79,23 @@ class SchedulerManagerViewModel @Inject constructor(
         settings.hintBatteryDismissed.flow,
     ) { isIgnoring, isDismissed ->
         !isDismissed && !isIgnoring
+    }
+
+    // Risk type to surface (NONE = hide), gated by everything except "is there an enabled AppCleaner schedule"
+    // (that part needs schedulerManager.state, resolved in the main combine).
+    private val acsScreenLockedRisk = combine(
+        appCleanerAdvisor.acsScheduleRisk,
+        settings.useAutomation.flow,
+        generalSettings.hasAcsConsent.flow,
+        settings.hintAcsScreenLockedDismissed.flow,
+    ) { risk, useAutomation, hasConsent, dismissed ->
+        resolveAcsScreenLockedHint(
+            risk = risk,
+            schedulerUsesAutomation = useAutomation,
+            hasAcsConsent = hasConsent == true,
+            hasEnabledAppCleanerSchedule = true,
+            dismissed = dismissed,
+        )
     }
 
     init {
@@ -99,21 +122,54 @@ class SchedulerManagerViewModel @Inject constructor(
                 settings.hintBatteryDismissed.value(false)
             }
         }
+
+        // Re-arm the ACS screen-locked hint once the risky combination no longer applies, so a future
+        // reconfiguration surfaces it again instead of staying permanently dismissed. `dismissed` is intentionally
+        // excluded from the inputs (and not reset while the risk is active) so this never fights a fresh dismissal.
+        combine(
+            appCleanerAdvisor.acsScheduleRisk,
+            settings.useAutomation.flow,
+            generalSettings.hasAcsConsent.flow,
+            schedulerManager.state,
+        ) { risk, useAutomation, hasConsent, schedulerState ->
+            resolveAcsScreenLockedHint(
+                risk = risk,
+                schedulerUsesAutomation = useAutomation,
+                hasAcsConsent = hasConsent == true,
+                hasEnabledAppCleanerSchedule = schedulerState.schedules.any { it.isEnabled && it.useAppCleaner },
+                dismissed = false,
+            ) != AcsScheduleRisk.NONE
+        }
+            .distinctUntilChanged()
+            .onEach { riskActive ->
+                if (!riskActive && settings.hintAcsScreenLockedDismissed.value()) {
+                    log(TAG) { "Re-arming ACS screen-locked hint (risk no longer active)" }
+                    settings.hintAcsScreenLockedDismissed.value(false)
+                }
+            }
+            .launchInViewModel()
     }
 
     val state: StateFlow<State> = combine(
         schedulerManager.state,
         showBatteryOptimizationHint,
-    ) { schedulerState, showBatteryHint ->
+        acsScreenLockedRisk,
+    ) { schedulerState, showBatteryHint, acsRisk ->
         val sortedSchedules = schedulerState.schedules.sortedBy { it.label.lowercase() }
         // showCommands re-resolved per-emission via the suspend `combine` block; this only
         // refreshes when schedulerManager.state re-emits, so root/ADB becoming available mid-screen
         // won't surface until the next emission. Same trade-off as legacy.
         val showCommands = rootManager.canUseRootNow() || adbManager.canUseAdbNow()
+        val acsScreenLockedRisk = if (sortedSchedules.any { it.isEnabled && it.useAppCleaner }) {
+            acsRisk
+        } else {
+            AcsScheduleRisk.NONE
+        }
         State(
             schedules = sortedSchedules,
             showAlarmHint = sortedSchedules.any { it.isEnabled },
             showBatteryHint = hasApiLevel(31) && showBatteryHint && sortedSchedules.any { it.isEnabled },
+            acsScreenLockedRisk = acsScreenLockedRisk,
             showCommands = showCommands,
             isLoading = false,
         )
@@ -189,6 +245,11 @@ class SchedulerManagerViewModel @Inject constructor(
     fun dismissBatteryHint() = launch {
         log(TAG) { "dismissBatteryHint()" }
         settings.hintBatteryDismissed.value(true)
+    }
+
+    fun dismissAcsScreenLockedHint() = launch {
+        log(TAG) { "dismissAcsScreenLockedHint()" }
+        settings.hintAcsScreenLockedDismissed.value(true)
     }
 
     fun showHelp() {
@@ -279,6 +340,7 @@ class SchedulerManagerViewModel @Inject constructor(
         val schedules: List<Schedule> = emptyList(),
         val showAlarmHint: Boolean = false,
         val showBatteryHint: Boolean = false,
+        val acsScreenLockedRisk: AcsScheduleRisk = AcsScheduleRisk.NONE,
         val showCommands: Boolean = false,
         val isLoading: Boolean = true,
     )
@@ -292,4 +354,27 @@ class SchedulerManagerViewModel @Inject constructor(
         private val TAG = logTag("Scheduler", "Manager", "ViewModel")
         private const val HELP_URL = "https://github.com/d4rken-org/sdmaid-se/wiki/Scheduler"
     }
+}
+
+/**
+ * The screen-locked AppCleaner warning only makes sense when ACS is actually the active path AND the schedule will
+ * run it: ACS automation is needed ([risk] != NONE), the scheduler is allowed to use ACS, the user has consented to
+ * accessibility, an enabled schedule actually runs AppCleaner, and the hint hasn't been dismissed.
+ */
+internal fun resolveAcsScreenLockedHint(
+    risk: AcsScheduleRisk,
+    schedulerUsesAutomation: Boolean,
+    hasAcsConsent: Boolean,
+    hasEnabledAppCleanerSchedule: Boolean,
+    dismissed: Boolean,
+): AcsScheduleRisk = if (
+    risk == AcsScheduleRisk.NONE ||
+    !schedulerUsesAutomation ||
+    !hasAcsConsent ||
+    !hasEnabledAppCleanerSchedule ||
+    dismissed
+) {
+    AcsScheduleRisk.NONE
+} else {
+    risk
 }

--- a/app-tool-scheduler/src/main/java/eu/darken/sdmse/scheduler/ui/manager/items/AcsScreenLockedHintRow.kt
+++ b/app-tool-scheduler/src/main/java/eu/darken/sdmse/scheduler/ui/manager/items/AcsScreenLockedHintRow.kt
@@ -1,0 +1,112 @@
+package eu.darken.sdmse.scheduler.ui.manager.items
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.AccessibilityNew
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import eu.darken.sdmse.common.R as CommonR
+import eu.darken.sdmse.common.compose.preview.Preview2
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.main.core.taskmanager.AcsScheduleRisk
+import eu.darken.sdmse.scheduler.R
+
+@Composable
+internal fun AcsScreenLockedHintRow(
+    modifier: Modifier = Modifier,
+    risk: AcsScheduleRisk,
+    onDismiss: () -> Unit,
+) {
+    val titleRes: Int
+    val bodyRes: Int
+    when (risk) {
+        AcsScheduleRisk.ACS_REQUIRED_SYSTEM_APPS_ONLY -> {
+            titleRes = R.string.scheduler_acs_screenlocked_hint_systemapps_title
+            bodyRes = R.string.scheduler_acs_screenlocked_hint_systemapps_body
+        }
+        else -> {
+            titleRes = R.string.scheduler_acs_screenlocked_hint_title
+            bodyRes = R.string.scheduler_acs_screenlocked_hint_body
+        }
+    }
+
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+            contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+        ),
+        shape = RoundedCornerShape(16.dp),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    Icons.TwoTone.AccessibilityNew,
+                    contentDescription = null,
+                    modifier = Modifier.size(24.dp),
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = stringResource(titleRes),
+                    style = MaterialTheme.typography.titleMedium,
+                )
+            }
+            Spacer(modifier = Modifier.padding(vertical = 4.dp))
+            Text(
+                text = stringResource(bodyRes),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            Spacer(modifier = Modifier.padding(vertical = 4.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                TextButton(onClick = onDismiss) {
+                    Text(stringResource(CommonR.string.general_dismiss_action))
+                }
+            }
+        }
+    }
+}
+
+@Preview2
+@Composable
+private fun AcsScreenLockedHintRowPreview() {
+    PreviewWrapper {
+        AcsScreenLockedHintRow(
+            risk = AcsScheduleRisk.ACS_REQUIRED_ALL,
+            onDismiss = {},
+            modifier = Modifier.padding(16.dp),
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun AcsScreenLockedHintRowSystemAppsPreview() {
+    PreviewWrapper {
+        AcsScreenLockedHintRow(
+            risk = AcsScheduleRisk.ACS_REQUIRED_SYSTEM_APPS_ONLY,
+            onDismiss = {},
+            modifier = Modifier.padding(16.dp),
+        )
+    }
+}

--- a/app-tool-scheduler/src/main/res/values/strings.xml
+++ b/app-tool-scheduler/src/main/res/values/strings.xml
@@ -34,6 +34,11 @@
     <string name="scheduler_notification_result_title">Scheduler finished</string>
     <string name="scheduler_notification_result_success_message">All scheduled tasks ran successfully.</string>
     <string name="scheduler_notification_result_failure_message">Some scheduled tasks failed or encountered errors. Try running them manually.</string>
+    <string name="scheduler_notification_result_skipped_screen_unavailable">Skipped, screen was off or locked</string>
+    <string name="scheduler_acs_screenlocked_hint_title">App cleaning may be skipped</string>
+    <string name="scheduler_acs_screenlocked_hint_body">App cleaning uses the accessibility service, which needs the screen unlocked. Scheduled runs while the device is locked are skipped.\n\nUse Shizuku or root for background cleaning, or schedule it for when you\'re using the device.</string>
+    <string name="scheduler_acs_screenlocked_hint_systemapps_title">System apps may be skipped</string>
+    <string name="scheduler_acs_screenlocked_hint_systemapps_body">Shizuku cleans most caches in the background, but system apps need the accessibility service, which needs the screen unlocked. With \"Include system apps\" on, those are skipped when the device is locked.\n\nTurn off \"Include system apps\", or run the schedule while unlocked.</string>
     <string name="scheduler_commands_after_schedule_label">Post-schedule commands</string>
     <string name="scheduler_commands_after_schedule_desc">Android shell commands that will be executed at the end of a schedule.</string>
     <string name="scheduler_battery_optimization_hint">Consider disabling battery optimizations for SD Maid if you experience issues with background execution.</string>

--- a/app-tool-scheduler/src/test/java/eu/darken/sdmse/scheduler/core/SchedulerNotificationsErrorLabelTest.kt
+++ b/app-tool-scheduler/src/test/java/eu/darken/sdmse/scheduler/core/SchedulerNotificationsErrorLabelTest.kt
@@ -1,0 +1,41 @@
+package eu.darken.sdmse.scheduler.core
+
+import eu.darken.sdmse.automation.core.errors.AutomationSchedulerException
+import eu.darken.sdmse.automation.core.errors.ScreenUnavailableException
+import eu.darken.sdmse.scheduler.R
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import eu.darken.sdmse.common.R as CommonR
+
+class SchedulerNotificationsErrorLabelTest : BaseTest() {
+
+    @Test fun `direct screen-unavailable exception is a skip`() {
+        ScreenUnavailableException("Screen is unavailable!").isScreenUnavailableSkip() shouldBe true
+    }
+
+    @Test fun `scheduler-wrapped screen-unavailable exception is a skip`() {
+        // This is exactly how SchedulerWorker wraps the failure before it reaches the notification.
+        AutomationSchedulerException(ScreenUnavailableException("Screen is unavailable!"))
+            .isScreenUnavailableSkip() shouldBe true
+    }
+
+    @Test fun `additionally wrapped screen-unavailable exception is a skip`() {
+        RuntimeException(AutomationSchedulerException(ScreenUnavailableException("Screen is unavailable!")))
+            .isScreenUnavailableSkip() shouldBe true
+    }
+
+    @Test fun `unrelated exception is not a skip`() {
+        RuntimeException("Something else broke").isScreenUnavailableSkip() shouldBe false
+    }
+
+    @Test fun `error label resolves to the screen-unavailable string for a skip`() {
+        AutomationSchedulerException(ScreenUnavailableException("Screen is unavailable!"))
+            .toSchedulerErrorLabelRes() shouldBe R.string.scheduler_notification_result_skipped_screen_unavailable
+    }
+
+    @Test fun `error label resolves to the generic error string otherwise`() {
+        RuntimeException("Something else broke")
+            .toSchedulerErrorLabelRes() shouldBe CommonR.string.general_error_label
+    }
+}

--- a/app-tool-scheduler/src/test/java/eu/darken/sdmse/scheduler/ui/manager/AcsScreenLockedHintTest.kt
+++ b/app-tool-scheduler/src/test/java/eu/darken/sdmse/scheduler/ui/manager/AcsScreenLockedHintTest.kt
@@ -1,0 +1,49 @@
+package eu.darken.sdmse.scheduler.ui.manager
+
+import eu.darken.sdmse.main.core.taskmanager.AcsScheduleRisk
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class AcsScreenLockedHintTest : BaseTest() {
+
+    private fun resolve(
+        risk: AcsScheduleRisk = AcsScheduleRisk.ACS_REQUIRED_ALL,
+        schedulerUsesAutomation: Boolean = true,
+        hasAcsConsent: Boolean = true,
+        hasEnabledAppCleanerSchedule: Boolean = true,
+        dismissed: Boolean = false,
+    ) = resolveAcsScreenLockedHint(
+        risk = risk,
+        schedulerUsesAutomation = schedulerUsesAutomation,
+        hasAcsConsent = hasAcsConsent,
+        hasEnabledAppCleanerSchedule = hasEnabledAppCleanerSchedule,
+        dismissed = dismissed,
+    )
+
+    @Test fun `all conditions met - surfaces the underlying risk`() {
+        resolve(risk = AcsScheduleRisk.ACS_REQUIRED_ALL) shouldBe AcsScheduleRisk.ACS_REQUIRED_ALL
+        resolve(risk = AcsScheduleRisk.ACS_REQUIRED_SYSTEM_APPS_ONLY) shouldBe
+            AcsScheduleRisk.ACS_REQUIRED_SYSTEM_APPS_ONLY
+    }
+
+    @Test fun `no underlying risk - hidden`() {
+        resolve(risk = AcsScheduleRisk.NONE) shouldBe AcsScheduleRisk.NONE
+    }
+
+    @Test fun `scheduler automation off - hidden`() {
+        resolve(schedulerUsesAutomation = false) shouldBe AcsScheduleRisk.NONE
+    }
+
+    @Test fun `no accessibility consent - hidden`() {
+        resolve(hasAcsConsent = false) shouldBe AcsScheduleRisk.NONE
+    }
+
+    @Test fun `no enabled appcleaner schedule - hidden`() {
+        resolve(hasEnabledAppCleanerSchedule = false) shouldBe AcsScheduleRisk.NONE
+    }
+
+    @Test fun `dismissed - hidden`() {
+        resolve(dismissed = true) shouldBe AcsScheduleRisk.NONE
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/main/core/taskmanager/SchedulerAppCleanerAdvisorImpl.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/core/taskmanager/SchedulerAppCleanerAdvisorImpl.kt
@@ -1,0 +1,57 @@
+package eu.darken.sdmse.main.core.taskmanager
+
+import eu.darken.sdmse.appcleaner.core.AppCleanerSettings
+import eu.darken.sdmse.common.adb.AdbManager
+import eu.darken.sdmse.common.root.RootManager
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class SchedulerAppCleanerAdvisorImpl @Inject constructor(
+    private val appCleanerSettings: AppCleanerSettings,
+    private val rootManager: RootManager,
+    private val adbManager: AdbManager,
+) : SchedulerAppCleanerAdvisor {
+
+    // Reactive over both the AppCleaner settings and root/ADB availability, so the warning refreshes when the user
+    // grants/loses Shizuku or root mid-session, not just when an AppCleaner setting changes.
+    override val acsScheduleRisk: Flow<AcsScheduleRisk> = combine(
+        appCleanerSettings.includeInaccessibleEnabled.flow,
+        appCleanerSettings.filterDefaultCachesPublicEnabled.flow,
+        appCleanerSettings.filterDefaultCachesPrivateEnabled.flow,
+        appCleanerSettings.includeSystemAppsEnabled.flow,
+        combine(rootManager.useRoot, adbManager.useAdb) { root, adb -> root to adb },
+    ) { includeInaccessible, filterPublic, filterPrivate, includeSystemApps, (hasRoot, hasAdb) ->
+        classifyAcsScheduleRisk(
+            includeInaccessible = includeInaccessible,
+            filterPublic = filterPublic,
+            filterPrivate = filterPrivate,
+            hasRoot = hasRoot,
+            hasAdb = hasAdb,
+            includeSystemApps = includeSystemApps,
+        )
+    }
+}
+
+/**
+ * Mirrors the AppCleaner scanner/deleter gates that decide whether inaccessible-cache clearing falls back to ACS:
+ * - `AppScanner.determineInaccessibleCaches` skips entirely without [includeInaccessible], without both default-cache
+ *   filters, or when root is available.
+ * - `InaccessibleDeleter.trimCachesWithAdb` clears non-system apps via ADB/Shizuku; system apps still need ACS.
+ */
+internal fun classifyAcsScheduleRisk(
+    includeInaccessible: Boolean,
+    filterPublic: Boolean,
+    filterPrivate: Boolean,
+    hasRoot: Boolean,
+    hasAdb: Boolean,
+    includeSystemApps: Boolean,
+): AcsScheduleRisk = when {
+    !includeInaccessible || !filterPublic || !filterPrivate -> AcsScheduleRisk.NONE
+    hasRoot -> AcsScheduleRisk.NONE
+    !hasAdb -> AcsScheduleRisk.ACS_REQUIRED_ALL
+    includeSystemApps -> AcsScheduleRisk.ACS_REQUIRED_SYSTEM_APPS_ONLY
+    else -> AcsScheduleRisk.NONE
+}

--- a/app/src/main/java/eu/darken/sdmse/main/core/taskmanager/TaskManagerModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/core/taskmanager/TaskManagerModule.kt
@@ -17,4 +17,8 @@ abstract class TaskManagerModule {
     @Binds
     @Singleton
     abstract fun schedulerTaskFactory(impl: SchedulerTaskFactoryImpl): SchedulerTaskFactory
+
+    @Binds
+    @Singleton
+    abstract fun schedulerAppCleanerAdvisor(impl: SchedulerAppCleanerAdvisorImpl): SchedulerAppCleanerAdvisor
 }

--- a/app/src/test/java/eu/darken/sdmse/main/core/taskmanager/SchedulerAppCleanerAdvisorImplTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/core/taskmanager/SchedulerAppCleanerAdvisorImplTest.kt
@@ -1,0 +1,50 @@
+package eu.darken.sdmse.main.core.taskmanager
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class SchedulerAppCleanerAdvisorImplTest : BaseTest() {
+
+    private fun classify(
+        includeInaccessible: Boolean = true,
+        filterPublic: Boolean = true,
+        filterPrivate: Boolean = true,
+        hasRoot: Boolean = false,
+        hasAdb: Boolean = false,
+        includeSystemApps: Boolean = false,
+    ) = classifyAcsScheduleRisk(
+        includeInaccessible = includeInaccessible,
+        filterPublic = filterPublic,
+        filterPrivate = filterPrivate,
+        hasRoot = hasRoot,
+        hasAdb = hasAdb,
+        includeSystemApps = includeSystemApps,
+    )
+
+    @Test fun `no privileged access, inaccessible cleaning on - ACS needed for all`() {
+        classify() shouldBe AcsScheduleRisk.ACS_REQUIRED_ALL
+    }
+
+    @Test fun `root available - no ACS, inaccessible detection is skipped`() {
+        classify(hasRoot = true) shouldBe AcsScheduleRisk.NONE
+        classify(hasRoot = true, hasAdb = true, includeSystemApps = true) shouldBe AcsScheduleRisk.NONE
+    }
+
+    @Test fun `adb covers normal apps - no ACS when system apps excluded`() {
+        classify(hasAdb = true, includeSystemApps = false) shouldBe AcsScheduleRisk.NONE
+    }
+
+    @Test fun `adb present but system apps included - ACS needed for system apps only`() {
+        classify(hasAdb = true, includeSystemApps = true) shouldBe AcsScheduleRisk.ACS_REQUIRED_SYSTEM_APPS_ONLY
+    }
+
+    @Test fun `inaccessible cleaning disabled - no ACS`() {
+        classify(includeInaccessible = false) shouldBe AcsScheduleRisk.NONE
+    }
+
+    @Test fun `default cache filters disabled - no ACS, scanner finds no inaccessible targets`() {
+        classify(filterPublic = false) shouldBe AcsScheduleRisk.NONE
+        classify(filterPrivate = false) shouldBe AcsScheduleRisk.NONE
+    }
+}


### PR DESCRIPTION
## What changed

If you scheduled the app cleaner to run automatically (for example overnight) and rely on the accessibility service to clear caches, the cleaner can only work while the screen is on and unlocked. Unattended runs were quietly failing, and the scheduler reported a confusing "AppCleaner: Error".

Two improvements:

- The scheduler result notification now reads "Skipped, screen was off or locked" instead of a generic error, so it's clear this is a limitation rather than a malfunction.
- The Scheduler screen now shows an advisory note when your settings would hit this limitation — explaining that the combination only works while the device is unlocked, and pointing to Shizuku/root or scheduling for a time you're using the device. If you use Shizuku, it specifically calls out that only system-app caches are affected (because "Include system apps" is enabled).

## Technical Context

- **Root cause**: a scheduled AppCleaner run clears inaccessible/third-party caches via the accessibility service (`ClearCacheTask`). The `Stepper` screen guard throws `ScreenUnavailableException` when the screen is off/locked; it propagates (no per-step catch in `AppCleaner`) and aborts the task, which the scheduler wrapped as a generic error.
- **Warning trigger** is computed by a new app-module `SchedulerAppCleanerAdvisor` (interface in `app-common`, impl + Hilt binding in `app`) so `app-tool-scheduler` doesn't depend on `app-tool-appcleaner`. It mirrors the real scanner/deleter gates: `includeInaccessible` + both default-cache filters on, `!root` (root skips inaccessible detection entirely), and `!adb || includeSystemApps` — Shizuku's `trimCaches` only clears non-system apps, so system apps still fall through to ACS.
- The card is additionally gated by the scheduler's automation option, accessibility consent, and an enabled AppCleaner schedule. It's dismissible (persisted) and re-arms reactively once the risky combination no longer applies. Two copy variants distinguish the all-ACS case from the Shizuku/system-apps-only case.
- **Presentation-only**: no change to scheduling or execution behavior. Pure helpers extracted for the risk classifier and the hint gate, both covered by unit tests.

Found via a support investigation (Xiaomi/MIUI, accessibility-only mode, 01:00 schedule).
