### PR TITLE
General: Show an error when Google Play can't start a purchase

### DIFF
--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplay.kt
@@ -4,7 +4,9 @@ import android.app.Activity
 import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
@@ -12,6 +14,7 @@ import eu.darken.sdmse.common.flow.setupCommonEventHandlers
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
 import eu.darken.sdmse.common.upgrade.core.billing.BillingData
 import eu.darken.sdmse.common.upgrade.core.billing.BillingManager
+import eu.darken.sdmse.common.upgrade.core.billing.ItemAlreadyOwnedBillingException
 import eu.darken.sdmse.common.upgrade.core.billing.PurchasedSku
 import eu.darken.sdmse.common.upgrade.core.billing.Sku
 import eu.darken.sdmse.common.upgrade.core.billing.SkuDetails
@@ -28,6 +31,7 @@ import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import java.time.Duration
 import java.time.Instant
 import javax.inject.Inject
@@ -92,12 +96,33 @@ class UpgradeRepoGplay @Inject constructor(
             try {
                 billingManager.startIapFlow(activity, sku, offer)
             } catch (e: Exception) {
-                if (e is UserCanceledBillingException) {
-                    log(TAG) { "User canceled billing flow" }
-                    return@launch
+                when {
+                    e is UserCanceledBillingException -> log(TAG) { "User canceled billing flow" }
+
+                    e is ItemAlreadyOwnedBillingException -> {
+                        // Stale local state: Play says they already own it, so tapping "buy" really
+                        // means "unlock what I own" — restore instead of showing an error.
+                        log(TAG, INFO) { "Launch says already owned -> restoring purchase" }
+                        val restored = try {
+                            withTimeoutOrNull(RESTORE_ON_OWNED_TIMEOUT_MS) { restorePurchaseNow() }
+                        } catch (re: CancellationException) {
+                            throw re
+                        } catch (re: Exception) {
+                            log(TAG, WARN) { "Restore after already-owned failed: ${re.asLog()}" }
+                            null
+                        }
+                        if (restored?.isPro != true) {
+                            // Couldn't reconcile the entitlement (pending purchase, account mismatch,
+                            // Play quirk) — fall back to the already-owned dialog with restore tips.
+                            onError(e)
+                        }
+                    }
+
+                    else -> {
+                        log(TAG) { "startIapFlow failed:${e.asLog()}" }
+                        onError(e)
+                    }
                 }
-                log(TAG) { "startIapFlow failed:${e.asLog()}" }
-                onError(e)
             }
         }
     }
