### PR TITLE
General: Show total space freed on the home-screen widget

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/widget/ui/WidgetContent.kt
+++ b/app/src/main/java/eu/darken/sdmse/widget/ui/WidgetContent.kt
@@ -50,6 +50,15 @@ private val STACKED_MIN_HEIGHT = 110.dp
 private val RING_MAX_WIDTH = 190.dp     // below this (1 row) → ring (~2 col)
 private val BUTTON_LABEL_MIN_WIDTH = 300.dp // at/above this (1 row) → show the Clean text (~4 col)
 
+// Shared with WidgetChrome's padding() call below so the two stay in sync.
+private val WIDGET_CHROME_VERTICAL_PADDING = 12.dp
+
+// WidgetChrome's vertical padding (both sides) leaves ~56dp of content height at 80dp outer height —
+// enough for the row's text+bar+freed-text stack; below this the compact 2-line layout (value + bar)
+// stays as-is. Must stay below STACKED_MIN_HEIGHT, otherwise ValueRowLayout is never reached at this
+// height and the freed-text branch becomes dead code.
+private val VALUE_ROW_FREED_MIN_HEIGHT = 80.dp
+
 // Equal element size for the symmetric narrow (ring) row.
 private val NARROW_ELEMENT_SIZE = 44.dp
 
@@ -113,7 +122,11 @@ internal fun WidgetContent(state: WidgetRenderState) {
                 when {
                     size.height >= STACKED_MIN_HEIGHT -> StackedLayout(state)
                     size.width < RING_MAX_WIDTH -> RingRowLayout(state)
-                    else -> ValueRowLayout(state, showButtonLabel = size.width >= BUTTON_LABEL_MIN_WIDTH)
+                    else -> ValueRowLayout(
+                        state,
+                        showButtonLabel = size.width >= BUTTON_LABEL_MIN_WIDTH,
+                        showFreedText = size.height >= VALUE_ROW_FREED_MIN_HEIGHT,
+                    )
                 }
             }
 
@@ -144,7 +157,7 @@ private fun WidgetChrome(content: @Composable () -> Unit) {
                 .appWidgetBackground()
                 .background(GlanceTheme.colors.background)
                 .cornerRadius(20.dp)
-                .padding(horizontal = 14.dp, vertical = 12.dp),
+                .padding(horizontal = 14.dp, vertical = WIDGET_CHROME_VERTICAL_PADDING),
         ) {
             content()
         }
