### PR TITLE
Media Squeeze: Make the quality slider easier to adjust

### DIFF
--- a/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/ui/setup/SqueezerSetupScreen.kt
+++ b/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/ui/setup/SqueezerSetupScreen.kt
@@ -73,6 +73,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import java.time.Duration
+import kotlin.math.roundToInt
 
 @Composable
 fun SqueezerSetupScreenHost(
@@ -135,7 +136,7 @@ fun SqueezerSetupScreenHost(
         // Debug builds allow extreme low-quality values to exercise the compressor. Read once
         // here (Host scope) so the inner `internal` Screen has no compile-time dependency on
         // BuildConfigWrap — keeping the Screen JVM-unit-testable without a generated BuildConfig.
-        minQuality = if (BuildConfigWrap.DEBUG) 1 else MIN_QUALITY_RELEASE,
+        minQuality = if (BuildConfigWrap.DEBUG) MIN_QUALITY_DEBUG else MIN_QUALITY_RELEASE,
         onNavigateUp = vm::navUp,
         onPathsClick = vm::openPathPicker,
         onQualityChange = vm::updateQuality,
@@ -360,8 +361,10 @@ private fun QualityCard(
                 Slider(
                     value = quality.toFloat(),
                     valueRange = minQuality.toFloat()..100f,
-                    steps = 100 - minQuality - 1,
-                    onValueChange = { onQualityChange(it.toInt()) },
+                    // 5% increments: ticks land on clean multiples of QUALITY_STEP because both
+                    // min bounds are divisible by it, so the range divides evenly.
+                    steps = (100 - minQuality) / QUALITY_STEP - 1,
+                    onValueChange = { onQualityChange(it.roundToInt()) },
                     modifier = Modifier.weight(1f),
                 )
                 Spacer(Modifier.width(8.dp))
@@ -471,9 +474,14 @@ private fun AgeCard(
     }
 }
 
-// Lower bound the quality slider exposes on release builds. Debug builds use 1 to exercise
-// the compressor at extreme settings.
+// Lower bound the quality slider exposes on release builds. Debug builds go lower to exercise
+// the compressor at extreme settings. Both must be divisible by QUALITY_STEP so the slider's
+// 5% ticks divide the range evenly.
 private const val MIN_QUALITY_RELEASE = 20
+private const val MIN_QUALITY_DEBUG = 5
+
+// Quality slider granularity: the slider snaps to multiples of this (5% increments).
+private const val QUALITY_STEP = 5
 
 @Preview2
 @Composable


### PR DESCRIPTION
## What changed

The compression quality slider in Media Squeeze now moves in 5% steps instead of 1%. The old slider had up to 80 tiny stops, which made it fiddly to drag to the value you wanted — now it snaps to clean 5% marks (20%, 25%, … 100%) and is much easier to set.

## Technical Context

- Granularity is driven by a `QUALITY_STEP = 5` constant: `steps = (100 - minQuality) / QUALITY_STEP - 1`.
- Both slider lower bounds are kept divisible by 5 so the range divides evenly and ticks land on exact multiples: release stays at 20, debug moves from 1 to 5 (`MIN_QUALITY_DEBUG`). Debug still reaches an extreme-low setting for exercising the compressor.
- The slider value is now rounded to the nearest int (`roundToInt`) instead of truncated, so a float tick can't drop one below its label.
- No migration needed: an existing stored value that isn't a multiple of 5 displays as-is until first touch, then snaps. Default quality (80) already lands on-grid.
