### PR TITLE
Deduplicator: Fix screen tests broken by size-label and grid changes

### DIFF
--- a/app-tool-deduplicator/src/main/res/values-af-rZA/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-af-rZA/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">Oudiogebaseerde ooreenkoms</string>
     <string name="deduplicator_media_match_visual">Video-gebaseerde ooreenkoms</string>
     <string name="deduplicator_media_match_audio_visual">Oudio- en video-gebaseerde ooreenkoms</string>
-    <string name="deduplicator_occupied_space_label">Besette berging</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s word deur duplikate beset</item>
         <item quantity="other">%s word deur duplikate beset</item>

--- a/app-tool-deduplicator/src/main/res/values-am/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-am/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">በድምፅ ላይ የተመሰረተ ተዛምዶ</string>
     <string name="deduplicator_media_match_visual">በቪዲዮ ላይ የተመሰረተ ተዛምዶ</string>
     <string name="deduplicator_media_match_audio_visual">በድምፅ እና ቪዲዮ ላይ የተመሰረተ ተዛምዶ</string>
-    <string name="deduplicator_occupied_space_label">የተያዘ ማጠራቀሚያ</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s በተመሳሳዮች ተይዟል</item>
         <item quantity="other">%s በተመሳሳዮች ተይዘዋል</item>

--- a/app-tool-deduplicator/src/main/res/values-ar/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-ar/strings.xml
@@ -35,7 +35,6 @@
     <string name="deduplicator_media_match_audio">تطابق قائم على الصوت</string>
     <string name="deduplicator_media_match_visual">تطابق قائم على الفيديو</string>
     <string name="deduplicator_media_match_audio_visual">تطابق قائم على الصوت والفيديو</string>
-    <string name="deduplicator_occupied_space_label">المساحة المستخدمة</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="zero">%s مشغولة بالنسخ المكررة</item>
         <item quantity="one">%s مشغولة بالنسخ المكررة</item>

--- a/app-tool-deduplicator/src/main/res/values-az/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-az/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">Səsə əsaslanan uyğunluq</string>
     <string name="deduplicator_media_match_visual">Videoya əsaslanan uyğunluq</string>
     <string name="deduplicator_media_match_audio_visual">Səs və videoya əsaslanan uyğunluq</string>
-    <string name="deduplicator_occupied_space_label">Tutulan yaddaş</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s dublikatlar tərəfindən tutulub</item>
         <item quantity="other">%s dublikatlar tərəfindən tutulub</item>

--- a/app-tool-deduplicator/src/main/res/values-be/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-be/strings.xml
@@ -31,7 +31,6 @@
     <string name="deduplicator_media_match_audio">Супадзенне па аўдыя</string>
     <string name="deduplicator_media_match_visual">Супадзенне па відэа</string>
     <string name="deduplicator_media_match_audio_visual">Супадзенне па аўдыя і відэа</string>
-    <string name="deduplicator_occupied_space_label">Занятае сховішча</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s занята дублікатамі</item>
         <item quantity="few">%s заняты дублікатамі</item>

--- a/app-tool-deduplicator/src/main/res/values-bg/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-bg/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">Съвпадение по аудио</string>
     <string name="deduplicator_media_match_visual">Съвпадение по видео</string>
     <string name="deduplicator_media_match_audio_visual">Съвпадение по аудио и видео</string>
-    <string name="deduplicator_occupied_space_label">Заето хранилище</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s е заето от дубликати</item>
         <item quantity="other">%s са заети от дубликати</item>

--- a/app-tool-deduplicator/src/main/res/values-bn-rBD/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-bn-rBD/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">অডিও-ভিত্তিক মিল</string>
     <string name="deduplicator_media_match_visual">ভিডিও-ভিত্তিক মিল</string>
     <string name="deduplicator_media_match_audio_visual">অডিও এবং ভিডিও-ভিত্তিক মিল</string>
-    <string name="deduplicator_occupied_space_label">সঞ্চয়স্থান দখল</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s ডুপ্লিকেট দ্বারা দখল করা আছে</item>
         <item quantity="other">%s ডুপ্লিকেট দ্বারা দখল করা আছে</item>

--- a/app-tool-deduplicator/src/main/res/values-ca/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-ca/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">Coincidència basada en àudio</string>
     <string name="deduplicator_media_match_visual">Coincidència basada en vídeo</string>
     <string name="deduplicator_media_match_audio_visual">Coincidència basada en àudio i vídeo</string>
-    <string name="deduplicator_occupied_space_label">Emmagatzematge ocupat</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s està ocupat per duplicats</item>
         <item quantity="other">%s estan ocupats per duplicats</item>

--- a/app-tool-deduplicator/src/main/res/values-ckb-rIR/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-ckb-rIR/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">هاوبێشی لەسەر دەنگ</string>
     <string name="deduplicator_media_match_visual">هاوبێشی لەسەر ڤیدیۆ</string>
     <string name="deduplicator_media_match_audio_visual">هاوبێشی لەسەر دەنگ و ڤیدیۆ</string>
-    <string name="deduplicator_occupied_space_label">ئەمبارەی پڕکراو</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s لەلایەن دووبارەکانەوە پڕکراوە</item>
         <item quantity="other">%s لەلایەن دووبارەکانەوە پڕکراون</item>

--- a/app-tool-deduplicator/src/main/res/values-cs/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-cs/strings.xml
@@ -31,7 +31,6 @@
     <string name="deduplicator_media_match_audio">Shoda na základě zvuku</string>
     <string name="deduplicator_media_match_visual">Shoda na základě videa</string>
     <string name="deduplicator_media_match_audio_visual">Shoda na základě zvuku a videa</string>
-    <string name="deduplicator_occupied_space_label">Obsazené úložiště</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">Obsazeno duplikáty je %s</item>
         <item quantity="few">Obsazeno duplikáty je %s</item>

--- a/app-tool-deduplicator/src/main/res/values-cy/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-cy/strings.xml
@@ -14,7 +14,6 @@
     <string name="deduplicator_detection_method_checksum_summary">Pennu dyblygu trwy gyfrifo symiau gwirio ar gyfer ffeiliau. Mae gan ffeiliau gyda symiau gwirio cyfatebol yr union yr un cynnwys.</string>
     <string name="deduplicator_detection_method_phash_title">Hash canfyddiadol</string>
     <string name="deduplicator_detection_method_phash_summary">Dod o hyd i ffeiliau tebyg trwy ddadansoddi nodweddion cynnwys a chymharu gwerthoedd hash canfyddiadol.</string>