@@ -174,7 +187,7 @@ private fun StackedLayout(data: WidgetRenderState.Data) {
  * shows at the widest sizes; at ~3 columns it's icon-only so the value isn't truncated.
  */
 @Composable
-private fun ValueRowLayout(data: WidgetRenderState.Data, showButtonLabel: Boolean) {
+private fun ValueRowLayout(data: WidgetRenderState.Data, showButtonLabel: Boolean, showFreedText: Boolean) {
     val context = LocalContext.current
     Row(
         modifier = GlanceModifier.fillMaxSize(),
@@ -189,8 +202,16 @@ private fun ValueRowLayout(data: WidgetRenderState.Data, showButtonLabel: Boolea
                     style = TextStyle(color = GlanceTheme.colors.onBackground, fontSize = 14.sp, fontWeight = FontWeight.Bold),
                     maxLines = 1,
                 )
-                Spacer(GlanceModifier.height(5.dp))
+                Spacer(GlanceModifier.height(3.dp))
                 StorageBar(entry.usedRatio)
+                if (showFreedText) {
+                    Spacer(GlanceModifier.height(3.dp))
+                    Text(
+                        text = freedLabel(context, data.freedBytes),
+                        style = TextStyle(color = GlanceTheme.colors.onSurfaceVariant, fontSize = 12.sp),
+                        maxLines = 1,
+                    )
+                }
             }
         }
         Spacer(GlanceModifier.width(12.dp))
@@ -232,7 +253,7 @@ private fun BrandingHeader(freedBytes: Long, modifier: GlanceModifier = GlanceMo
             )
             Spacer(GlanceModifier.height(2.dp))
             Text(
-                text = context.getString(R.string.widget_home_freed_label, formatSize(context, freedBytes)),
+                text = freedLabel(context, freedBytes),
                 style = TextStyle(color = GlanceTheme.colors.onSurfaceVariant, fontSize = 11.sp),
                 maxLines = 1,
             )
@@ -407,3 +428,6 @@ private fun storageLabelRes(kind: WidgetRenderState.Data.StorageEntry.Kind): Int
 
 private fun formatSize(context: Context, bytes: Long): String =
     Formatter.formatShortFileSize(context, bytes)
+
+private fun freedLabel(context: Context, freedBytes: Long): String =
+    context.getString(R.string.widget_home_freed_label, formatSize(context, freedBytes))

--- a/app/src/main/java/eu/darken/sdmse/widget/ui/WidgetContentPreviews.kt
+++ b/app/src/main/java/eu/darken/sdmse/widget/ui/WidgetContentPreviews.kt
@@ -43,6 +43,37 @@ private fun WidgetContentRowNarrowPreview() {
     WidgetContent(WidgetRenderState.Data(listOf(internal(45, 128)), freedBytes = 12 * GB))
 }
 
+// Below VALUE_ROW_FREED_MIN_HEIGHT (80dp) — the freed-text line must stay hidden, compact 1-line layout only.
+@Preview(widthDp = 300, heightDp = 64)
+@Composable
+private fun WidgetContentRowCompactPreview() {
+    WidgetContent(WidgetRenderState.Data(listOf(internal(45, 128)), freedBytes = 12 * GB))
+}
+
+// At the 80dp breakpoint with large values, to check the used/total and freed-text lines don't overflow
+// their column width once the freed-text line is showing.
+@Preview(widthDp = 300, heightDp = 80)
+@Composable
+private fun WidgetContentRowWideLargeValuesPreview() {
+    WidgetContent(WidgetRenderState.Data(listOf(internal(998, 999)), freedBytes = 999 * GB))
+}
+
+@Preview(widthDp = 220, heightDp = 80)
+@Composable
+private fun WidgetContentRowMediumLargeValuesPreview() {
+    WidgetContent(WidgetRenderState.Data(listOf(internal(998, 999)), freedBytes = 999 * GB))
+}
+
+// Row layout's working/cancellable states, at the breakpoint height — the other working/cancellable
+// previews below are all 140dp tall and only ever exercise StackedLayout.
+@Preview(widthDp = 220, heightDp = 80)
+@Composable
+private fun WidgetContentRowCancellablePreview() {
+    WidgetContent(
+        WidgetRenderState.Data(listOf(internal(45, 128)), freedBytes = 12 * GB, isWorking = true, isCancellable = true)
+    )
+}
+
 @Preview(widthDp = 200, heightDp = 140)
 @Composable
 private fun WidgetContentNearFullPreview() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -366,7 +366,7 @@
     <string name="widget_home_description">Storage usage and one-tap cleanup</string>
     <string name="widget_home_storage_internal">Internal</string>
     <string name="widget_home_storage_external">External</string>
-    <string name="widget_home_freed_label">Freed: %1$s</string>
+    <string name="widget_home_freed_label">Lifetime: %1$s</string>
     <string name="widget_home_clean_action">Clean</string>
     <string name="widget_home_working">Working…</string>
     <string name="widget_home_unavailable">Storage unavailable</string>


### PR DESCRIPTION
## What changed

- The home-screen widget's compact size now shows how much storage SD Maid has freed over its lifetime, right below the storage bar — matching the info already shown in the larger widget size.
- Relabeled it from "Freed: X" to "Lifetime: X" so it's clear this is a running total, not the result of the most recent cleanup. This also updates the wording in the larger widget size, which already showed this number.
- Tightened the vertical spacing between the storage numbers, the progress bar, and the new lifetime-freed line so they're evenly spaced, and made the lifetime text slightly larger.

## Technical Context

- The new line only appears once the widget is tall enough (≥80dp) to fit it without crowding; smaller widget placements keep today's compact layout unchanged.
- Extracted the freed-label formatting into a shared helper so both widget layouts stay in sync.
- Review guidance: the 80dp breakpoint is a starting point verified on-device (incl. 1.3x system font scale) rather than an exact measurement — if it ever clips on an unusual launcher/font-scale combination, that constant is the first thing to bump.
