### PR TITLE
General: Fix selecting folders in the file picker on Android TV

### DIFF
--- a/app-common-picker/src/main/java/eu/darken/sdmse/common/picker/PickerScreen.kt
+++ b/app-common-picker/src/main/java/eu/darken/sdmse/common/picker/PickerScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.items
@@ -141,9 +142,14 @@ internal fun PickerScreen(
         else sheetScaffoldState.bottomSheetState.partialExpand()
     }
 
+    // With nothing selected the sheet has no content worth peeking; on D-pad (TV) its drag handle
+    // isn't focusable, so a permanent peek is just a stranded, un-openable box. Collapse it fully
+    // until there's a selection (which auto-expands the panel below).
+    val peekHeight = if (hasSelection) SHEET_PEEK_HEIGHT else 0.dp
+
     BottomSheetScaffold(
         scaffoldState = sheetScaffoldState,
-        sheetPeekHeight = SHEET_PEEK_HEIGHT,
+        sheetPeekHeight = peekHeight,
         // Color the whole sheet (incl. the drag-handle strip) so it matches the panel content
         // instead of the default container color showing a seam above the content.
         sheetContainerColor = MaterialTheme.colorScheme.surfaceVariant,
@@ -241,10 +247,24 @@ internal fun PickerScreen(
                     // the bottom by the peek height plus the nav-bar inset to keep the last row reachable
                     // (legacy PickerFragment padded the list the same way).
                     contentPadding = PaddingValues(
-                        bottom = SHEET_PEEK_HEIGHT +
+                        bottom = peekHeight +
                             WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding(),
                     ),
                 ) {
+                    // D-pad users can't reach the row checkbox in the grid; surface the long-press
+                    // affordance so selecting an item is discoverable (harmless caption on touch too).
+                    if (state.items.any { it.item.selectable }) {
+                        item(key = "picker_select_hint", span = { GridItemSpan(maxLineSpan) }) {
+                            Text(
+                                text = stringResource(UiR.string.picker_select_hint),
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                            )
+                        }
+                    }
                     items(state.items, key = { it.id }) { row ->
                         Column {
                             PickerItemRow(

--- a/app-common-picker/src/main/java/eu/darken/sdmse/common/picker/items/PickerItemRow.kt
+++ b/app-common-picker/src/main/java/eu/darken/sdmse/common/picker/items/PickerItemRow.kt
@@ -1,6 +1,9 @@
 package eu.darken.sdmse.common.picker.items
 
+import android.os.SystemClock
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -15,9 +18,11 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -31,6 +36,12 @@ import eu.darken.sdmse.common.files.labelRes
 import eu.darken.sdmse.common.picker.PickerViewModel
 import eu.darken.sdmse.common.ui.R as UiR
 
+// Window within which repeated long-click fires (from a held DPAD_CENTER auto-repeat) collapse into
+// one selection toggle. Comfortably longer than the key-repeat interval, shorter than a deliberate
+// second long-press.
+private const val LONG_PRESS_DEBOUNCE_MS = 600L
+
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun PickerItemRow(
     modifier: Modifier = Modifier,
@@ -48,12 +59,38 @@ fun PickerItemRow(
         FileType.DIRECTORY, FileType.FILE, FileType.SYMBOLIC_LINK, FileType.UNKNOWN -> item.lookup.fileType.labelRes
     }
 
+    // Android TV auto-repeats a held DPAD_CENTER, so Compose's key-based long-click fires repeatedly
+    // for a single physical hold. Because selection toggles, an even number of fires would land back
+    // on "unselected". Collapse the repeat burst into one toggle per hold. Plain holder (not a State)
+    // so writing it doesn't recompose; keyed by row id so a recycled grid slot never inherits it.
+    val lastLongPressAt = remember(row.id) { longArrayOf(0L) }
+    val onLongPressSelect: (() -> Unit)? = if (item.selectable) {
+        {
+            // Monotonic clock — wall-clock adjustments must not affect input debouncing.
+            val now = SystemClock.uptimeMillis()
+            // Only the leading edge of a burst toggles; the timestamp updates on EVERY fire so a
+            // continuous auto-repeat (even a multi-second hold) keeps sliding the window and can't
+            // re-toggle. A fresh, deliberate long-press after the gap toggles again.
+            val wasIdle = now - lastLongPressAt[0] > LONG_PRESS_DEBOUNCE_MS
+            lastLongPressAt[0] = now
+            if (wasIdle) onToggleSelect()
+        }
+    } else {
+        null
+    }
+
     Row(
         modifier = modifier
             .fillMaxWidth()
             // Directories/area-roots open on a body tap; a file has nothing to open into, so its
             // body tap toggles selection instead (only the checkbox would otherwise select it).
-            .clickable(onClick = { if (row.navigable) onClick() else onToggleSelect() })
+            // On D-pad (TV) the trailing checkbox is unreachable in the multi-column grid — left/right
+            // moves between grid columns — so a long-press (remote center-hold / touch press-and-hold)
+            // toggles selection as a reachable alternative to tapping the checkbox.
+            .combinedClickable(
+                onClick = { if (row.navigable) onClick() else onToggleSelect() },
+                onLongClick = onLongPressSelect,
+            )
             .padding(horizontal = 16.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -96,10 +133,14 @@ fun PickerItemRow(
             // Enlarge the tap target around the checkbox so taps landing slightly beside it still
             // toggle selection instead of falling through to the row's open-folder click. The
             // checkbox itself is passive (onCheckedChange = null) — the Box owns the click.
+            // Not a D-pad focus target: in the multi-column grid left/right skips it anyway, and
+            // letting it take focus made the highlight jump here after a long-press select. Touch
+            // taps still work (clickable is independent of focusability).
             Box(
                 modifier = Modifier
                     .size(56.dp)
                     .clip(CircleShape)
+                    .focusProperties { canFocus = false }
                     .clickable(onClick = onToggleSelect),
                 contentAlignment = Alignment.Center,
             ) {

--- a/app-common-ui/src/main/res/values/strings.xml
+++ b/app-common-ui/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
         <item quantity="other">%d paths selected</item>
     </plurals>
     <string name="picker_home_action">Data areas</string>
+    <string name="picker_select_hint">Hold an item to select it</string>
 
     <string name="tour_action_next">Next</string>
     <string name="tour_action_previous">Previous</string>


### PR DESCRIPTION
## What changed

On Android TV (and any remote/D-pad device), the file picker — used for things like the Deduplicator's **Search locations** — couldn't be used to select anything: pressing the remote on a folder only drilled deeper, and the checkbox on each row was unreachable. The "Selected paths" area at the bottom also showed as a broken, un-openable box. Now you **hold an item to select it** (a hint explains this), and the bottom panel only appears once something is selected.

## Technical Context

- **Root cause (selection):** the picker is a multi-column `LazyVerticalGrid`; D-pad left/right moves between grid columns, so the per-row checkbox is never focusable — selection was effectively touch-only. Reproduced on the `Android_TV_720p` emulator.
- **Long-press to select** via `combinedClickable(onLongClick = …)`; short press still opens folders / toggles files (touch behaviour unchanged).
- **Debounce (found while testing on-device):** Android TV auto-repeats a held `DPAD_CENTER`, so Compose's key-based long-click fires *repeatedly* for a single physical hold. Because selection toggles, a long hold could land back on "unselected". Fixed with a leading-edge debounce — per-row (keyed by row id), `SystemClock.uptimeMillis()`, timestamp updated on every fire so a continuous burst keeps sliding the window.
- **Bottom sheet:** the empty peek was a stranded box on TV (its drag handle isn't focusable). Peek height is now `0.dp` until there's a selection (auto-expands then); the panel's remove button is D-pad reachable.
- **Focus:** marked the checkbox `Box` non-focusable so the highlight doesn't jump to it after a long-press select; touch taps are unaffected.
- Reviewed by Codex (monotonic clock, row-keyed holder, stable item key folded in). New English string `picker_select_hint` (translations via the usual pipeline).

## Verification

Verified on the `Android_TV_720p` emulator: long-press selects; two rapid long-presses net to **one** selection (debounce holds); focus stays on the row; empty-state box gone; hint shown. The genuine *held-remote* auto-repeat can't be reproduced via `adb` (its synthetic long-press is one-shot), so a quick confirmation on a real remote is worth doing before merge.