### PR TITLE
General: Stop long translated values from squashing settings rows

### DIFF
--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/settings/SettingsBaseItem.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/settings/SettingsBaseItem.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -39,6 +40,7 @@ fun SettingsBaseItem(
     iconTint: Color? = null,
     iconSize: Dp = 24.dp,
     subtitle: String? = null,
+    value: String? = null,
     enabled: Boolean = true,
     requiresUpgrade: Boolean = false,
     onLongClick: (() -> Unit)? = null,
@@ -106,15 +108,23 @@ fun SettingsBaseItem(
                     )
                     if (requiresUpgrade) {
                         Spacer(Modifier.width(6.dp))
-                        UpgradeBadge()
+                        UpgradeBadge(modifier = Modifier.alpha(contentAlpha))
                     }
+                }
+                if (value != null) {
+                    Text(
+                        text = value,
+                        style = MaterialTheme.typography.labelLarge,
+                        color = MaterialTheme.colorScheme.tertiary.copy(alpha = contentAlpha),
+                        modifier = Modifier.padding(top = 2.dp),
+                    )
                 }
                 if (subtitle != null) {
                     Text(
                         text = subtitle,
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f * contentAlpha),
-                        modifier = Modifier.padding(top = 2.dp),
+                        modifier = Modifier.padding(top = if (value != null) 4.dp else 2.dp),
                     )
                 }
             }
@@ -158,6 +168,14 @@ private fun SettingsBaseItemPreview() {
                 onClick = {},
                 icon = Icons.TwoTone.Settings,
                 requiresUpgrade = true,
+            )
+            SettingsBaseItem(
+                title = "Wykrywanie systemu operacyjnego",
+                value = "Automatyczne (domyślnie)",
+                subtitle = "Automatyzacja oparta na usłudze ułatwień dostępu może się nie powieść, " +
+                    "jeśli SD Maid nie wykryje poprawnie systemu operacyjnego.",
+                onClick = {},
+                icon = Icons.TwoTone.Settings,
             )
         }
     }

--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/settings/SettingsPreferenceItem.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/settings/SettingsPreferenceItem.kt
@@ -1,16 +1,12 @@
 package eu.darken.sdmse.common.compose.settings
 
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.Settings
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.unit.dp
 import eu.darken.sdmse.common.compose.preview.Preview2
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 
@@ -30,8 +26,6 @@ fun SettingsPreferenceItem(
     onLongClick: (() -> Unit)? = null,
     focusKey: String? = null,
 ) {
-    val contentAlpha = if (enabled) 1f else 0.5f
-
     SettingsBaseItem(
         icon = icon,
         iconPainter = iconPainter,
@@ -42,18 +36,9 @@ fun SettingsPreferenceItem(
         focusKey = focusKey,
         modifier = modifier,
         subtitle = subtitle,
+        value = value,
         enabled = enabled,
         requiresUpgrade = requiresUpgrade,
-        trailingContent = if (value != null) {
-            {
-                Text(
-                    text = value,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f * contentAlpha),
-                    modifier = Modifier.padding(start = 16.dp),
-                )
-            }
-        } else null,
     )
 }
 
