### PR TITLE
General: Fix Home-button cancel on Android TV stopping to work mid-run

### DIFF
--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/AutomationService.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/AutomationService.kt
@@ -506,6 +506,10 @@ class AutomationService : AccessibilityService(), AutomationHost, AutomationServ
                     if (hostState.value.hasOverlay) {
                         log(TAG, INFO) { "submit($id): User left to home screen, cancelling task" }
                         userCancelCurrentTask()
+                    } else {
+                        // E.g. task-startup navigation before the spec armed the overlay. The guard
+                        // re-arms: the next home sighting emits again.
+                        log(TAG) { "submit($id): Home sighting while overlay isn't armed, ignoring" }
                     }
                 }
                 .launchIn(serviceScope)

--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/LeaveCancelGuard.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/LeaveCancelGuard.kt
@@ -3,22 +3,26 @@ package eu.darken.sdmse.automation.core
 import eu.darken.sdmse.common.pkgs.Pkg
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.conflate
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.transform
 
 /**
- * Emits exactly once when the user appears to have left the automated app for the home/launcher
- * screen, i.e. the foreground became a [homePkgs] package and stayed there for [graceMs].
+ * Emits when the user appears to have left the automated app for the home/launcher screen,
+ * i.e. the foreground became a [homePkgs] package, after a [graceMs] settling delay.
  *
  * Used on Android TV where the on-screen Cancel button is unreachable by D-pad: pressing the
  * Home button surfaces the launcher, which we treat as an intentional cancel.
  *
  * Semantics:
- * - **Latched, non-resetting**: the first home sighting commits to a cancel after [graceMs]. We do
- *   NOT reset if the target app reappears mid-grace, because that reappearance is almost always the
+ * - **Latched per sighting**: a home sighting commits to an emission after [graceMs]. It does NOT
+ *   reset if the target app reappears mid-grace, because that reappearance is almost always the
  *   automation engine re-launching Settings — honoring the user's Home press is the intent.
+ * - **Re-arming**: consumers may suppress an emission (e.g. the overlay wasn't armed yet, so the
+ *   sighting was task-startup navigation rather than a user leave); every later home sighting
+ *   emits again. A single-shot latch here would permanently disarm Home-to-cancel for the rest
+ *   of a possibly multi-minute task while the overlay still promises it.
  * - **Null/foreign foreground ignored**: only home packages matter; everything else is dropped.
  *
  * Callers are expected to feed a stream already restricted to foreground-window changes
@@ -30,7 +34,15 @@ internal fun leaveSignals(
     homePkgs: Set<String>,
     graceMs: Long,
 ): Flow<Unit> = foregroundPkgs
+    // A single Home press can produce several window events for the launcher; they are one
+    // sighting, not several (a suppressed first firing must not leave a queued duplicate behind
+    // that then cancels without a second Home press).
+    .distinctUntilChanged()
     .filter { it != null && it.name in homePkgs }
-    .take(1)
-    .onEach { delay(graceMs) }
-    .map { }
+    // Sightings arriving while a grace delay is running collapse into at most one pending
+    // emission — also keeps this slow collector from backpressuring the shared event stream.
+    .conflate()
+    .transform {
+        delay(graceMs)
+        emit(Unit)
+    }

--- a/app-common-automation/src/test/java/eu/darken/sdmse/automation/core/LeaveCancelGuardTest.kt
+++ b/app-common-automation/src/test/java/eu/darken/sdmse/automation/core/LeaveCancelGuardTest.kt
@@ -29,6 +29,24 @@ class LeaveCancelGuardTest : BaseTest() {
     }
 
     @Test
+    fun `a suppressed sighting does not disarm the guard - later home sightings emit again`() = runTest2 {
+        // Regression guard: with a single-shot latch, a home sighting during the task-start window
+        // (overlay not armed yet, so the consumer suppresses it) permanently disarmed
+        // Home-to-cancel for the rest of the task. Each home sighting must produce an emission.
+        leaveSignals(flowOf<Pkg.Id?>(launcher, settings, launcher), home, grace)
+            .toList() shouldHaveSize 2
+    }
+
+    @Test
+    fun `duplicate launcher events from one Home press are one sighting`() = runTest2 {
+        // A single Home press can fire several window events for the launcher. They must not
+        // queue extra emissions — a suppressed first firing followed by a queued duplicate would
+        // cancel the task without a second Home press.
+        leaveSignals(flowOf<Pkg.Id?>(launcher, launcher, launcher), home, grace)
+            .toList() shouldHaveSize 1
+    }
+
+    @Test
     fun `only non-home foreground never emits`() = runTest2 {
         leaveSignals(flowOf<Pkg.Id?>(settings, settings), home, grace).toList().shouldBeEmpty()
     }


### PR DESCRIPTION
## What changed

Fixed cancelling app cleaning with the Home button on Android TV sometimes not working: if Home was pressed within the first second of the automation starting, the cancel-by-Home feature silently stopped working for the rest of that run — even though the on-screen hint kept promising it. Now every Home press during a run is honored.

## Technical Context

- Root cause: the leave-cancel guard was a single-shot latch (`take(1)`). The consumer legitimately suppresses a firing while the overlay isn't armed yet (the task's own startup navigation window), but with `take(1)` that suppression consumed the only emission.
- New semantics: latched *per sighting* — a suppressed emission re-arms; target-app reappearance mid-grace still can't reset an in-flight sighting (unchanged intent, since the engine re-launching Settings must not cancel the user's Home press).
- Hardening from review: `distinctUntilChanged` collapses the several launcher window-events a single Home press can produce (a queued duplicate after a suppressed first firing would otherwise cancel without a second press), and `conflate` bounds pending emissions to one while a grace delay runs — also keeping this slow collector from backpressuring the shared accessibility event stream.
- Also corrects the KDoc's grace-period description (it claimed "stayed on home for graceMs"; the implementation is an unconditional post-sighting delay, which is the intended latch behavior).
- Regression tests verified to fail against the single-shot latch.
