### PR TITLE
General: Cancel automation on Android TV with the Home button

### DIFF
--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/AutomationModuleExtensions.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/AutomationModuleExtensions.kt
@@ -20,6 +20,13 @@ suspend fun AutomationModule.finishAutomation(
     returnToAppIntent: Intent?,
     deviceDetective: DeviceDetective,
 ) = withContext(if (userCancelled) NonCancellable else EmptyCoroutineContext) {
+    // On TV a guard cancels the task when the user surfaces the home screen. Our own exit
+    // navigation below (BACK/HOME) could trip that guard, so hide the overlay first to disarm it.
+    // changeOptions() is awaited here so the disarm lands before we navigate.
+    if (deviceDetective.isTvLikeDevice()) {
+        log(TAG, INFO) { "finishAutomation(...): Hiding overlay to disarm TV leave-guard" }
+        host.changeOptions { it.copy(showOverlay = false) }
+    }
     if (returnToAppIntent != null) {
         // Settings may have multiple screens open (e.g. App Info → Storage).
         // Press BACK until we're back at SD Maid, closing all settings screens along the way.

--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/AutomationService.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/AutomationService.kt
@@ -2,6 +2,7 @@ package eu.darken.sdmse.automation.core
 
 import android.accessibilityservice.AccessibilityService
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.graphics.PixelFormat
 import android.view.Gravity
 import android.view.View
@@ -28,6 +29,7 @@ import eu.darken.sdmse.automation.ui.AutomationOverlay
 import eu.darken.sdmse.automation.ui.AutomationOverlayState
 import eu.darken.sdmse.automation.ui.OverlayLifecycleOwner
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
+import eu.darken.sdmse.common.device.DeviceDetective
 import eu.darken.sdmse.common.theming.SdmSeTheme
 import eu.darken.sdmse.common.theming.ThemeState
 import eu.darken.sdmse.common.datastore.value
@@ -92,8 +94,30 @@ class AutomationService : AccessibilityService(), AutomationHost, AutomationServ
     @Inject lateinit var automationManager: AutomationManager
     @Inject @SetupBinding(SetupModule.Type.AUTOMATION) lateinit var automationSetupModule: SetupModule
     @Inject lateinit var screenState: ScreenState
+    @Inject lateinit var deviceDetective: DeviceDetective
 
     private lateinit var windowManager: WindowManager
+
+    /** Leanback/TV-style device: the overlay Cancel button is unreachable by D-pad here. */
+    private val isTvDevice: Boolean by lazy { deviceDetective.isTvLikeDevice() }
+
+    /**
+     * The default launcher package. On TV we treat the user surfacing the launcher (Home button) as
+     * an intentional cancel. We resolve the *default* home (MATCH_DEFAULT_ONLY) rather than querying
+     * all CATEGORY_HOME registrants: on Android TV the Settings app registers a `FallbackHome`
+     * activity for CATEGORY_HOME, and since automation runs inside Settings, including it would make
+     * the guard cancel the moment automation enters Settings. `MATCH_DEFAULT_ONLY` yields only the
+     * actual launcher the user lands on. Empty if it resolves to the system chooser or nothing — then
+     * the overlay won't promise a Home-to-cancel.
+     */
+    private val homePackages: Set<String> by lazy {
+        val intent = Intent(Intent.ACTION_MAIN).addCategory(Intent.CATEGORY_HOME)
+        val resolved = packageManager.resolveActivity(intent, PackageManager.MATCH_DEFAULT_ONLY)
+        val pkg = resolved?.activityInfo?.packageName?.takeUnless { it == "android" }
+        val pkgs = setOfNotNull(pkg)
+        log(TAG, INFO) { "Home package resolved: $pkgs (from $resolved)" }
+        pkgs
+    }
 
     private val automationEvents = MutableSharedFlow<Snapshot>(
         extraBufferCapacity = 10,
@@ -394,10 +418,9 @@ class AutomationService : AccessibilityService(), AutomationHost, AutomationServ
                             val s by overlayState.collectAsState()
                             AutomationOverlay(
                                 state = s,
-                                onCancel = {
-                                    serviceScope.launch { changeOptions { it.copy(showOverlay = false) } }
-                                    currentTask.value?.second?.cancel(cause = UserCancelledAutomationException())
-                                },
+                                isTv = isTvDevice,
+                                showHomeCancelHint = isTvDevice && homePackages.isNotEmpty(),
+                                onCancel = { userCancelCurrentTask() },
                             )
                         }
                     }
@@ -465,8 +488,38 @@ class AutomationService : AccessibilityService(), AutomationHost, AutomationServ
         }
         currentTask.value = task to deferred
         automationManager.setCurrentTask(task)
