### PR TITLE
General: Fix flaky DebugLogSessionManager deadlock test

### DIFF
--- a/app/src/test/java/eu/darken/sdmse/common/debug/recorder/core/DebugLogSessionManagerTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/common/debug/recorder/core/DebugLogSessionManagerTest.kt
@@ -862,6 +862,10 @@ class DebugLogSessionManagerTest : BaseTest() {
             override val IO = Dispatchers.IO
         }
 
+        // Deadlock-detection deadline. Only reached if the scan genuinely never returns; kept well
+        // above any realistic scan/scheduler latency so a loaded CI runner can't false-fail.
+        private val DEADLOCK_TIMEOUT_MS = 30_000L
+
         @Test
         fun `sessions scan completes while a long zip holds the lock`() {
             // Regression for the dashboard "stuck on loading spinner" deadlock: the read-only sessions
@@ -882,16 +886,23 @@ class DebugLogSessionManagerTest : BaseTest() {
                 logDir = zippingDir,
             )
 
-            val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+            // IO, not Default: the manager's scope hosts the flow sharing + async zip launch. Default's
+            // parallelism is the CPU count (2 on a CI runner), and the zip parks one pool thread on
+            // releaseZip.await() for the whole test — leaving the flow plumbing to fight over the
+            // remainder. IO's large pool removes that starvation so scheduling can't stall the scan.
+            val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
             try {
                 val manager = DebugLogSessionManager(scope, realDispatchers, recorderModule, debugLogZipper)
                 runBlocking {
                     // Triggers zipSessionAsync -> acquires fsMutex and blocks inside zip().
                     manager.requestStopRecording()
-                    zipHoldsLock.await(5, TimeUnit.SECONDS) shouldBe true
+                    // Generous deadline: this is a deadlock-detection guard, not a latency assertion.
+                    // The happy path signals in milliseconds; only a genuine hang (or a wedged CI
+                    // scheduler) reaches the timeout. Tight 5s bounds false-failed under CI load.
+                    zipHoldsLock.await(DEADLOCK_TIMEOUT_MS, TimeUnit.MILLISECONDS) shouldBe true
 
                     // Before the fix this hangs forever (scan waits on fsMutex held by the zip).
-                    val sessions = withTimeout(5_000) { manager.sessions.first() }
+                    val sessions = withTimeout(DEADLOCK_TIMEOUT_MS) { manager.sessions.first() }
                     sessions.map { it.id } shouldContain sessionId("ready")
                 }
             } finally {


### PR DESCRIPTION
## What changed

No user-facing behavior change. This stabilizes a flaky unit test — no production code is touched.

## Technical Context

`DebugLogSessionManagerTest.DeadlockRegression > "sessions scan completes while a long zip holds the lock"` flaked nondeterministically in CI: it failed in `testFoss` on some runs and `testGplay` on others, always *only* this one test, uncorrelated with the PR under test (it's tripped several unrelated PRs).

**Why it flaked (not a product bug):** the test is a "prove no-hang" guard. The production code is correct — the `sessions` scan deliberately runs `withContext(IO)` *without* `fsMutex`, so a long-running zip (which holds `fsMutex`) can't block it. The test drives that with real threads + `CountDownLatch`, and two things made the *harness* timing-fragile:

- The manager's scope was `Dispatchers.Default`, whose parallelism is the CPU count (2 on a CI runner). The zip parks one pool thread on `releaseZip.await()` for the whole test, leaving the flow plumbing to fight over what's left.
- Two tight **5-second** wall-clock timeouts (`zipHoldsLock.await` and `withTimeout`) false-failed when the scheduler was merely slow under load — not actually hung.

**Fix:**

- Run the manager's scope on `Dispatchers.IO` for thread headroom. The scan and zip still execute on real IO threads holding the real `fsMutex`, so the regression contract is unchanged — only the flow-sharing/launch scheduling gets more room.
- Widen both timeouts to a shared `DEADLOCK_TIMEOUT_MS = 30s`. A genuine deadlock never completes, so a generous deadline still catches it; it just stops false-failing on scheduler latency.

**Why this doesn't hide a real regression:** the zip mock keeps `fsMutex` held until the test's `finally`, so if anyone reintroduced `fsMutex` acquisition into the scan path, `sessions.first()` would still hang indefinitely and the 30s deadline would fire. The change only affects failure *latency* (5s → 30s), not detection.

**Validation:** ran the test 20/20 green under full CPU-core saturation (the flake condition) locally.
