### PR TITLE
General: Fix connection loss after cancelling scans with root/ADB

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/LocalPathIPCFlow.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/LocalPathIPCFlow.kt
@@ -133,9 +133,12 @@ fun Flow<LocalPath>.toRemoteInputStream(scope: CoroutineScope): RemoteInputStrea
                 buffer.close()
             }
         }
-        .catch {
-            log(FileOpsHost.TAG, ERROR) { "Flow<LocalPath>.toRemoteInputStream failed: ${it.asLog()}" }
-            throw it
+        .catch { exception ->
+            if (exception is CancellationException) throw exception
+            // Usually "Pipe closed": the client cancelled and closed its end, nobody is left to
+            // report to. Must not rethrow — `scope` is the helper's unsupervised app scope, and an
+            // uncaught exception there kills the whole privileged process with it (BaseRootHost).
+            log(FileOpsHost.TAG, ERROR) { "Flow<LocalPath>.toRemoteInputStream failed: ${exception.asLog()}" }
         }
         .launchIn(scope)
 

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/LocalPathLookupExtendedIPCFlow.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/LocalPathLookupExtendedIPCFlow.kt
@@ -133,9 +133,12 @@ fun Flow<LocalPathLookupExtended>.toRemoteInputStream(scope: CoroutineScope): Re
                 buffer.close()
             }
         }
-        .catch {
-            log(FileOpsHost.TAG, ERROR) { "Flow<LocalPathLookupExtended>.toRemoteInputStream failed: ${it.asLog()}" }
-            throw it
+        .catch { exception ->
+            if (exception is CancellationException) throw exception
+            // Usually "Pipe closed": the client cancelled and closed its end, nobody is left to
+            // report to. Must not rethrow — `scope` is the helper's unsupervised app scope, and an
+            // uncaught exception there kills the whole privileged process with it (BaseRootHost).
+            log(FileOpsHost.TAG, ERROR) { "Flow<LocalPathLookupExtended>.toRemoteInputStream failed: ${exception.asLog()}" }
         }
         .launchIn(scope)
 

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/LocalPathLookupIPCFlow.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/LocalPathLookupIPCFlow.kt
@@ -133,9 +133,12 @@ fun Flow<LocalPathLookup>.toRemoteInputStream(scope: CoroutineScope): RemoteInpu
                 buffer.close()
             }
         }
