### PR TITLE
AppControl: Library tags and a search-closing fix

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/PkgExtensions.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/PkgExtensions.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import androidx.core.net.toUri
 import eu.darken.sdmse.common.pkgs.container.ArchivedPkg
+import eu.darken.sdmse.common.pkgs.container.LibraryPkg
 import eu.darken.sdmse.common.pkgs.container.UninstalledPkg
 import eu.darken.sdmse.common.pkgs.features.InstallDetails
 
@@ -21,6 +22,9 @@ val Pkg.isArchived: Boolean
 
 val Pkg.isUninstalled: Boolean
     get() = this is UninstalledPkg
+
+val Pkg.isLibrary: Boolean
+    get() = this is LibraryPkg
 
 val Pkg.isInstalled: Boolean
     get() = !isArchived && !isUninstalled

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/pkgs/PkgExtensionsTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/pkgs/PkgExtensionsTest.kt
@@ -123,4 +123,16 @@ class PkgExtensionsTest : BaseTest() {
         // PackageInfo. The extension now reaches this via InstallDetails.
         libraryPkg(enabled = true).isSystemApp shouldBe true
     }
+
+    @Test fun `LibraryPkg reports isLibrary=true`() {
+        libraryPkg(enabled = true).isLibrary shouldBe true
+    }
+
+    @Test fun `NormalPkg reports isLibrary=false`() {
+        normalPkg(enabled = true).isLibrary shouldBe false
+    }
+
+    @Test fun `ArchivedPkg reports isLibrary=false`() {
+        archivedPkg().isLibrary shouldBe false
+    }
 }

--- a/app-common/src/main/res/values/strings.xml
+++ b/app-common/src/main/res/values/strings.xml
@@ -71,6 +71,7 @@
     <string name="general_sort_name_asc">Name (A → Z)</string>
     <string name="general_sort_size_desc">Largest first</string>
     <string name="general_tag_system">System</string>
+    <string name="general_tag_library">Library</string>
     <string name="general_navigate_up_action">Navigate up</string>
     <string name="general_filter_action">Filter</string>
     <string name="general_filter_by_tags_label">Filter by tags</string>

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/AppInfo.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/AppInfo.kt
@@ -10,6 +10,7 @@ import eu.darken.sdmse.common.pkgs.features.InstallDetails
 import eu.darken.sdmse.common.pkgs.features.InstallId
 import eu.darken.sdmse.common.pkgs.features.Installed
 import eu.darken.sdmse.common.pkgs.features.SourceAvailable
+import eu.darken.sdmse.common.pkgs.isLibrary
 import eu.darken.sdmse.common.pkgs.pkgops.PkgOps
 import eu.darken.sdmse.common.user.UserProfile2
 import java.time.Instant