-    <string name="deduplicator_occupied_space_label">Storfa wedi\'i meddiannu</string>
     <string name="deduplicator_file_size_label">Maint ffeil</string>
     <string name="deduplicator_average_size_label">Maint cyfartalog</string>
     <string name="deduplicator_cluster_x_label">Clwstwr %s</string>

--- a/app-tool-deduplicator/src/main/res/values-da/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-da/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">Lydbaseret match</string>
     <string name="deduplicator_media_match_visual">Videobaseret match</string>
     <string name="deduplicator_media_match_audio_visual">Lyd- og videobaseret match</string>
-    <string name="deduplicator_occupied_space_label">Optaget lagerplads</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s er optaget af duplikater</item>
         <item quantity="other">%s er optaget af duplikater</item>

--- a/app-tool-deduplicator/src/main/res/values-de/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-de/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">Audio-basierte Übereinstimmung</string>
     <string name="deduplicator_media_match_visual">Video-basierte Übereinstimmung</string>
     <string name="deduplicator_media_match_audio_visual">Audio- und videobasierte Übereinstimmung</string>
-    <string name="deduplicator_occupied_space_label">Belegter Speicher</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s ist von Duplikaten belegt</item>
         <item quantity="other">%s sind von Duplikaten belegt</item>

--- a/app-tool-deduplicator/src/main/res/values-el/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-el/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">Αντιστοιχία βάσει ήχου</string>
     <string name="deduplicator_media_match_visual">Αντιστοιχία βάσει βίντεο</string>
     <string name="deduplicator_media_match_audio_visual">Αντιστοιχία βάσει ήχου και βίντεο</string>
-    <string name="deduplicator_occupied_space_label">Αποθηκευτικός χώρος που χρησιμοποιείται</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s καταλαμβάνεται από διπλότυπα</item>
         <item quantity="other">%s καταλαμβάνονται από διπλότυπα</item>

--- a/app-tool-deduplicator/src/main/res/values-eo/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-eo/strings.xml
@@ -14,7 +14,6 @@
     <string name="deduplicator_detection_method_checksum_summary">Determini duoblaĵojn kalkulante kontrolsumojn por dosieroj. Dosieroj kun kongruaj kontrolsumoj havas precize la saman enhavon.</string>
     <string name="deduplicator_detection_method_phash_title">Percepta hakaĵo</string>
     <string name="deduplicator_detection_method_phash_summary">Trovi similajn dosierojn analizante enhavajn trajtojn kaj komparante perceptajn hakaĵajn valorojn.</string>
-    <string name="deduplicator_occupied_space_label">Okupita stokado</string>
     <string name="deduplicator_file_size_label">Dosiera grandeco</string>
     <string name="deduplicator_average_size_label">Averaĝa grandeco</string>
     <string name="deduplicator_cluster_x_label">Fasko %s</string>

--- a/app-tool-deduplicator/src/main/res/values-es-rAR/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-es-rAR/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">Coincidencia basada en audio</string>
     <string name="deduplicator_media_match_visual">Coincidencia basada en video</string>
     <string name="deduplicator_media_match_audio_visual">Coincidencia basada en audio y video</string>
-    <string name="deduplicator_occupied_space_label">Almacenamiento ocupado</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s está ocupado por duplicados</item>
         <item quantity="other">%s están ocupados por duplicados</item>

--- a/app-tool-deduplicator/src/main/res/values-es-rMX/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-es-rMX/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">Coincidencia basada en audio</string>
     <string name="deduplicator_media_match_visual">Coincidencia basada en video</string>
     <string name="deduplicator_media_match_audio_visual">Coincidencia basada en audio y video</string>
-    <string name="deduplicator_occupied_space_label">Almacenamiento ocupado</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s está ocupado por duplicados</item>
         <item quantity="other">%s están ocupados por duplicados</item>

--- a/app-tool-deduplicator/src/main/res/values-es/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-es/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">Coincidencia basada en audio</string>
     <string name="deduplicator_media_match_visual">Coincidencia basada en vídeo</string>
     <string name="deduplicator_media_match_audio_visual">Coincidencia basada en audio y vídeo</string>
-    <string name="deduplicator_occupied_space_label">Almacenamiento ocupado</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s está ocupado por duplicados</item>
         <item quantity="other">%s están ocupadas por duplicados</item>

--- a/app-tool-deduplicator/src/main/res/values-et-rEE/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-et-rEE/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">Helipõhine vaste</string>
     <string name="deduplicator_media_match_visual">Videopõhine vaste</string>
     <string name="deduplicator_media_match_audio_visual">Heli- ja videopõhine vaste</string>
-    <string name="deduplicator_occupied_space_label">Kasutatud salvestusruum</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s kasutab koopiad</item>
         <item quantity="other">%s kasutavad koopiad</item>

--- a/app-tool-deduplicator/src/main/res/values-eu-rES/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-eu-rES/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">Audio-oinarritutako bat etortzea</string>
     <string name="deduplicator_media_match_visual">Bideo-oinarritutako bat etortzea</string>
     <string name="deduplicator_media_match_audio_visual">Audio eta bideo-oinarritutako bat etortzea</string>
-    <string name="deduplicator_occupied_space_label">Erabilitako biltegiratzea</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s bikoiztuek hartuta dago</item>
         <item quantity="other">%s bikoiztuek hartuta daude</item>

--- a/app-tool-deduplicator/src/main/res/values-fa/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-fa/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">تطابق مبتنی بر صدا</string>
     <string name="deduplicator_media_match_visual">تطابق مبتنی بر ویدیو</string>
     <string name="deduplicator_media_match_audio_visual">تطابق مبتنی بر صدا و ویدیو</string>
-    <string name="deduplicator_occupied_space_label">حافظه اشغال شده</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s توسط فایل‌های تکراری اشغال شده</item>
         <item quantity="other">%s توسط فایل‌های تکراری اشغال شده</item>

