### PR TITLE
General: Fix rare root/Shizuku access errors that resolved on retry

### DIFF
--- a/app-common/src/main/java/eu/darken/sdmse/common/sharedresource/SharedResource.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/sharedresource/SharedResource.kt
@@ -110,31 +110,72 @@ open class SharedResource<T : Any>(
     suspend fun get(): Resource<T> {
         var attempt = 0
         while (true) {
-            val (generation, value, lease) = acquireGeneration()
-            val reusable = isReusable ?: return Resource(value, lease)
+            val (generation, value, lease) = try {
+                acquireGeneration()
+            } catch (e: StaleReuseAcquireException) {
+                // A REUSED generation died before producing a value — the failure belongs to that
+                // dying generation, not to this caller. It has been force-detached; retry fresh
+                // instead of rethrowing an error a moment-later call would never have seen.
+                if (Bugs.isTrace) log(iTag, DEBUG) { "[${e.generationId}]-get() reused a dying generation, retrying" }
+                if (++attempt >= reuseValidationAttempts) {
+                    throw IllegalStateException(
+                        "[$iTag] kept acquiring dying generations after $attempt attempts",
+                        e.cause,
+                    )
+                }
+                continue
+            }
 
-            val alive = try {
-                reusable(value)
-            } catch (e: Throwable) {
-                // The validator threw, or the caller was cancelled at this suspension point. Release only
-                // our provisional lease and propagate — do NOT tear down the shared generation for others.
-                releaseProvisionalLease(lease, "reuse-validation-error")
-                throw e
+            val reusable = isReusable
+            if (reusable != null) {
+                val alive = try {
+                    reusable(value)
+                } catch (e: Throwable) {
+                    // The validator threw, or the caller was cancelled at this suspension point. Release only
+                    // our provisional lease and propagate — do NOT tear down the shared generation for others.
+                    releaseProvisionalLease(lease, "reuse-validation-error")
+                    throw e
+                }
+                if (!alive) {
+                    // The cached generation's resource has died (e.g. its shell process exited) but the async
+                    // onCompletion detach hasn't cleared `active` yet, so acquireGeneration() handed back a dead
+                    // value. Drop our provisional lease + force-detach the stale generation, then retry for a fresh one.
+                    if (Bugs.isTrace) {
+                        log(iTag, DEBUG) { "[${generation.id}]-get() reused resource failed liveness check, detaching + retrying" }
+                    }
+                    detachInvalidReuse(generation, lease, "reuse-invalid")
+                    if (++attempt >= reuseValidationAttempts) {
+                        throw IllegalStateException("[$iTag] resource failed the reuse liveness check after $attempt attempts")
+                    }
+                    continue
+                }
             }
-            if (alive) return Resource(value, lease)
 
-            // The cached generation's resource has died (e.g. its shell process exited) but the async
-            // onCompletion detach hasn't cleared `active` yet, so acquireGeneration() handed back a dead
-            // value. Drop our provisional lease + force-detach the stale generation, then retry for a fresh one.
-            if (Bugs.isTrace) {
-                log(iTag, DEBUG) { "[${generation.id}]-get() reused resource failed liveness check, detaching + retrying" }
+            // A concurrent close()/self-teardown may have force-closed every lease — including the one
+            // we just registered — between acquireGeneration() releasing coreLock and here. Handing
+            // that lease out would make the caller's first `.item` access throw ("closed resource");
+            // the generation is already torn down by whoever closed it, so simply retry.
+            if (lease.isClosed) {
+                if (Bugs.isTrace) log(iTag, DEBUG) { "[${generation.id}]-get() lease force-closed during acquisition, retrying" }
+                if (++attempt >= reuseValidationAttempts) {
+                    throw IllegalStateException("[$iTag] resource kept closing mid-acquisition after $attempt attempts")
+                }
+                continue
             }
-            detachInvalidReuse(generation, lease, "reuse-invalid")
-            if (++attempt >= reuseValidationAttempts) {
-                throw IllegalStateException("[$iTag] resource failed the reuse liveness check after $attempt attempts")
-            }
+
+            return Resource(value, lease)
         }
     }
+
+    /**
+     * Acquisition failed because a REUSED generation errored before producing a value. Retryable:
+     * the dying generation was force-detached, a fresh acquisition starts a new source. Never
+     * thrown for freshly-created generations — their startup failures propagate unchanged.
+     */
+    private class StaleReuseAcquireException(
+        val generationId: String,
+        override val cause: Throwable,
+    ) : Exception()
 
     private suspend fun acquireGeneration(): Triple<Generation<T>, T, Lease> {
         val lId = "L:${UUID.randomUUID().toString().takeLast(4)}"
@@ -145,6 +186,7 @@ open class SharedResource<T : Any>(
 
         var lease: Lease? = null
         var gen: Generation<T>? = null
+        var reused = false
 
         coreLock.withLock("[$sId|$lId]-get()-sourcejob") {
             withContext(NonCancellable) {
@@ -169,6 +211,7 @@ open class SharedResource<T : Any>(
                 active?.let {
                     if (Bugs.isTrace) log(iTag, VERBOSE) { "[$sId|$lId]-get() Source job already exists" }
                     gen = it
+                    reused = true
                     return@withContext
                 }
 
@@ -255,15 +298,26 @@ open class SharedResource<T : Any>(
             generation.ready.await()
         } catch (e: Throwable) {
             if (Bugs.isTrace) log(iTag, DEBUG) { "[${generation.id}|$lId]-get() await failed (${e.javaClass.simpleName}), releasing provisional lease" }
+            if (reused && e !is CancellationException) {
+                // We latched onto an already-running generation that then died before producing a value.
+                // Its startup error belongs to the caller that STARTED it, not to us — force-detach the
+                // corpse (async onCompletion teardown may not have run yet) and signal get() to retry fresh.
+                detachInvalidReuse(generation, lease!!, "stale-reuse")
+                throw StaleReuseAcquireException(generation.id, e)
+            }
             lease!!.close()
             throw e
         }
 
         val value = generation.value
         if (value == null) {
-            lease!!.close()
             val error = generation.error ?: IllegalStateException("Source produced no value")
             if (Bugs.isTrace) log(iTag, WARN) { "[${generation.id}|$lId]-get() no value, throwing $error" }
+            if (reused && error !is CancellationException) {
+                detachInvalidReuse(generation, lease!!, "stale-reuse")
+                throw StaleReuseAcquireException(generation.id, error)
+            }
+            lease!!.close()
             throw error
         }
 

--- a/app-common/src/test/java/eu/darken/sdmse/common/sharedresource/SharedResourceTest.kt
+++ b/app-common/src/test/java/eu/darken/sdmse/common/sharedresource/SharedResourceTest.kt
@@ -948,38 +948,61 @@ class SharedResourceTest : BaseTest() {
         val attempts = AtomicInteger(0)
         val firstStarted = CompletableDeferred<Unit>()
         val failFirst = CompletableDeferred<Unit>()
-        val sr = SharedResource<Int>(
-            tag = "stale-reuse",
-            parentScope = this + Dispatchers.IO,
-            stopTimeout = Duration.ZERO,
-            source = flow {
-                if (attempts.incrementAndGet() == 1) {
-                    firstStarted.complete(Unit)
-                    failFirst.await()
-                    throw IOException("source died before producing a value")
+
+        // Completed when the second get() has REUSED the running generation — the "Source job already
+        // exists" breadcrumb is logged under coreLock exactly where the reuse decision falls, and only
+        // a reusing caller emits it. Deterministic, unlike a sleep: without this the reuser could start
+        // only after generation 1 already failed, acquire a fresh generation, and pass vacuously.
+        val reuserLatched = CompletableDeferred<Unit>()
+        val capture = object : Logging.Logger {
+            override fun log(
+                priority: Logging.Priority,
+                tag: String,
+                message: String,
+                metaData: Map<String, Any>?
+            ) {
+                if (tag == "stale-reuse:SR" && message.contains("Source job already exists")) {
+                    reuserLatched.complete(Unit)
                 }
-                emit(attempts.get())
-                awaitCancellation()
-            },
-        )
+            }
+        }
+        Logging.install(capture)
+        try {
+            val sr = SharedResource<Int>(
+                tag = "stale-reuse",
+                parentScope = this + Dispatchers.IO,
+                stopTimeout = Duration.ZERO,
+                source = flow {
+                    if (attempts.incrementAndGet() == 1) {
+                        firstStarted.complete(Unit)
+                        failFirst.await()
+                        throw IOException("source died before producing a value")
+                    }
+                    emit(attempts.get())
+                    awaitCancellation()
+                },
+            )
 
-        val creator = async(Dispatchers.IO) { runCatching { sr.get() } }
-        firstStarted.await()
-        // The source is running but has produced no value yet, so this get() REUSES generation 1
-        // and parks on its ready-gate...
-        val reuser = async(Dispatchers.IO) { runCatching { sr.get() } }
-        delay(100)
-        // ...then generation 1 dies before ever producing a value.
-        failFirst.complete(Unit)
+            val creator = async(Dispatchers.IO) { runCatching { sr.get() } }
+            firstStarted.await()
+            // The source is running but has produced no value yet, so this get() REUSES generation 1
+            // and awaits its ready-gate...
+            val reuser = async(Dispatchers.IO) { runCatching { sr.get() } }
+            reuserLatched.await()
+            // ...then generation 1 dies before ever producing a value.
+            failFirst.complete(Unit)
 
-        // The caller that STARTED the doomed source sees its original failure...
-        (creator.await().exceptionOrNull() is IOException) shouldBe true
-        // ...but the caller that merely latched onto the dying generation must not inherit that stale
-        // error — it retries onto a fresh generation instead.
-        val resource = reuser.await().getOrThrow()
-        resource.item shouldBe 2
+            // The caller that STARTED the doomed source sees its original failure...
+            (creator.await().exceptionOrNull() is IOException) shouldBe true
+            // ...but the caller that merely latched onto the dying generation must not inherit that
+            // stale error — it retries onto a fresh generation instead.
+            val resource = reuser.await().getOrThrow()
+            resource.item shouldBe 2
 
-        resource.close()
-        sr.close()
+            resource.close()
+            sr.close()
+        } finally {
+            Logging.remove(capture)
+        }
     }
 }

--- a/app-common/src/test/java/eu/darken/sdmse/common/sharedresource/SharedResourceTest.kt
+++ b/app-common/src/test/java/eu/darken/sdmse/common/sharedresource/SharedResourceTest.kt
@@ -911,4 +911,75 @@ class SharedResourceTest : BaseTest() {
         second.close()
         sr.close()
     }
+
+    @Test
+    fun `get retries when a concurrent close force-closes the lease mid-acquisition`() = runTest2 {
+        // Real dispatcher: Lease.close/close() use runBlocking.
+        val produced = AtomicInteger(0)
+        val closeTriggered = AtomicInteger(0)
+        lateinit var sr: SharedResource<Int>
+        sr = SharedResource(
+            tag = "close-race",
+            parentScope = this + Dispatchers.IO,
+            stopTimeout = Duration.ZERO,
+            source = flow {
+                emit(produced.incrementAndGet())
+                awaitCancellation()
+            },
+            // The validator runs in the window between lease registration (under coreLock) and get()
+            // returning — exactly where a concurrent close() can force-close the just-created lease.
+            // Trigger that close() deterministically on the first acquisition.
+            isReusable = {
+                if (closeTriggered.incrementAndGet() == 1) sr.close()
+                true
+            },
+        )
+
+        val resource = sr.get()
+        // Without the retry, get() hands back generation 1's force-closed lease and this access throws.
+        // With it, get() notices the closed lease and re-acquires a fresh generation.
+        resource.item shouldBe 2
+        resource.close()
+        sr.close()
+    }
+
+    @Test
+    fun `a reused generation dying before its first value does not poison the reusing caller`(): Unit = runBlocking {
+        val attempts = AtomicInteger(0)
+        val firstStarted = CompletableDeferred<Unit>()
+        val failFirst = CompletableDeferred<Unit>()
+        val sr = SharedResource<Int>(
+            tag = "stale-reuse",
+            parentScope = this + Dispatchers.IO,
+            stopTimeout = Duration.ZERO,
+            source = flow {
+                if (attempts.incrementAndGet() == 1) {
+                    firstStarted.complete(Unit)
+                    failFirst.await()
+                    throw IOException("source died before producing a value")
+                }
+                emit(attempts.get())
+                awaitCancellation()
+            },
+        )
+
+        val creator = async(Dispatchers.IO) { runCatching { sr.get() } }
+        firstStarted.await()
+        // The source is running but has produced no value yet, so this get() REUSES generation 1
+        // and parks on its ready-gate...
+        val reuser = async(Dispatchers.IO) { runCatching { sr.get() } }
+        delay(100)
+        // ...then generation 1 dies before ever producing a value.
+        failFirst.complete(Unit)
+
+        // The caller that STARTED the doomed source sees its original failure...
+        (creator.await().exceptionOrNull() is IOException) shouldBe true
+        // ...but the caller that merely latched onto the dying generation must not inherit that stale
+        // error — it retries onto a fresh generation instead.
+        val resource = reuser.await().getOrThrow()
+        resource.item shouldBe 2
+
+        resource.close()
+        sr.close()
+    }
 }


### PR DESCRIPTION
## What changed

Fixed two rare timing issues that could make root or Shizuku access fail with an error even though everything was actually fine — retrying immediately would have worked. The app now recovers from these situations by itself.

## Technical Context

- `SharedResource.get()` registers its provisional lease under `coreLock` but awaits the first source value and runs the liveness validator off-lock. Two windows in that off-lock stretch are closed here:
  - **Closed-lease return**: a concurrent `close()`/self-teardown force-closes every lease — including the just-registered one — before `get()` returns, so the caller's first `.item` access threw "Trying to access closed resource". `get()` now checks `lease.isClosed` before returning and retries.
  - **Stale-error reuse**: a `get()` that latched onto an already-running generation which then died before producing a value inherited that generation's startup error. The failure belongs to the caller that *started* the source; the reusing caller now force-detaches the corpse (`detachInvalidReuse`, same `leaseCheckLock → coreLock` order as `leaseCheck`/`onCompletion`) and retries a fresh generation via an internal `StaleReuseAcquireException`.
- Deliberately preserved behavior: freshly-*created* generations still propagate their own startup errors unchanged, and `CancellationException` is never converted or retried (caller cancellation must win). Both retry loops share the existing `reuseValidationAttempts = 5` bound, so a pathological close-storm terminates with a clear `IllegalStateException` instead of livelocking.
- Review guidance: the trickiest interaction is `detachInvalidReuse` racing the dying generation's own async `onCompletion` teardown — both re-validate `active === generation` under the same lock order, so the loser degrades to closing only its own provisional lease (idempotent).
- Both regression tests are deterministic (no sleeps-as-synchronization for the closed-lease case: the liveness validator itself triggers `close()` inside the vulnerable window) and were verified to fail against the unfixed code.

