### PR TITLE
General: UI polish across dashboard, setup, and cleaning tools

### DIFF
--- a/app-common-coil/src/main/java/eu/darken/sdmse/common/coil/AppIconFetcher.kt
+++ b/app-common-coil/src/main/java/eu/darken/sdmse/common/coil/AppIconFetcher.kt
@@ -1,5 +1,9 @@
 package eu.darken.sdmse.common.coil
 
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Rect
+import android.graphics.drawable.BitmapDrawable
 import androidx.core.content.ContextCompat
 import coil.ImageLoader
 import coil.decode.DataSource
@@ -26,10 +30,24 @@ class AppIconFetcher @Inject constructor(
             data.icon?.invoke(options.context) ?: packageManager.getIcon2(data.id)
         } ?: ContextCompat.getDrawable(options.context, eu.darken.sdmse.common.io.R.drawable.ic_default_app_icon_24)!!
 
+        // Coil 2 only writes BitmapDrawable fetch results to its memory cache. Rasterizing here also
+        // moves adaptive/vector icon drawing off the UI thread and makes subsequent requests cheap.
+        val (width, height) = options.resolveAppIconSize()
+        val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888).apply {
+            density = options.context.resources.displayMetrics.densityDpi
+        }
+        val previousBounds = Rect(baseIcon.bounds)
+        try {
+            baseIcon.setBounds(0, 0, width, height)
+            baseIcon.draw(Canvas(bitmap))
+        } finally {
+            baseIcon.bounds = previousBounds
+        }
+
         return DrawableResult(
-            drawable = baseIcon,
+            drawable = BitmapDrawable(options.context.resources, bitmap),
             isSampled = false,
-            dataSource = DataSource.DISK
+            dataSource = DataSource.MEMORY,
         )
     }
 
@@ -44,4 +62,3 @@ class AppIconFetcher @Inject constructor(
         ): Fetcher = AppIconFetcher(ipcFunnel, data, options)
     }
 }
-

--- a/app-common-coil/src/main/java/eu/darken/sdmse/common/coil/AppIconKeyer.kt
+++ b/app-common-coil/src/main/java/eu/darken/sdmse/common/coil/AppIconKeyer.kt
@@ -1,0 +1,54 @@
+package eu.darken.sdmse.common.coil
+
+import android.content.res.Configuration
+import coil.key.Keyer
+import coil.request.Options
+import coil.size.Dimension
+import eu.darken.sdmse.common.pkgs.Pkg
+import eu.darken.sdmse.common.pkgs.features.Installed
+import eu.darken.sdmse.common.pkgs.features.PkgInfo
+
+class AppIconKeyer : Keyer<Pkg> {
+
+    override fun key(data: Pkg, options: Options): String {
+        val configuration = options.context.resources.configuration
+        val (width, height) = options.resolveAppIconSize()
+        val pkgInfo = data as? PkgInfo
+
+        return buildString {
+            append("sdmse:app-icon:v1")
+            append("|type=").append(data.javaClass.name)
+            append("|package=").append(data.id.name)
+            append("|user=").append((data as? Installed)?.userHandle?.handleId ?: NO_USER)
+            append("|version=").append(pkgInfo?.versionCode ?: NO_VERSION)
+            append("|updated=").append(pkgInfo?.packageInfo?.lastUpdateTime ?: NO_UPDATE_TIME)
+            append("|icon=").append(pkgInfo?.applicationInfo?.icon ?: NO_ICON_RESOURCE)
+            append("|source=").append(pkgInfo?.applicationInfo?.sourceDir.orEmpty())
+            append("|density=").append(options.context.resources.displayMetrics.densityDpi)
+            append("|night=").append(configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK)
+            append("|size=").append(width).append('x').append(height)
+        }
+    }
+
+    private companion object {
+        const val NO_USER = "none"
+        const val NO_VERSION = "unknown"
+        const val NO_UPDATE_TIME = "unknown"
+        const val NO_ICON_RESOURCE = "unknown"
+    }
+}
+
+internal fun Options.resolveAppIconSize(): Pair<Int, Int> {
+    val requestedWidth = (size.width as? Dimension.Pixels)?.px
+    val requestedHeight = (size.height as? Dimension.Pixels)?.px
+    val fallbackSize = (DEFAULT_SIZE_DP * context.resources.displayMetrics.density)
+        .toInt()
+        .coerceAtLeast(1)
+
+    val inferredSize = requestedWidth ?: requestedHeight ?: fallbackSize
+    return (requestedWidth ?: inferredSize).coerceIn(1, MAX_SIZE_PX) to
+        (requestedHeight ?: inferredSize).coerceIn(1, MAX_SIZE_PX)
+}
+
+private const val DEFAULT_SIZE_DP = 48
+private const val MAX_SIZE_PX = 512