--- a/app-tool-deduplicator/src/main/res/values-fi/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-fi/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">Äänipohjainen vastaavuus</string>
     <string name="deduplicator_media_match_visual">Videopohjainen vastaavuus</string>
     <string name="deduplicator_media_match_audio_visual">Ääni- ja videopohjainen vastaavuus</string>
-    <string name="deduplicator_occupied_space_label">Käytetty tallennustila</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s on kaksoiskappaleiden käyttämää</item>
         <item quantity="other">%s on kaksoiskappaleiden käyttämää</item>

--- a/app-tool-deduplicator/src/main/res/values-fil/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-fil/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">Tugma batay sa audio</string>
     <string name="deduplicator_media_match_visual">Tugma batay sa video</string>
     <string name="deduplicator_media_match_audio_visual">Tugma batay sa audio at video</string>
-    <string name="deduplicator_occupied_space_label">Ginamit na storage</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s ay ginagamit ng mga duplicate</item>
         <item quantity="other">%s ay ginagamit ng mga duplicate</item>

--- a/app-tool-deduplicator/src/main/res/values-fr/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-fr/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">Correspondance basée sur le son</string>
     <string name="deduplicator_media_match_visual">Correspondance basée sur la vidéo</string>
     <string name="deduplicator_media_match_audio_visual">Correspondance basée sur le son et la vidéo</string>
-    <string name="deduplicator_occupied_space_label">Mémoire occupée</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s est occupé par des doublons</item>
         <item quantity="other">%s sont occupés par des doublons</item>

--- a/app-tool-deduplicator/src/main/res/values-ga/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-ga/strings.xml
@@ -14,7 +14,6 @@
     <string name="deduplicator_detection_method_checksum_summary">Déan cinneadh ar dhúblachtaí trí sheicsuim a ríomh do chomhaid. Tá an t-inneachar céanna beacht ag comhaid le seicsuim chomhoiriúnacha.</string>
     <string name="deduplicator_detection_method_phash_title">Haiseáil tuisceanach</string>
     <string name="deduplicator_detection_method_phash_summary">Faigh comhaid chosúla trí anailís a dhéanamh ar ghnéithe inneachair agus luachanna haiseála tuisceanach a chur i gcomparáid.</string>
-    <string name="deduplicator_occupied_space_label">Stóráil áitithe</string>
     <string name="deduplicator_file_size_label">Méid comhaid</string>
     <string name="deduplicator_average_size_label">Meánmhéid</string>
     <string name="deduplicator_cluster_x_label">Braislín %s</string>

--- a/app-tool-deduplicator/src/main/res/values-gl-rES/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-gl-rES/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">Coincidencia baseada en audio</string>
     <string name="deduplicator_media_match_visual">Coincidencia baseada en vídeo</string>
     <string name="deduplicator_media_match_audio_visual">Coincidencia baseada en audio e vídeo</string>
-    <string name="deduplicator_occupied_space_label">Almacenamento ocupado</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s está ocupado por duplicados</item>
         <item quantity="other">%s están ocupados por duplicados</item>

--- a/app-tool-deduplicator/src/main/res/values-hi-rIN/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-hi-rIN/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">ऑडियो-आधारित मिलान</string>
     <string name="deduplicator_media_match_visual">वीडियो-आधारित मिलान</string>
     <string name="deduplicator_media_match_audio_visual">ऑडियो और वीडियो-आधारित मिलान</string>
-    <string name="deduplicator_occupied_space_label">कब्जाया गया स्थान</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s डुप्लिकेट्स द्वारा कब्जा किया गया है</item>
         <item quantity="other">%s डुप्लिकेट्स द्वारा कब्जा किया गया है</item>

--- a/app-tool-deduplicator/src/main/res/values-hr/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-hr/strings.xml
@@ -29,7 +29,6 @@
     <string name="deduplicator_media_match_audio">Podudaranje temeljeno na zvuku</string>
     <string name="deduplicator_media_match_visual">Podudaranje temeljeno na videu</string>
     <string name="deduplicator_media_match_audio_visual">Podudaranje temeljeno na zvuku i videu</string>
-    <string name="deduplicator_occupied_space_label">Zauzeta pohrana</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s je zauzet duplikatima</item>
         <item quantity="few">%s su zauzeta duplikatima</item>

--- a/app-tool-deduplicator/src/main/res/values-hu/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-hu/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">Hangalapú egyezés</string>
     <string name="deduplicator_media_match_visual">Videóalapú egyezés</string>
     <string name="deduplicator_media_match_audio_visual">Hang- és videóalapú egyezés</string>
-    <string name="deduplicator_occupied_space_label">Foglalt tároló</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s duplikátummal elfoglalva</item>
         <item quantity="other">%s duplikátummal elfoglalva</item>

--- a/app-tool-deduplicator/src/main/res/values-in/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-in/strings.xml
@@ -25,7 +25,6 @@
     <string name="deduplicator_media_match_audio">Kecocokan berbasis audio</string>
     <string name="deduplicator_media_match_visual">Kecocokan berbasis video</string>
     <string name="deduplicator_media_match_audio_visual">Kecocokan berbasis audio dan video</string>
-    <string name="deduplicator_occupied_space_label">Penyimpanan terpakai</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="other">%s ditempati oleh duplikat</item>
     </plurals>

--- a/app-tool-deduplicator/src/main/res/values-is/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-is/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">Samsvörun byggð á hljóði</string>
     <string name="deduplicator_media_match_visual">Samsvörun byggð á myndbandi</string>
     <string name="deduplicator_media_match_audio_visual">Samsvörun byggð á hljóði og myndbandi</string>
-    <string name="deduplicator_occupied_space_label">Upptekið geymslupláss</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s er tekið af tvítekningum</item>
         <item quantity="other">%s eru tekin af tvítekningum</item>

--- a/app-tool-deduplicator/src/main/res/values-it/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-it/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">Corrispondenza basata sull\'audio</string>
     <string name="deduplicator_media_match_visual">Corrispondenza basata sul video</string>
     <string name="deduplicator_media_match_audio_visual">Corrispondenza basata su audio e video</string>
