### PR TITLE
General: Fix rare shell errors when a session is reused right after shutdown

### DIFF
--- a/app-common-shell/src/main/java/eu/darken/sdmse/common/shell/SharedShell.kt
+++ b/app-common-shell/src/main/java/eu/darken/sdmse/common/shell/SharedShell.kt
@@ -63,7 +63,14 @@ class SharedShell(
         }
     }
 
-    val session = SharedResource(aTag, scope, source)
+    val session = SharedResource(
+        tag = aTag,
+        parentScope = scope,
+        source = source,
+        // A shell whose process has died must never be handed to a reuse: SharedResource caches the
+        // session and its async teardown can lag, so validate liveness and re-acquire a fresh shell.
+        isReusable = { it.isAlive() },
+    )
 
     override val sharedResource: SharedResource<FlowCmdShell.Session> = session
 

--- a/app-common-shell/src/test/java/eu/darken/sdmse/common/shell/SharedShellTest.kt
+++ b/app-common-shell/src/test/java/eu/darken/sdmse/common/shell/SharedShellTest.kt
@@ -87,4 +87,18 @@ class SharedShellTest : BaseTest() {
             sharedShell.useRes { FlowCmd("echo test-$count").execute(it) }.isSuccessful shouldBe true
         }
     }
+
+    @Test fun `a dead shell session is never handed to a reuse`() = runTest2(autoCancel = true, timeout = 60.seconds) {
+        val sharedShell = SharedShell("SDMSE", this + Dispatchers.Default)
+
+        // `kill $$` makes the shell process exit mid-command -> the same failure mode as the reuse-with-cancel
+        // flake: the command sees no exit-code marker and throws (session died externally).
+        shouldThrow<IllegalStateException> {
+            sharedShell.useRes { FlowCmd("kill \$\$").execute(it) }
+        }
+
+        // The cached session is now dead but SharedResource's detach is asynchronous. Without the liveness
+        // check, the next get() reuses the dead session and fails the same way. It must instead get a fresh shell.
+        sharedShell.useRes { FlowCmd("echo after").execute(it) }.output shouldBe listOf("after")
+    }
 }