-        .catch {
-            log(FileOpsHost.TAG, ERROR) { "toRemoteInputStreamWithExceptions failed: ${it.asLog()}" }
-            throw it
+        .catch { exception ->
+            if (exception is CancellationException) throw exception
+            // Usually "Pipe closed": the client cancelled and closed its end, nobody is left to
+            // report to. Must not rethrow — `scope` is the helper's unsupervised app scope, and an
+            // uncaught exception there kills the whole privileged process with it (BaseRootHost).
+            log(FileOpsHost.TAG, ERROR) { "Flow<LocalPathLookup>.toRemoteInputStream failed: ${exception.asLog()}" }
         }
         .launchIn(scope)
 

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/ipc/LocalPathIPCFlowTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/ipc/LocalPathIPCFlowTest.kt
@@ -8,15 +8,20 @@ import eu.darken.sdmse.common.ipc.remoteInputStream
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import okio.ByteString.Companion.toByteString
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -26,6 +31,7 @@ import testhelpers.BaseTest
 import testhelpers.TestApplication
 import java.io.ByteArrayInputStream
 import java.io.IOException
+import java.util.concurrent.CopyOnWriteArrayList
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [33], application = TestApplication::class)
@@ -135,6 +141,34 @@ class LocalPathIPCFlowTest : BaseTest() {
                     source.toRemoteInputStream(scope).toLocalPathFlow().toList()
                 }.exceptionOrNull()
                 thrown.shouldBeInstanceOf<IOException>()
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `consumer cancellation does not propagate into the host scope`() {
+        // Regression guard: the client decoder closes the pipe when its collector is cancelled
+        // (take(), user-cancelled scan). The host writer then fails with "Pipe closed" — that
+        // failure must be contained, not rethrown into `scope`: in production that is the
+        // helper's unsupervised app scope, where an uncaught exception kills the privileged
+        // process (surfacing as ServiceConnectionLost on the next IPC call).
+        val uncaught = CopyOnWriteArrayList<Throwable>()
+        val supervisor = SupervisorJob()
+        val scope = CoroutineScope(
+            supervisor + Dispatchers.IO + CoroutineExceptionHandler { _, e -> uncaught += e },
+        )
+        try {
+            runBlocking {
+                val source: Flow<LocalPath> = flow {
+                    repeat(100_000) { emit(path("file$it")) }
+                }
+                val collected = source.toRemoteInputStream(scope).toLocalPathFlow().take(3).toList()
+                collected.size shouldBe 3
+                // The writer must unwind on the broken pipe instead of hanging or throwing.
+                withTimeout(10_000) { supervisor.children.toList().joinAll() }
+                uncaught shouldBe emptyList<Throwable>()
             }
         } finally {
             scope.cancel()

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/ipc/LocalPathLookupExtendedIPCFlowTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/ipc/LocalPathLookupExtendedIPCFlowTest.kt
@@ -9,15 +9,20 @@ import eu.darken.sdmse.common.ipc.remoteInputStream
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import okio.ByteString.Companion.toByteString
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -28,6 +33,7 @@ import testhelpers.TestApplication
 import java.io.ByteArrayInputStream
 import java.io.IOException
 import java.time.Instant
+import java.util.concurrent.CopyOnWriteArrayList
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [33], application = TestApplication::class)
@@ -128,6 +134,34 @@ class LocalPathLookupExtendedIPCFlowTest : BaseTest() {
                 }.exceptionOrNull()
                 thrown.shouldBeInstanceOf<IllegalStateException>()
                 thrown.message shouldBe "extended lookup blew up"
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `consumer cancellation does not propagate into the host scope`() {
+        // Regression guard: the client decoder closes the pipe when its collector is cancelled
+        // (take(), user-cancelled scan). The host writer then fails with "Pipe closed" — that
+        // failure must be contained, not rethrown into `scope`: in production that is the
+        // helper's unsupervised app scope, where an uncaught exception kills the privileged
+        // process (surfacing as ServiceConnectionLost on the next IPC call).
+        val uncaught = CopyOnWriteArrayList<Throwable>()
+        val supervisor = SupervisorJob()
+        val scope = CoroutineScope(
+            supervisor + Dispatchers.IO + CoroutineExceptionHandler { _, e -> uncaught += e },
+        )
+        try {
+            runBlocking {
+                val source: Flow<LocalPathLookupExtended> = flow {
+                    repeat(100_000) { emit(lookup("file$it")) }
+                }
+                val collected = source.toRemoteInputStream(scope).toLocalPathLookupExtendedFlow().take(3).toList()
+                collected.size shouldBe 3
+                // The writer must unwind on the broken pipe instead of hanging or throwing.
+                withTimeout(10_000) { supervisor.children.toList().joinAll() }
+                uncaught shouldBe emptyList<Throwable>()
             }
         } finally {
             scope.cancel()

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/ipc/LocalPathLookupIPCFlowTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/ipc/LocalPathLookupIPCFlowTest.kt
@@ -8,15 +8,20 @@ import eu.darken.sdmse.common.ipc.remoteInputStream
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import okio.ByteString.Companion.toByteString
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -27,6 +32,7 @@ import testhelpers.TestApplication
 import java.io.ByteArrayInputStream
 import java.io.IOException
 import java.time.Instant
+import java.util.concurrent.CopyOnWriteArrayList
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [33], application = TestApplication::class)
@@ -155,6 +161,34 @@ class LocalPathLookupIPCFlowTest : BaseTest() {
                     source.toRemoteInputStream(scope).toLocalPathLookupFlow().toList()
                 }.exceptionOrNull()
                 thrown.shouldBeInstanceOf<IOException>()
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `consumer cancellation does not propagate into the host scope`() {
+        // Regression guard: the client decoder closes the pipe when its collector is cancelled
+        // (take(), user-cancelled scan). The host writer then fails with "Pipe closed" — that
+        // failure must be contained, not rethrown into `scope`: in production that is the
+        // helper's unsupervised app scope, where an uncaught exception kills the privileged
+        // process (surfacing as ServiceConnectionLost on the next IPC call).
+        val uncaught = CopyOnWriteArrayList<Throwable>()
+        val supervisor = SupervisorJob()
+        val scope = CoroutineScope(
+            supervisor + Dispatchers.IO + CoroutineExceptionHandler { _, e -> uncaught += e },
+        )
+        try {
+            runBlocking {
+                val source: Flow<LocalPathLookup> = flow {
+                    repeat(100_000) { emit(lookup("file$it")) }
+                }
+                val collected = source.toRemoteInputStream(scope).toLocalPathLookupFlow().take(3).toList()
+                collected.size shouldBe 3
+                // The writer must unwind on the broken pipe instead of hanging or throwing.
+                withTimeout(10_000) { supervisor.children.toList().joinAll() }
+                uncaught shouldBe emptyList<Throwable>()
             }
         } finally {
             scope.cancel()


### PR DESCRIPTION
## What changed

Fixed an issue where cancelling a scan (or any operation that stopped reading a large folder early) on devices using root or Shizuku/ADB could break the elevated connection — subsequent operations would then fail with "connection lost" errors until the app was restarted.

## Technical Context

- Root cause: the host-side writer coroutine of the three streaming IPC codecs ended with `.catch { log; throw it }.launchIn(scope)`. That scope is the helper's app scope (`SupervisorJob`, no `CoroutineExceptionHandler`), so the rethrow became an uncaught exception and `BaseRootHost`'s handler killed the entire privileged helper process.
- The trigger is new with the streaming rework: the client decoders close the pipe in a `finally`, including on collector cancellation, so the writer's next write throws `IOException("Pipe closed")`. Reachable by a user cancelling an AppCleaner scan on root, and deterministically by Analyzer's `take(100_001)` walk on >100k-entry privileged trees.
- Fix: the writer catch rethrows `CancellationException` and contains everything else with an ERROR log. No error information is lost — source failures are still encoded as Error frames upstream of the writer, and a stream that breaks before the terminal marker is already rejected client-side as truncation ("stream ended without terminal event").
- Deliberately also contains non-`IOException` failures (including `Error`s): a dying writer plus a logged error is strictly better than killing the process that holds root access, and the client-side truncation check covers the user-visible outcome.
- Review guidance: the per-codec regression test was verified to fail against the unfixed code (writer exception reaching a production-like unsupervised scope) and asserts the writer job terminates instead of hanging on the broken pipe.
