### PR TITLE
General: Fix stale duplicate details and wasted work during scans

### DIFF
--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/details/AppJunkDetailsViewModel.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/details/AppJunkDetailsViewModel.kt
@@ -28,6 +28,7 @@ import eu.darken.sdmse.main.core.taskmanager.uniqueTaskResults
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
@@ -66,7 +67,7 @@ class AppJunkDetailsViewModel @Inject constructor(
         // re-sort the junk list and re-run resolveTarget. Progress is merged in last (below) as a
         // cheap field swap that preserves the items List instance, letting keyed pager pages skip.
         val itemsState = combine(
-            appCleaner.state.map { it.data }.filterNotNull(),
+            appCleaner.state.map { it.data }.filterNotNull().distinctUntilChanged(),
             collapsedByJunk,
         ) { data, collapsed ->
             // Drop fully-empty junks left over after path-only `appCleaner.exclude(installId, paths)`

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/list/AppCleanerListViewModel.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/list/AppCleanerListViewModel.kt
@@ -26,6 +26,7 @@ import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
@@ -65,7 +66,7 @@ class AppCleanerListViewModel @Inject constructor(
     // and re-map the whole junk list. Progress is merged in last (below) as a cheap field swap that
     // preserves the rows List instance, letting keyed lazy rows skip recomposition.
     private val rowsState = combine(
-        appCleaner.state.map { it.data },
+        appCleaner.state.map { it.data }.distinctUntilChanged(),
         searchQuery,
     ) { data, rawQuery ->
         val all = data?.junks?.sortedByDescending { it.size }

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListViewModel.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListViewModel.kt
@@ -52,6 +52,7 @@ import eu.darken.sdmse.setup.SetupModule
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -132,7 +133,7 @@ class AppControlListViewModel @Inject constructor(
     // filterSortRows over hundreds of apps. Progress is merged in the outer combine (below) as a
     // cheap field swap that preserves the rows List instance, letting keyed lazy rows skip.
     private val rowsState = combine(
-        appControl.state,
+        appControl.state.distinctUntilChangedBy { it.copy(progress = null) },
         displayOptions,
     ) { acState, options ->
         // If the selected sort's backing data wasn't loaded by the current scan (missing or

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/actions/AppActionViewModel.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/actions/AppActionViewModel.kt
@@ -49,6 +49,8 @@ import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
@@ -88,6 +90,7 @@ class AppActionViewModel @Inject constructor(
                     // Wait for data to be loaded before deciding the app is gone — otherwise the
                     // transient null state during a scan refresh would dismiss the sheet.
                     .mapNotNull { it.data }
+                    .distinctUntilChanged()
                     .map { data -> data.apps.firstOrNull { app -> app.installId == id } to id }
             }
             .filter { (app, _) -> app == null }
@@ -101,12 +104,14 @@ class AppActionViewModel @Inject constructor(
 
     val events = SingleEventFlow<Event>()
 
-    val state: StateFlow<State> = combine(
+    // Item production excludes progress so high-frequency progress ticks (which re-emit the tool
+    // state with the same data instance) don't re-scan the app list and rebuild the action items
+    // while the sheet is open. Progress is merged in last (below) as a cheap field swap.
+    private val baseState = combine(
         installIdFlow,
-        appControl.state,
-        appControl.progress,
+        appControl.state.distinctUntilChangedBy { it.copy(progress = null) },
         exclusionManager.exclusions,
-    ) { installId, acState, progress, _ ->
+    ) { installId, acState, _ ->
         if (installId == null) return@combine State()
         val appInfo = acState.data?.apps?.firstOrNull { it.installId == installId }
             ?: return@combine State()
@@ -130,7 +135,14 @@ class AppActionViewModel @Inject constructor(
             existingExclusionId = existingExclusion?.id,
         )
         val items = buildAppActionItems(appInfo, ctx)
-        State(appInfo = appInfo, progress = progress, items = items)
+        State(appInfo = appInfo, items = items)
+    }
+
+    val state: StateFlow<State> = combine(
+        baseState,
+        appControl.progress,
+    ) { base, progress ->
+        base.copy(progress = progress)
     }.safeStateIn(
         initialValue = State(),
         onError = { State() },

--- a/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/ui/details/CorpseDetailsViewModel.kt
+++ b/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/ui/details/CorpseDetailsViewModel.kt
@@ -23,6 +23,7 @@ import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
 import eu.darken.sdmse.main.core.taskmanager.uniqueTaskResults
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
@@ -60,6 +61,7 @@ class CorpseDetailsViewModel @Inject constructor(
         val itemsState = corpseFinder.state
             .map { it.data }
             .filterNotNull()
+            .distinctUntilChanged()
             .map { data ->
                 val sortedCorpses = data.corpses
                     .sortedByDescending { it.size }

--- a/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/ui/list/CorpseFinderListViewModel.kt
+++ b/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/ui/list/CorpseFinderListViewModel.kt
@@ -17,6 +17,7 @@ import eu.darken.sdmse.corpsefinder.ui.CorpseDetailsRoute
 import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
@@ -52,6 +53,7 @@ class CorpseFinderListViewModel @Inject constructor(
     // preserves the rows List instance, letting keyed lazy rows skip recomposition.
     private val rowsState = corpseFinder.state
         .map { it.data }
+        .distinctUntilChanged()
         .map { data ->
             val rows = data?.corpses
                 ?.sortedByDescending { it.size }

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/ui/list/CorpseFinderListViewModelTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/ui/list/CorpseFinderListViewModelTest.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -57,7 +58,7 @@ class CorpseFinderListViewModelTest : BaseTest() {
         val vm: CorpseFinderListViewModel,
         val corpseFinder: CorpseFinder,
         val taskSubmitter: TaskSubmitter,
-        val stateFlow: MutableStateFlow<CorpseFinder.State>,
+        val dataFlow: MutableStateFlow<CorpseFinder.Data?>,
         val progressFlow: MutableStateFlow<Progress.Data?>,
     )
 
@@ -84,10 +85,16 @@ class CorpseFinderListViewModelTest : BaseTest() {
         data: CorpseFinder.Data? = null,
         progress: Progress.Data? = null,
     ): Harness {
-        val stateFlow = MutableStateFlow(cfState(data = data, progress = progress))
+        val dataFlow = MutableStateFlow(data)
         val progressFlow = MutableStateFlow(progress)
         val corpseFinder = mockk<CorpseFinder>(relaxed = true).apply {
-            every { this@apply.state } returns stateFlow
+            // Mirror production wiring: CorpseFinder.state is a combine over data and progress,
+            // so a progress tick reaches the VM as a NEW State instance carrying the SAME Data
+            // instance. Stubbing state and progress as independent flows would make the
+            // rows-instance guard below pass vacuously.
+            every { this@apply.state } returns combine(dataFlow, progressFlow) { d, p ->
+                cfState(data = d, progress = p)
+            }
             every { this@apply.progress } returns progressFlow
         }
         val taskSubmitter = mockk<TaskSubmitter>(relaxed = true)
@@ -96,7 +103,7 @@ class CorpseFinderListViewModelTest : BaseTest() {
             corpseFinder = corpseFinder,
             taskSubmitter = taskSubmitter,
         )
-        return Harness(vm, corpseFinder, taskSubmitter, stateFlow, progressFlow)
+        return Harness(vm, corpseFinder, taskSubmitter, dataFlow, progressFlow)
     }
 
     @Test
@@ -138,15 +145,20 @@ class CorpseFinderListViewModelTest : BaseTest() {
 
     @Test
     fun `progress-only emission preserves the rows instance (no re-sort)`() = runTest2 {
-        // P0 perf guard: progress is decoupled from row production, so a progress tick must update
-        // only the progress field and reuse the exact same rows List — the sort/map must NOT re-run.
-        val h = harness(data = CorpseFinder.Data(corpses = listOf(corpse("a", 100), corpse("b", 200))))
+        // P0 perf guard: progress is decoupled from row production, so a progress tick must not
+        // re-run the sort/map pipeline. Checking only the published rows instance is NOT enough:
+        // StateFlow's structural-equality conflation can preserve the old instance even while the
+        // pipeline wastefully re-executed. The iteration counter observes the executions directly
+        // (the init navUp watcher only calls isEmpty() and never iterates).
+        val corpses = IterationCountingList(listOf(corpse("a", 100), corpse("b", 200)))
+        val h = harness(data = CorpseFinder.Data(corpses = corpses))
         // Keep the WhileSubscribed state alive so the upstream chain actually runs.
         val job = launch(start = CoroutineStart.UNDISPATCHED) { h.vm.state.collect { } }
         advanceUntilIdle()
 
         val rowsBefore = h.vm.state.value.rows
         rowsBefore.shouldNotBeNull()
+        val iterationsBefore = corpses.iterations.get()
 
         // Emit a progress-only change; data is untouched.
         val tick = Progress.Data(extra = "tick")
@@ -154,9 +166,22 @@ class CorpseFinderListViewModelTest : BaseTest() {
         advanceUntilIdle()
 
         h.vm.state.value.progress shouldBe tick
-        // Same instance ⇒ the row pipeline did not re-execute on the progress tick.
+        // The row pipeline did not touch the corpse list again...
+        corpses.iterations.get() shouldBe iterationsBefore
+        // ...and the published rows are still the exact same instance.
         (h.vm.state.value.rows === rowsBefore) shouldBe true
         job.cancel()
+    }
+
+    /** Counts iterations so tests can observe whether the sort/map pipeline (re-)executed. */
+    private class IterationCountingList<T>(
+        private val backing: List<T>,
+    ) : List<T> by backing {
+        val iterations = java.util.concurrent.atomic.AtomicInteger()
+        override fun iterator(): Iterator<T> {
+            iterations.incrementAndGet()
+            return backing.iterator()
+        }
     }
 
     @Test
@@ -313,7 +338,7 @@ class CorpseFinderListViewModelTest : BaseTest() {
         val h = harness(data = initial)
 
         // drop(1) skips the initial replay; the second emission with empty data triggers navUp.
-        h.stateFlow.value = cfState(data = CorpseFinder.Data(corpses = emptyList()))
+        h.dataFlow.value = CorpseFinder.Data(corpses = emptyList())
         advanceUntilIdle()
 
         h.vm.navEvents.first() shouldBe NavEvent.Up
@@ -328,7 +353,7 @@ class CorpseFinderListViewModelTest : BaseTest() {
         val h = harness(data = CorpseFinder.Data(corpses = listOf(c)))
         val collected = collectNavEvents(h.vm)
 
-        h.stateFlow.value = cfState(data = null)
+        h.dataFlow.value = null
         advanceUntilIdle()
 
         // No navUp emitted — the tightened filter (data != null && data.corpses.isEmpty())

--- a/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/details/DeduplicatorDetailsViewModel.kt
+++ b/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/details/DeduplicatorDetailsViewModel.kt
@@ -35,7 +35,7 @@ import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
 import eu.darken.sdmse.main.core.taskmanager.uniqueTaskResults
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.distinctUntilChangedBy
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
@@ -80,13 +80,17 @@ class DeduplicatorDetailsViewModel @Inject constructor(
 
     val state: StateFlow<State?> = routeFlow.filterNotNull().flatMapLatest { route ->
         // Item production excludes progress so high-frequency progress ticks during a scan don't
-        // re-sort the clusters and re-run resolveTarget. Progress is merged in last (below) as a
-        // cheap field swap that preserves the items List instance, letting keyed pager pages skip.
+        // re-sort the clusters and re-run resolveTarget: ticks re-emit the same Data instance, so
+        // the reference-dedup drops them. Anything that builds new Data (prune after deleting or
+        // excluding duplicates inside a surviving cluster) passes through and refreshes the pager —
+        // an id-set key would wrongly suppress those intra-cluster changes and keep showing deleted
+        // files. Progress is merged in last (below) as a cheap field swap that preserves the items
+        // List instance, letting keyed pager pages skip.
         val itemsState = combine(
             deduplicator.state
                 .map { it.data }
                 .filterNotNull()
-                .distinctUntilChangedBy { data -> data.clusters.map { it.identifier }.toSet() },
+                .distinctUntilChanged(),
             settings.isDirectoryViewEnabled.flow,
             settings.allowDeleteAll.flow,
             collapsedDirsFlow,

--- a/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListViewModel.kt
+++ b/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListViewModel.kt
@@ -29,6 +29,7 @@ import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
 import eu.darken.sdmse.main.core.taskmanager.getLatestTask
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
@@ -83,6 +84,7 @@ class DeduplicatorListViewModel @Inject constructor(
     private val rowsFlow = deduplicator.state
         .map { it.data }
         .filterNotNull()
+        .distinctUntilChanged()
         .map { data ->
             data.clusters
                 .sortedByDescending { it.averageSize }

--- a/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/ui/details/DeduplicatorDetailsViewModelTest.kt
+++ b/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/ui/details/DeduplicatorDetailsViewModelTest.kt
@@ -211,6 +211,25 @@ class DeduplicatorDetailsViewModelTest : BaseTest() {
     }
 
     @Test
+    fun `intra-cluster deletion refreshes items - deleted duplicates disappear`() = runTest2 {
+        // Regression guard: the items pipeline used to dedup on the SET OF CLUSTER IDS, so a
+        // prune() after deleting duplicates inside a surviving cluster (same cluster ids, fewer
+        // duplicates) was suppressed — the pager kept showing the deleted file with stale sizes
+        // until a full rescan. The reference-dedup must let the new Data instance through.
+        val a = cluster("a", dupeSizes = listOf(100L, 100L, 100L))
+        val h = harness(clusters = setOf(a))
+        h.vm.bindRoute(DeduplicatorDetailsRoute(identifier = a.identifier))
+        h.vm.state.filterNotNull().first().items.single().count shouldBe 3
+
+        // Same cluster id, one duplicate pruned — exactly what prune() publishes after a
+        // partial delete.
+        val pruned = cluster("a", dupeSizes = listOf(100L, 100L))
+        h.stateFlow.value = Deduplicator.State(data = Deduplicator.Data(clusters = setOf(pruned)), progress = null)
+
+        h.vm.state.filterNotNull().first().items.single().count shouldBe 2
+    }
+
+    @Test
     fun `state target initially matches route identifier`() = runTest2 {
         val a = cluster("a", dupeSizes = listOf(100L, 100L))
         val b = cluster("b", dupeSizes = listOf(200L, 200L))
@@ -830,12 +849,11 @@ class DeduplicatorDetailsViewModelTest : BaseTest() {
         coVerify(exactly = 1) { h.deduplicator.undoExclude(undo) }
 
         // currentTarget was set to b inside the launched coroutine, but the state's combine()
-        // only re-runs when one of its inputs emits. The cluster-set didn't change (the mock
-        // doesn't actually persist anything), and the deduplicator.state input passes through
-        // distinctUntilChangedBy { clusters.identifiers }, so re-pushing the same data is
-        // dropped. Force a re-emit through `deduplicator.progress` (a different combine input)
-        // so the next state value reflects the restored target. Progress changes don't leave
-        // residual UI state behind.
+        // only re-runs when one of its inputs emits. The mock doesn't actually persist anything,
+        // and the deduplicator.state input dedups by Data reference, so re-pushing the same
+        // instance would be dropped. Force a re-emit through `deduplicator.progress` (a different
+        // combine input) so the next state value reflects the restored target. Progress changes
+        // don't leave residual UI state behind.
         h.progressFlow.value = Progress.Data()
         h.vm.state.filterNotNull().first().target shouldBe b.identifier
     }

--- a/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/ui/list/SqueezerListViewModel.kt
+++ b/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/ui/list/SqueezerListViewModel.kt
@@ -26,6 +26,7 @@ import eu.darken.sdmse.squeezer.core.tasks.SqueezerProcessTask
 import eu.darken.sdmse.squeezer.core.tasks.SqueezerTask
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
@@ -65,6 +66,7 @@ class SqueezerListViewModel @Inject constructor(
     // cheap field swap that preserves the media List instance, letting keyed lazy rows skip.
     private val mediaState = squeezer.state
         .map { it.data }
+        .distinctUntilChanged()
         .map { data -> State(media = data?.media?.sortedByDescending { it.size }) }
 
     val state: StateFlow<State> = combine(

--- a/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/details/FilterContentDetailsViewModel.kt
+++ b/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/details/FilterContentDetailsViewModel.kt
@@ -29,6 +29,7 @@ import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerTask
 import eu.darken.sdmse.systemcleaner.ui.FilterContentDetailsRoute
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
@@ -64,6 +65,7 @@ class FilterContentDetailsViewModel @Inject constructor(
         val itemsState = systemCleaner.state
             .map { it.data }
             .filterNotNull()
+            .distinctUntilChanged()
             .map { data ->
                 val sortedContents = data.filterContents.sortedByDescending { it.size }
 

--- a/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/list/SystemCleanerListViewModel.kt
+++ b/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/list/SystemCleanerListViewModel.kt
@@ -19,6 +19,7 @@ import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerProcessingTask
 import eu.darken.sdmse.systemcleaner.ui.FilterContentDetailsRoute
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
@@ -56,6 +57,7 @@ class SystemCleanerListViewModel @Inject constructor(
     // swap that preserves the rows List instance, letting keyed lazy rows skip recomposition.
     private val rowsState = systemCleaner.state
         .map { it.data }
+        .distinctUntilChanged()
         .map { data ->
             val rows = data?.filterContents
                 ?.sortedByDescending { it.size }


### PR DESCRIPTION
## What changed

Fixed the Deduplicator's detail view showing files that were already deleted: after removing individual copies inside a group of duplicates, the deleted files kept appearing (with outdated sizes) until a full re-scan. Also removed a hidden performance drain in every tool: while a scan, deletion, or compression was running, each progress update needlessly re-sorted and rebuilt the whole result list in the background (no visual glitch, but wasted CPU and battery — worst in the Squeezer, which re-sorted the entire media list on every per-file update).

## Technical Context

- Root cause: every tool's `state` is a `combine` over `internalData` + `progress`, so each progress tick emits a *new* `State` carrying the *same* data instance. The rows pipelines (`state.map { it.data }.map { sort/map }`) had no dedup, so they re-ran per tick — the decoupling e0b7e7135 claimed never held. Its guard test passed vacuously because the harness stubbed `state` and `progress` as independent flows.
- Fix shape: reference-dedup right after data extraction (`.map { it.data }.distinctUntilChanged()`) across 9 ViewModels; AppControl (list + action sheet) dedups on `state.copy(progress = null)` because its pipelines read capability fields beyond `data` (the identical data reference keeps the data-class comparison cheap).
- The Deduplicator stale-pager bug was the flip side of the same mechanism: its details pipeline deduped on the *set of cluster ids*, which also suppressed legitimate `prune()` results (same cluster id, fewer duplicates). Reference-dedup drops ticks (same instance) but passes prune output (new instance).
- Review guidance / test subtlety worth knowing: asserting that the published rows *instance* is unchanged is not a valid guard on its own — `StateFlow`'s structural-equality conflation can preserve the old instance even when the pipeline wastefully re-executed (emission-order dependent). The strengthened guard counts iterations of the source list instead, and was verified to fail against the unfixed ViewModels, as was the new stale-pager regression test.
