### PR TITLE
Deduplicator: Make the similarity-detection warning clearer

### DIFF
--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/settings/SettingsBaseItem.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/settings/SettingsBaseItem.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -43,8 +44,9 @@ fun SettingsBaseItem(
     onLongClick: (() -> Unit)? = null,
     focusKey: String? = null,
     trailingContent: @Composable (() -> Unit)? = null,
+    content: @Composable (() -> Unit)? = null,
 ) {
-    Row(
+    Column(
         modifier = modifier
             .fillMaxWidth()
             // Before combinedClickable so the requester/observer attach to the row's focus
@@ -56,7 +58,6 @@ fun SettingsBaseItem(
                 onLongClick = onLongClick,
             )
             .padding(horizontal = 16.dp, vertical = 16.dp),
-        verticalAlignment = Alignment.CenterVertically,
     ) {
         val contentAlpha = if (enabled) 1f else 0.5f
         val hasIcon = icon != null || iconPainter != null
@@ -66,55 +67,65 @@ fun SettingsBaseItem(
             else -> Color.Unspecified
         }
 
-        if (icon != null) {
-            Icon(
-                imageVector = icon,
-                contentDescription = null,
-                modifier = Modifier.size(iconSize),
-                tint = tint,
-            )
-        } else if (iconPainter != null) {
-            Icon(
-                painter = iconPainter,
-                contentDescription = null,
-                modifier = Modifier.size(iconSize),
-                tint = tint,
-            )
-        }
-
-        Column(
-            modifier = Modifier
-                .weight(1f)
-                .padding(start = if (hasIcon) 16.dp else 0.dp),
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
         ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Text(
-                    text = title,
-                    style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = FontWeight.Normal,
-                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = contentAlpha),
-                    // Only constrain the title when a badge needs to sit beside it; ungated
-                    // rows keep their original wrap behavior.
-                    maxLines = if (requiresUpgrade) 1 else Int.MAX_VALUE,
-                    overflow = if (requiresUpgrade) TextOverflow.Ellipsis else TextOverflow.Clip,
-                    modifier = if (requiresUpgrade) Modifier.weight(1f, fill = false) else Modifier,
+            if (icon != null) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    modifier = Modifier.size(iconSize),
+                    tint = tint,
                 )
-                if (requiresUpgrade) {
-                    Spacer(Modifier.width(6.dp))
-                    UpgradeBadge()
+            } else if (iconPainter != null) {
+                Icon(
+                    painter = iconPainter,
+                    contentDescription = null,
+                    modifier = Modifier.size(iconSize),
+                    tint = tint,
+                )
+            }
+
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(start = if (hasIcon) 16.dp else 0.dp),
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.Normal,
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = contentAlpha),
+                        // Only constrain the title when a badge needs to sit beside it; ungated
+                        // rows keep their original wrap behavior.
+                        maxLines = if (requiresUpgrade) 1 else Int.MAX_VALUE,
+                        overflow = if (requiresUpgrade) TextOverflow.Ellipsis else TextOverflow.Clip,
+                        modifier = if (requiresUpgrade) Modifier.weight(1f, fill = false) else Modifier,
+                    )
+                    if (requiresUpgrade) {
+                        Spacer(Modifier.width(6.dp))
+                        UpgradeBadge()
+                    }
+                }
+                if (subtitle != null) {
+                    Text(
+                        text = subtitle,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f * contentAlpha),
+                        modifier = Modifier.padding(top = 2.dp),
+                    )
                 }
             }
-            if (subtitle != null) {
-                Text(
-                    text = subtitle,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f * contentAlpha),
-                    modifier = Modifier.padding(top = 2.dp),
-                )
-            }
+
+            trailingContent?.invoke()
         }
 
-        trailingContent?.invoke()
+        if (content != null) {
+            Spacer(Modifier.height(12.dp))
+            content()
+        }
     }
 }
 

