### PR TITLE
Fix: Delete app data on SD cards correctly on Android 11 and 12

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalGateway.kt
@@ -625,8 +625,8 @@ class LocalGateway @Inject constructor(
                         javaFile.exists() -> true
                         // This is a bit iffy, but checking readability on the parent has proven reliable
                         javaFileParent?.exists() == true && javaFileParent.canRead() -> true
-                        // On Android 12+ Android/data isn't accessible anymore via normal java file access.
-                        hasApiLevel(32) && storageEnvironment.publicDataDirs.any { it.isAncestorOf(path) } -> false
+                        // On Android 11+ other apps' Android/data isn't accessible anymore via normal java file access.
+                        hasApiLevel(30) && storageEnvironment.publicDataDirs.any { it.isAncestorOf(path) } -> false
                         // If the file path is on public storage, and it wasn't Android/data then, assume true
                         else -> storageEnvironment.externalDirs
                             .firstOrNull { it.isAncestorOf(path) }
@@ -818,8 +818,8 @@ class LocalGateway @Inject constructor(
                 javaFile.exists() -> false
                 // Does it not exist or do we lack permission? Also see `LocalGateway.exists(...)`
                 else -> when {
-                    // On Android 12+ Android/data isn't accessible anymore via normal java file access.
-                    hasApiLevel(32) && storageEnvironment.publicDataDirs.any { it.isAncestorOf(path) } -> false
+                    // On Android 11+ other apps' Android/data isn't accessible anymore via normal java file access.
+                    hasApiLevel(30) && storageEnvironment.publicDataDirs.any { it.isAncestorOf(path) } -> false
                     // If the file path is on public storage, and it wasn't Android/data then, assume true
                     else -> storageEnvironment.externalDirs
                         .firstOrNull { it.isAncestorOf(path) }
@@ -845,30 +845,27 @@ class LocalGateway @Inject constructor(
                     }
 
                     if (!success) {
-                        success = !javaFile.exists()
-                        if (success) {
-                            log(TAG, WARN) { "Tried to delete file, but it's already gone: $path" }
-                        } else if (!normalCanWrite) {
-                            // This was not AUTO, but Mode.NORMAL, we don't try other modes after this
-                            throw WriteException(path = path)
-                        }
+                        // On Android 11+ exists() may be unreliable under Android/data: scoped storage can hide
+                        // paths from normal java file access, so invisibility is not proof of successful deletion.
+                        val existsIsReliable = !hasApiLevel(30) ||
+                            storageEnvironment.publicDataDirs.none { it.isAncestorOf(path) }
+                        success = existsIsReliable && !javaFile.exists()
+                        if (success) log(TAG, WARN) { "Tried to delete file, but it's already gone: $path" }
                     }
 
                     if (!success) {
-                        if (mode == Mode.AUTO && hasRoot()) {
-                            delete(path, recursive = recursive, mode = Mode.ROOT)
-                            return@runIO
-                        } else {
-                            throw IOException("delete() call returned false")
-                        }
-                    }
+                        when {
+                            mode == Mode.AUTO && hasRoot() -> {
+                                delete(path, recursive = recursive, mode = Mode.ROOT)
+                                return@runIO
+                            }
 
-                    if (!success) {
-                        if (mode == Mode.AUTO && hasAdb()) {
-                            delete(path, recursive = recursive, mode = Mode.ADB)
-                            return@runIO
-                        } else {
-                            throw IOException("delete() call returned false")
+                            mode == Mode.AUTO && hasAdb() -> {
+                                delete(path, recursive = recursive, mode = Mode.ADB)
+                                return@runIO
+                            }
+
+                            else -> throw IOException("delete() call returned false")
                         }
                     }
                 }

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/LocalGatewayTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/LocalGatewayTest.kt
@@ -1,10 +1,22 @@
 package eu.darken.sdmse.common.files.local
 
+import eu.darken.sdmse.common.adb.AdbManager
+import eu.darken.sdmse.common.adb.service.AdbServiceClient
+import eu.darken.sdmse.common.adb.service.runModuleAction
 import eu.darken.sdmse.common.files.FileType
+import eu.darken.sdmse.common.files.WriteException
+import eu.darken.sdmse.common.files.local.ipc.FileOpsClient
 import eu.darken.sdmse.common.root.RootManager
+import eu.darken.sdmse.common.storage.StorageEnvironment
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.flowOf
 import org.junit.After
 import org.junit.Test
@@ -26,8 +38,139 @@ class LocalGatewayTest : BaseTest() {
 
     @After
     fun cleanup() {
+        unmockkAll()
         testDir.deleteRecursively()
     }
+
+    // Mirrors the reported bug setup: a secondary storage (SD card) whose root is writable while
+    // another app's Android/data subtree is completely invisible to normal java.io.File access.
+    private val storageRoot = File(testDir, "storage/1234-5678")
+    private val publicData = File(storageRoot, "Android/data")
+    private val hiddenTarget = File(publicData, "com.example.app/files")
+
+    private fun CoroutineScope.gateway(
+        rootAvailable: Boolean = false,
+        adbAvailable: Boolean = false,
+    ) = LocalGateway(
+        ipcFunnel = mockk(),
+        libcoreTool = mockk(),
+        appScope = this,
+        dispatcherProvider = TestDispatcherProvider(),
+        storageEnvironment = mockk<StorageEnvironment> {
+            every { externalDirs } returns listOf(LocalPath.build(storageRoot))
+            every { publicDataDirs } returns listOf(LocalPath.build(publicData))
+        },
+        rootManager = mockk<RootManager> { every { useRoot } returns flowOf(rootAvailable) },
+        adbManager = mockk<AdbManager> {
+            every { useAdb } returns flowOf(adbAvailable)
+            every { serviceClient } returns mockk(relaxed = true)
+        },
+    )
+
+    private fun mockAdbFileOps(): FileOpsClient {
+        val fileOps = mockk<FileOpsClient>()
+        mockkStatic("eu.darken.sdmse.common.adb.service.AdbServiceClientExtensionsKt")
+        coEvery {
+            any<AdbServiceClient>().runModuleAction<FileOpsClient, Any?>(FileOpsClient::class.java, any())
+        } coAnswers {
+            arg<suspend (FileOpsClient) -> Any?>(2).invoke(fileOps)
+        }
+        return fileOps
+    }
+
+    @Test
+    @Config(sdk = [30, 31])
+    fun `AUTO delete escalates hidden public Android-data paths to ADB on API30+`() =
+        runTest2(autoCancel = true) {
+            storageRoot.mkdirs()
+            val targetPath = LocalPath.build(hiddenTarget)
+            val fileOps = mockAdbFileOps().apply {
+                every { delete(targetPath, recursive = true, dryRun = false) } returns true
+            }
+
+            // Precondition (SM-G973F@API31 bug scenario): storage root writable, target invisible.
+            storageRoot.canWrite() shouldBe true
+            hiddenTarget.exists() shouldBe false
+
+            // Old behavior: hasApiLevel(32) guard didn't fire on API 30/31, the writable storage root
+            // made this a NORMAL delete, and !exists() was misread as "already gone" -> false
+            // success without ever touching ADB.
+            gateway(adbAvailable = true).delete(targetPath, recursive = true, mode = LocalGateway.Mode.AUTO)
+
+            verify(exactly = 1) { fileOps.delete(targetPath, recursive = true, dryRun = false) }
+        }
+
+    @Test
+    @Config(sdk = [30, 31])
+    fun `AUTO delete does not fake success for hidden public Android-data paths without escalation`() =
+        runTest2(autoCancel = true) {
+            storageRoot.mkdirs()
+
+            // Old behavior: silent false success ("already gone"). Without root/adb there is no way
+            // to verify or perform this deletion, so it must fail instead of inflating results.
+            shouldThrow<WriteException> {
+                gateway().delete(LocalPath.build(hiddenTarget), recursive = true, mode = LocalGateway.Mode.AUTO)
+            }
+        }
+
+    @Test
+    @Config(sdk = [30, 31])
+    fun `NORMAL delete of an invisible public Android-data path fails instead of faking success`() =
+        runTest2(autoCancel = true) {
+            storageRoot.mkdirs()
+
+            // Explicit NORMAL forces the direct attempt: delete() returns false and raw exists() is
+            // also false. Previously that combination was reported as "already gone" success.
+            shouldThrow<WriteException> {
+                gateway().delete(LocalPath.build(hiddenTarget), recursive = true, mode = LocalGateway.Mode.NORMAL)
+            }
+        }
+
+    @Test
+    fun `AUTO delete falls back to ADB when a NORMAL delete attempt fails`() =
+        runTest2(autoCancel = true) {
+            // Visible, writable, non-empty directory: NORMAL is chosen, but a non-recursive
+            // File.delete() fails on it and the target still exists afterwards.
+            val fullDir = File(storageRoot, "Documents/full").apply { mkdirs() }
+            File(fullDir, "content.txt").writeText("data")
+            val targetPath = LocalPath.build(fullDir)
+            val fileOps = mockAdbFileOps().apply {
+                every { delete(targetPath, recursive = true, dryRun = false) } returns true
+            }
+
+            // Old behavior: the ADB fallback after a failed NORMAL delete was dead code, AUTO threw
+            // instead of escalating to an available ADB connection.
+            gateway(adbAvailable = true).delete(targetPath, recursive = false, mode = LocalGateway.Mode.AUTO)
+
+            verify(exactly = 1) { fileOps.delete(targetPath, recursive = true, dryRun = false) }
+        }
+
+    @Test
+    @Config(sdk = [31])
+    fun `AUTO delete keeps already-gone semantics outside public Android-data`() =
+        runTest2(autoCancel = true) {
+            storageRoot.mkdirs()
+            val missing = File(storageRoot, "Documents/missing.txt")
+
+            // Not under Android/data: exists() is trustworthy, a missing target stays a no-op success.
+            gateway().delete(LocalPath.build(missing), recursive = true, mode = LocalGateway.Mode.AUTO)
+        }
+
+    @Test
+    @Config(sdk = [30, 31])
+    fun `AUTO exists escalates hidden public Android-data paths to ADB on API30+`() =
+        runTest2(autoCancel = true) {
+            storageRoot.mkdirs()
+            val targetPath = LocalPath.build(hiddenTarget)
+            val fileOps = mockAdbFileOps().apply {
+                every { exists(targetPath) } returns true
+            }
+
+            // Old behavior: NORMAL was considered usable and reported false for content that ADB can see.
+            gateway(adbAvailable = true).exists(targetPath, LocalGateway.Mode.AUTO) shouldBe true
+
+            verify(exactly = 1) { fileOps.exists(targetPath) }
+        }
 
     @Test
     fun `lookup of a broken symlink resolves app-side without privileged escalation`() =


### PR DESCRIPTION
## What changed

Fixed a bug where cleaning another app's data stored on the SD card (`Android/data`) on Android 11 and 12 reported success but didn't actually delete anything. The freed-space results were inflated by the files that survived. Deletion of these paths now goes through ADB/root as intended.

Origin: user support report with debug logs (Galaxy S10, Android 12, Shizuku enabled) — a SystemCleaner custom filter deleted the app's internal data but silently skipped the matching files on the SD card while reporting ~60 MB freed.

## Technical Context

- Root cause: `LocalGateway`'s guard for "other apps' `Android/data` isn't reachable via normal java file access" was gated on `hasApiLevel(32)`, but the platform restriction exists since Android 11 (API 30). On API 30/31 the guard never fired, so the delete was routed to plain `java.io.File`.
- On secondary storage these paths are completely invisible to direct file access, so the failed delete's `!exists()` check was misread as "already gone" → false success, and ADB/root escalation was skipped. On primary storage the same path is visible, which forced escalation — that's why internal data deleted fine while SD-card data survived.
- Same wrong threshold existed in `exists()`; fixed both.
- Also fixed while in there: the NORMAL→ADB fallback in `delete()` was unreachable (the preceding failure block either returned or threw), so a failed direct delete could never escalate to ADB for no-root users. The two blocks are now one escalation step: ROOT preferred, ADB otherwise.
- Hardening: invisibility (`!exists()`) is no longer accepted as proof of deletion under `Android/data` on API 30+, preventing this class of false success even if the mode heuristic misjudges again.
- Behavior notes for review: an explicit `Mode.NORMAL` delete of an invisible `Android/data` path now throws `WriteException` instead of falsely succeeding, and its cause chain changed slightly (`WriteException(cause=IOException)` instead of a nested `WriteException`).
- Known pre-existing issue, intentionally not touched here: the ROOT/ADB delete branches hardcode `recursive = true` regardless of the caller's argument.
- Regression tests cover API 30 and 31: ADB escalation for hidden SD-card `Android/data` paths (delete + exists), no false success without escalation options, direct hardening via `Mode.NORMAL`, the restored NORMAL→ADB fallback, and unchanged "already gone" semantics outside `Android/data`.
