### PR TITLE
Analyzer: Fix crash after granting storage access

### DIFF
--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/Analyzer.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/Analyzer.kt
@@ -22,9 +22,11 @@ import eu.darken.sdmse.analyzer.core.storage.toFlatContent
 import eu.darken.sdmse.analyzer.core.storage.toNestedContent
 import eu.darken.sdmse.common.collections.mutate
 import eu.darken.sdmse.common.coroutine.AppScope
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.GatewaySwitch
@@ -48,6 +50,7 @@ import eu.darken.sdmse.setup.IncompleteSetupException
 import eu.darken.sdmse.setup.SetupModule
 import eu.darken.sdmse.setup.isComplete
 import eu.darken.sdmse.stats.core.SpaceTracker
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -128,17 +131,29 @@ class Analyzer @Inject constructor(
         // ran before the storage permission was granted, that stale flag (and the permission-limited
         // content) sticks in the cached data until the next scan — so the UI keeps showing
         // "permissions missing" and the storage card bounces through a Setup screen that immediately
-        // closes. When the storage setup transitions to complete, re-scan so the stale flag clears and
-        // the real content loads. No loop: after the rescan no DeviceStorage carries setupIncomplete,
-        // and the setup state stays complete (distinctUntilChanged), so this stops firing.
-        storageSetupModule.state
-            .map { it.isComplete }
+        // closes. Whenever setup is complete AND the cached data carries the stale flag, re-scan.
+        // Observing both flows covers setup completing mid-scan: the finishing scan publishes the
+        // stale devices after the setup transition, which re-evaluates the condition. No loop: a
+        // successful rescan bakes setupIncomplete=false into every device, and a failed one leaves
+        // the devices cleared (scan start empties them) — either way the condition turns false.
+        combine(
+            storageSetupModule.state.map { it.isComplete }.distinctUntilChanged(),
+            storageDevices,
+        ) { setupComplete, devices ->
+            setupComplete && devices.any { it.setupIncomplete }
+        }
             .distinctUntilChanged()
-            .filter { isComplete -> isComplete }
+            .filter { staleWhileComplete -> staleWhileComplete }
             .onEach {
-                if (storageDevices.value.any { it.setupIncomplete }) {
-                    log(TAG, INFO) { "Storage setup completed while cached storage data is stale; re-scanning" }
+                log(TAG, INFO) { "Storage setup is complete but cached storage data is stale; re-scanning" }
+                try {
                     submit(DeviceStorageScanTask())
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    // Background heal only — appScope has no exception handler, so anything
+                    // escaping here would kill the whole process. The next manual scan recovers.
+                    log(TAG, ERROR) { "Automatic storage re-scan failed: ${e.asLog()}" }
                 }
             }
             .launchIn(appScope)

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/AnalyzerAutoRescanTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/AnalyzerAutoRescanTest.kt
@@ -1,0 +1,203 @@
+package eu.darken.sdmse.analyzer.core
+
+import eu.darken.sdmse.analyzer.core.device.DeviceStorage
+import eu.darken.sdmse.analyzer.core.device.DeviceStorageScanTask
+import eu.darken.sdmse.analyzer.core.device.DeviceStorageScanner
+import eu.darken.sdmse.analyzer.core.storage.StorageScanner
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.files.GatewaySwitch
+import eu.darken.sdmse.common.files.MediaStoreTool
+import eu.darken.sdmse.common.sharedresource.SharedResource
+import eu.darken.sdmse.common.storage.StorageId
+import eu.darken.sdmse.setup.SetupModule
+import eu.darken.sdmse.stats.core.SpaceTracker
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.io.IOException
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicInteger
+import javax.inject.Provider
+
+/**
+ * The auto-rescan that heals stale `setupIncomplete` flags runs unattended on the app scope,
+ * which has no exception handler — anything escaping it kills the process. These tests pin the
+ * containment and the trigger conditions.
+ */
+class AnalyzerAutoRescanTest : BaseTest() {
+
+    private val setupState = MutableStateFlow<SetupModule.State>(setupModuleState(isComplete = false))
+
+    private fun setupModuleState(isComplete: Boolean): SetupModule.State.Current = mockk {
+        every { this@mockk.isComplete } returns isComplete
+    }
+
+    private fun storage(stale: Boolean) = DeviceStorage(
+        id = StorageId(internalId = null, externalId = UUID.randomUUID()),
+        label = "storage".toCaString(),
+        type = DeviceStorage.Type.PRIMARY,
+        hardware = DeviceStorage.Hardware.BUILT_IN,
+        spaceCapacity = 100L,
+        spaceFree = 50L,
+        setupIncomplete = stale,
+    )
+
+    private class Harness(
+        val analyzer: Analyzer,
+        val appScope: CoroutineScope,
+        val uncaught: MutableList<Throwable>,
+    )
+
+    private fun TestScope.createHarness(scanner: DeviceStorageScanner): Harness {
+        val uncaught = mutableListOf<Throwable>()
+        val appScope = CoroutineScope(
+            SupervisorJob() +
+                UnconfinedTestDispatcher(testScheduler) +
+                CoroutineExceptionHandler { _, e -> uncaught += e },
+        )
+        val analyzer = Analyzer(
+            appScope = appScope,
+            deviceScanner = Provider { scanner },
+            storageScanner = Provider { mockk<StorageScanner>() },
+            gatewaySwitch = mockk<GatewaySwitch> {
+                every { sharedResource } returns SharedResource.createKeepAlive("test:gateway", appScope)
+            },
+            appInventorySetupModule = mockk { every { state } returns emptyFlow() },
+            storageSetupModule = mockk { every { state } returns setupState },
+            mediaStoreTool = mockk<MediaStoreTool>(relaxed = true),
+            spaceTracker = mockk<SpaceTracker>(relaxed = true),
+        )
+        return Harness(analyzer, appScope, uncaught)
+    }
+
+    private fun scanner(scanCalls: AtomicInteger, onScan: suspend (Int) -> Set<DeviceStorage>) =
+        mockk<DeviceStorageScanner> {
+            every { progress } returns flowOf(null)
+            coEvery { scan() } coAnswers { onScan(scanCalls.incrementAndGet()) }
+        }
+
+    @Test
+    fun `a failing auto-rescan is contained instead of reaching the app scope`() = runTest {
+        val scanCalls = AtomicInteger()
+        val harness = createHarness(
+            scanner(scanCalls) { call ->
+                when (call) {
+                    1 -> setOf(storage(stale = true))
+                    else -> throw IOException("binder died mid-scan")
+                }
+            },
+        )
+        try {
+            // Manual scan while setup is incomplete caches stale data.
+            harness.analyzer.submit(DeviceStorageScanTask())
+            scanCalls.get() shouldBe 1
+
+            // Setup completes -> auto-rescan fires and blows up. Without containment this is an
+            // uncaught exception on the app scope, i.e. process death.
+            setupState.value = setupModuleState(isComplete = true)
+            advanceUntilIdle()
+
+            scanCalls.get() shouldBe 2
+            harness.uncaught.shouldBeEmpty()
+        } finally {
+            harness.appScope.cancel()
+        }
+    }
+
+    @Test
+    fun `setup completing mid-scan still triggers the healing rescan`() = runTest {
+        val scanCalls = AtomicInteger()
+        val firstScanGate = CompletableDeferred<Unit>()
+        val harness = createHarness(
+            scanner(scanCalls) { call ->
+                when (call) {
+                    1 -> {
+                        firstScanGate.await()
+                        // Baked while setup was still incomplete at scan start.
+                        setOf(storage(stale = true))
+                    }
+                    else -> setOf(storage(stale = false))
+                }
+            },
+        )
+        try {
+            val firstScan = launch { harness.analyzer.submit(DeviceStorageScanTask()) }
+            runCurrent()
+            scanCalls.get() shouldBe 1
+
+            // Setup completes while the scan is in flight: cached devices are still empty at this
+            // moment, so a trigger that only samples the current value would do nothing - the
+            // stale result published after the transition must re-evaluate the condition.
+            setupState.value = setupModuleState(isComplete = true)
+            runCurrent()
+
+            firstScanGate.complete(Unit)
+            firstScan.join()
+            advanceUntilIdle()
+
+            scanCalls.get() shouldBe 2
+            harness.analyzer.data.first().storages.none { it.setupIncomplete } shouldBe true
+            harness.uncaught.shouldBeEmpty()
+        } finally {
+            harness.appScope.cancel()
+        }
+    }
+
+    @Test
+    fun `no rescan when setup completes without stale data`() = runTest {
+        val scanCalls = AtomicInteger()
+        val harness = createHarness(scanner(scanCalls) { setOf(storage(stale = false)) })
+        try {
+            setupState.value = setupModuleState(isComplete = true)
+            advanceUntilIdle()
+
+            scanCalls.get() shouldBe 0
+            harness.uncaught.shouldBeEmpty()
+        } finally {
+            harness.appScope.cancel()
+        }
+    }
+
+    @Test
+    fun `successful rescan does not loop`() = runTest {
+        val scanCalls = AtomicInteger()
+        val harness = createHarness(
+            scanner(scanCalls) { call ->
+                when (call) {
+                    1 -> setOf(storage(stale = true))
+                    else -> setOf(storage(stale = false))
+                }
+            },
+        )
+        try {
+            harness.analyzer.submit(DeviceStorageScanTask())
+            setupState.value = setupModuleState(isComplete = true)
+            advanceUntilIdle()
+
+            scanCalls.get() shouldBe 2
+            harness.analyzer.data.first().storages.none { it.setupIncomplete } shouldBe true
+            harness.uncaught.shouldBeEmpty()
+        } finally {
+            harness.appScope.cancel()
+        }
+    }
+}


### PR DESCRIPTION
## What changed

Fixed a crash that could bring down the whole app right after granting the storage permission: the Analyzer automatically refreshes its storage overview in the background when setup completes, and any hiccup during that refresh (a busy system service, a storage error) crashed the app instead of being retried later. Also fixed a gap where that automatic refresh never happened if setup was completed while a scan was already running — the "permissions missing" hint could then stick around until a manual re-scan.

## Technical Context

- Root cause: `submit(DeviceStorageScanTask())` ran bare inside `onEach{}.launchIn(appScope)`; `AppCoroutineScope` has no `CoroutineExceptionHandler` and the default uncaught handler kills the process. Every comparable submit site routes through `vmScope` (errors → `errorEvents`) or the TaskManager — this was the only unprotected one.
- The mid-scan window: the old trigger sampled `storageDevices.value` at the setup-transition instant, but `scanStorageDevices` clears that set at scan start, so a scan finishing *after* the transition baked the stale flag with nothing left to re-trigger. The trigger is now a `combine` of both flows so the stale result itself re-evaluates the condition.
- Loop safety in both directions: a successful rescan bakes `setupIncomplete=false` (condition flips false); a failed one leaves the devices cleared (also false) and changes nothing else, so containment can't turn into a retry loop.
- Review guidance: the new tests run against a production-like unsupervised scope (`SupervisorJob` + capturing handler) and were verified to fail on the unfixed code — the containment test captured the escaped `IOException`, the mid-scan test observed the missed rescan.
