### PR TITLE
General: Fix Pro users seeing the upgrade screen right after app start

### DIFF
--- a/app-common-exclusion/src/main/java/eu/darken/sdmse/exclusion/ui/list/ExclusionListViewModel.kt
+++ b/app-common-exclusion/src/main/java/eu/darken/sdmse/exclusion/ui/list/ExclusionListViewModel.kt
@@ -26,7 +26,7 @@ import eu.darken.sdmse.common.pkgs.pkgs
 import eu.darken.sdmse.common.readAsText
 import eu.darken.sdmse.common.uix.ViewModel4
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
-import eu.darken.sdmse.common.upgrade.isPro
+import eu.darken.sdmse.common.upgrade.isProForUi
 import eu.darken.sdmse.exclusion.core.DefaultExclusions
 import eu.darken.sdmse.exclusion.core.ExclusionImporter
 import eu.darken.sdmse.exclusion.core.ExclusionManager
@@ -254,7 +254,7 @@ class ExclusionListViewModel @Inject constructor(
     fun exportExclusions(ids: Set<ExclusionId>) = launch {
         log(TAG) { "exportExclusions($ids)" }
 
-        if (!upgradeRepo.isPro()) {
+        if (!upgradeRepo.isProForUi()) {
             log(TAG) { "Pro upgrade required" }
             navTo(UpgradeRoute())
             return@launch

--- a/app-common-stats/src/main/java/eu/darken/sdmse/stats/ui/reports/reports/ReportsViewModel.kt
+++ b/app-common-stats/src/main/java/eu/darken/sdmse/stats/ui/reports/reports/ReportsViewModel.kt
@@ -8,7 +8,7 @@ import eu.darken.sdmse.common.flow.SingleEventFlow
 import eu.darken.sdmse.common.flow.intervalFlow
 import eu.darken.sdmse.common.navigation.routes.UpgradeRoute
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
-import eu.darken.sdmse.common.upgrade.isPro
+import eu.darken.sdmse.common.upgrade.isProForUi
 import eu.darken.sdmse.common.uix.ViewModel4
 import eu.darken.sdmse.main.core.SDMTool
 import eu.darken.sdmse.stats.core.Report
@@ -66,7 +66,7 @@ class ReportsViewModel @Inject constructor(
 
     fun onStorageTrendClick() = launch {
         log(TAG) { "onStorageTrendClick()" }
-        if (upgradeRepo.isPro()) {
+        if (upgradeRepo.isProForUi()) {
             navTo(SpaceHistoryRoute())
         } else {
             navTo(UpgradeRoute(forced = true))

--- a/app-common-stats/src/main/java/eu/darken/sdmse/stats/ui/spacehistory/SpaceHistoryViewModel.kt
+++ b/app-common-stats/src/main/java/eu/darken/sdmse/stats/ui/spacehistory/SpaceHistoryViewModel.kt
@@ -13,7 +13,7 @@ import eu.darken.sdmse.common.stats.R
 import eu.darken.sdmse.common.storage.StorageId
 import eu.darken.sdmse.common.storage.StorageManager2
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
-import eu.darken.sdmse.common.upgrade.isPro
+import eu.darken.sdmse.common.upgrade.isProForUi
 import eu.darken.sdmse.common.uix.ViewModel4
 import eu.darken.sdmse.stats.core.SpaceHistoryRepo
 import eu.darken.sdmse.stats.core.db.ReportEntity
@@ -137,7 +137,7 @@ class SpaceHistoryViewModel @Inject constructor(
 
     fun selectRange(range: Range) = launch {
         log(TAG) { "selectRange($range)" }
-        if (range != Range.DAYS_7 && !upgradeRepo.isPro()) {
+        if (range != Range.DAYS_7 && !upgradeRepo.isProForUi()) {
             navTo(UpgradeRoute())
             return@launch
         }

--- a/app-common/src/main/java/eu/darken/sdmse/common/upgrade/UpgradeRepo.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/upgrade/UpgradeRepo.kt
@@ -10,6 +10,14 @@ interface UpgradeRepo {
 
     val upgradeInfo: Flow<Info>
 
+    /**
+     * Whether [upgradeInfo] reflects a real entitlement lookup yet. On GPlay this is `false`
+     * until the first billing result arrives after process start (during that window
+     * [upgradeInfo] reports non-Pro even for paying users); FOSS reads a local cache and is
+     * always settled. See `isProForUi` for the gate that uses this.
+     */
+    val isSettled: Flow<Boolean>
+
     suspend fun refresh()
 
     interface Info {

--- a/app-common/src/main/java/eu/darken/sdmse/common/upgrade/UpgradeRepoExtensions.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/upgrade/UpgradeRepoExtensions.kt
@@ -39,3 +39,28 @@ suspend fun UpgradeRepo.isProSettled(timeout: Duration = 5.seconds): Boolean = t
     log(TAG, WARN) { "isProSettled() failed, failing open (allowing): ${e.asLog()}" }
     true
 }
+
+/**
+ * Pro check for UI gates: tap handlers that route between a gated action and the upgrade screen.
+ *
+ * Resolves immediately in the common cases — already Pro, or billing settled and not Pro — so the
+ * upgrade screen stays snappy for free users (unlike [isProSettled], whose non-Pro path always
+ * waits out its timeout). Only while billing is still connecting (GPlay cold start or reconnect,
+ * where [UpgradeRepo.upgradeInfo] reports non-Pro even for paying users) does it wait, up to
+ * [timeout], for the first real billing result — so a Pro user isn't bounced to the upgrade
+ * screen by the handshake race. On timeout or error it falls back to the current state: the UI
+ * route is recoverable, and the backend [isProSettled] gate remains the enforcement safety net.
+ */
+suspend fun UpgradeRepo.isProForUi(timeout: Duration = 3.seconds): Boolean = try {
+    when {
+        upgradeInfo.first().isPro -> true
+        isSettled.first() -> false
+        else -> {
+            withTimeoutOrNull(timeout) { isSettled.first { settled -> settled } }
+            upgradeInfo.first().isPro
+        }
+    }
+} catch (e: Exception) {
+    log(TAG, WARN) { "isProForUi() failed, failing open (allowing): ${e.asLog()}" }
+    true
+}

--- a/app-common/src/test/java/eu/darken/sdmse/common/backup/ConfigBackupManagerTest.kt
+++ b/app-common/src/test/java/eu/darken/sdmse/common/backup/ConfigBackupManagerTest.kt
@@ -41,6 +41,7 @@ class ConfigBackupManagerTest : BaseTest() {
         override val upgradeSite = ""
         override val betaSite = ""
         override val upgradeInfo: Flow<UpgradeRepo.Info> = flowOf(FakeInfo(pro))
+        override val isSettled: Flow<Boolean> = flowOf(true)
         override suspend fun refresh() {}
     }
 

--- a/app-common/src/test/java/eu/darken/sdmse/common/backup/GoldenBackupFormatTest.kt
+++ b/app-common/src/test/java/eu/darken/sdmse/common/backup/GoldenBackupFormatTest.kt
@@ -12,6 +12,7 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Test
@@ -85,7 +86,7 @@ class GoldenBackupFormatTest : BaseTest() {
             sectionContributors = sections,
             databaseContributors = databases,
             json = json,
-            upgradeRepo = mockk<UpgradeRepo>(relaxed = true),
+            upgradeRepo = mockk<UpgradeRepo>(relaxed = true).apply { every { isSettled } returns flowOf(true) },
             envelopeSource = envelopeSource,
             gate = BackupOperationGate(),
             limits = BackupLimits(),

--- a/app-common/src/test/java/eu/darken/sdmse/common/upgrade/UpgradeRepoExtensionsTest.kt
+++ b/app-common/src/test/java/eu/darken/sdmse/common/upgrade/UpgradeRepoExtensionsTest.kt
@@ -1,0 +1,106 @@
+package eu.darken.sdmse.common.upgrade
+
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.currentTime
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.time.Instant
+import kotlinx.coroutines.launch
+
+class UpgradeRepoExtensionsTest : BaseTest() {
+
+    private class FakeInfo(override val isPro: Boolean) : UpgradeRepo.Info {
+        override val type: UpgradeRepo.Type = UpgradeRepo.Type.FOSS
+        override val upgradedAt: Instant? = null
+        override val error: Throwable? = null
+    }
+
+    private class FakeRepo(
+        pro: Boolean,
+        settled: Boolean,
+    ) : UpgradeRepo {
+        val proFlow = MutableStateFlow<UpgradeRepo.Info>(FakeInfo(pro))
+        val settledFlow = MutableStateFlow(settled)
+        var refreshCalls = 0
+
+        override val storeSite: String = ""
+        override val upgradeSite: String = ""
+        override val betaSite: String = ""
+        override val upgradeInfo: Flow<UpgradeRepo.Info> = proFlow
+        override val isSettled: Flow<Boolean> = settledFlow
+        override suspend fun refresh() {
+            refreshCalls++
+        }
+
+        fun settle(pro: Boolean) {
+            proFlow.value = FakeInfo(pro)
+            settledFlow.value = true
+        }
+    }
+
+    @Test
+    fun `pro user resolves true without waiting`() = runTest {
+        val repo = FakeRepo(pro = true, settled = false)
+        repo.isProForUi() shouldBe true
+        currentTime shouldBe 0
+    }
+
+    @Test
+    fun `settled non-pro resolves false without waiting`() = runTest {
+        // The whole point over isProSettled: a free user's tap must route to the upgrade screen
+        // immediately, not after a timeout spent waiting for a Pro state that never comes.
+        val repo = FakeRepo(pro = false, settled = true)
+        repo.isProForUi() shouldBe false
+        currentTime shouldBe 0
+    }
+
+    @Test
+    fun `unsettled billing waits and honors the late pro result`() = runTest {
+        // GPlay cold start: upgradeInfo reports non-Pro until the first billing result. A paying
+        // user must not be bounced to the upgrade screen by that race.
+        val repo = FakeRepo(pro = false, settled = false)
+
+        launch {
+            advanceTimeBy(500)
+            repo.settle(pro = true)
+        }
+
+        repo.isProForUi() shouldBe true
+    }
+
+    @Test
+    fun `unsettled billing waits and honors the late non-pro result`() = runTest {
+        val repo = FakeRepo(pro = false, settled = false)
+
+        launch {
+            advanceTimeBy(500)
+            repo.settle(pro = false)
+        }
+
+        repo.isProForUi() shouldBe false
+    }
+
+    @Test
+    fun `billing that never settles falls back to non-pro after the timeout`() = runTest {
+        val repo = FakeRepo(pro = false, settled = false)
+        repo.isProForUi() shouldBe false
+        currentTime shouldBe 3_000
+    }
+
+    @Test
+    fun `errors fail open`() = runTest {
+        val repo = object : UpgradeRepo {
+            override val storeSite: String = ""
+            override val upgradeSite: String = ""
+            override val betaSite: String = ""
+            override val upgradeInfo: Flow<UpgradeRepo.Info> get() = throw IllegalStateException("billing exploded")
+            override val isSettled: Flow<Boolean> = MutableStateFlow(true)
+            override suspend fun refresh() = Unit
+        }
+        repo.isProForUi() shouldBe true
+    }
+}

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentViewModel.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentViewModel.kt
@@ -38,7 +38,7 @@ import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.common.ui.LayoutMode
 import eu.darken.sdmse.common.uix.ViewModel4
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
-import eu.darken.sdmse.common.upgrade.isPro
+import eu.darken.sdmse.common.upgrade.isProForUi
 import eu.darken.sdmse.exclusion.core.ExclusionManager
 import eu.darken.sdmse.exclusion.core.types.PathExclusion
 import eu.darken.sdmse.exclusion.ui.PathExclusionEditorRoute
@@ -268,7 +268,7 @@ class ContentViewModel @Inject constructor(
             log(TAG, WARN) { "createFilter(): Blocked — content is read-only" }
             return@launch
         }
-        if (!upgradeRepo.isPro()) {
+        if (!upgradeRepo.isProForUi()) {
             log(TAG) { "Not PRO, redirecting to upgrade screen." }
             navTo(UpgradeRoute())
             return@launch

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/details/AppJunkDetailsViewModel.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/details/AppJunkDetailsViewModel.kt
@@ -20,7 +20,7 @@ import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.common.uix.PagedDetailsViewModel
 import eu.darken.sdmse.common.uix.resolveTarget
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
-import eu.darken.sdmse.common.upgrade.isPro
+import eu.darken.sdmse.common.upgrade.isProForUi
 import eu.darken.sdmse.exclusion.ui.ExclusionsListRoute
 import eu.darken.sdmse.main.core.SDMTool
 import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
@@ -114,7 +114,7 @@ class AppJunkDetailsViewModel @Inject constructor(
 
     fun requestDelete(spec: DeleteSpec) = launch {
         log(TAG, INFO) { "requestDelete($spec)" }
-        if (!upgradeRepo.isPro()) {
+        if (!upgradeRepo.isProForUi()) {
             navTo(UpgradeRoute())
             return@launch
         }
@@ -125,7 +125,7 @@ class AppJunkDetailsViewModel @Inject constructor(
 
     fun confirmDelete(spec: DeleteSpec) = launch {
         log(TAG, INFO) { "confirmDelete($spec)" }
-        if (!upgradeRepo.isPro()) {
+        if (!upgradeRepo.isProForUi()) {
             navTo(UpgradeRoute())
             return@launch
         }

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/list/AppCleanerListViewModel.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/list/AppCleanerListViewModel.kt
@@ -20,7 +20,7 @@ import eu.darken.sdmse.common.pkgs.features.InstallId
 import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.common.uix.ViewModel4
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
-import eu.darken.sdmse.common.upgrade.isPro
+import eu.darken.sdmse.common.upgrade.isProForUi
 import eu.darken.sdmse.exclusion.ui.ExclusionsListRoute
 import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -106,7 +106,7 @@ class AppCleanerListViewModel @Inject constructor(
 
     fun onRowClick(row: Row) = launch {
         log(TAG, INFO) { "onRowClick(${row.identifier})" }
-        if (!upgradeRepo.isPro()) {
+        if (!upgradeRepo.isProForUi()) {
             navTo(UpgradeRoute())
             return@launch
         }
@@ -121,7 +121,7 @@ class AppCleanerListViewModel @Inject constructor(
     fun onDeleteSelected(ids: Set<InstallId>) = launch {
         log(TAG, INFO) { "onDeleteSelected(${ids.size})" }
         if (ids.isEmpty()) return@launch
-        if (!upgradeRepo.isPro()) {
+        if (!upgradeRepo.isProForUi()) {
             navTo(UpgradeRoute())
             return@launch
         }
@@ -130,7 +130,7 @@ class AppCleanerListViewModel @Inject constructor(
 
     fun onDeleteConfirmed(ids: Set<InstallId>) = launch {
         log(TAG, INFO) { "onDeleteConfirmed(${ids.size})" }
-        if (!upgradeRepo.isPro()) {
+        if (!upgradeRepo.isProForUi()) {
             navTo(UpgradeRoute())
             return@launch
         }

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/AppCleanerTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/AppCleanerTest.kt
@@ -95,7 +95,10 @@ class AppCleanerTest : BaseTest() {
 
     private fun mockUpgradeRepo(pro: Boolean): UpgradeRepo {
         val info = mockk<UpgradeRepo.Info>().apply { every { isPro } returns pro }
-        return mockk<UpgradeRepo>(relaxed = true) { every { upgradeInfo } returns flowOf(info) }
+        return mockk<UpgradeRepo>(relaxed = true) {
+            every { upgradeInfo } returns flowOf(info)
+            every { isSettled } returns flowOf(true)
+        }
     }
 
     private fun setupCleaner(

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/ui/details/AppJunkDetailsViewModelTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/ui/details/AppJunkDetailsViewModelTest.kt
@@ -101,6 +101,7 @@ class AppJunkDetailsViewModelTest : BaseTest() {
         }
         val upgradeRepo = mockk<UpgradeRepo>().apply {
             every { upgradeInfo } returns flowOf(upgradeInfo(isPro = isPro))
+            every { isSettled } returns flowOf(true)
         }
         val vm = AppJunkDetailsViewModel(
             handle = savedHandle,

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/ui/list/AppCleanerListViewModelTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/ui/list/AppCleanerListViewModelTest.kt
@@ -110,6 +110,7 @@ class AppCleanerListViewModelTest : BaseTest() {
         val taskSubmitter = mockk<TaskSubmitter>(relaxed = true)
         val upgradeRepo = mockk<UpgradeRepo>().apply {
             every { upgradeInfo } returns flowOf(upgradeInfo(isPro = isPro))
+            every { isSettled } returns flowOf(true)
         }
         val context = mockk<Context>(relaxed = true)
         val vm = AppCleanerListViewModel(

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListViewModel.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListViewModel.kt
@@ -41,7 +41,7 @@ import eu.darken.sdmse.common.pkgs.toKnownPkg
 import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.common.uix.ViewModel4
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
-import eu.darken.sdmse.common.upgrade.isPro
+import eu.darken.sdmse.common.upgrade.isProForUi
 import eu.darken.sdmse.exclusion.core.ExclusionManager
 import eu.darken.sdmse.exclusion.core.types.PkgExclusion
 import eu.darken.sdmse.exclusion.ui.ExclusionsListRoute
@@ -388,7 +388,7 @@ class AppControlListViewModel @Inject constructor(
 
     fun onForceStopRequested(ids: Set<InstallId>) = launch {
         if (ids.isEmpty()) return@launch
-        if (ids.size > 1 && !upgradeRepo.isPro()) {
+        if (ids.size > 1 && !upgradeRepo.isProForUi()) {
             navTo(UpgradeRoute())
             return@launch
         }
@@ -399,7 +399,7 @@ class AppControlListViewModel @Inject constructor(
         log(TAG, INFO) { "onForceStopConfirmed(${ids.size})" }
         val valid = liveIntersect(ids)
         if (valid.isEmpty()) return@launch
-        if (valid.size > 1 && !upgradeRepo.isPro()) {
+        if (valid.size > 1 && !upgradeRepo.isProForUi()) {
             navTo(UpgradeRoute())
             return@launch
         }
@@ -409,7 +409,7 @@ class AppControlListViewModel @Inject constructor(
 
     fun onArchiveRequested(ids: Set<InstallId>) = launch {
         if (ids.isEmpty()) return@launch
-        if (ids.size > 1 && !upgradeRepo.isPro()) {
+        if (ids.size > 1 && !upgradeRepo.isProForUi()) {
             navTo(UpgradeRoute())
             return@launch
         }
@@ -420,7 +420,7 @@ class AppControlListViewModel @Inject constructor(
         log(TAG, INFO) { "onArchiveConfirmed(${ids.size})" }
         val valid = liveIntersect(ids)
         if (valid.isEmpty()) return@launch
-        if (valid.size > 1 && !upgradeRepo.isPro()) {
+        if (valid.size > 1 && !upgradeRepo.isProForUi()) {
             navTo(UpgradeRoute())
             return@launch
         }
@@ -430,7 +430,7 @@ class AppControlListViewModel @Inject constructor(
 
     fun onRestoreRequested(ids: Set<InstallId>) = launch {
         if (ids.isEmpty()) return@launch
-        if (ids.size > 1 && !upgradeRepo.isPro()) {
+        if (ids.size > 1 && !upgradeRepo.isProForUi()) {
             navTo(UpgradeRoute())
             return@launch
         }
@@ -441,7 +441,7 @@ class AppControlListViewModel @Inject constructor(
         log(TAG, INFO) { "onRestoreConfirmed(${ids.size})" }
         val valid = liveIntersect(ids)
         if (valid.isEmpty()) return@launch
-        if (valid.size > 1 && !upgradeRepo.isPro()) {
+        if (valid.size > 1 && !upgradeRepo.isProForUi()) {
             navTo(UpgradeRoute())
             return@launch
         }
@@ -452,7 +452,7 @@ class AppControlListViewModel @Inject constructor(
     fun onExportRequested(ids: Set<InstallId>) = launch {
         log(TAG, INFO) { "onExportRequested(${ids.size})" }
         if (ids.isEmpty()) return@launch
-        if (ids.size > 1 && !upgradeRepo.isPro()) {
+        if (ids.size > 1 && !upgradeRepo.isProForUi()) {
             navTo(UpgradeRoute())
             return@launch
         }
@@ -465,7 +465,7 @@ class AppControlListViewModel @Inject constructor(
         if (uri == null) return@launch
         val valid = liveIntersect(ids)
         if (valid.isEmpty()) return@launch
-        if (valid.size > 1 && !upgradeRepo.isPro()) {
+        if (valid.size > 1 && !upgradeRepo.isProForUi()) {
             navTo(UpgradeRoute())
             return@launch
         }

--- a/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListViewModelTest.kt
+++ b/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListViewModelTest.kt
@@ -282,6 +282,7 @@ class AppControlListViewModelTest : BaseTest() {
         val exclusionManager = mockk<ExclusionManager>(relaxed = true)
         val upgradeRepo = mockk<UpgradeRepo>().apply {
             every { this@apply.upgradeInfo } returns flowOf(upgradeInfo(isPro = isPro))
+            every { this@apply.isSettled } returns flowOf(true)
         }
         val context = mockk<Context>(relaxed = true)
         val usageStatsSetupModule = mockk<SetupModule>(relaxed = true)

--- a/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/ui/settings/AppControlSettingsViewModelTest.kt
+++ b/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/ui/settings/AppControlSettingsViewModelTest.kt
@@ -117,6 +117,7 @@ class AppControlSettingsViewModelTest : BaseTest() {
         }
         val upgradeRepo = mockk<UpgradeRepo>().apply {
             every { upgradeInfo } returns MutableStateFlow(upgradeInfo(isPro = isPro))
+            every { isSettled } returns flowOf(true)
         }
 
         val rootManager = mockk<RootManager>().apply {

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/ui/settings/CorpseFinderSettingsViewModelTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/ui/settings/CorpseFinderSettingsViewModelTest.kt
@@ -143,6 +143,7 @@ class CorpseFinderSettingsViewModelTest : BaseTest() {
         }
         val upgradeRepo = mockk<UpgradeRepo>().apply {
             every { upgradeInfo } returns flowOf(upgradeInfo(isPro = isPro))
+            every { isSettled } returns flowOf(true)
         }
         val rootManager = mockk<RootManager>().apply {
             every { accessState } returns flowOf(rootAccess)

--- a/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/details/DeduplicatorDetailsViewModel.kt
+++ b/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/details/DeduplicatorDetailsViewModel.kt
@@ -19,7 +19,7 @@ import eu.darken.sdmse.common.uix.PagedDetailsViewModel
 import eu.darken.sdmse.common.uix.resolveTarget
 import eu.darken.sdmse.exclusion.ui.ExclusionsListRoute
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
-import eu.darken.sdmse.common.upgrade.isPro
+import eu.darken.sdmse.common.upgrade.isProForUi
 import eu.darken.sdmse.deduplicator.core.Deduplicator
 import eu.darken.sdmse.deduplicator.core.DeduplicatorSettings
 import eu.darken.sdmse.deduplicator.core.Duplicate
@@ -199,7 +199,7 @@ class DeduplicatorDetailsViewModel @Inject constructor(
             return@launch
         }
 
-        if (!upgradeRepo.isPro()) {
+        if (!upgradeRepo.isProForUi()) {
             navTo(UpgradeRoute())
             return@launch
         }
@@ -235,7 +235,7 @@ class DeduplicatorDetailsViewModel @Inject constructor(
             return@launch
         }
 
-        if (!upgradeRepo.isPro()) {
+        if (!upgradeRepo.isProForUi()) {
             navTo(UpgradeRoute())
             return@launch
         }
@@ -269,7 +269,7 @@ class DeduplicatorDetailsViewModel @Inject constructor(
             return@launch
         }
 
-        if (!upgradeRepo.isPro()) {
+        if (!upgradeRepo.isProForUi()) {
             navTo(UpgradeRoute())
             return@launch
         }

--- a/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListViewModel.kt
+++ b/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListViewModel.kt
@@ -15,7 +15,7 @@ import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.common.ui.LayoutMode
 import eu.darken.sdmse.common.uix.ViewModel4
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
-import eu.darken.sdmse.common.upgrade.isPro
+import eu.darken.sdmse.common.upgrade.isProForUi
 import eu.darken.sdmse.deduplicator.core.Deduplicator
 import eu.darken.sdmse.deduplicator.core.DeduplicatorSettings
 import eu.darken.sdmse.deduplicator.core.Duplicate
@@ -164,7 +164,7 @@ class DeduplicatorListViewModel @Inject constructor(
                 return@launch
             }
 
-            if (!upgradeRepo.isPro()) {
+            if (!upgradeRepo.isProForUi()) {
                 navTo(UpgradeRoute())
                 return@launch
             }
@@ -189,7 +189,7 @@ class DeduplicatorListViewModel @Inject constructor(
             return@launch
         }
 
-        if (!upgradeRepo.isPro()) {
+        if (!upgradeRepo.isProForUi()) {
             navTo(UpgradeRoute())
             return@launch
         }
@@ -221,7 +221,7 @@ class DeduplicatorListViewModel @Inject constructor(
             return@launch
         }
 
-        if (!upgradeRepo.isPro()) {
+        if (!upgradeRepo.isProForUi()) {
             navTo(UpgradeRoute())
             return@launch
         }

--- a/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/core/DeduplicatorTest.kt
+++ b/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/core/DeduplicatorTest.kt
@@ -49,6 +49,7 @@ class DeduplicatorTest : BaseTest() {
         every { info.isPro } returns isPro
         val upgradeRepo = mockk<UpgradeRepo>(relaxed = true)
         every { upgradeRepo.upgradeInfo } returns flowOf(info)
+        every { upgradeRepo.isSettled } returns flowOf(true)
         return Deduplicator(
             appScope = gateScope,
             gatewaySwitch = mockk(relaxed = true),

--- a/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/ui/details/DeduplicatorDetailsViewModelTest.kt
+++ b/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/ui/details/DeduplicatorDetailsViewModelTest.kt
@@ -148,6 +148,7 @@ class DeduplicatorDetailsViewModelTest : BaseTest() {
         }
         val upgradeRepo = mockk<UpgradeRepo>().apply {
             every { upgradeInfo } returns flowOf(upgradeInfo(isPro = isPro))
+            every { isSettled } returns flowOf(true)
         }
         val viewIntentTool = mockk<ViewIntentTool>(relaxed = true)
         val vm = DeduplicatorDetailsViewModel(

--- a/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListViewModelTest.kt
+++ b/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListViewModelTest.kt
@@ -156,6 +156,7 @@ class DeduplicatorListViewModelTest : BaseTest() {
         }
         val upgradeRepo = mockk<UpgradeRepo>().apply {
             every { upgradeInfo } returns flowOf(upgradeInfo(isPro = isPro))
+            every { isSettled } returns flowOf(true)
         }
         val vm = DeduplicatorListViewModel(
             dispatcherProvider = TestDispatcherProvider(),

--- a/app-tool-scheduler/src/main/java/eu/darken/sdmse/scheduler/ui/manager/SchedulerManagerViewModel.kt
+++ b/app-tool-scheduler/src/main/java/eu/darken/sdmse/scheduler/ui/manager/SchedulerManagerViewModel.kt
@@ -25,7 +25,7 @@ import eu.darken.sdmse.common.shell.ShellOps
 import eu.darken.sdmse.common.shell.ipc.ShellOpsCmd
 import eu.darken.sdmse.common.uix.ViewModel4
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
-import eu.darken.sdmse.common.upgrade.isPro
+import eu.darken.sdmse.common.upgrade.isProForUi
 import eu.darken.sdmse.main.core.GeneralSettings
 import eu.darken.sdmse.main.core.taskmanager.AcsScheduleRisk
 import eu.darken.sdmse.main.core.taskmanager.SchedulerAppCleanerAdvisor
@@ -201,7 +201,7 @@ class SchedulerManagerViewModel @Inject constructor(
     fun toggleSchedule(id: ScheduleId) = launch {
         log(TAG) { "toggleSchedule($id)" }
         val live = schedulerManager.state.first().schedules.firstOrNull { it.id == id } ?: return@launch
-        if (!upgradeRepo.isPro()) {
+        if (!upgradeRepo.isProForUi()) {
             navTo(UpgradeRoute())
             return@launch
         }

--- a/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/ui/list/SqueezerListViewModel.kt
+++ b/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/ui/list/SqueezerListViewModel.kt
@@ -15,7 +15,7 @@ import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.common.ui.LayoutMode
 import eu.darken.sdmse.common.uix.ViewModel4
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
-import eu.darken.sdmse.common.upgrade.isPro
+import eu.darken.sdmse.common.upgrade.isProForUi
 import eu.darken.sdmse.exclusion.ui.ExclusionsListRoute
 import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
 import eu.darken.sdmse.squeezer.core.CompressibleMedia
@@ -122,7 +122,7 @@ class SqueezerListViewModel @Inject constructor(
             return@launch
         }
 
-        if (!upgradeRepo.isPro()) {
+        if (!upgradeRepo.isProForUi()) {
             navTo(UpgradeRoute())
             return@launch
         }

--- a/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/ui/list/SqueezerListViewModelTest.kt
+++ b/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/ui/list/SqueezerListViewModelTest.kt
@@ -134,6 +134,7 @@ class SqueezerListViewModelTest : BaseTest() {
         val taskSubmitter = mockk<TaskSubmitter>(relaxed = true)
         val upgradeRepo = mockk<UpgradeRepo>().apply {
             every { upgradeInfo } returns flowOf(upgradeInfo(isPro = isPro))
+            every { isSettled } returns flowOf(true)
         }
 
         val vm = SqueezerListViewModel(

--- a/app-tool-swiper/src/test/java/eu/darken/sdmse/swiper/ui/sessions/SwiperSessionsViewModelTest.kt
+++ b/app-tool-swiper/src/test/java/eu/darken/sdmse/swiper/ui/sessions/SwiperSessionsViewModelTest.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -122,6 +123,7 @@ class SwiperSessionsViewModelTest : BaseTest() {
         val taskSubmitter = mockk<TaskSubmitter>(relaxed = true)
         val upgradeRepo = mockk<UpgradeRepo>().apply {
             every { this@apply.upgradeInfo } returns upgradeFlow
+            every { this@apply.isSettled } returns flowOf(true)
         }
         // currentAreas() is an extension that reads state.first().areas — no separate stub needed.
         val dataAreaManager = mockk<DataAreaManager>().apply {

--- a/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/list/CustomFilterListViewModel.kt
+++ b/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/list/CustomFilterListViewModel.kt
@@ -19,7 +19,7 @@ import eu.darken.sdmse.common.navigation.routes.UpgradeRoute
 import eu.darken.sdmse.common.readAsText
 import eu.darken.sdmse.common.uix.ViewModel4
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
-import eu.darken.sdmse.common.upgrade.isPro
+import eu.darken.sdmse.common.upgrade.isProForUi
 import eu.darken.sdmse.systemcleaner.core.SystemCleanerSettings
 import eu.darken.sdmse.systemcleaner.core.filter.custom.CustomFilterConfig
 import eu.darken.sdmse.systemcleaner.core.filter.custom.CustomFilterRepo
@@ -75,7 +75,7 @@ class CustomFilterListViewModel @Inject constructor(
 
     fun onEditClick(row: FilterRow) = launch {
         log(TAG) { "onEditClick($row)" }
-        if (!upgradeRepo.isPro()) {
+        if (!upgradeRepo.isProForUi()) {
             navTo(UpgradeRoute())
             return@launch
         }
@@ -84,7 +84,7 @@ class CustomFilterListViewModel @Inject constructor(
 
     fun onCreateClick() = launch {
         log(TAG) { "onCreateClick()" }
-        if (!upgradeRepo.isPro()) {
+        if (!upgradeRepo.isProForUi()) {
             navTo(UpgradeRoute())
             return@launch
         }
@@ -138,7 +138,7 @@ class CustomFilterListViewModel @Inject constructor(
 
     fun exportRows(rows: Collection<FilterRow>) = launch {
         log(TAG) { "exportRows($rows)" }
-        if (!upgradeRepo.isPro()) {
+        if (!upgradeRepo.isProForUi()) {
             navTo(UpgradeRoute())
             return@launch
         }

--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/customfilter/list/CustomFilterListViewModelTest.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/customfilter/list/CustomFilterListViewModelTest.kt
@@ -67,6 +67,7 @@ class CustomFilterListViewModelTest : BaseTest() {
         }
         val upgradeRepo = mockk<UpgradeRepo>().apply {
             every { upgradeInfo } returns upgradeFlow
+            every { isSettled } returns flowOf(true)
         }
         val webpageTool = mockk<WebpageTool>(relaxed = true)
         val context = mockk<Context>(relaxed = true)

--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/settings/SystemCleanerSettingsViewModelTest.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/settings/SystemCleanerSettingsViewModelTest.kt
@@ -154,6 +154,7 @@ class SystemCleanerSettingsViewModelTest : BaseTest() {
             every { upgradeInfo } returns flowOf(
                 mockk<UpgradeRepo.Info>().apply { every { this@apply.isPro } returns isPro },
             )
+            every { isSettled } returns flowOf(true)
         }
         val rootManager = mockk<RootManager>().apply {
             every { accessState } returns flowOf(

--- a/app/src/foss/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoFoss.kt
+++ b/app/src/foss/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoFoss.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import java.time.Instant
@@ -31,6 +32,10 @@ class UpgradeRepoFoss @Inject constructor(
     override val betaSite: String = BETA_SITE
 
     private val refreshTrigger = MutableStateFlow(UUID.randomUUID())
+
+    // The FOSS entitlement is a local cache read — upgradeInfo is authoritative from its first
+    // emission, there is no billing handshake to wait out.
+    override val isSettled: Flow<Boolean> = flowOf(true)
 
     override val upgradeInfo: Flow<UpgradeRepo.Info> = combine(
         fossCache.upgrade.flow,

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplay.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
@@ -42,6 +43,15 @@ class UpgradeRepoGplay @Inject constructor(
     override val storeSite: String = STORE_SITE
     override val upgradeSite: String = UPGRADE_SITE
     override val betaSite: String = BETA_SITE
+
+    // False until the first real billing result after process start — the window where
+    // upgradeInfo below reports non-Pro even for paying users (its flow is seeded with null).
+    // An errored lookup counts as settled: gating callers must not wait on a broken connection.
+    override val isSettled: Flow<Boolean> = billingManager.billingData
+        .map { true }
+        .catch { emit(true) }
+        .onStart { emit(false) }
+        .distinctUntilChanged()
 
     override val upgradeInfo: Flow<Info> = billingManager.billingData
         .map<BillingData, BillingData?> { it }

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionEngine.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionEngine.kt
@@ -13,7 +13,7 @@ import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.flow.intervalFlow
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
-import eu.darken.sdmse.common.upgrade.isPro
+import eu.darken.sdmse.common.upgrade.isProForUi
 import eu.darken.sdmse.corpsefinder.core.CorpseFinder
 import eu.darken.sdmse.corpsefinder.core.hasData
 import eu.darken.sdmse.corpsefinder.core.tasks.CorpseFinderDeleteTask
@@ -347,7 +347,7 @@ class DashboardMainActionEngine(
                 BottomBarState.Action.WORKING_CANCELABLE -> taskManager.cancel(SDMTool.Type.APPCLEANER)
                 BottomBarState.Action.WORKING -> {}
                 BottomBarState.Action.DELETE -> {
-                    if (appCleaner.state.first().data != null && upgradeRepo.isPro()) {
+                    if (appCleaner.state.first().data != null && upgradeRepo.isProForUi()) {
                         accumulateFreed(SDMTool.Type.APPCLEANER, submitTask(AppCleanerProcessingTask()))
                     } else if (appCleaner.state.first().data.hasData && !corpseFinder.state.first().data.hasData && !systemCleaner.state.first().data.hasData) {
                         onUpgradeRequired()
@@ -355,7 +355,7 @@ class DashboardMainActionEngine(
                 }
 
                 BottomBarState.Action.ONECLICK -> {
-                    if (upgradeRepo.isPro()) {
+                    if (upgradeRepo.isProForUi()) {
                         accumulateFreed(SDMTool.Type.APPCLEANER, submitTask(AppCleanerOneClickTask()))
                     } else if (appCleaner.state.first().data.hasData && !corpseFinder.state.first().data.hasData && !systemCleaner.state.first().data.hasData) {
                         onUpgradeRequired()
@@ -373,12 +373,12 @@ class DashboardMainActionEngine(
                 BottomBarState.Action.SCAN -> submitTask(DeduplicatorScanTask())
                 BottomBarState.Action.WORKING_CANCELABLE -> taskManager.cancel(SDMTool.Type.DEDUPLICATOR)
                 BottomBarState.Action.WORKING -> {}
-                BottomBarState.Action.DELETE -> if (deduplicator.state.first().data != null && upgradeRepo.isPro()) {
+                BottomBarState.Action.DELETE -> if (deduplicator.state.first().data != null && upgradeRepo.isProForUi()) {
                     accumulateFreed(SDMTool.Type.DEDUPLICATOR, submitTask(DeduplicatorDeleteTask()))
                 }
 
                 BottomBarState.Action.ONECLICK -> {
-                    if (upgradeRepo.isPro()) {
+                    if (upgradeRepo.isProForUi()) {
                         accumulateFreed(SDMTool.Type.DEDUPLICATOR, submitTask(DeduplicatorOneClickTask()))
                     } else if (deduplicator.state.first().data.hasData && !corpseFinder.state.first().data.hasData && !systemCleaner.state.first().data.hasData) {
                         onUpgradeRequired()

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModel.kt
@@ -48,7 +48,7 @@ import eu.darken.sdmse.common.rngString
 import eu.darken.sdmse.common.uix.ViewModel4
 import eu.darken.sdmse.common.updater.UpdateService
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
-import eu.darken.sdmse.common.upgrade.isPro
+import eu.darken.sdmse.common.upgrade.isProForUi
 import eu.darken.sdmse.corpsefinder.core.CorpseFinder
 import eu.darken.sdmse.corpsefinder.core.hasData
 import eu.darken.sdmse.corpsefinder.core.tasks.CorpseFinderDeleteTask
@@ -537,7 +537,7 @@ class DashboardViewModel @Inject constructor(
     fun confirmAppJunkDeletion() = launch {
         log(TAG, INFO) { "confirmAppJunkDeletion()" }
 
-        if (!upgradeRepo.isPro()) {
+        if (!upgradeRepo.isProForUi()) {
             navTo(UpgradeRoute())
             return@launch
         }
@@ -601,7 +601,7 @@ class DashboardViewModel @Inject constructor(
     fun confirmDeduplicatorDeletion() = launch {
         log(TAG, INFO) { "confirmDeduplicatorDeletion()" }
 
-        if (!upgradeRepo.isPro()) {
+        if (!upgradeRepo.isProForUi()) {
             navTo(UpgradeRoute())
             return@launch
         }

--- a/app/src/main/java/eu/darken/sdmse/main/ui/shortcuts/ShortcutActivity.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/shortcuts/ShortcutActivity.kt
@@ -13,7 +13,7 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
-import eu.darken.sdmse.common.upgrade.isPro
+import eu.darken.sdmse.common.upgrade.isProForUi
 import eu.darken.sdmse.corpsefinder.core.CorpseFinder
 import eu.darken.sdmse.corpsefinder.core.tasks.CorpseFinderOneClickTask
 import eu.darken.sdmse.deduplicator.core.Deduplicator
@@ -71,7 +71,7 @@ class ShortcutActivity : ComponentActivity() {
     }
 
     private fun handleScanDeleteShortcut() = appScope.launch {
-        if (!upgradeRepo.isPro()) {
+        if (!upgradeRepo.isProForUi()) {
             log(TAG, INFO) { "Scan/Delete shortcut requires Pro version, opening upgrade screen" }
             val upgradeIntent = Intent(this@ShortcutActivity, MainActivity::class.java).apply {
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardDiscardTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardDiscardTest.kt
@@ -33,6 +33,7 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import org.junit.jupiter.api.Test
@@ -95,7 +96,10 @@ internal class DashboardDiscardTest : BaseTest() {
                 every { getSessionsWithStats() } returns emptyFlow()
                 every { progress } returns emptyFlow()
             },
-            upgradeRepo = mockk<UpgradeRepo>(relaxed = true).apply { every { upgradeInfo } returns emptyFlow() },
+            upgradeRepo = mockk<UpgradeRepo>(relaxed = true).apply {
+                every { upgradeInfo } returns emptyFlow()
+                every { isSettled } returns flowOf(true)
+            },
             generalSettings = mockk<GeneralSettings>(relaxed = true),
             webpageTool = mockk<WebpageTool>(relaxed = true),
             schedulerManager = mockk<SchedulerManager>(relaxed = true).apply { every { state } returns emptyFlow() },

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardHeroToolRoutingTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardHeroToolRoutingTest.kt
@@ -42,6 +42,7 @@ import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -83,7 +84,10 @@ internal class DashboardHeroToolRoutingTest : BaseTest() {
             every { getSessionsWithStats() } returns emptyFlow()
             every { progress } returns emptyFlow()
         }
-        val upgradeRepo = mockk<UpgradeRepo>(relaxed = true).apply { every { upgradeInfo } returns emptyFlow() }
+        val upgradeRepo = mockk<UpgradeRepo>(relaxed = true).apply {
+            every { upgradeInfo } returns emptyFlow()
+            every { isSettled } returns flowOf(true)
+        }
         val updateService = mockk<UpdateService>(relaxed = true).apply { every { availableUpdate } returns emptyFlow() }
         val debugCardProvider = mockk<DebugCardProvider>(relaxed = true).apply {
             every { create(any(), any(), any(), any()) } returns emptyFlow()

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionEngineTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionEngineTest.kt
@@ -90,7 +90,7 @@ internal class DashboardMainActionEngineTest : BaseTest() {
             appCleaner = appCleaner,
             deduplicator = deduplicator,
             generalSettings = generalSettings,
-            upgradeRepo = mockk<UpgradeRepo>(relaxed = true),
+            upgradeRepo = mockk<UpgradeRepo>(relaxed = true).apply { every { isSettled } returns flowOf(true) },
             upgradeInfo = flowOf(null),
             submitTask = { task ->
                 submittedTasks.add(task)
@@ -159,6 +159,7 @@ internal class DashboardMainActionEngineTest : BaseTest() {
         val proInfo = mockk<UpgradeRepo.Info>(relaxed = true) { every { isPro } returns true }
         val upgradeRepo = mockk<UpgradeRepo>(relaxed = true) {
             every { upgradeInfo } returns MutableStateFlow(proInfo)
+            every { isSettled } returns flowOf(true)
         }
         val taskManager = mockk<TaskManager>(relaxed = true) {
             every { state } returns MutableStateFlow(TaskSubmitter.State())

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModelResilienceTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModelResilienceTest.kt
@@ -119,7 +119,10 @@ internal class DashboardViewModelResilienceTest : BaseTest() {
             every { getSessionsWithStats() } returns srcOr("swiper", emptyFlow())
             every { progress } returns emptyFlow()
         }
-        val upgradeRepo = mockk<UpgradeRepo>(relaxed = true).apply { every { upgradeInfo } returns emptyFlow() }
+        val upgradeRepo = mockk<UpgradeRepo>(relaxed = true).apply {
+            every { upgradeInfo } returns emptyFlow()
+            every { isSettled } returns flowOf(true)
+        }
         val updateService = mockk<UpdateService>(relaxed = true).apply { every { availableUpdate } returns emptyFlow() }
         val debugCardProvider = mockk<DebugCardProvider>(relaxed = true).apply {
             every { create(any(), any(), any(), any()) } returns srcOr("debug", emptyFlow())

--- a/app/src/test/java/eu/darken/sdmse/main/ui/settings/support/contactform/SupportContactFormViewModelTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/settings/support/contactform/SupportContactFormViewModelTest.kt
@@ -16,6 +16,7 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -52,6 +53,7 @@ class SupportContactFormViewModelTest : BaseTest() {
         coEvery { sessionManager.forceStopRecording() } returns null
 
         every { upgradeRepo.upgradeInfo } returns upgradeFlow
+        every { upgradeRepo.isSettled } returns flowOf(true)
 
         every { emailTool.build(any(), any()) } returns Intent(Intent.ACTION_SEND)
     }


### PR DESCRIPTION
## What changed

Fixed paying users on Google Play briefly being sent to the upgrade screen when tapping a Pro feature right after the app started, before the connection to Google Play Billing had finished. Free users are unaffected — the upgrade screen still appears instantly for them.

## Technical Context

- Root cause: every UI Pro gate used raw `isPro()` (`upgradeInfo.first().isPro`), and GPlay's `upgradeInfo` is null-seeded (non-Pro) until the first billing result. The existing `isProSettled()` helper couldn't be reused for UI: its non-Pro path always waits out the full 5s timeout (it waits for a Pro state that never arrives for free users), which would have permanently delayed the upgrade screen on every free-user tap.
- New `UpgradeRepo.isSettled: Flow<Boolean>`: GPlay derives it from `BillingManager.billingData` (errored lookups count as settled so gates never hang on a broken connection; `billingData` is hot-shared with replay, so no extra billing connections); FOSS is constantly `true` (local cache is authoritative).
- New `isProForUi()` gate: Pro → true immediately; settled non-Pro → false immediately; only mid-handshake does it wait (≤3s) for the first real result, then falls back to current state. The backend `isProSettled()` gates remain the enforcement safety net — this only fixes the UI routing.
- Scope: all 35 tap-time gate sites (dashboard main actions, shortcuts, reports routing, and every tool's delete/action gates). Passive `isPro` reads and backend gates untouched; `Swiper.kt`'s backend scan-limit read is intentionally out of scope.
- Review guidance: extension tests pin the latency contract with virtual time (`currentTime == 0` for both fast paths — the settled-non-Pro no-wait assertion is the one that distinguishes this from `isProSettled`). Both flavors' full app test suites pass.
