### PR TITLE
AppControl: Fix slow force stop on vivo devices

### DIFF
--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/common/ACSNodeInfoExtensions.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/common/ACSNodeInfoExtensions.kt
@@ -42,7 +42,7 @@ fun ACSNodeInfo.textEndsWithAny(candidates: Collection<String>): Boolean =
 val ACSNodeInfo.contentDescVariants: Set<String>
     get() {
         val target = contentDescription?.toString() ?: return emptySet()
-        return setOf(target, target.replace(' ', ' '))
+        return setOf(target, target.replace(' ', ' '))
     }
 
 fun ACSNodeInfo.contentDescMatches(candidate: String): Boolean {

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/automation/AppControlAutomation.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/automation/AppControlAutomation.kt
@@ -18,6 +18,7 @@ import eu.darken.sdmse.appcontrol.core.automation.specs.aosp.AOSPSpecs
 import eu.darken.sdmse.appcontrol.core.automation.specs.hyperos.HyperOsSpecs
 import eu.darken.sdmse.appcontrol.core.automation.specs.miui.MIUISpecs
 import eu.darken.sdmse.appcontrol.core.automation.specs.oneui.OneUISpecs
+import eu.darken.sdmse.appcontrol.core.automation.specs.originos.OriginOSSpecs
 import eu.darken.sdmse.automation.core.ForceStopAutomationTask
 import eu.darken.sdmse.appcontrol.core.restore.RestoreAutomationTask
 import eu.darken.sdmse.automation.core.AutomationHost
@@ -93,7 +94,7 @@ class AppControlAutomation @AssistedInject constructor(
 //                is LGESpecs -> 130
 //                is ColorOSSpecs -> 110
 //                is FlymeSpecs -> 100
-//                is VivoSpecs -> 80
+                is OriginOSSpecs -> 80
                 is AndroidTVSpecs -> 70
 //                is NubiaSpecs -> 60
 //                is OnePlusSpecs -> 30

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/originos/OriginOSSpecs.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/originos/OriginOSSpecs.kt
@@ -1,0 +1,176 @@
+package eu.darken.sdmse.appcontrol.core.automation.specs.originos
+
+import dagger.Binds
+import dagger.Module
+import dagger.Reusable
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoSet
+import eu.darken.sdmse.appcontrol.core.automation.specs.AppControlSpecGenerator
+import eu.darken.sdmse.appcontrol.core.automation.specs.aosp.AOSPLabels
+import eu.darken.sdmse.automation.core.common.crawl
+import eu.darken.sdmse.automation.core.common.findParentOrNull
+import eu.darken.sdmse.automation.core.common.isClickyButton
+import eu.darken.sdmse.automation.core.common.pkgId
+import eu.darken.sdmse.automation.core.common.stepper.AutomationStep
+import eu.darken.sdmse.automation.core.common.stepper.StepContext
+import eu.darken.sdmse.automation.core.common.stepper.Stepper
+import eu.darken.sdmse.automation.core.common.stepper.clickNormal
+import eu.darken.sdmse.automation.core.common.stepper.findClickableParent
+import eu.darken.sdmse.automation.core.common.stepper.findNode
+import eu.darken.sdmse.automation.core.common.stepper.findNodeByContentDesc
+import eu.darken.sdmse.automation.core.common.textMatchesAny
+import eu.darken.sdmse.automation.core.specs.AutomationExplorer
+import eu.darken.sdmse.automation.core.specs.AutomationSpec
+import eu.darken.sdmse.automation.core.specs.defaultNodeRecovery
+import eu.darken.sdmse.automation.core.specs.windowCheck
+import eu.darken.sdmse.automation.core.specs.windowCheckDefaultSettings
+import eu.darken.sdmse.automation.core.specs.windowLauncherDefaultSettings
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.datastore.value
+import eu.darken.sdmse.common.debug.Bugs
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.device.DeviceDetective
+import eu.darken.sdmse.common.device.RomType
+import eu.darken.sdmse.common.funnel.IPCFunnel
+import eu.darken.sdmse.common.pkgs.features.Installed
+import eu.darken.sdmse.common.pkgs.toPkgId
+import eu.darken.sdmse.common.progress.withProgress
+import eu.darken.sdmse.main.core.GeneralSettings
+import javax.inject.Inject
+
+@Reusable
+class OriginOSSpecs @Inject constructor(
+    private val ipcFunnel: IPCFunnel,
+    private val deviceDetective: DeviceDetective,
+    private val aospLabels: AOSPLabels,
+    private val generalSettings: GeneralSettings,
+    private val stepper: Stepper,
+) : AppControlSpecGenerator {
+
+    override val tag: String = TAG
+
+    override suspend fun isResponsible(pkg: Installed): Boolean {
+        val romType = generalSettings.romTypeDetection.value()
+        if (romType == RomType.ORIGINOS) return true
+        if (romType != RomType.AUTO) return false
+
+        return deviceDetective.getROMType() == RomType.ORIGINOS
+    }
+
+    override suspend fun getForceStop(pkg: Installed): AutomationSpec = object : AutomationSpec.Explorer {
+        override val tag: String = TAG
+        override suspend fun createPlan(): suspend AutomationExplorer.Context.() -> Unit = {
+            forceStopPlan(pkg)
+        }
+    }
+
+    override suspend fun getArchive(pkg: Installed): AutomationSpec {
+        throw UnsupportedOperationException("Archive automation not yet supported on OriginOS")
+    }
+
+    override suspend fun getRestore(pkg: Installed): AutomationSpec {
+        throw UnsupportedOperationException("Restore automation not yet supported on OriginOS")
+    }
+
+    private val forceStopPlan: suspend AutomationExplorer.Context.(Installed) -> Unit = plan@{ pkg ->
+        log(TAG, INFO) { "Executing plan for ${pkg.installId} with context $this" }
+
+        val forceStopLabels = aospLabels.getForceStopButtonDynamic(this)
+        var wasDisabled = false
+
+        run {
+            val action: suspend StepContext.() -> Boolean = action@{
+                // OriginOS action buttons are nested "vbuttons": the semantic Button
+                // (id=right_button) carries the label in contentDescription and the real enabled
+                // state, but wraps an always-enabled clickable LinearLayout holding the label
+                // TextView (id=vbutton_title). Resolve the Button, never the wrapper — the
+                // wrapper's enabled=true is meaningless and clicking it is a no-op while the
+                // Button is disabled.
+                val target = findNodeByContentDesc(forceStopLabels) { it.isClickyButton() }
+                    ?: findNode { it.textMatchesAny(forceStopLabels) }?.let { label ->
+                        if (label.isClickyButton()) label
+                        else label.findParentOrNull(maxNesting = 4) { it.isClickyButton() }
+                    }
+                    ?: return@action false
+
+                if (!target.isEnabled) {
+                    wasDisabled = true
+                    return@action true
+                }
+
+                clickNormal(node = target)
+            }
+
+            val step = AutomationStep(
+                source = TAG,
+                descriptionInternal = "Force stop button for $pkg",
+                label = eu.darken.sdmse.appcontrol.R.string.appcontrol_automation_progress_find_force_stop.toCaString(forceStopLabels),
+                windowLaunch = windowLauncherDefaultSettings(pkg),
+                windowCheck = windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg),
+                nodeRecovery = defaultNodeRecovery(pkg),
+                nodeAction = action,
+            )
+            stepper.withProgress(this) { process(this@plan, step) }
+        }
+
+        if (wasDisabled) {
+            log(TAG) { "Force stop button was disabled, app is already stopped." }
+            return@plan
+        }
+
+        run {
+            val titleLbl = aospLabels.getForceStopDialogTitleDynamic(this) + forceStopLabels.map { "$it?" }
+            val okLbl = aospLabels.getForceStopDialogOkDynamic(this)
+            val cancelLbl = aospLabels.getForceStopDialogCancelDynamic(this)
+
+            val windowCheck = windowCheck { _, root ->
+                if (root.pkgId != SETTINGS_PKG) return@windowCheck false
+                root.crawl().map { it.node }.any { subNode -> subNode.textMatchesAny(titleLbl) }
+            }
+
+            val action: suspend StepContext.() -> Boolean = action@{
+                // The confirm button may be a plain Button with text, or another vbutton whose
+                // label sits in a child TextView. Match the label, exclude the dialog title
+                // (which can carry the same text), then click the nearest clickable.
+                val labels = when (Bugs.isDryRun) {
+                    true -> cancelLbl
+                    false -> okLbl + forceStopLabels
+                }
+                val candidate = findNode { node ->
+                    node.textMatchesAny(labels) && !node.textMatchesAny(titleLbl)
+                } ?: return@action false
+                val mapped = when {
+                    candidate.isClickyButton() -> candidate
+                    else -> candidate.findParentOrNull(maxNesting = 4) { it.isClickyButton() }
+                        ?: findClickableParent(includeSelf = true, node = candidate)
+                        ?: return@action false
+                }
+                clickNormal(node = mapped)
+            }
+
+            val step = AutomationStep(
+                source = TAG,
+                descriptionInternal = "Confirm force stop for $pkg",
+                label = eu.darken.sdmse.automation.R.string.automation_progress_find_ok_confirmation.toCaString(titleLbl + okLbl + forceStopLabels),
+                windowCheck = windowCheck,
+                nodeAction = action,
+            )
+            stepper.withProgress(this) { process(this@plan, step) }
+        }
+    }
+
+    @Module @InstallIn(SingletonComponent::class)
+    abstract class DIM {
+        @Binds @IntoSet abstract fun mod(mod: OriginOSSpecs): AppControlSpecGenerator
+    }
+
+    companion object {
+        val SETTINGS_PKG = "com.android.settings".toPkgId()
+
+        val TAG: String = logTag("AppControl", "Automation", "OriginOS", "Specs")
+    }
+
+}

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/originos/OriginOSSpecs.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/originos/OriginOSSpecs.kt
@@ -15,6 +15,7 @@ import eu.darken.sdmse.automation.core.common.pkgId
 import eu.darken.sdmse.automation.core.common.stepper.AutomationStep
 import eu.darken.sdmse.automation.core.common.stepper.StepContext
 import eu.darken.sdmse.automation.core.common.stepper.Stepper
+import eu.darken.sdmse.automation.core.common.stepper.clickGesture
 import eu.darken.sdmse.automation.core.common.stepper.clickNormal
 import eu.darken.sdmse.automation.core.common.stepper.findClickableParent
 import eu.darken.sdmse.automation.core.common.stepper.findNode
@@ -85,10 +86,8 @@ class OriginOSSpecs @Inject constructor(
             val action: suspend StepContext.() -> Boolean = action@{
                 // OriginOS action buttons are nested "vbuttons": the semantic Button
                 // (id=right_button) carries the label in contentDescription and the real enabled
-                // state, but wraps an always-enabled clickable LinearLayout holding the label
-                // TextView (id=vbutton_title). Resolve the Button, never the wrapper — the
-                // wrapper's enabled=true is meaningless and clicking it is a no-op while the
-                // Button is disabled.
+                // state, but wraps an always-clickable, always-enabled LinearLayout holding the
+                // label TextView (id=vbutton_title). Resolve the Button, never the wrapper.
                 val target = findNodeByContentDesc(forceStopLabels) { it.isClickyButton() }
                     ?: findNode { it.textMatchesAny(forceStopLabels) }?.let { label ->
                         if (label.isClickyButton()) label
@@ -101,7 +100,10 @@ class OriginOSSpecs @Inject constructor(
                     return@action true
                 }
 
-                clickNormal(node = target)
+                // Tap via gesture instead of ACTION_CLICK: on OriginOS an accessibility click on
+                // these vbuttons emits TYPE_VIEW_CLICKED but never triggers the handler, so the
+                // confirmation dialog never opens. A dispatched tap at the button reliably fires it.
+                clickGesture(node = target)
             }
 
             val step = AutomationStep(


### PR DESCRIPTION
## What changed

Fixed force-stopping apps being broken and extremely slow on vivo devices (OriginOS). When SD Maid used the accessibility service to force-stop apps — for example with AppCleaner's "force stop apps before cleaning" option — every app stalled for 30 seconds and nothing was actually stopped, whether the app was already stopped or currently running. With a long app list that's many minutes of pointless waiting. Now already-stopped apps are skipped instantly and running apps are force-stopped correctly.

## Technical Context

- Root cause: vivo's App-info action row uses nested "vbuttons". The semantic `Button` (`right_button`) carries the label in `contentDescription` and the real enabled state, but wraps an always-clickable, always-enabled `LinearLayout` that holds the label `TextView`. The AOSP fallback spec matched the label by text and clicked the first clickable ancestor — the wrapper — which on vivo emits a `TYPE_VIEW_CLICKED` event but never triggers the button's handler. So the "already stopped" fast path never fired, the click was a functional no-op, and every app timed out after 30s.
- Chose a dedicated OriginOS AppControl spec (the established per-ROM pattern, like OneUI/MIUI) over hardening the shared AOSP spec — keeps the blast radius to vivo devices only.
- Button resolution: `contentDescription` match on the semantic Button first, then a text-label match that climbs to the Button ancestor — both gated on `isClickyButton()` so the always-enabled wrapper can never be selected. Disabled button ⇒ app already stopped ⇒ skip instantly.
- The button is tapped via a dispatched **gesture** rather than an accessibility `ACTION_CLICK`: two device logs confirmed that an accessibility click on these vbuttons fires the click event but does not trigger the handler (the confirmation dialog never opens), for both already-stopped and running apps. The confirmation dialog's OK button stays on `ACTION_CLICK` (standard AlertDialog button — no evidence it's affected).
- Also fixes a latent no-op in the shared `contentDescVariants` helper: its "normalization" replaced a regular space with a regular space (copy-paste artifact); it now normalizes non-breaking spaces the same way `textVariants` does.

## Evidence

Two debug logs from a vivo PD2507 (Android 16, no root/ADB):
- Log 1 (apps already stopped): the disabled `right_button` + always-enabled wrapper structure; each app hung 30s.
- Log 2 (apps running): `right_button` correctly reports `enabled=true`; the old spec's wrapper `ACTION_CLICK` fired `TYPE_VIEW_CLICKED` but did not force-stop or open a dialog — all 66 apps timed out, zero succeeded. This drove the gesture-tap decision.

## Review guidance

The confirm-dialog path (button tap → "Force stop?" dialog → OK) could not be observed end-to-end because the old spec never opened the dialog on this device; the gesture tap is the evidence-backed way to open it, but final confirmation of the running-app flow on a fixed build is pending device validation — hence draft.
