### PR TITLE
General: Prevent slow shell cleanup from stalling the root/ADB helper

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/shell/ipc/ShellOpsHost.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/shell/ipc/ShellOpsHost.kt
@@ -26,7 +26,10 @@ class ShellOpsHost @Inject constructor(
     private val dispatcherProvider: DispatcherProvider,
 ) : ShellOpsConnection.Stub(), IpcHostModule {
 
-    private val sharedShell = SharedShell(TAG, appScope + dispatcherProvider.Default)
+    // IO, not Default: SharedShell's teardown blocks its thread for up to 5s (runBlocking session
+    // close + waitFor), which would starve the host process's small Default pool. Mirrors the
+    // RootModule/AdbModule SharedShells and the app-side privileged clients (see PR #2543).
+    private val sharedShell = SharedShell(TAG, appScope + dispatcherProvider.IO)
 
     override fun execute(cmd: ShellOpsCmd): ShellOpsResult = try {
         runBlocking {


### PR DESCRIPTION
## What changed

No user-facing behavior change. This closes out the last spot where slow shell cleanup could tie up the wrong thread pool inside the root/ADB helper process — the same class of problem as the Android TV freeze fixed in #2543, just on the helper side instead of the app side.

## Technical Context

- `ShellOpsHost`'s `SharedShell` was the one remaining `SharedResource` with genuinely blocking, slow teardown (`runBlocking { session.close() }` with a 5s timeout plus `session.waitFor()`) still parented on `Dispatchers.Default`. `SharedResource` runs its source lifecycle and teardown on the parent scope's dispatcher, so that blocking work landed on the helper process's small Default pool.
- The sibling `SharedShell` constructions (`RootModule`, `AdbModule`) already parent on `dispatcherProvider.IO`, as do the app-side privileged clients since #2543 — this aligns the outlier. The `+ Default` dates back to the original Shizuku host commit, predating the `+ IO` convention.
- Scope note: this runs in the privileged helper process, not the app process, so it could not reproduce the #2543 UI freeze — it's a consistency/robustness fix, not a user-reported bug.
- Verified all other `SharedResource` sites: everything else with a non-trivial teardown is already on IO, and the remaining Default-parented ones (`TaskManager`, per-tool keep-alives) have empty `awaitClose` bodies.

Refs #2543
