### PR TITLE
General: Keep Pro grace reliable and record its history in debug logs

### DIFF
--- a/app-common/src/main/java/eu/darken/sdmse/main/core/CurriculumVitae.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/main/core/CurriculumVitae.kt
@@ -4,7 +4,12 @@ import android.content.Context
 import android.content.pm.PackageInfo
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import dagger.Lazy
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.sdmse.common.BuildConfigWrap
 import eu.darken.sdmse.common.coroutine.AppScope
@@ -45,7 +50,9 @@ class CurriculumVitae @Inject constructor(
     @ApplicationContext private val context: Context,
     @AppScope private val appScope: CoroutineScope,
     json: Json,
-    private val upgradeRepo: UpgradeRepo,
+    // Lazy: UpgradeRepoGplay reports Pro-state transitions back to us (updateProState), which
+    // would otherwise be a dependency cycle.
+    private val upgradeRepo: Lazy<UpgradeRepo>,
     private val dispatcherProvider: DispatcherProvider,
 ) {
 
@@ -82,7 +89,7 @@ class CurriculumVitae @Inject constructor(
         log(TAG, VERBOSE) { "updateInstalledAt(): system: $systemInstalledAt" }
 
         val upgradedAt = try {
-            upgradeRepo.upgradeInfo
+            upgradeRepo.get().upgradeInfo
                 .filter { !it.isPro || it.upgradedAt != null }
                 .timeout(5.seconds)
                 .first()
@@ -173,6 +180,66 @@ class CurriculumVitae @Inject constructor(
         _openedCount.value(newOpenedcount)
     }
 
+    // Lifetime Pro-state history: how often the billing grace period had to save this install, and
+    // whether/when Pro was actually lost. Written by the gplay UpgradeRepo from FRESH Play data
+    // only; surfaced in every debug log recording so billing complaints arrive with context.
+    // Raw preference keys (not DataStoreValues): a transition must update state, counter, and
+    // timestamp in ONE transaction.
+    private val proStateLastKey = stringPreferencesKey("stats.pro.state.last")
+    private val proGraceCountKey = intPreferencesKey("stats.pro.grace.count")
+    private val proGraceLastKey = longPreferencesKey("stats.pro.grace.last")
+    private val proLostCountKey = intPreferencesKey("stats.pro.lost.count")
+    private val proLostLastKey = longPreferencesKey("stats.pro.lost.last")
+
+    enum class ProState { PURCHASED, GRACE, FREE }
+
+    data class ProHistory(
+        val lastState: ProState?,
+        val graceEngagedCount: Int,
+        val graceEngagedLast: Instant?,
+        val proLostCount: Int,
+        val proLostLast: Instant?,
+    )
+
+    // Suspend on purpose: the caller's collector is ordered (billing commit order) and a
+    // fire-and-forget launch per update could apply rapid transitions out of order.
+    suspend fun updateProState(state: ProState) {
+        dataStore.edit { prefs ->
+            val previous = parseProState(prefs[proStateLastKey])
+            if (previous == state) return@edit
+            log(TAG, INFO) { "updateProState(): $previous -> $state" }
+            val now = Instant.now().toEpochMilli()
+            when (proTransitionOf(previous, state)) {
+                ProTransition.GRACE_ENGAGED -> {
+                    prefs[proGraceCountKey] = (prefs[proGraceCountKey] ?: 0) + 1
+                    prefs[proGraceLastKey] = now
+                }
+
+                ProTransition.PRO_LOST -> {
+                    prefs[proLostCountKey] = (prefs[proLostCountKey] ?: 0) + 1
+                    prefs[proLostLastKey] = now
+                }
+
+                // First observation (or an unknown/corrupt stored value): baseline only.
+                null -> {}
+            }
+            prefs[proStateLastKey] = state.name
+        }
+    }
+
+    suspend fun proHistory(): ProHistory {
+        val prefs = dataStore.data.first()
+        return ProHistory(
+            lastState = parseProState(prefs[proStateLastKey]),
+            graceEngagedCount = prefs[proGraceCountKey] ?: 0,
+            graceEngagedLast = prefs[proGraceLastKey]?.let { Instant.ofEpochMilli(it) },
+            proLostCount = prefs[proLostCountKey] ?: 0,
+            proLostLast = prefs[proLostLastKey]?.let { Instant.ofEpochMilli(it) },
+        )
+    }
+
+    internal enum class ProTransition { GRACE_ENGAGED, PRO_LOST }
+
     fun isAnniversary(): Boolean {
         val installedAt = _installedFirst.valueBlocking ?: return false
         val now = LocalDate.now()
@@ -206,5 +273,21 @@ class CurriculumVitae @Inject constructor(
 
     companion object {
         internal val TAG = logTag("Debug", "CurriculumVitae")
+
+        // Tolerant of blank/corrupt/future enum names: an unknown stored value must behave like a
+        // fresh baseline, not kill the update job or the recorder's history read.
+        internal fun parseProState(raw: String?): ProState? =
+            raw?.let { r -> ProState.entries.firstOrNull { it.name == r } }
+
+        // Which transitions count: grace only "engages" coming FROM a confirmed purchase, and Pro
+        // is only "lost" when a previously Pro-ish state drops to FREE. Everything else (baseline,
+        // recovery, unknown previous value) just moves the stored state. Pure and unit-tested.
+        internal fun proTransitionOf(previous: ProState?, current: ProState): ProTransition? = when {
+            previous == ProState.PURCHASED && current == ProState.GRACE -> ProTransition.GRACE_ENGAGED
+            (previous == ProState.PURCHASED || previous == ProState.GRACE) && current == ProState.FREE ->
+                ProTransition.PRO_LOST
+
+            else -> null
+        }
     }
 }

--- a/app-common/src/test/java/eu/darken/sdmse/main/core/CurriculumVitaeProHistoryTest.kt
+++ b/app-common/src/test/java/eu/darken/sdmse/main/core/CurriculumVitaeProHistoryTest.kt
@@ -1,0 +1,83 @@
+package eu.darken.sdmse.main.core
+
+import androidx.test.core.app.ApplicationProvider
+import dagger.Lazy
+import eu.darken.sdmse.common.serialization.SerializationCommonModule
+import eu.darken.sdmse.common.upgrade.UpgradeRepo
+import eu.darken.sdmse.main.core.CurriculumVitae.ProState
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+import testhelpers.coroutine.TestDispatcherProvider
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class CurriculumVitaeProHistoryTest : BaseTest() {
+
+    // One test method on purpose: DataStore forbids two active instances on the same file, and
+    // CurriculumVitae is a @Singleton in production.
+    @Test
+    fun `pro state transitions persist counters atomically and in order`() = runTest {
+        // The real DI Json config: CV's existing values (e.g. the Instant install date) need the
+        // contextual serializers.
+        val serialization = SerializationCommonModule()
+        val cv = CurriculumVitae(
+            context = ApplicationProvider.getApplicationContext(),
+            appScope = CoroutineScope(Dispatchers.Unconfined),
+            json = serialization.json(),
+            upgradeRepo = Lazy<UpgradeRepo> { mockk(relaxed = true) },
+            dispatcherProvider = TestDispatcherProvider(),
+        )
+
+        cv.proHistory() shouldBe CurriculumVitae.ProHistory(
+            lastState = null,
+            graceEngagedCount = 0,
+            graceEngagedLast = null,
+            proLostCount = 0,
+            proLostLast = null,
+        )
+
+        // First observation is a baseline, not a transition.
+        cv.updateProState(ProState.PURCHASED)
+        cv.proHistory().apply {
+            lastState shouldBe ProState.PURCHASED
+            graceEngagedCount shouldBe 0
+            proLostCount shouldBe 0
+        }
+
+        // Repeats are no-ops.
+        cv.updateProState(ProState.PURCHASED)
+        cv.proHistory().graceEngagedCount shouldBe 0
+
+        // A rapid PURCHASED -> GRACE -> FREE episode: exactly one increment each, final state FREE.
+        cv.updateProState(ProState.GRACE)
+        cv.updateProState(ProState.FREE)
+        cv.proHistory().apply {
+            lastState shouldBe ProState.FREE
+            graceEngagedCount shouldBe 1
+            graceEngagedLast shouldNotBe null
+            proLostCount shouldBe 1
+            proLostLast shouldNotBe null
+        }
+
+        // Recovery doesn't count; a second full episode counts again.
+        cv.updateProState(ProState.PURCHASED)
+        cv.updateProState(ProState.GRACE)
+        cv.updateProState(ProState.PURCHASED)
+        cv.updateProState(ProState.FREE)
+        cv.proHistory().apply {
+            lastState shouldBe ProState.FREE
+            graceEngagedCount shouldBe 2
+            proLostCount shouldBe 2
+        }
+    }
+}

--- a/app-common/src/test/java/eu/darken/sdmse/main/core/CurriculumVitaeProStateTest.kt
+++ b/app-common/src/test/java/eu/darken/sdmse/main/core/CurriculumVitaeProStateTest.kt
@@ -1,0 +1,44 @@
+package eu.darken.sdmse.main.core
+
+import eu.darken.sdmse.main.core.CurriculumVitae.ProState
+import eu.darken.sdmse.main.core.CurriculumVitae.ProTransition
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class CurriculumVitaeProStateTest : BaseTest() {
+
+    @Test fun `grace only engages coming from a confirmed purchase`() {
+        CurriculumVitae.proTransitionOf(ProState.PURCHASED, ProState.GRACE) shouldBe ProTransition.GRACE_ENGAGED
+
+        // A launch that settles straight into grace (or a baseline) is not a new engagement.
+        CurriculumVitae.proTransitionOf(null, ProState.GRACE) shouldBe null
+        CurriculumVitae.proTransitionOf(ProState.FREE, ProState.GRACE) shouldBe null
+        CurriculumVitae.proTransitionOf(ProState.GRACE, ProState.GRACE) shouldBe null
+    }
+
+    @Test fun `pro is lost when a pro-ish state drops to free`() {
+        CurriculumVitae.proTransitionOf(ProState.PURCHASED, ProState.FREE) shouldBe ProTransition.PRO_LOST
+        CurriculumVitae.proTransitionOf(ProState.GRACE, ProState.FREE) shouldBe ProTransition.PRO_LOST
+
+        CurriculumVitae.proTransitionOf(null, ProState.FREE) shouldBe null
+        CurriculumVitae.proTransitionOf(ProState.FREE, ProState.FREE) shouldBe null
+    }
+
+    @Test fun `recovering pro is never a counted transition`() {
+        CurriculumVitae.proTransitionOf(null, ProState.PURCHASED) shouldBe null
+        CurriculumVitae.proTransitionOf(ProState.GRACE, ProState.PURCHASED) shouldBe null
+        CurriculumVitae.proTransitionOf(ProState.FREE, ProState.PURCHASED) shouldBe null
+        CurriculumVitae.proTransitionOf(ProState.PURCHASED, ProState.PURCHASED) shouldBe null
+    }
+
+    @Test fun `stored state parsing tolerates blank, corrupt and future values`() {
+        CurriculumVitae.parseProState(null) shouldBe null
+        CurriculumVitae.parseProState("") shouldBe null
+        CurriculumVitae.parseProState("garbage") shouldBe null
+        CurriculumVitae.parseProState("PURCHASED_V2") shouldBe null
+        CurriculumVitae.parseProState("PURCHASED") shouldBe ProState.PURCHASED
+        CurriculumVitae.parseProState("GRACE") shouldBe ProState.GRACE
+        CurriculumVitae.parseProState("FREE") shouldBe ProState.FREE
+    }
+}

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplay.kt
@@ -40,17 +40,18 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeoutOrNull
+import eu.darken.sdmse.main.core.CurriculumVitae
 import java.time.Duration
 import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlin.math.pow
 
 @Singleton
 class UpgradeRepoGplay @Inject constructor(
     @AppScope private val scope: CoroutineScope,
     private val billingManager: BillingManager,
     private val billingCache: BillingCache,
+    private val curriculumVitae: CurriculumVitae,
 ) : UpgradeRepo {
 
     override val storeSite: String = STORE_SITE
@@ -77,6 +78,7 @@ class UpgradeRepoGplay @Inject constructor(
             .onEach { fresh ->
                 try {
                     stampLastProState(fresh)
+                    trackProState(fresh)
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Exception) {
@@ -114,17 +116,27 @@ class UpgradeRepoGplay @Inject constructor(
         .map { data: BillingData? -> data.toUpgradeInfo() }
         .distinctUntilChanged()
         .retryWhen { error, attempt ->
-            // Ignore Google Play errors if the last pro state was recent
-            val now = System.currentTimeMillis()
-            val lastProStateAt = billingCache.lastProStateAt.value()
-            log(TAG) { "Catch: now=$now, lastProStateAt=$lastProStateAt, attempt=$attempt, error=$error" }
-            if ((now - lastProStateAt) < graceWindowMs()) {
-                log(TAG, VERBOSE) { "We are not pro, but were recently, and just got an error, what is GPlay doing???" }
-                emit(Info(gracePeriod = true, billingData = null))
-            } else {
-                emit(Info(billingData = null, error = error))
+            if (error is CancellationException) return@retryWhen false
+            // Billing connection errors can no longer reach this flow (the connect loop retries
+            // them internally) — what CAN fail here are the LOCAL DataStore reads in the Pro
+            // mapping, plausible exactly when storage is full. Keep the flow alive and keep a
+            // recently-Pro user in their grace window.
+            log(TAG, WARN) { "upgradeInfo mapping failed (attempt=$attempt): ${error.asLog()}" }
+            val fallback = try {
+                if ((System.currentTimeMillis() - billingCache.lastProStateAt.value()) < graceWindowMs()) {
+                    Info(gracePeriod = true, billingData = null)
+                } else {
+                    Info(billingData = null, error = error)
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                // The grace probe reads the same storage that just failed — a second failure must
+                // not kill the retry loop that exists for exactly this situation.
+                Info(billingData = null, error = error)
             }
-            delay(30_000L * 2.0.pow(attempt.toDouble()).toLong())
+            emit(fallback)
+            delay(retryDelayMs(attempt))
             true
         }
         .setupCommonEventHandlers(TAG) { "upgradeInfo2" }
@@ -241,6 +253,25 @@ class UpgradeRepoGplay @Inject constructor(
         }
     }
 
+    // Reports the Pro-state transition history to CurriculumVitae (grace engaged, Pro lost) —
+    // lifetime counters that end up in every debug log recording. Fed from FRESH data only:
+    // upgradeInfo's null-seeded replay would fake a PURCHASED->GRACE->PURCHASED round trip on
+    // every app launch. A partial snapshot without a known upgrade proves nothing about absence,
+    // so it records nothing — grace engagements during a TOTAL Play outage are only counted once
+    // Play answers again (accepted trade-off: no false positives).
+    private suspend fun trackProState(fresh: BillingManager.FreshData) {
+        val info = Info(billingData = fresh.data)
+        val state = when {
+            info.upgrades.isNotEmpty() -> CurriculumVitae.ProState.PURCHASED
+            !fresh.isFullSnapshot -> return
+            (System.currentTimeMillis() - billingCache.lastProStateAt.value()) < graceWindowMs() ->
+                CurriculumVitae.ProState.GRACE
+
+            else -> CurriculumVitae.ProState.FREE
+        }
+        curriculumVitae.updateProState(state)
+    }
+
     // Persists "we saw a known Pro purchase" for the grace machinery. Only ever fed by the
     // freshBillingData collector — fresh Play round-trips, never replayed flow data, so a refunded
     // purchase can't keep re-stamping its grace window.
@@ -267,18 +298,24 @@ class UpgradeRepoGplay @Inject constructor(
     // Only relinquishes Pro if we haven't had it for a while (grace period). READ-ONLY: this runs on
     // replayed shared-flow data too, so it must never stamp the grace cache — see stampLastProState().
     private suspend fun BillingData?.toUpgradeInfo(): Info {
+        // Branch on MAPPED upgrades, not raw purchases: a purchase list containing only products
+        // this app doesn't know maps to zero upgrades and must fall through to the grace check —
+        // otherwise a recently-Pro user is denied grace they're entitled to. A known purchase is
+        // decided before any grace-cache read, so failing local storage can't turn a confirmed
+        // purchase into an error episode.
+        val mapped = Info(billingData = this)
+        if (mapped.upgrades.isNotEmpty()) return mapped
+
         val now = System.currentTimeMillis()
         val lastProStateAt = billingCache.lastProStateAt.value()
         log(TAG) { "toUpgradeInfo(): now=$now, lastProStateAt=$lastProStateAt, data=$this" }
         return when {
-            this?.purchases?.isNotEmpty() == true -> Info(billingData = this)
-
             (now - lastProStateAt) < graceWindowMs() -> {
                 log(TAG, VERBOSE) { "We are not pro, but were recently, did GPlay try annoy us again?" }
                 Info(gracePeriod = true, billingData = null)
             }
 
-            else -> Info(billingData = this)
+            else -> mapped
         }
     }
 
@@ -343,5 +380,11 @@ class UpgradeRepoGplay @Inject constructor(
         // null when no known Pro SKU is owned.
         internal fun preferredProSku(upgrades: Collection<PurchasedSku>): Sku? =
             upgrades.firstOrNull { it.sku.type == Sku.Type.IAP }?.sku ?: upgrades.firstOrNull()?.sku
+
+        // Backoff for the local-failure retry in upgradeInfo: 30s/60s/120s/240s, capped at 5min.
+        // Integer math on purpose — the old Double-pow formula slept for hours and could overflow
+        // into a hot loop at extreme attempt counts. Pure and unit-tested.
+        internal fun retryDelayMs(attempt: Long): Long =
+            if (attempt >= 4) 300_000L else 30_000L shl attempt.toInt()
     }
 }

--- a/app/src/main/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModule.kt
@@ -24,6 +24,7 @@ import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.flow.DynamicStateFlow
 import eu.darken.sdmse.common.getPackageInfo
 import eu.darken.sdmse.main.core.CurriculumVitae
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
@@ -251,6 +252,17 @@ class RecorderModule @Inject constructor(
         state?.areas?.forEachIndexed { index, dataArea -> log(TAG, INFO) { "#$index $dataArea" } }
 
         log(TAG, INFO) { "Update history: ${curriculumVitae.history.firstOrNull()}" }
+
+        try {
+            // Billing complaints usually arrive as debug logs: having the lifetime grace/Pro-loss
+            // history in the header saves a support round-trip.
+            log(TAG, INFO) { "Pro history: ${curriculumVitae.proHistory()}" }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            // Diagnostics only — a broken history read must not stop the recorder from starting.
+            log(TAG, WARN) { "Pro history unavailable: ${e.asLog()}" }
+        }
     }
 
     sealed class StopResult {

--- a/app/src/test/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModuleTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModuleTest.kt
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.io.TempDir
 import testhelpers.BaseTest
 import testhelpers.coroutine.TestDispatcherProvider
 import java.io.File
+import java.io.IOException
 import javax.inject.Provider
 
 class RecorderModuleTest : BaseTest() {
@@ -70,6 +71,13 @@ class RecorderModuleTest : BaseTest() {
         every { sdmId.id } returns "abcd"
         every { dataAreaManager.latestState } returns emptyFlow()
         every { curriculumVitae.history } returns emptyFlow()
+        coEvery { curriculumVitae.proHistory() } returns CurriculumVitae.ProHistory(
+            lastState = null,
+            graceEngagedCount = 0,
+            graceEngagedLast = null,
+            proLostCount = 0,
+            proLostLast = null,
+        )
 
         every { recorderProvider.get() } returns mockRecorder
         coEvery { mockRecorder.start(any()) } returns Unit
@@ -159,6 +167,21 @@ class RecorderModuleTest : BaseTest() {
             val pathSlot = slot<(String?) -> String?>()
             coVerify { recorderPath.update(capture(pathSlot)) }
             pathSlot.captured("ignored") shouldNotBe null
+        }
+
+        @Test
+        fun `a failing pro history read does not prevent recording`() = runTest {
+            // The pro history line in the log header is diagnostics only -- a broken DataStore
+            // must not stop the recorder from starting.
+            File(externalDir, "force_debug_run").createNewFile()
+            coEvery { recorderPath.value() } returns null
+            coEvery { curriculumVitae.proHistory() } throws IOException("disk full")
+
+            val dispatcher = StandardTestDispatcher(testScheduler)
+            val module = createModule(backgroundScope, dispatcher)
+            advanceUntilIdle()
+
+            module.state.first { it.isRecording }.isRecording shouldBe true
         }
 
         @Test

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplayTest.kt
@@ -11,8 +11,10 @@ import eu.darken.sdmse.common.upgrade.core.billing.BillingManager
 import eu.darken.sdmse.common.upgrade.core.billing.ItemAlreadyOwnedBillingException
 import eu.darken.sdmse.common.upgrade.core.billing.PurchasedSku
 import eu.darken.sdmse.common.upgrade.core.billing.UserCanceledBillingException
+import eu.darken.sdmse.main.core.CurriculumVitae
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.coEvery
 import io.mockk.coJustRun
@@ -26,10 +28,14 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.runTest2
+import java.io.IOException
 import java.time.Duration
 import java.time.Instant
 
@@ -38,6 +44,7 @@ class UpgradeRepoGplayTest : BaseTest() {
     private val scope = CoroutineScope(Dispatchers.Unconfined)
     private val billingManager = mockk<BillingManager>()
     private val billingCache = mockk<BillingCache>()
+    private val curriculumVitae = mockk<CurriculumVitae>(relaxed = true)
     private lateinit var lastProAtMock: DataStoreValue<Long>
     private lateinit var lastProSkuMock: DataStoreValue<String>
 
@@ -65,7 +72,7 @@ class UpgradeRepoGplayTest : BaseTest() {
         }
         every { billingCache.lastProStateSku } returns lastProSkuMock
         coJustRun { billingCache.stampLastProState(any(), any()) }
-        return UpgradeRepoGplay(scope, billingManager, billingCache)
+        return UpgradeRepoGplay(scope, billingManager, billingCache, curriculumVitae)
     }
 
     private fun result(code: Int): BillingResult = BillingResult.newBuilder().setResponseCode(code).build()
@@ -366,6 +373,115 @@ class UpgradeRepoGplayTest : BaseTest() {
         errors shouldBe emptyList()
         repo.autoRestoreBusy.first() shouldBe false
     }
+
+    @Test fun `unknown-only purchases still fall through to the grace check`() = runTest2 {
+        // A purchase list containing only products this app doesn't know maps to zero upgrades:
+        // it must not take the "has purchases" branch and deny a recently-Pro user their grace.
+        val unknown = mockk<Purchase>().apply {
+            every { products } returns listOf("some.unknown.product")
+            every { purchaseTime } returns 1_000L
+        }
+        coEvery { billingManager.refresh() } returns BillingData(setOf(unknown))
+
+        repo(lastProAt = System.currentTimeMillis() - 1_000).restorePurchaseNow().isPro shouldBe true
+    }
+
+    @Test fun `unknown-only purchases without recent grace are not pro`() = runTest2 {
+        val unknown = mockk<Purchase>().apply {
+            every { products } returns listOf("some.unknown.product")
+            every { purchaseTime } returns 1_000L
+        }
+        coEvery { billingManager.refresh() } returns BillingData(setOf(unknown))
+
+        repo(lastProAt = 0L).restorePurchaseNow().isPro shouldBe false
+    }
+
+    @Test fun `a known purchase is pro even when the grace cache is unreadable`() = runTest2 {
+        // Known purchases are decided before any grace-cache read: failing local storage (full
+        // disk) must not turn a confirmed purchase into an error episode.
+        coEvery { billingManager.refresh() } returns BillingData(setOf(proPurchase()))
+        val repo = repo(lastProAt = 0L)
+        every { lastProAtMock.flow } returns flow { throw IOException("disk full") }
+
+        repo.restorePurchaseNow().isPro shouldBe true
+    }
+
+    @Test fun `upgradeInfo recovers after a transient grace cache failure`() = runTest2 {
+        val repo = repo(lastProAt = 0L)
+        var reads = 0
+        every { lastProAtMock.flow } returns flow {
+            if (reads++ == 0) throw IOException("disk full")
+            emit(0L)
+        }
+
+        // First the mapping fails (and the fallback probe fails too, since it reads the same
+        // storage) -> an error Info keeps the flow alive; after the capped delay it recovers.
+        val infos = repo.upgradeInfo.take(2).toList()
+        infos[0].error shouldNotBe null
+        infos[1].error shouldBe null
+        infos[1].isPro shouldBe false
+    }
+
+    @Test fun `a persistently failing grace cache does not kill upgradeInfo`() = runTest2 {
+        val repo = repo(lastProAt = 0L)
+        every { lastProAtMock.flow } returns flow { throw IOException("disk full") }
+
+        // The retry predicate's own cache probe fails as well -- the flow must still emit instead
+        // of terminating.
+        repo.upgradeInfo.first().error shouldNotBe null
+    }
+
+    @Test fun `retry delay grows and caps at five minutes`() {
+        UpgradeRepoGplay.retryDelayMs(0) shouldBe 30_000L
+        UpgradeRepoGplay.retryDelayMs(1) shouldBe 60_000L
+        UpgradeRepoGplay.retryDelayMs(2) shouldBe 120_000L
+        UpgradeRepoGplay.retryDelayMs(3) shouldBe 240_000L
+        UpgradeRepoGplay.retryDelayMs(4) shouldBe 300_000L
+        UpgradeRepoGplay.retryDelayMs(100) shouldBe 300_000L
+        UpgradeRepoGplay.retryDelayMs(Long.MAX_VALUE) shouldBe 300_000L
+    }
+
+    // region pro state tracking
+
+    @Test fun `fresh data with a known purchase records PURCHASED`() = runTest2 {
+        repo(
+            lastProAt = 0L,
+            freshBillingData = BillingManager.FreshData(BillingData(setOf(proPurchase())), isFullSnapshot = false),
+        )
+
+        coVerify(exactly = 1) { curriculumVitae.updateProState(CurriculumVitae.ProState.PURCHASED) }
+    }
+
+    @Test fun `an empty full snapshot within grace records GRACE`() = runTest2 {
+        repo(
+            lastProAt = System.currentTimeMillis() - 1_000,
+            freshBillingData = BillingManager.FreshData(BillingData(emptySet()), isFullSnapshot = true),
+        )
+
+        coVerify(exactly = 1) { curriculumVitae.updateProState(CurriculumVitae.ProState.GRACE) }
+    }
+
+    @Test fun `an empty full snapshot outside grace records FREE`() = runTest2 {
+        repo(
+            lastProAt = 0L,
+            freshBillingData = BillingManager.FreshData(BillingData(emptySet()), isFullSnapshot = true),
+        )
+
+        coVerify(exactly = 1) { curriculumVitae.updateProState(CurriculumVitae.ProState.FREE) }
+    }
+
+    @Test fun `an empty partial snapshot records nothing`() = runTest2 {
+        // A partial refresh proves ownership of what it contains, never absence: without a known
+        // upgrade it can't distinguish GRACE from FREE and must not fake a downward transition.
+        repo(
+            lastProAt = 0L,
+            freshBillingData = BillingManager.FreshData(BillingData(emptySet()), isFullSnapshot = false),
+        )
+
+        coVerify(exactly = 0) { curriculumVitae.updateProState(any()) }
+    }
+
+    // endregion
 
     @Test fun `auto restore busy state rises and falls around the recovery`() = runTest2 {
         coEvery { billingManager.startIapFlow(any(), any(), null) } throws


### PR DESCRIPTION
## What changed

Follow-ups to the billing hardening in #2564, closing the loose ends it deliberately left out:

- A user whose purchase list only contains products the app doesn't recognize is no longer silently denied their outage grace period — and a confirmed purchase now counts as Pro even if the app's local storage is failing (e.g. a completely full disk, which is exactly when people run SD Maid).
- The Pro-state fallback that keeps recently-paying users Pro through local storage failures can no longer die permanently when storage stays broken, and no longer sleeps for hours between retries.
- Debug logs now start with a small lifetime "Pro history": how often the billing grace period had to step in and whether/when Pro was actually lost. Since the app has no telemetry, this is the only way billing complaints (which usually arrive as debug logs) can show what happened before the recording started.

## Technical Context

- These are the three items explicitly deferred from #2564: the near-dead `upgradeInfo` retry (kept — it still guards DataStore reads, now with a fault-tolerant fallback and an integer 30s→5min capped backoff replacing a Double-pow formula that slept for hours and could overflow into a hot loop), the pre-existing unknown-SKU grace bypass (branch on mapped upgrades, decided before any grace-cache read), and the grace/Pro-loss counters.
- Counters live in `CurriculumVitae` (not the billing code): the debug-log recorder is flavor-shared and already dumps CV data into every recording header, so history arrives with each complaint for free. Transitions are written in ONE DataStore transaction through a suspend API called from the commit-ordered fresh-data collector — a fire-and-forget job per update could apply rapid `PURCHASED→GRACE→FREE` sequences out of order.
- Only FULL ownership snapshots may record downward states (GRACE/FREE); partial refreshes and purchase events prove ownership, never absence — so the history can't contain false "grace engaged" entries. Trade-off: grace engagements during a total Play outage are only counted once Play answers again.
- `CurriculumVitae`'s existing `UpgradeRepo` dependency became `dagger.Lazy` — the gplay repo now reports transitions back to CV, which would otherwise be a cycle. Verified on both flavor builds.
- Review guidance: the transition semantics (what counts as "grace engaged" vs baseline vs recovery) are in the pure `proTransitionOf` function with a full table test; the retry behavior has recovery, persistent-failure, and delay-cap tests.

Refs #2564
