### PR TITLE
AppControl: Fix HyperOS 3 force-stop button label matching

### DIFF
--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/AppControlLabelDebugger.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/AppControlLabelDebugger.kt
@@ -36,6 +36,7 @@ class AppControlLabelDebugger @Inject constructor(
             "com.miui.securitycenter",
         ).map { it.toPkgId() }
         private val RES_IDS_FORCE_STOP = setOf(
+            "menu_item_force_stop",
             "force_stop",
             "force_stop_dlg_title",
             "okay",

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/hyperos/HyperOsLabels.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/hyperos/HyperOsLabels.kt
@@ -4,6 +4,7 @@ import dagger.Reusable
 import eu.darken.sdmse.appcontrol.core.automation.specs.AppControlLabelSource
 import eu.darken.sdmse.appcontrol.core.automation.specs.aosp.AOSPLabels
 import eu.darken.sdmse.automation.core.specs.AutomationExplorer
+import eu.darken.sdmse.automation.core.specs.getLocales
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.pkgs.toPkgId
 import javax.inject.Inject
@@ -15,14 +16,39 @@ class HyperOsLabels @Inject constructor(
 
     fun getForceStopButtonDynamic(acsContext: AutomationExplorer.Context): Set<String> {
         val labels = mutableSetOf<String>()
-        acsContext.getStrings(SETTINGS_PKG, setOf("force_stop")).run {
+        // `menu_item_force_stop` is the actual SecurityCenter key; `force_stop` doesn't exist there
+        // and only ever resolved via the AOSP fallback below.
+        acsContext.getStrings(SETTINGS_PKG, setOf("menu_item_force_stop", "force_stop")).run {
             labels.addAll(this)
         }
         if (labels.isEmpty()) {
             labels.addAll(aospLabels.getForceStopButtonDynamic(acsContext))
         }
+        // Always union: HyperOS 3 relabels the button (e.g. ru "Закрыть") independently of the
+        // resource lookups above, which may still return the stale AOSP/SecurityCenter value.
+        labels.addAll(getForceStopButtonFallback(acsContext))
         return labels
     }
+
+    /**
+     * Hardcoded fallbacks for the force-stop button label on HyperOS.
+     * HyperOS 3 (Android 16) renamed it to a "close app" style label that the dynamic
+     * SecurityCenter/AOSP lookups don't return. Extend per-locale as device reports arrive.
+     */
+    private fun getForceStopButtonFallback(
+        acsContext: AutomationExplorer.Context
+    ): Set<String> = acsContext.getLocales()
+        .map { Triple(it.language, it.script, it.country) }
+        .mapNotNull { (lang, _, _) ->
+            when {
+                "en".toLang() == lang -> setOf("Close app")
+                // POCO F8 Ultra, HyperOS 3.0.301.0 (OS3.0.301.0.WPMMIXM), Android 16
+                "ru".toLang() == lang -> setOf("Закрыть")
+                else -> null
+            }
+        }
+        .flatten()
+        .toSet()
 
     fun getForceStopDialogTitleDynamic(acsContext: AutomationExplorer.Context): Set<String> {
         val labels = mutableSetOf<String>()


### PR DESCRIPTION
## What changed

On Xiaomi HyperOS 3 (Android 16), clearing app caches did nothing when "Force-stop apps before clearing cache" was enabled — the automation would sit on the app's info screen unable to find the button, and the run ended without freeing any space. This fixes the automation so it recognizes HyperOS 3's renamed force-stop button.

## Technical Context

- **Root cause (from a user debug log):** HyperOS 3 relabels the App Info force-stop button to a "close app" style label — ru **"Закрыть"**. The force-stop spec resolved its label to "Остановить": it queried `com.miui.securitycenter` for the key `force_stop`, which returned nothing, and fell back to AOSP `com.android.settings:force_stop`. The on-screen "Закрыть" never matched `findNode`, so the step looped node-recovery for its full timeout until the user cancelled — and a cancel during the force-stop pre-step aborts cache clearing entirely (`InaccessibleDeleter`).
- **The SecurityCenter key was wrong all along:** the real key is `menu_item_force_stop` (confirmed against public MIUI SecurityCenter resource dumps), not `force_stop`. So the SecurityCenter force-stop lookup had *never* resolved on any MIUI/HyperOS build — it always silently fell back to AOSP. That happened to work while the button matched the AOSP label; HyperOS 3 broke it.
- **Fix:** query `menu_item_force_stop` (+ keep `force_stop`), and **always union** a hardcoded per-locale fallback (mirroring appcleaner's `HyperOsLabels`) seeded with ru "Закрыть" and en "Close app". "Always union" matters because the dynamic lookup may still return a stale value (e.g. "Остановить") on an uncovered device, so the observed label must be added unconditionally.
- Also added `menu_item_force_stop` to `AppControlLabelDebugger` so future HyperOS logs surface the corrected key.
- **Review guidance / low risk:** `findNode` matches exact, text-only, and the whole spec is gated to HyperOS (`isResponsible`) and to the App Info window. The sibling "Clear cache" button has the identical node shape and already matches, so adding the correct label is sufficient.

## Still needs (why this is a draft)

- **On-device verification** on a HyperOS 3 device: (1) confirm "Закрыть" actually force-stops (vs. just closing the screen), and (2) confirm whether force-stop shows a confirmation dialog on HyperOS 3 — if it stops immediately, the spec's second (confirm) step may need adjustment. Neither is reachable in the source log because the button was never found.
- An **A1 dump** of `com.miui.securitycenter` on HyperOS 3 would confirm the exact resource key/value for "Закрыть", potentially letting the hardcoded fallback shrink.

## Noticed but out of scope

`HyperOsLabels.getForceStopDialogCancelDynamic()` falls back to `aospLabels.getForceStopDialogOkDynamic()` (OK labels) instead of the cancel labels — a pre-existing copy-paste bug in the dialog-cancel path, unrelated to this button-label fix. Left for a separate change.
