### PR TITLE
General: Upgrade Android Gradle Plugin and Gradle wrapper

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:9.1.0")
+        classpath("com.android.tools.build:gradle:9.3.0")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.Kotlin.core}")
         classpath("com.google.dagger:hilt-android-gradle-plugin:${Versions.Dagger.core}")
         classpath("org.jetbrains.kotlin:kotlin-serialization:${Versions.Kotlin.core}")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -17,7 +17,7 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    implementation("com.android.tools.build:gradle:9.1.0")
+    implementation("com.android.tools.build:gradle:9.3.0")
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.10")
     implementation("com.squareup:javapoet:1.13.0")
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 #Tue Jan 20 11:53:55 CET 2026
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=b266d5ff6b90eada6dc3b20cb090e3731302e553a27c5d3e4df1f0d76beaff06
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+distributionSha256Sum=553c78f50dafcd54d65b9a444649057857469edf836431389695608536d6b746
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## What changed

No user-facing behavior change. Updates the Android build tooling to newer versions.

## Technical Context

- **AGP 9.1.0 → 9.3.0** (`build.gradle.kts` and `buildSrc/build.gradle.kts`).
- **Gradle wrapper 9.3.1 → 9.5.0** (`distributionUrl` + `distributionSha256Sum`).
- Generated by the Android Studio AGP upgrade assistant.
- Verified locally on the new toolchain (Gradle 9.5.0 / Java 21): `assembleFossDebug` and `lintVitalFossRelease` both pass, no new compile errors or fatal lint.
- Only pre-existing deprecation warnings remain — `android.newDsl=false` and the legacy variant APIs (`applicationVariants`, `libraryVariants`, etc.) the project intentionally keeps enabled. Unchanged by this bump; they'll matter for a future AGP 10 migration, not this one.