-    <string name="deduplicator_occupied_space_label">Spazio occupato</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s è occupato da duplicati</item>
         <item quantity="other">%s sono occupati da duplicati</item>

--- a/app-tool-deduplicator/src/main/res/values-iw/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-iw/strings.xml
@@ -31,7 +31,6 @@
     <string name="deduplicator_media_match_audio">התאמה מבוססת-אודיו</string>
     <string name="deduplicator_media_match_visual">התאמה מבוססת-וידאו</string>
     <string name="deduplicator_media_match_audio_visual">התאמה מבוססת-אודיו ווידאו</string>
-    <string name="deduplicator_occupied_space_label">נפח אחסון תפוס</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s תפוס על ידי כפילויות</item>
         <item quantity="two">%s תפוס על ידי כפילויות</item>

--- a/app-tool-deduplicator/src/main/res/values-ja/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-ja/strings.xml
@@ -25,7 +25,6 @@
     <string name="deduplicator_media_match_audio">音声ベースの一致</string>
     <string name="deduplicator_media_match_visual">映像ベースの一致</string>
     <string name="deduplicator_media_match_audio_visual">音声・映像ベースの一致</string>
-    <string name="deduplicator_occupied_space_label">占拠されたストレージ</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="other">%sが重複により占有されています</item>
     </plurals>

--- a/app-tool-deduplicator/src/main/res/values-ka-rGE/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-ka-rGE/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">აუდიოზე დაფუძნებული დამთხვევა</string>
     <string name="deduplicator_media_match_visual">ვიდეოზე დაფუძნებული დამთხვევა</string>
     <string name="deduplicator_media_match_audio_visual">აუდიო და ვიდეოზე დაფუძნებული დამთხვევა</string>
-    <string name="deduplicator_occupied_space_label">დაკავებული მეხსიერება</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s დაკავებულია დუბლიკატებით</item>
         <item quantity="other">%s დაკავებულია დუბლიკატებით</item>

--- a/app-tool-deduplicator/src/main/res/values-kaa/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-kaa/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">Аудиоға тийкарланған сәйкеслик</string>
     <string name="deduplicator_media_match_visual">Видеоға тийкарланған сәйкеслик</string>
     <string name="deduplicator_media_match_audio_visual">Аудио ҳәм видеоға тийкарланған сәйкеслик</string>
-    <string name="deduplicator_occupied_space_label">Bándelgen saqlawsh</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s dublikatlları iyelep turır</item>
         <item quantity="other">%s dublikatlları iyelep turır</item>

--- a/app-tool-deduplicator/src/main/res/values-km-rKH/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-km-rKH/strings.xml
@@ -25,7 +25,6 @@
     <string name="deduplicator_media_match_audio">ការ​ផ្គូផ្គង​ផ្អែក​លើ​សំឡេង</string>
     <string name="deduplicator_media_match_visual">ការ​ផ្គូផ្គង​ផ្អែក​លើ​វីដេអូ</string>
     <string name="deduplicator_media_match_audio_visual">ការ​ផ្គូផ្គង​ផ្អែក​លើ​សំឡេង​និង​វីដេអូ</string>
-    <string name="deduplicator_occupied_space_label">ទាក​ស្តោរេជ​បាន​ប្រើ​ប្រាស់</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="other">%s ត្រួវ​បាន​ប្រើ​ប្រាស់​ដោយ​សែសែ</item>
     </plurals>

--- a/app-tool-deduplicator/src/main/res/values-ko/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-ko/strings.xml
@@ -25,7 +25,6 @@
     <string name="deduplicator_media_match_audio">오디오 기반 일치</string>
     <string name="deduplicator_media_match_visual">동영상 기반 일치</string>
     <string name="deduplicator_media_match_audio_visual">오디오 및 동영상 기반 일치</string>
-    <string name="deduplicator_occupied_space_label">사용 중인 저장공간</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="other">%s가 중복 파일로 점유되고 있습니다</item>
     </plurals>

--- a/app-tool-deduplicator/src/main/res/values-lo-rLA/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-lo-rLA/strings.xml
@@ -25,7 +25,6 @@
     <string name="deduplicator_media_match_audio">ກົງກັນໂດຍອ້າງອີງສຽງ</string>
     <string name="deduplicator_media_match_visual">ກົງກັນໂດຍອ້າງອີງວິດີໂອ</string>
     <string name="deduplicator_media_match_audio_visual">ກົງກັນໂດຍອ້າງອີງສຽງ ແລະ ວິດີໂອ</string>
-    <string name="deduplicator_occupied_space_label">ຫນ່ວຍເກັບຂໍ້ມູລທີ່ຖືກໃຊ້</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="other">%s ຖືກໃຊ້ໂດຍສຳເນົາທີ່ຊ້າ</item>
     </plurals>

--- a/app-tool-deduplicator/src/main/res/values-lt/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-lt/strings.xml
@@ -31,7 +31,6 @@
     <string name="deduplicator_media_match_audio">Atitiktis pagal garsą</string>
     <string name="deduplicator_media_match_visual">Atitiktis pagal vaizdą</string>
     <string name="deduplicator_media_match_audio_visual">Atitiktis pagal garsą ir vaizdą</string>
-    <string name="deduplicator_occupied_space_label">Užimta atmintis</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s užimama dublikatų</item>
         <item quantity="few">%s užimama dublikatų</item>

--- a/app-tool-deduplicator/src/main/res/values-lv/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-lv/strings.xml
@@ -29,7 +29,6 @@
     <string name="deduplicator_media_match_audio">Uz audio balstīta atbilstība</string>
     <string name="deduplicator_media_match_visual">Uz video balstīta atbilstība</string>
     <string name="deduplicator_media_match_audio_visual">Uz audio un video balstīta atbilstība</string>
-    <string name="deduplicator_occupied_space_label">Aizņemtais krātuves apjoms</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="zero">%s ir aizņemti ar dublikātiem</item>
         <item quantity="one">%s ir aizņemts ar dublikātiem</item>

--- a/app-tool-deduplicator/src/main/res/values-mk-rMK/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-mk-rMK/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">Совпаѓање засновано на аудио</string>
     <string name="deduplicator_media_match_visual">Совпаѓање засновано на видео</string>
     <string name="deduplicator_media_match_audio_visual">Совпаѓање засновано на аудио и видео</string>
