### PR TITLE
General: Make billing recover from Play outages and stale purchase data

### DIFF
--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplay.kt
@@ -1,6 +1,7 @@
 package eu.darken.sdmse.common.upgrade.core
 
 import android.app.Activity
+import com.android.billingclient.api.BillingClient.BillingResponseCode
 import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
@@ -26,7 +27,10 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.flow.shareIn
@@ -48,6 +52,45 @@ class UpgradeRepoGplay @Inject constructor(
     override val storeSite: String = STORE_SITE
     override val upgradeSite: String = UPGRADE_SITE
     override val betaSite: String = BETA_SITE
+
+    init {
+        // Fresh-provenance grace stamping: billingData emissions are only produced by fresh query
+        // writes or purchase events; replay can't reach this collector (subscribed before the first
+        // emission, never re-subscribes). This is what keeps a purchase completion stamping the
+        // grace cache — the reactive upgradeInfo map deliberately writes nothing anymore.
+        billingManager.billingData
+            .distinctUntilChanged()
+            .onEach {
+                try {
+                    recordProState(Info(billingData = it))
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    // A failed DataStore write must not kill this process-lifetime collector.
+                    log(TAG, WARN) { "Failed to record pro state: ${e.asLog()}" }
+                }
+            }
+            .setupCommonEventHandlers(TAG) { "proStateRecorder" }
+            .launchIn(scope)
+
+        // Async variant of the launch-result ITEM_ALREADY_OWNED case: Play told us mid-flow that the
+        // user already owns it. Reconcile silently — Play shows its own UI for purchase-sheet
+        // failures, so no app-side dialog here.
+        billingManager.purchaseFailures
+            .filter { it.responseCode == BillingResponseCode.ITEM_ALREADY_OWNED }
+            .onEach {
+                log(TAG, INFO) { "Async already-owned event -> restoring purchase" }
+                try {
+                    withTimeoutOrNull(RESTORE_ON_OWNED_TIMEOUT_MS) { restorePurchaseNow() }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    log(TAG, WARN) { "Async already-owned restore failed: ${e.asLog()}" }
+                }
+            }
+            .setupCommonEventHandlers(TAG) { "asyncAlreadyOwned" }
+            .launchIn(scope)
+    }
 
     // False until the first real billing result after process start — the window where
     // upgradeInfo below reports non-Pro even for paying users (its flow is seeded with null).
@@ -83,7 +126,9 @@ class UpgradeRepoGplay @Inject constructor(
 
     // True once we've ever confirmed a (known) Pro purchase on this install; drives the proactive
     // restore banner. Local signal only — a fresh install or switched Google account starts false.
-    val wasEverPro: Flow<Boolean> = billingCache.lastProStateAt.flow.map { it > 0 }
+    val wasEverPro: Flow<Boolean> = billingCache.lastProStateAt.flow
+        .map { it > 0 }
+        .distinctUntilChanged()
 
     fun launchBillingFlow(
         activity: Activity,
@@ -132,7 +177,10 @@ class UpgradeRepoGplay @Inject constructor(
     override suspend fun refresh() {
         log(TAG) { "refresh()" }
         try {
-            billingManager.refresh()
+            // Bounded: with unbounded connection retry, an unavailable Play would otherwise keep
+            // background callers (MainViewModel, isProSettled gates) suspended indefinitely.
+            val fresh = withTimeoutOrNull(REFRESH_TIMEOUT_MS) { billingManager.refresh() } ?: return
+            recordProState(Info(billingData = fresh))
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -148,7 +196,9 @@ class UpgradeRepoGplay @Inject constructor(
     suspend fun restorePurchaseNow(): Info {
         log(TAG) { "restorePurchaseNow()" }
         return try {
-            billingManager.refresh().toUpgradeInfo()
+            val info = billingManager.refresh().toUpgradeInfo()
+            recordProState(info)
+            info
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -166,22 +216,14 @@ class UpgradeRepoGplay @Inject constructor(
     }
 
     // Shared Pro/grace mapping used by both the reactive upgradeInfo flow and restorePurchaseNow().
-    // Only relinquishes Pro if we haven't had it for a while (grace period).
+    // Only relinquishes Pro if we haven't had it for a while (grace period). READ-ONLY: this runs on
+    // replayed shared-flow data too, so it must never stamp the grace cache — see recordProState().
     private suspend fun BillingData?.toUpgradeInfo(): Info {
         val now = System.currentTimeMillis()
         val lastProStateAt = billingCache.lastProStateAt.value()
         log(TAG) { "toUpgradeInfo(): now=$now, lastProStateAt=$lastProStateAt, data=$this" }
         return when {
-            this?.purchases?.isNotEmpty() == true -> {
-                val info = Info(billingData = this)
-                // Only a *known* Pro SKU counts as "last Pro state" — an unrecognized purchase must
-                // not refresh the grace timestamp. Prefer the permanent IAP so it drives the window.
-                preferredProSku(info.upgrades)?.let { sku ->
-                    billingCache.lastProStateAt.value(now)
-                    billingCache.lastProStateSku.value(sku.id)
-                }
-                info
-            }
+            this?.purchases?.isNotEmpty() == true -> Info(billingData = this)
 
             (now - lastProStateAt) < graceWindowMs() -> {
                 log(TAG, VERBOSE) { "We are not pro, but were recently, did GPlay try annoy us again?" }
@@ -190,6 +232,18 @@ class UpgradeRepoGplay @Inject constructor(
 
             else -> Info(billingData = this)
         }
+    }
+
+    // Persists "we saw a known Pro purchase" for the grace machinery. Callers must only pass Info
+    // built from FRESH data (returned query results, or new emissions seen by the init collector) —
+    // never from replayed flow data, so a refunded purchase can't keep re-stamping its grace window.
+    // Only a *known* Pro SKU counts; the permanent IAP is preferred so it drives the window length.
+    private suspend fun recordProState(info: Info) {
+        val sku = preferredProSku(info.upgrades) ?: return
+        // SKU before timestamp: the timestamp gates grace, the SKU only modifies its length — this
+        // order can't leave a fresh gate pointing at a stale modifier if we die between the writes.
+        billingCache.lastProStateSku.value(sku.id)
+        billingCache.lastProStateAt.value(System.currentTimeMillis())
     }
 
     // Grace window depends on what was last owned: a permanent one-time purchase gets a long window,
@@ -245,6 +299,7 @@ class UpgradeRepoGplay @Inject constructor(
         val GRACE_PERIOD_MS = Duration.ofDays(7).toMillis()
         val GRACE_PERIOD_IAP_MS = Duration.ofDays(30).toMillis()
         private const val RESTORE_ON_OWNED_TIMEOUT_MS = 15_000L
+        private const val REFRESH_TIMEOUT_MS = 30_000L
         val TAG: String = logTag("Upgrade", "Gplay", "Repo")
 
         // The SKU whose grace window applies when several are owned: the permanent one-time purchase

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManager.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManager.kt
@@ -2,6 +2,7 @@ package eu.darken.sdmse.common.upgrade.core.billing
 
 import android.app.Activity
 import com.android.billingclient.api.BillingClient.BillingResponseCode
+import com.android.billingclient.api.BillingResult
 import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.*
@@ -34,7 +35,19 @@ class BillingManager @Inject constructor(
                 log(TAG, ERROR) { "Initial purchase data refresh failed: ${e.asLog()}" }
             }
         }
-        .catch { log(TAG, ERROR) { "Unable to provide client connection:\n${it.asLog()}" } }
+        .retryWhen { cause, attempt ->
+            // Never give up terminally: the ack collector pins this shareIn forever, so WhileSubscribed
+            // can't restart a completed upstream — a swallowed terminal failure (e.g. one transient
+            // BILLING_UNAVAILABLE while Play updates itself at boot) would leave billing dead until
+            // process restart. Retry with capped backoff instead; Play recovering makes this heal.
+            if (cause is CancellationException) {
+                false
+            } else {
+                log(TAG, WARN) { "Billing connection failed (attempt=$attempt), will retry: ${cause.asLog()}" }
+                delay((30_000L * (attempt + 1)).coerceAtMost(300_000L))
+                true
+            }
+        }
         .setupCommonEventHandlers(TAG) { "connection" }
         .shareIn(scope, WhileSubscribed(3000L, 0L), replay = 1)
 
@@ -47,6 +60,10 @@ class BillingManager @Inject constructor(
     val billingData: Flow<BillingData> = purchases
         .map { BillingData(purchases = it) }
         .shareIn(scope, WhileSubscribed(3000L, 0L), replay = 1)
+
+    val purchaseFailures: Flow<BillingResult> = connection
+        .flatMapLatest { it.purchaseFailures }
+        .setupCommonEventHandlers(TAG) { "purchaseFailures" }
 
     init {
         purchases

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingConnection.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingConnection.kt
@@ -25,7 +25,9 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
@@ -55,6 +57,13 @@ data class BillingConnection(
 
         combined.sortedByDescending { it.purchaseTime }
     }.setupCommonEventHandlers(TAG) { "purchases" }
+
+    // Non-OK results from onPurchasesUpdated (e.g. async ITEM_ALREADY_OWNED after the Play sheet
+    // opened). Consumed by a single persistent collector in UpgradeRepoGplay — not an event bus.
+    val purchaseFailures: Flow<BillingResult> = purchaseEvents
+        .filterNotNull()
+        .filter { (result, _) -> !result.isSuccess }
+        .map { (result, _) -> result }
 
     private suspend fun queryPurchases(@BillingClient.ProductType type: String): Collection<Purchase> {
         val params = QueryPurchasesParams.newBuilder().apply {

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingConnectionProvider.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingConnectionProvider.kt
@@ -45,12 +45,14 @@ class BillingConnectionProvider @Inject constructor(
                     log(TAG) {
                         "onPurchasesUpdated(code=${result.responseCode}, message=${result.debugMessage}, purchases=$purchases)"
                     }
-                    purchaseEvents.value = result to purchases
                 } else {
                     log(TAG, WARN) {
                         "error: onPurchasesUpdated(code=${result.responseCode}, message=${result.debugMessage}, purchases=$purchases)"
                     }
                 }
+                // Failures are stored too: async ITEM_ALREADY_OWNED drives the auto-restore in
+                // UpgradeRepoGplay. Success-only consumers (the purchases combine) filter on result.
+                purchaseEvents.value = result to purchases
             }
         }.build()
 

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplayTest.kt
@@ -11,11 +11,17 @@ import eu.darken.sdmse.common.upgrade.core.billing.PurchasedSku
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+import com.android.billingclient.api.BillingClient.BillingResponseCode
+import com.android.billingclient.api.BillingResult
 import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.coVerifyOrder
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
@@ -28,21 +34,32 @@ class UpgradeRepoGplayTest : BaseTest() {
     private val scope = CoroutineScope(Dispatchers.Unconfined)
     private val billingManager = mockk<BillingManager>()
     private val billingCache = mockk<BillingCache>()
+    private lateinit var lastProAtMock: DataStoreValue<Long>
+    private lateinit var lastProSkuMock: DataStoreValue<String>
 
-    // Builds a repo whose stored last-Pro timestamp is `lastProAt`. billingData is stubbed only
-    // because the upgradeInfo flow references it at construction; it is never collected here.
-    private fun repo(lastProAt: Long, lastSku: String = ""): UpgradeRepoGplay {
-        every { billingManager.billingData } returns flowOf(BillingData(emptySet()))
-        val lastPro = mockk<DataStoreValue<Long>>(relaxed = true).apply {
+    // Builds a repo whose stored last-Pro timestamp is `lastProAt`. The Unconfined scope runs the
+    // init collectors (grace stamping, async already-owned) eagerly against the stubbed flows.
+    private fun repo(
+        lastProAt: Long,
+        lastSku: String = "",
+        billingData: BillingData = BillingData(emptySet()),
+        purchaseFailures: List<BillingResult> = emptyList(),
+    ): UpgradeRepoGplay {
+        every { billingManager.billingData } returns flowOf(billingData)
+        every { billingManager.purchaseFailures } returns
+            if (purchaseFailures.isEmpty()) emptyFlow() else flowOf(*purchaseFailures.toTypedArray())
+        lastProAtMock = mockk<DataStoreValue<Long>>(relaxed = true).apply {
             every { flow } returns flowOf(lastProAt)
         }
-        every { billingCache.lastProStateAt } returns lastPro
-        val lastProSku = mockk<DataStoreValue<String>>(relaxed = true).apply {
+        every { billingCache.lastProStateAt } returns lastProAtMock
+        lastProSkuMock = mockk<DataStoreValue<String>>(relaxed = true).apply {
             every { flow } returns flowOf(lastSku)
         }
-        every { billingCache.lastProStateSku } returns lastProSku
+        every { billingCache.lastProStateSku } returns lastProSkuMock
         return UpgradeRepoGplay(scope, billingManager, billingCache)
     }
+
+    private fun result(code: Int): BillingResult = BillingResult.newBuilder().setResponseCode(code).build()
 
     private fun proPurchase() = mockk<Purchase>().apply {
         every { products } returns OurSku.PRO_SKUS.map { it.id }
@@ -182,5 +199,55 @@ class UpgradeRepoGplayTest : BaseTest() {
         repo(lastProAt = 0L).launchBillingFlow(mockk<Activity>(), OurSku.Iap.PRO_UPGRADE, null) { errors.add(it) }
 
         errors.single().shouldBeInstanceOf<ItemAlreadyOwnedBillingException>()
+    }
+
+    @Test fun `explicit restore stamps the grace cache, sku before timestamp`() = runTest2 {
+        coEvery { billingManager.refresh() } returns BillingData(setOf(proPurchase()))
+
+        repo(lastProAt = 0L).restorePurchaseNow().isPro shouldBe true
+
+        coVerifyOrder {
+            lastProSkuMock.update(any())
+            lastProAtMock.update(any())
+        }
+    }
+
+    @Test fun `background refresh stamps the grace cache from the fresh result`() = runTest2 {
+        coEvery { billingManager.refresh() } returns BillingData(setOf(proPurchase()))
+
+        repo(lastProAt = 0L).refresh()
+
+        coVerify(exactly = 1) { lastProAtMock.update(any()) }
+    }
+
+    @Test fun `reactive emissions stamp once via the init collector, the map never stamps`() = runTest2 {
+        // billingData carries a pro purchase: the persistent init collector stamps exactly once.
+        // Collecting upgradeInfo runs the map at least twice (onStart-null + pro data) — the map is
+        // read-only now, so if it still stamped the count would exceed one.
+        val repo = repo(lastProAt = 0L, billingData = BillingData(setOf(proPurchase())))
+
+        repo.upgradeInfo.first { it.isPro }.isPro shouldBe true
+
+        coVerify(exactly = 1) { lastProAtMock.update(any()) }
+    }
+
+    @Test fun `async already-owned purchase event triggers a silent restore`() = runTest2 {
+        coEvery { billingManager.refresh() } returns BillingData(setOf(proPurchase()))
+
+        repo(
+            lastProAt = 0L,
+            purchaseFailures = listOf(result(BillingResponseCode.ITEM_ALREADY_OWNED)),
+        )
+
+        coVerify(exactly = 1) { billingManager.refresh() }
+    }
+
+    @Test fun `other async purchase failures do not trigger a restore`() = runTest2 {
+        repo(
+            lastProAt = 0L,
+            purchaseFailures = listOf(result(BillingResponseCode.DEVELOPER_ERROR)),
+        )
+
+        coVerify(exactly = 0) { billingManager.refresh() }
     }
 }


### PR DESCRIPTION
## What changed

Three fixes that make Pro purchases and billing more reliable:

- If Google Play is briefly unavailable when SD Maid first checks billing (for example while the Play Store updates itself), billing now recovers on its own — previously it could stay broken until the app process restarted.
- If Google Play reports mid-purchase that you already own the upgrade, SD Maid now restores it automatically (the same behavior that already existed when Play reports it immediately).
- A refund now reliably ends the Pro grace period on schedule — the grace timer can no longer be extended by stale, cached billing data.

## Technical Context

Follow-up hardening from a cross-app review of the shared billing code lineage (Octi/Butler ports); all three verified in SD Maid and fixed here first as upstream.

- **Connection death (P1):** `catch{log}` + `shareIn(WhileSubscribed)` swallowed terminal connection failures, and the ack collector pins the subscription for the process lifetime — so a completed upstream could never restart. One transient `BILLING_UNAVAILABLE` at first use bricked billing for the whole process (`useConnection()` suspends behind UI timeouts, no replay value exists). Now: unbounded `retryWhen` with capped (5 min) backoff before the `shareIn`.
- **Async ITEM_ALREADY_OWNED:** `onPurchasesUpdated` failures were dropped; now stored (success-only consumers filter), exposed as `purchaseFailures`, consumed by one persistent repo collector that silently runs the existing `restorePurchaseNow()`. Only this one code is handled — Play shows its own UI for other purchase-sheet failures, so no app-side dialogs (no doubling).
- **Grace provenance:** `toUpgradeInfo()` stamped the grace cache inside the reactive map, which also runs on **replayed** shared-flow data — a refunded user's window could keep re-stamping in long-lived processes. The map is now read-only; `recordProState()` stamps only from fresh-provenance sites: the `BillingData` **returned** by `refresh()`/`restorePurchaseNow()` (covers steady owners — critical because StateFlow dedupe means unchanged query results never re-emit through the flows) plus one persistent `billingData` collector subscribed before the first emission (covers purchase completions; replay can't reach it). SKU is written before the timestamp (crash between the two writes can no longer pair a fresh grace gate with a stale window length).
- Background `refresh()` bounded at 30s (unbounded connection retry would otherwise suspend `isProSettled` gates indefinitely); `wasEverPro` gains `distinctUntilChanged`.
- **Review guidance:** the subtle part is fix 3's stamping sites — see the `recordProState` doc comment for the provenance argument. The naive "stamp in a distinct-collector only" design has a regression (steady owners never re-stamp) that the returned-data sites prevent.
- Tests: stamp order, refresh/restore stamping, map-never-stamps (exact update-count), async already-owned → restore, other async codes ignored.
