### PR TITLE
General: Quiet repeated purchase acknowledgement log spam

### DIFF
--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManager.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManager.kt
@@ -164,6 +164,15 @@ class BillingManager @Inject constructor(
         .setupCommonEventHandlers(TAG) { "freshBillingData" }
         .shareIn(scope, SharingStarted.Eagerly, replay = 1)
 
+    // Tokens we've already SUCCESSFULLY acknowledged this process. LOG-LEVEL HINT ONLY: it selects
+    // INFO (first ack) vs DEBUG (idempotent repeat) and MUST NOT gate the acknowledgePurchase call
+    // below. The immutable Purchase snapshot keeps reporting isAcknowledged=false until a fresh Play
+    // query supersedes it, so the ack re-fires every emission until then; re-acking is a documented
+    // no-op on Play's side, whereas skipping a needed ack gets the purchase auto-refunded after 3
+    // days -- so the ack stays unconditional and this set only quiets the log spam. Single
+    // sequential collector (the onEach below), no locking needed.
+    private val loggedAckTokens = mutableSetOf<String>()
+
     init {
         purchases
             .onEach { purchases ->
@@ -171,18 +180,24 @@ class BillingManager @Inject constructor(
                     .filter {
                         val needsAck = !it.isAcknowledged
 
-                        if (needsAck) log(TAG, INFO) { "Needs ACK: $it" }
+                        if (needsAck) log(TAG) { "Needs ACK: $it" }
                         else log(TAG) { "Already ACK'ed: $it" }
 
                         needsAck
                     }
                     .forEach {
-                        log(TAG, INFO) { "Acknowledging purchase: $it" }
+                        // First ack of a token is INFO; idempotent repeats drop to DEBUG. This never
+                        // gates the ack -- acknowledgePurchase runs regardless of set membership.
+                        val ackPriority = if (it.purchaseToken in loggedAckTokens) DEBUG else INFO
+                        log(TAG, ackPriority) { "Acknowledging purchase: $it" }
 
                         try {
                             useConnection {
                                 acknowledgePurchase(it)
                             }
+                            // Only after a *successful* ack (acknowledgePurchase throws on non-OK):
+                            // a failed ack never lands here, so it stays loud and retryable.
+                            loggedAckTokens.add(it.purchaseToken)
                         } catch (e: CancellationException) {
                             // AppScope death is not an acknowledgement failure.
                             throw e

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingConnection.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingConnection.kt
@@ -105,8 +105,9 @@ class BillingConnection(
 
         // Snapshots first, overlay overwrites: a surviving overlay entry is by construction newer
         // than the last successful query of its type (older ones were cleared), so its purchase
-        // data (ack state etc.) is fresher. purchaseToken is the real purchase identity — Purchase
-        // has no equals(), object-identity dedup would keep duplicates.
+        // data (ack state etc.) is fresher. Dedup by purchaseToken (the stable purchase identity):
+        // snapshot and overlay instances of the same purchase can differ in ack state, so Purchase
+        // equality or object identity would retain both instead of letting the newer one win.
         internal fun merged(): Collection<Purchase> {
             val byToken = LinkedHashMap<String, Purchase>()
             iapSnapshot.orEmpty().forEach { byToken[it.purchaseToken] = it }


### PR DESCRIPTION
## What changed

No user-facing behavior change. This reduces log noise from Google Play purchase acknowledgement. The acknowledgement step re-fires on every billing update while a just-acknowledged purchase still reports itself as not-yet-acknowledged, and each repeat was logged at INFO. Repeats now log at DEBUG. Also fixes a misleading code comment.

## Technical Context

- The Play billing snapshot keeps reporting `isAcknowledged=false` until a fresh query supersedes it, so the ack loop legitimately re-fires until then. Re-acknowledging is a documented no-op on Play's side, so the only cost was log spam.
- A process-local `loggedAckTokens` set is used **only** to pick the log level (first ack of a token = INFO, idempotent repeats = DEBUG). It is recorded strictly after a *successful* `acknowledgePurchase` (which throws on any non-OK result), and it **never** gates the ack call — `acknowledgePurchase` still fires on every emission. This deliberately preserves the safe over-acknowledge bias: skipping a genuinely-needed ack would get the purchase auto-refunded by Play after 3 days, so the ack stays unconditional and this set only quiets the logs.
- The set is mutated from a single sequential flow collector, so no synchronization is needed.
- Comment fix in `BillingConnection.merged()`: the old comment claimed `Purchase` has no `equals()`. Play Billing's `Purchase` does implement `equals()`/`hashCode()` (originalJson + signature); the actual reason dedup is keyed on `purchaseToken` is that the snapshot and overlay versions of the same purchase differ in ack state and would otherwise both be retained.
- **Review guidance / out of scope**: a pre-existing gap (unchanged here) — the per-purchase `catch` swallows ack failures, so a failed ack is not retried on a backoff, only on the next billing emission/refresh. Left for a separate change to avoid mixing a risky money-path behavioral fix into a log-only tweak.
