### PR TITLE
AppControl: Keep search open when the keyboard hides

### DIFF
--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListScreen.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListScreen.kt
@@ -10,10 +10,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.isImeVisible
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
@@ -346,28 +344,22 @@ internal fun AppControlListScreen(
 
     val gridState = rememberLazyGridState()
 
-    BackHandler(enabled = searchActive && !selectionActive && activeSheet == null) {
+    // Collapse the search field and clear its query. Search open/closed is intentionally decoupled
+    // from the keyboard: dismissing the IME (tapping a row that opens the action sheet, focus moving
+    // away, swipe-down on gesture nav) leaves search open — only an explicit close collapses it.
+    // This matches the canonical Android search view, where the keyboard is incidental to the
+    // search-open state.
+    val closeSearch: () -> Unit = {
         onSearchQueryChanged("")
         searchActive = false
     }
 
-    // The IME's window-level back handler grabs the first back press while the search field has
-    // focus, which prevents the BackHandler above from firing. Watch the IME insets and treat the
-    // first IME-hide after the field opened (and got the IME up) as a request to collapse search,
-    // so a single back press both hides the keyboard and closes the search bar.
-    val isImeVisible = WindowInsets.isImeVisible
-    var searchImeWasShown by remember { mutableStateOf(false) }
-    LaunchedEffect(searchActive, isImeVisible) {
-        if (!searchActive) {
-            searchImeWasShown = false
-            return@LaunchedEffect
-        }
-        if (isImeVisible) {
-            searchImeWasShown = true
-        } else if (searchImeWasShown && activeSheet == null && !selection.isActive) {
-            onSearchQueryChanged("")
-            searchActive = false
-        }
+    // System back closes search — but only once the IME is down. While the keyboard is up, Android's
+    // IME consumes the first back press to hide it (as it does for any focused field); a second back
+    // then reaches this handler. That two-step "back hides keyboard, back closes search" is the
+    // standard behaviour; we intentionally do not collapse search off IME-visibility changes.
+    BackHandler(enabled = searchActive && !selectionActive && activeSheet == null) {
+        closeSearch()
     }
 
     // Auto-open the search field if a query is restored (e.g. after process death) so the user
@@ -457,10 +449,7 @@ internal fun AppControlListScreen(
                                     SdmSearchBar(
                                         query = state.options.searchQuery,
                                         onQueryChange = onSearchQueryChanged,
-                                        onClose = {
-                                            onSearchQueryChanged("")
-                                            searchActive = false
-                                        },
+                                        onClose = closeSearch,
                                         modifier = Modifier.fillMaxWidth(),
                                     )
                                 } else {
@@ -473,10 +462,15 @@ internal fun AppControlListScreen(
                                 }
                             },
                             navigationIcon = {
+                                // While search is active the leading arrow collapses search (canonical
+                                // search-view behaviour); otherwise it leaves the screen.
                                 SdmTooltipIconButton(
                                     icon = Icons.AutoMirrored.TwoTone.ArrowBack,
-                                    label = stringResource(CommonR.string.general_navigate_up_action),
-                                    onClick = onNavigateUp,
+                                    label = stringResource(
+                                        if (searchActive) CommonR.string.general_close_action
+                                        else CommonR.string.general_navigate_up_action,
+                                    ),
+                                    onClick = if (searchActive) closeSearch else onNavigateUp,
                                 )
                             },
                             actions = {


### PR DESCRIPTION
## What changed

Fixed AppControl search closing unexpectedly. With search open, typing a query and tapping a result closed the search bar and reset the list back to all apps. Now search stays open with its query — opening an app, dismissing its sheet, or hiding the keyboard all keep your search and filtered results.

Search now closes only when you mean it: the **X**, the **back arrow** (which collapses search instead of leaving the screen), or the system back button.

## Technical Context

- Root cause: the search-open state was inferred from the soft keyboard. A `WindowInsets.isImeVisible` observer collapsed search whenever the IME hid — a workaround so one back press could both hide the keyboard and close search. But the keyboard also hides when focus moves away: tapping a result opens the app action sheet (a modal bottom-sheet nav destination) over the still-composed list, hiding the IME, so search collapsed and the query reset.
- Fix: **decouple search-open state from the keyboard**, matching the canonical Android search view. The IME-visibility observer is removed entirely. Search closes only via explicit actions (X / leading arrow / system back once the keyboard is down). The leading arrow collapses search while active (content description becomes "Close") instead of leaving the screen. By design, with the keyboard up it's the standard two-step back (back hides keyboard, back closes search).
- Not unit-tested: the IME + modal-nav focus timing isn't reproducible in the JVM/Robolectric harness. Verified end-to-end on a Pixel 8 — opening an app keeps search + filtered list; dismissing the sheet keeps search; back#1 hides the keyboard and keeps search; back#2 closes search; the X and the leading arrow both close search.

Note: this lands the search fix that was left out when #2538 was squash-merged (only the library-tag change from that PR made it into main).
