### PR TITLE
General: Clean up compiler build warnings

### DIFF
--- a/app-common-automation/build.gradle.kts
+++ b/app-common-automation/build.gradle.kts
@@ -33,7 +33,7 @@ android {
     }
 }
 
-setupKotlinOptions()
+setupKotlinOptions(compose = true)
 
 dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:${Versions.Desugar.core}")

--- a/app-common-coil/build.gradle.kts
+++ b/app-common-coil/build.gradle.kts
@@ -33,7 +33,7 @@ android {
     }
 }
 
-setupKotlinOptions()
+setupKotlinOptions(compose = true)
 
 dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:${Versions.Desugar.core}")

--- a/app-common-coil/src/main/java/eu/darken/sdmse/common/coil/FileHandleImageSource.kt
+++ b/app-common-coil/src/main/java/eu/darken/sdmse/common/coil/FileHandleImageSource.kt
@@ -1,6 +1,7 @@
 package eu.darken.sdmse.common.coil
 
 import android.media.MediaDataSource
+import coil.annotation.ExperimentalCoilApi
 import coil.decode.ImageSource
 import coil.fetch.MediaDataSourceFetcher.MediaSourceMetadata
 import eu.darken.sdmse.common.files.callbacks
@@ -8,6 +9,7 @@ import okio.FileHandle
 import okio.buffer
 import java.io.File
 
+@OptIn(ExperimentalCoilApi::class)
 suspend fun FileHandle.toImageSource(
     cacheDir: File,
 ): ImageSource {

--- a/app-common-exclusion/build.gradle.kts
+++ b/app-common-exclusion/build.gradle.kts
@@ -33,7 +33,7 @@ android {
     }
 }
 
