### PR TITLE
General: Fix Google Play billing getting stuck and missing purchases

### DIFF
--- a/app-common/src/main/res/values/strings.xml
+++ b/app-common/src/main/res/values/strings.xml
@@ -37,6 +37,7 @@
     <string name="general_error_label">Error</string>
     <string name="general_upgrade_action">Upgrade</string>
     <string name="general_refresh_action">Refresh</string>
+    <string name="general_retry_action">Retry</string>
     <string name="general_progress_searching">Searching</string>
     <string name="general_progress_generating_searchpaths">Generating search paths</string>
     <string name="general_progress_filtering">Filtering</string>

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/BillingCache.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/BillingCache.kt
@@ -3,8 +3,13 @@ package eu.darken.sdmse.common.upgrade.core
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.sdmse.common.datastore.basicReader
+import eu.darken.sdmse.common.datastore.basicWriter
 import eu.darken.sdmse.common.datastore.createValue
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -19,6 +24,28 @@ class BillingCache @Inject constructor(
     private val dataStore: DataStore<Preferences>
         get() = context.dataStore
 
-    val lastProStateAt = dataStore.createValue("gplay.cache.lastProAt", 0L)
-    val lastProStateSku = dataStore.createValue("gplay.cache.lastProSku", "")
+    // Raw keys shared between the DataStoreValues and stampLastProState's transaction — one
+    // source of truth for key name and encoding.
+    private val lastProStateAtKey = longPreferencesKey("gplay.cache.lastProAt")
+    private val lastProStateSkuKey = stringPreferencesKey("gplay.cache.lastProSku")
+
+    val lastProStateAt = dataStore.createValue(
+        key = lastProStateAtKey,
+        reader = basicReader(0L),
+        writer = basicWriter(),
+    )
+    val lastProStateSku = dataStore.createValue(
+        key = lastProStateSkuKey,
+        reader = basicReader(""),
+        writer = basicWriter(),
+    )
+
+    // One transaction for both values: the timestamp gates the grace period and the SKU modifies
+    // its window length — they must never be observable half-updated.
+    suspend fun stampLastProState(skuId: String, at: Long) {
+        dataStore.edit { prefs ->
+            prefs[lastProStateSkuKey] = skuId
+            prefs[lastProStateAtKey] = at
+        }
+    }
 }

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplay.kt
@@ -22,10 +22,12 @@ import eu.darken.sdmse.common.upgrade.core.billing.SkuDetails
 import eu.darken.sdmse.common.upgrade.core.billing.UserCanceledBillingException
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.launchIn
@@ -35,6 +37,8 @@ import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeoutOrNull
 import java.time.Duration
 import java.time.Instant
