### PR TITLE
General: Fix crashing Compose previews for tour-enabled screens

### DIFF
--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/preview/ComposePreviewHelpers.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/preview/ComposePreviewHelpers.kt
@@ -3,6 +3,10 @@ package eu.darken.sdmse.common.compose.preview
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalInspectionMode
+import eu.darken.sdmse.common.compose.tour.LocalGuidedTourController
+import eu.darken.sdmse.common.compose.tour.NoOpGuidedTourAccess
 import eu.darken.sdmse.common.theming.SdmSeTheme
 import eu.darken.sdmse.common.theming.ThemeMode
 import eu.darken.sdmse.common.theming.ThemeState
@@ -15,7 +19,17 @@ fun PreviewWrapper(
 ) {
     SdmSeTheme(state = theme) {
         Surface(color = MaterialTheme.colorScheme.background) {
-            content()
+            // Screens read LocalGuidedTourController, which is only provided by MainActivity at runtime. In
+            // @Preview/inspection there's no provider, so supply a no-op to keep previews from hitting the
+            // local's error() default. Gated on LocalInspectionMode so screen tests — which nest PreviewWrapper
+            // inside their own CompositionLocalProvider(... provides mockController) — keep their mock.
+            if (LocalInspectionMode.current) {
+                CompositionLocalProvider(LocalGuidedTourController provides NoOpGuidedTourAccess) {
+                    content()
+                }
+            } else {
+                content()
+            }
         }
     }
 }

