### PR TITLE
General: Keep Pro restore options reliable during Play outages

### DIFF
--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/BillingCache.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/BillingCache.kt
@@ -51,13 +51,18 @@ class BillingCache @Inject constructor(
     )
 
     // One transaction for all three values: the timestamp gates the grace period, the SKU modifies
-    // its window length, and a confirmation closes any unconfirmed episode — none of it may be
-    // observable half-updated.
+    // its window length, and a confirmation closes the unconfirmed episode — none of it may be
+    // observable half-updated. `at` is the confirmation's OCCURRENCE time (commit time of the Play
+    // round-trip). The episode is closed only if it began at or before `at`: a failure that occurred
+    // AFTER this confirmation (e.g. a connection drop right after this success, delivered to the
+    // entitlement layer out of order) opened a still-valid episode that this older confirmation must
+    // not erase.
     suspend fun stampLastProState(skuId: String, at: Long) {
         dataStore.edit { prefs ->
             prefs[lastProStateSkuKey] = skuId
             prefs[lastProStateAtKey] = at
-            prefs[proUnconfirmedSinceKey] = 0L
+            val episodeStart = prefs[proUnconfirmedSinceKey] ?: 0L
+            if (episodeStart in 1..at) prefs[proUnconfirmedSinceKey] = 0L
         }
     }
 }

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplay.kt
@@ -107,6 +107,18 @@ class UpgradeRepoGplay @Inject constructor(
             }
             .setupCommonEventHandlers(TAG) { "asyncAlreadyOwned" }
             .launchIn(scope)
+
+        // Connect-loop failures never reach an explicit refresh() caller (the loop retries
+        // internally and downstream flows just go quiet), so without this a sustained Play outage
+        // between ON_RESUME refreshes wouldn't advance the grace episode clock. The emitted value is
+        // the failure's occurrence time: recordProUnconfirmed uses it (not processing-time) so a
+        // buffered failure that a later success already superseded is dropped rather than reopening a
+        // closed episode. Set-if-unset and grace-guarded, so repeated outages collapse to a single
+        // episode start and installs that were never Pro (lastProStateAt == 0) are ignored.
+        billingManager.connectionFailures
+            .onEach { failedAt -> recordProUnconfirmed(failedAt) }
+            .setupCommonEventHandlers(TAG) { "connectionFailureRecorder" }
+            .launchIn(scope)
     }
 
     // False until the first real billing outcome after process start — the window where
@@ -330,7 +342,8 @@ class UpgradeRepoGplay @Inject constructor(
         if (sku == null) {
             // A full snapshot proves absence; a partial one (purchase event, single-type query)
             // only proves presence of what it contains and must not start an unconfirmed episode.
-            if (fresh.isFullSnapshot) recordProUnconfirmedLocked()
+            // occurredAt is the snapshot's commit time — when Play confirmed the absence.
+            if (fresh.isFullSnapshot) recordProUnconfirmedLocked(fresh.occurredAt)
             return@withLock
         }
         val storedSkuId = billingCache.lastProStateSku.value()
@@ -347,28 +360,38 @@ class UpgradeRepoGplay @Inject constructor(
             sku.id
         }
         log(TAG, VERBOSE) { "Fresh Pro state confirmed by $sku, stamping $effectiveSkuId" }
-        // One transaction: also closes any unconfirmed episode atomically.
-        billingCache.stampLastProState(effectiveSkuId, System.currentTimeMillis())
+        // Stamp with the confirmation's OWN commit time, not processing-now: the same value gates
+        // which unconfirmed episode this closes (BillingCache only clears an episode that began at or
+        // before it) and lets a later connection failure be correctly ordered against this success.
+        billingCache.stampLastProState(effectiveSkuId, fresh.occurredAt)
     }
 
-    private suspend fun recordProUnconfirmed() = proStateLock.withLock { recordProUnconfirmedLocked() }
+    private suspend fun recordProUnconfirmed(occurredAt: Long = System.currentTimeMillis()) =
+        proStateLock.withLock { recordProUnconfirmedLocked(occurredAt) }
 
     // Fresh reconciliation failed to confirm a known Pro purchase (full-snapshot empty result or
     // query error). Starts the unconfirmed-episode clock that delays the grace hint on the upgrade
     // screen. Set-if-unset so follow-up failures never refresh it; stamps from an earlier episode
     // (older than the last confirmation) or from the future (clock changes) are replaced.
     // Fail-quiet: purely informational, must never affect entitlement handling.
