### PR TITLE
General: Reconnect billing instantly on user actions and fix trial wording

### DIFF
--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManager.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManager.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.flow.SharingStarted.Companion.WhileSubscribed
+import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -26,6 +27,10 @@ class BillingManager @Inject constructor(
     @AppScope private val scope: CoroutineScope,
     connectionProvider: BillingConnectionProvider,
 ) {
+
+    // Wakes a pending connection-retry backoff early. Zero replay: kicks fired while no retry is
+    // waiting are dropped, so a healthy connection can't accumulate stale wake-ups.
+    private val connectionKick = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
 
     private val connection = connectionProvider.connection
         .onEach {
@@ -44,7 +49,11 @@ class BillingManager @Inject constructor(
                 false
             } else {
                 log(TAG, WARN) { "Billing connection failed (attempt=$attempt), will retry: ${cause.asLog()}" }
-                delay((30_000L * (attempt + 1)).coerceAtMost(300_000L))
+                val backoff = (30_000L * (attempt + 1)).coerceAtMost(300_000L)
+                // Interruptible backoff: an explicit billing action (restore tap, app-open refresh)
+                // wakes the retry immediately — the user may have just fixed Play, don't make them
+                // wait out up to 5 minutes for us to notice.
+                withTimeoutOrNull(backoff) { connectionKick.first() }
                 true
             }
         }
@@ -118,10 +127,14 @@ class BillingManager @Inject constructor(
             .launchIn(scope)
     }
 
-    private suspend fun <T> useConnection(action: suspend BillingConnection.() -> T): T = connection
-        .map { action(it) }
-        .take(1)
-        .single()
+    private suspend fun <T> useConnection(action: suspend BillingConnection.() -> T): T {
+        // Every explicit billing operation counts as a user-driven "try again NOW".
+        connectionKick.tryEmit(Unit)
+        return connection
+            .map { action(it) }
+            .take(1)
+            .single()
+    }
 
     suspend fun querySkus(vararg skus: Sku): Collection<SkuDetails> = useConnection {
         log(TAG) { "querySkus(): $skus..." }

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeScreen.kt
@@ -144,7 +144,16 @@ internal fun UpgradeScreen(
                 title = stringResource(R.string.upgrade_screen_how_title),
                 icon = Icons.TwoTone.Payments,
             ) {
-                UpgradeSectionBody(text = stringResource(R.string.upgrade_screen_how_body))
+                // Only promise the 14-day trial when Play actually returned the trial offer —
+                // otherwise the static copy contradicts the plain "Subscribe" button next to it.
+                val trialAvailable = uiState is GplayUpgradeUiState.Loaded &&
+                    uiState.subscriptionAction == SubscriptionAction.TRIAL
+                UpgradeSectionBody(
+                    text = stringResource(
+                        if (trialAvailable) R.string.upgrade_screen_how_body
+                        else R.string.upgrade_screen_how_body_no_trial
+                    )
+                )
             }
 
             UpgradeActionCard {

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
@@ -103,6 +103,12 @@ class UpgradeViewModel @Inject constructor(
             return@combine GplayUpgradeUiState.Unavailable(serviceUnavailableError)
         }
 
+        // Diagnosability: distinguishes "Play withheld the trial offer" from "offer matching failed"
+        // when users report a missing trial (see upgrade_screen_how_body_no_trial fallback).
+        sub?.firstOrNull()?.details?.subscriptionOfferDetails?.let { offers ->
+            log(TAG) { "Subscription offers from Play: ${offers.map { "${it.basePlanId}/${it.offerId}" }}" }
+        }
+
         toLoadedState(
             iap = iap?.firstOrNull(),
             sub = sub?.firstOrNull(),

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -26,6 +26,7 @@
     <string name="upgrade_screen_benefits_body">• Clean app caches and expendable data\n• Remove duplicate files\n• Enable scheduled cleanups\n• Create custom filters and cleanup rules\n• Track storage trends and cleanup history\n• More features and controls across the app\n• Support continued development</string>
     <string name="upgrade_screen_how_title">Options</string>
     <string name="upgrade_screen_how_body">You can choose between a one-time purchase and a cheaper yearly subscription.\nThe subscription starts with a free 14-day trial, after which you\'ll be charged once per year. Trial and subscription are cancellable at any time.\nSame features, just different pricing models.</string>
+    <string name="upgrade_screen_how_body_no_trial">You can choose between a one-time purchase and a cheaper yearly subscription.\nThe subscription is charged once per year and is cancellable at any time.\nSame features, just different pricing models.</string>
     <string name="upgrade_screen_subscription_offer_title">Yearly subscription</string>
     <string name="upgrade_screen_iap_offer_title">Buy once</string>
     <string name="upgrade_screen_offer_recommended">Recommended</string>

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManagerTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManagerTest.kt
@@ -9,6 +9,7 @@ import eu.darken.sdmse.common.upgrade.core.billing.client.BillingClientException
 import eu.darken.sdmse.common.upgrade.core.billing.client.BillingConnection
 import eu.darken.sdmse.common.upgrade.core.billing.client.BillingConnectionProvider
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.justRun
@@ -17,9 +18,15 @@ import io.mockk.mockkObject
 import io.mockk.unmockkObject
 import io.mockk.verify
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.currentTime
+import kotlinx.coroutines.test.runCurrent
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -97,5 +104,50 @@ class BillingManagerTest : BaseTest() {
             manager.startIapFlow(activity, OurSku.Iap.PRO_UPGRADE, null)
         }
         verify(exactly = 1) { Bugs.report(any()) }
+    }
+
+    // A provider whose first connection attempt fails; subsequent attempts succeed. Drives the
+    // retryWhen backoff in BillingManager.connection under virtual time.
+    private fun flakyProvider(connection: BillingConnection): BillingConnectionProvider {
+        var attempts = 0
+        return mockk<BillingConnectionProvider>().apply {
+            every { this@apply.connection } returns flow {
+                if (attempts++ == 0) throw BillingException("first connect fails")
+                emit(connection)
+            }
+        }
+    }
+
+    private fun healthyConnection(): BillingConnection = mockk<BillingConnection>().apply {
+        coEvery { refreshPurchases() } returns emptyList()
+        // Must emit (not emptyFlow): billingData.first() in these tests completes on this emission.
+        every { purchases } returns flowOf(emptyList())
+    }
+
+    @Test
+    fun `connection retry waits out its backoff when nothing kicks it`() = runTest2 {
+        val manager = BillingManager(backgroundScope, flakyProvider(healthyConnection()))
+
+        val t0 = currentTime
+        manager.billingData.first()
+
+        // First backoff is 30s; a passive subscriber sits it out (virtual time auto-advances).
+        (currentTime - t0 >= 30_000) shouldBe true
+    }
+
+    @Test
+    fun `an explicit billing action wakes the connection retry out of its backoff`() = runTest2 {
+        val manager = BillingManager(backgroundScope, flakyProvider(healthyConnection()))
+
+        // Passive subscriber triggers the first (failing) attempt; the retry enters its backoff.
+        val warmup = backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            manager.billingData.first()
+        }
+        runCurrent()
+
+        val t0 = currentTime
+        manager.refresh() // useConnection kicks the backoff -> immediate reconnect
+        (currentTime - t0 < 30_000) shouldBe true
+        warmup.join()
     }
 }

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/ui/GplayUpgradeScreenTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/ui/GplayUpgradeScreenTest.kt
@@ -32,7 +32,7 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
         composeRule.onAllNodesWithTag(UpgradeScreenTags.ACTIONS).assertCountEquals(0)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_preamble)).assertCountEquals(1)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_benefits_title)).assertCountEquals(1)
