### PR TITLE
General: Polish spacing, readability, and card visuals across tools

### DIFF
--- a/app-common-coil/src/main/java/eu/darken/sdmse/common/coil/FilePreviewImage.kt
+++ b/app-common-coil/src/main/java/eu/darken/sdmse/common/coil/FilePreviewImage.kt
@@ -87,7 +87,7 @@ fun FilePreviewImage(
                     Icon(
                         painter = painterResource(fallbackRes),
                         contentDescription = contentDescription,
-                        modifier = Modifier.fillMaxSize(0.5f),
+                        modifier = Modifier.fillMaxSize(0.4f),
                         tint = fallbackTint,
                     )
                 }

--- a/app-common-coil/src/main/java/eu/darken/sdmse/common/coil/FilePreviewImage.kt
+++ b/app-common-coil/src/main/java/eu/darken/sdmse/common/coil/FilePreviewImage.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.painterResource
 import coil.compose.SubcomposeAsyncImage
 import coil.request.ImageRequest
@@ -106,7 +107,10 @@ fun FilePreviewImage(
         }
     }
 
-    if (!lookup.canAttemptFilePreview()) {
+    // Under @Preview the mock lookups point at paths that don't exist on the render host; letting Coil
+    // resolve them trips Studio's render sandbox (SecurityException: read access not allowed). Render the
+    // placeholder instead so previews stay side-effect free.
+    if (!lookup.canAttemptFilePreview() || LocalInspectionMode.current) {
         fallbackContent(modifier)
         return
     }

--- a/app-common-exclusion/src/main/java/eu/darken/sdmse/exclusion/ui/editor/path/PathExclusionEditorScreen.kt
+++ b/app-common-exclusion/src/main/java/eu/darken/sdmse/exclusion/ui/editor/path/PathExclusionEditorScreen.kt
@@ -1,7 +1,6 @@
 package eu.darken.sdmse.exclusion.ui.editor.path
 
 import androidx.activity.compose.BackHandler
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -222,9 +221,8 @@ private fun ReadyContent(
             .padding(16.dp),
     ) {
         ElevatedCard(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clickable { onEditPath() },
+            onClick = { onEditPath() },
+            modifier = Modifier.fillMaxWidth(),
         ) {
             Column(modifier = Modifier.padding(16.dp)) {
                 Text(

--- a/app-common-stats/src/main/java/eu/darken/sdmse/stats/ui/paths/items/AffectedPathRow.kt
+++ b/app-common-stats/src/main/java/eu/darken/sdmse/stats/ui/paths/items/AffectedPathRow.kt
@@ -41,9 +41,9 @@ fun AffectedPathRow(
         Text(
             modifier = Modifier.weight(1f),
             text = pathText,
-            style = MaterialTheme.typography.bodyMedium,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
+            style = MaterialTheme.typography.bodySmall,
+            maxLines = 3,
+            overflow = TextOverflow.MiddleEllipsis,
         )
     }
 }

--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/dialog/SdmDialogButtonBar.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/dialog/SdmDialogButtonBar.kt
@@ -19,8 +19,8 @@ import androidx.compose.ui.unit.dp
 import eu.darken.sdmse.common.compose.preview.Preview2
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 
-private val HorizontalSpacing = 8.dp
-private val VerticalSpacing = 12.dp
+private val HorizontalSpacing = 4.dp
+private val VerticalSpacing = 2.dp
 
 /**
  * Adaptive dialog action bar that never wraps label text inside buttons.

--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/progress/ProgressOverlay.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/progress/ProgressOverlay.kt
@@ -149,27 +149,30 @@ private fun ProgressOverlayPanel(
                         overflow = TextOverflow.Ellipsis,
                     )
                 }
-                if (primary.isNotEmpty()) {
-                    Text(
-                        text = primary,
-                        style = MaterialTheme.typography.bodyMedium,
-                        textAlign = TextAlign.Center,
-                        maxLines = 2,
-                        overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.padding(top = if (countText.isNullOrEmpty()) 0.dp else 12.dp),
-                    )
-                }
-                if (secondary.isNotEmpty()) {
-                    Text(
-                        text = secondary,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        textAlign = TextAlign.Center,
-                        maxLines = 3,
-                        overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.padding(top = 6.dp),
-                    )
-                }
+                // Reserve fixed line counts (minLines == maxLines) and render both slots unconditionally so
+                // the inner block stays a constant height. Otherwise a secondary path going 1↔2 lines — or a
+                // message toggling empty↔present — changes the column height, and because the column is
+                // vertically centered it re-centers and visibly jumps on every progress tick. Empty reserved
+                // lines are invisible (no glyphs), so this costs nothing when a message is short or absent.
+                Text(
+                    text = primary,
+                    style = MaterialTheme.typography.bodyMedium,
+                    textAlign = TextAlign.Center,
+                    minLines = 1,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.padding(top = if (countText.isNullOrEmpty()) 0.dp else 12.dp),
+                )
+                Text(
+                    text = secondary,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                    minLines = 2,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.padding(top = 6.dp),
+                )
             }
         }
     }

--- a/app-common/src/main/java/eu/darken/sdmse/common/debug/Bugs.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/debug/Bugs.kt
@@ -1,12 +1,25 @@
 package eu.darken.sdmse.common.debug
 
+import android.app.Application
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 
 object Bugs {
-    var reporter: AutomaticBugReporter? = null
+    var reporter: AutomaticBugReporter? = object : AutomaticBugReporter {
+        override fun setup(application: Application) {
+            log(TAG, INFO) { "Bug reporting is NOOP." }
+        }
+
+        override fun leaveBreadCrumb(crumb: String) { /* NOOP */
+        }
+
+        override fun notify(throwable: Throwable) { /* NOOP */
+        }
+
+    }
 
     fun report(exception: Exception) {
         log(TAG, VERBOSE) { "Reporting $exception" }

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/app/items/AppDetailsGroupRow.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/app/items/AppDetailsGroupRow.kt
@@ -2,7 +2,6 @@ package eu.darken.sdmse.analyzer.ui.storage.app.items
 
 import android.text.format.Formatter
 import androidx.annotation.StringRes
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -43,9 +42,8 @@ internal fun AppDetailsGroupRow(
     val sizeText = Formatter.formatShortFileSize(context, group.groupSize)
 
     Card(
-        modifier = modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick),
+        onClick = onClick,
+        modifier = modifier.fillMaxWidth(),
         elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
     ) {
         Row(

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/apps/AppsItemRow.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/apps/AppsItemRow.kt
@@ -2,7 +2,6 @@ package eu.darken.sdmse.analyzer.ui.storage.apps
 
 import android.text.format.Formatter
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -39,9 +38,8 @@ internal fun AppsItemRow(
     val sizeText = Formatter.formatShortFileSize(context, row.pkgStat.totalSize)
 
     Card(
-        modifier = modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick),
+        onClick = onClick,
+        modifier = modifier.fillMaxWidth(),
         elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
     ) {
         Column {

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentItemRow.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentItemRow.kt
@@ -13,11 +13,13 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
@@ -104,7 +106,9 @@ internal fun ContentItemRow(
             if (lookup != null && content.type == FileType.FILE && (content.size ?: 0L) > 0L) {
                 FileListThumbnail(
                     lookup = lookup,
-                    modifier = Modifier.size(24.dp),
+                    modifier = Modifier
+                        .size(24.dp)
+                        .clip(RoundedCornerShape(4.dp)),
                 )
             } else {
                 Icon(

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/device/DeviceStorageItemCard.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/device/DeviceStorageItemCard.kt
@@ -1,7 +1,6 @@
 package eu.darken.sdmse.analyzer.ui.storage.device
 
 import android.text.format.Formatter
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -63,9 +62,8 @@ internal fun DeviceStorageItemCard(
     val formattedFree = Formatter.formatShortFileSize(context, storage.spaceFree)
 
     ElevatedCard(
-        modifier = modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick),
+        onClick = onClick,
+        modifier = modifier.fillMaxWidth(),
         colors = CardDefaults.elevatedCardColors(containerColor = MaterialTheme.colorScheme.surface),
         elevation = CardDefaults.elevatedCardElevation(defaultElevation = 2.dp),
     ) {

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/storage/categories/AppCategoryCard.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/storage/categories/AppCategoryCard.kt
@@ -1,7 +1,6 @@
 package eu.darken.sdmse.analyzer.ui.storage.storage.categories
 
 import android.text.format.Formatter
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -49,9 +48,8 @@ internal fun AppCategoryCard(
     val usedText = Formatter.formatShortFileSize(context, content.spaceUsed)
 
     Card(
-        modifier = modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick),
+        onClick = onClick,
+        modifier = modifier.fillMaxWidth(),
         elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
     ) {
         Column(modifier = Modifier.padding(16.dp)) {

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/storage/categories/MediaCategoryCard.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/storage/categories/MediaCategoryCard.kt
@@ -1,7 +1,6 @@
 package eu.darken.sdmse.analyzer.ui.storage.storage.categories
 
 import android.text.format.Formatter
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -49,9 +48,8 @@ internal fun MediaCategoryCard(
     val usedText = Formatter.formatShortFileSize(context, content.spaceUsed)
 
     Card(
-        modifier = modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick),
+        onClick = onClick,
+        modifier = modifier.fillMaxWidth(),
         elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
     ) {
         Column(modifier = Modifier.padding(16.dp)) {

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/storage/categories/SystemCategoryCard.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/storage/categories/SystemCategoryCard.kt
@@ -1,9 +1,9 @@
 package eu.darken.sdmse.analyzer.ui.storage.storage.categories
 
 import android.text.format.Formatter
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -48,16 +48,7 @@ internal fun SystemCategoryCard(
     } else 0
     val usedText = Formatter.formatShortFileSize(context, content.spaceUsed)
 
-    val cardModifier = if (content.isBrowsable) {
-        modifier.fillMaxWidth().clickable(onClick = onClick)
-    } else {
-        modifier.fillMaxWidth()
-    }
-
-    Card(
-        modifier = cardModifier,
-        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
-    ) {
+    val cardContent: @Composable ColumnScope.() -> Unit = {
         Column(modifier = Modifier.padding(16.dp)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Icon(
@@ -95,6 +86,24 @@ internal fun SystemCategoryCard(
                 )
             }
         }
+    }
+
+    val elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    if (content.isBrowsable) {
+        // Use the clickable Card overload so the hover/ripple indication is clipped to the
+        // card's rounded shape instead of drawing against the rectangular bounds.
+        Card(
+            onClick = onClick,
+            modifier = modifier.fillMaxWidth(),
+            elevation = elevation,
+            content = cardContent,
+        )
+    } else {
+        Card(
+            modifier = modifier.fillMaxWidth(),
+            elevation = elevation,
+            content = cardContent,
+        )
     }
 }
 

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/details/page/AppJunkPage.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/details/page/AppJunkPage.kt
@@ -2,7 +2,6 @@ package eu.darken.sdmse.appcleaner.ui.details.page
 
 import android.text.format.Formatter
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -292,10 +291,10 @@ private fun AppJunkInaccessibleRow(
 ) {
     val context = LocalContext.current
     Card(
+        onClick = onClick,
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 4.dp)
-            .clickable(onClick = onClick),
+            .padding(horizontal = 16.dp, vertical = 4.dp),
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
@@ -344,10 +343,10 @@ private fun AppJunkCategoryCard(
     )
     val subtitle = "${Formatter.formatShortFileSize(context, totalSize)} ($itemCountText)"
     Card(
+        onClick = onClick,
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 4.dp)
-            .clickable(onClick = onClick),
+            .padding(horizontal = 16.dp, vertical = 4.dp),
     ) {
         Column(modifier = Modifier.padding(vertical = 8.dp)) {
             Row(

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/details/page/AppJunkPage.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/details/page/AppJunkPage.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.FormatListBulleted
 import androidx.compose.material.icons.twotone.DeleteSweep
@@ -31,6 +32,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
@@ -415,7 +417,9 @@ private fun AppJunkFileRow(
     ) {
         FileListThumbnail(
             lookup = match.lookup,
-            modifier = Modifier.size(40.dp),
+            modifier = Modifier
+                .size(40.dp)
+                .clip(RoundedCornerShape(4.dp)),
         )
         Spacer(Modifier.width(16.dp))
         Column(modifier = Modifier.weight(1f)) {

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/details/page/AppJunkPage.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/details/page/AppJunkPage.kt
@@ -422,8 +422,8 @@ private fun AppJunkFileRow(
             Text(
                 text = match.lookup.userReadablePath.get(context),
                 style = MaterialTheme.typography.bodySmall,
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
+                maxLines = 3,
+                overflow = TextOverflow.MiddleEllipsis,
             )
         }
         Spacer(Modifier.width(8.dp))

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListFilters.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListFilters.kt
@@ -62,55 +62,64 @@ internal fun AppControlFilterRow(
     val ordered = remember(activeTags, allowFilterActive) {
         FilterSettings.Tag.entries.filter { it in activeTags && (it != FilterSettings.Tag.ACTIVE || allowFilterActive) }
     }
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .height(56.dp)
-            .padding(horizontal = 4.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
+    // Full-width tonal band so the filter/sort controls read as a distinct toolbar rather than
+    // floating on the app bar's surface color. surfaceContainerHigh sits a tonal step above the
+    // app bar and the list (both surface). The offset for collapse-on-scroll is applied to this
+    // Surface so the whole band slides together.
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
     ) {
-        if (ordered.isEmpty()) {
-            Text(
-                text = stringResource(CommonR.string.general_filter_empty_row_hint),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier
-                    .weight(1f)
-                    .padding(horizontal = 12.dp),
-            )
-        } else {
-            LazyRow(
-                modifier = Modifier.weight(1f),
-                contentPadding = PaddingValues(horizontal = 4.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                items(ordered, key = { it.name }) { tag -> ActiveTagChip(tag = tag, onRemove = { onTagRemove(tag) }) }
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(56.dp)
+                .padding(horizontal = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            if (ordered.isEmpty()) {
+                Text(
+                    text = stringResource(CommonR.string.general_filter_empty_row_hint),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(horizontal = 12.dp),
+                )
+            } else {
+                LazyRow(
+                    modifier = Modifier.weight(1f),
+                    contentPadding = PaddingValues(horizontal = 4.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    items(ordered, key = { it.name }) { tag -> ActiveTagChip(tag = tag, onRemove = { onTagRemove(tag) }) }
+                }
             }
-        }
-        IconButton(
-            onClick = onAddTags,
-            modifier = addTagsModifier,
-        ) {
-            Icon(
-                imageVector = Icons.TwoTone.Add,
-                contentDescription = stringResource(CommonR.string.general_filter_add_action),
-            )
-        }
-        IconButton(
-            onClick = onSort,
-            modifier = sortModifier,
-        ) {
-            BadgedBox(
-                badge = {
-                    if (sortNonDefault) Badge()
-                },
+            IconButton(
+                onClick = onAddTags,
+                modifier = addTagsModifier,
             ) {
                 Icon(
-                    imageVector = Icons.AutoMirrored.TwoTone.Sort,
-                    contentDescription = stringResource(CommonR.string.general_sort_by_title),
+                    imageVector = Icons.TwoTone.Add,
+                    contentDescription = stringResource(CommonR.string.general_filter_add_action),
                 )
+            }
+            IconButton(
+                onClick = onSort,
+                modifier = sortModifier,
+            ) {
+                BadgedBox(
+                    badge = {
+                        if (sortNonDefault) Badge()
+                    },
+                ) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.TwoTone.Sort,
+                        contentDescription = stringResource(CommonR.string.general_sort_by_title),
+                    )
+                }
             }
         }
     }

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListScreen.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListScreen.kt
@@ -433,9 +433,10 @@ internal fun AppControlListScreen(
     // rows reorder mid-tour (e.g., a background install changes ordering).
     var tourFirstRowId by remember { mutableStateOf<InstallId?>(null) }
     // Gate on !isBusy as well as rows being present: the search icon (if !searchActive && !isBusy)
-    // and the filter/sort chips (AnimatedVisibility visible = !isBusy) aren't composed while a load
-    // is in progress. rowsReady can flip true while progress is still non-null, so starting on
-    // rowsReady alone left steps 0-2 with no registered target and they grace-skipped.
+    // and the filter/sort chips (AnimatedVisibility visible = !isBusy && rows != null) aren't
+    // composed while a load is in progress. rowsReady can flip true while progress is still
+    // non-null, so starting on rowsReady alone left steps 0-2 with no registered target and they
+    // grace-skipped.
     val tourReady = !rows.isNullOrEmpty() && !isBusy
     LaunchedEffect(tourReady) {
         if (!tourReady || tourStartAttempted) return@LaunchedEffect
@@ -532,7 +533,13 @@ internal fun AppControlListScreen(
                         val visibleHeight = with(density) {
                             (filterRowHeightPx.toFloat() + topBarState.heightOffset).coerceAtLeast(0f).toDp()
                         }
-                        AnimatedVisibility(visible = !isBusy) {
+                        // Also gate on rows != null so the row doesn't flash on cold start: the
+                        // initial state has progress == null (not yet busy) before the first scan's
+                        // progress propagates, which would briefly show the row and then animate it
+                        // out. rows stays null until the first scan finishes, so the row only ever
+                        // appears once there's data to filter. An empty result (rows == emptyList)
+                        // still shows the row so filters remain adjustable.
+                        AnimatedVisibility(visible = !isBusy && rows != null) {
                             Box(
                                 modifier = Modifier
                                     .fillMaxWidth()

--- a/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListScreenTest.kt
+++ b/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListScreenTest.kt
@@ -229,6 +229,26 @@ class AppControlListScreenTest : BaseComposeRobolectricTest() {
     }
 
     @Test
+    fun `filter row is hidden on first load before rows arrive`() {
+        // Cold start: progress is still null (not yet busy) but rows haven't loaded. The row must
+        // stay hidden so it doesn't briefly appear and then animate out once the initial scan's
+        // progress propagates (the first-load flash). Gated on rows != null in the screen.
+        composeRule.setListScreen(
+            AppControlListViewModel.State(
+                rows = null,
+                progress = null,
+                options = AppControlListViewModel.DisplayOptions(
+                    listFilter = FilterSettings(tags = setOf(FilterSettings.Tag.USER)),
+                ),
+            ),
+        )
+
+        composeRule.onAllNodesWithText("User").assertCountEquals(0)
+        // Only the filter row is gated — the top bar (tool name) still renders.
+        composeRule.onNodeWithText("AppControl").assertExists()
+    }
+
+    @Test
     fun `inspection mode renders populated rows without a tour controller`() {
         // In @Preview/inspection mode no real LocalGuidedTourController is provided; PreviewWrapper supplies
         // NoOpGuidedTourAccess when LocalInspectionMode is true, so the screen reads a no-op instead of hitting

--- a/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/tasks/UninstallWatcherTask.kt
+++ b/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/tasks/UninstallWatcherTask.kt
@@ -6,6 +6,7 @@ import eu.darken.sdmse.common.ca.caString
 import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.getQuantityString2
 import eu.darken.sdmse.common.pkgs.Pkg
+import eu.darken.sdmse.corpsefinder.R
 import eu.darken.sdmse.stats.core.ReportDetails
 import eu.darken.sdmse.stats.core.Reportable
 import kotlinx.parcelize.Parcelize
@@ -27,19 +28,17 @@ data class UninstallWatcherTask(
 
         override val primaryInfo: CaString
             get() = caString {
-                val itemText = getQuantityString2(
-                    eu.darken.sdmse.common.R.plurals.general_delete_success_deleted_x,
-                    affectedPaths.size,
+                getQuantityString2(R.plurals.corpsefinder_result_x_corpses_deleted, affectedPaths.size)
+            }
+
+        override val secondaryInfo: CaString
+            get() = caString {
+                val (formatted, quantity) = ByteFormatter.formatSize(this, affectedSpace)
+                getQuantityString2(
+                    eu.darken.sdmse.common.R.plurals.general_result_x_space_freed,
+                    quantity,
+                    formatted,
                 )
-                val spaceText = run {
-                    val (spaceFormatted, spaceQuantity) = ByteFormatter.formatSize(this, affectedSpace)
-                    getQuantityString2(
-                        eu.darken.sdmse.common.R.plurals.general_result_x_space_freed,
-                        spaceQuantity,
-                        spaceFormatted,
-                    )
-                }
-                "$itemText $spaceText"
             }
     }
 }

--- a/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/ui/details/content/CorpseContent.kt
+++ b/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/ui/details/content/CorpseContent.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.DeleteSweep
@@ -27,6 +28,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
@@ -247,7 +249,9 @@ private fun CorpseFileRow(
     ) {
         FileListThumbnail(
             lookup = lookup,
-            modifier = Modifier.size(20.dp),
+            modifier = Modifier
+                .size(20.dp)
+                .clip(RoundedCornerShape(4.dp)),
         )
         Spacer(Modifier.width(16.dp))
         Column(modifier = Modifier.weight(1f)) {

--- a/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/details/cluster/ClusterContent.kt
+++ b/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/details/cluster/ClusterContent.kt
@@ -217,13 +217,18 @@ private fun ClusterHeaderRow(
                 Formatter.formatShortFileSize(context, cluster.redundantSize),
             )
             Text(
-                text = stringResource(DeduplicatorR.string.deduplicator_occupied_space_label),
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                text = freeable,
+                style = MaterialTheme.typography.titleMedium,
+            )
+            val itemCount = pluralStringResource(
+                CommonR.plurals.result_x_items,
+                cluster.count,
+                cluster.count,
             )
             Text(
-                text = "$totalSize ($freeable)",
-                style = MaterialTheme.typography.titleMedium,
+                text = "$itemCount · $totalSize",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             val checksumCount = cluster.groups.filterIsInstance<ChecksumDuplicate.Group>().sumOf { it.count }
             val similarCount = cluster.groups.filterIsInstance<PHashDuplicate.Group>().sumOf { it.count } +
@@ -539,7 +544,7 @@ private fun ImageFileRow(
             contentScale = ContentScale.Crop,
             modifier = Modifier
                 .size(48.dp)
-                .clip(RoundedCornerShape(8.dp))
+                .clip(RoundedCornerShape(4.dp))
                 .combinedClickableSafe(onClick = onPreviewClick),
         )
         Spacer(Modifier.width(12.dp))

--- a/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/details/cluster/ClusterContent.kt
+++ b/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/details/cluster/ClusterContent.kt
@@ -297,10 +297,10 @@ private fun DirectoryHeaderRow(
 ) {
     val context = LocalContext.current
     Card(
+        onClick = onDeleteAll,
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 8.dp, vertical = 2.dp)
-            .combinedClickableSafe(onClick = onDeleteAll),
+            .padding(horizontal = 8.dp, vertical = 2.dp),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHigh),
     ) {
         Row(
@@ -361,10 +361,10 @@ private fun GroupHeaderCard(
     val overlayColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.85f)
     val overlayContent = MaterialTheme.colorScheme.onSurfaceVariant
     Card(
+        onClick = onView,
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 8.dp, vertical = 4.dp)
-            .combinedClickableSafe(onClick = onView),
+            .padding(horizontal = 8.dp, vertical = 4.dp),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer),
     ) {
         Box(

--- a/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/list/items/DeduplicatorGridRow.kt
+++ b/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/list/items/DeduplicatorGridRow.kt
@@ -1,6 +1,7 @@
 package eu.darken.sdmse.deduplicator.ui.list.items
 
 import android.text.format.Formatter
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
@@ -8,8 +9,9 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -71,16 +73,22 @@ internal fun DeduplicatorGridRow(
     Card(
         modifier = modifier.padding(4.dp),
         colors = CardDefaults.cardColors(containerColor = containerColor),
+        border = if (selected) BorderStroke(3.dp, MaterialTheme.colorScheme.primary) else null,
     ) {
-        Box(modifier = Modifier.fillMaxWidth()) {
+        // Square tile: the preview fills the card and the caption is overlaid on a scrim at the bottom,
+        // mirroring the Analyzer's content grid so every grid tile shares the same square footprint.
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(1f),
+        ) {
             // Tapping the thumbnail deletes the cluster's duplicates (confirm dialog); long-press selects.
             FilePreviewImage(
                 lookup = cluster.previewFile,
                 contentDescription = stringResource(DeduplicatorR.string.deduplicator_cluster_preview_image),
                 contentScale = ContentScale.Crop,
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .height(120.dp)
+                    .fillMaxSize()
                     .combinedClickable(
                         role = Role.Button,
                         onClickLabel = deleteLabel,
@@ -96,47 +104,50 @@ internal fun DeduplicatorGridRow(
                     .align(Alignment.TopStart)
                     .padding(4.dp),
             )
-        }
-        // Caption tap = open details; long-press selects.
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .combinedClickable(
-                    role = Role.Button,
-                    onClickLabel = detailsLabel,
-                    onClick = onCaptionClick,
-                    onLongClick = onLongClick,
-                )
-                .padding(vertical = 8.dp, horizontal = 12.dp),
-        ) {
-            Text(
-                text = stringResource(
-                    DeduplicatorR.string.deduplicator_list_grid_freeable_x,
-                    Formatter.formatShortFileSize(context, row.freeableSize),
-                ),
-                style = MaterialTheme.typography.titleSmall,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
+            // Caption overlaid at the bottom: tap = open details; long-press selects.
+            Column(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .fillMaxWidth()
+                    .combinedClickable(
+                        role = Role.Button,
+                        onClickLabel = detailsLabel,
+                        onClick = onCaptionClick,
+                        onLongClick = onLongClick,
+                    )
+                    .background(Color.Black.copy(alpha = 0.6f))
+                    .padding(vertical = 4.dp, horizontal = 8.dp),
             ) {
                 Text(
-                    text = pluralStringResource(
-                        CommonR.plurals.result_x_items,
-                        cluster.count,
-                        cluster.count,
+                    text = stringResource(
+                        DeduplicatorR.string.deduplicator_list_grid_freeable_x,
+                        Formatter.formatShortFileSize(context, row.freeableSize),
                     ),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    style = MaterialTheme.typography.titleSmall,
+                    color = Color.White,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.weight(1f),
                 )
-                if (cluster.types.isNotEmpty()) {
-                    Spacer(Modifier.width(8.dp))
-                    MatchTypeIcons(types = cluster.types)
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = pluralStringResource(
+                            CommonR.plurals.result_x_items,
+                            cluster.count,
+                            cluster.count,
+                        ),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = Color.White.copy(alpha = 0.85f),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f),
+                    )
+                    if (cluster.types.isNotEmpty()) {
+                        Spacer(Modifier.width(8.dp))
+                        MatchTypeIcons(types = cluster.types)
+                    }
                 }
             }
         }
@@ -181,7 +192,7 @@ private fun MatchTypeIcons(types: Set<Duplicate.Type>) {
                 imageVector = SdmIcons.CodeEqualBox,
                 contentDescription = stringResource(DeduplicatorR.string.deduplicator_detection_method_checksum_title),
                 tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.size(18.dp),
+                modifier = Modifier.size(16.dp),
             )
         }
         if (Duplicate.Type.PHASH in types) {
@@ -189,7 +200,7 @@ private fun MatchTypeIcons(types: Set<Duplicate.Type>) {
                 imageVector = SdmIcons.ApproximatelyEqualBox,
                 contentDescription = stringResource(DeduplicatorR.string.deduplicator_detection_method_phash_title),
                 tint = MaterialTheme.colorScheme.secondary,
-                modifier = Modifier.size(18.dp),
+                modifier = Modifier.size(16.dp),
             )
         }
         if (Duplicate.Type.MEDIA in types) {
@@ -197,7 +208,7 @@ private fun MatchTypeIcons(types: Set<Duplicate.Type>) {
                 imageVector = Icons.TwoTone.GraphicEq,
                 contentDescription = stringResource(DeduplicatorR.string.deduplicator_detection_method_media_title),
                 tint = MaterialTheme.colorScheme.tertiary,
-                modifier = Modifier.size(18.dp),
+                modifier = Modifier.size(16.dp),
             )
         }
     }

--- a/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/list/items/DeduplicatorLinearRow.kt
+++ b/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/list/items/DeduplicatorLinearRow.kt
@@ -99,7 +99,7 @@ internal fun DeduplicatorLinearRow(
                 contentScale = ContentScale.Crop,
                 modifier = Modifier
                     .size(72.dp)
-                    .clip(RoundedCornerShape(8.dp))
+                    .clip(RoundedCornerShape(4.dp))
                     .combinedClickable(
                         role = Role.Button,
                         onClickLabel = previewLabel,
@@ -116,17 +116,18 @@ internal fun DeduplicatorLinearRow(
                     Formatter.formatShortFileSize(context, cluster.redundantSize),
                 )
                 Text(
-                    text = "$totalSize ($freeable)",
+                    text = freeable,
                     style = MaterialTheme.typography.titleMedium,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
                 )
+                val itemCount = pluralStringResource(
+                    CommonR.plurals.result_x_items,
+                    cluster.count,
+                    cluster.count,
+                )
                 Text(
-                    text = pluralStringResource(
-                        CommonR.plurals.result_x_items,
-                        cluster.count,
-                        cluster.count,
-                    ),
+                    text = "$itemCount · $totalSize",
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -221,7 +222,7 @@ private fun DuplicateSubRow(
                 contentScale = ContentScale.Crop,
                 modifier = Modifier
                     .size(36.dp)
-                    .clip(RoundedCornerShape(8.dp))
+                    .clip(RoundedCornerShape(4.dp))
                     .combinedClickable(
                         onClick = if (selectionActive) onClick else onPreviewClick,
                         onLongClick = onLongClick,

--- a/app-tool-deduplicator/src/main/res/values/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">Audio-based match</string>
     <string name="deduplicator_media_match_visual">Video-based match</string>
     <string name="deduplicator_media_match_audio_visual">Audio and video-based match</string>
-    <string name="deduplicator_occupied_space_label">Occupied storage</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s is occupied by duplicates</item>
         <item quantity="other">%s are occupied by duplicates</item>

--- a/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/ui/setup/SqueezerSetupScreen.kt
+++ b/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/ui/setup/SqueezerSetupScreen.kt
@@ -1,7 +1,6 @@
 package eu.darken.sdmse.squeezer.ui.setup
 
 import android.text.format.Formatter
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -291,9 +290,8 @@ private fun PathsCard(
         scanPaths.joinToString("\n") { it.userReadablePath.get(context) }
     }
     Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick),
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth(),
     ) {
         Row(
             modifier = Modifier.padding(16.dp),
@@ -431,9 +429,8 @@ private fun AgeCard(
     val days = minAge.toDays().toInt()
     val valueText = pluralStringResource(R.plurals.squeezer_min_age_x_days, days, days)
     Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick),
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth(),
     ) {
         Row(
             modifier = Modifier.padding(16.dp),

--- a/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/swipe/items/SwiperProgressPager.kt
+++ b/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/swipe/items/SwiperProgressPager.kt
@@ -2,7 +2,6 @@ package eu.darken.sdmse.swiper.ui.swipe.items
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -120,7 +119,8 @@ private fun ProgressThumb(
         if (isCurrent) BorderStroke(3.dp, MaterialTheme.colorScheme.primary)
         else BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant)
     Card(
-        modifier = modifier.clickable(onClick = onClick),
+        onClick = onClick,
+        modifier = modifier,
         shape = RoundedCornerShape(12.dp),
         colors = CardDefaults.cardColors(containerColor = containerColor),
         border = border,

--- a/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/details/page/FilterContentPage.kt
+++ b/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/details/page/FilterContentPage.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.DeleteSweep
@@ -27,6 +28,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
@@ -220,7 +222,9 @@ private fun FilterContentFileRow(
             .padding(horizontal = 16.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        val thumbnailModifier = Modifier.size(28.dp)
+        val thumbnailModifier = Modifier
+            .size(28.dp)
+            .clip(RoundedCornerShape(4.dp))
         // Only make the thumbnail a preview tap-target when a preview can be attempted (a non-empty
         // file); folders and empty items are never preview targets.
         if (onPreviewClick != null && !selectionActive && match.lookup.canAttemptFilePreview()) {

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/ToolDashboardCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/ToolDashboardCard.kt
@@ -61,6 +61,9 @@ internal fun ToolDashboardCard(
 ) {
     val toolName = stringResource(toolNameRes(item.toolType))
     val toolDescription = stringResource(toolDescriptionRes(item.toolType))
+    // The whole card opens the tool's live list. Gate on onDelete != null: after a clean the
+    // result text persists but the live data is empty, so navigating would open a list that
+    // immediately closes itself (flicker). onDelete goes null in that state, disabling the click.
     val clickable = item.progress == null && item.onDelete != null
 
     DashboardCard(
@@ -99,10 +102,6 @@ internal fun ToolDashboardCard(
             Spacer(modifier = Modifier.height(16.dp))
             ProgressContainer(
                 modifier = Modifier.fillMaxWidth(),
-                // Only allow opening the tool's live list when there's data to show.
-                // After a clean the result text persists but the live data is empty, so
-                // navigating would open a list that immediately closes itself (flicker).
-                onClick = item.onViewTool.takeIf { item.result != null && item.progress == null && item.onDelete != null },
                 progress = item.progress,
                 resultPrimary = item.result?.primaryInfo?.asComposable(),
                 resultSecondary = item.result?.secondaryInfo?.asComposable()?.takeUnless { it.isBlank() },

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/common/DashboardCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/common/DashboardCard.kt
@@ -1,6 +1,5 @@
 package eu.darken.sdmse.main.ui.dashboard.cards.common
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Spacer
@@ -26,22 +25,36 @@ internal fun DashboardCard(
     onClick: (() -> Unit)? = null,
     content: @Composable ColumnScope.() -> Unit,
 ) {
-    val clickableModifier = if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier
-    Card(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(horizontal = 8.dp, vertical = 8.dp)
-            .then(clickableModifier),
-        colors = CardDefaults.cardColors(
-            containerColor = containerColor,
-            contentColor = contentColorFor(containerColor),
-        ),
-    ) {
+    val cardModifier = modifier
+        .fillMaxWidth()
+        .padding(horizontal = 8.dp, vertical = 8.dp)
+    val colors = CardDefaults.cardColors(
+        containerColor = containerColor,
+        contentColor = contentColorFor(containerColor),
+    )
+    val cardContent: @Composable ColumnScope.() -> Unit = {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(16.dp),
             content = content,
+        )
+    }
+    if (onClick != null) {
+        // Use the clickable Card overload so the hover/ripple indication is clipped to the
+        // card's rounded shape. Applying Modifier.clickable to the outer modifier instead
+        // draws the indication against the rectangular bounds (square highlight on the corners).
+        Card(
+            onClick = onClick,
+            modifier = cardModifier,
+            colors = colors,
+            content = cardContent,
+        )
+    } else {
+        Card(
+            modifier = cardModifier,
+            colors = colors,
+            content = cardContent,
         )
     }
 }

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/common/DashboardProgress.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/common/DashboardProgress.kt
@@ -1,6 +1,5 @@
 package eu.darken.sdmse.main.ui.dashboard.cards.common
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -28,13 +27,12 @@ import eu.darken.sdmse.common.progress.Progress
 @Composable
 internal fun ProgressContainer(
     modifier: Modifier = Modifier,
-    onClick: (() -> Unit)?,
     progress: Progress.Data?,
     resultPrimary: String?,
     resultSecondary: String?,
 ) {
     Surface(
-        modifier = modifier.then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier),
+        modifier = modifier,
         color = MaterialTheme.colorScheme.secondaryContainer,
         shape = RoundedCornerShape(12.dp),
     ) {
@@ -133,7 +131,6 @@ private fun ProgressContainerIndeterminatePreview() {
     PreviewWrapper {
         ProgressContainer(
             modifier = Modifier.width(280.dp),
-            onClick = null,
             progress = Progress.Data(
                 primary = "Scanning…".toCaString(),
                 secondary = "".toCaString(),
@@ -151,7 +148,6 @@ private fun ProgressContainerPercentPreview() {
     PreviewWrapper {
         ProgressContainer(
             modifier = Modifier.width(280.dp),
-            onClick = null,
             progress = Progress.Data(
                 primary = "Scanning files…".toCaString(),
                 secondary = "Checking app caches".toCaString(),
@@ -169,7 +165,6 @@ private fun ProgressContainerCounterZeroPreview() {
     PreviewWrapper {
         ProgressContainer(
             modifier = Modifier.width(280.dp),
-            onClick = null,
             progress = Progress.Data(
                 primary = "Starting scan…".toCaString(),
                 secondary = "".toCaString(),
@@ -187,7 +182,6 @@ private fun ProgressContainerLongPathPreview() {
     PreviewWrapper {
         ProgressContainer(
             modifier = Modifier.width(280.dp),
-            onClick = null,
             progress = Progress.Data(
                 primary = "Looking for orphaned data with a primary line that is also way too long to fit".toCaString(),
                 secondary = "/storage/emulated/0/Android/data/com.example.someapp/files/cache/very/deeply/nested/path/that/wraps".toCaString(),
@@ -205,7 +199,6 @@ private fun ProgressContainerResultPreview() {
     PreviewWrapper {
         ProgressContainer(
             modifier = Modifier.width(280.dp),
-            onClick = {},
             progress = null,
             resultPrimary = "Found 12 corpses (2.4 GB)",
             resultSecondary = "Last scan completed 5 minutes ago",
@@ -219,7 +212,6 @@ private fun ProgressContainerResultPrimaryOnlyPreview() {
     PreviewWrapper {
         ProgressContainer(
             modifier = Modifier.width(280.dp),
-            onClick = {},
             progress = null,
             resultPrimary = "Nothing to clean",
             resultSecondary = null,


### PR DESCRIPTION
## What changed

A batch of visual polish across many screens — no functional/behavioral changes, just how things look:

- Card tap/hover highlights are now clipped to the card's rounded corners instead of spilling out as a square overlay. Affects the dashboard, storage analyzer, app cleaner, deduplicator, exclusion editor, squeezer, and swiper.
- The deduplicator grid now uses square tiles with the size/count caption overlaid on the preview image, matching the storage analyzer's content grid.
- The storage analyzer's scan progress text no longer jumps around while a scan runs.
- File-preview thumbnails now have rounded corners in tool detail lists.
- Tighter, more consistent spacing in dialog action buttons and various list rows.
- More readable file paths in app-cleaner, corpse-finder, and history detail rows.

## Technical Context

- Purely visual; no scan/delete logic, settings, or user data touched.
- The square-hover fix switches clickable `Card`/`ElevatedCard` composables to Material3's `Card(onClick=…)` / `ElevatedCard(onClick=…)` overload, which draws the ripple/hover indication inside the card's shape clip. The previous `Modifier.clickable` (or `combinedClickable`) on the outer modifier rendered the indication against the rectangular bounds, overflowing the rounded corners. `SystemCategoryCard` branches so its non-browsable variant stays a plain (non-clickable) card.
- Bundles 12 independent UI/UX polish commits — easiest to review commit-by-commit.
