### PR TITLE
Media Squeeze: Fix confusing "0 of N" search progress

### DIFF
--- a/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/scanner/MediaScanner.kt
+++ b/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/scanner/MediaScanner.kt
@@ -172,7 +172,8 @@ class MediaScanner @Inject constructor(
 
         searchFlow.collect { lookup ->
             scannedCount++
-            updateProgressCount(Progress.Count.Counter(scannedCount))
+            // Keep the indeterminate "searching…" state during the walk — the total isn't known
+            // yet, and a Count here rendered a misleading "0/N" (Counter(Int) sets current=0).
             updateProgressSecondary(lookup.userReadablePath)
 
             val mimeType = mimeTypeTool.determineMimeType(lookup)
@@ -200,7 +201,7 @@ class MediaScanner @Inject constructor(
         }
 
         log(TAG) {
-            "Scan complete: ${results.size} compressible media found, " +
+            "Scan complete: $scannedCount files scanned, ${results.size} compressible media found, " +
                 "${skippedInaccessible.get()} skipped (inaccessible), " +
                 "${skippedLossyAux.get()} skipped (HDR/depth aux)"
         }


### PR DESCRIPTION
## What changed

While Squeezer searches your folders, the progress no longer shows a confusing "0 of N" that stayed stuck at 0. During the search it now shows the normal "searching…" state along with the file it's currently looking at.

## Technical Context

- Root cause: the search loop set progress via `Progress.Count.Counter(scannedCount)`. A single `Int` argument resolves to the `Counter(max)` constructor, which pins `current = 0`, so it rendered `0/1`, `0/2`, `0/3`… — a permanent 0 numerator with the file-scan count as the denominator.
- The total is unknown during an unbounded filesystem walk, so the count is dropped and the indeterminate "searching…" state is kept (the current path is still shown as secondary progress). The scanned-file count is folded into the scan-complete log line for observability.
