### PR TITLE
General: Update Jetpack Compose to the latest version

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -164,8 +164,7 @@ fun DependencyHandlerScope.addCompose() {
     androidTestImplementation(composeBom)
     testImplementation(composeBom)
 
-    // Override foundation to get Modifier.visible()
-    implementation("androidx.compose.foundation:foundation:${Versions.AndroidX.Compose.foundationOverride}")
+    implementation("androidx.compose.foundation:foundation")
 
     implementation("androidx.compose.material3:material3")
     implementation("androidx.compose.ui:ui-tooling-preview")

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -15,8 +15,7 @@ object Versions {
         }
 
         object Compose {
-            const val bom = "2025.12.00"
-            const val foundationOverride = "1.11.0-alpha01"
+            const val bom = "2026.06.00"
         }
 
         object Glance {


### PR DESCRIPTION
## What changed

No user-facing behavior change. Updates Jetpack Compose to the current stable release and removes an unused, out-of-band version pin.

## Technical Context

- Bumps the Compose BOM `2025.12.00` → `2026.06.00` and deletes the `foundation` override that pinned `androidx.compose.foundation` to `1.11.0-alpha01`.
- The override existed to expose `Modifier.visible()` (per its comment), but that API has **zero call sites** — it was carried over from the sibling project during the Compose rewrite bootstrap and never used.
- The pin left `foundation` a full minor version ahead of the rest of the stack (runtime/ui/material3 were on the `1.10.0` train under the old BOM). Foundation and runtime share snapshot machinery, so the skew was a suspect for a layoutlib `IndexOutOfBoundsException` in `advanceGlobalSnapshot` when rendering Compose **dialog previews**. The new BOM ships `foundation 1.11.x` as a coordinated stable version, removing the skew.
- Compiles cleanly against the new foundation/runtime with the existing Kotlin `2.2.10` Compose compiler (`assembleFossDebug` green).

## Review guidance

- Draft: the preview-render fix is **not yet confirmed** in the IDE — the crash is a layoutlib (Android Studio-bundled) render-time issue, and a green build can't verify it. This PR stands on its own as a Compose modernization + removal of a dead alpha pin regardless of that outcome. Mark ready once the preview render is confirmed (or after deciding the modernization is worth landing independently).
