### PR TITLE
General: Show returning Pro buyers a Restore prompt, not a paywall

### DIFF
--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplay.kt
@@ -77,6 +77,10 @@ class UpgradeRepoGplay @Inject constructor(
         .setupCommonEventHandlers(TAG) { "upgradeInfo2" }
         .shareIn(scope, SharingStarted.WhileSubscribed(3000L, 0L), replay = 1)
 
+    // True once we've ever confirmed a (known) Pro purchase on this install; drives the proactive
+    // restore banner. Local signal only — a fresh install or switched Google account starts false.
+    val wasEverPro: Flow<Boolean> = billingCache.lastProStateAt.flow.map { it > 0 }
+
     fun launchBillingFlow(
         activity: Activity,
         sku: Sku,

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.AutoAwesome
 import androidx.compose.material.icons.twotone.Payments
+import androidx.compose.material.icons.twotone.Restore
 import androidx.compose.material.icons.twotone.WarningAmber
 import androidx.compose.material3.Button
 import androidx.compose.material3.CardDefaults
@@ -120,6 +121,10 @@ internal fun UpgradeScreen(
                     contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
                 ),
             )
+
+            if (uiState is GplayUpgradeUiState.Loaded && uiState.wasPreviouslyPro) {
+                UpgradeRestoreBanner(onRestore = onRestore)
+            }
 
             UpgradeSectionCard(
                 title = stringResource(R.string.upgrade_screen_benefits_title),
@@ -241,6 +246,35 @@ private fun LoadedOffers(
     }
 }
 
+@Composable
+private fun UpgradeRestoreBanner(
+    onRestore: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    UpgradeSectionCard(
+        title = stringResource(R.string.upgrade_screen_restore_banner_title),
+        icon = Icons.TwoTone.Restore,
+        modifier = modifier.testTag(UpgradeScreenTags.GPLAY_RESTORE_BANNER),
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+            contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+        ),
+    ) {
+        Text(
+            text = stringResource(R.string.upgrade_screen_restore_banner_body),
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        Button(
+            onClick = onRestore,
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag(UpgradeScreenTags.GPLAY_RESTORE_BANNER_ACTION),
+        ) {
+            Text(stringResource(R.string.upgrade_screen_restore_purchase_action))
+        }
+    }
+}
+
 internal sealed interface GplayUpgradeUiState {
     data object Loading : GplayUpgradeUiState
 
@@ -254,6 +288,7 @@ internal sealed interface GplayUpgradeUiState {
         val subscriptionPrice: String?,
         val iapEnabled: Boolean,
         val iapPrice: String?,
+        val wasPreviouslyPro: Boolean = false,
     ) : GplayUpgradeUiState
 }
 
@@ -268,6 +303,7 @@ internal fun toLoadedState(
     sub: eu.darken.sdmse.common.upgrade.core.billing.SkuDetails?,
     hasIap: Boolean,
     hasSub: Boolean,
+    wasPreviouslyPro: Boolean = false,
 ): GplayUpgradeUiState.Loaded {
     val iapOffer = iap?.details?.oneTimePurchaseOfferDetails
     val subOffer = sub?.details?.subscriptionOfferDetails?.singleOrNull { offer ->
@@ -287,6 +323,7 @@ internal fun toLoadedState(
         subscriptionPrice = subOffer?.pricingPhases?.pricingPhaseList?.lastOrNull()?.formattedPrice,
         iapEnabled = iapOffer != null && !hasIap,
         iapPrice = iapOffer?.formattedPrice,
+        wasPreviouslyPro = wasPreviouslyPro,
     )
 }
 
@@ -309,6 +346,23 @@ private fun UpgradeScreenLoadedPreview() {
                 subscriptionPrice = "$12.99",
                 iapEnabled = true,
                 iapPrice = "$24.99",
+            ),
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun UpgradeScreenReturningBuyerPreview() {
+    PreviewWrapper {
+        UpgradeScreen(
+            uiState = GplayUpgradeUiState.Loaded(
+                subscriptionAction = SubscriptionAction.STANDARD,
+                subscriptionEnabled = true,
+                subscriptionPrice = "$12.99",
+                iapEnabled = true,
+                iapPrice = "$24.99",
+                wasPreviouslyPro = true,
             ),
         )
     }

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
@@ -69,7 +69,8 @@ class UpgradeViewModel @Inject constructor(
         querySkuDetails(OurSku.Iap.PRO_UPGRADE),
         querySkuDetails(OurSku.Sub.PRO_UPGRADE),
         upgradeRepo.upgradeInfo,
-    ) { iap, sub, current ->
+        upgradeRepo.wasEverPro,
+    ) { iap, sub, current, wasEverPro ->
         val serviceUnavailableError = if (iap == null && sub == null) {
             GplayServiceUnavailableException(RuntimeException("IAP and SUB data request timed out."))
         } else {
@@ -104,6 +105,7 @@ class UpgradeViewModel @Inject constructor(
             sub = sub?.firstOrNull(),
             hasIap = current.upgrades.any { it.sku == OurSku.Iap.PRO_UPGRADE },
             hasSub = current.upgrades.any { it.sku == OurSku.Sub.PRO_UPGRADE },
+            wasPreviouslyPro = wasEverPro && !current.isPro,
         )
     }.safeStateIn(
         initialValue = GplayUpgradeUiState.Loading,

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -37,6 +37,8 @@
     <string name="upgrade_screen_iap_action_hint">The one-time purchase costs %s.</string>
     <string name="upgrade_screen_thanks_toast">You are the best! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Restore purchase</string>
+    <string name="upgrade_screen_restore_banner_title">Already bought Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">It looks like you upgraded to Pro on this device before. Restore your purchase to unlock it again.</string>
     <string name="upgrade_screen_restore_purchase_message">Your upgrade is valid across devices on the same Google account.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Troubleshooting tips for unrecognized upgrades:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store synchronization may take time. Try rebooting, clearing Google Play cache or simply wait.</string>

--- a/app/src/main/java/eu/darken/sdmse/common/upgrade/ui/UpgradeContent.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/upgrade/ui/UpgradeContent.kt
@@ -58,6 +58,8 @@ internal object UpgradeScreenTags {
     const val GPLAY_SUBSCRIPTION = "upgrade_gplay_subscription"
     const val GPLAY_IAP = "upgrade_gplay_iap"
     const val GPLAY_RESTORE = "upgrade_gplay_restore"
+    const val GPLAY_RESTORE_BANNER = "upgrade_gplay_restore_banner"
+    const val GPLAY_RESTORE_BANNER_ACTION = "upgrade_gplay_restore_banner_action"
     const val GPLAY_UNAVAILABLE = "upgrade_gplay_unavailable"
     const val GPLAY_RECOMMENDED = "upgrade_gplay_recommended"
 }

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/ui/GplayUpgradeScreenTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/ui/GplayUpgradeScreenTest.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.sdmse.R
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
@@ -104,6 +105,46 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_offers_unavailable_message)).assertCountEquals(1)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_benefits_title)).assertCountEquals(1)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_how_body)).assertCountEquals(1)
+    }
+
+    @Test
+    fun `returning buyer sees the restore banner and can trigger restore`() {
+        var restoreClicks = 0
+        composeRule.setUpgradeContent {
+            UpgradeScreen(
+                uiState = GplayUpgradeUiState.Loaded(
+                    subscriptionAction = SubscriptionAction.STANDARD,
+                    subscriptionEnabled = true,
+                    subscriptionPrice = "$12.99",
+                    iapEnabled = true,
+                    iapPrice = "$24.99",
+                    wasPreviouslyPro = true,
+                ),
+                onRestore = { restoreClicks++ },
+            )
+        }
+
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_RESTORE_BANNER).assertCountEquals(1)
+        composeRule.onNodeWithTag(UpgradeScreenTags.GPLAY_RESTORE_BANNER_ACTION).performClick()
+        composeRule.runOnIdle { check(restoreClicks == 1) { "expected 1 restore click, got $restoreClicks" } }
+    }
+
+    @Test
+    fun `banner is hidden without a prior purchase on this device`() {
+        composeRule.setUpgradeContent {
+            UpgradeScreen(
+                uiState = GplayUpgradeUiState.Loaded(
+                    subscriptionAction = SubscriptionAction.STANDARD,
+                    subscriptionEnabled = true,
+                    subscriptionPrice = "$12.99",
+                    iapEnabled = true,
+                    iapPrice = "$24.99",
+                    wasPreviouslyPro = false,
+                ),
+            )
+        }
+
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_RESTORE_BANNER).assertCountEquals(0)
     }
 }
 

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/ui/GplayUpgradeViewModelTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/ui/GplayUpgradeViewModelTest.kt
@@ -53,6 +53,7 @@ class GplayUpgradeViewModelTest : BaseTest() {
         val upgradeInfo = MutableStateFlow(UpgradeRepoGplay.Info(false, null, null))
         val repo = mockk<UpgradeRepoGplay>(relaxed = true)
         every { repo.upgradeInfo } returns upgradeInfo
+        every { repo.wasEverPro } returns MutableStateFlow(false)
         coEvery { repo.querySkus(OurSku.Iap.PRO_UPGRADE) } coAnswers {
             delay(6_000)
             emptyList()
@@ -85,6 +86,7 @@ class GplayUpgradeViewModelTest : BaseTest() {
 
     private fun mockRepo(): UpgradeRepoGplay = mockk<UpgradeRepoGplay>(relaxed = true).apply {
         every { upgradeInfo } returns MutableStateFlow(UpgradeRepoGplay.Info(false, null, null))
+        every { wasEverPro } returns MutableStateFlow(false)
     }
 
     private fun buildVm(repo: UpgradeRepoGplay): UpgradeViewModel = UpgradeViewModel(
@@ -134,5 +136,40 @@ class GplayUpgradeViewModelTest : BaseTest() {
         advanceUntilIdle()
 
         forwardedError.await() shouldBe boom
+    }
+
+    @Test
+    fun `previously-pro on this device flows into the loaded banner flag`() = runTest2(context = testDispatcher) {
+        val repo = mockk<UpgradeRepoGplay>(relaxed = true)
+        every { repo.upgradeInfo } returns MutableStateFlow(UpgradeRepoGplay.Info(false, null, null))
+        every { repo.wasEverPro } returns MutableStateFlow(true)
+        coEvery { repo.querySkus(OurSku.Iap.PRO_UPGRADE) } returns emptyList()
+        coEvery { repo.querySkus(OurSku.Sub.PRO_UPGRADE) } returns emptyList()
+        val vm = buildVm(repo)
+
+        val loaded = async {
+            vm.state.first { it is GplayUpgradeUiState.Loaded } as GplayUpgradeUiState.Loaded
+        }
+        advanceUntilIdle()
+
+        loaded.await().wasPreviouslyPro shouldBe true
+    }
+
+    @Test
+    fun `banner flag stays off while grace still keeps the user pro`() = runTest2(context = testDispatcher) {
+        val repo = mockk<UpgradeRepoGplay>(relaxed = true)
+        // gracePeriod = true => Info.isPro is true even without a current raw purchase.
+        every { repo.upgradeInfo } returns MutableStateFlow(UpgradeRepoGplay.Info(gracePeriod = true, billingData = null))
+        every { repo.wasEverPro } returns MutableStateFlow(true)
+        coEvery { repo.querySkus(OurSku.Iap.PRO_UPGRADE) } returns emptyList()
+        coEvery { repo.querySkus(OurSku.Sub.PRO_UPGRADE) } returns emptyList()
+        val vm = buildVm(repo)
+
+        val loaded = async {
+            vm.state.first { it is GplayUpgradeUiState.Loaded } as GplayUpgradeUiState.Loaded
+        }
+        advanceUntilIdle()
+
+        loaded.await().wasPreviouslyPro shouldBe false
     }
 }


### PR DESCRIPTION
## What changed

When you open the upgrade screen and this device remembers that you bought Pro before — but Google Play isn't currently showing you as Pro — SD Maid now shows a friendly **"Already bought Pro? → Restore purchase"** banner at the top, instead of leading you straight to the paywall. It makes it obvious to a returning buyer that they should restore rather than pay again.

## Technical Context

- New reactive `wasEverPro` signal in `UpgradeRepoGplay` (`lastProStateAt > 0`) — a **local** signal, set only on a confirmed *known* Pro purchase.
- The ViewModel folds it into the loaded state as `wasPreviouslyPro = wasEverPro && !isPro`, so the banner hides while a grace period or an actual purchase keeps the user Pro.
- The banner reuses the existing hardened `restorePurchase()` path; the small bottom "Restore purchase" link stays for everyone.
- **Scope / limit:** local-only signal — a fresh install or a switched Google account has no prior-Pro record and won't see the banner (there's no local signal to key on in that case). The copy is deliberately hedged ("looks like you upgraded before") rather than asserting ownership.
- **Tests:** VM plumbing (previously-Pro → banner flag on; grace keeps it off) + Compose (banner shows and restores on click; hidden without a prior purchase).