--- a/app-common/src/main/java/eu/darken/sdmse/common/sharedresource/SharedResource.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/sharedresource/SharedResource.kt
@@ -48,6 +48,14 @@ open class SharedResource<T : Any>(
      * Off by default — opt in per resource where silent failures are a known support pain point.
      */
     private val verboseLifecycle: Boolean = false,
+    /**
+     * Optional liveness check for a REUSED resource. Before handing back a cached generation, [get]
+     * validates its value with this; if it returns false the dead generation is detached and [get]
+     * retries with a fresh one. Guards against the window where a resource's backing has already died
+     * (e.g. a shell process exited) but the asynchronous onCompletion detach hasn't cleared [active]
+     * yet, so a reuse would otherwise be handed a dead resource. Null (default) disables validation.
+     */
+    private val isReusable: (suspend (T) -> Boolean)? = null,
 ) : KeepAlive {
     private val iTag = "$tag:SR"
     override val resourceId: String = iTag
@@ -57,6 +65,9 @@ open class SharedResource<T : Any>(
     }
 
     private val coreLock = Mutex()
+
+    /** Max times [get] will detach a dead reused generation and retry before giving up. */
+    private val reuseValidationAttempts = 5
 
     private val leaseScope = CoroutineScope(parentScope.newCoroutineContext(SupervisorJob()))
 
@@ -97,6 +108,35 @@ open class SharedResource<T : Any>(
         get() = active == null
 
     suspend fun get(): Resource<T> {
+        var attempt = 0
+        while (true) {
+            val (generation, value, lease) = acquireGeneration()
+            val reusable = isReusable ?: return Resource(value, lease)
+
+            val alive = try {
+                reusable(value)
+            } catch (e: Throwable) {
+                // The validator threw, or the caller was cancelled at this suspension point. Release only
+                // our provisional lease and propagate — do NOT tear down the shared generation for others.
+                releaseProvisionalLease(lease, "reuse-validation-error")
+                throw e
+            }
+            if (alive) return Resource(value, lease)
+
+            // The cached generation's resource has died (e.g. its shell process exited) but the async
+            // onCompletion detach hasn't cleared `active` yet, so acquireGeneration() handed back a dead
+            // value. Drop our provisional lease + force-detach the stale generation, then retry for a fresh one.
+            if (Bugs.isTrace) {
+                log(iTag, DEBUG) { "[${generation.id}]-get() reused resource failed liveness check, detaching + retrying" }
+            }
+            detachInvalidReuse(generation, lease, "reuse-invalid")
+            if (++attempt >= reuseValidationAttempts) {
+                throw IllegalStateException("[$iTag] resource failed the reuse liveness check after $attempt attempts")
+            }
+        }
+    }
+
+    private suspend fun acquireGeneration(): Triple<Generation<T>, T, Lease> {
         val lId = "L:${UUID.randomUUID().toString().takeLast(4)}"
         if (Bugs.isTrace) {
             val call = traceCall()
@@ -228,8 +268,49 @@ open class SharedResource<T : Any>(
         }
 
         if (Bugs.isTrace) log(iTag) { "[${generation.id}|$lId]-get() returning value $value" }
-        return Resource(value, lease!!)
+        return Triple(generation, value, lease!!)
     }
+
+    /**
+     * Release only [lease] (under coreLock, as [closeLease] requires) and run the idle lease-check, for when
+     * acquisition fails after the provisional lease was taken — e.g. the reuse liveness validator threw or the
+     * caller was cancelled. Does NOT detach the generation, so other holders are unaffected. NonCancellable so
+     * the lease can't leak if we're being cancelled.
+     */
+    private suspend fun releaseProvisionalLease(lease: Lease, tag: String) = withContext(NonCancellable) {
+        coreLock.withLock("releaseProvisional-$tag") { closeLease(tag, lease) }
+        leaseCheck(tag, forced = false)
+    }
+
+    /**
+     * A reused generation failed the liveness check. Drop [lease] and, if [generation] is still active,
+     * force-detach it (mirrors the asynchronous onCompletion self-teardown) so a retrying get() starts a fresh
+     * generation. leaseCheckLock -> coreLock, the order leaseCheck()/onCompletion use. NonCancellable so a
+     * cancellation mid-detach can't strand a half-torn-down generation.
+     */
+    private suspend fun detachInvalidReuse(generation: Generation<T>, lease: Lease, tag: String) =
+        withContext(NonCancellable) {
+            val detached = leaseCheckLock.withLock {
+                val didDetach = coreLock.withLock("detachInvalidReuse-$tag") {
+                    if (active !== generation) {
+                        // Superseded: a fresh generation is already installed. Only drop our provisional lease.
+                        closeLease(tag, lease)
+                        false
+                    } else {
+                        closeLeasesLocked(tag) // closes every lease on the dead generation, including ours
+                        detachLocked(tag)
+                        true
+                    }
+                }
+                if (didDetach) {
+                    leaseCheckJob?.cancelAndJoin()
+                    leaseCheckJob = null
+                }
+                didDetach
+            }
+            // Superseded path only dropped one lease; idle-check the leases that remain.
+            if (!detached) leaseCheck(tag, forced = false)
+        }
 
     // Must be called with coreLock.withLock { }
     private suspend fun closeLease(tag: String, lease: Lease): Unit = withContext(NonCancellable) {

--- a/app-common/src/test/java/eu/darken/sdmse/common/sharedresource/SharedResourceTest.kt
+++ b/app-common/src/test/java/eu/darken/sdmse/common/sharedresource/SharedResourceTest.kt
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.runTest2
 import java.time.Duration
+import java.util.concurrent.atomic.AtomicInteger
 
 class SharedResourceTest : BaseTest() {
     @BeforeEach
@@ -876,5 +877,38 @@ class SharedResourceTest : BaseTest() {
         parent.isClosed shouldBe true   // detach completed despite the throwing child
         goodChildClosed shouldBe true   // iteration continued past the thrower (per-child runCatching)
         sourceTornDown shouldBe true    // source teardown was enqueued before the child loop, not stranded
+    }
+
+    @Test
+    fun `get re-acquires a fresh generation when a reused one fails the liveness check`() = runTest2 {
+        // Real dispatcher, like the other tests here: SharedResource's Lease.close uses runBlocking, which
+        // deadlocks a single-threaded test dispatcher.
+        val produced = AtomicInteger(0)
+        val liveThreshold = AtomicInteger(0) // resources with id > threshold are considered alive
+        val sr = SharedResource<Int>(
+            tag = "reuse-liveness",
+            parentScope = this + Dispatchers.IO,
+            source = flow {
+                emit(produced.incrementAndGet())
+                awaitCancellation()
+            },
+            isReusable = { it > liveThreshold.get() },
+        )
+
+        // A held lease pins generation 1 as `active`, so no idle-teardown can race this test.
+        val pin = sr.get()
+        pin.item shouldBe 1
+
+        // Resource 1 is now "dead" WITHOUT completing its source, so `active` still points at generation 1 —
+        // exactly the window where SharedResource's async detach hasn't cleared the dead generation yet.
+        liveThreshold.set(1)
+
+        // Without the fix, get() reuses the stale dead generation 1. With it, get() fails the liveness
+        // check, detaches generation 1, and re-acquires a fresh generation 2.
+        val second = sr.get()
+        second.item shouldBe 2
+
+        second.close()
+        sr.close()
     }
 }


### PR DESCRIPTION
## What changed

Fixed a rare, intermittent failure when the app reuses a background shell right after one was shut down (for example when a running operation is cancelled and another starts immediately). Occasionally the app would hand out a shell whose process had already exited, and the next command would fail with an internal "shell session likely died externally" error. This is also the cause of the flaky `SharedShellTest.reuse with cancel` CI test.

## Technical Context

- **Root cause:** `SharedResource.get()` reused the cached `active` generation without checking that its resource was still alive. When a shell's process exits, `SharedResource` detaches the dead generation **asynchronously** (source `onCompletion` → a launched coroutine that takes `coreLock`). That leaves a window where `active` still points at the dead generation, so a reuse landing in that window is handed the dead `FlowCmdShell.Session` → `IllegalStateException` at `FlowCmdShell:184`. Confirmed deterministically: `FlowCmd("kill \$\$")` reproduces the exact exception.
- **Fix:** an optional `isReusable: suspend (T) -> Boolean` liveness check on `SharedResource`. `get()` validates a generation's value before returning it; on failure it drops the provisional lease, force-detaches the stale generation (`leaseCheckLock → coreLock`, mirroring the existing `onCompletion` self-teardown), and re-acquires a fresh generation. Retries are bounded and it throws if a live resource can't be obtained. A thrown/cancelled validator releases only the provisional lease. `null` (the default) preserves existing behavior for every other `SharedResource`. `SharedShell` opts in with `{ it.isAlive() }`.
- **Why here, not in `execute()`:** the reused command can only succeed on a *live* session, so the guarantee has to be at resource-acquisition time, not at command time.
- **Review guidance:** the change is in concurrency-critical `SharedResource` locking. The two new helpers keep `closeLease` under `coreLock` (its contract) and run cleanup under `NonCancellable` so a cancelled caller can't leak a lease. Reviewed for lock-ordering/leaks with a second tool; the deterministic unit test fails if the liveness check is removed.

### Verification
- New `SharedResourceTest` unit test proves `get()` re-acquires a fresh generation when a reused one fails the liveness check — and **fails when the check is neutered**.
- New `SharedShellTest` integration test kills its own shell mid-command, then asserts the next reuse gets a fresh live shell.
- `SharedResourceTest` 31/31, `SharedShellTest` 5/5, no regressions.