### PR TITLE
Analyzer: Fix storage size shown as double on some realme devices

### DIFF
--- a/app-common-data/src/main/java/eu/darken/sdmse/common/storage/StorageSpaceReconcile.kt
+++ b/app-common-data/src/main/java/eu/darken/sdmse/common/storage/StorageSpaceReconcile.kt
@@ -1,0 +1,82 @@
+package eu.darken.sdmse.common.storage
+
+import kotlin.math.abs
+
+/**
+ * Reconciles capacity/free-space readings from [StorageStatsManager2] against the filesystem
+ * (StatFs/File) reading for the same volume.
+ *
+ * `StorageStatsManager.getTotalBytes(...)` is unreliable on some vendor ROMs. We've seen it:
+ * - return ~2x the real capacity for the PRIMARY volume on realme/ColorOS Android 15 (free stays
+ *   correct, so used = capacity - free gets doubled too).
+ * - return a doubled/garbage total for FAT-synthesised-UUID SD cards
+ *   (https://github.com/d4rken-org/sdmaid-se/issues/2389).
+ *
+ * When the framework value is implausible we fall back to the filesystem reading, which matches
+ * what other tools (e.g. DiskInfo) and the actual partition report.
+ */
+object StorageSpaceReconcile {
+
+    data class Result(
+        val total: Long,
+        val free: Long,
+        /** True when the filesystem reading was preferred over the StorageStatsManager values. */
+        val usedFileFallback: Boolean,
+    )
+
+    /**
+     * PRIMARY volume policy.
+     *
+     * `getTotalBytes(UUID_DEFAULT)` is legitimately a little larger than `StatFs` on the data
+     * partition (AOSP rounds it up to the advertised "marketing" size), so a symmetric mismatch
+     * rule like the secondary one would regress normal devices. We therefore only override on
+     * *gross* over-inflation (>1.5x the filesystem total) AND only when the free-space readings
+     * agree — the doubled-total bug leaves free correct, so free agreement is the signal that the
+     * two APIs describe the same volume and the total is simply wrong.
+     */
+    fun reconcilePrimary(
+        statsTotal: Long,
+        statsFree: Long,
+        fileTotal: Long,
+        fileFree: Long,
+    ): Result {
+        val statsResult = Result(statsTotal, statsFree, usedFileFallback = false)
+
+        // No usable filesystem cross-check.
+        if (fileTotal <= 0L) return statsResult
+        // Filesystem pair must itself be sane before we trust it.
+        if (fileFree < 0L || fileFree > fileTotal) return statsResult
+
+        // statsTotal > 1.5 * fileTotal, expressed without floating point.
+        val grosslyInflated = statsTotal * 2 > fileTotal * 3
+        // Free readings agree within ~5% of capacity -> same volume, only the total is wrong.
+        val freeAgrees = abs(statsFree - fileFree) * 20 < fileTotal
+
+        return if (grosslyInflated && freeAgrees) {
+            Result(fileTotal, fileFree, usedFileFallback = true)
+        } else {
+            statsResult
+        }
+    }
+
+    /**
+     * SECONDARY volume policy (unchanged from #2389).
+     *
+     * For FAT synthesised UUIDs, StorageStatsManager is unreliable on some devices. If StatFs
+     * disagrees with the API by more than 10%, trust the filesystem.
+     */
+    fun reconcileSecondary(
+        statsTotal: Long,
+        statsFree: Long,
+        fileTotal: Long,
+        fileFree: Long,
+        isFatUuid: Boolean,
+    ): Result {
+        val mismatches = isFatUuid && fileTotal > 0L && abs(statsTotal - fileTotal) * 10 > fileTotal
+        return if (mismatches) {
+            Result(fileTotal, fileFree, usedFileFallback = true)
+        } else {
+            Result(statsTotal, statsFree, usedFileFallback = false)
+        }
+    }
+}

