### PR TITLE
General: Show progress while restoring a purchase

### DIFF
--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeScreen.kt
@@ -7,7 +7,10 @@ import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.AutoAwesome
 import androidx.compose.material.icons.twotone.Payments
@@ -15,6 +18,7 @@ import androidx.compose.material.icons.twotone.Restore
 import androidx.compose.material.icons.twotone.WarningAmber
 import androidx.compose.material3.Button
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
@@ -123,7 +127,10 @@ internal fun UpgradeScreen(
             )
 
             if (uiState is GplayUpgradeUiState.Loaded && uiState.wasPreviouslyPro) {
-                UpgradeRestoreBanner(onRestore = onRestore)
+                UpgradeRestoreBanner(
+                    onRestore = onRestore,
+                    restoreInProgress = uiState.restoreInProgress,
+                )
             }
 
             UpgradeSectionCard(
@@ -239,6 +246,7 @@ private fun LoadedOffers(
 
         TextButton(
             onClick = onRestore,
+            enabled = !uiState.restoreInProgress,
             modifier = Modifier.testTag(UpgradeScreenTags.GPLAY_RESTORE),
         ) {
             Text(stringResource(R.string.upgrade_screen_restore_purchase_action))
@@ -250,6 +258,7 @@ private fun LoadedOffers(
 private fun UpgradeRestoreBanner(
     onRestore: () -> Unit,
     modifier: Modifier = Modifier,
+    restoreInProgress: Boolean = false,
 ) {
     UpgradeSectionCard(
         title = stringResource(R.string.upgrade_screen_restore_banner_title),
@@ -266,10 +275,18 @@ private fun UpgradeRestoreBanner(
         )
         Button(
             onClick = onRestore,
+            enabled = !restoreInProgress,
             modifier = Modifier
                 .fillMaxWidth()
                 .testTag(UpgradeScreenTags.GPLAY_RESTORE_BANNER_ACTION),
         ) {
+            if (restoreInProgress) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(18.dp),
+                    strokeWidth = 2.dp,
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+            }
             Text(stringResource(R.string.upgrade_screen_restore_purchase_action))
         }
     }
@@ -289,6 +306,7 @@ internal sealed interface GplayUpgradeUiState {
         val iapEnabled: Boolean,
         val iapPrice: String?,
         val wasPreviouslyPro: Boolean = false,
+        val restoreInProgress: Boolean = false,
     ) : GplayUpgradeUiState
 }
 
@@ -304,6 +322,7 @@ internal fun toLoadedState(
     hasIap: Boolean,
     hasSub: Boolean,
     wasPreviouslyPro: Boolean = false,
+    restoreInProgress: Boolean = false,
 ): GplayUpgradeUiState.Loaded {
     val iapOffer = iap?.details?.oneTimePurchaseOfferDetails
     val subOffer = sub?.details?.subscriptionOfferDetails?.singleOrNull { offer ->
@@ -324,6 +343,7 @@ internal fun toLoadedState(
         iapEnabled = iapOffer != null && !hasIap,
         iapPrice = iapOffer?.formattedPrice,
         wasPreviouslyPro = wasPreviouslyPro,
+        restoreInProgress = restoreInProgress,
     )
 }
 

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
@@ -65,12 +65,15 @@ class UpgradeViewModel @Inject constructor(
             .launchInViewModel()
     }
 
+    private val restoring = MutableStateFlow(false)
+
     internal val state: StateFlow<GplayUpgradeUiState> = combine(
         querySkuDetails(OurSku.Iap.PRO_UPGRADE),
         querySkuDetails(OurSku.Sub.PRO_UPGRADE),
         upgradeRepo.upgradeInfo,
         upgradeRepo.wasEverPro,
-    ) { iap, sub, current, wasEverPro ->
+        restoring,
+    ) { iap, sub, current, wasEverPro, isRestoring ->
         val serviceUnavailableError = if (iap == null && sub == null) {
             GplayServiceUnavailableException(RuntimeException("IAP and SUB data request timed out."))
         } else {
@@ -106,6 +109,7 @@ class UpgradeViewModel @Inject constructor(
             hasIap = current.upgrades.any { it.sku == OurSku.Iap.PRO_UPGRADE },
             hasSub = current.upgrades.any { it.sku == OurSku.Sub.PRO_UPGRADE },
             wasPreviouslyPro = wasEverPro && !current.isPro,
+            restoreInProgress = isRestoring,
         )
     }.safeStateIn(
         initialValue = GplayUpgradeUiState.Loading,
@@ -154,10 +158,31 @@ class UpgradeViewModel @Inject constructor(
     }
 
     fun restorePurchase() = launch {
+        // Single-flight: repeated taps while a restore is running (worst case bounded by
+        // RESTORE_TIMEOUT_MS) must not stack concurrent restores and duplicate result dialogs.
+        if (!restoring.compareAndSet(expect = false, update = true)) {
+            log(TAG) { "restorePurchase() ignored, already in progress" }
+            return@launch
+        }
         log(TAG) { "restorePurchase()" }
 
-        val restored = try {
-            withTimeoutOrNull(RESTORE_TIMEOUT_MS) { upgradeRepo.restorePurchaseNow() }
+        try {
+            val restored = withTimeoutOrNull(RESTORE_TIMEOUT_MS) { upgradeRepo.restorePurchaseNow() }
+            when {
+                restored == null -> {
+                    // Play never answered in time; the restore-failed dialog already suggests waiting /
+                    // clearing the Play cache, which fits a timeout too.
+                    log(TAG, WARN) { "Restore purchase timed out" }
+                    events.tryEmit(UpgradeEvents.RestoreFailed)
+                }
+
+                restored.isPro -> log(TAG, INFO) { "Restored purchase :))" }
+
+                else -> {
+                    log(TAG, WARN) { "Restore purchase failed" }
+                    events.tryEmit(UpgradeEvents.RestoreFailed)
+                }
+            }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -165,23 +190,9 @@ class UpgradeViewModel @Inject constructor(
             // of the generic "restore failed" message, so the user can tell the two cases apart.
             log(TAG, WARN) { "Restore purchase errored: ${e.asLog()}" }
             errorEvents.tryEmit(e)
-            return@launch
-        }
-
-        when {
-            restored == null -> {
-                // Play never answered in time; the restore-failed dialog already suggests waiting /
-                // clearing the Play cache, which fits a timeout too.
-                log(TAG, WARN) { "Restore purchase timed out" }
-                events.tryEmit(UpgradeEvents.RestoreFailed)
-            }
-
-            restored.isPro -> log(TAG, INFO) { "Restored purchase :))" }
-
-            else -> {
-                log(TAG, WARN) { "Restore purchase failed" }
-                events.tryEmit(UpgradeEvents.RestoreFailed)
-            }
+        } finally {
+            // Reset only after result handling, so the single-flight guard covers the whole action.
+            restoring.value = false
         }
     }
 

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/ui/GplayUpgradeScreenTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/ui/GplayUpgradeScreenTest.kt
@@ -146,6 +146,26 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
 
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_RESTORE_BANNER).assertCountEquals(0)
     }
+
+    @Test
+    fun `both restore affordances are disabled while a restore is running`() {
+        composeRule.setUpgradeContent {
+            UpgradeScreen(
+                uiState = GplayUpgradeUiState.Loaded(
+                    subscriptionAction = SubscriptionAction.STANDARD,
+                    subscriptionEnabled = true,
+                    subscriptionPrice = "$12.99",
+                    iapEnabled = true,
+                    iapPrice = "$24.99",
+                    wasPreviouslyPro = true,
+                    restoreInProgress = true,
+                ),
+            )
+        }
+
+        composeRule.onNodeWithTag(UpgradeScreenTags.GPLAY_RESTORE_BANNER_ACTION).assertIsNotEnabled()
+        composeRule.onNodeWithTag(UpgradeScreenTags.GPLAY_RESTORE).assertIsNotEnabled()
+    }
 }
 
 private fun ComposeContentTestRule.setUpgradeContent(

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/ui/GplayUpgradeViewModelTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/ui/GplayUpgradeViewModelTest.kt
@@ -172,4 +172,35 @@ class GplayUpgradeViewModelTest : BaseTest() {
 
         loaded.await().wasPreviouslyPro shouldBe false
     }
+
+    @Test
+    fun `restore is single-flight, taps during a running restore are ignored`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        coEvery { repo.restorePurchaseNow() } coAnswers {
+            delay(5_000)
+            UpgradeRepoGplay.Info(gracePeriod = true, billingData = null)
+        }
+        val vm = buildVm(repo)
+
+        vm.restorePurchase()
+        vm.restorePurchase()
+        vm.restorePurchase()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { repo.restorePurchaseNow() }
+    }
+
+    @Test
+    fun `a finished restore allows a new attempt`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        coEvery { repo.restorePurchaseNow() } returns UpgradeRepoGplay.Info(false, null, null)
+        val vm = buildVm(repo)
+
+        vm.restorePurchase()
+        advanceUntilIdle()
+        vm.restorePurchase()
+        advanceUntilIdle()
+
+        coVerify(exactly = 2) { repo.restorePurchaseNow() }
+    }
 }


### PR DESCRIPTION
## What changed

Tapping "Restore purchase" now shows a spinner and disables the restore buttons while the check is running, instead of appearing to do nothing (the check can take several seconds if Google Play is slow). Tapping repeatedly no longer starts multiple overlapping restore attempts that could each pop their own result dialog.

## Technical Context

- Follow-up to the restore-reliability work (#2554, #2555, #2556): the restore banner made restore prominent, which made the missing in-flight feedback user-visible (worst case is the 15s restore timeout).
- A `restoring` flag in the ViewModel makes `restorePurchase()` single-flight (`MutableStateFlow.compareAndSet` guard; reset in `finally` *after* result handling so the guard covers the whole user-visible action, including dialog emission).
- The flag flows into the loaded UI state; both restore affordances disable and the banner button shows a spinner.
- The VM guard is the real protection (UI disabling can lag a dispatch turn); tests cover single-flight, re-enable after completion, and the disabled UI state.