-    <string name="deduplicator_occupied_space_label">Зафатено складирање</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s е зафатено од дупликати</item>
         <item quantity="other">%s се зафатени од дупликати</item>

--- a/app-tool-deduplicator/src/main/res/values-ml-rIN/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-ml-rIN/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">ഓഡിയോ അടിസ്ഥാനത്തിലുള്ള പൊരുത്തം</string>
     <string name="deduplicator_media_match_visual">വീഡിയോ അടിസ്ഥാനത്തിലുള്ള പൊരുത്തം</string>
     <string name="deduplicator_media_match_audio_visual">ഓഡിയോ, വീഡിയോ അടിസ്ഥാനത്തിലുള്ള പൊരുത്തം</string>
-    <string name="deduplicator_occupied_space_label">ഉപയോഗിക്കുന്ന സ്റ്റോറേജ്</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s ഡ്യൂപ്ലിക്കേറ്റ് ഉപയോഗിക്കുന്നു</item>
         <item quantity="other">%s ഡ്യൂപ്ലിക്കേറ്റുകൾ ഉപയോഗിക്കുന്നു</item>

--- a/app-tool-deduplicator/src/main/res/values-mn-rMN/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-mn-rMN/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">Аудиод суурилсан тохирц</string>
     <string name="deduplicator_media_match_visual">Видеод суурилсан тохирц</string>
     <string name="deduplicator_media_match_audio_visual">Аудио болон видеод суурилсан тохирц</string>
-    <string name="deduplicator_occupied_space_label">Езлэгдсэн санах</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s давхардах файлууд эзлаад байна</item>
         <item quantity="other">%s давхардах файлууд эзлаад байна</item>

--- a/app-tool-deduplicator/src/main/res/values-ms/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-ms/strings.xml
@@ -25,7 +25,6 @@
     <string name="deduplicator_media_match_audio">Padanan berasaskan audio</string>
     <string name="deduplicator_media_match_visual">Padanan berasaskan video</string>
     <string name="deduplicator_media_match_audio_visual">Padanan berasaskan audio dan video</string>
-    <string name="deduplicator_occupied_space_label">Storan yang digunakan</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="other">%s diduduki oleh pendua</item>
     </plurals>

--- a/app-tool-deduplicator/src/main/res/values-my-rMM/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-my-rMM/strings.xml
@@ -25,7 +25,6 @@
     <string name="deduplicator_media_match_audio">အသံအပေါ် အခြေပြုသော ကိုက်ညီမှု</string>
     <string name="deduplicator_media_match_visual">ဗီဒီယိုအပေါ် အခြေပြုသော ကိုက်ညီမှု</string>
     <string name="deduplicator_media_match_audio_visual">အသံနှင့် ဗီဒီယိုအပေါ် အခြေပြုသော ကိုက်ညီမှု</string>
-    <string name="deduplicator_occupied_space_label">လွှမ်းမိုးထားသော သိုလှောင့်မှု</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="other">%s ကို ထပ်တူများက လွှမ်းမိုးထေသည်</item>
     </plurals>

--- a/app-tool-deduplicator/src/main/res/values-nb/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-nb/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">Lydbasert treff</string>
     <string name="deduplicator_media_match_visual">Videobasert treff</string>
     <string name="deduplicator_media_match_audio_visual">Lyd- og videobasert treff</string>
-    <string name="deduplicator_occupied_space_label">Brukt lagringsplass</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s er brukt av duplikater</item>
         <item quantity="other">%s er brukt av duplikater</item>

--- a/app-tool-deduplicator/src/main/res/values-ne-rNP/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-ne-rNP/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">अडियो-आधारित मिलान</string>
     <string name="deduplicator_media_match_visual">भिडियो-आधारित मिलान</string>
     <string name="deduplicator_media_match_audio_visual">अडियो र भिडियो-आधारित मिलान</string>
-    <string name="deduplicator_occupied_space_label">कब्जा गरिएको भण्डारण</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s डुप्लिकेटले ओगटेको छ</item>
         <item quantity="other">%s डुप्लिकेटले ओगटेका छन्</item>

--- a/app-tool-deduplicator/src/main/res/values-nl/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-nl/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">Op audio gebaseerde overeenkomst</string>
     <string name="deduplicator_media_match_visual">Op video gebaseerde overeenkomst</string>
     <string name="deduplicator_media_match_audio_visual">Op audio en video gebaseerde overeenkomst</string>
-    <string name="deduplicator_occupied_space_label">Gebruikte opslag</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s wordt ingenomen door duplicaten</item>
         <item quantity="other">%s worden ingenomen door duplicaten</item>

--- a/app-tool-deduplicator/src/main/res/values-or-rIN/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-or-rIN/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">ଅଡ଼ିଓ ଆଧାରିତ ମିଳାଣ</string>
     <string name="deduplicator_media_match_visual">ଭିଡ଼ିଓ ଆଧାରିତ ମିଳାଣ</string>
     <string name="deduplicator_media_match_audio_visual">ଅଡ଼ିଓ ଓ ଭିଡ଼ିଓ ଆଧାରିତ ମିଳାଣ</string>
-    <string name="deduplicator_occupied_space_label">ଅଧିକୃତ ଷ୍ଟୋରେଜ୍</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s ନକଲ ଦ୍ୱାରା ଦଖଲ ହୋଇଛି</item>
         <item quantity="other">%s ନକଲ ଦ୍ୱାରା ଦଖଲ ହୋଇଛି</item>

--- a/app-tool-deduplicator/src/main/res/values-pa-rIN/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-pa-rIN/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">ਆਡੀਓ-ਆਧਾਰਿਤ ਮੇਲ</string>
     <string name="deduplicator_media_match_visual">ਵੀਡੀਓ-ਆਧਾਰਿਤ ਮੇਲ</string>
     <string name="deduplicator_media_match_audio_visual">ਆਡੀਓ ਅਤੇ ਵੀਡੀਓ-ਆਧਾਰਿਤ ਮੇਲ</string>
