### PR TITLE
General: Smoother multi-select in Deduplicator and SystemCleaner lists

### DIFF
--- a/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/details/DeduplicatorDetailsScreen.kt
+++ b/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/details/DeduplicatorDetailsScreen.kt
@@ -265,7 +265,17 @@ internal fun DeduplicatorDetailsScreen(
         // delete removed members) or a saved selection was restored against a smaller cluster, the
         // retained set could otherwise exceed maxSelection and let a delete take the whole cluster.
         if (selection.count > maxSelection) {
-            selection.setSelection(selection.selected.take(maxSelection).toSet())
+            // Deterministic re-cap: follow the live duplicate order (set iteration order is
+            // arbitrary) and drop keepers first — a keep-one delete preserves those copies
+            // anyway, so deselecting them loses the least of the user's intent.
+            val keeperIds = currentCluster?.groups?.mapNotNull { it.keeperIdentifier }?.toSet() ?: emptySet()
+            val ordered = currentCluster?.groups
+                ?.flatMap { it.duplicates }
+                ?.map { it.identifier }
+                ?.filter { it in selection.selected }
+                ?.sortedBy { it in keeperIds } // stable: non-keepers keep live order, keepers go last
+                ?: selection.selected.toList()
+            selection.setSelection(ordered.take(maxSelection).toSet())
         }
     }
 

--- a/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListScreen.kt
+++ b/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListScreen.kt
@@ -25,6 +25,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -118,6 +121,46 @@ private fun MixedSelection.toggleClusterTargets(
         copy(dupes = dupes - clusterId)
     } else {
         addClusterTargets(clusterId, targets, cap)
+    }
+}
+
+/**
+ * Compose-isolated access to [MixedSelection], mirroring [eu.darken.sdmse.common.compose.selection.SelectionState]'s
+ * per-id derivedStateOf pattern: passing the raw value into the list composables subscribed every
+ * visible row to any selection change, so toggling one duplicate recomposed the whole
+ * thumbnail-heavy window. The structured per-cluster shape doesn't map onto SelectionState<T>,
+ * hence the bespoke holder with the same isolation semantics.
+ */
+@Stable
+private class MixedSelectionHolder(initial: MixedSelection) {
+
+    var value by mutableStateOf(initial)
+
+    /** Notifies only on the empty <-> non-empty transition. */
+    val isActive: Boolean by derivedStateOf { !value.isEmpty }
+
+    /** Notifies only when the selected-file count changes (top-bar "N selected"). */
+    val fileCount: Int by derivedStateOf { value.fileCount }
+
+    /** Per-cluster selected duplicates; only rows whose set actually changes recompose. */
+    @Composable
+    fun selectedDupes(clusterId: Duplicate.Cluster.Id): Set<Duplicate.Id> {
+        val state = remember(this, clusterId) { derivedStateOf { value.dupes[clusterId] ?: emptySet() } }
+        return state.value
+    }
+
+    /** Per-cluster "has any selection" flag for the grid tiles. */
+    @Composable
+    fun hasSelectedDupes(clusterId: Duplicate.Cluster.Id): Boolean {
+        val state = remember(this, clusterId) { derivedStateOf { value.dupes[clusterId]?.isNotEmpty() == true } }
+        return state.value
+    }
+
+    companion object {
+        fun saver(): Saver<MixedSelectionHolder, MixedSelection> = Saver(
+            save = { it.value },
+            restore = { MixedSelectionHolder(it) },
+        )
     }
 }
 
