### PR TITLE
General: Keep one-time Pro buyers Pro through longer Play outages

### DIFF
--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplay.kt
@@ -65,7 +65,7 @@ class UpgradeRepoGplay @Inject constructor(
             val now = System.currentTimeMillis()
             val lastProStateAt = billingCache.lastProStateAt.value()
             log(TAG) { "Catch: now=$now, lastProStateAt=$lastProStateAt, attempt=$attempt, error=$error" }
-            if ((now - lastProStateAt) < GRACE_PERIOD_MS) {
+            if ((now - lastProStateAt) < graceWindowMs()) {
                 log(TAG, VERBOSE) { "We are not pro, but were recently, and just got an error, what is GPlay doing???" }
                 emit(Info(gracePeriod = true, billingData = null))
             } else {
@@ -127,7 +127,7 @@ class UpgradeRepoGplay @Inject constructor(
             // keeps us Pro via the grace period; otherwise surface the error so the caller can show
             // the proper "Play unavailable" message instead of a generic restore failure.
             val lastProStateAt = billingCache.lastProStateAt.value()
-            if ((System.currentTimeMillis() - lastProStateAt) < GRACE_PERIOD_MS) {
+            if ((System.currentTimeMillis() - lastProStateAt) < graceWindowMs()) {
                 log(TAG, VERBOSE) { "restore hit a Play error but we were Pro recently -> grace" }
                 Info(gracePeriod = true, billingData = null)
             } else {
@@ -144,18 +144,33 @@ class UpgradeRepoGplay @Inject constructor(
         log(TAG) { "toUpgradeInfo(): now=$now, lastProStateAt=$lastProStateAt, data=$this" }
         return when {
             this?.purchases?.isNotEmpty() == true -> {
-                // If we are pro refresh timestamp
-                billingCache.lastProStateAt.value(now)
-                Info(billingData = this)
+                val info = Info(billingData = this)
+                // Only a *known* Pro SKU counts as "last Pro state" — an unrecognized purchase must
+                // not refresh the grace timestamp. Prefer the permanent IAP so it drives the window.
+                preferredProSku(info.upgrades)?.let { sku ->
+                    billingCache.lastProStateAt.value(now)
+                    billingCache.lastProStateSku.value(sku.id)
+                }
+                info
             }
 
-            (now - lastProStateAt) < GRACE_PERIOD_MS -> {
+            (now - lastProStateAt) < graceWindowMs() -> {
                 log(TAG, VERBOSE) { "We are not pro, but were recently, did GPlay try annoy us again?" }
                 Info(gracePeriod = true, billingData = null)
             }
 
             else -> Info(billingData = this)
         }
+    }
+
+    // Grace window depends on what was last owned: a permanent one-time purchase gets a long window,
+    // a subscription (or an unknown/legacy last SKU) gets the short default.
+    private suspend fun graceWindowMs(): Long {
+        val lastSku = billingCache.lastProStateSku.value()
+        val type = OurSku.PRO_SKUS.singleOrNull { it.id == lastSku }?.type
+        val window = if (type == Sku.Type.IAP) GRACE_PERIOD_IAP_MS else GRACE_PERIOD_MS
+        log(TAG) { "graceWindowMs(): lastSku=$lastSku, type=$type -> ${window}ms" }
+        return window
     }
 
     data class Info(
@@ -194,8 +209,18 @@ class UpgradeRepoGplay @Inject constructor(
         private const val STORE_SITE = "https://play.google.com/store/apps/details?id=eu.darken.sdmse"
         private const val UPGRADE_SITE = "https://play.google.com/store/apps/details?id=eu.darken.sdmse"
         private const val BETA_SITE = "https://play.google.com/apps/testing/eu.darken.sdmse"
-        // Keep paying users Pro through transient empty/failed Play Billing responses
+        // Keep paying users Pro through transient empty/failed Play Billing responses. A permanent
+        // one-time purchase should almost never be dropped on a hiccup, so it gets a long window; a
+        // subscription legitimately lapses, so it keeps the short one. GRACE_PERIOD_MS is the
+        // subscription/default window (also used when the last-owned SKU is unknown/legacy).
         val GRACE_PERIOD_MS = Duration.ofDays(7).toMillis()
+        val GRACE_PERIOD_IAP_MS = Duration.ofDays(30).toMillis()
         val TAG: String = logTag("Upgrade", "Gplay", "Repo")
+
+        // The SKU whose grace window applies when several are owned: the permanent one-time purchase
+        // wins over a subscription (purchases are time-sorted, so firstOrNull alone isn't enough).
+        // null when no known Pro SKU is owned.
+        internal fun preferredProSku(upgrades: Collection<PurchasedSku>): Sku? =
+            upgrades.firstOrNull { it.sku.type == Sku.Type.IAP }?.sku ?: upgrades.firstOrNull()?.sku
     }
 }

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplayTest.kt
@@ -5,6 +5,7 @@ import eu.darken.sdmse.common.datastore.DataStoreValue
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
 import eu.darken.sdmse.common.upgrade.core.billing.BillingData
 import eu.darken.sdmse.common.upgrade.core.billing.BillingManager
+import eu.darken.sdmse.common.upgrade.core.billing.PurchasedSku
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
@@ -16,6 +17,7 @@ import kotlinx.coroutines.flow.flowOf
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.runTest2
+import java.time.Duration
 import java.time.Instant
 
 class UpgradeRepoGplayTest : BaseTest() {
@@ -26,12 +28,16 @@ class UpgradeRepoGplayTest : BaseTest() {
 
     // Builds a repo whose stored last-Pro timestamp is `lastProAt`. billingData is stubbed only
     // because the upgradeInfo flow references it at construction; it is never collected here.
-    private fun repo(lastProAt: Long): UpgradeRepoGplay {
+    private fun repo(lastProAt: Long, lastSku: String = ""): UpgradeRepoGplay {
         every { billingManager.billingData } returns flowOf(BillingData(emptySet()))
         val lastPro = mockk<DataStoreValue<Long>>(relaxed = true).apply {
             every { flow } returns flowOf(lastProAt)
         }
         every { billingCache.lastProStateAt } returns lastPro
+        val lastProSku = mockk<DataStoreValue<String>>(relaxed = true).apply {
+            every { flow } returns flowOf(lastSku)
+        }
+        every { billingCache.lastProStateSku } returns lastProSku
         return UpgradeRepoGplay(scope, billingManager, billingCache)
     }
 
@@ -107,5 +113,37 @@ class UpgradeRepoGplayTest : BaseTest() {
         shouldThrow<RuntimeException> {
             repo(lastProAt = 0L).restorePurchaseNow()
         }
+    }
+
+    @Test fun `permanent IAP keeps grace well beyond the subscription window`() = runTest2 {
+        coEvery { billingManager.refresh() } returns BillingData(emptySet())
+        // 20 days ago: past the 7-day subscription window, but within the 30-day IAP window.
+        val twentyDaysAgo = System.currentTimeMillis() - Duration.ofDays(20).toMillis()
+
+        repo(lastProAt = twentyDaysAgo, lastSku = OurSku.Iap.PRO_UPGRADE.id)
+            .restorePurchaseNow().isPro shouldBe true
+    }
+
+    @Test fun `subscription grace expires after the short window`() = runTest2 {
+        coEvery { billingManager.refresh() } returns BillingData(emptySet())
+        val twentyDaysAgo = System.currentTimeMillis() - Duration.ofDays(20).toMillis()
+
+        repo(lastProAt = twentyDaysAgo, lastSku = OurSku.Sub.PRO_UPGRADE.id)
+            .restorePurchaseNow().isPro shouldBe false
+    }
+
+    @Test fun `IAP grace window is longer than the subscription window`() {
+        (UpgradeRepoGplay.GRACE_PERIOD_IAP_MS > UpgradeRepoGplay.GRACE_PERIOD_MS) shouldBe true
+        UpgradeRepoGplay.GRACE_PERIOD_IAP_MS shouldBe Duration.ofDays(30).toMillis()
+    }
+
+    @Test fun `preferredProSku prefers the permanent IAP when both are owned`() {
+        val iap = PurchasedSku(OurSku.Iap.PRO_UPGRADE, mockk<Purchase>())
+        val sub = PurchasedSku(OurSku.Sub.PRO_UPGRADE, mockk<Purchase>())
+
+        UpgradeRepoGplay.preferredProSku(listOf(sub, iap))?.id shouldBe OurSku.Iap.PRO_UPGRADE.id
+        UpgradeRepoGplay.preferredProSku(listOf(iap))?.id shouldBe OurSku.Iap.PRO_UPGRADE.id
+        UpgradeRepoGplay.preferredProSku(listOf(sub))?.id shouldBe OurSku.Sub.PRO_UPGRADE.id
+        UpgradeRepoGplay.preferredProSku(emptyList()) shouldBe null
     }
 }


### PR DESCRIPTION
## What changed

People who bought the **one-time Pro upgrade** now stay Pro for up to **30 days** through Google Play billing hiccups (Play temporarily returning no/failed purchase info), up from 7 days. **Subscriptions keep the 7-day window** since they can genuinely lapse. This cuts down on the "it's asking me to pay again" cases for people who already own the permanent upgrade.

## Technical Context

- Wires up the previously-dead `lastProStateSku` cache field to record the last-owned SKU.
- `graceWindowMs()` resolves the window from that SKU's type — 30d for the permanent IAP, 7d for the subscription (or an unknown/legacy last SKU). Applied at all three grace sites: the reactive `upgradeInfo` map, its `retryWhen`, and the explicit restore error path.
- Only a **known Pro SKU** refreshes the grace timestamp now — an unrecognized purchase no longer bumps it while leaving a stale SKU.
- `preferredProSku()` picks the permanent IAP when both an IAP and a subscription are owned (purchases are time-sorted, so a plain `first()` could otherwise pick a newer subscription and shrink the window).
- **Fail-open cache caveat:** a refunded / charged-back / account-switched IAP keeps Pro for up to 30 days. Tunable via `GRACE_PERIOD_IAP_MS`.
- **Tests:** IAP → 30d, subscription → 7d, prefer-IAP-when-both-owned, legacy empty SKU → 7d, and the constant relationship.
