### PR TITLE
General: Upgrade Gradle wrapper to 9.6.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 #Tue Jan 20 11:53:55 CET 2026
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=553c78f50dafcd54d65b9a444649057857469edf836431389695608536d6b746
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
+distributionSha256Sum=9c0f7faeeb306cb14e4279a3e084ca6b596894089a0638e68a07c945a32c9e14
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## What changed

No user-facing behavior change. Updates the project's Gradle build tool from 9.5.0 to 9.6.1.

## Technical Context

- Bumps the Gradle wrapper distribution URL and its `distributionSha256Sum` (verified against the official `gradle-9.6.1-bin.zip.sha256` checksum).
- Distribution-only bump — the wrapper JAR and `gradlew` scripts are unchanged.
- Validated locally with a clean `assembleFossDebug` on the new distribution: BUILD SUCCESSFUL, no new incompatibilities. The only deprecation warnings are pre-existing AGP "Gradle 10 compatibility" notices, unrelated to this bump.
- The debug APK was installed and launched on a physical device to confirm the build runs.