@@ -269,7 +312,10 @@ internal fun DeduplicatorListScreen(
     val layoutMode = state?.layoutMode ?: LayoutMode.GRID
     val allowDeleteAll = state?.allowDeleteAll ?: false
 
-    var selection by rememberSaveable { mutableStateOf(MixedSelection.Empty) }
+    val selectionHolder = rememberSaveable(saver = MixedSelectionHolder.saver()) {
+        MixedSelectionHolder(MixedSelection.Empty)
+    }
+    var selection by selectionHolder::value
     val snackScope = rememberCoroutineScope()
 
     val rowsById = rows?.associateBy { it.cluster.identifier } ?: emptyMap()
@@ -286,7 +332,7 @@ internal fun DeduplicatorListScreen(
         val pruned = MixedSelection(dupes = prunedDupes)
         if (pruned != selection) selection = pruned
     }
-    BackHandler(enabled = !selection.isEmpty) { selection = MixedSelection.Empty }
+    BackHandler(enabled = selectionHolder.isActive) { selection = MixedSelection.Empty }
 
     val capRejectMsg = stringResource(DeduplicatorR.string.deduplicator_selection_keep_one_required)
     val notifyCapExceeded: () -> Unit = {
@@ -305,7 +351,7 @@ internal fun DeduplicatorListScreen(
 
     SdmScaffold(
         topBar = {
-            if (selection.isEmpty) {
+            if (!selectionHolder.isActive) {
                 SdmTopAppBar(
                     title = stringResource(CommonR.string.deduplicator_tool_name),
                     subtitle = subtitle,
@@ -328,7 +374,7 @@ internal fun DeduplicatorListScreen(
             } else {
                 val safeTargetUnion = rows.orEmpty().flatMap { it.deleteTargetIds }.toSet()
                 SdmSelectionTopAppBar(
-                    selectedCount = selection.fileCount,
+                    selectedCount = selectionHolder.fileCount,
                     onClearSelection = { selection = MixedSelection.Empty },
                     actions = {
                         SdmDeleteAction(onClick = {
@@ -421,7 +467,7 @@ internal fun DeduplicatorListScreen(
                         when (layoutMode) {
                             LayoutMode.LINEAR -> LinearList(
                                 rows = rows,
-                                selection = selection,
+                                selection = selectionHolder,
                                 onHeaderClick = onClusterDeleteTap,
                                 onThumbnailClick = onClusterPreviewTap,
                                 onClusterLongPress = onClusterLongPress,
@@ -432,7 +478,7 @@ internal fun DeduplicatorListScreen(
 
                             LayoutMode.GRID -> GridList(
                                 rows = rows,
-                                selection = selection,
+                                selection = selectionHolder,
                                 onThumbnailClick = onClusterDeleteTap,
                                 onCaptionClick = onClusterDetailsTap,
                                 onPreviewButtonClick = onClusterPreviewTap,
@@ -449,7 +495,7 @@ internal fun DeduplicatorListScreen(
 @Composable
 private fun LinearList(
     rows: List<DeduplicatorListViewModel.DeduplicatorListRow>,
-    selection: MixedSelection,
+    selection: MixedSelectionHolder,
     onHeaderClick: (Duplicate.Cluster) -> Unit,
     onThumbnailClick: (Duplicate.Cluster) -> Unit,
     onClusterLongPress: (Duplicate.Cluster) -> Unit,
@@ -457,13 +503,13 @@ private fun LinearList(
     onDuplicateLongPress: (Duplicate.Cluster, Duplicate) -> Unit,
     onDuplicatePreview: (Duplicate.Cluster, Duplicate) -> Unit,
 ) {
-    val selectionActive = !selection.isEmpty
+    val selectionActive = selection.isActive
     LazyColumn(
         modifier = Modifier.fillMaxWidth(),
         contentPadding = SdmListDefaults.FullWidthContentPadding,
     ) {
         items(rows, key = { it.cluster.identifier.value }) { row ->
-            val selectedDupes = selection.dupes[row.cluster.identifier] ?: emptySet()
+            val selectedDupes = selection.selectedDupes(row.cluster.identifier)
             DeduplicatorLinearRow(
                 row = row,
                 selected = false,
@@ -483,7 +529,7 @@ private fun LinearList(
 @Composable
 private fun GridList(
     rows: List<DeduplicatorListViewModel.DeduplicatorListRow>,
-    selection: MixedSelection,
+    selection: MixedSelectionHolder,
     onThumbnailClick: (Duplicate.Cluster) -> Unit,
     onCaptionClick: (Duplicate.Cluster) -> Unit,
     onPreviewButtonClick: (Duplicate.Cluster) -> Unit,
@@ -500,7 +546,7 @@ private fun GridList(
             horizontalArrangement = Arrangement.spacedBy(0.dp),
         ) {
             items(rows, key = { it.cluster.identifier.value }) { row ->
-                val isSelected = selection.dupes[row.cluster.identifier]?.isNotEmpty() == true
+                val isSelected = selection.hasSelectedDupes(row.cluster.identifier)
                 DeduplicatorGridRow(
                     row = row,
                     selected = isSelected,

--- a/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/list/CustomFilterListScreen.kt
+++ b/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/list/CustomFilterListScreen.kt
@@ -177,6 +177,14 @@ internal fun CustomFilterListScreen(
     val selection = rememberSelectionState<String>()
     val listState = rememberLazyListState()
 
+    // Standard selection prune (same as the other tool lists): ids whose rows disappeared —
+    // removal on another screen, an import replacing filters — must not linger in the count/title
+    // or the next action's input.
+    val rowIds = state?.rows?.map { it.id }?.toSet()
+    LaunchedEffect(rowIds) {
+        if (rowIds != null) selection.retainAll(rowIds)
+    }
+
     BackHandler(enabled = selection.isActive) { selection.clear() }
 
     SdmScaffold(


### PR DESCRIPTION
## What changed

Performance and consistency polish for multi-select: selecting duplicates in the Deduplicator list no longer redraws every visible row on each tap (noticeable on the thumbnail grid); the SystemCleaner custom-filter list's selection counter can no longer show entries that don't exist anymore; and when a duplicate group shrinks while items are selected, the selection now trims itself predictably instead of dropping a random item.

## Technical Context

- DeduplicatorListScreen kept its bespoke per-cluster `MixedSelection` (doesn't map onto `SelectionState<T>`) but gains a `@Stable` holder replicating the SelectionState isolation semantics: derived `isActive`/`fileCount`, per-cluster `derivedStateOf` reads inside `items{}`, custom `Saver`. Existing write sites unchanged via `var selection by selectionHolder::value`.
- CustomFilterListScreen's new prune skips while rows are null so the WhileSubscribed initial frame can't wipe a restored selection.
- The details re-cap orders by the live duplicate list with keepers sorted last (stable sort), so the dropped item is deterministic and keep-one-safe.
- Full Deduplicator (289) and SystemCleaner (331) suites green, including the Robolectric screen tests.
