### PR TITLE
General: Move guided tour controls below the tour text

### DIFF
--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/tour/TourBubble.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/tour/TourBubble.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -434,7 +435,42 @@ private fun StepContent(
                 .fillMaxWidth()
                 .padding(start = mascotWidth, end = 16.dp, top = 16.dp, bottom = 16.dp),
         ) {
-            // Header: square nav buttons flank a flexible middle cell, so the step dots stay
+            // Body sits above the controls so the step reads top-to-bottom: explanation first,
+            // then the actions. Weighted (fill = false) so short copy stays compact against the
+            // control row, while long copy is capped at the remaining height and scrolls — the
+            // control row keeps its fixed height and stays pinned to the bubble's bottom edge.
+            // Focusable so long step text can be scrolled with the D-pad from inside the focus
+            // trap (scrollables handle arrow keys when focused). Tinted while focused since
+            // plain focusable() has no indication of its own.
+            var bodyFocused by remember { mutableStateOf(false) }
+            Column(
+                modifier = Modifier
+                    .weight(1f, fill = false)
+                    .padding(bottom = 16.dp)
+                    .onFocusChanged { bodyFocused = it.isFocused }
+                    .background(
+                        color = if (bodyFocused) {
+                            MaterialTheme.colorScheme.onSurface.copy(alpha = 0.08f)
+                        } else Color.Transparent,
+                        shape = RoundedCornerShape(8.dp),
+                    )
+                    .verticalScroll(rememberScrollState())
+                    .focusable(),
+            ) {
+                step.title?.let { title ->
+                    Text(
+                        text = title.get(context),
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                    Spacer(Modifier.height(4.dp))
+                }
+                Text(
+                    text = step.body.get(context),
+                    style = MaterialTheme.typography.bodyLarge,
+                )
+            }
+            // Controls: square nav buttons flank a flexible middle cell, so the step dots stay
             // centered in the free space between the left cluster (exit + back) and the Next
             // button — not pinned to the bubble's geometric center, which looked off-balance
             // once the clusters had unequal widths.
@@ -489,42 +525,21 @@ private fun StepContent(
                     )
                 }
             }
-            // Focusable so long step text can be scrolled with the D-pad from inside the focus
-            // trap (scrollables handle arrow keys when focused). Tinted while focused since
-            // plain focusable() has no indication of its own.
-            var bodyFocused by remember { mutableStateOf(false) }
-            Column(
-                modifier = Modifier
-                    .padding(top = 16.dp)
-                    .onFocusChanged { bodyFocused = it.isFocused }
-                    .background(
-                        color = if (bodyFocused) {
-                            MaterialTheme.colorScheme.onSurface.copy(alpha = 0.08f)
-                        } else Color.Transparent,
-                        shape = RoundedCornerShape(8.dp),
-                    )
-                    .verticalScroll(rememberScrollState())
-                    .focusable(),
-            ) {
-                step.title?.let { title ->
-                    Text(
-                        text = title.get(context),
-                        style = MaterialTheme.typography.titleMedium,
-                        color = MaterialTheme.colorScheme.primary,
-                    )
-                    Spacer(Modifier.height(4.dp))
-                }
-                Text(
-                    text = step.body.get(context),
-                    style = MaterialTheme.typography.bodyLarge,
-                )
-            }
         }
-        SdmMascot(
-            modifier = Modifier
-                .align(Alignment.CenterStart)
-                .width(mascotWidth),
-        )
+        // Overlay the mascot in a matchParentSize box so it tracks the content column's height
+        // rather than driving it. The mascot renders tall (portrait aspect); left free to set the
+        // bubble height it would, on short steps, push the bubble past the content and leave slack
+        // below the now-bottom control row. Bounded to fillMaxHeight it fits the content instead —
+        // controls stay flush to the bottom edge, and on tall steps (content already taller than the
+        // mascot) this is a no-op.
+        Box(modifier = Modifier.matchParentSize()) {
+            SdmMascot(
+                modifier = Modifier
+                    .align(Alignment.CenterStart)
+                    .fillMaxHeight()
+                    .width(mascotWidth),
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## What changed

The in-app guided tours now show their progress dots and the cancel / back / next controls **below** the explanation text instead of above it. Each step now reads top-to-bottom: read what the step is telling you, then act on it. The controls stay pinned to the bottom of the tour bubble and remain visible even when a step's text is long enough to scroll.

## Technical Context

- A single shared composable (`TourBubble`'s `StepContent`) renders every tour, so this one change applies consistently across all of them (Dashboard, Setup, AppControl, CorpseFinder, Squeezer, …).
- The text column is `weight(1f, fill = false)` + `verticalScroll`, so short copy stays compact against the control row while long copy caps at the available height and scrolls — the fixed-height control row keeps its height and stays pinned to the bubble's bottom edge.
- The mascot is overlaid on the left and renders tall (portrait aspect, sized from its width). It's now wrapped in a `matchParentSize` box with `fillMaxHeight` so it tracks the content column's height instead of driving it. Without this, on short steps the tall mascot would make the bubble taller than the content and leave slack beneath the now-bottom controls. On short steps the mascot scales down slightly to fit; on tall steps it's unchanged.
- Verified on-device (Setup tour + Dashboard tour, covering the centerless intro step and anchored steps with the tail). All 61 tour unit tests pass; existing tests match by text/content-description rather than vertical position, so the reorder didn't affect them.