--- a/app-common-data/src/test/java/eu/darken/sdmse/common/storage/StorageSpaceReconcileTest.kt
+++ b/app-common-data/src/test/java/eu/darken/sdmse/common/storage/StorageSpaceReconcileTest.kt
@@ -1,0 +1,146 @@
+package eu.darken.sdmse.common.storage
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class StorageSpaceReconcileTest : BaseTest() {
+
+    // ~1TB device reported as 2TB, free correct. Reproduces realme/ColorOS A15 report.
+    private val TB = 1_000_000_000_000L
+    private val GB = 1_000_000_000L
+
+    // --- reconcilePrimary ---
+
+    @Test
+    fun `primary grossly inflated total with agreeing free prefers File`() {
+        val result = StorageSpaceReconcile.reconcilePrimary(
+            statsTotal = 2 * TB,
+            statsFree = 104 * GB,
+            fileTotal = 1_010 * GB,
+            fileFree = 105 * GB,
+        )
+        result.total shouldBe 1_010 * GB
+        result.free shouldBe 105 * GB
+        result.usedFileFallback shouldBe true
+    }
+
+    @Test
+    fun `primary normal marketing round-up keeps stats`() {
+        // getTotalBytes rounds up to advertised size; StatFs on data is slightly smaller. Not a bug.
+        val result = StorageSpaceReconcile.reconcilePrimary(
+            statsTotal = 128 * GB,
+            statsFree = 64 * GB,
+            fileTotal = 115 * GB,
+            fileFree = 60 * GB,
+        )
+        result.total shouldBe 128 * GB
+        result.usedFileFallback shouldBe false
+    }
+
+    @Test
+    fun `primary at exactly 1_5x keeps stats`() {
+        // statsTotal * 2 > fileTotal * 3 is a strict >1.5x; exactly 1.5x must NOT override.
+        val result = StorageSpaceReconcile.reconcilePrimary(
+            statsTotal = 150 * GB,
+            statsFree = 50 * GB,
+            fileTotal = 100 * GB,
+            fileFree = 50 * GB,
+        )
+        result.total shouldBe 150 * GB
+        result.usedFileFallback shouldBe false
+    }
+
+    @Test
+    fun `primary just above 1_5x with agreeing free prefers File`() {
+        val result = StorageSpaceReconcile.reconcilePrimary(
+            statsTotal = 151 * GB,
+            statsFree = 50 * GB,
+            fileTotal = 100 * GB,
+            fileFree = 50 * GB,
+        )
+        result.total shouldBe 100 * GB
+        result.usedFileFallback shouldBe true
+    }
+
+    @Test
+    fun `primary inflated total but divergent free keeps stats`() {
+        // Free readings disagree -> the two APIs may describe different scopes; don't second-guess.
+        val result = StorageSpaceReconcile.reconcilePrimary(
+            statsTotal = 2 * TB,
+            statsFree = 500 * GB,
+            fileTotal = 1_010 * GB,
+            fileFree = 105 * GB,
+        )
+        result.total shouldBe 2 * TB
+        result.usedFileFallback shouldBe false
+    }
+
+    @Test
+    fun `primary with no filesystem total keeps stats`() {
+        val result = StorageSpaceReconcile.reconcilePrimary(
+            statsTotal = 2 * TB,
+            statsFree = 104 * GB,
+            fileTotal = 0L,
+            fileFree = 0L,
+        )
+        result.total shouldBe 2 * TB
+        result.usedFileFallback shouldBe false
+    }
+
+    @Test
+    fun `primary with invalid filesystem pair keeps stats`() {
+        // fileFree > fileTotal is nonsensical; never override to a bad pair.
+        val result = StorageSpaceReconcile.reconcilePrimary(
+            statsTotal = 2 * TB,
+            statsFree = 104 * GB,
+            fileTotal = 1_010 * GB,
+            fileFree = 2_000 * GB,
+        )
+        result.total shouldBe 2 * TB
+        result.usedFileFallback shouldBe false
+    }
+
+    // --- reconcileSecondary (behavior-preserving, #2389) ---
+
+    @Test
+    fun `secondary FAT big mismatch prefers File`() {
+        val result = StorageSpaceReconcile.reconcileSecondary(
+            statsTotal = 256 * GB,
+            statsFree = 4 * GB,
+            fileTotal = 128 * GB,
+            fileFree = 4 * GB,
+            isFatUuid = true,
+        )
+        result.total shouldBe 128 * GB
+        result.free shouldBe 4 * GB
+        result.usedFileFallback shouldBe true
+    }
+
+    @Test
+    fun `secondary FAT small mismatch keeps stats`() {
+        val result = StorageSpaceReconcile.reconcileSecondary(
+            statsTotal = 130 * GB,
+            statsFree = 52 * GB,
+            fileTotal = 128 * GB,
+            fileFree = 50 * GB,
+            isFatUuid = true,
+        )
+        result.total shouldBe 130 * GB
+        result.usedFileFallback shouldBe false
+    }
+
+    @Test
+    fun `secondary non-FAT big mismatch keeps stats`() {
+        // Non-FAT UUIDs are trusted even on large disagreement — the primary guard does not apply here.
+        val result = StorageSpaceReconcile.reconcileSecondary(
+            statsTotal = 256 * GB,
+            statsFree = 100 * GB,
+            fileTotal = 128 * GB,
+            fileFree = 64 * GB,
+            isFatUuid = false,
+        )
+        result.total shouldBe 256 * GB
+        result.usedFileFallback shouldBe false
+    }
+}

