### PR TITLE
General: Fix Select all in the file picker deselecting chosen items

### DIFF
--- a/app-common-picker/src/main/java/eu/darken/sdmse/common/picker/PickerScreen.kt
+++ b/app-common-picker/src/main/java/eu/darken/sdmse/common/picker/PickerScreen.kt
@@ -187,7 +187,10 @@ internal fun PickerScreen(
                             label = stringResource(CommonR.string.general_save_action),
                             onClick = onSave,
                         )
-                        SdmTooltipIconButton(
+                        // Without either entry (single-selection mode at the picker root) the
+                        // overflow would open an empty menu.
+                        val hasOverflowItems = navigatable || state.allowSelectAll
+                        if (hasOverflowItems) SdmTooltipIconButton(
                             icon = Icons.TwoTone.MoreVert,
                             label = stringResource(CommonR.string.general_options_label),
                             onClick = { overflowOpen = true },
@@ -204,10 +207,12 @@ internal fun PickerScreen(
                                     onClick = { overflowOpen = false; onHome() },
                                 )
                             }
-                            DropdownMenuItem(
-                                text = { Text(stringResource(CommonR.string.general_list_select_all_action)) },
-                                onClick = { overflowOpen = false; onSelectAll() },
-                            )
+                            if (state.allowSelectAll) {
+                                DropdownMenuItem(
+                                    text = { Text(stringResource(CommonR.string.general_list_select_all_action)) },
+                                    onClick = { overflowOpen = false; onSelectAll() },
+                                )
+                            }
                         }
                     }
                 },

--- a/app-common-picker/src/main/java/eu/darken/sdmse/common/picker/PickerViewModel.kt
+++ b/app-common-picker/src/main/java/eu/darken/sdmse/common/picker/PickerViewModel.kt
@@ -284,6 +284,7 @@ class PickerViewModel @Inject constructor(
                     items = emptyList(),
                     selected = selectedRows,
                     hasChanges = hasChanges,
+                    allowSelectAll = req.mode != PickerRequest.PickMode.DIR,
                     progress = Progress.Data(),
                 ),
             )
@@ -298,6 +299,7 @@ class PickerViewModel @Inject constructor(
                         items = items,
                         selected = selectedRows,
                         hasChanges = hasChanges,
+                        allowSelectAll = req.mode != PickerRequest.PickMode.DIR,
                         progress = null,
                     ),
                 )
