### PR TITLE
General: Stop telling people we checked Google Play when we didn't

### DIFF
--- a/app-common/src/main/java/eu/darken/sdmse/common/upgrade/UpgradeDiagnostics.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/upgrade/UpgradeDiagnostics.kt
@@ -1,0 +1,15 @@
+package eu.darken.sdmse.common.upgrade
+
+/**
+ * Flavor-specific entitlement diagnostics for the debug log header.
+ *
+ * Deliberately separate from [UpgradeRepo]: the recorder must be able to read this without
+ * constructing the billing stack. Resolving [UpgradeRepo] on GPlay would build UpgradeRepoGplay ->
+ * BillingManager and start its AppScope collectors and connect loop, so simply enabling a debug
+ * recording would change when billing initializes. Implementations must stay inert.
+ */
+interface UpgradeDiagnostics {
+
+    /** One-line summary for the log header, or null when the flavor has nothing to report. */
+    suspend fun debugInfo(): String?
+}

--- a/app/src/foss/java/eu/darken/sdmse/common/upgrade/UpgradeModule.kt
+++ b/app/src/foss/java/eu/darken/sdmse/common/upgrade/UpgradeModule.kt
@@ -4,6 +4,7 @@ import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import eu.darken.sdmse.common.upgrade.core.UpgradeDiagnosticsFoss
 import eu.darken.sdmse.common.upgrade.core.UpgradeRepoFoss
 import javax.inject.Singleton
 
@@ -13,5 +14,9 @@ abstract class UpgradeModule {
     @Binds
     @Singleton
     abstract fun control(foss: UpgradeRepoFoss): UpgradeRepo
+
+    @Binds
+    @Singleton
+    abstract fun diagnostics(foss: UpgradeDiagnosticsFoss): UpgradeDiagnostics
 
 }

--- a/app/src/foss/java/eu/darken/sdmse/common/upgrade/core/UpgradeDiagnosticsFoss.kt
+++ b/app/src/foss/java/eu/darken/sdmse/common/upgrade/core/UpgradeDiagnosticsFoss.kt
@@ -1,0 +1,15 @@
+package eu.darken.sdmse.common.upgrade.core
+
+import eu.darken.sdmse.common.upgrade.UpgradeDiagnostics
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * FOSS has no store entitlement to reconcile: the upgrade state is a local sponsor record, already
+ * covered by the existing header fields. Nothing to add.
+ */
+@Singleton
+class UpgradeDiagnosticsFoss @Inject constructor() : UpgradeDiagnostics {
+
+    override suspend fun debugInfo(): String? = null
+}

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/UpgradeModule.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/UpgradeModule.kt
@@ -4,6 +4,7 @@ import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import eu.darken.sdmse.common.upgrade.core.UpgradeDiagnosticsGplay
 import eu.darken.sdmse.common.upgrade.core.UpgradeRepoGplay
 import javax.inject.Singleton
 
@@ -13,5 +14,9 @@ abstract class UpgradeModule {
     @Binds
     @Singleton
     abstract fun control(gplay: UpgradeRepoGplay): UpgradeRepo
+
+    @Binds
+    @Singleton
+    abstract fun diagnostics(gplay: UpgradeDiagnosticsGplay): UpgradeDiagnostics
 
 }

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/BillingCache.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/BillingCache.kt
@@ -11,6 +11,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.sdmse.common.datastore.basicReader
 import eu.darken.sdmse.common.datastore.basicWriter
 import eu.darken.sdmse.common.datastore.createValue
+import kotlinx.coroutines.flow.first
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -49,6 +50,24 @@ class BillingCache @Inject constructor(
         reader = basicReader(0L),
         writer = basicWriter(),
     )
+
+    // Point-in-time view of all three values. Reading them via three separate .value() calls can
+    // straddle a concurrent stampLastProState() and observe a combination that never existed --
+    // that write is transactional precisely because the values are only meaningful together.
+    data class Snapshot(
+        val lastProStateAt: Long,
+        val lastProStateSku: String,
+        val proUnconfirmedSince: Long,
+    )
+
+    suspend fun snapshot(): Snapshot {
+        val prefs = dataStore.data.first()
+        return Snapshot(
+            lastProStateAt = prefs[lastProStateAtKey] ?: 0L,
+            lastProStateSku = prefs[lastProStateSkuKey] ?: "",
+            proUnconfirmedSince = prefs[proUnconfirmedSinceKey] ?: 0L,
+        )
+    }
 
     // One transaction for all three values: the timestamp gates the grace period, the SKU modifies
     // its window length, and a confirmation closes the unconfirmed episode — none of it may be

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeDiagnosticsGplay.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeDiagnosticsGplay.kt
@@ -1,0 +1,31 @@
+package eu.darken.sdmse.common.upgrade.core
+
+import eu.darken.sdmse.common.upgrade.UpgradeDiagnostics
+import java.time.Instant
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Reports the local billing cache into the debug log header.
+ *
+ * `lastProStateAt > 0` is the "this install once confirmed a real Pro purchase" bit. It predates
+ * the CurriculumVitae pro-state counters by years and lives in a DataStore that was never migrated
+ * or renamed, so it survives update chains that the newer counters can't speak to. Without it in
+ * the header, a purchase complaint can't be told apart from a never-bought install.
+ *
+ * Depends on [BillingCache] alone -- see [UpgradeDiagnostics] for why this must not pull in
+ * UpgradeRepoGplay.
+ */
+@Singleton
+class UpgradeDiagnosticsGplay @Inject constructor(
+    private val billingCache: BillingCache,
+) : UpgradeDiagnostics {
+
+    override suspend fun debugInfo(): String {
+        val snapshot = billingCache.snapshot()
+        val lastProAt = snapshot.lastProStateAt.takeIf { it > 0 }?.let { Instant.ofEpochMilli(it) } ?: "never"
+        val lastProSku = snapshot.lastProStateSku.takeIf { it.isNotEmpty() } ?: "unknown/legacy"
+        val unconfirmedSince = snapshot.proUnconfirmedSince.takeIf { it > 0 }?.let { Instant.ofEpochMilli(it) } ?: "none"
+        return "BillingCache(lastProStateAt=$lastProAt, lastProStateSku=$lastProSku, proUnconfirmedSince=$unconfirmedSince)"
+    }
+}

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplay.kt
@@ -21,6 +21,7 @@ import eu.darken.sdmse.common.upgrade.core.billing.PurchasedSku
 import eu.darken.sdmse.common.upgrade.core.billing.Sku
 import eu.darken.sdmse.common.upgrade.core.billing.SkuDetails
 import eu.darken.sdmse.common.upgrade.core.billing.UserCanceledBillingException
