### PR TITLE
General: Move Swiper & Media Squeeze up, remove their New tags

### DIFF
--- a/app-common-data/src/main/java/eu/darken/sdmse/main/core/DashboardCardType.kt
+++ b/app-common-data/src/main/java/eu/darken/sdmse/main/core/DashboardCardType.kt
@@ -10,9 +10,9 @@ enum class DashboardCardType {
     @SerialName("APPCLEANER") APPCLEANER,
     @SerialName("DEDUPLICATOR") DEDUPLICATOR,
     @SerialName("APPCONTROL") APPCONTROL,
-    @SerialName("ANALYZER") ANALYZER,
     @SerialName("SWIPER") SWIPER,
     @SerialName("SQUEEZER") SQUEEZER,
+    @SerialName("ANALYZER") ANALYZER,
     @SerialName("SCHEDULER") SCHEDULER,
     @SerialName("STATS") STATS,
 }

--- a/app/src/main/java/eu/darken/sdmse/main/core/DashboardCardTypeExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/core/DashboardCardTypeExtensions.kt
@@ -24,9 +24,9 @@ val DashboardCardType.labelRes: Int
         DashboardCardType.APPCLEANER -> CommonR.string.appcleaner_tool_name
         DashboardCardType.DEDUPLICATOR -> CommonR.string.deduplicator_tool_name
         DashboardCardType.APPCONTROL -> CommonR.string.appcontrol_tool_name
-        DashboardCardType.ANALYZER -> CommonR.string.analyzer_tool_name
         DashboardCardType.SWIPER -> CommonR.string.swiper_tool_name
         DashboardCardType.SQUEEZER -> CommonR.string.squeezer_tool_name
+        DashboardCardType.ANALYZER -> CommonR.string.analyzer_tool_name
         DashboardCardType.SCHEDULER -> eu.darken.sdmse.scheduler.R.string.scheduler_label
         DashboardCardType.STATS -> CommonR.string.stats_label
     }
@@ -38,9 +38,9 @@ val DashboardCardType.icon: ImageVector
         DashboardCardType.APPCLEANER -> Icons.TwoTone.Recycling
         DashboardCardType.DEDUPLICATOR -> Icons.TwoTone.ContentCopy
         DashboardCardType.APPCONTROL -> Icons.TwoTone.Apps
-        DashboardCardType.ANALYZER -> Icons.TwoTone.DataUsage
         DashboardCardType.SWIPER -> Icons.TwoTone.Swipe
         DashboardCardType.SQUEEZER -> Icons.TwoTone.Compress
