### PR TITLE
General: Prevent brief purchase prompts for users who already own Pro

### DIFF
--- a/app-common/src/main/java/eu/darken/sdmse/common/upgrade/UpgradeRepo.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/upgrade/UpgradeRepo.kt
@@ -10,20 +10,22 @@ interface UpgradeRepo {
 
     val upgradeInfo: Flow<Info>
 
-    /**
-     * Whether [upgradeInfo] reflects a real entitlement lookup yet. On GPlay this is `false`
-     * until the first billing result arrives after process start (during that window
-     * [upgradeInfo] reports non-Pro even for paying users); FOSS reads a local cache and is
-     * always settled. See `isProForUi` for the gate that uses this.
-     */
-    val isSettled: Flow<Boolean>
-
     suspend fun refresh()
 
     interface Info {
         val type: Type
 
         val isPro: Boolean
+
+        /**
+         * Whether this Info reflects a real entitlement lookup (or a definitive can't-reach-Play
+         * outcome). Settledness rides each emission instead of a parallel flow, so it can never
+         * be observed out of step with the ownership data it describes. On GPlay the seed emitted
+         * before the first billing result after process start is unsettled (and reports non-Pro
+         * even for paying users); FOSS reads a local cache and is settled from the first
+         * emission. See `isProForUi` for the gate that uses this.
+         */
+        val isSettled: Boolean
 
         val upgradedAt: Instant?
 

--- a/app-common/src/main/java/eu/darken/sdmse/common/upgrade/UpgradeRepoExtensions.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/upgrade/UpgradeRepoExtensions.kt
@@ -4,6 +4,7 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.withTimeoutOrNull
@@ -35,6 +36,9 @@ suspend fun UpgradeRepo.isProSettled(timeout: Duration = 5.seconds): Boolean = t
         refresh()
         withTimeoutOrNull(timeout) { upgradeInfo.firstOrNull { it.isPro } != null } == true
     }
+} catch (e: CancellationException) {
+    // A cancelled caller must not continue down the Pro path via the fail-open below.
+    throw e
 } catch (e: Exception) {
     log(TAG, WARN) { "isProSettled() failed, failing open (allowing): ${e.asLog()}" }
     true
@@ -47,19 +51,25 @@ suspend fun UpgradeRepo.isProSettled(timeout: Duration = 5.seconds): Boolean = t
  * upgrade screen stays snappy for free users (unlike [isProSettled], whose non-Pro path always
  * waits out its timeout). Only while billing is still connecting (GPlay cold start or reconnect,
  * where [UpgradeRepo.upgradeInfo] reports non-Pro even for paying users) does it wait, up to
- * [timeout], for the first real billing result — so a Pro user isn't bounced to the upgrade
- * screen by the handshake race. On timeout or error it falls back to the current state: the UI
- * route is recoverable, and the backend [isProSettled] gate remains the enforcement safety net.
+ * [timeout], for the first settled Info — so a Pro user isn't bounced to the upgrade screen by
+ * the handshake race. Every decision reads isPro and isSettled off the SAME Info emission, so a
+ * settle signal can never pair with stale ownership. On timeout or error it falls back to the
+ * current state: the UI route is recoverable, and the backend [isProSettled] gate remains the
+ * enforcement safety net.
  */
 suspend fun UpgradeRepo.isProForUi(timeout: Duration = 3.seconds): Boolean = try {
+    val current = upgradeInfo.first()
     when {
-        upgradeInfo.first().isPro -> true
-        isSettled.first() -> false
+        current.isPro -> true
+        current.isSettled -> false
         else -> {
-            withTimeoutOrNull(timeout) { isSettled.first { settled -> settled } }
-            upgradeInfo.first().isPro
+            val settled = withTimeoutOrNull(timeout) { upgradeInfo.first { it.isSettled } }
+            (settled ?: upgradeInfo.first()).isPro
         }
     }
+} catch (e: CancellationException) {
+    // A cancelled caller must not continue down the Pro path via the fail-open below.
+    throw e
 } catch (e: Exception) {
     log(TAG, WARN) { "isProForUi() failed, failing open (allowing): ${e.asLog()}" }
     true

--- a/app-common/src/test/java/eu/darken/sdmse/common/backup/ConfigBackupManagerTest.kt
+++ b/app-common/src/test/java/eu/darken/sdmse/common/backup/ConfigBackupManagerTest.kt
@@ -34,6 +34,7 @@ class ConfigBackupManagerTest : BaseTest() {
         override val type = UpgradeRepo.Type.FOSS
         override val upgradedAt: Instant? = null
         override val error: Throwable? = null
+        override val isSettled: Boolean = true
     }
 
     private class FakeUpgradeRepo(pro: Boolean) : UpgradeRepo {
@@ -41,7 +42,6 @@ class ConfigBackupManagerTest : BaseTest() {
         override val upgradeSite = ""
         override val betaSite = ""
         override val upgradeInfo: Flow<UpgradeRepo.Info> = flowOf(FakeInfo(pro))
-        override val isSettled: Flow<Boolean> = flowOf(true)
         override suspend fun refresh() {}
     }
 

--- a/app-common/src/test/java/eu/darken/sdmse/common/backup/GoldenBackupFormatTest.kt
+++ b/app-common/src/test/java/eu/darken/sdmse/common/backup/GoldenBackupFormatTest.kt
@@ -86,7 +86,7 @@ class GoldenBackupFormatTest : BaseTest() {
             sectionContributors = sections,
             databaseContributors = databases,
             json = json,
-            upgradeRepo = mockk<UpgradeRepo>(relaxed = true).apply { every { isSettled } returns flowOf(true) },
+            upgradeRepo = mockk<UpgradeRepo>(relaxed = true),
             envelopeSource = envelopeSource,
             gate = BackupOperationGate(),
             limits = BackupLimits(),

--- a/app-common/src/test/java/eu/darken/sdmse/common/upgrade/UpgradeRepoExtensionsTest.kt
+++ b/app-common/src/test/java/eu/darken/sdmse/common/upgrade/UpgradeRepoExtensionsTest.kt
@@ -1,10 +1,14 @@
 package eu.darken.sdmse.common.upgrade
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.currentTime
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
@@ -13,7 +17,10 @@ import kotlinx.coroutines.launch
 
 class UpgradeRepoExtensionsTest : BaseTest() {
 
-    private class FakeInfo(override val isPro: Boolean) : UpgradeRepo.Info {
+    private class FakeInfo(
+        override val isPro: Boolean,
+        override val isSettled: Boolean,
+    ) : UpgradeRepo.Info {
         override val type: UpgradeRepo.Type = UpgradeRepo.Type.FOSS
         override val upgradedAt: Instant? = null
         override val error: Throwable? = null
@@ -23,22 +30,20 @@ class UpgradeRepoExtensionsTest : BaseTest() {
         pro: Boolean,
         settled: Boolean,
     ) : UpgradeRepo {
-        val proFlow = MutableStateFlow<UpgradeRepo.Info>(FakeInfo(pro))
-        val settledFlow = MutableStateFlow(settled)
+        // Settledness rides the Info itself — a single flow, like the production repos.
+        val infoFlow = MutableStateFlow<UpgradeRepo.Info>(FakeInfo(pro, settled))
         var refreshCalls = 0
 
         override val storeSite: String = ""
         override val upgradeSite: String = ""
         override val betaSite: String = ""
-        override val upgradeInfo: Flow<UpgradeRepo.Info> = proFlow
-        override val isSettled: Flow<Boolean> = settledFlow
+        override val upgradeInfo: Flow<UpgradeRepo.Info> = infoFlow
         override suspend fun refresh() {
             refreshCalls++
         }
 
         fun settle(pro: Boolean) {
-            proFlow.value = FakeInfo(pro)
-            settledFlow.value = true
+            infoFlow.value = FakeInfo(pro, isSettled = true)
         }
     }
 
@@ -85,10 +90,36 @@ class UpgradeRepoExtensionsTest : BaseTest() {
     }
 
     @Test
+    fun `the settle decision reads ownership off the settling Info itself`() = runTest {
+        // The old two-step (wait on isSettled, re-read upgradeInfo) could pair the settle signal
+        // with a stale replay. Now the Info that satisfies the settled-wait IS the decision.
+        val repo = FakeRepo(pro = false, settled = false)
+
+        launch {
+            advanceTimeBy(500)
+            repo.infoFlow.value = FakeInfo(isPro = true, isSettled = true)
+        }
+
+        repo.isProForUi() shouldBe true
+    }
+
+    @Test
     fun `billing that never settles falls back to non-pro after the timeout`() = runTest {
         val repo = FakeRepo(pro = false, settled = false)
         repo.isProForUi() shouldBe false
         currentTime shouldBe 3_000
+    }
+
+    @Test
+    fun `cancellation during the settle wait propagates instead of failing open`() = runTest {
+        // A destroyed caller (ViewModel gone mid-wait) must not continue down the Pro path.
+        val repo = FakeRepo(pro = false, settled = false)
+
+        val gate = async { repo.isProForUi() }
+        runCurrent()
+        gate.cancel()
+
+        shouldThrow<CancellationException> { gate.await() }
     }
 
     @Test
@@ -98,7 +129,6 @@ class UpgradeRepoExtensionsTest : BaseTest() {
             override val upgradeSite: String = ""
             override val betaSite: String = ""
             override val upgradeInfo: Flow<UpgradeRepo.Info> get() = throw IllegalStateException("billing exploded")
-            override val isSettled: Flow<Boolean> = MutableStateFlow(true)
             override suspend fun refresh() = Unit
         }
         repo.isProForUi() shouldBe true

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/AppCleanerTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/AppCleanerTest.kt
@@ -94,10 +94,12 @@ class AppCleanerTest : BaseTest() {
     }
 
     private fun mockUpgradeRepo(pro: Boolean): UpgradeRepo {
-        val info = mockk<UpgradeRepo.Info>().apply { every { isPro } returns pro }
+        val info = mockk<UpgradeRepo.Info>().apply {
+            every { isPro } returns pro
+            every { isSettled } returns true
+        }
         return mockk<UpgradeRepo>(relaxed = true) {
             every { upgradeInfo } returns flowOf(info)
-            every { isSettled } returns flowOf(true)
         }
     }
 

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/ui/details/AppJunkDetailsViewModelTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/ui/details/AppJunkDetailsViewModelTest.kt
@@ -63,6 +63,7 @@ class AppJunkDetailsViewModelTest : BaseTest() {
 
     private fun upgradeInfo(isPro: Boolean): UpgradeRepo.Info = mockk<UpgradeRepo.Info>().apply {
         every { this@apply.isPro } returns isPro
+        every { isSettled } returns true
     }
 
     private class Harness(
@@ -101,7 +102,6 @@ class AppJunkDetailsViewModelTest : BaseTest() {
         }
         val upgradeRepo = mockk<UpgradeRepo>().apply {
             every { upgradeInfo } returns flowOf(upgradeInfo(isPro = isPro))
-            every { isSettled } returns flowOf(true)
         }
         val vm = AppJunkDetailsViewModel(
             handle = savedHandle,

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/ui/list/AppCleanerListViewModelTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/ui/list/AppCleanerListViewModelTest.kt
@@ -58,6 +58,7 @@ class AppCleanerListViewModelTest : BaseTest() {
 
     private fun upgradeInfo(isPro: Boolean): UpgradeRepo.Info = mockk<UpgradeRepo.Info>().apply {
         every { this@apply.isPro } returns isPro
+        every { isSettled } returns true
     }
 
     private class Harness(
@@ -110,7 +111,6 @@ class AppCleanerListViewModelTest : BaseTest() {
         val taskSubmitter = mockk<TaskSubmitter>(relaxed = true)
         val upgradeRepo = mockk<UpgradeRepo>().apply {
             every { upgradeInfo } returns flowOf(upgradeInfo(isPro = isPro))
-            every { isSettled } returns flowOf(true)
         }
         val context = mockk<Context>(relaxed = true)
         val vm = AppCleanerListViewModel(

--- a/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListViewModelTest.kt
+++ b/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListViewModelTest.kt
@@ -162,6 +162,7 @@ class AppControlListViewModelTest : BaseTest() {
 
     private fun upgradeInfo(isPro: Boolean): UpgradeRepo.Info = mockk<UpgradeRepo.Info>().apply {
         every { this@apply.isPro } returns isPro
+        every { isSettled } returns true
         every { type } returns UpgradeRepo.Type.FOSS
         every { upgradedAt } returns null
         every { error } returns null
@@ -278,7 +279,6 @@ class AppControlListViewModelTest : BaseTest() {
         val exclusionManager = mockk<ExclusionManager>(relaxed = true)
         val upgradeRepo = mockk<UpgradeRepo>().apply {
             every { this@apply.upgradeInfo } returns flowOf(upgradeInfo(isPro = isPro))
-            every { this@apply.isSettled } returns flowOf(true)
         }
         val context = mockk<Context>(relaxed = true)
         val usageStatsSetupModule = mockk<SetupModule>(relaxed = true)

--- a/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/ui/settings/AppControlSettingsViewModelTest.kt
+++ b/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/ui/settings/AppControlSettingsViewModelTest.kt
@@ -60,6 +60,7 @@ class AppControlSettingsViewModelTest : BaseTest() {
 
     private fun upgradeInfo(isPro: Boolean): UpgradeRepo.Info = mockk<UpgradeRepo.Info>().apply {
         every { this@apply.isPro } returns isPro
+        every { isSettled } returns true
         every { type } returns UpgradeRepo.Type.FOSS
         every { upgradedAt } returns null
         every { error } returns null
@@ -117,7 +118,6 @@ class AppControlSettingsViewModelTest : BaseTest() {
         }
         val upgradeRepo = mockk<UpgradeRepo>().apply {
             every { upgradeInfo } returns MutableStateFlow(upgradeInfo(isPro = isPro))
-            every { isSettled } returns flowOf(true)
         }
 
         val rootManager = mockk<RootManager>().apply {

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/ui/settings/CorpseFinderSettingsViewModelTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/ui/settings/CorpseFinderSettingsViewModelTest.kt
@@ -50,6 +50,7 @@ class CorpseFinderSettingsViewModelTest : BaseTest() {
 
     private fun upgradeInfo(isPro: Boolean): UpgradeRepo.Info = mockk<UpgradeRepo.Info>().apply {
         every { this@apply.isPro } returns isPro
+        every { isSettled } returns true
     }
 
     private class Values(
@@ -143,7 +144,6 @@ class CorpseFinderSettingsViewModelTest : BaseTest() {
         }
         val upgradeRepo = mockk<UpgradeRepo>().apply {
             every { upgradeInfo } returns flowOf(upgradeInfo(isPro = isPro))
-            every { isSettled } returns flowOf(true)
         }
         val rootManager = mockk<RootManager>().apply {
             every { accessState } returns flowOf(rootAccess)

--- a/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/core/DeduplicatorTest.kt
+++ b/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/core/DeduplicatorTest.kt
@@ -47,9 +47,9 @@ class DeduplicatorTest : BaseTest() {
     private fun buildDeduplicator(isPro: Boolean): Deduplicator {
         val info = mockk<UpgradeRepo.Info>()
         every { info.isPro } returns isPro
+        every { info.isSettled } returns true
         val upgradeRepo = mockk<UpgradeRepo>(relaxed = true)
         every { upgradeRepo.upgradeInfo } returns flowOf(info)
-        every { upgradeRepo.isSettled } returns flowOf(true)
         return Deduplicator(
             appScope = gateScope,
             gatewaySwitch = mockk(relaxed = true),

--- a/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/ui/details/DeduplicatorDetailsViewModelTest.kt
+++ b/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/ui/details/DeduplicatorDetailsViewModelTest.kt
@@ -77,6 +77,7 @@ class DeduplicatorDetailsViewModelTest : BaseTest() {
 
     private fun upgradeInfo(isPro: Boolean): UpgradeRepo.Info = mockk<UpgradeRepo.Info>().apply {
         every { this@apply.isPro } returns isPro
+        every { isSettled } returns true
     }
 
     private class Values(
@@ -148,7 +149,6 @@ class DeduplicatorDetailsViewModelTest : BaseTest() {
         }
         val upgradeRepo = mockk<UpgradeRepo>().apply {
             every { upgradeInfo } returns flowOf(upgradeInfo(isPro = isPro))
-            every { isSettled } returns flowOf(true)
         }
         val viewIntentTool = mockk<ViewIntentTool>(relaxed = true)
         val vm = DeduplicatorDetailsViewModel(

--- a/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListViewModelTest.kt
+++ b/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListViewModelTest.kt
@@ -78,6 +78,7 @@ class DeduplicatorListViewModelTest : BaseTest() {
 
     private fun upgradeInfo(isPro: Boolean): UpgradeRepo.Info = mockk<UpgradeRepo.Info>().apply {
         every { this@apply.isPro } returns isPro
+        every { isSettled } returns true
     }
 
     private class Values(
@@ -156,7 +157,6 @@ class DeduplicatorListViewModelTest : BaseTest() {
         }
         val upgradeRepo = mockk<UpgradeRepo>().apply {
             every { upgradeInfo } returns flowOf(upgradeInfo(isPro = isPro))
-            every { isSettled } returns flowOf(true)
         }
         val vm = DeduplicatorListViewModel(
             dispatcherProvider = TestDispatcherProvider(),

--- a/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/ui/list/SqueezerListViewModelTest.kt
+++ b/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/ui/list/SqueezerListViewModelTest.kt
@@ -61,6 +61,7 @@ class SqueezerListViewModelTest : BaseTest() {
 
     private fun upgradeInfo(isPro: Boolean): UpgradeRepo.Info = mockk<UpgradeRepo.Info>().apply {
         every { this@apply.isPro } returns isPro
+        every { isSettled } returns true
     }
 
     // Mirrors the helper used in CorpseFinderSettingsViewModelTest. `.value(value: T)` is an
@@ -134,7 +135,6 @@ class SqueezerListViewModelTest : BaseTest() {
         val taskSubmitter = mockk<TaskSubmitter>(relaxed = true)
         val upgradeRepo = mockk<UpgradeRepo>().apply {
             every { upgradeInfo } returns flowOf(upgradeInfo(isPro = isPro))
-            every { isSettled } returns flowOf(true)
         }
 
         val vm = SqueezerListViewModel(

--- a/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/sessions/SwiperSessionsViewModel.kt
+++ b/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/sessions/SwiperSessionsViewModel.kt
@@ -65,12 +65,11 @@ class SwiperSessionsViewModel @Inject constructor(
         swiper.progress,
         selectedPaths,
         upgradeRepo.upgradeInfo,
-        upgradeRepo.isSettled,
         scanningSessionId,
         cancellingSessionId,
         refreshingSessionId,
         dataAreaManager.state,
-    ) { sessionsWithStats, progress, paths, upgradeInfo, isUpgradeSettled,
+    ) { sessionsWithStats, progress, paths, upgradeInfo,
         scanningId, cancellingId, refreshingId, areaState ->
         val riskySessionPaths = sessionsWithStats
             .associate { entry ->
@@ -85,9 +84,10 @@ class SwiperSessionsViewModel @Inject constructor(
             progress = progress,
             // GPlay initially reports non-Pro while its billing handshake is still in flight.
             // Keep that state unknown so the free-tier card is only shown after a real lookup.
+            // Settledness rides the same Info emission, so it can't pair with stale ownership.
             isPro = when {
                 upgradeInfo.isPro -> true
-                isUpgradeSettled -> false
+                upgradeInfo.isSettled -> false
                 else -> null
             },
             scanningSessionId = scanningId,

--- a/app-tool-swiper/src/test/java/eu/darken/sdmse/swiper/ui/sessions/SwiperSessionsViewModelTest.kt
+++ b/app-tool-swiper/src/test/java/eu/darken/sdmse/swiper/ui/sessions/SwiperSessionsViewModelTest.kt
@@ -81,7 +81,7 @@ class SwiperSessionsViewModelTest : BaseTest() {
         val taskSubmitter: TaskSubmitter,
         val navCtrl: NavigationController,
         val pickerResults: MutableSharedFlow<PickerResult>,
-        val isUpgradeSettledFlow: MutableStateFlow<Boolean>,
+        val upgradeFlow: MutableStateFlow<UpgradeRepo.Info>,
     )
 
     private class CollectedEvents<T>(val list: MutableList<T>, private val job: Job) {
@@ -110,9 +110,9 @@ class SwiperSessionsViewModelTest : BaseTest() {
         val progressFlow = MutableStateFlow(progress)
         val upgradeInfo: UpgradeRepo.Info = mockk<UpgradeRepo.Info>(relaxed = true).apply {
             every { this@apply.isPro } returns isPro
+            every { this@apply.isSettled } returns isUpgradeSettled
         }
-        val upgradeFlow = MutableStateFlow<UpgradeRepo.Info>(upgradeInfo)
-        val isUpgradeSettledFlow = MutableStateFlow(isUpgradeSettled)
+        val upgradeFlow = MutableStateFlow(upgradeInfo)
         val areaStateFlow = MutableStateFlow(DataAreaManager.State(areas = areas))
         // Use a hot SharedFlow so tests can inject picker results after construction. The VM's init
         // block collects this; emitting a PickerResult here exercises the createSession path.
@@ -125,7 +125,6 @@ class SwiperSessionsViewModelTest : BaseTest() {
         val taskSubmitter = mockk<TaskSubmitter>(relaxed = true)
         val upgradeRepo = mockk<UpgradeRepo>().apply {
             every { this@apply.upgradeInfo } returns upgradeFlow
-            every { this@apply.isSettled } returns isUpgradeSettledFlow
         }
         // currentAreas() is an extension that reads state.first().areas — no separate stub needed.
         val dataAreaManager = mockk<DataAreaManager>().apply {
@@ -156,7 +155,7 @@ class SwiperSessionsViewModelTest : BaseTest() {
             taskSubmitter = taskSubmitter,
             navCtrl = navCtrl,
             pickerResults = pickerResults,
-            isUpgradeSettledFlow = isUpgradeSettledFlow,
+            upgradeFlow = upgradeFlow,
         )
     }
 
@@ -198,7 +197,11 @@ class SwiperSessionsViewModelTest : BaseTest() {
 
         h.vm.state.first().isPro shouldBe null
 
-        h.isUpgradeSettledFlow.value = true
+        // Settledness arrives ON the Info emission itself, never on a parallel signal.
+        h.upgradeFlow.value = mockk<UpgradeRepo.Info>(relaxed = true).apply {
+            every { isPro } returns false
+            every { isSettled } returns true
+        }
         advanceUntilIdle()
 
         h.vm.state.first().isPro shouldBe false

--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/customfilter/list/CustomFilterListViewModelTest.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/customfilter/list/CustomFilterListViewModelTest.kt
@@ -56,7 +56,12 @@ class CustomFilterListViewModelTest : BaseTest() {
         val configsFlow = MutableStateFlow(configs)
         val upgradeFlow = MutableSharedFlow<UpgradeRepo.Info>(replay = if (emitUpgradeInfo) 1 else 0)
         if (emitUpgradeInfo) {
-            upgradeFlow.tryEmit(mockk<UpgradeRepo.Info>().apply { every { this@apply.isPro } returns isPro })
+            upgradeFlow.tryEmit(
+                mockk<UpgradeRepo.Info>().apply {
+                    every { this@apply.isPro } returns isPro
+                    every { isSettled } returns true
+                }
+            )
         }
         val repo = mockk<CustomFilterRepo>(relaxed = true).apply {
             every { this@apply.configs } returns configsFlow
@@ -67,7 +72,6 @@ class CustomFilterListViewModelTest : BaseTest() {
         }
         val upgradeRepo = mockk<UpgradeRepo>().apply {
             every { upgradeInfo } returns upgradeFlow
-            every { isSettled } returns flowOf(true)
         }
         val webpageTool = mockk<WebpageTool>(relaxed = true)
         val context = mockk<Context>(relaxed = true)

--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/settings/SystemCleanerSettingsViewModelTest.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/settings/SystemCleanerSettingsViewModelTest.kt
@@ -152,9 +152,11 @@ class SystemCleanerSettingsViewModelTest : BaseTest() {
         }
         val upgradeRepo = mockk<UpgradeRepo>().apply {
             every { upgradeInfo } returns flowOf(
-                mockk<UpgradeRepo.Info>().apply { every { this@apply.isPro } returns isPro },
+                mockk<UpgradeRepo.Info>().apply {
+                    every { this@apply.isPro } returns isPro
+                    every { isSettled } returns true
+                },
             )
-            every { isSettled } returns flowOf(true)
         }
         val rootManager = mockk<RootManager>().apply {
             every { accessState } returns flowOf(

--- a/app/src/foss/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoFoss.kt
+++ b/app/src/foss/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoFoss.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import java.time.Instant
@@ -32,10 +31,6 @@ class UpgradeRepoFoss @Inject constructor(
     override val betaSite: String = BETA_SITE
 
     private val refreshTrigger = MutableStateFlow(UUID.randomUUID())
-
-    // The FOSS entitlement is a local cache read — upgradeInfo is authoritative from its first
-    // emission, there is no billing handshake to wait out.
-    override val isSettled: Flow<Boolean> = flowOf(true)
 
     override val upgradeInfo: Flow<UpgradeRepo.Info> = combine(
         fossCache.upgrade.flow,
@@ -81,6 +76,10 @@ class UpgradeRepoFoss @Inject constructor(
         override val error: Throwable? = null,
     ) : UpgradeRepo.Info {
         override val type: UpgradeRepo.Type = UpgradeRepo.Type.FOSS
+
+        // The FOSS entitlement is a local cache read — authoritative from the first emission,
+        // there is no billing handshake to wait out.
+        override val isSettled: Boolean = true
     }
 
     companion object {

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplay.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.launchIn
@@ -36,6 +37,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.retryWhen
+import kotlinx.coroutines.flow.runningReduce
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
@@ -121,18 +123,29 @@ class UpgradeRepoGplay @Inject constructor(
             .launchIn(scope)
     }
 
-    // False until the first real billing outcome after process start — the window where
-    // upgradeInfo below reports non-Pro even for paying users (its flow is seeded with null).
-    // A failed connection attempt counts as settled: gating callers must not wait on a broken
-    // connection (the connect loop keeps retrying, but that can take arbitrarily long).
-    override val isSettled: Flow<Boolean> = billingManager.isSettled
-        .distinctUntilChanged()
-
-    override val upgradeInfo: Flow<Info> = billingManager.billingData
-        .map<BillingData, BillingData?> { it }
-        .onStart { emit(null) }
+    // Settledness travels WITH the ownership data (Info.isSettled), never on a parallel flow —
+    // a parallel signal could be observed out of step and pair "settled" with a stale non-Pro
+    // seed for one emission (the old cosmetic flash at owners).
+    //
+    // Per emission: data != null means a COMMITTED Play round-trip happened by construction
+    // (BillingConnection.purchases only emits after refreshPurchases committed under the reducer
+    // lock, and the manager only publishes the connection after that refresh succeeded). Note:
+    // committed, not necessarily complete — combinePurchaseResults tolerates one failed product
+    // type when the other returned a purchase, so a partial snapshot also settles (same as the
+    // old signal; grace covers a recently-confirmed Pro whose type failed). A null seed settles
+    // only via isFailureSettled: Play is unreachable, so seed + grace mapping IS the best
+    // knowledge. Accepted residual: isFailureSettled is sticky, so after a failure-then-recovery
+    // a fresh resubscribe can briefly pair the seed with settled=true before the data replay
+    // lands — identical to the old signal's stickiness, covered by grace + the UI Loading gates;
+    // the pure-success-path race (settled leading the FIRST reconciliation) is now impossible.
+    override val upgradeInfo: Flow<Info> = combine(
+        billingManager.billingData
+            .map<BillingData, BillingData?> { it }
+            .onStart { emit(null) },
+        billingManager.isFailureSettled,
+    ) { data, failureSettled -> data to (data != null || failureSettled) }
         .setupCommonEventHandlers(TAG) { "upgradeInfo1" }
-        .map { data: BillingData? -> data.toUpgradeInfo() }
+        .map { (data, settled) -> data.toUpgradeInfo(settled = settled) }
         .distinctUntilChanged()
         .retryWhen { error, attempt ->
             if (error is CancellationException) return@retryWhen false
@@ -141,22 +154,30 @@ class UpgradeRepoGplay @Inject constructor(
             // mapping, plausible exactly when storage is full. Keep the flow alive and keep a
             // recently-Pro user in their grace window.
             log(TAG, WARN) { "upgradeInfo mapping failed (attempt=$attempt): ${error.asLog()}" }
+            // Fallbacks are settled: a local storage failure is a definitive best-knowledge
+            // outcome — gates must resolve now, not stall out a 30s+ retry backoff.
             val fallback = try {
                 if ((System.currentTimeMillis() - billingCache.lastProStateAt.value()) < graceWindowMs()) {
-                    Info(gracePeriod = true, billingData = null)
+                    Info(gracePeriod = true, billingData = null, isSettled = true)
                 } else {
-                    Info(billingData = null, error = error)
+                    Info(billingData = null, error = error, isSettled = true)
                 }
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
                 // The grace probe reads the same storage that just failed — a second failure must
                 // not kill the retry loop that exists for exactly this situation.
-                Info(billingData = null, error = error)
+                Info(billingData = null, error = error, isSettled = true)
             }
             emit(fallback)
             delay(retryDelayMs(attempt))
             true
+        }
+        // Settledness is monotonic within a subscription span: the retry above resubscribes the
+        // upstream, whose onStart re-emits the null seed — without this latch, that seed would
+        // regress an already-settled stream back to unsettled until the billing replay lands.
+        .runningReduce { acc, next ->
+            if (acc.isSettled && !next.isSettled) next.copy(isSettled = true) else next
         }
         .setupCommonEventHandlers(TAG) { "upgradeInfo2" }
         .shareIn(scope, SharingStarted.WhileSubscribed(3000L, 0L), replay = 1)
@@ -296,7 +317,8 @@ class UpgradeRepoGplay @Inject constructor(
     suspend fun restorePurchaseNow(): Info {
         log(TAG) { "restorePurchaseNow()" }
         return try {
-            billingManager.refresh().toUpgradeInfo()
+            // A restore result IS a real Play round-trip outcome -> settled.
+            billingManager.refresh().toUpgradeInfo(settled = true)
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -307,7 +329,7 @@ class UpgradeRepoGplay @Inject constructor(
             if ((System.currentTimeMillis() - lastProStateAt) < graceWindowMs()) {
                 log(TAG, VERBOSE) { "restore hit a Play error but we were Pro recently -> grace" }
                 recordProUnconfirmed()
-                Info(gracePeriod = true, billingData = null)
+                Info(gracePeriod = true, billingData = null, isSettled = true)
             } else {
                 throw e
             }
@@ -403,13 +425,15 @@ class UpgradeRepoGplay @Inject constructor(
     // Shared Pro/grace mapping used by both the reactive upgradeInfo flow and restorePurchaseNow().
     // Only relinquishes Pro if we haven't had it for a while (grace period). READ-ONLY: this runs on
     // replayed shared-flow data too, so it must never stamp the grace cache — see recordProState().
-    private suspend fun BillingData?.toUpgradeInfo(): Info {
+    // settled comes from the caller, never from billingData nullness: the grace branch returns an
+    // Info with billingData = null that may well be settled (built from a real empty snapshot).
+    private suspend fun BillingData?.toUpgradeInfo(settled: Boolean): Info {
         // Branch on MAPPED upgrades, not raw purchases: a purchase list containing only products
         // this app doesn't know maps to zero upgrades and must fall through to the grace check —
         // otherwise a recently-Pro user is denied grace they're entitled to. A known purchase is
         // decided before any grace-cache read, so failing local storage can't turn a confirmed
         // purchase into an error episode.
-        val mapped = Info(billingData = this)
+        val mapped = Info(billingData = this, isSettled = settled)
         if (mapped.upgrades.isNotEmpty()) return mapped
 
         val now = System.currentTimeMillis()
@@ -418,7 +442,7 @@ class UpgradeRepoGplay @Inject constructor(
         return when {
             (now - lastProStateAt) < graceWindowMs() -> {
                 log(TAG, VERBOSE) { "We are not pro, but were recently, did GPlay try annoy us again?" }
-                Info(gracePeriod = true, billingData = null)
+                Info(gracePeriod = true, billingData = null, isSettled = settled)
             }
 
             else -> mapped
@@ -439,6 +463,10 @@ class UpgradeRepoGplay @Inject constructor(
         private val gracePeriod: Boolean = false,
         private val billingData: BillingData?,
         override val error: Throwable? = null,
+        // Default false is the fail-safe direction: a forgotten stamp shows up as "never
+        // settles" (loud), never as a settled pre-reconciliation flash. Mapping-only
+        // constructions (trackProState, recordProState) never read this.
+        override val isSettled: Boolean = false,
     ) : UpgradeRepo.Info {
 
         override val type: UpgradeRepo.Type = UpgradeRepo.Type.GPLAY

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManager.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManager.kt
@@ -63,11 +63,14 @@ class BillingManager @Inject constructor(
     // dead connection is unreachable by construction — no replay cache to serve stale clients.
     private val connectionHolder = MutableStateFlow<BillingConnection?>(null)
 
-    // First real billing outcome after process start, success OR failure. The connect loop
-    // swallows connection errors (it retries forever), so downstream flows just stay quiet during
-    // an outage — gates that used to observe a propagated error need this explicit signal.
-    private val settledOnce = MutableStateFlow(false)
-    val isSettled: Flow<Boolean> = settledOnce
+    // At least one connect-loop iteration FAILED since process start. Success needs no explicit
+    // signal: it is implied by billingData emitting (the connection is only published after its
+    // initial refreshPurchases committed), so settledness travels with the data itself and can't
+    // lead it. Failures are different — the connect loop swallows them (it retries forever) and
+    // downstream flows just stay quiet during an outage, so consumers need this explicit signal
+    // to settle their null seed instead of waiting on a broken connection indefinitely.
+    private val failedOnce = MutableStateFlow(false)
+    val isFailureSettled: Flow<Boolean> = failedOnce
 
     // Fires once per failed connect-loop iteration: connection setup failure, the mandatory initial
     // refreshPurchases erroring or timing out, an established connection dropping, an action-level
@@ -114,7 +117,7 @@ class BillingManager @Inject constructor(
                                 // A refresh that can't verify anything (nothing found + a query
                                 // failed) throws and counts as a connection failure — otherwise a
                                 // cold start against a broken Play would starve billingData and
-                                // isSettled forever with no retry. withTimeoutOrNull, NOT
+                                // isFailureSettled forever with no retry. withTimeoutOrNull, NOT
                                 // withTimeout: TimeoutCancellationException is a
                                 // CancellationException and would kill this loop.
                                 withTimeoutOrNull(INITIAL_REFRESH_TIMEOUT_MS) {
@@ -122,7 +125,6 @@ class BillingManager @Inject constructor(
                                 } ?: throw BillingException("Initial purchase refresh timed out")
 
                                 failStreak = 0
-                                settledOnce.value = true
                                 connectionHolder.value = connection
                                 log(TAG, INFO) { "Billing connection established" }
                             }
@@ -145,7 +147,9 @@ class BillingManager @Inject constructor(
                     connectionFailuresChannel.trySend(System.currentTimeMillis())
                 }
                 connectionHolder.value = null
-                settledOnce.value = true
+                // Only reachable via the catch above (the collect never returns normally and
+                // cancellation rethrows past this) — a genuinely failure-only signal.
+                failedOnce.value = true
                 // A swallowed cancellation (e.g. via a flow wrapper) must not convert scope death
                 // into another connection attempt.
                 ensureActive()

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
@@ -139,14 +139,13 @@ class UpgradeViewModel @Inject constructor(
     internal val state: StateFlow<GplayUpgradeUiState> = combine(
         skuQueries,
         upgradeRepo.upgradeInfo,
-        upgradeRepo.isSettled,
         upgradeRepo.wasEverPro,
         upgradeRepo.proUnconfirmedSince,
         graceTick,
         restoring,
         upgradeRepo.autoRestoreBusy,
         verifying,
-    ) { queries, current, settled, wasEverPro, proUnconfirmedSince, _, isRestoring, isAutoRestoring, isVerifying ->
+    ) { queries, current, wasEverPro, proUnconfirmedSince, _, isRestoring, isAutoRestoring, isVerifying ->
         val ownership = current.toOwnership()
         // Pro without any owned purchase == grace. Stage 1 (quiet "still active" line) shows
         // immediately; the diagnostics + restore CTA only once the unconfirmed episode has aged
@@ -168,10 +167,18 @@ class UpgradeViewModel @Inject constructor(
             // A new attempt starts a new error episode.
             hasShownServiceUnavailableError = false
             hasShownPartialQueryError = false
-            // Acquisition renders with prices like it always has; billing must have settled first
-            // either way (an unsettled owner must not be flashed acquisition offers).
-            if (!settled || !priceIndependent) return@combine GplayUpgradeUiState.Loading
         }
+        // Structural close: entitlement-dependent UI never renders from a pre-reconciliation
+        // Info — even if fast SKU queries finish before the reconciled Info propagates, an
+        // unsettled owner must not be flashed acquisition offers. Carve-out: a Done where BOTH
+        // fresh SKU queries failed is itself a definitive can't-reach-Play outcome and may
+        // resolve to Unavailable/grace without waiting for the connect loop's failure signal
+        // (preserves the ~15s bound from the query timeouts during a total Play hang).
+        val bothQueriesFailed = done != null && done.iap.isFailure && done.sub.isFailure
+        if (!current.isSettled && !bothQueriesFailed) return@combine GplayUpgradeUiState.Loading
+        // Acquisition renders with prices like it always has; owners and grace users render
+        // their status immediately without waiting for prices.
+        if (done == null && !priceIndependent) return@combine GplayUpgradeUiState.Loading
 
         val iap = done?.iap?.getOrNull()
         val sub = done?.sub?.getOrNull()

--- a/app/src/test/java/eu/darken/sdmse/main/core/shortcuts/OneTapCleanerTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/core/shortcuts/OneTapCleanerTest.kt
@@ -42,9 +42,11 @@ class OneTapCleanerTest : BaseTest() {
         app: Boolean = false,
         dedup: Boolean = false,
     ) {
-        val info = mockk<UpgradeRepo.Info> { every { isPro } returns pro }
+        val info = mockk<UpgradeRepo.Info> {
+            every { isPro } returns pro
+            every { isSettled } returns true
+        }
         every { upgradeRepo.upgradeInfo } returns flowOf(info)
-        every { upgradeRepo.isSettled } returns flowOf(true)
         every { generalSettings.oneClickCorpseFinderEnabled } returns mockSetting(corpse)
         every { generalSettings.oneClickSystemCleanerEnabled } returns mockSetting(system)
         every { generalSettings.oneClickAppCleanerEnabled } returns mockSetting(app)

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardDiscardTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardDiscardTest.kt
@@ -98,7 +98,6 @@ internal class DashboardDiscardTest : BaseTest() {
             },
             upgradeRepo = mockk<UpgradeRepo>(relaxed = true).apply {
                 every { upgradeInfo } returns emptyFlow()
-                every { isSettled } returns flowOf(true)
             },
             generalSettings = mockk<GeneralSettings>(relaxed = true),
             webpageTool = mockk<WebpageTool>(relaxed = true),

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardHeroToolRoutingTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardHeroToolRoutingTest.kt
@@ -86,7 +86,6 @@ internal class DashboardHeroToolRoutingTest : BaseTest() {
         }
         val upgradeRepo = mockk<UpgradeRepo>(relaxed = true).apply {
             every { upgradeInfo } returns emptyFlow()
-            every { isSettled } returns flowOf(true)
         }
         val updateService = mockk<UpdateService>(relaxed = true).apply { every { availableUpdate } returns emptyFlow() }
         val debugCardProvider = mockk<DebugCardProvider>(relaxed = true).apply {

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionEngineTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionEngineTest.kt
@@ -90,7 +90,7 @@ internal class DashboardMainActionEngineTest : BaseTest() {
             appCleaner = appCleaner,
             deduplicator = deduplicator,
             generalSettings = generalSettings,
-            upgradeRepo = mockk<UpgradeRepo>(relaxed = true).apply { every { isSettled } returns flowOf(true) },
+            upgradeRepo = mockk<UpgradeRepo>(relaxed = true),
             upgradeInfo = flowOf(null),
             submitTask = { task ->
                 submittedTasks.add(task)
@@ -156,10 +156,12 @@ internal class DashboardMainActionEngineTest : BaseTest() {
     fun `freed hero includes the deduplicator removable-file count`() {
         // Regression for the post-delete path: a deduplicator-only cleanup must report the deleted
         // file count, not 0. The FREED itemCount used to exclude the deduplicator entirely.
-        val proInfo = mockk<UpgradeRepo.Info>(relaxed = true) { every { isPro } returns true }
+        val proInfo = mockk<UpgradeRepo.Info>(relaxed = true) {
+            every { isPro } returns true
+            every { isSettled } returns true
+        }
         val upgradeRepo = mockk<UpgradeRepo>(relaxed = true) {
             every { upgradeInfo } returns MutableStateFlow(proInfo)
-            every { isSettled } returns flowOf(true)
         }
         val taskManager = mockk<TaskManager>(relaxed = true) {
             every { state } returns MutableStateFlow(TaskSubmitter.State())

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardScreenDpadWrapTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardScreenDpadWrapTest.kt
@@ -346,7 +346,10 @@ class DashboardScreenDpadWrapTest : BaseComposeRobolectricTest() {
 
     @Test
     fun `UP climbs the hero for Pro users without the upgrade button`() {
-        val proInfo = mockk<UpgradeRepo.Info> { every { isPro } returns true }
+        val proInfo = mockk<UpgradeRepo.Info> {
+            every { isPro } returns true
+            every { isSettled } returns true
+        }
         composeRule.setDashboardContent(
             listState = DashboardViewModel.ListState(items = defaultItems()),
             bottomBarState = bottomBarState(heroSummary = heroSummary()).copy(upgradeInfo = proInfo),

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModelResilienceTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModelResilienceTest.kt
@@ -134,7 +134,6 @@ internal class DashboardViewModelResilienceTest : BaseTest() {
         }
         val upgradeRepo = mockk<UpgradeRepo>(relaxed = true).apply {
             every { upgradeInfo } returns emptyFlow()
-            every { isSettled } returns flowOf(true)
         }
         val updateService = mockk<UpdateService>(relaxed = true).apply { every { availableUpdate } returns emptyFlow() }
         val debugCardProvider = mockk<DebugCardProvider>(relaxed = true).apply {

--- a/app/src/test/java/eu/darken/sdmse/main/ui/settings/support/contactform/SupportContactFormViewModelTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/settings/support/contactform/SupportContactFormViewModelTest.kt
@@ -44,6 +44,7 @@ class SupportContactFormViewModelTest : BaseTest() {
             override val isPro = false
             override val upgradedAt: Instant? = null
             override val error: Throwable? = null
+            override val isSettled = true
         })
 
         every { sessionManager.sessions } returns sessionsFlow
@@ -53,7 +54,6 @@ class SupportContactFormViewModelTest : BaseTest() {
         coEvery { sessionManager.forceStopRecording() } returns null
 
         every { upgradeRepo.upgradeInfo } returns upgradeFlow
-        every { upgradeRepo.isSettled } returns flowOf(true)
 
         every { emailTool.build(any(), any()) } returns Intent(Intent.ACTION_SEND)
     }

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplayTest.kt
@@ -24,11 +24,13 @@ import io.mockk.mockk
 import io.mockk.slot
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
@@ -59,16 +61,18 @@ class UpgradeRepoGplayTest : BaseTest() {
         lastProAt: Long,
         lastSku: String = "",
         billingData: BillingData = BillingData(emptySet()),
+        billingDataFlow: Flow<BillingData>? = null,
         freshBillingData: BillingManager.FreshData? = null,
         purchaseFailures: List<BillingResult> = emptyList(),
         proUnconfirmedSince: Long = 0L,
         connectionFailures: Flow<Long> = emptyFlow(),
+        failureSettled: Flow<Boolean> = flowOf(false),
     ): UpgradeRepoGplay {
-        every { billingManager.billingData } returns flowOf(billingData)
+        every { billingManager.billingData } returns (billingDataFlow ?: flowOf(billingData))
         every { billingManager.freshBillingData } returns
             (freshBillingData?.let { flowOf(it) } ?: emptyFlow())
         every { billingManager.connectionFailures } returns connectionFailures
-        every { billingManager.isSettled } returns flowOf(true)
+        every { billingManager.isFailureSettled } returns failureSettled
         every { billingManager.purchaseFailures } returns
             if (purchaseFailures.isEmpty()) emptyFlow() else flowOf(*purchaseFailures.toTypedArray())
         lastProAtMock = mockk<DataStoreValue<Long>>(relaxed = true).apply {
@@ -638,8 +642,13 @@ class UpgradeRepoGplayTest : BaseTest() {
         // storage) -> an error Info keeps the flow alive; after the capped delay it recovers.
         val infos = repo.upgradeInfo.take(2).toList()
         infos[0].error shouldNotBe null
+        // A local storage failure is a definitive best-knowledge outcome -> settled.
+        infos[0].isSettled shouldBe true
         infos[1].error shouldBe null
         infos[1].isPro shouldBe false
+        // Monotonic across the retry resubscribe: the re-emitted null seed must not regress an
+        // already-settled stream back to unsettled (the runningReduce latch).
+        infos[1].isSettled shouldBe true
     }
 
     @Test fun `a persistently failing grace cache does not kill upgradeInfo`() = runTest2 {
@@ -650,6 +659,107 @@ class UpgradeRepoGplayTest : BaseTest() {
         // of terminating.
         repo.upgradeInfo.first().error shouldNotBe null
     }
+
+    // region settledness travels with the data
+
+    @Test fun `ownership and settledness arrive in the same emission`() = runTest2 {
+        // The core structural guarantee: no settled-non-Pro emission may precede the owner
+        // emission on a healthy cold start — settled-by-success IS the data emission.
+        val repo = repo(lastProAt = 0L, billingData = BillingData(setOf(proPurchase())))
+
+        val infos = repo.upgradeInfo.take(2).toList()
+        infos[0].isPro shouldBe false
+        infos[0].isSettled shouldBe false
+        infos[1].isPro shouldBe true
+        infos[1].isSettled shouldBe true
+    }
+
+    @Test fun `the pre-settle seed is unsettled`() = runTest2 {
+        val repo = repo(lastProAt = 0L, billingDataFlow = emptyFlow())
+
+        repo.upgradeInfo.first().apply {
+            isPro shouldBe false
+            isSettled shouldBe false
+        }
+    }
+
+    @Test fun `a connect-loop failure settles the seed`() = runTest2 {
+        val repo = repo(lastProAt = 0L, billingDataFlow = emptyFlow(), failureSettled = flowOf(true))
+
+        repo.upgradeInfo.first { it.isSettled }.isPro shouldBe false
+    }
+
+    @Test fun `a connect-loop failure settles the grace mapping for a recent owner`() = runTest2 {
+        val repo = repo(
+            lastProAt = System.currentTimeMillis() - 1_000,
+            billingDataFlow = emptyFlow(),
+            failureSettled = flowOf(true),
+        )
+
+        repo.upgradeInfo.first { it.isSettled }.isPro shouldBe true
+    }
+
+    @Test fun `a settled flip on identical content passes distinctUntilChanged`() = runTest2 {
+        val failureSettled = MutableStateFlow(false)
+        val repo = repo(lastProAt = 0L, billingDataFlow = emptyFlow(), failureSettled = failureSettled)
+
+        val infos = async { repo.upgradeInfo.take(2).toList() }
+        advanceUntilIdle()
+        failureSettled.value = true
+
+        infos.await().let {
+            it[0].isSettled shouldBe false
+            it[1].isSettled shouldBe true
+            it[1].isPro shouldBe it[0].isPro
+        }
+    }
+
+    @Test fun `restore results are settled`() = runTest2 {
+        coEvery { billingManager.refresh() } returns BillingData(setOf(proPurchase()))
+        repo(lastProAt = 0L).restorePurchaseNow().isSettled shouldBe true
+
+        // The grace fallback is a definitive substitution for a real round-trip -> also settled.
+        coEvery { billingManager.refresh() } throws RuntimeException("Play unavailable")
+        repo(lastProAt = System.currentTimeMillis() - 1_000).restorePurchaseNow().apply {
+            isPro shouldBe true
+            isSettled shouldBe true
+        }
+    }
+
+    @Test fun `after a failure the seed settles before the data lands - accepted residual`() = runTest2 {
+        // Documented D7 residual: isFailureSettled is sticky, so a failure-then-recovery sequence
+        // pairs the null seed with settled=true for the moment before the billing replay arrives —
+        // identical to the old sticky settledOnce, and strictly narrower (requires a prior
+        // failure). The structural guarantee this change makes is about the PURE success path:
+        // without a failure, no settled emission ever precedes the first reconciled data.
+        val failureSettled = MutableStateFlow(true) // a previous connect attempt failed
+        val repo = repo(
+            lastProAt = 0L,
+            billingData = BillingData(setOf(proPurchase())),
+            failureSettled = failureSettled,
+        )
+
+        val infos = repo.upgradeInfo.take(2).toList()
+        infos[0].isPro shouldBe false
+        infos[0].isSettled shouldBe true
+        infos[1].isPro shouldBe true
+        infos[1].isSettled shouldBe true
+    }
+
+    @Test fun `a committed partial snapshot settles even without a known purchase`() = runTest2 {
+        // data != null means a COMMITTED round-trip, not a complete one: the manager tolerates one
+        // failed product type when the other returned a purchase, so an unknown-only result still
+        // settles (matches the old parallel signal; grace covers a recently-confirmed owner).
+        val unknown = mockk<Purchase>().apply {
+            every { products } returns listOf("some.unknown.product")
+            every { purchaseTime } returns 1_000L
+        }
+        val repo = repo(lastProAt = 0L, billingData = BillingData(setOf(unknown)))
+
+        repo.upgradeInfo.first { it.isSettled }.isPro shouldBe false
+    }
+
+    // endregion
 
     @Test fun `retry delay grows and caps at five minutes`() {
         UpgradeRepoGplay.retryDelayMs(0) shouldBe 30_000L

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManagerTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManagerTest.kt
@@ -216,9 +216,9 @@ class BillingManagerTest : BaseTest() {
         attempts shouldBe 2
     }
 
-    @Test fun `a failed first attempt marks billing as settled`() = runTest2 {
+    @Test fun `a failed first attempt trips the failure-settled signal`() = runTest2 {
         // The connect loop swallows connection errors (it retries forever), so downstream flows
-        // stay silent during an outage -- gates like isProSettled need the explicit signal.
+        // stay silent during an outage -- consumers need the explicit signal to settle their seed.
         val provider = mockk<BillingConnectionProvider>().apply {
             every { this@apply.connection } returns flow {
                 throw BillingException("Play is down")
@@ -226,14 +226,23 @@ class BillingManagerTest : BaseTest() {
         }
         val manager = manager(provider)
 
-        manager.isSettled.first() shouldBe false
+        manager.isFailureSettled.first() shouldBe false
         runCurrent() // first attempt fails
-        manager.isSettled.first() shouldBe true
+        manager.isFailureSettled.first() shouldBe true
+    }
+
+    @Test fun `a healthy connection does not trip the failure-settled signal`() = runTest2 {
+        // Success-settledness travels WITH the data: billingData emitting IS the settle signal,
+        // there is no parallel success flag that could lead the data.
+        val manager = manager(connection(purchasesFlow = flowOf(listOf(purchase()))))
+
+        manager.billingData.first().purchases.size shouldBe 1
+        manager.isFailureSettled.first() shouldBe false
     }
 
     @Test fun `a cold refresh that can't verify anything retries instead of starving billing`() = runTest2 {
         // "Nothing found AND a query failed" throws from refreshPurchases: the old onEach swallowed
-        // that, leaving billingData/isSettled starved forever with no retry.
+        // that, leaving billingData/isFailureSettled starved forever with no retry.
         val bad = connection().apply {
             coEvery { refreshPurchases() } throws
                 GplayServiceUnavailableException(RuntimeException("cold Play, broken queries"))
@@ -250,7 +259,7 @@ class BillingManagerTest : BaseTest() {
         val manager = manager(provider)
 
         runCurrent() // attempt 1: connects, initial refresh fails -> connection failure
-        manager.isSettled.first() shouldBe true
+        manager.isFailureSettled.first() shouldBe true
 
         advanceTimeBy(2_001) // backoff, then attempt 2 heals
         manager.billingData.first() shouldBe BillingData(emptyList())

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/ui/GplayUpgradeViewModelTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/ui/GplayUpgradeViewModelTest.kt
@@ -184,8 +184,7 @@ class GplayUpgradeViewModelTest : BaseTest() {
     }
 
     private fun mockRepo(): UpgradeRepoGplay = mockk<UpgradeRepoGplay>(relaxed = true).apply {
-        every { upgradeInfo } returns MutableStateFlow(UpgradeRepoGplay.Info(false, null, null))
-        every { isSettled } returns MutableStateFlow(true)
+        every { upgradeInfo } returns MutableStateFlow(UpgradeRepoGplay.Info(false, null, null, isSettled = true))
         every { wasEverPro } returns MutableStateFlow(false)
         every { proUnconfirmedSince } returns MutableStateFlow(0L)
         // Relaxed mocks return a no-op Flow that never emits -- the state combine would starve.
@@ -212,6 +211,8 @@ class GplayUpgradeViewModelTest : BaseTest() {
         false,
         BillingData(purchases = purchases.toList()),
         null,
+        // Ownership data implies a committed reconciliation -> always settled.
+        isSettled = true,
     )
 
     @Test
@@ -267,7 +268,7 @@ class GplayUpgradeViewModelTest : BaseTest() {
         val repo = mockRepo()
         coEvery { repo.restorePurchaseNow() } coAnswers {
             delay(30_000) // longer than the 15s restore timeout
-            UpgradeRepoGplay.Info(gracePeriod = true, billingData = null)
+            UpgradeRepoGplay.Info(gracePeriod = true, billingData = null, isSettled = true)
         }
         val vm = buildVm(repo)
 
@@ -312,7 +313,7 @@ class GplayUpgradeViewModelTest : BaseTest() {
     fun `banner flag stays off while grace still keeps the user pro`() = runTest2(context = testDispatcher) {
         val repo = mockRepo()
         // gracePeriod = true => Info.isPro is true even without a current raw purchase.
-        every { repo.upgradeInfo } returns MutableStateFlow(UpgradeRepoGplay.Info(gracePeriod = true, billingData = null))
+        every { repo.upgradeInfo } returns MutableStateFlow(UpgradeRepoGplay.Info(gracePeriod = true, billingData = null, isSettled = true))
         every { repo.wasEverPro } returns MutableStateFlow(true)
         coEvery { repo.querySkus(OurSku.Iap.PRO_UPGRADE) } returns emptyList()
         coEvery { repo.querySkus(OurSku.Sub.PRO_UPGRADE) } returns emptyList()
@@ -331,7 +332,7 @@ class GplayUpgradeViewModelTest : BaseTest() {
         val repo = mockRepo()
         coEvery { repo.restorePurchaseNow() } coAnswers {
             delay(5_000)
-            UpgradeRepoGplay.Info(gracePeriod = true, billingData = null)
+            UpgradeRepoGplay.Info(gracePeriod = true, billingData = null, isSettled = true)
         }
         val vm = buildVm(repo)
 
@@ -501,16 +502,16 @@ class GplayUpgradeViewModelTest : BaseTest() {
     }
 
     @Test
-    fun `unsettled billing stays loading only while detail queries are pending`() = runTest2(
+    fun `successful queries never render from an unsettled Info`() = runTest2(
         context = testDispatcher,
     ) {
+        // The adversarial order behind the old flash: SKU queries finish BEFORE the reconciled
+        // Info propagates. The screen must hold at Loading instead of rendering acquisition UI
+        // from the pre-reconciliation seed — even though the queries are done.
         val repo = mockRepo()
-        every { repo.upgradeInfo } returns MutableStateFlow(proInfo(mockPurchase("upgrade.pro")))
-        every { repo.isSettled } returns MutableStateFlow(false)
-        coEvery { repo.querySkus(any()) } coAnswers {
-            delay(2_000)
-            emptyList()
-        }
+        val infos = MutableStateFlow(UpgradeRepoGplay.Info(false, null, null))
+        every { repo.upgradeInfo } returns infos
+        coEvery { repo.querySkus(any()) } returns emptyList()
         val vm = buildVm(repo)
 
         val collector = launch(start = CoroutineStart.UNDISPATCHED) { vm.state.collect { } }
@@ -518,10 +519,47 @@ class GplayUpgradeViewModelTest : BaseTest() {
         testScheduler.advanceTimeBy(1_000)
         vm.state.value shouldBe GplayUpgradeUiState.Loading
 
-        // The settling wait is bounded by the detail queries: once they resolve, rendering
-        // proceeds even if billing never settles — a starved billing layer must degrade to a
-        // rendered screen, not an endless spinner.
+        // The settled Info arrives (here: reconciled ownership) -> rendering proceeds.
+        infos.value = proInfo(mockPurchase("upgrade.pro"))
         advanceUntilIdle()
+        vm.state.value.shouldBeInstanceOf<GplayUpgradeUiState.Loaded>()
+        collector.cancel()
+    }
+
+    @Test
+    fun `two failed queries resolve to unavailable without waiting for settled`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // Carve-out: a Done where BOTH fresh SKU queries failed is itself a definitive
+        // can't-reach-Play outcome — the Unavailable card keeps its ~15s worst-case bound from
+        // the query timeouts instead of also waiting out the connect loop's failure signal.
+        val repo = mockRepo()
+        every { repo.upgradeInfo } returns MutableStateFlow(UpgradeRepoGplay.Info(false, null, null))
+        coEvery { repo.querySkus(any()) } throws IllegalStateException("Play unavailable")
+        val vm = buildVm(repo)
+
+        val unavailable = async { vm.state.first { it is GplayUpgradeUiState.Unavailable } }
+        advanceUntilIdle()
+
+        unavailable.await().shouldBeInstanceOf<GplayUpgradeUiState.Unavailable>()
+    }
+
+    @Test
+    fun `settled owner renders ownership while queries are still pending`() = runTest2(
+        context = testDispatcher,
+    ) {
+        val repo = mockRepo()
+        every { repo.upgradeInfo } returns MutableStateFlow(proInfo(mockPurchase("upgrade.pro")))
+        coEvery { repo.querySkus(any()) } coAnswers {
+            delay(60_000) // effectively never within this test
+            emptyList()
+        }
+        val vm = buildVm(repo)
+
+        val collector = launch(start = CoroutineStart.UNDISPATCHED) { vm.state.collect { } }
+
+        testScheduler.advanceTimeBy(1_000)
+        // Owners don't depend on offer prices: status renders immediately, never acquisition.
         vm.state.value.shouldBeInstanceOf<GplayUpgradeUiState.Loaded>()
         collector.cancel()
     }
@@ -559,7 +597,7 @@ class GplayUpgradeViewModelTest : BaseTest() {
     @Test
     fun `grace-only pro gets a quiet hint without diagnostics`() = runTest2(context = testDispatcher) {
         val repo = mockRepo()
-        every { repo.upgradeInfo } returns MutableStateFlow(UpgradeRepoGplay.Info(gracePeriod = true, billingData = null))
+        every { repo.upgradeInfo } returns MutableStateFlow(UpgradeRepoGplay.Info(gracePeriod = true, billingData = null, isSettled = true))
         coEvery { repo.querySkus(any()) } returns emptyList()
         val vm = buildVm(repo)
 
@@ -573,7 +611,7 @@ class GplayUpgradeViewModelTest : BaseTest() {
     @Test
     fun `young grace episode keeps diagnostics hidden`() = runTest2(context = testDispatcher) {
         val repo = mockRepo()
-        every { repo.upgradeInfo } returns MutableStateFlow(UpgradeRepoGplay.Info(gracePeriod = true, billingData = null))
+        every { repo.upgradeInfo } returns MutableStateFlow(UpgradeRepoGplay.Info(gracePeriod = true, billingData = null, isSettled = true))
         every { repo.proUnconfirmedSince } returns MutableStateFlow(
             System.currentTimeMillis() - Duration.ofHours(1).toMillis()
         )
@@ -589,7 +627,7 @@ class GplayUpgradeViewModelTest : BaseTest() {
     @Test
     fun `aged grace episode shows diagnostics`() = runTest2(context = testDispatcher) {
         val repo = mockRepo()
-        every { repo.upgradeInfo } returns MutableStateFlow(UpgradeRepoGplay.Info(gracePeriod = true, billingData = null))
+        every { repo.upgradeInfo } returns MutableStateFlow(UpgradeRepoGplay.Info(gracePeriod = true, billingData = null, isSettled = true))
         every { repo.proUnconfirmedSince } returns MutableStateFlow(
             System.currentTimeMillis() - UpgradeViewModel.GRACE_DIAGNOSTICS_AFTER_MS - 1_000
         )
@@ -630,7 +668,7 @@ class GplayUpgradeViewModelTest : BaseTest() {
     @Test
     fun `grace user keeps the grace card when both detail queries fail`() = runTest2(context = testDispatcher) {
         val repo = mockRepo()
-        every { repo.upgradeInfo } returns MutableStateFlow(UpgradeRepoGplay.Info(gracePeriod = true, billingData = null))
+        every { repo.upgradeInfo } returns MutableStateFlow(UpgradeRepoGplay.Info(gracePeriod = true, billingData = null, isSettled = true))
         // During an outage (exactly when grace matters) the price queries fail too — the user
         // must keep the Loaded grace presentation, not get an acquisition-style Unavailable.
         coEvery { repo.querySkus(any()) } throws IllegalStateException("Play unavailable")
@@ -645,7 +683,7 @@ class GplayUpgradeViewModelTest : BaseTest() {
     @Test
     fun `grace diagnostics appear when the episode crosses the threshold`() = runTest2(context = testDispatcher) {
         val repo = mockRepo()
-        every { repo.upgradeInfo } returns MutableStateFlow(UpgradeRepoGplay.Info(gracePeriod = true, billingData = null))
+        every { repo.upgradeInfo } returns MutableStateFlow(UpgradeRepoGplay.Info(gracePeriod = true, billingData = null, isSettled = true))
         val base = System.currentTimeMillis()
         // Episode is 10 virtual seconds short of the threshold.
         every { repo.proUnconfirmedSince } returns MutableStateFlow(
@@ -673,7 +711,7 @@ class GplayUpgradeViewModelTest : BaseTest() {
     fun `restore that only finds grace shows the troubleshooting dialog`() = runTest2(context = testDispatcher) {
         val repo = mockRepo()
         // Grace keeps isPro=true, but no actual purchase came back — not a restore success.
-        coEvery { repo.restorePurchaseNow() } returns UpgradeRepoGplay.Info(gracePeriod = true, billingData = null)
+        coEvery { repo.restorePurchaseNow() } returns UpgradeRepoGplay.Info(gracePeriod = true, billingData = null, isSettled = true)
         val vm = buildVm(repo)
 
         val event = async { vm.events.first() }


### PR DESCRIPTION
## What changed

If you own Pro, the upgrade screen could briefly show purchase options before it finished checking your purchase with Google Play. The window was very short and the screen corrected itself immediately, but it could look like your purchase wasn't recognized. The screen now waits for a real answer from Play before it shows anything that depends on whether you own Pro.

If Play is unreachable, the screen still resolves as quickly as it did before instead of spinning longer.

## Technical Context

- **Root cause**: the "billing has settled" signal and the ownership data travelled on two separate flows. `BillingManager` flipped its settled flag one line *before* publishing the connection that carries reconciled purchases, and consumers combined the two as independent branches — so `settled=true` could pair with the seeded non-Pro `Info` for a transient window.
- **Approach**: settledness now rides the ownership emission itself (`UpgradeRepo.Info.isSettled`) rather than a parallel flow, which was removed from the interface entirely. Non-null billing data implies a committed Play round-trip by construction, so the settle bit and the data proving it can no longer be observed out of step. Alternatives considered: reordering the two writes (rejected — both still travel independent async paths to the UI, so it gives no happens-before), and splitting visibility from enablement in the UI (rejected — hides the symptom rather than closing the race).
- **Sticky-failure residual (deliberate)**: the failure signal remains sticky, so a failure-then-recovery sequence can pair the seed with `settled=true` before the data replay lands. This matches the previous behaviour exactly and is strictly narrower (it now requires a prior failure). Documented at the combine and pinned by a test named for it, rather than silently accepted.
- **Behaviour change worth noting**: `isProForUi()`/`isProSettled()` no longer swallow `CancellationException` into their fail-open path. A caller cancelled mid-check now propagates instead of resolving to "Pro" — correct, but it may surface cancellation paths that were previously hidden.
- **Loading gate trade-off**: the upgrade screen's settled gate is now unconditional, with one carve-out — a product-details result where *both* queries failed is itself a definitive "can't reach Play" outcome and resolves immediately. Without that carve-out, a total Play hang would have pushed the unavailable/grace card from ~15s out to ~30-60s.
- **Review guidance**: the flow wiring in `UpgradeRepoGplay.upgradeInfo` deserves the closest look — specifically the `runningReduce` latch, which exists because `retryWhen` resubscribes the upstream and re-runs its `onStart` seed, which would otherwise regress an already-settled stream back to unsettled.
- **Scope**: FOSS is unaffected in behaviour (it reads a local cache and is settled from the first emission). The Swiper sessions screen uses the same signal and was updated in step. The bulk of the diff is test updates making `isSettled` explicit on `Info` fakes and mocks, now that the property is abstract.
