### PR TITLE
General: Detect Shizuku even when hidden from other apps

### DIFF
--- a/app-common-adb/src/main/java/eu/darken/sdmse/common/adb/shizuku/ShizukuWrapper.kt
+++ b/app-common-adb/src/main/java/eu/darken/sdmse/common/adb/shizuku/ShizukuWrapper.kt
@@ -1,13 +1,17 @@
 package eu.darken.sdmse.common.adb.shizuku
 
+import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Handler
 import android.os.HandlerThread
+import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.flow.setupCommonEventHandlers
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.flow.Flow
@@ -16,13 +20,41 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import rikka.shizuku.Shizuku
 import rikka.shizuku.ShizukuBinderWrapper
+import rikka.shizuku.ShizukuProvider
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class ShizukuWrapper @Inject constructor(
+    @ApplicationContext private val context: Context,
     private val dispatcherProvider: DispatcherProvider,
 ) {
+
+    /**
+     * Package that declares the Shizuku permission, or null if no installed app declares it.
+     *
+     * Detects Shizuku via its permission ([ShizukuProvider.PERMISSION]) instead of a fixed package
+     * name. The permission name is shared across Shizuku forks, so this keeps working when a fork
+     * hides its package from enumeration ("Hide Shizuku from other apps") or ships under a different
+     * package name. Permissions live in a global namespace, so the lookup isn't subject to the
+     * package-visibility filtering that hides the app itself.
+     */
+    suspend fun getManagerPackage(): String? = withContext(dispatcherProvider.IO) {
+        try {
+            context.packageManager
+                .getPermissionInfo(ShizukuProvider.PERMISSION, 0)
+                .packageName
+                ?.takeUnless { it.isBlank() }
+        } catch (e: PackageManager.NameNotFoundException) {
+            log(TAG) { "getManagerPackage(): Shizuku permission not declared by any app" }
+            null
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, WARN) { "getManagerPackage(): Lookup failed: ${e.asLog()}" }
+            null
+        }
+    }
 
     private val handlerThread: HandlerThread by lazy {
         HandlerThread("shizuku:binder-handler")

--- a/app-common-adb/src/test/java/eu/darken/sdmse/common/adb/shizuku/ShizukuWrapperTest.kt
+++ b/app-common-adb/src/test/java/eu/darken/sdmse/common/adb/shizuku/ShizukuWrapperTest.kt
@@ -1,0 +1,74 @@
+package eu.darken.sdmse.common.adb.shizuku
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.content.pm.PermissionInfo
+import eu.darken.sdmse.common.coroutine.DispatcherProvider
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * Covers [ShizukuWrapper.getManagerPackage] — permission-based Shizuku detection that survives
+ * "Hide Shizuku from other apps" mode and forks that rename their package (issue #2405).
+ */
+class ShizukuWrapperTest {
+
+    private val context = mockk<Context>()
+    private val packageManager = mockk<PackageManager>()
+
+    private val dispatcherProvider = object : DispatcherProvider {
+        override val IO: CoroutineDispatcher = Dispatchers.Unconfined
+    }
+
+    private fun wrapper(): ShizukuWrapper {
+        every { context.packageManager } returns packageManager
+        return ShizukuWrapper(context, dispatcherProvider)
+    }
+
+    // mockk gives us a real (Objenesis-instantiated) PermissionInfo whose inherited public
+    // packageName field we can set directly, without invoking the Android constructor.
+    private fun permissionInfo(pkg: String?) = mockk<PermissionInfo>().apply { packageName = pkg }
+
+    @Test
+    fun `resolves the declaring package when the Shizuku permission exists`() = runTest {
+        every { packageManager.getPermissionInfo(any(), any<Int>()) } returns
+            permissionInfo("moe.shizuku.privileged.api")
+
+        wrapper().getManagerPackage() shouldBe "moe.shizuku.privileged.api"
+    }
+
+    @Test
+    fun `resolves a fork declaring the permission under a different package`() = runTest {
+        every { packageManager.getPermissionInfo(any(), any<Int>()) } returns
+            permissionInfo("com.example.shizuku.fork")
+
+        wrapper().getManagerPackage() shouldBe "com.example.shizuku.fork"
+    }
+
+    @Test
+    fun `returns null when no app declares the Shizuku permission`() = runTest {
+        every { packageManager.getPermissionInfo(any(), any<Int>()) } throws
+            PackageManager.NameNotFoundException()
+
+        wrapper().getManagerPackage() shouldBe null
+    }
+
+    @Test
+    fun `returns null on unexpected PackageManager failure`() = runTest {
+        every { packageManager.getPermissionInfo(any(), any<Int>()) } throws RuntimeException("OEM quirk")
+
+        wrapper().getManagerPackage() shouldBe null
+    }
+
+    @Test
+    fun `returns null when the declaring package name is blank`() = runTest {
+        every { packageManager.getPermissionInfo(any(), any<Int>()) } returns permissionInfo("")
+
+        wrapper().getManagerPackage() shouldBe null
+    }
+}

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/adb/shizuku/ShizukuManager.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/adb/shizuku/ShizukuManager.kt
@@ -1,8 +1,5 @@
 package eu.darken.sdmse.common.adb.shizuku
 
-import android.content.Context
-import android.content.pm.PackageManager
-import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.sdmse.common.access.AccessState
 import eu.darken.sdmse.common.adb.AdbSettings
 import eu.darken.sdmse.common.adb.service.AdbServiceClient
@@ -37,7 +34,6 @@ import javax.inject.Singleton
 
 @Singleton
 class ShizukuManager @Inject constructor(
-    @ApplicationContext private val context: Context,
     @AppScope private val appScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
     settings: AdbSettings,
@@ -45,7 +41,9 @@ class ShizukuManager @Inject constructor(
     val serviceClient: AdbServiceClient,
 ) {
 
-    suspend fun managerIds() = setOf(PKG_ID)
+    // The reference package plus, if a fork under a different package name is installed, its package too.
+    // Consumers (e.g. AppCleaner) use this to recognize the Shizuku manager app.
+    suspend fun managerIds(): Set<Pkg.Id> = setOf(PKG_ID) + listOfNotNull(getManagerId())
 
     val permissionGrantEvents: Flow<ShizukuWrapper.ShizukuPermissionRequest> = shizukuWrapper.permissionGrantEvents
         .setupCommonEventHandlers(TAG) { "grantEvents" }
@@ -99,18 +97,20 @@ class ShizukuManager @Inject constructor(
         }
     }
 
+    // Reference package, also used as a fallback for previews and when nothing is installed.
     val shizukuPkgId: Pkg.Id
         get() = PKG_ID
 
+    /**
+     * The installed Shizuku manager's package, resolved via its permission so forks and hidden-mode
+     * installs are handled, or null if Shizuku isn't installed.
+     */
+    suspend fun getManagerId(): Pkg.Id? = shizukuWrapper.getManagerPackage()?.toPkgId()
+
     // Not cached: a stale "not installed" result would keep the binder gate (see shizukuBinder) closed
-    // even after Shizuku gets installed, until the next process restart. The package lookup is cheap.
+    // even after Shizuku gets installed, until the next process restart. The lookup is cheap.
     suspend fun isInstalled(): Boolean {
-        val installed = try {
-            context.packageManager.getPackageInfo(PKG_ID.name, 0)
-            true
-        } catch (_: PackageManager.NameNotFoundException) {
-            false
-        }
+        val installed = getManagerId() != null
         log(TAG) { "isInstalled(): $installed" }
         return installed
     }

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/adb/shizuku/ShizukuManagerTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/adb/shizuku/ShizukuManagerTest.kt
@@ -1,11 +1,9 @@
 package eu.darken.sdmse.common.adb.shizuku
 
-import android.content.Context
-import android.content.pm.PackageInfo
-import android.content.pm.PackageManager
 import eu.darken.sdmse.common.adb.AdbSettings
 import eu.darken.sdmse.common.adb.service.AdbServiceClient
 import eu.darken.sdmse.common.datastore.DataStoreValue
+import eu.darken.sdmse.common.pkgs.toPkgId
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.every
@@ -17,6 +15,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -26,8 +25,6 @@ import testhelpers.flow.test
 
 class ShizukuManagerTest : BaseTest() {
 
-    private val context: Context = mockk()
-    private val packageManager: PackageManager = mockk()
     private val settings: AdbSettings = mockk()
     private val shizukuWrapper: ShizukuWrapper = mockk()
     private val serviceClient: AdbServiceClient = mockk(relaxed = true)
@@ -44,7 +41,6 @@ class ShizukuManagerTest : BaseTest() {
         useShizukuFlow = MutableStateFlow(true)
         scope = CoroutineScope(Dispatchers.Unconfined + SupervisorJob())
 
-        every { context.packageManager } returns packageManager
         every { settings.useShizuku } returns useShizukuValue
         every { useShizukuValue.flow } returns useShizukuFlow
 
@@ -63,7 +59,6 @@ class ShizukuManagerTest : BaseTest() {
     }
 
     private fun manager() = ShizukuManager(
-        context = context,
         appScope = scope,
         dispatcherProvider = TestDispatcherProvider(),
         settings = settings,
@@ -71,18 +66,12 @@ class ShizukuManagerTest : BaseTest() {
         serviceClient = serviceClient,
     )
 
-    private fun setShizukuInstalled(installed: Boolean) {
-        if (installed) {
-            every { packageManager.getPackageInfo(ShizukuManager.PKG_ID.name, 0) } returns PackageInfo()
-        } else {
-            every {
-                packageManager.getPackageInfo(ShizukuManager.PKG_ID.name, 0)
-            } throws PackageManager.NameNotFoundException()
-        }
+    private fun setShizukuPackage(pkg: String?) {
+        coEvery { shizukuWrapper.getManagerPackage() } returns pkg
     }
 
     @Test fun `binder is not probed when Shizuku is not installed`() {
-        setShizukuInstalled(false)
+        setShizukuPackage(null)
         val mgr = manager()
 
         val collector = mgr.shizukuBinder.test(tag = "binder", scope = scope)
@@ -91,11 +80,11 @@ class ShizukuManagerTest : BaseTest() {
         collector.latestValues.last() shouldBe null
         binderSubscriptions shouldBe 0
 
-        kotlinx.coroutines.runBlocking { collector.cancelAndJoin() }
+        runBlocking { collector.cancelAndJoin() }
     }
 
     @Test fun `binder is probed when Shizuku is installed`() {
-        setShizukuInstalled(true)
+        setShizukuPackage(ShizukuManager.PKG_ID.name)
         val mgr = manager()
 
         val collector = mgr.shizukuBinder.test(tag = "binder", scope = scope)
@@ -103,11 +92,11 @@ class ShizukuManagerTest : BaseTest() {
 
         binderSubscriptions shouldBe 1
 
-        kotlinx.coroutines.runBlocking { collector.cancelAndJoin() }
+        runBlocking { collector.cancelAndJoin() }
     }
 
     @Test fun `binder stays closed when user opted out even if installed`() {
-        setShizukuInstalled(true)
+        setShizukuPackage(ShizukuManager.PKG_ID.name)
         useShizukuFlow.value = false
         val mgr = manager()
 
@@ -117,17 +106,48 @@ class ShizukuManagerTest : BaseTest() {
         collector.latestValues.last() shouldBe null
         binderSubscriptions shouldBe 0
 
-        kotlinx.coroutines.runBlocking { collector.cancelAndJoin() }
+        runBlocking { collector.cancelAndJoin() }
     }
 
     @Test fun `isInstalled is not cached and re-evaluates each call`() {
         val mgr = manager()
 
-        setShizukuInstalled(false)
-        kotlinx.coroutines.runBlocking { mgr.isInstalled() } shouldBe false
+        setShizukuPackage(null)
+        runBlocking { mgr.isInstalled() } shouldBe false
 
         // Shizuku gets installed afterwards: the next call must reflect it (no stale cache).
-        setShizukuInstalled(true)
-        kotlinx.coroutines.runBlocking { mgr.isInstalled() } shouldBe true
+        setShizukuPackage(ShizukuManager.PKG_ID.name)
+        runBlocking { mgr.isInstalled() } shouldBe true
+    }
+
+    @Test fun `getManagerId resolves the detected package`() {
+        val mgr = manager()
+
+        setShizukuPackage(null)
+        runBlocking { mgr.getManagerId() } shouldBe null
+
+        setShizukuPackage(ShizukuManager.PKG_ID.name)
+        runBlocking { mgr.getManagerId() } shouldBe ShizukuManager.PKG_ID
+    }
+
+    @Test fun `getManagerId resolves a fork under a different package name`() {
+        val forkPkg = "com.example.shizuku.fork"
+        setShizukuPackage(forkPkg)
+        val mgr = manager()
+
+        runBlocking { mgr.getManagerId() } shouldBe forkPkg.toPkgId()
+    }
+
+    @Test fun `managerIds always includes the reference package plus any detected fork`() {
+        val mgr = manager()
+
+        // Nothing installed: just the reference package.
+        setShizukuPackage(null)
+        runBlocking { mgr.managerIds() } shouldBe setOf(ShizukuManager.PKG_ID)
+
+        // Fork installed under a different package: both the reference and the fork are protected.
+        val forkPkg = "com.example.shizuku.fork"
+        setShizukuPackage(forkPkg)
+        runBlocking { mgr.managerIds() } shouldBe setOf(ShizukuManager.PKG_ID, forkPkg.toPkgId())
     }
 }

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/PostProcessorModule.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/PostProcessorModule.kt
@@ -20,6 +20,7 @@ import eu.darken.sdmse.common.files.containsSegments
 import eu.darken.sdmse.common.files.segs
 import eu.darken.sdmse.common.flow.throttleLatest
 import eu.darken.sdmse.common.hasApiLevel
+import eu.darken.sdmse.common.pkgs.Pkg
 import eu.darken.sdmse.common.pkgs.toPkgId
 import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.common.root.RootManager
@@ -52,9 +53,15 @@ class PostProcessorModule @Inject constructor(
         val minCacheSize = settings.minCacheSizeBytes.value()
         log(TAG, INFO) { "Minimum cache size is $minCacheSize" }
 
+        val useAdb = adbManager.canUseAdbNow()
+        // Resolve the Shizuku manager package(s) once per scan instead of per-app: managerIds() now
+        // performs a PackageManager lookup (permission-based Shizuku detection), so calling it inside
+        // the per-app checkExclusions loop would issue one binder round-trip per scanned app.
+        val adbManagerIds = if (useAdb) adbManager.managerIds() else emptySet()
+
         val processed = apps
             .map { checkAliasedItems(it) }
-            .mapNotNull { checkExclusions(it) }
+            .mapNotNull { checkExclusions(it, useAdb, adbManagerIds) }
             .map { checkForHiddenModules(it) }
             .filter {
                 val isMinSize = it.size >= minCacheSize
@@ -89,13 +96,15 @@ class PostProcessorModule @Inject constructor(
         return after
     }
 
-    private suspend fun checkExclusions(before: AppJunk): AppJunk? {
+    private suspend fun checkExclusions(
+        before: AppJunk,
+        useAdb: Boolean,
+        adbManagerIds: Set<Pkg.Id>,
+    ): AppJunk? {
         // Empty apps don't generate edge cases (and are omitted).
         if (before.expendables.isNullOrEmpty()) return before
 
-        val useAdb = adbManager.canUseAdbNow()
-
-        if (useAdb && adbManager.managerIds().contains(before.pkg.id)) {
+        if (useAdb && adbManagerIds.contains(before.pkg.id)) {
             log(TAG, WARN) { "ADB is being used, excluding related packages." }
             return null
         }

--- a/app/src/main/java/eu/darken/sdmse/setup/shizuku/ShizukuSetupModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/shizuku/ShizukuSetupModule.kt
@@ -68,10 +68,11 @@ class ShizukuSetupModule @Inject constructor(
         adbSettings.useShizuku.flow,
         rootManager.useRoot,
     ) { _, useShizuku, useRoot ->
+        val managerId = shizukuManager.getManagerId()
         val baseState = Result(
-            pkg = shizukuManager.shizukuPkgId,
+            pkg = managerId ?: shizukuManager.shizukuPkgId,
             useShizuku = useShizuku,
-            isInstalled = shizukuManager.isInstalled(),
+            isInstalled = managerId != null,
             isCompatible = shizukuManager.isCompatible(),
             alsoHasRoot = useRoot,
         )

--- a/app/src/test/java/eu/darken/sdmse/setup/shizuku/ShizukuSetupModuleTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/setup/shizuku/ShizukuSetupModuleTest.kt
@@ -52,7 +52,7 @@ class ShizukuSetupModuleTest : BaseTest() {
         every { shizukuManager.shizukuPkgId } returns "moe.shizuku.privileged.api".toPkgId()
         every { shizukuManager.shizukuBinder } returns flowOf(null)
         every { shizukuManager.permissionGrantEvents } returns emptyFlow()
-        coEvery { shizukuManager.isInstalled() } returns true
+        coEvery { shizukuManager.getManagerId() } returns "moe.shizuku.privileged.api".toPkgId()
         coEvery { shizukuManager.isCompatible() } returns true
         coEvery { shizukuManager.isGranted() } returns true
         coEvery { shizukuManager.isOurServiceAvailable() } coAnswers { probeCount++; true }


### PR DESCRIPTION
## What changed

SD Maid now detects Shizuku even when you're running a Shizuku fork with "Hide Shizuku from other apps" enabled, or a fork that ships under a different app package name. Previously SD Maid would report Shizuku as not installed in those cases, forcing users to unhide Shizuku whenever they needed it.

## Technical Context

- Detection now resolves Shizuku via its **permission** (`ShizukuProvider.PERMISSION`, shared across forks) with `getPermissionInfo()`, instead of a hardcoded `getPackageInfo("moe.shizuku.privileged.api")`. Permissions live in a global namespace, so the lookup isn't subject to the package-visibility filtering that hides the app itself. SD Maid only `<uses-permission>`s that permission (never `<permission>`-declares it), so it resolves to the Shizuku manager app — never SD Maid itself.
- The manager's **actual package** is derived from the permission (`PermissionInfo.packageName`) so the setup card's "Open" button and AppCleaner's manager-package exclusion keep working for forks that rename their package. Falls back to the reference package when nothing is installed.
- `managerIds()` is now resolved **once per scan** in the AppCleaner post-processor instead of per-app: the detection is an intentionally-uncached `PackageManager` lookup (was previously a constant set), so calling it inside the per-app loop would add a binder round-trip per scanned app.
- Known limitation: if a fork hides so aggressively that even `getLaunchIntentForPackage()` returns null, the setup card's "Open" button is a no-op (unchanged pre-existing behavior).

Closes #2405