+
+        // On TV the overlay Cancel button is unreachable by D-pad. Instead, watch for the user
+        // surfacing the home screen (Home button) during the task and treat it as a cancel.
+        // Launched after currentTask is assigned so the cancel can't no-op; torn down with the task.
+        if (isTvDevice && homePackages.isNotEmpty()) {
+            val leaveGuardJob = leaveSignals(
+                foregroundPkgs = automationEvents
+                    .filter { it.eventType == AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED }
+                    .map { it.pkgId },
+                homePkgs = homePackages,
+                graceMs = LEAVE_CANCEL_GRACE_MS,
+            )
+                .onEach {
+                    // Re-check the overlay is still armed: finishAutomation() hides it before its own
+                    // BACK/HOME exit navigation, so the engine's exit isn't misread as a user-leave.
+                    if (hostState.value.hasOverlay) {
+                        log(TAG, INFO) { "submit($id): User left to home screen, cancelling task" }
+                        userCancelCurrentTask()
+                    }
+                }
+                .launchIn(serviceScope)
+            deferred.invokeOnCompletion { leaveGuardJob.cancel() }
+        }
+
         log(TAG) { "submit($id): ...waiting for result" }
         deferred.await().also { log(TAG) { "submit($id): Result available: $it" } }
+    }
+
+    /** Hide the overlay and cancel the running task as if the user pressed Cancel (overlay button / TV Home). */
+    private fun userCancelCurrentTask() {
+        serviceScope.launch { changeOptions { it.copy(showOverlay = false) } }
+        currentTask.value?.second?.cancel(cause = UserCancelledAutomationException())
     }
 
     override fun cancelTask(): Boolean {
@@ -480,5 +533,8 @@ class AutomationService : AccessibilityService(), AutomationHost, AutomationServ
     companion object {
         val TAG: String = logTag("Automation", "Service")
         var instance: AutomationService? = null
+
+        /** How long the home screen must stay foreground before a TV "leave" counts as a cancel. */
+        private const val LEAVE_CANCEL_GRACE_MS = 1000L
     }
 }

--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/LeaveCancelGuard.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/LeaveCancelGuard.kt
@@ -1,0 +1,36 @@
+package eu.darken.sdmse.automation.core
+
+import eu.darken.sdmse.common.pkgs.Pkg
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.take
+
+/**
+ * Emits exactly once when the user appears to have left the automated app for the home/launcher
+ * screen, i.e. the foreground became a [homePkgs] package and stayed there for [graceMs].
+ *
+ * Used on Android TV where the on-screen Cancel button is unreachable by D-pad: pressing the
+ * Home button surfaces the launcher, which we treat as an intentional cancel.
+ *
+ * Semantics:
+ * - **Latched, non-resetting**: the first home sighting commits to a cancel after [graceMs]. We do
+ *   NOT reset if the target app reappears mid-grace, because that reappearance is almost always the
+ *   automation engine re-launching Settings — honoring the user's Home press is the intent.
+ * - **Null/foreign foreground ignored**: only home packages matter; everything else is dropped.
+ *
+ * Callers are expected to feed a stream already restricted to foreground-window changes
+ * (`TYPE_WINDOW_STATE_CHANGED`) and to re-check that a cancel is still wanted (e.g. the overlay is
+ * still armed) before acting.
+ */
+internal fun leaveSignals(
+    foregroundPkgs: Flow<Pkg.Id?>,
+    homePkgs: Set<String>,
+    graceMs: Long,
+): Flow<Unit> = foregroundPkgs
+    .filter { it != null && it.name in homePkgs }
+    .take(1)
+    .onEach { delay(graceMs) }
+    .map { }

