### PR TITLE
General: Capture ADB/Shizuku host crashes in the debug log

### DIFF
--- a/app-common-adb/src/main/java/eu/darken/sdmse/common/adb/service/internal/BaseAdbHost.kt
+++ b/app-common-adb/src/main/java/eu/darken/sdmse/common/adb/service/internal/BaseAdbHost.kt
@@ -2,6 +2,8 @@ package eu.darken.sdmse.common.adb.service.internal
 
 import android.annotation.SuppressLint
 import android.content.Context
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -16,6 +18,15 @@ abstract class BaseAdbHost(
 ) : AdbConnection.Stub() {
 
     val hostScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    init {
+        val oldHandler = Thread.getDefaultUncaughtExceptionHandler()
+        Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
+            log(iTag, ERROR) { "Uncaught exception within AdbHost: ${throwable.asLog()}" }
+            if (oldHandler != null) oldHandler.uncaughtException(thread, throwable)
+            else exitProcess(1)
+        }
+    }
 
     override fun destroy() {
         log(iTag) { "destroy()" }


### PR DESCRIPTION
## What changed

When you record a debug log for a Shizuku/ADB problem, crashes that happen inside SD Maid's helper process (the part that runs through Shizuku) are now written to that log. Previously those crashes left no trace, which made some Shizuku connection problems impossible to diagnose from a submitted log.

No user-facing behavior change on the happy path — this only improves what ends up in the debug log when something goes wrong.

## Technical Context

- The ADB/Shizuku host runs in a separate, Shizuku-forked process. `BaseAdbHost` had no default uncaught-exception handler, so any JVM crash on a host thread died silently and nothing reached `adb.log`.
- Adds a `Thread.setDefaultUncaughtExceptionHandler` in `BaseAdbHost`, mirroring the existing handler in `BaseRootHost`: it logs the throwable via the host logger, then delegates to the previous handler if present, otherwise `exitProcess(1)`. The handler is installed in an `init` block, so it's active before any host work runs; by the time it can fire, the concrete `AdbHost` has already wired up its file logger, so the line lands in `adb.log`.
- Motivated by a support case (Samsung, Android 16 / OneUI) where Shizuku dies ~1–2s after SD Maid binds its user service. The submitted log showed the host connecting and working, then Shizuku's server binder dying — but couldn't show whether SD Maid's host itself crashed, because host-side crashes were invisible. This closes that gap so the next such log is conclusive.
- Purely additive; no API or AIDL surface change.