--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/tour/GuidedTourController.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/tour/GuidedTourController.kt
@@ -24,10 +24,10 @@ import javax.inject.Singleton
 class GuidedTourController @Inject constructor(
     private val generalSettings: GeneralSettings,
     @AppScope private val scope: CoroutineScope,
-) {
+) : GuidedTourAccess {
 
     private val _session = MutableStateFlow<TourSession?>(null)
-    val session: StateFlow<TourSession?> = _session.asStateFlow()
+    override val session: StateFlow<TourSession?> = _session.asStateFlow()
 
     @Volatile private var currentTopRoute: NavKey? = null
     @Volatile private var routeAtStart: NavKey? = null
@@ -43,7 +43,7 @@ class GuidedTourController @Inject constructor(
 
     private val mutationMutex = Mutex()
 
-    suspend fun shouldStart(definition: TourDefinition): Boolean {
+    override suspend fun shouldStart(definition: TourDefinition): Boolean {
         if (!generalSettings.isGuidedToursEnabled.value()) return false
         if (_session.value != null) return false
         val raw = definition.id.raw
@@ -52,7 +52,7 @@ class GuidedTourController @Inject constructor(
         return raw !in prefs.completed && raw !in prefs.dismissed
     }
 
-    suspend fun start(definition: TourDefinition) = mutationMutex.withLock {
+    override suspend fun start(definition: TourDefinition) = mutationMutex.withLock {
         if (!shouldStart(definition)) {
             log(TAG, VERBOSE) { "start(${definition.id.raw}): blocked by prefs or active session" }
             return@withLock
@@ -102,7 +102,7 @@ class GuidedTourController @Inject constructor(
      * Exit the current session and suppress this tour for the rest of the app process.
      * The skip is in-memory only, so after the app is restarted the tour becomes eligible again.
      */
-    suspend fun skipForNow() = mutationMutex.withLock {
+    override suspend fun skipForNow() = mutationMutex.withLock {
         val s = _session.value ?: return@withLock
         log(TAG) { "skipForNow(${s.definition.id.raw})" }
         skippedThisSession += s.definition.id.raw

--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/tour/LocalGuidedTourController.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/tour/LocalGuidedTourController.kt
@@ -1,7 +1,37 @@
 package eu.darken.sdmse.common.compose.tour
 
 import androidx.compose.runtime.staticCompositionLocalOf
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
-val LocalGuidedTourController = staticCompositionLocalOf<GuidedTourController> {
+/**
+ * Screen-facing slice of the guided-tour API — the only operations a screen composable performs through
+ * [LocalGuidedTourController]. Host/settings operations (`next`, `previous`, `dismissForever`, `disableAllTours`,
+ * `markStepRendered`, `onRouteChanged`, `reset`, `complete`) stay on the concrete [GuidedTourController], which is
+ * injected directly where those are needed.
+ */
+interface GuidedTourAccess {
+    val session: StateFlow<TourSession?>
+    suspend fun shouldStart(definition: TourDefinition): Boolean
+    suspend fun start(definition: TourDefinition)
+    suspend fun skipForNow()
+}
+
+/**
+ * No-op [GuidedTourAccess] used for `@Preview` / inspection rendering, where no real controller is wired.
+ * [shouldStart] returns `false` so no tour ever starts in a preview.
+ */
+object NoOpGuidedTourAccess : GuidedTourAccess {
+    override val session: StateFlow<TourSession?> = MutableStateFlow(null)
+    override suspend fun shouldStart(definition: TourDefinition): Boolean = false
+    override suspend fun start(definition: TourDefinition) {}
+    override suspend fun skipForNow() {}
+}
+
+/**
+ * Provides the screen-facing tour API to composables. The default throws so a missing provider in the real app
+ * fails loudly; previews get [NoOpGuidedTourAccess] via `PreviewWrapper` (gated on `LocalInspectionMode`).
+ */
+val LocalGuidedTourController = staticCompositionLocalOf<GuidedTourAccess> {
     error("GuidedTourController not provided")
 }

--- a/app-common-ui/src/test/java/eu/darken/sdmse/common/compose/preview/PreviewWrapperTourProviderTest.kt
+++ b/app-common-ui/src/test/java/eu/darken/sdmse/common/compose/preview/PreviewWrapperTourProviderTest.kt
@@ -1,0 +1,36 @@
+package eu.darken.sdmse.common.compose.preview
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.test.onNodeWithText
+import eu.darken.sdmse.common.compose.tour.GuidedTourAccess
+import eu.darken.sdmse.common.compose.tour.LocalGuidedTourController
+import eu.darken.sdmse.common.compose.tour.NoOpGuidedTourAccess
+import org.junit.Assert.assertSame
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+
+/**
+ * Verifies that [PreviewWrapper] itself fixes tour-enabled previews: under inspection it provides
+ * [NoOpGuidedTourAccess] so a composable reading [LocalGuidedTourController] renders instead of hitting the
+ * local's `error()` default. This is the central mechanism that keeps every screen's `@Preview` from crashing.
+ */
+class PreviewWrapperTourProviderTest : BaseComposeRobolectricTest() {
+
+    @Test
+    fun `provides no-op tour controller under inspection`() {
+        var seen: GuidedTourAccess? = null
+        composeRule.setContent {
+            CompositionLocalProvider(LocalInspectionMode provides true) {
+                PreviewWrapper {
+                    seen = LocalGuidedTourController.current
+                    Text("shown")
+                }
+            }
+        }
+
+        composeRule.onNodeWithText("shown").assertExists()
+        assertSame(NoOpGuidedTourAccess, seen)
+    }
+}

--- a/app-common-ui/src/test/java/eu/darken/sdmse/common/compose/tour/NoOpGuidedTourAccessTest.kt
+++ b/app-common-ui/src/test/java/eu/darken/sdmse/common/compose/tour/NoOpGuidedTourAccessTest.kt
@@ -1,0 +1,24 @@
+package eu.darken.sdmse.common.compose.tour
+
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class NoOpGuidedTourAccessTest : BaseTest() {
+
+    @Test
+    fun `shouldStart is always false`() = runTest {
+        NoOpGuidedTourAccess.shouldStart(mockk(relaxed = true)) shouldBe false
+    }
+
+    @Test
+    fun `session stays null across start and skip`() = runTest {
+        val definition = mockk<TourDefinition>(relaxed = true)
+        NoOpGuidedTourAccess.session.value shouldBe null
+        NoOpGuidedTourAccess.start(definition)
+        NoOpGuidedTourAccess.skipForNow()
+        NoOpGuidedTourAccess.session.value shouldBe null
+    }
+}

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListScreen.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListScreen.kt
@@ -62,7 +62,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.pluralStringResource
@@ -423,14 +422,8 @@ internal fun AppControlListScreen(
         }
     }
 
-    // The pure Screen reads the guided-tour controller from the composition local, which is only
-    // provided by the host Activity at runtime (and by the screen test). In @Preview/inspection
-    // mode there's no provider — reading `.current` would hit the local's error() default and crash
-    // the preview — so skip all tour wiring when inspecting. This is a no-op at runtime and in tests
-    // (LocalInspectionMode is false there), so guided-tour behavior is unchanged.
-    val tourController = if (LocalInspectionMode.current) null else LocalGuidedTourController.current
-    val tourSession by (tourController?.session ?: remember { MutableStateFlow(null) })
-        .collectAsStateWithLifecycle()
+    val tourController = LocalGuidedTourController.current
+    val tourSession by tourController.session.collectAsStateWithLifecycle()
     val tourActive = tourSession != null
     val tourDef = remember { AppControlListTour.definition() }
     // Track whether we already tried to start the tour in this composition: rows can oscillate
@@ -443,15 +436,12 @@ internal fun AppControlListScreen(
     // and the filter/sort chips (AnimatedVisibility visible = !isBusy) aren't composed while a load
     // is in progress. rowsReady can flip true while progress is still non-null, so starting on
     // rowsReady alone left steps 0-2 with no registered target and they grace-skipped.
-    val tourReady = tourController != null && !rows.isNullOrEmpty() && !isBusy
-    LaunchedEffect(tourReady, tourController) {
+    val tourReady = !rows.isNullOrEmpty() && !isBusy
+    LaunchedEffect(tourReady) {
         if (!tourReady || tourStartAttempted) return@LaunchedEffect
-        // tourController is non-null whenever tourReady is true; the elvis return is just a smart-cast
-        // anchor (it never actually returns here).
-        val controller = tourController ?: return@LaunchedEffect
         // shouldStart() is false for both "done/dismissed" and "another tour active"; mark attempted
         // only after it passes so a transient block can't permanently suppress this tour.
-        if (!controller.shouldStart(tourDef)) return@LaunchedEffect
+        if (!tourController.shouldStart(tourDef)) return@LaunchedEffect
         tourStartAttempted = true
         tourFirstRowId = rows?.firstOrNull()?.installId
         tourController.start(tourDef)

--- a/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListScreenTest.kt
+++ b/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListScreenTest.kt
@@ -230,9 +230,9 @@ class AppControlListScreenTest : BaseComposeRobolectricTest() {
 
     @Test
     fun `inspection mode renders populated rows without a tour controller`() {
-        // In @Preview/inspection mode no LocalGuidedTourController is provided. The screen must
-        // skip its tour wiring (guarded by LocalInspectionMode) instead of hitting the local's
-        // error() default. Deliberately do NOT provide LocalGuidedTourController here.
+        // In @Preview/inspection mode no real LocalGuidedTourController is provided; PreviewWrapper supplies
+        // NoOpGuidedTourAccess when LocalInspectionMode is true, so the screen reads a no-op instead of hitting
+        // the local's error() default. Deliberately do NOT provide LocalGuidedTourController here.
         composeRule.setContent {
             CompositionLocalProvider(LocalInspectionMode provides true) {
                 PreviewWrapper {


### PR DESCRIPTION
## What changed

No user-facing behavior change — this is a developer-tooling fix.

Android Studio's Compose preview pane crashed with `GuidedTourController not provided` when previewing any screen that participates in the guided tour (Scheduler, CorpseFinder, SystemCleaner, Dashboard, Squeezer, Analyzer, Swiper, Setup, Deduplicator). Those full-screen previews now render, so the screens can be designed and reviewed without launching the app.

## Technical Context

- **Root cause:** `LocalGuidedTourController` is a `staticCompositionLocalOf` whose default throws, and only `MainActivity` provides it. `PreviewWrapper` never did, so every tour-reading screen's `@Preview` hit the `error()` default. `AppControlListScreen` had already worked around it per-screen with a `LocalInspectionMode` guard; the other screens hadn't.
- **Fix:** introduced a small screen-facing `GuidedTourAccess` interface (the four members screens actually consume via the local — `session`, `shouldStart`, `start`, `skipForNow`), implemented by `GuidedTourController`, and retyped the composition local to it. `PreviewWrapper` now provides a `NoOpGuidedTourAccess`.
- **Load-bearing detail:** the no-op is provided **only under `LocalInspectionMode`**. Screen Robolectric tests nest `PreviewWrapper` *inside* their own `CompositionLocalProvider(... provides mockController)`; an unconditional provide would shadow those mocks. Robolectric tests don't set inspection mode, so their mocks survive.
- The local keeps its `error()` default, so a missing provider in the real app still fails loudly. No production wiring or injection sites changed — the concrete `GuidedTourController` is still injected directly for host/settings operations (`next`, `dismissForever`, `onRouteChanged`, `reset`, …).
- Retired the now-redundant per-screen `LocalInspectionMode` guard in `AppControlListScreen` so the codebase converges on a single pattern.
- Adds a unit test for the no-op and a Robolectric compose test proving `PreviewWrapper` renders under inspection without a real controller.