--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/ui/AutomationOverlay.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/ui/AutomationOverlay.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -48,6 +49,8 @@ internal data class AutomationOverlayState(
 internal fun AutomationOverlay(
     modifier: Modifier = Modifier,
     state: AutomationOverlayState,
+    isTv: Boolean = false,
+    showHomeCancelHint: Boolean = false,
     onCancel: () -> Unit,
 ) {
     val progress = state.progress ?: return
@@ -70,7 +73,14 @@ internal fun AutomationOverlay(
             )
 
             Text(
-                text = stringResource(AutomationR.string.automation_screenoverlay_explanation),
+                text = stringResource(
+                    when {
+                        isTv && showHomeCancelHint -> AutomationR.string.automation_screenoverlay_explanation_tv
+                        // TV without a resolvable launcher: no reachable cancel, so don't promise one.
+                        isTv -> AutomationR.string.automation_screenoverlay_explanation_nocancel
+                        else -> AutomationR.string.automation_screenoverlay_explanation
+                    },
+                ),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurface,
                 modifier = Modifier.padding(horizontal = 32.dp, vertical = 16.dp),
@@ -81,6 +91,7 @@ internal fun AutomationOverlay(
             ControlCard(
                 state = state,
                 progress = progress,
+                isTv = isTv,
                 onCancel = onCancel,
                 modifier = Modifier
                     .fillMaxWidth()
@@ -97,6 +108,7 @@ private fun ControlCard(
     modifier: Modifier = Modifier,
     state: AutomationOverlayState,
     progress: Progress.Data,
+    isTv: Boolean = false,
     onCancel: () -> Unit,
 ) {
     val ctx = LocalContext.current
@@ -161,22 +173,28 @@ private fun ControlCard(
             overflow = TextOverflow.Ellipsis,
         )
 
-        Button(
-            onClick = onCancel,
-            colors = ButtonDefaults.buttonColors(
-                containerColor = MaterialTheme.colorScheme.error,
-                contentColor = MaterialTheme.colorScheme.onError,
-            ),
-            modifier = Modifier
-                .align(Alignment.End)
-                .padding(16.dp),
-        ) {
-            Icon(
-                imageVector = Icons.TwoTone.Cancel,
-                contentDescription = null,
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-            Text(stringResource(CommonR.string.general_cancel_action))
+        if (isTv) {
+            // No touchscreen and the overlay window isn't D-pad focusable, so the button would be
+            // unreachable. Cancel happens via the Home button (see the explanation text) instead.
+            Spacer(modifier = Modifier.height(16.dp))
+        } else {
+            Button(
+                onClick = onCancel,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.error,
+                    contentColor = MaterialTheme.colorScheme.onError,
+                ),
+                modifier = Modifier
+                    .align(Alignment.End)
+                    .padding(16.dp),
+            ) {
+                Icon(
+                    imageVector = Icons.TwoTone.Cancel,
+                    contentDescription = null,
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(stringResource(CommonR.string.general_cancel_action))
+            }
         }
     }
 }
@@ -259,6 +277,27 @@ private fun AutomationOverlayPercentPreview() {
                     count = Progress.Count.Percent(current = 33, max = 100),
                 ),
             ),
+            onCancel = {},
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun AutomationOverlayTvPreview() {
+    PreviewWrapper {
+        AutomationOverlay(
+            state = AutomationOverlayState(
+                title = "AppCleaner".toCaString(),
+                subtitle = "Clearing caches…".toCaString(),
+                progress = Progress.Data(
+                    primary = "com.example.app".toCaString(),
+                    secondary = "/storage/emulated/0/Android/data/com.example.app/cache".toCaString(),
+                    count = Progress.Count.Indeterminate(),
+                ),
+            ),
+            isTv = true,
+            showHomeCancelHint = true,
             onCancel = {},
         )
     }

--- a/app-common-automation/src/main/res/values/strings.xml
+++ b/app-common-automation/src/main/res/values/strings.xml
@@ -2,6 +2,8 @@
 <resources>
     <string name="automation_accessibility_service_description">Users with special accessibility needs can enable this service to allow SD Maid to automate tasks that would otherwise require tedious manual user interaction (e.g. cache deletion).\n\nExample: If you instruct SD Maid to stop multiple apps then SD Maid can use this service to open each apps settings screen, find the \'Force Stop\' button and tap it.\n\nSD Maid will always prominently show when using this service and provide an easy way for the user to cancel any interaction immediately.\n\nNo actions will be performed without prior user approval. This service can be disabled again at any time without adverse effects.</string>
     <string name="automation_screenoverlay_explanation">SD Maid is interacting with your device. It\'s not possible to use the screen at the same time. Wait until the operation is finished or cancel it.</string>
+    <string name="automation_screenoverlay_explanation_tv">SD Maid is interacting with your device. It\'s not possible to use the screen at the same time. Wait until the operation is finished, or press the Home button to cancel.</string>
+    <string name="automation_screenoverlay_explanation_nocancel">SD Maid is interacting with your device. It\'s not possible to use the screen at the same time. Wait until the operation is finished.</string>
     <string name="automation_active_title">SD Maid is working</string>
     <string name="automation_error_no_consent_title">Automation error</string>
     <string name="automation_error_no_consent_body">Accessibility service is not set up. Complete the setup and give consent.</string>

--- a/app-common-automation/src/test/java/eu/darken/sdmse/automation/core/LeaveCancelGuardTest.kt
+++ b/app-common-automation/src/test/java/eu/darken/sdmse/automation/core/LeaveCancelGuardTest.kt
@@ -1,0 +1,64 @@
+package eu.darken.sdmse.automation.core
+
+import eu.darken.sdmse.common.pkgs.Pkg
+import eu.darken.sdmse.common.pkgs.toPkgId
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+
+class LeaveCancelGuardTest : BaseTest() {
+
+    private val home = setOf("com.android.tv.launcher", "com.google.android.tvlauncher")
+    private val launcher: Pkg.Id = "com.android.tv.launcher".toPkgId()
+    private val settings: Pkg.Id = "com.android.tv.settings".toPkgId()
+    private val grace = 1000L
+
+    @Test
+    fun `home foreground sustained emits once`() = runTest2 {
+        leaveSignals(flowOf<Pkg.Id?>(launcher), home, grace).toList() shouldHaveSize 1
+    }
+
+    @Test
+    fun `only non-home foreground never emits`() = runTest2 {
+        leaveSignals(flowOf<Pkg.Id?>(settings, settings), home, grace).toList().shouldBeEmpty()
+    }
+
+    @Test
+    fun `null foreground is ignored, a later home still emits`() = runTest2 {
+        leaveSignals(flowOf<Pkg.Id?>(null, settings, launcher), home, grace).toList() shouldHaveSize 1
+    }
+
+    @Test
+    fun `home then engine relaunching settings still emits (latched)`() = runTest2 {
+        // After the user presses Home the engine may re-launch Settings; we still honor the Home press.
+        leaveSignals(flowOf<Pkg.Id?>(launcher, settings), home, grace).toList() shouldHaveSize 1
+    }
+
+    @Test
+    fun `does not emit before the grace window elapses`() = runTest2 {
+        val results = mutableListOf<Unit>()
+        val job = leaveSignals(flow { emit(launcher); awaitCancellation() }, home, grace)
+            .onEach { results.add(it) }
+            .launchIn(backgroundScope)
+
+        advanceTimeBy(grace - 1)
+        runCurrent()
+        results.shouldBeEmpty()
+
+        advanceTimeBy(2)
+        runCurrent()
+        results shouldHaveSize 1
+
+        job.cancel()
+    }
+}

--- a/app-common-automation/src/test/java/eu/darken/sdmse/automation/ui/AutomationOverlayTest.kt
+++ b/app-common-automation/src/test/java/eu/darken/sdmse/automation/ui/AutomationOverlayTest.kt
@@ -1,0 +1,55 @@
+package eu.darken.sdmse.automation.ui
+
+import android.content.Context
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.sdmse.automation.R as AutomationR
+import eu.darken.sdmse.common.R as CommonR
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.common.progress.Progress
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+
+class AutomationOverlayTest : BaseComposeRobolectricTest() {
+
+    private val ctx = ApplicationProvider.getApplicationContext<Context>()
+
+    private val sampleState = AutomationOverlayState(
+        title = "AppCleaner".toCaString(),
+        subtitle = "Clearing caches…".toCaString(),
+        progress = Progress.Data(
+            primary = "com.example.app".toCaString(),
+            secondary = "/storage/emulated/0/Android/data/com.example.app/cache".toCaString(),
+            count = Progress.Count.Indeterminate(),
+        ),
+    )
+
+    @Test
+    fun `phone shows the touch cancel button`() {
+        composeRule.setContent {
+            PreviewWrapper {
+                AutomationOverlay(state = sampleState, isTv = false, onCancel = {})
+            }
+        }
+        composeRule.onNodeWithText(ctx.getString(CommonR.string.general_cancel_action)).assertExists()
+    }
+
+    @Test
+    fun `tv hides the cancel button and shows the home-to-cancel hint`() {
+        composeRule.setContent {
+            PreviewWrapper {
+                AutomationOverlay(
+                    state = sampleState,
+                    isTv = true,
+                    showHomeCancelHint = true,
+                    onCancel = {},
+                )
+            }
+        }
+        composeRule.onNodeWithText(ctx.getString(CommonR.string.general_cancel_action)).assertDoesNotExist()
+        composeRule
+            .onNodeWithText(ctx.getString(AutomationR.string.automation_screenoverlay_explanation_tv))
+            .assertExists()
+    }
+}


### PR DESCRIPTION
## What changed

On Android TV, SD Maid's accessibility automation (used for clearing app caches and force‑stopping apps) shows an overlay while it works. That overlay had a Cancel button — but a TV has no touchscreen and the overlay can't take D‑pad focus, so the button was impossible to reach. The overlay even told you that you could cancel, which you couldn't.

Now, on Android TV, pressing the **Home** button while automation is running cancels it cleanly — the same graceful stop you'd get from tapping Cancel on a phone. On TV the unreachable button is hidden and the text tells you to use the Home button instead. As a bonus, leaving the settings screen mid‑run no longer leaves the task spinning until it times out.

Phones are completely unchanged.

## Technical Context

- **Detection**: a TV‑only, task‑level guard watches the existing accessibility event stream (`TYPE_WINDOW_STATE_CHANGED`) for the launcher coming to the foreground and cancels via the existing `UserCancelledAutomationException` path — identical to the on‑screen button, so no per‑module changes were needed.
- **Launcher resolution is the subtle part**: it resolves the *default* launcher via `resolveActivity` + `MATCH_DEFAULT_ONLY`, not every `CATEGORY_HOME` registrant. On Android TV the Settings app registers a `FallbackHome` activity for `CATEGORY_HOME`; since automation runs *inside* Settings, a naive `queryIntentActivities` would have included the Settings package and cancelled the instant automation started. This exact false‑positive was caught on a TV emulator and is what the `MATCH_DEFAULT_ONLY` resolution fixes.
- **Disarm**: `finishAutomation` hides the overlay before its own BACK/HOME exit navigation, so the engine's own exit isn't misread as a user leave.
- **Latch semantics**: the first launcher sighting commits to a cancel after a ~1s grace and does not reset if Settings reappears — that reappearance is almost always the engine re‑launching Settings, and we want to honor the user's Home press.
- **Review guidance**: the detection logic (`leaveSignals`) is a small pure function with unit tests; the TV overlay variant has a Compose test.

## Verification

- Unit tests (`leaveSignals`) and the Compose overlay test pass; consumers compile.
- Validated end‑to‑end on an Android TV emulator (API 34): Home during automation cancels gracefully, while normal completion **and** the engine's own exit navigation do **not** false‑cancel.