-    private suspend fun recordProUnconfirmedLocked() {
+    //
+    // occurredAt is WHEN the failure happened. Imperative callers (refresh/restore/empty snapshot)
+    // pass the default (now), which is also their event time. The buffered connectionFailures feed
+    // passes the failure's own timestamp so that a failure which happened BEFORE the latest
+    // confirmation — e.g. one enqueued during an outage but consumed only after a later retry
+    // succeeded and stamped Pro — is rejected by the sinceConfirm <= 0 guard instead of reopening
+    // an episode Play already closed.
+    private suspend fun recordProUnconfirmedLocked(occurredAt: Long = System.currentTimeMillis()) {
         try {
             val lastProStateAt = billingCache.lastProStateAt.value()
-            val now = System.currentTimeMillis()
-            val sinceConfirm = now - lastProStateAt
-            // sinceConfirm <= 0 also rejects future confirmations (clock moved backwards) — they
-            // would otherwise pass the window check and re-stamp the episode on every attempt.
+            val sinceConfirm = occurredAt - lastProStateAt
+            // sinceConfirm <= 0 rejects failures superseded by a later confirmation AND future
+            // confirmations (clock moved backwards) — both would otherwise pass the window check and
+            // (re)stamp the episode.
             if (lastProStateAt <= 0L || sinceConfirm <= 0L || sinceConfirm >= graceWindowMs()) return
             billingCache.proUnconfirmedSince.update { current ->
-                val stale = current <= 0L || current < lastProStateAt || current > now
-                if (stale) now else current
+                val stale = current <= 0L || current < lastProStateAt || current > occurredAt
+                if (stale) occurredAt else current
             }
         } catch (e: CancellationException) {
             throw e

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManager.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManager.kt
@@ -39,6 +39,8 @@ class BillingManager @Inject constructor(
     data class FreshData(
         val data: BillingData,
         val isFullSnapshot: Boolean,
+        // Commit time of the underlying Play round-trip — see BillingConnection.FreshUpdate.occurredAt.
+        val occurredAt: Long = System.currentTimeMillis(),
     )
 
     // Bumped whenever someone actively wants billing NOW (see useConnection): a pending reconnect
@@ -66,6 +68,25 @@ class BillingManager @Inject constructor(
     // an outage — gates that used to observe a propagated error need this explicit signal.
     private val settledOnce = MutableStateFlow(false)
     val isSettled: Flow<Boolean> = settledOnce
+
+    // Fires once per failed connect-loop iteration: connection setup failure, the mandatory initial
+    // refreshPurchases erroring or timing out, an established connection dropping, an action-level
+    // invalidation (SERVICE_DISCONNECTED/SERVICE_TIMEOUT from any useConnection call), or an
+    // unexpected provider completion. Every one is a fresh reconciliation that couldn't confirm Pro.
+    // The connect loop retries these internally and downstream flows just go quiet, so without this
+    // explicit signal the grace episode clock (UpgradeRepoGplay.proUnconfirmedSince) would only
+    // advance on an explicit ON_RESUME refresh().
+    //
+    // Each value is the failure's OCCURRENCE time (epoch millis). It has to be, not a bare Unit: the
+    // channel buffers, and this feed and freshBillingData are separate flows with no cross-stream
+    // ordering, so a failure enqueued before a later retry succeeds could be consumed AFTER that
+    // success already confirmed Pro and closed the episode. Carrying the failure's own timestamp lets
+    // the consumer compare it against the last confirmation and drop a superseded one instead of
+    // reopening a closed episode. UNLIMITED + receiveAsFlow (same idiom as BillingConnection
+    // .freshUpdates): one lifetime consumer, buffered so a failure that fires before it subscribes
+    // isn't lost.
+    private val connectionFailuresChannel = Channel<Long>(Channel.UNLIMITED)
+    val connectionFailures: Flow<Long> = connectionFailuresChannel.receiveAsFlow()
 
     init {
         // The connect loop: owns ALL retry policy. Deliberately NOT wrapped in
@@ -117,6 +138,11 @@ class BillingManager @Inject constructor(
                     throw e
                 } catch (e: Exception) {
                     log(TAG, WARN) { "Billing connection failed: ${e.asLog()}" }
+                    // A failed iteration is a fresh reconciliation that couldn't confirm Pro — signal
+                    // it (with its occurrence time) so the entitlement layer can advance the grace
+                    // episode clock even when no explicit refresh() caller is watching. Superseded
+                    // failures are dropped downstream; duplicates are idempotent (set-if-unset).
+                    connectionFailuresChannel.trySend(System.currentTimeMillis())
                 }
                 connectionHolder.value = null
                 settledOnce.value = true
@@ -160,7 +186,7 @@ class BillingManager @Inject constructor(
     // consumer — this chain — which must not depend on downstream subscribers.
     val freshBillingData: Flow<FreshData> = connectionHolder
         .flatMapLatest { it?.freshUpdates ?: emptyFlow() }
-        .map { FreshData(data = BillingData(purchases = it.purchases), isFullSnapshot = it.isFullSnapshot) }
+        .map { FreshData(data = BillingData(purchases = it.purchases), isFullSnapshot = it.isFullSnapshot, occurredAt = it.occurredAt) }
         .setupCommonEventHandlers(TAG) { "freshBillingData" }
         .shareIn(scope, SharingStarted.Eagerly, replay = 1)
 

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingConnection.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingConnection.kt
@@ -125,6 +125,14 @@ class BillingConnection(
     data class FreshUpdate(
         val purchases: Collection<Purchase>,
         val isFullSnapshot: Boolean,
+        // Wall-clock time this update was COMMITTED under reducerLock — i.e. when Play actually
+        // confirmed this data. Defaults to construction time, which at every production call site is
+        // the commit instant (this type is only ever built inside the reducer commit below). The Pro
+        // entitlement layer stamps its grace anchor with this so a confirmation and a later
+        // connection failure are ordered by when they HAPPENED, not by when each separate flow got
+        // around to processing them — see UpgradeRepoGplay.recordProState / BillingCache
+        // .stampLastProState.
+        val occurredAt: Long = System.currentTimeMillis(),
     )
 
     // Guards state mutation + fresh emission as one atomic step. Kept a plain monitor (not a

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/BillingCacheTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/BillingCacheTest.kt
@@ -36,5 +36,16 @@ class BillingCacheTest : BaseTest() {
 
         cache.lastProStateAt.value() shouldBe 5678L
         cache.lastProStateSku.value() shouldBe OurSku.Sub.PRO_UPGRADE.id
+
+        // Occurrence-aware episode clear: a confirmation closes an episode that began at or before
+        // it, but must leave a NEWER episode intact — a connection failure that occurred after this
+        // confirmation but was processed out of order opened a still-valid episode.
+        cache.proUnconfirmedSince.value(4_000L)
+        cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 5_000L) // confirmation newer than episode
+        cache.proUnconfirmedSince.value() shouldBe 0L
+
+        cache.proUnconfirmedSince.value(9_000L)
+        cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 8_000L) // confirmation older than episode
+        cache.proUnconfirmedSince.value() shouldBe 9_000L
     }
 }

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplayTest.kt
@@ -28,12 +28,14 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.advanceUntilIdle
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.runTest2
@@ -60,10 +62,12 @@ class UpgradeRepoGplayTest : BaseTest() {
         freshBillingData: BillingManager.FreshData? = null,
         purchaseFailures: List<BillingResult> = emptyList(),
         proUnconfirmedSince: Long = 0L,
+        connectionFailures: Flow<Long> = emptyFlow(),
     ): UpgradeRepoGplay {
         every { billingManager.billingData } returns flowOf(billingData)
         every { billingManager.freshBillingData } returns
             (freshBillingData?.let { flowOf(it) } ?: emptyFlow())
+        every { billingManager.connectionFailures } returns connectionFailures
         every { billingManager.isSettled } returns flowOf(true)
         every { billingManager.purchaseFailures } returns
             if (purchaseFailures.isEmpty()) emptyFlow() else flowOf(*purchaseFailures.toTypedArray())
@@ -223,6 +227,23 @@ class UpgradeRepoGplayTest : BaseTest() {
         )
 
         coVerify(exactly = 1) { billingCache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, any()) }
+    }
+
+    @Test fun `a confirmation stamps the grace cache with the fresh data's occurrence time`() = runTest2 {
+        // The confirmation anchor must be the success's COMMIT time, not processing-now: it's what
+        // BillingCache compares against to decide which episode to close and how a later failure
+        // orders against this success.
+        val occurredAt = 7_777_000L
+        repo(
+            lastProAt = 0L,
+            freshBillingData = BillingManager.FreshData(
+                BillingData(setOf(proPurchase())),
+                isFullSnapshot = true,
+                occurredAt = occurredAt,
+            ),
+        )
+
+        coVerify(exactly = 1) { billingCache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, occurredAt) }
     }
 
     @Test fun `fresh data without a known pro SKU does not stamp`() = runTest2 {
@@ -435,6 +456,68 @@ class UpgradeRepoGplayTest : BaseTest() {
         // A future stamp (clock moved backwards since it was written) is replaced.
         val future = System.currentTimeMillis() + Duration.ofDays(1).toMillis()
         transform.captured(future) shouldBe stamped
+    }
+
+    @Test fun `a connection-failure feed emission during grace starts the episode`() = runTest2 {
+        // Connect-loop failures don't reach an explicit refresh() caller; the feed must still
+        // advance the episode clock for a recently-Pro user. Driven as a live hot emission AFTER
+        // construction, so it proves the collector reacts to real events, not just wiring.
+        val failures = MutableSharedFlow<Long>(extraBufferCapacity = 1)
+        val confirmedAt = System.currentTimeMillis() - 1_000
+        repo(lastProAt = confirmedAt, connectionFailures = failures)
+
+        val failedAt = confirmedAt + 500 // after the confirmation -> a genuine post-confirm outage
+        failures.emit(failedAt)
+        advanceUntilIdle()
+
+        val transform = slot<(Long) -> Long?>()
+        coVerify { proUnconfirmedMock.update(capture(transform)) }
+        // The episode is stamped with the failure's OWN occurrence time, not processing-now.
+        transform.captured(0L) shouldBe failedAt
+    }
+
+    @Test fun `a connection-failure feed emission without recent pro does not start the episode`() = runTest2 {
+        val failures = MutableSharedFlow<Long>(extraBufferCapacity = 1)
+        repo(lastProAt = 0L, connectionFailures = failures)
+
+        failures.emit(System.currentTimeMillis())
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { proUnconfirmedMock.update(any()) }
+    }
+
+    @Test fun `a connection failure superseded by a later confirmation does not reopen the episode`() = runTest2 {
+        // The blocker case: a failure buffered during an outage is consumed only AFTER a later retry
+        // succeeded and stamped Pro (lastProStateAt). Because the event carries its own time, which
+        // is older than the confirmation, it must be dropped rather than reopening a closed episode.
+        val failures = MutableSharedFlow<Long>(extraBufferCapacity = 1)
+        val confirmedAt = System.currentTimeMillis()
+        repo(lastProAt = confirmedAt, connectionFailures = failures)
+
+        failures.emit(confirmedAt - 5_000) // the failure happened before the confirmation
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { proUnconfirmedMock.update(any()) }
+    }
+
+    @Test fun `repeated connection failures keep the original episode timestamp`() = runTest2 {
+        val failures = MutableSharedFlow<Long>(extraBufferCapacity = 1)
+        val confirmedAt = System.currentTimeMillis() - 10_000
+        repo(lastProAt = confirmedAt, connectionFailures = failures)
+
+        val firstFailure = confirmedAt + 1_000
+        val secondFailure = confirmedAt + 2_000
+        failures.emit(firstFailure)
+        failures.emit(secondFailure)
+        advanceUntilIdle()
+
+        // Both failures are processed (neither is dropped), so the count is exactly two.
+        val transforms = mutableListOf<(Long) -> Long?>()
+        coVerify(exactly = 2) { proUnconfirmedMock.update(capture(transforms)) }
+        transforms.size shouldBe 2
+        // Set-if-unset: the second failure, applied to the first episode's stamp, preserves it —
+        // the episode start never moves once opened.
+        transforms[1](firstFailure) shouldBe firstFailure
     }
 
     @Test fun `already-owned restore that only yields grace still surfaces the error`() = runTest2 {

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManagerTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManagerTest.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -169,13 +170,16 @@ class BillingManagerTest : BaseTest() {
         val manager = manager(
             connection(
                 freshUpdatesFlow = flowOf(
-                    BillingConnection.FreshUpdate(listOf(owned), isFullSnapshot = false),
+                    BillingConnection.FreshUpdate(listOf(owned), isFullSnapshot = false, occurredAt = 4242L),
                 ),
             )
         )
 
-        manager.freshBillingData.first() shouldBe
-            BillingManager.FreshData(BillingData(listOf(owned)), isFullSnapshot = false)
+        val fresh = manager.freshBillingData.first()
+        fresh.data shouldBe BillingData(listOf(owned))
+        fresh.isFullSnapshot shouldBe false
+        // The commit time must propagate verbatim: the entitlement layer keys episode ordering on it.
+        fresh.occurredAt shouldBe 4242L
     }
 
     @Test fun `non-OK purchase events are exposed as purchase failures`() = runTest2 {
@@ -481,6 +485,153 @@ class BillingManagerTest : BaseTest() {
 
         refreshed.await() shouldBe BillingData(listOf(owned))
         attempts shouldBe 2
+    }
+
+    // endregion
+
+    // region connection failure feed
+
+    // Drains the manager's connectionFailures (occurrence timestamps) into a list. Launched on
+    // backgroundScope so it lives for the whole test.
+    private fun TestScope.collectFailures(manager: BillingManager): List<Long> = mutableListOf<Long>().also { out ->
+        backgroundScope.launch { manager.connectionFailures.collect { out.add(it) } }
+    }
+
+    @Test fun `a failure buffered before subscription is still delivered`() = runTest2 {
+        // The consumer (UpgradeRepoGplay) and the connect loop both start in init with no ordering,
+        // so a failure can fire before anyone subscribes — the UNLIMITED channel must buffer it.
+        val provider = mockk<BillingConnectionProvider>().apply {
+            every { this@apply.connection } returns flow { throw BillingException("Play is down") }
+        }
+        val manager = manager(provider)
+        runCurrent() // attempt 1 fails and enqueues BEFORE any collector subscribes
+
+        val failures = collectFailures(manager)
+        runCurrent()
+        failures.isNotEmpty() shouldBe true
+    }
+
+    @Test fun `a failed connection attempt emits a connection failure`() = runTest2 {
+        val provider = mockk<BillingConnectionProvider>().apply {
+            every { this@apply.connection } returns flow { throw BillingException("Play is down") }
+        }
+        val manager = manager(provider)
+        val failures = collectFailures(manager)
+
+        runCurrent() // attempt 1 fails (backoff not yet elapsed -> exactly one iteration)
+        failures.size shouldBe 1
+    }
+
+    @Test fun `a failing initial refresh emits a connection failure`() = runTest2 {
+        val bad = connection().apply {
+            coEvery { refreshPurchases() } throws
+                GplayServiceUnavailableException(RuntimeException("cold Play, broken queries"))
+        }
+        val manager = manager(bad)
+        val failures = collectFailures(manager)
+
+        runCurrent() // connects, initial refresh throws -> connection failure
+        failures.size shouldBe 1
+    }
+
+    @Test fun `a hanging initial refresh emits a connection failure on timeout`() = runTest2 {
+        val bad = connection().apply {
+            coEvery { refreshPurchases() } coAnswers { awaitCancellation() }
+        }
+        val manager = manager(bad)
+        val failures = collectFailures(manager)
+
+        runCurrent() // attempt 1: refresh hangs
+        advanceTimeBy(30_001) // initial-refresh timeout fires -> failure (backoff not yet elapsed)
+        runCurrent()
+        failures.size shouldBe 1
+    }
+
+    @Test fun `an unexpected provider completion emits a connection failure`() = runTest2 {
+        val provider = mockk<BillingConnectionProvider>().apply {
+            every { this@apply.connection } returns flow<BillingConnection> {
+                // completes normally without ever emitting -> treated as a failure
+            }
+        }
+        val manager = manager(provider)
+        val failures = collectFailures(manager)
+
+        runCurrent()
+        failures.size shouldBe 1
+    }
+
+    @Test fun `an established connection alone does not emit`() = runTest2 {
+        // A healthy connection that stays open must not look like a reconciliation failure.
+        val manager = manager(connection())
+        val failures = collectFailures(manager)
+
+        runCurrent()
+        failures shouldBe emptyList()
+    }
+
+    @Test fun `a cancelled connect loop does not emit`() = runTest2 {
+        // Scope death is not an outage: the CancellationException path must stay silent.
+        val provider = mockk<BillingConnectionProvider>().apply {
+            every { this@apply.connection } returns flow { throw CancellationException("scope died") }
+        }
+        val manager = manager(provider)
+        val failures = collectFailures(manager)
+
+        runCurrent()
+        failures shouldBe emptyList()
+    }
+
+    @Test fun `an action-level disconnect emits a connection failure`() = runTest2 {
+        val owned = purchase()
+        // Connection 1 connects, then a later action reports the binder dead (invalidating code) —
+        // the invalidation tears the connection down, which the connect loop sees as a failure.
+        val dead = connection().apply {
+            coEvery { refreshPurchases() } returns
+                BillingConnection.PurchaseRefresh(emptyList(), isComplete = true) andThenThrows
+                GplayServiceUnavailableException(
+                    BillingClientException(result(BillingResponseCode.SERVICE_DISCONNECTED))
+                )
+        }
+        val good = connection(refreshResults = listOf(emptyList(), listOf(owned)))
+        var attempts = 0
+        val provider = mockk<BillingConnectionProvider>().apply {
+            every { this@apply.connection } returns flow {
+                attempts++
+                emit(if (attempts == 1) dead else good)
+                awaitCancellation()
+            }
+        }
+        val manager = manager(provider)
+        val failures = collectFailures(manager)
+        runCurrent() // connected via connection 1 (success, no emit)
+
+        shouldThrow<GplayServiceUnavailableException> { manager.refresh() }
+
+        // A second action is fresh demand: it deterministically drives the loop THROUGH the
+        // invalidation catch (where the failure is emitted) and onto connection 2, which heals.
+        val refreshed = async { manager.refresh() }
+        advanceUntilIdle()
+        refreshed.await() shouldBe BillingData(listOf(owned))
+
+        // The invalidated connection is a failed reconciliation. Exact count isn't pinned (the
+        // reconnect may fail an extra iteration) and doesn't matter — downstream is idempotent.
+        failures.isNotEmpty() shouldBe true
+    }
+
+    @Test fun `a non-invalidating action error does not emit`() = runTest2 {
+        // A strict querySubscriptions failure whose code is NOT invalidating leaves the connection
+        // installed, so no connect-loop iteration fails and nothing feeds the episode clock.
+        val conn = connection().apply {
+            coEvery { querySubscriptions() } throws BillingClientException(result(BillingResponseCode.ERROR))
+        }
+        val manager = manager(conn)
+        val failures = collectFailures(manager)
+        runCurrent() // connection established
+
+        shouldThrow<Exception> { manager.querySubscriptions() }
+        advanceUntilIdle()
+
+        failures shouldBe emptyList()
     }
 
     // endregion

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingConnectionTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingConnectionTest.kt
@@ -423,12 +423,17 @@ class BillingConnectionTest : BaseTest() {
             ),
         )
 
+        val beforeCommit = System.currentTimeMillis()
         connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(owned))
         connection.refreshPurchases() // complete, clears the event
 
         val updates = connection.freshUpdates.take(2).toList()
-        updates[0] shouldBe BillingConnection.FreshUpdate(listOf(owned), isFullSnapshot = false)
-        updates[1] shouldBe BillingConnection.FreshUpdate(emptyList(), isFullSnapshot = true)
+        updates[0].purchases shouldBe listOf(owned)
+        updates[0].isFullSnapshot shouldBe false
+        // Each update is stamped with its commit time (wall-clock), not left unset.
+        (updates[0].occurredAt >= beforeCommit) shouldBe true
+        updates[1].purchases shouldBe emptyList()
+        updates[1].isFullSnapshot shouldBe true
     }
 
     @Test fun `fresh updates carry only query-confirmed data, never retained stale purchases`() = runTest2 {
@@ -449,10 +454,12 @@ class BillingConnectionTest : BaseTest() {
         shouldThrow<Exception> { connection.refreshPurchases() }
 
         val updates = connection.freshUpdates.take(2).toList()
-        updates[0] shouldBe BillingConnection.FreshUpdate(listOf(iapOwned), isFullSnapshot = true)
+        updates[0].purchases shouldBe listOf(iapOwned)
+        updates[0].isFullSnapshot shouldBe true
         // The retained IAP purchase is still in the reactive view, but it is NOT fresh Play data —
         // re-emitting it would keep re-stamping the grace window without a real round-trip.
-        updates[1] shouldBe BillingConnection.FreshUpdate(emptyList(), isFullSnapshot = false)
+        updates[1].purchases shouldBe emptyList()
+        updates[1].isFullSnapshot shouldBe false
         connection.purchases.first().map { it.purchaseToken } shouldBe listOf("iap")
     }
 
@@ -480,7 +487,8 @@ class BillingConnectionTest : BaseTest() {
         refresh.await()
 
         val updates = connection.freshUpdates.take(2).toList()
-        updates[0] shouldBe BillingConnection.FreshUpdate(listOf(raced), isFullSnapshot = false)
+        updates[0].purchases shouldBe listOf(raced)
+        updates[0].isFullSnapshot shouldBe false
         updates[1].purchases shouldBe emptyList()
         updates[1].isFullSnapshot shouldBe false
     }
@@ -531,7 +539,8 @@ class BillingConnectionTest : BaseTest() {
         connection.purchases.first().map { it.purchaseToken } shouldContainExactly listOf("sub", "iap")
         val updates = connection.freshUpdates.take(2).toList()
         // Partial by definition: it proves what the SUBS query found, never absence of the rest.
-        updates[1] shouldBe BillingConnection.FreshUpdate(listOf(subOwned), isFullSnapshot = false)
+        updates[1].purchases shouldBe listOf(subOwned)
+        updates[1].isFullSnapshot shouldBe false
     }
 
     @Test fun `a failed querySubscriptions propagates and commits nothing`() = runTest2 {


### PR DESCRIPTION
## What changed

The upgrade/status screen surfaces recovery actions — **Restore purchase** and the **switch-to-one-time-purchase** offer — once a Pro purchase has failed to reconfirm with Google Play for a while (a deliberate delay, so a brief Play hiccup doesn't nag anyone).

Two problems are fixed:

- If Google Play was unreachable for an extended stretch while the app wasn't actively refreshing (e.g. between app opens), the "how long has this been failing" timer never started — so the recovery actions could stay hidden exactly when a lapsed subscriber needed them.
- A stale failure arriving late (after Play had already reconfirmed the purchase) could reset the timer and briefly delay those actions.

Now the timer advances whenever the billing connection itself fails, and confirmations and failures are ordered by when they actually happened rather than by which internal listener ran first.

No entitlement change: this only affects **when** the recovery UI appears, never whether the user is Pro.

## Technical Context

- **Root cause:** the `proUnconfirmedSince` episode clock was only advanced by explicit `refresh()` callers (fired on `ON_RESUME`). `BillingManager`'s connect loop swallows connection/query failures to retry internally, so a sustained outage between resumes produced no signal to advance it.
- **Fix:** a `connectionFailures` feed emitted from the connect-loop catch, consumed by `UpgradeRepoGplay`. Purely additive — existing `refresh()` / `restorePurchaseNow()` stamping is unchanged (double-stamping is idempotent / set-if-unset).
- **Cross-stream ordering:** confirmations (`freshBillingData`) and failures (`connectionFailures`) are independent flows. Each now carries its **occurrence time** — commit time for confirmations via `FreshUpdate.occurredAt`, failure time for the feed. `recordProUnconfirmed` drops a failure at/before the last confirmation; `BillingCache.stampLastProState` closes an episode only if it began at or before the confirmation. Ordering is therefore by when events happened, not by collector scheduling.
- **Known limitation (safe bias):** a three-event interleaving (old failure < recovery < newer failure, delivered out of order under pathological collector starvation) can drop the newer failure's episode. It fails safe — it only *delays* the optional recovery UI, self-corrects on the next failure / `ON_RESUME` refresh, and never affects `isPro`. Fully ordering arbitrary interleavings would mean restructuring the entitlement-gating confirmation path, which isn't worth it for a 24h-gated informational signal.
- **Review guidance:** `BillingCache.stampLastProState` now clears the episode conditionally (`episodeStart in 1..at`) instead of unconditionally — that is the occurrence-aware close. The `occurredAt` defaults on `FreshUpdate` / `FreshData` are evaluated at construction, which at every production call site is the reducer commit instant.
- **Tests:** producer emissions (setup / initial-refresh / timeout / disconnect vs cancellation / healthy / non-invalidating query error), consumer stamping + superseded-failure drop, the occurrence-aware cache clear (real DataStore), and occurrence-time propagation pinned with sentinel values.