-    <string name="deduplicator_occupied_space_label">ਵਰਤੀ ਗਈ ਸਟੋਰੇਜ</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s ਡੁਪਲੀਕੇਟਸ ਦੁਆਰਾ ਲਿਆ ਗਿਆ ਹੈ</item>
         <item quantity="other">%s ਡੁਪਲੀਕੇਟਸ ਦੁਆਰਾ ਲਿਆ ਗਿਆ ਹੈ</item>

--- a/app-tool-deduplicator/src/main/res/values-pl/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-pl/strings.xml
@@ -31,7 +31,6 @@
     <string name="deduplicator_media_match_audio">Dopasowanie na podstawie dźwięku</string>
     <string name="deduplicator_media_match_visual">Dopasowanie na podstawie wideo</string>
     <string name="deduplicator_media_match_audio_visual">Dopasowanie na podstawie dźwięku i wideo</string>
-    <string name="deduplicator_occupied_space_label">Zajęta pamięć</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s jest zajęty przez duplikaty</item>
         <item quantity="few">%s jest zajęte przez duplikaty</item>

--- a/app-tool-deduplicator/src/main/res/values-pt-rBR/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-pt-rBR/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">Correspondência baseada em áudio</string>
     <string name="deduplicator_media_match_visual">Correspondência baseada em vídeo</string>
     <string name="deduplicator_media_match_audio_visual">Correspondência baseada em áudio e vídeo</string>
-    <string name="deduplicator_occupied_space_label">Armazenamento ocupado</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s está ocupado por duplicados</item>
         <item quantity="other">%s estão ocupados por duplicados</item>

--- a/app-tool-deduplicator/src/main/res/values-pt/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-pt/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">Correspondência baseada em áudio</string>
     <string name="deduplicator_media_match_visual">Correspondência baseada em vídeo</string>
     <string name="deduplicator_media_match_audio_visual">Correspondência baseada em áudio e vídeo</string>
-    <string name="deduplicator_occupied_space_label">Armazenamento Ocupado</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s está ocupado por duplicados </item>
         <item quantity="other">%s estão ocupados por duplicados</item>

--- a/app-tool-deduplicator/src/main/res/values-ro/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-ro/strings.xml
@@ -29,7 +29,6 @@
     <string name="deduplicator_media_match_audio">Potrivire bazată pe audio</string>
     <string name="deduplicator_media_match_visual">Potrivire bazată pe video</string>
     <string name="deduplicator_media_match_audio_visual">Potrivire bazată pe audio și video</string>
-    <string name="deduplicator_occupied_space_label">Spațiu de stocare ocupat</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s este ocupat de duplicate</item>
         <item quantity="few">%s sunt ocupate de duplicate</item>

--- a/app-tool-deduplicator/src/main/res/values-ru/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-ru/strings.xml
@@ -31,7 +31,6 @@
     <string name="deduplicator_media_match_audio">Совпадение на основе аудио</string>
     <string name="deduplicator_media_match_visual">Совпадение на основе видео</string>
     <string name="deduplicator_media_match_audio_visual">Совпадение на основе аудио и видео</string>
-    <string name="deduplicator_occupied_space_label">Используемая память</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">Дубликатами занято: %s</item>
         <item quantity="few">Дубликатами занято: %s</item>

--- a/app-tool-deduplicator/src/main/res/values-sc-rIT/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-sc-rIT/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">Cumbinadura basada in s\'àudio</string>
     <string name="deduplicator_media_match_visual">Cumbinadura basada in su vìdeo</string>
     <string name="deduplicator_media_match_audio_visual">Cumbinadura basada in àudio e vìdeo</string>
-    <string name="deduplicator_occupied_space_label">Archìviu ocupadu</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s est ocupadu dae duplicados</item>
         <item quantity="other">%s sunt ocupados dae duplicados</item>

--- a/app-tool-deduplicator/src/main/res/values-si-rLK/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-si-rLK/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">ශ්‍රව්‍ය-පදනම් ගැළපීම</string>
     <string name="deduplicator_media_match_visual">වීඩියෝ-පදනම් ගැළපීම</string>
     <string name="deduplicator_media_match_audio_visual">ශ්‍රව්‍ය සහ වීඩියෝ-පදනම් ගැළපීම</string>
-    <string name="deduplicator_occupied_space_label">අවවන් න් ඇත ආචයනය</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s බහුපත විසින් අවවන් න් වෙ</item>
         <item quantity="other">%s බහුපත විසින් අවවන් න් වෙ</item>

--- a/app-tool-deduplicator/src/main/res/values-sk/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-sk/strings.xml
@@ -31,7 +31,6 @@
     <string name="deduplicator_media_match_audio">Zhoda na základe zvuku</string>
     <string name="deduplicator_media_match_visual">Zhoda na základe videa</string>
     <string name="deduplicator_media_match_audio_visual">Zhoda na základe zvuku a videa</string>
-    <string name="deduplicator_occupied_space_label">Obsadené úložisko</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s je obsadené duplikátmi</item>
         <item quantity="few">%s sú obsadené duplikátmi</item>

--- a/app-tool-deduplicator/src/main/res/values-sl/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-sl/strings.xml
@@ -31,7 +31,6 @@
     <string name="deduplicator_media_match_audio">Ujemanje na podlagi zvoka</string>
     <string name="deduplicator_media_match_visual">Ujemanje na podlagi videa</string>
     <string name="deduplicator_media_match_audio_visual">Ujemanje na podlagi zvoka in videa</string>
-    <string name="deduplicator_occupied_space_label">Zaseden prostor</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s zasedajo dvojniki.</item>
         <item quantity="two">%s zasedajo dvojniki.</item>

--- a/app-tool-deduplicator/src/main/res/values-sq-rAL/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-sq-rAL/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">Përputhje e bazuar në audio</string>
     <string name="deduplicator_media_match_visual">Përputhje e bazuar në video</string>
     <string name="deduplicator_media_match_audio_visual">Përputhje e bazuar në audio dhe video</string>
-    <string name="deduplicator_occupied_space_label">Magazina e zënë</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s është zënë nga dublikata</item>
         <item quantity="other">%s janë zënë nga dublikata</item>