--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/settings/SettingsSwitchItem.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/settings/SettingsSwitchItem.kt
@@ -25,6 +25,7 @@ fun SettingsSwitchItem(
     requiresUpgrade: Boolean = false,
     onUpgrade: () -> Unit = {},
     focusKey: String? = null,
+    content: @Composable (() -> Unit)? = null,
 ) {
     SettingsBaseItem(
         icon = icon,
@@ -36,6 +37,7 @@ fun SettingsSwitchItem(
         subtitle = subtitle,
         enabled = enabled,
         requiresUpgrade = requiresUpgrade,
+        content = content,
         trailingContent = {
             Switch(
                 checked = checked,

--- a/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/settings/DeduplicatorSettingsScreen.kt
+++ b/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/settings/DeduplicatorSettingsScreen.kt
@@ -174,6 +174,11 @@ internal fun DeduplicatorSettingsScreen(
                     subtitle = stringResource(R.string.deduplicator_detection_method_phash_summary),
                     checked = state.isSleuthPHashEnabled,
                     onCheckedChange = onSleuthPHashChanged,
+                    content = if (state.isSleuthPHashEnabled) {
+                        { DetectionCaveatCard() }
+                    } else {
+                        null
+                    },
                 )
             }
             item {
@@ -183,6 +188,11 @@ internal fun DeduplicatorSettingsScreen(
                     subtitle = stringResource(R.string.deduplicator_detection_method_media_summary),
                     checked = state.isSleuthMediaEnabled,
                     onCheckedChange = onSleuthMediaChanged,
+                    content = if (state.isSleuthMediaEnabled) {
+                        { DetectionCaveatCard() }
+                    } else {
+                        null
+                    },
                 )
             }
         }
@@ -201,6 +211,23 @@ private fun DeduplicatorSettingsScreenPreview() {
                 isSleuthChecksumEnabled = true,
                 isSleuthPHashEnabled = false,
                 isSleuthMediaEnabled = false,
+            ),
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun DeduplicatorSettingsScreenSimilarityPreview() {
+    PreviewWrapper {
+        DeduplicatorSettingsScreen(
+            state = DeduplicatorSettingsViewModel.State(
+                allowDeleteAll = false,
+                minSizeBytes = 2 * 1024L,
+                skipUncommon = true,
+                isSleuthChecksumEnabled = true,
+                isSleuthPHashEnabled = true,
+                isSleuthMediaEnabled = true,
             ),
         )
     }

--- a/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/settings/DetectionCaveatCard.kt
+++ b/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/settings/DetectionCaveatCard.kt
@@ -1,0 +1,60 @@
+package eu.darken.sdmse.deduplicator.ui.settings
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.Warning
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import eu.darken.sdmse.common.compose.preview.Preview2
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.deduplicator.R
+
+@Composable
+internal fun DetectionCaveatCard(modifier: Modifier = Modifier) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+            contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+        ),
+        shape = RoundedCornerShape(16.dp),
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = Icons.TwoTone.Warning,
+                contentDescription = null,
+                modifier = Modifier.size(24.dp),
+            )
+            Spacer(Modifier.width(12.dp))
+            Text(
+                text = stringResource(R.string.deduplicator_detection_method_similarity_caveat),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+    }
+}
+
+@Preview2
+@Composable
+private fun DetectionCaveatCardPreview() {
+    PreviewWrapper {
+        DetectionCaveatCard()
+    }
+}

--- a/app-tool-deduplicator/src/main/res/values/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values/strings.xml
@@ -21,9 +21,10 @@
     <string name="deduplicator_detection_method_checksum_title">Content checksum</string>
     <string name="deduplicator_detection_method_checksum_summary">Determine duplicates by calculating checksums for files. Files with matching checksums have the exact same content.</string>
     <string name="deduplicator_detection_method_phash_title">Perceptual hash</string>
-    <string name="deduplicator_detection_method_phash_summary">Find similar files by analyzing content features and comparing perceptual hash values. ⚠️ Similarity-based detection may include false positives requiring manual verification.</string>
+    <string name="deduplicator_detection_method_phash_summary">Find similar files by analyzing content features and comparing perceptual hash values.</string>
     <string name="deduplicator_detection_method_media_title">Media fingerprint</string>
-    <string name="deduplicator_detection_method_media_summary">Find similar video and audio files by analyzing audio fingerprints. ⚠️ Similarity-based detection may include false positives requiring manual verification.</string>
+    <string name="deduplicator_detection_method_media_summary">Find similar video and audio files by analyzing audio fingerprints.</string>
+    <string name="deduplicator_detection_method_similarity_caveat">Similarity-based detection may include false positives requiring manual verification.</string>
     <string name="deduplicator_media_match_audio">Audio-based match</string>
     <string name="deduplicator_media_match_visual">Video-based match</string>
     <string name="deduplicator_media_match_audio_visual">Audio and video-based match</string>


### PR DESCRIPTION
## What changed

In the Deduplicator settings, the two similarity-based detection methods — Perceptual hash and Media fingerprint — used to bury a warning about possible false positives at the end of their description text, repeated word-for-word in both. That warning now appears as a distinct highlighted box inside the setting, and only while that method is turned on, so it's easier to notice and no longer duplicated across descriptions.

## Technical Context

- The caveat sentence was duplicated inside both method summary strings; it's extracted to a single `deduplicator_detection_method_similarity_caveat` string. Existing locale translations still carry the old inline caveat until Crowdin re-syncs the shortened English sources — a known, temporary mismatch for non-English users.
- The caveat is co-located **inside** each method's setting cell rather than as a separate list item, so toggling the switch reveals it in the same viewport (an earlier bottom-of-list placement was easy to miss without scrolling).
- `SettingsBaseItem` gained an optional below-content slot; its root is now a `Column` wrapping the original row. With the slot unused it renders identically, so other settings screens are unaffected.
- The box uses `tertiaryContainer`, matching the existing advisory hint-card convention (e.g. the Scheduler battery/ACS hints).
- Verified on a Pixel 7a: box appears per enabled method, disappears when disabled.