-        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_how_body)).assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_how_body_no_trial)).assertCountEquals(1)
     }
 
     @Test
@@ -104,7 +104,7 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_UNAVAILABLE).assertCountEquals(1)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_offers_unavailable_message)).assertCountEquals(1)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_benefits_title)).assertCountEquals(1)
-        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_how_body)).assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_how_body_no_trial)).assertCountEquals(1)
     }
 
     @Test
@@ -165,6 +165,42 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
 
         composeRule.onNodeWithTag(UpgradeScreenTags.GPLAY_RESTORE_BANNER_ACTION).assertIsNotEnabled()
         composeRule.onNodeWithTag(UpgradeScreenTags.GPLAY_RESTORE).assertIsNotEnabled()
+    }
+
+    @Test
+    fun `options copy promises the trial only when Play returned the trial offer`() {
+        composeRule.setUpgradeContent {
+            UpgradeScreen(
+                uiState = GplayUpgradeUiState.Loaded(
+                    subscriptionAction = SubscriptionAction.TRIAL,
+                    subscriptionEnabled = true,
+                    subscriptionPrice = "$12.99",
+                    iapEnabled = true,
+                    iapPrice = "$24.99",
+                ),
+            )
+        }
+
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_how_body)).assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_how_body_no_trial)).assertCountEquals(0)
+    }
+
+    @Test
+    fun `options copy drops the trial promise when only the base offer is available`() {
+        composeRule.setUpgradeContent {
+            UpgradeScreen(
+                uiState = GplayUpgradeUiState.Loaded(
+                    subscriptionAction = SubscriptionAction.STANDARD,
+                    subscriptionEnabled = true,
+                    subscriptionPrice = "$12.99",
+                    iapEnabled = true,
+                    iapPrice = "$24.99",
+                ),
+            )
+        }
+
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_how_body_no_trial)).assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_how_body)).assertCountEquals(0)
     }
 }
 


### PR DESCRIPTION
## What changed

Two follow-ups from the live outage test and the cross-app billing review:

- If Google Play was unavailable and you just fixed it (signed in, updated the Play Store), tapping "Restore purchase" or reopening the app now reconnects **immediately** — previously the app waited out its retry timer (up to 5 minutes, ~4 minutes measured live) before noticing Play was back.
- The upgrade screen no longer promises a "free 14-day trial" in its text when Google Play doesn't actually offer the trial — the copy now matches the button.

## Technical Context

- **Interruptible backoff:** the connection retry's `delay(backoff)` became `withTimeoutOrNull(backoff) { kick.first() }`; `useConnection()` fires the zero-replay kick on every explicit billing operation (restore, refresh, SKU query, buy). Kicks with no retry waiting are dropped — a healthy connection can't accumulate stale wake-ups. Verified with virtual-time tests: a passive subscriber waits the full 30s backoff; an explicit `refresh()` completes without advancing the clock.
- **Trial copy:** `upgrade_screen_how_body` (static 14-day-trial promise) now only renders when `subscriptionAction == TRIAL`; a new `upgrade_screen_how_body_no_trial` variant covers Loading/Unavailable/base-offer-only states. Subscription offer ids returned by Play are logged, so "Play withheld the trial" vs "offer matching failed" is diagnosable from debug logs.
- The recovery-latency gap was quantified during the live smoke test of #2561 (Play re-enabled → same-process heal after ~4 min); this closes it for user-driven actions. Background recovery keeps the capped backoff.
- New string needs translation in the next Crowdin cycle (same as the restore-banner strings).
- Note for the maintainer: worth checking the Play Console trial-offer eligibility config — a fresh account not being offered the trial was observed in the sibling app's test.
