### PR TITLE
AppControl: Fix force-stop opening the uninstall dialog by mistake

### DIFF
--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/common/stepper/StepperExtensions.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/common/stepper/StepperExtensions.kt
@@ -188,6 +188,58 @@ suspend fun StepContext.findNearestTo(
     return nearestNode
 }
 
+/**
+ * Finds the clickable node that visually *owns* [label] in a row of icon+label action buttons
+ * (e.g. the AOSP App-Info top action row: Archive / Uninstall / Force stop). On Android 15+ the
+ * icon and label are separate, unclickable nodes and the tappable wrapper is a sibling; picking
+ * the merely-nearest clickable ([findNearestTo]) would grab an adjacent action (e.g. the Uninstall
+ * button for a Force-stop label). This restricts the match to a clickable that sits in the SAME
+ * column as the label: it horizontally contains the label's center-X, is vertically related to the
+ * label (overlapping it, or directly above/below within ~2 label-heights — covering both the
+ * icon-over-label grid and the button-over-text list layouts), and is not wide enough to span
+ * multiple action columns.
+ *
+ * Returns null when no such clickable exists. On this action row a button exposes a clickable
+ * wrapper only while enabled, so absence usually means the action is disabled — callers decide
+ * what that means.
+ */
+suspend fun StepContext.findColumnAlignedClickable(
+    label: ACSNodeInfo,
+    maxNesting: Int = 3,
+): ACSNodeInfo? {
+    val labelBounds = label.getScreenBounds()
+    if (labelBounds.isEmpty()) {
+        log(tag, WARN) { "findColumnAlignedClickable: label bounds empty/degenerate: $label" }
+        return null
+    }
+    val labelCenterX = (labelBounds.left + labelBounds.right) / 2
+    val labelHeight = labelBounds.bottom - labelBounds.top
+    // A single action cell is well under half the row width; reject a full-width clickable that
+    // would span several columns (and thus horizontally contain multiple action labels).
+    val maxTargetWidth = host.windowRoot()?.getScreenBounds()
+        ?.let { it.right - it.left }
+        ?.takeIf { it > 0 }
+        ?.let { it / 2 }
+        ?: Int.MAX_VALUE
+
+    return findNearestTo(maxNesting = maxNesting, node = label) { candidate ->
+        if (!candidate.isClickable) return@findNearestTo false
+        val b = candidate.getScreenBounds()
+        if (b.isEmpty()) return@findNearestTo false
+        val containsCenterX = labelCenterX in b.left until b.right
+        // Same cell: the wrapper overlaps the label, or sits directly above/below it. The layout
+        // varies (grid cell spanning icon+label vs. a button stacked over its text), so accept both
+        // overlap and tight adjacency. Full-width rows that happen to be adjacent are excluded by
+        // the width cap below.
+        val overlapsY = b.top < labelBounds.bottom && b.bottom > labelBounds.top
+        val adjacentAbove = (labelBounds.top - b.bottom) in 0..(2 * labelHeight)
+        val adjacentBelow = (b.top - labelBounds.bottom) in 0..(2 * labelHeight)
+        val verticallyRelated = overlapsY || adjacentAbove || adjacentBelow
+        val singleColumn = (b.right - b.left) <= maxTargetWidth
+        containsCenterX && verticallyRelated && singleColumn
+    }
+}
+
 fun StepContext.clickNormal(
     isDryRun: Boolean = false,
     node: ACSNodeInfo,

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/aosp/AOSPSpecs.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/aosp/AOSPSpecs.kt
@@ -8,13 +8,14 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.appcontrol.core.automation.specs.AppControlSpecGenerator
 import eu.darken.sdmse.automation.core.common.crawl
+import eu.darken.sdmse.automation.core.common.isEmpty
 import eu.darken.sdmse.automation.core.common.pkgId
 import eu.darken.sdmse.automation.core.common.stepper.AutomationStep
 import eu.darken.sdmse.automation.core.common.stepper.StepContext
 import eu.darken.sdmse.automation.core.common.stepper.Stepper
 import eu.darken.sdmse.automation.core.common.stepper.clickNormal
 import eu.darken.sdmse.automation.core.common.stepper.findClickableParent
-import eu.darken.sdmse.automation.core.common.stepper.findNearestTo
+import eu.darken.sdmse.automation.core.common.stepper.findColumnAlignedClickable
 import eu.darken.sdmse.automation.core.common.stepper.findNode
 import eu.darken.sdmse.automation.core.common.textMatchesAny
 import eu.darken.sdmse.automation.core.specs.AutomationExplorer
@@ -95,12 +96,24 @@ class AOSPSpecs @Inject constructor(
 
                 var target = findClickableParent(maxNesting = 3, includeSelf = true, node = candidate)
 
-                // Seen on Pixel 8 with Android 16 (beta)
-                // Force stop may consist of a button (no text)) and a textview (unclickable), same layout as everything else
+                // Android 15+: the action button's icon and label are separate, unclickable nodes;
+                // the tappable wrapper is a sibling (seen on Pixel 8 / Android 16 beta). Match ONLY
+                // a clickable in the SAME column as the label, so we never grab an adjacent action
+                // such as Uninstall.
                 if (target == null && hasApiLevel(35)) {
                     log(TAG, WARN) { "No clickable parent found for $candidate" }
-                    target = findNearestTo(node = candidate) { it.isClickable }
-                    if (target != null) log(TAG, INFO) { "Clickable sibling found: $target" }
+                    target = findColumnAlignedClickable(candidate)
+                    if (target != null) {
+                        log(TAG, INFO) { "Column-aligned clickable found: $target" }
+                    } else if (!candidate.getScreenBounds().isEmpty()) {
+                        // On this action row a button is clickable iff enabled. A well-bounded Force
+                        // stop label with no column-aligned clickable therefore means the button is
+                        // disabled -> the app is already stopped. Bail cleanly instead of clicking a
+                        // neighbouring action.
+                        log(TAG, WARN) { "No Force stop button in its column, treating as already-stopped: $candidate" }
+                        wasDisabled = true
+                        return@action true
+                    }
                 }
 
                 if (target == null) {
@@ -179,13 +192,19 @@ class AOSPSpecs @Inject constructor(
 
                 var target = findClickableParent(maxNesting = 3, includeSelf = true, node = candidate)
 
+                // Android 15+: icon and label are separate, unclickable nodes; the tappable wrapper
+                // is a sibling. Match only a clickable in the label's own column so we never grab an
+                // adjacent action.
                 if (target == null && hasApiLevel(35)) {
                     log(TAG, WARN) { "No clickable parent found for $candidate" }
-                    target = findNearestTo(node = candidate) { it.isClickable }
-                    if (target != null) log(TAG, INFO) { "Clickable sibling found: $target" }
+                    target = findColumnAlignedClickable(candidate)
+                    if (target != null) log(TAG, INFO) { "Column-aligned clickable found: $target" }
                 }
 
                 if (target == null) {
+                    // Unlike force-stop, a missing Archive button is not a success state. Return false
+                    // so the step retries and ultimately fails honestly rather than reporting a no-op
+                    // success (which the caller would only discover after the archive-verify timeout).
                     log(TAG, WARN) { "No clickable target found for $candidate" }
                     return@action false
                 }
@@ -231,13 +250,19 @@ class AOSPSpecs @Inject constructor(
 
                 var target = findClickableParent(maxNesting = 3, includeSelf = true, node = candidate)
 
+                // Android 15+: icon and label are separate, unclickable nodes; the tappable wrapper
+                // is a sibling. Match only a clickable in the label's own column so we never grab an
+                // adjacent action.
                 if (target == null && hasApiLevel(35)) {
                     log(TAG, WARN) { "No clickable parent found for $candidate" }
-                    target = findNearestTo(node = candidate) { it.isClickable }
-                    if (target != null) log(TAG, INFO) { "Clickable sibling found: $target" }
+                    target = findColumnAlignedClickable(candidate)
+                    if (target != null) log(TAG, INFO) { "Column-aligned clickable found: $target" }
                 }
 
                 if (target == null) {
+                    // Unlike force-stop, a missing Restore button is not a success state. Return false
+                    // so the step retries and ultimately fails honestly rather than reporting a no-op
+                    // success (which the caller would only discover after the restore-verify timeout).
                     log(TAG, WARN) { "No clickable target found for $candidate" }
                     return@action false
                 }

--- a/app/src/test/java/eu/darken/sdmse/appcontrol/core/automation/specs/aosp/AOSPSpecsTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcontrol/core/automation/specs/aosp/AOSPSpecsTest.kt
@@ -1,0 +1,194 @@
+package eu.darken.sdmse.appcontrol.core.automation.specs.aosp
+
+import android.graphics.Rect
+import eu.darken.sdmse.automation.core.common.ACSNodeInfo
+import eu.darken.sdmse.automation.core.common.stepper.AutomationStep
+import eu.darken.sdmse.automation.core.common.stepper.StepContext
+import eu.darken.sdmse.automation.core.common.stepper.Stepper
+import eu.darken.sdmse.automation.core.specs.AutomationExplorer
+import eu.darken.sdmse.automation.core.specs.AutomationSpec
+import eu.darken.sdmse.common.device.DeviceDetective
+import eu.darken.sdmse.common.funnel.IPCFunnel
+import eu.darken.sdmse.common.hasApiLevel
+import eu.darken.sdmse.common.pkgs.features.InstallId
+import eu.darken.sdmse.common.pkgs.features.Installed
+import eu.darken.sdmse.common.pkgs.toPkgId
+import eu.darken.sdmse.common.progress.Progress
+import eu.darken.sdmse.common.user.UserHandle2
+import eu.darken.sdmse.main.core.GeneralSettings
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestACSNodeInfo
+import testhelpers.TestApplication
+import testhelpers.automation.TestAutomationHost
+
+/**
+ * Regression coverage for the AOSP force-stop plan on the Android 15+ App-Info action row, where
+ * each action button is an icon + label pair and only the *enabled* buttons expose a clickable
+ * wrapper. When Force stop is disabled (app already stopped) the old fallback grabbed the nearest
+ * clickable — the Uninstall button — and opened the "Uninstall this app?" dialog.
+ *
+ * Robolectric so `android.graphics.Rect` (node bounds) actually works — the geometry is the point.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class AOSPSpecsTest : BaseTest() {
+
+    private lateinit var ipcFunnel: IPCFunnel
+    private lateinit var deviceDetective: DeviceDetective
+    private lateinit var generalSettings: GeneralSettings
+    private lateinit var stepper: Stepper
+    private lateinit var labels: AOSPLabels
+
+    @Before
+    fun setup() {
+        ipcFunnel = mockk(relaxed = true)
+        deviceDetective = mockk(relaxed = true)
+        generalSettings = mockk(relaxed = true)
+        stepper = mockk(relaxed = true)
+        labels = mockk {
+            every { getForceStopButtonDynamic(any()) } returns setOf("Force stop", "Beenden erzwingen")
+            every { getForceStopDialogTitleDynamic(any()) } returns emptySet()
+            every { getForceStopDialogOkDynamic(any()) } returns setOf("OK")
+            every { getForceStopDialogCancelDynamic(any()) } returns setOf("Cancel")
+        }
+        // Android 15+ split action-row layout (Robolectric SDK is 33, so mock the level check).
+        mockkStatic(::hasApiLevel)
+        every { hasApiLevel(any()) } answers { firstArg<Int>() <= 35 }
+    }
+
+    @After
+    fun cleanup() {
+        // BaseTest's JUnit5 @AfterAll does not run under JUnit4/Robolectric.
+        unmockkAll()
+    }
+
+    private fun createSpec() = AOSPSpecs(
+        ipcFunnel = ipcFunnel,
+        deviceDetective = deviceDetective,
+        aospLabels = labels,
+        generalSettings = generalSettings,
+        stepper = stepper,
+    )
+
+    private fun createTestPkg(packageName: String = "com.superthomaslab.hueessentials"): Installed = mockk {
+        every { installId } returns InstallId(
+            pkgId = packageName.toPkgId(),
+            userHandle = mockk<UserHandle2> { every { handleId } returns 0 },
+        )
+        every { this@mockk.packageName } returns packageName
+        every { id } returns packageName.toPkgId()
+    }
+
+    private fun testContext(scope: TestScope, root: TestACSNodeInfo): AutomationExplorer.Context {
+        val testHost = TestAutomationHost(scope).apply { setWindowRoot(root) }
+        return object : AutomationExplorer.Context {
+            override val host get() = testHost
+            override val progress = emptyFlow<Progress.Data?>()
+            override fun updateProgress(update: (Progress.Data?) -> Progress.Data?) {}
+        }
+    }
+
+    /**
+     * Runs the real force-stop plan, executing only the "Force stop button" step's nodeAction
+     * against [context]. Returns the descriptions of every step handed to the stepper (so callers
+     * can assert whether the confirmation step was reached).
+     */
+    private suspend fun runForceStopPlan(context: AutomationExplorer.Context, pkg: Installed): List<String> {
+        val processed = mutableListOf<String>()
+        coEvery { stepper.process(any(), any()) } coAnswers {
+            val step = secondArg<AutomationStep>()
+            processed += step.descriptionInternal
+            if (step.descriptionInternal.startsWith("Force stop button")) {
+                val stepContext = StepContext(hostContext = context, tag = "test", stepAttempts = 0)
+                step.nodeAction?.let { action ->
+                    for (i in 0 until 5) {
+                        if (action.invoke(stepContext)) break
+                    }
+                }
+            }
+            Unit
+        }
+
+        val plan = (createSpec().getForceStop(pkg) as AutomationSpec.Explorer).createPlan()
+        plan.invoke(context)
+        return processed
+    }
+
+    /** Uninstall is the only clickable in this row (Force stop disabled -> no clickable wrapper). */
+    private fun disabledForceStopRow(): Pair<TestACSNodeInfo, TestACSNodeInfo> {
+        val root = TestACSNodeInfo(viewIdResourceName = "root", packageName = "com.android.settings", bounds = Rect(0, 0, 960, 2142))
+        val row = TestACSNodeInfo(viewIdResourceName = "row", bounds = Rect(0, 600, 960, 900))
+        val uninstall = TestACSNodeInfo(viewIdResourceName = "uninstall", isClickable = true, bounds = Rect(332, 649, 628, 828))
+        val fsLabel = TestACSNodeInfo(text = "Force stop", viewIdResourceName = "fs_label", bounds = Rect(646, 789, 906, 873))
+        row.addChildren(uninstall, fsLabel)
+        root.addChild(row)
+        return root to uninstall
+    }
+
+    @Test
+    fun `force stop on already-stopped app does not click Uninstall and skips confirmation`() = runTest {
+        val (root, uninstall) = disabledForceStopRow()
+        val context = testContext(this, root)
+
+        val processed = runForceStopPlan(context, createTestPkg())
+
+        // The Uninstall button must never be clicked.
+        uninstall.performedActions shouldBe emptyList()
+        // Only the force-stop step runs; the confirmation step is skipped (button was disabled).
+        processed.size shouldBe 1
+        processed.single().startsWith("Force stop button") shouldBe true
+    }
+
+    @Test
+    fun `force stop clicks the column-aligned force-stop button, not the Uninstall neighbour`() = runTest {
+        val root = TestACSNodeInfo(viewIdResourceName = "root", packageName = "com.android.settings", bounds = Rect(0, 0, 960, 2142))
+        val row = TestACSNodeInfo(viewIdResourceName = "row", bounds = Rect(0, 600, 960, 900))
+        val uninstall = TestACSNodeInfo(viewIdResourceName = "uninstall", isClickable = true, bounds = Rect(332, 649, 628, 828))
+        val fsClickable = TestACSNodeInfo(viewIdResourceName = "fs_clickable", isClickable = true, bounds = Rect(646, 649, 906, 828))
+        val fsLabel = TestACSNodeInfo(text = "Force stop", viewIdResourceName = "fs_label", bounds = Rect(646, 789, 906, 873))
+        row.addChildren(uninstall, fsClickable, fsLabel)
+        root.addChild(row)
+        val context = testContext(this, root)
+
+        val processed = runForceStopPlan(context, createTestPkg())
+
+        fsClickable.performedActions shouldBe listOf(ACSNodeInfo.ACTION_CLICK)
+        uninstall.performedActions shouldBe emptyList()
+        // Force stop was clicked -> the confirmation step is reached.
+        processed.size shouldBe 2
+        processed[1].startsWith("Confirm force stop button") shouldBe true
+    }
+
+    @Test
+    fun `force stop clicks an enabled button stacked above its label (not treated as disabled)`() = runTest {
+        // "Button over text" layout: an ENABLED Force stop button sits directly above its
+        // non-overlapping label. Must be clicked, NOT misreported as already-stopped.
+        val root = TestACSNodeInfo(viewIdResourceName = "root", packageName = "com.android.settings", bounds = Rect(0, 0, 1080, 2400))
+        val fsClickable = TestACSNodeInfo(viewIdResourceName = "fs_clickable", isClickable = true, bounds = Rect(691, 959, 869, 1098))
+        val fsLabel = TestACSNodeInfo(text = "Force stop", viewIdResourceName = "fs_label", bounds = Rect(628, 1113, 931, 1181))
+        val action = TestACSNodeInfo(viewIdResourceName = "action", bounds = Rect(540, 900, 1020, 1240))
+        action.addChildren(fsClickable, fsLabel)
+        root.addChild(action)
+        val context = testContext(this, root)
+
+        val processed = runForceStopPlan(context, createTestPkg())
+
+        fsClickable.performedActions shouldBe listOf(ACSNodeInfo.ACTION_CLICK)
+        processed.size shouldBe 2
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/automation/core/common/stepper/StepperExtensionsBoundsTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/automation/core/common/stepper/StepperExtensionsBoundsTest.kt
@@ -2,8 +2,12 @@ package eu.darken.sdmse.automation.core.common.stepper
 
 import android.graphics.Rect
 import eu.darken.sdmse.automation.core.specs.AutomationExplorer
+import eu.darken.sdmse.common.progress.Progress
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
 import io.mockk.mockk
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -12,6 +16,7 @@ import org.robolectric.annotation.Config
 import testhelpers.BaseTest
 import testhelpers.TestACSNodeInfo
 import testhelpers.TestApplication
+import testhelpers.automation.TestAutomationHost
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [29], application = TestApplication::class)
@@ -179,6 +184,103 @@ class StepperExtensionsBoundsTest : BaseTest() {
         val result = context.findNearestTo(maxNesting = 2, node = targetNode)
 
         result shouldBe distantSibling
+    }
+
+    // ============================================================
+    // findColumnAlignedClickable - AOSP App-Info action row geometry
+    // ============================================================
+
+    /** Builds a StepContext whose host reports [root] as the window root (needed for the width cap). */
+    private fun TestScope.contextWithRoot(root: TestACSNodeInfo): StepContext {
+        val testHost = TestAutomationHost(this).apply { setWindowRoot(root) }
+        val context = object : AutomationExplorer.Context {
+            override val host get() = testHost
+            override val progress = emptyFlow<Progress.Data?>()
+            override fun updateProgress(update: (Progress.Data?) -> Progress.Data?) {}
+        }
+        return StepContext(hostContext = context, tag = "test", stepAttempts = 0)
+    }
+
+    // Real geometry from the reported AOSP action row (960px-wide window): Force stop label
+    // center-X ≈ 776; the only clickable is the Uninstall cell at x[332,628].
+
+    @Test
+    fun `findColumnAlignedClickable returns null when only a neighbouring action is clickable`() = runTest {
+        // Force stop disabled -> no clickable in its column; the nearest clickable is the Uninstall
+        // cell, which must NOT be matched (that was the Uninstall-instead-of-force-stop bug).
+        val root = TestACSNodeInfo(viewIdResourceName = "root", bounds = Rect(0, 0, 960, 2142))
+        val row = TestACSNodeInfo(viewIdResourceName = "row", bounds = Rect(0, 600, 960, 900))
+        val uninstall = TestACSNodeInfo(viewIdResourceName = "uninstall", isClickable = true, bounds = Rect(332, 649, 628, 828))
+        val fsLabel = TestACSNodeInfo(text = "Force stop", viewIdResourceName = "fs_label", bounds = Rect(646, 789, 906, 873))
+        row.addChildren(uninstall, fsLabel)
+        root.addChild(row)
+
+        val context = contextWithRoot(root)
+
+        context.findColumnAlignedClickable(fsLabel) shouldBe null
+    }
+
+    @Test
+    fun `findColumnAlignedClickable returns the same-column clickable, not the neighbour`() = runTest {
+        // Force stop enabled -> its own clickable wrapper sits in the label's column.
+        val root = TestACSNodeInfo(viewIdResourceName = "root", bounds = Rect(0, 0, 960, 2142))
+        val row = TestACSNodeInfo(viewIdResourceName = "row", bounds = Rect(0, 600, 960, 900))
+        val uninstall = TestACSNodeInfo(viewIdResourceName = "uninstall", isClickable = true, bounds = Rect(332, 649, 628, 828))
+        val fsClickable = TestACSNodeInfo(viewIdResourceName = "fs_clickable", isClickable = true, bounds = Rect(646, 649, 906, 828))
+        val fsLabel = TestACSNodeInfo(text = "Force stop", viewIdResourceName = "fs_label", bounds = Rect(646, 789, 906, 873))
+        row.addChildren(uninstall, fsClickable, fsLabel)
+        root.addChild(row)
+
+        val context = contextWithRoot(root)
+
+        context.findColumnAlignedClickable(fsLabel) shouldBeSameInstanceAs fsClickable
+    }
+
+    @Test
+    fun `findColumnAlignedClickable matches a clickable stacked directly above the label`() = runTest {
+        // Android 16 "button over text" layout: the clickable Button sits above its non-overlapping
+        // label TextView in the same column (real shape from the clear-cache action row).
+        val root = TestACSNodeInfo(viewIdResourceName = "root", bounds = Rect(0, 0, 1080, 2400))
+        val action = TestACSNodeInfo(viewIdResourceName = "action", bounds = Rect(540, 900, 1020, 1240))
+        val button = TestACSNodeInfo(viewIdResourceName = "button", isClickable = true, bounds = Rect(691, 959, 869, 1098))
+        val label = TestACSNodeInfo(text = "Force stop", viewIdResourceName = "label", bounds = Rect(628, 1113, 931, 1181))
+        action.addChildren(button, label)
+        root.addChild(action)
+
+        val context = contextWithRoot(root)
+
+        context.findColumnAlignedClickable(label) shouldBeSameInstanceAs button
+    }
+
+    @Test
+    fun `findColumnAlignedClickable rejects a full-width clickable row below the action grid`() = runTest {
+        // A full-width settings row below the grid horizontally contains the label center but does
+        // not vertically overlap it (and spans multiple columns) -> must be rejected.
+        val root = TestACSNodeInfo(viewIdResourceName = "root", bounds = Rect(0, 0, 960, 2142))
+        val row = TestACSNodeInfo(viewIdResourceName = "row", bounds = Rect(0, 600, 960, 1100))
+        val fsLabel = TestACSNodeInfo(text = "Force stop", viewIdResourceName = "fs_label", bounds = Rect(646, 789, 906, 873))
+        val notifRow = TestACSNodeInfo(viewIdResourceName = "notif", isClickable = true, bounds = Rect(36, 907, 924, 1069))
+        row.addChildren(fsLabel, notifRow)
+        root.addChild(row)
+
+        val context = contextWithRoot(root)
+
+        context.findColumnAlignedClickable(fsLabel) shouldBe null
+    }
+
+    @Test
+    fun `findColumnAlignedClickable returns null for empty label bounds`() = runTest {
+        val root = TestACSNodeInfo(viewIdResourceName = "root", bounds = Rect(0, 0, 960, 2142))
+        val row = TestACSNodeInfo(viewIdResourceName = "row", bounds = Rect(0, 600, 960, 900))
+        val uninstall = TestACSNodeInfo(viewIdResourceName = "uninstall", isClickable = true, bounds = Rect(332, 649, 628, 828))
+        // Degenerate/clipped label (left >= right): geometry is meaningless -> no match.
+        val fsLabel = TestACSNodeInfo(text = "Force stop", viewIdResourceName = "fs_label", bounds = Rect(646, 789, 646, 789))
+        row.addChildren(uninstall, fsLabel)
+        root.addChild(row)
+
+        val context = contextWithRoot(root)
+
+        context.findColumnAlignedClickable(fsLabel) shouldBe null
     }
 
     @Test


### PR DESCRIPTION
## What changed

Fixed a bug where using **Force stop** in AppControl on an app that was *already stopped* would pop up the "Uninstall this app?" dialog instead, and the progress card would then hang at 0%.

On recent Android versions the App-Info screen shows the actions (Archive / Uninstall / Force stop) as a row of icon buttons. When an app is already stopped, the Force-stop button is greyed out — and the automation was mistakenly reaching for the neighbouring Uninstall button. It now recognises that Force stop isn't available (the app is already stopped) and simply finishes, without touching any other button.

Archive and Restore on these screens are more robust for the same reason and no longer risk hitting the wrong action.

## Technical Context

- **Root cause:** on the Android 15+ App-Info action row each button is an icon + a separate, unclickable label, and a button only exposes a clickable node while *enabled*. A disabled Force stop has no clickable node, so the previous fallback (`findNearestTo { isClickable }`) selected the nearest clickable by raw distance — the enabled Uninstall button — and clicked it. The confirm step then waited for a force-stop dialog title that never appeared, so it stalled.
- **Why absence-of-clickable is the signal:** the accessibility `enabled` flag is unreliable here — the debug log shows `enabled=true` on the label/icon of a functionally-disabled Force stop button — so the structural fact "no clickable wrapper in this column" is what distinguishes disabled from enabled.
- **Fix:** new `findColumnAlignedClickable(label)` matches only a clickable in the label's own column (contains its center-X, vertically overlapping **or** directly adjacent, not wide enough to span multiple columns). This covers both the icon-over-label grid *and* the button-over-text list layouts, so an adjacent action can never be selected. Force-stop treats "well-bounded label, no column-aligned clickable" as already-stopped and bails; archive/restore return `false` on a missing button so the step retries and fails honestly rather than reporting a no-op success (which would only surface after the archive/restore verification timeout).
- **Review guidance:** the geometry predicate lives in `app-common-automation` `StepperExtensions.kt`; the per-action decisions (disabled-bail vs. retry) are in `AOSPSpecs.kt`. `AOSPSpecsTest` drives the *real* force-stop plan through a stepper intercept and asserts the Uninstall node receives no click — it must run under Robolectric so `android.graphics.Rect` (node bounds) is functional.
- **Known limitation:** the "not multiple columns" width guard is derived from the whole window width, so on tablets / split-screen Settings a pane-wide clickable could theoretically pass it; the center-X + vertical-adjacency checks are the primary guards.