+import eu.darken.sdmse.common.upgrade.core.billing.client.redacted
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
@@ -264,7 +265,9 @@ class UpgradeRepoGplay @Inject constructor(
             autoRestoreJob?.takeIf { it.isActive } ?: scope.async {
                 autoRestoreState.value = true
                 try {
-                    withTimeoutOrNull(RESTORE_ON_OWNED_TIMEOUT_MS) { restorePurchaseNow() }
+                    // Provenance is irrelevant here: the caller only checks whether the claimed SKU
+                    // came back, and a grace-only result doesn't reconcile it either way.
+                    withTimeoutOrNull(RESTORE_ON_OWNED_TIMEOUT_MS) { restorePurchaseNow().info }
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Exception) {
@@ -314,11 +317,13 @@ class UpgradeRepoGplay @Inject constructor(
     // Explicit "Restore purchase": query Play now and evaluate Pro from the returned data in the same
     // coroutine (real happens-before), so we never read a stale upgradeInfo replay. Billing errors
     // propagate so the caller can distinguish "not owned" from "Play unavailable".
-    suspend fun restorePurchaseNow(): Info {
-        log(TAG) { "restorePurchaseNow()" }
+    suspend fun restorePurchaseNow(): RestoreOutcome {
+        // INFO: pairs with the refreshPurchases() outcome line so a support log shows which Play
+        // round-trip belongs to an explicit restore tap.
+        log(TAG, INFO) { "restorePurchaseNow()" }
         return try {
             // A restore result IS a real Play round-trip outcome -> settled.
-            billingManager.refresh().toUpgradeInfo(settled = true)
+            RestoreOutcome.Checked(billingManager.refresh().toUpgradeInfo(settled = true))
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -329,11 +334,31 @@ class UpgradeRepoGplay @Inject constructor(
             if ((System.currentTimeMillis() - lastProStateAt) < graceWindowMs()) {
                 log(TAG, VERBOSE) { "restore hit a Play error but we were Pro recently -> grace" }
                 recordProUnconfirmed()
-                Info(gracePeriod = true, billingData = null, isSettled = true)
+                // Grace keeps Pro, but the lookup itself never landed. Reported as Inconclusive so
+                // the UI can't claim a completed check: an owner in grace is exactly who must not
+                // be told "we checked Play and found nothing".
+                RestoreOutcome.Inconclusive(Info(gracePeriod = true, billingData = null, isSettled = true), e)
             } else {
                 throw e
             }
         }
+    }
+
+    /**
+     * Provenance of an explicit restore, kept apart from [Info] so entitlement stays untouched.
+     *
+     * [Info] alone can't carry this: a grace-substituted `Info(gracePeriod = true, billingData =
+     * null)` is produced both by a successful empty query (a real answer) and by a swallowed Play
+     * error (no answer at all). Those need opposite UI treatment.
+     */
+    sealed interface RestoreOutcome {
+        val info: Info
+
+        /** Play answered. [info] reflects a real entitlement lookup. */
+        data class Checked(override val info: Info) : RestoreOutcome
+
+        /** Play couldn't be reached; [info] is grace-substituted and ownership stays unknown. */
+        data class Inconclusive(override val info: Info, val cause: Throwable) : RestoreOutcome
     }
 
     // Reports the Pro-state transition history to CurriculumVitae (grace engaged, Pro lost) —
@@ -476,10 +501,10 @@ class UpgradeRepoGplay @Inject constructor(
                 purchase.products.mapNotNull { productId ->
                     val sku = OurSku.PRO_SKUS.singleOrNull { it.id == productId }
                     if (sku == null) {
-                        log(TAG, ERROR) { "Unknown product: $productId ($purchase)" }
+                        log(TAG, ERROR) { "Unknown product: $productId (${purchase.redacted()})" }
                         return@mapNotNull null
                     } else {
-                        log(TAG) { "Mapped $productId to $sku ($purchase)" }
+                        log(TAG) { "Mapped $productId to $sku (${purchase.redacted()})" }
                     }
                     PurchasedSku(sku, purchase)
                 }

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManager.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManager.kt
@@ -14,6 +14,7 @@ import eu.darken.sdmse.common.flow.setupCommonEventHandlers
 import eu.darken.sdmse.common.upgrade.core.billing.client.BillingClientException
 import eu.darken.sdmse.common.upgrade.core.billing.client.BillingConnection
 import eu.darken.sdmse.common.upgrade.core.billing.client.BillingConnectionProvider
+import eu.darken.sdmse.common.upgrade.core.billing.client.redacted
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
@@ -210,8 +211,8 @@ class BillingManager @Inject constructor(
                     .filter {
                         val needsAck = !it.isAcknowledged
 
-                        if (needsAck) log(TAG) { "Needs ACK: $it" }
-                        else log(TAG) { "Already ACK'ed: $it" }
+                        if (needsAck) log(TAG) { "Needs ACK: ${it.redacted()}" }
+                        else log(TAG) { "Already ACK'ed: ${it.redacted()}" }
 
                         needsAck
                     }
@@ -219,7 +220,7 @@ class BillingManager @Inject constructor(
                         // First ack of a token is INFO; idempotent repeats drop to DEBUG. This never
                         // gates the ack -- acknowledgePurchase runs regardless of set membership.
                         val ackPriority = if (it.purchaseToken in loggedAckTokens) DEBUG else INFO
-                        log(TAG, ackPriority) { "Acknowledging purchase: $it" }
+                        log(TAG, ackPriority) { "Acknowledging purchase: ${it.redacted()}" }
 
                         try {
                             useConnection {

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingClientExtensions.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingClientExtensions.kt
@@ -2,7 +2,30 @@ package eu.darken.sdmse.common.upgrade.core.billing.client
 
 import com.android.billingclient.api.BillingClient
 import com.android.billingclient.api.BillingResult
+import com.android.billingclient.api.Purchase
 
 
 internal val BillingResult.isSuccess: Boolean
     get() = responseCode == BillingClient.BillingResponseCode.OK
+
+/**
+ * Log-safe rendering of a [Purchase].
+ *
+ * `Purchase.toString()` dumps the original response JSON, which carries the purchase token and the
+ * order ID. Debug recordings are attached to support emails by users, so anything logged here ends
+ * up in an inbox and wherever the user forwarded it. Everything actually useful for diagnosing an
+ * entitlement problem is non-identifying, so log only that.
+ *
+ * Total by construction: this runs inside `log {}` lambdas, which evaluate on the billing path
+ * whenever a recording is active. A formatter that can throw there would replace a real billing
+ * result (or a real billing exception) with a diagnostics failure, which is strictly worse than a
+ * degraded log line.
+ */
+internal fun Purchase.redacted(): String = runCatching {
+    "Purchase(products=$products, state=$purchaseState, acknowledged=$isAcknowledged, " +
+        "autoRenewing=$isAutoRenewing, purchaseTime=$purchaseTime)"
+}.getOrElse { "Purchase(unreadable: ${it::class.simpleName})" }
+
+internal fun Collection<Purchase>.redacted(): String = runCatching {
+    joinToString(prefix = "[", postfix = "]") { it.redacted() }
+}.getOrElse { "[unreadable: ${it::class.simpleName}]" }

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingConnection.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingConnection.kt
@@ -10,6 +10,7 @@ import com.android.billingclient.api.Purchase
 import com.android.billingclient.api.Purchase.PurchaseState
 import com.android.billingclient.api.QueryProductDetailsParams
 import com.android.billingclient.api.QueryPurchasesParams
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
@@ -162,7 +163,8 @@ class BillingConnection(
     internal fun onPurchasesUpdated(result: BillingResult, purchases: Collection<Purchase>?) {
         if (result.isSuccess) {
             log(TAG) {
-                "onPurchasesUpdated(code=${result.responseCode}, message=${result.debugMessage}, purchases=$purchases)"
+                "onPurchasesUpdated(code=${result.responseCode}, message=${result.debugMessage}, " +
+                    "purchases=${purchases?.redacted()})"
             }
             // PENDING purchases must never surface as owned (or stamp the Pro grace cache).
             val purchased = purchases.orEmpty().filter { it.purchaseState == PurchaseState.PURCHASED }
@@ -174,7 +176,8 @@ class BillingConnection(
             }
         } else {
             log(TAG, WARN) {
-                "error: onPurchasesUpdated(code=${result.responseCode}, message=${result.debugMessage}, purchases=$purchases)"
+                "error: onPurchasesUpdated(code=${result.responseCode}, message=${result.debugMessage}, " +
+                    "purchases=${purchases?.redacted()})"
             }
             failureChannel.trySend(result)
         }
@@ -212,7 +215,7 @@ class BillingConnection(
             val subJob = async { queryPurchasedProducts(BillingClient.ProductType.SUBS) }
             val iap = iapJob.await()
             val sub = subJob.await()
-            log(TAG) { "Refreshed IAPs=${iap.getOrNull()}, SUBs=${sub.getOrNull()}" }
+            log(TAG) { "Refreshed IAPs=${iap.getOrNull()?.redacted()}, SUBs=${sub.getOrNull()?.redacted()}" }
 
             // Commit BEFORE the couldn't-verify error check: a successful per-type result is
             // authoritative even when its sibling failed — verified absence (e.g. a refunded IAP)
@@ -238,6 +241,17 @@ class BillingConnection(
                     freshUpdatesChannel.trySend(FreshUpdate(confirmed, isFullSnapshot = provesAbsence))
                 }
                 next
+            }
+
+            // Support-log anchor, at INFO because purchase complaints arrive as debug recordings.
+            // Logs what these queries CONFIRMED, kept distinct from the committed view: merged()
+            // retains a failed type's previous purchases, so reporting it as "what Play returned"
+            // would be the same false-certainty trap the copy elsewhere had to fix. Product IDs
+            // only -- never the Purchase, which carries order and token data.
+            log(TAG, INFO) {
+                val confirmedIds = (iap.getOrNull().orEmpty() + sub.getOrNull().orEmpty()).flatMap { it.products }
+                "refreshPurchases(): confirmed=$confirmedIds, isComplete=$isComplete, " +
+                    "iapOk=${iap.isSuccess}, subOk=${sub.isSuccess}, merged=${committed.merged().size}"
             }
 
             // Throws when nothing was found and a query failed, so the caller can tell "not
@@ -278,7 +292,8 @@ class BillingConnection(
         }
 
         log(TAG) {
-            "queryPurchases($type): code=${billingResult.isSuccess}, message=${billingResult.debugMessage}, purchaseData=${purchaseData}"
+            "queryPurchases($type): code=${billingResult.isSuccess}, message=${billingResult.debugMessage}, " +
+                "purchaseData=${purchaseData.redacted()}"
         }
 
         if (!billingResult.isSuccess) {
@@ -331,7 +346,8 @@ class BillingConnection(
             }
         }
         log(TAG) {
-            "acknowledgePurchase(purchase=$purchase): code=${ackResult.responseCode}, message=${ackResult.debugMessage})"
+            "acknowledgePurchase(purchase=${purchase.redacted()}): code=${ackResult.responseCode}, " +
+                "message=${ackResult.debugMessage})"
         }
 
         if (!ackResult.isSuccess) {

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeEvents.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeEvents.kt
@@ -2,7 +2,16 @@ package eu.darken.sdmse.common.upgrade.ui
 
 sealed class UpgradeEvents {
     data object RestoreSucceeded : UpgradeEvents()
+
+    /** Play answered and no purchase was found. A real result: troubleshooting and escalation apply. */
     data object RestoreFailed : UpgradeEvents()
+
+    /**
+     * The restore didn't finish within its budget, so ownership is simply unknown. Kept apart from
+     * [RestoreFailed] because that dialog asserts a completed check and steers toward the
+     * multi-account explanation, neither of which is warranted here.
+     */
+    data object RestoreInconclusive : UpgradeEvents()
     data object SubscriptionStillRenewing : UpgradeEvents()
     data object SubscriptionCheckFailed : UpgradeEvents()
 }

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeScreen.kt
@@ -18,7 +18,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -53,9 +53,12 @@ fun UpgradeScreenHost(
     // No screen-level resume refresh: MainActivity already refreshes the upgrade repo on every
     // activity resume, which covers returning from Play after cancelling the subscription there.
 
-    var showRestoreFailed by remember { mutableStateOf(false) }
-    var showStillRenewing by remember { mutableStateOf(false) }
-    var showCheckFailed by remember { mutableStateOf(false) }
+    // rememberSaveable, not remember: these are driven by one-shot events that are already consumed
+    // from the flow, so a rotation while a dialog is up would drop it for good.
+    var showRestoreFailed by rememberSaveable { mutableStateOf(false) }
+    var showRestoreInconclusive by rememberSaveable { mutableStateOf(false) }
+    var showStillRenewing by rememberSaveable { mutableStateOf(false) }
+    var showCheckFailed by rememberSaveable { mutableStateOf(false) }
 
     LaunchedEffect(vm) {
         vm.events.collect { event ->
@@ -67,6 +70,7 @@ fun UpgradeScreenHost(
                 ).show()
 
                 UpgradeEvents.RestoreFailed -> showRestoreFailed = true
+                UpgradeEvents.RestoreInconclusive -> showRestoreInconclusive = true
                 UpgradeEvents.SubscriptionStillRenewing -> showStillRenewing = true
                 UpgradeEvents.SubscriptionCheckFailed -> showCheckFailed = true
             }
@@ -74,28 +78,22 @@ fun UpgradeScreenHost(
     }
 
     if (showRestoreFailed) {
-        // Leads with the just-happened live Play check (hedged: RestoreFailed also fires on
-        // timeout). This dialog is the ONLY contact-support surface — escalation comes after an
-        // empty restore, never before.
-        val checkedMsg = stringResource(R.string.upgrade_screen_restore_checked_message)
-        val multiAccountHint = stringResource(R.string.upgrade_screen_restore_multiaccount_hint)
-        val syncHint = stringResource(R.string.upgrade_screen_restore_sync_patience_hint)
-        val contactHint = stringResource(R.string.upgrade_screen_restore_contact_hint)
-        val message = "$checkedMsg\n\n$multiAccountHint\n\n$syncHint\n\n$contactHint"
-        SdmConfirmDialog(
-            message = message,
-            onDismissRequest = { showRestoreFailed = false },
-            positive = SdmDialogAction(
-                label = stringResource(R.string.upgrade_screen_contact_support_action),
-                onClick = {
-                    showRestoreFailed = false
-                    vm.onContactSupport()
-                },
-            ),
-            negative = SdmDialogAction(
-                label = stringResource(CommonR.string.general_dismiss_action),
-                onClick = { showRestoreFailed = false },
-            ),
+        RestoreFailedDialog(
+            onContactSupport = {
+                showRestoreFailed = false
+                vm.onContactSupport()
+            },
+            onDismiss = { showRestoreFailed = false },
+        )
+    }
+
+    if (showRestoreInconclusive) {
+        RestoreInconclusiveDialog(
+            onRetry = {
+                showRestoreInconclusive = false
+                vm.restorePurchase()
+            },
+            onDismiss = { showRestoreInconclusive = false },
         )
     }
 
@@ -140,6 +138,60 @@ fun UpgradeScreenHost(
         onManageSubscription = vm::onManageSubscription,
         onRetry = vm::retrySkuQuery,
         onNavigateUp = vm::navUp,
+    )
+}
+
+/**
+ * Shown when Play answered and no purchase was found. Leads with the just-happened live check,
+ * which is literally true here: non-answers route to [RestoreInconclusiveDialog] instead. This is
+ * the ONLY contact-support surface — escalation comes after an empty restore, never before.
+ */
+@Composable
+internal fun RestoreFailedDialog(
+    onContactSupport: () -> Unit = {},
+    onDismiss: () -> Unit = {},
+) {
+    val checkedMsg = stringResource(R.string.upgrade_screen_restore_checked_message)
+    val multiAccountHint = stringResource(R.string.upgrade_screen_restore_multiaccount_hint)
+    val syncHint = stringResource(R.string.upgrade_screen_restore_sync_patience_hint)
+    val contactHint = stringResource(R.string.upgrade_screen_restore_contact_hint)
+    SdmConfirmDialog(
+        message = "$checkedMsg\n\n$multiAccountHint\n\n$syncHint\n\n$contactHint",
+        onDismissRequest = onDismiss,
+        positive = SdmDialogAction(
+            label = stringResource(R.string.upgrade_screen_contact_support_action),
+            onClick = onContactSupport,
+        ),
+        negative = SdmDialogAction(
+            label = stringResource(CommonR.string.general_dismiss_action),
+            onClick = onDismiss,
+        ),
+    )
+}
+
+/**
+ * Shown when the restore never got an answer (timeout, or a Play error absorbed by grace). Carries
+ * no multi-account hint and no contact-support action: nothing was established, so both would be
+ * premature. Retry is the useful move, and `restorePurchase()` is single-flight.
+ */
+@Composable
+internal fun RestoreInconclusiveDialog(
+    onRetry: () -> Unit = {},
+    onDismiss: () -> Unit = {},
+) {
+    val inconclusiveMsg = stringResource(R.string.upgrade_screen_restore_inconclusive_message)
+    val syncHint = stringResource(R.string.upgrade_screen_restore_sync_patience_hint)
+    SdmConfirmDialog(
+        message = "$inconclusiveMsg\n\n$syncHint",
+        onDismissRequest = onDismiss,
+        positive = SdmDialogAction(
+            label = stringResource(CommonR.string.general_retry_action),
+            onClick = onRetry,
+        ),
+        negative = SdmDialogAction(
+            label = stringResource(CommonR.string.general_dismiss_action),
+            onClick = onDismiss,
+        ),
     )
 }
 

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
@@ -365,13 +365,23 @@ class UpgradeViewModel @Inject constructor(
             }
             when {
                 restored == null -> {
-                    // Play never answered in time; the restore-failed dialog already suggests waiting /
-                    // clearing the Play cache, which fits a timeout too.
+                    // Budget covers connecting, the refresh mutex AND both queries, so a query may
+                    // well have started. All we know is the check didn't finish -- not that Play
+                    // said no. Reporting this as a completed check would send an owner chasing the
+                    // multi-account explanation for what is really a slow or unreachable Play.
                     log(TAG, WARN) { "Restore purchase timed out" }
-                    events.tryEmit(UpgradeEvents.RestoreFailed)
+                    events.tryEmit(UpgradeEvents.RestoreInconclusive)
                 }
 
-                restored.upgrades.isNotEmpty() -> {
+                restored is UpgradeRepoGplay.RestoreOutcome.Inconclusive -> {
+                    // Play errored and grace kept Pro alive. Same non-answer as a timeout, and the
+                    // user is by definition a recent owner -- the last person to tell that we
+                    // checked and found nothing.
+                    log(TAG, WARN) { "Restore purchase inconclusive: ${restored.cause.asLog()}" }
+                    events.tryEmit(UpgradeEvents.RestoreInconclusive)
+                }
+
+                restored.info.upgrades.isNotEmpty() -> {
                     log(TAG, INFO) { "Restored purchase :))" }
                     // Explicit feedback: on the ownership screen a successful restore changes
                     // nothing visible (the user already is Pro), so silence reads as "broken".
@@ -379,9 +389,10 @@ class UpgradeViewModel @Inject constructor(
                 }
 
                 else -> {
-                    // Includes grace-only results: Pro may still be active, but the restore found
-                    // no actual purchase — troubleshooting dialog, not a success toast.
-                    log(TAG, WARN) { "Restore purchase found no purchases (isPro=${restored.isPro})" }
+                    // Play answered and had nothing. Includes a grace-only result from a successful
+                    // EMPTY query: Pro may still be active, but the check really did complete, so
+                    // troubleshooting and escalation are warranted.
+                    log(TAG, WARN) { "Restore purchase found no purchases (isPro=${restored.info.isPro})" }
                     events.tryEmit(UpgradeEvents.RestoreFailed)
                 }
             }

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -68,4 +68,5 @@
     <string name="upgrade_screen_contact_support_action">Contact support</string>
     <string name="upgrade_screen_restore_checked_message">SD Maid just checked Google Play, but no Pro purchase could be confirmed for the account Google Play is using for this app.</string>
     <string name="upgrade_screen_restore_contact_hint">Still stuck? Contact support from the email that made the purchase and include your Google Play order number.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">The check with Google Play didn\'t finish in time, so your purchase status is still unknown. Nothing has changed on your account.</string>
 </resources>

--- a/app/src/main/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModule.kt
@@ -23,6 +23,7 @@ import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.flow.DynamicStateFlow
 import eu.darken.sdmse.common.getPackageInfo
+import eu.darken.sdmse.common.upgrade.UpgradeDiagnostics
 import eu.darken.sdmse.main.core.CurriculumVitae
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -55,6 +56,7 @@ class RecorderModule @Inject constructor(
     private val sdmId: SDMId,
     private val debugSettings: DebugSettings,
     private val curriculumVitae: CurriculumVitae,
+    private val upgradeDiagnostics: UpgradeDiagnostics,
     private val recorderProvider: Provider<Recorder>,
 ) {
 
@@ -262,6 +264,17 @@ class RecorderModule @Inject constructor(
         } catch (e: Exception) {
             // Diagnostics only — a broken history read must not stop the recorder from starting.
             log(TAG, WARN) { "Pro history unavailable: ${e.asLog()}" }
+        }
+
+        // Separate boundary from the block above on purpose: these read different DataStores, and
+        // the counters above only cover installs new enough to have them. A failure to read one
+        // must not suppress the other's independent evidence.
+        try {
+            upgradeDiagnostics.debugInfo()?.let { log(TAG, INFO) { "Upgrade diagnostics: $it" } }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, WARN) { "Upgrade diagnostics unavailable: ${e.asLog()}" }
         }
     }
 

--- a/app/src/test/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModuleTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModuleTest.kt
@@ -12,6 +12,7 @@ import eu.darken.sdmse.common.datastore.DataStoreValue
 import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.DebugSettings
 import eu.darken.sdmse.common.getPackageInfo
+import eu.darken.sdmse.common.upgrade.UpgradeDiagnostics
 import eu.darken.sdmse.main.core.CurriculumVitae
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -51,6 +52,7 @@ class RecorderModuleTest : BaseTest() {
     private val sdmId: SDMId = mockk()
     private val dataAreaManager: DataAreaManager = mockk()
     private val curriculumVitae: CurriculumVitae = mockk()
+    private val upgradeDiagnostics: UpgradeDiagnostics = mockk()
     private val recorderProvider: Provider<Recorder> = mockk()
     private val mockRecorder: Recorder = mockk()
 
@@ -78,6 +80,8 @@ class RecorderModuleTest : BaseTest() {
             proLostCount = 0,
             proLostLast = null,
         )
+
+        coEvery { upgradeDiagnostics.debugInfo() } returns "BillingCache(test)"
 
         every { recorderProvider.get() } returns mockRecorder
         coEvery { mockRecorder.start(any()) } returns Unit
@@ -118,6 +122,7 @@ class RecorderModuleTest : BaseTest() {
             sdmId = sdmId,
             debugSettings = debugSettings,
             curriculumVitae = curriculumVitae,
+            upgradeDiagnostics = upgradeDiagnostics,
             recorderProvider = recorderProvider,
         )
 
@@ -182,6 +187,49 @@ class RecorderModuleTest : BaseTest() {
             advanceUntilIdle()
 
             module.state.first { it.isRecording }.isRecording shouldBe true
+        }
+
+        @Test
+        fun `a failing upgrade diagnostics read does not prevent recording`() = runTest {
+            File(externalDir, "force_debug_run").createNewFile()
+            coEvery { recorderPath.value() } returns null
+            coEvery { upgradeDiagnostics.debugInfo() } throws IOException("disk full")
+
+            val dispatcher = StandardTestDispatcher(testScheduler)
+            val module = createModule(backgroundScope, dispatcher)
+            advanceUntilIdle()
+
+            module.state.first { it.isRecording }.isRecording shouldBe true
+        }
+
+        @Test
+        fun `a failing pro history read still reports upgrade diagnostics`() = runTest {
+            // Separate failure boundaries: these read different DataStores, and the pro-state
+            // counters are too new to speak for installs that predate them. One failing must not
+            // suppress the other's evidence.
+            File(externalDir, "force_debug_run").createNewFile()
+            coEvery { recorderPath.value() } returns null
+            coEvery { curriculumVitae.proHistory() } throws IOException("disk full")
+
+            val dispatcher = StandardTestDispatcher(testScheduler)
+            val module = createModule(backgroundScope, dispatcher)
+            advanceUntilIdle()
+
+            module.state.first { it.isRecording }
+            coVerify { upgradeDiagnostics.debugInfo() }
+        }
+
+        @Test
+        fun `upgrade diagnostics are not read when recording does not start`() = runTest {
+            // Resolving diagnostics must stay inert and lazy: on GPlay this path must never be the
+            // thing that first touches the billing stack.
+            coEvery { recorderPath.value() } returns null
+
+            val dispatcher = StandardTestDispatcher(testScheduler)
+            createModule(backgroundScope, dispatcher)
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) { upgradeDiagnostics.debugInfo() }
         }
 
         @Test

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/BillingCacheTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/BillingCacheTest.kt
@@ -27,6 +27,15 @@ class BillingCacheTest : BaseTest() {
         cache.lastProStateAt.value() shouldBe 0L
         cache.lastProStateSku.value() shouldBe ""
 
+        // Defaults on a never-Pro install: this exact triple is what the debug-log header reports
+        // as "never / unknown-legacy / none", and it's the signal that separates a never-bought
+        // install from one whose entitlement went missing.
+        cache.snapshot() shouldBe BillingCache.Snapshot(
+            lastProStateAt = 0L,
+            lastProStateSku = "",
+            proUnconfirmedSince = 0L,
+        )
+
         cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 1234L)
 
         cache.lastProStateAt.value() shouldBe 1234L
@@ -47,5 +56,14 @@ class BillingCacheTest : BaseTest() {
         cache.proUnconfirmedSince.value(9_000L)
         cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 8_000L) // confirmation older than episode
         cache.proUnconfirmedSince.value() shouldBe 9_000L
+
+        // snapshot() must agree with the individual reads. It exists so the debug-log header reads
+        // all three in ONE DataStore emission: three separate reads can straddle a concurrent
+        // stampLastProState and report a combination that never existed.
+        cache.snapshot() shouldBe BillingCache.Snapshot(
+            lastProStateAt = 8_000L,
+            lastProStateSku = OurSku.Iap.PRO_UPGRADE.id,
+            proUnconfirmedSince = 9_000L,
+        )
     }
 }

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeDiagnosticsGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeDiagnosticsGplayTest.kt
@@ -1,0 +1,55 @@
+package eu.darken.sdmse.common.upgrade.core
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class UpgradeDiagnosticsGplayTest : BaseTest() {
+
+    private fun create(snapshot: BillingCache.Snapshot) = UpgradeDiagnosticsGplay(
+        billingCache = mockk<BillingCache>().apply { coEvery { this@apply.snapshot() } returns snapshot },
+    )
+
+    @Test
+    fun `a never-pro install is reported as never, not as epoch zero`() = runTest {
+        // The whole point of this line in the log header is telling "never bought" apart from
+        // "bought once, entitlement now missing". A raw 0 reads as a 1970 timestamp.
+        val info = create(
+            BillingCache.Snapshot(lastProStateAt = 0L, lastProStateSku = "", proUnconfirmedSince = 0L)
+        ).debugInfo()
+
+        info shouldBe "BillingCache(lastProStateAt=never, lastProStateSku=unknown/legacy, proUnconfirmedSince=none)"
+    }
+
+    @Test
+    fun `a confirmed purchase reports an instant and the sku`() = runTest {
+        val info = create(
+            BillingCache.Snapshot(
+                lastProStateAt = 1_700_000_000_000L,
+                lastProStateSku = OurSku.Iap.PRO_UPGRADE.id,
+                proUnconfirmedSince = 0L,
+            )
+        ).debugInfo()
+
+        info shouldContain "lastProStateAt=2023-11-14T22:13:20Z"
+        info shouldContain "lastProStateSku=${OurSku.Iap.PRO_UPGRADE.id}"
+        info shouldContain "proUnconfirmedSince=none"
+    }
+
+    @Test
+    fun `an open unconfirmed episode is reported as an instant`() = runTest {
+        val info = create(
+            BillingCache.Snapshot(
+                lastProStateAt = 1_700_000_000_000L,
+                lastProStateSku = OurSku.Sub.PRO_UPGRADE.id,
+                proUnconfirmedSince = 1_700_000_500_000L,
+            )
+        ).debugInfo()
+
+        info shouldContain "proUnconfirmedSince=2023-11-14T22:21:40Z"
+    }
+}

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplayTest.kt
@@ -137,26 +137,26 @@ class UpgradeRepoGplayTest : BaseTest() {
     @Test fun `restore returns pro when a purchase is found`() = runTest2 {
         coEvery { billingManager.refresh() } returns BillingData(setOf(proPurchase()))
 
-        repo(lastProAt = 0L).restorePurchaseNow().isPro shouldBe true
+        repo(lastProAt = 0L).restorePurchaseNow().info.isPro shouldBe true
     }
 
     @Test fun `restore keeps pro within grace when the query comes back empty`() = runTest2 {
         coEvery { billingManager.refresh() } returns BillingData(emptySet())
 
-        repo(lastProAt = System.currentTimeMillis() - 1_000).restorePurchaseNow().isPro shouldBe true
+        repo(lastProAt = System.currentTimeMillis() - 1_000).restorePurchaseNow().info.isPro shouldBe true
     }
 
     @Test fun `restore is not pro when the query is empty and grace has expired`() = runTest2 {
         coEvery { billingManager.refresh() } returns BillingData(emptySet())
 
         val expired = System.currentTimeMillis() - UpgradeRepoGplay.GRACE_PERIOD_MS - 1_000
-        repo(lastProAt = expired).restorePurchaseNow().isPro shouldBe false
+        repo(lastProAt = expired).restorePurchaseNow().info.isPro shouldBe false
     }
 
     @Test fun `restore keeps pro within grace when the query errors`() = runTest2 {
         coEvery { billingManager.refresh() } throws RuntimeException("Play unavailable")
 
-        repo(lastProAt = System.currentTimeMillis() - 1_000).restorePurchaseNow().isPro shouldBe true
+        repo(lastProAt = System.currentTimeMillis() - 1_000).restorePurchaseNow().info.isPro shouldBe true
     }
 
     @Test fun `restore rethrows the error when it happens outside grace`() = runTest2 {
@@ -173,7 +173,7 @@ class UpgradeRepoGplayTest : BaseTest() {
         val twentyDaysAgo = System.currentTimeMillis() - Duration.ofDays(20).toMillis()
 
         repo(lastProAt = twentyDaysAgo, lastSku = OurSku.Iap.PRO_UPGRADE.id)
-            .restorePurchaseNow().isPro shouldBe true
+            .restorePurchaseNow().info.isPro shouldBe true
     }
 
     @Test fun `subscription grace expires after the short window`() = runTest2 {
@@ -181,7 +181,7 @@ class UpgradeRepoGplayTest : BaseTest() {
         val twentyDaysAgo = System.currentTimeMillis() - Duration.ofDays(20).toMillis()
 
         repo(lastProAt = twentyDaysAgo, lastSku = OurSku.Sub.PRO_UPGRADE.id)
-            .restorePurchaseNow().isPro shouldBe false
+            .restorePurchaseNow().info.isPro shouldBe false
     }
 
     @Test fun `legacy empty last SKU falls back to the short window`() = runTest2 {
@@ -190,7 +190,7 @@ class UpgradeRepoGplayTest : BaseTest() {
 
         // Existing installs have a timestamp but no recorded SKU: they keep the old 7-day window
         // until the next successful query records one.
-        repo(lastProAt = twentyDaysAgo, lastSku = "").restorePurchaseNow().isPro shouldBe false
+        repo(lastProAt = twentyDaysAgo, lastSku = "").restorePurchaseNow().info.isPro shouldBe false
     }
 
     @Test fun `IAP grace window is longer than the subscription window`() {
@@ -607,7 +607,7 @@ class UpgradeRepoGplayTest : BaseTest() {
         }
         coEvery { billingManager.refresh() } returns BillingData(setOf(unknown))
 
-        repo(lastProAt = System.currentTimeMillis() - 1_000).restorePurchaseNow().isPro shouldBe true
+        repo(lastProAt = System.currentTimeMillis() - 1_000).restorePurchaseNow().info.isPro shouldBe true
     }
 
     @Test fun `unknown-only purchases without recent grace are not pro`() = runTest2 {
@@ -617,7 +617,7 @@ class UpgradeRepoGplayTest : BaseTest() {
         }
         coEvery { billingManager.refresh() } returns BillingData(setOf(unknown))
 
-        repo(lastProAt = 0L).restorePurchaseNow().isPro shouldBe false
+        repo(lastProAt = 0L).restorePurchaseNow().info.isPro shouldBe false
     }
 
     @Test fun `a known purchase is pro even when the grace cache is unreadable`() = runTest2 {
@@ -627,7 +627,7 @@ class UpgradeRepoGplayTest : BaseTest() {
         val repo = repo(lastProAt = 0L)
         every { lastProAtMock.flow } returns flow { throw IOException("disk full") }
 
-        repo.restorePurchaseNow().isPro shouldBe true
+        repo.restorePurchaseNow().info.isPro shouldBe true
     }
 
     @Test fun `upgradeInfo recovers after a transient grace cache failure`() = runTest2 {
@@ -716,14 +716,38 @@ class UpgradeRepoGplayTest : BaseTest() {
 
     @Test fun `restore results are settled`() = runTest2 {
         coEvery { billingManager.refresh() } returns BillingData(setOf(proPurchase()))
-        repo(lastProAt = 0L).restorePurchaseNow().isSettled shouldBe true
+        repo(lastProAt = 0L).restorePurchaseNow().info.isSettled shouldBe true
 
         // The grace fallback is a definitive substitution for a real round-trip -> also settled.
         coEvery { billingManager.refresh() } throws RuntimeException("Play unavailable")
-        repo(lastProAt = System.currentTimeMillis() - 1_000).restorePurchaseNow().apply {
+        repo(lastProAt = System.currentTimeMillis() - 1_000).restorePurchaseNow().info.apply {
             isPro shouldBe true
             isSettled shouldBe true
         }
+    }
+
+    @Test fun `a Play error absorbed by grace is reported as inconclusive`() = runTest2 {
+        // Entitlement is unchanged (grace still keeps Pro), but the lookup never landed. Without
+        // this the UI can't tell it apart from a successful empty query and would tell a recent
+        // owner that Play was checked and had nothing.
+        val boom = RuntimeException("Play unavailable")
+        coEvery { billingManager.refresh() } throws boom
+
+        val outcome = repo(lastProAt = System.currentTimeMillis() - 1_000).restorePurchaseNow()
+
+        outcome.shouldBeInstanceOf<UpgradeRepoGplay.RestoreOutcome.Inconclusive>()
+        outcome.cause shouldBe boom
+        outcome.info.isPro shouldBe true
+    }
+
+    @Test fun `a successful empty query is reported as checked even when grace keeps pro`() = runTest2 {
+        // Mirror image of the test above: Play DID answer, so escalation copy is warranted.
+        coEvery { billingManager.refresh() } returns BillingData(emptySet())
+
+        val outcome = repo(lastProAt = System.currentTimeMillis() - 1_000).restorePurchaseNow()
+
+        outcome.shouldBeInstanceOf<UpgradeRepoGplay.RestoreOutcome.Checked>()
+        outcome.info.isPro shouldBe true
     }
 
     @Test fun `after a failure the seed settles before the data lands - accepted residual`() = runTest2 {

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingClientExtensionsTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingClientExtensionsTest.kt
@@ -1,0 +1,53 @@
+package eu.darken.sdmse.common.upgrade.core.billing.client
+
+import com.android.billingclient.api.Purchase
+import com.android.billingclient.api.Purchase.PurchaseState
+import eu.darken.sdmse.common.upgrade.core.OurSku
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class BillingClientExtensionsTest : BaseTest() {
+
+    @Test
+    fun `redacted keeps the diagnostic fields and drops the identifying ones`() {
+        val purchase = mockk<Purchase>().apply {
+            every { products } returns listOf(OurSku.Iap.PRO_UPGRADE.id)
+            every { purchaseState } returns PurchaseState.PURCHASED
+            every { isAcknowledged } returns true
+            every { isAutoRenewing } returns false
+            every { purchaseTime } returns 1234L
+        }
+
+        val rendered = purchase.redacted()
+
+        rendered shouldContain OurSku.Iap.PRO_UPGRADE.id
+        rendered shouldContain "acknowledged=true"
+        // Never touches the accessors that carry the token / order ID, so they cannot reach a
+        // support log even indirectly through toString().
+        rendered shouldNotContain "token"
+        rendered shouldNotContain "orderId"
+    }
+
+    @Test
+    fun `redacted never throws, so a diagnostic cannot break the billing path`() {
+        // These lambdas run on the billing path whenever a recording is active. A formatter that
+        // throws would replace a real billing result -- or a real billing exception -- with a
+        // diagnostics failure.
+        val hostile = mockk<Purchase>().apply {
+            every { products } throws RuntimeException("nope")
+        }
+
+        hostile.redacted() shouldContain "unreadable"
+        listOf(hostile).redacted() shouldContain "unreadable"
+    }
+
+    @Test
+    fun `an empty collection renders as empty, not as null`() {
+        emptyList<Purchase>().redacted() shouldBe "[]"
+    }
+}

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/ui/GplayUpgradeScreenTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/ui/GplayUpgradeScreenTest.kt
@@ -19,6 +19,7 @@ import eu.darken.sdmse.common.R as CommonR
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import eu.darken.sdmse.common.upgrade.core.OurSku
 import eu.darken.sdmse.common.upgrade.core.billing.SkuDetails
+import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.Test
@@ -531,6 +532,62 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_subscription_offer_body_no_trial))
             .assertCountEquals(1)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_subscription_offer_body)).assertCountEquals(0)
+    }
+
+    @Test
+    fun `the inconclusive dialog neither claims a check nor escalates`() {
+        // The whole point of splitting this off RestoreFailed: a non-answer must not assert that
+        // Play was checked, must not blame the account setup, and must not push toward support.
+        composeRule.setUpgradeContent { RestoreInconclusiveDialog() }
+
+        composeRule.onNodeWithText(
+            context.getString(R.string.upgrade_screen_restore_inconclusive_message),
+            substring = true,
+        ).assertExists()
+        composeRule.onNodeWithText(
+            context.getString(R.string.upgrade_screen_restore_sync_patience_hint),
+            substring = true,
+        ).assertExists()
+
+        composeRule.onAllNodesWithText(
+            context.getString(R.string.upgrade_screen_restore_checked_message),
+            substring = true,
+        ).assertCountEquals(0)
+        composeRule.onAllNodesWithText(
+            context.getString(R.string.upgrade_screen_restore_multiaccount_hint),
+            substring = true,
+        ).assertCountEquals(0)
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_contact_support_action))
+            .assertCountEquals(0)
+    }
+
+    @Test
+    fun `the inconclusive dialog offers a retry that fires the callback`() {
+        var retries = 0
+        composeRule.setUpgradeContent { RestoreInconclusiveDialog(onRetry = { retries++ }) }
+
+        composeRule.onNodeWithText(context.getString(CommonR.string.general_retry_action)).performClick()
+        composeRule.runOnIdle { retries shouldBe 1 }
+    }
+
+    @Test
+    fun `the empty-result dialog keeps the escalation path`() {
+        // Counterpart to the test above: here Play really did answer, so the multi-account hint and
+        // contact-support action remain warranted.
+        var supportTaps = 0
+        composeRule.setUpgradeContent { RestoreFailedDialog(onContactSupport = { supportTaps++ }) }
+
+        composeRule.onNodeWithText(
+            context.getString(R.string.upgrade_screen_restore_checked_message),
+            substring = true,
+        ).assertExists()
+        composeRule.onNodeWithText(
+            context.getString(R.string.upgrade_screen_restore_multiaccount_hint),
+            substring = true,
+        ).assertExists()
+
+        composeRule.onNodeWithText(context.getString(R.string.upgrade_screen_contact_support_action)).performClick()
+        composeRule.runOnIdle { supportTaps shouldBe 1 }
     }
 }
 

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/ui/GplayUpgradeViewModelTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/ui/GplayUpgradeViewModelTest.kt
@@ -215,10 +215,13 @@ class GplayUpgradeViewModelTest : BaseTest() {
         isSettled = true,
     )
 
+    /** Play answered. The default for restore mocks; use Inconclusive only to model a non-answer. */
+    private fun checked(info: UpgradeRepoGplay.Info) = UpgradeRepoGplay.RestoreOutcome.Checked(info)
+
     @Test
     fun `restore that finds a purchase emits RestoreSucceeded`() = runTest2(context = testDispatcher) {
         val repo = mockRepo()
-        coEvery { repo.restorePurchaseNow() } returns proInfo(mockPurchase("eu.darken.sdmse.iap.upgrade.pro"))
+        coEvery { repo.restorePurchaseNow() } returns checked(proInfo(mockPurchase("eu.darken.sdmse.iap.upgrade.pro")))
         val vm = buildVm(repo)
 
         val event = async { vm.events.first() }
@@ -233,7 +236,7 @@ class GplayUpgradeViewModelTest : BaseTest() {
         // The repo answers instantly here — the user must still see the check "run": the result
         // event may only surface once RESTORE_MIN_VISIBLE_MS elapsed.
         val repo = mockRepo()
-        coEvery { repo.restorePurchaseNow() } returns proInfo(mockPurchase("eu.darken.sdmse.iap.upgrade.pro"))
+        coEvery { repo.restorePurchaseNow() } returns checked(proInfo(mockPurchase("eu.darken.sdmse.iap.upgrade.pro")))
         val vm = buildVm(repo)
 
         val received = mutableListOf<UpgradeEvents>()
@@ -253,7 +256,7 @@ class GplayUpgradeViewModelTest : BaseTest() {
     @Test
     fun `restore with no purchase emits RestoreFailed`() = runTest2(context = testDispatcher) {
         val repo = mockRepo()
-        coEvery { repo.restorePurchaseNow() } returns UpgradeRepoGplay.Info(false, null, null)
+        coEvery { repo.restorePurchaseNow() } returns checked(UpgradeRepoGplay.Info(false, null, null))
         val vm = buildVm(repo)
 
         val event = async { vm.events.first() }
@@ -264,11 +267,14 @@ class GplayUpgradeViewModelTest : BaseTest() {
     }
 
     @Test
-    fun `restore that times out emits RestoreFailed`() = runTest2(context = testDispatcher) {
+    fun `restore that times out emits RestoreInconclusive not RestoreFailed`() = runTest2(context = testDispatcher) {
+        // A timeout proves nothing about ownership: the budget also covers connecting and the
+        // refresh mutex. RestoreFailed would assert a completed check and steer the user toward
+        // the multi-account explanation for what may just be a slow Play.
         val repo = mockRepo()
         coEvery { repo.restorePurchaseNow() } coAnswers {
             delay(30_000) // longer than the 15s restore timeout
-            UpgradeRepoGplay.Info(gracePeriod = true, billingData = null, isSettled = true)
+            checked(UpgradeRepoGplay.Info(gracePeriod = true, billingData = null, isSettled = true))
         }
         val vm = buildVm(repo)
 
@@ -276,7 +282,27 @@ class GplayUpgradeViewModelTest : BaseTest() {
         vm.restorePurchase()
         advanceUntilIdle()
 
-        event.await() shouldBe UpgradeEvents.RestoreFailed
+        event.await() shouldBe UpgradeEvents.RestoreInconclusive
+    }
+
+    @Test
+    fun `a Play error absorbed by grace emits RestoreInconclusive not RestoreFailed`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // Same non-answer as a timeout, and the affected user is by definition a recent owner --
+        // exactly who must not be told Play was checked and had nothing.
+        val repo = mockRepo()
+        coEvery { repo.restorePurchaseNow() } returns UpgradeRepoGplay.RestoreOutcome.Inconclusive(
+            UpgradeRepoGplay.Info(gracePeriod = true, billingData = null, isSettled = true),
+            RuntimeException("Play unavailable"),
+        )
+        val vm = buildVm(repo)
+
+        val event = async { vm.events.first() }
+        vm.restorePurchase()
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.RestoreInconclusive
     }
 
     @Test
@@ -332,7 +358,7 @@ class GplayUpgradeViewModelTest : BaseTest() {
         val repo = mockRepo()
         coEvery { repo.restorePurchaseNow() } coAnswers {
             delay(5_000)
-            UpgradeRepoGplay.Info(gracePeriod = true, billingData = null, isSettled = true)
+            checked(UpgradeRepoGplay.Info(gracePeriod = true, billingData = null, isSettled = true))
         }
         val vm = buildVm(repo)
 
@@ -347,7 +373,7 @@ class GplayUpgradeViewModelTest : BaseTest() {
     @Test
     fun `a finished restore allows a new attempt`() = runTest2(context = testDispatcher) {
         val repo = mockRepo()
-        coEvery { repo.restorePurchaseNow() } returns UpgradeRepoGplay.Info(false, null, null)
+        coEvery { repo.restorePurchaseNow() } returns checked(UpgradeRepoGplay.Info(false, null, null))
         val vm = buildVm(repo)
 
         vm.restorePurchase()
@@ -711,7 +737,7 @@ class GplayUpgradeViewModelTest : BaseTest() {
     fun `restore that only finds grace shows the troubleshooting dialog`() = runTest2(context = testDispatcher) {
         val repo = mockRepo()
         // Grace keeps isPro=true, but no actual purchase came back — not a restore success.
-        coEvery { repo.restorePurchaseNow() } returns UpgradeRepoGplay.Info(gracePeriod = true, billingData = null, isSettled = true)
+        coEvery { repo.restorePurchaseNow() } returns checked(UpgradeRepoGplay.Info(gracePeriod = true, billingData = null, isSettled = true))
         val vm = buildVm(repo)
 
         val event = async { vm.events.first() }


### PR DESCRIPTION
## What changed

The app no longer tells you it checked Google Play when it didn't.

If a restore doesn't get an answer, either because it timed out or because Play returned an error, you now get a "the check didn't finish" message with a Retry button. Previously you were told Play had been checked and your purchase wasn't found, along with advice about multiple Google accounts and a prompt to contact support. That wording still appears when Play genuinely answers and finds nothing, which is when the advice actually helps.

Debug logs now record whether this install ever confirmed a Pro purchase, which is the most useful single fact when someone reports a missing upgrade. Purchase tokens and order numbers no longer appear in those logs, which matters because people email them to support.

## Technical Context

- Root cause of the false "we checked Play" message: two paths produced a non-answer that was reported as a completed check. The 15s restore timeout covers connecting, the refresh mutex and both queries, so it proves nothing about ownership. A Play error absorbed by the grace period does the same, and is worse, because being in grace means the user is a recent owner.
- `Info(gracePeriod = true, billingData = null)` is produced *both* by a successful empty query and by a swallowed error, and those need opposite UI treatment. Provenance rides on a new `RestoreOutcome` wrapper rather than inside `Info`, so `isPro`, grace bookkeeping and cache writes are untouched. A grace-only result from a genuinely empty query still reports as a completed check.
- Chose a separate `UpgradeDiagnostics` binding over a method on `UpgradeRepo`: resolving `UpgradeRepo` from the recorder would construct `UpgradeRepoGplay` and `BillingManager` and start their AppScope collectors and connect loop. A resumed recorder runs inside `RecorderModule.init`, so enabling a recording would have changed when billing initializes.
- Why `lastProStateAt` and not the existing pro-state counters: `gplay.cache.lastProAt` shipped in v0.10.0-beta0, `stats.pro.state.last` only in v2.0.1-beta0. For any older install the counters can't distinguish "never bought" from "entitlement went missing".
- Logged the query-confirmed purchases inside `refreshPurchases()` rather than at the restore boundary, because `BillingManager.refresh()` returns the merged view, which deliberately retains a failed query type's previous purchases. Logging that as "what Play returned" would have produced the same false certainty this PR removes.
- `redacted()` cannot throw, by construction. Log lambdas are skipped only when there are zero receivers, not per-priority, so during a recording they evaluate on the billing path; a throwing formatter would replace a real billing result or exception with a diagnostics failure. An unguarded first version broke 49 tests.
- Behavioral side effect beyond the fix: dialog visibility moved to `rememberSaveable`, so the three pre-existing dialogs now survive rotation and process death where a consumed one-shot event was previously lost.
- Review guidance: the invariant worth checking is that no Pro calculation, grace window, cache write or purchase mapping behaves differently. `UpgradeRepoGplayTest` pins error-in-grace against empty-in-grace. Not covered: an assertion on the log line's text, since there's no log-capture helper and the underlying data distinction is already pinned by `BillingConnectionTest`.
