### PR TITLE
General: Remove unused strings and polish in-app wording

### DIFF
--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/tour/TourBubble.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/tour/TourBubble.kt
@@ -75,6 +75,7 @@ import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.compose.SdmMascot
 import eu.darken.sdmse.common.compose.preview.Preview2
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.common.R as CommonR
 import eu.darken.sdmse.common.ui.R as UiR
 
 // The tail's vertical extent must stay in sync between SpeechBubbleShape (which draws the tail
@@ -518,7 +519,7 @@ private fun StepContent(
                         imageVector = if (session.isLast) Icons.TwoTone.Check
                         else Icons.AutoMirrored.TwoTone.ArrowForward,
                         contentDescription = stringResource(
-                            if (session.isLast) UiR.string.tour_action_done
+                            if (session.isLast) CommonR.string.general_done_action
                             else UiR.string.tour_action_next,
                         ),
                         modifier = Modifier.size(20.dp),

--- a/app-common-ui/src/main/res/values-af-rZA/strings.xml
+++ b/app-common-ui/src/main/res/values-af-rZA/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">Data-areas</string>
     <string name="tour_action_next">Volgende</string>
     <string name="tour_action_previous">Vorige</string>
-    <string name="tour_action_done">Klaar</string>
     <string name="tour_action_cancel">Slaan oor</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Slaan die rondleiding oor?</string>
     <string name="tour_confirm_message">Jy kan rondleidings enige tyd weer aktiveer vanuit Instellings.</string>
     <string name="tour_confirm_continue">Gaan voort</string>

--- a/app-common-ui/src/main/res/values-am/strings.xml
+++ b/app-common-ui/src/main/res/values-am/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">የውሂብ አካባቢዎች</string>
     <string name="tour_action_next">ቀጥሎ</string>
     <string name="tour_action_previous">ቀዳሚ</string>
-    <string name="tour_action_done">ተከናውኗል</string>
     <string name="tour_action_cancel">ዝለል</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">ጉብኝቱን ዝለል?</string>
     <string name="tour_confirm_message">ከማቅናቶች ውስጥ ማንኛውም ጊዜ ጉብኝቶችን እንደገና ማብራት ይችላሉ።</string>
     <string name="tour_confirm_continue">ጉብኝቱን ቀጥል</string>

--- a/app-common-ui/src/main/res/values-ar/strings.xml
+++ b/app-common-ui/src/main/res/values-ar/strings.xml
@@ -14,9 +14,7 @@
     <string name="picker_home_action">مناطق البيانات</string>
     <string name="tour_action_next">التالي</string>
     <string name="tour_action_previous">السابق</string>
-    <string name="tour_action_done">تم</string>
     <string name="tour_action_cancel">تخطي</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">تخطي الجولة؟</string>
     <string name="tour_confirm_message">يمكنك إعادة تفعيل الجولات في أي وقت من الإعدادات.</string>
     <string name="tour_confirm_continue">متابعة الجولة</string>

--- a/app-common-ui/src/main/res/values-az/strings.xml
+++ b/app-common-ui/src/main/res/values-az/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">Məlumat sahələri</string>
     <string name="tour_action_next">Sonrakı</string>
     <string name="tour_action_previous">Əvvəlki</string>
-    <string name="tour_action_done">Tamamlandı</string>
     <string name="tour_action_cancel">Atla</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Turu keçmək istəyirsiniz?</string>
     <string name="tour_confirm_message">Turu istənilən zaman Parametrlərdən yenidən aktivləşdirə bilərsiniz.</string>
     <string name="tour_confirm_continue">Tura davam et</string>

--- a/app-common-ui/src/main/res/values-be/strings.xml
+++ b/app-common-ui/src/main/res/values-be/strings.xml
@@ -12,9 +12,7 @@
     <string name="picker_home_action">Вобласці даных</string>
     <string name="tour_action_next">Далей</string>
     <string name="tour_action_previous">Папярэдні</string>
-    <string name="tour_action_done">Гатова</string>
     <string name="tour_action_cancel">Прапусціць</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Прапусціць тур?</string>
     <string name="tour_confirm_message">Вы можаце ў любы час заноў ўключыць туры з Налад.</string>
     <string name="tour_confirm_continue">Працягнуць тур</string>

--- a/app-common-ui/src/main/res/values-bg/strings.xml
+++ b/app-common-ui/src/main/res/values-bg/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">Области с данни</string>
     <string name="tour_action_next">Следващ</string>
     <string name="tour_action_previous">Предишен</string>
-    <string name="tour_action_done">Готово</string>
     <string name="tour_action_cancel">Пропусни</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Да се пропусне ли турата?</string>
     <string name="tour_confirm_message">Можете да активирате отново туровете по всяко време от Настройките.</string>
     <string name="tour_confirm_continue">Продължи обиколката</string>

--- a/app-common-ui/src/main/res/values-bn-rBD/strings.xml
+++ b/app-common-ui/src/main/res/values-bn-rBD/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">ডেটা এলাকা</string>
     <string name="tour_action_next">পরবর্তী</string>
     <string name="tour_action_previous">পূর্ববর্তী</string>
-    <string name="tour_action_done">সম্পন্ন</string>
     <string name="tour_action_cancel">এড়িয়ে যান</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">ট্যুর এড়িয়ে যাবেন?</string>
     <string name="tour_confirm_message">আপনি যেকোনো সময় সেটিংস থেকে ট্যুর পুনরায় সক্ষম করতে পারেন।</string>
     <string name="tour_confirm_continue">ট্যুর চালিয়ে যান</string>

--- a/app-common-ui/src/main/res/values-ca/strings.xml
+++ b/app-common-ui/src/main/res/values-ca/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">Àrees de dades</string>
     <string name="tour_action_next">Següent</string>
     <string name="tour_action_previous">Anterior</string>
-    <string name="tour_action_done">Fet</string>
     <string name="tour_action_cancel">Omet</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Vols saltar la visita guiada?</string>
     <string name="tour_confirm_message">Pots reactivar les visites guiades en qualsevol moment des de Configuració.</string>
     <string name="tour_confirm_continue">Continua la visita guiada</string>

--- a/app-common-ui/src/main/res/values-ckb-rIR/strings.xml
+++ b/app-common-ui/src/main/res/values-ckb-rIR/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">بەشی دەرەنجام</string>
     <string name="tour_action_next">دواتر</string>
     <string name="tour_action_previous">پێشوو</string>
-    <string name="tour_action_done">تەواو</string>
     <string name="tour_action_cancel">تێپەڕاندن</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">گەشتەکە تێپەڕێنیت؟</string>
     <string name="tour_confirm_message">دەتوانیت لە رێکخستندا گەشتەکان کاتێخی دووبارە چالاک بکەیتەوە.</string>
     <string name="tour_confirm_continue">گەشت بەردەوام بکە</string>

--- a/app-common-ui/src/main/res/values-cs/strings.xml
+++ b/app-common-ui/src/main/res/values-cs/strings.xml
@@ -12,9 +12,7 @@
     <string name="picker_home_action">Oblasti dat</string>
     <string name="tour_action_next">Další</string>
     <string name="tour_action_previous">Předchozí</string>
-    <string name="tour_action_done">Hotovo</string>
     <string name="tour_action_cancel">Přeskočit</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Přeskočit prohlídku?</string>
     <string name="tour_confirm_message">Prohlídky můžete kdykoliv znovu povolit v Nastavení.</string>
     <string name="tour_confirm_continue">Pokračovat v prohlídce</string>

--- a/app-common-ui/src/main/res/values-da/strings.xml
+++ b/app-common-ui/src/main/res/values-da/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">Dataområder</string>
     <string name="tour_action_next">Næste</string>
     <string name="tour_action_previous">Forrige</string>
-    <string name="tour_action_done">Færdig</string>
     <string name="tour_action_cancel">Spring over</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Spring rundvisningen over?</string>
     <string name="tour_confirm_message">Du kan altid genaktivere rundvisninger fra Indstillinger.</string>
     <string name="tour_confirm_continue">Fortsæt rundvisning</string>

--- a/app-common-ui/src/main/res/values-de/strings.xml
+++ b/app-common-ui/src/main/res/values-de/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">Datenbereiche</string>
     <string name="tour_action_next">Weiter</string>
     <string name="tour_action_previous">Zurück</string>
-    <string name="tour_action_done">Fertig</string>
     <string name="tour_action_cancel">Überspringen</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Tour überspringen?</string>
     <string name="tour_confirm_message">Sie können Touren jederzeit über die Einstellungen erneut aktivieren.</string>
     <string name="tour_confirm_continue">Tour fortsetzen</string>

--- a/app-common-ui/src/main/res/values-el/strings.xml
+++ b/app-common-ui/src/main/res/values-el/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">Περιοχές δεδομένων</string>
     <string name="tour_action_next">Επόμενο</string>
     <string name="tour_action_previous">Προηγούμενο</string>
-    <string name="tour_action_done">Τέλος</string>
     <string name="tour_action_cancel">Παράλειψη</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Παράλειψη της περιήγησης;</string>
     <string name="tour_confirm_message">Μπορείτε να ενεργοποιήσετε ξανά τις περιηγήσεις οποτεδήποτε από τις Ρυθμίσεις.</string>
     <string name="tour_confirm_continue">Συνέχεια περιήγησης</string>

--- a/app-common-ui/src/main/res/values-es-rAR/strings.xml
+++ b/app-common-ui/src/main/res/values-es-rAR/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">Áreas de datos</string>
     <string name="tour_action_next">Siguiente</string>
     <string name="tour_action_previous">Anterior</string>
-    <string name="tour_action_done">Listo</string>
     <string name="tour_action_cancel">Saltar</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">¿Saltear el tour?</string>
     <string name="tour_confirm_message">Podés volver a habilitar los tours en cualquier momento desde Ajustes.</string>
     <string name="tour_confirm_continue">Continuá la visita</string>

--- a/app-common-ui/src/main/res/values-es-rMX/strings.xml
+++ b/app-common-ui/src/main/res/values-es-rMX/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">Áreas de datos</string>
     <string name="tour_action_next">Siguiente</string>
     <string name="tour_action_previous">Anterior</string>
-    <string name="tour_action_done">Listo</string>
     <string name="tour_action_cancel">Omitir</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">¿Omitir el tour?</string>
     <string name="tour_confirm_message">Puedes volver a habilitar los tours en cualquier momento desde Configuración.</string>
     <string name="tour_confirm_continue">Continuar tour</string>

--- a/app-common-ui/src/main/res/values-es/strings.xml
+++ b/app-common-ui/src/main/res/values-es/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">Áreas de datos</string>
     <string name="tour_action_next">Siguiente</string>
     <string name="tour_action_previous">Anterior</string>
-    <string name="tour_action_done">Hecho</string>
     <string name="tour_action_cancel">Omitir</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">¿Omitir el tour?</string>
     <string name="tour_confirm_message">Puedes volver a habilitar los tours en cualquier momento desde Configuración.</string>
     <string name="tour_confirm_continue">Continuar el tour</string>

--- a/app-common-ui/src/main/res/values-et-rEE/strings.xml
+++ b/app-common-ui/src/main/res/values-et-rEE/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">Andmekogud</string>
     <string name="tour_action_next">Järgmine</string>
     <string name="tour_action_previous">Eelmine</string>
-    <string name="tour_action_done">Valmis</string>
     <string name="tour_action_cancel">Jäta vahele</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Jäta tuur vahele?</string>
     <string name="tour_confirm_message">Saate tuurid seadete kaudu igal ajal uuesti lubada.</string>
     <string name="tour_confirm_continue">Jätka tuuri</string>

--- a/app-common-ui/src/main/res/values-eu-rES/strings.xml
+++ b/app-common-ui/src/main/res/values-eu-rES/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">Datu-eremuak</string>
     <string name="tour_action_next">Hurrengoa</string>
     <string name="tour_action_previous">Aurrekoa</string>
-    <string name="tour_action_done">Eginda</string>
     <string name="tour_action_cancel">Saltatu</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Ibilbidea saltatu?</string>
     <string name="tour_confirm_message">Ibilbideak berriro gaitu ditzakezu noiznahi Ezarpenetan.</string>
     <string name="tour_confirm_continue">Jarraitu ibilbidea</string>

--- a/app-common-ui/src/main/res/values-fa/strings.xml
+++ b/app-common-ui/src/main/res/values-fa/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">مناطق داده</string>
     <string name="tour_action_next">بعدی</string>
     <string name="tour_action_previous">قبلی</string>
-    <string name="tour_action_done">انجام شد</string>
     <string name="tour_action_cancel">رد کردن</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">از تور رد شود؟</string>
     <string name="tour_confirm_message">می‌توانید هر زمان تورها را از تنظیمات دوباره فعال کنید.</string>
     <string name="tour_confirm_continue">ادامه تور</string>

--- a/app-common-ui/src/main/res/values-fi/strings.xml
+++ b/app-common-ui/src/main/res/values-fi/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">Tietoalueet</string>
     <string name="tour_action_next">Seuraava</string>
     <string name="tour_action_previous">Edellinen</string>
-    <string name="tour_action_done">Valmis</string>
     <string name="tour_action_cancel">Ohita</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Ohita kierros?</string>
     <string name="tour_confirm_message">Voit ottaa kierrokset uudelleen käyttöön asetuksista milloin tahansa.</string>
     <string name="tour_confirm_continue">Jatka opastusta</string>

--- a/app-common-ui/src/main/res/values-fil/strings.xml
+++ b/app-common-ui/src/main/res/values-fil/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">Mga data area</string>
     <string name="tour_action_next">Susunod</string>
     <string name="tour_action_previous">Nakaraan</string>
-    <string name="tour_action_done">Tapos na</string>
     <string name="tour_action_cancel">Laktawan</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Laktawan ang tour?</string>
     <string name="tour_confirm_message">Maaari mong i-enable muli ang mga tour anumang oras mula sa Settings.</string>
     <string name="tour_confirm_continue">Magpatuloy sa tour</string>

--- a/app-common-ui/src/main/res/values-fr/strings.xml
+++ b/app-common-ui/src/main/res/values-fr/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">Zones des données</string>
     <string name="tour_action_next">Suivant</string>
     <string name="tour_action_previous">Précédent</string>
-    <string name="tour_action_done">Terminé</string>
     <string name="tour_action_cancel">Ignorer</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Ignorer la visite guidée ?</string>
     <string name="tour_confirm_message">Vous pouvez réactiver les visites guidées à tout moment dans Paramètres.</string>
     <string name="tour_confirm_continue">Continuer la visite</string>

--- a/app-common-ui/src/main/res/values-gl-rES/strings.xml
+++ b/app-common-ui/src/main/res/values-gl-rES/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">Áreas de datos</string>
     <string name="tour_action_next">Seguinte</string>
     <string name="tour_action_previous">Anterior</string>
-    <string name="tour_action_done">Feito</string>
     <string name="tour_action_cancel">Omitir</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Omitir a visita guiada?</string>
     <string name="tour_confirm_message">Podes volver activar as visitas guiadas en calquera momento desde Axustes.</string>
     <string name="tour_confirm_continue">Continúa a visita guiada</string>

--- a/app-common-ui/src/main/res/values-hi-rIN/strings.xml
+++ b/app-common-ui/src/main/res/values-hi-rIN/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">डेटा क्षेत्र</string>
     <string name="tour_action_next">अगला</string>
     <string name="tour_action_previous">पिछला</string>
-    <string name="tour_action_done">पूर्ण</string>
     <string name="tour_action_cancel">छोड़ें</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">टूर छोड़ दें?</string>
     <string name="tour_confirm_message">आप किसी भी समय सेटिंग्स से टूर को फिर से सक्षम कर सकते हैं।</string>
     <string name="tour_confirm_continue">टूर जारी रखें</string>

--- a/app-common-ui/src/main/res/values-hr/strings.xml
+++ b/app-common-ui/src/main/res/values-hr/strings.xml
@@ -11,9 +11,7 @@
     <string name="picker_home_action">Područja podataka</string>
     <string name="tour_action_next">Dalje</string>
     <string name="tour_action_previous">Prethodno</string>
-    <string name="tour_action_done">Gotovo</string>
     <string name="tour_action_cancel">Preskoči</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Preskočiti obilazak?</string>
     <string name="tour_confirm_message">Vodiče možete ponovno omogućiti bilo kada iz Postavki.</string>
     <string name="tour_confirm_continue">Nastavite vodič</string>

--- a/app-common-ui/src/main/res/values-hu/strings.xml
+++ b/app-common-ui/src/main/res/values-hu/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">Adatterületek</string>
     <string name="tour_action_next">Következő</string>
     <string name="tour_action_previous">Előző</string>
-    <string name="tour_action_done">Kész</string>
     <string name="tour_action_cancel">Kihagyás</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Kihagyja a bemutatót?</string>
     <string name="tour_confirm_message">A bemutatókat a Beállításokban bármikor újra engedélyezheti.</string>
     <string name="tour_confirm_continue">Bemutató folytatása</string>

--- a/app-common-ui/src/main/res/values-in/strings.xml
+++ b/app-common-ui/src/main/res/values-in/strings.xml
@@ -9,9 +9,7 @@
     <string name="picker_home_action">Area data</string>
     <string name="tour_action_next">Berikutnya</string>
     <string name="tour_action_previous">Sebelumnya</string>
-    <string name="tour_action_done">Selesai</string>
     <string name="tour_action_cancel">Lewati</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Lewati tur?</string>
     <string name="tour_confirm_message">Anda dapat mengaktifkan kembali tur kapan saja dari Pengaturan.</string>
     <string name="tour_confirm_continue">Lanjutkan tur</string>

--- a/app-common-ui/src/main/res/values-is/strings.xml
+++ b/app-common-ui/src/main/res/values-is/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">Gagnasvæði</string>
     <string name="tour_action_next">Næst</string>
     <string name="tour_action_previous">Fyrri</string>
-    <string name="tour_action_done">Lokið</string>
     <string name="tour_action_cancel">Sleppa</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Sleppa skoðuninni?</string>
     <string name="tour_confirm_message">Þú getur endurvirkjað skoðanir hvenær sem er úr Stillingum.</string>
     <string name="tour_confirm_continue">Halda áfram</string>

--- a/app-common-ui/src/main/res/values-it/strings.xml
+++ b/app-common-ui/src/main/res/values-it/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">Aree di dati</string>
     <string name="tour_action_next">Avanti</string>
     <string name="tour_action_previous">Precedente</string>
-    <string name="tour_action_done">Fatto</string>
     <string name="tour_action_cancel">Salta</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Saltare il tour?</string>
     <string name="tour_confirm_message">Puoi riabilitare i tour in qualsiasi momento dalle Impostazioni.</string>
     <string name="tour_confirm_continue">Continua il tour</string>

--- a/app-common-ui/src/main/res/values-iw/strings.xml
+++ b/app-common-ui/src/main/res/values-iw/strings.xml
@@ -12,9 +12,7 @@
     <string name="picker_home_action">אזורי נתונים</string>
     <string name="tour_action_next">הבא</string>
     <string name="tour_action_previous">הקודם</string>
-    <string name="tour_action_done">סיום</string>
     <string name="tour_action_cancel">דלג</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">לדלג על הסיור?</string>
     <string name="tour_confirm_message">ניתן להפעיל סיורים מחדש בכל עת מהגדרות.</string>
     <string name="tour_confirm_continue">המשך בסיור</string>

--- a/app-common-ui/src/main/res/values-ja/strings.xml
+++ b/app-common-ui/src/main/res/values-ja/strings.xml
@@ -9,9 +9,7 @@
     <string name="picker_home_action">データ領域</string>
     <string name="tour_action_next">次へ</string>
     <string name="tour_action_previous">前へ</string>
-    <string name="tour_action_done">完了</string>
     <string name="tour_action_cancel">スキップ</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">ツアーをスキップしますか？</string>
     <string name="tour_confirm_message">設定からいつでもツアーを再度有効にできます。</string>
     <string name="tour_confirm_continue">ツアーを続行</string>

--- a/app-common-ui/src/main/res/values-ka-rGE/strings.xml
+++ b/app-common-ui/src/main/res/values-ka-rGE/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">მონაცემთა ზონები</string>
     <string name="tour_action_next">შემდეგი</string>
     <string name="tour_action_previous">წინა</string>
-    <string name="tour_action_done">დასრულდა</string>
     <string name="tour_action_cancel">გამოტოვება</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">გამოტოვოთ ტური?</string>
     <string name="tour_confirm_message">თქვენ შეგიძლიათ ხელახლა ჩართოთ ტურები ნებისმიერ დროს პარამეტრებიდან.</string>
     <string name="tour_confirm_continue">განაგრძელეთ ტური</string>

--- a/app-common-ui/src/main/res/values-kaa/strings.xml
+++ b/app-common-ui/src/main/res/values-kaa/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">Ma\'lumot sahalar</string>
     <string name="tour_action_next">Keyingi</string>
     <string name="tour_action_previous">Aldıńǵı</string>
-    <string name="tour_action_done">Tayar</string>
     <string name="tour_action_cancel">Ótkerip jiber</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Sayaxattı ótkerip jiberiw me?</string>
     <string name="tour_confirm_message">Sazlamalardan sayaxatlardı qálegen waqıtta qayta qosa alasız.</string>
     <string name="tour_confirm_continue">Sayaxattı dawam etiw</string>

--- a/app-common-ui/src/main/res/values-km-rKH/strings.xml
+++ b/app-common-ui/src/main/res/values-km-rKH/strings.xml
@@ -9,9 +9,7 @@
     <string name="picker_home_action">ត្រងតវ័ភបល័យ</string>
     <string name="tour_action_next">បន្ទាប់</string>
     <string name="tour_action_previous">មុន</string>
-    <string name="tour_action_done">រួចរាល់</string>
     <string name="tour_action_cancel">រំលង</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">រំលងដំណើរណែនាំ?</string>
     <string name="tour_confirm_message">អ្នកអាចបើកដំណើរណែនាំឡើងវិញបានគ្រប់ពេលវេលាពីការកំណត់។</string>
     <string name="tour_confirm_continue">បន្តដំណើរណែនាំ</string>

--- a/app-common-ui/src/main/res/values-ko/strings.xml
+++ b/app-common-ui/src/main/res/values-ko/strings.xml
@@ -9,9 +9,7 @@
     <string name="picker_home_action">데이터 영역</string>
     <string name="tour_action_next">다음</string>
     <string name="tour_action_previous">이전</string>
-    <string name="tour_action_done">완료</string>
     <string name="tour_action_cancel">건너뛰기</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">투어를 건너뛰시겠습니까?</string>
     <string name="tour_confirm_message">설정에서 언제든지 투어를 다시 활성화할 수 있습니다.</string>
     <string name="tour_confirm_continue">투어 계속하기</string>

--- a/app-common-ui/src/main/res/values-lo-rLA/strings.xml
+++ b/app-common-ui/src/main/res/values-lo-rLA/strings.xml
@@ -9,9 +9,7 @@
     <string name="picker_home_action">ພື້ນທີ່ຂໍ້ມູນ</string>
     <string name="tour_action_next">ຕໍ່ໄປ</string>
     <string name="tour_action_previous">ກໍ່ນ</string>
-    <string name="tour_action_done">ສຳເລັດ</string>
     <string name="tour_action_cancel">ຂ້າມ</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">ຂ້າມການທ່ຽວທໍງບໍ?</string>
     <string name="tour_confirm_message">ທ່ານສາມາດເປີດໃຊ້ການທ່ຽວທໍງໄດ້ທຸກເວລາຈາກການຕັ້ງຄ່າ.</string>
     <string name="tour_confirm_continue">ສືບຕໍ່ການທ່ຽວທໍງ</string>

--- a/app-common-ui/src/main/res/values-lt/strings.xml
+++ b/app-common-ui/src/main/res/values-lt/strings.xml
@@ -12,9 +12,7 @@
     <string name="picker_home_action">Duomenų sritys</string>
     <string name="tour_action_next">Kitas</string>
     <string name="tour_action_previous">Ankstesnis</string>
-    <string name="tour_action_done">Atlikta</string>
     <string name="tour_action_cancel">Praleisti</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Praleisti turą?</string>
     <string name="tour_confirm_message">Turus galite iš naujo įjungti iš Nustatymų bet kada.</string>
     <string name="tour_confirm_continue">Tęsti turą</string>

--- a/app-common-ui/src/main/res/values-lv/strings.xml
+++ b/app-common-ui/src/main/res/values-lv/strings.xml
@@ -11,9 +11,7 @@
     <string name="picker_home_action">Datu apgabali</string>
     <string name="tour_action_next">Nākamais</string>
     <string name="tour_action_previous">Iepriekšējais</string>
-    <string name="tour_action_done">Gatavs</string>
     <string name="tour_action_cancel">Izlaist</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Izlaist apskati?</string>
     <string name="tour_confirm_message">Jebkurā laikā varat atkārtoti iespējot apskates no Iestatījumiem.</string>
     <string name="tour_confirm_continue">Turpināt tūri</string>

--- a/app-common-ui/src/main/res/values-mk-rMK/strings.xml
+++ b/app-common-ui/src/main/res/values-mk-rMK/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">Области со податоци</string>
     <string name="tour_action_next">Следно</string>
     <string name="tour_action_previous">Претходно</string>
-    <string name="tour_action_done">Готово</string>
     <string name="tour_action_cancel">Прескочи</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Да се прескокне водичот?</string>
     <string name="tour_confirm_message">Можете да ги овозможите водичите во секое време од Поставките.</string>
     <string name="tour_confirm_continue">Продолжи тур</string>

--- a/app-common-ui/src/main/res/values-ml-rIN/strings.xml
+++ b/app-common-ui/src/main/res/values-ml-rIN/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">ഡേറ്റ മേഖലകൾ</string>
     <string name="tour_action_next">അടുത്തത്</string>
     <string name="tour_action_previous">മുമ്പത്തെ</string>
-    <string name="tour_action_done">പൂർത്തിയായി</string>
     <string name="tour_action_cancel">ഒഴിവാക്കുക</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">ടൂർ ഒഴിവാക്കണോ?</string>
     <string name="tour_confirm_message">നിങ്ങൾക്ക് എതു സമയത്തും സെറ്റിംഗുകളിൽ നിന്നും ടൂറുകൾ വീണ്ടും ഓണാക്കാം.</string>
     <string name="tour_confirm_continue">ടൂർ തുടരുക</string>

--- a/app-common-ui/src/main/res/values-mn-rMN/strings.xml
+++ b/app-common-ui/src/main/res/values-mn-rMN/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">Өгөгдлийн бүсүүд</string>
     <string name="tour_action_next">Дараа</string>
     <string name="tour_action_previous">Өмнөх</string>
-    <string name="tour_action_done">Дуусав</string>
     <string name="tour_action_cancel">Алгасах</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Аялалыг алгасах уу?</string>
     <string name="tour_confirm_message">Та аливаа цагт Тохиргооноос аялалыг дахин идэвхжүүлэх боломжтой.</string>
     <string name="tour_confirm_continue">Аялалыг үргэлжлүүлэх</string>

--- a/app-common-ui/src/main/res/values-ms/strings.xml
+++ b/app-common-ui/src/main/res/values-ms/strings.xml
@@ -9,9 +9,7 @@
     <string name="picker_home_action">Rumah</string>
     <string name="tour_action_next">Seterusnya</string>
     <string name="tour_action_previous">Sebelumnya</string>
-    <string name="tour_action_done">Selesai</string>
     <string name="tour_action_cancel">Langkau</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Langkau lawatan?</string>
     <string name="tour_confirm_message">Anda boleh mengaktifkan semula lawatan bila-bila masa dari Tetapan.</string>
     <string name="tour_confirm_continue">Teruskan lawatan</string>

--- a/app-common-ui/src/main/res/values-my-rMM/strings.xml
+++ b/app-common-ui/src/main/res/values-my-rMM/strings.xml
@@ -9,9 +9,7 @@
     <string name="picker_home_action">တဪဖိုင်နေရာများ</string>
     <string name="tour_action_next">ရှေ့သို့</string>
     <string name="tour_action_previous">ယခင်သို့</string>
-    <string name="tour_action_done">ပြီးပါပြီ</string>
     <string name="tour_action_cancel">ကျော်သွားပါ</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">ခရီးစဉ်ကို ကျော်သွားမည်လား?</string>
     <string name="tour_confirm_message">သင်သည် ဆက်တင်များမှ ခရီးစဉ်များကို အချိန်အခါတွင် ပြန်ဖွင့်နိုင်သည်။</string>
     <string name="tour_confirm_continue">ထပ်မံ ဆက်လက်ရန်</string>

--- a/app-common-ui/src/main/res/values-nb/strings.xml
+++ b/app-common-ui/src/main/res/values-nb/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">Dataområder</string>
     <string name="tour_action_next">Neste</string>
     <string name="tour_action_previous">Forrige</string>
-    <string name="tour_action_done">Ferdig</string>
     <string name="tour_action_cancel">Hopp over</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Hoppe over turen?</string>
     <string name="tour_confirm_message">Du kan aktivere turer på nytt når som helst fra Innstillinger.</string>
     <string name="tour_confirm_continue">Fortsett omvisning</string>

--- a/app-common-ui/src/main/res/values-ne-rNP/strings.xml
+++ b/app-common-ui/src/main/res/values-ne-rNP/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">डेटा क्षेत्रहरू</string>
     <string name="tour_action_next">अर्को</string>
     <string name="tour_action_previous">अघिल्लो</string>
-    <string name="tour_action_done">सम्पन्न</string>
     <string name="tour_action_cancel">छोड्नुहोस्</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">भ्रमण छोड्नुहोस्?</string>
     <string name="tour_confirm_message">तपाईं सेटिङ्सबाट कहिले पनि भ्रमणहरू पुन: सक्षम गर्न सक्नुहुन्छ।</string>
     <string name="tour_confirm_continue">भ्रमण जारी राख्नुहोस्</string>

--- a/app-common-ui/src/main/res/values-nl/strings.xml
+++ b/app-common-ui/src/main/res/values-nl/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">Datagebieden</string>
     <string name="tour_action_next">Volgende</string>
     <string name="tour_action_previous">Vorige</string>
-    <string name="tour_action_done">Klaar</string>
     <string name="tour_action_cancel">Overslaan</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Tour overslaan?</string>
     <string name="tour_confirm_message">Je kunt tours op elk moment opnieuw inschakelen via Instellingen.</string>
     <string name="tour_confirm_continue">Tour voortzetten</string>

--- a/app-common-ui/src/main/res/values-or-rIN/strings.xml
+++ b/app-common-ui/src/main/res/values-or-rIN/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">ଡାଟା କ୍ଷେତ୍ର</string>
     <string name="tour_action_next">ଆଗେ</string>
     <string name="tour_action_previous">ପଛେ</string>
-    <string name="tour_action_done">ସମ୍ପନ୍ନ</string>
     <string name="tour_action_cancel">ଛାଡ଼ନ୍ତୁ</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">ଭ୍ରମଣ ଛାଡ଼ିବେ?</string>
     <string name="tour_confirm_message">ଆପଣ ୟେକୌଣସି ସମୟରେ ସେଟିଂସ୍‌ରୁ ଭ୍ରମଣ ପୁନଃ ସକ୍ରିୟ କରିପାରିବେ।</string>
     <string name="tour_confirm_continue">ଟୁର ଜାରି ରଖନ୍ତୁ</string>

--- a/app-common-ui/src/main/res/values-pa-rIN/strings.xml
+++ b/app-common-ui/src/main/res/values-pa-rIN/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">ਡਾਟਾ ਖੇਤਰ</string>
     <string name="tour_action_next">ਅਗਲਾ</string>
     <string name="tour_action_previous">ਪਿਛਲਾ</string>
-    <string name="tour_action_done">ਮੁਕੰਮਲ</string>
     <string name="tour_action_cancel">ਛੱਡੋ</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">ਟੂਰ ਛੱਡ ਦਿਓ?</string>
     <string name="tour_confirm_message">ਤੁਸੀਂ ਸੈਟਿੰਗਾਂ ਵਿੱਚ ਕਦੇ ਵੀ ਟੂਰ ਨੂੰ ਮੁੜ-ਸਮਰਥ ਕਰ ਸਕਦੇ ਹੋ।</string>
     <string name="tour_confirm_continue">ਟੂਰ ਜਾਰੀ ਰੱਖੋ</string>

--- a/app-common-ui/src/main/res/values-pl/strings.xml
+++ b/app-common-ui/src/main/res/values-pl/strings.xml
@@ -12,9 +12,7 @@
     <string name="picker_home_action">Obszary danych</string>
     <string name="tour_action_next">Dalej</string>
     <string name="tour_action_previous">Wstecz</string>
-    <string name="tour_action_done">Zrobione</string>
     <string name="tour_action_cancel">Pomiń</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Pominąć przewodnik?</string>
     <string name="tour_confirm_message">Przewodniki możesz ponownie włączyć w dowolnym momencie z Ustawień.</string>
     <string name="tour_confirm_continue">Kontynuuj przewodnik</string>

--- a/app-common-ui/src/main/res/values-pt-rBR/strings.xml
+++ b/app-common-ui/src/main/res/values-pt-rBR/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">Áreas de dados</string>
     <string name="tour_action_next">Próximo</string>
     <string name="tour_action_previous">Anterior</string>
-    <string name="tour_action_done">Concluído</string>
     <string name="tour_action_cancel">Pular</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Pular o tour guiado?</string>
     <string name="tour_confirm_message">Você pode reativar os tours guiados a qualquer momento nas Configurações.</string>
     <string name="tour_confirm_continue">Continuar tour</string>

--- a/app-common-ui/src/main/res/values-pt/strings.xml
+++ b/app-common-ui/src/main/res/values-pt/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">Áreas de dados</string>
     <string name="tour_action_next">Seguinte</string>
     <string name="tour_action_previous">Anterior</string>
-    <string name="tour_action_done">Pronto</string>
     <string name="tour_action_cancel">Saltar</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Saltar a visita guiada?</string>
     <string name="tour_confirm_message">Pode reativar as visitas guiadas a qualquer momento nas Definições.</string>
     <string name="tour_confirm_continue">Continuar visita guiada</string>

--- a/app-common-ui/src/main/res/values-ro/strings.xml
+++ b/app-common-ui/src/main/res/values-ro/strings.xml
@@ -11,9 +11,7 @@
     <string name="picker_home_action">Zone de date</string>
     <string name="tour_action_next">Următor</string>
     <string name="tour_action_previous">Anterior</string>
-    <string name="tour_action_done">Terminat</string>
     <string name="tour_action_cancel">Omite</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Omiți turul?</string>
     <string name="tour_confirm_message">Poți reactiva tururile oricând din Setări.</string>
     <string name="tour_confirm_continue">Continuă turul</string>

--- a/app-common-ui/src/main/res/values-ru/strings.xml
+++ b/app-common-ui/src/main/res/values-ru/strings.xml
@@ -12,9 +12,7 @@
     <string name="picker_home_action">Области данных</string>
     <string name="tour_action_next">Далее</string>
     <string name="tour_action_previous">Назад</string>
-    <string name="tour_action_done">Готово</string>
     <string name="tour_action_cancel">Пропустить</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Пропустить тур?</string>
     <string name="tour_confirm_message">Вы можете повторно включить туры в любое время в Настройках.</string>
     <string name="tour_confirm_continue">Продолжить тур</string>

--- a/app-common-ui/src/main/res/values-sc-rIT/strings.xml
+++ b/app-common-ui/src/main/res/values-sc-rIT/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">Zonas de datos</string>
     <string name="tour_action_next">Prossima</string>
     <string name="tour_action_previous">Anteriore</string>
-    <string name="tour_action_done">Acabadu</string>
     <string name="tour_action_cancel">Salta</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Saltare sa vìsita?</string>
     <string name="tour_confirm_message">Podes reabilitare sas vìsitas in ununale momento dae is Definitziones.</string>
     <string name="tour_confirm_continue">Continua sa tura</string>

--- a/app-common-ui/src/main/res/values-si-rLK/strings.xml
+++ b/app-common-ui/src/main/res/values-si-rLK/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">දත්ත ප්‍රදේශ</string>
     <string name="tour_action_next">ඉදිරි</string>
     <string name="tour_action_previous">පෙර</string>
-    <string name="tour_action_done">අවසන්</string>
     <string name="tour_action_cancel">මඟ හරින්න</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">මාර්ගෝපදේශිත චාරිකාව මඟ හරන්නද?</string>
     <string name="tour_confirm_message">ඔබට ඕනෑම අවස්ථාවක සැකසීම් සිට මාර්ගෝපදේශිත චාරිකා නැවත සක්‍රීය කළ හැක.</string>
     <string name="tour_confirm_continue">චාරිකාව දිගටම කරගෙන යන්න</string>

--- a/app-common-ui/src/main/res/values-sk/strings.xml
+++ b/app-common-ui/src/main/res/values-sk/strings.xml
@@ -12,9 +12,7 @@
     <string name="picker_home_action">Dátové oblasti</string>
     <string name="tour_action_next">Ďalej</string>
     <string name="tour_action_previous">Predchádzajúce</string>
-    <string name="tour_action_done">Hotovo</string>
     <string name="tour_action_cancel">Preskočiť</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Preskočiť prehliadku?</string>
     <string name="tour_confirm_message">Prehliadky môžete kedykoľvek znova aktivovať v Nastaveniach.</string>
     <string name="tour_confirm_continue">Pokračovať v prehliadke</string>

--- a/app-common-ui/src/main/res/values-sl/strings.xml
+++ b/app-common-ui/src/main/res/values-sl/strings.xml
@@ -12,9 +12,7 @@
     <string name="picker_home_action">Podatkovna področja</string>
     <string name="tour_action_next">Naprej</string>
     <string name="tour_action_previous">Nazaj</string>
-    <string name="tour_action_done">Končano</string>
     <string name="tour_action_cancel">Preskoči</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Preskočiti turo?</string>
     <string name="tour_confirm_message">Ture lahko kadar koli ponovno omogočite v nastavitvah.</string>
     <string name="tour_confirm_continue">Nadaljuj turo</string>

--- a/app-common-ui/src/main/res/values-sq-rAL/strings.xml
+++ b/app-common-ui/src/main/res/values-sq-rAL/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">Zonat e të dhënave</string>
     <string name="tour_action_next">Tjetra</string>
     <string name="tour_action_previous">Mëpara</string>
-    <string name="tour_action_done">U krye</string>
     <string name="tour_action_cancel">Anashkalo</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Anashkalo turin?</string>
     <string name="tour_confirm_message">Mund të riaktivizoni turet në çdo kohë nga Cilësimet.</string>
     <string name="tour_confirm_continue">Vazhdo turin</string>

--- a/app-common-ui/src/main/res/values-sr/strings.xml
+++ b/app-common-ui/src/main/res/values-sr/strings.xml
@@ -11,9 +11,7 @@
     <string name="picker_home_action">Области података</string>
     <string name="tour_action_next">Даље</string>
     <string name="tour_action_previous">Претходно</string>
-    <string name="tour_action_done">Готово</string>
     <string name="tour_action_cancel">Прескочи</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Прескочити туру?</string>
     <string name="tour_confirm_message">Можете поново омогућити туре било када из Подешавања.</string>
     <string name="tour_confirm_continue">Наставите туру</string>

--- a/app-common-ui/src/main/res/values-sv/strings.xml
+++ b/app-common-ui/src/main/res/values-sv/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">Dataområden</string>
     <string name="tour_action_next">Nästa</string>
     <string name="tour_action_previous">Tidigare</string>
-    <string name="tour_action_done">Klar</string>
     <string name="tour_action_cancel">Hoppa över</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Hoppa över rundturen?</string>
     <string name="tour_confirm_message">Du kan aktivera rundturer igen när som helst från Inställningar.</string>
     <string name="tour_confirm_continue">Fortsätt rundvisningen</string>

--- a/app-common-ui/src/main/res/values-sw/strings.xml
+++ b/app-common-ui/src/main/res/values-sw/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">Maeneo ya data</string>
     <string name="tour_action_next">Inayofuata</string>
     <string name="tour_action_previous">Iliyotangulia</string>
-    <string name="tour_action_done">Imekamilika</string>
     <string name="tour_action_cancel">Ruka</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Ruka ziara?</string>
     <string name="tour_confirm_message">Unaweza kuwezesha ziara tena wakati wowote kutoka Mipangilio.</string>
     <string name="tour_confirm_continue">Endelea na ziara</string>

--- a/app-common-ui/src/main/res/values-ta-rIN/strings.xml
+++ b/app-common-ui/src/main/res/values-ta-rIN/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">தரவு பகுதிகள்</string>
     <string name="tour_action_next">அடுத்தது</string>
     <string name="tour_action_previous">முந்தைய</string>
-    <string name="tour_action_done">முடிந்தது</string>
     <string name="tour_action_cancel">தவிர்</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">சுற்றுப்பயணத்தைத் தவிர்க்கவா?</string>
     <string name="tour_confirm_message">நீங்கள் எப்போது வேண்டுமானாலும் அமைப்புகளிலிருந்து சுற்றுப்பயணங்களை மீண்டும் இயக்கலாம்.</string>
     <string name="tour_confirm_continue">சுற்றுப்பயணத்தைத் தொடரவும்</string>

--- a/app-common-ui/src/main/res/values-te-rIN/strings.xml
+++ b/app-common-ui/src/main/res/values-te-rIN/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">డేటా ప్రాంతాలు</string>
     <string name="tour_action_next">తర్వాత</string>
     <string name="tour_action_previous">మునుపటి</string>
-    <string name="tour_action_done">పూర్తయింది</string>
     <string name="tour_action_cancel">దాటవేయండి</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">టూర్‌ను దాటవేయాలా?</string>
     <string name="tour_confirm_message">మీరు సెట్టింగ్‌ల నుండి ఎప్పుడైనా టూర్‌లను మళ్ళీ చేతనం చేయవచ్చు.</string>
     <string name="tour_confirm_continue">కొనసాగించండి</string>

--- a/app-common-ui/src/main/res/values-th/strings.xml
+++ b/app-common-ui/src/main/res/values-th/strings.xml
@@ -9,9 +9,7 @@
     <string name="picker_home_action">พื้นที่ข้อมูล</string>
     <string name="tour_action_next">ถัดไป</string>
     <string name="tour_action_previous">ก่อนหน้า</string>
-    <string name="tour_action_done">เสร็จ</string>
     <string name="tour_action_cancel">ข้าม</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">ข้ามทัวร์นี้หรือไม่</string>
     <string name="tour_confirm_message">คุณสามารถเปิดใช้งานทัวร์อีกครั้งจากการตั้งค่าได้ตลอดเวลา</string>
     <string name="tour_confirm_continue">ดำเนินการทัวร์ต่อ</string>

--- a/app-common-ui/src/main/res/values-tr/strings.xml
+++ b/app-common-ui/src/main/res/values-tr/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">Veri alanları</string>
     <string name="tour_action_next">Sonraki</string>
     <string name="tour_action_previous">Önceki</string>
-    <string name="tour_action_done">Tamamlandı</string>
     <string name="tour_action_cancel">Atla</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Tur atlansın mı?</string>
     <string name="tour_confirm_message">Turları istediğiniz zaman Ayarlar\'dan yeniden etkinleştirebilirsiniz.</string>
     <string name="tour_confirm_continue">Tura devam et</string>

--- a/app-common-ui/src/main/res/values-uk/strings.xml
+++ b/app-common-ui/src/main/res/values-uk/strings.xml
@@ -12,9 +12,7 @@
     <string name="picker_home_action">Області даних</string>
     <string name="tour_action_next">Далі</string>
     <string name="tour_action_previous">Назад</string>
-    <string name="tour_action_done">Готово</string>
     <string name="tour_action_cancel">Пропустити</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Пропустити екскурсію?</string>
     <string name="tour_confirm_message">Ви можете повторно увімкнути екскурсії будь-коли в Налаштуваннях.</string>
     <string name="tour_confirm_continue">Продовжити екскурсію</string>

--- a/app-common-ui/src/main/res/values-ur-rIN/strings.xml
+++ b/app-common-ui/src/main/res/values-ur-rIN/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">ڈیٹا ایریاز</string>
     <string name="tour_action_next">اگلا</string>
     <string name="tour_action_previous">پچھلا</string>
-    <string name="tour_action_done">ہو گیا</string>
     <string name="tour_action_cancel">چھوڑیں</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">ٹور کو چھوڑ دیں؟</string>
     <string name="tour_confirm_message">آپ سیٹنگز سے کسی بھی وقت ٹورز کو دوبارہ فعال کر سکتے ہیں۔</string>
     <string name="tour_confirm_continue">ٹور جاری رکھیں</string>

--- a/app-common-ui/src/main/res/values-uz/strings.xml
+++ b/app-common-ui/src/main/res/values-uz/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">Ma\'lumotlar sohalari</string>
     <string name="tour_action_next">Keyingi</string>
     <string name="tour_action_previous">Oldingi</string>
-    <string name="tour_action_done">Tayyor</string>
     <string name="tour_action_cancel">O\'tkazib yuborish</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Sayohat o\'tkazib yuborilsinmi?</string>
     <string name="tour_confirm_message">Sayohatlarni istalgan vaqt Sozlamalar orqali qayta yoqishingiz mumkin.</string>
     <string name="tour_confirm_continue">Sayohatni davom ettirish</string>

--- a/app-common-ui/src/main/res/values-vi/strings.xml
+++ b/app-common-ui/src/main/res/values-vi/strings.xml
@@ -9,9 +9,7 @@
     <string name="picker_home_action">Vùng dữ liệu</string>
     <string name="tour_action_next">Tiếp theo</string>
     <string name="tour_action_previous">Trước</string>
-    <string name="tour_action_done">Xong</string>
     <string name="tour_action_cancel">Bỏ qua</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Bỏ qua hướng dẫn?</string>
     <string name="tour_confirm_message">Bạn có thể bật lại hướng dẫn bất cứ lúc nào từ Cài đặt.</string>
     <string name="tour_confirm_continue">Tiếp tục hướng dẫn</string>

--- a/app-common-ui/src/main/res/values-zh-rCN/strings.xml
+++ b/app-common-ui/src/main/res/values-zh-rCN/strings.xml
@@ -9,9 +9,7 @@
     <string name="picker_home_action">数据区域</string>
     <string name="tour_action_next">下一个</string>
     <string name="tour_action_previous">上一个</string>
-    <string name="tour_action_done">完成</string>
     <string name="tour_action_cancel">跳过</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">跳过导览？</string>
     <string name="tour_confirm_message">您可以随时从设置中重新启用导览。</string>
     <string name="tour_confirm_continue">继续导览</string>

--- a/app-common-ui/src/main/res/values-zh-rHK/strings.xml
+++ b/app-common-ui/src/main/res/values-zh-rHK/strings.xml
@@ -9,9 +9,7 @@
     <string name="picker_home_action">資料區域</string>
     <string name="tour_action_next">下一步</string>
     <string name="tour_action_previous">上一步</string>
-    <string name="tour_action_done">完成</string>
     <string name="tour_action_cancel">跳過</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">跳過導引參觀？</string>
     <string name="tour_confirm_message">您可以隨時從設定重新啟用導引參觀。</string>
     <string name="tour_confirm_continue">繼續導引參觀</string>

--- a/app-common-ui/src/main/res/values-zh-rTW/strings.xml
+++ b/app-common-ui/src/main/res/values-zh-rTW/strings.xml
@@ -9,9 +9,7 @@
     <string name="picker_home_action">資料區域</string>
     <string name="tour_action_next">下一步</string>
     <string name="tour_action_previous">上一步</string>
-    <string name="tour_action_done">完成</string>
     <string name="tour_action_cancel">略過</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">要略過導覽嗎？</string>
     <string name="tour_confirm_message">您可以隨時從設定重新啟用導覽。</string>
     <string name="tour_confirm_continue">繼續導覽</string>

--- a/app-common-ui/src/main/res/values-zu/strings.xml
+++ b/app-common-ui/src/main/res/values-zu/strings.xml
@@ -10,9 +10,7 @@
     <string name="picker_home_action">Izindawo zedatha</string>
     <string name="tour_action_next">Okulandelayo</string>
     <string name="tour_action_previous">Okwandulele</string>
-    <string name="tour_action_done">Kwenziwe</string>
     <string name="tour_action_cancel">Yeqa</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Yeqa ithambekelo?</string>
     <string name="tour_confirm_message">Ungakwazi ukuzivumela izithambekelo nanoma nini kusuka kuSettings.</string>
     <string name="tour_confirm_continue">Qhubeka</string>

--- a/app-common-ui/src/main/res/values/strings.xml
+++ b/app-common-ui/src/main/res/values/strings.xml
@@ -12,14 +12,12 @@
 
     <string name="tour_action_next">Next</string>
     <string name="tour_action_previous">Previous</string>
-    <string name="tour_action_done">Done</string>
     <string name="tour_action_cancel">Skip</string>
-    <string name="tour_step_x_of_y">%1$d / %2$d</string>
     <string name="tour_confirm_title">Skip the tour?</string>
     <string name="tour_confirm_message">You can re-enable tours anytime from Settings.</string>
     <string name="tour_confirm_continue">Continue tour</string>
     <string name="tour_confirm_dont_show_this_tour">Don\'t show this tour</string>
     <string name="tour_confirm_disable_all">Disable all tours</string>
-    <string name="navigation_unknown_destination_title">Coming soon</string>
-    <string name="navigation_unknown_destination_message">This screen is still being migrated to the new UI.</string>
+    <string name="navigation_unknown_destination_title">Screen unavailable</string>
+    <string name="navigation_unknown_destination_message">This screen could not be opened.</string>
 </resources>

--- a/app-common/src/main/res/values-af-rZA/strings.xml
+++ b/app-common/src/main/res/values-af-rZA/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Voeg filter by</string>
     <string name="general_filter_remove_x_action">Verwyder %s filter</string>
     <string name="general_filter_empty_row_hint">Tik + om te filteer</string>
-    <string name="general_show_all_action">Wys alles</string>
     <string name="general_result_success_message">Operasie suksesvol</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">%s spasie vrygestel.</item>

--- a/app-common/src/main/res/values-am/strings.xml
+++ b/app-common/src/main/res/values-am/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">ማጣሪያ ያክሉ</string>
     <string name="general_filter_remove_x_action">%s ማጣሪያን ያስወግዱ</string>
     <string name="general_filter_empty_row_hint">ለማጣራት + ይጀኑ</string>
-    <string name="general_show_all_action">ሁሉንም አሳይ</string>
     <string name="general_result_success_message">ክንዋኔ ተሳክቷል</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">%s ቦታ ነፃ ተደርጓል።</item>

--- a/app-common/src/main/res/values-ar/strings.xml
+++ b/app-common/src/main/res/values-ar/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">إضافة مرشح</string>
     <string name="general_filter_remove_x_action">إزالة مرشح %s</string>
     <string name="general_filter_empty_row_hint">اضغط + للتصفية</string>
-    <string name="general_show_all_action">عرض الكل</string>
     <string name="general_result_success_message">تمت المهمة بنجاح</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="zero">أفرج عن مساحة %s.</item>

--- a/app-common/src/main/res/values-az/strings.xml
+++ b/app-common/src/main/res/values-az/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Filtr əlavə et</string>
     <string name="general_filter_remove_x_action">%s filtrini silin</string>
     <string name="general_filter_empty_row_hint">Filtrləmək üçün +-a toxunun</string>
-    <string name="general_show_all_action">Hamısını göstər</string>
     <string name="general_result_success_message">Əməliyyat uğurlu oldu</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">%s yer azad edildi.</item>

--- a/app-common/src/main/res/values-be/strings.xml
+++ b/app-common/src/main/res/values-be/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Дадаць фільтр</string>
     <string name="general_filter_remove_x_action">Выдаліць фільтр %s</string>
     <string name="general_filter_empty_row_hint">Націсніце +, каб адфільтраваць</string>
-    <string name="general_show_all_action">Паказаць усе</string>
     <string name="general_result_success_message">Аперацыя выканана</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">Вызвалена %s месца.</item>

--- a/app-common/src/main/res/values-bg/strings.xml
+++ b/app-common/src/main/res/values-bg/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Добави филтър</string>
     <string name="general_filter_remove_x_action">Премахни филтър %s</string>
     <string name="general_filter_empty_row_hint">Докосни + за филтър</string>
-    <string name="general_show_all_action">Показване на всички</string>
     <string name="general_result_success_message">Операцията е успешна</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">Освободено %s място.</item>

--- a/app-common/src/main/res/values-bn-rBD/strings.xml
+++ b/app-common/src/main/res/values-bn-rBD/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">ফিল্টার যোগ করুন</string>
     <string name="general_filter_remove_x_action">%s ফিল্টার সরান</string>
     <string name="general_filter_empty_row_hint">ফিল্টার করতে + ট্যাপ করুন</string>
-    <string name="general_show_all_action">সবগুলো দেখান </string>
     <string name="general_result_success_message">কাজটি সফল হয়েছে</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">%s স্থান খালি করা হয়েছে।</item>

--- a/app-common/src/main/res/values-ca/strings.xml
+++ b/app-common/src/main/res/values-ca/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Afegeix filtre</string>
     <string name="general_filter_remove_x_action">Elimina el filtre %s</string>
     <string name="general_filter_empty_row_hint">Toca + per filtrar</string>
-    <string name="general_show_all_action">Mostra-ho tot</string>
     <string name="general_result_success_message">Operació realitzada amb èxit</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">S\'ha alliberat %s d\'espai.</item>

--- a/app-common/src/main/res/values-ckb-rIR/strings.xml
+++ b/app-common/src/main/res/values-ckb-rIR/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">زیادکردنی پالاوتن</string>
     <string name="general_filter_remove_x_action">سڕینەوەی پالاوتنی %s</string>
     <string name="general_filter_empty_row_hint">داکێشە + بکە بۆ پالاوتنیکردن</string>
-    <string name="general_show_all_action">پیشاندانی هەموو</string>
     <string name="general_result_success_message">کارپێکردن سەرکەوتوو بوو</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">%s شوێن ئازادکرا.</item>

--- a/app-common/src/main/res/values-cs/strings.xml
+++ b/app-common/src/main/res/values-cs/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Přidat filtr</string>
     <string name="general_filter_remove_x_action">Odstranit filtr %s</string>
     <string name="general_filter_empty_row_hint">Klepnutím na + filtrovat</string>
-    <string name="general_show_all_action">Zobrazit vše</string>
     <string name="general_result_success_message">Operace úspěšně dokončena</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">Uvolněno prostoru: %s.</item>

--- a/app-common/src/main/res/values-da/strings.xml
+++ b/app-common/src/main/res/values-da/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Tilføj filter</string>
     <string name="general_filter_remove_x_action">Fjern %s filter</string>
     <string name="general_filter_empty_row_hint">Tryk + for at filtrere</string>
-    <string name="general_show_all_action">Vis alle</string>
     <string name="general_result_success_message">Operation lykkedes</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">Frigjort %s plads.</item>

--- a/app-common/src/main/res/values-de/strings.xml
+++ b/app-common/src/main/res/values-de/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Filter hinzufügen</string>
     <string name="general_filter_remove_x_action">%s-Filter entfernen</string>
     <string name="general_filter_empty_row_hint">Tippen Sie auf +, um zu filtern</string>
-    <string name="general_show_all_action">Zeige alles</string>
     <string name="general_result_success_message">Operation erfolgreich</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">%s Speicherplatz freigegeben.</item>

--- a/app-common/src/main/res/values-el/strings.xml
+++ b/app-common/src/main/res/values-el/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Προσθήκη φίλτρου</string>
     <string name="general_filter_remove_x_action">Κατάργηση φίλτρου %s</string>
     <string name="general_filter_empty_row_hint">Πατήστε + για φιλτράρισμα</string>
-    <string name="general_show_all_action">Εμφάνιση όλων</string>
     <string name="general_result_success_message">Λειτουργία επιτυχής</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">Απελευθερώθηκε %s χώρου.</item>

--- a/app-common/src/main/res/values-es-rAR/strings.xml
+++ b/app-common/src/main/res/values-es-rAR/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Agregar filtro</string>
     <string name="general_filter_remove_x_action">Eliminar el filtro %s</string>
     <string name="general_filter_empty_row_hint">Tocá + para filtrar</string>
-    <string name="general_show_all_action">Mostrar todo</string>
     <string name="general_result_success_message">Operación exitosa</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">Se limpió %s de espacio.</item>

--- a/app-common/src/main/res/values-es-rMX/strings.xml
+++ b/app-common/src/main/res/values-es-rMX/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Agregar filtro</string>
     <string name="general_filter_remove_x_action">Eliminar filtro %s</string>
     <string name="general_filter_empty_row_hint">Toca + para filtrar</string>
-    <string name="general_show_all_action">Mostrar todo</string>
     <string name="general_result_success_message">Operación exitosa</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">Se liberó %s de espacio.</item>

--- a/app-common/src/main/res/values-es/strings.xml
+++ b/app-common/src/main/res/values-es/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Agregar filtro</string>
     <string name="general_filter_remove_x_action">Eliminar filtro %s</string>
     <string name="general_filter_empty_row_hint">Toca + para filtrar</string>
-    <string name="general_show_all_action">Mostrar todo</string>
     <string name="general_result_success_message">Operación exitosa</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">Espacio liberado %s.</item>

--- a/app-common/src/main/res/values-et-rEE/strings.xml
+++ b/app-common/src/main/res/values-et-rEE/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Lisa filter</string>
     <string name="general_filter_remove_x_action">Eemalda %s filter</string>
     <string name="general_filter_empty_row_hint">Puuduta + et filtreerida</string>
-    <string name="general_show_all_action">Kuva kõik</string>
     <string name="general_result_success_message">Edukas toiming</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">Vabastati %s ruumi.</item>

--- a/app-common/src/main/res/values-eu-rES/strings.xml
+++ b/app-common/src/main/res/values-eu-rES/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Iragazki gehitu</string>
     <string name="general_filter_remove_x_action">Kendu %s iragazki</string>
     <string name="general_filter_empty_row_hint">Sakatu + iragazkitzeko</string>
-    <string name="general_show_all_action">Denak erakutsi</string>
     <string name="general_result_success_message">Eragiketa arrakastatsua</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">%s leku askatu da.</item>

--- a/app-common/src/main/res/values-fa/strings.xml
+++ b/app-common/src/main/res/values-fa/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">افزودن فیلتر</string>
     <string name="general_filter_remove_x_action">حذف فیلتر %s</string>
     <string name="general_filter_empty_row_hint">برای فیلتر + را لمس کنید</string>
-    <string name="general_show_all_action">نمایش همه</string>
     <string name="general_result_success_message">عملیات موفق</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">%s فضا آزاد شد.</item>

--- a/app-common/src/main/res/values-fi/strings.xml
+++ b/app-common/src/main/res/values-fi/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Lisää suodatin</string>
     <string name="general_filter_remove_x_action">Poista %s suodatin</string>
     <string name="general_filter_empty_row_hint">Napauta + suodattaaksesi</string>
-    <string name="general_show_all_action">Näytä kaikki</string>
     <string name="general_result_success_message">Toiminto onnistui</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">Vapautettiin %s tilaa.</item>

--- a/app-common/src/main/res/values-fil/strings.xml
+++ b/app-common/src/main/res/values-fil/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Magdagdag ng filter</string>
     <string name="general_filter_remove_x_action">Tanggalin ang %s filter</string>
     <string name="general_filter_empty_row_hint">Tapikin ang + para mag-filter</string>
-    <string name="general_show_all_action">Ipakita lahat</string>
     <string name="general_result_success_message">Matagumpay ang operasyon</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">Na-free na ang %s na espasyo.</item>

--- a/app-common/src/main/res/values-fr/strings.xml
+++ b/app-common/src/main/res/values-fr/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Ajouter un filtre</string>
     <string name="general_filter_remove_x_action">Supprimer le filtre %s</string>
     <string name="general_filter_empty_row_hint">Appuyez sur + pour filtrer</string>
-    <string name="general_show_all_action">Tout afficher</string>
     <string name="general_result_success_message">L’opération est réussie</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">%s libéré.</item>

--- a/app-common/src/main/res/values-gl-rES/strings.xml
+++ b/app-common/src/main/res/values-gl-rES/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Engadir filtro</string>
     <string name="general_filter_remove_x_action">Eliminar filtro %s</string>
     <string name="general_filter_empty_row_hint">Toca + para filtrar</string>
-    <string name="general_show_all_action">Mostrar todo</string>
     <string name="general_result_success_message">Operación exitosa</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">Liberáronse %s de espazo.</item>

--- a/app-common/src/main/res/values-hi-rIN/strings.xml
+++ b/app-common/src/main/res/values-hi-rIN/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">फ़िल्टर जोड़ें</string>
     <string name="general_filter_remove_x_action">%s फ़िल्टर हटाएं</string>
     <string name="general_filter_empty_row_hint">फ़िल्टर करने के लिए + टैप करें</string>
-    <string name="general_show_all_action">सभी दिखाएं</string>
     <string name="general_result_success_message">ऑपरेशन सफल रहा</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">%s स्थान मुक्त किया।</item>

--- a/app-common/src/main/res/values-hr/strings.xml
+++ b/app-common/src/main/res/values-hr/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Dodaj filter</string>
     <string name="general_filter_remove_x_action">Ukloni %s filter</string>
     <string name="general_filter_empty_row_hint">Dodirni + za filtriranje</string>
-    <string name="general_show_all_action">Prikaži sve</string>
     <string name="general_result_success_message">Operacija uspješna</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">Oslobođeno %s prostora.</item>

--- a/app-common/src/main/res/values-hu/strings.xml
+++ b/app-common/src/main/res/values-hu/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Szűrő hozzáadása</string>
     <string name="general_filter_remove_x_action">%s szűrő eltávolítása</string>
     <string name="general_filter_empty_row_hint">Szűréshez koppintson a + gombra</string>
-    <string name="general_show_all_action">Összes megjelenítése</string>
     <string name="general_result_success_message">A művelet sikeres</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">%s hely felszabadult.</item>

--- a/app-common/src/main/res/values-in/strings.xml
+++ b/app-common/src/main/res/values-in/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Tambah filter</string>
     <string name="general_filter_remove_x_action">Hapus %s filter</string>
     <string name="general_filter_empty_row_hint">Ketuk + untuk menyaring</string>
-    <string name="general_show_all_action">Tampilkan semua</string>
     <string name="general_result_success_message">Pekerjaan selesai</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="other">%s ruang dibebaskan.</item>

--- a/app-common/src/main/res/values-is/strings.xml
+++ b/app-common/src/main/res/values-is/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Bæta við síu</string>
     <string name="general_filter_remove_x_action">Fjarlægja %s síu</string>
     <string name="general_filter_empty_row_hint">Ýttu á + til að sía</string>
-    <string name="general_show_all_action">Sýna allt</string>
     <string name="general_result_success_message">Aðgerð tókst</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">%s pláss losað.</item>

--- a/app-common/src/main/res/values-it/strings.xml
+++ b/app-common/src/main/res/values-it/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Aggiungi filtro</string>
     <string name="general_filter_remove_x_action">Rimuovi filtro %s</string>
     <string name="general_filter_empty_row_hint">Tocca + per filtrare</string>
-    <string name="general_show_all_action">Mostra tutto</string>
     <string name="general_result_success_message">Operazione riuscita</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">%s di spazio liberato.</item>

--- a/app-common/src/main/res/values-iw/strings.xml
+++ b/app-common/src/main/res/values-iw/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">הוסף סנן</string>
     <string name="general_filter_remove_x_action">הסר סנן %s</string>
     <string name="general_filter_empty_row_hint">הקש על + כדי לסנן</string>
-    <string name="general_show_all_action">הצג הכל</string>
     <string name="general_result_success_message">הפעולה בוצעה בהצלחה</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">שוחרר %s מהמכשיר.</item>

--- a/app-common/src/main/res/values-ja/strings.xml
+++ b/app-common/src/main/res/values-ja/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">フィルターを追加</string>
     <string name="general_filter_remove_x_action">%sフィルターを削除</string>
     <string name="general_filter_empty_row_hint">+をタップしてフィルター</string>
-    <string name="general_show_all_action">すべて表示</string>
     <string name="general_result_success_message">実行成功</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="other">%sの容量を解放しました。</item>

--- a/app-common/src/main/res/values-ka-rGE/strings.xml
+++ b/app-common/src/main/res/values-ka-rGE/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">ფილტრის დამატება</string>
     <string name="general_filter_remove_x_action">%s ფილტრის წაშლა</string>
     <string name="general_filter_empty_row_hint">დააჭირე + ფილტრირებისთვის</string>
-    <string name="general_show_all_action">ყველას ჩვენება</string>
     <string name="general_result_success_message">ოპერაცია წარმატებული</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">%s ადგილი განთავისუფლდა.</item>

--- a/app-common/src/main/res/values-kaa/strings.xml
+++ b/app-common/src/main/res/values-kaa/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Súzgi qosıw</string>
     <string name="general_filter_remove_x_action">%s súzgisin óshiriw</string>
     <string name="general_filter_empty_row_hint">Súzgilew ushın + basıń</string>
-    <string name="general_show_all_action">Barlıǵın kórsetew</string>
     <string name="general_result_success_message">Amal jetiskerli</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">%s orın bostatıldı.</item>

--- a/app-common/src/main/res/values-km-rKH/strings.xml
+++ b/app-common/src/main/res/values-km-rKH/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">បន្ថែមតម្រង</string>
     <string name="general_filter_remove_x_action">លុបតម្រង %s</string>
     <string name="general_filter_empty_row_hint">ចុចលើ + ដើម្បីតម្រង</string>
-    <string name="general_show_all_action">បង្ហាញទាំងអស់</string>
     <string name="general_result_success_message">ប្រតិបត្តិការជោគជ័យ</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="other">ទំហំនៅទំនេរ %s។</item>

--- a/app-common/src/main/res/values-ko/strings.xml
+++ b/app-common/src/main/res/values-ko/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">필터 추가</string>
     <string name="general_filter_remove_x_action">%s 필터 제거</string>
     <string name="general_filter_empty_row_hint">+ 탭하여 필터</string>
-    <string name="general_show_all_action">모두 보기</string>
     <string name="general_result_success_message">작업 성공</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="other">%s 공간을 확보했습니다.</item>

--- a/app-common/src/main/res/values-lo-rLA/strings.xml
+++ b/app-common/src/main/res/values-lo-rLA/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">ເພີ່ມກັ່ນຫລາກ</string>
     <string name="general_filter_remove_x_action">ລົບກັ່ນຫລາກ %s</string>
     <string name="general_filter_empty_row_hint">ແຕະ + ເພື່ອກັ່ນຫລາກ</string>
-    <string name="general_show_all_action">ສະແດງທັງໝົດ</string>
     <string name="general_result_success_message">ການດຳເນີນງານສຳເລັດ</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="other">ພື້ນທີ່ %s ໄດ້ຖືກປົດປ່ອຍ.</item>

--- a/app-common/src/main/res/values-lt/strings.xml
+++ b/app-common/src/main/res/values-lt/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Pridėti filtrą</string>
     <string name="general_filter_remove_x_action">Pašalinti %s filtrą</string>
     <string name="general_filter_empty_row_hint">Bakstelėkite + norėdami filtruoti</string>
-    <string name="general_show_all_action">Rodyti visus</string>
     <string name="general_result_success_message">Operacija sėkminga</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">Atlaisvinta %s vietos.</item>

--- a/app-common/src/main/res/values-lv/strings.xml
+++ b/app-common/src/main/res/values-lv/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Pievienot filtru</string>
     <string name="general_filter_remove_x_action">Noņemt %s filtru</string>
     <string name="general_filter_empty_row_hint">Pieskarieties + lai filtrētu</string>
-    <string name="general_show_all_action">Rādīt visu</string>
     <string name="general_result_success_message">Operācija veiksmīga</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="zero">Atbrīvots %s vieta.</item>

--- a/app-common/src/main/res/values-mk-rMK/strings.xml
+++ b/app-common/src/main/res/values-mk-rMK/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Додајте филтер</string>
     <string name="general_filter_remove_x_action">Отстранете го филтерот %s</string>
     <string name="general_filter_empty_row_hint">Допрете + за да филтрирате</string>
-    <string name="general_show_all_action">Покажи се</string>
     <string name="general_result_success_message">Operation successful</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">Ослободен %s простор.</item>

--- a/app-common/src/main/res/values-ml-rIN/strings.xml
+++ b/app-common/src/main/res/values-ml-rIN/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">ഫിൽട്ടർ ചേർക്കുക</string>
     <string name="general_filter_remove_x_action">%s ഫിൽട്ടർ നീക്കം ചെയ്യുക</string>
     <string name="general_filter_empty_row_hint">ഫിൽട്ടർ ചെയ്യാൻ + അമർത്തുക</string>
-    <string name="general_show_all_action">എല്ലാം കാണിക്കുക</string>
     <string name="general_result_success_message">ഓപ്പറേഷൻ വിജയിച്ചു</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">%s സ്ഥലം സ്വതന്ത്രമാക്കി.</item>

--- a/app-common/src/main/res/values-mn-rMN/strings.xml
+++ b/app-common/src/main/res/values-mn-rMN/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Шүүлтүүр нэмэх</string>
     <string name="general_filter_remove_x_action">%s шүүлтүүрийг хасах</string>
     <string name="general_filter_empty_row_hint">Шүүхийн тулд + дээр дарна уу</string>
-    <string name="general_show_all_action">Бүгдийг харуулах</string>
     <string name="general_result_success_message">Амжилттай гүйцэтгэгдсэн</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">%s зай чөлөөлөгдсөн.</item>

--- a/app-common/src/main/res/values-ms/strings.xml
+++ b/app-common/src/main/res/values-ms/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Tambah penapis</string>
     <string name="general_filter_remove_x_action">Alih keluar penapis %s</string>
     <string name="general_filter_empty_row_hint">Sentuh + untuk penapis</string>
-    <string name="general_show_all_action">Tunjukkan semua</string>
     <string name="general_result_success_message">Operasi berjaya</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="other">Membebaskan %s ruang.</item>

--- a/app-common/src/main/res/values-my-rMM/strings.xml
+++ b/app-common/src/main/res/values-my-rMM/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">စစ်ထုတ်ကိရိယာ ထည့်သွင်ရန်</string>
     <string name="general_filter_remove_x_action">%s စစ်ထုတ်ကိရိယာ ဖျက်ရန်</string>
     <string name="general_filter_empty_row_hint">+ ကို ထိပြီး စစ်ထုတ်ရန်</string>
-    <string name="general_show_all_action">အားလုံးပြပါ</string>
     <string name="general_result_success_message">အောင်မြင်စွာ လုပ်ဆောင်ပြီးပါပြီ</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="other">%s နေရာလွတ်ပြီးပါပြီ။</item>

--- a/app-common/src/main/res/values-nb/strings.xml
+++ b/app-common/src/main/res/values-nb/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Legg til filter</string>
     <string name="general_filter_remove_x_action">Fjern %s filter</string>
     <string name="general_filter_empty_row_hint">Trykk + for å filtrere</string>
-    <string name="general_show_all_action">Vis alle</string>
     <string name="general_result_success_message">Operasjonen var vellykket</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">Frigjorde %s plass.</item>

--- a/app-common/src/main/res/values-ne-rNP/strings.xml
+++ b/app-common/src/main/res/values-ne-rNP/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">फिल्टर थप्नुहोस्</string>
     <string name="general_filter_remove_x_action">%s फिल्टर हटाउनुहोस्</string>
     <string name="general_filter_empty_row_hint">फिल्टर गर्नको लागि + ट्याप गर्नुहोस्</string>
-    <string name="general_show_all_action">सबै देखाउनुहोस्</string>
     <string name="general_result_success_message">सफलतापूर्वक सम्पन्न</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">%s ठाउँ खाली गरियो।</item>

--- a/app-common/src/main/res/values-nl/strings.xml
+++ b/app-common/src/main/res/values-nl/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Filter toevoegen</string>
     <string name="general_filter_remove_x_action">%s filter verwijderen</string>
     <string name="general_filter_empty_row_hint">Tik + om te filteren</string>
-    <string name="general_show_all_action">Toon alles</string>
     <string name="general_result_success_message">Bewerking geslaagd</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">%s ruimte vrijgemaakt.</item>

--- a/app-common/src/main/res/values-or-rIN/strings.xml
+++ b/app-common/src/main/res/values-or-rIN/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">ଫିଲ୍ଟର ୟୋଗ କରନ୍ତୁ</string>
     <string name="general_filter_remove_x_action">%s ଫିଲ୍ଟର ଅପସାରଣ କରନ୍ତୁ</string>
     <string name="general_filter_empty_row_hint">ଫିଲ୍ଟର କରିବାକୁ + ଟ୍ୟାପ କରନ୍ତୁ</string>
-    <string name="general_show_all_action">ସବୁ ଦେଖାଇବା</string>
     <string name="general_result_success_message">ପ୍ରକ୍ରିୟା ସଫଳ ହୋଇଛି</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">%s ସ୍ଥାନ ମୁକ୍ତ କରାଗଲା।</item>

--- a/app-common/src/main/res/values-pa-rIN/strings.xml
+++ b/app-common/src/main/res/values-pa-rIN/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">ਫਿਲਟਰ ਜੋੜੋ</string>
     <string name="general_filter_remove_x_action">%s ਫਿਲਟਰ ਨੂੰ ਹਟਾਓ</string>
     <string name="general_filter_empty_row_hint">ਫਿਲਟਰ ਕਰਨ ਲਈ + ਨੂੰ ਟੈਪ ਕਰੋ</string>
-    <string name="general_show_all_action">ਸਾਰੇ ਦਿਖਾਓ</string>
     <string name="general_result_success_message">ਕਾਰਵਾਈ ਸਫਲ ਹੋਈ</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">%s ਜਗ੍ਹਾ ਮੁਫਤ ਕੀਤੀ।</item>

--- a/app-common/src/main/res/values-pl/strings.xml
+++ b/app-common/src/main/res/values-pl/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Dodaj filtr</string>
     <string name="general_filter_remove_x_action">Usuń filtr %s</string>
     <string name="general_filter_empty_row_hint">Dotknij + aby filtrować</string>
-    <string name="general_show_all_action">Pokaż wszystkie</string>
     <string name="general_result_success_message">Operacja zakończona sukcesem</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">Zwolniono %s miejsca.</item>

--- a/app-common/src/main/res/values-pt-rBR/strings.xml
+++ b/app-common/src/main/res/values-pt-rBR/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Adicionar filtro</string>
     <string name="general_filter_remove_x_action">Remover filtro %s</string>
     <string name="general_filter_empty_row_hint">Toque em + para filtrar</string>
-    <string name="general_show_all_action">Exibir tudo</string>
     <string name="general_result_success_message">Operação bem sucedida</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">%s de espaço liberado.</item>

--- a/app-common/src/main/res/values-pt/strings.xml
+++ b/app-common/src/main/res/values-pt/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Adicionar filtro</string>
     <string name="general_filter_remove_x_action">Remover filtro %s</string>
     <string name="general_filter_empty_row_hint">Toque em + para filtrar</string>
-    <string name="general_show_all_action">Mostrar tudo</string>
     <string name="general_result_success_message">Operação bem sucedida</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">Libertou %s. espaço.</item>

--- a/app-common/src/main/res/values-ro/strings.xml
+++ b/app-common/src/main/res/values-ro/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Adaugă filtru</string>
     <string name="general_filter_remove_x_action">Elimină filtrul %s</string>
     <string name="general_filter_empty_row_hint">Apasă + pentru a filtra</string>
-    <string name="general_show_all_action">Arată tot</string>
     <string name="general_result_success_message">Operațiune cu succes</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">S-a eliberat %s spațiu.</item>

--- a/app-common/src/main/res/values-ru/strings.xml
+++ b/app-common/src/main/res/values-ru/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Добавить фильтр</string>
     <string name="general_filter_remove_x_action">Удалить фильтр %s</string>
     <string name="general_filter_empty_row_hint">Нажмите + для фильтрации</string>
-    <string name="general_show_all_action">Показать все</string>
     <string name="general_result_success_message">Операция выполнена</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">Освобождено места: %s</item>

--- a/app-common/src/main/res/values-sc-rIT/strings.xml
+++ b/app-common/src/main/res/values-sc-rIT/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Agiungire filtru</string>
     <string name="general_filter_remove_x_action">Bogare %s filtru</string>
     <string name="general_filter_empty_row_hint">Tocca + pro filtrare</string>
-    <string name="general_show_all_action">Ammustrare totu</string>
     <string name="general_result_success_message">Operatzione cumpletada cun èsitu</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">Isberaiu %s ispàtziu.</item>

--- a/app-common/src/main/res/values-si-rLK/strings.xml
+++ b/app-common/src/main/res/values-si-rLK/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">පෙරහන එකතු කරන්න</string>
     <string name="general_filter_remove_x_action">%s පෙරහන ඉවත් කරන්න</string>
     <string name="general_filter_empty_row_hint">පෙරීම සඳහා + ස්පර්ශ කරන්න</string>
-    <string name="general_show_all_action">සියල්ල පෙන්වන්න</string>
     <string name="general_result_success_message">සාර්ථකව සම්පූර්ණ කළා</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">%s ඉඩ නිදහස් කළා.</item>

--- a/app-common/src/main/res/values-sk/strings.xml
+++ b/app-common/src/main/res/values-sk/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Pridať filter</string>
     <string name="general_filter_remove_x_action">Odstrániť filter %s</string>
     <string name="general_filter_empty_row_hint">Klepnite na + pre filtrovanie</string>
-    <string name="general_show_all_action">Zobraziť všetko</string>
     <string name="general_result_success_message">Operácia úspešná</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">Uvoľnila sa %s.</item>

--- a/app-common/src/main/res/values-sl/strings.xml
+++ b/app-common/src/main/res/values-sl/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Dodaj filter</string>
     <string name="general_filter_remove_x_action">Odstrani filter %s</string>
     <string name="general_filter_empty_row_hint">Tapnite + za filtriranje</string>
-    <string name="general_show_all_action">Prikaži vse</string>
     <string name="general_result_success_message">Opravilo je bilo uspešno.</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">Sproščenih je bilo %s.</item>

--- a/app-common/src/main/res/values-sq-rAL/strings.xml
+++ b/app-common/src/main/res/values-sq-rAL/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Shto filtër</string>
     <string name="general_filter_remove_x_action">Largoje filtrin %s</string>
     <string name="general_filter_empty_row_hint">Prek + për të filtruar</string>
-    <string name="general_show_all_action">Shfaq të gjitha</string>
     <string name="general_result_success_message">Operation successful</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">Çliroi %s hapësirë.</item>

--- a/app-common/src/main/res/values-sr/strings.xml
+++ b/app-common/src/main/res/values-sr/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Додај филтер</string>
     <string name="general_filter_remove_x_action">Уклони %s филтер</string>
     <string name="general_filter_empty_row_hint">Додирни + за филтрирање</string>
-    <string name="general_show_all_action">Прикажи све</string>
     <string name="general_result_success_message">Операција успешна</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">Ослобођен %s простор.</item>

--- a/app-common/src/main/res/values-sv/strings.xml
+++ b/app-common/src/main/res/values-sv/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Lägg till filter</string>
     <string name="general_filter_remove_x_action">Ta bort %s filter</string>
     <string name="general_filter_empty_row_hint">Tryck + för att filtrera</string>
-    <string name="general_show_all_action">Visa allt</string>
     <string name="general_result_success_message">Operationen lyckades</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">Frigjorde %s utrymme.</item>

--- a/app-common/src/main/res/values-sw/strings.xml
+++ b/app-common/src/main/res/values-sw/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Ongeza kichujio</string>
     <string name="general_filter_remove_x_action">Ondoa kichujio cha %s</string>
     <string name="general_filter_empty_row_hint">Gusa + ili kuchuja</string>
-    <string name="general_show_all_action">Onyesha vyote</string>
     <string name="general_result_success_message">Imekamilika kwa mafanikio</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">Nafasi ya %s imeachiliwa.</item>

--- a/app-common/src/main/res/values-ta-rIN/strings.xml
+++ b/app-common/src/main/res/values-ta-rIN/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">வடிப்பெடுப்பைச் சேர்க்கவும்</string>
     <string name="general_filter_remove_x_action">%s வடிப்பெடுப்பை அகற்றவும்</string>
     <string name="general_filter_empty_row_hint">வடிப்பெடுக்க + ஐ தட்டவும்</string>
-    <string name="general_show_all_action">அனைத்தையும் காட்டு</string>
     <string name="general_result_success_message">வெற்றிகரமாக முடிக்கப்பட்டது</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">%s இடம் விடுவிக்கப்பட்டது.</item>

--- a/app-common/src/main/res/values-te-rIN/strings.xml
+++ b/app-common/src/main/res/values-te-rIN/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">ఫిల్టర్ జోడించండి</string>
     <string name="general_filter_remove_x_action">%s ఫిల్టర్ను తీసివేయండి</string>
     <string name="general_filter_empty_row_hint">ఫిల్టర్ చేయడానికి + ను ట్యాప్ చేయండి</string>
-    <string name="general_show_all_action">అన్నిటినీ చూపించండి</string>
     <string name="general_result_success_message">విజయవంతంగా పూర్తయింది</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">%s స్థలం ఖాళీ చేయబడింది.</item>

--- a/app-common/src/main/res/values-th/strings.xml
+++ b/app-common/src/main/res/values-th/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">เพิ่มตัวกรอง</string>
     <string name="general_filter_remove_x_action">ลบตัวกรอง %s</string>
     <string name="general_filter_empty_row_hint">แตะ + เพื่อกรอง</string>
-    <string name="general_show_all_action">แสดงทั้งหมด</string>
     <string name="general_result_success_message">การดำเนินการสำเร็จ</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="other">ปลดปล่อยพื้นที่ %s</item>

--- a/app-common/src/main/res/values-tr/strings.xml
+++ b/app-common/src/main/res/values-tr/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Filtre ekle</string>
     <string name="general_filter_remove_x_action">%s filtresini kaldır</string>
     <string name="general_filter_empty_row_hint">Filtrelemek için + tuşuna dokunun</string>
-    <string name="general_show_all_action">Hepsini göster</string>
     <string name="general_result_success_message">İşlem başarılı</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">%s alan serbest bırakıldı.</item>

--- a/app-common/src/main/res/values-uk/strings.xml
+++ b/app-common/src/main/res/values-uk/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Додати фільтр</string>
     <string name="general_filter_remove_x_action">Видалити фільтр %s</string>
     <string name="general_filter_empty_row_hint">Натисніть + для фільтрування</string>
-    <string name="general_show_all_action">Показати все</string>
     <string name="general_result_success_message">Операція успішна</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">Звільніть %s місця.</item>

--- a/app-common/src/main/res/values-ur-rIN/strings.xml
+++ b/app-common/src/main/res/values-ur-rIN/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">فلٹر شامل کریں</string>
     <string name="general_filter_remove_x_action">%s فلٹر ہٹائیں</string>
     <string name="general_filter_empty_row_hint">فلٹر کرنے کے لیے + پر ٹیپ کریں</string>
-    <string name="general_show_all_action">سب دکھائیں</string>
     <string name="general_result_success_message">کامیابی سے مکمل</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">%s جگہ آزاد کی گئی۔</item>

--- a/app-common/src/main/res/values-uz/strings.xml
+++ b/app-common/src/main/res/values-uz/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Filtr qo\'shish</string>
     <string name="general_filter_remove_x_action">%s filtrini olib tashlash</string>
     <string name="general_filter_empty_row_hint">Filtrlash uchun + belgisini bosing</string>
-    <string name="general_show_all_action">Barchasini ko\'rsatish</string>
     <string name="general_result_success_message">Muvaffaqiyatli bajarildi</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">%s joy bo\'shatildi.</item>

--- a/app-common/src/main/res/values-vi/strings.xml
+++ b/app-common/src/main/res/values-vi/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Thêm bộ lọc</string>
     <string name="general_filter_remove_x_action">Xóa bộ lọc %s</string>
     <string name="general_filter_empty_row_hint">Nhấn + để lọc</string>
-    <string name="general_show_all_action">Hiển thị tất cả</string>
     <string name="general_result_success_message">Thao tác thành công</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="other">Đã giải phóng %s dung lượng.</item>

--- a/app-common/src/main/res/values-zh-rCN/strings.xml
+++ b/app-common/src/main/res/values-zh-rCN/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">添加过滤器</string>
     <string name="general_filter_remove_x_action">删除 %s 过滤器</string>
     <string name="general_filter_empty_row_hint">轻点 + 来筛选</string>
-    <string name="general_show_all_action">全部显示</string>
     <string name="general_result_success_message">操作成功</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="other">已释放 %s 空间。</item>

--- a/app-common/src/main/res/values-zh-rHK/strings.xml
+++ b/app-common/src/main/res/values-zh-rHK/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">新增過濾器</string>
     <string name="general_filter_remove_x_action">移除 %s 過濾器</string>
     <string name="general_filter_empty_row_hint">輕按 + 即可過濾</string>
-    <string name="general_show_all_action">全部顯示</string>
     <string name="general_result_success_message">作業成功</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="other">已釋放 %s 空間。</item>

--- a/app-common/src/main/res/values-zh-rTW/strings.xml
+++ b/app-common/src/main/res/values-zh-rTW/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">新增篩選</string>
     <string name="general_filter_remove_x_action">移除 %s 篩選</string>
     <string name="general_filter_empty_row_hint">點擊 + 來篩選</string>
-    <string name="general_show_all_action">全部顯示</string>
     <string name="general_result_success_message">作業成功</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="other">已釋放 %s 空間。</item>

--- a/app-common/src/main/res/values-zu/strings.xml
+++ b/app-common/src/main/res/values-zu/strings.xml
@@ -78,7 +78,6 @@
     <string name="general_filter_add_action">Engeza isifaka</string>
     <string name="general_filter_remove_x_action">Susa %s isifaka</string>
     <string name="general_filter_empty_row_hint">Thinta + ukuhlela</string>
-    <string name="general_show_all_action">Bonisa konke</string>
     <string name="general_result_success_message">Kuqedwe ngempumelelo</string>
     <plurals name="general_result_x_space_freed">
         <item quantity="one">Isikhala se-%s sikhululiwe.</item>

--- a/app-common/src/main/res/values/strings.xml
+++ b/app-common/src/main/res/values/strings.xml
@@ -79,7 +79,6 @@
     <string name="general_filter_add_action">Add filter</string>
     <string name="general_filter_remove_x_action">Remove %s filter</string>
     <string name="general_filter_empty_row_hint">Tap + to filter</string>
-    <string name="general_show_all_action">Show all</string>
 
     <string name="general_result_success_message">Operation successful</string>
     <plurals name="general_result_x_space_freed">
@@ -189,8 +188,8 @@
     <string name="general_error_report_bug_action">Report bug</string>
     <string name="general_error_ipc_deadobject_title">Service Connection Lost</string>
     <string name="general_error_ipc_deadobject_description">The connection to a critical service (e.g. Magisk, Shizuku, or other system-level services) was unexpectedly lost. Please reboot your device. If the issue persists, check for updates or reach out to me so I can fix it.</string>
-    <string name="general_error_upgrade_required_title">Pro version required</string>
-    <string name="general_error_upgrade_required_description">This is a Pro feature. Please upgrade SD Maid SE to use it.</string>
+    <string name="general_error_upgrade_required_title">Upgrade required</string>
+    <string name="general_error_upgrade_required_description">This feature requires an upgrade. Please upgrade SD Maid SE to use it.</string>
 
     <string name="general_user_label_owner">Owner</string>
     <string name="general_user_label_system">System</string>

--- a/app-tool-appcontrol/src/main/res/values-af-rZA/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-af-rZA/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Grootte</string>
     <string name="appcontrol_list_sortmode_screentime_label">Skerm tyd</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Toepassing groottes is geskat vir prestasie redes. Gebruik die StorageAnalyzer gereedskap vir meer akkurate data.</string>
-    <string name="appcontrol_list_filteroptions_label">Filter opsies</string>
     <string name="appcontrol_progress_uninstalling_app">Deïnstalleer toepassing</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d toepassing was gedeïnstalleer</item>

--- a/app-tool-appcontrol/src/main/res/values-am/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-am/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">መጠን</string>
     <string name="appcontrol_list_sortmode_screentime_label">የማያ ጊዜ</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">የመተግበሪያ መጠኖች ለአፈጻጸም ምክንያቶች ይገመታሉ። ለተጨማሪ ትክክለኛ ውሂብ StorageAnalyzer መሳሪያን ይጠቀሙ።</string>
-    <string name="appcontrol_list_filteroptions_label">የማጣሪያ አማራጮች</string>
     <string name="appcontrol_progress_uninstalling_app">መተግበሪያን በማጥፋት ላይ</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d መተግበሪያ ተጥፏል</item>

--- a/app-tool-appcontrol/src/main/res/values-ar/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-ar/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">الحجم</string>
     <string name="appcontrol_list_sortmode_screentime_label">وقت الشاشة</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">أحجام التطبيقات مقدرة لأسباب تتعلق بالأداء. استخدم أداة تحليل التخزين للحصول على بيانات أدق.</string>
-    <string name="appcontrol_list_filteroptions_label">خيارات المرشح</string>
     <string name="appcontrol_progress_uninstalling_app">إلغاء تثبيت التطبيق</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="zero">تم إلغاء تثبيت %d من التطبيقات</item>

--- a/app-tool-appcontrol/src/main/res/values-az/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-az/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Ölçü</string>
     <string name="appcontrol_list_sortmode_screentime_label">Ekran vaxtı</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Tətbiq ölçüləri performans səbəbləri üçün təxmin edilir. Daha dəqiq məlumat üçün StorageAnalyzer alətindən istifadə edin.</string>
-    <string name="appcontrol_list_filteroptions_label">Filter seçimləri</string>
     <string name="appcontrol_progress_uninstalling_app">Tətbiq silinir</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d tətbiq silindi</item>

--- a/app-tool-appcontrol/src/main/res/values-be/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-be/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Памер</string>
     <string name="appcontrol_list_sortmode_screentime_label">Час выкарыстання</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Памеры праграм ацэньваюцца паводле іх прадукцыйнасці. З дапамогай Аналізу сховішча атрымайце больш дакладныя даныя.</string>
-    <string name="appcontrol_list_filteroptions_label">Параметры фільтра</string>
     <string name="appcontrol_progress_uninstalling_app">Выдаленне праграмы</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">Выдалена %d праграма</item>

--- a/app-tool-appcontrol/src/main/res/values-bg/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-bg/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Размер</string>
     <string name="appcontrol_list_sortmode_screentime_label">Време на екрана</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Размерите на приложенията са приблизителни поради съображения за производителност. Използвайте инструмента StorageAnalyzer за по-точни данни.</string>
-    <string name="appcontrol_list_filteroptions_label">Опции за филтриране</string>
     <string name="appcontrol_progress_uninstalling_app">Деинсталиране на приложение</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d приложение беше деинсталирано</item>

--- a/app-tool-appcontrol/src/main/res/values-bn-rBD/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-bn-rBD/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">আকার</string>
     <string name="appcontrol_list_sortmode_screentime_label">স্ক্রিন সময়</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">অ্যাপ্লিকেশান আকার কর্মক্ষমতা কারণে অনুমান করা হয়. আরও সঠিক তথ্যের জন্য স্টোরেজ অ্যানালাইজার টুল ব্যবহার করুন।</string>
-    <string name="appcontrol_list_filteroptions_label">ফিল্টার অপশন</string>
     <string name="appcontrol_progress_uninstalling_app">অ্যাপ আনইনস্টল করা হচ্ছে</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d অ্যাপ আনইনস্টল করা হয়েছে</item>

--- a/app-tool-appcontrol/src/main/res/values-ca/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-ca/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Mida</string>
     <string name="appcontrol_list_sortmode_screentime_label">Temps de pantalla</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Les mides de les aplicacions s\'estimen per raons de rendiment. Utilitzeu l\'eina Analitzador d\'emmagatzematge per obtenir dades més precises.</string>
-    <string name="appcontrol_list_filteroptions_label">Opcions de filtre</string>
     <string name="appcontrol_progress_uninstalling_app">Desinstal·lant l\'aplicació</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">S\'ha desinstal·lat %d aplicació</item>

--- a/app-tool-appcontrol/src/main/res/values-ckb-rIR/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-ckb-rIR/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">قەبارە</string>
     <string name="appcontrol_list_sortmode_screentime_label">کاتی شاشە</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">ئەپ sizes are estimated for performance reasons. Use the ناحیەکانAnalyzer tool for more accurate data.</string>
-    <string name="appcontrol_list_filteroptions_label">پاڵاوتن options</string>
     <string name="appcontrol_progress_uninstalling_app">لابردنی دامەزراندنing app</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d ئەپ لادرایەوە</item>

--- a/app-tool-appcontrol/src/main/res/values-cs/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-cs/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Velikost</string>
     <string name="appcontrol_list_sortmode_screentime_label">Čas u obrazovky</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Velikosti aplikací jsou z výkonnostních důvodů odhadovány. Pro přesnější údaje použijte Analyzátor úložiště.</string>
-    <string name="appcontrol_list_filteroptions_label">Možnosti filtrování</string>
     <string name="appcontrol_progress_uninstalling_app">Odinstalování aplikace</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d aplikace byla odinstalována</item>

--- a/app-tool-appcontrol/src/main/res/values-da/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-da/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Størrelse</string>
     <string name="appcontrol_list_sortmode_screentime_label">Skærmtid</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Appstørrelser er anslået af hensyn til ydeevnen. Brug værktøjet Lageranalyse for mere præcise data.</string>
-    <string name="appcontrol_list_filteroptions_label">Filtreringsmuligheder</string>
     <string name="appcontrol_progress_uninstalling_app">Afinstallerer app</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d app blev afinstalleret</item>

--- a/app-tool-appcontrol/src/main/res/values-de/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-de/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Größe</string>
     <string name="appcontrol_list_sortmode_screentime_label">Bildschirmzeit</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">App-Größen werden aus Leistungsgründen geschätzt. Verwende das Storage Analysator-Tool für genauere Daten.</string>
-    <string name="appcontrol_list_filteroptions_label">Filteroptionen</string>
     <string name="appcontrol_progress_uninstalling_app">Deinstalliert App</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d App wurde deinstalliert</item>

--- a/app-tool-appcontrol/src/main/res/values-el/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-el/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Μέγεθος</string>
     <string name="appcontrol_list_sortmode_screentime_label">Χρόνος χρήσης οθόνης</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Τα μεγέθη των εφαρμογών εκτιμώνται για λόγους απόδοσης. Χρησιμοποιήστε το εργαλείο Αναλυτής Αποθηκευτικού Χώρου για πιο ακριβή δεδομένα.</string>
-    <string name="appcontrol_list_filteroptions_label">Επιλογές φίλτρου</string>
     <string name="appcontrol_progress_uninstalling_app">Απεγκατάσταση εφαρμογής</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d εφαρμογή απεγκαταστάθηκε</item>

--- a/app-tool-appcontrol/src/main/res/values-es-rAR/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-es-rAR/strings.xml
@@ -44,7 +44,6 @@ Archivo: Textos de la aplicación (aplicación principal)</string>
     <string name="appcontrol_list_sortmode_size_label">Tamaño</string>
     <string name="appcontrol_list_sortmode_screentime_label">Tiempo de pantalla</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Los tamaños de las aplicaciones se estiman por motivos de rendimiento. Utilice la herramienta StorageAnalyzer para obtener datos más precisos.</string>
-    <string name="appcontrol_list_filteroptions_label">Opciones del filtro</string>
     <string name="appcontrol_progress_uninstalling_app">Desinstalando aplicación</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d aplicación fue desinstalada</item>

--- a/app-tool-appcontrol/src/main/res/values-es-rMX/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-es-rMX/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Tamaño</string>
     <string name="appcontrol_list_sortmode_screentime_label">Tiempo de pantalla</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Los tamaños de las aplicaciones son estimados por razones de rendimiento. Usa la herramienta Analizador de Almacenamiento para datos más precisos.</string>
-    <string name="appcontrol_list_filteroptions_label">Opciones de filtro</string>
     <string name="appcontrol_progress_uninstalling_app">Desinstalando aplicación</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d aplicación fue desinstalada</item>

--- a/app-tool-appcontrol/src/main/res/values-es/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-es/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Tamaño</string>
     <string name="appcontrol_list_sortmode_screentime_label">Tiempo de pantalla</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Los tamaños de las aplicaciones se estiman por motivos de rendimiento. Utilice la herramienta StorageAnalyzer para obtener datos más precisos.</string>
-    <string name="appcontrol_list_filteroptions_label">Opciones de filtrado</string>
     <string name="appcontrol_progress_uninstalling_app">Desinstalar la aplicación</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d aplicación desinstalada</item>

--- a/app-tool-appcontrol/src/main/res/values-et-rEE/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-et-rEE/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Maht</string>
     <string name="appcontrol_list_sortmode_screentime_label">Ekraaniaeg</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Rakenduse mahtu uuritakse jõudluse eesmärkidel. Täpsemad andmed saad hoiustamisruumi analüüsijaga.</string>
-    <string name="appcontrol_list_filteroptions_label">Filtri valikud</string>
     <string name="appcontrol_progress_uninstalling_app">Rakenduse eemaldamine</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d rakendus eemaldati</item>

--- a/app-tool-appcontrol/src/main/res/values-eu-rES/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-eu-rES/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Tamaina</string>
     <string name="appcontrol_list_sortmode_screentime_label">Pantaila-denbora</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Aplikazioen tamainak estimatuta daude errendimendu arrazoengatik. Erabili StorageAnalyzer tresna datu zehatzagoak lortzeko.</string>
-    <string name="appcontrol_list_filteroptions_label">Iragazki-aukerak</string>
     <string name="appcontrol_progress_uninstalling_app">Aplikazioa desinstalatzend</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d aplikazio desinstalatu da</item>

--- a/app-tool-appcontrol/src/main/res/values-fa/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-fa/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">اندازه‌</string>
     <string name="appcontrol_list_sortmode_screentime_label">مدت زمان نمایش</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">اندازه‌های برنامه به دلایل عملکردی تخمین زده می‌شوند. از ابزار آنالیز حافظه برای داده‌های دقیق‌تر استفاده کنید.</string>
-    <string name="appcontrol_list_filteroptions_label">گزینه‌های فیلتر</string>
     <string name="appcontrol_progress_uninstalling_app">حذف کردن برنامه</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d برنامه حذف نصب شد</item>

--- a/app-tool-appcontrol/src/main/res/values-fi/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-fi/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Koko</string>
     <string name="appcontrol_list_sortmode_screentime_label">Näyttöaika</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Sovelluskoot ovat arvioita suorituskyvyn vuoksi. Käytä Tallennustilan analysaattoria tarkempien tietojen saamiseksi.</string>
-    <string name="appcontrol_list_filteroptions_label">Suodatusasetukset</string>
     <string name="appcontrol_progress_uninstalling_app">Poistetaan sovelluksen asennus</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d sovellus poistettiin</item>

--- a/app-tool-appcontrol/src/main/res/values-fil/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-fil/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Laki</string>
     <string name="appcontrol_list_sortmode_screentime_label">Oras sa screen</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Ang mga laki ng app ay tinantya para sa performance. Gamitin ang StorageAnalyzer tool para sa mas tumpak na data.</string>
-    <string name="appcontrol_list_filteroptions_label">Mga filter option</string>
     <string name="appcontrol_progress_uninstalling_app">Inu-uninstall ang app</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d app ang na-uninstall</item>

--- a/app-tool-appcontrol/src/main/res/values-fr/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-fr/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Taille</string>
     <string name="appcontrol_list_sortmode_screentime_label">Temps d’écran</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">La taille des applis est estimée pour des raisons de performance. Utilisez l’Analyseur de mémoire pour obtenir des données plus justes.</string>
-    <string name="appcontrol_list_filteroptions_label">Options de filtrage</string>
     <string name="appcontrol_progress_uninstalling_app">Désinstallation de l’appli</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d appli a été désinstallée</item>

--- a/app-tool-appcontrol/src/main/res/values-gl-rES/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-gl-rES/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Tamaño</string>
     <string name="appcontrol_list_sortmode_screentime_label">Tempo de pantalla</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Os tamaños das aplicacións estímanse por razóns de rendemento. Use a ferramenta StorageAnalyzer para obter datos máis precisos.</string>
-    <string name="appcontrol_list_filteroptions_label">Opcións de filtro</string>
     <string name="appcontrol_progress_uninstalling_app">Desinstalando aplicación</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d aplicación foi desinstalada</item>

--- a/app-tool-appcontrol/src/main/res/values-hi-rIN/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-hi-rIN/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">आकार</string>
     <string name="appcontrol_list_sortmode_screentime_label">स्क्रीन समय</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">आकार की जानकारी उपलब्ध नहीं है।</string>
-    <string name="appcontrol_list_filteroptions_label">फ़िल्टर विकल्प</string>
     <string name="appcontrol_progress_uninstalling_app">ऐप्लिकेशन अनइंस्टॉल किया जा रहा है</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d ऐप अनइंस्टॉल किया गया</item>

--- a/app-tool-appcontrol/src/main/res/values-hr/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-hr/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Veličina</string>
     <string name="appcontrol_list_sortmode_screentime_label">Vrijeme upotrebe</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Veličine aplikacija su procijenjene radi boljih performansi. Za točnije podatke koristite alat Analizator pohrane.</string>
-    <string name="appcontrol_list_filteroptions_label">Opcije filtera</string>
     <string name="appcontrol_progress_uninstalling_app">Deinstaliranje aplikacije</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d aplikacija je deinstalirana</item>

--- a/app-tool-appcontrol/src/main/res/values-hu/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-hu/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Méret</string>
     <string name="appcontrol_list_sortmode_screentime_label">Képernyőidő</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Az alkalmazások mérete teljesítményi okokból becsült. Pontosabb adatokért használja a StorageAnalyzer eszközt.</string>
-    <string name="appcontrol_list_filteroptions_label">Szűrési lehetőségek</string>
     <string name="appcontrol_progress_uninstalling_app">App eltávolítása...</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d alkalmazás eltávolításra került</item>

--- a/app-tool-appcontrol/src/main/res/values-in/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-in/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Ukuran</string>
     <string name="appcontrol_list_sortmode_screentime_label">Waktu layar</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Ukuran aplikasi diperkirakan untuk alasan kinerja. Gunakan alat StorageAnalyzer untuk data yang lebih akurat.</string>
-    <string name="appcontrol_list_filteroptions_label">Pilihan filter</string>
     <string name="appcontrol_progress_uninstalling_app">Mencopot aplikasi</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="other">%d aplikasi dihapus</item>

--- a/app-tool-appcontrol/src/main/res/values-is/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-is/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Stærð</string>
     <string name="appcontrol_list_sortmode_screentime_label">Skjátími</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Stærðir forrita eru áætlaðar af afkastasökum. Notaðu StorageAnalyzer verkfærið fyrir nákvæmari gögn.</string>
-    <string name="appcontrol_list_filteroptions_label">Síuvalkostir</string>
     <string name="appcontrol_progress_uninstalling_app">Fjarlægi forrit</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d forrit var fjarlægt</item>

--- a/app-tool-appcontrol/src/main/res/values-it/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-it/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Dimensione</string>
     <string name="appcontrol_list_sortmode_screentime_label">Tempo schermo</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Le dimensioni delle app sono stimate per ragioni di prestazioni. Utilizzare lo StorageAnalyzer per dati più accurati.</string>
-    <string name="appcontrol_list_filteroptions_label">Opzioni filtro</string>
     <string name="appcontrol_progress_uninstalling_app">Rimozione app</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d app è stata disinstallata</item>

--- a/app-tool-appcontrol/src/main/res/values-iw/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-iw/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">גודל</string>
     <string name="appcontrol_list_sortmode_screentime_label">זמן מסך</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">גדלי האפליקציות משוערים מסיבות של ביצועים. השתמש בכלי מנתח אחסון לקבלת נתונים מדויקים יותר.</string>
-    <string name="appcontrol_list_filteroptions_label">אפשרויות סינון</string>
     <string name="appcontrol_progress_uninstalling_app">מסיר התקנה של אפליקציה</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">אפליקציה %d הוסרה</item>

--- a/app-tool-appcontrol/src/main/res/values-ja/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-ja/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">サイズ</string>
     <string name="appcontrol_list_sortmode_screentime_label">スクリーンタイム</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">パフォーマンス上の理由からアプリのサイズが推定されます。より正確なデータを取得するには、StorageAnalyzerツールを使用してください。</string>
-    <string name="appcontrol_list_filteroptions_label">フィルタオプション</string>
     <string name="appcontrol_progress_uninstalling_app">アプリのアンインストール中</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="other">%d個のアプリをアンインストールしました</item>

--- a/app-tool-appcontrol/src/main/res/values-ka-rGE/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-ka-rGE/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">ზომა</string>
     <string name="appcontrol_list_sortmode_screentime_label">ეკრანის დრო</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">აპების ზომები შეფასებულია წარმადობის მიზნებისთვის. გამოიყენეთ StorageAnalyzer ხელსაწყო უფრო ზუსტი მონაცემებისთვის.</string>
-    <string name="appcontrol_list_filteroptions_label">ფილტრის ოფციები</string>
     <string name="appcontrol_progress_uninstalling_app">აპის წაშლა</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d აპი წაშლილია</item>

--- a/app-tool-appcontrol/src/main/res/values-kaa/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-kaa/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Kólemi</string>
     <string name="appcontrol_list_sortmode_screentime_label">Ekran waqtı</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Qosímsha kólemleri ónimdilik maqsetinde shamamen esaplanǵan. Anıǵıraq maǵlıwmatlar ushın StorageAnalyzer quralın paydalanıń.</string>
-    <string name="appcontrol_list_filteroptions_label">Súzgiw opsiyaları</string>
     <string name="appcontrol_progress_uninstalling_app">Qosímsha óshiriliw</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d ilova o’chirildı</item>

--- a/app-tool-appcontrol/src/main/res/values-km-rKH/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-km-rKH/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">ទំហំ</string>
     <string name="appcontrol_list_sortmode_screentime_label">សម្អែវេលាស្វើសហន្តៀឧបករណ៍</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">ទំហំកម្មវិធីត្រូវបានប័តិម្ឡ័លសម្រាប់លក្ខណៈសម្វ័ង។ ប្រើបរស់ឡាឡ់ StorageAnalyzer សម្រាប់តិន្នន័យផ័ត់ពិតជាង។</string>
-    <string name="appcontrol_list_filteroptions_label">ជម្រើសប័ន្ទ័វរង់</string>
     <string name="appcontrol_progress_uninstalling_app">កំពុងដកតិត្តាក់កម្មវិធី</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="other">%d កម្មវិធីត្រូវបានដកតិត្តាក់</item>

--- a/app-tool-appcontrol/src/main/res/values-ko/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-ko/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">크기</string>
     <string name="appcontrol_list_sortmode_screentime_label">화면 시간</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">앱 크기는 성능상의 이유로 추정된 것입니다. 보다 정확한 데이터를 확인하려면 StorageAnalyzer tool을 사용하세요.</string>
-    <string name="appcontrol_list_filteroptions_label">필터 설정</string>
     <string name="appcontrol_progress_uninstalling_app">앱 제거하기</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="other">%d 앱을 제거했습니다.</item>

--- a/app-tool-appcontrol/src/main/res/values-lo-rLA/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-lo-rLA/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">ຂນາດ</string>
     <string name="appcontrol_list_sortmode_screentime_label">ເວລາໃຊ້ຫນ້າຈອ</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">ຂນາດແອບຖືກປະເມີນເພື່ອເຫດຜອງດ້ານປະສິທຘິພາບ. ໃຊ້ໂຄຣງການ StorageAnalyzer ສຳຫລັບຂ້ອມູນທີ່ຖືກຕ້ອງກວ່າ.</string>
-    <string name="appcontrol_list_filteroptions_label">ຕັວເລືອກການການຕອງການ</string>
     <string name="appcontrol_progress_uninstalling_app">ກຳລັງຖອນຕິດຕັ້ງແອບ</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="other">ຖອນຕິດຕັ້ງ %d ແອບແລ້ວ</item>

--- a/app-tool-appcontrol/src/main/res/values-lt/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-lt/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Dydis</string>
     <string name="appcontrol_list_sortmode_screentime_label">Ekrano laikas</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Programų dyžių sąmatos yra apytikslės dėl našumo priežasių. Naudokite įrankio Atminties analizatorius tikslesniems duomenims.</string>
-    <string name="appcontrol_list_filteroptions_label">Filtravimo parinktys</string>
     <string name="appcontrol_progress_uninstalling_app">Pašalinama programa</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d programa buvo pašalinta</item>

--- a/app-tool-appcontrol/src/main/res/values-lv/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-lv/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Izmērs</string>
     <string name="appcontrol_list_sortmode_screentime_label">Ekrāna laiks</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Lietotniņu izmēri tiek aptuveni apreksināti veiktspējas iemeslu dēļ. Izmantojiet StorageAnalyzer rīku precizākiem datiem.</string>
-    <string name="appcontrol_list_filteroptions_label">Filtrēšanas opcijas</string>
     <string name="appcontrol_progress_uninstalling_app">Lietotnes atinstalēšana</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="zero">%d lietotnes tika atinstalētas</item>

--- a/app-tool-appcontrol/src/main/res/values-mk-rMK/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-mk-rMK/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Големина</string>
     <string name="appcontrol_list_sortmode_screentime_label">Време на екран</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Големините на апликациите се проценети заради перформанси. Користете ја алатката StorageAnalyzer за попрецизни податоци.</string>
-    <string name="appcontrol_list_filteroptions_label">Опции за филтрирање</string>
     <string name="appcontrol_progress_uninstalling_app">Деинсталирање апликација</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d апликација е деинсталирана</item>

--- a/app-tool-appcontrol/src/main/res/values-ml-rIN/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-ml-rIN/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">വലിപ്പം</string>
     <string name="appcontrol_list_sortmode_screentime_label">സ്ക്രീൻ സമയം</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">ആപ്പ് വലിപ്പങ്ങൾ പ്രകടനകാരണങ്ങൾക്കായി കണക്കാക്കല്പിക്കപ്പെടുന്നു. കൂടുതൽ കൃത്യമായ ഡേറ്റക്കായി StorageAnalyzer ടൂൾ ഉപയോഗിക്കുക.</string>
-    <string name="appcontrol_list_filteroptions_label">ഫിൽടർ ഓപ്ഷൻസ്</string>
     <string name="appcontrol_progress_uninstalling_app">ആപ്പ് അൻ ഇൻസ്റ്റാൾ ചെയ്യുന്നു</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d ആപ്പ് അൻഇൻസ്റ്റാൾ ചെയ്തു</item>

--- a/app-tool-appcontrol/src/main/res/values-mn-rMN/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-mn-rMN/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Хэмжээ</string>
     <string name="appcontrol_list_sortmode_screentime_label">Дэлгэцийн цаг</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Гүйцэтгийн шалтгаараас аппын хэмжээг төсөөлдөж тооцолдого. Илүү нарийн өгөгдөлд StorageAnalyzer багажийг ашигла.</string>
-    <string name="appcontrol_list_filteroptions_label">Шүүгах сонгоо</string>
     <string name="appcontrol_progress_uninstalling_app">Аппыг устгаж байна</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d апп устгагдсан</item>

--- a/app-tool-appcontrol/src/main/res/values-ms/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-ms/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Saiz</string>
     <string name="appcontrol_list_sortmode_screentime_label">Masa skrin</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Penyusunan mengikut saiz mungkin perlahan pada sesetengah peranti</string>
-    <string name="appcontrol_list_filteroptions_label">Pilihan penapis</string>
     <string name="appcontrol_progress_uninstalling_app">Menyahpasang aplikasi</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="other">%d aplikasi telah dinyahpasang</item>

--- a/app-tool-appcontrol/src/main/res/values-my-rMM/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-my-rMM/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">အရွယ်အစား</string>
     <string name="appcontrol_list_sortmode_screentime_label">စကᒰမှအပြပ်ချသောအချား</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">အကြေးအရွယ်အစားများကို စကင်ᄀောင်းသော ခန့်မှန်းပြမည့်တွက်များသာမှု ခန့်မှန်းပြမည့်တွက်များသည်။ ပိုအနက်အခြေအနေရာအတွက် အသုံး StorageAnalyzer ကြေးဆိုင်တွဲကို အသုံးချသည်။</string>
-    <string name="appcontrol_list_filteroptions_label">ဆပ်ရှားများ</string>
     <string name="appcontrol_progress_uninstalling_app">အကြေးကို ဖက်ချတစ်ချနေစ်သည်</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="other">%d အကြေး ဖက်ချတစ်ချပြီးသည်</item>

--- a/app-tool-appcontrol/src/main/res/values-nb/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-nb/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Størrelse</string>
     <string name="appcontrol_list_sortmode_screentime_label">Skjermtid</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">App-størrelser er estimert av ytelsesgrunner. Bruk Lagringsanalysator-verktøyet for mer nøyaktig data.</string>
-    <string name="appcontrol_list_filteroptions_label">Alternativer for filter</string>
     <string name="appcontrol_progress_uninstalling_app">Avinstallerer app</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d app ble avinstallert</item>

--- a/app-tool-appcontrol/src/main/res/values-ne-rNP/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-ne-rNP/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">साइज</string>
     <string name="appcontrol_list_sortmode_screentime_label">स्क्रिन समय</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">प्रदर्शन कारणहरूले गर्दा App साइजहरू अनुमानित छन्। थप सटीक डेटाका लागि StorageAnalyzer उपकरण प्रयोग गर्नुहोस्।</string>
-    <string name="appcontrol_list_filteroptions_label">फिल्टर विकल्पहरू</string>
     <string name="appcontrol_progress_uninstalling_app">App हटाउँदै</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d अनुप्रयोग अनइन्स्टल गरियो</item>

--- a/app-tool-appcontrol/src/main/res/values-nl/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-nl/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Grootte</string>
     <string name="appcontrol_list_sortmode_screentime_label">Schermtijd</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">App-grootes worden geschat om prestatieredenen. Gebruik de StorageAnalyzer-tool voor nauwkeurigere gegevens.</string>
-    <string name="appcontrol_list_filteroptions_label">Filter opties</string>
     <string name="appcontrol_progress_uninstalling_app">App verwijderen</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d app werd verwijderd</item>

--- a/app-tool-appcontrol/src/main/res/values-or-rIN/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-or-rIN/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">ଆକାର</string>
     <string name="appcontrol_list_sortmode_screentime_label">ସ୍କ୍ରିନ୍ ସମୟ</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">କାର୍ଯ୍ୟକ୍ଷମତା କାରଣରୁ ଆପ୍ ଆକାରଗୁଡ଼ିକ ଆନୁମାନିକ। ଅଧିକ ସଠିକ ଡାଟା ପାଇଁ StorageAnalyzer ଟୁଲ୍ ବ୍ୟବହାର କରନ୍ତୁ।</string>
-    <string name="appcontrol_list_filteroptions_label">ଫିଲ୍ଟର ବିକଳ୍ପଗୁଡ଼ିକ</string>
     <string name="appcontrol_progress_uninstalling_app">ଆପ୍ ଅନଇନଷ୍ଟଲ କରୁଛି</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d ଆପ୍ ଅନଇନଷ୍ଟଲ୍ ହୋଇଛି</item>

--- a/app-tool-appcontrol/src/main/res/values-pa-rIN/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-pa-rIN/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">ਆਕਾਰ</string>
     <string name="appcontrol_list_sortmode_screentime_label">ਸਕ੍ਰੀਨ ਸਮਾਂ</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">ਕਾਰਗੁਜ਼ਾਰੀ ਕਾਰਨਾਂ ਕਰਕੇ ਐਪ ਦੇ ਆਕਾਰ ਦਾ ਅੰਦਾਜ਼ਾ ਲਗਾਇਆ ਜਾਂਦਾ ਹੈ। ਵਧੇਰੇ ਸਟੀਕ ਡਾਟਾ ਲਈ StorageAnalyzer ਟੂਲ ਵਰਤੋ।</string>
-    <string name="appcontrol_list_filteroptions_label">ਫਿਲਟਰ ਵਿਕਲਪ</string>
     <string name="appcontrol_progress_uninstalling_app">ਐਪ ਨੂੰ ਅਣਸਥਾਪਿਤ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d ਐਪ ਅਣਸਥਾਪਿਤ ਕੀਤੀ ਗਈ</item>

--- a/app-tool-appcontrol/src/main/res/values-pl/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-pl/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Rozmiar</string>
     <string name="appcontrol_list_sortmode_screentime_label">Czas przed ekranem</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Rozmiary aplikacji są szacowane ze względu na wydajność. Aby uzyskać dokładniejsze dane, użyj narzędzia Analizowanie pamięci.</string>
-    <string name="appcontrol_list_filteroptions_label">Opcje filtrowania</string>
     <string name="appcontrol_progress_uninstalling_app">Odinstalowywanie aplikacji</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">Odinstalowano %d aplikację</item>

--- a/app-tool-appcontrol/src/main/res/values-pt-rBR/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-pt-rBR/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Tamanho</string>
     <string name="appcontrol_list_sortmode_screentime_label">Tempo da tela</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Os tamanhos de apps são estimados por razões de desempenho. Use a ferramenta Analisador de Armazenamento para dados mais precisos.</string>
-    <string name="appcontrol_list_filteroptions_label">Opções de filtro</string>
     <string name="appcontrol_progress_uninstalling_app">Desinstalar aplicativo</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d aplicativo desinstalado com sucesso</item>

--- a/app-tool-appcontrol/src/main/res/values-pt/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-pt/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Tamanho</string>
     <string name="appcontrol_list_sortmode_screentime_label">Tempo de Ecrã Ligado</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Tamanhos das apps são estimados pelo desempenho. Use a ferramenta de Análise de Armazenamento para dados mais precisos.</string>
-    <string name="appcontrol_list_filteroptions_label">Opções de filtro</string>
     <string name="appcontrol_progress_uninstalling_app">Desinstalando a aplicação</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">Uma aplicação foi desinstalada</item>

--- a/app-tool-appcontrol/src/main/res/values-ro/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-ro/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Dimensiune</string>
     <string name="appcontrol_list_sortmode_screentime_label">Timp ecran pornit</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Dimensiunile aplicației sunt estimate din motive de performanță. Utilizați unealta de analiză a stocării pentru date mai exacte.</string>
-    <string name="appcontrol_list_filteroptions_label">Opțiuni pentru filtre</string>
     <string name="appcontrol_progress_uninstalling_app">Dezinstalare aplicație</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d aplicație a fost dezinstalată</item>

--- a/app-tool-appcontrol/src/main/res/values-ru/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-ru/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Размер</string>
     <string name="appcontrol_list_sortmode_screentime_label">Время экрана</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Размеры приложений оцениваются для анализа производительности. Используйте инструмент Анализ памяти для получения более точных данных.</string>
-    <string name="appcontrol_list_filteroptions_label">Параметры фильтра</string>
     <string name="appcontrol_progress_uninstalling_app">Удаление приложения</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">Удалено приложений: %d</item>

--- a/app-tool-appcontrol/src/main/res/values-sc-rIT/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-sc-rIT/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Mannària</string>
     <string name="appcontrol_list_sortmode_screentime_label">Tempus de ischermada</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Is mannarias de aplicatziones sunt istimadas pro raxones de rendimentu. Imprea s\'aina StorageAnalyzer pro datos prus curatos.</string>
-    <string name="appcontrol_list_filteroptions_label">Optziones de filtru</string>
     <string name="appcontrol_progress_uninstalling_app">Disinstallende aplicatzione</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d aplicatzione fiat disinstallada</item>

--- a/app-tool-appcontrol/src/main/res/values-si-rLK/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-si-rLK/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">ප්‍රමාණය</string>
     <string name="appcontrol_list_sortmode_screentime_label">තිර කාලය</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">කාර්යක්ෂමතා හේතුවෙන් යෙදුම් ප්‍රමාණ අනුමාන කර ඇත. වැඩා නිවැරදි දත්ත සඳහා StorageAnalyzer මෙවලම භාවිතා කරන්න.</string>
-    <string name="appcontrol_list_filteroptions_label">පෙරණ විකල්ප</string>
     <string name="appcontrol_progress_uninstalling_app">යෙදුම ඉවත් කරමින්</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d යෙදුමක් ඉවත් කරන ලදී</item>

--- a/app-tool-appcontrol/src/main/res/values-sk/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-sk/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Veľkosť</string>
     <string name="appcontrol_list_sortmode_screentime_label">Čas obrazovky</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Veľkosti aplikácií sú odhadované z dôvodu výkonu. Pre presnejšie údaje použite nástroj Analyzátor úložiska.</string>
-    <string name="appcontrol_list_filteroptions_label">Možnosti filtrovania</string>
     <string name="appcontrol_progress_uninstalling_app">Odinštaluje sa</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d aplikácia bola odinštalovaná</item>

--- a/app-tool-appcontrol/src/main/res/values-sl/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-sl/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Velikost</string>
     <string name="appcontrol_list_sortmode_screentime_label">Čas zaslona</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Velikosti programov se določajo zaradi zmogljivosti.  Za natančnejše podatke uporabite Analizatorja shrambe.</string>
-    <string name="appcontrol_list_filteroptions_label">Možnosti filtra</string>
     <string name="appcontrol_progress_uninstalling_app">Odstranjevanje programa</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d program je bil odstranjen.</item>

--- a/app-tool-appcontrol/src/main/res/values-sq-rAL/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-sq-rAL/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Madhësia</string>
     <string name="appcontrol_list_sortmode_screentime_label">Koha e ekranit</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Madhësitë e aplikacioneve vlerësohen për arsye të performancës. Përdorni mjetin StorageAnalyzer për të dhëna më të sakta.</string>
-    <string name="appcontrol_list_filteroptions_label">Opsionet e filtrit</string>
     <string name="appcontrol_progress_uninstalling_app">Po çinstalon aplikacionin</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d aplikacion u çinstalua</item>

--- a/app-tool-appcontrol/src/main/res/values-sr/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-sr/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Величина</string>
     <string name="appcontrol_list_sortmode_screentime_label">Време на екрану</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Величине апликација су процењене из разлога перформанси. Користите алат StorageAnalyzer за прецизније податке.</string>
-    <string name="appcontrol_list_filteroptions_label">Опције филтера</string>
     <string name="appcontrol_progress_uninstalling_app">Деинсталирање апликације</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d апликација је деинсталирана</item>

--- a/app-tool-appcontrol/src/main/res/values-sv/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-sv/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Storlek</string>
     <string name="appcontrol_list_sortmode_screentime_label">Skärmtid</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Appstorlekar är uppskattade av prestandaskäl. Använd StorageAnalyzer-verktyget för mer exakta data.</string>
-    <string name="appcontrol_list_filteroptions_label">Filteralternativ</string>
     <string name="appcontrol_progress_uninstalling_app">Avinstallerar app</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d app avinstallerades</item>

--- a/app-tool-appcontrol/src/main/res/values-sw/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-sw/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Ukubwa</string>
     <string name="appcontrol_list_sortmode_screentime_label">Muda wa skrini</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Ukubwa wa programu unakadirika kwa sababu za utendaji. Tumia zana ya StorageAnalyzer kwa data sahihi zaidi.</string>
-    <string name="appcontrol_list_filteroptions_label">Chaguo za kichungi</string>
     <string name="appcontrol_progress_uninstalling_app">Inaondoa programu</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">Programu %d imeondolewa</item>

--- a/app-tool-appcontrol/src/main/res/values-ta-rIN/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-ta-rIN/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">அளவு</string>
     <string name="appcontrol_list_sortmode_screentime_label">திரை நேரம்</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">செயல்திறன் காரணங்களால் பயன்பாட்டு அளவுகள் அனுமானிக்கப்பட்டுள்ளன. மிகவும் தரவிற்கான StorageAnalyzer கருவியைப் பயன்படுத்தவும்.</string>
-    <string name="appcontrol_list_filteroptions_label">வடிகட்டல் விருப்பங்கள்</string>
     <string name="appcontrol_progress_uninstalling_app">பயன்பாடை அன்இன்ஸ்டால் செய்கிறது</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d பயன்பாடு அன்இன்ஸ்டால் செய்யப்பட்டது</item>

--- a/app-tool-appcontrol/src/main/res/values-te-rIN/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-te-rIN/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">పరిమాణం</string>
     <string name="appcontrol_list_sortmode_screentime_label">స్క్రీన్ సమయం</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">యాప్ పరిమాణాలు పరఫార్మెన్స్ కారణాల అందాజులు. మరింత ఖుదాయిన డేటా కోసం StorageAnalyzer టూల్‌ను ఉపయోగించండి.</string>
-    <string name="appcontrol_list_filteroptions_label">ఫిల్టర్ ఎంపికలు</string>
     <string name="appcontrol_progress_uninstalling_app">యాప్‌ను అనిన్‌స్టాల్ చేస్తోంది</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d యాప్ అనిన్‌స్టాల్ చేయబడింది</item>

--- a/app-tool-appcontrol/src/main/res/values-th/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-th/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">ขนาด</string>
     <string name="appcontrol_list_sortmode_screentime_label">เวลาใช้งานหน้าจอ</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">ขนาดแอพเป็นการประมาณเพื่อประสิทธิภาพการทำงาน ใช้เครื่องมือ StorageAnalyzer สำหรับข้อมูลที่แม่นยำกว่า</string>
-    <string name="appcontrol_list_filteroptions_label">ตัวเลือกการกรอง</string>
     <string name="appcontrol_progress_uninstalling_app">กำลังถอนการติดตั้งแอพ</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="other">ถอนการติดตั้งแอพ %d แอพแล้ว</item>

--- a/app-tool-appcontrol/src/main/res/values-tr/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-tr/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Boyut</string>
     <string name="appcontrol_list_sortmode_screentime_label">Ekran süresi</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Uygulama boyutları performans nedeniyle tahmini olarak verilmiştir. Daha doğru veriler için StorageAnalyzer aracını kullanın.</string>
-    <string name="appcontrol_list_filteroptions_label">Filtre seçenekleri</string>
     <string name="appcontrol_progress_uninstalling_app">Uygulama kaldırılıyor</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d uygulama kaldırıldı</item>

--- a/app-tool-appcontrol/src/main/res/values-uk/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-uk/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Розмір</string>
     <string name="appcontrol_list_sortmode_screentime_label">Екранний час</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Розміри додатків оцінюються з міркувань продуктивності. Використовуйте інструмент Аналізатор сховища для отримання більш точних даних.</string>
-    <string name="appcontrol_list_filteroptions_label">Параметри фільтрування</string>
     <string name="appcontrol_progress_uninstalling_app">Видалення додатка</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d додаток було видалено</item>

--- a/app-tool-appcontrol/src/main/res/values-ur-rIN/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-ur-rIN/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">سائز</string>
     <string name="appcontrol_list_sortmode_screentime_label">سکرین ٹائم</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">ایپ کے سائز کارکردگی کی وجہ سے تخمینی ہیں۔ زیادہ درست ڈیٹا کے لیے StorageAnalyzer ٹول استعمال کریں۔</string>
-    <string name="appcontrol_list_filteroptions_label">فلٹر آپشنز</string>
     <string name="appcontrol_progress_uninstalling_app">ایپ ان انسٹال کر رہے ہیں</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d ایپ ان انسٹال ہوئی</item>

--- a/app-tool-appcontrol/src/main/res/values-uz/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-uz/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Hajm</string>
     <string name="appcontrol_list_sortmode_screentime_label">Ekran vaqti</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Ilova hajmlari ishlash sabablari uchun taxmin qilinadi. Aniqroq ma\'lumotlar uchun StorageAnalyzer vositasidan foydalaning.</string>
-    <string name="appcontrol_list_filteroptions_label">Filtr variantlari</string>
     <string name="appcontrol_progress_uninstalling_app">Ilovani o\'chirish</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d ilova o\'chirildi</item>

--- a/app-tool-appcontrol/src/main/res/values-vi/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-vi/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Kích thước</string>
     <string name="appcontrol_list_sortmode_screentime_label">Thời gian sử dụng màn hình</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Kích thước ứng dụng được ước tính vì lý do hiệu suất. Sử dụng công cụ StorageAnalyzer để có dữ liệu chính xác hơn.</string>
-    <string name="appcontrol_list_filteroptions_label">Tùy chọn bộ lọc</string>
     <string name="appcontrol_progress_uninstalling_app">Đang gỡ cài đặt ứng dụng</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="other">%d ứng dụng đã được gỡ cài đặt</item>

--- a/app-tool-appcontrol/src/main/res/values-zh-rCN/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-zh-rCN/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">大小</string>
     <string name="appcontrol_list_sortmode_screentime_label">屏幕使用时间</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">出于性能考虑，应用大小为估算所得。请使用「存储分析器」工具获取更准确的数据</string>
-    <string name="appcontrol_list_filteroptions_label">过滤器选项</string>
     <string name="appcontrol_progress_uninstalling_app">正在卸载应用</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="other">已卸载 %d 应用</item>

--- a/app-tool-appcontrol/src/main/res/values-zh-rHK/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-zh-rHK/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">大小</string>
     <string name="appcontrol_list_sortmode_screentime_label">螢幕時間</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">出於性能考慮，應用程序大小為估計值。請使用存儲分析器以獲得更準確的數據。</string>
-    <string name="appcontrol_list_filteroptions_label">過濾器選項</string>
     <string name="appcontrol_progress_uninstalling_app">正在解除安裝應用程式</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="other">已解除安裝 %d 個應用程式</item>

--- a/app-tool-appcontrol/src/main/res/values-zh-rTW/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-zh-rTW/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">大小</string>
     <string name="appcontrol_list_sortmode_screentime_label">螢幕時間</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">應用程式大小是因節約效能原因而估計的，可使用儲存分析器工具以取得更精確的資料。</string>
-    <string name="appcontrol_list_filteroptions_label">過濾器選項</string>
     <string name="appcontrol_progress_uninstalling_app">正在解除安裝應用程式</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="other">已解除安裝 %d 個應用程式</item>

--- a/app-tool-appcontrol/src/main/res/values-zu/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values-zu/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Usayizi</string>
     <string name="appcontrol_list_sortmode_screentime_label">Isikhathi sesikrini</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">Osayizi bezinhlelo zokusebenza balinganiswa ngenxa yezizathu zokusebenza. Sebenzisa ithuluzi le-StorageAnalyzer ukuze uthole idatha enembile.</string>
-    <string name="appcontrol_list_filteroptions_label">Izinketho zokusihluza</string>
     <string name="appcontrol_progress_uninstalling_app">Kukhipha uhlelo</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">Uhlelo olu-%d lukhishiwe</item>

--- a/app-tool-appcontrol/src/main/res/values/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values/strings.xml
@@ -37,7 +37,6 @@
     <string name="appcontrol_list_sortmode_size_label">Size</string>
     <string name="appcontrol_list_sortmode_screentime_label">Screen time</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">App sizes are estimated for performance reasons. Use the StorageAnalyzer tool for more accurate data.</string>
-    <string name="appcontrol_list_filteroptions_label">Filter options</string>
     <string name="appcontrol_progress_uninstalling_app">Uninstalling app</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d app was uninstalled</item>

--- a/app-tool-corpsefinder/src/main/res/values/strings.xml
+++ b/app-tool-corpsefinder/src/main/res/values/strings.xml
@@ -61,6 +61,6 @@
     <string name="corpsefinder_markers_dialog_normal_description">Standard remnant. Generally safe to remove — these files belong to apps that are no longer installed.</string>
 
     <!-- Guided tour -->
-    <string name="tour_corpsefinder_intro_body">CorpseFinder finds data left behind by apps you\'ve already uninstalled. It no longer belongs to anything installed, so removing it is safe and frees up space.</string>
+    <string name="tour_corpsefinder_intro_body">CorpseFinder finds data left behind by apps you\'ve already uninstalled. It no longer belongs to anything installed, so removing it frees up space. Most of it is safe to remove, but check the marker when you\'re unsure.</string>
     <string name="tour_corpsefinder_row_body">Each item is leftover data and the app it came from. The marker shows how confident SD Maid is that it\'s safe to remove — tap the ⓘ at the top to learn what the markers mean.</string>
 </resources>

--- a/app-tool-swiper/src/main/res/values/strings.xml
+++ b/app-tool-swiper/src/main/res/values/strings.xml
@@ -161,8 +161,8 @@
     <string name="swiper_open_externally_action">Open in external app</string>
 
     <!-- Guided tour -->
-    <string name="tour_swiper_gestures_body">Swipe a photo to decide its fate: Sideways to keep or delete, up to skip, down to undo. The buttons below do the same — and show which side is which.</string>
-    <string name="tour_swiper_openin_body">This button opens the photo in another app, handy to check it before deciding.</string>
+    <string name="tour_swiper_gestures_body">Swipe a file to decide its fate: sideways to keep or delete, up to skip, down to undo. The buttons below do the same — and show which side is which.</string>
+    <string name="tour_swiper_openin_body">This button opens the file in another app, handy to check it before deciding.</string>
     <string name="tour_swiper_preview_body">This button opens a full-screen preview for a closer look.</string>
     <string name="tour_swiper_actions_body">Don\'t like swiping? We\'ve got buttons too! Skip leaves it undecided for later, and long-pressing Skip excludes a file from future scans. Undo reverts your last choice.</string>
     <string name="tour_swiper_review_body">Your keep and delete choices are only staged. Open Review to go over them and apply the deletions when you\'re ready.</string>

--- a/app-tool-systemcleaner/src/main/res/values/strings.xml
+++ b/app-tool-systemcleaner/src/main/res/values/strings.xml
@@ -103,6 +103,6 @@
     <string name="systemcleaner_customfilter_export_action">Export selected filter</string>
 
     <!-- Guided tour -->
-    <string name="tour_systemcleaner_intro_body">SystemCleaner finds junk using app unspecific filters. Ready-made rules exist for things like empty folders, leftover logs and stale thumbnails. Visit the settings if you want to create your own.</string>
+    <string name="tour_systemcleaner_intro_body">SystemCleaner finds junk using filters that aren\'t app-specific. Ready-made rules exist for things like empty folders, leftover logs and stale thumbnails. Visit the settings if you want to create your own.</string>
     <string name="tour_systemcleaner_filter_body">Each row is a filter and what it found. Open its details to see exactly which files match before you delete anything.</string>
 </resources>

--- a/app/src/foss/res/values-af-rZA/strings.xml
+++ b/app/src/foss/res/values-af-rZA/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">Gradeer SD Maid SE op</string>
     <string name="upgrades_dashcard_body">Ontsluit addisionele funksies en word \'n beskermheer om voortgesette ontwikkeling te ondersteun!</string>
     <string name="upgrades_dashcard_upgrade_action">Gradeer op</string>

--- a/app/src/foss/res/values-am/strings.xml
+++ b/app/src/foss/res/values-am/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE ያሻሽሉ</string>
     <string name="upgrades_dashcard_body">ተጨማሪ ባህሪያትን ይክፈቱ እና ቀጣይ ልማትን ለመደገፍ ደጋፊ ይሁኑ!</string>
     <string name="upgrades_dashcard_upgrade_action">ያሻሽሉ</string>

--- a/app/src/foss/res/values-ar/strings.xml
+++ b/app/src/foss/res/values-ar/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">البرمجيات الحرة (FOSS)</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">ترقية SD Maid SE</string>
     <string name="upgrades_dashcard_body">افتح ميزات إضافية وكن راعياً لدعم التطوير المستمر!</string>
     <string name="upgrades_dashcard_upgrade_action">ترقية</string>

--- a/app/src/foss/res/values-az/strings.xml
+++ b/app/src/foss/res/values-az/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Açıq mənbəli proqram təminatı</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE-ni yüksəldin</string>
     <string name="upgrades_dashcard_body">Əlavə xüsusiyyətləri açın və davamlı inkişafı dəstəkləmək üçün himayədar olun!</string>
     <string name="upgrades_dashcard_upgrade_action">Yüksəlt</string>

--- a/app/src/foss/res/values-be/strings.xml
+++ b/app/src/foss/res/values-be/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">Абнавіць SD Maid SE</string>
     <string name="upgrades_dashcard_body">Адкрыйце дадатковыя функцыі і станьце спонсарам, каб падтрымаць далейшую распрацоўку!</string>
     <string name="upgrades_dashcard_upgrade_action">Абнавіць</string>

--- a/app/src/foss/res/values-bg/strings.xml
+++ b/app/src/foss/res/values-bg/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">Надстройте SD Maid SE</string>
     <string name="upgrades_dashcard_body">Отключете допълнителни функции и станете покровител, за да подкрепите непрекъснатото развитие!</string>
     <string name="upgrades_dashcard_upgrade_action">Надстройване</string>

--- a/app/src/foss/res/values-bn-rBD/strings.xml
+++ b/app/src/foss/res/values-bn-rBD/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE আপগ্রেড করুন</string>
     <string name="upgrades_dashcard_body">অতিরিক্ত ফিচার আনলক করুন এবং ক্রমাগত বিকাশকে সমর্থন করার জন্য একজন পৃষ্ঠপোষক হন!</string>
     <string name="upgrades_dashcard_upgrade_action">আপগ্রেড করুন</string>

--- a/app/src/foss/res/values-ca/strings.xml
+++ b/app/src/foss/res/values-ca/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">Millora l\'SD Maid SE</string>
     <string name="upgrades_dashcard_body">Desbloquegeu funcions addicionals i convertiu-vos en mecenes per donar suport al continuïtat del suport!</string>
     <string name="upgrades_dashcard_upgrade_action">Millora</string>

--- a/app/src/foss/res/values-ckb-rIR/strings.xml
+++ b/app/src/foss/res/values-ckb-rIR/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">نوێکردنەوەی SD Maid SE</string>
     <string name="upgrades_dashcard_body">تایبەتمەندی زیاتر بکەرەوە و ببە بە سپۆنسەر بۆ پشتگیریکردنی پەرەپێدانی بەردەوام!</string>
     <string name="upgrades_dashcard_upgrade_action">نوێکردنەوە</string>

--- a/app/src/foss/res/values-cs/strings.xml
+++ b/app/src/foss/res/values-cs/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">Upgradovat SD Maid SE</string>
     <string name="upgrades_dashcard_body">Odemkněte další funkce a staňte se patronem, který podpoří další vývoj!</string>
     <string name="upgrades_dashcard_upgrade_action">Upgradovat</string>

--- a/app/src/foss/res/values-da/strings.xml
+++ b/app/src/foss/res/values-da/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">Opgrader SD Maid SE</string>
     <string name="upgrades_dashcard_body">Lås op for flere funktioner, og bliv patron for at støtte den fortsatte udvikling!</string>
     <string name="upgrades_dashcard_upgrade_action">Opgrader</string>

--- a/app/src/foss/res/values-de/strings.xml
+++ b/app/src/foss/res/values-de/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE upgraden</string>
     <string name="upgrades_dashcard_body">Schalten Sie zusätzliche Funktionen frei und werden Sie Patron, um die Weiterentwicklung zu unterstützen!</string>
     <string name="upgrades_dashcard_upgrade_action">Upgrade</string>

--- a/app/src/foss/res/values-el/strings.xml
+++ b/app/src/foss/res/values-el/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">Αναβάθμιση SD Maid SE</string>
     <string name="upgrades_dashcard_body">Ξεκλειδώστε πρόσθετες δυνατότητες και γίνετε patron για να υποστηρίξετε τη συνεχή ανάπτυξη!</string>
     <string name="upgrades_dashcard_upgrade_action">Αναβάθμιση</string>

--- a/app/src/foss/res/values-es-rAR/strings.xml
+++ b/app/src/foss/res/values-es-rAR/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">Mejorar SD Maid SE</string>
     <string name="upgrades_dashcard_body">¡Desbloqueá funciones adicionales y hacete patreon para ayudar a continuar el desarrollo!</string>
     <string name="upgrades_dashcard_upgrade_action">Mejorar</string>

--- a/app/src/foss/res/values-es-rMX/strings.xml
+++ b/app/src/foss/res/values-es-rMX/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">Actualizar SD Maid SE</string>
     <string name="upgrades_dashcard_body">¡Desbloquea funciones adicionales y conviértete en pratrocinador para apoyar el desarrollo continuo!</string>
     <string name="upgrades_dashcard_upgrade_action">Actualizar</string>

--- a/app/src/foss/res/values-es/strings.xml
+++ b/app/src/foss/res/values-es/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">Actualizar SD Maid SE</string>
     <string name="upgrades_dashcard_body">¡Desbloquea las funciones adicionales y conviértete en patrocinador para apoyar el desarrollo continuo!</string>
     <string name="upgrades_dashcard_upgrade_action">Actualizar</string>

--- a/app/src/foss/res/values-et-rEE/strings.xml
+++ b/app/src/foss/res/values-et-rEE/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE täiendamine</string>
     <string name="upgrades_dashcard_body">Lubage lisavõimalused ja hakake toetajaks, et edendada arendamist.</string>
     <string name="upgrades_dashcard_upgrade_action">Täienda</string>

--- a/app/src/foss/res/values-eu-rES/strings.xml
+++ b/app/src/foss/res/values-eu-rES/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">Eguneratu SD Maid SE</string>
     <string name="upgrades_dashcard_body">Eginbide gehigarriak desblokeatu eta babesle izan etengabeko garapena laguntzeko!</string>
     <string name="upgrades_dashcard_upgrade_action">Eguneratu</string>

--- a/app/src/foss/res/values-fa/strings.xml
+++ b/app/src/foss/res/values-fa/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">منبع‌آزاد</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">ارتقاء SD Maid SE</string>
     <string name="upgrades_dashcard_body">قفل ویژگی های اضافی را باز کنید و برای حمایت از توسعه مداوم، حامی شوید!</string>
     <string name="upgrades_dashcard_upgrade_action">ارتقاء</string>

--- a/app/src/foss/res/values-fi/strings.xml
+++ b/app/src/foss/res/values-fi/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">Päivitä SD Maid SE</string>
     <string name="upgrades_dashcard_body">Avaa lisäominaisuuksia ja ryhdy tukijaksi tukeaksesi jatkuvaa kehitystä!</string>
     <string name="upgrades_dashcard_upgrade_action">Päivitä</string>

--- a/app/src/foss/res/values-fil/strings.xml
+++ b/app/src/foss/res/values-fil/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">I-upgrade ang SD Maid SE</string>
     <string name="upgrades_dashcard_body">I-unlock ang mga karagdagang feature at maging patron para suportahan ang patuloy na development!</string>
     <string name="upgrades_dashcard_upgrade_action">I-upgrade</string>

--- a/app/src/foss/res/values-fr/strings.xml
+++ b/app/src/foss/res/values-fr/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Logiciel libre</string>
-    <string name="upgrade_badge_label">Logiciel libre</string>
     <string name="upgrades_dashcard_title">Passer à SD Maid SE Pro</string>
     <string name="upgrades_dashcard_body">Débloquez des fonctions supplémentaires et devenez mécène pour soutenir le développement continu.</string>
     <string name="upgrades_dashcard_upgrade_action">Passer Pro</string>

--- a/app/src/foss/res/values-gl-rES/strings.xml
+++ b/app/src/foss/res/values-gl-rES/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">Actualizar SD Maid SE</string>
     <string name="upgrades_dashcard_body">Desbloquea características adicionais e convértete en mecenas para apoiar o desenvolvemento continuo!</string>
     <string name="upgrades_dashcard_upgrade_action">Actualizar</string>

--- a/app/src/foss/res/values-hi-rIN/strings.xml
+++ b/app/src/foss/res/values-hi-rIN/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE को उन्नत करें</string>
     <string name="upgrades_dashcard_body">अतिरिक्त सुविधाओं को अनलॉक करें और निरंतर विकास का समर्थन करने के लिए संरक्षक बनें!</string>
     <string name="upgrades_dashcard_upgrade_action">उन्नत करें</string>

--- a/app/src/foss/res/values-hr/strings.xml
+++ b/app/src/foss/res/values-hr/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">Nadogradite SD Maid</string>
     <string name="upgrades_dashcard_body">Otključajte dodatne značajke i postanite pokrovitelj kako biste podržali daljnji razvoj!</string>
     <string name="upgrades_dashcard_upgrade_action">Nadogradnja</string>

--- a/app/src/foss/res/values-hu/strings.xml
+++ b/app/src/foss/res/values-hu/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE frissítése</string>
     <string name="upgrades_dashcard_body">Fedezze fel a további funkciókat, és legyen patron támogató, hogy támogassa a folyamatos fejlesztést!</string>
     <string name="upgrades_dashcard_upgrade_action">Frissítés</string>

--- a/app/src/foss/res/values-in/strings.xml
+++ b/app/src/foss/res/values-in/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">Tingkatkan SD Maid SE</string>
     <string name="upgrades_dashcard_body">Buka fitur-fitur tambahan dan jadilah penyokong yang mendukung pengembangan yang berkelanjutan!</string>
     <string name="upgrades_dashcard_upgrade_action">Tingkatkan</string>

--- a/app/src/foss/res/values-is/strings.xml
+++ b/app/src/foss/res/values-is/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">Uppfæra SD Maid SE</string>
     <string name="upgrades_dashcard_body">Opnaðu viðbótareiginleika og vertu styrktaraðili til að styðja áframhaldandi þróun!</string>
     <string name="upgrades_dashcard_upgrade_action">Uppfæra</string>

--- a/app/src/foss/res/values-it/strings.xml
+++ b/app/src/foss/res/values-it/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">Aggiorna SD Maid SE</string>
     <string name="upgrades_dashcard_body">Sblocca funzioni aggiuntive e diventa un sostenitore per supportare lo sviluppo continuo!</string>
     <string name="upgrades_dashcard_upgrade_action">Aggiorna</string>

--- a/app/src/foss/res/values-iw/strings.xml
+++ b/app/src/foss/res/values-iw/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">שדרג את SD Maid SE</string>
     <string name="upgrades_dashcard_body">בטל נעילה של תכונות נוספות והפוך לפטרון לתמיכה בהמשך הפיתוח!</string>
     <string name="upgrades_dashcard_upgrade_action">שדרוג</string>

--- a/app/src/foss/res/values-ja/strings.xml
+++ b/app/src/foss/res/values-ja/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE をアップグレード</string>
     <string name="upgrades_dashcard_body">開発を続けるためパトロンになって追加機能を解除してください</string>
     <string name="upgrades_dashcard_upgrade_action">アップグレード</string>

--- a/app/src/foss/res/values-ka-rGE/strings.xml
+++ b/app/src/foss/res/values-ka-rGE/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE-ის განახლება</string>
     <string name="upgrades_dashcard_body">განბლოკეთ დამატებითი ფუნქციები და გახდით მფარველი მუდმივი განვითარების მხარდასაჭერად!</string>
     <string name="upgrades_dashcard_upgrade_action">გარემონტება</string>

--- a/app/src/foss/res/values-kaa/strings.xml
+++ b/app/src/foss/res/values-kaa/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE jańalaw</string>
     <string name="upgrades_dashcard_body">Qosımsha mümkinliklerdi ashıń hám uzlıksız rawajlanıwdı qollap-quwatlawshı úshin homiyshı bolıń!</string>
     <string name="upgrades_dashcard_upgrade_action">Jańalaw</string>

--- a/app/src/foss/res/values-km-rKH/strings.xml
+++ b/app/src/foss/res/values-km-rKH/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">ធ្វើឱ្យប្រសើរ SD Maid SE</string>
     <string name="upgrades_dashcard_body">ដោះសោមុខងារបន្ថែម និងក្លាយជាអ្នកឧបត្ថម្ភដើម្បីគាំទ្រការអភិវឌ្ឍន៍បន្ត!</string>
     <string name="upgrades_dashcard_upgrade_action">វិសិដ្ឋកម្ម</string>

--- a/app/src/foss/res/values-ko/strings.xml
+++ b/app/src/foss/res/values-ko/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE 업그레이드</string>
     <string name="upgrades_dashcard_body">후원자가 되어 앱 개발을 지원하고 추가 기능을 잠금해제 하세요!</string>
     <string name="upgrades_dashcard_upgrade_action">업그레이드</string>

--- a/app/src/foss/res/values-lo-rLA/strings.xml
+++ b/app/src/foss/res/values-lo-rLA/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">ອັບເກຣດ SD Maid SE</string>
     <string name="upgrades_dashcard_body">ປົດລັອກຄຸນສົມບັດເພີ່ມເຕີມ ແລະ ກາຍເປັນຜູ້ອຸປະຖໍາເພື່ອສະໜັບສະໜູນການພັດທະນາຢ່າງຕໍ່ເນື່ອງ!</string>
     <string name="upgrades_dashcard_upgrade_action">ອັບເກຣດ</string>

--- a/app/src/foss/res/values-lt/strings.xml
+++ b/app/src/foss/res/values-lt/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">Atnaujinti SD Maid SE</string>
     <string name="upgrades_dashcard_body">Atrakinkite papildomas funkcijas ir tapkite globėju, kad palaikytumėte tolesnį plėtojimą!</string>
     <string name="upgrades_dashcard_upgrade_action">Atnaujinti</string>

--- a/app/src/foss/res/values-lv/strings.xml
+++ b/app/src/foss/res/values-lv/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">Uzlabojiet SD Maid SE</string>
     <string name="upgrades_dashcard_body">Atslēdziet papildu funkcijas un kļūstiet par aizbildni, lai atbalstītu turpmāko attīstību!</string>
     <string name="upgrades_dashcard_upgrade_action">Uzlabot</string>

--- a/app/src/foss/res/values-mk-rMK/strings.xml
+++ b/app/src/foss/res/values-mk-rMK/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">Надградете го SD Maid SE</string>
     <string name="upgrades_dashcard_body">Отклучете дополнителни функции и станете покровител за да го поддржите континуираниот развој!</string>
     <string name="upgrades_dashcard_upgrade_action">Надградете</string>

--- a/app/src/foss/res/values-ml-rIN/strings.xml
+++ b/app/src/foss/res/values-ml-rIN/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE അപ്ഗ്രേഡ് ചെയ്യുക</string>
     <string name="upgrades_dashcard_body">കൂടുതൽ സവിശേഷതകൾ അൺലോക്കുചെയ്‌ത് തുടർ വികസനത്തെ പിന്തുണയ്ക്കുന്നതിന് ഒരു പാട്രോൺ ആകുക!</string>
     <string name="upgrades_dashcard_upgrade_action">അപ്ഗ്രേഡുചെയ്യുക</string>

--- a/app/src/foss/res/values-mn-rMN/strings.xml
+++ b/app/src/foss/res/values-mn-rMN/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE-г шинэчлэх</string>
     <string name="upgrades_dashcard_body">Нэмэлт боломжуудыг нээж, тасралтгүй хөгжлийг дэмжихийн тулд ивээн тэтгэгч болоорой!</string>
     <string name="upgrades_dashcard_upgrade_action">Шинэчлэх</string>

--- a/app/src/foss/res/values-ms/strings.xml
+++ b/app/src/foss/res/values-ms/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">Naik taraf SD Maid SE</string>
     <string name="upgrades_dashcard_body">Buka kunci ciri tambahan dan menjadi penaung untuk menyokong pembangunan berterusan!</string>
     <string name="upgrades_dashcard_upgrade_action">Naik taraf</string>

--- a/app/src/foss/res/values-my-rMM/strings.xml
+++ b/app/src/foss/res/values-my-rMM/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE ကို အဆင့်မြှင့်ရန်</string>
     <string name="upgrades_dashcard_body">အပိုဝန်ဆောင်မှုများကို ဖွင့်ပြီး ဆက်လက်ဖွံ့ဖြိုးတိုးတက်မှုကို ပံ့ပိုးရန် ကူညီသူဖြစ်လာပါ!</string>
     <string name="upgrades_dashcard_upgrade_action">အဆင့်မြှင့်ရန်</string>

--- a/app/src/foss/res/values-nb/strings.xml
+++ b/app/src/foss/res/values-nb/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">Oppgrader SD Maid SE</string>
     <string name="upgrades_dashcard_body">Lås opp flere funksjoner og bli en patron for å støtte utviklingen videre!</string>
     <string name="upgrades_dashcard_upgrade_action">Oppgrader</string>

--- a/app/src/foss/res/values-ne-rNP/strings.xml
+++ b/app/src/foss/res/values-ne-rNP/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE अपग्रेड गर्नुहोस्</string>
     <string name="upgrades_dashcard_body">थप सुविधाहरू अनलक गर्नुहोस् र निरन्तर विकासलाई समर्थन गर्न संरक्षक बन्नुहोस्!</string>
     <string name="upgrades_dashcard_upgrade_action">अपग्रेड गर्नुहोस्</string>

--- a/app/src/foss/res/values-nl/strings.xml
+++ b/app/src/foss/res/values-nl/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE upgraden</string>
     <string name="upgrades_dashcard_body">Ontgrendel extra functies en word een patroon om verdere ontwikkeling te ondersteunen!</string>
     <string name="upgrades_dashcard_upgrade_action">Upgraden</string>

--- a/app/src/foss/res/values-or-rIN/strings.xml
+++ b/app/src/foss/res/values-or-rIN/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE ଅପଗ୍ରେଡ କରନ୍ତୁ</string>
     <string name="upgrades_dashcard_body">ଅତିରିକ୍ତ ବୈଶିଷ୍ଟ୍ୟଗୁଡ଼ିକ ଅନଲକ କରନ୍ତୁ ଏବଂ ନିରନ୍ତର ବିକାଶକୁ ସମର୍ଥନ କରିବା ପାଇଁ ଜଣେ ପୃଷ୍ଠପୋଷକ ହୋଇଯାଆନ୍ତୁ!</string>
     <string name="upgrades_dashcard_upgrade_action">ଅପଗ୍ରେଡ କରନ୍ତୁ</string>

--- a/app/src/foss/res/values-pa-rIN/strings.xml
+++ b/app/src/foss/res/values-pa-rIN/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE ਅੱਪਗ੍ਰੇਡ ਕਰੋ</string>
     <string name="upgrades_dashcard_body">ਵਾਧੂ ਵਿਸ਼ੇਸ਼ਤਾਵਾਂ ਨੂੰ ਅਨਲੌਕ ਕਰੋ ਅਤੇ ਨਿਰੰਤਰ ਵਿਕਾਸ ਦਾ ਸਮਰਥਨ ਕਰਨ ਲਈ ਸਰਪ੍ਰਸਤ ਬਣੋ!</string>
     <string name="upgrades_dashcard_upgrade_action">ਅੱਪਗ੍ਰੇਡ ਕਰੋ</string>

--- a/app/src/foss/res/values-pl/strings.xml
+++ b/app/src/foss/res/values-pl/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">Uaktualnij SD Maid SE</string>
     <string name="upgrades_dashcard_body">Odblokuj dodatkowe funkcje i zostań patronem, aby wesprzeć dalszy rozwój!</string>
     <string name="upgrades_dashcard_upgrade_action">Uaktualnij</string>

--- a/app/src/foss/res/values-pt-rBR/strings.xml
+++ b/app/src/foss/res/values-pt-rBR/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">Atualizar SD Maid SE</string>
     <string name="upgrades_dashcard_body">Desbloqueie recursos adicionais e torne-se um patrão para apoiar o desenvolvimento contínuo!</string>
     <string name="upgrades_dashcard_upgrade_action">Atualizar</string>

--- a/app/src/foss/res/values-pt/strings.xml
+++ b/app/src/foss/res/values-pt/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">Upgrade do SD Maid</string>
     <string name="upgrades_dashcard_body">Desbloqueie funcionalidades extra e torne-se um patrono para apoiar o desenvolvimento contínuo!</string>
     <string name="upgrades_dashcard_upgrade_action">Atualizar</string>

--- a/app/src/foss/res/values-ro/strings.xml
+++ b/app/src/foss/res/values-ro/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">Actualizați SD Maid SE</string>
     <string name="upgrades_dashcard_body">Deblochează funcții suplimentare și devino un patron pentru a suporta dezvoltarea continuată!</string>
     <string name="upgrades_dashcard_upgrade_action">Actualizează</string>

--- a/app/src/foss/res/values-ru/strings.xml
+++ b/app/src/foss/res/values-ru/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">Обновление SD Maid SE</string>
     <string name="upgrades_dashcard_body">Разблокируйте дополнительные возможности и станьте спонсором, чтобы поддержать разработку приложения!</string>
     <string name="upgrades_dashcard_upgrade_action">Обновить</string>

--- a/app/src/foss/res/values-sc-rIT/strings.xml
+++ b/app/src/foss/res/values-sc-rIT/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">Atualizare SD Maid SE</string>
     <string name="upgrades_dashcard_body">Aberri funtzionalidades addizionales e diventa patronu pro sustènnere su isvilupu continuadu!</string>
     <string name="upgrades_dashcard_upgrade_action">Atualizare</string>

--- a/app/src/foss/res/values-si-rLK/strings.xml
+++ b/app/src/foss/res/values-si-rLK/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE වැඩිදියුණු කරන්න</string>
     <string name="upgrades_dashcard_body">අමතර විශේෂාංග අඟුල හරිමින් අඛණ්ඩ සංවර්ධනයට සහාය වීමට අනුග්‍රාහකයෙකු වන්න!</string>
     <string name="upgrades_dashcard_upgrade_action">වැඩිදියුණු කරන්න</string>

--- a/app/src/foss/res/values-sk/strings.xml
+++ b/app/src/foss/res/values-sk/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">Inovovať SD Maid SE</string>
     <string name="upgrades_dashcard_body">Odomknite ďalšie funkcie a staňte sa patrónom na podporu ďalšieho vývoja!</string>
     <string name="upgrades_dashcard_upgrade_action">Inovovať</string>

--- a/app/src/foss/res/values-sl/strings.xml
+++ b/app/src/foss/res/values-sl/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">Nadgradi SD Maid SE</string>
     <string name="upgrades_dashcard_body">Odklenite dodatne funkcije in postanite pokrovitelj, da podprete nadaljnji razvoj!</string>
     <string name="upgrades_dashcard_upgrade_action">Nadgradi</string>

--- a/app/src/foss/res/values-sq-rAL/strings.xml
+++ b/app/src/foss/res/values-sq-rAL/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">Përmirëso SD Maid SE</string>
     <string name="upgrades_dashcard_body">Çelni veçori shtesë dhe bëhuni një mbrojtës për të mbështetur zhvillimin e vazhdueshëm!</string>
     <string name="upgrades_dashcard_upgrade_action">Përmirëso</string>

--- a/app/src/foss/res/values-sr/strings.xml
+++ b/app/src/foss/res/values-sr/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">Надогради SD Maid SE</string>
     <string name="upgrades_dashcard_body">Откључај додатне функције и постани покровитељ да подржиш континуирани развој!</string>
     <string name="upgrades_dashcard_upgrade_action">Надогради</string>

--- a/app/src/foss/res/values-sv/strings.xml
+++ b/app/src/foss/res/values-sv/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">Uppgradera SD Maid SE</string>
     <string name="upgrades_dashcard_body">Lås upp ytterligare funktioner och bli en beskyddare för att stödja fortsatt utveckling!</string>
     <string name="upgrades_dashcard_upgrade_action">Uppgradera</string>

--- a/app/src/foss/res/values-sw/strings.xml
+++ b/app/src/foss/res/values-sw/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">Boresha SD Maid SE</string>
     <string name="upgrades_dashcard_body">Fungua vipengele vya ziada na uwe mfumo wa kuunga mkono maendeleo ya kuendelea!</string>
     <string name="upgrades_dashcard_upgrade_action">Boresha</string>

--- a/app/src/foss/res/values-ta-rIN/strings.xml
+++ b/app/src/foss/res/values-ta-rIN/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE ஐ மேம்படுத்தவும்</string>
     <string name="upgrades_dashcard_body">கூடுதல் அம்சங்களைத் திறக்கவும் மற்றும் தொடர்ச்சியான மேம்பாட்டை ஆதரிக்க புரவலராக மாறவும்!</string>
     <string name="upgrades_dashcard_upgrade_action">மேம்படுத்தவும்</string>

--- a/app/src/foss/res/values-te-rIN/strings.xml
+++ b/app/src/foss/res/values-te-rIN/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE అప్‌గ్రేడ్ చేయండి</string>
     <string name="upgrades_dashcard_body">అదనపు ఫీచర్లను అన్‌లాక్ చేసి, నిరంతర అభివృద్ధికి మద్దతు ఇవ్వడానికి పేట్రన్ అవ్వండి!</string>
     <string name="upgrades_dashcard_upgrade_action">అప్‌గ్రేడ్ చేయండి</string>

--- a/app/src/foss/res/values-th/strings.xml
+++ b/app/src/foss/res/values-th/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">บังคับ</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">อัปเกรด SD Maid SE</string>
     <string name="upgrades_dashcard_body">ปลดล็อกฟีเจอร์เพิ่มเติมและเป็นผู้อุปถัมภ์เพื่อสนับสนุนการพัฒนาอย่างต่อเนื่อง!</string>
     <string name="upgrades_dashcard_upgrade_action">อัปเกรด</string>

--- a/app/src/foss/res/values-tr/strings.xml
+++ b/app/src/foss/res/values-tr/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE\'yi yükseltin</string>
     <string name="upgrades_dashcard_body">Ek özelliklerin kilidini açın ve sürekli gelişimi desteklemek için bir patron olun!</string>
     <string name="upgrades_dashcard_upgrade_action">Yükselt</string>

--- a/app/src/foss/res/values-uk/strings.xml
+++ b/app/src/foss/res/values-uk/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">Оновлення SD Maid SE</string>
     <string name="upgrades_dashcard_body">Розблокуйте додаткові функції та станьте спонсором, щоб підтримати подальший розвиток!</string>
     <string name="upgrades_dashcard_upgrade_action">Оновлення</string>

--- a/app/src/foss/res/values-ur-rIN/strings.xml
+++ b/app/src/foss/res/values-ur-rIN/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE اپگریڈ کریں</string>
     <string name="upgrades_dashcard_body">اضافی خصوصیات کو غیر مقفل کریں اور مسلسل ترقی کی حمایت کے لیے سرپرست بنیں!</string>
     <string name="upgrades_dashcard_upgrade_action">اپگریڈ کریں</string>

--- a/app/src/foss/res/values-uz/strings.xml
+++ b/app/src/foss/res/values-uz/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE-ni yangilash</string>
     <string name="upgrades_dashcard_body">Qo\'shimcha xususiyatlarni oching va doimiy rivojlanishni qo\'llab-quvvatlash uchun homiy bo\'ling!</string>
     <string name="upgrades_dashcard_upgrade_action">Yangilash</string>

--- a/app/src/foss/res/values-vi/strings.xml
+++ b/app/src/foss/res/values-vi/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">Nâng cấp SD Maid SE</string>
     <string name="upgrades_dashcard_body">Mở khóa các tính năng bổ sung và trở thành người bảo trợ để hỗ trợ sự phát triển liên tục!</string>
     <string name="upgrades_dashcard_upgrade_action">Nâng cấp</string>

--- a/app/src/foss/res/values-zh-rCN/strings.xml
+++ b/app/src/foss/res/values-zh-rCN/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">升级 SD Maid SE</string>
     <string name="upgrades_dashcard_body">解锁附加功能，成为支持持续开发的赞助人！</string>
     <string name="upgrades_dashcard_upgrade_action">升级</string>

--- a/app/src/foss/res/values-zh-rHK/strings.xml
+++ b/app/src/foss/res/values-zh-rHK/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">升級 SD Maid SE</string>
     <string name="upgrades_dashcard_body">解鎖額外功能，並成為贊助者，以支持持續開發！</string>
     <string name="upgrades_dashcard_upgrade_action">升級</string>

--- a/app/src/foss/res/values-zh-rTW/strings.xml
+++ b/app/src/foss/res/values-zh-rTW/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">升級 SD Maid SE</string>
     <string name="upgrades_dashcard_body">解鎖額外功能，並成為贊助者，以支持持續開發！</string>
     <string name="upgrades_dashcard_upgrade_action">升級</string>

--- a/app/src/foss/res/values-zu/strings.xml
+++ b/app/src/foss/res/values-zu/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrades_dashcard_title">Thuthukisa SD Maid SE</string>
     <string name="upgrades_dashcard_body">Vula izici ezengeziwe futhi ube ngumnikazi ukuze usekele ukuthuthukiswa okuqhubekayo!</string>
     <string name="upgrades_dashcard_upgrade_action">Thuthukisa</string>

--- a/app/src/foss/res/values/strings.xml
+++ b/app/src/foss/res/values/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="app_name_upgrade_postfix">FOSS</string>
 
-    <string name="upgrade_badge_label">FOSS</string>
 
     <string name="upgrades_dashcard_title">Upgrade SD Maid SE</string>
     <string name="upgrades_dashcard_body">Unlock additional features and become a patron to support continued development!</string>

--- a/app/src/main/java/eu/darken/sdmse/main/ui/MainActivity.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/MainActivity.kt
@@ -135,7 +135,7 @@ class MainActivity : ComponentActivity() {
 
                 CompositionLocalProvider(
                     LocalNavigationController provides navCtrl,
-                    LocalUpgradeBadgeLabel provides stringResource(R.string.upgrade_badge_label),
+                    LocalUpgradeBadgeLabel provides stringResource(R.string.app_name_upgrade_postfix),
                 ) {
                     ErrorEventHandler(vm)
                     NavigationEventHandler(vm)

--- a/app/src/main/java/eu/darken/sdmse/main/ui/backup/BackupRestoreScreen.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/backup/BackupRestoreScreen.kt
@@ -115,7 +115,7 @@ fun BackupRestoreScreenHost(
                             event.failedSections.joinToString(", "),
                         ),
                         actionLabel = if (event.canUndo) {
-                            context.getString(R.string.backup_restore_undo_action)
+                            context.getString(CommonR.string.general_undo_action)
                         } else {
                             null
                         },

--- a/app/src/main/java/eu/darken/sdmse/main/ui/settings/general/GeneralSettingsScreen.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/settings/general/GeneralSettingsScreen.kt
@@ -236,7 +236,7 @@ internal fun GeneralSettingsScreen(
             item {
                 SettingsSwitchItem(
                     icon = Icons.TwoTone.Widgets,
-                    title = stringResource(R.string.widget_settings_oneclick_title),
+                    title = stringResource(R.string.dashboard_settings_oneclick_title),
                     subtitle = stringResource(R.string.widget_settings_oneclick_summary),
                     checked = state.widgetOneClickEnabled,
                     onCheckedChange = onWidgetOneClickChanged,

--- a/app/src/main/res/values-af-rZA/strings.xml
+++ b/app/src/main/res/values-af-rZA/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">Privaatheid beleid</string>
     <string name="settings_privacy_policy_desc">Hanteer data verantwoordelik.</string>
     <string name="settings_category_other_label">Ander</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">Algemeen</string>
     <string name="general_settings_desc">Algemene aanpassings wat die hele toepassing affekteer.</string>
     <string name="settings_category_ui_label">Gebruikerskoppelvlak</string>
@@ -339,7 +338,6 @@
     <string name="backup_restore_export_partial">Rugsteun geskep, maar hierdie dele het gefaal: %1$s</string>
     <string name="backup_restore_restore_success">Rugsteun herstel</string>
     <string name="backup_restore_restore_failed">Herstel het gefaal (%1$s). Jou vorige konfigurasie is gestoor.</string>
-    <string name="backup_restore_undo_action">Ontdoen</string>
     <string name="backup_restore_recovery_title">Herstel vorige konfigurasie</string>
     <string name="backup_restore_recovery_desc">\'n Veiligheidskiekopie van \'n onvoltooide herstel is beskikbaar</string>
     <string name="backup_restore_confirm_title">Herstel hierdie rugsteun?</string>

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">የግላዊነት ፖሊሲ</string>
     <string name="settings_privacy_policy_desc">ውሂቡን በኃላፊነት መያዝ።</string>
     <string name="settings_category_other_label">ሌላ</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">አጠቃላይ</string>
     <string name="general_settings_desc">መሙሉ መተግበሪያ የሚነኩ አጠቃላይ ማስተካከያዎች።</string>
     <string name="settings_category_ui_label">የተጠቃሚ በይነገጽ</string>
@@ -339,7 +338,6 @@
     <string name="backup_restore_export_partial">መገልገያ ተፍጠረ ግን እነዝህ ክፍሎች ወድቁ: %1$s</string>
     <string name="backup_restore_restore_success">መገልገያ ወደ ነበረበት ተመላሰ</string>
     <string name="backup_restore_restore_failed">ወደ ነበረበት መመለስ ወድቆል (%1$s)። የእርስዎ ቅድሞ ውቅር ተቅምጧል።</string>
-    <string name="backup_restore_undo_action">መልስ</string>
     <string name="backup_restore_recovery_title">ቀዕሙ ውቅር ወደ ነበረበት ማምጣ</string>
     <string name="backup_restore_recovery_desc">ከ ያልተማላ ወደ ነበረበት መመለስ ደህነነት ሽፍታ ይገኛል</string>
     <string name="backup_restore_confirm_title">ይህን መገልገያ ወደ ነበረበት ብመለስ?</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -119,7 +119,6 @@
     <string name="settings_privacy_policy_label">سياسة الخصوصية</string>
     <string name="settings_privacy_policy_desc">التعامل مع البيانات بمسؤولية.</string>
     <string name="settings_category_other_label">أخرى</string>
-    <string name="upgrade_badge_label">احترافي</string>
     <string name="general_settings_label">عام</string>
     <string name="general_settings_desc">التعديلات العامة التي تؤثر على التطبيق بأكمله.</string>
     <string name="settings_category_ui_label">واجهة المستخدم</string>
@@ -367,7 +366,6 @@
     <string name="backup_restore_export_partial">تم إنشاء النسخة الاحتياطية، لكن فشلت هذه الأجزاء: %1$s</string>
     <string name="backup_restore_restore_success">تم استعادة النسخة الاحتياطية</string>
     <string name="backup_restore_restore_failed">فشلت الاستعادة (%1$s). تم حفظ إعداداتك السابقة.</string>
-    <string name="backup_restore_undo_action">تراجع</string>
     <string name="backup_restore_recovery_title">استرجع الإعدادات السابقة</string>
     <string name="backup_restore_recovery_desc">لقطة أمان من استعادة غير مكتملة متاحة</string>
     <string name="backup_restore_confirm_title">استعادة هذه النسخة الاحتياطية؟</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">Gizlilik siyasəti</string>
     <string name="settings_privacy_policy_desc">Məlumatları məsuliyyətlə idarə etmək.</string>
     <string name="settings_category_other_label">Digər</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">Ümumi</string>
     <string name="general_settings_desc">Bütün tətbiqi təsir edən ümumi tənzimlər.</string>
     <string name="settings_category_ui_label">İstifadəçi interfeysi</string>
@@ -339,7 +338,6 @@
     <string name="backup_restore_export_partial">Ehtiyat nüsxə yaradıldı, lakin bu hissələr uğursuz oldu: %1$s</string>
     <string name="backup_restore_restore_success">Ehtiyat nüsxə bərpa edildi</string>
     <string name="backup_restore_restore_failed">Bərpa uğursuz oldu (%1$s). Əvvəlki konfiqurasiyanız saxlanıldı.</string>
-    <string name="backup_restore_undo_action">Geri al</string>
     <string name="backup_restore_recovery_title">Əvvəlki konfiqurasiyanı bərpa et</string>
     <string name="backup_restore_recovery_desc">Bitməmiş bərpadan bir təhlükəsizlik ehtiyat nüsxəsi mövcuddur</string>
     <string name="backup_restore_confirm_title">Bu ehtiyat nüsxəni bərpa et?</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -113,7 +113,6 @@
     <string name="settings_privacy_policy_label">Палітыка канфідэнцыяльнасці</string>
     <string name="settings_privacy_policy_desc">Адказнае абыходжанне з данымі.</string>
     <string name="settings_category_other_label">Іншае</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">Агульныя</string>
     <string name="general_settings_desc">Агульныя налады, якія ўплываюць на ўсю праграму.</string>
     <string name="settings_category_ui_label">Карыстальніцкі інтэрфейс</string>
@@ -353,7 +352,6 @@
     <string name="backup_restore_export_partial">Рэзервовая копія створана, але гэтыя часткі не атрымаліся: %1$s</string>
     <string name="backup_restore_restore_success">Рэзервовая копія адноўлена</string>
     <string name="backup_restore_restore_failed">Аднаўленне не ўдалося (%1$s). Ваша папярэдняя канфігурацыя была захавана.</string>
-    <string name="backup_restore_undo_action">Скасаваць</string>
     <string name="backup_restore_recovery_title">Аднавіць папярэднюю канфігурацыю</string>
     <string name="backup_restore_recovery_desc">Даступны бяспечны здымак ад незавершанага аднаўлення</string>
     <string name="backup_restore_confirm_title">Аднавіць гэту рэзервовую копію?</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">Политика за поверителност</string>
     <string name="settings_privacy_policy_desc">Отговорно управление на данните.</string>
     <string name="settings_category_other_label">Други</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">Общи</string>
     <string name="general_settings_desc">Общи настройки, които засягат цялото приложение.</string>
     <string name="settings_category_ui_label">Потребителски интерфейс</string>
@@ -339,7 +338,6 @@
     <string name="backup_restore_export_partial">Резервното копие е създадено, но тези части не успяха: %1$s</string>
     <string name="backup_restore_restore_success">Резервното копие е възстановено</string>
     <string name="backup_restore_restore_failed">Възстановяването не успя (%1$s). Вашата предишна конфигурация е запазена.</string>
-    <string name="backup_restore_undo_action">Отмяна</string>
     <string name="backup_restore_recovery_title">Възстанови предишната конфигурация</string>
     <string name="backup_restore_recovery_desc">Налична е предпазна снимка от незавършено възстановяване</string>
     <string name="backup_restore_confirm_title">Да се възстанови ли това резервно копие?</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">গোপনীয়তার নীতিমালা</string>
     <string name="settings_privacy_policy_desc">দায়িত্বের সাথে ডেটা পরিচালনা করা।</string>
     <string name="settings_category_other_label">অন্যান্য</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">সাধারণ</string>
     <string name="general_settings_desc">খুঁটিনাটি পরিবর্তন যা পুরো অ্যাপকে প্রভাবিত করে।</string>
     <string name="settings_category_ui_label">ব্যবহারকারীর ইন্টারফেস</string>
@@ -339,7 +338,6 @@
     <string name="backup_restore_export_partial">ব্যাকআপ তৈরি করা হয়েছে, তবে এই অংশগুলি ব্যর্থ হয়েছে: %1$s</string>
     <string name="backup_restore_restore_success">ব্যাকআপ পুনরুদ্ধার করা হয়েছে</string>
     <string name="backup_restore_restore_failed">পুনরুদ্ধার ব্যর্থ হয়েছে (%1$s)। আপনার পূর্ববর্তী কনফিগারেশন সংরক্ষিত হয়েছে।</string>
-    <string name="backup_restore_undo_action">পূর্বাবস্থায় ফিরিয়ে আনুন</string>
     <string name="backup_restore_recovery_title">পূর্ববর্তী কনফিগারেশন পুনরুদ্ধার করুন</string>
     <string name="backup_restore_recovery_desc">একটি অসম্পূর্ণ পুনরুদ্ধার থেকে একটি নিরাপত্তা স্ন্যাপশট উপলব্ধ</string>
     <string name="backup_restore_confirm_title">এই ব্যাকআপ পুনরুদ্ধার করবেন?</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">Política de privadesa</string>
     <string name="settings_privacy_policy_desc">Tractament responsable de les dades.</string>
     <string name="settings_category_other_label">Altres</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">General</string>
     <string name="general_settings_desc">Retocs generals que afecten tota l\'aplicació.</string>
     <string name="settings_category_ui_label">Interfície d\'usuari</string>
@@ -339,7 +338,6 @@
     <string name="backup_restore_export_partial">Còpia de seguretat creada, però aquestes parts han fallat: %1$s</string>
     <string name="backup_restore_restore_success">Còpia de seguretat restaurada</string>
     <string name="backup_restore_restore_failed">La restauració ha fallat (%1$s). S\'ha desat la configuració anterior.</string>
-    <string name="backup_restore_undo_action">Desfés</string>
     <string name="backup_restore_recovery_title">Recupera la configuració anterior</string>
     <string name="backup_restore_recovery_desc">Hi ha disponible una còpia de seguretat d\'una restauració inacabada</string>
     <string name="backup_restore_confirm_title">Vols restaurar aquesta còpia de seguretat?</string>

--- a/app/src/main/res/values-ckb-rIR/strings.xml
+++ b/app/src/main/res/values-ckb-rIR/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">سیاسەتی تایبەتمەندی</string>
     <string name="settings_privacy_policy_desc">مامەڵەکردن لەگەڵ داتا بە بەرپرسیارێتییەوە.</string>
     <string name="settings_category_other_label">هی تر</string>
-    <string name="upgrade_badge_label">پرۆ</string>
     <string name="general_settings_label">گشتی</string>
     <string name="general_settings_desc">گۆڕانکاریەکانی گشتی کە کاریگەری لەسەر تەواوی ئەپەکە دەبێت.</string>
     <string name="settings_category_ui_label">ڕووکاری بەکارهێنەر</string>
@@ -341,7 +340,6 @@
     <string name="backup_restore_export_partial">پاڅپشت دروستکرا، بەڵام ئەم بەشانە شکست خوردن: %1$s</string>
     <string name="backup_restore_restore_success">پاڅپشت گێڕانەوە کرا</string>
     <string name="backup_restore_restore_failed">گێڕانەوە سەرکەوتوو نەبوو (%1$s). ڕێکخستنی پێشووی تۆ پاشکەوتکرابوو.</string>
-    <string name="backup_restore_undo_action">پووچ کردنەوە</string>
     <string name="backup_restore_recovery_title">ڕێکخستنی پێشووی بیهێنان</string>
     <string name="backup_restore_recovery_desc">وێنەیەکی ئاسایش لە گێڕانەوەیەکی نەتەواو هەیە</string>
     <string name="backup_restore_confirm_title">ئەم پاڅپشتە گێڕانەوە بکەم؟</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -113,7 +113,6 @@
     <string name="settings_privacy_policy_label">Zásady ochrany osobních údajů</string>
     <string name="settings_privacy_policy_desc">Zodpovědné nakládání s daty.</string>
     <string name="settings_category_other_label">Ostatní</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">Obecné</string>
     <string name="general_settings_desc">Obecná vylepšení, která ovlivňují celou aplikaci.</string>
     <string name="settings_category_ui_label">Uživatelské rozhraní</string>
@@ -353,7 +352,6 @@
     <string name="backup_restore_export_partial">Záloha vytvořena, ale tyto části selhaly: %1$s</string>
     <string name="backup_restore_restore_success">Záloha obnovena</string>
     <string name="backup_restore_restore_failed">Obnovení selhalo (%1$s). Vaše předchozí konfigurace byla uložena.</string>
-    <string name="backup_restore_undo_action">Vrátit zpět</string>
     <string name="backup_restore_recovery_title">Obnovit předchozí konfiguraci</string>
     <string name="backup_restore_recovery_desc">Je k dispozici bezpečnostní snímek z neúplného obnovení</string>
     <string name="backup_restore_confirm_title">Obnovit tuto zálohu?</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">Privatlivspolitik</string>
     <string name="settings_privacy_policy_desc">Håndterer data ansvarligt.</string>
     <string name="settings_category_other_label">Andet</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">Generel</string>
     <string name="general_settings_desc">Generelle justeringer, der påvirker hele appen.</string>
     <string name="settings_category_ui_label">Brugergrænseflade</string>
@@ -339,7 +338,6 @@
     <string name="backup_restore_export_partial">Sikkerhedskopi oprettet, men disse dele mislykkedes: %1$s</string>
     <string name="backup_restore_restore_success">Sikkerhedskopi gendannet</string>
     <string name="backup_restore_restore_failed">Gendan mislykkedes (%1$s). Din tidligere konfiguration blev gemt.</string>
-    <string name="backup_restore_undo_action">Fortryd</string>
     <string name="backup_restore_recovery_title">Gendan tidligere konfiguration</string>
     <string name="backup_restore_recovery_desc">Et sikkerhedssnapshot fra en uafsluttet gendannelse er tilgængeligt</string>
     <string name="backup_restore_confirm_title">Gendan denne sikkerhedskopi?</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">Datenschutz-Bestimmungen</string>
     <string name="settings_privacy_policy_desc">Verantwortungsvoller Umgang mit Daten.</string>
     <string name="settings_category_other_label">Sonstiges</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">Allgemein</string>
     <string name="general_settings_desc">Allgemeine Optimierungen, die die gesamte App betreffen.</string>
     <string name="settings_category_ui_label">Benutzeroberfläche</string>
@@ -339,7 +338,6 @@
     <string name="backup_restore_export_partial">Sicherung erstellt, aber diese Teile konnten nicht gesichert werden: %1$s</string>
     <string name="backup_restore_restore_success">Sicherung wiederhergestellt</string>
     <string name="backup_restore_restore_failed">Wiederherstellung fehlgeschlagen (%1$s). Ihre vorherige Konfiguration wurde gespeichert.</string>
-    <string name="backup_restore_undo_action">Rückgängig machen</string>
     <string name="backup_restore_recovery_title">Vorherige Konfiguration wiederherstellen</string>
     <string name="backup_restore_recovery_desc">Eine Sicherheitskopie aus einer unvollendeten Wiederherstellung ist verfügbar</string>
     <string name="backup_restore_confirm_title">Diese Sicherung wiederherstellen?</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">Πολιτική απορρήτου</string>
     <string name="settings_privacy_policy_desc">Υπεύθυνη διαχείριση δεδομένων.</string>
     <string name="settings_category_other_label">Άλλο</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">Γενικά</string>
     <string name="general_settings_desc">Γενικές τροποποιήσεις που επηρεάζουν ολόκληρη την εφαρμογή.</string>
     <string name="settings_category_ui_label">Περιβάλλον χρήστη</string>
@@ -339,7 +338,6 @@
     <string name="backup_restore_export_partial">Αντίγραφο ασφαλείας δημιουργήθηκε, αλλά αυτά τα μέρη απέτυχαν: %1$s</string>
     <string name="backup_restore_restore_success">Αντίγραφο ασφαλείας επαναφέρθηκε</string>
     <string name="backup_restore_restore_failed">Η επαναφορά απέτυχε (%1$s). Η προηγούμενη ρύθμισή σας αποθηκεύτηκε.</string>
-    <string name="backup_restore_undo_action">Αναίρεση</string>
     <string name="backup_restore_recovery_title">Ανάκτηση προηγούμενης ρύθμισης</string>
     <string name="backup_restore_recovery_desc">Ένα στιγμιότυπο ασφαλείας από μια ημιτελή επαναφορά είναι διαθέσιμο</string>
     <string name="backup_restore_confirm_title">Επαναφορά αυτού του αντιγράφου ασφαλείας;</string>

--- a/app/src/main/res/values-es-rAR/strings.xml
+++ b/app/src/main/res/values-es-rAR/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">Política de privacidad</string>
     <string name="settings_privacy_policy_desc">Manejando datos de forma responsable.</string>
     <string name="settings_category_other_label">Otros</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">General</string>
     <string name="general_settings_desc">Ajustes generales que afectan a toda la aplicación.</string>
     <string name="settings_category_ui_label">Interfaz de usuario</string>
@@ -339,7 +338,6 @@
     <string name="backup_restore_export_partial">Copia de seguridad creada, pero estas partes fallaron: %1$s</string>
     <string name="backup_restore_restore_success">Copia de seguridad restaurada</string>
     <string name="backup_restore_restore_failed">La restauración falló (%1$s). Tu configuración anterior fue guardada.</string>
-    <string name="backup_restore_undo_action">Deshacer</string>
     <string name="backup_restore_recovery_title">Recuperar configuración anterior</string>
     <string name="backup_restore_recovery_desc">Una instantánea de seguridad de una restauración incompleta está disponible</string>
     <string name="backup_restore_confirm_title">¿Restaurar esta copia de seguridad?</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">Política de privacidad</string>
     <string name="settings_privacy_policy_desc">Tratamiento responsable de datos.</string>
     <string name="settings_category_other_label">Otros</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">General</string>
     <string name="general_settings_desc">Ajustes generales que afectan toda la aplicación.</string>
     <string name="settings_category_ui_label">Interfaz de usuario</string>
@@ -339,7 +338,6 @@
     <string name="backup_restore_export_partial">Copia de seguridad creada, pero estas partes fallaron: %1$s</string>
     <string name="backup_restore_restore_success">Copia de seguridad restaurada</string>
     <string name="backup_restore_restore_failed">Error al restaurar (%1$s). Se guardó tu configuración anterior.</string>
-    <string name="backup_restore_undo_action">Deshacer</string>
     <string name="backup_restore_recovery_title">Recuperar configuración anterior</string>
     <string name="backup_restore_recovery_desc">Una instantánea de seguridad de una restauración incompleta está disponible</string>
     <string name="backup_restore_confirm_title">¿Restaurar esta copia de seguridad?</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">Política de privacidad</string>
     <string name="settings_privacy_policy_desc">Tratamiento responsable de los datos.</string>
     <string name="settings_category_other_label">Otros</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">General</string>
     <string name="general_settings_desc">Ajustes generales que afectan a toda la aplicación.</string>
     <string name="settings_category_ui_label">Interfaz de usuario</string>
@@ -339,7 +338,6 @@
     <string name="backup_restore_export_partial">Copia de seguridad creada, pero estas partes fallaron: %1$s</string>
     <string name="backup_restore_restore_success">Copia de seguridad restaurada</string>
     <string name="backup_restore_restore_failed">Falló la restauración (%1$s). Se guardó tu configuración anterior.</string>
-    <string name="backup_restore_undo_action">Deshacer</string>
     <string name="backup_restore_recovery_title">Recuperar configuración anterior</string>
     <string name="backup_restore_recovery_desc">Hay disponible una instantánea de seguridad de una restauración inacabada</string>
     <string name="backup_restore_confirm_title">¿Restaurar esta copia de seguridad?</string>

--- a/app/src/main/res/values-et-rEE/strings.xml
+++ b/app/src/main/res/values-et-rEE/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">Privaatsusteatis</string>
     <string name="settings_privacy_policy_desc">Andmete vastutustundlik haldamine.</string>
     <string name="settings_category_other_label">Muu</string>
-    <string name="upgrade_badge_label">Tasuline</string>
     <string name="general_settings_label">Üldine</string>
     <string name="general_settings_desc">Üldseaded, mis mõjutavad kogu rakendust.</string>
     <string name="settings_category_ui_label">Kasutajaliides</string>
@@ -339,7 +338,6 @@
     <string name="backup_restore_export_partial">Varukoopia loodi, kuid need osad ebaõnnestusid: %1$s</string>
     <string name="backup_restore_restore_success">Varukoopia taastati</string>
     <string name="backup_restore_restore_failed">Taastamine ebaõnnestus (%1$s). Teie eelmine konfiguratsioon salvestati.</string>
-    <string name="backup_restore_undo_action">Tühista</string>
     <string name="backup_restore_recovery_title">Taasta eelmine konfiguratsioon</string>
     <string name="backup_restore_recovery_desc">Lõpetamata taastamisest on saadaval turvalisuse hetktõmmis</string>
     <string name="backup_restore_confirm_title">Taastada see varukoopia?</string>

--- a/app/src/main/res/values-eu-rES/strings.xml
+++ b/app/src/main/res/values-eu-rES/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">Pribatutasun-politika</string>
     <string name="settings_privacy_policy_desc">Datuak erantzunkidetasunez kudeatzea.</string>
     <string name="settings_category_other_label">Bestelakoak</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">Orokorra</string>
     <string name="general_settings_desc">Aplikazio osoa eragiten duten doikuntza orokorrak.</string>
     <string name="settings_category_ui_label">Erabiltzaile-interfazea</string>
@@ -341,7 +340,6 @@ Probatu: %3$s</item>
     <string name="backup_restore_export_partial">Babeskopia sortu da, baina zati hauek huts egin zuten: %1$s</string>
     <string name="backup_restore_restore_success">Babeskopia berreskuratu da</string>
     <string name="backup_restore_restore_failed">Berreskuratzeak huts egin du (%1$s). Zure aurreko konfigurazioa gorde da.</string>
-    <string name="backup_restore_undo_action">Desegin</string>
     <string name="backup_restore_recovery_title">Aurreko konfigurazioa berreskuratu</string>
     <string name="backup_restore_recovery_desc">Amaitu gabeko berreskuratzearen segurtasun-kopia dago</string>
     <string name="backup_restore_confirm_title">Babeskopia hau berreskuratu?</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">سیاست حفظ حریم خصوصی</string>
     <string name="settings_privacy_policy_desc">رعایت مسئولانه داده‌ها.</string>
     <string name="settings_category_other_label">بقیه</string>
-    <string name="upgrade_badge_label">حرفه‌ای</string>
     <string name="general_settings_label">عمومی</string>
     <string name="general_settings_desc">تغییرات عمومی که بر کل برنامه تأثیر می‌گذارد.</string>
     <string name="settings_category_ui_label">رابط کاربری</string>
@@ -339,7 +338,6 @@
     <string name="backup_restore_export_partial">پشتیبان ایجاد شد، اما این قسمت‌ها ناموفق بودند: %1$s</string>
     <string name="backup_restore_restore_success">پشتیبان بازگردانی شد</string>
     <string name="backup_restore_restore_failed">بازگردانی ناموفق (%1$s). پیکربندی قبلی شما ذخیره شد.</string>
-    <string name="backup_restore_undo_action">واگرد</string>
     <string name="backup_restore_recovery_title">بازیابی پیکربندی قبلی</string>
     <string name="backup_restore_recovery_desc">تصویری ایمن از بازگردانی ناتمام موجود است</string>
     <string name="backup_restore_confirm_title">این پشتیبان را بازگردانی کنیم؟</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">Tietosuojakäytäntö</string>
     <string name="settings_privacy_policy_desc">Vastuullinen tietojen käsittely.</string>
     <string name="settings_category_other_label">Muut</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">Yleiset</string>
     <string name="general_settings_desc">Yleiset säädöt jotka vaikuttavat koko sovellukseen.</string>
     <string name="settings_category_ui_label">Käyttöliittymä</string>
@@ -339,7 +338,6 @@
     <string name="backup_restore_export_partial">Varmuuskopio luotu, mutta nämä osat epäonnistuivat: %1$s</string>
     <string name="backup_restore_restore_success">Varmuuskopio palautettu</string>
     <string name="backup_restore_restore_failed">Palautus epäonnistui (%1$s). Aiempi konfiguraatiosi tallennettiin.</string>
-    <string name="backup_restore_undo_action">Kumoa</string>
     <string name="backup_restore_recovery_title">Palauta aiempi konfiguraatio</string>
     <string name="backup_restore_recovery_desc">Turvallinen tilannekuva keskeneräisestä palautuksesta on saatavilla</string>
     <string name="backup_restore_confirm_title">Palautetaanko tämä varmuuskopio?</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">Patakaran sa Pagkapribado</string>
     <string name="settings_privacy_policy_desc">Responsableng hinaawakan ang datos.</string>
     <string name="settings_category_other_label">Iba</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">Pangkalahatan</string>
     <string name="general_settings_desc">Mga pangkalahatang pagbabago na nakakaapekto sa buong app.</string>
     <string name="settings_category_ui_label">User interface</string>
@@ -339,7 +338,6 @@
     <string name="backup_restore_export_partial">Ang backup ay nabuo, ngunit ang mga bahaging ito ay nabigo: %1$s</string>
     <string name="backup_restore_restore_success">Ang backup ay na-restore</string>
     <string name="backup_restore_restore_failed">Ang pag-restore ay nabigo (%1$s). Ang iyong nakaraang configuration ay nai-save.</string>
-    <string name="backup_restore_undo_action">I-undo</string>
     <string name="backup_restore_recovery_title">I-recover ang nakaraang configuration</string>
     <string name="backup_restore_recovery_desc">May available na safety snapshot mula sa hindi pa tapos na pag-restore</string>
     <string name="backup_restore_confirm_title">I-restore ang backup na ito?</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">Politique de confidentialité</string>
     <string name="settings_privacy_policy_desc">Traitement responsable des données.</string>
     <string name="settings_category_other_label">Autres</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">Général</string>
     <string name="general_settings_desc">Peaufinages généraux qui affectent l’ensemble de l’appli.</string>
     <string name="settings_category_ui_label">Interface utilisateur</string>
@@ -339,7 +338,6 @@
     <string name="backup_restore_export_partial">Sauvegarde créée, mais ces parties ont échoué : %1$s</string>
     <string name="backup_restore_restore_success">Sauvegarde restaurée</string>
     <string name="backup_restore_restore_failed">La restauration a échoué (%1$s). Votre configuration précédente a été enregistrée.</string>
-    <string name="backup_restore_undo_action">Annuler</string>
     <string name="backup_restore_recovery_title">Récupérer la configuration précédente</string>
     <string name="backup_restore_recovery_desc">Une capture de sécurité d’une restauration inachevée est disponible</string>
     <string name="backup_restore_confirm_title">Restaurer cette sauvegarde ?</string>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">Política de privacidade</string>
     <string name="settings_privacy_policy_desc">Manexando os datos responsablemente.</string>
     <string name="settings_category_other_label">Outros</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">Xeral</string>
     <string name="general_settings_desc">Axustes xerais que afectan toda a aplicación.</string>
     <string name="settings_category_ui_label">Interface de usuario</string>
@@ -339,7 +338,6 @@
     <string name="backup_restore_export_partial">Copia de seguridade creada, pero estas partes fallaron: %1$s</string>
     <string name="backup_restore_restore_success">Copia de seguridade restaurada</string>
     <string name="backup_restore_restore_failed">A restauración fallou (%1$s). A túa configuración anterior foi gardada.</string>
-    <string name="backup_restore_undo_action">Desfacer</string>
     <string name="backup_restore_recovery_title">Recuperar configuración anterior</string>
     <string name="backup_restore_recovery_desc">Unha instantánea de seguridade dunha restauración sen rematar está dispoñible</string>
     <string name="backup_restore_confirm_title">Restaurar esta copia de seguridade?</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">निजता नीति</string>
     <string name="settings_privacy_policy_desc">डेटा को जिम्मेदारी से संभालना।</string>
     <string name="settings_category_other_label">अन्य</string>
-    <string name="upgrade_badge_label">प्रो</string>
     <string name="general_settings_label">सामान्य</string>
     <string name="general_settings_desc">सामान्य बदलाव जो पूरे ऐप को प्रभावित करते हैं।</string>
     <string name="settings_category_ui_label">उपयोगकर्ता अंतरपृष्‍ठ</string>
@@ -342,7 +341,6 @@
     <string name="backup_restore_export_partial">बैकअप बनाया गया, लेकिन ये भाग विफल रहे: %1$s</string>
     <string name="backup_restore_restore_success">बैकअप पुनः स्थापित किया गया</string>
     <string name="backup_restore_restore_failed">पुनः स्थापन विफल (%1$s)। आपकी पिछली कॉन्फ़िगरेशन सहेजी गई थी।</string>
-    <string name="backup_restore_undo_action">पूर्ववत</string>
     <string name="backup_restore_recovery_title">पिछली कॉन्फ़िगरेशन को पुनः प्राप्त करें</string>
     <string name="backup_restore_recovery_desc">एक अधूरे पुनः स्थापन से एक सुरक्षा स्नैपशॉट उपलब्ध है</string>
     <string name="backup_restore_confirm_title">क्या इस बैकअप को पुनः स्थापित करें?</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -110,7 +110,6 @@
     <string name="settings_privacy_policy_label">Politika privatnosti</string>
     <string name="settings_privacy_policy_desc">Odgovorno postupanje s podacima.</string>
     <string name="settings_category_other_label">Ostalo</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">Općenito</string>
     <string name="general_settings_desc">Opće postavke koje utječu na cijelu aplikaciju.</string>
     <string name="settings_category_ui_label">Korisničko sučelje</string>
@@ -346,7 +345,6 @@
     <string name="backup_restore_export_partial">Sigurnosna kopija kreirana, ali ovi dijelovi nisu uspjeli: %1$s</string>
     <string name="backup_restore_restore_success">Sigurnosna kopija obnovljena</string>
     <string name="backup_restore_restore_failed">Obnova nije uspjela (%1$s). Vaša prethodna konfiguracija je spremljena.</string>
-    <string name="backup_restore_undo_action">Poništi</string>
     <string name="backup_restore_recovery_title">Oporavi prethodnu konfiguraciju</string>
     <string name="backup_restore_recovery_desc">Dostupna je sigurnosna snimka iz nedovršene obnove</string>
     <string name="backup_restore_confirm_title">Obnoviti ovu sigurnosnu kopiju?</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">Adatvédelmi irányelvek</string>
     <string name="settings_privacy_policy_desc">Az adatok felelősségteljes kezelése.</string>
     <string name="settings_category_other_label">Egyéb</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">Általános</string>
     <string name="general_settings_desc">Általános módosítások, amelyek az egész alkalmazást érintik.</string>
     <string name="settings_category_ui_label">Felhasználói felület</string>
@@ -339,7 +338,6 @@
     <string name="backup_restore_export_partial">Biztonsági mentés létrehozva, de az alábbi részek meghíusultak: %1$s</string>
     <string name="backup_restore_restore_success">Biztonsági mentés helyreállítva</string>
     <string name="backup_restore_restore_failed">A helyreállítás meghíusult (%1$s). Az előző konfiguráció mentésre került.</string>
-    <string name="backup_restore_undo_action">Visszavonás</string>
     <string name="backup_restore_recovery_title">Korábbi konfiguráció helyreállítása</string>
     <string name="backup_restore_recovery_desc">A befejezetlen helyreállítás biztonsági mentése elérhető</string>
     <string name="backup_restore_confirm_title">Vissza szeretné állítani ezt a biztonsági mentést?</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -104,7 +104,6 @@
     <string name="settings_privacy_policy_label">Kebijakan privasi</string>
     <string name="settings_privacy_policy_desc">Menangani data secara bertanggung jawab.</string>
     <string name="settings_category_other_label">Lainnya</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">Umum</string>
     <string name="general_settings_desc">Tweak umum yang memengaruhi seluruh aplikasi.</string>
     <string name="settings_category_ui_label">Antarmuka pengguna</string>
@@ -332,7 +331,6 @@
     <string name="backup_restore_export_partial">Cadangan dibuat, tetapi bagian-bagian ini gagal: %1$s</string>
     <string name="backup_restore_restore_success">Cadangan dipulihkan</string>
     <string name="backup_restore_restore_failed">Pemulihan gagal (%1$s). Konfigurasi sebelumnya Anda telah disimpan.</string>
-    <string name="backup_restore_undo_action">Batalkan</string>
     <string name="backup_restore_recovery_title">Pulihkan konfigurasi sebelumnya</string>
     <string name="backup_restore_recovery_desc">Snapshot keamanan dari pemulihan yang belum selesai tersedia</string>
     <string name="backup_restore_confirm_title">Pulihkan cadangan ini?</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">Friðhelgisstefna</string>
     <string name="settings_privacy_policy_desc">Ábyrgð meðhöndlun gagna.</string>
     <string name="settings_category_other_label">Annað</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">Almennt</string>
     <string name="general_settings_desc">Almennar stillingar sem hafa áhrif á allt forritið.</string>
     <string name="settings_category_ui_label">Notendaviðmót</string>
@@ -339,7 +338,6 @@
     <string name="backup_restore_export_partial">Afrit búið til, en þessir hlutir mistókust: %1$s</string>
     <string name="backup_restore_restore_success">Afrit endurheimtað</string>
     <string name="backup_restore_restore_failed">Endurheimting mistókst (%1$s). Fyrri stilling þín var vistuð.</string>
-    <string name="backup_restore_undo_action">Afturkalla</string>
     <string name="backup_restore_recovery_title">Endurheimta fyrri stillingu</string>
     <string name="backup_restore_recovery_desc">Öryggisafrit frá ólokinni endurheimtun er tiltækt</string>
     <string name="backup_restore_confirm_title">Endurheimta þetta afrit?</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">Informativa sulla privacy</string>
     <string name="settings_privacy_policy_desc">Trattamento responsabile dei dati.</string>
     <string name="settings_category_other_label">Altro</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">Generale</string>
     <string name="general_settings_desc">Modifiche generali che interessano l\'intera app.</string>
     <string name="settings_category_ui_label">Interfaccia utente</string>
@@ -339,7 +338,6 @@
     <string name="backup_restore_export_partial">Backup creato, ma questi componenti non sono riusciti: %1$s</string>
     <string name="backup_restore_restore_success">Backup ripristinato</string>
     <string name="backup_restore_restore_failed">Il ripristino non è riuscito (%1$s). La configurazione precedente è stata salvata.</string>
-    <string name="backup_restore_undo_action">Annulla</string>
     <string name="backup_restore_recovery_title">Recupera la configurazione precedente</string>
     <string name="backup_restore_recovery_desc">È disponibile uno snapshot di sicurezza da un ripristino non completato</string>
     <string name="backup_restore_confirm_title">Ripristinare questo backup?</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -113,7 +113,6 @@
     <string name="settings_privacy_policy_label">מדיניות פרטיות</string>
     <string name="settings_privacy_policy_desc">טיפול בנתונים בצורה אחראית.</string>
     <string name="settings_category_other_label">אחר</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">כללי</string>
     <string name="general_settings_desc">שינויים כללים המשפיעים על כל האפליקציה.</string>
     <string name="settings_category_ui_label">ממשק משתמש</string>
@@ -354,7 +353,6 @@ SD Maid ישתמש בו כאלטרנטיבה.</string>
     <string name="backup_restore_export_partial">הגיבוי נוצר, אך החלקים הבאים נכשלו: %1$s</string>
     <string name="backup_restore_restore_success">הגיבוי שוחזר</string>
     <string name="backup_restore_restore_failed">השחזור נכשל (%1$s). התצורה הקודמת שלך נשמרה.</string>
-    <string name="backup_restore_undo_action">ביטול</string>
     <string name="backup_restore_recovery_title">שחזר את התצורה הקודמת</string>
     <string name="backup_restore_recovery_desc">צילום בטיחות משחזור שלא הושלם זמין</string>
     <string name="backup_restore_confirm_title">לשחזר את הגיבוי הזה?</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -104,7 +104,6 @@
     <string name="settings_privacy_policy_label">プライバシーポリシー</string>
     <string name="settings_privacy_policy_desc">責任を持ってデータを扱います。</string>
     <string name="settings_category_other_label">その他</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">一般</string>
     <string name="general_settings_desc">アプリ全体に影響を与える一般的な調整。</string>
     <string name="settings_category_ui_label">ユーザーインターフェース</string>
@@ -332,7 +331,6 @@
     <string name="backup_restore_export_partial">バックアップが作成されましたが、以下の項目は失敗しました: %1$s</string>
     <string name="backup_restore_restore_success">バックアップが復元されました</string>
     <string name="backup_restore_restore_failed">復元に失敗しました (%1$s)。以前の構成は保存されました。</string>
-    <string name="backup_restore_undo_action">戻す</string>
     <string name="backup_restore_recovery_title">以前の構成を復旧する</string>
     <string name="backup_restore_recovery_desc">未完了の復元のセーフティスナップショットが利用可能です</string>
     <string name="backup_restore_confirm_title">このバックアップを復元しますか？</string>

--- a/app/src/main/res/values-ka-rGE/strings.xml
+++ b/app/src/main/res/values-ka-rGE/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">Კონფიდენციალურობის პოლიტიკა</string>
     <string name="settings_privacy_policy_desc">მონაცემების პასუხისმგებლობით დამუშავება.</string>
     <string name="settings_category_other_label">სხვა</string>
-    <string name="upgrade_badge_label">პრო</string>
     <string name="general_settings_label">ზოგადი</string>
     <string name="general_settings_desc">ზოგადი შესწორებები, რომლებიც გავლენას ახდენს მთელ აპლიკაციაზე.</string>
     <string name="settings_category_ui_label">Მომხმარებლის ინტერფეისი</string>
@@ -339,7 +338,6 @@
     <string name="backup_restore_export_partial">სარეზერვო კოპია შეიქმნა, მაგრამ ეს ნაწილები ვერ მოხერხდა: %1$s</string>
     <string name="backup_restore_restore_success">სარეზერვო კოპია აღდგა</string>
     <string name="backup_restore_restore_failed">აღდგენა ვერ მოხერხდა (%1$s). თქვენი წინა კონფიგურაცია შენახულია.</string>
-    <string name="backup_restore_undo_action">დაბრუნება</string>
     <string name="backup_restore_recovery_title">წინა კონფიგურაციის აღდგენა</string>
     <string name="backup_restore_recovery_desc">დაუსრულებელი აღდგენიდან უსაფრთხოების ასლი ხელმისაწვდომია</string>
     <string name="backup_restore_confirm_title">აღვადგინო ეს სარეზერვო კოპია?</string>

--- a/app/src/main/res/values-kaa/strings.xml
+++ b/app/src/main/res/values-kaa/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">Qupiyalıq siyasatı</string>
     <string name="settings_privacy_policy_desc">Maǵlıwmatlarǵa juwapkershilik penen qayta islew.</string>
     <string name="settings_category_other_label">Basqa</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">Ulıwmalıq</string>
     <string name="general_settings_desc">Pútkil qosımshaǵa tásir etetuǵın ulıwma sazlawlar.</string>
     <string name="settings_category_ui_label">Paydalanıwshı interfeysı</string>
@@ -339,7 +338,6 @@
     <string name="backup_restore_export_partial">Zápasnı nusxa jasalǵan, biraq bul bólekler sátsiz boldı: %1$s</string>
     <string name="backup_restore_restore_success">Zápasnı nusxa qaytarıldı</string>
     <string name="backup_restore_restore_failed">Qaytarıw sátsiz boldı (%1$s). Aldınǵı konfiguraciyańız saqlandı.</string>
-    <string name="backup_restore_undo_action">Biykarlaw</string>
     <string name="backup_restore_recovery_title">Aldınǵı konfiguraciyani qayta tiklew</string>
     <string name="backup_restore_recovery_desc">Tamamlanbaǵan qayta tiklewden qawipsizlik saqlaw nusxasi bar</string>
     <string name="backup_restore_confirm_title">Bul zápasnı nusxa qayta tiklensin be?</string>

--- a/app/src/main/res/values-km-rKH/strings.xml
+++ b/app/src/main/res/values-km-rKH/strings.xml
@@ -104,7 +104,6 @@
     <string name="settings_privacy_policy_label">គោលការណ៍ឯកជនភាព</string>
     <string name="settings_privacy_policy_desc">ការដោះស្រាយទិន្នន័យដោយមានការទទួលខុសត្រូវ។</string>
     <string name="settings_category_other_label">ដទៃ</string>
-    <string name="upgrade_badge_label">ប្រូ</string>
     <string name="general_settings_label">ជាទូទៅ</string>
     <string name="general_settings_desc">ការកែលម្អ ទូទៅដែលប៉ះពាល់ដល់កម្មវិធីទាំងមូល។</string>
     <string name="settings_category_ui_label">អន្តរមុខអ្នកប្រើ</string>
@@ -332,7 +331,6 @@
     <string name="backup_restore_export_partial">បានបង្កើតការបម្រុង ប៉ុន្តែផ្នែកទាំងនេះបានបរាជ័យ៖ %1$s</string>
     <string name="backup_restore_restore_success">បានស្ដារការបម្រុង</string>
     <string name="backup_restore_restore_failed">ការស្ដារបានបរាជ័យ (%1$s)។ ការកំណត់របស់អ្នកដែលបានកន្លងទៅត្រូវបានរក្សាទុក។</string>
-    <string name="backup_restore_undo_action">អាន់ឌូ</string>
     <string name="backup_restore_recovery_title">ស្ដារការកំណត់របស់អ្នកដែលបានកន្លងទៅ</string>
     <string name="backup_restore_recovery_desc">ឯកសារបម្រុងសុវត្ថិភាពពីការស្ដារដែលមិនបានបញ្ចប់គឺមាន</string>
     <string name="backup_restore_confirm_title">ស្ដារការបម្រុងនេះឬ?</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -104,7 +104,6 @@
     <string name="settings_privacy_policy_label">개인정보보호정책</string>
     <string name="settings_privacy_policy_desc">개인정보를 책임지고 다룹니다.</string>
     <string name="settings_category_other_label">기타</string>
-    <string name="upgrade_badge_label">프로</string>
     <string name="general_settings_label">일반</string>
     <string name="general_settings_desc">전체 앱의 작동에 영향을 주는 일반적 설정입니다.</string>
     <string name="settings_category_ui_label">인터페이스</string>
@@ -332,7 +331,6 @@
     <string name="backup_restore_export_partial">백업이 생성되었지만 다음 항목이 실패했습니다: %1$s</string>
     <string name="backup_restore_restore_success">백업이 복원되었습니다</string>
     <string name="backup_restore_restore_failed">복원에 실패했습니다 (%1$s). 이전 구성이 저장되었습니다.</string>
-    <string name="backup_restore_undo_action">실행취소</string>
     <string name="backup_restore_recovery_title">이전 구성 복구</string>
     <string name="backup_restore_recovery_desc">미완료된 복원의 안전 스냅샷이 있습니다</string>
     <string name="backup_restore_confirm_title">이 백업을 복원하시겠습니까?</string>

--- a/app/src/main/res/values-lo-rLA/strings.xml
+++ b/app/src/main/res/values-lo-rLA/strings.xml
@@ -104,7 +104,6 @@
     <string name="settings_privacy_policy_label">ນະໂຍບາຍຄວາມເປັນສ່ວນຕົວ</string>
     <string name="settings_privacy_policy_desc">ການຈັດການຂໍ້ມູນຢ່າງມີຄວາມຮັບຜິດຊອບ.</string>
     <string name="settings_category_other_label">ອື່ນໆ</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">ທົ່ວໄປ</string>
     <string name="general_settings_desc">ການປັບຕົວທົ່ວໄປທີ່ສົ່ງຜົນຕໍ່ແອັບທັງຫມົດ.</string>
     <string name="settings_category_ui_label">ການໂຕ້ຕອບຜູ້ໃຊ້</string>
@@ -333,7 +332,6 @@
     <string name="backup_restore_export_partial">ສຳໝອງຂໍ້ມູນສ້າງຂຶ້ນແລ້ວ ແຕ່ສ່ວນເໝຼ່ານີ້ລໍ້ມເຫວ: %1$s</string>
     <string name="backup_restore_restore_success">ສຳໝອງຂໍ້ມູນກູ້ຄືນແລ້ວ</string>
     <string name="backup_restore_restore_failed">ການກູ້ຄືນລໍ້ມເຫລວ (%1$s). ການຕັ້ງຄ່າກ່ອນໜ້າຂອງທ່ານໄດ້ຖືກບັນທຶກໄວ້.</string>
-    <string name="backup_restore_undo_action">ຍໍກເລີກ</string>
     <string name="backup_restore_recovery_title">ກູ້ຄືນການຕັ້ງຄ່າກ່ອນໜ້າ</string>
     <string name="backup_restore_recovery_desc">ມີສະແນັກປອດໄພຈາກການກູ້ຄືນທີ່ບໍ່ສໍາເລັດ</string>
     <string name="backup_restore_confirm_title">ກູ້ຄືນສໍາເນົາທີ່ບັນທຶກໄວ້ນີ້ບໍ?</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -113,7 +113,6 @@
     <string name="settings_privacy_policy_label">Privatumo politika</string>
     <string name="settings_privacy_policy_desc">Atsakingas duomenų tvarkymas.</string>
     <string name="settings_category_other_label">Kita</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">Bendrieji</string>
     <string name="general_settings_desc">Bendrieji patobulinimai, turintys įtakos visai programėlei.</string>
     <string name="settings_category_ui_label">Vartotojo sąsaja</string>
@@ -357,7 +356,6 @@ Bandykite: %3$s</item>
     <string name="backup_restore_export_partial">Atsarginė kopija sukurta, tačiau šios dalys nepavyko: %1$s</string>
     <string name="backup_restore_restore_success">Atsarginė kopija atkurta</string>
     <string name="backup_restore_restore_failed">Atkūrimas nepavyko (%1$s). Jūsų ankstesnė konfigūracija buvo išsaugota.</string>
-    <string name="backup_restore_undo_action">Atšaukti</string>
     <string name="backup_restore_recovery_title">Atkurti ankstesnę konfigūraciją</string>
     <string name="backup_restore_recovery_desc">Yra saugos kopija iš nebaigto atkūrimo</string>
     <string name="backup_restore_confirm_title">Atkurti šią atsarginę kopiją?</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -110,7 +110,6 @@
     <string name="settings_privacy_policy_label">Privātuma politika</string>
     <string name="settings_privacy_policy_desc">Atbildīga datu apstrāde.</string>
     <string name="settings_category_other_label">Cits</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">Vispārīgi</string>
     <string name="general_settings_desc">Vispārīgi pielāgojumi, kas ietekmē visu lietotni.</string>
     <string name="settings_category_ui_label">Lietotāja saskarne</string>
@@ -349,7 +348,6 @@ Mēģiniet: %3$s</item>
     <string name="backup_restore_export_partial">Rezerves kopija izveidota, bet šīs daļas neizdevās: %1$s</string>
     <string name="backup_restore_restore_success">Rezerves kopija atjaunota</string>
     <string name="backup_restore_restore_failed">Atjaunošana neizdevās (%1$s). Jūsu iepriekšējā konfigurācija tika saglabāta.</string>
-    <string name="backup_restore_undo_action">Atsaukt</string>
     <string name="backup_restore_recovery_title">Atgūt iepriekšējo konfigurāciju</string>
     <string name="backup_restore_recovery_desc">Drošības momentuzņēmums no nepabeigtas atjaunošanas ir pieejams</string>
     <string name="backup_restore_confirm_title">Atjaunot šo rezerves kopiju?</string>

--- a/app/src/main/res/values-mk-rMK/strings.xml
+++ b/app/src/main/res/values-mk-rMK/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">Политика за приватност</string>
     <string name="settings_privacy_policy_desc">Одговорно ракување со податоци.</string>
     <string name="settings_category_other_label">Друго</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">Општо</string>
     <string name="general_settings_desc">Општи прилагодувања што влијаат на целата апликација.</string>
     <string name="settings_category_ui_label">Кориснички интерфејс</string>
@@ -339,7 +338,6 @@
     <string name="backup_restore_export_partial">Резервна копија креирана, но овие делови не успеаја: %1$s</string>
     <string name="backup_restore_restore_success">Резервна копија вратена</string>
     <string name="backup_restore_restore_failed">Враќањето не успеа (%1$s). Вашата претходна конфигурација беше зачувана.</string>
-    <string name="backup_restore_undo_action">Врати</string>
     <string name="backup_restore_recovery_title">Врати претходна конфигурација</string>
     <string name="backup_restore_recovery_desc">Достапна е безбедносна копија од незавршена операција на враќање</string>
     <string name="backup_restore_confirm_title">Врати ја оваа резервна копија?</string>

--- a/app/src/main/res/values-ml-rIN/strings.xml
+++ b/app/src/main/res/values-ml-rIN/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">സ്വകാര്യതാ നയം</string>
     <string name="settings_privacy_policy_desc">ഡാറ്റ ഉത്തരവാദിത്തത്തോടെ കൈകാര്യം ചെയ്യുന്നു.</string>
     <string name="settings_category_other_label">മറ്റുള്ളവ</string>
-    <string name="upgrade_badge_label">പ്രോ</string>
     <string name="general_settings_label">പൊതുവായ</string>
     <string name="general_settings_desc">മുഴുവൻ ആപ്പിനെയും ബാധിക്കുന്ന പൊതുവായ ക്രമീകരണങ്ങൾ.</string>
     <string name="settings_category_ui_label">ഉപയോക്തൃ ഇന്റർഫേസ്</string>
@@ -341,7 +340,6 @@
     <string name="backup_restore_export_partial">ബാക്കപ്പ് സൃഷ്ടിച്ചു, എന്നാൽ ഇതിലെ ഭാഗങ്ങൾ പരാജയപ്പെട്ടു: %1$s</string>
     <string name="backup_restore_restore_success">ബാക്കപ്പ് പുനരുദ്ധരിച്ചു</string>
     <string name="backup_restore_restore_failed">പുനരുദ്ധരണം പരാജയപ്പെട്ടു (%1$s). നിങ്ങളുടെ മുൻ കോൺഫിഗുറേഷൻ സംരക്ഷിച്ചു.</string>
-    <string name="backup_restore_undo_action">പഴയപടിയാക്കുക</string>
     <string name="backup_restore_recovery_title">മുൻ കോൺഫിഗുറേഷൻ വീണ്ടെടുക്കുക</string>
     <string name="backup_restore_recovery_desc">പൂർത്തിയാകാത്ത പുനരുദ്ധരണത്തിന്റെ ഒരു സുരക്ഷാ സ്നാപ്പ്ഷോട്ട് ലഭ്യമാണ്</string>
     <string name="backup_restore_confirm_title">ഈ ബാക്കപ്പ് പുനരുദ്ധരിക്കണോ?</string>

--- a/app/src/main/res/values-mn-rMN/strings.xml
+++ b/app/src/main/res/values-mn-rMN/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">Нууцлалын бодлого</string>
     <string name="settings_privacy_policy_desc">Өгөгдлийг хариуцлагатай зохицуулах.</string>
     <string name="settings_category_other_label">Бусад</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">Ерөнхий</string>
     <string name="general_settings_desc">Аппликешн даяар нөлөөлөх ерөнхий тохиргоо.</string>
     <string name="settings_category_ui_label">Хэрэглэгчийн интерфейс</string>
@@ -339,7 +338,6 @@
     <string name="backup_restore_export_partial">Нөөц хуулбар үүсгэгдсэн боловч эдгээр хэсэгүүд амжилтгүй болсон: %1$s</string>
     <string name="backup_restore_restore_success">Нөөц хуулбар сэргээгдсэн</string>
     <string name="backup_restore_restore_failed">Сэргээх амжилтгүй болсон (%1$s). Таны өмнөх конфигурацийг хадгалсан.</string>
-    <string name="backup_restore_undo_action">Буцаах</string>
     <string name="backup_restore_recovery_title">Өмнөх конфигурацийг сэргээх</string>
     <string name="backup_restore_recovery_desc">Дуусаагүй сэргээлтээс аюлгүй байдлын агшин зураг боломжтой</string>
     <string name="backup_restore_confirm_title">Энэ нөөц хуулбарыг сэргээх үү?</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -104,7 +104,6 @@
     <string name="settings_privacy_policy_label">Dasar privasi</string>
     <string name="settings_privacy_policy_desc">Mengendalikan data secara bertanggungjawab.</string>
     <string name="settings_category_other_label">Lain-lain</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">Umum</string>
     <string name="general_settings_desc">Tweak umum yang mempengaruhi keseluruhan aplikasi.</string>
     <string name="settings_category_ui_label">Antaramuka pengguna</string>
@@ -332,7 +331,6 @@
     <string name="backup_restore_export_partial">Sandaran telah dibuat, tetapi bahagian ini gagal: %1$s</string>
     <string name="backup_restore_restore_success">Sandaran telah dipulihkan</string>
     <string name="backup_restore_restore_failed">Pemulihan gagal (%1$s). Konfigurasi terdahulu anda telah disimpan.</string>
-    <string name="backup_restore_undo_action">Buat asal</string>
     <string name="backup_restore_recovery_title">Pulihkan konfigurasi terdahulu</string>
     <string name="backup_restore_recovery_desc">Tangkapan keselamatan daripada pemulihan yang tidak selesai tersedia</string>
     <string name="backup_restore_confirm_title">Pulihkan sandaran ini?</string>

--- a/app/src/main/res/values-my-rMM/strings.xml
+++ b/app/src/main/res/values-my-rMM/strings.xml
@@ -104,7 +104,6 @@
     <string name="settings_privacy_policy_label">ကိုယ်ပိုင်လုံခြုံမှု မူဝါဒ</string>
     <string name="settings_privacy_policy_desc">ဒေတာကို တာဝန်ယူစွာ ကိုင်တွယ်ခြင်း။</string>
     <string name="settings_category_other_label">အခြား</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">ယေဘူယျ</string>
     <string name="general_settings_desc">အက်ပ်တစ်ခုလုံးကို ထိခိုက်စေသော ယေဘူယျ ချိန်ညှိမှုများ။</string>
     <string name="settings_category_ui_label">အသုံးပြုသူ အင်တာဖေ့စ်</string>
@@ -332,7 +331,6 @@
     <string name="backup_restore_export_partial">အရန်ကူးယူမှု ကူးယူခဲ့သည်၊ သို့သော် ဤအပိုင်းများ မအောင်မြင်ခဲ့ပါ: %1$s</string>
     <string name="backup_restore_restore_success">အရန်ကူးယူမှုကို ပြန်သုံးခဲ့သည်</string>
     <string name="backup_restore_restore_failed">ပြန်သုံးမှု မအောင်မြင်ခဲ့သည် (%1$s)။ သင်၏ အရင်ကဆက်တင်များကို သိမ်းဆည်းခဲ့သည်။</string>
-    <string name="backup_restore_undo_action">ပြန်လုပ်ပါ</string>
     <string name="backup_restore_recovery_title">အရင်ကဆက်တင်များကို ပြန်ရယူပါ</string>
     <string name="backup_restore_recovery_desc">မပြီးမြောက်သည့် ပြန်သုံးမှုမှ လုံခြုံရေး ကူးယူ ရှိသည်</string>
     <string name="backup_restore_confirm_title">ဤအရန်ကူးယူမှုကို ပြန်သုံးမည်လား</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">Personvernregler</string>
     <string name="settings_privacy_policy_desc">Håndterer data ansvarlig.</string>
     <string name="settings_category_other_label">Andre</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">Generelt</string>
     <string name="general_settings_desc">Generelle justeringer som påvirker hele appen.</string>
     <string name="settings_category_ui_label">Brukergrensesnitt</string>
@@ -339,7 +338,6 @@
     <string name="backup_restore_export_partial">Sikkerhetskopi opprettet, men disse delene mislyktes: %1$s</string>
     <string name="backup_restore_restore_success">Sikkerhetskopi gjenopprettet</string>
     <string name="backup_restore_restore_failed">Gjenoppretting mislyktes (%1$s). Din tidligere konfigurasjon ble lagret.</string>
-    <string name="backup_restore_undo_action">Angre</string>
     <string name="backup_restore_recovery_title">Gjenopprett tidligere konfigurasjon</string>
     <string name="backup_restore_recovery_desc">En sikkerhetskopi fra en uferdig gjenoppretting er tilgjengelig</string>
     <string name="backup_restore_confirm_title">Gjenopprette denne sikkerhetskopien?</string>

--- a/app/src/main/res/values-ne-rNP/strings.xml
+++ b/app/src/main/res/values-ne-rNP/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">गोपनीयता नीति</string>
     <string name="settings_privacy_policy_desc">डेटा जिम्मेवारीपूर्वक ह्यान्डल गर्दै।</string>
     <string name="settings_category_other_label">अन्य</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">सामान्य</string>
     <string name="general_settings_desc">सम्पूर्ण एपलाई प्रभावित गर्ने सामान्य समायोजनहरू।</string>
     <string name="settings_category_ui_label">प्रयोगकर्ता इन्टरफेस</string>
@@ -341,7 +340,6 @@
     <string name="backup_restore_export_partial">ब्याकअप सिर्जना गरिएको छ, तर यी भागहरू असफल भएः %1$s</string>
     <string name="backup_restore_restore_success">ब्याकअप पुनःस्थापित गरिएको छ</string>
     <string name="backup_restore_restore_failed">पुनःस्थापन असफल भयो (%1$s)। तपाईंको अघिल्लो कन्फिगरेसन सुरक्षित गरिएको छ।</string>
-    <string name="backup_restore_undo_action">पूर्ववत गर्नुहोस्</string>
     <string name="backup_restore_recovery_title">अघिल्लो कन्फिगरेसन पुनः प्राप्त गर्नुहोस्</string>
     <string name="backup_restore_recovery_desc">अधूरो पुनःस्थापनबाट एक सुरक्षा स्न्यापसट उपलब्ध छ</string>
     <string name="backup_restore_confirm_title">यो ब्याकअप पुनर्स्थापित गर्नुहोस्?</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">Privacybeleid</string>
     <string name="settings_privacy_policy_desc">Verantwoord met gegevens omgaan.</string>
     <string name="settings_category_other_label">Andere</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">Algemeen</string>
     <string name="general_settings_desc">Algemene aanpassingen die de hele app beïnvloeden.</string>
     <string name="settings_category_ui_label">Gebruikersinterface</string>
@@ -339,7 +338,6 @@
     <string name="backup_restore_export_partial">Back-up gemaakt, maar deze onderdelen zijn mislukt: %1$s</string>
     <string name="backup_restore_restore_success">Back-up hersteld</string>
     <string name="backup_restore_restore_failed">Herstellen mislukt (%1$s). Uw vorige configuratie is opgeslagen.</string>
-    <string name="backup_restore_undo_action">Ongedaan maken</string>
     <string name="backup_restore_recovery_title">Vorige configuratie herstellen</string>
     <string name="backup_restore_recovery_desc">Een veiligheidsmomentopname van een onafgerond herstel is beschikbaar</string>
     <string name="backup_restore_confirm_title">Deze back-up herstellen?</string>

--- a/app/src/main/res/values-or-rIN/strings.xml
+++ b/app/src/main/res/values-or-rIN/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">ଗୋପନୀୟତା ନୀତି</string>
     <string name="settings_privacy_policy_desc">ଦାୟିତ୍ୱପୂର୍ଣ୍ଣ ଭାବରେ ତଥ୍ୟ ପରିଚାଳନା କରିବା।</string>
     <string name="settings_category_other_label">ଅନ୍ୟ</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">ସାଧାରଣ</string>
     <string name="general_settings_desc">ସମଗ୍ର ଆପ୍‌କୁ ପ୍ରଭାବିତ କରୁଥିବା ସାଧାରଣ ଟ୍ୱିକ୍ସ।</string>
     <string name="settings_category_ui_label">ବ୍ୟବହାରକାରୀ ଇଣ୍ଟରଫେସ୍</string>
@@ -339,7 +338,6 @@
     <string name="backup_restore_export_partial">ବ୍ୟାକଅପ୍ ସୃଷ୍ଟି ହୋଇଛି, କିନ୍ତୁ ଏହି ଅଂଶଗୁଡ଼ିକ ବିଫଳ ହୋଇଛି: %1$s</string>
     <string name="backup_restore_restore_success">ବ୍ୟାକଅପ୍ ପୁନରସ୍ଥାପନ ହୋଇଛି</string>
     <string name="backup_restore_restore_failed">ପୁନରସ୍ଥାପନ ବିଫଳ ହୋଇଛି (%1$s)। ଆପଣଙ୍କ ପୂର୍ବବର୍ତ୍ତୀ ସଂରଚନା ସଂରକ୍ଷିତ ହୋଇଛି।</string>
-    <string name="backup_restore_undo_action">ପୂର୍ବବତ୍ କରନ୍ତୁ</string>
     <string name="backup_restore_recovery_title">ପୂର୍ବବର୍ତ୍ତୀ ସଂରଚନା ପୁନରୁଦ୍ଧାର କରନ୍ତୁ</string>
     <string name="backup_restore_recovery_desc">ଏକ ଅସମ୍ପୂର୍ଣ ପୁନରସ୍ଥାପନରୁ ଏକ ନିରାପତ୍ତା ସ୍ନାପସଟ୍ ଉପଲବ୍ଧ</string>
     <string name="backup_restore_confirm_title">ଏହି ବ୍ୟାକଅପ୍ ପୁନରସ୍ଥାପନ କରିବେ?</string>

--- a/app/src/main/res/values-pa-rIN/strings.xml
+++ b/app/src/main/res/values-pa-rIN/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">ਪਰਦੇਦਾਰੀ ਨੀਤੀ</string>
     <string name="settings_privacy_policy_desc">ਡੇਟਾ ਨੂੰ ਜ਼ਿੰਮੇਵਾਰੀ ਨਾਲ ਸੰਭਾਲ ਰਿਹਾ ਹੈ।</string>
     <string name="settings_category_other_label">ਹੋਰ</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">ਆਮ</string>
     <string name="general_settings_desc">ਆਮ ਟਵੀਕਸ ਜੋ ਪੂਰੀ ਐਪ ਨੂੰ ਪ੍ਰਭਾਵਿਤ ਕਰਦੇ ਹਨ।</string>
     <string name="settings_category_ui_label">ਵਰਤੋਂਕਾਰ ਇੰਟਰਫੇਸ</string>
@@ -339,7 +338,6 @@
     <string name="backup_restore_export_partial">ਬੈਕਅੱਪ ਬਣਾਇਆ ਗਿਆ, ਪਰ ਇਹ ਭਾਗ ਅਸਫਲ ਰਹੇ: %1$s</string>
     <string name="backup_restore_restore_success">ਬੈਕਅੱਪ ਬਹਾਲ ਕੀਤਾ ਗਿਆ</string>
     <string name="backup_restore_restore_failed">ਬਹਾਲੀ ਅਸਫਲ (%1$s)। ਤੁਹਾਡੀ ਪਿਛਲੀ ਸੰਰਚਨਾ ਸੁਰੱਖਿਅਤ ਕੀਤੀ ਗਈ ਸੀ।</string>
-    <string name="backup_restore_undo_action">ਅਣਕੀਤਾ ਕਰੋ</string>
     <string name="backup_restore_recovery_title">ਪਿਛਲੀ ਸੰਰਚਨਾ ਨੂੰ ਪੁਨਰ ਪ੍ਰਾਪਤ ਕਰੋ</string>
     <string name="backup_restore_recovery_desc">ਇੱਕ ਅਧੂਰੀ ਬਹਾਲੀ ਤੋਂ ਸੁਰੱਖਿਆ ਸਨੈਪਸ਼ਾਟ ਉਪਲਬਧ ਹੈ</string>
     <string name="backup_restore_confirm_title">ਕੀ ਇਸ ਬੈਕਅੱਪ ਨੂੰ ਬਹਾਲ ਕਰੀਏ?</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -113,7 +113,6 @@
     <string name="settings_privacy_policy_label">Polityka prywatności</string>
     <string name="settings_privacy_policy_desc">Odpowiedzialne zarządzanie danymi.</string>
     <string name="settings_category_other_label">Inne</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">Ogólne</string>
     <string name="general_settings_desc">Ogólne ustawienia wpływające na całą aplikację.</string>
     <string name="settings_category_ui_label">Interfejs użytkownika</string>
@@ -354,7 +353,6 @@ Karol Szastok (K4r0lSz);</string>
     <string name="backup_restore_export_partial">Kopia zapasowa utworzona, ale części się nie powiodły: %1$s</string>
     <string name="backup_restore_restore_success">Kopia zapasowa przywrócona</string>
     <string name="backup_restore_restore_failed">Przywracanie nie powiodło się (%1$s). Poprzednia konfiguracja została zapisana.</string>
-    <string name="backup_restore_undo_action">Cofnij</string>
     <string name="backup_restore_recovery_title">Przywróć poprzednią konfigurację</string>
     <string name="backup_restore_recovery_desc">Dostępna jest migawka bezpieczeństwa z niezakończonego przywracania</string>
     <string name="backup_restore_confirm_title">Przywrócić tę kopię zapasową?</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">Política de privacidade</string>
     <string name="settings_privacy_policy_desc">Manipulação responsável dos dados.</string>
     <string name="settings_category_other_label">Outros</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">Gerais</string>
     <string name="general_settings_desc">Ajustes gerais que afetam todo o aplicativo.</string>
     <string name="settings_category_ui_label">Interface de usuário</string>
@@ -339,7 +338,6 @@
     <string name="backup_restore_export_partial">Backup criado, mas estas partes falharam: %1$s</string>
     <string name="backup_restore_restore_success">Backup restaurado</string>
     <string name="backup_restore_restore_failed">Falha na restauração (%1$s). Sua configuração anterior foi salva.</string>
-    <string name="backup_restore_undo_action">Desfazer</string>
     <string name="backup_restore_recovery_title">Recuperar configuração anterior</string>
     <string name="backup_restore_recovery_desc">Um instantâneo de segurança de uma restauração inacabada está disponível</string>
     <string name="backup_restore_confirm_title">Restaurar este backup?</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">Política de privacidade</string>
     <string name="settings_privacy_policy_desc">Responsabilidade de lidar com dados.</string>
     <string name="settings_category_other_label">Outro</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">Geral</string>
     <string name="general_settings_desc">Ajustes gerais que afetam toda a aplicação.</string>
     <string name="settings_category_ui_label">Interface do utilizador</string>
@@ -339,7 +338,6 @@
     <string name="backup_restore_export_partial">Cópia de segurança criada, mas estas partes falharam: %1$s</string>
     <string name="backup_restore_restore_success">Cópia de segurança restaurada</string>
     <string name="backup_restore_restore_failed">Falha ao restaurar (%1$s). A configuração anterior foi guardada.</string>
-    <string name="backup_restore_undo_action">Desfazer</string>
     <string name="backup_restore_recovery_title">Recuperar configuração anterior</string>
     <string name="backup_restore_recovery_desc">Uma cópia de segurança de uma restauração incompleta está disponível</string>
     <string name="backup_restore_confirm_title">Restaurar esta cópia de segurança?</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -110,7 +110,6 @@
     <string name="settings_privacy_policy_label">Politica de confidențialitate</string>
     <string name="settings_privacy_policy_desc">Gestionarea responsabilă a datelor.</string>
     <string name="settings_category_other_label">Altele</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">General</string>
     <string name="general_settings_desc">Ajustări generale care afectează întreaga aplicație.</string>
     <string name="settings_category_ui_label">Interfața utilizatorului</string>
@@ -346,7 +345,6 @@
     <string name="backup_restore_export_partial">Copie de siguranță creată, dar aceste componente au eșuat: %1$s</string>
     <string name="backup_restore_restore_success">Copia de siguranță restaurată</string>
     <string name="backup_restore_restore_failed">Restaurarea a eșuat (%1$s). Configurația ta anterioară a fost salvată.</string>
-    <string name="backup_restore_undo_action">Anulă</string>
     <string name="backup_restore_recovery_title">Recuperează configurația anterioară</string>
     <string name="backup_restore_recovery_desc">O copie de siguranță dintr-o restabilire neterminată este disponibilă</string>
     <string name="backup_restore_confirm_title">Restabilești această copie de siguranță?</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -113,7 +113,6 @@
     <string name="settings_privacy_policy_label">Политика конфиденциальности</string>
     <string name="settings_privacy_policy_desc">Ответственность за обращение с данными.</string>
     <string name="settings_category_other_label">Прочее</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">Общее</string>
     <string name="general_settings_desc">Настройки, которые влияют на всё приложение.</string>
     <string name="settings_category_ui_label">Интерфейс пользователя</string>
@@ -353,7 +352,6 @@
     <string name="backup_restore_export_partial">Резервная копия создана, но эти части не удалось создать: %1$s</string>
     <string name="backup_restore_restore_success">Резервная копия восстановлена</string>
     <string name="backup_restore_restore_failed">Восстановление не удалось (%1$s). Ваша предыдущая конфигурация была сохранена.</string>
-    <string name="backup_restore_undo_action">Отменить</string>
     <string name="backup_restore_recovery_title">Восстановить предыдущую конфигурацию</string>
     <string name="backup_restore_recovery_desc">Доступен снимок безопасности из незавершённого восстановления</string>
     <string name="backup_restore_confirm_title">Восстановить эту резервную копию?</string>

--- a/app/src/main/res/values-sc-rIT/strings.xml
+++ b/app/src/main/res/values-sc-rIT/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">Polìtica de riservadesa</string>
     <string name="settings_privacy_policy_desc">Gestimentu responsàbile de sos datos.</string>
     <string name="settings_category_other_label">Àteru</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">Generale</string>
     <string name="general_settings_desc">Agiustedas generales chi afetant tota s\'aplicaçione.</string>
     <string name="settings_category_ui_label">Interfache de s\'impreadore</string>
@@ -339,7 +338,6 @@
     <string name="backup_restore_export_partial">Copia creatza, ma istas partis fallint: %1$s</string>
     <string name="backup_restore_restore_success">Copia ripristinada</string>
     <string name="backup_restore_restore_failed">Su ripristinu fallit (%1$s). Sa tua configuratzione anteriore est istada sarvada.</string>
-    <string name="backup_restore_undo_action">Annulla</string>
     <string name="backup_restore_recovery_title">Recupera sa configuratzione anteriore</string>
     <string name="backup_restore_recovery_desc">Una istantanea de seguidade da unu ripristinu non finidu est disponibile</string>
     <string name="backup_restore_confirm_title">Ripristina sa copia?</string>

--- a/app/src/main/res/values-si-rLK/strings.xml
+++ b/app/src/main/res/values-si-rLK/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">පෞද්ගලිකත්ව ප්‍රතිපත්තිය</string>
     <string name="settings_privacy_policy_desc">දත්ත වගකීමෙන් හැසිරවීම.</string>
     <string name="settings_category_other_label">වෙනත්</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">සාමාන්‍ය</string>
     <string name="general_settings_desc">සමස්ත යෙදුම බලපාන සාමාන්‍ය සකසන.</string>
     <string name="settings_category_ui_label">පරිශීලක අතුරුමුඛය</string>
@@ -339,7 +338,6 @@
     <string name="backup_restore_export_partial">උපස්ථය නිර්මාණය කරන ලදී, නමුත් මෙම කොටස් අසාර්ථක විය: %1$s</string>
     <string name="backup_restore_restore_success">උපස්ථය නැවත ස්ථාපනය කරන ලදී</string>
     <string name="backup_restore_restore_failed">නැවත ස්ථාපනය අසාර්ථක විය (%1$s). ඔබේ පෙර වින්‍යාසය සුරකින ලදී.</string>
-    <string name="backup_restore_undo_action">අහෝසි කරන්න</string>
     <string name="backup_restore_recovery_title">පෙර වින්‍යාසය ප්‍රතිසාධනය කරන්න</string>
     <string name="backup_restore_recovery_desc">අසම්පූර්ණ නැවත ස්ථාපනයෙන් ආරක්ෂණ ප්‍රතිරූපයක් තිබේ</string>
     <string name="backup_restore_confirm_title">මෙම උපස්ථය නැවත ස්ථාපනය කරන්නද?</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -113,7 +113,6 @@
     <string name="settings_privacy_policy_label">Zásady ochrany osobných údajov</string>
     <string name="settings_privacy_policy_desc">Zodpovedné zaobchádzanie s údajmi.</string>
     <string name="settings_category_other_label">Iné</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">Všeobecné</string>
     <string name="general_settings_desc">Všeobecné vylepšenia, ktoré ovplyvňujú celú aplikáciu.</string>
     <string name="settings_category_ui_label">Používateľské rozhranie</string>
@@ -353,7 +352,6 @@
     <string name="backup_restore_export_partial">Záloha vytvorená, ale tieto časti zlyhali: %1$s</string>
     <string name="backup_restore_restore_success">Záloha obnovená</string>
     <string name="backup_restore_restore_failed">Obnova zlyhala (%1$s). Vaša predchádzajúca konfigurácia bola uložená.</string>
-    <string name="backup_restore_undo_action">Vrátiť späť</string>
     <string name="backup_restore_recovery_title">Obnoviť predchádzajúcu konfiguráciu</string>
     <string name="backup_restore_recovery_desc">Bezpečnostný snímok z nedokončenej obnovy je dostupný</string>
     <string name="backup_restore_confirm_title">Obnoviť túto zálohu?</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -113,7 +113,6 @@
     <string name="settings_privacy_policy_label">Pravilnik o zasebnosti</string>
     <string name="settings_privacy_policy_desc">Odgovorno ravnanje s podatki.</string>
     <string name="settings_category_other_label">Drugo</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">Splošno</string>
     <string name="general_settings_desc">Splošne prilagoditve, ki vplivajo na cel program.</string>
     <string name="settings_category_ui_label">Uporabniški vmesnik</string>
@@ -353,7 +352,6 @@
     <string name="backup_restore_export_partial">Varnostna kopija je bila ustvarjena, vendar so ti deli spodleteli: %1$s</string>
     <string name="backup_restore_restore_success">Varnostna kopija je bila obnovljena</string>
     <string name="backup_restore_restore_failed">Obnovitev je spodletela (%1$s). Vaša prejšnja konfiguracija je bila shranjena.</string>
-    <string name="backup_restore_undo_action">Razveljavi</string>
     <string name="backup_restore_recovery_title">Obnovi prejšnjo konfiguracijo</string>
     <string name="backup_restore_recovery_desc">Na voljo je varnostni posnetek iz nedokončane obnovitve</string>
     <string name="backup_restore_confirm_title">Želite obnoviti to varnostno kopijo?</string>

--- a/app/src/main/res/values-sq-rAL/strings.xml
+++ b/app/src/main/res/values-sq-rAL/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">Politika e privatësisë</string>
     <string name="settings_privacy_policy_desc">Trajtimi i të dhënave me përgjegjësi.</string>
     <string name="settings_category_other_label">Tjetër</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">Gjenerik</string>
     <string name="general_settings_desc">Rregullime të përgjithshme që prekin të gjithë aplikacionin.</string>
     <string name="settings_category_ui_label">Ndërfaqja e përdoruesit</string>
@@ -339,7 +338,6 @@
     <string name="backup_restore_export_partial">Kopja e rezervuar u krijua, por këto pjesë dështuan: %1$s</string>
     <string name="backup_restore_restore_success">Kopja e rezervuar u rikthye</string>
     <string name="backup_restore_restore_failed">Rikthimi dështoi (%1$s). Konfigurimi juaj i mëparshëm u ruajt.</string>
-    <string name="backup_restore_undo_action">Zhbëj</string>
     <string name="backup_restore_recovery_title">Rikthej konfigurimin e mëparshëm</string>
     <string name="backup_restore_recovery_desc">Një kopje sigurie nga një rikthim i papërfunduar është e disponueshme</string>
     <string name="backup_restore_confirm_title">Të rikthehet kjo kopje rezervuar?</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -110,7 +110,6 @@
     <string name="settings_privacy_policy_label">Политика приватности</string>
     <string name="settings_privacy_policy_desc">Одговорно поступање са подацима.</string>
     <string name="settings_category_other_label">Остало</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">Oпште</string>
     <string name="general_settings_desc">Општа подешавања која утичу на целу апликацију.</string>
     <string name="settings_category_ui_label">Кориснички интерфејс</string>
@@ -347,7 +346,6 @@
     <string name="backup_restore_export_partial">Резервна копија је креирана, али ови делови нису успели: %1$s</string>
     <string name="backup_restore_restore_success">Резервна копија је враћена</string>
     <string name="backup_restore_restore_failed">Враћање није успело (%1$s). Ваша претходна конфигурација је сачувана.</string>
-    <string name="backup_restore_undo_action">Опозови</string>
     <string name="backup_restore_recovery_title">Опорави претходну конфигурацију</string>
     <string name="backup_restore_recovery_desc">Доступан је безбедносни снимак из недовршеног враћања</string>
     <string name="backup_restore_confirm_title">Вратити ову резервну копију?</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">Sekretesspolicy</string>
     <string name="settings_privacy_policy_desc">Hantering av uppgifter på ett ansvarsfullt sätt.</string>
     <string name="settings_category_other_label">Övriga</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">Allmänt</string>
     <string name="general_settings_desc">Allmänna justeringar som påverkar hela appen.</string>
     <string name="settings_category_ui_label">Användargränssnitt</string>
@@ -339,7 +338,6 @@
     <string name="backup_restore_export_partial">Säkerhetskopia skapad, men dessa delar misslyckades: %1$s</string>
     <string name="backup_restore_restore_success">Säkerhetskopia återställd</string>
     <string name="backup_restore_restore_failed">Återställning misslyckades (%1$s). Din tidigare konfiguration sparades.</string>
-    <string name="backup_restore_undo_action">Ångra</string>
     <string name="backup_restore_recovery_title">Återställ tidigare konfiguration</string>
     <string name="backup_restore_recovery_desc">En säkerhetskopia från en oavslutad återställning är tillgänglig</string>
     <string name="backup_restore_confirm_title">Återställ denna säkerhetskopia?</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">Sera ya faragha</string>
     <string name="settings_privacy_policy_desc">Kushughulikia data kwa uwazi.</string>
     <string name="settings_category_other_label">Nyingine</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">Jumla</string>
     <string name="general_settings_desc">Marekebisho ya jumla yanayoathiri programu nzima.</string>
     <string name="settings_category_ui_label">Kiolesura cha mtumiaji</string>
@@ -339,7 +338,6 @@
     <string name="backup_restore_export_partial">Nakala rudufu imeundwa, lakini sehemu hizi hazikufanikiwa: %1$s</string>
     <string name="backup_restore_restore_success">Nakala rudufu imerejeshwa</string>
     <string name="backup_restore_restore_failed">Urejeshaji haukufanikiwa (%1$s). Usanidi wako wa awali ulihifadhiwa.</string>
-    <string name="backup_restore_undo_action">Tendua</string>
     <string name="backup_restore_recovery_title">Rejesha usanidi wa awali</string>
     <string name="backup_restore_recovery_desc">Nakala ya usalama kutoka urejeshaji usiokamilika inapatikana</string>
     <string name="backup_restore_confirm_title">Rejesha nakala rudufu hii?</string>

--- a/app/src/main/res/values-ta-rIN/strings.xml
+++ b/app/src/main/res/values-ta-rIN/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">தனியுரிமை கொள்கை</string>
     <string name="settings_privacy_policy_desc">தகவலை பொறுப்புடனுடன் கைகாளவது.</string>
     <string name="settings_category_other_label">மற்றவை</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">பொது</string>
     <string name="general_settings_desc">முழு பயன்பாட்டையும் பாதிக்கும் பொது வின்யாசங்கள்.</string>
     <string name="settings_category_ui_label">பயனர் இணையதுளம்</string>
@@ -339,7 +338,6 @@
     <string name="backup_restore_export_partial">பேக்கப் உருவாக்கப்பட்டது, ஆனால் இந்தப் பகுதிகள் தோல்வியடைந்தன: %1$s</string>
     <string name="backup_restore_restore_success">பேக்கப் மீட்டெடுக்கப்பட்டது</string>
     <string name="backup_restore_restore_failed">மீட்டெடுக்கல் தோல்வியடைந்தது (%1$s). உங்கள் முந்தைய கட்டமைப்பு சேமிக்கப்பட்டது.</string>
-    <string name="backup_restore_undo_action">செயல்நீக்கு</string>
     <string name="backup_restore_recovery_title">முந்தைய கட்டமைப்பை மீட்டெடுக்கவும்</string>
     <string name="backup_restore_recovery_desc">முடிக்கப்படாத மீட்டெடுக்கலிலிருந்து ஒரு பாதுகாப்பு ஸ்னாப்ஷாட் கிடைக்கிறது</string>
     <string name="backup_restore_confirm_title">இந்தப் பேக்கப்பை மீட்டெடுக்கவா?</string>

--- a/app/src/main/res/values-te-rIN/strings.xml
+++ b/app/src/main/res/values-te-rIN/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">గోప్యతా విధానం</string>
     <string name="settings_privacy_policy_desc">డేటాను బాధ్యతగా నిర్వహించడం.</string>
     <string name="settings_category_other_label">ఇతర</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">సాధారణ</string>
     <string name="general_settings_desc">ముందు ఎప్లికేషన్‌ను ప్రభావితం చేసే సాధారణ సెట్టింగ్సు.</string>
     <string name="settings_category_ui_label">వాడుకరి ఇంటర్‌ఫేస్</string>
@@ -339,7 +338,6 @@
     <string name="backup_restore_export_partial">బ్యాకప్ సృష్టించబడింది, కానీ ఈ భాగాలు విఫలమయ్యాయి: %1$s</string>
     <string name="backup_restore_restore_success">బ్యాకప్ పునరుద్ధరించబడింది</string>
     <string name="backup_restore_restore_failed">పునరుద్ధరణ విఫలమైంది (%1$s). మీ మునుపటి కాన్ఫిగరేషన్ సేవ్ చేయబడింది.</string>
-    <string name="backup_restore_undo_action">రద్దు చేయండి</string>
     <string name="backup_restore_recovery_title">మునుపటి కాన్ఫిగరేషన్‌ను పునరుద్ధరించండి</string>
     <string name="backup_restore_recovery_desc">అసంపూర్ణ పునరుద్ధరణ నుండి భద్రతా స్నాప్‌షాట్ అందుబాటులో ఉంది</string>
     <string name="backup_restore_confirm_title">ఈ బ్యాకప్‌ను పునరుద్ధరించాలా?</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -104,7 +104,6 @@
     <string name="settings_privacy_policy_label">นโยบายความเป็นส่วนตัว</string>
     <string name="settings_privacy_policy_desc">จัดการข้อมูลอย่างมีความรับผิดชอบ</string>
     <string name="settings_category_other_label">อื่นๆ</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">ทั่วไป</string>
     <string name="general_settings_desc">ตัวปรับแต่งทั่วไปที่มีผลต่อทั้งแอพ</string>
     <string name="settings_category_ui_label">ส่วนติดต่อผู้ใช้</string>
@@ -332,7 +331,6 @@
     <string name="backup_restore_export_partial">สร้างการสำรองข้อมูลแล้ว แต่ส่วนต่อไปนี้ล้มเหลว: %1$s</string>
     <string name="backup_restore_restore_success">กู้คืนการสำรองข้อมูลแล้ว</string>
     <string name="backup_restore_restore_failed">การกู้คืนล้มเหลว (%1$s) การตั้งค่าก่อนหน้าของคุณได้ถูกบันทึกไว้</string>
-    <string name="backup_restore_undo_action">เลิกทำ</string>
     <string name="backup_restore_recovery_title">กู้คืนการตั้งค่าก่อนหน้า</string>
     <string name="backup_restore_recovery_desc">มีภาพสำรองความปลอดภัยจากการกู้คืนที่ไม่เสร็จพร้อมใช้งาน</string>
     <string name="backup_restore_confirm_title">กู้คืนการสำรองข้อมูลนี้หรือไม่</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">Gizlilik politikası</string>
     <string name="settings_privacy_policy_desc">Veriler sorumlu bir şekilde işlenir.</string>
     <string name="settings_category_other_label">Diğer</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">Genel</string>
     <string name="general_settings_desc">Tüm uygulamayı etkileyen genel ince ayarlar.</string>
     <string name="settings_category_ui_label">Kullanıcı arayüzü</string>
@@ -339,7 +338,6 @@
     <string name="backup_restore_export_partial">Yedek oluşturuldu, ancak bu bölümler başarısız oldu: %1$s</string>
     <string name="backup_restore_restore_success">Yedek geri yüklendi</string>
     <string name="backup_restore_restore_failed">Geri yükleme başarısız oldu (%1$s). Önceki yapılandırmanız kaydedildi.</string>
-    <string name="backup_restore_undo_action">Geri al</string>
     <string name="backup_restore_recovery_title">Önceki yapılandırmayı kurtar</string>
     <string name="backup_restore_recovery_desc">Tamamlanmamış bir geri yüklemeden bir güvenlik anlık görüntüsü kullanılabilir</string>
     <string name="backup_restore_confirm_title">Bu yedek geri yüklensin mi?</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -113,7 +113,6 @@
     <string name="settings_privacy_policy_label">Політика конфіденційності</string>
     <string name="settings_privacy_policy_desc">Відповідальне поводження з даними.</string>
     <string name="settings_category_other_label">Інше</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">Загальні</string>
     <string name="general_settings_desc">Загальні налаштування, які впливають на весь додаток.</string>
     <string name="settings_category_ui_label">Інтерфейс користувача</string>
@@ -353,7 +352,6 @@
     <string name="backup_restore_export_partial">Резервну копію створено, але ці частини не вдалися: %1$s</string>
     <string name="backup_restore_restore_success">Резервну копію відновлено</string>
     <string name="backup_restore_restore_failed">Не вдалося відновити (%1$s). Вашу попередню конфігурацію збережено.</string>
-    <string name="backup_restore_undo_action">Скасувати</string>
     <string name="backup_restore_recovery_title">Відновити попередню конфігурацію</string>
     <string name="backup_restore_recovery_desc">Доступний резервний знімок з незавершеного відновлення</string>
     <string name="backup_restore_confirm_title">Відновити цю резервну копію?</string>

--- a/app/src/main/res/values-ur-rIN/strings.xml
+++ b/app/src/main/res/values-ur-rIN/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">پرائیویسی پالیسی</string>
     <string name="settings_privacy_policy_desc">ڈیٹا کو ذمہ داری سے سنبھالنا۔</string>
     <string name="settings_category_other_label">دیگر</string>
-    <string name="upgrade_badge_label">پرو</string>
     <string name="general_settings_label">عمومی</string>
     <string name="general_settings_desc">عمومی تبدیلیاں جو پوری ایپ کو متاثر کرتی ہیں۔</string>
     <string name="settings_category_ui_label">یوزر انٹرفیس</string>
@@ -339,7 +338,6 @@
     <string name="backup_restore_export_partial">بیک اپ بنایا گیا، لیکن یہ حصے ناکام رہے: %1$s</string>
     <string name="backup_restore_restore_success">بیک اپ بحال کیا گیا</string>
     <string name="backup_restore_restore_failed">بحالی ناکام ہو گئی (%1$s)۔ آپ کی پچھلی ترتیبات محفوظ کر دی گئی ہیں۔</string>
-    <string name="backup_restore_undo_action">کالعدم کریں</string>
     <string name="backup_restore_recovery_title">پچھلی ترتیب کو بحال کریں</string>
     <string name="backup_restore_recovery_desc">ایک نامکمل بحالی سے ایک حفاظتی نقل دستیاب ہے</string>
     <string name="backup_restore_confirm_title">کیا یہ بیک اپ بحال کریں؟</string>

--- a/app/src/main/res/values-uz/strings.xml
+++ b/app/src/main/res/values-uz/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">Maxfiylik siyosati</string>
     <string name="settings_privacy_policy_desc">Ma\'lumotlar bilan mas\'uliyat bilan ishlash.</string>
     <string name="settings_category_other_label">Boshqa</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">Umumiy</string>
     <string name="general_settings_desc">Butun ilovaga ta\'sir qiladigan umumiy sozlamalar.</string>
     <string name="settings_category_ui_label">Foydalanuvchi interfeysi</string>
@@ -339,7 +338,6 @@
     <string name="backup_restore_export_partial">Zaxira nusxasi yaratildi, ammo quyidagi qismlar amalga oshmadi: %1$s</string>
     <string name="backup_restore_restore_success">Zaxira nusxasi tiklandi</string>
     <string name="backup_restore_restore_failed">Tiklash amalga oshmadi (%1$s). Oldingi konfiguratsiyangiz saqlab qo\'yildi.</string>
-    <string name="backup_restore_undo_action">Bekor qilish</string>
     <string name="backup_restore_recovery_title">Oldingi konfiguratsiyani tiklash</string>
     <string name="backup_restore_recovery_desc">Tugallanmagan tiklashdan xavfsizlik nusxasi mavjud</string>
     <string name="backup_restore_confirm_title">Ushbu zaxira nusxasi tiklansinmi?</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -104,7 +104,6 @@
     <string name="settings_privacy_policy_label">Chính sách bảo mật</string>
     <string name="settings_privacy_policy_desc">Xử lý dữ liệu có trách nhiệm.</string>
     <string name="settings_category_other_label">Khác</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">Tổng quan</string>
     <string name="general_settings_desc">Các chỉnh sửa chung ảnh hưởng đến toàn bộ ứng dụng.</string>
     <string name="settings_category_ui_label">Giao diện người dùng</string>
@@ -334,7 +333,6 @@ TheNothingGuy</string>
     <string name="backup_restore_export_partial">Đã tạo sao lưu, nhưng các phần này không thành công: %1$s</string>
     <string name="backup_restore_restore_success">Đã khôi phục sao lưu</string>
     <string name="backup_restore_restore_failed">Khôi phục không thành công (%1$s). Cấu hình trước đó của bạn đã được lưu.</string>
-    <string name="backup_restore_undo_action">Hoàn tác</string>
     <string name="backup_restore_recovery_title">Khôi phục cấu hình trước đó</string>
     <string name="backup_restore_recovery_desc">Có một ảnh chụp nhanh an toàn từ lần khôi phục chưa hoàn thành</string>
     <string name="backup_restore_confirm_title">Khôi phục sao lưu này?</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -104,7 +104,6 @@
     <string name="settings_privacy_policy_label">隐私政策</string>
     <string name="settings_privacy_policy_desc">以负责任的态度来处理数据。</string>
     <string name="settings_category_other_label">其他</string>
-    <string name="upgrade_badge_label">专业版</string>
     <string name="general_settings_label">常规</string>
     <string name="general_settings_desc">影响整个应用的常规设置。</string>
     <string name="settings_category_ui_label">用户界面</string>
@@ -332,7 +331,6 @@
     <string name="backup_restore_export_partial">备份已创建，但以下部分失败：%1$s</string>
     <string name="backup_restore_restore_success">备份已恢复</string>
     <string name="backup_restore_restore_failed">恢复失败（%1$s）。您的先前配置已保存。</string>
-    <string name="backup_restore_undo_action">撤销</string>
     <string name="backup_restore_recovery_title">恢复以前的配置</string>
     <string name="backup_restore_recovery_desc">有一个来自未完成的恢复操作的安全快照可用</string>
     <string name="backup_restore_confirm_title">恢复此备份？</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -104,7 +104,6 @@
     <string name="settings_privacy_policy_label">私隱政策</string>
     <string name="settings_privacy_policy_desc">以負責的態度處理資料。</string>
     <string name="settings_category_other_label">其他</string>
-    <string name="upgrade_badge_label">專業版</string>
     <string name="general_settings_label">一般</string>
     <string name="general_settings_desc">影響整個應用程式的一般調校。</string>
     <string name="settings_category_ui_label">使用者介面</string>
@@ -332,7 +331,6 @@
     <string name="backup_restore_export_partial">已建立備份，但下列部分失敗：%1$s</string>
     <string name="backup_restore_restore_success">備份已還原</string>
     <string name="backup_restore_restore_failed">還原失敗（%1$s）。您的先前設定已儲存。</string>
-    <string name="backup_restore_undo_action">復原</string>
     <string name="backup_restore_recovery_title">復原先前的設定</string>
     <string name="backup_restore_recovery_desc">有一份未完成還原的安全快照可用</string>
     <string name="backup_restore_confirm_title">還原此備份？</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -104,7 +104,6 @@
     <string name="settings_privacy_policy_label">隱私權政策</string>
     <string name="settings_privacy_policy_desc">以負責的態度處理資料。</string>
     <string name="settings_category_other_label">其他</string>
-    <string name="upgrade_badge_label">專業版</string>
     <string name="general_settings_label">一般</string>
     <string name="general_settings_desc">影響整個應用程式的一般調校。</string>
     <string name="settings_category_ui_label">使用者介面</string>
@@ -332,7 +331,6 @@
     <string name="backup_restore_export_partial">備份已建立，但這些部分失敗：%1$s</string>
     <string name="backup_restore_restore_success">已還原備份</string>
     <string name="backup_restore_restore_failed">還原失敗（%1$s）。您先前的設定已儲存。</string>
-    <string name="backup_restore_undo_action">復原</string>
     <string name="backup_restore_recovery_title">復原先前的設定</string>
     <string name="backup_restore_recovery_desc">有一份未完成還原的安全快照可用</string>
     <string name="backup_restore_confirm_title">要還原此備份嗎？</string>

--- a/app/src/main/res/values-zu/strings.xml
+++ b/app/src/main/res/values-zu/strings.xml
@@ -107,7 +107,6 @@
     <string name="settings_privacy_policy_label">Inqubomgomo yobumfihlo</string>
     <string name="settings_privacy_policy_desc">Ukuphatha idatha ngokufanele.</string>
     <string name="settings_category_other_label">Okunye</string>
-    <string name="upgrade_badge_label">Pro</string>
     <string name="general_settings_label">Okujwayelekile</string>
     <string name="general_settings_desc">Izilungiso ezijwayelekile ezithinta uhlelo lonke.</string>
     <string name="settings_category_ui_label">Isixhumi somsebenzisi</string>
@@ -339,7 +338,6 @@
     <string name="backup_restore_export_partial">I-backup yenziwe, kodwa lezi izingxenye zehlulekile: %1$s</string>
     <string name="backup_restore_restore_success">I-backup ibuyisiwe</string>
     <string name="backup_restore_restore_failed">Ukubuyisa kwehlulekile (%1$s). Isiqweqwe sakho esandulele sisisiwe.</string>
-    <string name="backup_restore_undo_action">Hlehlisa</string>
     <string name="backup_restore_recovery_title">Buyisa isiqweqwe esandulele</string>
     <string name="backup_restore_recovery_desc">Isithombe sokuphepha esivela ekubuyiseni elingaziwa kunala</string>
     <string name="backup_restore_confirm_title">Buyisa le-backup?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,7 +40,7 @@
     <string name="debug_logview_search_next_action">Next match</string>
     <string name="debug_logview_jump_to_bottom_action">Jump to latest</string>
     <string name="debug_logview_paused_msg">Paused — buffer frozen</string>
-    <string name="debug_logview_paused_dropped_msg">Paused — %1$d new line(s) skipped</string>
+    <string name="debug_logview_paused_dropped_msg">Paused — new lines skipped: %1$d</string>
     <string name="debug_logview_copied_msg">Log copied to clipboard</string>
     <string name="debug_logview_share_label">Share log</string>
     <string name="debug_debuglog_screen_title">Debug Log</string>
@@ -114,7 +114,6 @@
 
     <string name="settings_upgrade_description">Upgrade status and options.</string>
 
-    <string name="upgrade_badge_label">Pro</string>
 
     <string name="general_settings_label">General</string>
     <string name="general_settings_desc">General tweaks that affect the whole app.</string>
@@ -371,14 +370,13 @@
     <string name="widget_home_unavailable">Storage unavailable</string>
 
     <string name="settings_category_widget">Widget</string>
-    <string name="widget_settings_oneclick_title">One-Tap Mode</string>
     <string name="widget_settings_oneclick_summary">Let the home-screen widget\'s Clean button scan and delete in one tap, without asking each time.</string>
     <string name="widget_oneclick_consent_title">Enable one-tap cleaning?</string>
     <string name="widget_oneclick_consent_message">The widget\'s Clean button will scan and delete in one go, without asking first or letting you review what gets removed.</string>
     <string name="widget_oneclick_consent_enable_action">Enable</string>
     <string name="widget_oneclick_consent_decline_action">Not now</string>
 
-    <string name="shortcut_onetap_started">Scan &amp; delete started…</string>
+    <string name="shortcut_onetap_started">Scan + Delete started…</string>
     <string name="shortcut_onetap_nothing_enabled">No one-tap tools are enabled</string>
 
     <!-- Config backup & restore -->
@@ -392,7 +390,6 @@
     <string name="backup_restore_export_partial">Backup created, but these parts failed: %1$s</string>
     <string name="backup_restore_restore_success">Backup restored</string>
     <string name="backup_restore_restore_failed">Restore failed (%1$s). Your previous configuration was saved.</string>
-    <string name="backup_restore_undo_action">Undo</string>
     <string name="backup_restore_recovery_title">Recover previous configuration</string>
     <string name="backup_restore_recovery_desc">A safety snapshot from an unfinished restore is available</string>
     <string name="backup_restore_confirm_title">Restore this backup?</string>
@@ -407,7 +404,7 @@
     <string name="backup_restore_warn_android_body">This backup was made on Android %1$s, but this device runs Android %2$s.</string>
     <string name="backup_restore_warn_device_body">This backup was made on a different device (%1$s vs %2$s).</string>
     <string name="backup_restore_warn_flavor_body">This backup is from a different app edition (%1$s vs %2$s).</string>
-    <string name="backup_restore_warn_history_body">This backup\'s history data (statistics, compression history, swipe sessions) is from a different app version and can\'t be restored. Everything else will be.</string>
+    <string name="backup_restore_warn_history_body">This backup\'s history data (statistics, compression history, swipe sessions) is from a different app version and can\'t be restored. Everything else will be restored.</string>
     <string name="backup_restore_ack_understand">I understand and want to continue</string>
     <string name="backup_restore_action_restore">Restore</string>
 </resources>


### PR DESCRIPTION
## What changed

Tidied up the app's English text before it goes out for translation. Some unused and duplicate wording was removed, and a few messages were fixed or clarified. Visible tweaks include a clearer "Screen unavailable" fallback, an upgrade prompt that no longer assumes the paid tier is called "Pro" (it isn't in the FOSS build), and clearer guided-tour text.

## Technical Context

- Pre-Crowdin source cleanup so translators aren't handed dead or duplicate keys on the next upload.
- Removed 3 unused keys (`tour_step_x_of_y`, `appcontrol_list_filteroptions_label`, `general_show_all_action`).
- Consolidated 4 duplicate keys onto existing shared equivalents, swapping each call site: `backup_restore_undo_action`→`general_undo_action`, `tour_action_done`→`general_done_action`, `widget_settings_oneclick_title`→`dashboard_settings_oneclick_title`, `upgrade_badge_label`→`app_name_upgrade_postfix`.
- Copy fixes: stale `navigation_unknown_destination_*` ("still being migrated" — migration is done), flavor-neutral `general_error_upgrade_required_*` (was "Pro"), qualified the blanket "safe" claim in the CorpseFinder tour intro, "photo"→"file" in the Swiper tour, count-neutral `debug_logview_paused_dropped_msg`, and minor grammar.
- Deleted keys were also stripped from every `values-*/strings.xml`. `ExtraTranslation` is a **fatal** lint gate for release builds here, so orphaned translations would fail CI — hence the large locale-file diff (deletions only).
- No behavioral change beyond the copy edits. Verified green locally: `assembleFossDebug`, `assembleGplayDebug`, `lintVitalFossRelease`, `lintVitalGplayRelease`.
