### PR TITLE
General: Fix app freeze on Android TV after one-click cleaning

### DIFF
--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/AutomationManager.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/AutomationManager.kt
@@ -16,6 +16,7 @@ import eu.darken.sdmse.common.SystemSettingsProvider
 import eu.darken.sdmse.common.adb.AdbManager
 import eu.darken.sdmse.common.adb.canUseAdbNow
 import eu.darken.sdmse.common.coroutine.AppScope
+import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
@@ -49,6 +50,7 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.plus
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
@@ -59,6 +61,7 @@ class AutomationManager @Inject constructor(
     @ApplicationContext val context: Context,
     private val settings: GeneralSettings,
     @AppScope private val appScope: CoroutineScope,
+    private val dispatcherProvider: DispatcherProvider,
     private val setupHelper: SetupHelper,
     private val settingsProvider: SystemSettingsProvider,
     private val acsWriteReliability: AcsWriteReliability,
@@ -351,7 +354,11 @@ class AutomationManager @Inject constructor(
     }
         .setupCommonEventHandlers(TAG) { "serviceLauncher" }
 
-    private val serviceResource = SharedResource(TAG, appScope, serviceLauncher)
+    // Run source lifecycle + teardown (incl. the awaitClose { runBlocking { stopService() } } which
+    // writes ACS secure settings via ADB/root) on IO, not the @AppScope Default pool. On low-core
+    // devices this teardown would otherwise starve Dispatchers.Default — the pool vmScope uses —
+    // freezing the dashboard after an ACS one-click. Mirrors ShellOps/PkgOps.
+    private val serviceResource = SharedResource(TAG, appScope + dispatcherProvider.IO, serviceLauncher)
 
     override suspend fun submit(task: AutomationTask): AutomationTask.Result {
         log(TAG) { "submit(): $task" }

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/adb/service/AdbServiceClient.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/adb/service/AdbServiceClient.kt
@@ -6,6 +6,7 @@ import eu.darken.sdmse.common.adb.AdbUnavailableException
 import eu.darken.sdmse.common.adb.service.internal.AdbConnection
 import eu.darken.sdmse.common.adb.service.internal.AdbHostLauncher
 import eu.darken.sdmse.common.coroutine.AppScope
+import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.DebugSettings
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
@@ -30,6 +31,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.plus
 import java.time.Duration
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -38,6 +40,7 @@ import javax.inject.Singleton
 class AdbServiceClient @Inject constructor(
     serviceLauncher: AdbHostLauncher,
     @AppScope coroutineScope: CoroutineScope,
+    dispatcherProvider: DispatcherProvider,
     private val adbSettings: AdbSettings,
     private val debugSettings: DebugSettings,
     private val fileOpsClientFactory: FileOpsClient.Factory,
@@ -45,7 +48,10 @@ class AdbServiceClient @Inject constructor(
     private val shellOpsClientFactory: ShellOpsClient.Factory,
 ) : SharedResource<AdbServiceClient.Connection>(
     tag = TAG,
-    parentScope = coroutineScope,
+    // Run source lifecycle + teardown on IO, not the @AppScope Default pool. On low-core devices the
+    // slow host-disconnect IPC during keep-alive expiry would otherwise starve Dispatchers.Default —
+    // the same pool the UI's vmScope uses — wedging the dashboard. Mirrors ShellOps/PkgOps.
+    parentScope = coroutineScope + dispatcherProvider.IO,
     stopTimeout = ADB_HOST_KEEPALIVE,
     verboseLifecycle = true,
     source = callbackFlow {

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/root/service/RootServiceClient.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/root/service/RootServiceClient.kt
@@ -1,6 +1,7 @@
 package eu.darken.sdmse.common.root.service
 
 import eu.darken.sdmse.common.coroutine.AppScope
+import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.DebugSettings
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
@@ -30,12 +31,14 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.plus
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class RootServiceClient @Inject constructor(
     @AppScope coroutineScope: CoroutineScope,
+    dispatcherProvider: DispatcherProvider,
     private val rootHostLauncher: RootHostLauncher,
     private val rootSettings: RootSettings,
     private val debugSettings: DebugSettings,
@@ -44,7 +47,10 @@ class RootServiceClient @Inject constructor(
     private val shellOpsClientFactory: ShellOpsClient.Factory,
 ) : SharedResource<RootServiceClient.Connection>(
     tag = TAG,
-    parentScope = coroutineScope,
+    // Run source lifecycle + teardown on IO, not the @AppScope Default pool. On low-core devices the
+    // slow host-disconnect IPC during teardown would otherwise starve Dispatchers.Default — the same
+    // pool the UI's vmScope uses — wedging the dashboard. Mirrors ShellOps/PkgOps.
+    parentScope = coroutineScope + dispatcherProvider.IO,
     verboseLifecycle = true,
     source = callbackFlow {
         log(TAG) { "Instantiating Root launcher..." }


### PR DESCRIPTION
## What changed

Fixed a freeze on Android TV (and other low-core devices) where, after running a one-click clean that used the accessibility (ACS) cleaning overlay together with ADB/Shizuku, the app's main clean button (dashboard ✕) would stop responding — the progress overlay disappeared but the app stayed frozen, and only force-killing and relaunching recovered it.

## Technical Context

- **Root cause:** the privileged access clients (ADB/Shizuku `AdbServiceClient`, root `RootServiceClient`) and the accessibility service resource (`AutomationManager`) ran their `SharedResource` source lifecycle and teardown on `@AppScope`, which is `SupervisorJob + Dispatchers.Default` — the **same pool** the UI's `vmScope` uses. On a low-core device the blocking teardown (the `runBlocking` closes in `SharedResource`, the slow privileged-host disconnect IPC, and the ACS secure-settings shell writes) could occupy every `Default` worker. With `Default` starved, the dashboard's main-action coroutines never dispatched, so the ✕ became a silent no-op.
- **Fix:** parent those three privileged `SharedResource`s on `dispatcherProvider.IO` instead of `Default`, mirroring `ShellOps`/`PkgOps` which already do exactly this. No lifecycle change — `SharedResource` already derives a standalone `SupervisorJob` from the parent scope; only the dispatcher moves.
- **Evidence:** diagnosed from a beta tester's WAIPU TV (Android 14, low-core) debug log — `mainAction(ONECLICK)` reached the engine but none of its four branches produced any log (classic `Default` starvation), ~30s after an ACS one-click (the ADB host keep-alive expiry). The activity had to be force-killed to recover.
- **Related:** #2453 and #2524 fixed the same class of root/Shizuku teardown freezes; this extends the fix to the ADB + ACS teardown paths.
- **Out of scope (follow-up):** `TaskManager` and the per-tool one-click `SharedResource`s still parent on `Default`, but they only do fast lease bookkeeping on close; the slow privileged teardown is what moved here. A connect-timeout on the ADB host bind is a separate, pre-existing hang risk.

## Verification / review guidance

- Compile-verified; the change is a convention alignment with the existing `ShellOps`/`PkgOps` pattern.
- **Draft because:** this is a low-core thread-pool starvation that does **not** reproduce on a multi-core TV emulator, so full confirmation needs the reporter's physical WAIPU TV. Marking ready once confirmed on-device.
- I prototyped a `SharedResource` starvation regression test but it wedged the JVM test worker (non-daemon single-thread executor + `runBlocking`-in-`awaitClose` never let the suite finish), so I dropped it rather than risk CI hangs. The existing `get() does not block on a slow-closing generation` test already covers the teardown-doesn't-block-the-caller behaviour this fix relies on.