### PR TITLE
General: Fix dashboard size not updating after excluding items

### DIFF
--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
@@ -211,14 +211,12 @@ class AppCleaner @Inject constructor(
         results.forEach { it.size }
         log(TAG) { "Field warm up done." }
 
-        internalData.value = Data(
+        val data = Data(
             junks = results,
         )
+        internalData.value = data
 
-        return AppCleanerScanTask.Success(
-            itemCount = results.sumOf { it.itemCount },
-            recoverableSpace = results.sumOf { it.size },
-        )
+        return data.toScanSuccess()
     }
 
     private suspend fun performProcessing(
@@ -483,6 +481,12 @@ class AppCleaner @Inject constructor(
     ) {
         val totalSize: Long get() = junks.sumOf { it.size }
         val totalCount: Int get() = junks.sumOf { it.itemCount }
+
+        /** Live scan summary. Single source of truth shared with [performScan] and the dashboard card. */
+        fun toScanSuccess() = AppCleanerScanTask.Success(
+            itemCount = totalCount,
+            recoverableSpace = totalSize,
+        )
     }
 
     @InstallIn(SingletonComponent::class)

--- a/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/CorpseFinder.kt
+++ b/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/CorpseFinder.kt
@@ -234,11 +234,9 @@ class CorpseFinder @Inject constructor(
         // background events don't disturb the user's open CorpseFinder view.
         internalData.value = null
         val results = runScan(task)
-        internalData.value = Data(corpses = results)
-        return CorpseFinderScanTask.Success(
-            itemCount = results.size,
-            recoverableSpace = results.sumOf { it.size },
-        )
+        val data = Data(corpses = results)
+        internalData.value = data
+        return data.toScanSuccess()
     }
 
     /**
@@ -506,6 +504,12 @@ class CorpseFinder @Inject constructor(
     ) {
         val totalSize: Long get() = corpses.sumOf { it.size }
         val totalCount: Int get() = corpses.size
+
+        /** Live scan summary. Single source of truth shared with [performScan] and the dashboard card. */
+        fun toScanSuccess() = CorpseFinderScanTask.Success(
+            itemCount = totalCount,
+            recoverableSpace = totalSize,
+        )
     }
 
     @InstallIn(SingletonComponent::class)

--- a/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/core/Deduplicator.kt
+++ b/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/core/Deduplicator.kt
@@ -187,10 +187,7 @@ class Deduplicator @Inject constructor(
         val data = Data(clusters = results)
         internalData.value = data
 
-        return DeduplicatorScanTask.Success(
-            itemCount = data.clusters.size,
-            recoverableSpace = data.redundantSize,
-        )
+        return data.toScanSuccess()
     }
 
     private suspend fun performDelete(
@@ -365,6 +362,15 @@ class Deduplicator @Inject constructor(
 
         /** Files a default keep-one delete removes across all clusters. See [Duplicate.Cluster.redundantCount]. */
         val redundantCount: Int get() = clusters.sumOf { it.redundantCount }
+
+        /**
+         * Live scan summary. Single source of truth shared with [performScan] and the dashboard card.
+         * itemCount is the cluster count (matching the scan result), not [redundantCount].
+         */
+        fun toScanSuccess() = DeduplicatorScanTask.Success(
+            itemCount = clusters.size,
+            recoverableSpace = redundantSize,
+        )
     }
 
     @InstallIn(SingletonComponent::class)

--- a/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/core/SystemCleaner.kt
+++ b/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/core/SystemCleaner.kt
@@ -152,14 +152,12 @@ class SystemCleaner @Inject constructor(
         results.forEach { it.size }
         log(TAG) { "Field warm up done." }
 
-        internalData.value = Data(
+        val data = Data(
             filterContents = results
         )
+        internalData.value = data
 
-        return SystemCleanerScanTask.Success(
-            itemCount = results.sumOf { it.items.size },
-            recoverableSpace = results.sumOf { it.size },
-        )
+        return data.toScanSuccess()
     }
 
     private suspend fun performProcessing(
@@ -298,6 +296,12 @@ class SystemCleaner @Inject constructor(
     ) {
         val totalSize: Long get() = filterContents.sumOf { it.size }
         val totalCount: Int get() = filterContents.sumOf { it.items.size }
+
+        /** Live scan summary. Single source of truth shared with [performScan] and the dashboard card. */
+        fun toScanSuccess() = SystemCleanerScanTask.Success(
+            itemCount = totalCount,
+            recoverableSpace = totalSize,
+        )
     }
 
     @InstallIn(SingletonComponent::class)

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardCardFlows.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardCardFlows.kt
@@ -107,14 +107,53 @@ internal fun DashboardViewModel.buildTitleCardItem(): Flow<TitleDashboardCardIte
     )
 }
 
-internal fun DashboardViewModel.buildCorpseFinderItem(): Flow<ToolDashboardCardItem> = combine(
-    (corpseFinder.state as Flow<CorpseFinder.State?>).onStart { emit(null) },
-    taskManager.state.map { it.getLatestResult(SDMTool.Type.CORPSEFINDER) },
-) { state, lastResult ->
+/**
+ * Resolves the result shown on a tool's dashboard card. The dashboard historically showed the tool's
+ * last *task* result — a snapshot frozen at scan completion — so post-scan mutations that only touch
+ * live data (applying exclusions, the uninstall watcher pruning corpses) left the card advertising a
+ * stale freeable size while the hero summary, which reads live data, disagreed. This prefers a summary
+ * rebuilt from live tool [data] whenever a scan is on screen, while preserving frozen "freed X"
+ * outcomes from a completed delete/one-click (those are not scan results).
+ */
+internal inline fun <D : Any> resolveScanCardResult(
+    isInitializing: Boolean,
+    isWorking: Boolean,
+    data: D?,
+    hasData: Boolean,
+    lastResult: SDMTool.Task.Result?,
+    lastResultIsScan: Boolean,
+    reconstruct: (D) -> SDMTool.Task.Result,
+): SDMTool.Task.Result? = when {
+    // Tool state not resolved yet, or a task is running (the card shows progress): keep the frozen result.
+    isInitializing || isWorking -> lastResult
+    // Live scan data was invalidated without a new task (e.g. Deduplicator arbiter-config change): drop a
+    // now-stale scan result so the card falls back to its description instead of advertising vanished space.
+    data == null -> lastResult.takeUnless { lastResultIsScan }
+    // A scan is on screen — data present, or the last result is a scan even if data is now empty after
+    // excluding everything: rebuild the freeable summary from live data (empty data yields Success(0, 0)).
+    hasData || lastResultIsScan -> reconstruct(data)
+    // Empty data with a non-scan result (a completed delete's "freed X"): keep that outcome.
+    else -> lastResult
+}
+
+internal fun DashboardViewModel.buildCorpseFinderItem(): Flow<ToolDashboardCardItem> =
+    (corpseFinder.state as Flow<CorpseFinder.State?>).onStart { emit(null) }.map { state ->
+    val data = state?.data
+    // CorpseFinder records the user-visible result in Data.lastResult and deliberately does NOT let the
+    // background uninstall watcher overwrite it. Prefer that over TaskManager, whose newest entry for this
+    // tool may be a watcher event — which would otherwise surface on the card as the user's last action.
+    val lastResult = data?.lastResult
     ToolDashboardCardItem(
         toolType = SDMTool.Type.CORPSEFINDER,
         isInitializing = state == null,
-        result = lastResult,
+        result = resolveScanCardResult(
+            isInitializing = state == null,
+            isWorking = state?.progress != null,
+            data = data,
+            hasData = data.hasData,
+            lastResult = lastResult,
+            lastResultIsScan = lastResult is CorpseFinderScanTask.Success,
+        ) { it.toScanSuccess() },
         progress = state?.progress,
         showProRequirement = false,
         onScan = {
@@ -138,10 +177,18 @@ internal fun DashboardViewModel.buildSystemCleanerItem(): Flow<ToolDashboardCard
     (systemCleaner.state as Flow<SystemCleaner.State?>).onStart { emit(null) },
     taskManager.state.map { it.getLatestResult(SDMTool.Type.SYSTEMCLEANER) },
 ) { state, lastResult ->
+    val data = state?.data
     ToolDashboardCardItem(
         toolType = SDMTool.Type.SYSTEMCLEANER,
         isInitializing = state == null,
-        result = lastResult,
+        result = resolveScanCardResult(
+            isInitializing = state == null,
+            isWorking = state?.progress != null,
+            data = data,
+            hasData = data.hasData,
+            lastResult = lastResult,
+            lastResultIsScan = lastResult is SystemCleanerScanTask.Success,
+        ) { it.toScanSuccess() },
         progress = state?.progress,
         showProRequirement = false,
         onScan = {
@@ -166,10 +213,18 @@ internal fun DashboardViewModel.buildAppCleanerItem(): Flow<ToolDashboardCardIte
     taskManager.state.map { it.getLatestResult(SDMTool.Type.APPCLEANER) },
     upgradeInfo.map { it?.isPro ?: false },
 ) { state, lastResult, isPro ->
+    val data = state?.data
     ToolDashboardCardItem(
         toolType = SDMTool.Type.APPCLEANER,
         isInitializing = state == null,
-        result = lastResult,
+        result = resolveScanCardResult(
+            isInitializing = state == null,
+            isWorking = state?.progress != null,
+            data = data,
+            hasData = data.hasData,
+            lastResult = lastResult,
+            lastResultIsScan = lastResult is AppCleanerScanTask.Success,
+        ) { it.toScanSuccess() },
         progress = state?.progress,
         showProRequirement = !isPro,
         onScan = {
@@ -194,10 +249,18 @@ internal fun DashboardViewModel.buildDeduplicatorItem(): Flow<ToolDashboardCardI
     taskManager.state.map { it.getLatestResult(SDMTool.Type.DEDUPLICATOR) },
     upgradeInfo.map { it?.isPro ?: false },
 ) { state, lastResult, isPro ->
+    val data = state?.data
     ToolDashboardCardItem(
         toolType = SDMTool.Type.DEDUPLICATOR,
         isInitializing = state == null,
-        result = lastResult,
+        result = resolveScanCardResult(
+            isInitializing = state == null,
+            isWorking = state?.progress != null,
+            data = data,
+            hasData = data.hasData,
+            lastResult = lastResult,
+            lastResultIsScan = lastResult is DeduplicatorScanTask.Success,
+        ) { it.toScanSuccess() },
         progress = state?.progress,
         showProRequirement = !isPro,
         onScan = {

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardCardResultTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardCardResultTest.kt
@@ -1,0 +1,147 @@
+package eu.darken.sdmse.main.ui.dashboard
+
+import eu.darken.sdmse.appcleaner.core.AppCleaner
+import eu.darken.sdmse.appcleaner.core.AppJunk
+import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerScanTask
+import eu.darken.sdmse.corpsefinder.core.Corpse
+import eu.darken.sdmse.corpsefinder.core.CorpseFinder
+import eu.darken.sdmse.corpsefinder.core.tasks.CorpseFinderScanTask
+import eu.darken.sdmse.deduplicator.core.Deduplicator
+import eu.darken.sdmse.deduplicator.core.Duplicate
+import eu.darken.sdmse.deduplicator.core.tasks.DeduplicatorScanTask
+import eu.darken.sdmse.main.core.SDMTool
+import eu.darken.sdmse.systemcleaner.core.FilterContent
+import eu.darken.sdmse.systemcleaner.core.SystemCleaner
+import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerScanTask
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+/**
+ * Unit tests for the dashboard tool card result logic:
+ *  - each tool's [*.Data.toScanSuccess] mapping (the single source of truth shared with performScan)
+ *  - [resolveScanCardResult]'s state-resolution branches
+ */
+class DashboardCardResultTest : BaseTest() {
+
+    // --- Per-tool Data.toScanSuccess() mappings ---------------------------------------------------
+
+    @Test
+    fun `appcleaner data maps to scan success by item count and size`() {
+        val data = AppCleaner.Data(
+            junks = listOf(
+                mockk<AppJunk> { every { size } returns 400L; every { itemCount } returns 3 },
+                mockk<AppJunk> { every { size } returns 100L; every { itemCount } returns 2 },
+            ),
+        )
+        data.toScanSuccess() shouldBe AppCleanerScanTask.Success(itemCount = 5, recoverableSpace = 500L)
+    }
+
+    @Test
+    fun `corpsefinder data maps to scan success by corpse count and size`() {
+        val data = CorpseFinder.Data(
+            corpses = listOf(
+                mockk<Corpse> { every { size } returns 400L },
+                mockk<Corpse> { every { size } returns 100L },
+            ),
+        )
+        data.toScanSuccess() shouldBe CorpseFinderScanTask.Success(itemCount = 2, recoverableSpace = 500L)
+    }
+
+    @Test
+    fun `systemcleaner data maps to scan success by contained item count and size`() {
+        val data = SystemCleaner.Data(
+            filterContents = listOf(
+                mockk<FilterContent> { every { items } returns listOf(mockk(), mockk(), mockk()); every { size } returns 400L },
+                mockk<FilterContent> { every { items } returns listOf(mockk(), mockk()); every { size } returns 100L },
+            ),
+        )
+        data.toScanSuccess() shouldBe SystemCleanerScanTask.Success(itemCount = 5, recoverableSpace = 500L)
+    }
+
+    @Test
+    fun `deduplicator data maps item count to cluster count not redundant count`() {
+        // Trap guard: itemCount must be the cluster count (2), NOT the summed redundantCount (11).
+        val data = Deduplicator.Data(
+            clusters = setOf(
+                mockk<Duplicate.Cluster> { every { redundantSize } returns 400L; every { redundantCount } returns 7 },
+                mockk<Duplicate.Cluster> { every { redundantSize } returns 100L; every { redundantCount } returns 4 },
+            ),
+        )
+        data.toScanSuccess() shouldBe DeduplicatorScanTask.Success(itemCount = 2, recoverableSpace = 500L)
+    }
+
+    // --- resolveScanCardResult branches -----------------------------------------------------------
+
+    private val frozen = mockk<SDMTool.Task.Result>()
+    private val rebuilt = mockk<SDMTool.Task.Result>()
+
+    private fun resolve(
+        isInitializing: Boolean = false,
+        isWorking: Boolean = false,
+        data: String? = "data",
+        hasData: Boolean = true,
+        lastResult: SDMTool.Task.Result? = frozen,
+        lastResultIsScan: Boolean = true,
+    ): SDMTool.Task.Result? = resolveScanCardResult(
+        isInitializing = isInitializing,
+        isWorking = isWorking,
+        data = data,
+        hasData = hasData,
+        lastResult = lastResult,
+        lastResultIsScan = lastResultIsScan,
+    ) { rebuilt }
+
+    @Test
+    fun `while initializing keeps the frozen result without reconstructing`() {
+        resolveScanCardResult(
+            isInitializing = true,
+            isWorking = false,
+            data = "data",
+            hasData = true,
+            lastResult = frozen,
+            lastResultIsScan = true,
+        ) { error("must not reconstruct while initializing") } shouldBe frozen
+    }
+
+    @Test
+    fun `while working keeps the frozen result without reconstructing`() {
+        resolveScanCardResult(
+            isInitializing = false,
+            isWorking = true,
+            data = "data",
+            hasData = true,
+            lastResult = frozen,
+            lastResultIsScan = true,
+        ) { error("must not reconstruct while working") } shouldBe frozen
+    }
+
+    @Test
+    fun `live data present rebuilds the summary`() {
+        resolve(hasData = true) shouldBe rebuilt
+    }
+
+    @Test
+    fun `empty live data superseding a scan rebuilds to a zero summary`() {
+        // exclude-all / scan-found-nothing: data loaded but empty, last result was a scan.
+        resolve(hasData = false, lastResultIsScan = true) shouldBe rebuilt
+    }
+
+    @Test
+    fun `empty live data with a non-scan result keeps the freed outcome`() {
+        // post-delete "freed X": empty data, last result is a processing result.
+        resolve(hasData = false, lastResultIsScan = false) shouldBe frozen
+    }
+
+    @Test
+    fun `invalidated null data drops a stale scan result`() {
+        resolve(data = null, hasData = false, lastResultIsScan = true) shouldBe null
+    }
+
+    @Test
+    fun `invalidated null data keeps a non-scan result`() {
+        resolve(data = null, hasData = false, lastResultIsScan = false) shouldBe frozen
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModelResilienceTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModelResilienceTest.kt
@@ -2,6 +2,8 @@ package eu.darken.sdmse.main.ui.dashboard
 
 import eu.darken.sdmse.analyzer.core.Analyzer
 import eu.darken.sdmse.appcleaner.core.AppCleaner
+import eu.darken.sdmse.appcleaner.core.AppJunk
+import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerScanTask
 import eu.darken.sdmse.appcontrol.core.AppControl
 import eu.darken.sdmse.common.WebpageTool
 import eu.darken.sdmse.common.areas.DataAreaManager
@@ -12,10 +14,12 @@ import eu.darken.sdmse.common.review.ReviewTool
 import eu.darken.sdmse.common.updater.UpdateService
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
 import eu.darken.sdmse.corpsefinder.core.CorpseFinder
+import eu.darken.sdmse.corpsefinder.core.tasks.CorpseFinderScanTask
 import eu.darken.sdmse.deduplicator.core.Deduplicator
 import eu.darken.sdmse.main.core.DashboardCardConfig
 import eu.darken.sdmse.main.core.DashboardCardType
 import eu.darken.sdmse.main.core.GeneralSettings
+import eu.darken.sdmse.main.core.SDMTool
 import eu.darken.sdmse.main.core.motd.MotdRepo
 import eu.darken.sdmse.main.core.release.ReleaseManager
 import eu.darken.sdmse.main.core.taskmanager.TaskManager
@@ -78,24 +82,33 @@ internal class DashboardViewModelResilienceTest : BaseTest() {
         // config legitimately keeps the spinner — see `stalled card config keeps the loading spinner`.
         cardConfig: Flow<DashboardCardConfig> = flowOf(DashboardCardConfig()),
         emittingToolStates: Boolean = false,
+        appCleanerState: Flow<AppCleaner.State>? = null,
+        corpseFinderState: Flow<CorpseFinder.State>? = null,
+        taskManagerState: Flow<TaskSubmitter.State>? = null,
     ): DashboardViewModel {
         fun <T> srcOr(name: String, default: Flow<T>): Flow<T> = if (stall == name) stalled() else default
 
         val taskManager = mockk<TaskManager>(relaxed = true).apply {
-            every { state } returns MutableStateFlow(TaskSubmitter.State())
+            every { state } returns (taskManagerState ?: MutableStateFlow(TaskSubmitter.State()))
         }
         // The bottom bar combine has no fallbacks; give it live (data-less) tool states when needed.
         val corpseFinder = mockk<CorpseFinder>(relaxed = true).apply {
-            every { state } returns
-                if (emittingToolStates) MutableStateFlow(mockk<CorpseFinder.State>(relaxed = true) { every { data } returns null }) else emptyFlow()
+            every { state } returns when {
+                corpseFinderState != null -> corpseFinderState
+                emittingToolStates -> MutableStateFlow(mockk<CorpseFinder.State>(relaxed = true) { every { data } returns null })
+                else -> emptyFlow()
+            }
         }
         val systemCleaner = mockk<SystemCleaner>(relaxed = true).apply {
             every { state } returns
                 if (emittingToolStates) MutableStateFlow(mockk<SystemCleaner.State>(relaxed = true) { every { data } returns null }) else emptyFlow()
         }
         val appCleaner = mockk<AppCleaner>(relaxed = true).apply {
-            every { state } returns
-                if (emittingToolStates) MutableStateFlow(mockk<AppCleaner.State>(relaxed = true) { every { data } returns null }) else emptyFlow()
+            every { state } returns when {
+                appCleanerState != null -> appCleanerState
+                emittingToolStates -> MutableStateFlow(mockk<AppCleaner.State>(relaxed = true) { every { data } returns null })
+                else -> emptyFlow()
+            }
         }
         val deduplicator = mockk<Deduplicator>(relaxed = true).apply {
             every { state } returns
@@ -231,6 +244,69 @@ internal class DashboardViewModelResilienceTest : BaseTest() {
 
         bar.upgradeInfo shouldBe null
         bar.actionState shouldBe BottomBarState.Action.SCAN
+    }
+
+    @Test
+    fun `appcleaner card derives freeable size from live data not the frozen scan result`() = runTest2 {
+        fun junk(size: Long, items: Int): AppJunk = mockk {
+            every { this@mockk.size } returns size
+            every { itemCount } returns items
+        }
+        fun appState(vararg junks: AppJunk): AppCleaner.State = mockk(relaxed = true) {
+            every { data } returns AppCleaner.Data(junks = junks.toList())
+            every { progress } returns null
+        }
+
+        val liveState = MutableStateFlow(appState(junk(400L, 3), junk(100L, 2))) // live: 500 / 5
+
+        // A completed scan task whose frozen result advertises a now-stale, larger total.
+        val frozenScan = AppCleanerScanTask.Success(itemCount = 10, recoverableSpace = 1000L)
+        val completedTask = mockk<TaskSubmitter.ManagedTask>(relaxed = true) {
+            every { toolType } returns SDMTool.Type.APPCLEANER
+            every { isComplete } returns true
+            every { completedAt } returns Instant.EPOCH
+            every { result } returns frozenScan
+        }
+
+        val vm = harness(
+            appCleanerState = liveState,
+            taskManagerState = MutableStateFlow(TaskSubmitter.State(tasks = listOf(completedTask))),
+        )
+
+        fun appCard() = vm.listState.mapNotNull { list ->
+            list?.items?.filterIsInstance<ToolDashboardCardItem>()?.firstOrNull { it.toolType == SDMTool.Type.APPCLEANER }
+        }
+
+        // The card reflects LIVE data (500 / 5), not the frozen scan result (1000 / 10).
+        appCard().first { it.result == AppCleanerScanTask.Success(itemCount = 5, recoverableSpace = 500L) }
+
+        // Applying an exclusion shrinks live data; the card refreshes without a new task being submitted.
+        liveState.value = appState(junk(100L, 2)) // live: 100 / 2
+        appCard().first { it.result == AppCleanerScanTask.Success(itemCount = 2, recoverableSpace = 100L) }
+    }
+
+    @Test
+    fun `corpsefinder card reflects live data via lastResult ignoring the uninstall watcher`() = runTest2 {
+        // Simulates: a user scan found 1 corpse, then the background uninstall watcher deleted it.
+        // CorpseFinder keeps the user-visible scan result in Data.lastResult (never overwritten by the
+        // watcher) while corpses drain to empty. The card must show the live-derived Success(0, 0),
+        // sourced from Data.lastResult — not the watcher's task result from TaskManager.
+        val corpseState = MutableStateFlow<CorpseFinder.State>(
+            mockk(relaxed = true) {
+                every { data } returns CorpseFinder.Data(
+                    corpses = emptyList(),
+                    lastResult = CorpseFinderScanTask.Success(itemCount = 1, recoverableSpace = 100L),
+                )
+                every { progress } returns null
+            }
+        )
+        val vm = harness(corpseFinderState = corpseState)
+
+        vm.listState
+            .mapNotNull { list ->
+                list?.items?.filterIsInstance<ToolDashboardCardItem>()?.firstOrNull { it.toolType == SDMTool.Type.CORPSEFINDER }
+            }
+            .first { it.result == CorpseFinderScanTask.Success(itemCount = 0, recoverableSpace = 0L) }
     }
 
     @Test


### PR DESCRIPTION
## What changed

After applying exclusions to a cleaning tool's results (for example, excluding an app in AppCleaner) and returning to the dashboard, that tool's card kept showing the original amount of freeable space — still counting the items you just excluded. The card now updates immediately to reflect what's actually left to clean.

## Technical Context

- **Root cause:** the per-tool dashboard cards took their freeable-size text from the last completed task result, a value frozen at scan completion. Applying an exclusion mutates the tool's live data but submits no new task, so the frozen figure never refreshed — even though the hero/bottom-bar summary, which already reads live data, did. The two visibly disagreed after an exclusion.
- **Fix:** a per-tool `Data.toScanSuccess()` mapper (now also the single source of truth inside each `performScan()`) plus `resolveScanCardResult()`, which rebuilds the card's scan figure from live tool data whenever a scan is on screen. It also handles exclude-all (→ empty summary), data invalidation (Deduplicator arbiter-config change clears the card instead of advertising vanished space), and preserves the "freed X" confirmation shown after a real deletion (a processing result, not a scan result).
- **CorpseFinder** additionally sources its result from `Data.lastResult` instead of TaskManager. The tool deliberately keeps that field free of the background uninstall-watcher event, so a background cleanup no longer surfaces on the card as if it were the user's last action.
- **No extra churn:** reconstruction is skipped while a tool is scanning/deleting (the card shows progress then), so this adds no per-progress-tick recompute.
- **Review guidance / tests:** per-tool mapping tests (including the Deduplicator cluster-count vs redundant-count distinction), every `resolveScanCardResult` branch (with guards proving no reconstruction in the frozen branches), and two flow-level regressions — AppCleaner refreshing on live-data change, and CorpseFinder ignoring the watcher via `Data.lastResult`.
