### PR TITLE
Squeezer: Never silently strip photo metadata and report skipped HDR photos

### DIFF
--- a/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/Squeezer.kt
+++ b/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/Squeezer.kt
@@ -200,6 +200,7 @@ class Squeezer @Inject constructor(
             processedCount = allSuccess.size,
             failedCount = allFailures.size,
             failureReasons = failureReasons,
+            guardSkippedCount = imageResult.skippedGuarded.size,
         )
     }
 

--- a/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/processor/ExifPreserver.kt
+++ b/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/processor/ExifPreserver.kt
@@ -6,6 +6,7 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.squeezer.core.MetadataPreservationException
 import java.io.File
 import javax.inject.Inject
 
@@ -23,6 +24,12 @@ class ExifPreserver @Inject constructor() {
         val altitude: Double? = null,
     )
 
+    /**
+     * Returns `null` only when the file genuinely carries no EXIF worth preserving. A failed
+     * extraction throws [MetadataPreservationException] instead — `null` would be
+     * indistinguishable from "nothing to preserve" and the photo would get compressed with its
+     * date/location/camera tags silently stripped (the HEIC path fails closed the same way).
+     */
     fun extractExif(file: File): ExifData? {
         return try {
             val exif = ExifInterface(file)
@@ -48,7 +55,10 @@ class ExifPreserver @Inject constructor() {
             }
         } catch (e: Exception) {
             log(TAG, WARN) { "Failed to extract EXIF: ${e.message}" }
-            null
+            throw MetadataPreservationException(
+                "EXIF metadata of ${file.path} could not be read (${e.message}); " +
+                    "aborting to avoid silently stripping date/location/camera tags",
+            )
         }
     }
 

--- a/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/processor/HeifExifExtractor.kt
+++ b/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/processor/HeifExifExtractor.kt
@@ -258,6 +258,9 @@ class HeifExifExtractor @Inject constructor() {
             entryCount = raf.readInt()
             entriesStart = iinf.payloadStart + 8
         }
+        // A 32-bit count reads negative for corrupt values >= 2^31. Failing open here would skip
+        // the entry loop entirely and report "no Exif item" — silently stripping metadata.
+        if (entryCount < 0) return ItemLookup.ParseError("implausible iinf entry count $entryCount")
 
         var pos = entriesStart
         var seen = 0
@@ -273,6 +276,11 @@ class HeifExifExtractor @Inject constructor() {
             }
             pos = h.boxEnd
             seen++
+        }
+        if (seen < entryCount) {
+            // Truncated iinf: it declared more entries than its box holds. One of the missing
+            // entries could have been the Exif item — we can't tell, so fail closed.
+            return ItemLookup.ParseError("iinf truncated: saw $seen of $entryCount declared entries")
         }
         return ItemLookup.NotPresent
     }

--- a/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/tasks/SqueezerProcessTask.kt
+++ b/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/tasks/SqueezerProcessTask.kt
@@ -42,6 +42,12 @@ data class SqueezerProcessTask(
         val processedCount: Int,
         val failedCount: Int = 0,
         val failureReasons: Map<FailureReason, Int> = emptyMap(),
+        /**
+         * Photos skipped at process time to preserve their HDR gain map / depth data (the
+         * guard re-checks the setting per item). Without this the items just vanish from the
+         * pending list, counted neither as processed nor failed.
+         */
+        val guardSkippedCount: Int = 0,
     ) : Result, ReportDetails.AffectedSpace, ReportDetails.AffectedPaths {
 
         /** Files aborted to preserve metadata (part of [failedCount], surfaced as their own clause). */
@@ -80,6 +86,12 @@ data class SqueezerProcessTask(
                     fragments += getQuantityString2(
                         R.plurals.squeezer_result_x_metadata_unpreservable,
                         metadataUnpreservableCount,
+                    )
+                }
+                if (guardSkippedCount > 0) {
+                    fragments += getQuantityString2(
+                        R.plurals.squeezer_result_x_skipped_lossy_aux,
+                        guardSkippedCount,
                     )
                 }
                 fragments.joinToString(" • ")

--- a/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/core/processor/ExifPreserverTest.kt
+++ b/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/core/processor/ExifPreserverTest.kt
@@ -2,6 +2,7 @@ package eu.darken.sdmse.squeezer.core.processor
 
 import android.graphics.Bitmap
 import androidx.exifinterface.media.ExifInterface
+import eu.darken.sdmse.squeezer.core.MetadataPreservationException
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -41,6 +42,18 @@ class ExifPreserverTest : BaseTest() {
             bitmap.compress(Bitmap.CompressFormat.JPEG, 90, out)
         }
         bitmap.recycle()
+    }
+
+    @Test
+    fun `extractExif throws instead of failing open when the file can't be read`() {
+        // Regression guard: a failed extraction used to return null — indistinguishable from
+        // "no EXIF present" — so the photo was compressed with its date/location/camera tags
+        // silently stripped. Extraction failures must abort the compression instead.
+        val missing = File(testDir, "does_not_exist.jpg")
+
+        shouldThrow<MetadataPreservationException> {
+            exifPreserver.extractExif(missing)
+        }
     }
 
     // === Compression Marker Tests ===
@@ -155,15 +168,6 @@ class ExifPreserverTest : BaseTest() {
         exifData.shouldNotBeNull()
         exifData.attributes[ExifInterface.TAG_MAKE] shouldBe "TestCamera"
         exifData.attributes[ExifInterface.TAG_MODEL] shouldBe "TestModel"
-    }
-
-    @Test
-    fun `extractExif returns null for non-existent file`() {
-        val file = File(testDir, "does_not_exist.jpg")
-
-        val exifData = exifPreserver.extractExif(file)
-
-        exifData.shouldBeNull()
     }
 
     // === EXIF Apply Tests ===