--- a/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/SpaceTracker.kt
+++ b/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/SpaceTracker.kt
@@ -11,6 +11,7 @@ import eu.darken.sdmse.common.files.asFile
 import eu.darken.sdmse.common.storage.StorageEnvironment
 import eu.darken.sdmse.common.storage.StorageId
 import eu.darken.sdmse.common.storage.StorageManager2
+import eu.darken.sdmse.common.storage.StorageSpaceReconcile
 import eu.darken.sdmse.common.storage.StorageStatsManager2
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.withContext
@@ -19,7 +20,6 @@ import java.time.Instant
 import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlin.math.abs
 
 @Singleton
 class SpaceTracker @Inject constructor(
@@ -115,17 +115,30 @@ class SpaceTracker @Inject constructor(
                 internalId = null,
                 externalId = primaryUuid,
             )
-            val totalBytes = try {
-                storageStatsManager.getTotalBytes(storageId)
+            val dataDirFile = storageEnvironment.dataDir.asFile()
+            val fileTotal = dataDirFile.totalSpace
+            val fileFree = dataDirFile.freeSpace
+
+            val (totalBytes, freeBytes) = try {
+                // Keep the pair coupled: if either call fails the other is suspect too.
+                val statsTotal = storageStatsManager.getTotalBytes(storageId)
+                val statsFree = storageStatsManager.getFreeBytes(storageId)
+
+                val reconciled = StorageSpaceReconcile.reconcilePrimary(
+                    statsTotal = statsTotal,
+                    statsFree = statsFree,
+                    fileTotal = fileTotal,
+                    fileFree = fileFree,
+                )
+                if (reconciled.usedFileFallback) {
+                    log(TAG, WARN) {
+                        "Primary StorageStats total=$statsTotal implausible vs File=$fileTotal; using File"
+                    }
+                }
+                reconciled.total to reconciled.free
             } catch (e: Exception) {
-                log(TAG, WARN) { "Failed to get total bytes for primary storage: ${e.asLog()}" }
-                storageEnvironment.dataDir.asFile().totalSpace
-            }
-            val freeBytes = try {
-                storageStatsManager.getFreeBytes(storageId)
-            } catch (e: Exception) {
-                log(TAG, WARN) { "Failed to get free bytes for primary storage: ${e.asLog()}" }
-                storageEnvironment.dataDir.asFile().freeSpace
+                log(TAG, WARN) { "StorageStatsManager failed for primary storage, using File API: ${e.asLog()}" }
+                fileTotal to fileFree
             }
 
             StorageSnapshot(
@@ -170,19 +183,19 @@ class SpaceTracker @Inject constructor(
                         val statsTotal = storageStatsManager.getTotalBytes(storageId)
                         val statsFree = storageStatsManager.getFreeBytes(storageId)
 
-                        // For FAT synthesised UUIDs, StorageStatsManager is unreliable on some devices (#2389).
-                        // If statfs disagrees with the API by >10%, trust the filesystem.
-                        val mismatches = isFatUuid
-                            && fileTotal > 0
-                            && abs(statsTotal - fileTotal) * 10 > fileTotal
-                        if (mismatches) {
+                        val reconciled = StorageSpaceReconcile.reconcileSecondary(
+                            statsTotal = statsTotal,
+                            statsFree = statsFree,
+                            fileTotal = fileTotal,
+                            fileFree = fileFree,
+                            isFatUuid = isFatUuid,
+                        )
+                        if (reconciled.usedFileFallback) {
                             log(TAG, WARN) {
                                 "StorageStats total=$statsTotal disagrees with File=$fileTotal for FAT $storageId; using File"
                             }
-                            fileTotal to fileFree
-                        } else {
-                            statsTotal to statsFree
                         }
+                        reconciled.total to reconciled.free
                     } catch (e: Exception) {
                         log(TAG, WARN) { "StorageStatsManager failed for $storageId, using File API: ${e.asLog()}" }
                         fileTotal to fileFree

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/device/DeviceStorageScanner.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/device/DeviceStorageScanner.kt
@@ -13,6 +13,7 @@ import eu.darken.sdmse.common.progress.updateProgressSecondary
 import eu.darken.sdmse.common.storage.StorageEnvironment
 import eu.darken.sdmse.common.storage.StorageId
 import eu.darken.sdmse.common.storage.StorageManager2
+import eu.darken.sdmse.common.storage.StorageSpaceReconcile
 import eu.darken.sdmse.common.storage.StorageStatsManager2
 import eu.darken.sdmse.setup.SetupModule
 import eu.darken.sdmse.setup.isComplete
@@ -55,17 +56,30 @@ class DeviceStorageScanner @Inject constructor(
                 externalId = primaryUuid,
             )
 
-            val totalBytes = try {
-                storageStatsmanager.getTotalBytes(id)
+            val dataDirFile = environment.dataDir.asFile()
+            val fileTotal = dataDirFile.totalSpace
+            val fileFree = dataDirFile.freeSpace
+
+            val (totalBytes, freeBytes) = try {
+                // Keep the pair coupled: if either call fails the other is suspect too.
+                val statsTotal = storageStatsmanager.getTotalBytes(id)
+                val statsFree = storageStatsmanager.getFreeBytes(id)
+
+                val reconciled = StorageSpaceReconcile.reconcilePrimary(
+                    statsTotal = statsTotal,
+                    statsFree = statsFree,
+                    fileTotal = fileTotal,
+                    fileFree = fileFree,
+                )
+                if (reconciled.usedFileFallback) {
+                    log(TAG, WARN) {
+                        "Primary StorageStats total=$statsTotal implausible vs File=$fileTotal for $id; using File"
+                    }
+                }
+                reconciled.total to reconciled.free
             } catch (e: Exception) {
-                log(TAG, WARN) { "Failed to get total bytes for $id" }
-                environment.dataDir.asFile().totalSpace
-            }
-            val freeBytes = try {
-                storageStatsmanager.getFreeBytes(id)
-            } catch (e: Exception) {
-                log(TAG, WARN) { "Failed to get free bytes for $id" }
-                environment.dataDir.asFile().freeSpace
+                log(TAG, WARN) { "StorageStatsManager failed for primary $id, using File API: ${e.message}" }
+                fileTotal to fileFree
             }
 
             DeviceStorage(
@@ -106,19 +120,19 @@ class DeviceStorageScanner @Inject constructor(
                     val statsTotal = storageStatsmanager.getTotalBytes(id)
                     val statsFree = storageStatsmanager.getFreeBytes(id)
 
-                    // For FAT synthesised UUIDs, StorageStatsManager is unreliable on some devices (#2389).
-                    // If statfs disagrees with the API by >10%, trust the filesystem.
-                    val mismatches = isFatUuid
-                        && fileTotal > 0
-                        && kotlin.math.abs(statsTotal - fileTotal) * 10 > fileTotal
-                    if (mismatches) {
+                    val reconciled = StorageSpaceReconcile.reconcileSecondary(
+                        statsTotal = statsTotal,
+                        statsFree = statsFree,
+                        fileTotal = fileTotal,
+                        fileFree = fileFree,
+                        isFatUuid = isFatUuid,
+                    )
+                    if (reconciled.usedFileFallback) {
                         log(TAG, WARN) {
                             "StorageStats total=$statsTotal disagrees with File=$fileTotal for FAT $id; using File"
                         }
-                        fileTotal to fileFree
-                    } else {
-                        statsTotal to statsFree
                     }
+                    reconciled.total to reconciled.free
                 } catch (e: Exception) {
                     log(TAG, WARN) { "StorageStatsManager failed for $id, using File API: ${e.message}" }
                     fileTotal to fileFree

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/device/DeviceStorageScannerTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/device/DeviceStorageScannerTest.kt
@@ -1,5 +1,6 @@
 package eu.darken.sdmse.analyzer.core.device
 
+import eu.darken.sdmse.common.files.local.LocalPath
 import eu.darken.sdmse.common.storage.StorageEnvironment
 import eu.darken.sdmse.common.storage.StorageId
 import eu.darken.sdmse.common.storage.StorageManager2
@@ -45,6 +46,13 @@ class DeviceStorageScannerTest : BaseTest() {
         every { this@apply.path } returns "/storage/mocked"
     }
 
+    private fun mockDataDir(totalSpace: Long, freeSpace: Long) {
+        val dataDir = mockk<LocalPath>().apply {
+            every { this@apply.file } returns mockFile(totalSpace = totalSpace, freeSpace = freeSpace)
+        }
+        every { environment.dataDir } returns dataDir
+    }
+
     @BeforeEach
     fun setup() {
         val completeState = mockk<SetupModule.State.Current> {
@@ -52,9 +60,10 @@ class DeviceStorageScannerTest : BaseTest() {
             every { type } returns SetupModule.Type.STORAGE
         }
         every { setupModule.state } returns flowOf(completeState)
-        // Primary block: let stats succeed so environment.dataDir fallback is not exercised.
+        // Primary block: stats succeed and agree with the filesystem so no fallback fires by default.
         coEvery { statsManager.getTotalBytes(match { it.internalId == null }) } returns 128_000_000_000L
         coEvery { statsManager.getFreeBytes(match { it.internalId == null }) } returns 64_000_000_000L
+        mockDataDir(totalSpace = 128_000_000_000L, freeSpace = 64_000_000_000L)
     }
 
     private fun createScanner() = DeviceStorageScanner(
@@ -65,6 +74,36 @@ class DeviceStorageScannerTest : BaseTest() {
     )
 
     private fun Set<DeviceStorage>.secondary() = firstOrNull { it.type == DeviceStorage.Type.SECONDARY }
+
+    private fun Set<DeviceStorage>.primary() = firstOrNull { it.type == DeviceStorage.Type.PRIMARY }
+
+    @Test
+    fun `primary grossly inflated total prefers File (reproduces realme A15 2x)`() = runTest {
+        // Device reports 2x real capacity for the primary volume; free stays correct.
+        every { storageManager2.volumes } returns emptyList()
+        coEvery { statsManager.getTotalBytes(match { it.internalId == null }) } returns 2_000_000_000_000L
+        coEvery { statsManager.getFreeBytes(match { it.internalId == null }) } returns 104_000_000_000L
+        mockDataDir(totalSpace = 1_010_000_000_000L, freeSpace = 105_000_000_000L)
+
+        val primary = createScanner().scan().primary()
+
+        primary shouldNotBe null
+        primary!!.spaceCapacity shouldBe 1_010_000_000_000L
+        primary.spaceFree shouldBe 105_000_000_000L
+    }
+
+    @Test
+    fun `primary getFreeBytes throws falls back to File for both`() = runTest {
+        every { storageManager2.volumes } returns emptyList()
+        coEvery { statsManager.getTotalBytes(match { it.internalId == null }) } returns 128_000_000_000L
+        coEvery { statsManager.getFreeBytes(match { it.internalId == null }) } throws IllegalStateException("sentinel")
+        mockDataDir(totalSpace = 120_000_000_000L, freeSpace = 30_000_000_000L)
+
+        val primary = createScanner().scan().primary()
+
+        primary!!.spaceCapacity shouldBe 120_000_000_000L
+        primary.spaceFree shouldBe 30_000_000_000L
+    }
 
     @Test
     fun `stats succeed on non-FAT UUID uses stats values`() = runTest {


### PR DESCRIPTION
## What changed

Fixed the Storage Analyzer showing the wrong device storage size on some phones. Affected users (seen on realme / ColorOS Android 15) saw their storage reported as roughly **double** the real amount — e.g. a 1 TB phone shown as ~2 TB total and ~1.9 TB used — even though the free-space figure was correct.

After the fix, the Analyzer cross-checks the value against the actual filesystem and falls back to the real size when the system-reported total is obviously inflated, so the total and used figures match what the device (and other tools) report.

## Technical Context

- **Root cause:** on these devices the framework `StorageStatsManager.getTotalBytes(UUID_DEFAULT)` returns ~2× the real capacity for the primary volume, while `getFreeBytes()` stays correct. Because used space is derived as `capacity − free`, both total and used were doubled while free stayed right — exactly the reported symptom.
- The existing cross-check from #2389 only guarded **FAT secondary** volumes (SD cards). The **primary** volume had no plausibility check and trusted the framework value directly. The `ERROR_MAX` sentinel in `StorageStatsManager2` is an exact-equality guard on 1 TB, so a ~2 TB value passed through untouched.
- **Fix:** extracted the stats-vs-filesystem reconciliation into a small pure helper (`StorageSpaceReconcile`) used by both the Analyzer scanner and the space-history tracker. The **primary** policy is intentionally *not* a copy of the secondary 10% rule: `getTotalBytes` on the primary is legitimately a little larger than `StatFs` on `/data` (AOSP rounds it up to the advertised size), so it only overrides on **gross over-inflation (>1.5×)** *and* only when the **free-space readings agree** — free agreement is the signal that both APIs describe the same volume and only the total is wrong. This preserves the normal display on healthy devices.
- Applied in both `DeviceStorageScanner` (the Analyzer card) and `SpaceTracker` (space-history snapshots, which had been persisting the doubled value and feeding it into the 7‑day trend chart).
- **Known cosmetic side effect:** affected users have doubled capacity already stored in space-history. New snapshots record the corrected (halved) value, so the trend chart will show a one-time step-down. Not migrating old snapshots — the discontinuity is cosmetic and self-heals as history rolls forward; rewriting stored stats isn't worth the complexity for a rare device-specific bug.
- **Tests:** new `StorageSpaceReconcileTest` covers the primary policy (2× override, exactly-1.5× keeps stats, inflated-but-divergent-free keeps stats, no/invalid filesystem pair) and the unchanged secondary policy. Added primary-path cases to `DeviceStorageScannerTest` (2× override, and `getFreeBytes` failure → File pair).

**Review guidance:** the load-bearing decision is the `reconcilePrimary` heuristic in `StorageSpaceReconcile.kt` — specifically the >1.5× threshold and the free-space-agreement gate. This is still **draft** pending a debug log from the reporter to confirm the exact framework `total`/`free` values on the affected device before marking ready.

Refs #2389, #1575
