### PR TITLE
General: Fix stale gallery entries, slow live search, and lost filter edits

### DIFF
--- a/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/core/deleter/SwiperDeleter.kt
+++ b/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/core/deleter/SwiperDeleter.kt
@@ -10,6 +10,8 @@ import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.delete
 import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.files.saf.SAFPath
+import eu.darken.sdmse.common.storage.PathMapper
 import eu.darken.sdmse.common.flow.throttleLatest
 import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.common.progress.updateProgressCount
@@ -25,6 +27,7 @@ import javax.inject.Inject
 class SwiperDeleter @Inject constructor(
     @ApplicationContext private val context: Context,
     private val gatewaySwitch: GatewaySwitch,
+    private val pathMapper: PathMapper,
 ) : Progress.Host, Progress.Client {
 
     private val progressPub = MutableStateFlow<Progress.Data?>(Progress.Data())
@@ -82,25 +85,33 @@ class SwiperDeleter @Inject constructor(
         )
     }
 
-    private fun notifyMediaScanner(path: APath) {
+    private suspend fun notifyMediaScanner(path: APath) {
         when (path.pathType) {
-            APath.PathType.LOCAL ->
-                try {
-                    val localPath = path as LocalPath
-                    MediaScannerConnection.scanFile(
-                        context,
-                        arrayOf(localPath.file.absolutePath),
-                        null,
-                        null,
-                    )
-                } catch (e: Exception) {
-                    log(TAG, WARN) { "MediaScanner notification failed for $path: ${e.message}" }
-                }
+            APath.PathType.LOCAL -> scanFile(path as LocalPath)
             APath.PathType.SAF -> {
-                log(TAG, WARN) { "Notifying media scanner about SAF changes is not supported atm." }
-                // TODO implement this?
+                // SAF documents live on real storage; map the tree URI back to its mount point so
+                // gallery apps drop the deleted entry instead of showing it until their own rescan.
+                val localPath = pathMapper.toLocalPath(path as SAFPath)
+                if (localPath != null) {
+                    scanFile(localPath)
+                } else {
+                    log(TAG, WARN) { "No filesystem mapping for $path, media scanner not notified" }
+                }
             }
             APath.PathType.RAW -> throw IllegalStateException("How did we get $path here")
+        }
+    }
+
+    private fun scanFile(localPath: LocalPath) {
+        try {
+            MediaScannerConnection.scanFile(
+                context,
+                arrayOf(localPath.file.absolutePath),
+                null,
+                null,
+            )
+        } catch (e: Exception) {
+            log(TAG, WARN) { "MediaScanner notification failed for $localPath: ${e.message}" }
         }
     }
 

--- a/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/CustomFilterEditorViewModel.kt
+++ b/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/CustomFilterEditorViewModel.kt
@@ -291,9 +291,13 @@ class CustomFilterEditorViewModel @Inject constructor(
             combine(
                 crawler.matchEvents
                     .map { LiveSearchMatch(lookup = it.match) }
-                    .scan(listOf<LiveSearchMatch>()) { list, event ->
-                        if (list.any { it.id == event.id }) list else list + event
-                    },
+                    // Paired seen-set keeps the per-event dedup O(1); a list scan made large live
+                    // searches quadratic. Mutating the set inside scan is safe: accumulation is
+                    // sequential and downstream only reads the list.
+                    .scan(listOf<LiveSearchMatch>() to hashSetOf<String>()) { (list, seen), event ->
+                        if (seen.add(event.id)) (list + event) to seen else list to seen
+                    }
+                    .map { (list, _) -> list },
                 crawler.progress,
                 crawlerJobFlow,
             ) { matches, progress, isWorking ->

--- a/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/TaggedInputField.kt
+++ b/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/TaggedInputField.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
@@ -45,10 +46,12 @@ internal fun TaggedInputField(
     onModeChange: (old: SieveCriterium, new: SieveCriterium) -> Unit,
     onFocusChange: ((Boolean) -> Unit)? = null,
 ) {
-    var typedText by remember { mutableStateOf(TextFieldValue("")) }
+    // Saveable: a config change mid-edit of a backspace-popped chip must not lose the chip — it
+    // was already removed from the draft, so the in-progress text is its only remaining copy.
+    var typedText by rememberSaveable(stateSaver = TextFieldValue.Saver) { mutableStateOf(TextFieldValue("")) }
     // The chip that was popped back into the input for editing (null while typing a fresh entry).
-    var editingCriterium by remember { mutableStateOf<SieveCriterium?>(null) }
-    var modeSwitcherFor by remember { mutableStateOf<SieveCriterium?>(null) }
+    var editingCriterium by rememberSaveable { mutableStateOf<SieveCriterium?>(null) }
+    var modeSwitcherFor by rememberSaveable { mutableStateOf<SieveCriterium?>(null) }
 
     fun commit() {
         val text = typedText.text.trim()


### PR DESCRIPTION
## What changed

Three small fixes: gallery apps now update right away when the Swiper deletes files on SD cards accessed via storage permissions (deleted photos no longer linger in galleries); the SystemCleaner custom-filter live search stays fast on folders with many matches; and rotating the screen while editing a filter keyword no longer loses the keyword being edited.

## Technical Context

- SAF deletions map back to their filesystem mount via the existing `PathMapper.toLocalPath` (tree URI → StorageVolume directory + segments) before the `MediaScannerConnection` notify — same treatment local deletions already got; unmappable paths keep the previous WARN behavior.
- Live-search dedup was a linear list scan per match event inside `scan{}` (quadratic overall); now a paired seen-`HashSet` accumulator, created per `flatMapLatest` execution so search restarts get a fresh set.
- `TaggedInputField`'s edit state (`TextFieldValue` + popped chip) moves to `rememberSaveable` — the popped chip is already removed from the ViewModel draft while being edited, so the in-progress input was its only copy across config changes.
- The audit's fourth item (Data Areas doc button deep link) is intentionally untouched: no data-areas wiki page exists yet, a deep link would 404.
