### PR TITLE
Deduplicator: Fix deletion of the copy that was meant to be kept

### DIFF
--- a/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/core/Duplicate.kt
+++ b/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/core/Duplicate.kt
@@ -84,7 +84,9 @@ interface Duplicate {
             get() {
                 val favId = favoriteGroupIdentifier
                 return groups.sumOf { group ->
-                    if (group.identifier == favId && group.count >= 2) group.redundantSize else group.totalSize
+                    // The favorite group's keeper survives a keep-one delete; a single-member
+                    // favorite group IS the keeper and frees nothing.
+                    if (group.identifier == favId) group.redundantSize else group.totalSize
                 }
             }
 
@@ -92,14 +94,15 @@ interface Duplicate {
          * Files a default keep-one delete removes: every duplicate except the favorite group's
          * keeper, distinct by id so cross-group path overlap isn't double-counted. The count
          * counterpart of [redundantSize]; exact vs DuplicatesDeleter for normalized (scanned)
-         * data. The keeper-less fallback mirrors [redundantSize] and is defensive only — the
+         * data. A single-member favorite group contributes nothing - its sole member is the kept
+         * copy. The keeper-less fallback mirrors [redundantSize] and is defensive only — the
          * scanner always assigns a keeper to every group with >= 2 members.
          */
         val redundantCount: Int
             get() {
                 val favId = favoriteGroupIdentifier
                 return groups.flatMap { group ->
-                    if (group.identifier == favId && group.count >= 2) {
+                    if (group.identifier == favId) {
                         val keeperId = group.keeperIdentifier ?: group.duplicates.firstOrNull()?.identifier
                         group.duplicates.filterNot { it.identifier == keeperId }.map { it.identifier }
                     } else {

--- a/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/core/deleter/DuplicatesDeleter.kt
+++ b/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/core/deleter/DuplicatesDeleter.kt
@@ -108,6 +108,7 @@ class DuplicatesDeleter @Inject constructor(
                         targets = setOf(favorite.identifier),
                         deleteAll = false,
                         strategy = strategy,
+                        isKeptGroup = true,
                     )
                     val restResult = targetGroups(
                         targets = rest.map { it.identifier }.toSet(),
@@ -124,14 +125,19 @@ class DuplicatesDeleter @Inject constructor(
         targets: Set<Duplicate.Group.Id>,
         deleteAll: Boolean = false,
         strategy: ArbiterStrategy,
+        isKeptGroup: Boolean = false,
     ): Collection<Duplicate> {
-        log(TAG, VERBOSE) { "#_targetGroups(deleteAll=$deleteAll): $targets" }
+        log(TAG, VERBOSE) { "#_targetGroups(deleteAll=$deleteAll, isKeptGroup=$isKeptGroup): $targets" }
         return clusters
             .flatMap { it.groups }
             .filter { group -> targets.contains(group.identifier) }
             .map { group ->
                 log(TAG, VERBOSE) { "__targetGroups(): Deleting from ${group.identifier} (dupes=${group.count})" }
-                if (deleteAll || group.duplicates.size == 1) {
+                // A directly targeted single-member group is deleted whole - the user explicitly
+                // picked it (e.g. a similar-image group in the details view). But a cluster's kept
+                // group must never lose its sole member that way: it is the copy being kept, and
+                // deleting it could remove the last remaining copy of the file.
+                if (deleteAll || (group.duplicates.size == 1 && !isKeptGroup)) {
                     targetDuplicates(group.duplicates.map { it.identifier }.toSet())
                 } else {
                     val keeperId = group.keeperIdentifier

--- a/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/core/DuplicateRedundantCountTest.kt
+++ b/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/core/DuplicateRedundantCountTest.kt
@@ -65,7 +65,7 @@ class DuplicateRedundantCountTest : BaseTest() {
     }
 
     @Test
-    fun `cluster - favorite group with 1 member removes the sole file`() {
+    fun `cluster - favorite group with 1 member keeps the sole file`() {
         val singleGroup = ChecksumDuplicate.Group(
             identifier = Duplicate.Group.Id("g1"),
             duplicates = setOf(mockChecksumDupe("a")),
@@ -81,9 +81,9 @@ class DuplicateRedundantCountTest : BaseTest() {
             groups = setOf(singleGroup, multiGroup),
             favoriteGroupIdentifier = Duplicate.Group.Id("g1"),
         )
-        // Favorite has <2 members so the keep-one rule doesn't apply: its sole file is removed (1).
-        // Non-favorite: removes b and c (2). Mirrors the redundantSize totalSize branch.
-        cluster.redundantCount shouldBe 3
+        // Favorite's sole file is the kept copy: removes nothing (0).
+        // Non-favorite: removes b and c (2). Mirrors the redundantSize favorite branch.
+        cluster.redundantCount shouldBe 2
     }
 
     @Test

--- a/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/core/DuplicateRedundantSizeTest.kt
+++ b/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/core/DuplicateRedundantSizeTest.kt
@@ -132,7 +132,7 @@ class DuplicateRedundantSizeTest : BaseTest() {
     }
 
     @Test
-    fun `cluster - favorite group with 1 member uses totalSize`() {
+    fun `cluster - favorite group with 1 member frees nothing`() {
         val singleGroup = ChecksumDuplicate.Group(
             identifier = Duplicate.Group.Id("g1"),
             duplicates = setOf(mockChecksumDupe("a", 150L)),
@@ -151,9 +151,9 @@ class DuplicateRedundantSizeTest : BaseTest() {
             groups = setOf(singleGroup, multiGroup),
             favoriteGroupIdentifier = Duplicate.Group.Id("g1"),
         )
-        // Favorite (1 member): totalSize = 150 (deleter deletes sole file)
+        // Favorite (1 member): its sole file IS the kept copy, frees 0
         // Non-favorite: totalSize = 500
-        cluster.redundantSize shouldBe 650L
+        cluster.redundantSize shouldBe 500L
     }
 
     @Test

--- a/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/core/DuplicatesDeleterTest.kt
+++ b/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/core/DuplicatesDeleterTest.kt
@@ -234,4 +234,102 @@ class DuplicatesDeleterTest : BaseTest() {
 
         result.success shouldBe setOf(dupe1, dupe2, dupe4)
     }
+
+    private fun dupe(name: String) = ChecksumDuplicate(
+        lookup = mockk<APathLookup<*>>().apply {
+            every { lookedUp } returns LocalPath.build("path", name)
+            every { path } returns lookedUp.path
+            every { userReadablePath } returns lookedUp.userReadablePath
+        },
+        hash = Hasher.Result(type = Hasher.Type.MD5, hash = "hash-$name".toByteString()),
+    )
+
+    @Test
+    fun `keep-one cluster delete never deletes the favorite groups sole member`() = runTest {
+        val deleter = create()
+
+        val kept = dupe("kept")
+        val other1 = dupe("other1")
+        val other2 = dupe("other2")
+
+        // The state prune() produces after a partial delete, or a PREFER_PHASH scan: the
+        // cluster's favorite group holds a single file - the copy being kept. Deleting it
+        // would remove the last remaining copy while the confirm dialog promised to keep it.
+        val data = Deduplicator.Data(
+            clusters = setOf(
+                Duplicate.Cluster(
+                    identifier = Duplicate.Cluster.Id("cluster1"),
+                    groups = setOf(
+                        ChecksumDuplicate.Group(
+                            identifier = Duplicate.Group.Id("favorite"),
+                            duplicates = setOf(kept),
+                        ),
+                        ChecksumDuplicate.Group(
+                            identifier = Duplicate.Group.Id("rest"),
+                            duplicates = setOf(other1, other2),
+                            keeperIdentifier = other1.identifier,
+                        ),
+                    ),
+                    favoriteGroupIdentifier = Duplicate.Group.Id("favorite"),
+                )
+            )
+        )
+
+        deleter.delete(
+            task = DeduplicatorDeleteTask(
+                mode = DeduplicatorDeleteTask.TargetMode.Clusters(
+                    deleteAll = false,
+                    targets = setOf(Duplicate.Cluster.Id("cluster1")),
+                )
+            ),
+            data = data,
+        ).success shouldBe setOf(other1, other2)
+
+        // The default task (TargetMode.All) routes through the same keep-one path.
+        deleter.delete(
+            task = DeduplicatorDeleteTask(),
+            data = data,
+        ).success shouldBe setOf(other1, other2)
+    }
+
+    @Test
+    fun `explicitly targeted single-member group is still deleted whole`() = runTest {
+        val deleter = create()
+
+        val solo = dupe("solo")
+        val other1 = dupe("other1")
+        val other2 = dupe("other2")
+
+        val data = Deduplicator.Data(
+            clusters = setOf(
+                Duplicate.Cluster(
+                    identifier = Duplicate.Cluster.Id("cluster1"),
+                    groups = setOf(
+                        ChecksumDuplicate.Group(
+                            identifier = Duplicate.Group.Id("group1"),
+                            duplicates = setOf(other1, other2),
+                            keeperIdentifier = other1.identifier,
+                        ),
+                        ChecksumDuplicate.Group(
+                            identifier = Duplicate.Group.Id("group2"),
+                            duplicates = setOf(solo),
+                        ),
+                    ),
+                    favoriteGroupIdentifier = Duplicate.Group.Id("group1"),
+                )
+            )
+        )
+
+        // Details-screen flow: the user explicitly picked this group (e.g. a similar-image
+        // group), so its single member is exactly what they asked to delete.
+        deleter.delete(
+            task = DeduplicatorDeleteTask(
+                mode = DeduplicatorDeleteTask.TargetMode.Groups(
+                    deleteAll = false,
+                    targets = setOf(Duplicate.Group.Id("group2")),
+                )
+            ),
+            data = data,
+        ).success shouldBe setOf(solo)
+    }
 }


### PR DESCRIPTION
## What changed

Fixed a bug where the Deduplicator could delete the copy it promised to keep. When deleting a duplicate cluster with the default "keep one copy" behavior, a cluster whose kept group contained only a single file would have that file deleted too — in the worst case removing the *last remaining copy* of a file while the confirmation dialog said it would be kept.

## Technical Context

- Root cause: the keep-one cluster path routed the favorite group through `targetGroups(deleteAll=false)`, whose `deleteAll || group.duplicates.size == 1` branch deletes *all* members of a single-member group. The list UI's `computeDeleteTargets` excluded exactly that file, so the confirm dialog and the deleter disagreed.
- Two reachable routes: a "prefer similar-image match" arbiter config makes a 1-member similarity group the cluster favorite straight from a scan; and `prune()` keeps 1-member groups after a partial sub-row delete, so a follow-up cluster or dashboard delete hit the same branch.
- The `size == 1` fast path is deliberately preserved for explicit group targets (`TargetMode.Groups`): deleting a 1-member similar-image group from the details screen must still delete that member — that's the branch's historical purpose. Only the cluster keep-one path marks the favorite group as kept.
- `Cluster.redundantSize`/`redundantCount` had `count >= 2` guards written to agree with the deleter's buggy behavior (the linear list header showed a different "freeable" figure than the grid line and confirm dialog on the same screen). A solo favorite group now contributes zero everywhere.
- Review guidance: the new deleter regression test was verified to fail against the unfixed code; the two metric tests that pinned the old behavior were updated, and the solo-kept-group case safely no-ops through the arbiter (`decideDuplicates(single)` returns an empty non-keeper set).
