### PR TITLE
AppControl: Always-visible floating scrollbar in the app list

### DIFF
--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/SdmFastScroller.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/SdmFastScroller.kt
@@ -54,7 +54,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlin.math.roundToInt
 
-val SdmFastScrollerLaneWidth = 48.dp
+val SdmFastScrollerLaneWidth = 32.dp
 internal val ThumbWidth = 8.dp
 internal val ThumbHeight = 48.dp
 internal val BubbleEndPadding = 8.dp

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/AppControlSettings.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/AppControlSettings.kt
@@ -25,7 +25,6 @@ class AppControlSettings @Inject constructor(
     val listSort = dataStore.createValue("list.sort.settings", SortSettings(), json)
     val listFilter = dataStore.createValue("list.filter.settings", FilterSettings(), json)
     val ackSizeSortCaveat = dataStore.createValue("list.filter.sizesort.caveat.ack", false)
-    val listFastScrollerEnabled = dataStore.createValue("list.fastscroller.enabled", false)
     val moduleSizingEnabled = dataStore.createValue("module.sizing.enabled", true)
     val moduleActivityEnabled = dataStore.createValue("module.activity.enabled", true)
     val includeMultiUserEnabled = dataStore.createValue("include.multiuser.enabled", false)

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListScreen.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.WindowInsets
@@ -17,7 +16,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.isImeVisible
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
@@ -26,7 +24,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.ArrowBack
 import androidx.compose.material.icons.twotone.AcUnit
 import androidx.compose.material.icons.twotone.Archive
-import androidx.compose.material.icons.twotone.Check
 import androidx.compose.material.icons.twotone.Close
 import androidx.compose.material.icons.twotone.Delete
 import androidx.compose.material.icons.twotone.MoreVert
@@ -85,8 +82,6 @@ import eu.darken.sdmse.common.compose.preview.Preview2
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import eu.darken.sdmse.common.compose.FastScrollSection
 import eu.darken.sdmse.common.compose.SdmFastScroller
-import eu.darken.sdmse.common.compose.SdmFastScrollerDefaultMinItems
-import eu.darken.sdmse.common.compose.SdmFastScrollerLaneWidth
 import eu.darken.sdmse.common.compose.SdmModalBottomSheet
 import eu.darken.sdmse.common.compose.dialog.SdmConfirmDialog
 import eu.darken.sdmse.common.compose.dialog.SdmDialogAction
@@ -189,7 +184,6 @@ fun AppControlListScreenHost(
         onRestoreSelected = vm::onRestoreRequested,
         onExportSelected = vm::onExportRequested,
         onShareSelected = vm::onShareList,
-        onToggleFastScroller = vm::onToggleFastScroller,
         onRefresh = { vm.onRefresh(refreshPkgCache = true) },
     )
 
@@ -331,7 +325,6 @@ internal fun AppControlListScreen(
     onRestoreSelected: (Set<InstallId>) -> Unit = {},
     onExportSelected: (Set<InstallId>) -> Unit = {},
     onShareSelected: (Set<InstallId>) -> Unit = {},
-    onToggleFastScroller: () -> Unit = {},
     onRefresh: () -> Unit = {},
 ) {
     val state by stateSource.collectAsStateWithLifecycle()
@@ -348,7 +341,6 @@ internal fun AppControlListScreen(
     BackHandler(enabled = selectionActive) { selection.clear() }
 
     var selectionOverflowOpen by remember { mutableStateOf(false) }
-    var normalOverflowOpen by remember { mutableStateOf(false) }
     var searchActive by rememberSaveable { mutableStateOf(false) }
     var activeSheet by rememberSaveable { mutableStateOf<Sheet?>(null) }
 
@@ -495,37 +487,10 @@ internal fun AppControlListScreen(
                                         modifier = Modifier.guidedTourTarget(AppControlListTour.SEARCH_TARGET),
                                     )
                                     SdmTooltipIconButton(
-                                        icon = Icons.TwoTone.MoreVert,
-                                        label = stringResource(CommonR.string.general_options_label),
-                                        onClick = { normalOverflowOpen = true },
+                                        icon = Icons.TwoTone.Refresh,
+                                        label = stringResource(CommonR.string.general_refresh_action),
+                                        onClick = onRefresh,
                                     )
-                                    DropdownMenu(
-                                        expanded = normalOverflowOpen,
-                                        onDismissRequest = { normalOverflowOpen = false },
-                                    ) {
-                                        DropdownMenuItem(
-                                            text = { Text(stringResource(CommonR.string.general_refresh_action)) },
-                                            leadingIcon = { Icon(Icons.TwoTone.Refresh, contentDescription = null) },
-                                            onClick = {
-                                                normalOverflowOpen = false
-                                                onRefresh()
-                                            },
-                                        )
-                                        DropdownMenuItem(
-                                            text = { Text(stringResource(R.string.appcontrol_list_fastscroller_action)) },
-                                            leadingIcon = {
-                                                if (state.fastScrollerEnabled) {
-                                                    Icon(Icons.TwoTone.Check, contentDescription = null)
-                                                } else {
-                                                    Spacer(Modifier.size(24.dp))
-                                                }
-                                            },
-                                            onClick = {
-                                                normalOverflowOpen = false
-                                                onToggleFastScroller()
-                                            },
-                                        )
-                                    }
                                 }
                             },
                         )