--- a/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/core/processor/HeifExifExtractorTest.kt
+++ b/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/core/processor/HeifExifExtractorTest.kt
@@ -86,6 +86,37 @@ class HeifExifExtractorTest : BaseTest() {
         result.shouldBeInstanceOf<HeifExifExtractor.Result.NoExif>()
     }
 
+    @Test
+    fun `iinf with a corrupt negative entry count is Unsupported not NoExif`() {
+        // A 32-bit v1 entry count >= 2^31 reads negative. Failing open would skip the entry loop
+        // and claim "no Exif item" — the file would be compressed with metadata silently stripped.
+        val ftyp = box("ftyp", "heic".ascii() + beInt(0) + "heic".ascii())
+        // iinf v1: version+flags, 4-byte entry_count with the sign bit set, no entries.
+        val iinf = box("iinf", beInt(0x01000000) + beInt(-1))
+        val iloc = box("iloc", ByteArray(0))
+        val meta = box("meta", beInt(0) + iinf + iloc)
+        val fixture = File(testDir, "negative_count.heic").apply { writeBytes(ftyp + meta) }
+
+        val result = subject.extractExifBlock(fixture)
+        result.shouldBeInstanceOf<HeifExifExtractor.Result.Unsupported>()
+    }
+
+    @Test
+    fun `iinf declaring more entries than it holds is Unsupported not NoExif`() {
+        // A truncated iinf ends before all declared entries were seen. One of the missing entries
+        // could have been the Exif item, so this must fail closed instead of reporting NoExif.
+        val ftyp = box("ftyp", "heic".ascii() + beInt(0) + "heic".ascii())
+        val infe = box("infe", beInt(0x02000000) + beShort(1) + beShort(0) + "hvc1".ascii())
+        // iinf v0 declares 3 entries but holds only 1.
+        val iinf = box("iinf", beInt(0) + beShort(3) + infe)
+        val iloc = box("iloc", ByteArray(0))
+        val meta = box("meta", beInt(0) + iinf + iloc)
+        val fixture = File(testDir, "truncated_iinf.heic").apply { writeBytes(ftyp + meta) }
+
+        val result = subject.extractExifBlock(fixture)
+        result.shouldBeInstanceOf<HeifExifExtractor.Result.Unsupported>()
+    }
+
     private fun copyResource(name: String): File {
         val out = File(testDir, name)
         javaClass.classLoader!!.getResourceAsStream(name)!!.use { input ->

--- a/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/core/tasks/SqueezerProcessTaskResultTest.kt
+++ b/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/core/tasks/SqueezerProcessTaskResultTest.kt
@@ -1,0 +1,46 @@
+package eu.darken.sdmse.squeezer.core.tasks
+
+import androidx.test.core.app.ApplicationProvider
+import android.content.Context
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class SqueezerProcessTaskResultTest : BaseTest() {
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `guard-skipped photos appear in the result summary`() {
+        // Items skipped at process time to preserve HDR/depth data used to vanish silently:
+        // pruned from the pending list but counted neither as processed nor failed.
+        val success = SqueezerProcessTask.Success(
+            affectedSpace = 1024L,
+            affectedPaths = emptySet(),
+            processedCount = 2,
+            guardSkippedCount = 3,
+        )
+
+        val summary = success.secondaryInfo.get(context)
+        summary shouldContain "3 skipped"
+        summary shouldContain "HDR"
+    }
+
+    @Test
+    fun `summary omits the skip clause when nothing was guard-skipped`() {
+        val success = SqueezerProcessTask.Success(
+            affectedSpace = 1024L,
+            affectedPaths = emptySet(),
+            processedCount = 2,
+        )
+
+        success.secondaryInfo.get(context) shouldNotContain "HDR"
+    }
+}


### PR DESCRIPTION
## What changed

Made photo compression safer around metadata: two rare cases where a photo with damaged-but-present metadata could be compressed with its date, location, and camera information silently removed are now skipped instead (the original stays untouched). Also, photos that get skipped during compression to protect their HDR or depth data are now shown in the result summary instead of silently disappearing from the list.

## Technical Context

- `HeifExifExtractor` failed open on malformed `iinf` boxes: a corrupt 32-bit v1 entry count ≥ 2³¹ reads negative (the entry scan loop never ran) and a truncated `iinf` declaring more entries than present both reported "no EXIF item" → compression proceeded metadata-less. Both now fail closed as `Unsupported` → `METADATA_UNPRESERVABLE`, like the rest of the HEIC parser (same hardening pattern as `HeifTransformInspector` in #2508).
- `ExifPreserver.extractExif` (JPEG/WebP) returned `null` on *any* exception — indistinguishable from "no EXIF present". It now throws `MetadataPreservationException`; the exception maps to the existing failure accounting and `FileTransaction` keeps the original (temp output cleaned). The old test that pinned the fail-open `null` was replaced.
- Process-time guard skips (HDR/depth photos when `includeLossyAuxImages` changed between scan and compress) are now carried in `SqueezerProcessTask.Success.guardSkippedCount` and surfaced in the summary, reusing the existing "skipped (HDR/depth preserved)" plural — previously those items were pruned from the pending list but counted neither as processed nor failed.
- Review guidance: all three fixes were verified to fail against the reverted code; the new field uses a default value so all construction sites stay source-compatible.