-setupKotlinOptions()
+setupKotlinOptions(compose = true)
 
 dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:${Versions.Desugar.core}")

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/PackageManagerExtensions.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/PackageManagerExtensions.kt
@@ -89,13 +89,13 @@ fun PackageManager.getInstalledPackagesAsUser(
             method.invoke(this, flags.toInt(), userHandle.handleId) as List<PackageInfo>
         }
     } else {
-        @Suppress("UNCHECKED_CAST")
         val method = PackageManager::class.java.getMethod(
             "getInstalledPackagesAsUser",
             Int::class.javaPrimitiveType,
             Int::class.javaPrimitiveType,
         )
-        method.invoke(this, flags.toInt(), userHandle.handleId) as List<PackageInfo>
+        @Suppress("UNCHECKED_CAST")
+        (method.invoke(this, flags.toInt(), userHandle.handleId) as List<PackageInfo>)
     }
 } catch (e: Exception) {
     log(ERROR) { e.asLog() }

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/storage/StorageEnvironment.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/storage/StorageEnvironment.kt
@@ -2,7 +2,6 @@ package eu.darken.sdmse.common.storage
 
 import android.content.Context
 import android.os.Environment
-import androidx.core.content.ContextCompat
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
@@ -50,7 +49,7 @@ class StorageEnvironment @Inject constructor(
         get() = Environment.getDataDirectory().toLocalPath()
 
     val externalDirs: List<LocalPath>
-        get() = ContextCompat.getExternalFilesDirs(context, null)
+        get() = context.getExternalFilesDirs(null)
             .filter { it != null && it.isAbsolute }
             .mapNotNull { base ->
                 var root = base
@@ -62,7 +61,7 @@ class StorageEnvironment @Inject constructor(
             }
 
     val publicDataDirs: List<LocalPath>
-        get() = ContextCompat.getExternalFilesDirs(context, null)
+        get() = context.getExternalFilesDirs(null)
             .filter { it != null && it.isAbsolute }
             .mapNotNull { base ->
                 var root = base
@@ -102,7 +101,7 @@ class StorageEnvironment @Inject constructor(
 
         val pathResult = mutableListOf<LocalPath>()
 
-        ContextCompat.getExternalFilesDirs(context, null)
+        context.getExternalFilesDirs(null)
             .filterNotNull()
             .filter { it.isAbsolute }
             .mapNotNull { extMyDir ->

--- a/app-common-picker/build.gradle.kts
+++ b/app-common-picker/build.gradle.kts
@@ -33,7 +33,7 @@ android {
     }
 }
 
-setupKotlinOptions()
+setupKotlinOptions(compose = true)
 
 dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:${Versions.Desugar.core}")

--- a/app-common-root/src/main/java/eu/darken/sdmse/common/root/service/internal/BaseRootHost.kt
+++ b/app-common-root/src/main/java/eu/darken/sdmse/common/root/service/internal/BaseRootHost.kt
@@ -74,7 +74,8 @@ abstract class BaseRootHost(
         }
 
         runBlocking {
-            log(iTag) { "Running on threadId=${Thread.currentThread().id}" }
+            @Suppress("DEPRECATION") val threadId = Thread.currentThread().id
+            log(iTag) { "Running on threadId=$threadId" }
             onInit()
             onExecute()
         }

--- a/app-common-stats/build.gradle.kts
+++ b/app-common-stats/build.gradle.kts
@@ -33,7 +33,7 @@ android {
     }
 }
 
-setupKotlinOptions()
+setupKotlinOptions(compose = true)
 
 ksp {
     arg("room.schemaLocation", "$projectDir/schemas")

--- a/app-common-ui/build.gradle.kts
+++ b/app-common-ui/build.gradle.kts
@@ -33,7 +33,7 @@ android {
     }
 }
 
-setupKotlinOptions()
+setupKotlinOptions(compose = true)
 
 dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:${Versions.Desugar.core}")

--- a/app-tool-analyzer/build.gradle.kts
+++ b/app-tool-analyzer/build.gradle.kts
@@ -33,7 +33,7 @@ android {
     }
 }
 
-setupKotlinOptions()
+setupKotlinOptions(compose = true)
 
 dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:${Versions.Desugar.core}")

--- a/app-tool-appcleaner/build.gradle.kts
+++ b/app-tool-appcleaner/build.gradle.kts
@@ -33,7 +33,7 @@ android {
     }
 }
 
-setupKotlinOptions()
+setupKotlinOptions(compose = true)
 
 dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:${Versions.Desugar.core}")

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/settings/AppCleanerSettingsScreen.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/settings/AppCleanerSettingsScreen.kt
@@ -5,21 +5,21 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.ArrowBack
+import androidx.compose.material.icons.automirrored.twotone.Chat
 import androidx.compose.material.icons.automirrored.twotone.FormatListBulleted
 import androidx.compose.material.icons.automirrored.twotone.InsertDriveFile
+import androidx.compose.material.icons.automirrored.twotone.RotateRight
 import androidx.compose.material.icons.twotone.AdsClick
 import androidx.compose.material.icons.twotone.Analytics
 import androidx.compose.material.icons.twotone.Apps
 import androidx.compose.material.icons.twotone.BugReport
 import androidx.compose.material.icons.twotone.Cancel
-import androidx.compose.material.icons.twotone.Chat
 import androidx.compose.material.icons.twotone.DeleteForever
 import androidx.compose.material.icons.twotone.FolderOff
 import androidx.compose.material.icons.twotone.Groups
 import androidx.compose.material.icons.twotone.History
 import androidx.compose.material.icons.twotone.PhotoLibrary
 import androidx.compose.material.icons.twotone.PlayCircleOutline
-import androidx.compose.material.icons.twotone.RotateRight
 import androidx.compose.material.icons.twotone.SignalCellularOff
 import androidx.compose.material.icons.twotone.VisibilityOff
 import eu.darken.sdmse.common.compose.layout.SdmScaffold
@@ -243,7 +243,7 @@ internal fun AppCleanerSettingsScreen(
             }
             item {
                 SettingsBadgedSwitchItem(
-                    icon = Icons.TwoTone.RotateRight,
+                    icon = Icons.AutoMirrored.TwoTone.RotateRight,
                     title = stringResource(R.string.appcleaner_include_runningapps_label),
                     subtitle = stringResource(R.string.appcleaner_include_runningapps_summary),
                     checked = state.includeRunningApps,
@@ -445,7 +445,7 @@ internal fun AppCleanerSettingsScreen(
             }
             item {
                 SettingsSwitchItem(
-                    icon = Icons.TwoTone.Chat,
+                    icon = Icons.AutoMirrored.TwoTone.Chat,
                     title = stringResource(R.string.appcleaner_filter_telegram_label),
                     subtitle = stringResource(R.string.appcleaner_filter_telegram_summary),
                     checked = state.filterTelegram,
@@ -454,7 +454,7 @@ internal fun AppCleanerSettingsScreen(
             }
             item {
                 SettingsSwitchItem(
-                    icon = Icons.TwoTone.Chat,
+                    icon = Icons.AutoMirrored.TwoTone.Chat,
                     title = stringResource(R.string.appcleaner_filter_threema_label),
                     subtitle = stringResource(R.string.appcleaner_filter_threema_summary),
                     checked = state.filterThreema,
@@ -472,7 +472,7 @@ internal fun AppCleanerSettingsScreen(
             }
             item {
                 SettingsSwitchItem(
-                    icon = Icons.TwoTone.Chat,
+                    icon = Icons.AutoMirrored.TwoTone.Chat,
                     title = stringResource(R.string.appcleaner_filter_viber_label),
                     subtitle = stringResource(R.string.appcleaner_filter_viber_summary),
                     checked = state.filterViber,

--- a/app-tool-appcontrol/build.gradle.kts
+++ b/app-tool-appcontrol/build.gradle.kts
@@ -33,7 +33,7 @@ android {
     }
 }
 
-setupKotlinOptions()
+setupKotlinOptions(compose = true)
 
 dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:${Versions.Desugar.core}")

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/settings/AppControlSettingsScreen.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/settings/AppControlSettingsScreen.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.ArrowBack
-import androidx.compose.material.icons.twotone.DirectionsRun
+import androidx.compose.material.icons.automirrored.twotone.DirectionsRun
 import androidx.compose.material.icons.twotone.Groups
 import androidx.compose.material.icons.twotone.MonitorWeight
 import eu.darken.sdmse.common.compose.layout.SdmScaffold
@@ -103,7 +103,7 @@ internal fun AppControlSettingsScreen(
             }
             item {
                 SettingsBadgedSwitchItem(
-                    icon = Icons.TwoTone.DirectionsRun,
+                    icon = Icons.AutoMirrored.TwoTone.DirectionsRun,
                     title = stringResource(R.string.appcontrol_settings_module_activity_enabled_label),
                     subtitle = stringResource(R.string.appcontrol_settings_module_activity_enabled_description),
                     checked = state.activityEnabled,

--- a/app-tool-corpsefinder/build.gradle.kts
+++ b/app-tool-corpsefinder/build.gradle.kts
@@ -33,7 +33,7 @@ android {
     }
 }
 
-setupKotlinOptions()
+setupKotlinOptions(compose = true)
 
 dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:${Versions.Desugar.core}")

--- a/app-tool-deduplicator/build.gradle.kts
+++ b/app-tool-deduplicator/build.gradle.kts
@@ -33,7 +33,7 @@ android {
     }
 }
 
-setupKotlinOptions()
+setupKotlinOptions(compose = true)
 
 dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:${Versions.Desugar.core}")

--- a/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/core/scanner/media/MediaSleuth.kt
+++ b/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/core/scanner/media/MediaSleuth.kt
@@ -202,7 +202,7 @@ class MediaSleuth @Inject constructor(
                             null
                         }
                     } else {
-                        if (sim != null && sim > NEAR_MISS_THRESHOLD) {
+                        if (sim > NEAR_MISS_THRESHOLD) {
                             log(TAG, VERBOSE) {
                                 "Near-miss (below reject): ${String.format("%.2f%%", sim * 100)}" +
                                         " : ${target.lookup.path} <-> ${other.lookup.path}"

--- a/app-tool-scheduler/build.gradle.kts
+++ b/app-tool-scheduler/build.gradle.kts
@@ -33,7 +33,7 @@ android {
     }
 }
 
-setupKotlinOptions()
+setupKotlinOptions(compose = true)
 
 dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:${Versions.Desugar.core}")

--- a/app-tool-squeezer/build.gradle.kts
+++ b/app-tool-squeezer/build.gradle.kts
@@ -43,7 +43,7 @@ ksp {
     arg("room.schemaLocation", "$projectDir/schemas")
 }
 
-setupKotlinOptions()
+setupKotlinOptions(compose = true)
 
 dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:${Versions.Desugar.core}")

--- a/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/processor/VideoTranscoder.kt
+++ b/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/processor/VideoTranscoder.kt
@@ -164,7 +164,12 @@ class VideoTranscoder @Inject constructor(
 
                         val mediaItem = MediaItem.fromUri(Uri.fromFile(inputFile))
                         val editedItem = EditedMediaItem.Builder(mediaItem).build()
-                        val sequence = EditedMediaItemSequence.Builder(listOf(editedItem)).build()
+                        // All item-taking EditedMediaItemSequence.Builder constructors are @Deprecated
+                        // in media3 1.10; the non-deprecated replacements (withAudioAndVideoFrom /
+                        // Builder(trackTypes)) change track-selection semantics, so keep the single-item
+                        // constructor and suppress rather than risk altering transcode output.
+                        @Suppress("DEPRECATION")
+                        val sequence = EditedMediaItemSequence.Builder(editedItem).build()
                         val composition = Composition.Builder(sequence)
                             .setTransmuxAudio(true)
                             .build()

--- a/app-tool-swiper/build.gradle.kts
+++ b/app-tool-swiper/build.gradle.kts
@@ -39,7 +39,7 @@ android {
     }
 }
 
-setupKotlinOptions()
+setupKotlinOptions(compose = true)
 
 ksp {
     arg("room.schemaLocation", "$projectDir/schemas")

--- a/app-tool-systemcleaner/build.gradle.kts
+++ b/app-tool-systemcleaner/build.gradle.kts
@@ -33,7 +33,7 @@ android {
     }
 }
 
-setupKotlinOptions()
+setupKotlinOptions(compose = true)
 
 dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:${Versions.Desugar.core}")

--- a/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/list/CustomFilterListScreen.kt
+++ b/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/list/CustomFilterListScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.ArrowBack
+import androidx.compose.material.icons.automirrored.twotone.HelpOutline
 import androidx.compose.material.icons.twotone.Add
 import androidx.compose.material.icons.twotone.Close
 import androidx.compose.material.icons.twotone.Delete
@@ -24,7 +25,6 @@ import androidx.compose.material.icons.twotone.Edit
 import androidx.compose.material.icons.twotone.SelectAll
 import androidx.compose.material.icons.twotone.FileDownload
 import androidx.compose.material.icons.twotone.FileUpload
-import androidx.compose.material.icons.twotone.HelpOutline
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.Icon
@@ -206,7 +206,7 @@ internal fun CustomFilterListScreen(
                             onClick = onImport,
                         )
                         SdmTooltipIconButton(
-                            icon = Icons.TwoTone.HelpOutline,
+                            icon = Icons.AutoMirrored.TwoTone.HelpOutline,
                             label = stringResource(CommonR.string.general_help_action),
                             onClick = onHelp,
                         )

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -180,7 +180,7 @@ androidComponents {
     }
 }
 
-setupKotlinOptions()
+setupKotlinOptions(compose = true)
 
 afterEvaluate {
     tasks.matching { it.name == "bundleGplayBeta" }.configureEach {

--- a/buildSrc/src/main/java/ProjectExtensions.kt
+++ b/buildSrc/src/main/java/ProjectExtensions.kt
@@ -69,7 +69,15 @@ fun LibraryExtension.setupModuleBuildTypes() {
     }
 }
 
-fun Project.setupKotlinOptions() {
+/**
+ * @param compose pass `true` for modules that apply Compose (i.e. call `addCompose()`), so the
+ * Compose opt-ins are added only where the markers are on the classpath. Adding them globally
+ * would emit an "opt-in requirement marker is unresolved" warning in every non-Compose module.
+ * Experimental Compose APIs (Material3 TopAppBar/Scaffold/ModalBottomSheet/TimePicker, foundation
+ * FlowRow, …) are used pervasively across the UI, so a module-level opt-in is preferable to
+ * scattering per-file `@OptIn` across dozens of screens.
+ */
+fun Project.setupKotlinOptions(compose: Boolean = false) {
     tasks.withType<KotlinCompile>().configureEach {
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_17)
@@ -83,15 +91,20 @@ fun Project.setupKotlinOptions() {
                     "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
                     "-opt-in=kotlinx.coroutines.FlowPreview",
                     "-opt-in=kotlinx.serialization.ExperimentalSerializationApi",
-                    "-opt-in=androidx.compose.material3.ExperimentalMaterial3Api",
-                    "-opt-in=androidx.compose.foundation.ExperimentalFoundationApi",
-                    "-opt-in=androidx.compose.foundation.layout.ExperimentalLayoutApi",
-                    "-opt-in=coil.annotation.ExperimentalCoilApi",
                     "-Xjvm-default=all",
                     "-Xcontext-parameters",
                     "-Xannotation-default-target=param-property",
                 )
             )
+            if (compose) {
+                freeCompilerArgs.addAll(
+                    listOf(
+                        "-opt-in=androidx.compose.material3.ExperimentalMaterial3Api",
+                        "-opt-in=androidx.compose.foundation.ExperimentalFoundationApi",
+                        "-opt-in=androidx.compose.foundation.layout.ExperimentalLayoutApi",
+                    )
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## What changed

No user-facing behavior change. Clears out the compiler warnings that were cluttering the build output.

## Technical Context

- **Opt-in marker noise (the bulk of it):** `setupKotlinOptions()` appended the Compose (Material3 / foundation / layout) and Coil experimental opt-in args to *every* module, so the many non-Compose modules (shell, root, io, adb, pkgs, data, setup) emitted "opt-in requirement marker is unresolved" — the marker class simply isn't on their classpath. Fix: gate the three Compose opt-ins behind a new `setupKotlinOptions(compose = true)` parameter, applied to exactly the 16 modules that call `addCompose()`. A full `beta` compile of both flavors proved these markers are *load-bearing* in Compose modules — experimental Material3/foundation/layout APIs are used pervasively and mostly un-annotated — so a module-level opt-in is correct rather than scattering `@OptIn` across ~40 screens. Coil had a single real usage, so it's dropped from the global list in favor of one explicit `@OptIn(ExperimentalCoilApi::class)`.
- **Deprecations / smells:** AutoMirrored icon variants (RTL-correct) for `DirectionsRun`/`HelpOutline`/`RotateRight`/`Chat`; `ContextCompat.getExternalFilesDirs` → `context.getExternalFilesDirs` (behavior-identical on minSdk 26); relocated an ineffective `@Suppress("UNCHECKED_CAST")` onto the cast expression it was meant to cover; dropped an always-true null check; suppressed the deprecated `Thread.id` read.
- **media3:** all item-taking `EditedMediaItemSequence.Builder` constructors are deprecated in 1.10, and the non-deprecated replacements (`withAudioAndVideoFrom` / `Builder(trackTypes)`) change track-selection semantics — so the single-item constructor is kept and suppressed rather than risk altering transcode output.
- **Verification:** both `:app:compileFossBetaKotlin` and `:app:compileGplayBetaKotlin` compile with zero opt-in/deprecation warnings; 959/959 unit tests pass across the touched-logic modules (io, root, deduplicator, squeezer).
- **Left as-is:** the native-strip warning (`libandroidx.graphics.path.so`, `libdatastore_shared_counter.so`) is benign prebuilt-AndroidX noise, not something we control.