@@ -53,16 +57,26 @@ class UpgradeRepoGplay @Inject constructor(
     override val upgradeSite: String = UPGRADE_SITE
     override val betaSite: String = BETA_SITE
 
+    // Coalescing single-flight for the invisible already-owned recoveries: overlapping triggers
+    // (async Play event racing a buy tap's launch result) join the SAME restore instead of
+    // stacking concurrent Play queries. Busy state is exact because at most one job runs.
+    private val autoRestoreLock = Mutex()
+    private var autoRestoreJob: Deferred<Info?>? = null
+    private val autoRestoreState = MutableStateFlow(false)
+
+    // The already-owned auto-restores run invisibly on AppScope; expose their busy state so the
+    // UI can pause entitlement actions instead of racing them with a manual restore or a buy.
+    val autoRestoreBusy: Flow<Boolean> = autoRestoreState
+
     init {
-        // Fresh-provenance grace stamping: billingData emissions are only produced by fresh query
-        // writes or purchase events; replay can't reach this collector (subscribed before the first
-        // emission, never re-subscribes). This is what keeps a purchase completion stamping the
-        // grace cache — the reactive upgradeInfo map deliberately writes nothing anymore.
-        billingManager.billingData
-            .distinctUntilChanged()
-            .onEach {
+        // Grace bookkeeping is driven by *fresh* Play data only: freshBillingData emissions each
+        // represent an actual Play round-trip (per-connection/manual query results, completed
+        // purchase events) — never the replayed billingData/upgradeInfo flows, whose old data
+        // must not keep re-stamping the grace window (e.g. after a refund).
+        billingManager.freshBillingData
+            .onEach { fresh ->
                 try {
-                    recordProState(Info(billingData = it))
+                    stampLastProState(fresh)
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Exception) {
@@ -73,32 +87,24 @@ class UpgradeRepoGplay @Inject constructor(
             .setupCommonEventHandlers(TAG) { "proStateRecorder" }
             .launchIn(scope)
 
-        // Async variant of the launch-result ITEM_ALREADY_OWNED case: Play told us mid-flow that the
-        // user already owns it. Reconcile silently — Play shows its own UI for purchase-sheet
+        // Async variant of the launch-result ITEM_ALREADY_OWNED case: Play told us mid-flow that
+        // the user already owns it. Reconcile silently — Play shows its own UI for purchase-sheet
         // failures, so no app-side dialog here.
         billingManager.purchaseFailures
             .filter { it.responseCode == BillingResponseCode.ITEM_ALREADY_OWNED }
             .onEach {
                 log(TAG, INFO) { "Async already-owned event -> restoring purchase" }
-                try {
-                    withTimeoutOrNull(RESTORE_ON_OWNED_TIMEOUT_MS) { restorePurchaseNow() }
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    log(TAG, WARN) { "Async already-owned restore failed: ${e.asLog()}" }
-                }
+                autoRestore()
             }
             .setupCommonEventHandlers(TAG) { "asyncAlreadyOwned" }
             .launchIn(scope)
     }
 
-    // False until the first real billing result after process start — the window where
+    // False until the first real billing outcome after process start — the window where
     // upgradeInfo below reports non-Pro even for paying users (its flow is seeded with null).
-    // An errored lookup counts as settled: gating callers must not wait on a broken connection.
-    override val isSettled: Flow<Boolean> = billingManager.billingData
-        .map { true }
-        .catch { emit(true) }
-        .onStart { emit(false) }
+    // A failed connection attempt counts as settled: gating callers must not wait on a broken
+    // connection (the connect loop keeps retrying, but that can take arbitrarily long).
+    override val isSettled: Flow<Boolean> = billingManager.isSettled
         .distinctUntilChanged()
 
     override val upgradeInfo: Flow<Info> = billingManager.billingData
@@ -137,9 +143,15 @@ class UpgradeRepoGplay @Inject constructor(
         onError: (Throwable) -> Unit,
     ) {
         log(TAG) { "launchBillingFlow($activity,$sku)" }
+        // AppScope on purpose: the purchase flow and the already-owned recovery below must survive
+        // the upgrade screen being closed; the reactive isPro emission unlocks the app either way.
         scope.launch {
             try {
                 billingManager.startIapFlow(activity, sku, offer)
+            } catch (e: CancellationException) {
+                // Not an error: must not reach onError (spurious dialog) — rethrow for structured
+                // cancellation.
+                throw e
             } catch (e: Exception) {
                 when {
                     e is UserCanceledBillingException -> log(TAG) { "User canceled billing flow" }
@@ -148,14 +160,7 @@ class UpgradeRepoGplay @Inject constructor(
                         // Stale local state: Play says they already own it, so tapping "buy" really
                         // means "unlock what I own" — restore instead of showing an error.
                         log(TAG, INFO) { "Launch says already owned -> restoring purchase" }
-                        val restored = try {
-                            withTimeoutOrNull(RESTORE_ON_OWNED_TIMEOUT_MS) { restorePurchaseNow() }
-                        } catch (re: CancellationException) {
-                            throw re
-                        } catch (re: Exception) {
-                            log(TAG, WARN) { "Restore after already-owned failed: ${re.asLog()}" }
-                            null
-                        }
+                        val restored = autoRestore()
                         if (restored?.isPro != true) {
                             // Couldn't reconcile the entitlement (pending purchase, account mismatch,
                             // Play quirk) — fall back to the already-owned dialog with restore tips.
@@ -172,6 +177,29 @@ class UpgradeRepoGplay @Inject constructor(
         }
     }
 
+    // Bounded, silent restore for the already-owned recovery paths. Coalescing: a trigger that
+    // arrives while one is running awaits the running one. Returns null when the restore failed
+    // or timed out — never throws (except cancellation of the AWAITING caller; the job itself
+    // finishes on AppScope either way).
+    private suspend fun autoRestore(): Info? {
+        val job = autoRestoreLock.withLock {
+            autoRestoreJob?.takeIf { it.isActive } ?: scope.async {
+                autoRestoreState.value = true
+                try {
+                    withTimeoutOrNull(RESTORE_ON_OWNED_TIMEOUT_MS) { restorePurchaseNow() }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    log(TAG, WARN) { "Already-owned restore failed: ${e.asLog()}" }
+                    null
+                } finally {
+                    autoRestoreState.value = false
+                }
+            }.also { autoRestoreJob = it }
+        }
+        return job.await()
+    }
+
     suspend fun querySkus(vararg skus: Sku): Collection<SkuDetails> = billingManager.querySkus(*skus)
 
     override suspend fun refresh() {
@@ -179,8 +207,8 @@ class UpgradeRepoGplay @Inject constructor(
         try {
             // Bounded: with unbounded connection retry, an unavailable Play would otherwise keep
             // background callers (MainViewModel, isProSettled gates) suspended indefinitely.
-            val fresh = withTimeoutOrNull(REFRESH_TIMEOUT_MS) { billingManager.refresh() } ?: return
-            recordProState(Info(billingData = fresh))
+            // Grace stamping happens via the freshBillingData collector, not here.
+            withTimeoutOrNull(REFRESH_TIMEOUT_MS) { billingManager.refresh() }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -196,9 +224,7 @@ class UpgradeRepoGplay @Inject constructor(
     suspend fun restorePurchaseNow(): Info {
         log(TAG) { "restorePurchaseNow()" }
         return try {
-            val info = billingManager.refresh().toUpgradeInfo()
-            recordProState(info)
-            info
+            billingManager.refresh().toUpgradeInfo()
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -215,9 +241,31 @@ class UpgradeRepoGplay @Inject constructor(
         }
     }
 
+    // Persists "we saw a known Pro purchase" for the grace machinery. Only ever fed by the
+    // freshBillingData collector — fresh Play round-trips, never replayed flow data, so a refunded
+    // purchase can't keep re-stamping its grace window.
+    private suspend fun stampLastProState(fresh: BillingManager.FreshData) {
+        val sku = preferredProSku(Info(billingData = fresh.data).upgrades) ?: return
+        val storedSkuId = billingCache.lastProStateSku.value()
+        val storedType = OurSku.PRO_SKUS.singleOrNull { it.id == storedSkuId }?.type
+        // A non-full snapshot (purchase event, partial refresh) proves ownership of what it
+        // contains, but not the ABSENCE of anything else: it must not downgrade the grace class of
+        // a previously confirmed permanent IAP (30d) to the subscription window (7d). Only a full
+        // snapshot, where Play confirmed the IAP is really gone, may do that.
+        val effectiveSkuId = if (
+            !fresh.isFullSnapshot && storedType == Sku.Type.IAP && sku.type != Sku.Type.IAP
+        ) {
+            storedSkuId
+        } else {
+            sku.id
+        }
+        log(TAG, VERBOSE) { "Fresh Pro state confirmed by $sku, stamping $effectiveSkuId" }
+        billingCache.stampLastProState(effectiveSkuId, System.currentTimeMillis())
+    }
+
     // Shared Pro/grace mapping used by both the reactive upgradeInfo flow and restorePurchaseNow().
     // Only relinquishes Pro if we haven't had it for a while (grace period). READ-ONLY: this runs on
-    // replayed shared-flow data too, so it must never stamp the grace cache — see recordProState().
+    // replayed shared-flow data too, so it must never stamp the grace cache — see stampLastProState().
     private suspend fun BillingData?.toUpgradeInfo(): Info {
         val now = System.currentTimeMillis()
         val lastProStateAt = billingCache.lastProStateAt.value()
@@ -232,18 +280,6 @@ class UpgradeRepoGplay @Inject constructor(
 
             else -> Info(billingData = this)
         }
-    }
-
-    // Persists "we saw a known Pro purchase" for the grace machinery. Callers must only pass Info
-    // built from FRESH data (returned query results, or new emissions seen by the init collector) —
-    // never from replayed flow data, so a refunded purchase can't keep re-stamping its grace window.
-    // Only a *known* Pro SKU counts; the permanent IAP is preferred so it drives the window length.
-    private suspend fun recordProState(info: Info) {
-        val sku = preferredProSku(info.upgrades) ?: return
-        // SKU before timestamp: the timestamp gates grace, the SKU only modifies its length — this
-        // order can't leave a fresh gate pointing at a stale modifier if we die between the writes.
-        billingCache.lastProStateSku.value(sku.id)
-        billingCache.lastProStateAt.value(System.currentTimeMillis())
     }
 
     // Grace window depends on what was last owned: a permanent one-time purchase gets a long window,

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManager.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManager.kt
@@ -15,9 +15,13 @@ import eu.darken.sdmse.common.upgrade.core.billing.client.BillingConnection
 import eu.darken.sdmse.common.upgrade.core.billing.client.BillingConnectionProvider
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.flow.SharingStarted.Companion.WhileSubscribed
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -28,40 +32,113 @@ class BillingManager @Inject constructor(
     connectionProvider: BillingConnectionProvider,
 ) {
 
-    // Wakes a pending connection-retry backoff early. Zero replay: kicks fired while no retry is
-    // waiting are dropped, so a healthy connection can't accumulate stale wake-ups.
-    private val connectionKick = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    // Fresh Play data plus its provenance: a query result covers owned products of the queried
+    // types, while a purchase event only carries the products of that transaction — consumers
+    // deciding between per-SKU behaviors (like grace windows) need to know the difference.
+    data class FreshData(
+        val data: BillingData,
+        val isFullSnapshot: Boolean,
+    )
 
-    private val connection = connectionProvider.connection
-        .onEach {
-            try {
-                it.refreshPurchases()
-            } catch (e: Exception) {
-                log(TAG, ERROR) { "Initial purchase data refresh failed: ${e.asLog()}" }
+    // Bumped whenever someone actively wants billing NOW (see useConnection): a pending reconnect
+    // backoff is cut short instead of making the user wait out the timer. A generation counter
+    // (compared against the value captured at attempt start) instead of an event flow, so demand
+    // arriving while a connection attempt is still in flight isn't lost, while demand that was
+    // already satisfied by a healthy connection can't skip a future backoff.
+    private val connectionDemand = MutableStateFlow(0)
+
+    // Highest demand generation whose useConnection call already terminated (served, failed, or
+    // cancelled): settled demand must not skip a backoff after a later disconnect.
+    private val servedDemand = MutableStateFlow(0)
+
+    // Signalled when an action fails with a response code that means the current connection is
+    // dead (binder gone) — Play doesn't always deliver onBillingServiceDisconnected, and a dead
+    // connection must not stay installed for later callers.
+    private val invalidations = Channel<Unit>(Channel.CONFLATED)
+
+    // The currently usable connection, null while (re)connecting. Nulled BEFORE any backoff, so a
+    // dead connection is unreachable by construction — no replay cache to serve stale clients.
+    private val connectionHolder = MutableStateFlow<BillingConnection?>(null)
+
+    // First real billing outcome after process start, success OR failure. The connect loop
+    // swallows connection errors (it retries forever), so downstream flows just stay quiet during
+    // an outage — gates that used to observe a propagated error need this explicit signal.
+    private val settledOnce = MutableStateFlow(false)
+    val isSettled: Flow<Boolean> = settledOnce
+
+    init {
+        // The connect loop: owns ALL retry policy. Deliberately NOT wrapped in
+        // setupCommonEventHandlers — its catch{} swallows cancellations, and this loop must die
+        // with the scope, not retry through it.
+        scope.launch {
+            var failStreak = 0
+            while (true) {
+                val demandAtStart = connectionDemand.value
+                // Drain invalidations from the previous connection's lifetime: a signal referring
+                // to an already-dead connection must not kill the upcoming attempt. (A racing
+                // signal between here and the watcher below costs one extra reconnect, nothing
+                // more.)
+                while (invalidations.tryReceive().isSuccess) {
+                    // drained
+                }
+                try {
+                    coroutineScope {
+                        val invalidationWatcher = launch {
+                            invalidations.receive()
+                            throw BillingException("Billing connection invalidated by a failed action")
+                        }
+                        try {
+                            connectionProvider.connection.collect { connection ->
+                                // A refresh that can't verify anything (nothing found + a query
+                                // failed) throws and counts as a connection failure — otherwise a
+                                // cold start against a broken Play would starve billingData and
+                                // isSettled forever with no retry. withTimeoutOrNull, NOT
+                                // withTimeout: TimeoutCancellationException is a
+                                // CancellationException and would kill this loop.
+                                withTimeoutOrNull(INITIAL_REFRESH_TIMEOUT_MS) {
+                                    connection.refreshPurchases()
+                                } ?: throw BillingException("Initial purchase refresh timed out")
+
+                                failStreak = 0
+                                settledOnce.value = true
+                                connectionHolder.value = connection
+                                log(TAG, INFO) { "Billing connection established" }
+                            }
+                            // The provider flow stays open for the connection's lifetime; a normal
+                            // completion means the connection is gone without an error — treat it
+                            // like one so we reconnect (with backoff, no tight loop).
+                            throw BillingException("Billing connection completed unexpectedly")
+                        } finally {
+                            invalidationWatcher.cancel()
+                        }
+                    }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    log(TAG, WARN) { "Billing connection failed: ${e.asLog()}" }
+                }
+                connectionHolder.value = null
+                settledOnce.value = true
+                // A swallowed cancellation (e.g. via a flow wrapper) must not convert scope death
+                // into another connection attempt.
+                ensureActive()
+                failStreak++
+                val backoffMs = if (failStreak >= 5) MAX_BACKOFF_MS else 2_000L shl (2 * (failStreak - 1))
+                log(TAG) { "Billing reconnect backoff: streak=$failStreak, waiting ${backoffMs}ms" }
+                // Interruptible backoff: demand that is newer than this attempt AND not yet served
+                // skips the wait — a user who just fixed their Play situation shouldn't wait out
+                // the timer. The demandAtStart comparison limits a still-waiting caller to one
+                // skip per attempt (no tight retry loop).
+                withTimeoutOrNull(backoffMs) {
+                    connectionDemand.first { it != demandAtStart && it > servedDemand.value }
+                }
             }
         }
-        .retryWhen { cause, attempt ->
-            // Never give up terminally: the ack collector pins this shareIn forever, so WhileSubscribed
-            // can't restart a completed upstream — a swallowed terminal failure (e.g. one transient
-            // BILLING_UNAVAILABLE while Play updates itself at boot) would leave billing dead until
-            // process restart. Retry with capped backoff instead; Play recovering makes this heal.
-            if (cause is CancellationException) {
-                false
-            } else {
-                log(TAG, WARN) { "Billing connection failed (attempt=$attempt), will retry: ${cause.asLog()}" }
-                val backoff = (30_000L * (attempt + 1)).coerceAtMost(300_000L)
-                // Interruptible backoff: an explicit billing action (restore tap, app-open refresh)
-                // wakes the retry immediately — the user may have just fixed Play, don't make them
-                // wait out up to 5 minutes for us to notice.
-                withTimeoutOrNull(backoff) { connectionKick.first() }
-                true
-            }
-        }
-        .setupCommonEventHandlers(TAG) { "connection" }
-        .shareIn(scope, WhileSubscribed(3000L, 0L), replay = 1)
+    }
 
-    private val purchases = connection
-        .flatMapLatest { it.purchases }
+    private val purchases = connectionHolder
+        // NOT filterNotNull(): the null emission is what detaches a dead connection's inner flows.
+        .flatMapLatest { it?.purchases ?: emptyFlow() }
         .distinctUntilChanged()
         .setupCommonEventHandlers(TAG) { "purchases" }
         .shareIn(scope, WhileSubscribed(3000L, 0L), replay = 1)
@@ -70,9 +147,21 @@ class BillingManager @Inject constructor(
         .map { BillingData(purchases = it) }
         .shareIn(scope, WhileSubscribed(3000L, 0L), replay = 1)
 
-    val purchaseFailures: Flow<BillingResult> = connection
-        .flatMapLatest { it.purchaseFailures }
+    val purchaseFailures: Flow<BillingResult> = connectionHolder
+        .flatMapLatest { it?.purchaseFailures ?: emptyFlow() }
         .setupCommonEventHandlers(TAG) { "purchaseFailures" }
+
+    // Only data that was *freshly* obtained from Play, in the connection's COMMIT ORDER: query
+    // results and completed purchase events, emitted by the reducer itself. Unlike billingData
+    // (whose shareIn replay re-serves old data to late subscribers), every emission here
+    // represents an actual Play round-trip, so consumers can safely use it for time-based
+    // bookkeeping like the Pro grace period. Eagerly: the per-connection channel has exactly one
+    // consumer — this chain — which must not depend on downstream subscribers.
+    val freshBillingData: Flow<FreshData> = connectionHolder
+        .flatMapLatest { it?.freshUpdates ?: emptyFlow() }
+        .map { FreshData(data = BillingData(purchases = it.purchases), isFullSnapshot = it.isFullSnapshot) }
+        .setupCommonEventHandlers(TAG) { "freshBillingData" }
+        .shareIn(scope, SharingStarted.Eagerly, replay = 1)
 
     init {
         purchases
@@ -93,6 +182,9 @@ class BillingManager @Inject constructor(
                             useConnection {
                                 acknowledgePurchase(it)
                             }
+                        } catch (e: CancellationException) {
+                            // AppScope death is not an acknowledgement failure.
+                            throw e
                         } catch (e: Exception) {
                             log(TAG, ERROR) { "Failed to ancknowledge purchase: $it\n${e.asLog()}" }
                         }
@@ -128,12 +220,35 @@ class BillingManager @Inject constructor(
     }
 
     private suspend fun <T> useConnection(action: suspend BillingConnection.() -> T): T {
-        // Every explicit billing operation counts as a user-driven "try again NOW".
-        connectionKick.tryEmit(Unit)
-        return connection
-            .map { action(it) }
-            .take(1)
-            .single()
+        // Every caller here is active demand (opening the upgrade screen, restore/buy taps,
+        // purchase acks) — cut a pending reconnect backoff short. A no-op while healthy.
+        val demandGen = connectionDemand.updateAndGet { it + 1 }
+        var used: BillingConnection? = null
+        try {
+            val connection = connectionHolder.filterNotNull().first().also { used = it }
+            return connection.action()
+        } catch (e: Exception) {
+            // These codes mean the binder is gone. Play doesn't reliably deliver
+            // onBillingServiceDisconnected for them, so uninstall the dead connection RIGHT HERE
+            // (the loop's teardown takes several dispatches — later callers must not grab the
+            // stale holder in that window) and tell the connect loop to clean up and reconnect.
+            // The failure may arrive user-friendly-mapped (e.g. GplayServiceUnavailableException
+            // from a refresh), so inspect the cause chain, not just the exception itself.
+            // CAS + identity check: a fresh replacement must not be killed for its predecessor's
+            // failure.
+            val clientError = (e as? BillingClientException) ?: (e.cause as? BillingClientException)
+            if (clientError != null && clientError.result.responseCode in INVALIDATING_CODES && used != null) {
+                if (connectionHolder.compareAndSet(used, null)) {
+                    log(TAG, WARN) { "Connection reported dead by action (${clientError.result.responseCode}), invalidating." }
+                    invalidations.trySend(Unit)
+                }
+            }
+            throw e
+        } finally {
+            // Settled on ANY termination — success, error, or the caller's own timeout/cancel: a
+            // call that is over is no longer pending demand and must not skip a later backoff.
+            servedDemand.update { served -> maxOf(served, demandGen) }
+        }
     }
 
     suspend fun querySkus(vararg skus: Sku): Collection<SkuDetails> = useConnection {
@@ -148,6 +263,10 @@ class BillingManager @Inject constructor(
             useConnection {
                 launchBillingFlow(activity, sku, offer)
             }
+        } catch (e: CancellationException) {
+            // Not an error: routing this into Bugs.report (or mapping it) would fake telemetry
+            // and break structured cancellation.
+            throw e
         } catch (e: Exception) {
             log(TAG, WARN) { "Failed to start IAP flow:\n${e.asLog()}" }
             // Expected environmental/user situations — user-facing handling only, no bug report.
@@ -174,9 +293,11 @@ class BillingManager @Inject constructor(
     suspend fun refresh(): BillingData {
         log(TAG) { "refresh()" }
         // Query in the caller's context and return the result directly, so callers get the fresh
-        // purchases (and any billing error) with a real happens-before instead of racing the shared
-        // upgradeInfo replay cache.
-        return BillingData(purchases = useConnection { refreshPurchases() })
+        // purchases (and any billing error) with a real happens-before instead of racing the
+        // shared upgradeInfo replay cache. The freshBillingData emission happens inside the
+        // reducer's commit, in commit order — not here.
+        val fresh = useConnection { refreshPurchases() }
+        return BillingData(purchases = fresh.purchases)
     }
 
     companion object {
@@ -195,6 +316,15 @@ class BillingManager @Inject constructor(
                 else -> this
             }
         }
+
+        @Suppress("DEPRECATION")
+        private val INVALIDATING_CODES = setOf(
+            BillingResponseCode.SERVICE_DISCONNECTED,
+            BillingResponseCode.SERVICE_TIMEOUT,
+        )
+
+        private const val INITIAL_REFRESH_TIMEOUT_MS = 30_000L
+        private const val MAX_BACKOFF_MS = 300_000L
 
         val TAG: String = logTag("Upgrade", "Gplay", "Billing", "Manager")
     }

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManager.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManager.kt
@@ -186,7 +186,7 @@ class BillingManager @Inject constructor(
                             // AppScope death is not an acknowledgement failure.
                             throw e
                         } catch (e: Exception) {
-                            log(TAG, ERROR) { "Failed to ancknowledge purchase: $it\n${e.asLog()}" }
+                            log(TAG, ERROR) { "Failed to acknowledge purchase: $it\n${e.asLog()}" }
                         }
                     }
             }

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingConnection.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingConnection.kt
@@ -5,71 +5,264 @@ import com.android.billingclient.api.AcknowledgePurchaseParams
 import com.android.billingclient.api.BillingClient
 import com.android.billingclient.api.BillingFlowParams
 import com.android.billingclient.api.BillingResult
+import com.android.billingclient.api.ProductDetails
 import com.android.billingclient.api.Purchase
 import com.android.billingclient.api.Purchase.PurchaseState
 import com.android.billingclient.api.QueryProductDetailsParams
-import com.android.billingclient.api.QueryProductDetailsResult
 import com.android.billingclient.api.QueryPurchasesParams
-import com.android.billingclient.api.queryPurchasesAsync
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.flow.setupCommonEventHandlers
+import eu.darken.sdmse.common.upgrade.core.OurSku
 import eu.darken.sdmse.common.upgrade.core.billing.BillingManager.Companion.tryMapUserFriendly
 import eu.darken.sdmse.common.upgrade.core.billing.Sku
 import eu.darken.sdmse.common.upgrade.core.billing.SkuDetails
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.resume
-import kotlin.coroutines.suspendCoroutine
 
-data class BillingConnection(
+class BillingConnection(
     private val client: BillingClient,
-    val purchaseEvents: Flow<Pair<BillingResult, Collection<Purchase>?>?>,
+    private val skuTypeOf: (String) -> Sku.Type? = DEFAULT_SKU_TYPE_RESOLVER,
 ) {
 
-    private val queryCacheIaps = MutableStateFlow<Collection<Purchase>?>(null)
-    private val queryCacheSubs = MutableStateFlow<Collection<Purchase>?>(null)
+    // A purchase proven by an onPurchasesUpdated success event. Additive only: events prove
+    // ownership, never absence. `gen` orders it against queries (a query that STARTED before this
+    // event must not clear it); `type` is resolved at ingestion so a later per-type query that
+    // confirms absence can supersede it (null = product unknown to this app, only a complete
+    // refresh may clear it).
+    data class OverlayEntry(
+        val purchase: Purchase,
+        val gen: Long,
+        val type: Sku.Type?,
+    )
 
-    val purchases: Flow<Collection<Purchase>> = combine(
-        purchaseEvents,
-        queryCacheIaps.filterNotNull(),
-        queryCacheSubs.filterNotNull(),
-    ) { purchaseEvent, iapCache, subCache ->
-        val combined = mutableSetOf<Purchase>()
+    // The single, atomically-updated ownership state of this connection. Split state (per-type
+    // caches, separate event flows) exposed intermediate combinations and starved on partial
+    // failures — every mutation here is a pure copy applied under `reducerLock`, so observers only
+    // ever see committed states and refreshPurchases() can return the exact state it committed.
+    data class ReducerState(
+        val iapSnapshot: Collection<Purchase>? = null,
+        val subSnapshot: Collection<Purchase>? = null,
+        val overlay: List<OverlayEntry> = emptyList(),
+        val eventGen: Long = 0L,
+    ) {
 
-        combined.addAll(iapCache)
-        combined.addAll(subCache)
+        internal fun withEvent(
+            purchased: Collection<Purchase>,
+            typeOf: (String) -> Sku.Type?,
+        ): ReducerState {
+            val gen = eventGen + 1
+            val entries = purchased.map { purchase ->
+                OverlayEntry(
+                    purchase = purchase,
+                    gen = gen,
+                    type = purchase.products.firstNotNullOfOrNull(typeOf),
+                )
+            }
+            return copy(eventGen = gen, overlay = overlay + entries)
+        }
 
-        purchaseEvent
-            ?.takeIf { (result, _) -> result.isSuccess }
-            ?.let { (_, purchases) -> purchases?.filter { it.purchaseState == PurchaseState.PURCHASED } }
-            ?.let { combined.addAll(it) }
+        internal fun withQueryResults(
+            iap: Collection<Purchase>?,
+            sub: Collection<Purchase>?,
+            genAtQueryStart: Long,
+        ): ReducerState {
+            val clearedTypes = setOfNotNull(
+                Sku.Type.IAP.takeIf { iap != null },
+                Sku.Type.SUBSCRIPTION.takeIf { sub != null },
+            )
+            val isComplete = clearedTypes.size == 2
+            return copy(
+                iapSnapshot = iap ?: iapSnapshot,
+                subSnapshot = sub ?: subSnapshot,
+                // A successful per-type query is authoritative for that type: overlay entries it
+                // could have seen (gen <= start) are superseded by its result. Entries of a FAILED
+                // type survive, as do events that arrived after the query started. Untyped entries
+                // (unknown product) only fall to a complete refresh.
+                overlay = overlay.filterNot { entry ->
+                    entry.gen <= genAtQueryStart &&
+                        (entry.type in clearedTypes || (isComplete && entry.type == null))
+                },
+            )
+        }
 
-        combined.sortedByDescending { it.purchaseTime }
-    }.setupCommonEventHandlers(TAG) { "purchases" }
+        // Never verified anything this connection: downstream must not mistake "don't know yet"
+        // for "owns nothing".
+        internal val isSettled: Boolean
+            get() = iapSnapshot != null || subSnapshot != null
+
+        // Snapshots first, overlay overwrites: a surviving overlay entry is by construction newer
+        // than the last successful query of its type (older ones were cleared), so its purchase
+        // data (ack state etc.) is fresher. purchaseToken is the real purchase identity — Purchase
+        // has no equals(), object-identity dedup would keep duplicates.
+        internal fun merged(): Collection<Purchase> {
+            val byToken = LinkedHashMap<String, Purchase>()
+            iapSnapshot.orEmpty().forEach { byToken[it.purchaseToken] = it }
+            subSnapshot.orEmpty().forEach { byToken[it.purchaseToken] = it }
+            overlay.forEach { byToken[it.purchase.purchaseToken] = it.purchase }
+            return byToken.values.sortedByDescending { it.purchaseTime }
+        }
+    }
+
+    // Fresh data straight from a Play round-trip, in COMMIT ORDER: emitted under the same lock
+    // that mutates the reducer state, so a consumer can never observe a purchase event AFTER the
+    // query commit that superseded it (or a stale snapshot after a newer event). Query emissions
+    // carry only what the queries confirmed — never retained stale data — because consumers use
+    // this for time-based bookkeeping like the Pro grace period.
+    data class FreshUpdate(
+        val purchases: Collection<Purchase>,
+        val isFullSnapshot: Boolean,
+    )
+
+    // Guards state mutation + fresh emission as one atomic step. Kept a plain monitor (not a
+    // Mutex): the listener path is synchronous on Play's callback thread.
+    private val reducerLock = Any()
+    private val state = MutableStateFlow(ReducerState())
+    // UNLIMITED: event volume is tiny and a silently dropped item would lose a grace stamp or an
+    // already-owned recovery. Closed by the provider when the connection dies.
+    private val freshUpdatesChannel = Channel<FreshUpdate>(Channel.UNLIMITED)
+    private val failureChannel = Channel<BillingResult>(Channel.UNLIMITED)
+
+    val freshUpdates: Flow<FreshUpdate> = freshUpdatesChannel.receiveAsFlow()
 
     // Non-OK results from onPurchasesUpdated (e.g. async ITEM_ALREADY_OWNED after the Play sheet
-    // opened). Consumed by a single persistent collector in UpgradeRepoGplay — not an event bus.
-    val purchaseFailures: Flow<BillingResult> = purchaseEvents
-        .filterNotNull()
-        .filter { (result, _) -> !result.isSuccess }
-        .map { (result, _) -> result }
+    // opened). A channel, not state: events must not conflate, and a late subscriber must not be
+    // served a stale failure. Consumed by a single persistent collector chain.
+    val purchaseFailures: Flow<BillingResult> = failureChannel.receiveAsFlow()
+
+    val purchases: Flow<Collection<Purchase>> = state
+        .mapNotNull { current -> current.takeIf { it.isSettled }?.merged() }
+        .setupCommonEventHandlers(TAG) { "purchases" }
+
+    // Called synchronously from the PurchasesUpdatedListener on Play's callback thread:
+    // exactly-once per callback, ordered, and atomic with the fresh emission. Success and failure
+    // results stay strictly apart — a failure (reopened sheet -> USER_CANCELED) must not evict a
+    // fresh purchase event.
+    internal fun onPurchasesUpdated(result: BillingResult, purchases: Collection<Purchase>?) {
+        if (result.isSuccess) {
+            log(TAG) {
+                "onPurchasesUpdated(code=${result.responseCode}, message=${result.debugMessage}, purchases=$purchases)"
+            }
+            // PENDING purchases must never surface as owned (or stamp the Pro grace cache).
+            val purchased = purchases.orEmpty().filter { it.purchaseState == PurchaseState.PURCHASED }
+            synchronized(reducerLock) {
+                state.value = state.value.withEvent(purchased, skuTypeOf)
+                if (purchased.isNotEmpty()) {
+                    freshUpdatesChannel.trySend(FreshUpdate(purchased, isFullSnapshot = false))
+                }
+            }
+        } else {
+            log(TAG, WARN) {
+                "error: onPurchasesUpdated(code=${result.responseCode}, message=${result.debugMessage}, purchases=$purchases)"
+            }
+            failureChannel.trySend(result)
+        }
+    }
+
+    // Called by the provider when this connection ends: completes the event flows so consumers
+    // don't wait on a dead connection's channels.
+    internal fun close() {
+        freshUpdatesChannel.close()
+        failureChannel.close()
+    }
+
+    // The purchases of a refresh plus whether it covered both product types: a partial result (one
+    // query failed) is still authoritative for what it FOUND, but must not be treated as proof of
+    // absence for the type that couldn't be checked.
+    data class PurchaseRefresh(
+        val purchases: Collection<Purchase>,
+        val isComplete: Boolean,
+    )
+
+    // Serializes concurrent refreshes (manual, background, auto-restore): an older query that got
+    // descheduled after Play answered must not commit over a newer one's result.
+    private val refreshMutex = Mutex()
+
+    // Queries both product types and commits the result into the reducer state in ONE atomic
+    // update, then returns the merged view of exactly that committed state — so the reactive
+    // purchases flow and this return value can never disagree. Tolerant of a single product-type
+    // failure: found purchases are authoritative, and an error only propagates when nothing was
+    // found AND a query failed, so the caller can tell "not owned" apart from "couldn't verify".
+    suspend fun refreshPurchases(): PurchaseRefresh = refreshMutex.withLock {
+        coroutineScope {
+            log(TAG) { "refreshPurchases()" }
+            val genAtQueryStart = state.value.eventGen
+            val iapJob = async { queryPurchasedProducts(BillingClient.ProductType.INAPP) }
+            val subJob = async { queryPurchasedProducts(BillingClient.ProductType.SUBS) }
+            val iap = iapJob.await()
+            val sub = subJob.await()
+            log(TAG) { "Refreshed IAPs=${iap.getOrNull()}, SUBs=${sub.getOrNull()}" }
+
+            // Commit BEFORE the couldn't-verify error check: a successful per-type result is
+            // authoritative even when its sibling failed — verified absence (e.g. a refunded IAP)
+            // must not be discarded just because the SUB query errored.
+            val isComplete = iap.isSuccess && sub.isSuccess
+            val committed = synchronized(reducerLock) {
+                val next = state.value.withQueryResults(
+                    iap = iap.getOrNull(),
+                    sub = sub.getOrNull(),
+                    genAtQueryStart = genAtQueryStart,
+                )
+                state.value = next
+                if (iap.isSuccess || sub.isSuccess) {
+                    // Only what the queries CONFIRMED — retained stale data of a failed type stays
+                    // out of the fresh stream (it would keep re-stamping the grace window).
+                    val confirmed = (iap.getOrNull().orEmpty() + sub.getOrNull().orEmpty())
+                        .sortedByDescending { it.purchaseTime }
+                    freshUpdatesChannel.trySend(FreshUpdate(confirmed, isFullSnapshot = isComplete))
+                }
+                next
+            }
+
+            // Throws when nothing was found and a query failed, so the caller can tell "not
+            // owned" apart from "couldn't verify".
+            combinePurchaseResults(iap, sub)
+
+            PurchaseRefresh(
+                purchases = committed.merged(),
+                isComplete = isComplete,
+            )
+        }
+    }
+
+    // Never throws except on cancellation, so a single failing product-type query doesn't cancel
+    // the sibling query (or the coroutineScope). The exception is already user-friendly-mapped.
+    private suspend fun queryPurchasedProducts(
+        @BillingClient.ProductType type: String,
+    ): Result<Collection<Purchase>> = try {
+        Result.success(queryPurchases(type).filter { it.purchaseState == PurchaseState.PURCHASED })
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        Result.failure(e.tryMapUserFriendly())
+    }
 
     private suspend fun queryPurchases(@BillingClient.ProductType type: String): Collection<Purchase> {
         val params = QueryPurchasesParams.newBuilder().apply {
             setProductType(type)
         }.build()
-        val (billingResult, purchaseData) = client.queryPurchasesAsync(params)
+        // Own cancellable wrapper instead of the billing-ktx extension: a non-cancellable
+        // suspension would make the timeouts around refreshes hang until Play's callback fires.
+        // The onCancellation overload makes a callback racing the cancellation a no-op instead of
+        // an IllegalStateException on Play's thread.
+        val (billingResult, purchaseData) = suspendCancellableCoroutine<Pair<BillingResult, List<Purchase>>> { continuation ->
+            client.queryPurchasesAsync(params) { result, purchases ->
+                if (continuation.isActive) continuation.resume(result to purchases) { _, _, _ -> }
+            }
+        }
 
         log(TAG) {
             "queryPurchases($type): code=${billingResult.isSuccess}, message=${billingResult.debugMessage}, purchaseData=${purchaseData}"
@@ -83,43 +276,15 @@ data class BillingConnection(
         return purchaseData
     }
 
-    // Returns the freshly queried PURCHASED purchases so callers get a guaranteed happens-before
-    // relation instead of racing the shared purchases/upgradeInfo replay caches after a refresh.
-    // Tolerant of a single product-type failure: if either query finds a purchase we treat that as
-    // authoritative, and only propagate an error when nothing was found AND a query failed — so the
-    // caller can tell "not owned" apart from "couldn't verify".
-    suspend fun refreshPurchases(): Collection<Purchase> = coroutineScope {
-        log(TAG) { "refreshPurchases()" }
-        val iapJob = async { queryPurchasedProducts(BillingClient.ProductType.INAPP) { queryCacheIaps.value = it } }
-        val subJob = async { queryPurchasedProducts(BillingClient.ProductType.SUBS) { queryCacheSubs.value = it } }
-        val iap = iapJob.await()
-        val sub = subJob.await()
-        log(TAG) { "Refreshed IAPs=${iap.getOrNull()}, SUBs=${sub.getOrNull()}" }
-        combinePurchaseResults(iap, sub)
-    }
-
-    // Never throws except on cancellation, so a single failing product-type query doesn't cancel the
-    // sibling query (or the coroutineScope). The exception is already user-friendly-mapped.
-    private suspend fun queryPurchasedProducts(
-        @BillingClient.ProductType type: String,
-        cache: (Collection<Purchase>) -> Unit,
-    ): Result<Collection<Purchase>> = try {
-        val purchased = queryPurchases(type).filter { it.purchaseState == PurchaseState.PURCHASED }
-        cache(purchased)
-        Result.success(purchased)
-    } catch (e: CancellationException) {
-        throw e
-    } catch (e: Exception) {
-        Result.failure(e.tryMapUserFriendly())
-    }
-
     suspend fun acknowledgePurchase(purchase: Purchase): BillingResult {
         val ack = AcknowledgePurchaseParams.newBuilder().apply {
             setPurchaseToken(purchase.purchaseToken)
         }.build()
 
-        val ackResult = suspendCoroutine<BillingResult> { continuation ->
-            client.acknowledgePurchase(ack) { continuation.resume(it) }
+        val ackResult = suspendCancellableCoroutine<BillingResult> { continuation ->
+            client.acknowledgePurchase(ack) {
+                if (continuation.isActive) continuation.resume(it) { _, _, _ -> }
+            }
         }
         log(TAG) {
             "acknowledgePurchase(purchase=$purchase): code=${ackResult.responseCode}, message=${ackResult.debugMessage})"
@@ -149,21 +314,23 @@ data class BillingConnection(
             setProductList(productList)
         }.build()
 
-        val (result, queryResult) = suspendCoroutine<Pair<BillingResult, QueryProductDetailsResult>> { continuation ->
-            client.queryProductDetailsAsync(params) { result: BillingResult, queryResult: QueryProductDetailsResult ->
-                continuation.resume(result to queryResult)
+        // Cancellable so the ViewModel's query timeout and flatMapLatest-based retry actually work:
+        // with suspendCoroutine a missing Play callback kept the timeout suspended indefinitely.
+        val (result, details) = suspendCancellableCoroutine<Pair<BillingResult, Collection<ProductDetails>?>> { continuation ->
+            client.queryProductDetailsAsync(params) { result, queryResult ->
+                if (continuation.isActive) {
+                    continuation.resume(result to queryResult.productDetailsList) { _, _, _ -> }
+                }
             }
         }
 
-        val details = queryResult.productDetailsList
-        
         log(TAG) {
             "querySkus(skus=${skus.joinToString { it.print() }}): code=${result.responseCode}, debug=${result.debugMessage}), skuDetails=$details"
         }
 
         if (!result.isSuccess) throw BillingClientException(result)
 
-        if (details.isEmpty()) {
+        if (details.isNullOrEmpty()) {
             throw IllegalStateException("No details available for ${skus.joinToString { "${it.type}-${it.id}" }}")
         }
 
@@ -217,9 +384,18 @@ data class BillingConnection(
     companion object {
         val TAG: String = logTag("Upgrade", "Gplay", "Billing", "ClientConnection")
 
+        // Classifies event purchases by product type at ingestion, so a later per-type query can
+        // authoritatively supersede them. Unknown products stay untyped (cleared only by a
+        // complete refresh).
+        internal val DEFAULT_SKU_TYPE_RESOLVER: (String) -> Sku.Type? = { productId ->
+            OurSku.PRO_SKUS.singleOrNull { it.id == productId }?.type
+        }
+
         // Combines the two product-type query results: a purchase found by either type is
         // authoritative; an error is only propagated when nothing was found, so callers can tell
-        // "not owned" apart from "couldn't verify one product type". Pure and unit-tested.
+        // "not owned" apart from "couldn't verify one product type". Treating any found purchase
+        // as authoritative is safe because every product this app sells is a Pro SKU (see
+        // OurSku.PRO_SKUS). Pure and unit-tested.
         internal fun combinePurchaseResults(
             iap: Result<Collection<Purchase>>,
             sub: Result<Collection<Purchase>>,

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingConnection.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingConnection.kt
@@ -31,7 +31,6 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
-import kotlin.coroutines.resume
 
 class BillingConnection(
     private val client: BillingClient,

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingConnectionProvider.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingConnectionProvider.kt
@@ -6,7 +6,6 @@ import com.android.billingclient.api.BillingClient.BillingResponseCode
 import com.android.billingclient.api.BillingClientStateListener
 import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.PendingPurchasesParams
-import com.android.billingclient.api.Purchase
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
@@ -15,24 +14,30 @@ import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.flow.setupCommonEventHandlers
 import eu.darken.sdmse.common.upgrade.core.billing.BillingException
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.callbackFlow
-import kotlinx.coroutines.flow.retryWhen
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
 
+// A single connection attempt: emits one BillingConnection, stays open for its lifetime, and
+// closes with the exception on setup failure or disconnect. NO retry here — BillingManager's
+// connect loop owns all retry policy, so every wait stays interruptible by user demand (the old
+// nested retryWhen added up to ~30s of demand-blind delays before the manager ever saw a failure).
 @Singleton
 class BillingConnectionProvider @Inject constructor(
     @ApplicationContext private val context: Context,
 ) {
 
-    private val provider: Flow<BillingConnection> = callbackFlow {
-        val purchaseEvents = MutableStateFlow<Pair<BillingResult, Collection<Purchase>?>?>(null)
+    val connection: Flow<BillingConnection> = callbackFlow {
+        // The listener must exist before the client, the connection needs the client: bridge via
+        // this reference. onPurchasesUpdated can only fire for an ACTIVE connection, i.e. after
+        // setup finished and the reference was set — a null here would be a Play contract breach,
+        // and dropping such an event is the only sane response.
+        var connectionRef: BillingConnection? = null
 
         val client = BillingClient.newBuilder(context).apply {
             enablePendingPurchases(
@@ -41,31 +46,30 @@ class BillingConnectionProvider @Inject constructor(
                 }.build()
             )
             setListener { result, purchases ->
-                if (result.isSuccess) {
-                    log(TAG) {
-                        "onPurchasesUpdated(code=${result.responseCode}, message=${result.debugMessage}, purchases=$purchases)"
-                    }
-                } else {
-                    log(TAG, WARN) {
-                        "error: onPurchasesUpdated(code=${result.responseCode}, message=${result.debugMessage}, purchases=$purchases)"
-                    }
-                }
-                // Failures are stored too: async ITEM_ALREADY_OWNED drives the auto-restore in
-                // UpgradeRepoGplay. Success-only consumers (the purchases combine) filter on result.
-                purchaseEvents.value = result to purchases
+                connectionRef?.onPurchasesUpdated(result, purchases)
+                    ?: log(TAG, WARN) { "onPurchasesUpdated(code=${result.responseCode}) before setup finished?!" }
             }
         }.build()
+
+        // A never-answering Play (no setup callback at all) must fail this attempt into the
+        // manager's backoff instead of hanging it outside any timeout.
+        val setupTimeout = launch {
+            delay(SETUP_TIMEOUT_MS)
+            close(BillingException("Billing client setup timed out"))
+        }
 
         log(TAG, VERBOSE) { "startConnection(...)" }
         client.startConnection(object : BillingClientStateListener {
             override fun onBillingSetupFinished(result: BillingResult) {
+                setupTimeout.cancel()
                 log(TAG, VERBOSE) {
                     "onBillingSetupFinished(code=${result.responseCode}, message=${result.debugMessage})"
                 }
 
                 when (result.responseCode) {
                     BillingResponseCode.OK -> {
-                        val connection = BillingConnection(client, purchaseEvents)
+                        val connection = BillingConnection(client)
+                        connectionRef = connection
                         trySendBlocking(connection)
                     }
 
@@ -85,44 +89,18 @@ class BillingConnectionProvider @Inject constructor(
         awaitClose {
             try {
                 log(TAG) { "Stopping billing client connection" }
+                // Complete the event channels first so consumers stop waiting on a dead connection.
+                connectionRef?.close()
                 client.endConnection()
             } catch (e: Exception) {
                 log(TAG, WARN) { "Couldn't end billing client connection: ${e.asLog()}" }
             }
         }
-    }
-
-    val connection: Flow<BillingConnection> = provider
-        .setupCommonEventHandlers(TAG) { "provider" }
-        .retryWhen { cause, attempt ->
-            log(TAG) { "Billing client connection error: ${cause.asLog()}" }
-
-            if (cause is CancellationException) {
-                log(TAG) { "BillingClient connection cancelled." }
-                return@retryWhen false
-            }
-
-            if (cause !is BillingException) {
-                log(TAG, WARN) { "Unknown exception type: $cause" }
-                return@retryWhen false
-            }
-
-            if (cause is BillingClientException && cause.result.responseCode == BillingResponseCode.BILLING_UNAVAILABLE) {
-                log(TAG) { "Got BILLING_UNAVAILABLE while trying to connect client." }
-                return@retryWhen false
-            }
-
-            if (attempt > 5) {
-                log(TAG, WARN) { "Reached attempt limit: $attempt due to $cause" }
-                return@retryWhen false
-            }
-
-            log(TAG) { "Will retry BillingClient connection... *sigh*" }
-            delay(2000 * attempt)
-            true
-        }
+    }.setupCommonEventHandlers(TAG) { "provider" }
 
     companion object {
+        private const val SETUP_TIMEOUT_MS = 30_000L
+
         val TAG: String = logTag("Upgrade", "Gplay", "Billing", "Client", "ConnectionProvider")
     }
 }

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeScreen.kt
@@ -93,6 +93,7 @@ fun UpgradeScreenHost(
         onSubscription = { activity?.let { vm.onGoSubscription(it) } },
         onSubscriptionTrial = { activity?.let { vm.onGoSubscriptionTrial(it) } },
         onRestore = vm::restorePurchase,
+        onRetry = vm::retrySkuQuery,
         onNavigateUp = vm::navUp,
     )
 }
@@ -104,6 +105,7 @@ internal fun UpgradeScreen(
     onSubscription: () -> Unit = {},
     onSubscriptionTrial: () -> Unit = {},
     onRestore: () -> Unit = {},
+    onRetry: () -> Unit = {},
     onNavigateUp: () -> Unit = {},
 ) {
     UpgradeScreenScaffold(
@@ -168,7 +170,18 @@ internal fun UpgradeScreen(
                             title = stringResource(R.string.upgrades_gplay_unavailable_error_title),
                             body = stringResource(R.string.upgrade_screen_offers_unavailable_message),
                             icon = Icons.TwoTone.WarningAmber,
-                        )
+                        ) {
+                            // Play can be slow rather than broken (cold store, first sign-in): let
+                            // the user re-run the offer queries instead of leaving a dead screen.
+                            OutlinedButton(
+                                onClick = onRetry,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .testTag(UpgradeScreenTags.GPLAY_RETRY),
+                            ) {
+                                Text(stringResource(CommonR.string.general_retry_action))
+                            }
+                        }
                         is GplayUpgradeUiState.Loaded -> LoadedOffers(
                             uiState = state,
                             onIap = onIap,
@@ -347,9 +360,12 @@ internal fun toLoadedState(
             subOffer != null -> SubscriptionAction.STANDARD
             else -> SubscriptionAction.UNAVAILABLE
         },
-        subscriptionEnabled = (subOffer != null || subOfferTrial != null) && !hasSub,
+        // A running restore (manual or the invisible already-owned recovery) pauses the buy
+        // actions too — starting a purchase while an entitlement is being reconciled just races
+        // Play into ITEM_ALREADY_OWNED.
+        subscriptionEnabled = (subOffer != null || subOfferTrial != null) && !hasSub && !restoreInProgress,
         subscriptionPrice = subOffer?.pricingPhases?.pricingPhaseList?.lastOrNull()?.formattedPrice,
-        iapEnabled = iapOffer != null && !hasIap,
+        iapEnabled = iapOffer != null && !hasIap && !restoreInProgress,
         iapPrice = iapOffer?.formattedPrice,
         wasPreviouslyPro = wasPreviouslyPro,
         restoreInProgress = restoreInProgress,

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
@@ -18,6 +18,8 @@ import eu.darken.sdmse.common.upgrade.core.billing.GplayServiceUnavailableExcept
 import eu.darken.sdmse.common.upgrade.core.billing.Sku
 import eu.darken.sdmse.common.upgrade.core.billing.SkuDetails
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -25,9 +27,11 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
 
@@ -42,6 +46,7 @@ class UpgradeViewModel @Inject constructor(
     private val routeFlow = MutableStateFlow<UpgradeRoute?>(null)
     private var hasShownRepoError: Boolean = false
     private var hasShownServiceUnavailableError: Boolean = false
+    private var hasShownPartialQueryError: Boolean = false
     val events = SingleEventFlow<UpgradeEvents>()
 
     fun bindRoute(route: UpgradeRoute) {
@@ -66,30 +71,87 @@ class UpgradeViewModel @Inject constructor(
     }
 
     private val restoring = MutableStateFlow(false)
+    private val retryTrigger = MutableStateFlow(0)
+
+    // One aggregate query per retry generation: both SKU lookups run concurrently and land in a
+    // single Done, so the UI can never combine results from two different retry attempts.
+    private sealed interface SkuQueries {
+        data object Pending : SkuQueries
+        data class Done(
+            val iap: Result<Collection<SkuDetails>>,
+            val sub: Result<Collection<SkuDetails>>,
+        ) : SkuQueries
+    }
+
+    private val skuQueries: Flow<SkuQueries> = retryTrigger.flatMapLatest {
+        flow {
+            emit(SkuQueries.Pending)
+            val done = coroutineScope {
+                val iap = async { querySkuDetails(OurSku.Iap.PRO_UPGRADE) }
+                val sub = async { querySkuDetails(OurSku.Sub.PRO_UPGRADE) }
+                SkuQueries.Done(iap = iap.await(), sub = sub.await())
+            }
+            emit(done)
+        }
+    }
+
+    private suspend fun querySkuDetails(sku: Sku): Result<Collection<SkuDetails>> = try {
+        val details = withTimeoutOrNull(SKU_QUERY_TIMEOUT_MS) { upgradeRepo.querySkus(sku) }
+            ?: throw GplayServiceUnavailableException(RuntimeException("SKU query timed out for ${sku.id}"))
+        Result.success(details)
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        log(TAG, WARN) { "querySkuDetails($sku) failed: ${e.asLog()}" }
+        Result.failure(e)
+    }
 
     internal val state: StateFlow<GplayUpgradeUiState> = combine(
-        querySkuDetails(OurSku.Iap.PRO_UPGRADE),
-        querySkuDetails(OurSku.Sub.PRO_UPGRADE),
+        skuQueries,
         upgradeRepo.upgradeInfo,
         upgradeRepo.wasEverPro,
         restoring,
-    ) { iap, sub, current, wasEverPro, isRestoring ->
-        val serviceUnavailableError = if (iap == null && sub == null) {
-            GplayServiceUnavailableException(RuntimeException("IAP and SUB data request timed out."))
-        } else {
-            null
+        upgradeRepo.autoRestoreBusy,
+    ) { queries, current, wasEverPro, isRestoring, isAutoRestoring ->
+        if (queries is SkuQueries.Pending) {
+            // A new attempt starts a new error episode.
+            hasShownServiceUnavailableError = false
+            hasShownPartialQueryError = false
+            return@combine GplayUpgradeUiState.Loading
         }
+        queries as SkuQueries.Done
 
-        if (serviceUnavailableError != null) {
+        val iap = queries.iap.getOrNull()
+        val sub = queries.sub.getOrNull()
+
+        if (iap == null && sub == null) {
+            val serviceUnavailableError = GplayServiceUnavailableException(
+                queries.iap.exceptionOrNull() ?: RuntimeException("IAP and SUB data request failed.")
+            )
+            // This combine re-runs on every upstream change (e.g. restore progress toggling) —
+            // emit the unavailable error once per failure episode, not once per recombination.
             if (!hasShownServiceUnavailableError) {
                 hasShownServiceUnavailableError = true
                 errorEvents.tryEmit(serviceUnavailableError)
             }
+            return@combine GplayUpgradeUiState.Unavailable(serviceUnavailableError)
+        }
+        hasShownServiceUnavailableError = false
+
+        // Exactly one product type failed: keep today's behavior — show what's available, surface
+        // the failure once. No retry affordance; re-entering the screen (or the working offer)
+        // covers this, only the full Unavailable state is a dead end.
+        val partialError = queries.iap.exceptionOrNull() ?: queries.sub.exceptionOrNull()
+        if (partialError != null) {
+            if (!hasShownPartialQueryError) {
+                hasShownPartialQueryError = true
+                errorEvents.tryEmit(partialError)
+            }
         } else {
-            hasShownServiceUnavailableError = false
+            hasShownPartialQueryError = false
         }
 
-        if (serviceUnavailableError == null && !current.isPro && current.error != null) {
+        if (!current.isPro && current.error != null) {
             if (!hasShownRepoError) {
                 hasShownRepoError = true
                 @Suppress("UNNECESSARY_NOT_NULL_ASSERTION")
@@ -97,10 +159,6 @@ class UpgradeViewModel @Inject constructor(
             }
         } else {
             hasShownRepoError = false
-        }
-
-        if (serviceUnavailableError != null) {
-            return@combine GplayUpgradeUiState.Unavailable(serviceUnavailableError)
         }
 
         // Diagnosability: distinguishes "Play withheld the trial offer" from "offer matching failed"
@@ -115,7 +173,9 @@ class UpgradeViewModel @Inject constructor(
             hasIap = current.upgrades.any { it.sku == OurSku.Iap.PRO_UPGRADE },
             hasSub = current.upgrades.any { it.sku == OurSku.Sub.PRO_UPGRADE },
             wasPreviouslyPro = wasEverPro && !current.isPro,
-            restoreInProgress = isRestoring,
+            // Manual restore or the repo's invisible already-owned auto-restore: either pauses the
+            // entitlement actions, so the two can't be raced against each other from the UI.
+            restoreInProgress = isRestoring || isAutoRestoring,
         )
     }.safeStateIn(
         initialValue = GplayUpgradeUiState.Loading,
@@ -125,17 +185,11 @@ class UpgradeViewModel @Inject constructor(
         onError = { error -> GplayUpgradeUiState.Unavailable(error) },
     )
 
-    private fun querySkuDetails(sku: Sku): Flow<Collection<SkuDetails>?> = flow {
-        val data = withTimeoutOrNull(5000) {
-            try {
-                upgradeRepo.querySkus(sku)
-            } catch (e: Exception) {
-                if (e is CancellationException) throw e
-                errorEvents.tryEmit(e)
-                null
-            }
-        }
-        emit(data)
+    // Re-runs the SKU queries after a full "Play unavailable" episode — without this, the Lazily
+    // cached failure bricked the screen for the whole ViewModel lifetime.
+    fun retrySkuQuery() {
+        log(TAG) { "retrySkuQuery()" }
+        retryTrigger.update { it + 1 }
     }
 
     fun onGoIap(activity: Activity) {
@@ -204,6 +258,10 @@ class UpgradeViewModel @Inject constructor(
 
     companion object {
         private const val RESTORE_TIMEOUT_MS = 15_000L
+
+        // The very first billing query after Play sign-in can take >8s (measured 8.5s) while Play
+        // warms up — 5s produced false "Play unavailable" dialogs on slow-but-healthy stores.
+        private const val SKU_QUERY_TIMEOUT_MS = 15_000L
         private val TAG = logTag("Upgrade", "Gplay", "ViewModel")
     }
 }

--- a/app/src/main/java/eu/darken/sdmse/common/upgrade/ui/UpgradeContent.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/upgrade/ui/UpgradeContent.kt
@@ -61,6 +61,7 @@ internal object UpgradeScreenTags {
     const val GPLAY_RESTORE_BANNER = "upgrade_gplay_restore_banner"
     const val GPLAY_RESTORE_BANNER_ACTION = "upgrade_gplay_restore_banner_action"
     const val GPLAY_UNAVAILABLE = "upgrade_gplay_unavailable"
+    const val GPLAY_RETRY = "upgrade_gplay_retry"
     const val GPLAY_RECOMMENDED = "upgrade_gplay_recommended"
 }
 
@@ -443,6 +444,7 @@ internal fun UpgradeInlineStateCard(
     body: String,
     icon: ImageVector,
     modifier: Modifier = Modifier,
+    content: @Composable ColumnScope.() -> Unit = {},
 ) {
     UpgradeSectionCard(
         title = title,
@@ -459,5 +461,6 @@ internal fun UpgradeInlineStateCard(
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onErrorContainer,
         )
+        content()
     }
 }

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/BillingCacheTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/BillingCacheTest.kt
@@ -1,0 +1,40 @@
+package eu.darken.sdmse.common.upgrade.core
+
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.sdmse.common.datastore.value
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class BillingCacheTest : BaseTest() {
+
+    // One test method on purpose: BillingCache is a @Singleton in production, and DataStore
+    // forbids two active instances on the same file — a second BillingCache in this process
+    // would crash, not exercise anything real.
+    @Test
+    fun `stampLastProState round-trips through the DataStoreValues`() = runTest {
+        // Real DataStore, no mocks: this catches an encoding mismatch between the raw keys the
+        // atomic stamp transaction writes and the keys/types the DataStoreValues read.
+        val cache = BillingCache(ApplicationProvider.getApplicationContext())
+
+        cache.lastProStateAt.value() shouldBe 0L
+        cache.lastProStateSku.value() shouldBe ""
+
+        cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 1234L)
+
+        cache.lastProStateAt.value() shouldBe 1234L
+        cache.lastProStateSku.value() shouldBe OurSku.Iap.PRO_UPGRADE.id
+
+        cache.stampLastProState(OurSku.Sub.PRO_UPGRADE.id, 5678L)
+
+        cache.lastProStateAt.value() shouldBe 5678L
+        cache.lastProStateSku.value() shouldBe OurSku.Sub.PRO_UPGRADE.id
+    }
+}

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplayTest.kt
@@ -1,6 +1,8 @@
 package eu.darken.sdmse.common.upgrade.core
 
 import android.app.Activity
+import com.android.billingclient.api.BillingClient.BillingResponseCode
+import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.Purchase
 import eu.darken.sdmse.common.datastore.DataStoreValue
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
@@ -8,18 +10,20 @@ import eu.darken.sdmse.common.upgrade.core.billing.BillingData
 import eu.darken.sdmse.common.upgrade.core.billing.BillingManager
 import eu.darken.sdmse.common.upgrade.core.billing.ItemAlreadyOwnedBillingException
 import eu.darken.sdmse.common.upgrade.core.billing.PurchasedSku
+import eu.darken.sdmse.common.upgrade.core.billing.UserCanceledBillingException
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
-import com.android.billingclient.api.BillingClient.BillingResponseCode
-import com.android.billingclient.api.BillingResult
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import io.mockk.coVerify
-import io.mockk.coVerifyOrder
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
@@ -43,9 +47,13 @@ class UpgradeRepoGplayTest : BaseTest() {
         lastProAt: Long,
         lastSku: String = "",
         billingData: BillingData = BillingData(emptySet()),
+        freshBillingData: BillingManager.FreshData? = null,
         purchaseFailures: List<BillingResult> = emptyList(),
     ): UpgradeRepoGplay {
         every { billingManager.billingData } returns flowOf(billingData)
+        every { billingManager.freshBillingData } returns
+            (freshBillingData?.let { flowOf(it) } ?: emptyFlow())
+        every { billingManager.isSettled } returns flowOf(true)
         every { billingManager.purchaseFailures } returns
             if (purchaseFailures.isEmpty()) emptyFlow() else flowOf(*purchaseFailures.toTypedArray())
         lastProAtMock = mockk<DataStoreValue<Long>>(relaxed = true).apply {
@@ -56,6 +64,7 @@ class UpgradeRepoGplayTest : BaseTest() {
             every { flow } returns flowOf(lastSku)
         }
         every { billingCache.lastProStateSku } returns lastProSkuMock
+        coJustRun { billingCache.stampLastProState(any(), any()) }
         return UpgradeRepoGplay(scope, billingManager, billingCache)
     }
 
@@ -152,6 +161,15 @@ class UpgradeRepoGplayTest : BaseTest() {
             .restorePurchaseNow().isPro shouldBe false
     }
 
+    @Test fun `legacy empty last SKU falls back to the short window`() = runTest2 {
+        coEvery { billingManager.refresh() } returns BillingData(emptySet())
+        val twentyDaysAgo = System.currentTimeMillis() - Duration.ofDays(20).toMillis()
+
+        // Existing installs have a timestamp but no recorded SKU: they keep the old 7-day window
+        // until the next successful query records one.
+        repo(lastProAt = twentyDaysAgo, lastSku = "").restorePurchaseNow().isPro shouldBe false
+    }
+
     @Test fun `IAP grace window is longer than the subscription window`() {
         (UpgradeRepoGplay.GRACE_PERIOD_IAP_MS > UpgradeRepoGplay.GRACE_PERIOD_MS) shouldBe true
         UpgradeRepoGplay.GRACE_PERIOD_IAP_MS shouldBe Duration.ofDays(30).toMillis()
@@ -166,6 +184,80 @@ class UpgradeRepoGplayTest : BaseTest() {
         UpgradeRepoGplay.preferredProSku(listOf(sub))?.id shouldBe OurSku.Sub.PRO_UPGRADE.id
         UpgradeRepoGplay.preferredProSku(emptyList()) shouldBe null
     }
+
+    // region grace stamping provenance
+
+    @Test fun `mapped billing data does not stamp the grace timestamp`() = runTest2 {
+        // The reactive mapping runs on replayed (stale) data too, e.g. when the upgrade screen is
+        // reopened in a long-lived process -- that must not extend the grace window.
+        val repo = repo(lastProAt = 0L, billingData = BillingData(setOf(proPurchase())))
+
+        repo.upgradeInfo.first { it.isPro }.isPro shouldBe true
+        repo.upgradeInfo.first { it.isPro }.isPro shouldBe true
+
+        coVerify(exactly = 0) { billingCache.stampLastProState(any(), any()) }
+    }
+
+    @Test fun `fresh billing data stamps the grace cache`() = runTest2 {
+        repo(
+            lastProAt = 0L,
+            freshBillingData = BillingManager.FreshData(
+                BillingData(setOf(proPurchase())),
+                isFullSnapshot = true,
+            ),
+        )
+
+        coVerify(exactly = 1) { billingCache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, any()) }
+    }
+
+    @Test fun `fresh data without a known pro SKU does not stamp`() = runTest2 {
+        val unknown = mockk<Purchase>().apply {
+            every { products } returns listOf("some.unknown.product")
+            every { purchaseTime } returns 1_000L
+        }
+        repo(
+            lastProAt = 0L,
+            freshBillingData = BillingManager.FreshData(BillingData(setOf(unknown)), isFullSnapshot = true),
+        )
+
+        coVerify(exactly = 0) { billingCache.stampLastProState(any(), any()) }
+    }
+
+    @Test fun `a non-full snapshot does not downgrade the IAP grace class`() = runTest2 {
+        // A purchase event or partial refresh proves ownership of what it contains, not the
+        // absence of the permanent IAP -- the 30d window must not silently become 7d.
+        val subOnly = mockk<Purchase>().apply {
+            every { products } returns listOf(OurSku.Sub.PRO_UPGRADE.id)
+            every { purchaseTime } returns 1_000L
+        }
+        repo(
+            lastProAt = 1_000L,
+            lastSku = OurSku.Iap.PRO_UPGRADE.id,
+            freshBillingData = BillingManager.FreshData(BillingData(setOf(subOnly)), isFullSnapshot = false),
+        )
+
+        // Timestamp refreshes, but the stored SKU keeps the permanent IAP's 30-day class.
+        coVerify(exactly = 1) { billingCache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, any()) }
+    }
+
+    @Test fun `a full snapshot with only a subscription stamps the subscription class`() = runTest2 {
+        // Play confirmed the IAP is really gone: downgrading the grace class is now legitimate.
+        val subOnly = mockk<Purchase>().apply {
+            every { products } returns listOf(OurSku.Sub.PRO_UPGRADE.id)
+            every { purchaseTime } returns 1_000L
+        }
+        repo(
+            lastProAt = 1_000L,
+            lastSku = OurSku.Iap.PRO_UPGRADE.id,
+            freshBillingData = BillingManager.FreshData(BillingData(setOf(subOnly)), isFullSnapshot = true),
+        )
+
+        coVerify(exactly = 1) { billingCache.stampLastProState(OurSku.Sub.PRO_UPGRADE.id, any()) }
+    }
+
+    // endregion
+
+    // region buy flow + already-owned recovery
 
     @Test fun `already-owned buy attempt silently restores the purchase instead of erroring`() = runTest2 {
         coEvery { billingManager.startIapFlow(any(), any(), null) } throws
@@ -201,34 +293,34 @@ class UpgradeRepoGplayTest : BaseTest() {
         errors.single().shouldBeInstanceOf<ItemAlreadyOwnedBillingException>()
     }
 
-    @Test fun `explicit restore stamps the grace cache, sku before timestamp`() = runTest2 {
-        coEvery { billingManager.refresh() } returns BillingData(setOf(proPurchase()))
+    @Test fun `user cancel during the buy flow stays silent`() = runTest2 {
+        coEvery { billingManager.startIapFlow(any(), any(), null) } throws
+            UserCanceledBillingException(RuntimeException("launch result"))
 
-        repo(lastProAt = 0L).restorePurchaseNow().isPro shouldBe true
+        val errors = mutableListOf<Throwable>()
+        repo(lastProAt = 0L).launchBillingFlow(mockk<Activity>(), OurSku.Iap.PRO_UPGRADE, null) { errors.add(it) }
 
-        coVerifyOrder {
-            lastProSkuMock.update(any())
-            lastProAtMock.update(any())
-        }
+        errors shouldBe emptyList()
     }
 
-    @Test fun `background refresh stamps the grace cache from the fresh result`() = runTest2 {
-        coEvery { billingManager.refresh() } returns BillingData(setOf(proPurchase()))
+    @Test fun `cancellation of the buy flow never reaches the error callback`() = runTest2 {
+        // A cancelled coroutine is not an error: surfacing it would show a spurious dialog.
+        coEvery { billingManager.startIapFlow(any(), any(), null) } throws CancellationException("scope died")
 
-        repo(lastProAt = 0L).refresh()
+        val errors = mutableListOf<Throwable>()
+        repo(lastProAt = 0L).launchBillingFlow(mockk<Activity>(), OurSku.Iap.PRO_UPGRADE, null) { errors.add(it) }
 
-        coVerify(exactly = 1) { lastProAtMock.update(any()) }
+        errors shouldBe emptyList()
     }
 
-    @Test fun `reactive emissions stamp once via the init collector, the map never stamps`() = runTest2 {
-        // billingData carries a pro purchase: the persistent init collector stamps exactly once.
-        // Collecting upgradeInfo runs the map at least twice (onStart-null + pro data) — the map is
-        // read-only now, so if it still stamped the count would exceed one.
-        val repo = repo(lastProAt = 0L, billingData = BillingData(setOf(proPurchase())))
+    @Test fun `other buy flow failures reach the error callback`() = runTest2 {
+        val failure = RuntimeException("launch failed")
+        coEvery { billingManager.startIapFlow(any(), any(), null) } throws failure
 
-        repo.upgradeInfo.first { it.isPro }.isPro shouldBe true
+        val errors = mutableListOf<Throwable>()
+        repo(lastProAt = 0L).launchBillingFlow(mockk<Activity>(), OurSku.Iap.PRO_UPGRADE, null) { errors.add(it) }
 
-        coVerify(exactly = 1) { lastProAtMock.update(any()) }
+        errors.single() shouldBe failure
     }
 
     @Test fun `async already-owned purchase event triggers a silent restore`() = runTest2 {
@@ -250,4 +342,49 @@ class UpgradeRepoGplayTest : BaseTest() {
 
         coVerify(exactly = 0) { billingManager.refresh() }
     }
+
+    @Test fun `overlapping already-owned recoveries coalesce into one restore`() = runTest2 {
+        coEvery { billingManager.startIapFlow(any(), any(), null) } throws
+            ItemAlreadyOwnedBillingException(RuntimeException("launch result"))
+        val gate = CompletableDeferred<Unit>()
+        coEvery { billingManager.refresh() } coAnswers {
+            gate.await()
+            BillingData(setOf(proPurchase()))
+        }
+
+        val errors = mutableListOf<Throwable>()
+        val repo = repo(lastProAt = 0L)
+        // Two buy taps race into the already-owned recovery while the first restore is in flight.
+        repo.launchBillingFlow(mockk<Activity>(), OurSku.Iap.PRO_UPGRADE, null) { errors.add(it) }
+        repo.launchBillingFlow(mockk<Activity>(), OurSku.Iap.PRO_UPGRADE, null) { errors.add(it) }
+
+        repo.autoRestoreBusy.first() shouldBe true
+        gate.complete(Unit)
+
+        // Both triggers joined the SAME restore -- one Play query, no stacked recoveries.
+        coVerify(exactly = 1) { billingManager.refresh() }
+        errors shouldBe emptyList()
+        repo.autoRestoreBusy.first() shouldBe false
+    }
+
+    @Test fun `auto restore busy state rises and falls around the recovery`() = runTest2 {
+        coEvery { billingManager.startIapFlow(any(), any(), null) } throws
+            ItemAlreadyOwnedBillingException(RuntimeException("launch result"))
+        val gate = CompletableDeferred<Unit>()
+        coEvery { billingManager.refresh() } coAnswers {
+            gate.await()
+            BillingData(setOf(proPurchase()))
+        }
+
+        val repo = repo(lastProAt = 0L)
+        repo.autoRestoreBusy.first() shouldBe false
+
+        repo.launchBillingFlow(mockk<Activity>(), OurSku.Iap.PRO_UPGRADE, null) { }
+        repo.autoRestoreBusy.first() shouldBe true
+
+        gate.complete(Unit)
+        repo.autoRestoreBusy.first() shouldBe false
+    }
+
+    // endregion
 }

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManagerTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManagerTest.kt
@@ -3,12 +3,15 @@ package eu.darken.sdmse.common.upgrade.core.billing
 import android.app.Activity
 import com.android.billingclient.api.BillingClient.BillingResponseCode
 import com.android.billingclient.api.BillingResult
+import com.android.billingclient.api.Purchase
+import com.android.billingclient.api.Purchase.PurchaseState
 import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.upgrade.core.OurSku
 import eu.darken.sdmse.common.upgrade.core.billing.client.BillingClientException
 import eu.darken.sdmse.common.upgrade.core.billing.client.BillingConnection
 import eu.darken.sdmse.common.upgrade.core.billing.client.BillingConnectionProvider
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.longs.shouldBeLessThan
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.every
@@ -17,14 +20,19 @@ import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
 import io.mockk.verify
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.CoroutineStart
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.currentTime
 import kotlinx.coroutines.test.runCurrent
 import org.junit.jupiter.api.AfterEach
@@ -34,9 +42,6 @@ import testhelpers.BaseTest
 import testhelpers.coroutine.runTest2
 
 class BillingManagerTest : BaseTest() {
-
-    private val scope = CoroutineScope(Dispatchers.Unconfined)
-    private val activity = mockk<Activity>()
 
     @BeforeEach
     fun setup() {
@@ -51,103 +56,432 @@ class BillingManagerTest : BaseTest() {
 
     private fun result(code: Int): BillingResult = BillingResult.newBuilder().setResponseCode(code).build()
 
-    // A manager whose connection fails launchBillingFlow with the given launch-result code —
+    private fun purchase() = mockk<Purchase>().apply {
+        every { purchaseState } returns PurchaseState.PURCHASED
+        every { purchaseTime } returns 1_000L
+        every { purchaseToken } returns "token"
+        every { isAcknowledged } returns true
+    }
+
+    private fun connection(
+        refreshResults: List<Collection<Purchase>> = listOf(emptyList()),
+        refreshComplete: Boolean = true,
+        purchasesFlow: Flow<Collection<Purchase>> = flowOf(emptyList()),
+        freshUpdatesFlow: Flow<BillingConnection.FreshUpdate> = emptyFlow(),
+        failures: Flow<BillingResult> = emptyFlow(),
+    ) = mockk<BillingConnection>().apply {
+        coEvery { refreshPurchases() } returnsMany
+            refreshResults.map { BillingConnection.PurchaseRefresh(it, isComplete = refreshComplete) }
+        every { purchases } returns purchasesFlow
+        every { freshUpdates } returns freshUpdatesFlow
+        every { purchaseFailures } returns failures
+    }
+
+    // The real provider flow emits one connection and stays open for its lifetime -- flowOf() would
+    // complete immediately, which the connect loop rightly treats as a connection failure.
+    private fun providerOf(connection: BillingConnection): BillingConnectionProvider =
+        mockk<BillingConnectionProvider>().apply {
+            every { this@apply.connection } returns flow {
+                emit(connection)
+                awaitCancellation()
+            }
+        }
+
+    private fun TestScope.manager(connection: BillingConnection): BillingManager =
+        BillingManager(backgroundScope, providerOf(connection))
+
+    private fun TestScope.manager(provider: BillingConnectionProvider): BillingManager =
+        BillingManager(backgroundScope, provider)
+
+    // region launch failure mapping
+
+    // A manager whose connection fails launchBillingFlow with the given launch-result code --
     // the path Play uses for immediate "buy" failures (returned result, not an exception).
-    private fun manager(launchFailureCode: Int): BillingManager {
-        val connection = mockk<BillingConnection>().apply {
-            coEvery { refreshPurchases() } returns emptyList()
-            every { purchases } returns emptyFlow()
-            coEvery { launchBillingFlow(any(), any(), null) } throws BillingClientException(result(launchFailureCode))
+    private fun TestScope.launchFailingManager(launchFailureCode: Int): BillingManager = manager(
+        connection().apply {
+            coEvery { launchBillingFlow(any(), any(), null) } throws
+                BillingClientException(result(launchFailureCode))
         }
-        val provider = mockk<BillingConnectionProvider>().apply {
-            every { this@apply.connection } returns flowOf(connection)
-        }
-        return BillingManager(scope, provider)
-    }
+    )
 
-    @Test
-    fun `already-owned launch surfaces the mapped exception without a bug report`() = runTest2 {
+    @Test fun `already-owned launch surfaces the mapped exception without a bug report`() = runTest2 {
         // The repo layer auto-handles this by restoring; it's an expected user state, not a defect.
-        val manager = manager(BillingResponseCode.ITEM_ALREADY_OWNED)
-
         shouldThrow<ItemAlreadyOwnedBillingException> {
-            manager.startIapFlow(activity, OurSku.Iap.PRO_UPGRADE, null)
+            launchFailingManager(BillingResponseCode.ITEM_ALREADY_OWNED)
+                .startIapFlow(mockk<Activity>(), OurSku.Iap.PRO_UPGRADE, null)
         }
         verify(exactly = 0) { Bugs.report(any()) }
     }
 
-    @Test
-    fun `user cancel from the launch result stays silent bug-report-wise`() = runTest2 {
-        val manager = manager(BillingResponseCode.USER_CANCELED)
-
+    @Test fun `user cancel from the launch result stays silent bug-report-wise`() = runTest2 {
         shouldThrow<UserCanceledBillingException> {
-            manager.startIapFlow(activity, OurSku.Iap.PRO_UPGRADE, null)
+            launchFailingManager(BillingResponseCode.USER_CANCELED)
+                .startIapFlow(mockk<Activity>(), OurSku.Iap.PRO_UPGRADE, null)
         }
         verify(exactly = 0) { Bugs.report(any()) }
     }
 
-    @Test
-    fun `billing-unavailable maps to the service error without a bug report`() = runTest2 {
-        val manager = manager(BillingResponseCode.BILLING_UNAVAILABLE)
-
+    @Test fun `billing-unavailable maps to the service error without a bug report`() = runTest2 {
         shouldThrow<GplayServiceUnavailableException> {
-            manager.startIapFlow(activity, OurSku.Iap.PRO_UPGRADE, null)
+            launchFailingManager(BillingResponseCode.BILLING_UNAVAILABLE)
+                .startIapFlow(mockk<Activity>(), OurSku.Iap.PRO_UPGRADE, null)
         }
         verify(exactly = 0) { Bugs.report(any()) }
     }
 
-    @Test
-    fun `developer errors are rethrown and reported`() = runTest2 {
-        val manager = manager(BillingResponseCode.DEVELOPER_ERROR)
-
+    @Test fun `developer errors are rethrown and reported`() = runTest2 {
         shouldThrow<BillingClientException> {
-            manager.startIapFlow(activity, OurSku.Iap.PRO_UPGRADE, null)
+            launchFailingManager(BillingResponseCode.DEVELOPER_ERROR)
+                .startIapFlow(mockk<Activity>(), OurSku.Iap.PRO_UPGRADE, null)
         }
         verify(exactly = 1) { Bugs.report(any()) }
     }
 
-    // A provider whose first connection attempt fails; subsequent attempts succeed. Drives the
-    // retryWhen backoff in BillingManager.connection under virtual time.
-    private fun flakyProvider(connection: BillingConnection): BillingConnectionProvider {
+    @Test fun `cancellation during the iap flow is neither reported nor mapped`() = runTest2 {
+        val manager = manager(
+            connection().apply {
+                coEvery { launchBillingFlow(any(), any(), null) } throws CancellationException("caller died")
+            }
+        )
+
+        shouldThrow<CancellationException> {
+            manager.startIapFlow(mockk<Activity>(), OurSku.Iap.PRO_UPGRADE, null)
+        }
+        verify(exactly = 0) { Bugs.report(any()) }
+    }
+
+    // endregion
+
+    // region fresh billing data
+
+    @Test fun `manual refresh returns the fresh purchases`() = runTest2 {
+        val owned = purchase()
+        // First result feeds the initial per-connection refresh, second the manual one.
+        val manager = manager(connection(refreshResults = listOf(emptyList(), listOf(owned))))
+
+        manager.refresh() shouldBe BillingData(listOf(owned))
+    }
+
+    @Test fun `the connection's fresh updates pass through as fresh billing data`() = runTest2 {
+        // The emissions themselves (commit order, query-confirmed-only, snapshot provenance) are
+        // produced and tested at the BillingConnection level; the manager only re-shapes them.
+        val owned = purchase()
+        val manager = manager(
+            connection(
+                freshUpdatesFlow = flowOf(
+                    BillingConnection.FreshUpdate(listOf(owned), isFullSnapshot = false),
+                ),
+            )
+        )
+
+        manager.freshBillingData.first() shouldBe
+            BillingManager.FreshData(BillingData(listOf(owned)), isFullSnapshot = false)
+    }
+
+    @Test fun `non-OK purchase events are exposed as purchase failures`() = runTest2 {
+        val alreadyOwned = result(BillingResponseCode.ITEM_ALREADY_OWNED)
+        val manager = manager(
+            connection(failures = flowOf(alreadyOwned))
+        )
+
+        manager.purchaseFailures.first() shouldBe alreadyOwned
+    }
+
+    // endregion
+
+    // region connect loop: retry, demand, invalidation
+
+    @Test fun `connection retry waits out its backoff when nothing kicks it`() = runTest2 {
         var attempts = 0
-        return mockk<BillingConnectionProvider>().apply {
+        val healthy = connection()
+        val provider = mockk<BillingConnectionProvider>().apply {
             every { this@apply.connection } returns flow {
-                if (attempts++ == 0) throw BillingException("first connect fails")
-                emit(connection)
+                attempts++
+                if (attempts == 1) throw BillingException("Play is updating itself")
+                emit(healthy)
+                awaitCancellation()
             }
         }
-    }
-
-    private fun healthyConnection(): BillingConnection = mockk<BillingConnection>().apply {
-        coEvery { refreshPurchases() } returns emptyList()
-        // Must emit (not emptyFlow): billingData.first() in these tests completes on this emission.
-        every { purchases } returns flowOf(emptyList())
-    }
-
-    @Test
-    fun `connection retry waits out its backoff when nothing kicks it`() = runTest2 {
-        val manager = BillingManager(backgroundScope, flakyProvider(healthyConnection()))
+        val manager = manager(provider)
 
         val t0 = currentTime
         manager.billingData.first()
 
-        // First backoff is 30s; a passive subscriber sits it out (virtual time auto-advances).
-        (currentTime - t0 >= 30_000) shouldBe true
+        // First backoff is 2s; a passive subscriber sits it out (virtual time auto-advances).
+        (currentTime - t0 >= 2_000) shouldBe true
+        attempts shouldBe 2
     }
 
-    @Test
-    fun `an explicit billing action wakes the connection retry out of its backoff`() = runTest2 {
-        val manager = BillingManager(backgroundScope, flakyProvider(healthyConnection()))
-
-        // Passive subscriber triggers the first (failing) attempt; the retry enters its backoff.
-        val warmup = backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) {
-            manager.billingData.first()
+    @Test fun `a failed first attempt marks billing as settled`() = runTest2 {
+        // The connect loop swallows connection errors (it retries forever), so downstream flows
+        // stay silent during an outage -- gates like isProSettled need the explicit signal.
+        val provider = mockk<BillingConnectionProvider>().apply {
+            every { this@apply.connection } returns flow {
+                throw BillingException("Play is down")
+            }
         }
+        val manager = manager(provider)
+
+        manager.isSettled.first() shouldBe false
+        runCurrent() // first attempt fails
+        manager.isSettled.first() shouldBe true
+    }
+
+    @Test fun `a cold refresh that can't verify anything retries instead of starving billing`() = runTest2 {
+        // "Nothing found AND a query failed" throws from refreshPurchases: the old onEach swallowed
+        // that, leaving billingData/isSettled starved forever with no retry.
+        val bad = connection().apply {
+            coEvery { refreshPurchases() } throws
+                GplayServiceUnavailableException(RuntimeException("cold Play, broken queries"))
+        }
+        val good = connection()
+        var attempts = 0
+        val provider = mockk<BillingConnectionProvider>().apply {
+            every { this@apply.connection } returns flow {
+                attempts++
+                emit(if (attempts == 1) bad else good)
+                awaitCancellation()
+            }
+        }
+        val manager = manager(provider)
+
+        runCurrent() // attempt 1: connects, initial refresh fails -> connection failure
+        manager.isSettled.first() shouldBe true
+
+        advanceTimeBy(2_001) // backoff, then attempt 2 heals
+        manager.billingData.first() shouldBe BillingData(emptyList())
+        attempts shouldBe 2
+    }
+
+    @Test fun `active demand cuts the reconnect backoff short`() = runTest2 {
+        val owned = purchase()
+        var attempts = 0
+        val healthy = connection(refreshResults = listOf(emptyList(), listOf(owned)))
+        val provider = mockk<BillingConnectionProvider>().apply {
+            every { this@apply.connection } returns flow {
+                attempts++
+                if (attempts == 1) throw BillingException("Play is updating itself")
+                emit(healthy)
+                awaitCancellation()
+            }
+        }
+        val manager = manager(provider)
+        runCurrent() // first connection attempt fails, the 2s backoff starts
+
+        // A user tapping restore/buy right after fixing their Play situation must not wait out the
+        // backoff timer -- the demand signal reconnects immediately.
+        val refreshed = async { manager.refresh() }
         runCurrent()
 
-        val t0 = currentTime
-        manager.refresh() // useConnection kicks the backoff -> immediate reconnect
-        (currentTime - t0 < 30_000) shouldBe true
-        warmup.join()
+        refreshed.await() shouldBe BillingData(listOf(owned))
+        attempts shouldBe 2
+        currentTime shouldBeLessThan 2_000L
     }
+
+    @Test fun `demand during a failing connection attempt is not lost`() = runTest2 {
+        val owned = purchase()
+        val healthy = connection(refreshResults = listOf(emptyList(), listOf(owned)))
+        var attempts = 0
+        val provider = mockk<BillingConnectionProvider>().apply {
+            every { this@apply.connection } returns flow {
+                attempts++
+                if (attempts == 1) {
+                    delay(1_000) // demand arrives while this attempt is still in flight
+                    throw BillingException("Play is updating itself")
+                }
+                emit(healthy)
+                awaitCancellation()
+            }
+        }
+        val manager = manager(provider)
+        runCurrent() // attempt 1 in flight, suspended
+
+        val refreshed = async { manager.refresh() } // demand lands mid-attempt
+        runCurrent()
+        advanceTimeBy(1_001) // attempt 1 fails; the pending demand must skip the backoff
+        runCurrent()
+
+        refreshed.await() shouldBe BillingData(listOf(owned))
+        attempts shouldBe 2
+        currentTime shouldBeLessThan 2_000L
+    }
+
+    @Test fun `demand served by a healthy connection does not skip a later backoff`() = runTest2 {
+        var attempts = 0
+        val die = CompletableDeferred<Unit>()
+        val healthy = connection(refreshResults = List(4) { emptyList<Purchase>() })
+        val provider = mockk<BillingConnectionProvider>().apply {
+            every { this@apply.connection } returns flow {
+                when (attempts++) {
+                    0 -> {
+                        emit(healthy)
+                        die.await()
+                        throw BillingException("connection died")
+                    }
+
+                    else -> {
+                        emit(healthy)
+                        awaitCancellation()
+                    }
+                }
+            }
+        }
+        val manager = manager(provider)
+        runCurrent()
+
+        val refreshed = async { manager.refresh() } // demand is served by the healthy connection
+        runCurrent()
+        refreshed.await()
+
+        die.complete(Unit) // now the connection dies
+        runCurrent()
+
+        // The long-served demand must not short-circuit this backoff.
+        advanceTimeBy(1_900)
+        runCurrent()
+        attempts shouldBe 1
+
+        advanceTimeBy(200)
+        runCurrent()
+        attempts shouldBe 2
+    }
+
+    @Test fun `backoff streak resets after a successful connection`() = runTest2 {
+        var attempts = 0
+        val healthy = connection(refreshResults = List(4) { emptyList<Purchase>() })
+        val provider = mockk<BillingConnectionProvider>().apply {
+            every { this@apply.connection } returns flow {
+                when (attempts++) {
+                    0 -> throw BillingException("fail 1") // streak 1 -> 2s backoff
+                    1 -> {
+                        emit(healthy) // success resets the streak...
+                        throw BillingException("fail 2") // ...so this must back off 2s, not 8s
+                    }
+
+                    else -> {
+                        emit(healthy)
+                        awaitCancellation()
+                    }
+                }
+            }
+        }
+        manager(provider)
+
+        advanceTimeBy(2_001)
+        runCurrent()
+        advanceTimeBy(2_001)
+        runCurrent()
+
+        // With a lifetime attempt counter the second backoff would be 8s and the third attempt
+        // wouldn't have run yet.
+        attempts shouldBe 3
+    }
+
+    @Test fun `unexpected provider completion does not tight-loop`() = runTest2 {
+        var attempts = 0
+        val provider = mockk<BillingConnectionProvider>().apply {
+            every { this@apply.connection } returns flow<BillingConnection> {
+                attempts++
+                // Completes normally without ever emitting -- the loop must treat this as a
+                // failure WITH growing backoff, not spin reconnecting.
+            }
+        }
+        manager(provider)
+
+        runCurrent()
+        attempts shouldBe 1
+        advanceTimeBy(1_999)
+        attempts shouldBe 1
+        advanceTimeBy(10) // ~2s: streak 1 backoff expires
+        runCurrent()
+        attempts shouldBe 2
+        // Streak grows (no successful connection in between): next backoff is 8s.
+        advanceTimeBy(7_000)
+        attempts shouldBe 2
+        advanceTimeBy(1_100)
+        runCurrent()
+        attempts shouldBe 3
+    }
+
+    @Test fun `a connection that dies after succeeding backs off without spinning`() = runTest2 {
+        var attempts = 0
+        val healthy = connection(refreshResults = List(6) { emptyList<Purchase>() })
+        val provider = mockk<BillingConnectionProvider>().apply {
+            every { this@apply.connection } returns flow {
+                attempts++
+                emit(healthy)
+                // Dies right after connecting: each cycle is a SUCCESS (streak resets) followed by
+                // a failure, so the backoff stays at the 2s floor -- but never below it.
+            }
+        }
+        manager(provider)
+
+        runCurrent()
+        attempts shouldBe 1
+        advanceTimeBy(1_999)
+        attempts shouldBe 1
+        advanceTimeBy(10)
+        runCurrent()
+        attempts shouldBe 2
+    }
+
+    @Test fun `a hanging initial refresh times out into the retry`() = runTest2 {
+        val bad = connection().apply {
+            coEvery { refreshPurchases() } coAnswers { awaitCancellation() }
+        }
+        val good = connection()
+        var attempts = 0
+        val provider = mockk<BillingConnectionProvider>().apply {
+            every { this@apply.connection } returns flow {
+                attempts++
+                emit(if (attempts == 1) bad else good)
+                awaitCancellation()
+            }
+        }
+        val manager = manager(provider)
+
+        runCurrent() // attempt 1: refresh hangs
+        advanceTimeBy(30_001) // initial-refresh timeout fires -> failure
+        advanceTimeBy(2_001) // backoff, attempt 2
+
+        manager.billingData.first() shouldBe BillingData(emptyList())
+        attempts shouldBe 2
+    }
+
+    @Test fun `an action-level disconnect invalidates the connection`() = runTest2 {
+        val owned = purchase()
+        // Connection 1: healthy initial refresh, but the next action reports the binder dead —
+        // arriving user-friendly-MAPPED, the way the refresh path actually delivers it.
+        val dead = connection().apply {
+            coEvery { refreshPurchases() } returns
+                BillingConnection.PurchaseRefresh(emptyList(), isComplete = true) andThenThrows
+                GplayServiceUnavailableException(
+                    BillingClientException(result(BillingResponseCode.SERVICE_DISCONNECTED))
+                )
+        }
+        val good = connection(refreshResults = listOf(emptyList(), listOf(owned)))
+        var attempts = 0
+        val provider = mockk<BillingConnectionProvider>().apply {
+            every { this@apply.connection } returns flow {
+                attempts++
+                emit(if (attempts == 1) dead else good)
+                awaitCancellation()
+            }
+        }
+        val manager = manager(provider)
+        runCurrent() // connected via connection 1
+
+        // Play never delivered onBillingServiceDisconnected: without invalidation, connection 1
+        // would stay installed and every later action would keep failing against a dead binder.
+        shouldThrow<GplayServiceUnavailableException> { manager.refresh() }
+
+        // The next action is fresh demand -- it skips the backoff and lands on connection 2.
+        val refreshed = async { manager.refresh() }
+        advanceUntilIdle()
+
+        refreshed.await() shouldBe BillingData(listOf(owned))
+        attempts shouldBe 2
+    }
+
+    // endregion
 }

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingConnectionTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingConnectionTest.kt
@@ -1,16 +1,51 @@
 package eu.darken.sdmse.common.upgrade.core.billing.client
 
+import com.android.billingclient.api.BillingClient
+import com.android.billingclient.api.BillingClient.BillingResponseCode
+import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.Purchase
+import com.android.billingclient.api.Purchase.PurchaseState
+import com.android.billingclient.api.PurchasesResponseListener
+import com.android.billingclient.api.QueryPurchasesParams
+import eu.darken.sdmse.common.upgrade.core.OurSku
+import eu.darken.sdmse.common.upgrade.core.billing.Sku
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
 
 class BillingConnectionTest : BaseTest() {
 
-    private fun purchase(time: Long) = mockk<Purchase>().apply { every { purchaseTime } returns time }
+    private fun purchase(
+        time: Long,
+        token: String = "token-$time",
+        products: List<String> = listOf(OurSku.Iap.PRO_UPGRADE.id),
+        acknowledged: Boolean = false,
+    ) = mockk<Purchase>().apply {
+        every { purchaseTime } returns time
+        every { purchaseToken } returns token
+        every { this@apply.products } returns products
+        every { purchaseState } returns PurchaseState.PURCHASED
+        every { isAcknowledged } returns acknowledged
+    }
+
+    private fun result(code: Int): BillingResult = BillingResult.newBuilder().setResponseCode(code).build()
+
+    private val typeOf: (String) -> Sku.Type? = { id -> OurSku.PRO_SKUS.singleOrNull { it.id == id }?.type }
+
+    // region combinePurchaseResults (pure)
 
     @Test fun `combines both product types, newest first`() {
         val older = purchase(1_000)
@@ -51,4 +86,389 @@ class BillingConnectionTest : BaseTest() {
             )
         }
     }
+
+    // endregion
+
+    // region ReducerState (pure)
+
+    @Test fun `events append typed overlay entries and bump the generation`() {
+        val iapPurchase = purchase(1_000, products = listOf(OurSku.Iap.PRO_UPGRADE.id))
+        val unknownPurchase = purchase(2_000, products = listOf("some.unknown.product"))
+
+        val state = BillingConnection.ReducerState()
+            .withEvent(listOf(iapPurchase), typeOf)
+            .withEvent(listOf(unknownPurchase), typeOf)
+
+        state.eventGen shouldBe 2L
+        state.overlay.map { it.gen } shouldBe listOf(1L, 2L)
+        state.overlay.map { it.type } shouldBe listOf(Sku.Type.IAP, null)
+    }
+
+    @Test fun `a per-type query replaces only its own snapshot`() {
+        val oldIap = purchase(1_000, token = "iap")
+        val newSub = purchase(2_000, token = "sub", products = listOf(OurSku.Sub.PRO_UPGRADE.id))
+
+        val state = BillingConnection.ReducerState(iapSnapshot = listOf(oldIap))
+            .withQueryResults(iap = null, sub = listOf(newSub), genAtQueryStart = 0L)
+
+        // The failed IAP query keeps the last-known IAP snapshot: a partial refresh must not turn
+        // "couldn't check" into "confirmed absent".
+        state.iapSnapshot shouldBe listOf(oldIap)
+        state.subSnapshot shouldBe listOf(newSub)
+        state.merged().map { it.purchaseToken } shouldContainExactly listOf("sub", "iap")
+    }
+
+    @Test fun `a per-type query clears its own older overlay entries even on a partial refresh`() {
+        val iapEvent = purchase(1_000, token = "iap-event")
+
+        val state = BillingConnection.ReducerState()
+            .withEvent(listOf(iapEvent), typeOf) // gen 1
+            // IAP query (started after the event, gen 1 visible) confirms absence; SUB query failed.
+            .withQueryResults(iap = emptyList(), sub = null, genAtQueryStart = 1L)
+
+        state.overlay shouldBe emptyList()
+        state.merged() shouldBe emptyList()
+    }
+
+    @Test fun `an event that raced the query survives its commit`() {
+        val racedEvent = purchase(1_000, token = "raced")
+
+        val state = BillingConnection.ReducerState()
+            // Query started at gen 0, event arrived while it was in flight (gen 1).
+            .withEvent(listOf(racedEvent), typeOf)
+            .withQueryResults(iap = emptyList(), sub = emptyList(), genAtQueryStart = 0L)
+
+        // The query began before the purchase existed — its empty result must not erase it.
+        state.merged().map { it.purchaseToken } shouldBe listOf("raced")
+    }
+
+    @Test fun `untyped overlay entries only fall to a complete refresh`() {
+        val unknown = purchase(1_000, token = "unknown", products = listOf("some.unknown.product"))
+        val base = BillingConnection.ReducerState().withEvent(listOf(unknown), typeOf) // gen 1
+
+        // Partial refresh (SUB failed): the unknown-type entry cannot be attributed, it stays.
+        base.withQueryResults(iap = emptyList(), sub = null, genAtQueryStart = 1L)
+            .merged().map { it.purchaseToken } shouldBe listOf("unknown")
+
+        // Complete refresh: authoritative for everything the queries could have seen.
+        base.withQueryResults(iap = emptyList(), sub = emptyList(), genAtQueryStart = 1L)
+            .merged() shouldBe emptyList()
+    }
+
+    @Test fun `duplicate purchase tokens dedup with the overlay winning`() {
+        // A surviving overlay entry is newer than the snapshot by construction — e.g. a purchase
+        // event whose type-query hasn't re-run yet carries fresher (un)acknowledged state.
+        val snapshotVersion = purchase(1_000, token = "same", acknowledged = true)
+        val eventVersion = purchase(1_000, token = "same", acknowledged = false)
+
+        val state = BillingConnection.ReducerState(iapSnapshot = listOf(snapshotVersion))
+            .withEvent(listOf(eventVersion), typeOf)
+
+        val merged = state.merged()
+        merged.size shouldBe 1
+        merged.single().isAcknowledged shouldBe false
+    }
+
+    @Test fun `a covering query supersedes the event representation of the same purchase`() {
+        val eventVersion = purchase(1_000, token = "same", acknowledged = false)
+        val queriedVersion = purchase(1_000, token = "same", acknowledged = true)
+
+        val state = BillingConnection.ReducerState()
+            .withEvent(listOf(eventVersion), typeOf) // gen 1
+            // Query started after the event (genAtQueryStart = 1): its result is fresher.
+            .withQueryResults(iap = listOf(queriedVersion), sub = emptyList(), genAtQueryStart = 1L)
+
+        state.merged().single().isAcknowledged shouldBe true
+    }
+
+    // endregion
+
+    // region refreshPurchases + reactive flow (integration)
+
+    // A client whose purchase queries answer synchronously, in call order (INAPP first, SUBS
+    // second — refreshPurchases starts them in that order on the single-threaded test dispatcher).
+    private fun clientReturning(vararg responses: Pair<BillingResult, List<Purchase>>): BillingClient {
+        val queue = ArrayDeque(responses.toList())
+        return mockk<BillingClient>().apply {
+            every { queryPurchasesAsync(any<QueryPurchasesParams>(), any()) } answers {
+                val (result, purchases) = queue.removeFirst()
+                secondArg<PurchasesResponseListener>().onQueryPurchasesResponse(result, purchases.toMutableList())
+            }
+        }
+    }
+
+    @Test fun `a partial-failure refresh still reaches the reactive purchases flow`() = runTest2 {
+        // A purchase found by one product type while the other query fails must not leave the
+        // reactive purchases/upgradeInfo chain starved — otherwise a successful restore would
+        // never actually unlock the app.
+        val owned = purchase(1_000)
+        val connection = BillingConnection(
+            client = clientReturning(
+                result(BillingResponseCode.OK) to listOf(owned),
+                result(BillingResponseCode.ERROR) to emptyList(),
+            ),
+        )
+
+        val refresh = connection.refreshPurchases()
+
+        refresh.purchases shouldBe listOf(owned)
+        refresh.isComplete shouldBe false
+        connection.purchases.first() shouldBe listOf(owned)
+    }
+
+    @Test fun `a failed sibling query keeps the previous refresh's snapshot for its type`() = runTest2 {
+        val iapOwned = purchase(1_000, token = "iap")
+        val subOwned = purchase(2_000, token = "sub", products = listOf(OurSku.Sub.PRO_UPGRADE.id))
+        val connection = BillingConnection(
+            client = clientReturning(
+                // Refresh 1: both succeed, IAP owned.
+                result(BillingResponseCode.OK) to listOf(iapOwned),
+                result(BillingResponseCode.OK) to emptyList(),
+                // Refresh 2: IAP query fails, SUB finds a purchase.
+                result(BillingResponseCode.ERROR) to emptyList(),
+                result(BillingResponseCode.OK) to listOf(subOwned),
+            ),
+        )
+
+        connection.refreshPurchases().isComplete shouldBe true
+        val second = connection.refreshPurchases()
+
+        // The IAP purchase from refresh 1 is retained — its query failing is not proof of absence.
+        second.isComplete shouldBe false
+        second.purchases.map { it.purchaseToken } shouldContainExactly listOf("sub", "iap")
+        connection.purchases.first().map { it.purchaseToken } shouldContainExactly listOf("sub", "iap")
+    }
+
+    @Test fun `a complete refresh clears event purchases it could have seen`() = runTest2 {
+        // Refund case: the purchase arrived via event, then a complete refresh confirms it's gone —
+        // the stale event must not keep it alive in the reactive flow.
+        val connection = BillingConnection(
+            client = clientReturning(
+                result(BillingResponseCode.OK) to emptyList(),
+                result(BillingResponseCode.OK) to emptyList(),
+            ),
+        )
+        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(purchase(1_000)))
+
+        val refresh = connection.refreshPurchases()
+
+        refresh.purchases shouldBe emptyList()
+        connection.purchases.first() shouldBe emptyList()
+    }
+
+    @Test fun `an event arriving while the query is in flight survives the commit`() = runTest2 {
+        val pendingListeners = mutableListOf<PurchasesResponseListener>()
+        val client = mockk<BillingClient>().apply {
+            every { queryPurchasesAsync(any<QueryPurchasesParams>(), any()) } answers {
+                pendingListeners.add(secondArg())
+            }
+        }
+        val connection = BillingConnection(client = client)
+
+        val refresh = async(start = CoroutineStart.UNDISPATCHED) { connection.refreshPurchases() }
+        runCurrent()
+        pendingListeners.size shouldBe 2
+
+        // Purchase event lands while both queries are still in flight.
+        val racedPurchase = purchase(1_000, token = "raced")
+        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(racedPurchase))
+
+        pendingListeners.forEach { it.onQueryPurchasesResponse(result(BillingResponseCode.OK), mutableListOf()) }
+        runCurrent()
+
+        // The queries began before the purchase existed — empty results must not erase it.
+        refresh.await().purchases.map { it.purchaseToken } shouldBe listOf("raced")
+        connection.purchases.first().map { it.purchaseToken } shouldBe listOf("raced")
+    }
+
+    @Test fun `verified absence survives a failed sibling query`() = runTest2 {
+        // The IAP query successfully confirms the purchase is GONE (refund) while the SUB query
+        // fails: the refresh reports the couldn't-verify error, but the verified absence must
+        // still have been committed — otherwise repeated SUB failures retain Pro indefinitely.
+        val owned = purchase(1_000)
+        val connection = BillingConnection(
+            client = clientReturning(
+                // Refresh 1: IAP owned, both types succeed.
+                result(BillingResponseCode.OK) to listOf(owned),
+                result(BillingResponseCode.OK) to emptyList(),
+                // Refresh 2: IAP verified empty, SUB fails.
+                result(BillingResponseCode.OK) to emptyList(),
+                result(BillingResponseCode.ERROR) to emptyList(),
+            ),
+        )
+        connection.refreshPurchases().purchases shouldBe listOf(owned)
+
+        shouldThrow<Exception> { connection.refreshPurchases() }
+
+        connection.purchases.first() shouldBe emptyList()
+    }
+
+    @Test fun `a refresh commits exactly one reactive emission`() = runTest2 {
+        val connection = BillingConnection(
+            client = clientReturning(
+                result(BillingResponseCode.OK) to listOf(purchase(1_000)),
+                result(BillingResponseCode.OK) to listOf(
+                    purchase(2_000, products = listOf(OurSku.Sub.PRO_UPGRADE.id))
+                ),
+            ),
+        )
+        val emissions = mutableListOf<Collection<Purchase>>()
+        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            connection.purchases.collect { emissions.add(it) }
+        }
+
+        connection.refreshPurchases()
+        runCurrent()
+
+        // Both per-type results land in ONE committed state — observers never see an intermediate
+        // combination that refreshPurchases() didn't return.
+        emissions.size shouldBe 1
+    }
+
+    @Test fun `concurrent refreshes are serialized`() = runTest2 {
+        val pendingListeners = mutableListOf<PurchasesResponseListener>()
+        val client = mockk<BillingClient>().apply {
+            every { queryPurchasesAsync(any<QueryPurchasesParams>(), any()) } answers {
+                pendingListeners.add(secondArg())
+            }
+        }
+        val connection = BillingConnection(client = client)
+
+        val first = async(start = CoroutineStart.UNDISPATCHED) { connection.refreshPurchases() }
+        val second = async(start = CoroutineStart.UNDISPATCHED) { connection.refreshPurchases() }
+        runCurrent()
+
+        // Only the first refresh may query; the second waits on the mutex instead of racing its
+        // commit against a possibly newer result.
+        pendingListeners.size shouldBe 2
+
+        val owned = purchase(1_000)
+        pendingListeners.forEach { it.onQueryPurchasesResponse(result(BillingResponseCode.OK), mutableListOf(owned)) }
+        runCurrent()
+        first.await().purchases shouldBe listOf(owned)
+
+        pendingListeners.size shouldBe 4
+        pendingListeners.drop(2).forEach {
+            it.onQueryPurchasesResponse(result(BillingResponseCode.OK), mutableListOf(owned))
+        }
+        runCurrent()
+        second.await().purchases shouldBe listOf(owned)
+    }
+
+    @Test fun `purchase failures are delivered as events, repeats included`() = runTest2 {
+        val connection = BillingConnection(client = mockk())
+        val alreadyOwned = result(BillingResponseCode.ITEM_ALREADY_OWNED)
+
+        connection.onPurchasesUpdated(alreadyOwned, null)
+        connection.onPurchasesUpdated(alreadyOwned, null)
+
+        // Two identical back-to-back failures both arrive — event semantics, no conflation.
+        val received = connection.purchaseFailures.take(2).toList()
+        received.map { it.responseCode } shouldBe
+            listOf(BillingResponseCode.ITEM_ALREADY_OWNED, BillingResponseCode.ITEM_ALREADY_OWNED)
+    }
+
+    @Test fun `a failure event does not evict a fresh purchase event`() = runTest2 {
+        // Failures and successes travel separately: a reopened-sheet USER_CANCELED must not
+        // overwrite (or conflate away) a fresh purchase that no query snapshot contains yet.
+        val connection = BillingConnection(
+            client = clientReturning(
+                result(BillingResponseCode.OK) to emptyList(),
+                result(BillingResponseCode.OK) to emptyList(),
+            ),
+        )
+        connection.refreshPurchases() // empty snapshot, predates the purchase
+
+        val owned = purchase(1_000)
+        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(owned))
+        connection.onPurchasesUpdated(result(BillingResponseCode.USER_CANCELED), null)
+
+        connection.purchases.first() shouldBe listOf(owned)
+        connection.purchaseFailures.first().responseCode shouldBe BillingResponseCode.USER_CANCELED
+    }
+
+    @Test fun `a pending purchase never surfaces as owned or as fresh data`() = runTest2 {
+        val pending = mockk<Purchase>().apply {
+            every { purchaseState } returns PurchaseState.PENDING
+            every { purchaseTime } returns 1_000L
+            every { purchaseToken } returns "pending"
+            every { this@apply.products } returns listOf(OurSku.Iap.PRO_UPGRADE.id)
+        }
+        val connection = BillingConnection(
+            client = clientReturning(
+                result(BillingResponseCode.OK) to emptyList(),
+                result(BillingResponseCode.OK) to emptyList(),
+            ),
+        )
+
+        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(pending))
+        connection.refreshPurchases()
+
+        connection.purchases.first() shouldBe emptyList()
+        // Only the refresh's own emission — the PENDING event never produced one.
+        val update = connection.freshUpdates.first()
+        update.purchases shouldBe emptyList()
+        update.isFullSnapshot shouldBe true
+    }
+
+    @Test fun `fresh updates arrive in commit order`() = runTest2 {
+        // The event's emission precedes the covering refresh's: a consumer stamping the Pro grace
+        // period can never process a superseded event AFTER the query that cleared it.
+        val owned = purchase(1_000)
+        val connection = BillingConnection(
+            client = clientReturning(
+                result(BillingResponseCode.OK) to emptyList(),
+                result(BillingResponseCode.OK) to emptyList(),
+            ),
+        )
+
+        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(owned))
+        connection.refreshPurchases() // complete, clears the event
+
+        val updates = connection.freshUpdates.take(2).toList()
+        updates[0] shouldBe BillingConnection.FreshUpdate(listOf(owned), isFullSnapshot = false)
+        updates[1] shouldBe BillingConnection.FreshUpdate(emptyList(), isFullSnapshot = true)
+    }
+
+    @Test fun `fresh updates carry only query-confirmed data, never retained stale purchases`() = runTest2 {
+        val iapOwned = purchase(1_000, token = "iap")
+        val connection = BillingConnection(
+            client = clientReturning(
+                // Refresh 1: both succeed, IAP owned.
+                result(BillingResponseCode.OK) to listOf(iapOwned),
+                result(BillingResponseCode.OK) to emptyList(),
+                // Refresh 2: IAP fails (stale snapshot retained), SUB verified empty.
+                result(BillingResponseCode.ERROR) to emptyList(),
+                result(BillingResponseCode.OK) to emptyList(),
+            ),
+        )
+        connection.refreshPurchases()
+        // Refresh 2 found nothing fresh AND a query failed: it reports the couldn't-verify error —
+        // after committing what the SUB query did confirm.
+        shouldThrow<Exception> { connection.refreshPurchases() }
+
+        val updates = connection.freshUpdates.take(2).toList()
+        updates[0] shouldBe BillingConnection.FreshUpdate(listOf(iapOwned), isFullSnapshot = true)
+        // The retained IAP purchase is still in the reactive view, but it is NOT fresh Play data —
+        // re-emitting it would keep re-stamping the grace window without a real round-trip.
+        updates[1] shouldBe BillingConnection.FreshUpdate(emptyList(), isFullSnapshot = false)
+        connection.purchases.first().map { it.purchaseToken } shouldBe listOf("iap")
+    }
+
+    @Test fun `a hanging sku query callback cannot defeat the caller's timeout`() = runTest2 {
+        val client = mockk<BillingClient>().apply {
+            every { queryProductDetailsAsync(any(), any()) } answers { /* Play never calls back */ }
+        }
+        val connection = BillingConnection(client = client)
+
+        // With a non-cancellable suspension this would hang past the deadline until Play answered;
+        // suspendCancellableCoroutine lets the timeout fire on time.
+        val outcome = withTimeoutOrNull(1_000) {
+            connection.querySkus(OurSku.Iap.PRO_UPGRADE)
+        }
+
+        outcome shouldBe null
+    }
+
+    // endregion
 }

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/ui/GplayUpgradeScreenTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/ui/GplayUpgradeScreenTest.kt
@@ -11,9 +11,15 @@ import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.test.core.app.ApplicationProvider
+import com.android.billingclient.api.ProductDetails
 import eu.darken.sdmse.R
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.common.upgrade.core.OurSku
+import eu.darken.sdmse.common.upgrade.core.billing.SkuDetails
+import io.mockk.every
+import io.mockk.mockk
 import org.junit.Test
 import testhelpers.compose.BaseComposeRobolectricTest
 
@@ -165,6 +171,64 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
 
         composeRule.onNodeWithTag(UpgradeScreenTags.GPLAY_RESTORE_BANNER_ACTION).assertIsNotEnabled()
         composeRule.onNodeWithTag(UpgradeScreenTags.GPLAY_RESTORE).assertIsNotEnabled()
+    }
+
+    @Test
+    fun `a running restore pauses the buy actions too`() {
+        // toLoadedState computes the enabled flags: a restore in progress (manual or the invisible
+        // already-owned recovery) must gate them even when offers are available -- a buy tap would
+        // just race the restore into ITEM_ALREADY_OWNED.
+        val iapOffer = mockk<ProductDetails.OneTimePurchaseOfferDetails>(relaxed = true)
+        val iapDetails = mockk<ProductDetails>(relaxed = true).apply {
+            every { oneTimePurchaseOfferDetails } returns iapOffer
+        }
+        val subOffer = mockk<ProductDetails.SubscriptionOfferDetails>(relaxed = true).apply {
+            every { basePlanId } returns OurSku.Sub.PRO_UPGRADE.BASE_OFFER.basePlanId
+            every { offerId } returns null
+        }
+        val subDetails = mockk<ProductDetails>(relaxed = true).apply {
+            every { subscriptionOfferDetails } returns listOf(subOffer)
+        }
+
+        val loaded = toLoadedState(
+            iap = SkuDetails(OurSku.Iap.PRO_UPGRADE, iapDetails),
+            sub = SkuDetails(OurSku.Sub.PRO_UPGRADE, subDetails),
+            hasIap = false,
+            hasSub = false,
+            restoreInProgress = true,
+        )
+
+        check(!loaded.iapEnabled) { "IAP buy must be disabled during a restore" }
+        check(!loaded.subscriptionEnabled) { "Subscription buy must be disabled during a restore" }
+
+        // Same offers without a running restore: both buys are available.
+        val idle = toLoadedState(
+            iap = SkuDetails(OurSku.Iap.PRO_UPGRADE, iapDetails),
+            sub = SkuDetails(OurSku.Sub.PRO_UPGRADE, subDetails),
+            hasIap = false,
+            hasSub = false,
+            restoreInProgress = false,
+        )
+        check(idle.iapEnabled) { "IAP buy should be enabled when idle" }
+        check(idle.subscriptionEnabled) { "Subscription buy should be enabled when idle" }
+    }
+
+    @Test
+    fun `unavailable state offers a retry that fires the callback`() {
+        var retryClicks = 0
+        composeRule.setUpgradeContent {
+            UpgradeScreen(
+                uiState = GplayUpgradeUiState.Unavailable(
+                    error = RuntimeException("Google Play services unavailable"),
+                ),
+                onRetry = { retryClicks++ },
+            )
+        }
+
+        // The unavailable card sits below the fold of the scrollable screen: an offscreen click
+        // would silently miss the button.
+        composeRule.onNodeWithTag(UpgradeScreenTags.GPLAY_RETRY).performScrollTo().performClick()
+        composeRule.runOnIdle { check(retryClicks == 1) { "expected 1 retry click, got $retryClicks" } }
     }
 
     @Test

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/ui/GplayUpgradeViewModelTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/ui/GplayUpgradeViewModelTest.kt
@@ -50,24 +50,17 @@ class GplayUpgradeViewModelTest : BaseTest() {
     fun `service timeout becomes unavailable state and error event instead of crashing`() = runTest2(
         context = testDispatcher,
     ) {
-        val upgradeInfo = MutableStateFlow(UpgradeRepoGplay.Info(false, null, null))
-        val repo = mockk<UpgradeRepoGplay>(relaxed = true)
-        every { repo.upgradeInfo } returns upgradeInfo
-        every { repo.wasEverPro } returns MutableStateFlow(false)
+        val repo = mockRepo()
         coEvery { repo.querySkus(OurSku.Iap.PRO_UPGRADE) } coAnswers {
-            delay(6_000)
+            delay(20_000) // longer than the 15s SKU query timeout
             emptyList()
         }
         coEvery { repo.querySkus(OurSku.Sub.PRO_UPGRADE) } coAnswers {
-            delay(6_000)
+            delay(20_000)
             emptyList()
         }
 
-        val vm = UpgradeViewModel(
-            handle = SavedStateHandle(mapOf("forced" to false)),
-            dispatcherProvider = TestDispatcherProvider(testDispatcher),
-            upgradeRepo = repo,
-        )
+        val vm = buildVm(repo)
 
         val unavailableState = async {
             vm.state.first { it is GplayUpgradeUiState.Unavailable }
@@ -84,9 +77,102 @@ class GplayUpgradeViewModelTest : BaseTest() {
         coVerify(exactly = 1) { repo.querySkus(OurSku.Sub.PRO_UPGRADE) }
     }
 
+    @Test
+    fun `a slow but healthy Play store loads instead of tripping the timeout`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // The first-ever billing query after Play sign-in measured 8.5s on-device: the old 5s
+        // timeout turned that healthy store into a false "Play unavailable".
+        val repo = mockRepo()
+        coEvery { repo.querySkus(any()) } coAnswers {
+            delay(9_000)
+            emptyList()
+        }
+
+        val vm = buildVm(repo)
+
+        val loaded = async { vm.state.first { it is GplayUpgradeUiState.Loaded } }
+        advanceUntilIdle()
+
+        loaded.await().shouldBeInstanceOf<GplayUpgradeUiState.Loaded>()
+    }
+
+    @Test
+    fun `retry recovers the screen after a full unavailable episode`() = runTest2(
+        context = testDispatcher,
+    ) {
+        val repo = mockRepo()
+        var calls = 0
+        coEvery { repo.querySkus(any()) } coAnswers {
+            // First generation (both product types) fails; the retried generation succeeds.
+            if (calls++ < 2) throw GplayServiceUnavailableException(RuntimeException("Play hiccup"))
+            emptyList()
+        }
+        val vm = buildVm(repo)
+
+        val unavailable = async { vm.state.first { it is GplayUpgradeUiState.Unavailable } }
+        advanceUntilIdle()
+        unavailable.await().shouldBeInstanceOf<GplayUpgradeUiState.Unavailable>()
+
+        // Without the retry, the Lazily-cached failure bricked the screen for the VM lifetime.
+        vm.retrySkuQuery()
+        val loaded = async { vm.state.first { it is GplayUpgradeUiState.Loaded } }
+        advanceUntilIdle()
+
+        loaded.await().shouldBeInstanceOf<GplayUpgradeUiState.Loaded>()
+        coVerify(exactly = 4) { repo.querySkus(any()) }
+    }
+
+    @Test
+    fun `a single failed product type keeps the screen loaded and surfaces the error once`() = runTest2(
+        context = testDispatcher,
+    ) {
+        val repo = mockRepo()
+        val boom = IllegalStateException("IAP details broken")
+        coEvery { repo.querySkus(OurSku.Iap.PRO_UPGRADE) } throws boom
+        coEvery { repo.querySkus(OurSku.Sub.PRO_UPGRADE) } returns emptyList()
+        val vm = buildVm(repo)
+
+        val loaded = async { vm.state.first { it is GplayUpgradeUiState.Loaded } }
+        val forwardedError = async { vm.errorEvents.first() }
+        advanceUntilIdle()
+
+        // The working product type is still offered; only the failure is reported.
+        loaded.await().shouldBeInstanceOf<GplayUpgradeUiState.Loaded>()
+        forwardedError.await() shouldBe boom
+    }
+
+    @Test
+    fun `the repo's auto-restore busy state folds into restoreInProgress`() = runTest2(
+        context = testDispatcher,
+    ) {
+        val autoBusy = MutableStateFlow(false)
+        val repo = mockRepo()
+        every { repo.autoRestoreBusy } returns autoBusy
+        coEvery { repo.querySkus(any()) } returns emptyList()
+        val vm = buildVm(repo)
+
+        val idle = async {
+            vm.state.first { it is GplayUpgradeUiState.Loaded } as GplayUpgradeUiState.Loaded
+        }
+        advanceUntilIdle()
+        idle.await().restoreInProgress shouldBe false
+
+        // The invisible already-owned recovery must pause the entitlement actions like a manual
+        // restore does -- the user can't be allowed to race it with a buy or another restore.
+        autoBusy.value = true
+        val busy = async {
+            vm.state.first { it is GplayUpgradeUiState.Loaded && it.restoreInProgress }
+        }
+        advanceUntilIdle()
+        (busy.await() as GplayUpgradeUiState.Loaded).restoreInProgress shouldBe true
+    }
+
     private fun mockRepo(): UpgradeRepoGplay = mockk<UpgradeRepoGplay>(relaxed = true).apply {
         every { upgradeInfo } returns MutableStateFlow(UpgradeRepoGplay.Info(false, null, null))
         every { wasEverPro } returns MutableStateFlow(false)
+        // Relaxed mocks return a no-op Flow that never emits -- the state combine would starve.
+        every { autoRestoreBusy } returns MutableStateFlow(false)
     }
 
     private fun buildVm(repo: UpgradeRepoGplay): UpgradeViewModel = UpgradeViewModel(
@@ -140,8 +226,7 @@ class GplayUpgradeViewModelTest : BaseTest() {
 
     @Test
     fun `previously-pro on this device flows into the loaded banner flag`() = runTest2(context = testDispatcher) {
-        val repo = mockk<UpgradeRepoGplay>(relaxed = true)
-        every { repo.upgradeInfo } returns MutableStateFlow(UpgradeRepoGplay.Info(false, null, null))
+        val repo = mockRepo()
         every { repo.wasEverPro } returns MutableStateFlow(true)
         coEvery { repo.querySkus(OurSku.Iap.PRO_UPGRADE) } returns emptyList()
         coEvery { repo.querySkus(OurSku.Sub.PRO_UPGRADE) } returns emptyList()
@@ -157,7 +242,7 @@ class GplayUpgradeViewModelTest : BaseTest() {
 
     @Test
     fun `banner flag stays off while grace still keeps the user pro`() = runTest2(context = testDispatcher) {
-        val repo = mockk<UpgradeRepoGplay>(relaxed = true)
+        val repo = mockRepo()
         // gracePeriod = true => Info.isPro is true even without a current raw purchase.
         every { repo.upgradeInfo } returns MutableStateFlow(UpgradeRepoGplay.Info(gracePeriod = true, billingData = null))
         every { repo.wasEverPro } returns MutableStateFlow(true)


### PR DESCRIPTION
## What changed

Google Play billing recovers much more reliably from outages, slow stores, and mid-purchase hiccups:

- If Google Play is unavailable, tapping restore, buy, or reopening the upgrade screen now reconnects immediately instead of waiting out a retry timer of up to 5 minutes — and repeated outages no longer start at the maximum wait.
- A restore that succeeded no longer sometimes leaves the app locked anyway (the restore result and the app's Pro state could disagree when Play only answered half the query).
- The upgrade screen's price loading now tolerates a slow-but-healthy Play store (first query after sign-in can take ~9 seconds) instead of showing a false "Google Play unavailable" error, and when Play really is unavailable, the screen now has a Retry button instead of staying dead until reopened.
- Buying is paused while a restore is running, so the two can no longer race each other into "you already own this" errors and duplicate dialogs.
- One-time Pro buyers can no longer have their 30-day outage grace period silently shortened to 7 days by an incomplete answer from Play.

## Technical Context

- These are seven defects found while porting the recent billing series (#2554–#2562) to a sibling app, where the ports were review-hardened and live-smoke-tested; all seven were confirmed present here.
- Root causes, briefly: a zero-replay kick signal dropped reconnect demand that arrived mid-attempt, and `retryWhen`'s lifetime attempt counter never reset; per-type query caches behind `filterNotNull()` starved the reactive purchases flow on partial failures; success and failure purchase events shared one `MutableStateFlow`, so a later cancel could evict a fresh purchase; grace stamping couldn't distinguish full ownership snapshots from partial data.
- Rather than porting the reference fixes verbatim, the weak structures were redesigned: one demand-aware connect loop in `BillingManager` owns all retry policy (the provider is now a single-attempt `callbackFlow`), and `BillingConnection` tracks ownership in a single atomically-committed reducer state (per-type snapshots + a generation-tagged purchase-event overlay) whose merged view feeds both the reactive flow and `refreshPurchases()` returns — so restore results and reactive state agree by construction. Fresh-data emissions for grace bookkeeping happen inside the reducer's commit, in commit order.
- Behavioral side effects worth knowing: reconnect backoff is now 2s/8s/32s/128s/300s (streak-based, resets on success); a cold start where one product query fails and nothing is found now retries as a connection failure instead of leaving `isSettled` starved forever; `suspendCoroutine` → `suspendCancellableCoroutine` in the Play callback wrappers means the SKU/refresh timeouts actually fire when Play never answers.
- Review guidance: the connect loop (demand counters, invalidation race) and the reducer's overlay-clearing rules are the tricky parts; both have dedicated regression tests (46 billing tests total, 1070 module-wide green, lint-vital clean).
- Verified on an emulator with a license-tester account: cold owned start (connect → query → Pro → ack → single grace stamp), full outage cycle with backoff progression, and recovery — a Retry tap during the 300s backoff reconnected in 31ms and the upgrade screen auto-closed as Pro landed.
