### PR TITLE
General: Confirm before the home-screen widget deletes in one tap

### DIFF
--- a/app-common-data/src/main/java/eu/darken/sdmse/main/core/GeneralSettings.kt
+++ b/app-common-data/src/main/java/eu/darken/sdmse/main/core/GeneralSettings.kt
@@ -67,6 +67,13 @@ class GeneralSettings @Inject constructor(
     val oneClickDeduplicatorEnabled = dataStore.createValue("dashboard.oneclick.deduplicator.enabled", false)
     val shortcutOneClickEnabled = dataStore.createValue("shortcut.oneclick.enabled", false)
 
+    // Home-screen widget "Clean" one-tap consent. The widget's Clean button never scan+deletes
+    // without opt-in: [widgetOneClickEnabled] must be on. [widgetOneClickConsentAsked] records
+    // that the one-time in-app consent prompt has been shown (so it never reappears), regardless
+    // of the user's answer or a later manual toggle.
+    val widgetOneClickEnabled = dataStore.createValue("widget.oneclick.enabled", false)
+    val widgetOneClickConsentAsked = dataStore.createValue("widget.oneclick.consent.asked", false)
+
     val isUpdateCheckEnabled = dataStore.createValue("updater.check.enabled", updateChecker.isEnabledByDefault())
 
     val romTypeDetection = dataStore.createValue("core.romtype.detection", RomType.AUTO, json)

--- a/app/src/main/java/eu/darken/sdmse/main/core/shortcuts/OneTapCleaner.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/core/shortcuts/OneTapCleaner.kt
@@ -1,0 +1,157 @@
+package eu.darken.sdmse.main.core.shortcuts
+
+import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerOneClickTask
+import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerScanTask
+import eu.darken.sdmse.common.datastore.value
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.upgrade.UpgradeRepo
+import eu.darken.sdmse.common.upgrade.isProForUi
+import eu.darken.sdmse.corpsefinder.core.tasks.CorpseFinderOneClickTask
+import eu.darken.sdmse.corpsefinder.core.tasks.CorpseFinderScanTask
+import eu.darken.sdmse.deduplicator.core.tasks.DeduplicatorOneClickTask
+import eu.darken.sdmse.deduplicator.core.tasks.DeduplicatorScanTask
+import eu.darken.sdmse.main.core.GeneralSettings
+import eu.darken.sdmse.main.core.SDMTool
+import eu.darken.sdmse.main.core.taskmanager.TaskManager
+import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerOneClickTask
+import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerScanTask
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.job
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Shared execution of the "one-tap" (scan + delete) and scan-only cleaning runs. Extracted from
+ * [ShortcutActivity] so every entry point — launcher shortcut, home-screen widget, and the in-app
+ * widget-consent prompt — runs the *exact same* guarded logic: Pro gate, [OneTapRunGuard]
+ * single-flight, and per-tool cancellation handling.
+ *
+ * [runOneClick] must be invoked from a coroutine on a long-lived scope (e.g. `AppScope`), because
+ * [OneTapRunGuard] registers that coroutine's job so a widget "Cancel" can abort not-yet-submitted
+ * tools even after the caller UI is gone.
+ */
+@Singleton
+class OneTapCleaner @Inject constructor(
+    private val taskManager: TaskManager,
+    private val generalSettings: GeneralSettings,
+    private val upgradeRepo: UpgradeRepo,
+    private val oneTapRunGuard: OneTapRunGuard,
+) {
+
+    sealed interface Outcome {
+        /** Not a Pro user — the caller should route to the upgrade screen. */
+        data object NotPro : Outcome
+
+        /** No one-click tools are enabled — nothing to run. */
+        data object NothingEnabled : Outcome
+
+        /** A one-tap run is already in progress (single-flight) — the caller may open the app. */
+        data object AlreadyRunning : Outcome
+
+        /** The run started; since the submits suspend, it has finished by the time this returns. */
+        data object Ran : Outcome
+    }
+
+    /**
+     * Runs the guarded one-click scan + delete for every enabled tool. [onStarted] fires once the
+     * guard is acquired and before the (suspending) submits, so the caller can surface a "started"
+     * hint at the right moment. Suspends until the whole sequence completes.
+     */
+    suspend fun runOneClick(shortcutMode: Boolean, onStarted: suspend () -> Unit = {}): Outcome {
+        if (!upgradeRepo.isProForUi()) {
+            log(TAG, INFO) { "runOneClick(): requires Pro" }
+            return Outcome.NotPro
+        }
+
+        val corpseEnabled = generalSettings.oneClickCorpseFinderEnabled.value()
+        val systemEnabled = generalSettings.oneClickSystemCleanerEnabled.value()
+        val appCleanerEnabled = generalSettings.oneClickAppCleanerEnabled.value()
+        val deduplicatorEnabled = generalSettings.oneClickDeduplicatorEnabled.value()
+
+        if (!corpseEnabled && !systemEnabled && !appCleanerEnabled && !deduplicatorEnabled) {
+            log(TAG, INFO) { "runOneClick(): no one-tap tools enabled" }
+            return Outcome.NothingEnabled
+        }
+
+        // Single-flight: if a OneTap run is already in progress, don't stack another. Registering
+        // this coroutine's job lets a widget "Cancel" abort not-yet-submitted tools too.
+        if (!oneTapRunGuard.tryStart(currentCoroutineContext().job)) {
+            log(TAG, INFO) { "runOneClick(): already running" }
+            return Outcome.AlreadyRunning
+        }
+
+        try {
+            onStarted()
+            if (corpseEnabled) submitOneTapTask(CorpseFinderOneClickTask())
+            if (systemEnabled) submitOneTapTask(SystemCleanerOneClickTask())
+            if (appCleanerEnabled) submitOneTapTask(AppCleanerOneClickTask(shortcutMode = shortcutMode))
+            if (deduplicatorEnabled) submitOneTapTask(DeduplicatorOneClickTask())
+        } finally {
+            oneTapRunGuard.finish()
+        }
+        return Outcome.Ran
+    }
+
+    /**
+     * Submits a plain *scan* (no deletion) for every enabled one-click tool, so the dashboard can
+     * present the results for a normal confirmed delete. Best-effort per tool.
+     */
+    suspend fun runScanOnly() {
+        log(TAG, INFO) { "runScanOnly()" }
+        if (generalSettings.oneClickCorpseFinderEnabled.value()) submitScanTask(CorpseFinderScanTask())
+        if (generalSettings.oneClickSystemCleanerEnabled.value()) submitScanTask(SystemCleanerScanTask())
+        if (generalSettings.oneClickAppCleanerEnabled.value()) submitScanTask(AppCleanerScanTask())
+        if (generalSettings.oneClickDeduplicatorEnabled.value()) submitScanTask(DeduplicatorScanTask())
+    }
+
+    private suspend fun submitScanTask(task: SDMTool.Task) {
+        try {
+            currentCoroutineContext().ensureActive()
+            taskManager.submit(task)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG) { "Failed to submit scan ${task::class.simpleName}: $e" }
+        }
+    }
+
+    private suspend fun submitOneTapTask(task: SDMTool.Task) {
+        try {
+            // Don't queue a new task into an already-cancelled run: a cancel landing between two
+            // submits wouldn't stop submit() from registering the next task (TaskManager queues it
+            // inside a NonCancellable block before reaching a cancellable suspension).
+            currentCoroutineContext().ensureActive()
+            taskManager.submit(task)
+        } catch (e: CancellationException) {
+            if (!currentCoroutineContext().isActive) {
+                // The RUN was cancelled (widget Cancel → OneTapRunGuard.cancelRun()): abort the
+                // sequence. The submit may have slipped the task into the queue inside TaskManager's
+                // NonCancellable block after the cancel sweep — cancel its type again so nothing
+                // keeps running.
+                taskManager.cancel(task.type)
+                throw e
+            }
+            // A per-tool cancel (e.g. from the dashboard) only skips that tool.
+            log(TAG) { "${task::class.simpleName} was cancelled individually, continuing run: $e" }
+        } catch (e: Exception) {
+            log(TAG) { "Failed to submit ${task::class.simpleName}: $e" }
+        }
+    }
+
+    companion object {
+        private val TAG = logTag("OneTap", "Cleaner")
+
+        /** The tools the one-click run submits and the cancel action targets (dashboard parity). */
+        val ONECLICK_TYPES = setOf(
+            SDMTool.Type.CORPSEFINDER,
+            SDMTool.Type.SYSTEMCLEANER,
+            SDMTool.Type.APPCLEANER,
+            SDMTool.Type.DEDUPLICATOR,
+        )
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/main/ui/MainActivity.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/MainActivity.kt
@@ -53,6 +53,8 @@ import eu.darken.sdmse.common.navigation.NavigationDestination
 import eu.darken.sdmse.common.navigation.NavigationEntry
 import eu.darken.sdmse.common.navigation.NavigationEventHandler
 import eu.darken.sdmse.common.navigation.UnknownDestinationScreen
+import eu.darken.sdmse.common.compose.dialog.SdmConfirmDialog
+import eu.darken.sdmse.common.compose.dialog.SdmDialogAction
 import eu.darken.sdmse.common.compose.settings.LocalUpgradeBadgeLabel
 import eu.darken.sdmse.common.compose.tour.GuidedTourHost
 import eu.darken.sdmse.common.navigation.routes.AppControlListRoute
@@ -110,6 +112,11 @@ class MainActivity : ComponentActivity() {
             null
         }
 
+        // Widget "Clean" that opens the app (consent prompt / scan fallback). Gated on a fresh
+        // start so a config change doesn't re-trigger it; the CLEAR_TASK widget intents recreate
+        // MainActivity cold with a Dashboard-seeded stack, so no navigation reset is needed here.
+        if (savedInstanceState == null) maybeHandleWidgetIntent(intent)
+
         setContent {
             // Prime WindowInsets to prevent UI jumping on first composition
             val primedInsets = WindowInsets.safeDrawing
@@ -155,6 +162,23 @@ class MainActivity : ComponentActivity() {
                     Box(modifier = Modifier.fillMaxSize()) {
                         Navigation()
                         FloatingLogPanelHost()
+                    }
+
+                    val showWidgetConsent by vm.showWidgetConsent.collectAsStateWithLifecycle()
+                    if (showWidgetConsent) {
+                        SdmConfirmDialog(
+                            title = stringResource(R.string.widget_oneclick_consent_title),
+                            message = stringResource(R.string.widget_oneclick_consent_message),
+                            onDismissRequest = vm::onWidgetConsentDecline,
+                            positive = SdmDialogAction(
+                                label = stringResource(R.string.widget_oneclick_consent_enable_action),
+                                onClick = vm::onWidgetConsentEnable,
+                            ),
+                            negative = SdmDialogAction(
+                                label = stringResource(R.string.widget_oneclick_consent_decline_action),
+                                onClick = vm::onWidgetConsentDecline,
+                            ),
+                        )
                     }
                 }
             }
@@ -266,7 +290,25 @@ class MainActivity : ComponentActivity() {
             else -> null
         }
 
+    /**
+     * Widget "Clean" fallout that lands in the app: the one-time consent prompt, or a scan whose
+     * results the Dashboard already reflects (the scan was submitted by [ShortcutActivity]). Ignored
+     * during onboarding — the widget must not drive the app past consent. Returns true when handled.
+     */
+    private fun maybeHandleWidgetIntent(intent: Intent?): Boolean {
+        if (vm.startRoute != DashboardRoute) return false
+        return when (intent?.getStringExtra(ShortcutActivity.EXTRA_SHORTCUT_ACTION)) {
+            ShortcutActivity.ACTION_WIDGET_CONSENT -> {
+                vm.requestWidgetConsent()
+                true
+            }
+            ShortcutActivity.ACTION_WIDGET_SCAN -> true
+            else -> false
+        }
+    }
+
     private fun handleShortcutAction(intent: Intent) {
+        if (maybeHandleWidgetIntent(intent)) return
         val route = shortcutRoute(intent)
         if (route == null) {
             // A plain delivery (launcher icon / widget open-app tap) onto the live singleTask

--- a/app/src/main/java/eu/darken/sdmse/main/ui/MainViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/MainViewModel.kt
@@ -4,27 +4,37 @@ import androidx.lifecycle.SavedStateHandle
 import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.sdmse.automation.core.errors.AutomationException
 import eu.darken.sdmse.common.BuildConfigWrap
+import eu.darken.sdmse.common.coroutine.AppCoroutineScope
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
+import eu.darken.sdmse.common.datastore.value
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.datastore.valueBlocking
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.navigation.NavigationDestination
 import eu.darken.sdmse.common.navigation.routes.DashboardRoute
+import eu.darken.sdmse.common.navigation.routes.UpgradeRoute
 import eu.darken.sdmse.common.theming.ThemeState
 import eu.darken.sdmse.common.uix.ViewModel4
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
+import eu.darken.sdmse.common.upgrade.isProForUi
 import eu.darken.sdmse.main.core.GeneralSettings
+import eu.darken.sdmse.main.core.shortcuts.OneTapCleaner
 import eu.darken.sdmse.main.core.themeState
 import eu.darken.sdmse.main.ui.navigation.OnboardingWelcomeRoute
 import eu.darken.sdmse.main.core.SDMTool
 import eu.darken.sdmse.main.core.taskmanager.TaskManager
 import eu.darken.sdmse.main.core.taskmanager.getLatestTask
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import java.time.Duration
 import java.time.Instant
 import javax.inject.Inject
@@ -36,6 +46,8 @@ class MainViewModel @Inject constructor(
     private val upgradeRepo: UpgradeRepo,
     private val taskManager: TaskManager,
     private val generalSettings: GeneralSettings,
+    private val oneTapCleaner: OneTapCleaner,
+    private val appScope: AppCoroutineScope,
 ) : ViewModel4(dispatcherProvider = dispatcherProvider) {
 
     val startRoute: NavigationDestination = if (generalSettings.isOnboardingCompleted.valueBlocking) {
@@ -53,6 +65,50 @@ class MainViewModel @Inject constructor(
     fun checkUpgrades() = launch {
         log(TAG) { "checkUpgrades()" }
         upgradeRepo.refresh()
+    }
+
+    private val showWidgetConsentInternal = MutableStateFlow(false)
+
+    /** Whether the one-time "enable widget one-tap cleaning?" consent dialog should be shown. */
+    val showWidgetConsent: StateFlow<Boolean> = showWidgetConsentInternal.asStateFlow()
+
+    /** Triggered by a widget "Clean" tap when the user hasn't been asked to opt in yet. */
+    fun requestWidgetConsent() {
+        log(TAG, INFO) { "requestWidgetConsent()" }
+        showWidgetConsentInternal.value = true
+    }
+
+    /**
+     * Consent granted: remember it, enable widget one-tap, and run the scan+delete the user
+     * originally intended right away. The Pro check and any upgrade navigation run on the VM scope
+     * (alive with the dialog); only the actual cleaning is handed to [appScope] so it survives this
+     * screen going away mid-run.
+     */
+    fun onWidgetConsentEnable() {
+        log(TAG, INFO) { "onWidgetConsentEnable()" }
+        showWidgetConsentInternal.value = false
+        launch {
+            generalSettings.widgetOneClickEnabled.value(true)
+            generalSettings.widgetOneClickConsentAsked.value(true)
+            if (!upgradeRepo.isProForUi()) {
+                navTo(UpgradeRoute())
+                return@launch
+            }
+            appScope.launch { oneTapCleaner.runOneClick(shortcutMode = true) }
+        }
+    }
+
+    /**
+     * Consent declined (or the dialog dismissed): remember we asked (never prompt again) and fall
+     * back to a plain scan so the dashboard shows results for a normal confirmed delete.
+     */
+    fun onWidgetConsentDecline() {
+        log(TAG, INFO) { "onWidgetConsentDecline()" }
+        showWidgetConsentInternal.value = false
+        appScope.launch {
+            generalSettings.widgetOneClickConsentAsked.value(true)
+            oneTapCleaner.runScanOnly()
+        }
     }
 
     private var handledErrors: Set<String>

--- a/app/src/main/java/eu/darken/sdmse/main/ui/settings/general/GeneralSettingsScreen.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/settings/general/GeneralSettingsScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.icons.twotone.Palette
 import androidx.compose.material.icons.twotone.PhoneAndroid
 import androidx.compose.material.icons.twotone.SystemUpdate
 import androidx.compose.material.icons.twotone.TouchApp
+import androidx.compose.material.icons.twotone.Widgets
 import androidx.compose.material.icons.automirrored.twotone.ViewList
 import eu.darken.sdmse.common.compose.layout.SdmScaffold
 import androidx.compose.material3.Text
@@ -67,6 +68,7 @@ fun GeneralSettingsScreenHost(
         onThemeColorChanged = vm::setThemeColor,
         onOneClickChanged = vm::toggleOneClick,
         onShortcutOneClickChanged = vm::toggleShortcutOneClick,
+        onWidgetOneClickChanged = vm::toggleWidgetOneClick,
         onPreviewsChanged = vm::togglePreviews,
         onUpdateCheckChanged = vm::toggleUpdateCheck,
         onMotdChanged = vm::toggleMotd,
@@ -92,6 +94,7 @@ internal fun GeneralSettingsScreen(
     onThemeColorChanged: (ThemeColor) -> Unit = {},
     onOneClickChanged: (Boolean) -> Unit = {},
     onShortcutOneClickChanged: (Boolean) -> Unit = {},
+    onWidgetOneClickChanged: (Boolean) -> Unit = {},
     onPreviewsChanged: (Boolean) -> Unit = {},
     onUpdateCheckChanged: (Boolean) -> Unit = {},
     onMotdChanged: (Boolean) -> Unit = {},
@@ -224,6 +227,19 @@ internal fun GeneralSettingsScreen(
                     subtitle = stringResource(R.string.shortcuts_onetap_enabled_summary),
                     checked = state.shortcutOneClickEnabled,
                     onCheckedChange = onShortcutOneClickChanged,
+                )
+            }
+
+            // Widget category
+            item { SettingsCategoryHeader(text = stringResource(R.string.settings_category_widget)) }
+
+            item {
+                SettingsSwitchItem(
+                    icon = Icons.TwoTone.Widgets,
+                    title = stringResource(R.string.widget_settings_oneclick_title),
+                    subtitle = stringResource(R.string.widget_settings_oneclick_summary),
+                    checked = state.widgetOneClickEnabled,
+                    onCheckedChange = onWidgetOneClickChanged,
                 )
             }
 

--- a/app/src/main/java/eu/darken/sdmse/main/ui/settings/general/GeneralSettingsViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/settings/general/GeneralSettingsViewModel.kt
@@ -56,8 +56,9 @@ class GeneralSettingsViewModel @Inject constructor(
         generalSettings.oneClickSystemCleanerEnabled.flow,
         generalSettings.oneClickAppCleanerEnabled.flow,
         generalSettings.oneClickDeduplicatorEnabled.flow,
+        generalSettings.widgetOneClickEnabled.flow,
     ) { isPro, isUpdateCheckSupported, oneClick, shortcut, theme, previews, romType, updateCheck, motd, debug, locales,
-        oneClickCorpseFinder, oneClickSystemCleaner, oneClickAppCleaner, oneClickDeduplicator ->
+        oneClickCorpseFinder, oneClickSystemCleaner, oneClickAppCleaner, oneClickDeduplicator, widgetOneClick ->
         State(
             isPro = isPro,
             isUpdateCheckSupported = isUpdateCheckSupported,
@@ -77,6 +78,7 @@ class GeneralSettingsViewModel @Inject constructor(
             oneClickSystemCleanerEnabled = oneClickSystemCleaner,
             oneClickAppCleanerEnabled = oneClickAppCleaner,
             oneClickDeduplicatorEnabled = oneClickDeduplicator,
+            widgetOneClickEnabled = widgetOneClick,
         )
     }.safeStateIn(
         initialValue = State(),
@@ -89,6 +91,13 @@ class GeneralSettingsViewModel @Inject constructor(
 
     fun toggleShortcutOneClick(enabled: Boolean) = launch {
         generalSettings.shortcutOneClickEnabled.value(enabled)
+    }
+
+    fun toggleWidgetOneClick(enabled: Boolean) = launch {
+        generalSettings.widgetOneClickEnabled.value(enabled)
+        // Enabling here counts as consent, so the widget's one-time in-app prompt never appears
+        // (and a later disable+widget-tap doesn't re-prompt).
+        if (enabled) generalSettings.widgetOneClickConsentAsked.value(true)
     }
 
     fun setThemeMode(mode: ThemeMode) = launch {
@@ -172,6 +181,7 @@ class GeneralSettingsViewModel @Inject constructor(
         val oneClickSystemCleanerEnabled: Boolean = true,
         val oneClickAppCleanerEnabled: Boolean = true,
         val oneClickDeduplicatorEnabled: Boolean = false,
+        val widgetOneClickEnabled: Boolean = false,
     )
 
     companion object {

--- a/app/src/main/java/eu/darken/sdmse/main/ui/shortcuts/ShortcutActivity.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/shortcuts/ShortcutActivity.kt
@@ -6,32 +6,17 @@ import android.widget.Toast
 import androidx.activity.ComponentActivity
 import dagger.hilt.android.AndroidEntryPoint
 import eu.darken.sdmse.R
-import eu.darken.sdmse.appcleaner.core.AppCleaner
-import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerOneClickTask
 import eu.darken.sdmse.common.coroutine.AppCoroutineScope
 import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
-import eu.darken.sdmse.common.upgrade.UpgradeRepo
-import eu.darken.sdmse.common.upgrade.isProForUi
-import eu.darken.sdmse.corpsefinder.core.CorpseFinder
-import eu.darken.sdmse.corpsefinder.core.tasks.CorpseFinderOneClickTask
-import eu.darken.sdmse.deduplicator.core.Deduplicator
-import eu.darken.sdmse.deduplicator.core.tasks.DeduplicatorOneClickTask
 import eu.darken.sdmse.main.core.GeneralSettings
-import eu.darken.sdmse.main.core.SDMTool
+import eu.darken.sdmse.main.core.shortcuts.OneTapCleaner
 import eu.darken.sdmse.main.core.shortcuts.OneTapRunGuard
 import eu.darken.sdmse.main.core.taskmanager.TaskManager
 import eu.darken.sdmse.main.ui.MainActivity
-import eu.darken.sdmse.systemcleaner.core.SystemCleaner
-import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerOneClickTask
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.currentCoroutineContext
-import kotlinx.coroutines.ensureActive
-import kotlinx.coroutines.isActive
-import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -40,14 +25,10 @@ import javax.inject.Inject
 class ShortcutActivity : ComponentActivity() {
 
     @Inject lateinit var taskManager: TaskManager
-    @Inject lateinit var upgradeRepo: UpgradeRepo
     @Inject lateinit var generalSettings: GeneralSettings
-    @Inject lateinit var corpseFinder: CorpseFinder
-    @Inject lateinit var systemCleaner: SystemCleaner
-    @Inject lateinit var appCleaner: AppCleaner
-    @Inject lateinit var deduplicator: Deduplicator
     @Inject lateinit var appScope: AppCoroutineScope
     @Inject lateinit var oneTapRunGuard: OneTapRunGuard
+    @Inject lateinit var oneTapCleaner: OneTapCleaner
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -57,11 +38,15 @@ class ShortcutActivity : ComponentActivity() {
 
         when (action) {
             ACTION_OPEN_APPCONTROL -> {
-                openAppControl()
+                startActivity(mainActivityIntent(ACTION_OPEN_APPCONTROL))
             }
 
             ACTION_SCAN_DELETE -> {
                 handleScanDeleteShortcut()
+            }
+
+            ACTION_WIDGET_SCAN_DELETE -> {
+                handleWidgetClean()
             }
 
             ACTION_CANCEL_ONECLICK -> {
@@ -75,64 +60,51 @@ class ShortcutActivity : ComponentActivity() {
         finish()
     }
 
-    private fun openAppControl() {
-        val mainIntent = Intent(this, MainActivity::class.java).apply {
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-            putExtra(EXTRA_SHORTCUT_ACTION, ACTION_OPEN_APPCONTROL)
+    /**
+     * Launcher "Scan + Delete" shortcut. Gated on [GeneralSettings.shortcutOneClickEnabled]: this
+     * activity is exported and the intent-filtered [ACTION_SCAN_DELETE] can be reached by a stale
+     * pinned shortcut or an external caller, so we re-check the opt-in at runtime rather than trust
+     * that the dynamic shortcut is only registered while enabled. Disabled → just open the app.
+     */
+    private fun handleScanDeleteShortcut() = appScope.launch {
+        if (!generalSettings.shortcutOneClickEnabled.value()) {
+            log(TAG, INFO) { "One-tap shortcut disabled, opening app instead of scan+delete" }
+            openMain(null)
+            return@launch
         }
-        startActivity(mainIntent)
+        runOneTap()
     }
 
-    private fun handleScanDeleteShortcut() = appScope.launch {
-        if (!upgradeRepo.isProForUi()) {
-            log(TAG, INFO) { "Scan/Delete shortcut requires Pro version, opening upgrade screen" }
-            val upgradeIntent = Intent(this@ShortcutActivity, MainActivity::class.java).apply {
-                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-                putExtra(EXTRA_SHORTCUT_ACTION, ACTION_UPGRADE)
-            }
-            withContext(Dispatchers.Main) {
-                startActivity(upgradeIntent)
-            }
-            return@launch
-        }
+    /**
+     * Home-screen widget "Clean" button. Never scan+deletes without opt-in:
+     * - one-tap enabled → run it in the background (no app open), like the shortcut;
+     * - not yet consented → open the app and show the one-time consent prompt;
+     * - consent declined earlier → open the app and run a scan (results shown for a confirmed delete).
+     */
+    private fun handleWidgetClean() = appScope.launch {
+        when {
+            generalSettings.widgetOneClickEnabled.value() -> runOneTap()
 
+            !generalSettings.widgetOneClickConsentAsked.value() -> {
+                log(TAG, INFO) { "Widget one-tap not consented yet, opening consent prompt" }
+                openMain(ACTION_WIDGET_CONSENT)
+            }
+
+            else -> {
+                log(TAG, INFO) { "Widget one-tap declined earlier, running scan fallback" }
+                // Open the dashboard first — submit() suspends until the scan finishes, and the
+                // dashboard reflects TaskManager state reactively, so it shows progress + results.
+                openMain(ACTION_WIDGET_SCAN)
+                oneTapCleaner.runScanOnly()
+            }
+        }
+    }
+
+    /** Runs the shared guarded one-tap and maps its outcome to the trampoline's UI affordances. */
+    private suspend fun runOneTap() {
         log(TAG, INFO) { "Executing scan and delete tasks" }
-
-        val corpseEnabled = generalSettings.oneClickCorpseFinderEnabled.value()
-        val systemEnabled = generalSettings.oneClickSystemCleanerEnabled.value()
-        val appCleanerEnabled = generalSettings.oneClickAppCleanerEnabled.value()
-        val deduplicatorEnabled = generalSettings.oneClickDeduplicatorEnabled.value()
-
-        if (!corpseEnabled && !systemEnabled && !appCleanerEnabled && !deduplicatorEnabled) {
-            log(TAG, INFO) { "No one-tap tools are enabled, nothing to run" }
-            withContext(Dispatchers.Main) {
-                Toast.makeText(
-                    this@ShortcutActivity,
-                    getString(R.string.shortcut_onetap_nothing_enabled),
-                    Toast.LENGTH_SHORT,
-                ).show()
-            }
-            return@launch
-        }
-
-        // Single-flight: if a OneTap run is already in progress, don't stack another — open the app so
-        // the user can watch progress (the widget's Clean button is already "working" by now). Placed
-        // after the Pro gate so the shared launcher shortcut keeps its non-Pro → upgrade behaviour.
-        // Registering this coroutine's job lets the widget's Cancel abort not-yet-submitted tools too.
-        if (!oneTapRunGuard.tryStart(coroutineContext.job)) {
-            log(TAG, INFO) { "OneTap already running, opening app instead of starting again" }
-            withContext(Dispatchers.Main) {
-                startActivity(
-                    Intent(this@ShortcutActivity, MainActivity::class.java).apply {
-                        flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-                    }
-                )
-            }
-            return@launch
-        }
-
-        try {
-            // Show "started" up front: submit() suspends until each task finishes, so showing it after
+        val outcome = oneTapCleaner.runOneClick(shortcutMode = true) {
+            // Show "started" up front: submit() suspends until each task finishes, so a toast after
             // the submits would land only once everything is already done.
             withContext(Dispatchers.Main) {
                 Toast.makeText(
@@ -141,51 +113,49 @@ class ShortcutActivity : ComponentActivity() {
                     Toast.LENGTH_SHORT,
                 ).show()
             }
-
-            if (corpseEnabled) submitOneTapTask(CorpseFinderOneClickTask())
-            if (systemEnabled) submitOneTapTask(SystemCleanerOneClickTask())
-            if (appCleanerEnabled) submitOneTapTask(AppCleanerOneClickTask(shortcutMode = true))
-            if (deduplicatorEnabled) submitOneTapTask(DeduplicatorOneClickTask())
-        } finally {
-            oneTapRunGuard.finish()
         }
-    }
-
-    private suspend fun submitOneTapTask(task: SDMTool.Task) {
-        try {
-            // Don't queue a new task into an already-cancelled run: a cancel landing between two
-            // submits wouldn't stop submit() from registering the next task (TaskManager queues it
-            // inside a NonCancellable block before reaching a cancellable suspension).
-            currentCoroutineContext().ensureActive()
-            taskManager.submit(task)
-        } catch (e: CancellationException) {
-            if (!currentCoroutineContext().isActive) {
-                // The RUN was cancelled (widget Cancel → OneTapRunGuard.cancelRun()): abort the
-                // sequence. The submit may have slipped the task into the queue inside TaskManager's
-                // NonCancellable block after handleCancelOneClick()'s sweep — cancel its type again
-                // so nothing keeps running.
-                taskManager.cancel(task.type)
-                throw e
+        when (outcome) {
+            OneTapCleaner.Outcome.NotPro -> {
+                log(TAG, INFO) { "One-tap requires Pro, opening upgrade screen" }
+                openMain(ACTION_UPGRADE)
             }
-            // A per-tool cancel (e.g. from the dashboard) only skips that tool. Swallowing this used
-            // to be unconditional, which made cancelling the run impossible.
-            log(TAG) { "${task::class.simpleName} was cancelled individually, continuing run: $e" }
-        } catch (e: Exception) {
-            log(TAG) { "Failed to submit ${task::class.simpleName}: $e" }
+
+            OneTapCleaner.Outcome.NothingEnabled -> withContext(Dispatchers.Main) {
+                Toast.makeText(
+                    this@ShortcutActivity,
+                    getString(R.string.shortcut_onetap_nothing_enabled),
+                    Toast.LENGTH_SHORT,
+                ).show()
+            }
+
+            // A run is already in progress — open the app so the user can watch progress.
+            OneTapCleaner.Outcome.AlreadyRunning -> openMain(null)
+
+            OneTapCleaner.Outcome.Ran -> {}
         }
     }
 
     /**
-     * Widget "Cancel" while working: stop the OneTap sequence (pending submits never start) and cancel
-     * the one-click cleaning tools' active/queued tasks — the same scope as the dashboard's cancel
-     * action. Other tools (Analyzer, AppControl, …) keep running; they were started from in-app UI
-     * that has its own cancel affordances. Not Pro-gated — cancelling is never a premium feature.
+     * Widget "Cancel" while working: stop the OneTap sequence (pending submits never start) and
+     * cancel the one-click cleaning tools' active/queued tasks — the same scope as the dashboard's
+     * cancel action. Other tools (Analyzer, AppControl, …) keep running. Not Pro-gated.
      */
     private fun handleCancelOneClick() {
         log(TAG, INFO) { "Cancelling OneTap run + one-click cleaning tasks" }
         oneTapRunGuard.cancelRun()
-        ONECLICK_TYPES.forEach { taskManager.cancel(it) }
+        OneTapCleaner.ONECLICK_TYPES.forEach { taskManager.cancel(it) }
     }
+
+    /** Launch [MainActivity] on the main thread — these run from the app-scope (Default) coroutines. */
+    private suspend fun openMain(shortcutAction: String?) = withContext(Dispatchers.Main) {
+        startActivity(mainActivityIntent(shortcutAction))
+    }
+
+    private fun mainActivityIntent(shortcutAction: String?): Intent =
+        Intent(this, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            shortcutAction?.let { putExtra(EXTRA_SHORTCUT_ACTION, it) }
+        }
 
     companion object {
         private val TAG = logTag("Shortcut", "Activity")
@@ -196,13 +166,12 @@ class ShortcutActivity : ComponentActivity() {
         const val ACTION_CANCEL_ONECLICK = "eu.darken.sdmse.ACTION_CANCEL_ONECLICK"
         const val ACTION_UPGRADE = "eu.darken.sdmse.ACTION_UPGRADE"
 
-        /** The tools the one-click run submits and the cancel action targets (dashboard parity). */
-        private val ONECLICK_TYPES = setOf(
-            SDMTool.Type.CORPSEFINDER,
-            SDMTool.Type.SYSTEMCLEANER,
-            SDMTool.Type.APPCLEANER,
-            SDMTool.Type.DEDUPLICATOR,
-        )
+        /** Widget Clean button → this activity (explicit component, not in the exported filter). */
+        const val ACTION_WIDGET_SCAN_DELETE = "eu.darken.sdmse.ACTION_WIDGET_SCAN_DELETE"
+
+        /** [EXTRA_SHORTCUT_ACTION] values routed to [MainActivity] for the widget consent flow. */
+        const val ACTION_WIDGET_CONSENT = "eu.darken.sdmse.ACTION_WIDGET_CONSENT"
+        const val ACTION_WIDGET_SCAN = "eu.darken.sdmse.ACTION_WIDGET_SCAN"
 
         const val EXTRA_SHORTCUT_ACTION = "shortcut_action"
     }

--- a/app/src/main/java/eu/darken/sdmse/widget/ui/WidgetContent.kt
+++ b/app/src/main/java/eu/darken/sdmse/widget/ui/WidgetContent.kt
@@ -38,7 +38,6 @@ import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
 import eu.darken.sdmse.R
-import eu.darken.sdmse.main.core.shortcuts.AppShortcut
 import eu.darken.sdmse.main.ui.MainActivity
 import eu.darken.sdmse.main.ui.shortcuts.ShortcutActivity
 import eu.darken.sdmse.widget.WidgetRenderState
@@ -92,6 +91,16 @@ internal fun widgetCancelIntent(context: Context): Intent =
         flags = Intent.FLAG_ACTIVITY_NEW_TASK
     }
 
+// The Clean button routes through ShortcutActivity's widget-specific action (NOT the launcher's
+// ACTION_SCAN_DELETE): ShortcutActivity reads the widget opt-in and either runs the one-tap in the
+// background, opens the one-time consent prompt, or runs a scan fallback. filterEquals-distinct from
+// the open-app/analyzer intents by component+action, and from cancel by action.
+internal fun widgetCleanIntent(context: Context): Intent =
+    Intent(context, ShortcutActivity::class.java).apply {
+        action = ShortcutActivity.ACTION_WIDGET_SCAN_DELETE
+        flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+    }
+
 @Composable
 private fun openApp(): Action = actionStartActivity(widgetOpenAppIntent(LocalContext.current))
 
@@ -102,7 +111,7 @@ private fun openAnalyzer(): Action = actionStartActivity(widgetOpenAnalyzerInten
 private fun cancel(): Action = actionStartActivity(widgetCancelIntent(LocalContext.current))
 
 @Composable
-private fun clean(): Action = actionStartActivity(AppShortcut.MainAction.OneTap.createIntent(LocalContext.current))
+private fun clean(): Action = actionStartActivity(widgetCleanIntent(LocalContext.current))
 
 @Composable
 internal fun WidgetContent(state: WidgetRenderState) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -375,7 +375,7 @@
     <string name="widget_settings_oneclick_title">One-Tap Mode</string>
     <string name="widget_settings_oneclick_summary">Let the home-screen widget\'s Clean button scan and delete in one tap, without asking each time.</string>
     <string name="widget_oneclick_consent_title">Enable one-tap cleaning?</string>
-    <string name="widget_oneclick_consent_message">The widget\'s Clean button can scan and delete in a single tap, without asking each time. Enable one-tap mode for the widget?\n\nYou can change this later in Settings.</string>
+    <string name="widget_oneclick_consent_message">The widget\'s Clean button will scan and delete in one go, without asking first or letting you review what gets removed.</string>
     <string name="widget_oneclick_consent_enable_action">Enable</string>
     <string name="widget_oneclick_consent_decline_action">Not now</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -371,6 +371,14 @@
     <string name="widget_home_working">Working…</string>
     <string name="widget_home_unavailable">Storage unavailable</string>
 
+    <string name="settings_category_widget">Widget</string>
+    <string name="widget_settings_oneclick_title">One-Tap Mode</string>
+    <string name="widget_settings_oneclick_summary">Let the home-screen widget\'s Clean button scan and delete in one tap, without asking each time.</string>
+    <string name="widget_oneclick_consent_title">Enable one-tap cleaning?</string>
+    <string name="widget_oneclick_consent_message">The widget\'s Clean button can scan and delete in a single tap, without asking each time. Enable one-tap mode for the widget?\n\nYou can change this later in Settings.</string>
+    <string name="widget_oneclick_consent_enable_action">Enable</string>
+    <string name="widget_oneclick_consent_decline_action">Not now</string>
+
     <string name="shortcut_onetap_started">Scan &amp; delete started…</string>
     <string name="shortcut_onetap_nothing_enabled">No one-tap tools are enabled</string>
 

--- a/app/src/test/java/eu/darken/sdmse/main/core/shortcuts/OneTapCleanerTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/core/shortcuts/OneTapCleanerTest.kt
@@ -1,0 +1,104 @@
+package eu.darken.sdmse.main.core.shortcuts
+
+import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerOneClickTask
+import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerScanTask
+import eu.darken.sdmse.common.datastore.DataStoreValue
+import eu.darken.sdmse.corpsefinder.core.tasks.CorpseFinderOneClickTask
+import eu.darken.sdmse.corpsefinder.core.tasks.CorpseFinderScanTask
+import eu.darken.sdmse.deduplicator.core.tasks.DeduplicatorOneClickTask
+import eu.darken.sdmse.deduplicator.core.tasks.DeduplicatorScanTask
+import eu.darken.sdmse.main.core.GeneralSettings
+import eu.darken.sdmse.main.core.taskmanager.TaskManager
+import eu.darken.sdmse.common.upgrade.UpgradeRepo
+import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerOneClickTask
+import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerScanTask
+import io.kotest.matchers.shouldBe
+import io.mockk.MockKAnnotations
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class OneTapCleanerTest : BaseTest() {
+
+    @MockK lateinit var taskManager: TaskManager
+    @MockK lateinit var generalSettings: GeneralSettings
+    @MockK lateinit var upgradeRepo: UpgradeRepo
+    private val guard = OneTapRunGuard()
+
+    private fun <T : Any> mockSetting(value: T): DataStoreValue<T> =
+        mockk<DataStoreValue<T>>(relaxed = true).apply { every { flow } returns flowOf(value) }
+
+    private fun setup(
+        pro: Boolean = true,
+        corpse: Boolean = false,
+        system: Boolean = false,
+        app: Boolean = false,
+        dedup: Boolean = false,
+    ) {
+        val info = mockk<UpgradeRepo.Info> { every { isPro } returns pro }
+        every { upgradeRepo.upgradeInfo } returns flowOf(info)
+        every { upgradeRepo.isSettled } returns flowOf(true)
+        every { generalSettings.oneClickCorpseFinderEnabled } returns mockSetting(corpse)
+        every { generalSettings.oneClickSystemCleanerEnabled } returns mockSetting(system)
+        every { generalSettings.oneClickAppCleanerEnabled } returns mockSetting(app)
+        every { generalSettings.oneClickDeduplicatorEnabled } returns mockSetting(dedup)
+    }
+
+    private fun create() = OneTapCleaner(taskManager, generalSettings, upgradeRepo, guard)
+
+    @BeforeEach
+    fun init() {
+        MockKAnnotations.init(this)
+    }
+
+    @Test
+    fun `runOneClick returns NotPro and submits nothing when not Pro`() = runTest {
+        setup(pro = false, corpse = true)
+        create().runOneClick(shortcutMode = true) shouldBe OneTapCleaner.Outcome.NotPro
+        coVerify(exactly = 0) { taskManager.submit(any()) }
+    }
+
+    @Test
+    fun `runOneClick returns NothingEnabled when no tools are enabled`() = runTest {
+        setup(pro = true)
+        create().runOneClick(shortcutMode = true) shouldBe OneTapCleaner.Outcome.NothingEnabled
+        coVerify(exactly = 0) { taskManager.submit(any()) }
+    }
+
+    @Test
+    fun `runOneClick submits one-click tasks for enabled tools and fires onStarted`() = runTest {
+        setup(pro = true, corpse = true, system = true)
+        var started = false
+        create().runOneClick(shortcutMode = true) { started = true } shouldBe OneTapCleaner.Outcome.Ran
+        started shouldBe true
+        coVerify(exactly = 1) { taskManager.submit(ofType(CorpseFinderOneClickTask::class)) }
+        coVerify(exactly = 1) { taskManager.submit(ofType(SystemCleanerOneClickTask::class)) }
+        coVerify(exactly = 0) { taskManager.submit(ofType(AppCleanerOneClickTask::class)) }
+        coVerify(exactly = 0) { taskManager.submit(ofType(DeduplicatorOneClickTask::class)) }
+    }
+
+    @Test
+    fun `runOneClick returns AlreadyRunning when a run is in progress`() = runTest {
+        setup(pro = true, corpse = true)
+        guard.tryStart(Job()) shouldBe true // pre-claim the single-flight guard
+        create().runOneClick(shortcutMode = true) shouldBe OneTapCleaner.Outcome.AlreadyRunning
+        coVerify(exactly = 0) { taskManager.submit(any()) }
+    }
+
+    @Test
+    fun `runScanOnly submits scan tasks only for enabled tools`() = runTest {
+        setup(pro = true, corpse = true, app = true)
+        create().runScanOnly()
+        coVerify(exactly = 1) { taskManager.submit(ofType(CorpseFinderScanTask::class)) }
+        coVerify(exactly = 1) { taskManager.submit(ofType(AppCleanerScanTask::class)) }
+        coVerify(exactly = 0) { taskManager.submit(ofType(SystemCleanerScanTask::class)) }
+        coVerify(exactly = 0) { taskManager.submit(ofType(DeduplicatorScanTask::class)) }
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/widget/ui/WidgetIntentsTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/widget/ui/WidgetIntentsTest.kt
@@ -2,7 +2,6 @@ package eu.darken.sdmse.widget.ui
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
-import eu.darken.sdmse.main.core.shortcuts.AppShortcut
 import eu.darken.sdmse.main.ui.shortcuts.ShortcutActivity
 import io.kotest.matchers.shouldBe
 import org.junit.Test
@@ -30,7 +29,7 @@ class WidgetIntentsTest : BaseTest() {
         val intents = listOf(
             widgetOpenAppIntent(context),
             widgetOpenAnalyzerIntent(context),
-            AppShortcut.MainAction.OneTap.createIntent(context),
+            widgetCleanIntent(context),
             widgetCancelIntent(context),
         )
 
@@ -56,6 +55,14 @@ class WidgetIntentsTest : BaseTest() {
         val cancel = widgetCancelIntent(context)
         cancel.component?.className shouldBe ShortcutActivity::class.java.name
         cancel.action shouldBe ShortcutActivity.ACTION_CANCEL_ONECLICK
+    }
+
+    @Test
+    fun `clean targets ShortcutActivity with the widget scan-delete action`() {
+        val clean = widgetCleanIntent(context)
+        clean.component?.className shouldBe ShortcutActivity::class.java.name
+        // The widget-specific action (gated on the widget opt-in), NOT the launcher ACTION_SCAN_DELETE.
+        clean.action shouldBe ShortcutActivity.ACTION_WIDGET_SCAN_DELETE
     }
 
     @Test


### PR DESCRIPTION
## What changed

The home-screen widget's **Clean** button used to scan and delete in a single tap the moment you placed the widget — no confirmation, no opt-in. Everywhere else, one-tap-without-confirmation is something you have to turn on first (the dashboard's One-Tap Mode, or the "Scan + Delete" app-icon shortcut). The widget skipped that step.

Now the widget asks first:

- A new **Widget → One-Tap Mode** switch in Settings (off by default).
- The first time you tap the widget's Clean button, the app opens and asks **"Enable one-tap cleaning?"**. Choose **Enable** and it turns on one-tap and cleans right away; choose **Not now** and it just runs a scan and shows the results on the dashboard so you can review and delete yourself. You're only asked once.
- Once One-Tap Mode is on, the widget cleans in one tap as before.

As a safety hardening, the app-icon "Scan + Delete" shortcut now also re-checks its own opt-in at run time, so a leftover pinned shortcut can't clean without it being enabled.

## Technical Context

- **Where the gap was**: the widget's Clean button fired `ShortcutActivity`'s `ACTION_SCAN_DELETE` — the exact background one-tap path as the launcher shortcut — but nothing in that path consulted an opt-in. A UI-only guard wouldn't be enough: `ShortcutActivity` is exported, so the gate has to live at the activity, not in the widget composable.
- **Two new settings**: `widgetOneClickEnabled` (the switch) and `widgetOneClickConsentAsked` (so the one-time prompt never reappears — also set when you enable the switch manually, and when the dialog is dismissed via back/outside).
- **Shared execution**: the one-tap and scan-only logic is extracted into a single `OneTapCleaner` so the shortcut, the widget, and the consent dialog all run identical guarded logic (Pro gate, `OneTapRunGuard` single-flight, `shortcutMode`, per-tool cancellation) — no divergent copy of the run loop.
- **No relay / no dashboard-VM coupling**: the widget fires a distinct `ACTION_WIDGET_SCAN_DELETE`; `ShortcutActivity` reads live settings and either runs the background one-tap, opens the consent prompt, or submits a scan and opens the dashboard (which reflects `TaskManager` state reactively — the scan results appear without any extra wiring).
- **Threading/lifecycle**: activity launches from the app-scope coroutine are marshalled to the main thread; the consent "Enable" path does its Pro check + any upgrade navigation on the ViewModel scope (alive with the dialog) and only hands the actual cleaning to the app scope so it survives the screen going away.
- **Review focus**: `OneTapCleaner` (the extraction — behavior parity with the old inline code) and the `ShortcutActivity` branching.
- Verified end-to-end on a Pixel 7a across all six states (not-consented → dialog, Enable → clean, Decline → scan, declined-earlier → scan, settings toggle, and the launcher gate). Unit tests cover `OneTapCleaner` outcomes and the new widget intent identity.