+        DashboardCardType.ANALYZER -> Icons.TwoTone.DataUsage
         DashboardCardType.SCHEDULER -> Icons.TwoTone.Alarm
         DashboardCardType.STATS -> Icons.TwoTone.BarChart
     }

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardCardFlows.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardCardFlows.kt
@@ -228,7 +228,6 @@ internal fun DashboardViewModel.buildSqueezerItem(): Flow<SqueezerDashboardCardI
         .mapLatest { state ->
             SqueezerDashboardCardItem(
                 isInitializing = state == null,
-                isNew = true,
                 data = state?.data,
                 progress = state?.progress,
                 onViewDetails = {

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModel.kt
@@ -397,11 +397,11 @@ class DashboardViewModel @Inject constructor(
                 DashboardCardType.SYSTEMCLEANER -> systemCleanerItem?.let { items.add(it) }
                 DashboardCardType.APPCLEANER -> appCleanerItem?.let { items.add(it) }
                 DashboardCardType.DEDUPLICATOR -> deduplicatorItem?.let { items.add(it) }
-                DashboardCardType.SQUEEZER -> squeezerItem?.let { items.add(it) }
                 DashboardCardType.APPCONTROL -> appControlItem?.let { items.add(it) }
+                DashboardCardType.SWIPER -> swiperItem?.let { items.add(it) }
+                DashboardCardType.SQUEEZER -> squeezerItem?.let { items.add(it) }
                 DashboardCardType.ANALYZER -> analyzerItem?.let { items.add(it) }
                 DashboardCardType.SCHEDULER -> schedulerItem?.let { items.add(it) }
-                DashboardCardType.SWIPER -> swiperItem?.let { items.add(it) }
                 DashboardCardType.STATS -> statsItem?.let { items.add(it) }
             }
         }

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/SqueezerDashboardCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/SqueezerDashboardCard.kt
@@ -25,14 +25,12 @@ import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.main.ui.dashboard.cards.common.DashboardActionIconSpacing
 import eu.darken.sdmse.main.ui.dashboard.cards.common.DashboardCard
 import eu.darken.sdmse.main.ui.dashboard.cards.common.DashboardFlatActionButton
-import eu.darken.sdmse.main.ui.dashboard.cards.common.NewBadge
 import eu.darken.sdmse.squeezer.core.Squeezer
 import eu.darken.sdmse.squeezer.R as SqueezerR
 
 data class SqueezerDashboardCardItem(
     val data: Squeezer.Data?,
     val isInitializing: Boolean,
-    val isNew: Boolean,
     val progress: Progress.Data?,
     val onViewDetails: () -> Unit,
 ) : DashboardItem {
@@ -53,10 +51,6 @@ internal fun SqueezerDashboardCard(item: SqueezerDashboardCardItem) {
                 text = stringResource(CommonR.string.squeezer_tool_name),
                 style = MaterialTheme.typography.titleMedium,
             )
-            if (item.isNew) {
-                Spacer(modifier = Modifier.width(4.dp))
-                NewBadge()
-            }
             Spacer(modifier = Modifier.weight(1f))
             if (item.isInitializing) {
                 CircularProgressIndicator(
@@ -98,7 +92,6 @@ private fun SqueezerDashboardCardPreview() {
             item = SqueezerDashboardCardItem(
                 data = null,
                 isInitializing = false,
-                isNew = true,
                 progress = null,
                 onViewDetails = {},
             ),

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/SwiperDashboardCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/SwiperDashboardCard.kt
@@ -25,7 +25,6 @@ import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.main.ui.dashboard.cards.common.DashboardActionIconSpacing
 import eu.darken.sdmse.main.ui.dashboard.cards.common.DashboardCard
 import eu.darken.sdmse.main.ui.dashboard.cards.common.DashboardFlatActionButton
-import eu.darken.sdmse.main.ui.dashboard.cards.common.NewBadge
 
 import eu.darken.sdmse.swiper.R as SwiperR
 import eu.darken.sdmse.swiper.core.SessionState
@@ -100,8 +99,6 @@ internal fun SwiperDashboardCard(
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
             )
-            Spacer(modifier = Modifier.width(4.dp))
-            NewBadge()
             Spacer(modifier = Modifier.weight(1f))
             if (item.progress != null || item.isInitializing) {
                 CircularProgressIndicator(

--- a/app/src/test/java/eu/darken/sdmse/main/core/DashboardCardConfigTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/core/DashboardCardConfigTest.kt
@@ -40,6 +40,23 @@ class DashboardCardConfigTest : BaseTest() {
     }
 
     @Test
+    fun `DashboardCardConfig default order places Swiper and Squeezer before Analyzer`() {
+        val order = DashboardCardConfig().cards.map { it.type }
+        order shouldBe listOf(
+            DashboardCardType.CORPSEFINDER,
+            DashboardCardType.SYSTEMCLEANER,
+            DashboardCardType.APPCLEANER,
+            DashboardCardType.DEDUPLICATOR,
+            DashboardCardType.APPCONTROL,
+            DashboardCardType.SWIPER,
+            DashboardCardType.SQUEEZER,
+            DashboardCardType.ANALYZER,
+            DashboardCardType.SCHEDULER,
+            DashboardCardType.STATS,
+        )
+    }
+
+    @Test
     fun `DashboardCardConfig serialization format`() {
         val config = DashboardCardConfig(
             cards = listOf(


### PR DESCRIPTION
## What changed

- Swiper and Media Squeeze now sit higher on the dashboard, above the storage Analyzer.
- Removed the "New" tag from both tools. They've been shipping since early 2026, so the tag no longer means anything.

Note: if you previously rearranged your dashboard cards, your custom layout is kept — only the default order changes.

## Technical Context

- Card order is driven by the `DashboardCardType` enum declaration order (the default `DashboardCardConfig`). The enum is serialized by `@SerialName`, so reordering it does **not** affect any stored user config.
- No migration: only users still on the default order pick up the new order. This matches how the previous card reorder shipped, and avoids silently overriding anyone who intentionally arranged their cards.
- The badges were hardcoded on (Media Squeeze via an `isNew` flag, Swiper unconditionally). The generic `NewBadge` component and its string are kept as reusable infra for a future new tool.
- Added an explicit default-order assertion test — the existing test compared against `DashboardCardType.entries`, so it was tautological for ordering.
