### PR TITLE
General: Fix a flaky debug log unit test in CI

### DIFF
--- a/app/src/test/java/eu/darken/sdmse/common/debug/recorder/core/DebugLogSessionManagerTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/common/debug/recorder/core/DebugLogSessionManagerTest.kt
@@ -14,7 +14,7 @@ import io.mockk.verify
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
@@ -890,7 +890,8 @@ class DebugLogSessionManagerTest : BaseTest() {
             // parallelism is the CPU count (2 on a CI runner), and the zip parks one pool thread on
             // releaseZip.await() for the whole test — leaving the flow plumbing to fight over the
             // remainder. IO's large pool removes that starvation so scheduling can't stall the scan.
-            val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+            val managerJob = SupervisorJob()
+            val scope = CoroutineScope(Dispatchers.IO + managerJob)
             try {
                 val manager = DebugLogSessionManager(scope, realDispatchers, recorderModule, debugLogZipper)
                 runBlocking {
@@ -907,7 +908,12 @@ class DebugLogSessionManagerTest : BaseTest() {
                 }
             } finally {
                 releaseZip.countDown()
-                scope.cancel()
+                // The woken zip thread still writes zipping.zip inside the mock answer, and JUnit
+                // deletes the @TempDir the instant this test returns — a write landing mid-cleanup
+                // fails the run with "Failed to close extension context" (DirectoryNotEmptyException).
+                // cancel() can't interrupt the blocking answer, so join until all manager work,
+                // including that write, has actually finished before teardown starts.
+                runBlocking { withTimeout(DEADLOCK_TIMEOUT_MS) { managerJob.cancelAndJoin() } }
             }
         }
     }


### PR DESCRIPTION
## What changed

No user-facing behavior change. Fixes a unit test that intermittently failed CI runs (the debug log deadlock-regression test, ~1 in 1000 runs) so it no longer produces false failures. The regression it guards — the sessions scan must not block behind a long-running zip — is fully preserved.

## Technical Context

- Root cause (from the failing run's JUnit XML, [run 28687450733 attempt 1](https://github.com/d4rken-org/sdmaid-se/actions/runs/28687450733/attempts/1), not the console summary): the test body passed all assertions in 0.08s; the actual failure was `JUnitException: Failed to close extension context` caused by a `DirectoryNotEmptyException` during JUnit's `@TempDir` cleanup.
- The test's `finally` block released the zip latch and called `scope.cancel()`, then returned — but `cancel()` cannot interrupt the blocking MockK zip answer. The woken zip thread wrote `zipping.zip` into the `@TempDir` while JUnit was recursively deleting it (the test's system-out shows "Zipping complete" logged ~75ms in, after the test returned).
- This was never a scan timeout or scheduler starvation: the earlier mitigations (#2534: `Dispatchers.IO` scope + 30s deadlines) targeted that theory, and the flake recurred with them already on main.
- Fix: keep a handle to the manager scope's `SupervisorJob` and `cancelAndJoin()` it (bounded by the existing 30s deadline) in `finally`, so all background work — including the zip file write — has finished before temp-dir cleanup starts.
- Deadlock-guard semantics unchanged: the zip still holds `fsMutex` on a real IO thread while `sessions.first()` must complete; if the scan ever reacquired the lock, the 30s `withTimeout` would still fail the test.
- Review note: the bounded join in `finally` could in theory mask an earlier assertion failure if it timed out, but that only occurs if the test is already catastrophically wedged — accepted trade-off over an unbounded join.
- Verified: 100 repetitions green under CPU load, full `:app:testFossDebugUnitTest` suite green (980/980).