@@ -331,11 +333,25 @@ class PickerViewModel @Inject constructor(
 
     fun selectAll() = launch {
         log(TAG) { "selectAll()" }
+        if (requestFlow.value?.mode == PickerRequest.PickMode.DIR) {
+            // Single-selection mode: "select everything here" has no meaning, and select() would
+            // just replace the selection with the first listed row.
+            log(TAG) { "selectAll(): ignored in single-selection mode" }
+            return@launch
+        }
         // Read from the directory listing (not state) so we never act on a transient loading frame
         // and end up selecting nothing.
         val loaded = dirListing.first { it is DirListing.Loaded } as DirListing.Loaded
+        val current = selectedItems.value
+        // select() toggles. Routing an already-selected row through it would DEselect what the
+        // user hand-picked before tapping "Select all", and routing a row that a selected
+        // ancestor already covers would swap that ancestor for just this child — silently
+        // dropping the rest of the ancestor's coverage. Select all is purely additive.
         val toSelect = loaded.items
             .map { it.lookup }
+            .filter { candidate ->
+                current.none { it.lookedUp == candidate.lookedUp || it.isAncestorOf(candidate) }
+            }
             .sortedByDescending { it.lookedUp.segments.size }
         select(toSelect)
     }
@@ -440,6 +456,8 @@ class PickerViewModel @Inject constructor(
         val items: List<PickerRow> = emptyList(),
         val selected: List<SelectedRow> = emptyList(),
         val hasChanges: Boolean = false,
+        /** Select-all is a multi-select affordance; single-selection (DIR) mode hides it. */
+        val allowSelectAll: Boolean = false,
         val progress: Progress.Data? = Progress.Data(),
     )
 

--- a/app-common-picker/src/test/java/eu/darken/sdmse/common/picker/PickerViewModelSelectAllTest.kt
+++ b/app-common-picker/src/test/java/eu/darken/sdmse/common/picker/PickerViewModelSelectAllTest.kt
@@ -1,0 +1,201 @@
+package eu.darken.sdmse.common.picker
+
+import androidx.lifecycle.SavedStateHandle
+import eu.darken.sdmse.common.areas.DataArea
+import eu.darken.sdmse.common.areas.DataAreaManager
+import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.files.FileType
+import eu.darken.sdmse.common.files.GatewaySwitch
+import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.files.local.LocalPathLookup
+import eu.darken.sdmse.common.navigation.NavigationController
+import eu.darken.sdmse.common.sharedresource.SharedResource
+import eu.darken.sdmse.common.user.UserHandle2
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import testhelpers.coroutine.runTest2
+import java.time.Instant
+
+class PickerViewModelSelectAllTest : BaseTest() {
+
+    private val areaPath = LocalPath.build("area")
+    private val area = DataArea(
+        path = areaPath,
+        type = DataArea.Type.SDCARD,
+        userHandle = UserHandle2(0),
+    )
+
+    private fun lookupOf(path: LocalPath, dir: Boolean = true) = LocalPathLookup(
+        lookedUp = path,
+        fileType = if (dir) FileType.DIRECTORY else FileType.FILE,
+        size = 0L,
+        modifiedAt = Instant.EPOCH,
+        target = null,
+    )
+
+    private class Harness(
+        val vm: PickerViewModel,
+        val resourceScope: CoroutineScope,
+    )
+
+    private fun harness(listings: Map<LocalPath, List<LocalPathLookup>>): Harness {
+        val resourceScope = CoroutineScope(SupervisorJob())
+        val gatewaySwitch = mockk<GatewaySwitch> {
+            every { sharedResource } returns SharedResource.createKeepAlive("test:gateway", resourceScope)
+            coEvery { lookup(any()) } answers { lookupOf(arg<APath>(0) as LocalPath) }
+            coEvery { lookupFiles(any()) } answers { listings[arg<APath>(0) as LocalPath] ?: emptyList() }
+        }
+        val dataAreaManager = mockk<DataAreaManager> {
+            every { state } returns flowOf(DataAreaManager.State(areas = setOf(area)))
+        }
+        val vm = PickerViewModel(
+            handle = SavedStateHandle(),
+            dispatcherProvider = TestDispatcherProvider(),
+            dataAreaManager = dataAreaManager,
+            navCtrl = mockk<NavigationController>(relaxed = true),
+            gatewaySwitch = gatewaySwitch,
+        )
+        return Harness(vm, resourceScope)
+    }
+
+    private suspend fun PickerViewModel.openRow(path: LocalPath) {
+        val row = state.first { st -> st.items.any { it.item.lookup.lookedUp == path } }
+            .items.first { it.item.lookup.lookedUp == path }
+        onRowClick(row)
+    }
+
+    @Test
+    fun `selectAll keeps rows the user already hand-picked`() = runTest2 {
+        // Regression guard: selectAll routed every listed item through the select() TOGGLE, so
+        // rows picked by hand before tapping "Select all" got DEselected by it.
+        val f1 = lookupOf(areaPath.child("f1"), dir = false)
+        val f2 = lookupOf(areaPath.child("f2"), dir = false)
+        val f3 = lookupOf(areaPath.child("f3"), dir = false)
+        val h = harness(mapOf(areaPath to listOf(f1, f2, f3)))
+        try {
+            h.vm.setRequest(PickerRequest(requestKey = "test", mode = PickerRequest.PickMode.FILES_AND_DIRS))
+            advanceUntilIdle()
+            h.vm.openRow(areaPath)
+            advanceUntilIdle()
+
+            h.vm.select(listOf(f1))
+            advanceUntilIdle()
+
+            h.vm.selectAll()
+            advanceUntilIdle()
+
+            h.vm.state.first().selected.map { it.lookup.lookedUp } shouldContainExactlyInAnyOrder
+                listOf(f1, f2, f3).map { it.lookedUp }
+        } finally {
+            h.resourceScope.cancel()
+        }
+    }
+
+    @Test
+    fun `selectAll keeps a selected ancestor instead of narrowing it to the listed children`() = runTest2 {
+        // A selected parent covers everything below it. Routing its listed children through the
+        // select() toggle would swap the parent for just those children, silently dropping the
+        // rest of the parent's coverage.
+        val parentPath = areaPath.child("parent")
+        val parent = lookupOf(parentPath, dir = true)
+        val c1 = lookupOf(parentPath.child("c1"), dir = false)
+        val c2 = lookupOf(parentPath.child("c2"), dir = false)
+        val h = harness(
+            mapOf(
+                areaPath to listOf(parent),
+                parentPath to listOf(c1, c2),
+            ),
+        )
+        try {
+            h.vm.setRequest(PickerRequest(requestKey = "test", mode = PickerRequest.PickMode.FILES_AND_DIRS))
+            advanceUntilIdle()
+            h.vm.openRow(areaPath)
+            advanceUntilIdle()
+
+            h.vm.select(listOf(parent))
+            advanceUntilIdle()
+
+            h.vm.openRow(parentPath)
+            advanceUntilIdle()
+
+            h.vm.selectAll()
+            advanceUntilIdle()
+
+            h.vm.state.first().selected.map { it.lookup.lookedUp } shouldContainExactlyInAnyOrder
+                listOf(parent.lookedUp)
+        } finally {
+            h.resourceScope.cancel()
+        }
+    }
+
+    @Test
+    fun `selectAll is a no-op in single-selection mode`() = runTest2 {
+        // DIR mode is single-selection (e.g. the path-exclusion picker); "select everything"
+        // has no meaning there and used to replace the selection with the first listed row.
+        val d1 = lookupOf(areaPath.child("d1"))
+        val d2 = lookupOf(areaPath.child("d2"))
+        val h = harness(mapOf(areaPath to listOf(d1, d2)))
+        try {
+            h.vm.setRequest(PickerRequest(requestKey = "test", mode = PickerRequest.PickMode.DIR))
+            advanceUntilIdle()
+            h.vm.openRow(areaPath)
+            advanceUntilIdle()
+
+            h.vm.select(listOf(d2))
+            advanceUntilIdle()
+
+            h.vm.selectAll()
+            advanceUntilIdle()
+
+            val state = h.vm.state.first()
+            state.selected.map { it.lookup.lookedUp } shouldContainExactlyInAnyOrder listOf(d2.lookedUp)
+            state.allowSelectAll shouldBe false
+        } finally {
+            h.resourceScope.cancel()
+        }
+    }
+
+    @Test
+    fun `selectAll still consolidates when a listed ancestor covers selected children`() = runTest2 {
+        // The reverse direction stays as-is: selecting a listed directory replaces its already
+        // selected descendants (the dir row covers them all).
+        val parentPath = areaPath.child("parent")
+        val parent = lookupOf(parentPath, dir = true)
+        val c1 = lookupOf(parentPath.child("c1"), dir = false)
+        val h = harness(
+            mapOf(
+                areaPath to listOf(parent),
+                parentPath to listOf(c1),
+            ),
+        )
+        try {
+            h.vm.setRequest(PickerRequest(requestKey = "test", mode = PickerRequest.PickMode.FILES_AND_DIRS))
+            advanceUntilIdle()
+            h.vm.openRow(areaPath)
+            advanceUntilIdle()
+
+            h.vm.select(listOf(c1))
+            advanceUntilIdle()
+
+            h.vm.selectAll()
+            advanceUntilIdle()
+
+            h.vm.state.first().selected.map { it.lookup.lookedUp } shouldContainExactlyInAnyOrder
+                listOf(parent.lookedUp)
+        } finally {
+            h.resourceScope.cancel()
+        }
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/TitleDashboardCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/TitleDashboardCard.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
@@ -153,6 +154,7 @@ internal fun TitleDashboardCard(item: TitleDashboardCardItem) {
                     Text(
                         text = titleText,
                         style = MaterialTheme.typography.headlineSmall,
+                        textAlign = TextAlign.Center,
                     )
                     Text(
                         text = sloganText,


### PR DESCRIPTION
## What changed

Fixed "Select all" in the file picker unintentionally *de*selecting items: rows the user had already picked by hand were toggled off, and if a selected folder's contents were being viewed, "Select all" replaced that folder selection with just the visible files — silently dropping everything else the folder covered. This broke the recommended Swiper workflow (select all, then deselect the subfolders you want to keep). "Select all" is also no longer offered in single-choice pickers (like the exclusion editor), where it made no sense.

## Technical Context

- Root cause: `selectAll()` fed every listed row through `select()`, which is a *toggle* with ancestor/descendant consolidation — already-selected rows flipped off, and children of a selected ancestor evicted that ancestor.
- Fix: `selectAll()` filters candidates to rows neither selected nor covered by a selected ancestor (purely additive). The useful reverse consolidation — selecting a listed directory replaces its selected descendants — is deliberately preserved and pinned by a test.
- DIR (single-selection) mode: found during review that the menu entry was reachable there and would replace the selection with the first listed row. Now the ViewModel ignores it, `State.allowSelectAll` hides the menu item, and the overflow button is hidden when it would open an empty menu (single-selection at the picker root).
- Review guidance: new `PickerViewModelSelectAllTest` builds a real VM harness (mocked `GatewaySwitch` listings); the two regression tests were verified to fail against the unfixed code.