@@ -83,6 +68,21 @@ private fun SettingsPreferenceItemGatedPreview() {
             onClick = {},
             requiresUpgrade = true,
             onUpgrade = {},
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun SettingsPreferenceItemLongValuePreview() {
+    PreviewWrapper {
+        SettingsPreferenceItem(
+            icon = Icons.TwoTone.Settings,
+            title = "Wykrywanie systemu operacyjnego",
+            value = "Automatyczne (domyślnie)",
+            subtitle = "Automatyzacja oparta na usłudze ułatwień dostępu może się nie powieść, " +
+                "jeśli SD Maid nie wykryje poprawnie systemu operacyjnego.",
+            onClick = {},
         )
     }
 }

--- a/app-common-ui/src/test/java/eu/darken/sdmse/common/compose/settings/SettingsPreferenceItemTest.kt
+++ b/app-common-ui/src/test/java/eu/darken/sdmse/common/compose/settings/SettingsPreferenceItemTest.kt
@@ -1,0 +1,328 @@
+package eu.darken.sdmse.common.compose.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.requiredWidth
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.hasAnyAncestor
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpRect
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+import kotlin.math.abs
+
+/**
+ * Guards the settings row layout: the value must render as its own line below the title instead of
+ * competing with the title/subtitle column for horizontal space. A long localized value (e.g. the
+ * Polish "Automatyczne (domyślnie)") used to take the width it needed and squeeze the text column
+ * down to a few characters per line.
+ *
+ * [SettingsBaseItem] applies `combinedClickable` to its outer column, which merges descendant
+ * semantics — a plain text lookup resolves to the whole row, not the individual `Text`. Every
+ * layout assertion here therefore runs against the unmerged tree.
+ */
+class SettingsPreferenceItemTest : BaseComposeRobolectricTest() {
+
+    @Test
+    fun `value renders below the title, not beside it`() {
+        composeRule.setContent {
+            PreviewWrapper {
+                Container {
+                    SettingsPreferenceItem(
+                        modifier = Modifier.testTag(TAG_VALUE),
+                        title = TITLE,
+                        subtitle = SUBTITLE,
+                        value = VALUE,
+                        onClick = {},
+                    )
+                }
+            }
+        }
+
+        val titleBounds = title(TAG_VALUE).getUnclippedBoundsInRoot()
+        val valueBounds = value(TAG_VALUE).getUnclippedBoundsInRoot()
+
+        withClue("value top ${valueBounds.top} must sit below title bottom ${titleBounds.bottom}") {
+            (valueBounds.top >= titleBounds.bottom) shouldBe true
+        }
+    }
+
+    @Test
+    fun `long value does not squeeze the title`() {
+        composeRule.setContent {
+            PreviewWrapper {
+                Container {
+                    SettingsPreferenceItem(
+                        modifier = Modifier.testTag(TAG_PLAIN),
+                        title = TITLE,
+                        subtitle = SUBTITLE,
+                        onClick = {},
+                    )
+                    SettingsPreferenceItem(
+                        modifier = Modifier.testTag(TAG_VALUE),
+                        title = TITLE,
+                        subtitle = SUBTITLE,
+                        value = VALUE,
+                        onClick = {},
+                    )
+                }
+            }
+        }
+
+        val plainTitle = title(TAG_PLAIN)
+        val valuedTitle = title(TAG_VALUE)
+
+        val plainWidth = plainTitle.getUnclippedBoundsInRoot().widthDp
+        val valuedWidth = valuedTitle.getUnclippedBoundsInRoot().widthDp
+        withClue("title width with value ($valuedWidth) must match the value-less row ($plainWidth)") {
+            valuedWidth shouldBe plainWidth
+        }
+
+        val plainLines = plainTitle.textLayoutResult().lineCount
+        val valuedLines = valuedTitle.textLayoutResult().lineCount
+        withClue("title line count with value ($valuedLines) must match the value-less row ($plainLines)") {
+            valuedLines shouldBe plainLines
+        }
+    }
+
+    @Test
+    fun `long value is not ellipsized`() {
+        composeRule.setContent {
+            PreviewWrapper {
+                Container {
+                    SettingsPreferenceItem(
+                        modifier = Modifier.testTag(TAG_VALUE),
+                        title = TITLE,
+                        subtitle = SUBTITLE,
+                        value = VALUE,
+                        onClick = {},
+                    )
+                }
+            }
+        }
+
+        value(TAG_VALUE).textLayoutResult().hasVisualOverflow shouldBe false
+    }
+
+    @Test
+    fun `merged semantics order is title, value, subtitle`() {
+        composeRule.setContent {
+            PreviewWrapper {
+                Container {
+                    SettingsPreferenceItem(
+                        modifier = Modifier.testTag(TAG_VALUE),
+                        title = TITLE,
+                        subtitle = SUBTITLE,
+                        value = VALUE,
+                        onClick = {},
+                    )
+                }
+            }
+        }
+
+        mergedTexts(TAG_VALUE) shouldBe listOf(TITLE, VALUE, SUBTITLE)
+    }
+
+    @Test
+    fun `upgrade badge coexists with the value`() {
+        var clicks = 0
+        var upgrades = 0
+        composeRule.setContent {
+            PreviewWrapper {
+                CompositionLocalProvider(LocalUpgradeBadgeLabel provides BADGE_LABEL) {
+                    Container {
+                        SettingsPreferenceItem(
+                            modifier = Modifier.testTag(TAG_VALUE),
+                            title = TITLE,
+                            subtitle = SUBTITLE,
+                            value = VALUE,
+                            requiresUpgrade = true,
+                            onClick = { clicks++ },
+                            onUpgrade = { upgrades++ },
+                        )
+                    }
+                }
+            }
+        }
+
+        val titleBounds = title(TAG_VALUE).getUnclippedBoundsInRoot()
+        val badgeBounds = composeRule
+            .onNodeWithText(BADGE_LABEL, useUnmergedTree = true)
+            .getUnclippedBoundsInRoot()
+        val valueBounds = value(TAG_VALUE).getUnclippedBoundsInRoot()
+
+        withClue("badge ($badgeBounds) must stay on the title line ($titleBounds)") {
+            (badgeBounds.top < titleBounds.bottom && titleBounds.top < badgeBounds.bottom) shouldBe true
+        }
+        withClue("value top ${valueBounds.top} must sit below title and badge") {
+            (valueBounds.top >= titleBounds.bottom && valueBounds.top >= badgeBounds.bottom) shouldBe true
+        }
+
+        mergedTexts(TAG_VALUE) shouldBe listOf(TITLE, BADGE_LABEL, VALUE, SUBTITLE)
+
+        composeRule.onNodeWithTag(TAG_VALUE).performClick()
+        composeRule.runOnIdle {
+            upgrades shouldBe 1
+            clicks shouldBe 0
+        }
+    }
+
+    @Test
+    fun `disabled value is dimmed tertiary labelLarge`() {
+        var expectedColor = Color.Unspecified
+        var expectedStyle = TextStyle.Default
+        composeRule.setContent {
+            PreviewWrapper {
+                expectedColor = MaterialTheme.colorScheme.tertiary
+                expectedStyle = MaterialTheme.typography.labelLarge
+                Container {
+                    SettingsPreferenceItem(
+                        modifier = Modifier.testTag(TAG_VALUE),
+                        title = TITLE,
+                        subtitle = SUBTITLE,
+                        value = VALUE,
+                        onClick = {},
+                    )
+                    SettingsPreferenceItem(
+                        modifier = Modifier.testTag(TAG_DISABLED),
+                        title = TITLE,
+                        subtitle = SUBTITLE,
+                        value = VALUE,
+                        enabled = false,
+                        onClick = {},
+                    )
+                }
+            }
+        }
+
+        val enabledStyle = value(TAG_VALUE).textLayoutResult().layoutInput.style
+        enabledStyle.fontSize shouldBe expectedStyle.fontSize
+        enabledStyle.fontWeight shouldBe expectedStyle.fontWeight
+        enabledStyle.color shouldBe expectedColor.copy(alpha = 1f)
+
+        val disabledStyle = value(TAG_DISABLED).textLayoutResult().layoutInput.style
+        disabledStyle.fontSize shouldBe expectedStyle.fontSize
+        disabledStyle.fontWeight shouldBe expectedStyle.fontWeight
+        disabledStyle.color shouldBe expectedColor.copy(alpha = 0.5f)
+    }
+
+    @Test
+    fun `large font scale keeps the value below the title`() {
+        composeRule.setContent {
+            PreviewWrapper {
+                val density = LocalDensity.current.density
+                CompositionLocalProvider(LocalDensity provides Density(density, fontScale = 2f)) {
+                    Container {
+                        SettingsPreferenceItem(
+                            modifier = Modifier.testTag(TAG_VALUE),
+                            title = TITLE,
+                            subtitle = SUBTITLE,
+                            value = VALUE,
+                            onClick = {},
+                        )
+                    }
+                }
+            }
+        }
+
+        val titleBounds = title(TAG_VALUE).getUnclippedBoundsInRoot()
+        val valueBounds = value(TAG_VALUE).getUnclippedBoundsInRoot()
+
+        withClue("value top ${valueBounds.top} must sit below title bottom ${titleBounds.bottom}") {
+            (valueBounds.top >= titleBounds.bottom) shouldBe true
+        }
+    }
+
+    @Test
+    fun `RTL keeps the value below the title and start-aligned`() {
+        composeRule.setContent {
+            PreviewWrapper {
+                CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl) {
+                    Container {
+                        SettingsPreferenceItem(
+                            modifier = Modifier.testTag(TAG_VALUE),
+                            title = TITLE,
+                            subtitle = SUBTITLE,
+                            value = VALUE,
+                            onClick = {},
+                        )
+                    }
+                }
+            }
+        }
+
+        val titleBounds = title(TAG_VALUE).getUnclippedBoundsInRoot()
+        val valueBounds = value(TAG_VALUE).getUnclippedBoundsInRoot()
+
+        withClue("value top ${valueBounds.top} must sit below title bottom ${titleBounds.bottom}") {
+            (valueBounds.top >= titleBounds.bottom) shouldBe true
+        }
+        withClue("value right ${valueBounds.right} must align with title right ${titleBounds.right}") {
+            (abs((valueBounds.right - titleBounds.right).value) < 1f) shouldBe true
+        }
+    }
+
+    @Composable
+    private fun Container(content: @Composable () -> Unit) {
+        Column(modifier = Modifier.requiredWidth(CONTAINER_WIDTH)) { content() }
+    }
+
+    private fun title(rowTag: String): SemanticsNodeInteraction = composeRule.onNode(
+        hasText(TITLE) and hasAnyAncestor(hasTestTag(rowTag)),
+        useUnmergedTree = true,
+    )
+
+    private fun value(rowTag: String): SemanticsNodeInteraction = composeRule.onNode(
+        hasText(VALUE) and hasAnyAncestor(hasTestTag(rowTag)),
+        useUnmergedTree = true,
+    )
+
+    private fun SemanticsNodeInteraction.textLayoutResult(): TextLayoutResult {
+        val results = mutableListOf<TextLayoutResult>()
+        fetchSemanticsNode().config[SemanticsActions.GetTextLayoutResult].action!!.invoke(results)
+        return results.first()
+    }
+
+    private fun mergedTexts(rowTag: String): List<String> = composeRule
+        .onNodeWithTag(rowTag)
+        .fetchSemanticsNode()
+        .config[SemanticsProperties.Text]
+        .map { it.text }
+
+    private val DpRect.widthDp: Dp get() = right - left
+
+    companion object {
+        private val CONTAINER_WIDTH = 360.dp
+        private const val TAG_PLAIN = "row-plain"
+        private const val TAG_VALUE = "row-value"
+        private const val TAG_DISABLED = "row-disabled"
+        private const val TITLE = "Wykrywanie systemu operacyjnego"
+        private const val VALUE = "Automatyczne (domyślnie)"
+        private const val SUBTITLE = "Automatyzacja oparta na usłudze ułatwień dostępu może się nie " +
+            "powieść, jeśli SD Maid nie wykryje poprawnie systemu operacyjnego."
+        private const val BADGE_LABEL = "Ulepszenie do wersji Pro"
+    }
+}