--- a/app-common-coil/src/main/java/eu/darken/sdmse/common/coil/CoilModule.kt
+++ b/app-common-coil/src/main/java/eu/darken/sdmse/common/coil/CoilModule.kt
@@ -27,6 +27,7 @@ import javax.inject.Singleton
 class CoilModule {
 
     @Provides
+    @Singleton
     fun imageLoader(
         @ApplicationContext context: Context,
         generalSettings: GeneralSettings,
@@ -51,6 +52,7 @@ class CoilModule {
             logger(logger)
         }
         components {
+            add(AppIconKeyer())
             add(appIconFetcherFactory)
             add(pathPreviewFetcher)
             add(bitmapFetcher)

--- a/app-common-coil/src/test/java/eu/darken/sdmse/common/coil/AppIconCacheTest.kt
+++ b/app-common-coil/src/test/java/eu/darken/sdmse/common/coil/AppIconCacheTest.kt
@@ -1,0 +1,137 @@
+package eu.darken.sdmse.common.coil
+
+import android.content.Context
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageInfo
+import android.graphics.Color
+import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.ColorDrawable
+import android.graphics.drawable.Drawable
+import androidx.test.core.app.ApplicationProvider
+import coil.ImageLoader
+import coil.decode.DataSource
+import coil.request.ImageRequest
+import coil.request.Options
+import coil.request.SuccessResult
+import coil.size.Size
+import eu.darken.sdmse.common.ca.CaString
+import eu.darken.sdmse.common.funnel.IPCFunnel
+import eu.darken.sdmse.common.pkgs.Pkg
+import eu.darken.sdmse.common.pkgs.container.NormalPkg
+import eu.darken.sdmse.common.pkgs.features.InstallerInfo
+import eu.darken.sdmse.common.user.UserHandle2
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+import testhelpers.coroutine.TestDispatcherProvider
+import java.util.concurrent.atomic.AtomicInteger
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class AppIconCacheTest : BaseTest() {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val keyer = AppIconKeyer()
+
+    @Test
+    fun `equivalent app metadata produces the same key`() {
+        val first = installedPkg(user = 10, version = 42, updated = 1234, iconResource = 7)
+        val second = installedPkg(user = 10, version = 42, updated = 1234, iconResource = 7)
+
+        key(first, size = 96) shouldBe key(second, size = 96)
+    }
+
+    @Test
+    fun `user app update icon and requested size invalidate the key`() {
+        val base = installedPkg(user = 0, version = 1, updated = 100, iconResource = 7)
+        val baseKey = key(base, size = 96)
+
+        key(installedPkg(user = 10, version = 1, updated = 100, iconResource = 7), 96) shouldNotBe baseKey
+        key(installedPkg(user = 0, version = 2, updated = 100, iconResource = 7), 96) shouldNotBe baseKey
+        key(installedPkg(user = 0, version = 1, updated = 200, iconResource = 7), 96) shouldNotBe baseKey
+        key(installedPkg(user = 0, version = 1, updated = 100, iconResource = 8), 96) shouldNotBe baseKey
+        key(base, size = 128) shouldNotBe baseKey
+    }
+
+    @Test
+    fun `second image request uses the global memory cache`() {
+        runBlocking {
+            val fetchCount = AtomicInteger()
+            val pkg = CountingPkg(Pkg.Id("test.cached.icon"), fetchCount)
+            val ipcFunnel = IPCFunnel(context, TestDispatcherProvider())
+            val imageLoader = ImageLoader.Builder(context)
+                .diskCache(null)
+                .dispatcher(Dispatchers.Unconfined)
+                .interceptorDispatcher(Dispatchers.Unconfined)
+                .components {
+                    add(AppIconKeyer())
+                    add(AppIconFetcher.Factory(ipcFunnel))
+                }
+                .build()
+
+            try {
+                fun request() = ImageRequest.Builder(context)
+                    .data(pkg)
+                    .size(64)
+                    .allowHardware(false)
+                    .build()
+
+                val first = imageLoader.execute(request()) as SuccessResult
+                val second = imageLoader.execute(request()) as SuccessResult
+
+                first.dataSource shouldBe DataSource.MEMORY
+                (first.drawable is BitmapDrawable) shouldBe true
+                (first.drawable as BitmapDrawable).bitmap.run {
+                    width shouldBe 64
+                    height shouldBe 64
+                }
+                second.dataSource shouldBe DataSource.MEMORY_CACHE
+                fetchCount.get() shouldBe 1
+            } finally {
+                imageLoader.shutdown()
+            }
+        }
+    }
+
+    private fun key(pkg: Pkg, size: Int): String = keyer.key(
+        pkg,
+        Options(context = context, size = Size(size, size)),
+    )
+
+    private fun installedPkg(
+        user: Int,
+        version: Long,
+        updated: Long,
+        iconResource: Int,
+    ) = NormalPkg(
+        packageInfo = PackageInfo().apply {
+            packageName = "test.installed.icon"
+            longVersionCode = version
+            lastUpdateTime = updated
+            applicationInfo = ApplicationInfo().apply {
+                icon = iconResource
+                sourceDir = "/data/app/test.installed.icon/base.apk"
+            }
+        },
+        installerInfo = InstallerInfo(),
+        userHandle = UserHandle2(user),
+    )
+
+    private class CountingPkg(
+        override val id: Pkg.Id,
+        fetchCount: AtomicInteger,
+    ) : Pkg {
+        override val label: CaString? = null
+        override val icon: ((Context) -> Drawable) = {
+            fetchCount.incrementAndGet()
+            ColorDrawable(Color.RED)
+        }
+    }
+}

--- a/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/AffectedPkg.kt
+++ b/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/AffectedPkg.kt
@@ -4,17 +4,18 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.AcUnit
 import androidx.compose.material.icons.twotone.Archive
 import androidx.compose.material.icons.twotone.Delete
-import androidx.compose.material.icons.twotone.DoNotDisturb
 import androidx.compose.material.icons.twotone.Save
 import androidx.compose.material.icons.twotone.SettingsBackupRestore
 import androidx.compose.material.icons.twotone.WarningAmber
 import androidx.compose.ui.graphics.vector.ImageVector
+import eu.darken.sdmse.common.compose.icons.SdmIcons
+import eu.darken.sdmse.common.compose.icons.SnowflakeOff
 
 val AffectedPkg.Action.icon: ImageVector
     get() = when (this) {
         AffectedPkg.Action.EXPORTED -> Icons.TwoTone.Save
         AffectedPkg.Action.STOPPED -> Icons.TwoTone.WarningAmber
-        AffectedPkg.Action.ENABLED -> Icons.TwoTone.DoNotDisturb
+        AffectedPkg.Action.ENABLED -> SdmIcons.SnowflakeOff
         AffectedPkg.Action.DISABLED -> Icons.TwoTone.AcUnit
         AffectedPkg.Action.DELETED -> Icons.TwoTone.Delete
         AffectedPkg.Action.ARCHIVED -> Icons.TwoTone.Archive

--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/SdmFastScroller.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/SdmFastScroller.kt
@@ -27,14 +27,12 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -50,8 +48,6 @@ import androidx.compose.ui.unit.dp
 import eu.darken.sdmse.common.R as CommonR
 import eu.darken.sdmse.common.compose.preview.Preview2
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
-import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlin.math.roundToInt
 
 val SdmFastScrollerLaneWidth = 32.dp
@@ -98,21 +94,21 @@ internal interface FastScrollAdapter {
     val totalItems: Int
     val viewportItems: Int
     val firstVisibleIndex: Int
-    suspend fun scrollToItem(index: Int)
+    fun requestScrollToItem(index: Int)
 }
 
 internal fun LazyListState.asFastScrollAdapter(): FastScrollAdapter = object : FastScrollAdapter {
     override val totalItems: Int get() = layoutInfo.totalItemsCount
     override val viewportItems: Int get() = layoutInfo.visibleItemsInfo.size
     override val firstVisibleIndex: Int get() = firstVisibleItemIndex
-    override suspend fun scrollToItem(index: Int) = this@asFastScrollAdapter.scrollToItem(index)
+    override fun requestScrollToItem(index: Int) = this@asFastScrollAdapter.requestScrollToItem(index)
 }
 
 internal fun LazyGridState.asFastScrollAdapter(): FastScrollAdapter = object : FastScrollAdapter {
     override val totalItems: Int get() = layoutInfo.totalItemsCount
     override val viewportItems: Int get() = layoutInfo.visibleItemsInfo.size
     override val firstVisibleIndex: Int get() = firstVisibleItemIndex
-    override suspend fun scrollToItem(index: Int) = this@asFastScrollAdapter.scrollToItem(index)
+    override fun requestScrollToItem(index: Int) = this@asFastScrollAdapter.requestScrollToItem(index)
 }
 
 @Composable
@@ -146,20 +142,6 @@ private fun SdmFastScrollerImpl(
         (adapter.firstVisibleIndex.toFloat() / scrollableRange).coerceIn(0f, 1f)
     }
 
-    // collectLatest cancels in-flight scrollToItem calls so the list always chases the most
-    // recent drag position instead of replaying every intermediate jump. Re-reading
-    // adapter.totalItems inside the snapshotFlow keeps the clamp fresh if items load/unload
-    // during a drag, without restarting the effect.
-    LaunchedEffect(adapter, dragging) {
-        if (!dragging) return@LaunchedEffect
-        snapshotFlow {
-            val count = adapter.totalItems
-            if (count <= 0) 0 else dragTargetIndex.coerceIn(0, count - 1)
-        }
-            .distinctUntilChanged()
-            .collectLatest { target -> adapter.scrollToItem(target) }
-    }
-
     val activeSection = if (!dragging || sections.isEmpty()) {
         null
     } else {
@@ -175,19 +157,36 @@ private fun SdmFastScrollerImpl(
             .fillMaxHeight()
             .onSizeChanged { trackHeightPx = it.height }
             .pointerInput(adapter, totalItems) {
+                var lastRequestedIndex = -1
+
+                fun updateDragPosition(y: Float) {
+                    val count = adapter.totalItems
+                    if (count <= 0) return
+
+                    val fraction = (y / size.height.toFloat()).coerceIn(0f, 1f)
+                    val target = (fraction * (count - 1)).roundToInt().coerceIn(0, count - 1)
+                    dragFraction = fraction
+                    dragTargetIndex = target
+
+                    if (target != lastRequestedIndex) {
+                        lastRequestedIndex = target
+                        // Unlike scrollToItem(), this schedules a remeasure instead of forcing one
+                        // synchronously. Rapid pointer updates therefore collapse to the newest
+                        // requested position before the next frame is measured.
+                        adapter.requestScrollToItem(target)
+                    }
+                }
+
                 detectVerticalDragGestures(
                     onDragStart = { offset ->
                         dragging = true
-                        val fraction = (offset.y / size.height.toFloat()).coerceIn(0f, 1f)
-                        dragFraction = fraction
-                        dragTargetIndex = (fraction * (totalItems - 1)).roundToInt()
-                            .coerceIn(0, totalItems - 1)
+                        // Always submit the first position of a new gesture, even when it matches
+                        // the previous gesture's last target and the list moved in between.
+                        lastRequestedIndex = -1
+                        updateDragPosition(offset.y)
                     },
                     onVerticalDrag = { change, _ ->
-                        val fraction = (change.position.y / size.height.toFloat()).coerceIn(0f, 1f)
-                        dragFraction = fraction
-                        dragTargetIndex = (fraction * (totalItems - 1)).roundToInt()
-                            .coerceIn(0, totalItems - 1)
+                        updateDragPosition(change.position.y)
                         change.consume()
                     },
                     onDragEnd = { dragging = false },

--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/icons/SnowflakeOff.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/icons/SnowflakeOff.kt
@@ -1,0 +1,110 @@
+package eu.darken.sdmse.common.compose.icons
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import eu.darken.sdmse.common.compose.preview.Preview2
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+
+val SdmIcons.SnowflakeOff: ImageVector
+    get() {
+        _snowflakeOff?.let { return it }
+        return ImageVector.Builder(
+            name = "SnowflakeOff",
+            defaultWidth = 24.dp,
+            defaultHeight = 24.dp,
+            viewportWidth = 24f,
+            viewportHeight = 24f,
+        ).apply {
+            path(
+                fill = SolidColor(Color.Black),
+            ) {
+                moveTo(11f, 5.12f)
+                lineTo(9.29f, 3.41f)
+                lineTo(10.71f, 2f)
+                lineTo(12f, 3.29f)
+                lineTo(13.29f, 2f)
+                lineTo(14.71f, 3.41f)
+                lineTo(13f, 5.12f)
+                verticalLineTo(7.38f)
+                lineTo(15.45f, 8.82f)
+                lineTo(17.45f, 7.69f)
+                lineTo(18.07f, 5.36f)
+                lineTo(20f, 5.88f)
+                lineTo(19.54f, 7.65f)
+                lineTo(21.31f, 8.12f)
+                lineTo(20.79f, 10.05f)
+                lineTo(18.46f, 9.43f)
+                lineTo(16.46f, 10.56f)
+                verticalLineTo(13.26f)
+                lineTo(14.5f, 11.3f)
+                verticalLineTo(10.56f)
+                lineTo(12.74f, 9.54f)
+                lineTo(10.73f, 7.53f)
+                lineTo(11f, 7.38f)
+                verticalLineTo(5.12f)
+                moveTo(18.46f, 14.57f)
+                lineTo(16.87f, 13.67f)
+                lineTo(19.55f, 16.35f)
+                lineTo(21.3f, 15.88f)
+                lineTo(20.79f, 13.95f)
+                lineTo(18.46f, 14.57f)
+                moveTo(13f, 16.62f)
+                verticalLineTo(18.88f)
+                lineTo(14.7f, 20.59f)
+                lineTo(13.29f, 22f)
+                lineTo(12f, 20.71f)
+                lineTo(10.71f, 22f)
+                lineTo(9.29f, 20.59f)
+                lineTo(11f, 18.88f)
+                verticalLineTo(16.62f)
+                lineTo(8.55f, 15.18f)
+                lineTo(6.55f, 16.31f)
+                lineTo(5.93f, 18.64f)
+                lineTo(4f, 18.12f)
+                lineTo(4.47f, 16.36f)
+                lineTo(2.7f, 15.89f)
+                lineTo(3.22f, 13.96f)
+                lineTo(5.55f, 14.58f)
+                lineTo(7.55f, 13.45f)
+                verticalLineTo(10.56f)
+                lineTo(5.55f, 9.43f)
+                lineTo(3.22f, 10.05f)
+                lineTo(2.7f, 8.12f)
+                lineTo(4.47f, 7.65f)
+                lineTo(4f, 5.89f)
+                lineTo(1.11f, 3f)
+                lineTo(2.39f, 1.73f)
+                lineTo(22.11f, 21.46f)
+                lineTo(20.84f, 22.73f)
+                lineTo(14.1f, 16f)
+                lineTo(13f, 16.62f)
+                moveTo(12f, 14.89f)
+                lineTo(12.63f, 14.5f)
+                lineTo(9.5f, 11.39f)
+                verticalLineTo(13.44f)
+                lineTo(12f, 14.89f)
+                close()
+            }
+        }.build().also { _snowflakeOff = it }
+    }
+
+@Preview2
+@Composable
+private fun SnowflakeOffPreview() {
+    PreviewWrapper {
+        Icon(
+            imageVector = SdmIcons.SnowflakeOff,
+            contentDescription = null,
+            modifier = Modifier.size(48.dp),
+        )
+    }
+}
+
+private var _snowflakeOff: ImageVector? = null

--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/layout/SdmListDefaults.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/layout/SdmListDefaults.kt
@@ -22,6 +22,12 @@ object SdmListDefaults {
      * reserving room). FAB height (56dp) + scaffold FAB margin (16dp) + breathing room (16dp).
      */
     val FabClearance: Dp = 88.dp
+
+    /**
+     * Extra breathing room below the last item of a scrollable list on scaffolds without a
+     * floating action button, so the final entry doesn't sit flush against the screen edge.
+     */
+    val ContentBottomSpacing: Dp = 16.dp
 }
 
 /** Returns a copy of these [PaddingValues] with [extra] added to the bottom. */

--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/tour/GuidedTourController.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/tour/GuidedTourController.kt
@@ -69,19 +69,23 @@ class GuidedTourController @Inject constructor(
         _session.value = TourSession(definition, stepIndex = 0)
     }
 
-    suspend fun next() = mutationMutex.withLock {
-        val s = _session.value ?: return@withLock
-        if (s.isLast) {
-            completeLocked()
-            return@withLock
+    suspend fun next() {
+        val onComplete: (suspend () -> Unit)? = mutationMutex.withLock {
+            val s = _session.value ?: return@withLock null
+            if (s.isLast) return@withLock completeLocked()
+
+            val nextStep = s.definition.steps[s.stepIndex + 1]
+            nextStep.prepareTarget?.invoke()
+            // Re-check session: prepareTarget may have suspended long enough for cancel/complete to fire.
+            val still = _session.value ?: return@withLock null
+            if (still.definition.id != s.definition.id) return@withLock null
+            log(TAG, VERBOSE) { "next(${s.definition.id.raw}): ${s.stepIndex} -> ${s.stepIndex + 1}" }
+            _session.value = still.copy(stepIndex = still.stepIndex + 1)
+            null
         }
-        val nextStep = s.definition.steps[s.stepIndex + 1]
-        nextStep.prepareTarget?.invoke()
-        // Re-check session: prepareTarget may have suspended long enough for cancel/complete to fire.
-        val still = _session.value ?: return@withLock
-        if (still.definition.id != s.definition.id) return@withLock
-        log(TAG, VERBOSE) { "next(${s.definition.id.raw}): ${s.stepIndex} -> ${s.stepIndex + 1}" }
-        _session.value = still.copy(stepIndex = still.stepIndex + 1)
+        // Screen callbacks can animate or acquire their own locks, so never run them while holding
+        // the controller mutation lock. completeLocked() has already persisted and cleared state.
+        onComplete?.invoke()
     }
 
     /** Go back one step. No-op when already at step 0. Re-runs the destination step's prepareTarget. */
@@ -133,7 +137,10 @@ class GuidedTourController @Inject constructor(
         generalSettings.isGuidedToursEnabled.value(false)
     }
 
-    suspend fun complete() = mutationMutex.withLock { completeLocked() }
+    suspend fun complete() {
+        val onComplete = mutationMutex.withLock { completeLocked() }
+        onComplete?.invoke()
+    }
 
     /**
      * Signal from the host that the session for [tourId] has shown at least one step (anchored or
@@ -145,8 +152,8 @@ class GuidedTourController @Inject constructor(
         if (_session.value?.definition?.id == tourId) sessionStepRendered = true
     }
 
-    private suspend fun completeLocked() {
-        val s = _session.value ?: return
+    private suspend fun completeLocked(): (suspend () -> Unit)? {
+        val s = _session.value ?: return null
         if (!sessionStepRendered) {
             // The whole tour fell through on missing-target grace-skips without a single step ever
             // being shown (anchors not registered yet, wrong target ids, or a transient layout
@@ -156,12 +163,13 @@ class GuidedTourController @Inject constructor(
             skippedThisSession += s.definition.id.raw
             _session.value = null
             routeAtStart = null
-            return
+            return null
         }
         log(TAG) { "complete(${s.definition.id.raw})" }
         persistCompleted(s.definition.id.raw)
         _session.value = null
         routeAtStart = null
+        return s.definition.onComplete
     }
 
     suspend fun reset() = mutationMutex.withLock {

--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/tour/Tour.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/tour/Tour.kt
@@ -25,6 +25,11 @@ data class TourDefinition(
     val id: TourId,
     val steps: List<TourStep>,
     val clickProtection: Boolean = true,
+    /**
+     * Runs after a successful completion has been persisted and the active session has been
+     * cleared. It is not invoked for skip, dismiss, disable-all, or a no-render grace-skip.
+     */
+    val onComplete: (suspend () -> Unit)? = null,
 )
 
 data class TourSession(

--- a/app-common-ui/src/test/java/eu/darken/sdmse/common/compose/SdmFastScrollerTest.kt
+++ b/app-common-ui/src/test/java/eu/darken/sdmse/common/compose/SdmFastScrollerTest.kt
@@ -5,6 +5,12 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items as gridItems
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Text
@@ -15,6 +21,8 @@ import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipeDown
 import androidx.compose.ui.unit.dp
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import org.junit.Test
@@ -78,5 +86,79 @@ class SdmFastScrollerTest : BaseComposeRobolectricTest() {
             }
         }
         composeRule.onAllNodesWithContentDescription(cd).assertCountEquals(0)
+    }
+
+    @Test
+    fun `dragging lane to bottom moves list to its last portion`() {
+        lateinit var state: LazyListState
+        val itemCount = 500
+        composeRule.setContent {
+            PreviewWrapper {
+                state = rememberLazyListState()
+                Box(modifier = Modifier.fillMaxSize()) {
+                    LazyColumn(state = state, modifier = Modifier.fillMaxSize()) {
+                        items((0 until itemCount).toList()) { index ->
+                            Text(text = "Item $index", modifier = Modifier.height(8.dp))
+                        }
+                    }
+                    SdmFastScroller(
+                        state = state,
+                        modifier = Modifier.align(Alignment.CenterEnd).fillMaxHeight(),
+                    )
+                }
+            }
+        }
+
+        composeRule.onNodeWithContentDescription(cd).performTouchInput {
+            swipeDown(durationMillis = 500)
+        }
+
+        composeRule.runOnIdle {
+            if (state.firstVisibleItemIndex <= itemCount / 2) {
+                throw AssertionError(
+                    "Expected fast-scroll drag to reach the last portion, " +
+                        "but first visible index was ${state.firstVisibleItemIndex}",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `dragging grid lane to bottom moves grid to its last portion`() {
+        lateinit var state: LazyGridState
+        val itemCount = 500
+        composeRule.setContent {
+            PreviewWrapper {
+                state = rememberLazyGridState()
+                Box(modifier = Modifier.fillMaxSize()) {
+                    LazyVerticalGrid(
+                        columns = GridCells.Fixed(2),
+                        state = state,
+                        modifier = Modifier.fillMaxSize(),
+                    ) {
+                        gridItems((0 until itemCount).toList()) { index ->
+                            Text(text = "Item $index", modifier = Modifier.height(8.dp))
+                        }
+                    }
+                    SdmFastScroller(
+                        state = state,
+                        modifier = Modifier.align(Alignment.CenterEnd).fillMaxHeight(),
+                    )
+                }
+            }
+        }
+
+        composeRule.onNodeWithContentDescription(cd).performTouchInput {
+            swipeDown(durationMillis = 500)
+        }
+
+        composeRule.runOnIdle {
+            if (state.firstVisibleItemIndex <= itemCount / 2) {
+                throw AssertionError(
+                    "Expected fast-scroll drag to reach the grid's last portion, " +
+                        "but first visible index was ${state.firstVisibleItemIndex}",
+                )
+            }
+        }
     }
 }

--- a/app-common-ui/src/test/java/eu/darken/sdmse/common/compose/tour/GuidedTourControllerTest.kt
+++ b/app-common-ui/src/test/java/eu/darken/sdmse/common/compose/tour/GuidedTourControllerTest.kt
@@ -196,6 +196,68 @@ class GuidedTourControllerTest : BaseTest() {
     }
 
     @Test
+    fun `successful completion invokes onComplete after persistence and session clearing`() = runTest {
+        lateinit var ctrl: GuidedTourController
+        var completionCalls = 0
+        val def = basicDefinition.copy(
+            id = TourId("test.oncomplete"),
+            onComplete = {
+                ctrl.session.value shouldBe null
+                prefsFlow.value.completed shouldBe setOf("test.oncomplete")
+                completionCalls++
+            },
+        )
+        ctrl = controller()
+        ctrl.start(def)
+        ctrl.markStepRendered(def.id)
+
+        ctrl.next()
+        ctrl.next()
+        ctrl.next() // Finish on the last step.
+
+        completionCalls shouldBe 1
+    }
+
+    @Test
+    fun `non-completion exits do not invoke onComplete`() = runTest {
+        var completionCalls = 0
+        fun definition(id: String) = basicDefinition.copy(
+            id = TourId(id),
+            onComplete = { completionCalls++ },
+        )
+
+        controller().apply {
+            start(definition("test.oncomplete.skip"))
+            skipForNow()
+        }
+        controller().apply {
+            start(definition("test.oncomplete.dismiss"))
+            dismissForever()
+        }
+        controller().apply {
+            start(definition("test.oncomplete.disable"))
+            disableAllTours()
+        }
+
+        completionCalls shouldBe 0
+    }
+
+    @Test
+    fun `no-render completion fallback does not invoke onComplete`() = runTest {
+        var completionCalls = 0
+        val def = basicDefinition.copy(
+            id = TourId("test.oncomplete.no-render"),
+            onComplete = { completionCalls++ },
+        )
+        val ctrl = controller()
+        ctrl.start(def)
+
+        ctrl.complete()
+
+        completionCalls shouldBe 0
+    }
+
+    @Test
     fun `next to end without any rendered step skips instead of persisting`() = runTest {
         val ctrl = controller()
         ctrl.start(basicDefinition) // no markStepRendered: every step grace-skipped, nothing shown

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/app/AppDetailsScreen.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/app/AppDetailsScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.icons.twotone.Inventory
 import androidx.compose.material.icons.twotone.PermMedia
 import androidx.compose.material.icons.twotone.Refresh
 import androidx.compose.material3.MaterialTheme
+import eu.darken.sdmse.common.compose.layout.SdmListDefaults
 import eu.darken.sdmse.common.compose.layout.SdmScaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -31,6 +32,7 @@ import eu.darken.sdmse.analyzer.ui.AppDetailsRoute
 import eu.darken.sdmse.analyzer.ui.storage.app.items.AppDetailsGroupRow
 import eu.darken.sdmse.analyzer.ui.storage.app.items.AppDetailsHeaderCard
 import eu.darken.sdmse.common.compose.layout.SdmTooltipIconButton
+import eu.darken.sdmse.common.compose.layout.plusBottom
 import eu.darken.sdmse.common.compose.preview.Preview2
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import eu.darken.sdmse.common.compose.progress.ProgressOverlay
@@ -152,7 +154,8 @@ internal fun AppDetailsScreen(
                 ) {
                     LazyColumn(
                         modifier = Modifier.fillMaxSize(),
-                        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
+                            .plusBottom(SdmListDefaults.ContentBottomSpacing),
                         verticalArrangement = Arrangement.spacedBy(8.dp),
                     ) {
                         item("header") {

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/apps/AppsScreen.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/apps/AppsScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.icons.twotone.Close
 import androidx.compose.material.icons.twotone.Search
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import eu.darken.sdmse.common.compose.layout.SdmListDefaults
 import eu.darken.sdmse.common.compose.layout.SdmScaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -41,6 +42,7 @@ import eu.darken.sdmse.analyzer.R
 import eu.darken.sdmse.analyzer.ui.AppsRoute
 import eu.darken.sdmse.common.R as CommonR
 import eu.darken.sdmse.common.compose.layout.SdmTooltipIconButton
+import eu.darken.sdmse.common.compose.layout.plusBottom
 import eu.darken.sdmse.common.compose.preview.Preview2
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import eu.darken.sdmse.common.compose.progress.ProgressOverlay
@@ -162,7 +164,8 @@ internal fun AppsScreen(
             LazyVerticalGrid(
                 columns = GridCells.Fixed(context.getSpanCount(widthDp = 360)),
                 modifier = Modifier.fillMaxSize(),
-                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
+                    .plusBottom(SdmListDefaults.ContentBottomSpacing),
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentScreen.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentScreen.kt
@@ -54,6 +54,7 @@ import eu.darken.sdmse.common.compose.dialog.SdmDialogAction
 import eu.darken.sdmse.common.compose.icons.SdmIcons
 import eu.darken.sdmse.common.compose.icons.ShieldAdd
 import eu.darken.sdmse.common.compose.layout.SdmListDefaults
+import eu.darken.sdmse.common.compose.layout.plusBottom
 import eu.darken.sdmse.common.compose.layout.SdmTooltipIconButton
 import eu.darken.sdmse.common.compose.preview.Preview2
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
@@ -394,7 +395,8 @@ internal fun ContentScreen(
                         when (s.layoutMode) {
                             LayoutMode.LINEAR -> LazyColumn(
                                 modifier = Modifier.fillMaxSize(),
-                                contentPadding = SdmListDefaults.FullWidthContentPadding,
+                                contentPadding = SdmListDefaults.FullWidthContentPadding
+                                    .plusBottom(SdmListDefaults.ContentBottomSpacing),
                             ) {
                                 s.infoBanner?.let { banner ->
                                     item(key = "info-banner") {
@@ -410,7 +412,8 @@ internal fun ContentScreen(
                             LayoutMode.GRID -> LazyVerticalGrid(
                                 columns = GridCells.Fixed(spanCount),
                                 modifier = Modifier.fillMaxSize(),
-                                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
+                                    .plusBottom(SdmListDefaults.ContentBottomSpacing),
                                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                                 verticalArrangement = Arrangement.spacedBy(8.dp),
                             ) {

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListScreen.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListScreen.kt
@@ -715,7 +715,8 @@ internal fun AppControlListScreen(
                             state = gridState,
                             modifier = Modifier
                                 .align(Alignment.CenterEnd)
-                                .fillMaxHeight(),
+                                .fillMaxHeight()
+                                .padding(vertical = 8.dp),
                             sections = sections,
                             minItemsToShow = 0,
                         )
@@ -813,4 +814,3 @@ private fun AppControlListScreenPopulatedPreview() {
         )
     }
 }
-

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListScreen.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -338,6 +339,15 @@ internal fun AppControlListScreen(
     val selectionActive = selection.isActive
     BackHandler(enabled = selectionActive) { selection.clear() }
 
+    val archiveSelectionTargets by remember(rows, selection) {
+        derivedStateOf {
+            resolveArchiveSelectionTargets(
+                rows = rows.orEmpty(),
+                selectedIds = selection.selected,
+            )
+        }
+    }
+
     var selectionOverflowOpen by remember { mutableStateOf(false) }
     var searchActive by rememberSaveable { mutableStateOf(false) }
     var activeSheet by rememberSaveable { mutableStateOf<Sheet?>(null) }
@@ -586,24 +596,24 @@ internal fun AppControlListScreen(
                                     },
                                 )
                             }
-                            if (state.allowActionArchive) {
+                            if (state.allowActionArchive && archiveSelectionTargets.archive.isNotEmpty()) {
                                 DropdownMenuItem(
                                     text = { Text(stringResource(R.string.appcontrol_archive_selection_action)) },
                                     leadingIcon = { Icon(Icons.TwoTone.Archive, contentDescription = null) },
                                     onClick = {
-                                        val ids = selection.selected
+                                        val ids = archiveSelectionTargets.archive
                                         selectionOverflowOpen = false
                                         selection.clear()
                                         onArchiveSelected(ids)
                                     },
                                 )
                             }
-                            if (state.allowActionRestore) {
+                            if (state.allowActionRestore && archiveSelectionTargets.restore.isNotEmpty()) {
                                 DropdownMenuItem(
                                     text = { Text(stringResource(R.string.appcontrol_restore_selection_action)) },
                                     leadingIcon = { Icon(Icons.TwoTone.Unarchive, contentDescription = null) },
                                     onClick = {
-                                        val ids = selection.selected
+                                        val ids = archiveSelectionTargets.restore
                                         selectionOverflowOpen = false
                                         selection.clear()
                                         onRestoreSelected(ids)
@@ -752,6 +762,27 @@ internal fun AppControlListScreen(
 }
 
 private enum class Sheet { Sort, Tags }
+
+private data class ArchiveSelectionTargets(
+    val archive: Set<InstallId>,
+    val restore: Set<InstallId>,
+)
+
+private fun resolveArchiveSelectionTargets(
+    rows: List<AppControlListViewModel.Row>,
+    selectedIds: Set<InstallId>,
+): ArchiveSelectionTargets {
+    val archive = mutableSetOf<InstallId>()
+    val restore = mutableSetOf<InstallId>()
+
+    rows.forEach { row ->
+        if (row.installId !in selectedIds) return@forEach
+        if (row.appInfo.canBeArchived) archive += row.installId
+        if (row.appInfo.canBeRestored) restore += row.installId
+    }
+
+    return ArchiveSelectionTargets(archive = archive, restore = restore)
+}
 
 internal fun buildFastScrollerSections(
     rows: List<AppControlListViewModel.Row>,

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/actions/AppActionSheet.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/actions/AppActionSheet.kt
@@ -20,7 +20,6 @@ import androidx.compose.material.icons.twotone.Delete
 import androidx.compose.material.icons.twotone.PowerSettingsNew
 import androidx.compose.material.icons.twotone.AcUnit
 import androidx.compose.material.icons.twotone.Archive
-import androidx.compose.material.icons.twotone.DoNotDisturb
 import androidx.compose.material.icons.twotone.Settings
 import androidx.compose.material.icons.twotone.SaveAlt
 import androidx.compose.material.icons.twotone.Shop
@@ -66,6 +65,7 @@ import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import eu.darken.sdmse.common.compose.icons.SdmIcons
 import eu.darken.sdmse.common.compose.icons.ShieldAdd
 import eu.darken.sdmse.common.compose.icons.ShieldEdit
+import eu.darken.sdmse.common.compose.icons.SnowflakeOff
 import eu.darken.sdmse.common.compose.progress.ProgressOverlay
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
@@ -353,7 +353,7 @@ private fun ActionItemRow(
             icon = if (item.isEnabled) {
                 rememberVectorPainter(Icons.TwoTone.AcUnit)
             } else {
-                rememberVectorPainter(Icons.TwoTone.DoNotDisturb)
+                rememberVectorPainter(SdmIcons.SnowflakeOff)
             },
             title = if (item.isEnabled) {
                 stringResource(R.string.appcontrol_toggle_app_disable_action)
@@ -438,4 +438,3 @@ private fun itemKey(item: AppActionItem): String = when (item) {
     is AppActionItem.Action.Restore -> "restore"
     is AppActionItem.Action.Export -> "export"
 }
-

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/items/AppControlListRow.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/items/AppControlListRow.kt
@@ -2,6 +2,7 @@ package eu.darken.sdmse.appcontrol.ui.list.items
 
 import android.text.format.Formatter
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -82,33 +83,46 @@ fun AppControlListRow(
                 )
             }
             val secondary = secondaryInfoFor(appInfo, sortMode, context)
-            if (secondary != null) {
-                Text(
-                    text = secondary,
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
+            val size = appInfo.sizes?.let { sizes ->
+                // Cheap single call; left un-remembered so the label tracks locale/config changes.
+                Formatter.formatShortFileSize(context, sizes.total)
+            }
+            if (secondary != null || size != null) {
+                Row(modifier = Modifier.fillMaxWidth()) {
+                    if (secondary != null) {
+                        Text(
+                            text = secondary,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier
+                                .weight(1f)
+                                .alignByBaseline(),
+                        )
+                    } else {
+                        Spacer(Modifier.weight(1f))
+                    }
+                    if (size != null) {
+                        if (secondary != null) Spacer(Modifier.width(8.dp))
+                        Text(
+                            text = size,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            // Keep the size clear of the always-on fast-scroll thumb that floats over
+                            // the list's right edge (rows stay full-width; only this value is inset).
+                            modifier = Modifier
+                                .padding(end = SdmFastScrollerLaneWidth)
+                                .alignByBaseline(),
+                        )
+                    }
+                }
             }
             AppInfoTagsRow(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(top = 4.dp),
                 appInfo = appInfo,
-            )
-        }
-        appInfo.sizes?.let { sizes ->
-            Spacer(Modifier.width(8.dp))
-            // Cheap single call; left un-remembered so the label tracks locale/config changes (the
-            // expensive per-row work was the DateTimeFormatter construction in secondaryInfoFor).
-            Text(
-                text = Formatter.formatShortFileSize(context, sizes.total),
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                // Keep the size clear of the always-on fast-scroll thumb that floats over the list's
-                // right edge (rows stay full-width; only this trailing value is inset).
-                modifier = Modifier.padding(end = SdmFastScrollerLaneWidth),
             )
         }
     }

--- a/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListScreenTest.kt
+++ b/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListScreenTest.kt
@@ -3,12 +3,14 @@ package eu.darken.sdmse.appcontrol.ui.list
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.hasScrollAction
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.dp
 import eu.darken.sdmse.appcontrol.core.AppInfo
 import eu.darken.sdmse.appcontrol.core.FilterSettings
 import eu.darken.sdmse.appcontrol.core.SortSettings
@@ -28,6 +30,7 @@ import io.mockk.mockk
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Test
 import testhelpers.compose.BaseComposeRobolectricTest
+import kotlin.math.abs
 
 class AppControlListScreenTest : BaseComposeRobolectricTest() {
 
@@ -125,6 +128,33 @@ class AppControlListScreenTest : BaseComposeRobolectricTest() {
         composeRule.onNodeWithText("com.alpha.app").assertExists()
         // Empty placeholder must NOT render.
         composeRule.onAllNodesWithText("Empty").assertCountEquals(0)
+    }
+
+    @Test
+    fun `fast scroller lane is inset from both grid edges`() {
+        composeRule.setListScreen(
+            AppControlListViewModel.State(
+                rows = List(60) { index -> row("com.example.app$index", label = "App $index") },
+            ),
+        )
+
+        val gridBounds = composeRule
+            .onAllNodes(hasScrollAction())
+            .fetchSemanticsNodes()
+            .maxBy { it.boundsInRoot.height }
+            .boundsInRoot
+        val scrollerBounds = composeRule
+            .onNodeWithContentDescription("Fast scroller")
+            .fetchSemanticsNode()
+            .boundsInRoot
+        val expectedInsetPx = with(composeRule.density) { 8.dp.toPx() }
+
+        if (abs(scrollerBounds.top - gridBounds.top - expectedInsetPx) > 0.5f) {
+            throw AssertionError("Expected fast scroller to be inset 8dp from the grid top")
+        }
+        if (abs(gridBounds.bottom - scrollerBounds.bottom - expectedInsetPx) > 0.5f) {
+            throw AssertionError("Expected fast scroller to be inset 8dp from the grid bottom")
+        }
     }
 
     @Test

--- a/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListScreenTest.kt
+++ b/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListScreenTest.kt
@@ -5,11 +5,13 @@ import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.hasScrollAction
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.unit.dp
 import eu.darken.sdmse.appcontrol.core.AppInfo
 import eu.darken.sdmse.appcontrol.core.FilterSettings
@@ -37,6 +39,8 @@ class AppControlListScreenTest : BaseComposeRobolectricTest() {
     private fun row(
         pkgName: String,
         label: String = pkgName,
+        canBeArchived: Boolean = false,
+        canBeRestored: Boolean = false,
     ): AppControlListViewModel.Row {
         val pkgId = Pkg.Id(pkgName)
         val userHandle = UserHandle2(0)
@@ -66,8 +70,8 @@ class AppControlListScreenTest : BaseComposeRobolectricTest() {
                 canBeStopped = false,
                 canBeExported = false,
                 canBeDeleted = false,
-                canBeArchived = false,
-                canBeRestored = false,
+                canBeArchived = canBeArchived,
+                canBeRestored = canBeRestored,
             ),
             sectionKeyName = label.firstOrNull()?.uppercaseChar()?.toString() ?: "?",
             sectionKeyPkg = pkgName.firstOrNull()?.uppercaseChar()?.toString() ?: "?",
@@ -181,6 +185,71 @@ class AppControlListScreenTest : BaseComposeRobolectricTest() {
         if (tapped.isEmpty()) throw AssertionError("Expected at least one tap callback but got none")
         // Last tap is for Beta — guards against the row builder using the wrong index.
         tapped.last() shouldBeEqual beta.installId
+    }
+
+    @Test
+    fun `selection menu only offers archive for an archivable app`() {
+        composeRule.setListScreen(
+            AppControlListViewModel.State(
+                rows = listOf(row("com.example.installed", label = "Installed", canBeArchived = true)),
+                allowActionArchive = true,
+                allowActionRestore = true,
+            ),
+        )
+
+        composeRule.onNodeWithText("Installed").performTouchInput { longClick() }
+        composeRule.onNodeWithContentDescription("Options").performClick()
+
+        composeRule.onNodeWithText("Archive apps").assertExists()
+        composeRule.onAllNodesWithText("Restore apps").assertCountEquals(0)
+    }
+
+    @Test
+    fun `selection menu only offers restore for an archived app`() {
+        composeRule.setListScreen(
+            AppControlListViewModel.State(
+                rows = listOf(row("com.example.archived", label = "Archived", canBeRestored = true)),
+                allowActionArchive = true,
+                allowActionRestore = true,
+            ),
+        )
+
+        composeRule.onNodeWithText("Archived").performTouchInput { longClick() }
+        composeRule.onNodeWithContentDescription("Options").performClick()
+
+        composeRule.onAllNodesWithText("Archive apps").assertCountEquals(0)
+        composeRule.onNodeWithText("Restore apps").assertExists()
+    }
+
+    @Test
+    fun `mixed selection offers both actions and restore receives only archived apps`() {
+        val installed = row("com.example.installed", label = "Installed", canBeArchived = true)
+        val archived = row("com.example.archived", label = "Archived", canBeRestored = true)
+        val restored = mutableListOf<Set<InstallId>>()
+        composeRule.setContent {
+            CompositionLocalProvider(LocalGuidedTourController provides mockTourController) {
+                PreviewWrapper {
+                    AppControlListScreen(
+                        stateSource = MutableStateFlow(
+                            AppControlListViewModel.State(
+                                rows = listOf(installed, archived),
+                                allowActionArchive = true,
+                                allowActionRestore = true,
+                            ),
+                        ),
+                        onRestoreSelected = { restored += it },
+                    )
+                }
+            }
+        }
+
+        composeRule.onNodeWithText("Installed").performTouchInput { longClick() }
+        composeRule.onNodeWithText("Archived").performClick()
+        composeRule.onNodeWithContentDescription("Options").performClick()
+
+        composeRule.onNodeWithText("Archive apps").assertExists()
+        composeRule.onNodeWithText("Restore apps").performClick()
+        restored.single() shouldBeEqual setOf(archived.installId)
     }
 
     @Test

--- a/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/sessions/SwiperSessionsScreen.kt
+++ b/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/sessions/SwiperSessionsScreen.kt
@@ -157,10 +157,10 @@ internal fun SwiperSessionsScreen(
                 .padding(paddingValues),
             contentPadding = PaddingValues(top = 8.dp, bottom = 8.dp + SdmListDefaults.FabClearance),
         ) {
-            if (state.sessionsWithStats.isEmpty()) {
+            if (state.areSessionsLoaded && state.sessionsWithStats.isEmpty()) {
                 item(key = "header") { SwiperSessionsHeaderCard() }
             }
-            if (!state.isPro) {
+            if (state.isPro == false) {
                 item(key = "upgrade") {
                     SwiperSessionsUpgradeCard(
                         freeVersionLimit = state.freeVersionLimit,
@@ -473,7 +473,12 @@ private fun SortOrderDialog(
 private fun SwiperSessionsScreenEmptyPreview() {
     PreviewWrapper {
         SwiperSessionsScreen(
-            stateSource = MutableStateFlow(SwiperSessionsViewModel.State()),
+            stateSource = MutableStateFlow(
+                SwiperSessionsViewModel.State(
+                    areSessionsLoaded = true,
+                    isPro = false,
+                ),
+            ),
         )
     }
 }

--- a/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/sessions/SwiperSessionsViewModel.kt
+++ b/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/sessions/SwiperSessionsViewModel.kt
@@ -31,7 +31,6 @@ import eu.darken.sdmse.swiper.ui.SwiperSwipeRoute
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 
@@ -65,12 +64,14 @@ class SwiperSessionsViewModel @Inject constructor(
         swiper.getSessionsWithStats(),
         swiper.progress,
         selectedPaths,
-        upgradeRepo.upgradeInfo.map { it?.isPro ?: false },
+        upgradeRepo.upgradeInfo,
+        upgradeRepo.isSettled,
         scanningSessionId,
         cancellingSessionId,
         refreshingSessionId,
         dataAreaManager.state,
-    ) { sessionsWithStats, progress, paths, isPro, scanningId, cancellingId, refreshingId, areaState ->
+    ) { sessionsWithStats, progress, paths, upgradeInfo, isUpgradeSettled,
+        scanningId, cancellingId, refreshingId, areaState ->
         val riskySessionPaths = sessionsWithStats
             .associate { entry ->
                 entry.session.sessionId to entry.session.sourcePaths.filter { p -> p.isSensitiveRootIn(areaState.areas) }
@@ -78,10 +79,17 @@ class SwiperSessionsViewModel @Inject constructor(
             .filterValues { it.isNotEmpty() }
         State(
             sessionsWithStats = sessionsWithStats,
+            areSessionsLoaded = true,
             selectedPaths = paths,
             isScanning = progress != null,
             progress = progress,
-            isPro = isPro,
+            // GPlay initially reports non-Pro while its billing handshake is still in flight.
+            // Keep that state unknown so the free-tier card is only shown after a real lookup.
+            isPro = when {
+                upgradeInfo.isPro -> true
+                isUpgradeSettled -> false
+                else -> null
+            },
             scanningSessionId = scanningId,
             cancellingSessionId = cancellingId,
             refreshingSessionId = refreshingId,
@@ -182,17 +190,19 @@ class SwiperSessionsViewModel @Inject constructor(
 
     data class State(
         val sessionsWithStats: List<Swiper.SessionWithStats> = emptyList(),
+        val areSessionsLoaded: Boolean = false,
         val selectedPaths: Set<APath> = emptySet(),
         val isScanning: Boolean = false,
         val progress: Progress.Data? = null,
-        val isPro: Boolean = false,
+        val isPro: Boolean? = null,
         val scanningSessionId: String? = null,
         val cancellingSessionId: String? = null,
         val refreshingSessionId: String? = null,
         val riskySessionIds: Set<String> = emptySet(),
         val riskySessionPaths: Map<String, List<APath>> = emptyMap(),
     ) {
-        val canCreateNewSession: Boolean = isPro || sessionsWithStats.size < SwiperSettings.FREE_VERSION_SESSION_LIMIT
+        val canCreateNewSession: Boolean =
+            isPro == true || sessionsWithStats.size < SwiperSettings.FREE_VERSION_SESSION_LIMIT
         val freeVersionLimit: Int = SwiperSettings.FREE_VERSION_LIMIT
         val freeSessionLimit: Int = SwiperSettings.FREE_VERSION_SESSION_LIMIT
 

--- a/app-tool-swiper/src/test/java/eu/darken/sdmse/swiper/ui/sessions/SwiperSessionsScreenTest.kt
+++ b/app-tool-swiper/src/test/java/eu/darken/sdmse/swiper/ui/sessions/SwiperSessionsScreenTest.kt
@@ -59,6 +59,52 @@ class SwiperSessionsScreenTest : BaseComposeRobolectricTest() {
     }
 
     @Test
+    fun `loading state does not show cards based on placeholder defaults`() {
+        composeRule.setSessionsScreen(SwiperSessionsViewModel.State())
+
+        composeRule.onNodeWithText("Ready to declutter?").assertDoesNotExist()
+        composeRule.onNodeWithText("Upgrade to remove", substring = true).assertDoesNotExist()
+    }
+
+    @Test
+    fun `loaded empty state shows header`() {
+        composeRule.setSessionsScreen(
+            SwiperSessionsViewModel.State(
+                areSessionsLoaded = true,
+            ),
+        )
+
+        composeRule.onNodeWithText("Ready to declutter?").assertExists()
+    }
+
+    @Test
+    fun `settled free state shows upgrade card`() {
+        composeRule.setSessionsScreen(
+            SwiperSessionsViewModel.State(
+                sessionsWithStats = listOf(row(sessionId = "s1", label = "Photos")),
+                areSessionsLoaded = true,
+                isPro = false,
+            ),
+        )
+
+        composeRule.onNodeWithText("Upgrade to remove", substring = true).assertExists()
+    }
+
+    @Test
+    fun `unsettled entitlement does not show upgrade card`() {
+        composeRule.setSessionsScreen(
+            SwiperSessionsViewModel.State(
+                sessionsWithStats = listOf(row(sessionId = "s1", label = "Photos")),
+                areSessionsLoaded = true,
+                isPro = null,
+            ),
+        )
+
+        composeRule.onNodeWithText("Upgrade to remove", substring = true).assertDoesNotExist()
+        composeRule.onNodeWithText("Photos").assertExists()
+    }
+
+    @Test
     fun `custom session label is rendered when set`() {
         // Custom labels live in the visible portion of the row (before any scrolling), so they
         // resolve via onNodeWithText. Default labels go through stringResource formatting (with

--- a/app-tool-swiper/src/test/java/eu/darken/sdmse/swiper/ui/sessions/SwiperSessionsViewModelTest.kt
+++ b/app-tool-swiper/src/test/java/eu/darken/sdmse/swiper/ui/sessions/SwiperSessionsViewModelTest.kt
@@ -34,7 +34,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -82,6 +81,7 @@ class SwiperSessionsViewModelTest : BaseTest() {
         val taskSubmitter: TaskSubmitter,
         val navCtrl: NavigationController,
         val pickerResults: MutableSharedFlow<PickerResult>,
+        val isUpgradeSettledFlow: MutableStateFlow<Boolean>,
     )
 
     private class CollectedEvents<T>(val list: MutableList<T>, private val job: Job) {
@@ -103,6 +103,7 @@ class SwiperSessionsViewModelTest : BaseTest() {
         sessions: List<Swiper.SessionWithStats> = emptyList(),
         progress: Progress.Data? = null,
         isPro: Boolean = false,
+        isUpgradeSettled: Boolean = true,
         areas: Set<DataArea> = emptySet(),
     ): Harness {
         val sessionsFlow = MutableStateFlow(sessions)
@@ -111,6 +112,7 @@ class SwiperSessionsViewModelTest : BaseTest() {
             every { this@apply.isPro } returns isPro
         }
         val upgradeFlow = MutableStateFlow<UpgradeRepo.Info>(upgradeInfo)
+        val isUpgradeSettledFlow = MutableStateFlow(isUpgradeSettled)
         val areaStateFlow = MutableStateFlow(DataAreaManager.State(areas = areas))
         // Use a hot SharedFlow so tests can inject picker results after construction. The VM's init
         // block collects this; emitting a PickerResult here exercises the createSession path.
@@ -123,7 +125,7 @@ class SwiperSessionsViewModelTest : BaseTest() {
         val taskSubmitter = mockk<TaskSubmitter>(relaxed = true)
         val upgradeRepo = mockk<UpgradeRepo>().apply {
             every { this@apply.upgradeInfo } returns upgradeFlow
-            every { this@apply.isSettled } returns flowOf(true)
+            every { this@apply.isSettled } returns isUpgradeSettledFlow
         }
         // currentAreas() is an extension that reads state.first().areas — no separate stub needed.
         val dataAreaManager = mockk<DataAreaManager>().apply {
@@ -154,6 +156,7 @@ class SwiperSessionsViewModelTest : BaseTest() {
             taskSubmitter = taskSubmitter,
             navCtrl = navCtrl,
             pickerResults = pickerResults,
+            isUpgradeSettledFlow = isUpgradeSettledFlow,
         )
     }
 
@@ -165,6 +168,7 @@ class SwiperSessionsViewModelTest : BaseTest() {
 
         val state = h.vm.state.first()
         state.sessionsWithStats shouldBe listOf(s)
+        state.areSessionsLoaded shouldBe true
         state.isScanning shouldBe false
     }
 
@@ -185,6 +189,27 @@ class SwiperSessionsViewModelTest : BaseTest() {
         val freeHarness = harness(isPro = false)
         advanceUntilIdle()
         freeHarness.vm.state.first().isPro shouldBe false
+    }
+
+    @Test
+    fun `state keeps Pro status unknown until a non-Pro entitlement is settled`() = runTest2 {
+        val h = harness(isPro = false, isUpgradeSettled = false)
+        advanceUntilIdle()
+
+        h.vm.state.first().isPro shouldBe null
+
+        h.isUpgradeSettledFlow.value = true
+        advanceUntilIdle()
+
+        h.vm.state.first().isPro shouldBe false
+    }
+
+    @Test
+    fun `state exposes confirmed Pro status before entitlement settles`() = runTest2 {
+        val h = harness(isPro = true, isUpgradeSettled = false)
+        advanceUntilIdle()
+
+        h.vm.state.first().isPro shouldBe true
     }
 
     @Test

--- a/app/src/foss/res/values/strings.xml
+++ b/app/src/foss/res/values/strings.xml
@@ -13,7 +13,7 @@
     <string name="upgrade_screen_how_title">How to help</string>
     <string name="upgrade_screen_how_body">Become a patron and sponsor development! Tap the button below to activate all extra features and open my GitHub Sponsors profile.</string>
     <string name="upgrade_screen_why_title">Upgrade benefits</string>
-    <string name="upgrade_screen_why_body">• Clean app caches and expendable data\n• Remove duplicate files\n• Enable scheduled cleanups\n• Create custom filters and cleanup rules\n• Track storage trends and cleanup history\n• More features and controls across the app\n• Support open-source work</string>
+    <string name="upgrade_screen_why_body">• App cache and junk cleaning\n• Duplicate file removal\n• Photo and video compression\n• Swipe-to-declutter old files\n• One-tap cleaning via widget\n• Cleanup scheduling\n• Custom filters and rules\n• Storage trends and history\n• More features and controls across the app\n• Support open-source work</string>
     <string name="upgrade_screen_sponsor_action">Sponsor development</string>
     <string name="upgrade_screen_sponsor_action_hint">The alternative are ads, analytics and Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Thank you for supporting open-source development ❤️</string>

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -23,7 +23,7 @@
     <string name="upgrade_screen_title">Get SD Maid SE Pro</string>
     <string name="upgrade_screen_preamble">SD Maid has no ads and doesn\'t sell user data. My work is financed by you ❤️.</string>
     <string name="upgrade_screen_benefits_title">Upgrade benefits</string>
-    <string name="upgrade_screen_benefits_body">• Clean app caches and expendable data\n• Remove duplicate files\n• Enable scheduled cleanups\n• Create custom filters and cleanup rules\n• Track storage trends and cleanup history\n• More features and controls across the app\n• Support continued development</string>
+    <string name="upgrade_screen_benefits_body">• App cache and junk cleaning\n• Duplicate file removal\n• Photo and video compression\n• Swipe-to-declutter old files\n• One-tap cleaning via widget\n• Cleanup scheduling\n• Custom filters and rules\n• Storage trends and history\n• More features and controls across the app\n• Support continued development</string>
     <string name="upgrade_screen_offers_title">Upgrade options</string>
     <string name="upgrade_screen_offers_body">Same features, just different pricing models.</string>
     <string name="upgrade_screen_offers_or">or</string>

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardScreen.kt
@@ -356,6 +356,9 @@ internal fun DashboardScreen(
             prepareManualTool = {
                 scrollToFirstMatching(gridState, itemsState.value) { it is SwiperDashboardCardItem }
             },
+            // Leave the dashboard in its natural starting position after the user successfully
+            // finishes the tour. The framework does not invoke this for skip/dismiss/disable.
+            onComplete = { gridState.animateScrollToItem(0) },
         )
     }
     // Don't start the tour until at least one tool card exists: the tools step targets the

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.SnackbarResult
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
@@ -34,14 +35,20 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusEvent
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.activity.compose.LocalActivity
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.Velocity
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import eu.darken.sdmse.R
@@ -213,6 +220,74 @@ internal fun DashboardScreen(
     var showOneClickOptions by rememberSaveable { mutableStateOf(false) }
     val gridState = rememberLazyGridState()
     var isBottomBarVisible by rememberSaveable { mutableStateOf(true) }
+    var mascotTopBump by remember { mutableIntStateOf(0) }
+
+    val density = LocalDensity.current
+    val topBumpLargeScrollPx = with(density) { MASCOT_TOP_BUMP_LARGE_SCROLL_DISTANCE.roundToPx() }
+    val topBumpFastDeltaPx = with(density) { MASCOT_TOP_BUMP_FAST_DELTA.toPx() }
+    val topBumpFastFlingPx = with(density) { MASCOT_TOP_BUMP_FAST_FLING_VELOCITY.toPx() }
+    val topBumpConnection = remember(
+        gridState,
+        topBumpLargeScrollPx,
+        topBumpFastDeltaPx,
+        topBumpFastFlingPx,
+    ) {
+        val detector = DashboardTopBumpDetector(topBumpLargeScrollPx)
+        object : NestedScrollConnection {
+            // Compose reports fling frames as SideEffect scrolls. Remember that they originated
+            // with the user's gesture so a fast return to the top still gets the same reaction.
+            var userFlingInProgress = false
+            var isFastReturnFling = false
+
+            override fun onPostScroll(
+                consumed: Offset,
+                available: Offset,
+                source: NestedScrollSource,
+            ): Offset {
+                val isUserMotion = source == NestedScrollSource.UserInput || userFlingInProgress
+                if (!isUserMotion) {
+                    detector.onNonUserScroll()
+                    return Offset.Zero
+                }
+
+                val deltaY = consumed.y + available.y
+                if (
+                    detector.onScroll(
+                        firstVisibleItemIndex = gridState.firstVisibleItemIndex,
+                        firstVisibleItemScrollOffset = gridState.firstVisibleItemScrollOffset,
+                        deltaY = deltaY,
+                        isFastReturn = isFastReturnFling || deltaY >= topBumpFastDeltaPx,
+                    )
+                ) {
+                    mascotTopBump++
+                }
+                return Offset.Zero
+            }
+
+            override suspend fun onPreFling(available: Velocity): Velocity {
+                userFlingInProgress = true
+                isFastReturnFling = available.y >= topBumpFastFlingPx
+                return Velocity.Zero
+            }
+
+            override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity {
+                val deltaY = consumed.y + available.y
+                if (
+                    detector.onScroll(
+                        firstVisibleItemIndex = gridState.firstVisibleItemIndex,
+                        firstVisibleItemScrollOffset = gridState.firstVisibleItemScrollOffset,
+                        deltaY = deltaY,
+                        isFastReturn = isFastReturnFling || deltaY >= topBumpFastDeltaPx,
+                    )
+                ) {
+                    mascotTopBump++
+                }
+                userFlingInProgress = false
+                isFastReturnFling = false
+                return Velocity.Zero
+            }
+        }
+    }
 
     val tourController = LocalGuidedTourController.current
     // Tour-aware screens watch this and freeze any transient dock (auto-hiding bottom bar,
@@ -455,6 +530,7 @@ internal fun DashboardScreen(
                     modifier = Modifier
                         .focusRequester(gridFocusRequester)
                         .focusGroup()
+                        .nestedScroll(topBumpConnection)
                         // Edge-to-dock jumps: perform the move ourselves; when it fails the
                         // cursor sits at a real grid edge — UP at the top row, LEFT/RIGHT at the
                         // horizontal edges, DOWN below the last row (mid-grid the lazy grid keeps
@@ -516,7 +592,10 @@ internal fun DashboardScreen(
                                 .focusRequester(cardFocusRequesters.getOrPut(item.stableId) { FocusRequester() })
                                 .onFocusEvent { if (it.hasFocus) lastFocusedCardId = item.stableId },
                         ) {
-                            DashboardListCard(item = item)
+                            DashboardListCard(
+                                item = item,
+                                mascotTopBump = mascotTopBump,
+                            )
                         }
                     }
                 }
@@ -535,6 +614,55 @@ private fun MascotOverlay() {
 }
 
 private val DASHBOARD_BOTTOM_CONTENT_PADDING = 128.dp
+private val MASCOT_TOP_BUMP_LARGE_SCROLL_DISTANCE = 160.dp
+private val MASCOT_TOP_BUMP_FAST_DELTA = 18.dp
+private val MASCOT_TOP_BUMP_FAST_FLING_VELOCITY = 1_600.dp
+
+/**
+ * Tracks a trip away from the top and emits only when the return was long or fast. Resting edge
+ * pulls, small leisurely scrolls, and programmatic tour motion therefore remain quiet.
+ */
+internal class DashboardTopBumpDetector(
+    private val largeScrollDistancePx: Int,
+) {
+    private var hasLeftTop = false
+    private var wasLargeScroll = false
+
+    init {
+        require(largeScrollDistancePx >= 0)
+    }
+
+    fun onScroll(
+        firstVisibleItemIndex: Int,
+        firstVisibleItemScrollOffset: Int,
+        deltaY: Float,
+        isFastReturn: Boolean = false,
+    ): Boolean {
+        if (firstVisibleItemIndex > 0 || firstVisibleItemScrollOffset > 0) {
+            hasLeftTop = true
+        }
+        if (firstVisibleItemIndex > 0 || firstVisibleItemScrollOffset >= largeScrollDistancePx) {
+            wasLargeScroll = true
+        }
+
+        val reachedTop = firstVisibleItemIndex == 0 && firstVisibleItemScrollOffset == 0
+        if (reachedTop && deltaY > 0f) {
+            val shouldBump = hasLeftTop && (wasLargeScroll || isFastReturn)
+            reset()
+            return shouldBump
+        }
+        return false
+    }
+
+    fun onNonUserScroll() {
+        reset()
+    }
+
+    private fun reset() {
+        hasLeftTop = false
+        wasLargeScroll = false
+    }
+}
 
 /**
  * Scroll the grid so the first item matching [predicate] anchors to the top. Index is resolved

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardBottomBar.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardBottomBar.kt
@@ -70,16 +70,17 @@ import eu.darken.sdmse.main.ui.dashboard.HeroSummary
 import eu.darken.sdmse.main.core.SDMTool
 import java.time.Instant
 
-// Playful overshoot for the hero's late arrival (ease-out-back).
-private val HeroOvershoot = CubicBezierEasing(0.34f, 1.56f, 0.64f, 1f)
+// Playful overshoot for the hero's and FAB's late arrival (ease-out-back).
+private val BubbleOvershoot = CubicBezierEasing(0.34f, 1.56f, 0.64f, 1f)
 
 /**
  * The dashboard bottom dock: a primary-coloured bar, the cradled main-action FAB, and — when the
  * latest main-action produced a result — a floating [DashboardHeroCard] above them.
  *
  * Each piece is bottom-anchored and animates **independently** so they cascade: on show the bar
- * leads, then the FAB, then the hero (with a playful overshoot); on hide they leave in reverse.
- * Each slides fully below the screen (including the nav inset) when hidden.
+ * leads, the FAB grows out of its cradle, then the hero arrives with a playful overshoot; on hide
+ * they leave in reverse. The bar and hero slide below the screen, while the FAB shrinks and fades
+ * in place so it never travels through the bar.
  */
 @Composable
 internal fun BottomBar(
@@ -103,13 +104,13 @@ internal fun BottomBar(
     val heroSummary = state?.heroSummary
     val showHero = heroVisible && heroSummary != null
 
-    // Hidden dock only slides off-screen via offset() — it stays composed for the exit
-    // animation, so it must be made unreachable explicitly: gate D-pad/keyboard focus for each
-    // layer's subtree on visibility (the hero additionally on showHero, so a dismissed card isn't
-    // focusable mid-exit). Grid↔dock D-pad crossings are handled by the caller's key handlers on
-    // the dock's focus group (see DashboardScreen); the only bridge here is the UP rung from the
-    // bar/FAB into the hero's entry control (Discard, or the Dismiss X), which would otherwise be
-    // unreachable — spatial search skips the hero's top-right controls.
+    // The hidden dock stays composed for its exit animation, so it must be made unreachable
+    // explicitly: gate D-pad/keyboard focus for each layer's subtree on visibility (the hero
+    // additionally on showHero, so a dismissed card isn't focusable mid-exit). Grid↔dock D-pad
+    // crossings are handled by the caller's key handlers on the dock's focus group (see
+    // DashboardScreen); the only bridge here is the UP rung from the bar/FAB into the hero's entry
+    // control (Discard, or the Dismiss X), which would otherwise be unreachable — spatial search
+    // skips the hero's top-right controls.
     val heroEntryFocusRequester = remember { FocusRequester() }
     val barFocus = Modifier.focusProperties {
         canFocus = isVisible
@@ -152,21 +153,32 @@ internal fun BottomBar(
         ),
         label = "dashboardBarOffset",
     )
-    val fabOffsetY by animateDpAsState(
-        targetValue = if (isVisible) -(navBottom + fabBottomInset) else DASHBOARD_FAB_SIZE,
+    // Keep the FAB fixed over its cradle. It bubbles in after the bar starts arriving and shrinks
+    // completely before the bar begins its delayed exit, avoiding the old trip through the dock.
+    val fabOffsetY = -(navBottom + fabBottomInset)
+    val fabScale by animateFloatAsState(
+        targetValue = if (isVisible) 1f else 0f,
         animationSpec = tween(
-            durationMillis = 260,
-            delayMillis = 80,
-            easing = FastOutSlowInEasing,
+            durationMillis = if (isVisible) 240 else 150,
+            delayMillis = if (isVisible) 80 else 0,
+            easing = if (isVisible) BubbleOvershoot else FastOutSlowInEasing,
         ),
-        label = "dashboardFabOffset",
+        label = "dashboardFabScale",
+    )
+    val fabAlpha by animateFloatAsState(
+        targetValue = if (isVisible) 1f else 0f,
+        animationSpec = tween(
+            durationMillis = if (isVisible) 140 else 100,
+            delayMillis = if (isVisible) 80 else 0,
+        ),
+        label = "dashboardFabAlpha",
     )
     val heroOffsetY by animateDpAsState(
         targetValue = if (isVisible && showHero) -(navBottom + heroBottomInset) else heroCardHeight,
         animationSpec = tween(
             durationMillis = 340,
             delayMillis = if (isVisible && showHero) 150 else 0,
-            easing = if (isVisible && showHero) HeroOvershoot else FastOutSlowInEasing,
+            easing = if (isVisible && showHero) BubbleOvershoot else FastOutSlowInEasing,
         ),
         label = "dashboardHeroOffset",
     )
@@ -195,8 +207,8 @@ internal fun BottomBar(
     val fabPresent = state?.isReady == true
     val barShape = dashboardBarShape(isReady = fabPresent)
 
-    // While hidden, the bar/FAB remain composed below the screen — drop them from the
-    // accessibility tree too, so TalkBack can't reach off-screen controls focus gating misses.
+    // While hidden, the dock remains composed for its exit animations — drop it from the
+    // accessibility tree too, so TalkBack can't reach controls that focus gating misses.
     val a11yGate = if (isVisible) Modifier else Modifier.clearAndSetSemantics { }
 
     Box(
@@ -275,9 +287,15 @@ internal fun BottomBar(
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
                     .offset(y = fabOffsetY)
+                    .graphicsLayer {
+                        scaleX = fabScale
+                        scaleY = fabScale
+                        alpha = fabAlpha
+                    }
                     .then(barFocus)
                     .then(mainActionModifier),
                 actionState = it.actionState,
+                enabled = isVisible,
                 onClick = onMainAction,
                 onLongClick = onMainActionLongClick,
             )
@@ -386,6 +404,7 @@ private fun BarContent(
 private fun MainActionFab(
     modifier: Modifier = Modifier,
     actionState: BottomBarState.Action,
+    enabled: Boolean,
     onClick: () -> Unit,
     onLongClick: () -> Unit,
 ) {
@@ -410,7 +429,7 @@ private fun MainActionFab(
             modifier = Modifier
                 .fillMaxSize()
                 .combinedClickable(
-                    enabled = actionState != BottomBarState.Action.WORKING,
+                    enabled = enabled && actionState != BottomBarState.Action.WORKING,
                     onClick = onClick,
                     onLongClick = onLongClick,
                 ),

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/DashboardListCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/DashboardListCard.kt
@@ -8,9 +8,13 @@ import androidx.compose.ui.Modifier
 internal fun DashboardListCard(
     modifier: Modifier = Modifier,
     item: DashboardItem,
+    mascotTopBump: Int = 0,
 ) {
     when (item) {
-        is TitleDashboardCardItem -> TitleDashboardCard(item)
+        is TitleDashboardCardItem -> TitleDashboardCard(
+            item = item,
+            mascotTopBump = mascotTopBump,
+        )
         is SetupDashboardCardItem -> SetupDashboardCard(modifier = modifier, item = item)
         is UpdateDashboardCardItem -> UpdateDashboardCard(item)
         is UpgradeDashboardCardItem -> UpgradeDashboardCard(item)

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/TitleDashboardCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/TitleDashboardCard.kt
@@ -2,6 +2,9 @@ package eu.darken.sdmse.main.ui.dashboard.cards
 
 import androidx.annotation.StringRes
 import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.FastOutLinearInEasing
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.awaitEachGesture
@@ -24,12 +27,13 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalContext
@@ -41,6 +45,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import eu.darken.sdmse.R
 import eu.darken.sdmse.common.BuildConfigWrap
@@ -76,7 +81,10 @@ data class TitleDashboardCardItem(
 }
 
 @Composable
-internal fun TitleDashboardCard(item: TitleDashboardCardItem) {
+internal fun TitleDashboardCard(
+    item: TitleDashboardCardItem,
+    mascotTopBump: Int = 0,
+) {
     val slogan = remember { getRngSlogan() }
     val sloganText = stringResource(slogan)
     val titleText = if (item.upgradeInfo?.isPro == true) {
@@ -94,8 +102,66 @@ internal fun TitleDashboardCard(item: TitleDashboardCardItem) {
     }
 
     val mascotRotation = remember { Animatable(0f) }
+    val mascotImpact = remember { Animatable(0f) }
+    val titleImpact = remember { Animatable(0f) }
+    val subtitleImpact = remember { Animatable(0f) }
     val clickCount = remember { mutableIntStateOf(0) }
     val scope = rememberCoroutineScope()
+
+    LaunchedEffect(mascotTopBump) {
+        if (mascotTopBump == 0) return@LaunchedEffect
+
+        // A quick squash on impact, then one small elastic recoil. New impacts cancel and restart
+        // this effect, so repeated enthusiastic scrolling never queues stale reactions.
+        mascotImpact.snapTo(0f)
+        mascotImpact.animateTo(
+            targetValue = 1f,
+            animationSpec = tween(durationMillis = 55, easing = FastOutLinearInEasing),
+        )
+        mascotImpact.animateTo(
+            targetValue = 0f,
+            animationSpec = spring(
+                dampingRatio = Spring.DampingRatioLowBouncy,
+                stiffness = Spring.StiffnessMedium,
+            ),
+        )
+    }
+
+    LaunchedEffect(mascotTopBump) {
+        if (mascotTopBump == 0) return@LaunchedEffect
+
+        delay(20)
+        titleImpact.snapTo(0f)
+        titleImpact.animateTo(
+            targetValue = 1f,
+            animationSpec = tween(durationMillis = 45, easing = FastOutLinearInEasing),
+        )
+        titleImpact.animateTo(
+            targetValue = 0f,
+            animationSpec = spring(
+                dampingRatio = Spring.DampingRatioLowBouncy,
+                stiffness = Spring.StiffnessMedium,
+            ),
+        )
+    }
+
+    LaunchedEffect(mascotTopBump) {
+        if (mascotTopBump == 0) return@LaunchedEffect
+
+        delay(45)
+        subtitleImpact.snapTo(0f)
+        subtitleImpact.animateTo(
+            targetValue = 1f,
+            animationSpec = tween(durationMillis = 40, easing = FastOutLinearInEasing),
+        )
+        subtitleImpact.animateTo(
+            targetValue = 0f,
+            animationSpec = spring(
+                dampingRatio = Spring.DampingRatioMediumBouncy,
+                stiffness = Spring.StiffnessMedium,
+            ),
+        )
+    }
 
     Box(
         modifier = Modifier
@@ -108,7 +174,13 @@ internal fun TitleDashboardCard(item: TitleDashboardCardItem) {
                 SdmMascot(
                     modifier = Modifier
                         .height(96.dp)
-                        .rotate(mascotRotation.value)
+                        .graphicsLayer {
+                            val impact = mascotImpact.value
+                            translationY = impact * 3.dp.toPx()
+                            scaleX = 1f + impact * 0.012f
+                            scaleY = 1f - impact * 0.02f
+                            rotationZ = mascotRotation.value
+                        }
                         .pointerInput(item) {
                             detectTapGestures(
                                 onTap = {
@@ -155,23 +227,36 @@ internal fun TitleDashboardCard(item: TitleDashboardCardItem) {
                         text = titleText,
                         style = MaterialTheme.typography.headlineSmall,
                         textAlign = TextAlign.Center,
+                        modifier = Modifier.graphicsLayer {
+                            val impact = titleImpact.value
+                            translationY = impact * 2.dp.toPx()
+                            scaleY = 1f - impact * 0.008f
+                        },
                     )
                     Text(
                         text = sloganText,
                         style = MaterialTheme.typography.bodySmall,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
-                        modifier = if (slogan == CommonR.string.slogan_message_8) {
-                            Modifier.pointerInput(item.webpageTool) {
-                                detectTapGestures(
-                                    onLongPress = {
-                                        item.webpageTool.open("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
-                                    },
-                                )
+                        modifier = Modifier
+                            .graphicsLayer {
+                                val impact = subtitleImpact.value
+                                translationY = impact * 1.25.dp.toPx()
+                                scaleX = 1f + impact * 0.005f
                             }
-                        } else {
-                            Modifier
-                        },
+                            .then(
+                                if (slogan == CommonR.string.slogan_message_8) {
+                                    Modifier.pointerInput(item.webpageTool) {
+                                        detectTapGestures(
+                                            onLongPress = {
+                                                item.webpageTool.open("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+                                            },
+                                        )
+                                    }
+                                } else {
+                                    Modifier
+                                },
+                            ),
                     )
                 }
             },

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/tour/DashboardTour.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/tour/DashboardTour.kt
@@ -39,9 +39,11 @@ object DashboardTour : GuidedTour {
         prepareSetup: (suspend () -> Unit)? = null,
         prepareTools: (suspend () -> Unit)? = null,
         prepareManualTool: (suspend () -> Unit)? = null,
+        onComplete: (suspend () -> Unit)? = null,
     ): TourDefinition = TourDefinition(
         id = id,
         clickProtection = true,
+        onComplete = onComplete,
         steps = buildList {
             add(
                 TourStep(

--- a/app/src/main/java/eu/darken/sdmse/main/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/settings/SettingsScreen.kt
@@ -167,16 +167,6 @@ internal fun SettingsScreen(
             modifier = Modifier.fillMaxSize(),
             contentPadding = paddingValues,
         ) {
-            // Exclusions
-            item {
-                SettingsPreferenceItem(
-                    icon = Icons.TwoTone.Shield,
-                    title = stringResource(eu.darken.sdmse.common.exclusion.R.string.exclusion_manager_title),
-                    subtitle = stringResource(eu.darken.sdmse.common.exclusion.R.string.exclusion_manager_desc),
-                    onClick = onExclusionsClick,
-                )
-            }
-
             // Tools category
             item { SettingsCategoryHeader(text = stringResource(CommonR.string.settings_category_tools_label)) }
 
@@ -246,6 +236,14 @@ internal fun SettingsScreen(
                     title = stringResource(R.string.general_settings_label),
                     subtitle = stringResource(R.string.general_settings_desc),
                     onClick = onGeneralSettingsClick,
+                )
+            }
+            item {
+                SettingsPreferenceItem(
+                    icon = Icons.TwoTone.Shield,
+                    title = stringResource(eu.darken.sdmse.common.exclusion.R.string.exclusion_manager_title),
+                    subtitle = stringResource(eu.darken.sdmse.common.exclusion.R.string.exclusion_manager_desc),
+                    onClick = onExclusionsClick,
                 )
             }
             item {

--- a/app/src/main/java/eu/darken/sdmse/setup/SetupCardContainer.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/SetupCardContainer.kt
@@ -1,5 +1,6 @@
 package eu.darken.sdmse.setup
 
+import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -34,7 +35,9 @@ internal fun SetupCardContainer(
     content: @Composable ColumnScope.() -> Unit,
 ) {
     ElevatedCard(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier
+            .fillMaxWidth()
+            .animateContentSize(),
         colors = CardDefaults.elevatedCardColors(
             containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
         ),

--- a/app/src/main/java/eu/darken/sdmse/setup/SetupScreen.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/SetupScreen.kt
@@ -421,6 +421,7 @@ private fun CardsContent(
             SetupCardDispatch(
                 item,
                 modifier = Modifier
+                    .animateItem()
                     .fillMaxWidth()
                     .onFocusChanged { if (it.hasFocus) focusedType = item.state.type },
             )

--- a/app/src/main/java/eu/darken/sdmse/setup/SetupViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/SetupViewModel.kt
@@ -270,18 +270,9 @@ class SetupViewModel @Inject constructor(
                         }
                     }
                 }
-                .sortedBy { item ->
-                    // Loading-state cards must also be promoted under showCompleted (legacy parity);
-                    // the `isComplete` extension already returns false for non-Current states, so no
-                    // `is State.Current` guard is needed (it would wrongly drop Loading cards).
-                    if (options.showCompleted && !item.state.isComplete) {
-                        Int.MIN_VALUE
-                    } else if (item is RootSetupCardItem && item.state.isInstalled && item.state.useRoot == null) {
-                        Int.MIN_VALUE
-                    } else {
-                        DISPLAY_ORDER.indexOfFirst { it == item.state.type }
-                    }
-                }
+                // A card changing between incomplete, loading and complete must not move under the
+                // user's finger. Completion is conveyed by each card's content; position is stable.
+                .sortedInSetupDisplayOrder()
                 .run { items.addAll(this) }
 
         items
@@ -374,16 +365,20 @@ class SetupViewModel @Inject constructor(
     }
 
     companion object {
-        private val DISPLAY_ORDER = listOf(
-            SetupModule.Type.INVENTORY,
-            SetupModule.Type.NOTIFICATION,
-            SetupModule.Type.STORAGE,
-            SetupModule.Type.SAF,
-            SetupModule.Type.SHIZUKU,
-            SetupModule.Type.ROOT,
-            SetupModule.Type.USAGE_STATS,
-            SetupModule.Type.AUTOMATION,
-        )
         private val TAG = logTag("Setup", "ViewModel")
     }
 }
+
+private val SETUP_DISPLAY_ORDER = listOf(
+    SetupModule.Type.INVENTORY,
+    SetupModule.Type.NOTIFICATION,
+    SetupModule.Type.STORAGE,
+    SetupModule.Type.SAF,
+    SetupModule.Type.SHIZUKU,
+    SetupModule.Type.ROOT,
+    SetupModule.Type.USAGE_STATS,
+    SetupModule.Type.AUTOMATION,
+)
+
+internal fun List<SetupCardItem>.sortedInSetupDisplayOrder(): List<SetupCardItem> =
+    sortedBy { item -> SETUP_DISPLAY_ORDER.indexOf(item.state.type) }

--- a/app/src/main/java/eu/darken/sdmse/setup/storage/StorageSetupCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/storage/StorageSetupCard.kt
@@ -4,7 +4,9 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
@@ -103,7 +105,7 @@ internal fun StoragePathRow(
                 role = Role.Button,
                 onClick = onClick,
             )
-            .padding(horizontal = 16.dp, vertical = 8.dp),
+            .padding(horizontal = 16.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
@@ -129,6 +131,7 @@ internal fun StoragePathRow(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             if (granted) {
+                Spacer(modifier = Modifier.height(4.dp))
                 Text(
                     text = stringResource(R.string.setup_permission_granted_label),
                     style = MaterialTheme.typography.labelMedium,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,7 +4,7 @@
     <string name="dashboard_hero_freed_headline">%1$s freed</string>
     <string name="dashboard_hero_freeable_x_items">%1$s can be removed</string>
     <string name="dashboard_hero_freed_x_items">%1$s removed</string>
-    <string name="dashboard_hero_freeable_hint">Tap the button to free space. Tap a chip to check first.</string>
+    <string name="dashboard_hero_freeable_hint">Tap the button to free space, or a chip to check first.</string>
     <string name="dashboard_hero_freed_hint">Tap a chip for details.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->
     <string name="dashboard_hero_scanned_timestamp_description">Scanned %1$s</string>

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardTopBumpDetectorTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardTopBumpDetectorTest.kt
@@ -1,0 +1,49 @@
+package eu.darken.sdmse.main.ui.dashboard
+
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+
+class DashboardTopBumpDetectorTest {
+
+    @Test
+    fun `returning to the top after a large scroll emits one bump`() {
+        val detector = DashboardTopBumpDetector(largeScrollDistancePx = 100)
+
+        detector.onScroll(0, 120, deltaY = -120f) shouldBe false
+        detector.onScroll(0, 20, deltaY = 100f) shouldBe false
+        detector.onScroll(0, 0, deltaY = 20f) shouldBe true
+        detector.onScroll(0, 0, deltaY = 8f) shouldBe false
+    }
+
+    @Test
+    fun `fast return emits a bump after a shorter scroll`() {
+        val detector = DashboardTopBumpDetector(largeScrollDistancePx = 100)
+
+        detector.onScroll(0, 30, deltaY = -30f) shouldBe false
+        detector.onScroll(0, 0, deltaY = 30f, isFastReturn = true) shouldBe true
+    }
+
+    @Test
+    fun `pulling at the resting top does not bump even when fast`() {
+        val detector = DashboardTopBumpDetector(largeScrollDistancePx = 100)
+
+        detector.onScroll(0, 0, deltaY = 20f, isFastReturn = true) shouldBe false
+    }
+
+    @Test
+    fun `small leisurely scroll does not bump`() {
+        val detector = DashboardTopBumpDetector(largeScrollDistancePx = 100)
+
+        detector.onScroll(0, 60, deltaY = -60f) shouldBe false
+        detector.onScroll(0, 0, deltaY = 10f) shouldBe false
+    }
+
+    @Test
+    fun `programmatic motion clears a pending bump`() {
+        val detector = DashboardTopBumpDetector(largeScrollDistancePx = 100)
+
+        detector.onScroll(1, 0, deltaY = -40f) shouldBe false
+        detector.onNonUserScroll()
+        detector.onScroll(0, 0, deltaY = 40f) shouldBe false
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardDockVisibilityTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardDockVisibilityTest.kt
@@ -14,9 +14,9 @@ import testhelpers.compose.BaseComposeRobolectricTest
 import eu.darken.sdmse.common.R as CommonR
 
 /**
- * Hidden dock slides off-screen via offset() but stays composed for its exit animation — these
- * tests pin down that it is unreachable while hidden: absent from the accessibility tree (which
- * also covers TalkBack) and not focusable, while visible dock stays fully interactive.
+ * The hidden dock stays composed for its exit animations — these tests pin down that it is
+ * unreachable while hidden: absent from the accessibility tree (which also covers TalkBack) and
+ * not focusable, while the visible dock stays fully interactive.
  */
 class DashboardDockVisibilityTest : BaseComposeRobolectricTest() {
 

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/tour/DashboardTourTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/tour/DashboardTourTest.kt
@@ -117,4 +117,14 @@ class DashboardTourTest : BaseTest() {
         def.steps.any { it.prepareTarget != null } shouldBe false
         called shouldBe false
     }
+
+    @Test
+    fun `onComplete is wired to the tour definition`() {
+        var called = false
+        val hook: suspend () -> Unit = { called = true }
+        val def = DashboardTour.definition(onComplete = hook)
+
+        def.onComplete shouldBe hook
+        called shouldBe false
+    }
 }

--- a/app/src/test/java/eu/darken/sdmse/setup/SetupCardOrderingTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/setup/SetupCardOrderingTest.kt
@@ -1,0 +1,49 @@
+package eu.darken.sdmse.setup
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class SetupCardOrderingTest : BaseTest() {
+
+    @Test
+    fun `card order stays canonical when completion changes`() {
+        val inputOrder = listOf(
+            SetupModule.Type.ROOT,
+            SetupModule.Type.AUTOMATION,
+            SetupModule.Type.INVENTORY,
+            SetupModule.Type.SHIZUKU,
+            SetupModule.Type.USAGE_STATS,
+            SetupModule.Type.SAF,
+            SetupModule.Type.NOTIFICATION,
+            SetupModule.Type.STORAGE,
+        )
+        val expectedOrder = listOf(
+            SetupModule.Type.INVENTORY,
+            SetupModule.Type.NOTIFICATION,
+            SetupModule.Type.STORAGE,
+            SetupModule.Type.SAF,
+            SetupModule.Type.SHIZUKU,
+            SetupModule.Type.ROOT,
+            SetupModule.Type.USAGE_STATS,
+            SetupModule.Type.AUTOMATION,
+        )
+
+        val initial = inputOrder.mapIndexed { index, type -> item(type, complete = index % 2 == 0) }
+        val updated = inputOrder.mapIndexed { index, type -> item(type, complete = index % 2 != 0) }
+
+        initial.sortedInSetupDisplayOrder().map { it.state.type } shouldBe expectedOrder
+        updated.sortedInSetupDisplayOrder().map { it.state.type } shouldBe expectedOrder
+    }
+
+    private fun item(moduleType: SetupModule.Type, complete: Boolean): SetupCardItem = TestItem(
+        state = object : SetupModule.State.Current {
+            override val type = moduleType
+            override val isComplete = complete
+        },
+    )
+
+    private data class TestItem(
+        override val state: SetupModule.State,
+    ) : SetupCardItem
+}


### PR DESCRIPTION
## What changed

A broad polishing pass across SD Maid SE's interface, touching several screens and tools:

**Dashboard**
- The header now bounces elastically when you scroll back to the top, with the mascot squashing on impact and the title, slogan, and mascot springing in a cascade.
- The main action button now pops into place with a scale-and-fade instead of sliding up from the bottom edge.
- The dashboard scrolls back to the top after you finish a guided tour, so it's left in its natural starting position.

**Setup**
- Setup cards keep a stable order as you work through the steps — they no longer jump around when their state changes.
- Tighter spacing on the storage path row.

**App Control**
- Archive and restore actions only appear in the menu when the current selection can actually be archived or restored.
- Restored the unfreeze icon, aligned app size with the secondary info text, and tidied fast-scroller spacing.

**Swiper**
- Provisional cards no longer flash while the session list is still loading.

**Storage Analyzer**
- Added breathing room below the last row/tile on the file and app listings, so the final entry no longer sits flush against the screen edge (list and grid views).

**General**
- Moved the exclusion manager into device settings.
- Smoother, non-blocking fast scrolling and cached app-icon loading for snappier lists.
- Expanded and tightened the upgrade screen benefit list.

## Technical Context

- This is a cumulative UI branch; each commit is scoped to one area (dashboard, setup, swiper, app control, analyzer, fast scroller, icon loading, tours). Reviewing commit-by-commit is easier than the combined diff.
- **App-icon loading**: icons are now rasterized to a bitmap at fetch time, moving drawable rendering off the UI thread and letting Coil cache the result. Covered by `AppIconCacheTest`.
- **Fast scroller**: switched from synchronous, layout-forcing scroll to non-blocking scroll requests (`SdmFastScrollerTest`).
- **Analyzer padding**: the affected screens (`ContentScreen` list + grid, `AppsScreen`, `AppDetailsScreen`) have no FAB, so a new shared `SdmListDefaults.ContentBottomSpacing` (16dp) is added via `plusBottom()` rather than reusing the 88dp `FabClearance`. The two FAB screens are untouched.
- Behavior-affecting changes carry tests (dashboard bounce/FAB visibility, setup card ordering, swiper provisional cards, app-control selection gating, tour scroll reset).
