### PR TITLE
General: Fix 'Restore purchase' failing when you already own Pro

### DIFF
--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplay.kt
@@ -16,6 +16,7 @@ import eu.darken.sdmse.common.upgrade.core.billing.PurchasedSku
 import eu.darken.sdmse.common.upgrade.core.billing.Sku
 import eu.darken.sdmse.common.upgrade.core.billing.SkuDetails
 import eu.darken.sdmse.common.upgrade.core.billing.UserCanceledBillingException
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -57,28 +58,7 @@ class UpgradeRepoGplay @Inject constructor(
         .map<BillingData, BillingData?> { it }
         .onStart { emit(null) }
         .setupCommonEventHandlers(TAG) { "upgradeInfo1" }
-        .map { data: BillingData? -> // Only relinquish pro state if we haven't had it for a while
-            val now = System.currentTimeMillis()
-            val lastProStateAt = billingCache.lastProStateAt.value()
-            log(TAG) { "Map: now=$now, lastProStateAt=$lastProStateAt, data=${data}" }
-
-            when {
-                data?.purchases?.isNotEmpty() == true -> {
-                    // If we are pro refresh timestamp
-                    billingCache.lastProStateAt.value(now)
-                    Info(billingData = data)
-                }
-
-                (now - lastProStateAt) < GRACE_PERIOD_MS -> {
-                    log(TAG, VERBOSE) { "We are not pro, but were recently, did GPlay try annoy us again?" }
-                    Info(gracePeriod = true, billingData = null)
-                }
-
-                else -> {
-                    Info(billingData = data)
-                }
-            }
-        }
+        .map { data: BillingData? -> data.toUpgradeInfo() }
         .distinctUntilChanged()
         .retryWhen { error, attempt ->
             // Ignore Google Play errors if the last pro state was recent
@@ -122,7 +102,60 @@ class UpgradeRepoGplay @Inject constructor(
 
     override suspend fun refresh() {
         log(TAG) { "refresh()" }
-        billingManager.refresh()
+        try {
+            billingManager.refresh()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            // Background refresh: keep the old swallow-and-log behaviour so callers like MainViewModel
+            // aren't affected. The explicit restore path uses restorePurchaseNow(), which surfaces errors.
+            log(TAG, ERROR) { "Background refresh failed: ${e.asLog()}" }
+        }
+    }
+
+    // Explicit "Restore purchase": query Play now and evaluate Pro from the returned data in the same
+    // coroutine (real happens-before), so we never read a stale upgradeInfo replay. Billing errors
+    // propagate so the caller can distinguish "not owned" from "Play unavailable".
+    suspend fun restorePurchaseNow(): Info {
+        log(TAG) { "restorePurchaseNow()" }
+        return try {
+            billingManager.refresh().toUpgradeInfo()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            // Mirror the reactive flow's retryWhen: a transient Play error while we were Pro recently
+            // keeps us Pro via the grace period; otherwise surface the error so the caller can show
+            // the proper "Play unavailable" message instead of a generic restore failure.
+            val lastProStateAt = billingCache.lastProStateAt.value()
+            if ((System.currentTimeMillis() - lastProStateAt) < GRACE_PERIOD_MS) {
+                log(TAG, VERBOSE) { "restore hit a Play error but we were Pro recently -> grace" }
+                Info(gracePeriod = true, billingData = null)
+            } else {
+                throw e
+            }
+        }
+    }
+
+    // Shared Pro/grace mapping used by both the reactive upgradeInfo flow and restorePurchaseNow().
+    // Only relinquishes Pro if we haven't had it for a while (grace period).
+    private suspend fun BillingData?.toUpgradeInfo(): Info {
+        val now = System.currentTimeMillis()
+        val lastProStateAt = billingCache.lastProStateAt.value()
+        log(TAG) { "toUpgradeInfo(): now=$now, lastProStateAt=$lastProStateAt, data=$this" }
+        return when {
+            this?.purchases?.isNotEmpty() == true -> {
+                // If we are pro refresh timestamp
+                billingCache.lastProStateAt.value(now)
+                Info(billingData = this)
+            }
+
+            (now - lastProStateAt) < GRACE_PERIOD_MS -> {
+                log(TAG, VERBOSE) { "We are not pro, but were recently, did GPlay try annoy us again?" }
+                Info(gracePeriod = true, billingData = null)
+            }
+
+            else -> Info(billingData = this)
+        }
     }
 
     data class Info(

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManager.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManager.kt
@@ -17,7 +17,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.flow.SharingStarted.Companion.WhileSubscribed
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -135,17 +134,12 @@ class BillingManager @Inject constructor(
         }
     }
 
-    suspend fun refresh() {
+    suspend fun refresh(): BillingData {
         log(TAG) { "refresh()" }
-        scope.launch {
-            useConnection {
-                try {
-                    refreshPurchases()
-                } catch (e: Exception) {
-                    log(TAG, ERROR) { "Manual purchase data refresh failed: ${e.asLog()}" }
-                }
-            }
-        }.join()
+        // Query in the caller's context and return the result directly, so callers get the fresh
+        // purchases (and any billing error) with a real happens-before instead of racing the shared
+        // upgradeInfo replay cache.
+        return BillingData(purchases = useConnection { refreshPurchases() })
     }
 
     companion object {

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingConnection.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingConnection.kt
@@ -84,15 +84,7 @@ data class BillingConnection(
         val iap = iapJob.await()
         val sub = subJob.await()
         log(TAG) { "Refreshed IAPs=${iap.getOrNull()}, SUBs=${sub.getOrNull()}" }
-
-        val found = iap.getOrNull().orEmpty() + sub.getOrNull().orEmpty()
-        when {
-            found.isNotEmpty() -> found.sortedByDescending { it.purchaseTime }
-            else -> {
-                (iap.exceptionOrNull() ?: sub.exceptionOrNull())?.let { throw it }
-                emptyList()
-            }
-        }
+        combinePurchaseResults(iap, sub)
     }
 
     // Never throws except on cancellation, so a single failing product-type query doesn't cancel the
@@ -201,5 +193,22 @@ data class BillingConnection(
 
     companion object {
         val TAG: String = logTag("Upgrade", "Gplay", "Billing", "ClientConnection")
+
+        // Combines the two product-type query results: a purchase found by either type is
+        // authoritative; an error is only propagated when nothing was found, so callers can tell
+        // "not owned" apart from "couldn't verify one product type". Pure and unit-tested.
+        internal fun combinePurchaseResults(
+            iap: Result<Collection<Purchase>>,
+            sub: Result<Collection<Purchase>>,
+        ): Collection<Purchase> {
+            val found = iap.getOrNull().orEmpty() + sub.getOrNull().orEmpty()
+            return when {
+                found.isNotEmpty() -> found.sortedByDescending { it.purchaseTime }
+                else -> {
+                    (iap.exceptionOrNull() ?: sub.exceptionOrNull())?.let { throw it }
+                    emptyList()
+                }
+            }
+        }
     }
 }

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingConnection.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingConnection.kt
@@ -18,8 +18,8 @@ import eu.darken.sdmse.common.flow.setupCommonEventHandlers
 import eu.darken.sdmse.common.upgrade.core.billing.BillingManager.Companion.tryMapUserFriendly
 import eu.darken.sdmse.common.upgrade.core.billing.Sku
 import eu.darken.sdmse.common.upgrade.core.billing.SkuDetails
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -72,27 +72,42 @@ data class BillingConnection(
         return purchaseData
     }
 
-    suspend fun refreshPurchases() = coroutineScope {
+    // Returns the freshly queried PURCHASED purchases so callers get a guaranteed happens-before
+    // relation instead of racing the shared purchases/upgradeInfo replay caches after a refresh.
+    // Tolerant of a single product-type failure: if either query finds a purchase we treat that as
+    // authoritative, and only propagate an error when nothing was found AND a query failed — so the
+    // caller can tell "not owned" apart from "couldn't verify".
+    suspend fun refreshPurchases(): Collection<Purchase> = coroutineScope {
         log(TAG) { "refreshPurchases()" }
-        val iapJob = async {
-            try {
-                val iaps = queryPurchases(BillingClient.ProductType.INAPP)
-                log(TAG) { "Refreshed IAPs: $iaps" }
-                queryCacheIaps.value = iaps.filter { it.purchaseState == PurchaseState.PURCHASED }
-            } catch (e: Exception) {
-                throw e.tryMapUserFriendly()
+        val iapJob = async { queryPurchasedProducts(BillingClient.ProductType.INAPP) { queryCacheIaps.value = it } }
+        val subJob = async { queryPurchasedProducts(BillingClient.ProductType.SUBS) { queryCacheSubs.value = it } }
+        val iap = iapJob.await()
+        val sub = subJob.await()
+        log(TAG) { "Refreshed IAPs=${iap.getOrNull()}, SUBs=${sub.getOrNull()}" }
+
+        val found = iap.getOrNull().orEmpty() + sub.getOrNull().orEmpty()
+        when {
+            found.isNotEmpty() -> found.sortedByDescending { it.purchaseTime }
+            else -> {
+                (iap.exceptionOrNull() ?: sub.exceptionOrNull())?.let { throw it }
+                emptyList()
             }
         }
-        val subJob = async {
-            try {
-                val subs = queryPurchases(BillingClient.ProductType.SUBS)
-                log(TAG) { "Refreshed SUBs: $subs" }
-                queryCacheSubs.value = subs.filter { it.purchaseState == PurchaseState.PURCHASED }
-            } catch (e: Exception) {
-                throw e.tryMapUserFriendly()
-            }
-        }
-        awaitAll(iapJob, subJob)
+    }
+
+    // Never throws except on cancellation, so a single failing product-type query doesn't cancel the
+    // sibling query (or the coroutineScope). The exception is already user-friendly-mapped.
+    private suspend fun queryPurchasedProducts(
+        @BillingClient.ProductType type: String,
+        cache: (Collection<Purchase>) -> Unit,
+    ): Result<Collection<Purchase>> = try {
+        val purchased = queryPurchases(type).filter { it.purchaseState == PurchaseState.PURCHASED }
+        cache(purchased)
+        Result.success(purchased)
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        Result.failure(e.tryMapUserFriendly())
     }
 
     suspend fun acknowledgePurchase(purchase: Purchase): BillingResult {

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
@@ -5,8 +5,8 @@ import androidx.lifecycle.SavedStateHandle
 import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
-import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.flow.SingleEventFlow
@@ -25,7 +25,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.take
@@ -155,21 +154,37 @@ class UpgradeViewModel @Inject constructor(
     fun restorePurchase() = launch {
         log(TAG) { "restorePurchase()" }
 
-        log(TAG, VERBOSE) { "Refreshing" }
-        upgradeRepo.refresh()
+        val restored = try {
+            withTimeoutOrNull(RESTORE_TIMEOUT_MS) { upgradeRepo.restorePurchaseNow() }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            // Play/billing error (e.g. service unavailable): surface the proper error dialog instead
+            // of the generic "restore failed" message, so the user can tell the two cases apart.
+            log(TAG, WARN) { "Restore purchase errored: ${e.asLog()}" }
+            errorEvents.tryEmit(e)
+            return@launch
+        }
 
-        val refreshedState = upgradeRepo.upgradeInfo.first()
-        log(TAG) { "Refreshed purchase state: $refreshedState" }
+        when {
+            restored == null -> {
+                // Play never answered in time; the restore-failed dialog already suggests waiting /
+                // clearing the Play cache, which fits a timeout too.
+                log(TAG, WARN) { "Restore purchase timed out" }
+                events.tryEmit(UpgradeEvents.RestoreFailed)
+            }
 
-        if (refreshedState.isPro) {
-            log(TAG, INFO) { "Restored purchase :))" }
-        } else {
-            log(TAG, WARN) { "Restore purchase failed" }
-            events.tryEmit(UpgradeEvents.RestoreFailed)
+            restored.isPro -> log(TAG, INFO) { "Restored purchase :))" }
+
+            else -> {
+                log(TAG, WARN) { "Restore purchase failed" }
+                events.tryEmit(UpgradeEvents.RestoreFailed)
+            }
         }
     }
 
     companion object {
+        private const val RESTORE_TIMEOUT_MS = 15_000L
         private val TAG = logTag("Upgrade", "Gplay", "ViewModel")
     }
 }

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplayTest.kt
@@ -1,29 +1,44 @@
 package eu.darken.sdmse.common.upgrade.core
 
 import com.android.billingclient.api.Purchase
+import eu.darken.sdmse.common.datastore.DataStoreValue
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
 import eu.darken.sdmse.common.upgrade.core.billing.BillingData
+import eu.darken.sdmse.common.upgrade.core.billing.BillingManager
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.flowOf
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
 import java.time.Instant
 
 class UpgradeRepoGplayTest : BaseTest() {
 
-    @BeforeEach
-    fun setup() {
+    private val scope = CoroutineScope(Dispatchers.Unconfined)
+    private val billingManager = mockk<BillingManager>()
+    private val billingCache = mockk<BillingCache>()
 
+    // Builds a repo whose stored last-Pro timestamp is `lastProAt`. billingData is stubbed only
+    // because the upgradeInfo flow references it at construction; it is never collected here.
+    private fun repo(lastProAt: Long): UpgradeRepoGplay {
+        every { billingManager.billingData } returns flowOf(BillingData(emptySet()))
+        val lastPro = mockk<DataStoreValue<Long>>(relaxed = true).apply {
+            every { flow } returns flowOf(lastProAt)
+        }
+        every { billingCache.lastProStateAt } returns lastPro
+        return UpgradeRepoGplay(scope, billingManager, billingCache)
     }
 
-    @AfterEach
-    fun teardown() {
-
+    private fun proPurchase() = mockk<Purchase>().apply {
+        every { products } returns OurSku.PRO_SKUS.map { it.id }
+        every { purchaseTime } returns Instant.parse("2024-01-01T00:00:00Z").toEpochMilli()
     }
-
 
     @Test fun `test upgrade info pro status mapping`() {
         UpgradeRepoGplay.Info(
@@ -59,5 +74,38 @@ class UpgradeRepoGplayTest : BaseTest() {
         // Guards against the unit error where 7 * 24 * 60 * 1000 (2.8h) was used instead of 7 days,
         // which dropped paying users to non-Pro within hours of a transient empty/failed billing response.
         UpgradeRepoGplay.GRACE_PERIOD_MS shouldBe 604_800_000L
+    }
+
+    @Test fun `restore returns pro when a purchase is found`() = runTest2 {
+        coEvery { billingManager.refresh() } returns BillingData(setOf(proPurchase()))
+
+        repo(lastProAt = 0L).restorePurchaseNow().isPro shouldBe true
+    }
+
+    @Test fun `restore keeps pro within grace when the query comes back empty`() = runTest2 {
+        coEvery { billingManager.refresh() } returns BillingData(emptySet())
+
+        repo(lastProAt = System.currentTimeMillis() - 1_000).restorePurchaseNow().isPro shouldBe true
+    }
+
+    @Test fun `restore is not pro when the query is empty and grace has expired`() = runTest2 {
+        coEvery { billingManager.refresh() } returns BillingData(emptySet())
+
+        val expired = System.currentTimeMillis() - UpgradeRepoGplay.GRACE_PERIOD_MS - 1_000
+        repo(lastProAt = expired).restorePurchaseNow().isPro shouldBe false
+    }
+
+    @Test fun `restore keeps pro within grace when the query errors`() = runTest2 {
+        coEvery { billingManager.refresh() } throws RuntimeException("Play unavailable")
+
+        repo(lastProAt = System.currentTimeMillis() - 1_000).restorePurchaseNow().isPro shouldBe true
+    }
+
+    @Test fun `restore rethrows the error when it happens outside grace`() = runTest2 {
+        coEvery { billingManager.refresh() } throws RuntimeException("Play unavailable")
+
+        shouldThrow<RuntimeException> {
+            repo(lastProAt = 0L).restorePurchaseNow()
+        }
     }
 }

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingConnectionTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingConnectionTest.kt
@@ -1,0 +1,54 @@
+package eu.darken.sdmse.common.upgrade.core.billing.client
+
+import com.android.billingclient.api.Purchase
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class BillingConnectionTest : BaseTest() {
+
+    private fun purchase(time: Long) = mockk<Purchase>().apply { every { purchaseTime } returns time }
+
+    @Test fun `combines both product types, newest first`() {
+        val older = purchase(1_000)
+        val newer = purchase(2_000)
+
+        BillingConnection.combinePurchaseResults(
+            iap = Result.success(listOf(older)),
+            sub = Result.success(listOf(newer)),
+        ) shouldBe listOf(newer, older)
+    }
+
+    @Test fun `a single product-type failure does not mask a purchase found by the other`() {
+        val owned = purchase(1_000)
+
+        BillingConnection.combinePurchaseResults(
+            iap = Result.success(listOf(owned)),
+            sub = Result.failure(RuntimeException("SUBS query failed")),
+        ) shouldBe listOf(owned)
+
+        BillingConnection.combinePurchaseResults(
+            iap = Result.failure(RuntimeException("IAP query failed")),
+            sub = Result.success(listOf(owned)),
+        ) shouldBe listOf(owned)
+    }
+
+    @Test fun `both product types empty returns empty`() {
+        BillingConnection.combinePurchaseResults(
+            iap = Result.success(emptyList()),
+            sub = Result.success(emptyList()),
+        ) shouldBe emptyList()
+    }
+
+    @Test fun `nothing found but a query failed rethrows the error`() {
+        shouldThrow<RuntimeException> {
+            BillingConnection.combinePurchaseResults(
+                iap = Result.success(emptyList()),
+                sub = Result.failure(RuntimeException("SUBS query failed")),
+            )
+        }
+    }
+}

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/ui/GplayUpgradeViewModelTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/ui/GplayUpgradeViewModelTest.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import eu.darken.sdmse.common.upgrade.core.OurSku
 import eu.darken.sdmse.common.upgrade.core.UpgradeRepoGplay
 import eu.darken.sdmse.common.upgrade.core.billing.GplayServiceUnavailableException
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -80,5 +81,58 @@ class GplayUpgradeViewModelTest : BaseTest() {
 
         coVerify(exactly = 1) { repo.querySkus(OurSku.Iap.PRO_UPGRADE) }
         coVerify(exactly = 1) { repo.querySkus(OurSku.Sub.PRO_UPGRADE) }
+    }
+
+    private fun mockRepo(): UpgradeRepoGplay = mockk<UpgradeRepoGplay>(relaxed = true).apply {
+        every { upgradeInfo } returns MutableStateFlow(UpgradeRepoGplay.Info(false, null, null))
+    }
+
+    private fun buildVm(repo: UpgradeRepoGplay): UpgradeViewModel = UpgradeViewModel(
+        handle = SavedStateHandle(mapOf("forced" to false)),
+        dispatcherProvider = TestDispatcherProvider(testDispatcher),
+        upgradeRepo = repo,
+    )
+
+    @Test
+    fun `restore with no purchase emits RestoreFailed`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        coEvery { repo.restorePurchaseNow() } returns UpgradeRepoGplay.Info(false, null, null)
+        val vm = buildVm(repo)
+
+        val event = async { vm.events.first() }
+        vm.restorePurchase()
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.RestoreFailed
+    }
+
+    @Test
+    fun `restore that times out emits RestoreFailed`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        coEvery { repo.restorePurchaseNow() } coAnswers {
+            delay(30_000) // longer than the 15s restore timeout
+            UpgradeRepoGplay.Info(gracePeriod = true, billingData = null)
+        }
+        val vm = buildVm(repo)
+
+        val event = async { vm.events.first() }
+        vm.restorePurchase()
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.RestoreFailed
+    }
+
+    @Test
+    fun `restore that errors forwards the error instead of RestoreFailed`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        val boom = IllegalStateException("Play unavailable")
+        coEvery { repo.restorePurchaseNow() } throws boom
+        val vm = buildVm(repo)
+
+        val forwardedError = async { vm.errorEvents.first() }
+        vm.restorePurchase()
+        advanceUntilIdle()
+
+        forwardedError.await() shouldBe boom
     }
 }


### PR DESCRIPTION
## What changed

Fixed the **"Restore purchase"** button sometimes reporting failure even when you already own Pro on your Google account. Restoring is now also more resilient when Google Play is slow, briefly unreachable, or returns an incomplete answer, and it shows a clearer "Google Play unavailable" message when the store itself is the problem (instead of the generic restore-failed dialog).

## Technical Context

- **Root cause:** the restore flow triggered a Play refresh and then read Pro state from the shared `upgradeInfo` flow's replay cache. The refresh only awaited the query-cache writes — not their propagation through three `shareIn(WhileSubscribed, replay=1)` hops on `AppScope` — so the read could return the stale pre-refresh (non-Pro) value and report "restore failed" for someone who actually owns Pro.
- **Fix:** the refresh path now returns the freshly queried purchases, and Pro is evaluated from that result in the same coroutine (a real happens-before), so no shared-flow replay is read.
- **Added robustness on the restore path:**
  - a transient Play error while still within the grace period keeps Pro, mirroring the reactive flow's `retryWhen`;
  - a single INAPP/SUBS query failure no longer masks a purchase found by the other product type (error only surfaces when nothing was found);
  - a 15s timeout stops the button hanging on an unresponsive connection;
  - billing errors route to the proper "Play unavailable" dialog rather than the generic restore-failed message.
- **Unchanged:** the background `refresh()` override still swallows errors, so `isProSettled()` callers (AppCleaner/Deduplicator/backup) are unaffected.
- **Review guidance:** the core logic is in `UpgradeRepoGplay.restorePurchaseNow()` and `BillingConnection.refreshPurchases()`; new `UpgradeRepoGplayTest` cases cover the pro / empty / within-grace / grace-expired / error outcomes.