--- a/app-common-ui/src/test/java/eu/darken/sdmse/common/compose/settings/SettingsPreferenceItemTest.kt
+++ b/app-common-ui/src/test/java/eu/darken/sdmse/common/compose/settings/SettingsPreferenceItemTest.kt
@@ -108,6 +108,12 @@ class SettingsPreferenceItemTest : BaseComposeRobolectricTest() {
         }
     }
 
+    /**
+     * "Not ellipsized" is asserted as "no characters were dropped": the last line's visible end
+     * covers the whole string and the layout isn't height/line truncated. `hasVisualOverflow` is
+     * unusable here — under Robolectric's font stack `didOverflowWidth` is true for every `Text`,
+     * including the untouched title, even when a 24px line sits in a 328px constraint.
+     */
     @Test
     fun `long value is not ellipsized`() {
         composeRule.setContent {
@@ -124,7 +130,15 @@ class SettingsPreferenceItemTest : BaseComposeRobolectricTest() {
             }
         }
 
-        value(TAG_VALUE).textLayoutResult().hasVisualOverflow shouldBe false
+        val layout = value(TAG_VALUE).textLayoutResult()
+
+        withClue("value must not be line-limited") {
+            layout.layoutInput.maxLines shouldBe Int.MAX_VALUE
+        }
+        layout.didOverflowHeight shouldBe false
+        withClue("last visible line must end at the full string length") {
+            layout.getLineEnd(layout.lineCount - 1, visibleEnd = true) shouldBe VALUE.length
+        }
     }
 
     @Test


