### PR TITLE
General: Center the dashboard title when it wraps onto two lines

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/TitleDashboardCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/TitleDashboardCard.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
@@ -153,6 +154,7 @@ internal fun TitleDashboardCard(item: TitleDashboardCardItem) {
                     Text(
                         text = titleText,
                         style = MaterialTheme.typography.headlineSmall,
+                        textAlign = TextAlign.Center,
                     )
                     Text(
                         text = sloganText,


### PR DESCRIPTION
## What changed

On the dashboard, the app title could wrap onto two lines when space was tight (e.g. with the Dev/Beta version badge next to it). The second line was stuck to the left edge instead of being centered like the rest of the header. The title now stays centered when it wraps.

## Technical Context

- Root cause: the title is a single `Text` ("SD Maid SE" + flavor/Pro postfix), and `TitleHeaderLayout` caps its width when the build-type ribbon is present. Wrapped lines use Compose's default start alignment, breaking the header's center-anchored composition.
- Fix is `textAlign = TextAlign.Center` on the title `Text` — the single-line case and the large-font-scale stacked branch are visually unchanged since the text box hugs its content.
- Alternatives rejected: auto-sizing the title to avoid the wrap would shrink the app name to accommodate a debug-only ribbon; forcing a permanent two-line lockup is unnecessary in the common case.
