### PR TITLE
General: Fix cancelled scans continuing to read folders in the background

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/EscalatingWalker.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/EscalatingWalker.kt
@@ -12,6 +12,7 @@ import eu.darken.sdmse.common.files.core.local.listFiles2
 import eu.darken.sdmse.common.files.isDirectory
 import eu.darken.sdmse.common.files.isFile
 import eu.darken.sdmse.common.files.isSymlink
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.AbstractFlow
 import kotlinx.coroutines.flow.FlowCollector
 import java.util.LinkedList
@@ -107,6 +108,11 @@ class EscalatingWalker(
                                 collector.emit(child)
                             }
                         continue
+                    } catch (e: CancellationException) {
+                        // A cancelled walk (scan aborted, take() satisfied) is not a read failure:
+                        // re-queueing would grind through the remaining frontier and end up routing
+                        // the cancellation to onError as if the filesystem failed.
+                        throw e
                     } catch (e: Exception) {
                         log(TAG, VERBOSE) { "Escalating ${item.target.lookedUp} to $escalationMode due to: $e" }
                         queue.addFirst(item.copy(targetMode = escalationMode, error = e))
@@ -126,6 +132,8 @@ class EscalatingWalker(
                                 collector.emit(child)
                             }
                         continue
+                    } catch (e: CancellationException) {
+                        throw e
                     } catch (e: Exception) {
                         log(TAG, DEBUG) { "Failed to read despite escalation: ${item.target.lookedUp}: $e" }
                         queue.addFirst(item.copy(targetMode = null, error = e))

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/EscalatingWalkerTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/EscalatingWalkerTest.kt
@@ -3,6 +3,7 @@ package eu.darken.sdmse.common.files.local
 import eu.darken.sdmse.common.files.APathGateway
 import eu.darken.sdmse.common.files.FileType
 import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -10,6 +11,7 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
@@ -107,5 +109,50 @@ class EscalatingWalkerTest : BaseTest() {
         names shouldContain "filelink"
         // Target (real.txt) is app-readable, so the symlink resolves app-side → no escalation needed.
         coVerify(exactly = 0) { gateway.walk(any(), any(), LocalGateway.Mode.ROOT) }
+    }
+
+    @Test
+    fun `cancellation mid-walk stops eagerly and is not routed to onError`() = runTest {
+        // Regression guard: a cancelled walk (aborted scan, satisfied take()) used to be caught
+        // like a read failure — the item was re-queued through the escalation/error branches, the
+        // remaining directory frontier was eagerly listed, and the cancellation ended up in the
+        // caller's onError as if the filesystem had failed.
+        val start = LocalPath.build(testDir)
+        File(testDir, "a.txt").writeText("a")
+        File(testDir, "sub").apply { mkdirs() }.let { File(it, "b.txt").writeText("b") }
+        File(testDir, "sub2").apply { mkdirs() }.let { File(it, "c.txt").writeText("c") }
+
+        var lookupCount = 0
+        mockkStatic("eu.darken.sdmse.common.files.local.LocalPathExtensionsKt")
+        every { any<LocalPath>().performLookup() } answers {
+            lookupCount++
+            val path = arg<LocalPath>(0)
+            lookup(path, if (File(path.path).isDirectory) FileType.DIRECTORY else FileType.FILE)
+        }
+
+        coEvery { gateway.lookup(start) } returns lookup(start, FileType.DIRECTORY)
+        coEvery { gateway.hasRoot() } returns false
+        coEvery { gateway.hasAdb() } returns false
+
+        val errors = mutableListOf<Exception>()
+        val walker = EscalatingWalker(
+            gateway = gateway,
+            start = start,
+            options = APathGateway.WalkOptions(
+                onError = { _, error ->
+                    errors.add(error)
+                    true
+                },
+            ),
+        )
+
+        val collected = walker.take(1).toList()
+
+        collected.size shouldBe 1
+        // Cancellation is not a filesystem failure and must never reach onError...
+        errors shouldBe emptyList()
+        // ...and the walk stops instead of grinding through the remaining directories: only the
+        // start dir's three children were ever looked up.
+        lookupCount shouldBe 3
     }
 }


### PR DESCRIPTION
## What changed

Fixed cancelled scans doing unnecessary work: when a scan was aborted (or an internal limit was reached) while walking storage, the app kept listing the remaining folders before actually stopping, and could log the cancellation as if reading the filesystem had failed.

## Technical Context

- `EscalatingWalker` (the AUTO-mode walker used for SDCARD walks by SystemCleaner, Deduplicator, and Swiper) caught `Exception` including `CancellationException` in both its catch blocks. A cancellation from `collector.emit` was re-queued through the escalation branch (which immediately fails again in the cancelled context) and then routed to the caller's `onError` as a filesystem error, while the queue loop eagerly listed the remaining directory frontier.
- Commit 1f97eab00 fixed the identical bug in `DirectLocalWalker`; this is the missed sibling. Both catch blocks now rethrow `CancellationException`.
- Interacts with #2506: before that fix, a cancellation inside an escalated direct root/ADB sub-walk both killed the helper *and* was swallowed here.
- Review guidance: the regression test drives a real temp-dir walk with `take(1)` and asserts the cancellation never reaches `onError` and that no further directories are listed; it was verified to fail against the unfixed code.
