### PR TITLE
Scheduler: Fix schedules silently stopping after a failed run

### DIFF
--- a/app-tool-scheduler/src/main/java/eu/darken/sdmse/scheduler/core/SchedulerNotifications.kt
+++ b/app-tool-scheduler/src/main/java/eu/darken/sdmse/scheduler/core/SchedulerNotifications.kt
@@ -215,8 +215,9 @@ class SchedulerNotifications @Inject constructor(
 
     companion object {
         val TAG = logTag("Scheduler", "Notifications", "Worker")
-        private val CHANNEL_ID = "${BuildConfigWrap.APPLICATION_ID}.notification.channel.scheduler"
-        private val RESULT_CHANNEL_ID = "${BuildConfigWrap.APPLICATION_ID}.notification.channel.scheduler.result"
+        // Lazy: BuildConfigWrap can't initialize on a plain JVM, and JVM tests mock this class
+        private val CHANNEL_ID by lazy { "${BuildConfigWrap.APPLICATION_ID}.notification.channel.scheduler" }
+        private val RESULT_CHANNEL_ID by lazy { "${BuildConfigWrap.APPLICATION_ID}.notification.channel.scheduler.result" }
         internal const val NOTIFICATION_ID_RANGE_STATE = 1000
         internal const val NOTIFICATION_ID_RANGE_RESULT = 1200
     }

--- a/app-tool-scheduler/src/main/java/eu/darken/sdmse/scheduler/core/SchedulerWorker.kt
+++ b/app-tool-scheduler/src/main/java/eu/darken/sdmse/scheduler/core/SchedulerWorker.kt
@@ -95,7 +95,10 @@ class SchedulerWorker @AssistedInject constructor(
 
         if (runAttemptCount > 0) {
             log(TAG, WARN) { "Repeat execution attempt ($runAttemptCount) for $schedule" }
-            Result.failure(inputData)
+            // The next occurrence is appended as a dependent of this still RUNNING work (see `finally`).
+            // Returning failure would make WorkManager fail the appended successor too,
+            // permanently severing the recurring chain until the next app start re-arms it.
+            Result.success(inputData)
         } else {
             val start = System.currentTimeMillis()
             log(TAG, INFO) { "Executing schedule $schedule" }
@@ -119,29 +122,45 @@ class SchedulerWorker @AssistedInject constructor(
         if (e !is CancellationException) {
             log(TAG, ERROR) { "Execution failed: ${e.asLog()}" }
             finishedWithError = true
-            schedulerNotifications.notifyError(scheduleId)
+            try {
+                schedulerNotifications.notifyError(scheduleId)
+            } catch (e2: Exception) {
+                log(TAG, ERROR) { "Failed to notify about error (error=$e): ${e2.asLog()}" }
+            }
 
-            Result.failure(inputData)
+            // Not Result.failure(...), that would sever the recurring chain, see above.
+            Result.success(inputData)
         } else {
             Result.success()
         }
     } finally {
-        schedulerManager.updateExecutedNow(scheduleId)
-
-        try {
-            schedulerNotifications.cancel(scheduleId)
-            schedulerManager.reschedule(scheduleId)
-        } catch (e: Exception) {
-            log(
-                TAG,
-                ERROR
-            ) { "Failed to clean up notifications and reschedule (error=$finishedWithError): ${e.asLog()}" }
-        }
-
+        // First, so stray task jobs can't outlive the worker even if cleanup below rethrows cancellation
         try {
             workerScope.cancel("Worker finished (withError?=$finishedWithError).")
         } catch (e: Exception) {
             log(TAG, ERROR) { "Failed to cancel worker scope (error=$finishedWithError): ${e.asLog()}" }
+        }
+
+        try {
+            schedulerManager.updateExecutedNow(scheduleId)
+        } catch (e: Exception) {
+            // On cancellation (e.g. schedule disabled) the schedule must not be re-armed
+            if (e is CancellationException) throw e
+            log(TAG, ERROR) { "Failed to update execution timestamp (error=$finishedWithError): ${e.asLog()}" }
+        }
+
+        try {
+            schedulerNotifications.cancel(scheduleId)
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            log(TAG, ERROR) { "Failed to clean up notifications (error=$finishedWithError): ${e.asLog()}" }
+        }
+
+        try {
+            schedulerManager.reschedule(scheduleId)
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            log(TAG, ERROR) { "Failed to reschedule (error=$finishedWithError): ${e.asLog()}" }
         }
     }
 

--- a/app-tool-scheduler/src/test/java/eu/darken/sdmse/scheduler/core/SchedulerWorkerTest.kt
+++ b/app-tool-scheduler/src/test/java/eu/darken/sdmse/scheduler/core/SchedulerWorkerTest.kt
@@ -1,0 +1,166 @@
+package eu.darken.sdmse.scheduler.core
+
+import android.content.Context
+import androidx.work.ForegroundInfo
+import androidx.work.ForegroundUpdater
+import androidx.work.ListenableWorker
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import com.google.common.util.concurrent.ListenableFuture
+import eu.darken.sdmse.common.adb.AdbManager
+import eu.darken.sdmse.common.root.RootManager
+import eu.darken.sdmse.common.shell.ShellOps
+import eu.darken.sdmse.main.core.taskmanager.SchedulerTaskFactory
+import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
+import eu.darken.sdmse.setup.SetupHealerSource
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import java.util.UUID
+import java.util.concurrent.Executor
+import java.util.concurrent.TimeUnit
+
+class SchedulerWorkerTest : BaseTest() {
+
+    private val scheduleId: ScheduleId = "test-schedule"
+    private val schedule = Schedule(id = scheduleId)
+
+    private val context = mockk<Context>(relaxed = true)
+    private val params = mockk<WorkerParameters>(relaxed = true)
+    private val taskSubmitter = mockk<TaskSubmitter>(relaxed = true)
+    private val schedulerTaskFactory = mockk<SchedulerTaskFactory>()
+    private val schedulerManager = mockk<SchedulerManager>()
+    private val schedulerNotifications = mockk<SchedulerNotifications>(relaxed = true)
+    private val setupHealer = mockk<SetupHealerSource>()
+    private val rootManager = mockk<RootManager>(relaxed = true)
+    private val adbManager = mockk<AdbManager>(relaxed = true)
+    private val shellOps = mockk<ShellOps>(relaxed = true)
+
+    private fun <T> immediateFuture(value: T): ListenableFuture<T> = object : ListenableFuture<T> {
+        override fun addListener(listener: Runnable, executor: Executor) = executor.execute(listener)
+        override fun cancel(mayInterruptIfRunning: Boolean): Boolean = false
+        override fun isCancelled(): Boolean = false
+        override fun isDone(): Boolean = true
+        override fun get(): T = value
+        override fun get(timeout: Long, unit: TimeUnit): T = value
+    }
+
+    @BeforeEach
+    fun setup() {
+        every { params.id } returns UUID.randomUUID()
+        every { params.inputData } returns workDataOf(SchedulerWorker.INPUT_SCHEDULE_ID to scheduleId)
+        every { params.runAttemptCount } returns 0
+        every { params.foregroundUpdater } returns object : ForegroundUpdater {
+            override fun setForegroundAsync(
+                context: Context,
+                id: UUID,
+                foregroundInfo: ForegroundInfo,
+            ): ListenableFuture<Void?> = immediateFuture(null)
+        }
+
+        coEvery { schedulerManager.getSchedule(scheduleId) } returns schedule
+        coEvery { schedulerManager.updateExecutedNow(scheduleId) } returns mockk()
+        coEvery { schedulerManager.reschedule(scheduleId) } returns Unit
+        coEvery { schedulerTaskFactory.createTasks(scheduleId, emptySet()) } returns emptyList()
+        every { setupHealer.state } returns flowOf(SetupHealerSource.State(healAttemptCount = 1))
+    }
+
+    private fun createWorker() = SchedulerWorker(
+        context = context,
+        params = params,
+        dispatcherProvider = TestDispatcherProvider(),
+        taskSubmitter = taskSubmitter,
+        schedulerTaskFactory = schedulerTaskFactory,
+        schedulerManager = schedulerManager,
+        schedulerNotifications = schedulerNotifications,
+        setupHealer = setupHealer,
+        rootManager = rootManager,
+        adbManager = adbManager,
+        shellOps = shellOps,
+    )
+
+    @Test
+    fun `successful execution returns success and re-arms the schedule`() = runTest {
+        val result = createWorker().doWork()
+
+        result.shouldBeInstanceOf<ListenableWorker.Result.Success>()
+        coVerify { schedulerManager.reschedule(scheduleId) }
+    }
+
+    @Test
+    fun `retry attempt skips execution but must not fail the appended successor`() = runTest {
+        // A killed 3AM run comes back as a retry; returning failure would cancel the
+        // next occurrence appended in the finally block and permanently stop the schedule.
+        every { params.runAttemptCount } returns 1
+
+        val result = createWorker().doWork()
+
+        result.shouldBeInstanceOf<ListenableWorker.Result.Success>()
+        coVerify(exactly = 0) { schedulerTaskFactory.createTasks(any(), any()) }
+        coVerify { schedulerManager.reschedule(scheduleId) }
+    }
+
+    @Test
+    fun `execution error notifies but must not fail the appended successor`() = runTest {
+        coEvery { schedulerTaskFactory.createTasks(scheduleId, emptySet()) } throws RuntimeException("factory broken")
+
+        val result = createWorker().doWork()
+
+        result.shouldBeInstanceOf<ListenableWorker.Result.Success>()
+        coVerify { schedulerNotifications.notifyError(scheduleId) }
+        coVerify { schedulerManager.reschedule(scheduleId) }
+    }
+
+    @Test
+    fun `failing error notification must not fail the appended successor either`() = runTest {
+        coEvery { schedulerTaskFactory.createTasks(scheduleId, emptySet()) } throws RuntimeException("factory broken")
+        every { schedulerNotifications.notifyError(scheduleId) } throws RuntimeException("notifications broken")
+
+        val result = createWorker().doWork()
+
+        result.shouldBeInstanceOf<ListenableWorker.Result.Success>()
+        coVerify { schedulerManager.reschedule(scheduleId) }
+    }
+
+    @Test
+    fun `failing to update the execution timestamp does not prevent rescheduling`() = runTest {
+        coEvery { schedulerManager.updateExecutedNow(scheduleId) } throws RuntimeException("storage broken")
+
+        val result = createWorker().doWork()
+
+        result.shouldBeInstanceOf<ListenableWorker.Result.Success>()
+        coVerify { schedulerManager.reschedule(scheduleId) }
+    }
+
+    @Test
+    fun `failing notification cleanup does not prevent rescheduling`() = runTest {
+        every { schedulerNotifications.cancel(scheduleId) } throws RuntimeException("notifications broken")
+
+        val result = createWorker().doWork()
+
+        result.shouldBeInstanceOf<ListenableWorker.Result.Success>()
+        coVerify { schedulerManager.reschedule(scheduleId) }
+    }
+
+    @Test
+    fun `cancellation does not re-arm the schedule`() = runTest {
+        // e.g. the user disabled the schedule, which cancels the running worker
+        coEvery { schedulerManager.updateExecutedNow(scheduleId) } throws CancellationException("cancelled")
+
+        shouldThrow<CancellationException> {
+            createWorker().doWork()
+        }
+
+        coVerify(exactly = 0) { schedulerManager.reschedule(any()) }
+    }
+}


### PR DESCRIPTION
## What changed

Fixed scheduled cleanings silently stopping: if a scheduled run failed or was interrupted (for example killed overnight by aggressive battery management, common on Samsung devices), the schedule would never fire again until the app was next opened.

## Technical Context

- Root cause: `SchedulerWorker` re-arms the next occurrence from its `finally` block via `enqueueUniqueWork(APPEND_OR_REPLACE)` while the current worker is still `RUNNING`, so the successor becomes a *dependent* of the current work. Returning `Result.failure` (retry guard after process death, or any execution error) makes WorkManager fail the appended successor too, permanently severing the recurring chain. Recovery only happened on app open (`checkSchedulingState`) or reboot.
- The retry-guard path (`runAttemptCount > 0`) is exactly what fires after an OEM kills the worker mid-run: the killed attempt never reaches `finally`, and the retry immediately returned failure — cancelling its own freshly-appended successor.
- Fix: handled outcomes now report `Result.success`; errors are still surfaced via the error notification. Only `Result.retry()` carries retry semantics, so no backoff behavior changes. WorkManager diagnostics record `SUCCEEDED` instead of `FAILED` for errored runs — nothing in the app reads that terminal state.
- Hardened the `finally` cleanup: the executedAt update, notification cleanup, and reschedule each get their own try, so one failing step can no longer skip the reschedule. `CancellationException` still propagates so a disabled schedule is not re-armed, and the worker scope is cancelled first so task jobs can't outlive the worker.
- `SchedulerNotifications` channel ids are now lazily initialized so JVM tests can mock the class (`BuildConfigWrap` can't initialize on a plain JVM); runtime behavior is unchanged.
- Alternatives considered: `REPLACE` from inside the worker's `finally` would cancel the still-running worker itself; decoupling the successor from the unique-work chain is a bigger redesign. The minimal terminal-state change was chosen.
- Review guidance: the new `SchedulerWorkerTest` verifies the worker's result contract (success + reschedule in all handled paths, no re-arm on cancellation); the actual WorkManager dependent-state transition is asserted from documented 2.11.0 behavior (`WorkerWrapper.setFailed()` recursively fails dependents).