@@ -705,21 +670,16 @@ internal fun AppControlListScreen(
                         val sections = remember(rows, state.options.listSort.mode) {
                             buildFastScrollerSections(rows, state.options.listSort.mode)
                         }
-                        // Only carve out gutter space when the scroller will actually render —
-                        // SdmFastScroller hides itself below SdmFastScrollerDefaultMinItems,
-                        // so matching the predicate here avoids dead end-padding on short lists.
-                        val fastScrollerVisible = state.fastScrollerEnabled &&
-                            rows.size >= SdmFastScrollerDefaultMinItems
                         LazyVerticalGrid(
                             columns = GridCells.Fixed(spanCount),
                             state = gridState,
                             modifier = Modifier
                                 .fillMaxSize()
                                 .nestedScroll(scrollBehavior.nestedScrollConnection),
+                            // No end gutter: the fast-scroller floats over the full-width list.
                             contentPadding = PaddingValues(
                                 top = 8.dp,
                                 bottom = 8.dp,
-                                end = if (fastScrollerVisible) SdmFastScrollerLaneWidth else 0.dp,
                             ),
                         ) {
                             items(rows, key = { it.installId.toString() }) { row ->
@@ -747,15 +707,17 @@ internal fun AppControlListScreen(
                                 )
                             }
                         }
-                        if (fastScrollerVisible) {
-                            SdmFastScroller(
-                                state = gridState,
-                                modifier = Modifier
-                                    .align(Alignment.CenterEnd)
-                                    .fillMaxHeight(),
-                                sections = sections,
-                            )
-                        }
+                        // Always-on floating drag-thumb over the full-width list; the widget
+                        // self-hides when the list isn't scrollable (minItemsToShow = 0 so it isn't
+                        // additionally gated by an item-count floor).
+                        SdmFastScroller(
+                            state = gridState,
+                            modifier = Modifier
+                                .align(Alignment.CenterEnd)
+                                .fillMaxHeight(),
+                            sections = sections,
+                            minItemsToShow = 0,
+                        )
                     }
                 }
             }

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListViewModel.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListViewModel.kt
@@ -167,11 +167,10 @@ class AppControlListViewModel @Inject constructor(
     val state: StateFlow<State> = combine(
         rowsState,
         appControl.progress,
-        settings.listFastScrollerEnabled.flow,
-    ) { base, progress, fastScrollerEnabled ->
-        // Outer combine: progress ticks and toggling the fast scroller setting must not invalidate
-        // the row pipeline above (which would re-sort and flash the loading overlay).
-        base.copy(progress = progress, fastScrollerEnabled = fastScrollerEnabled)
+    ) { base, progress ->
+        // Outer combine: progress ticks must not invalidate the row pipeline above (which would
+        // re-sort and flash the loading overlay).
+        base.copy(progress = progress)
     }
         .safeStateIn(initialValue = State(), onError = { State() })
 
@@ -330,11 +329,6 @@ class AppControlListViewModel @Inject constructor(
     fun onTagsReset() = launch {
         log(TAG) { "onTagsReset()" }
         settings.listFilter.update { FilterSettings() }
-    }
-
-    fun onToggleFastScroller() = launch {
-        log(TAG) { "onToggleFastScroller()" }
-        settings.listFastScrollerEnabled.update { current -> !current }
     }
 
     fun onRefresh(refreshPkgCache: Boolean = false) = launch {
@@ -531,7 +525,6 @@ class AppControlListViewModel @Inject constructor(
         val allowActionRestore: Boolean = false,
         val sizeSortModuleEnabled: Boolean = false,
         val allowFilterActive: Boolean = false,
-        val fastScrollerEnabled: Boolean = false,
     )
 
     data class Row(

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/items/AppControlListRow.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/items/AppControlListRow.kt
@@ -26,6 +26,7 @@ import eu.darken.sdmse.appcontrol.ui.list.AppControlListViewModel
 import eu.darken.sdmse.appcontrol.ui.list.AppInfoTagsRow
 import eu.darken.sdmse.appcontrol.ui.preview.previewAppControlRow
 import eu.darken.sdmse.common.R as CommonR
+import eu.darken.sdmse.common.compose.SdmFastScrollerLaneWidth
 import eu.darken.sdmse.common.compose.SelectableListRow
 import eu.darken.sdmse.common.compose.preview.Preview2
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
@@ -105,6 +106,9 @@ fun AppControlListRow(
                 text = Formatter.formatShortFileSize(context, sizes.total),
                 style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
+                // Keep the size clear of the always-on fast-scroll thumb that floats over the list's
+                // right edge (rows stay full-width; only this trailing value is inset).
+                modifier = Modifier.padding(end = SdmFastScrollerLaneWidth),
             )
         }
     }

--- a/app-tool-appcontrol/src/main/res/values-af-rZA/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-af-rZA/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Skerm tyd</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Toepassing groottes is geskat vir prestasie redes. Gebruik die StorageAnalyzer gereedskap vir meer akkurate data.</string>
     <string name="appcontrol_list_filteroptions_label">Filter opsies</string>
-    <string name="appcontrol_list_fastscroller_action">Vinnige rolbalk</string>
     <string name="appcontrol_progress_uninstalling_app">Deïnstalleer toepassing</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d toepassing was gedeïnstalleer</item>

--- a/app-tool-appcontrol/src/main/res/values-am/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-am/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">የማያ ጊዜ</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">የመተግበሪያ መጠኖች ለአፈጻጸም ምክንያቶች ይገመታሉ። ለተጨማሪ ትክክለኛ ውሂብ StorageAnalyzer መሳሪያን ይጠቀሙ።</string>
     <string name="appcontrol_list_filteroptions_label">የማጣሪያ አማራጮች</string>
-    <string name="appcontrol_list_fastscroller_action">ፈጣን ስክሮላር</string>
     <string name="appcontrol_progress_uninstalling_app">መተግበሪያን በማጥፋት ላይ</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d መተግበሪያ ተጥፏል</item>

--- a/app-tool-appcontrol/src/main/res/values-ar/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-ar/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">وقت الشاشة</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">أحجام التطبيقات مقدرة لأسباب تتعلق بالأداء. استخدم أداة تحليل التخزين للحصول على بيانات أدق.</string>
     <string name="appcontrol_list_filteroptions_label">خيارات المرشح</string>
-    <string name="appcontrol_list_fastscroller_action">التمرير السريع</string>
     <string name="appcontrol_progress_uninstalling_app">إلغاء تثبيت التطبيق</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="zero">تم إلغاء تثبيت %d من التطبيقات</item>

--- a/app-tool-appcontrol/src/main/res/values-az/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-az/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Ekran vaxtı</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Tətbiq ölçüləri performans səbəbləri üçün təxmin edilir. Daha dəqiq məlumat üçün StorageAnalyzer alətindən istifadə edin.</string>
     <string name="appcontrol_list_filteroptions_label">Filter seçimləri</string>
-    <string name="appcontrol_list_fastscroller_action">Tez sürüşdürmə</string>
     <string name="appcontrol_progress_uninstalling_app">Tətbiq silinir</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d tətbiq silindi</item>

--- a/app-tool-appcontrol/src/main/res/values-be/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-be/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Час выкарыстання</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Памеры праграм ацэньваюцца паводле іх прадукцыйнасці. З дапамогай Аналізу сховішча атрымайце больш дакладныя даныя.</string>
     <string name="appcontrol_list_filteroptions_label">Параметры фільтра</string>
-    <string name="appcontrol_list_fastscroller_action">Хуткі скролер</string>
     <string name="appcontrol_progress_uninstalling_app">Выдаленне праграмы</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">Выдалена %d праграма</item>

--- a/app-tool-appcontrol/src/main/res/values-bg/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-bg/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Време на екрана</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Размерите на приложенията са приблизителни поради съображения за производителност. Използвайте инструмента StorageAnalyzer за по-точни данни.</string>
     <string name="appcontrol_list_filteroptions_label">Опции за филтриране</string>
-    <string name="appcontrol_list_fastscroller_action">Бърз превъртач</string>
     <string name="appcontrol_progress_uninstalling_app">Деинсталиране на приложение</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d приложение беше деинсталирано</item>

--- a/app-tool-appcontrol/src/main/res/values-bn-rBD/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-bn-rBD/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">স্ক্রিন সময়</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">অ্যাপ্লিকেশান আকার কর্মক্ষমতা কারণে অনুমান করা হয়. আরও সঠিক তথ্যের জন্য স্টোরেজ অ্যানালাইজার টুল ব্যবহার করুন।</string>
     <string name="appcontrol_list_filteroptions_label">ফিল্টার অপশন</string>
-    <string name="appcontrol_list_fastscroller_action">দ্রুত স্ক্রলার</string>
     <string name="appcontrol_progress_uninstalling_app">অ্যাপ আনইনস্টল করা হচ্ছে</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d অ্যাপ আনইনস্টল করা হয়েছে</item>

--- a/app-tool-appcontrol/src/main/res/values-ca/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-ca/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Temps de pantalla</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Les mides de les aplicacions s\'estimen per raons de rendiment. Utilitzeu l\'eina Analitzador d\'emmagatzematge per obtenir dades més precises.</string>
     <string name="appcontrol_list_filteroptions_label">Opcions de filtre</string>
-    <string name="appcontrol_list_fastscroller_action">Desplaçador ràpid</string>
     <string name="appcontrol_progress_uninstalling_app">Desinstal·lant l\'aplicació</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">S\'ha desinstal·lat %d aplicació</item>

--- a/app-tool-appcontrol/src/main/res/values-ckb-rIR/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-ckb-rIR/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">کاتی شاشە</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">ئەپ sizes are estimated for performance reasons. Use the ناحیەکانAnalyzer tool for more accurate data.</string>
     <string name="appcontrol_list_filteroptions_label">پاڵاوتن options</string>
-    <string name="appcontrol_list_fastscroller_action">گۆڕانەوەی خێرا</string>
     <string name="appcontrol_progress_uninstalling_app">لابردنی دامەزراندنing app</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d ئەپ لادرایەوە</item>

--- a/app-tool-appcontrol/src/main/res/values-cs/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-cs/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Čas u obrazovky</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Velikosti aplikací jsou z výkonnostních důvodů odhadovány. Pro přesnější údaje použijte Analyzátor úložiště.</string>
     <string name="appcontrol_list_filteroptions_label">Možnosti filtrování</string>
-    <string name="appcontrol_list_fastscroller_action">Rychlý posuvník</string>
     <string name="appcontrol_progress_uninstalling_app">Odinstalování aplikace</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d aplikace byla odinstalována</item>

--- a/app-tool-appcontrol/src/main/res/values-da/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-da/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Skærmtid</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Appstørrelser er anslået af hensyn til ydeevnen. Brug værktøjet Lageranalyse for mere præcise data.</string>
     <string name="appcontrol_list_filteroptions_label">Filtreringsmuligheder</string>
-    <string name="appcontrol_list_fastscroller_action">Hurtig scroller</string>
     <string name="appcontrol_progress_uninstalling_app">Afinstallerer app</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d app blev afinstalleret</item>

--- a/app-tool-appcontrol/src/main/res/values-de/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-de/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Bildschirmzeit</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">App-Größen werden aus Leistungsgründen geschätzt. Verwende das Storage Analysator-Tool für genauere Daten.</string>
     <string name="appcontrol_list_filteroptions_label">Filteroptionen</string>
-    <string name="appcontrol_list_fastscroller_action">Schnellscroller</string>
     <string name="appcontrol_progress_uninstalling_app">Deinstalliert App</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d App wurde deinstalliert</item>

--- a/app-tool-appcontrol/src/main/res/values-el/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-el/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Χρόνος χρήσης οθόνης</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Τα μεγέθη των εφαρμογών εκτιμώνται για λόγους απόδοσης. Χρησιμοποιήστε το εργαλείο Αναλυτής Αποθηκευτικού Χώρου για πιο ακριβή δεδομένα.</string>
     <string name="appcontrol_list_filteroptions_label">Επιλογές φίλτρου</string>
-    <string name="appcontrol_list_fastscroller_action">Γρήγορη κύλιση</string>
     <string name="appcontrol_progress_uninstalling_app">Απεγκατάσταση εφαρμογής</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d εφαρμογή απεγκαταστάθηκε</item>

--- a/app-tool-appcontrol/src/main/res/values-es-rAR/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-es-rAR/strings.xml
@@ -45,7 +45,6 @@ Archivo: Textos de la aplicación (aplicación principal)</string>
     <string name="appcontrol_list_sortmode_screentime_label">Tiempo de pantalla</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Los tamaños de las aplicaciones se estiman por motivos de rendimiento. Utilice la herramienta StorageAnalyzer para obtener datos más precisos.</string>
     <string name="appcontrol_list_filteroptions_label">Opciones del filtro</string>
-    <string name="appcontrol_list_fastscroller_action">Desplazador rápido</string>
     <string name="appcontrol_progress_uninstalling_app">Desinstalando aplicación</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d aplicación fue desinstalada</item>

--- a/app-tool-appcontrol/src/main/res/values-es-rMX/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-es-rMX/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Tiempo de pantalla</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Los tamaños de las aplicaciones son estimados por razones de rendimiento. Usa la herramienta Analizador de Almacenamiento para datos más precisos.</string>
     <string name="appcontrol_list_filteroptions_label">Opciones de filtro</string>
-    <string name="appcontrol_list_fastscroller_action">Desplazador rápido</string>
     <string name="appcontrol_progress_uninstalling_app">Desinstalando aplicación</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d aplicación fue desinstalada</item>

--- a/app-tool-appcontrol/src/main/res/values-es/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-es/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Tiempo de pantalla</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Los tamaños de las aplicaciones se estiman por motivos de rendimiento. Utilice la herramienta StorageAnalyzer para obtener datos más precisos.</string>
     <string name="appcontrol_list_filteroptions_label">Opciones de filtrado</string>
-    <string name="appcontrol_list_fastscroller_action">Desplazador rápido</string>
     <string name="appcontrol_progress_uninstalling_app">Desinstalar la aplicación</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d aplicación desinstalada</item>

--- a/app-tool-appcontrol/src/main/res/values-et-rEE/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-et-rEE/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Ekraaniaeg</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Rakenduse mahtu uuritakse jõudluse eesmärkidel. Täpsemad andmed saad hoiustamisruumi analüüsijaga.</string>
     <string name="appcontrol_list_filteroptions_label">Filtri valikud</string>
-    <string name="appcontrol_list_fastscroller_action">Kiirkerimine</string>
     <string name="appcontrol_progress_uninstalling_app">Rakenduse eemaldamine</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d rakendus eemaldati</item>

--- a/app-tool-appcontrol/src/main/res/values-eu-rES/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-eu-rES/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Pantaila-denbora</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Aplikazioen tamainak estimatuta daude errendimendu arrazoengatik. Erabili StorageAnalyzer tresna datu zehatzagoak lortzeko.</string>
     <string name="appcontrol_list_filteroptions_label">Iragazki-aukerak</string>
-    <string name="appcontrol_list_fastscroller_action">Desplazatzaile bizia</string>
     <string name="appcontrol_progress_uninstalling_app">Aplikazioa desinstalatzend</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d aplikazio desinstalatu da</item>

--- a/app-tool-appcontrol/src/main/res/values-fa/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-fa/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">مدت زمان نمایش</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">اندازه‌های برنامه به دلایل عملکردی تخمین زده می‌شوند. از ابزار آنالیز حافظه برای داده‌های دقیق‌تر استفاده کنید.</string>
     <string name="appcontrol_list_filteroptions_label">گزینه‌های فیلتر</string>
-    <string name="appcontrol_list_fastscroller_action">پیمایش سریع</string>
     <string name="appcontrol_progress_uninstalling_app">حذف کردن برنامه</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d برنامه حذف نصب شد</item>

--- a/app-tool-appcontrol/src/main/res/values-fi/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-fi/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Näyttöaika</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Sovelluskoot ovat arvioita suorituskyvyn vuoksi. Käytä Tallennustilan analysaattoria tarkempien tietojen saamiseksi.</string>
     <string name="appcontrol_list_filteroptions_label">Suodatusasetukset</string>
-    <string name="appcontrol_list_fastscroller_action">Pikavieritin</string>
     <string name="appcontrol_progress_uninstalling_app">Poistetaan sovelluksen asennus</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d sovellus poistettiin</item>

--- a/app-tool-appcontrol/src/main/res/values-fil/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-fil/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Oras sa screen</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Ang mga laki ng app ay tinantya para sa performance. Gamitin ang StorageAnalyzer tool para sa mas tumpak na data.</string>
     <string name="appcontrol_list_filteroptions_label">Mga filter option</string>
-    <string name="appcontrol_list_fastscroller_action">Mabilis na pag-scroll</string>
     <string name="appcontrol_progress_uninstalling_app">Inu-uninstall ang app</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d app ang na-uninstall</item>

--- a/app-tool-appcontrol/src/main/res/values-fr/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-fr/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Temps d’écran</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">La taille des applis est estimée pour des raisons de performance. Utilisez l’Analyseur de mémoire pour obtenir des données plus justes.</string>
     <string name="appcontrol_list_filteroptions_label">Options de filtrage</string>
-    <string name="appcontrol_list_fastscroller_action">Défilement rapide</string>
     <string name="appcontrol_progress_uninstalling_app">Désinstallation de l’appli</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d appli a été désinstallée</item>

--- a/app-tool-appcontrol/src/main/res/values-gl-rES/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-gl-rES/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Tempo de pantalla</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Os tamaños das aplicacións estímanse por razóns de rendemento. Use a ferramenta StorageAnalyzer para obter datos máis precisos.</string>
     <string name="appcontrol_list_filteroptions_label">Opcións de filtro</string>
-    <string name="appcontrol_list_fastscroller_action">Desprazador rápido</string>
     <string name="appcontrol_progress_uninstalling_app">Desinstalando aplicación</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d aplicación foi desinstalada</item>

--- a/app-tool-appcontrol/src/main/res/values-hi-rIN/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-hi-rIN/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">स्क्रीन समय</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">आकार की जानकारी उपलब्ध नहीं है।</string>
     <string name="appcontrol_list_filteroptions_label">फ़िल्टर विकल्प</string>
-    <string name="appcontrol_list_fastscroller_action">तेज़ स्क्रोलर</string>
     <string name="appcontrol_progress_uninstalling_app">ऐप्लिकेशन अनइंस्टॉल किया जा रहा है</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d ऐप अनइंस्टॉल किया गया</item>

--- a/app-tool-appcontrol/src/main/res/values-hr/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-hr/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Vrijeme upotrebe</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Veličine aplikacija su procijenjene radi boljih performansi. Za točnije podatke koristite alat Analizator pohrane.</string>
     <string name="appcontrol_list_filteroptions_label">Opcije filtera</string>
-    <string name="appcontrol_list_fastscroller_action">Brzi klizač</string>
     <string name="appcontrol_progress_uninstalling_app">Deinstaliranje aplikacije</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d aplikacija je deinstalirana</item>

--- a/app-tool-appcontrol/src/main/res/values-hu/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-hu/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Képernyőidő</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Az alkalmazások mérete teljesítményi okokból becsült. Pontosabb adatokért használja a StorageAnalyzer eszközt.</string>
     <string name="appcontrol_list_filteroptions_label">Szűrési lehetőségek</string>
-    <string name="appcontrol_list_fastscroller_action">Gyors görgetés</string>
     <string name="appcontrol_progress_uninstalling_app">App eltávolítása...</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d alkalmazás eltávolításra került</item>

--- a/app-tool-appcontrol/src/main/res/values-in/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-in/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Waktu layar</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Ukuran aplikasi diperkirakan untuk alasan kinerja. Gunakan alat StorageAnalyzer untuk data yang lebih akurat.</string>
     <string name="appcontrol_list_filteroptions_label">Pilihan filter</string>
-    <string name="appcontrol_list_fastscroller_action">Penggulir cepat</string>
     <string name="appcontrol_progress_uninstalling_app">Mencopot aplikasi</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="other">%d aplikasi dihapus</item>

--- a/app-tool-appcontrol/src/main/res/values-is/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-is/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Skjátími</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Stærðir forrita eru áætlaðar af afkastasökum. Notaðu StorageAnalyzer verkfærið fyrir nákvæmari gögn.</string>
     <string name="appcontrol_list_filteroptions_label">Síuvalkostir</string>
-    <string name="appcontrol_list_fastscroller_action">Hraðskroli</string>
     <string name="appcontrol_progress_uninstalling_app">Fjarlægi forrit</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d forrit var fjarlægt</item>

--- a/app-tool-appcontrol/src/main/res/values-it/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-it/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Tempo schermo</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Le dimensioni delle app sono stimate per ragioni di prestazioni. Utilizzare lo StorageAnalyzer per dati più accurati.</string>
     <string name="appcontrol_list_filteroptions_label">Opzioni filtro</string>
-    <string name="appcontrol_list_fastscroller_action">Scorrimento veloce</string>
     <string name="appcontrol_progress_uninstalling_app">Rimozione app</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d app è stata disinstallata</item>

--- a/app-tool-appcontrol/src/main/res/values-iw/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-iw/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">זמן מסך</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">גדלי האפליקציות משוערים מסיבות של ביצועים. השתמש בכלי מנתח אחסון לקבלת נתונים מדויקים יותר.</string>
     <string name="appcontrol_list_filteroptions_label">אפשרויות סינון</string>
-    <string name="appcontrol_list_fastscroller_action">גלילה מהירה</string>
     <string name="appcontrol_progress_uninstalling_app">מסיר התקנה של אפליקציה</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">אפליקציה %d הוסרה</item>

--- a/app-tool-appcontrol/src/main/res/values-ja/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-ja/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">スクリーンタイム</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">パフォーマンス上の理由からアプリのサイズが推定されます。より正確なデータを取得するには、StorageAnalyzerツールを使用してください。</string>
     <string name="appcontrol_list_filteroptions_label">フィルタオプション</string>
-    <string name="appcontrol_list_fastscroller_action">高速スクローラー</string>
     <string name="appcontrol_progress_uninstalling_app">アプリのアンインストール中</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="other">%d個のアプリをアンインストールしました</item>

--- a/app-tool-appcontrol/src/main/res/values-ka-rGE/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-ka-rGE/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">ეკრანის დრო</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">აპების ზომები შეფასებულია წარმადობის მიზნებისთვის. გამოიყენეთ StorageAnalyzer ხელსაწყო უფრო ზუსტი მონაცემებისთვის.</string>
     <string name="appcontrol_list_filteroptions_label">ფილტრის ოფციები</string>
-    <string name="appcontrol_list_fastscroller_action">სწრაფი გადახრა</string>
     <string name="appcontrol_progress_uninstalling_app">აპის წაშლა</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d აპი წაშლილია</item>

--- a/app-tool-appcontrol/src/main/res/values-kaa/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-kaa/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Ekran waqtı</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Qosímsha kólemleri ónimdilik maqsetinde shamamen esaplanǵan. Anıǵıraq maǵlıwmatlar ushın StorageAnalyzer quralın paydalanıń.</string>
     <string name="appcontrol_list_filteroptions_label">Súzgiw opsiyaları</string>
-    <string name="appcontrol_list_fastscroller_action">Tez júgiriw paneli</string>
     <string name="appcontrol_progress_uninstalling_app">Qosímsha óshiriliw</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d ilova o’chirildı</item>

--- a/app-tool-appcontrol/src/main/res/values-km-rKH/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-km-rKH/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">សម្អែវេលាស្វើសហន្តៀឧបករណ៍</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">ទំហំកម្មវិធីត្រូវបានប័តិម្ឡ័លសម្រាប់លក្ខណៈសម្វ័ង។ ប្រើបរស់ឡាឡ់ StorageAnalyzer សម្រាប់តិន្នន័យផ័ត់ពិតជាង។</string>
     <string name="appcontrol_list_filteroptions_label">ជម្រើសប័ន្ទ័វរង់</string>
-    <string name="appcontrol_list_fastscroller_action">ឧបករណ៍រំកិលលឿន</string>
     <string name="appcontrol_progress_uninstalling_app">កំពុងដកតិត្តាក់កម្មវិធី</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="other">%d កម្មវិធីត្រូវបានដកតិត្តាក់</item>

--- a/app-tool-appcontrol/src/main/res/values-ko/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-ko/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">화면 시간</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">앱 크기는 성능상의 이유로 추정된 것입니다. 보다 정확한 데이터를 확인하려면 StorageAnalyzer tool을 사용하세요.</string>
     <string name="appcontrol_list_filteroptions_label">필터 설정</string>
-    <string name="appcontrol_list_fastscroller_action">빠른 스크롤러</string>
     <string name="appcontrol_progress_uninstalling_app">앱 제거하기</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="other">%d 앱을 제거했습니다.</item>

--- a/app-tool-appcontrol/src/main/res/values-lo-rLA/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-lo-rLA/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">ເວລາໃຊ້ຫນ້າຈອ</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">ຂນາດແອບຖືກປະເມີນເພື່ອເຫດຜອງດ້ານປະສິທຘິພາບ. ໃຊ້ໂຄຣງການ StorageAnalyzer ສຳຫລັບຂ້ອມູນທີ່ຖືກຕ້ອງກວ່າ.</string>
     <string name="appcontrol_list_filteroptions_label">ຕັວເລືອກການການຕອງການ</string>
-    <string name="appcontrol_list_fastscroller_action">ເຄື່ອງເລື່ອນໄວ</string>
     <string name="appcontrol_progress_uninstalling_app">ກຳລັງຖອນຕິດຕັ້ງແອບ</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="other">ຖອນຕິດຕັ້ງ %d ແອບແລ້ວ</item>

--- a/app-tool-appcontrol/src/main/res/values-lt/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-lt/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Ekrano laikas</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Programų dyžių sąmatos yra apytikslės dėl našumo priežasių. Naudokite įrankio Atminties analizatorius tikslesniems duomenims.</string>
     <string name="appcontrol_list_filteroptions_label">Filtravimo parinktys</string>
-    <string name="appcontrol_list_fastscroller_action">Greitas slinktuvas</string>
     <string name="appcontrol_progress_uninstalling_app">Pašalinama programa</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d programa buvo pašalinta</item>

--- a/app-tool-appcontrol/src/main/res/values-lv/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-lv/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Ekrāna laiks</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Lietotniņu izmēri tiek aptuveni apreksināti veiktspējas iemeslu dēļ. Izmantojiet StorageAnalyzer rīku precizākiem datiem.</string>
     <string name="appcontrol_list_filteroptions_label">Filtrēšanas opcijas</string>
-    <string name="appcontrol_list_fastscroller_action">Ātrā ritēšana</string>
     <string name="appcontrol_progress_uninstalling_app">Lietotnes atinstalēšana</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="zero">%d lietotnes tika atinstalētas</item>

--- a/app-tool-appcontrol/src/main/res/values-mk-rMK/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-mk-rMK/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Време на екран</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Големините на апликациите се проценети заради перформанси. Користете ја алатката StorageAnalyzer за попрецизни податоци.</string>
     <string name="appcontrol_list_filteroptions_label">Опции за филтрирање</string>
-    <string name="appcontrol_list_fastscroller_action">Брз скролер</string>
     <string name="appcontrol_progress_uninstalling_app">Деинсталирање апликација</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d апликација е деинсталирана</item>

--- a/app-tool-appcontrol/src/main/res/values-ml-rIN/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-ml-rIN/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">സ്ക്രീൻ സമയം</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">ആപ്പ് വലിപ്പങ്ങൾ പ്രകടനകാരണങ്ങൾക്കായി കണക്കാക്കല്പിക്കപ്പെടുന്നു. കൂടുതൽ കൃത്യമായ ഡേറ്റക്കായി StorageAnalyzer ടൂൾ ഉപയോഗിക്കുക.</string>
     <string name="appcontrol_list_filteroptions_label">ഫിൽടർ ഓപ്ഷൻസ്</string>
-    <string name="appcontrol_list_fastscroller_action">വേഗതയുള്ള സ്ക്രോളർ</string>
     <string name="appcontrol_progress_uninstalling_app">ആപ്പ് അൻ ഇൻസ്റ്റാൾ ചെയ്യുന്നു</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d ആപ്പ് അൻഇൻസ്റ്റാൾ ചെയ്തു</item>

--- a/app-tool-appcontrol/src/main/res/values-mn-rMN/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-mn-rMN/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Дэлгэцийн цаг</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Гүйцэтгийн шалтгаараас аппын хэмжээг төсөөлдөж тооцолдого. Илүү нарийн өгөгдөлд StorageAnalyzer багажийг ашигла.</string>
     <string name="appcontrol_list_filteroptions_label">Шүүгах сонгоо</string>
-    <string name="appcontrol_list_fastscroller_action">Хурдан гулсагч</string>
     <string name="appcontrol_progress_uninstalling_app">Аппыг устгаж байна</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d апп устгагдсан</item>

--- a/app-tool-appcontrol/src/main/res/values-ms/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-ms/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Masa skrin</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Penyusunan mengikut saiz mungkin perlahan pada sesetengah peranti</string>
     <string name="appcontrol_list_filteroptions_label">Pilihan penapis</string>
-    <string name="appcontrol_list_fastscroller_action">Penggulir Pantas</string>
     <string name="appcontrol_progress_uninstalling_app">Menyahpasang aplikasi</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="other">%d aplikasi telah dinyahpasang</item>

--- a/app-tool-appcontrol/src/main/res/values-my-rMM/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-my-rMM/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">စကᒰမှအပြပ်ချသောအချား</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">အကြေးအရွယ်အစားများကို စကင်ᄀောင်းသော ခန့်မှန်းပြမည့်တွက်များသာမှု ခန့်မှန်းပြမည့်တွက်များသည်။ ပိုအနက်အခြေအနေရာအတွက် အသုံး StorageAnalyzer ကြေးဆိုင်တွဲကို အသုံးချသည်။</string>
     <string name="appcontrol_list_filteroptions_label">ဆပ်ရှားများ</string>
-    <string name="appcontrol_list_fastscroller_action">လျင်မြန်သော စာရွက်လှည်း</string>
     <string name="appcontrol_progress_uninstalling_app">အကြေးကို ဖက်ချတစ်ချနေစ်သည်</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="other">%d အကြေး ဖက်ချတစ်ချပြီးသည်</item>

--- a/app-tool-appcontrol/src/main/res/values-nb/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-nb/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Skjermtid</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">App-størrelser er estimert av ytelsesgrunner. Bruk Lagringsanalysator-verktøyet for mer nøyaktig data.</string>
     <string name="appcontrol_list_filteroptions_label">Alternativer for filter</string>
-    <string name="appcontrol_list_fastscroller_action">Rask scroller</string>
     <string name="appcontrol_progress_uninstalling_app">Avinstallerer app</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d app ble avinstallert</item>

--- a/app-tool-appcontrol/src/main/res/values-ne-rNP/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-ne-rNP/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">स्क्रिन समय</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">प्रदर्शन कारणहरूले गर्दा App साइजहरू अनुमानित छन्। थप सटीक डेटाका लागि StorageAnalyzer उपकरण प्रयोग गर्नुहोस्।</string>
     <string name="appcontrol_list_filteroptions_label">फिल्टर विकल्पहरू</string>
-    <string name="appcontrol_list_fastscroller_action">द्रुत स्क्रोलर</string>
     <string name="appcontrol_progress_uninstalling_app">App हटाउँदै</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d अनुप्रयोग अनइन्स्टल गरियो</item>

--- a/app-tool-appcontrol/src/main/res/values-nl/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-nl/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Schermtijd</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">App-grootes worden geschat om prestatieredenen. Gebruik de StorageAnalyzer-tool voor nauwkeurigere gegevens.</string>
     <string name="appcontrol_list_filteroptions_label">Filter opties</string>
-    <string name="appcontrol_list_fastscroller_action">Snelle scroller</string>
     <string name="appcontrol_progress_uninstalling_app">App verwijderen</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d app werd verwijderd</item>

--- a/app-tool-appcontrol/src/main/res/values-or-rIN/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-or-rIN/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">ସ୍କ୍ରିନ୍ ସମୟ</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">କାର୍ଯ୍ୟକ୍ଷମତା କାରଣରୁ ଆପ୍ ଆକାରଗୁଡ଼ିକ ଆନୁମାନିକ। ଅଧିକ ସଠିକ ଡାଟା ପାଇଁ StorageAnalyzer ଟୁଲ୍ ବ୍ୟବହାର କରନ୍ତୁ।</string>
     <string name="appcontrol_list_filteroptions_label">ଫିଲ୍ଟର ବିକଳ୍ପଗୁଡ଼ିକ</string>
-    <string name="appcontrol_list_fastscroller_action">ଶୀଘ୍ର ସ୍କ୍ରୋଲର</string>
     <string name="appcontrol_progress_uninstalling_app">ଆପ୍ ଅନଇନଷ୍ଟଲ କରୁଛି</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d ଆପ୍ ଅନଇନଷ୍ଟଲ୍ ହୋଇଛି</item>

--- a/app-tool-appcontrol/src/main/res/values-pa-rIN/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-pa-rIN/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">ਸਕ੍ਰੀਨ ਸਮਾਂ</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">ਕਾਰਗੁਜ਼ਾਰੀ ਕਾਰਨਾਂ ਕਰਕੇ ਐਪ ਦੇ ਆਕਾਰ ਦਾ ਅੰਦਾਜ਼ਾ ਲਗਾਇਆ ਜਾਂਦਾ ਹੈ। ਵਧੇਰੇ ਸਟੀਕ ਡਾਟਾ ਲਈ StorageAnalyzer ਟੂਲ ਵਰਤੋ।</string>
     <string name="appcontrol_list_filteroptions_label">ਫਿਲਟਰ ਵਿਕਲਪ</string>
-    <string name="appcontrol_list_fastscroller_action">ਤੇਜ਼ ਸਕ੍ਰੋਲਰ</string>
     <string name="appcontrol_progress_uninstalling_app">ਐਪ ਨੂੰ ਅਣਸਥਾਪਿਤ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d ਐਪ ਅਣਸਥਾਪਿਤ ਕੀਤੀ ਗਈ</item>

--- a/app-tool-appcontrol/src/main/res/values-pl/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-pl/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Czas przed ekranem</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Rozmiary aplikacji są szacowane ze względu na wydajność. Aby uzyskać dokładniejsze dane, użyj narzędzia Analizowanie pamięci.</string>
     <string name="appcontrol_list_filteroptions_label">Opcje filtrowania</string>
-    <string name="appcontrol_list_fastscroller_action">Szybkie przewijanie</string>
     <string name="appcontrol_progress_uninstalling_app">Odinstalowywanie aplikacji</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">Odinstalowano %d aplikację</item>

--- a/app-tool-appcontrol/src/main/res/values-pt-rBR/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-pt-rBR/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Tempo da tela</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Os tamanhos de apps são estimados por razões de desempenho. Use a ferramenta Analisador de Armazenamento para dados mais precisos.</string>
     <string name="appcontrol_list_filteroptions_label">Opções de filtro</string>
-    <string name="appcontrol_list_fastscroller_action">Rolagem rápida</string>
     <string name="appcontrol_progress_uninstalling_app">Desinstalar aplicativo</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d aplicativo desinstalado com sucesso</item>

--- a/app-tool-appcontrol/src/main/res/values-pt/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-pt/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Tempo de Ecrã Ligado</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Tamanhos das apps são estimados pelo desempenho. Use a ferramenta de Análise de Armazenamento para dados mais precisos.</string>
     <string name="appcontrol_list_filteroptions_label">Opções de filtro</string>
-    <string name="appcontrol_list_fastscroller_action">Deslocador rápido</string>
     <string name="appcontrol_progress_uninstalling_app">Desinstalando a aplicação</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">Uma aplicação foi desinstalada</item>

--- a/app-tool-appcontrol/src/main/res/values-ro/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-ro/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Timp ecran pornit</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Dimensiunile aplicației sunt estimate din motive de performanță. Utilizați unealta de analiză a stocării pentru date mai exacte.</string>
     <string name="appcontrol_list_filteroptions_label">Opțiuni pentru filtre</string>
-    <string name="appcontrol_list_fastscroller_action">Derulator rapid</string>
     <string name="appcontrol_progress_uninstalling_app">Dezinstalare aplicație</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d aplicație a fost dezinstalată</item>

--- a/app-tool-appcontrol/src/main/res/values-ru/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-ru/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Время экрана</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Размеры приложений оцениваются для анализа производительности. Используйте инструмент Анализ памяти для получения более точных данных.</string>
     <string name="appcontrol_list_filteroptions_label">Параметры фильтра</string>
-    <string name="appcontrol_list_fastscroller_action">Быстрая прокрутка</string>
     <string name="appcontrol_progress_uninstalling_app">Удаление приложения</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">Удалено приложений: %d</item>

--- a/app-tool-appcontrol/src/main/res/values-sc-rIT/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-sc-rIT/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Tempus de ischermada</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Is mannarias de aplicatziones sunt istimadas pro raxones de rendimentu. Imprea s\'aina StorageAnalyzer pro datos prus curatos.</string>
     <string name="appcontrol_list_filteroptions_label">Optziones de filtru</string>
-    <string name="appcontrol_list_fastscroller_action">Desbilligu ladu</string>
     <string name="appcontrol_progress_uninstalling_app">Disinstallende aplicatzione</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d aplicatzione fiat disinstallada</item>

--- a/app-tool-appcontrol/src/main/res/values-si-rLK/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-si-rLK/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">තිර කාලය</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">කාර්යක්ෂමතා හේතුවෙන් යෙදුම් ප්‍රමාණ අනුමාන කර ඇත. වැඩා නිවැරදි දත්ත සඳහා StorageAnalyzer මෙවලම භාවිතා කරන්න.</string>
     <string name="appcontrol_list_filteroptions_label">පෙරණ විකල්ප</string>
-    <string name="appcontrol_list_fastscroller_action">වේගවත් ස්ක්‍රෝලර්</string>
     <string name="appcontrol_progress_uninstalling_app">යෙදුම ඉවත් කරමින්</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d යෙදුමක් ඉවත් කරන ලදී</item>

--- a/app-tool-appcontrol/src/main/res/values-sk/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-sk/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Čas obrazovky</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Veľkosti aplikácií sú odhadované z dôvodu výkonu. Pre presnejšie údaje použite nástroj Analyzátor úložiska.</string>
     <string name="appcontrol_list_filteroptions_label">Možnosti filtrovania</string>
-    <string name="appcontrol_list_fastscroller_action">Rýchly posúvač</string>
     <string name="appcontrol_progress_uninstalling_app">Odinštaluje sa</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d aplikácia bola odinštalovaná</item>

--- a/app-tool-appcontrol/src/main/res/values-sl/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-sl/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Čas zaslona</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Velikosti programov se določajo zaradi zmogljivosti.  Za natančnejše podatke uporabite Analizatorja shrambe.</string>
     <string name="appcontrol_list_filteroptions_label">Možnosti filtra</string>
-    <string name="appcontrol_list_fastscroller_action">Hitri drsnik</string>
     <string name="appcontrol_progress_uninstalling_app">Odstranjevanje programa</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d program je bil odstranjen.</item>

--- a/app-tool-appcontrol/src/main/res/values-sq-rAL/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-sq-rAL/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Koha e ekranit</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Madhësitë e aplikacioneve vlerësohen për arsye të performancës. Përdorni mjetin StorageAnalyzer për të dhëna më të sakta.</string>
     <string name="appcontrol_list_filteroptions_label">Opsionet e filtrit</string>
-    <string name="appcontrol_list_fastscroller_action">Rrëshqitës i shpejtë</string>
     <string name="appcontrol_progress_uninstalling_app">Po çinstalon aplikacionin</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d aplikacion u çinstalua</item>

--- a/app-tool-appcontrol/src/main/res/values-sr/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-sr/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Време на екрану</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Величине апликација су процењене из разлога перформанси. Користите алат StorageAnalyzer за прецизније податке.</string>
     <string name="appcontrol_list_filteroptions_label">Опције филтера</string>
-    <string name="appcontrol_list_fastscroller_action">Брзи клизач</string>
     <string name="appcontrol_progress_uninstalling_app">Деинсталирање апликације</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d апликација је деинсталирана</item>

--- a/app-tool-appcontrol/src/main/res/values-sv/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-sv/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Skärmtid</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Appstorlekar är uppskattade av prestandaskäl. Använd StorageAnalyzer-verktyget för mer exakta data.</string>
     <string name="appcontrol_list_filteroptions_label">Filteralternativ</string>
-    <string name="appcontrol_list_fastscroller_action">Snabbscroller</string>
     <string name="appcontrol_progress_uninstalling_app">Avinstallerar app</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d app avinstallerades</item>

--- a/app-tool-appcontrol/src/main/res/values-sw/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-sw/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Muda wa skrini</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Ukubwa wa programu unakadirika kwa sababu za utendaji. Tumia zana ya StorageAnalyzer kwa data sahihi zaidi.</string>
     <string name="appcontrol_list_filteroptions_label">Chaguo za kichungi</string>
-    <string name="appcontrol_list_fastscroller_action">Kitelezo cha haraka</string>
     <string name="appcontrol_progress_uninstalling_app">Inaondoa programu</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">Programu %d imeondolewa</item>

--- a/app-tool-appcontrol/src/main/res/values-ta-rIN/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-ta-rIN/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">திரை நேரம்</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">செயல்திறன் காரணங்களால் பயன்பாட்டு அளவுகள் அனுமானிக்கப்பட்டுள்ளன. மிகவும் தரவிற்கான StorageAnalyzer கருவியைப் பயன்படுத்தவும்.</string>
     <string name="appcontrol_list_filteroptions_label">வடிகட்டல் விருப்பங்கள்</string>
-    <string name="appcontrol_list_fastscroller_action">வேகமான உருட்டல்</string>
     <string name="appcontrol_progress_uninstalling_app">பயன்பாடை அன்இன்ஸ்டால் செய்கிறது</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d பயன்பாடு அன்இன்ஸ்டால் செய்யப்பட்டது</item>

--- a/app-tool-appcontrol/src/main/res/values-te-rIN/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-te-rIN/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">స్క్రీన్ సమయం</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">యాప్ పరిమాణాలు పరఫార్మెన్స్ కారణాల అందాజులు. మరింత ఖుదాయిన డేటా కోసం StorageAnalyzer టూల్‌ను ఉపయోగించండి.</string>
     <string name="appcontrol_list_filteroptions_label">ఫిల్టర్ ఎంపికలు</string>
-    <string name="appcontrol_list_fastscroller_action">వేగవంతమైన స్క్రోలర్</string>
     <string name="appcontrol_progress_uninstalling_app">యాప్‌ను అనిన్‌స్టాల్ చేస్తోంది</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d యాప్ అనిన్‌స్టాల్ చేయబడింది</item>

--- a/app-tool-appcontrol/src/main/res/values-th/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-th/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">เวลาใช้งานหน้าจอ</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">ขนาดแอพเป็นการประมาณเพื่อประสิทธิภาพการทำงาน ใช้เครื่องมือ StorageAnalyzer สำหรับข้อมูลที่แม่นยำกว่า</string>
     <string name="appcontrol_list_filteroptions_label">ตัวเลือกการกรอง</string>
-    <string name="appcontrol_list_fastscroller_action">เลื่อนเร็ว</string>
     <string name="appcontrol_progress_uninstalling_app">กำลังถอนการติดตั้งแอพ</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="other">ถอนการติดตั้งแอพ %d แอพแล้ว</item>

--- a/app-tool-appcontrol/src/main/res/values-tr/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-tr/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Ekran süresi</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Uygulama boyutları performans nedeniyle tahmini olarak verilmiştir. Daha doğru veriler için StorageAnalyzer aracını kullanın.</string>
     <string name="appcontrol_list_filteroptions_label">Filtre seçenekleri</string>
-    <string name="appcontrol_list_fastscroller_action">Hızlı kaydırıcı</string>
     <string name="appcontrol_progress_uninstalling_app">Uygulama kaldırılıyor</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d uygulama kaldırıldı</item>

--- a/app-tool-appcontrol/src/main/res/values-uk/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-uk/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Екранний час</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Розміри додатків оцінюються з міркувань продуктивності. Використовуйте інструмент Аналізатор сховища для отримання більш точних даних.</string>
     <string name="appcontrol_list_filteroptions_label">Параметри фільтрування</string>
-    <string name="appcontrol_list_fastscroller_action">Швидка прокрутка</string>
     <string name="appcontrol_progress_uninstalling_app">Видалення додатка</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d додаток було видалено</item>

--- a/app-tool-appcontrol/src/main/res/values-ur-rIN/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-ur-rIN/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">سکرین ٹائم</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">ایپ کے سائز کارکردگی کی وجہ سے تخمینی ہیں۔ زیادہ درست ڈیٹا کے لیے StorageAnalyzer ٹول استعمال کریں۔</string>
     <string name="appcontrol_list_filteroptions_label">فلٹر آپشنز</string>
-    <string name="appcontrol_list_fastscroller_action">تیز رفتار اسکرولر</string>
     <string name="appcontrol_progress_uninstalling_app">ایپ ان انسٹال کر رہے ہیں</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d ایپ ان انسٹال ہوئی</item>

--- a/app-tool-appcontrol/src/main/res/values-uz/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-uz/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Ekran vaqti</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Ilova hajmlari ishlash sabablari uchun taxmin qilinadi. Aniqroq ma\'lumotlar uchun StorageAnalyzer vositasidan foydalaning.</string>
     <string name="appcontrol_list_filteroptions_label">Filtr variantlari</string>
-    <string name="appcontrol_list_fastscroller_action">Tezkor aylantirgich</string>
     <string name="appcontrol_progress_uninstalling_app">Ilovani o\'chirish</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d ilova o\'chirildi</item>

--- a/app-tool-appcontrol/src/main/res/values-vi/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-vi/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Thời gian sử dụng màn hình</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Kích thước ứng dụng được ước tính vì lý do hiệu suất. Sử dụng công cụ StorageAnalyzer để có dữ liệu chính xác hơn.</string>
     <string name="appcontrol_list_filteroptions_label">Tùy chọn bộ lọc</string>
-    <string name="appcontrol_list_fastscroller_action">Thanh cuộn nhanh</string>
     <string name="appcontrol_progress_uninstalling_app">Đang gỡ cài đặt ứng dụng</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="other">%d ứng dụng đã được gỡ cài đặt</item>

--- a/app-tool-appcontrol/src/main/res/values-zh-rCN/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-zh-rCN/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">屏幕使用时间</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">出于性能考虑，应用大小为估算所得。请使用「存储分析器」工具获取更准确的数据</string>
     <string name="appcontrol_list_filteroptions_label">过滤器选项</string>
-    <string name="appcontrol_list_fastscroller_action">快速滚动条</string>
     <string name="appcontrol_progress_uninstalling_app">正在卸载应用</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="other">已卸载 %d 应用</item>

--- a/app-tool-appcontrol/src/main/res/values-zh-rHK/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-zh-rHK/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">螢幕時間</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">出於性能考慮，應用程序大小為估計值。請使用存儲分析器以獲得更準確的數據。</string>
     <string name="appcontrol_list_filteroptions_label">過濾器選項</string>
-    <string name="appcontrol_list_fastscroller_action">快速捲軸</string>
     <string name="appcontrol_progress_uninstalling_app">正在解除安裝應用程式</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="other">已解除安裝 %d 個應用程式</item>

--- a/app-tool-appcontrol/src/main/res/values-zh-rTW/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-zh-rTW/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">螢幕時間</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">應用程式大小是因節約效能原因而估計的，可使用儲存分析器工具以取得更精確的資料。</string>
     <string name="appcontrol_list_filteroptions_label">過濾器選項</string>
-    <string name="appcontrol_list_fastscroller_action">快速捲軸</string>
     <string name="appcontrol_progress_uninstalling_app">正在解除安裝應用程式</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="other">已解除安裝 %d 個應用程式</item>

--- a/app-tool-appcontrol/src/main/res/values-zu/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-zu/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Isikhathi sesikrini</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Osayizi bezinhlelo zokusebenza balinganiswa ngenxa yezizathu zokusebenza. Sebenzisa ithuluzi le-StorageAnalyzer ukuze uthole idatha enembile.</string>
     <string name="appcontrol_list_filteroptions_label">Izinketho zokusihluza</string>
-    <string name="appcontrol_list_fastscroller_action">Isikhuli esisheshayo</string>
     <string name="appcontrol_progress_uninstalling_app">Kukhipha uhlelo</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">Uhlelo olu-%d lukhishiwe</item>

--- a/app-tool-appcontrol/src/main/res/values/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values/strings.xml
@@ -38,7 +38,6 @@
     <string name="appcontrol_list_sortmode_screentime_label">Screen time</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">App sizes are estimated for performance reasons. Use the StorageAnalyzer tool for more accurate data.</string>
     <string name="appcontrol_list_filteroptions_label">Filter options</string>
-    <string name="appcontrol_list_fastscroller_action">Fast scroller</string>
     <string name="appcontrol_progress_uninstalling_app">Uninstalling app</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d app was uninstalled</item>

--- a/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListViewModelTest.kt
+++ b/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListViewModelTest.kt
@@ -180,7 +180,6 @@ class AppControlListViewModelTest : BaseTest() {
         val listSortBacking: MutableStateFlow<SortSettings>,
         val listFilter: DataStoreValue<FilterSettings>,
         val ackSizeSortCaveat: DataStoreValue<Boolean>,
-        val listFastScrollerEnabled: DataStoreValue<Boolean>,
         val moduleSizingEnabled: DataStoreValue<Boolean>,
         val moduleActivityEnabled: DataStoreValue<Boolean>,
         val includeMultiUserEnabled: DataStoreValue<Boolean>,
@@ -231,7 +230,6 @@ class AppControlListViewModelTest : BaseTest() {
         sizingEnabled: Boolean = true,
         activityEnabled: Boolean = true,
         multiUserEnabled: Boolean = false,
-        fastScrollerEnabled: Boolean = false,
         ackSizeSortCaveatValue: Boolean = false,
         isPro: Boolean = false,
         canToggle: Boolean = true,
@@ -266,7 +264,6 @@ class AppControlListViewModelTest : BaseTest() {
         val (listSort, listSortBacking) = mutableDataStoreValue(sort)
         val listFilter = rwDataStoreValue(filter)
         val ackSizeSortCaveatStore = rwDataStoreValue(ackSizeSortCaveatValue)
-        val listFastScrollerEnabledStore = rwDataStoreValue(fastScrollerEnabled)
         val moduleSizingEnabledStore = rwDataStoreValue(sizingEnabled)
         val moduleActivityEnabledStore = rwDataStoreValue(activityEnabled)
         val includeMultiUserEnabledStore = rwDataStoreValue(multiUserEnabled)
@@ -274,7 +271,6 @@ class AppControlListViewModelTest : BaseTest() {
             every { this@apply.listSort } returns listSort
             every { this@apply.listFilter } returns listFilter
             every { ackSizeSortCaveat } returns ackSizeSortCaveatStore
-            every { listFastScrollerEnabled } returns listFastScrollerEnabledStore
             every { moduleSizingEnabled } returns moduleSizingEnabledStore
             every { moduleActivityEnabled } returns moduleActivityEnabledStore
             every { includeMultiUserEnabled } returns includeMultiUserEnabledStore
@@ -313,7 +309,6 @@ class AppControlListViewModelTest : BaseTest() {
             listSortBacking = listSortBacking,
             listFilter = listFilter,
             ackSizeSortCaveat = ackSizeSortCaveatStore,
-            listFastScrollerEnabled = listFastScrollerEnabledStore,
             moduleSizingEnabled = moduleSizingEnabledStore,
             moduleActivityEnabled = moduleActivityEnabledStore,
             includeMultiUserEnabled = includeMultiUserEnabledStore,


### PR DESCRIPTION
## What changed

- In the app list, the draggable scroll thumb (the little pill you drag to jump quickly through a long list) is now **always available** and floats over the list — you no longer have to turn it on from a menu.
- The list now uses the **full screen width**; the thumb overlays the right edge, and each app's size is nudged slightly left so the thumb never sits on top of it.
- **Simplified the top menu:** Refresh is now a direct button next to Search, and the three-dot overflow menu (which only held Refresh and the old scrollbar toggle) is gone.

## Technical Context

- The thumb's visibility now keys off whether the list can actually scroll (`minItemsToShow = 0`) instead of the removed `list.fastscroller.enabled` opt-in setting. The grid no longer reserves an end-padding gutter, so rows are full-width and the thumb floats over them.
- The shared `SdmFastScroller` touch lane was narrowed 48dp → 32dp to reduce accidental right-edge drag interception now that it overlays row content.
- The trailing size value is inset by the lane width so it stays clear of the floating pill; rows and their background stay full-width.
- Removes the `list.fastscroller.enabled` setting, its ViewModel state/toggle, and the now-unused `appcontrol_list_fastscroller_action` string (and its translations).

Verified on a Pixel 7a: thumb always shown and floating, drag-scrub works, middle-of-list scrolling unaffected, size values clear of the thumb, menu shows only Search + Refresh.
