### PR TITLE
Media Squeeze: Zoom both comparison images together again

### DIFF
--- a/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/ui/comparison/SqueezerComparisonDialog.kt
+++ b/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/ui/comparison/SqueezerComparisonDialog.kt
@@ -1,8 +1,10 @@
 package eu.darken.sdmse.squeezer.ui.comparison
 
+import android.annotation.SuppressLint
 import android.content.res.Configuration
 import android.graphics.Bitmap
 import android.media.MediaMetadataRetriever
+import android.view.MotionEvent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -106,6 +108,10 @@ fun SqueezerComparisonDialog(
         // a single tempDir snapshot at dispose only cleans the last one and orphans the rest.
         val createdDirs = remember { mutableListOf<File>() }
 
+        // The two zoom views, captured so their gestures can be linked (see linkZoomGestures).
+        var originalView by remember { mutableStateOf<CoilZoomImageView?>(null) }
+        var compressedView by remember { mutableStateOf<CoilZoomImageView?>(null) }
+
         LaunchedEffect(media, quality) {
             failed = false
             originalFile = null
@@ -196,6 +202,20 @@ fun SqueezerComparisonDialog(
             }
         }
 
+        // Link zoom/pan across both panes once both views exist, so pinching or panning one
+        // mirrors onto the other and the user can compare the same detail at the same zoom level.
+        val original = originalView
+        val compressed = compressedView
+        DisposableEffect(original, compressed) {
+            if (original != null && compressed != null) {
+                linkZoomGestures(original, compressed)
+            }
+            onDispose {
+                original?.setOnTouchListener(null)
+                compressed?.setOnTouchListener(null)
+            }
+        }
+
         val orientation = LocalConfiguration.current.orientation
         val isLandscape = orientation == Configuration.ORIENTATION_LANDSCAPE
 
@@ -223,6 +243,8 @@ fun SqueezerComparisonDialog(
                             label = originalLabel,
                             file = originalFile,
                             failed = failed,
+                            onViewReady = { originalView = it },
+                            onViewReleased = { if (originalView === it) originalView = null },
                             modifier = Modifier
                                 .weight(1f)
                                 .fillMaxHeight(),
@@ -231,6 +253,8 @@ fun SqueezerComparisonDialog(
                             label = compressedLabel,
                             file = compressedFile,
                             failed = failed,
+                            onViewReady = { compressedView = it },
+                            onViewReleased = { if (compressedView === it) compressedView = null },
                             modifier = Modifier
                                 .weight(1f)
                                 .fillMaxHeight(),
@@ -242,6 +266,8 @@ fun SqueezerComparisonDialog(
                             label = originalLabel,
                             file = originalFile,
                             failed = failed,
+                            onViewReady = { originalView = it },
+                            onViewReleased = { if (originalView === it) originalView = null },
                             modifier = Modifier
                                 .weight(1f)
                                 .fillMaxWidth(),
@@ -250,6 +276,8 @@ fun SqueezerComparisonDialog(
                             label = compressedLabel,
                             file = compressedFile,
                             failed = failed,
+                            onViewReady = { compressedView = it },
+                            onViewReleased = { if (compressedView === it) compressedView = null },
                             modifier = Modifier
                                 .weight(1f)
                                 .fillMaxWidth(),
@@ -282,6 +310,8 @@ private fun ImagePane(
     label: String,
     file: File?,
     failed: Boolean,
+    onViewReady: (CoilZoomImageView) -> Unit = {},
+    onViewReleased: (CoilZoomImageView) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     Box(
@@ -290,13 +320,14 @@ private fun ImagePane(
         when {
             file != null -> {
                 AndroidView(
-                    factory = { ctx -> CoilZoomImageView(ctx) },
+                    factory = { ctx -> CoilZoomImageView(ctx).also(onViewReady) },
                     update = { view ->
                         view.load(file) {
                             memoryCachePolicy(CachePolicy.DISABLED)
                             diskCachePolicy(CachePolicy.DISABLED)
                         }
                     },
+                    onRelease = onViewReleased,
                     modifier = Modifier.fillMaxSize(),
                 )
             }
@@ -329,6 +360,35 @@ private fun ImagePane(
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             )
         }
+    }
+}
+
+/**
+ * Mirrors zoom/pan gestures between the two comparison panes by replaying each view's touch events
+ * onto the other, so zooming into a detail on one side shows the same detail on the other. Both
+ * panes are always the same size, so identical view-local coordinates land on the same content
+ * point. Forwarded events go straight to [android.view.View.onTouchEvent] (bypassing the listener),
+ * so there is no feedback loop; returning false lets the originating view still handle the gesture.
+ */
+@SuppressLint("ClickableViewAccessibility")
+private fun linkZoomGestures(viewA: CoilZoomImageView, viewB: CoilZoomImageView) {
+    viewA.setOnTouchListener { _, event ->
+        val cloned = MotionEvent.obtain(event)
+        try {
+            viewB.onTouchEvent(cloned)
+        } finally {
+            cloned.recycle()
+        }
+        false
+    }
+    viewB.setOnTouchListener { _, event ->
+        val cloned = MotionEvent.obtain(event)
+        try {
+            viewA.onTouchEvent(cloned)
+        } finally {
+            cloned.recycle()
+        }
+        false
     }
 }
 

--- a/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/ui/comparison/SqueezerComparisonDialog.kt
+++ b/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/ui/comparison/SqueezerComparisonDialog.kt
@@ -10,13 +10,15 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.add
 import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.union
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.Close
@@ -36,6 +38,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
@@ -243,16 +246,23 @@ fun SqueezerComparisonDialog(
                             label = originalLabel,
                             file = originalFile,
                             failed = failed,
+                            labelAlignment = Alignment.BottomStart,
                             onViewReady = { originalView = it },
                             onViewReleased = { if (originalView === it) originalView = null },
                             modifier = Modifier
                                 .weight(1f)
                                 .fillMaxHeight(),
                         )
+                        PaneDivider(
+                            modifier = Modifier
+                                .fillMaxHeight()
+                                .width(1.dp),
+                        )
                         ImagePane(
                             label = compressedLabel,
                             file = compressedFile,
                             failed = failed,
+                            labelAlignment = Alignment.BottomEnd,
                             onViewReady = { compressedView = it },
                             onViewReleased = { if (compressedView === it) compressedView = null },
                             modifier = Modifier
@@ -266,16 +276,23 @@ fun SqueezerComparisonDialog(
                             label = originalLabel,
                             file = originalFile,
                             failed = failed,
+                            labelAlignment = Alignment.TopCenter,
                             onViewReady = { originalView = it },
                             onViewReleased = { if (originalView === it) originalView = null },
                             modifier = Modifier
                                 .weight(1f)
                                 .fillMaxWidth(),
                         )
+                        PaneDivider(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(1.dp),
+                        )
                         ImagePane(
                             label = compressedLabel,
                             file = compressedFile,
                             failed = failed,
+                            labelAlignment = Alignment.BottomCenter,
                             onViewReady = { compressedView = it },
                             onViewReleased = { if (compressedView === it) compressedView = null },
                             modifier = Modifier
@@ -291,8 +308,8 @@ fun SqueezerComparisonDialog(
                         containerColor = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.65f),
                     ),
                     modifier = Modifier
-                        .align(Alignment.TopEnd)
-                        .windowInsetsPadding(WindowInsets.systemBars.add(WindowInsets.displayCutout))
+                        .align(Alignment.TopStart)
+                        .windowInsetsPadding(WindowInsets.systemBars.union(WindowInsets.displayCutout))
                         .padding(16.dp),
                 ) {
                     Icon(
@@ -310,12 +327,18 @@ private fun ImagePane(
     label: String,
     file: File?,
     failed: Boolean,
+    labelAlignment: Alignment = Alignment.TopStart,
     onViewReady: (CoilZoomImageView) -> Unit = {},
     onViewReleased: (CoilZoomImageView) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     Box(
-        modifier = modifier.background(Color.Black),
+        // Clip the zoom view to the pane: when zoomed in, its enlarged content would otherwise
+        // draw past its bounds and overlap the adjacent pane (Compose's AndroidView host doesn't
+        // clip the embedded view's overflow).
+        modifier = modifier
+            .clipToBounds()
+            .background(Color.Black),
     ) {
         when {
             file != null -> {
@@ -349,18 +372,23 @@ private fun ImagePane(
         Surface(
             color = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.65f),
             modifier = Modifier
-                .align(Alignment.TopStart)
-                .windowInsetsPadding(WindowInsets.systemBars.add(WindowInsets.displayCutout))
+                .align(labelAlignment)
+                .windowInsetsPadding(WindowInsets.systemBars.union(WindowInsets.displayCutout))
                 .padding(8.dp),
         ) {
             Text(
                 text = label,
                 color = MaterialTheme.colorScheme.onSecondaryContainer,
-                style = MaterialTheme.typography.labelMedium,
-                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                style = MaterialTheme.typography.labelLarge,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
             )
         }
     }
+}
+
+@Composable
+private fun PaneDivider(modifier: Modifier = Modifier) {
+    Box(modifier = modifier.background(Color.White.copy(alpha = 0.3f)))
 }
 
 /**

--- a/app-tool-squeezer/src/main/res/values/strings.xml
+++ b/app-tool-squeezer/src/main/res/values/strings.xml
@@ -116,6 +116,6 @@
     <string name="squeezer_onboarding_got_it">Got it</string>
 
     <!-- Guided tour -->
-    <string name="tour_squeezer_intro_body">Squeezer re-compresses your photos and videos so they take up less room. The files stay usable, just smaller, and each one shows its estimated saving.</string>
+    <string name="tour_squeezer_intro_body">Squeezer re-compresses your photos and videos so they take up less space. You trade a little quality for the room you get back. Each item shows its estimated saving, so you can decide what\'s worth it.</string>
     <string name="tour_squeezer_compress_body">Compress everything at once here, or tap a single item to shrink just that one. Long-press to pick several. You\'ll always see a preview before anything changes.</string>
 </resources>


### PR DESCRIPTION
## What changed

When you compare an image with its about-to-be-compressed version, zooming or panning one side again moves the other in lockstep, so you can line up and inspect the exact same detail on both. This had stopped working after the screen was rebuilt.

Also in this PR:

- Fixed a zoomed-in image spilling out of its half and covering the other image.
- Restored the comparison screen's look: close button back in the top-left, the "Original"/"Compressed" labels back to their larger size at the outer edges, and the divider line between the two images.
- Fixed the close button and labels sitting too far below the top of the screen.
- Reworded the Squeezer tour intro to state the quality/space tradeoff more honestly.

## Technical Context

- Linked zoom is restored by forwarding cloned `MotionEvent`s between the two `CoilZoomImageView`s (the same mechanism used before the Compose rewrite). Views are captured via an `onViewReady` callback with symmetric `onRelease` cleanup (identity-guarded) so no detached view lingers with a cross-referencing touch listener during quality changes or reload failures.
- Overflow fix: each pane is wrapped in `Modifier.clipToBounds()` — Compose's `AndroidView` host doesn't clip the embedded zoom view's zoomed overflow, so it drew over the sibling pane.
- Inset fix: the close button and labels combined `systemBars` and `displayCutout` with `add()`, which **sums** the insets and double-counts the top (the cutout sits inside the status-bar region); switched to `union()` (max per side).
- Includes a cherry-picked tour-intro string reword (hence the Translation label).