@@ -219,6 +244,7 @@ class UpgradeRepoGplay @Inject constructor(
         // subscription/default window (also used when the last-owned SKU is unknown/legacy).
         val GRACE_PERIOD_MS = Duration.ofDays(7).toMillis()
         val GRACE_PERIOD_IAP_MS = Duration.ofDays(30).toMillis()
+        private const val RESTORE_ON_OWNED_TIMEOUT_MS = 15_000L
         val TAG: String = logTag("Upgrade", "Gplay", "Repo")
 
         // The SKU whose grace window applies when several are owned: the permanent one-time purchase

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManager.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManager.kt
@@ -121,10 +121,12 @@ class BillingManager @Inject constructor(
         } catch (e: Exception) {
             log(TAG, WARN) { "Failed to start IAP flow:\n${e.asLog()}" }
             // Expected environmental/user situations — user-facing handling only, no bug report.
+            // ITEM_ALREADY_OWNED is auto-handled by UpgradeRepoGplay (restore instead of error).
             val ignoredCodes = listOf(
                 BillingResponseCode.USER_CANCELED,
                 BillingResponseCode.BILLING_UNAVAILABLE,
                 BillingResponseCode.ERROR,
+                BillingResponseCode.ITEM_ALREADY_OWNED,
             )
             when {
                 e !is BillingException -> {

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManager.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManager.kt
@@ -120,7 +120,12 @@ class BillingManager @Inject constructor(
             }
         } catch (e: Exception) {
             log(TAG, WARN) { "Failed to start IAP flow:\n${e.asLog()}" }
-            val ignoredCodes = listOf(3, 6)
+            // Expected environmental/user situations — user-facing handling only, no bug report.
+            val ignoredCodes = listOf(
+                BillingResponseCode.USER_CANCELED,
+                BillingResponseCode.BILLING_UNAVAILABLE,
+                BillingResponseCode.ERROR,
+            )
             when {
                 e !is BillingException -> {
                     Bugs.report(RuntimeException("State exception for $sku, U", e))

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingConnection.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingConnection.kt
@@ -19,12 +19,14 @@ import eu.darken.sdmse.common.upgrade.core.billing.BillingManager.Companion.tryM
 import eu.darken.sdmse.common.upgrade.core.billing.Sku
 import eu.darken.sdmse.common.upgrade.core.billing.SkuDetails
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.withContext
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
@@ -188,7 +190,19 @@ data class BillingConnection(
             setProductDetailsParamsList(listOf(productDetail))
         }.build()
 
-        return client.launchBillingFlow(activity, params)
+        // launchBillingFlow must run on the main thread (documented BillingClient contract), and its
+        // RETURNED result reports whether the flow could be launched at all (DEVELOPER_ERROR,
+        // ITEM_ALREADY_OWNED, BILLING_UNAVAILABLE, ...) — failures arrive here, not as exceptions.
+        // Throw like the other client calls do, so callers can surface them instead of silence.
+        val result = withContext(Dispatchers.Main) {
+            client.launchBillingFlow(activity, params)
+        }
+        log(TAG) {
+            "launchBillingFlow(sku=$sku): code=${result.responseCode}, message=${result.debugMessage}"
+        }
+        if (!result.isSuccess) throw BillingClientException(result)
+
+        return result
     }
 
     companion object {

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplayTest.kt
@@ -1,13 +1,16 @@
 package eu.darken.sdmse.common.upgrade.core
 
+import android.app.Activity
 import com.android.billingclient.api.Purchase
 import eu.darken.sdmse.common.datastore.DataStoreValue
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
 import eu.darken.sdmse.common.upgrade.core.billing.BillingData
 import eu.darken.sdmse.common.upgrade.core.billing.BillingManager
+import eu.darken.sdmse.common.upgrade.core.billing.ItemAlreadyOwnedBillingException
 import eu.darken.sdmse.common.upgrade.core.billing.PurchasedSku
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -145,5 +148,39 @@ class UpgradeRepoGplayTest : BaseTest() {
         UpgradeRepoGplay.preferredProSku(listOf(iap))?.id shouldBe OurSku.Iap.PRO_UPGRADE.id
         UpgradeRepoGplay.preferredProSku(listOf(sub))?.id shouldBe OurSku.Sub.PRO_UPGRADE.id
         UpgradeRepoGplay.preferredProSku(emptyList()) shouldBe null
+    }
+
+    @Test fun `already-owned buy attempt silently restores the purchase instead of erroring`() = runTest2 {
+        coEvery { billingManager.startIapFlow(any(), any(), null) } throws
+            ItemAlreadyOwnedBillingException(RuntimeException("launch result"))
+        coEvery { billingManager.refresh() } returns BillingData(setOf(proPurchase()))
+
+        val errors = mutableListOf<Throwable>()
+        repo(lastProAt = 0L).launchBillingFlow(mockk<Activity>(), OurSku.Iap.PRO_UPGRADE, null) { errors.add(it) }
+
+        errors shouldBe emptyList()
+    }
+
+    @Test fun `already-owned buy attempt falls back to the error dialog when restore finds nothing`() = runTest2 {
+        coEvery { billingManager.startIapFlow(any(), any(), null) } throws
+            ItemAlreadyOwnedBillingException(RuntimeException("launch result"))
+        coEvery { billingManager.refresh() } returns BillingData(emptySet())
+
+        val errors = mutableListOf<Throwable>()
+        // Grace expired -> the restore can't rescue the entitlement either.
+        repo(lastProAt = 0L).launchBillingFlow(mockk<Activity>(), OurSku.Iap.PRO_UPGRADE, null) { errors.add(it) }
+
+        errors.single().shouldBeInstanceOf<ItemAlreadyOwnedBillingException>()
+    }
+
+    @Test fun `already-owned buy attempt falls back to the error dialog when restore itself errors`() = runTest2 {
+        coEvery { billingManager.startIapFlow(any(), any(), null) } throws
+            ItemAlreadyOwnedBillingException(RuntimeException("launch result"))
+        coEvery { billingManager.refresh() } throws RuntimeException("Play unavailable")
+
+        val errors = mutableListOf<Throwable>()
+        repo(lastProAt = 0L).launchBillingFlow(mockk<Activity>(), OurSku.Iap.PRO_UPGRADE, null) { errors.add(it) }
+
+        errors.single().shouldBeInstanceOf<ItemAlreadyOwnedBillingException>()
     }
 }

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManagerTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManagerTest.kt
@@ -59,13 +59,14 @@ class BillingManagerTest : BaseTest() {
     }
 
     @Test
-    fun `failed launch surfaces as the already-owned user error and is reported`() = runTest2 {
+    fun `already-owned launch surfaces the mapped exception without a bug report`() = runTest2 {
+        // The repo layer auto-handles this by restoring; it's an expected user state, not a defect.
         val manager = manager(BillingResponseCode.ITEM_ALREADY_OWNED)
 
         shouldThrow<ItemAlreadyOwnedBillingException> {
             manager.startIapFlow(activity, OurSku.Iap.PRO_UPGRADE, null)
         }
-        verify(exactly = 1) { Bugs.report(any()) }
+        verify(exactly = 0) { Bugs.report(any()) }
     }
 
     @Test

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManagerTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManagerTest.kt
@@ -1,0 +1,100 @@
+package eu.darken.sdmse.common.upgrade.core.billing
+
+import android.app.Activity
+import com.android.billingclient.api.BillingClient.BillingResponseCode
+import com.android.billingclient.api.BillingResult
+import eu.darken.sdmse.common.debug.Bugs
+import eu.darken.sdmse.common.upgrade.core.OurSku
+import eu.darken.sdmse.common.upgrade.core.billing.client.BillingClientException
+import eu.darken.sdmse.common.upgrade.core.billing.client.BillingConnection
+import eu.darken.sdmse.common.upgrade.core.billing.client.BillingConnectionProvider
+import io.kotest.assertions.throwables.shouldThrow
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+
+class BillingManagerTest : BaseTest() {
+
+    private val scope = CoroutineScope(Dispatchers.Unconfined)
+    private val activity = mockk<Activity>()
+
+    @BeforeEach
+    fun setup() {
+        mockkObject(Bugs)
+        justRun { Bugs.report(any()) }
+    }
+
+    @AfterEach
+    fun teardown() {
+        unmockkObject(Bugs)
+    }
+
+    private fun result(code: Int): BillingResult = BillingResult.newBuilder().setResponseCode(code).build()
+
+    // A manager whose connection fails launchBillingFlow with the given launch-result code —
+    // the path Play uses for immediate "buy" failures (returned result, not an exception).
+    private fun manager(launchFailureCode: Int): BillingManager {
+        val connection = mockk<BillingConnection>().apply {
+            coEvery { refreshPurchases() } returns emptyList()
+            every { purchases } returns emptyFlow()
+            coEvery { launchBillingFlow(any(), any(), null) } throws BillingClientException(result(launchFailureCode))
+        }
+        val provider = mockk<BillingConnectionProvider>().apply {
+            every { this@apply.connection } returns flowOf(connection)
+        }
+        return BillingManager(scope, provider)
+    }
+
+    @Test
+    fun `failed launch surfaces as the already-owned user error and is reported`() = runTest2 {
+        val manager = manager(BillingResponseCode.ITEM_ALREADY_OWNED)
+
+        shouldThrow<ItemAlreadyOwnedBillingException> {
+            manager.startIapFlow(activity, OurSku.Iap.PRO_UPGRADE, null)
+        }
+        verify(exactly = 1) { Bugs.report(any()) }
+    }
+
+    @Test
+    fun `user cancel from the launch result stays silent bug-report-wise`() = runTest2 {
+        val manager = manager(BillingResponseCode.USER_CANCELED)
+
+        shouldThrow<UserCanceledBillingException> {
+            manager.startIapFlow(activity, OurSku.Iap.PRO_UPGRADE, null)
+        }
+        verify(exactly = 0) { Bugs.report(any()) }
+    }
+
+    @Test
+    fun `billing-unavailable maps to the service error without a bug report`() = runTest2 {
+        val manager = manager(BillingResponseCode.BILLING_UNAVAILABLE)
+
+        shouldThrow<GplayServiceUnavailableException> {
+            manager.startIapFlow(activity, OurSku.Iap.PRO_UPGRADE, null)
+        }
+        verify(exactly = 0) { Bugs.report(any()) }
+    }
+
+    @Test
+    fun `developer errors are rethrown and reported`() = runTest2 {
+        val manager = manager(BillingResponseCode.DEVELOPER_ERROR)
+
+        shouldThrow<BillingClientException> {
+            manager.startIapFlow(activity, OurSku.Iap.PRO_UPGRADE, null)
+        }
+        verify(exactly = 1) { Bugs.report(any()) }
+    }
+}


### PR DESCRIPTION
## What changed

If Google Play can't start the purchase flow when you tap a buy button, SD Maid now reacts instead of silently doing nothing:

- If Play says you **already own** the upgrade, SD Maid **restores it automatically** — tapping buy while owning Pro simply unlocks it, no dialog, no extra taps. Only if that restore can't find the purchase (e.g. account mismatch) do you get the "Already purchased" dialog with restore tips.
- Any other launch failure shows the matching error message instead of silence.

## Technical Context

- Root cause: `client.launchBillingFlow()` reports immediate launch failures through its **returned** `BillingResult` (not exceptions) — and that result was discarded. Non-OK meant the buy tap failed with no dialog, no log, no bug report. The error machinery (`tryMapUserFriendly`, error strings, VM `onError`) already existed but was never fed from this path.
- `BillingConnection.launchBillingFlow` now throws `BillingClientException` on a non-OK result, consistent with its sibling methods, and logs the result.
- **ITEM_ALREADY_OWNED → auto-restore**: `UpgradeRepoGplay` catches the mapped exception and runs `restorePurchaseNow()` (15s bound). Google's docs note this code can reflect stale cached purchase info — the user's buy tap means "unlock what I own". Success is silent (the reactive Pro emission closes the upgrade screen); failure falls back to the Already-purchased dialog. Behavior upstreamed from the Octi port of this fix, hardened with the fallback (Octi's version is fire-and-forget, which would recreate the silent-failure bug if the refresh finds nothing).
- The launch call now runs on `Dispatchers.Main` per the documented BillingClient contract (it previously ran on `AppScope`/Default) — a plausible contributor to sporadic silent buy failures.
- Bug-report gating: magic `listOf(3, 6)` became named constants; `USER_CANCELED` (possible synchronous launch result, must stay silent) and `ITEM_ALREADY_OWNED` (expected, auto-handled) added.
- Behavior change to be aware of: launch-time failures that used to be silent now show dialogs — that's the fix.
- Origin: raised during a cross-review of the shared billing code lineage with Octi; the main-thread contract issue and the fallback hardening came out of the design review.
- Tests: `BillingManagerTest` (mapped exceptions, report-vs-silent gating) + `UpgradeRepoGplayTest` (already-owned → silent restore; fallback when restore finds nothing or errors).