@@ -41,6 +42,17 @@ data class AppInfo(
 
     val installedAt: Instant?
         get() = (pkg as? InstallDetails)?.installedAt
+
+    /**
+     * Version string for display, or null when it should be hidden.
+     * Dynamic shared libraries have no version code (SharedLibraryInfo.longVersion == -1);
+     * the backing package's versionName isn't meaningful for the library, so drop the whole line.
+     */
+    val versionText: String?
+        get() = when {
+            pkg.isLibrary && pkg.versionCode == -1L -> null
+            else -> "${pkg.versionName ?: "?"} (${pkg.versionCode})"
+        }
 
     val exportType: AppExportType
         get() = when {

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListViewModel.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListViewModel.kt
@@ -478,8 +478,6 @@ class AppControlListViewModel @Inject constructor(
             val pkg = app.pkg
             val label = app.label.get(context)
             val pkgName = pkg.packageName
-            val versionName = pkg.versionName ?: "?"
-            val versionCode = pkg.versionCode
 
             val store = (pkg as? InstallDetails)?.installerInfo?.installer
                 ?.let { installer ->
@@ -487,7 +485,8 @@ class AppControlListViewModel @Inject constructor(
                 }
 
             buildString {
-                append("- **$label** `$pkgName` v$versionName ($versionCode)")
+                append("- **$label** `$pkgName`")
+                app.versionText?.let { append(" v$it") }
                 store?.urlGenerator?.invoke(pkg.id)?.let { storeLink ->
                     append(" [${store.storeLabel}]($storeLink)")
                 }

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppInfoTagsRow.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppInfoTagsRow.kt
@@ -24,6 +24,7 @@ import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import eu.darken.sdmse.common.pkgs.isArchived
 import eu.darken.sdmse.common.pkgs.isDebuggable
 import eu.darken.sdmse.common.pkgs.isEnabled
+import eu.darken.sdmse.common.pkgs.isLibrary
 import eu.darken.sdmse.common.pkgs.isSystemApp
 import eu.darken.sdmse.common.pkgs.isUninstalled
 
@@ -33,7 +34,9 @@ fun AppInfoTagsRow(
     appInfo: AppInfo,
 ) {
     val active = appInfo.isActive == true
-    val system = appInfo.pkg.isSystemApp
+    val library = appInfo.pkg.isLibrary
+    // Libraries are force-flagged as system apps; show the more specific "Library" tag instead.
+    val system = appInfo.pkg.isSystemApp && !library
     val debug = appInfo.pkg.isDebuggable
     val archived = appInfo.pkg.isArchived
     val uninstalled = appInfo.pkg.isUninstalled
@@ -41,7 +44,8 @@ fun AppInfoTagsRow(
     val apkBase = appInfo.exportType == AppExportType.APK
     val apkBundle = appInfo.exportType == AppExportType.BUNDLE
 
-    val anyVisible = active || system || debug || archived || uninstalled || disabled || apkBase || apkBundle
+    val anyVisible =
+        active || library || system || debug || archived || uninstalled || disabled || apkBase || apkBundle
     if (!anyVisible) return
 
     FlowRow(
@@ -73,6 +77,13 @@ fun AppInfoTagsRow(
         if (uninstalled) {
             Tag(
                 text = stringResource(R.string.appcontrol_tag_uninstalled),
+                background = MaterialTheme.colorScheme.tertiaryContainer,
+                contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+            )
+        }
+        if (library) {
+            Tag(
+                text = stringResource(CommonR.string.general_tag_library),
                 background = MaterialTheme.colorScheme.tertiaryContainer,
                 contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
             )

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/actions/AppActionSheet.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/actions/AppActionSheet.kt
@@ -239,11 +239,13 @@ internal fun AppActionSheet(
                                 maxLines = 1,
                                 overflow = TextOverflow.Ellipsis,
                             )
-                            Text(
-                                text = "${appInfo.pkg.versionName ?: "?"} (${appInfo.pkg.versionCode})",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
+                            appInfo.versionText?.let { versionText ->
+                                Text(
+                                    text = versionText,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
                             val userLabel = appInfo.userProfile?.getHumanLabel()?.get(context)
                             if (userLabel != null) {
                                 Text(

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/items/AppControlListRow.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/items/AppControlListRow.kt
@@ -150,7 +150,7 @@ private fun secondaryInfoFor(
         }
 
         SortSettings.Mode.NAME, SortSettings.Mode.PACKAGENAME, SortSettings.Mode.SIZE ->
-            "${appInfo.pkg.versionName ?: "?"} (${appInfo.pkg.versionCode})"
+            appInfo.versionText
     }
 }
 

--- a/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/core/AppInfoTest.kt
+++ b/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/core/AppInfoTest.kt
@@ -1,0 +1,93 @@
+package eu.darken.sdmse.appcontrol.core
+
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageInfo
+import android.content.pm.SharedLibraryInfo
+import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.pkgs.Pkg
+import eu.darken.sdmse.common.pkgs.container.LibraryPkg
+import eu.darken.sdmse.common.pkgs.features.InstallDetails
+import eu.darken.sdmse.common.pkgs.features.InstallId
+import eu.darken.sdmse.common.pkgs.features.Installed
+import eu.darken.sdmse.common.pkgs.features.InstallerInfo
+import eu.darken.sdmse.common.user.UserHandle2
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class AppInfoTest : BaseTest() {
+
+    private val userHandle = UserHandle2(0)
+
+    private fun appInfo(pkg: Installed) = AppInfo(
+        pkg = pkg,
+        isActive = null,
+        sizes = null,
+        usage = null,
+        userProfile = null,
+        canBeToggled = false,
+        canBeStopped = false,
+        canBeExported = false,
+        canBeDeleted = false,
+        canBeArchived = false,
+        canBeRestored = false,
+    )
+
+    private fun libraryPkg(longVersion: Long, versionName: String? = "1"): LibraryPkg {
+        val sharedLibraryInfo = mockk<SharedLibraryInfo>().apply {
+            every { name } returns "com.example.lib"
+            every { this@apply.longVersion } returns longVersion
+            // In plain JVM tests Build.VERSION.SDK_INT == 0, so LibraryPkg.versionCode takes the
+            // pre-API-28 branch reading the deprecated int `version`. Stub both, kept consistent.
+            @Suppress("DEPRECATION")
+            every { version } returns longVersion.toInt()
+            every { type } returns SharedLibraryInfo.TYPE_DYNAMIC
+        }
+        val packageInfo = PackageInfo().apply {
+            packageName = "com.example.lib"
+            this.versionName = versionName
+            applicationInfo = ApplicationInfo().apply {
+                packageName = "com.example.lib"
+                enabled = true
+            }
+        }
+        return LibraryPkg(
+            sharedLibraryInfo = sharedLibraryInfo,
+            apkPath = mockk<APath>(relaxed = true),
+            packageInfo = packageInfo,
+            userHandle = userHandle,
+        )
+    }
+
+    private fun normalPkg(versionName: String?, versionCode: Long): Installed {
+        val pkgId = Pkg.Id("com.test.app")
+        return mockk<Installed>(relaxed = true, moreInterfaces = arrayOf(InstallDetails::class)).apply {
+            every { id } returns pkgId
+            every { installId } returns InstallId(pkgId, userHandle)
+            every { this@apply.versionName } returns versionName
+            every { this@apply.versionCode } returns versionCode
+            every { (this@apply as InstallDetails).installerInfo } returns InstallerInfo()
+        }
+    }
+
+    @Test fun `library with sentinel version code hides the version line entirely`() {
+        // Dynamic shared libraries report longVersion == -1; the whole line is dropped
+        // even though versionName ("1") is non-null.
+        appInfo(libraryPkg(longVersion = -1L, versionName = "1")).versionText shouldBe null
+    }
+
+    @Test fun `library with a real version code still shows the version`() {
+        appInfo(libraryPkg(longVersion = 42L, versionName = "1")).versionText shouldBe "1 (42)"
+    }
+
+    @Test fun `non-library with sentinel version code is not hidden`() {
+        // The hide rule is scoped to libraries; a normal app with -1 is left untouched.
+        appInfo(normalPkg(versionName = "9.8", versionCode = -1L)).versionText shouldBe "9.8 (-1)"
+    }
+
+    @Test fun `normal app renders name and code`() {
+        appInfo(normalPkg(versionName = "1.2.3", versionCode = 42L)).versionText shouldBe "1.2.3 (42)"
+    }
+}

--- a/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/ui/list/AppInfoTagsRowTest.kt
+++ b/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/ui/list/AppInfoTagsRowTest.kt
@@ -1,0 +1,99 @@
+package eu.darken.sdmse.appcontrol.ui.list
+
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageInfo
+import android.content.pm.SharedLibraryInfo
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import eu.darken.sdmse.appcontrol.core.AppInfo
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.pkgs.Pkg
+import eu.darken.sdmse.common.pkgs.container.LibraryPkg
+import eu.darken.sdmse.common.pkgs.features.InstallDetails
+import eu.darken.sdmse.common.pkgs.features.InstallId
+import eu.darken.sdmse.common.pkgs.features.Installed
+import eu.darken.sdmse.common.pkgs.features.InstallerInfo
+import eu.darken.sdmse.common.user.UserHandle2
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+
+class AppInfoTagsRowTest : BaseComposeRobolectricTest() {
+
+    private val userHandle = UserHandle2(0)
+
+    private fun appInfo(pkg: Installed) = AppInfo(
+        pkg = pkg,
+        isActive = null,
+        sizes = null,
+        usage = null,
+        userProfile = null,
+        canBeToggled = false,
+        canBeStopped = false,
+        canBeExported = false,
+        canBeDeleted = false,
+        canBeArchived = false,
+        canBeRestored = false,
+    )
+
+    private fun libraryPkg(): LibraryPkg {
+        val sharedLibraryInfo = mockk<SharedLibraryInfo>().apply {
+            every { name } returns "android.ext.shared"
+            every { longVersion } returns -1L
+            every { type } returns SharedLibraryInfo.TYPE_DYNAMIC
+        }
+        val packageInfo = PackageInfo().apply {
+            packageName = "com.google.android.ext.shared"
+            applicationInfo = ApplicationInfo().apply {
+                packageName = "com.google.android.ext.shared"
+                enabled = true
+            }
+        }
+        return LibraryPkg(
+            sharedLibraryInfo = sharedLibraryInfo,
+            apkPath = mockk<APath>(relaxed = true),
+            packageInfo = packageInfo,
+            userHandle = userHandle,
+        )
+    }
+
+    private fun systemPkg(): Installed {
+        val pkgId = Pkg.Id("com.system.app")
+        return mockk<Installed>(relaxed = true, moreInterfaces = arrayOf(InstallDetails::class)).apply {
+            every { id } returns pkgId
+            every { installId } returns InstallId(pkgId, userHandle)
+            every { packageName } returns "com.system.app"
+            every { (this@apply as InstallDetails).isEnabled } returns true
+            every { (this@apply as InstallDetails).isSystemApp } returns true
+            every { (this@apply as InstallDetails).isDebuggable } returns false
+            every { (this@apply as InstallDetails).installerInfo } returns InstallerInfo()
+        }
+    }
+
+    @Test
+    fun `library entry renders the Library tag and not the System tag`() {
+        composeRule.setContent {
+            PreviewWrapper {
+                AppInfoTagsRow(appInfo = appInfo(libraryPkg()))
+            }
+        }
+
+        composeRule.onNodeWithText("Library").assertExists()
+        composeRule.onAllNodesWithText("System").assertCountEquals(0)
+    }
+
+    @Test
+    fun `normal system app renders the System tag and not the Library tag`() {
+        composeRule.setContent {
+            PreviewWrapper {
+                AppInfoTagsRow(appInfo = appInfo(systemPkg()))
+            }
+        }
+
+        composeRule.onNodeWithText("System").assertExists()
+        composeRule.onAllNodesWithText("Library").assertCountEquals(0)
+    }
+}


### PR DESCRIPTION
## What changed

Two AppControl improvements for shared-library entries and search:

**Shared libraries look right now**
- Shared libraries (like `android.ext.shared`) were tagged with the generic **"System"** label, making them look like ordinary system apps. They now get their own **"Library"** tag.
- They also showed a meaningless version like **"(-1)"** (a shared library has no real version number). That version line is now hidden for these entries.

**Search behaves like a normal Android search now**
- With search open, typing a query and tapping a result closed the search bar and reset the list back to all apps. Search no longer closes when the keyboard hides — opening an app, dismissing its sheet, or hiding the keyboard all keep your search and filtered results.
- Search now closes only when you mean it: the **X**, the **back arrow** (which collapses search instead of leaving the screen), or the system back button.

## Technical Context

**Library tag / version** (follow-up to the #2496 diagnosis; the "Disabled" state discussed there is intentional and untouched):
- `LibraryPkg` force-flags `isSystemApp = true`, which is why libraries rendered "System". New `Pkg.isLibrary` extension + `general_tag_library` string; `AppInfoTagsRow` renders "Library" and suppresses "System" when `isLibrary`. The tag row is shared by the list row and the action sheet.
- `-1` is `SharedLibraryInfo.longVersion`'s "no version" sentinel for dynamic libraries. New `AppInfo.versionText` returns `null` for `isLibrary && versionCode == -1`; wired into the list row, action sheet, and share-list export. Filtering is deliberately untouched — the `System` filter still returns library rows.

**Search:**
- Root cause: the previous code inferred "user wants to leave search" from the soft keyboard hiding (`WindowInsets.isImeVisible`) — a workaround so one back press could both hide the keyboard and close search. But the keyboard also hides when focus moves away, e.g. tapping a result opens the app action sheet (a modal bottom-sheet nav destination) over the still-composed list. So search collapsed and the query reset whenever the keyboard closed for any reason.
- Fix: **decouple search-open state from the keyboard** — the canonical Android search-view model. Removed the IME-visibility observer entirely. Search closes only via explicit actions (X / leading arrow / system back once the keyboard is down). The leading arrow collapses search while active (and its content description becomes "Close") instead of leaving the screen. Tradeoff, by design: with the keyboard up it's the standard two-step back (back hides keyboard, back closes search).
- Not unit-tested: the IME + modal-nav focus timing isn't reproducible in the JVM/Robolectric harness. Verified end-to-end on a Pixel 8: opening an app keeps search + filtered list; dismissing the sheet keeps search; back#1 hides the keyboard and keeps search; back#2 closes search; the X and the leading arrow both close search.

Refs #2496