--- a/app-tool-deduplicator/src/main/res/values-sr/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-sr/strings.xml
@@ -29,7 +29,6 @@
     <string name="deduplicator_media_match_audio">Подударање засновано на аудио</string>
     <string name="deduplicator_media_match_visual">Подударање засновано на видео</string>
     <string name="deduplicator_media_match_audio_visual">Подударање засновано на аудио и видео</string>
-    <string name="deduplicator_occupied_space_label">Заузето складиште</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s је заузет дупликатима</item>
         <item quantity="few">%s су заузета дупликатима</item>

--- a/app-tool-deduplicator/src/main/res/values-sv/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-sv/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">Ljudbaserad matchning</string>
     <string name="deduplicator_media_match_visual">Videobaserad matchning</string>
     <string name="deduplicator_media_match_audio_visual">Ljud- och videobaserad matchning</string>
-    <string name="deduplicator_occupied_space_label">Upptagen lagring</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s upptas av dubbletter</item>
         <item quantity="other">%s upptas av dubbletter</item>

--- a/app-tool-deduplicator/src/main/res/values-sw/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-sw/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">Mechi inayotegemea sauti</string>
     <string name="deduplicator_media_match_visual">Mechi inayotegemea video</string>
     <string name="deduplicator_media_match_audio_visual">Mechi inayotegemea sauti na video</string>
-    <string name="deduplicator_occupied_space_label">Hifadhi iliyotumika</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s inatumika na nakala</item>
         <item quantity="other">%s zinatumika na nakala</item>

--- a/app-tool-deduplicator/src/main/res/values-ta-rIN/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-ta-rIN/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">ஆடியோ அடிப்படையிலான பொருத்தம்</string>
     <string name="deduplicator_media_match_visual">வீடியோ அடிப்படையிலான பொருத்தம்</string>
     <string name="deduplicator_media_match_audio_visual">ஆடியோ மற்றும் வீடியோ அடிப்படையிலான பொருத்தம்</string>
-    <string name="deduplicator_occupied_space_label">ஆக்ரமிக்கப்பட்ட சேமிப்பு</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s நகல்களால் ஆக்ரமிக்கப்பட்டுள்ளது</item>
         <item quantity="other">%s நகல்களால் ஆக்ரமிக்கப்பட்டுள்ளன</item>

--- a/app-tool-deduplicator/src/main/res/values-te-rIN/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-te-rIN/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">ఆడియో-ఆధారిత సరిపోలిక</string>
     <string name="deduplicator_media_match_visual">వీడియో-ఆధారిత సరిపోలిక</string>
     <string name="deduplicator_media_match_audio_visual">ఆడియో మరియు వీడియో-ఆధారిత సరిపోలిక</string>
-    <string name="deduplicator_occupied_space_label">ఆక్రమించిన స్టోరేజీ</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s డుప్లికేట్‌లు ఆక్రమించాయి</item>
         <item quantity="other">%s డుప్లికేట్‌లు ఆక్రమించాయి</item>

--- a/app-tool-deduplicator/src/main/res/values-th/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-th/strings.xml
@@ -25,7 +25,6 @@
     <string name="deduplicator_media_match_audio">การจับคู่ตามเสียง</string>
     <string name="deduplicator_media_match_visual">การจับคู่ตามวิดีโอ</string>
     <string name="deduplicator_media_match_audio_visual">การจับคู่ตามเสียงและวิดีโอ</string>
-    <string name="deduplicator_occupied_space_label">พื้นที่ที่ถูกใช้งาน</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="other">%s ถูกใช้งานโดยไฟล์ซ้ำ</item>
     </plurals>

--- a/app-tool-deduplicator/src/main/res/values-tr/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-tr/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">Ses tabanlı eşleşme</string>
     <string name="deduplicator_media_match_visual">Video tabanlı eşleşme</string>
     <string name="deduplicator_media_match_audio_visual">Ses ve video tabanlı eşleşme</string>
-    <string name="deduplicator_occupied_space_label">Kullanılan depolama</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s kopyalar tarafından işgal edilmiş</item>
         <item quantity="other">%s kopyalar tarafından işgal edilmiş</item>

--- a/app-tool-deduplicator/src/main/res/values-uk/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-uk/strings.xml
@@ -31,7 +31,6 @@
     <string name="deduplicator_media_match_audio">Збіг на основі аудіо</string>
     <string name="deduplicator_media_match_visual">Збіг на основі відео</string>
     <string name="deduplicator_media_match_audio_visual">Збіг на основі аудіо та відео</string>
-    <string name="deduplicator_occupied_space_label">Зайняте сховище</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s зайнято дублікатами</item>
         <item quantity="few">%s зайнято дублікатами</item>

--- a/app-tool-deduplicator/src/main/res/values-ur-rIN/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-ur-rIN/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">آڈیو پر مبنی مماثلت</string>
     <string name="deduplicator_media_match_visual">ویڈیو پر مبنی مماثلت</string>
     <string name="deduplicator_media_match_audio_visual">آڈیو اور ویڈیو پر مبنی مماثلت</string>
-    <string name="deduplicator_occupied_space_label">قبضہ شدہ سٹوریج</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s ڈپلیکیٹس کے ذریعے قبضہ میں ہے</item>
         <item quantity="other">%s ڈپلیکیٹس کے ذریعے قبضہ میں ہیں</item>

--- a/app-tool-deduplicator/src/main/res/values-uz/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-uz/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">Audioga asoslangan moslik</string>
     <string name="deduplicator_media_match_visual">Videoga asoslangan moslik</string>
     <string name="deduplicator_media_match_audio_visual">Audio va videoga asoslangan moslik</string>
-    <string name="deduplicator_occupied_space_label">Band xotira</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">%s takrorlanganlar tomonidan band qilingan</item>
         <item quantity="other">%s takrorlanganlar tomonidan band qilingan</item>

--- a/app-tool-deduplicator/src/main/res/values-vi/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-vi/strings.xml
@@ -25,7 +25,6 @@
     <string name="deduplicator_media_match_audio">Khớp dựa trên âm thanh</string>
     <string name="deduplicator_media_match_visual">Khớp dựa trên video</string>
     <string name="deduplicator_media_match_audio_visual">Khớp dựa trên âm thanh và video</string>
-    <string name="deduplicator_occupied_space_label">Bộ nhớ bị chiếm dụng</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="other">%s bị chiếm bởi các bản sao</item>
     </plurals>

