### PR TITLE
General: Stop debug logs flagging user cancels as errors

### DIFF
--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/AutomationProcessor.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/AutomationProcessor.kt
@@ -14,6 +14,7 @@ import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.progress.updateProgressPrimary
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
@@ -67,6 +68,9 @@ class AutomationProcessor @AssistedInject constructor(
             withContext(dispatcherProvider.IO) {
                 module.process(task)
             }
+        } catch (e: CancellationException) {
+            log(TAG, INFO) { "process(): Task cancelled: $task ($e)" }
+            throw e
         } catch (e: Exception) {
             log(TAG, ERROR) { "process(): Task failed: $task\n${e.asLog()}" }
             throw e

--- a/app-common/src/main/java/eu/darken/sdmse/common/progress/ProgressExtensions.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/progress/ProgressExtensions.kt
@@ -5,7 +5,7 @@ import androidx.annotation.StringRes
 import eu.darken.sdmse.common.ca.CaString
 import eu.darken.sdmse.common.ca.caString
 import eu.darken.sdmse.common.ca.toCaString
-import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
@@ -59,7 +59,7 @@ fun <T : Progress.Client> T.increaseProgress(value: Int = 1) {
             is Progress.Count.Counter -> it.copy(count = (it.count as Progress.Count.Counter).increment(value))
             is Progress.Count.Percent -> it.copy(count = (it.count as Progress.Count.Percent).increment(value))
             else -> {
-                log(ERROR) { "Can't increaseProgress() on type: ${it?.count}" }
+                log(VERBOSE) { "Can't increaseProgress() on type: ${it?.count}" }
                 it
             }
         }


### PR DESCRIPTION
## What changed

No user-facing behavior change. Cleans up two misleading `ERROR` lines that showed up in debug logs when a cleaning run was cancelled — so bug reports aren't muddied by "errors" that are just normal cancellation.

## Technical Context

- When the user cancels a running accessibility-service automation (e.g. pressing HOME during a one-click cache clean), `module.process()` throws `UserCancelledAutomationException`, which **is a `CancellationException`**. `AutomationProcessor` caught it in the generic `catch (Exception)` and logged it at `ERROR` (`process(): Task failed`), so a routine user cancel looked like a crash. Now cancellation is caught in a dedicated `catch (CancellationException)` and logged at `INFO` before rethrowing — propagation/semantics are unchanged, only the log level and message differ.
- `increaseProgress()` landing on an `Indeterminate` count (a straggler call arriving after progress was reset during teardown) logged at `ERROR` in `ProgressExtensions`. It's a benign no-op, downgraded to `VERBOSE`.
- **Surfaced by** a WAIPU Android TV debug log: a HOME-cancel produced exactly these two `ERROR` lines despite an otherwise clean teardown (the freeze itself was already fixed in #2543). Not TV-specific — the noise applies to any device where a user cancels ACS cleaning.

## Review guidance

- The behavioral question is whether catching `CancellationException` separately is safe: it rethrows immediately, so cancellation still propagates exactly as before. No other control flow changes.