### PR DESCRIPTION
## What changed

Settings rows that show a current value — theme mode, theme style, theme color, operating system detection, cache size and age limits, stats retention — used to print that value on the right-hand edge of the row. In languages where the value is a long word or phrase, it stole so much width from the row that the setting's name and description got squeezed into a narrow column, turning a compact row into a very tall one. In Polish, the "Operating system detection" row rendered its title over 3 lines and its description over 10.

The value now sits on its own line directly under the setting name, in an accent color, with the description below it at full width. It looks the same in every language and can't be squeezed no matter how long the translation is.

## Technical Context

- **Root cause**: in `SettingsBaseItem` the title/subtitle `Column` had `weight(1f)` while the trailing value `Text` had no `maxLines` and no width cap. Compose measures unweighted `Row` children first at the full available width and hands only the remainder to weighted children, so the value took whatever it wanted and the text column absorbed the loss — with no floor at all. Longer translation, narrower title column, taller row.
- Measured worst cases for `general_rom_type_auto_label`: 35 chars in Zulu, 30 in Ukrainian, 24 in Polish, against 17 in English — which is why English never surfaces this.
- `SettingsPreferenceItem(value = …)` was the only mechanism rendering a trailing textual value; no screen used `SettingsBaseItem`'s `trailingContent` directly. The fix is therefore confined to the shared component and **none of the 10 call sites change**.
- **Accent is `colorScheme.tertiary`, not `primary`**, deliberately. `primary` already denotes three things on a settings screen (category headers, the upgrade badge, `Switch` checked tracks), so a primary-colored short value line would be near-indistinguishable from a primary-colored `SettingsCategoryHeader` when scanning. `tertiary` is otherwise unused on these screens and stays distinct across all three palettes and under Material You. `secondary` was rejected because M3 keeps it low-chroma — it reads as tinted grey rather than an accent.
- `trailingContent` is untouched on purpose: `SettingsSwitchItem` / `SettingsBadgedSwitchItem` use it for fixed-width controls, which have no width-contention problem.
- Also dims `UpgradeBadge` with `contentAlpha`. Pre-existing inconsistency: with `enabled = false, requiresUpgrade = true` the badge stayed fully opaque while everything around it dimmed. No current call site reaches that combination, but the block was being modified anyway.
- TalkBack reading order changes from title → subtitle → value to title → value → subtitle. There's a test asserting this.

### Review guidance

Two traps in the new test worth knowing about, both of which produce tests that silently assert nothing:

- `SettingsBaseItem` applies `combinedClickable` to its outer `Column`, which **merges descendant semantics**. A plain `onNodeWithText(title)` resolves to the whole row rather than the title `Text`, so every layout assertion runs against the *unmerged* tree.
- The "not ellipsized" test deliberately avoids `hasVisualOverflow`. Under Robolectric's font stack `didOverflowWidth` is true for *every* `Text` in the tree — including the untouched title, for a 24px line sitting in a 328px constraint. It asserts that no characters were dropped instead, which is the invariant that actually matters.

The "title is not squeezed" test is also relative rather than absolute — it renders the same title with and without a value and asserts identical width and line count, so it doesn't depend on Robolectric glyph metrics.

## Verification

- `:app-common-ui:testDebugUnitTest` 179 pass; `:app-tool-appcleaner` / `:app-tool-deduplicator` / `:app-tool-systemcleaner` 780 pass; `:app:testFossDebugUnitTest` 1016 pass
- `:app-common-ui:lintDebug` and `lintVitalFossRelease` pass
- `:app:assembleFossDebug` pass
- Manual runtime check on an emulator in both Polish and English, plus the reported row on a physical device