--- a/app-tool-deduplicator/src/main/res/values-zh-rCN/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-zh-rCN/strings.xml
@@ -25,7 +25,6 @@
     <string name="deduplicator_media_match_audio">基于音频的匹配</string>
     <string name="deduplicator_media_match_visual">基于视频的匹配</string>
     <string name="deduplicator_media_match_audio_visual">基于音频和视频的匹配</string>
-    <string name="deduplicator_occupied_space_label">占用的存储空间</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="other">重复项占用 %s</item>
     </plurals>

--- a/app-tool-deduplicator/src/main/res/values-zh-rHK/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-zh-rHK/strings.xml
@@ -25,7 +25,6 @@
     <string name="deduplicator_media_match_audio">基於音訊的匹配</string>
     <string name="deduplicator_media_match_visual">基於影片的匹配</string>
     <string name="deduplicator_media_match_audio_visual">基於音訊和影片的匹配</string>
-    <string name="deduplicator_occupied_space_label">已佔用空間</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="other">%s 被重複項佔用</item>
     </plurals>

--- a/app-tool-deduplicator/src/main/res/values-zh-rTW/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-zh-rTW/strings.xml
@@ -25,7 +25,6 @@
     <string name="deduplicator_media_match_audio">基於音訊的配對</string>
     <string name="deduplicator_media_match_visual">基於影片的配對</string>
     <string name="deduplicator_media_match_audio_visual">基於音訊和影片的配對</string>
-    <string name="deduplicator_occupied_space_label">佔用儲存空間</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="other">%s 被重複項目佔用</item>
     </plurals>

--- a/app-tool-deduplicator/src/main/res/values-zu/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-zu/strings.xml
@@ -27,7 +27,6 @@
     <string name="deduplicator_media_match_audio">Ukufanana okusekelwe kumazwi</string>
     <string name="deduplicator_media_match_visual">Ukufanana okusekelwe evidiyo</string>
     <string name="deduplicator_media_match_audio_visual">Ukufanana okusekelwe kumazwi nasevidiyo</string>
-    <string name="deduplicator_occupied_space_label">Isitoreji esihleli</string>
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="one">I-%s ihleli okukhophisiwe</item>
         <item quantity="other">I-%s zihleli okukhophisiwe</item>

--- a/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/ui/details/DeduplicatorDetailsScreenTest.kt
+++ b/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/ui/details/DeduplicatorDetailsScreenTest.kt
@@ -95,16 +95,17 @@ class DeduplicatorDetailsScreenTest : BaseComposeRobolectricTest() {
 
         composeRule.onNodeWithText("Deduplicator").assertExists()
         composeRule.onAllNodesWithText("Empty").assertCountEquals(0)
-        // The cluster summary card unconditionally renders the "Occupied storage" label — a
-        // load-bearing signal that ClusterContent composed, not just the top bar.
-        composeRule.onNodeWithText("Occupied storage").assertExists()
+        // The cluster summary card unconditionally renders the freeable-size headline
+        // ("… can be freed") — a load-bearing signal that ClusterContent composed, not just the
+        // top bar (which only shows "Deduplicator" / "Details").
+        composeRule.onNodeWithText("can be freed", substring = true).assertExists()
     }
 
     @Test
     fun `single-cluster state in directory view still renders the cluster summary card`() {
         // Switching to directory view changes the per-duplicate layout below the summary card but
-        // the "Occupied storage" header stays put. Asserting on it proves the summary card is
-        // intact under both view modes — a regression that gated it on flat-view would flunk.
+        // the freeable-size headline stays put. Asserting on it proves the summary card is intact
+        // under both view modes — a regression that gated it on flat-view would flunk.
         val onlyCluster = cluster("vacation", dupeNames = listOf("dirtest", "dirtest-copy"))
         composeRule.setDetailsScreen(
             DeduplicatorDetailsViewModel.State(
@@ -115,6 +116,6 @@ class DeduplicatorDetailsScreenTest : BaseComposeRobolectricTest() {
             ),
         )
 
-        composeRule.onNodeWithText("Occupied storage").assertExists()
+        composeRule.onNodeWithText("can be freed", substring = true).assertExists()
     }
 }

--- a/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListScreenTest.kt
+++ b/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListScreenTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.click
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onAllNodesWithText
@@ -177,7 +178,10 @@ class DeduplicatorListScreenTest : BaseComposeRobolectricTest() {
             onClusterClick = { details++ },
             onClusterPreview = { preview++ },
         )
-        composeRule.onNode(hasClickLabel("Delete duplicate set")).performClick()
+        // The details caption is overlaid on the bottom of the (square) thumbnail, so tap near the
+        // top of the thumbnail — clearly above the caption — to exercise the delete region. A
+        // center tap would land on the caption overlay on smaller tiles.
+        composeRule.onNode(hasClickLabel("Delete duplicate set")).performTouchInput { click(topCenter) }
         composeRule.runOnIdle {
             if (delete != 1 || details != 0 || preview != 0) {
                 throw AssertionError("delete=$delete details=$details preview=$preview")


### PR DESCRIPTION
## What changed

No user-facing behavior change. This fixes the deduplicator screen tests that started failing on `main` after the recent UI-polish work merged, and removes leftover translation entries for a string that was deleted.

## Technical Context

The UI-polish PR (#2532) landed with a red CI check; two of its changes moved the UI out from under the deduplicator screen tests:

- The cluster summary card no longer shows an "Occupied storage" label — it now leads with the freeable-size headline ("… can be freed"). The base string `deduplicator_occupied_space_label` was removed but its translations were left behind. `DeduplicatorDetailsScreenTest` now asserts the new headline.
- The grid tile redesign overlays the details caption on the bottom of the square thumbnail, so a center tap on the thumbnail lands on the caption. `DeduplicatorListScreenTest` now taps near the top of the thumbnail (clearly above the caption) to exercise the delete region.
- Removed the 76 orphaned `deduplicator_occupied_space_label` translation entries left behind when the base string was deleted (they only produced `ExtraTranslation` lint noise; Crowdin treats the now-deleted source as removed anyway).

All 289 `:app-tool-deduplicator` unit tests pass locally.
