### PR TITLE
General: Handle Google Play offers that are no longer available

### DIFF
--- a/app-common/src/main/java/eu/darken/sdmse/common/upgrade/UpgradeRepoExtensions.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/upgrade/UpgradeRepoExtensions.kt
@@ -6,7 +6,6 @@ import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -20,12 +19,16 @@ suspend fun UpgradeRepo.isPro(): Boolean = upgradeInfo.first().isPro
  *
  * Deliberately generous — it prefers to fail open rather than block a paying user:
  * - Returns `true` immediately if we already know the user is Pro (active purchase or grace period).
- * - Otherwise nudges a billing [UpgradeRepo.refresh] and waits up to [timeout] for a Pro state to
- *   appear. This rescues a genuine Pro user from the GPlay cold-start race, where [UpgradeRepo.upgradeInfo]
- *   reports non-Pro until the billing connection settles.
- * - Only denies when billing settles within the window and still reports no purchase (the realistic
- *   "free user reached a Pro-only path via a UI mistake" case, where billing is already connected).
- * - On any error, fails open (returns `true`) — a billing hiccup must never block a paying user.
+ * - Otherwise nudges a billing [UpgradeRepo.refresh] and waits for a Pro state to appear. This
+ *   rescues a genuine Pro user from the GPlay cold-start race, where [UpgradeRepo.upgradeInfo]
+ *   reports non-Pro until the billing connection settles. [timeout] is the budget for the WHOLE
+ *   reconciliation (refresh round-trip plus wait), so a Play call that hangs can't stretch the gate
+ *   past it.
+ * - Only denies when the state after that window is settled, error-free and still reports no
+ *   purchase (the realistic "free user reached a Pro-only path via a UI mistake" case, where billing
+ *   is already connected).
+ * - Fails open (returns `true`) when the window elapses without billing settling, when the settled
+ *   state carries an error, and on any exception — a billing hiccup must never block a paying user.
  *
  * The FOSS flavor reads from a synchronous cache, so the fast path resolves immediately there.
  */
@@ -33,8 +36,25 @@ suspend fun UpgradeRepo.isProSettled(timeout: Duration = 5.seconds): Boolean = t
     if (upgradeInfo.first().isPro) {
         true
     } else {
-        refresh()
-        withTimeoutOrNull(timeout) { upgradeInfo.firstOrNull { it.isPro } != null } == true
+        // One budget for the WHOLE reconciliation: refresh + wait. Waiting only for isPro (not
+        // isSettled) is deliberate — replayed emissions are already settled, so a settled-predicate
+        // would return the stale pre-refresh state instead of the refresh outcome.
+        val proAppeared = withTimeoutOrNull(timeout) {
+            refresh()
+            upgradeInfo.first { it.isPro }
+            true
+        } == true
+        if (proAppeared) {
+            true
+        } else {
+            // Full window elapsed after the refresh started — the pipeline has caught up by now.
+            val current = upgradeInfo.first()
+            when {
+                current.error != null -> true   // settled error state: fail open
+                current.isSettled -> false      // settled and still no purchase: the documented deny
+                else -> true                    // never settled within the budget: documented fail-open
+            }
+        }
     }
 } catch (e: CancellationException) {
     // A cancelled caller must not continue down the Pro path via the fail-open below.

--- a/app-common/src/test/java/eu/darken/sdmse/common/backup/ConfigBackupManagerTest.kt
+++ b/app-common/src/test/java/eu/darken/sdmse/common/backup/ConfigBackupManagerTest.kt
@@ -10,7 +10,7 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
@@ -41,7 +41,10 @@ class ConfigBackupManagerTest : BaseTest() {
         override val storeSite = ""
         override val upgradeSite = ""
         override val betaSite = ""
-        override val upgradeInfo: Flow<UpgradeRepo.Info> = flowOf(FakeInfo(pro))
+
+        // Hot and never-completing, like the production repos: the pro gate waits for a pro state to
+        // appear, so a finite flow would complete the wait instead of exercising the timeout budget.
+        override val upgradeInfo: Flow<UpgradeRepo.Info> = MutableStateFlow(FakeInfo(pro))
         override suspend fun refresh() {}
     }
 

--- a/app-common/src/test/java/eu/darken/sdmse/common/upgrade/UpgradeRepoExtensionsTest.kt
+++ b/app-common/src/test/java/eu/darken/sdmse/common/upgrade/UpgradeRepoExtensionsTest.kt
@@ -4,6 +4,8 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.advanceTimeBy
@@ -13,6 +15,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import java.time.Instant
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.launch
 
 class UpgradeRepoExtensionsTest : BaseTest() {
@@ -20,19 +23,24 @@ class UpgradeRepoExtensionsTest : BaseTest() {
     private class FakeInfo(
         override val isPro: Boolean,
         override val isSettled: Boolean,
+        override val error: Throwable? = null,
     ) : UpgradeRepo.Info {
         override val type: UpgradeRepo.Type = UpgradeRepo.Type.FOSS
         override val upgradedAt: Instant? = null
-        override val error: Throwable? = null
     }
 
     private class FakeRepo(
         pro: Boolean,
         settled: Boolean,
+        error: Throwable? = null,
     ) : UpgradeRepo {
         // Settledness rides the Info itself — a single flow, like the production repos.
-        val infoFlow = MutableStateFlow<UpgradeRepo.Info>(FakeInfo(pro, settled))
+        val infoFlow = MutableStateFlow<UpgradeRepo.Info>(FakeInfo(pro, settled, error))
         var refreshCalls = 0
+
+        // What a refresh() round-trip does before returning: production ones can hang, publish a
+        // new Info a dispatcher turn later, or land in an error state.
+        var onRefresh: suspend FakeRepo.() -> Unit = {}
 
         override val storeSite: String = ""
         override val upgradeSite: String = ""
@@ -40,12 +48,121 @@ class UpgradeRepoExtensionsTest : BaseTest() {
         override val upgradeInfo: Flow<UpgradeRepo.Info> = infoFlow
         override suspend fun refresh() {
             refreshCalls++
+            onRefresh()
         }
 
-        fun settle(pro: Boolean) {
-            infoFlow.value = FakeInfo(pro, isSettled = true)
+        fun settle(pro: Boolean, error: Throwable? = null) {
+            infoFlow.value = FakeInfo(pro, isSettled = true, error = error)
         }
     }
+
+    // region isProSettled (backend gate)
+
+    @Test
+    fun `a known pro user resolves true without refreshing`() = runTest {
+        val repo = FakeRepo(pro = true, settled = false)
+
+        repo.isProSettled() shouldBe true
+
+        repo.refreshCalls shouldBe 0
+        currentTime shouldBe 0
+    }
+
+    @Test
+    fun `a pro state published after the refresh returned still counts`() = runTest {
+        // The refresh discovers the purchase, but the shared upgradeInfo pipeline publishes the new
+        // Info a dispatcher turn later. Waiting on a settled-predicate would have matched the
+        // replayed pre-refresh emission and denied a paying user.
+        val repo = FakeRepo(pro = false, settled = true)
+        repo.onRefresh = {
+            backgroundScope.launch { settle(pro = true) }
+        }
+
+        repo.isProSettled() shouldBe true
+    }
+
+    @Test
+    fun `a pro state appearing within the window resolves true`() = runTest {
+        val repo = FakeRepo(pro = false, settled = false)
+        backgroundScope.launch {
+            delay(500)
+            repo.settle(pro = true)
+        }
+
+        repo.isProSettled() shouldBe true
+        currentTime shouldBe 500
+    }
+
+    @Test
+    fun `a settled state without a purchase denies after the full window`() = runTest {
+        // The realistic "free user reached a Pro-only path" case — the only one that denies.
+        val repo = FakeRepo(pro = false, settled = true)
+
+        repo.isProSettled() shouldBe false
+        currentTime shouldBe 5_000
+    }
+
+    @Test
+    fun `billing that never settles fails open`() = runTest {
+        // Unsettled means "couldn't verify", which must not be turned into "not entitled".
+        val repo = FakeRepo(pro = false, settled = false)
+
+        repo.isProSettled() shouldBe true
+        currentTime shouldBe 5_000
+    }
+
+    @Test
+    fun `an initial settled error state fails open`() = runTest {
+        val repo = FakeRepo(pro = false, settled = true, error = IllegalStateException("billing broke"))
+
+        repo.isProSettled() shouldBe true
+    }
+
+    @Test
+    fun `an error published by the refresh fails open`() = runTest {
+        val repo = FakeRepo(pro = false, settled = false)
+        repo.onRefresh = { settle(pro = false, error = IllegalStateException("billing broke")) }
+
+        repo.isProSettled() shouldBe true
+    }
+
+    @Test
+    fun `a hanging refresh fails open within the supplied budget`() = runTest {
+        // The timeout covers refresh + wait: the old shape started the wait only AFTER an unbounded
+        // refresh, so a hanging Play call could park a task-submit gate far past the window.
+        val repo = FakeRepo(pro = false, settled = false)
+        repo.onRefresh = { awaitCancellation() }
+
+        repo.isProSettled(timeout = 2.seconds) shouldBe true
+        currentTime shouldBe 2_000
+    }
+
+    @Test
+    fun `cancellation during the reconciliation propagates instead of failing open`() = runTest {
+        val repo = FakeRepo(pro = false, settled = false)
+        repo.onRefresh = { awaitCancellation() }
+
+        val gate = async { repo.isProSettled() }
+        runCurrent()
+        gate.cancel()
+
+        shouldThrow<CancellationException> { gate.await() }
+    }
+
+    @Test
+    fun `isProSettled errors fail open`() = runTest {
+        val repo = object : UpgradeRepo {
+            override val storeSite: String = ""
+            override val upgradeSite: String = ""
+            override val betaSite: String = ""
+            override val upgradeInfo: Flow<UpgradeRepo.Info> get() = throw IllegalStateException("billing exploded")
+            override suspend fun refresh() = Unit
+        }
+
+        repo.isProSettled() shouldBe true
+    }
+
+    // endregion
 
     @Test
     fun `pro user resolves true without waiting`() = runTest {

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/AppCleanerTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/AppCleanerTest.kt
@@ -97,9 +97,12 @@ class AppCleanerTest : BaseTest() {
         val info = mockk<UpgradeRepo.Info>().apply {
             every { isPro } returns pro
             every { isSettled } returns true
+            every { error } returns null
         }
         return mockk<UpgradeRepo>(relaxed = true) {
-            every { upgradeInfo } returns flowOf(info)
+            // Hot and never-completing, like the production repos: the pro gate waits for a pro
+            // state to appear, so a finite flow would complete the wait instead of denying.
+            every { upgradeInfo } returns MutableStateFlow(info)
         }
     }
 

--- a/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/core/DeduplicatorTest.kt
+++ b/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/core/DeduplicatorTest.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -48,8 +49,11 @@ class DeduplicatorTest : BaseTest() {
         val info = mockk<UpgradeRepo.Info>()
         every { info.isPro } returns isPro
         every { info.isSettled } returns true
+        every { info.error } returns null
         val upgradeRepo = mockk<UpgradeRepo>(relaxed = true)
-        every { upgradeRepo.upgradeInfo } returns flowOf(info)
+        // Hot and never-completing, like the production repos: the pro gate waits for a pro state
+        // to appear, so a finite flow would complete the wait instead of denying.
+        every { upgradeRepo.upgradeInfo } returns MutableStateFlow(info)
         return Deduplicator(
             appScope = gateScope,
             gatewaySwitch = mockk(relaxed = true),

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/OfferUnavailableBillingException.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/OfferUnavailableBillingException.kt
@@ -1,0 +1,28 @@
+package eu.darken.sdmse.common.upgrade.core.billing
+
+import eu.darken.sdmse.R
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.error.HasLocalizedError
+import eu.darken.sdmse.common.error.LocalizedError
+
+/**
+ * Play can't sell us this product/offer right now: it was omitted from the product-details response,
+ * came back ambiguous (duplicate rows), or is reported as unavailable.
+ *
+ * This is a merchandising state (region, account eligibility, a withheld or revoked offer), NOT a
+ * defect on our side — so it must stay off the bug-report path and surface as user-facing copy
+ * instead of the raw NoSuchElementException/NPE that the strict `single`/`!!` lookups produced.
+ */
+class OfferUnavailableBillingException(
+    val sku: Sku,
+    val offer: Sku.Subscription.Offer?,
+) : BillingException(
+    "Google Play has no usable offer for ${sku.print()} (offer=${offer?.let { "${it.basePlanId}/${it.offerId}" }})",
+), HasLocalizedError {
+
+    override fun getLocalizedError(): LocalizedError = LocalizedError(
+        throwable = this,
+        label = R.string.upgrades_gplay_offer_unavailable_title.toCaString(),
+        description = R.string.upgrades_gplay_offer_unavailable_description.toCaString(),
+    )
+}

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/PurchasedSku.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/PurchasedSku.kt
@@ -1,7 +1,11 @@
 package eu.darken.sdmse.common.upgrade.core.billing
 
 import com.android.billingclient.api.Purchase
+import eu.darken.sdmse.common.upgrade.core.billing.client.redacted
 
 data class PurchasedSku(val sku: Sku, val purchase: Purchase) {
-    override fun toString(): String = "IAP(sku=$sku, purchase=${purchase.skus})"
+    // Purchase.skus is deprecated (superseded by products); redacted() is the log-safe renderer used
+    // everywhere else on this path — it adds the diagnostic fields (state, ack, renewal) while
+    // keeping purchase token and order ID out of debug recordings.
+    override fun toString(): String = "PurchasedSku(sku=$sku, purchase=${purchase.redacted()})"
 }

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingConnection.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingConnection.kt
@@ -3,13 +3,15 @@ package eu.darken.sdmse.common.upgrade.core.billing.client
 import android.app.Activity
 import com.android.billingclient.api.AcknowledgePurchaseParams
 import com.android.billingclient.api.BillingClient
+import com.android.billingclient.api.BillingClient.BillingResponseCode
 import com.android.billingclient.api.BillingFlowParams
 import com.android.billingclient.api.BillingResult
-import com.android.billingclient.api.ProductDetails
 import com.android.billingclient.api.Purchase
 import com.android.billingclient.api.Purchase.PurchaseState
 import com.android.billingclient.api.QueryProductDetailsParams
+import com.android.billingclient.api.QueryProductDetailsResult
 import com.android.billingclient.api.QueryPurchasesParams
+import com.android.billingclient.api.UnfetchedProduct
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
@@ -17,6 +19,7 @@ import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.flow.setupCommonEventHandlers
 import eu.darken.sdmse.common.upgrade.core.OurSku
 import eu.darken.sdmse.common.upgrade.core.billing.BillingManager.Companion.tryMapUserFriendly
+import eu.darken.sdmse.common.upgrade.core.billing.OfferUnavailableBillingException
 import eu.darken.sdmse.common.upgrade.core.billing.Sku
 import eu.darken.sdmse.common.upgrade.core.billing.SkuDetails
 import kotlinx.coroutines.CancellationException
@@ -358,15 +361,17 @@ class BillingConnection(
 
     suspend fun querySkus(vararg skus: Sku): Collection<SkuDetails> {
         log(TAG) { "querySkus(skus=${skus.joinToString { it.print() }})..." }
-        val productList = skus.map { sku ->
+        // Play answers per product, not per request entry: a duplicated request entry would make the
+        // exactly-one-match rule below ambiguous for no reason.
+        val requested = skus.distinctBy { it.id to it.type }
+        if (requested.size != skus.size) {
+            log(TAG, WARN) { "querySkus(): deduped duplicate request entries: ${skus.joinToString { it.print() }}" }
+        }
+
+        val productList = requested.map { sku ->
             QueryProductDetailsParams.Product.newBuilder().apply {
                 setProductId(sku.id)
-                setProductType(
-                    when (sku.type) {
-                        Sku.Type.IAP -> BillingClient.ProductType.INAPP
-                        Sku.Type.SUBSCRIPTION -> BillingClient.ProductType.SUBS
-                    }
-                )
+                setProductType(sku.playProductType)
             }.build()
         }
 
@@ -376,33 +381,70 @@ class BillingConnection(
 
         // Cancellable so the ViewModel's query timeout and flatMapLatest-based retry actually work:
         // with suspendCoroutine a missing Play callback kept the timeout suspended indefinitely.
-        val (result, details) = suspendCancellableCoroutine<Pair<BillingResult, Collection<ProductDetails>?>> { continuation ->
+        val (result, queryResult) = suspendCancellableCoroutine<Pair<BillingResult, QueryProductDetailsResult>> { continuation ->
             client.queryProductDetailsAsync(params) { result, queryResult ->
                 if (continuation.isActive) {
-                    continuation.resume(result to queryResult.productDetailsList) { _, _, _ -> }
+                    continuation.resume(result to queryResult) { _, _, _ -> }
                 }
             }
         }
+        val details = queryResult.productDetailsList.orEmpty()
+        val unfetched = queryResult.unfetchedProductList.orEmpty()
 
         log(TAG) {
-            "querySkus(skus=${skus.joinToString { it.print() }}): code=${result.responseCode}, debug=${result.debugMessage}), skuDetails=$details"
+            "querySkus(skus=${skus.joinToString { it.print() }}): code=${result.responseCode}, " +
+                "debug=${result.debugMessage}, skuDetails=$details, unfetched=${unfetched.printed()}"
         }
 
-        if (!result.isSuccess) throw BillingClientException(result)
-
-        if (details.isNullOrEmpty()) {
-            throw IllegalStateException("No details available for ${skus.joinToString { "${it.type}-${it.id}" }}")
-        }
-
-        return details
-            .groupBy { it.productId }
-            .mapNotNull { (key, details) ->
-                val sku = skus
-                    .single { it.id == key }
-                val detail = details.single { it.productId == sku.id }
-
-                SkuDetails(sku, detail)
+        if (!result.isSuccess) {
+            log(TAG, WARN) { "querySkus() failed: code=${result.responseCode}, message=${result.debugMessage}" }
+            val firstSku = requested.firstOrNull()
+            if (result.responseCode == BillingResponseCode.ITEM_UNAVAILABLE && firstSku != null) {
+                // Merchandising state (region, account eligibility, pulled product), not a defect:
+                // typed so the user gets copy instead of a bug report.
+                throw OfferUnavailableBillingException(firstSku, null)
             }
+            throw BillingClientException(result)
+        }
+
+        if (unfetched.isNotEmpty()) {
+            log(TAG, WARN) { "querySkus(): Play did not fetch ${unfetched.printed()}" }
+        }
+        // A malformed product ID is OUR configuration defect and stays on the reportable path. The
+        // merchandising statuses (product pulled, no eligible offer) are normal Play conditions and
+        // fall out of the per-sku matching below as OfferUnavailableBillingException.
+        unfetched
+            .firstOrNull { it.statusCode == UnfetchedProduct.StatusCode.INVALID_PRODUCT_ID_FORMAT }
+            ?.let { invalid ->
+                throw BillingClientException(
+                    BillingResult.newBuilder().apply {
+                        setResponseCode(BillingResponseCode.DEVELOPER_ERROR)
+                        setDebugMessage("Invalid product id format: ${invalid.productId} (${invalid.productType})")
+                    }.build()
+                )
+            }
+
+        val returned = details.groupBy { it.productId to it.productType }
+        val requestedKeys = requested.map { it.id to it.playProductType }.toSet()
+        returned.keys
+            .filterNot { it in requestedKeys }
+            .forEach { (id, type) -> log(TAG, WARN) { "querySkus(): skipping unrequested product $id ($type)" } }
+
+        // Iterating the REQUEST (not the response) is what makes an omitted sku visible at all:
+        // walking the returned groups only ever visits what Play chose to send.
+        return requested.map { sku ->
+            val matches = returned[sku.id to sku.playProductType].orEmpty()
+            // Exactly one, never "the first of several": a duplicate row means we can't tell which
+            // one Play meant, and guessing would sell the user a different product.
+            val detail = matches.singleOrNull()
+            if (detail == null) {
+                log(TAG, WARN) {
+                    "querySkus(): expected exactly 1 detail for ${sku.print()}, got ${matches.size} of $details"
+                }
+                throw OfferUnavailableBillingException(sku, null)
+            }
+            SkuDetails(sku, detail)
+        }
     }
 
     suspend fun launchBillingFlow(activity: Activity, sku: Sku, targetOffer: Sku.Subscription.Offer?): BillingResult {
@@ -411,14 +453,31 @@ class BillingConnection(
             requireNotNull(targetOffer) { "SUB skus require a target offer" }
         }
 
-        val data = querySkus(sku).single { it.sku == sku }
+        val skuDetails = querySkus(sku)
+        val data = skuDetails.singleOrNull { it.sku == sku }
+        if (data == null) {
+            log(TAG, WARN) { "launchBillingFlow(): no unique details for ${sku.print()} in $skuDetails" }
+            throw OfferUnavailableBillingException(sku, targetOffer)
+        }
 
         val params = BillingFlowParams.newBuilder().apply {
             val productDetail = BillingFlowParams.ProductDetailsParams.newBuilder().apply {
                 setProductDetails(data.details)
                 if (sku is Sku.Subscription && targetOffer != null) {
-                    val offer = data.details.subscriptionOfferDetails!!.single {
+                    // singleOrNull, not single: an absent offer (withheld/revoked) and an ambiguous
+                    // duplicate both mean we must not guess an offer token — the wrong one bills the
+                    // user at the wrong price.
+                    val offer = data.details.subscriptionOfferDetails?.singleOrNull {
                         targetOffer.matches(it)
+                    }
+                    if (offer == null) {
+                        log(TAG, WARN) {
+                            val available = data.details.subscriptionOfferDetails
+                                ?.map { "${it.basePlanId}/${it.offerId}" }
+                            "launchBillingFlow(): offer ${targetOffer.basePlanId}/${targetOffer.offerId} " +
+                                "unavailable for ${sku.print()}, available=$available"
+                        }
+                        throw OfferUnavailableBillingException(sku, targetOffer)
                     }
                     setOfferToken(offer.offerToken)
                 }
@@ -436,13 +495,32 @@ class BillingConnection(
         log(TAG) {
             "launchBillingFlow(sku=$sku): code=${result.responseCode}, message=${result.debugMessage}"
         }
-        if (!result.isSuccess) throw BillingClientException(result)
+        if (!result.isSuccess) {
+            // Same merchandising state as at query time, just reported by the launch instead: the
+            // product/offer isn't purchasable, which is not a defect worth reporting.
+            if (result.responseCode == BillingResponseCode.ITEM_UNAVAILABLE) {
+                throw OfferUnavailableBillingException(sku, targetOffer)
+            }
+            throw BillingClientException(result)
+        }
 
         return result
     }
 
     companion object {
         val TAG: String = logTag("Upgrade", "Gplay", "Billing", "ClientConnection")
+
+        // Play's product-type string for one of our SKUs. Part of the match key: a product ID alone
+        // is not unique across product types.
+        private val Sku.playProductType: String
+            get() = when (type) {
+                Sku.Type.IAP -> BillingClient.ProductType.INAPP
+                Sku.Type.SUBSCRIPTION -> BillingClient.ProductType.SUBS
+            }
+
+        // Log-friendly rendering of the products Play refused to fetch (no purchase data involved).
+        private fun Collection<UnfetchedProduct>.printed(): String =
+            joinToString(prefix = "[", postfix = "]") { "${it.productId}(${it.productType})=${it.statusCode}" }
 
         // Classifies event purchases by product type at ingestion, so a later per-type query can
         // authoritatively supersede them. Unknown products stay untyped (cleared only by a

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -17,6 +17,9 @@
     <string name="upgrades_gplay_network_error_title">Connection error</string>
     <string name="upgrades_gplay_network_error_description">Unable to connect to Google Play. Please check your internet connection and try again.</string>
 
+    <string name="upgrades_gplay_offer_unavailable_title">Offer unavailable</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play is currently not offering this upgrade option. Please try again later or check the Google Play Store.</string>
+
     <string name="upgrades_gplay_already_owned_error_title">Already purchased</string>
     <string name="upgrades_gplay_already_owned_error_description">Use the \"Restore purchase\" option to restore your purchase. If the issue persists, try clearing Google Play cache and restarting your device.</string>
 

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManagerTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManagerTest.kt
@@ -160,6 +160,22 @@ class BillingManagerTest : BaseTest() {
         verify(exactly = 1) { Bugs.report(any()) }
     }
 
+    @Test fun `an unavailable offer surfaces without a bug report`() = runTest2 {
+        // Play withholding a product or offer is a merchandising state, not a defect on our side:
+        // it must stay off the bug-report path (it is already a user-friendly BillingException).
+        val manager = manager(
+            connection().apply {
+                coEvery { launchBillingFlow(any(), any(), null) } throws
+                    OfferUnavailableBillingException(OurSku.Iap.PRO_UPGRADE, null)
+            }
+        )
+
+        shouldThrow<OfferUnavailableBillingException> {
+            manager.startIapFlow(mockk<Activity>(), OurSku.Iap.PRO_UPGRADE, null)
+        }
+        verify(exactly = 0) { Bugs.report(any()) }
+    }
+
     @Test fun `cancellation during the iap flow is neither reported nor mapped`() = runTest2 {
         val manager = manager(
             connection().apply {

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/billing/PurchasedSkuTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/billing/PurchasedSkuTest.kt
@@ -1,0 +1,35 @@
+package eu.darken.sdmse.common.upgrade.core.billing
+
+import com.android.billingclient.api.Purchase
+import com.android.billingclient.api.Purchase.PurchaseState
+import eu.darken.sdmse.common.upgrade.core.OurSku
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class PurchasedSkuTest : BaseTest() {
+
+    @Test fun `rendering a purchased sku keeps identifying purchase data out of logs`() {
+        // Debug recordings are attached to support emails: the purchase token and order ID must not
+        // travel with them, while the entitlement-diagnosis fields must.
+        val purchase = mockk<Purchase>().apply {
+            every { products } returns listOf(OurSku.Iap.PRO_UPGRADE.id)
+            every { purchaseState } returns PurchaseState.PURCHASED
+            every { isAcknowledged } returns true
+            every { isAutoRenewing } returns false
+            every { purchaseTime } returns 1_000L
+            every { purchaseToken } returns "SENTINEL-TOKEN"
+            every { orderId } returns "SENTINEL-ORDER"
+        }
+
+        val rendered = PurchasedSku(OurSku.Iap.PRO_UPGRADE, purchase).toString()
+
+        rendered shouldNotContain "SENTINEL-TOKEN"
+        rendered shouldNotContain "SENTINEL-ORDER"
+        rendered shouldContain OurSku.Iap.PRO_UPGRADE.id
+        rendered shouldContain "acknowledged=true"
+    }
+}

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingConnectionTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingConnectionTest.kt
@@ -1,15 +1,21 @@
 package eu.darken.sdmse.common.upgrade.core.billing.client
 
+import android.text.TextUtils
 import com.android.billingclient.api.AcknowledgePurchaseParams
 import com.android.billingclient.api.AcknowledgePurchaseResponseListener
 import com.android.billingclient.api.BillingClient
 import com.android.billingclient.api.BillingClient.BillingResponseCode
 import com.android.billingclient.api.BillingResult
+import com.android.billingclient.api.ProductDetails
+import com.android.billingclient.api.ProductDetailsResponseListener
 import com.android.billingclient.api.Purchase
 import com.android.billingclient.api.Purchase.PurchaseState
 import com.android.billingclient.api.PurchasesResponseListener
+import com.android.billingclient.api.QueryProductDetailsResult
 import com.android.billingclient.api.QueryPurchasesParams
+import com.android.billingclient.api.UnfetchedProduct
 import eu.darken.sdmse.common.upgrade.core.OurSku
+import eu.darken.sdmse.common.upgrade.core.billing.OfferUnavailableBillingException
 import eu.darken.sdmse.common.upgrade.core.billing.Sku
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldContainExactly
@@ -17,21 +23,46 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import io.mockk.verify
 import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.setMain
 import kotlinx.coroutines.withTimeoutOrNull
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.runTest2
 
 class BillingConnectionTest : BaseTest() {
+
+    @BeforeEach
+    fun setup() {
+        // launchBillingFlow() hops to the main thread (documented BillingClient contract) --
+        // unconfined so the hop resolves in place on the test thread.
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+        // BillingFlowParams' builders validate through android.text.TextUtils, whose JVM stub throws
+        // "not mocked". Give it its real semantics instead.
+        mockkStatic(TextUtils::class)
+        every { TextUtils.isEmpty(any()) } answers { firstArg<CharSequence?>().isNullOrEmpty() }
+    }
+
+    @AfterEach
+    fun teardown() {
+        Dispatchers.resetMain()
+        unmockkStatic(TextUtils::class)
+    }
 
     private fun purchase(
         time: Long,
@@ -510,6 +541,262 @@ class BillingConnectionTest : BaseTest() {
         }
 
         outcome shouldBe null
+    }
+
+    // endregion
+
+    // region querySkus + offer resolution
+
+    private fun productDetails(
+        id: String,
+        type: String = BillingClient.ProductType.INAPP,
+        offers: List<ProductDetails.SubscriptionOfferDetails>? = null,
+    ) = mockk<ProductDetails>(relaxed = true).apply {
+        every { productId } returns id
+        every { productType } returns type
+        every { subscriptionOfferDetails } returns offers
+    }
+
+    private fun offerDetails(
+        offer: Sku.Subscription.Offer,
+        token: String = "offer-token",
+    ) = mockk<ProductDetails.SubscriptionOfferDetails>(relaxed = true).apply {
+        every { basePlanId } returns offer.basePlanId
+        every { offerId } returns offer.offerId
+        every { offerToken } returns token
+    }
+
+    private fun unfetchedProduct(
+        id: String,
+        status: Int,
+        type: String = BillingClient.ProductType.SUBS,
+    ) = mockk<UnfetchedProduct>(relaxed = true).apply {
+        every { productId } returns id
+        every { statusCode } returns status
+        every { productType } returns type
+    }
+
+    private fun skuClient(
+        queryResponse: BillingResult = result(BillingResponseCode.OK),
+        details: List<ProductDetails> = emptyList(),
+        unfetched: List<UnfetchedProduct> = emptyList(),
+        launchResult: BillingResult = result(BillingResponseCode.OK),
+    ): BillingClient {
+        val queryResult = mockk<QueryProductDetailsResult>().apply {
+            every { productDetailsList } returns details
+            every { unfetchedProductList } returns unfetched
+        }
+        return mockk<BillingClient>().apply {
+            every { queryProductDetailsAsync(any(), any()) } answers {
+                secondArg<ProductDetailsResponseListener>().onProductDetailsResponse(queryResponse, queryResult)
+            }
+            every { launchBillingFlow(any(), any()) } returns launchResult
+        }
+    }
+
+    @Test fun `an OK response with no details is an offer problem, not a raw state exception`() = runTest2 {
+        val connection = BillingConnection(client = skuClient(details = emptyList()))
+
+        // Play omitting the product entirely used to surface as IllegalStateException -> bug report
+        // plus an unlocalized dialog.
+        shouldThrow<OfferUnavailableBillingException> {
+            connection.querySkus(OurSku.Iap.PRO_UPGRADE)
+        }.sku shouldBe OurSku.Iap.PRO_UPGRADE
+    }
+
+    @Test fun `a requested sku omitted from the response throws for that sku`() = runTest2 {
+        // Iterating the response instead of the request would silently return only the IAP details
+        // and never notice that the subscription is missing.
+        val connection = BillingConnection(
+            client = skuClient(details = listOf(productDetails(OurSku.Iap.PRO_UPGRADE.id))),
+        )
+
+        shouldThrow<OfferUnavailableBillingException> {
+            connection.querySkus(OurSku.Iap.PRO_UPGRADE, OurSku.Sub.PRO_UPGRADE)
+        }.sku shouldBe OurSku.Sub.PRO_UPGRADE
+    }
+
+    @Test fun `duplicate details for one requested sku are ambiguous, never guessed`() = runTest2 {
+        val connection = BillingConnection(
+            client = skuClient(
+                details = listOf(
+                    productDetails(OurSku.Iap.PRO_UPGRADE.id),
+                    productDetails(OurSku.Iap.PRO_UPGRADE.id),
+                ),
+            ),
+        )
+
+        shouldThrow<OfferUnavailableBillingException> {
+            connection.querySkus(OurSku.Iap.PRO_UPGRADE)
+        }.sku shouldBe OurSku.Iap.PRO_UPGRADE
+    }
+
+    @Test fun `an unrequested row is skipped and does not satisfy the omitted request`() = runTest2 {
+        val connection = BillingConnection(
+            client = skuClient(details = listOf(productDetails("some.other.product"))),
+        )
+
+        shouldThrow<OfferUnavailableBillingException> {
+            connection.querySkus(OurSku.Iap.PRO_UPGRADE)
+        }.sku shouldBe OurSku.Iap.PRO_UPGRADE
+    }
+
+    @Test fun `duplicate request entries are deduped instead of failing`() = runTest2 {
+        val connection = BillingConnection(
+            client = skuClient(details = listOf(productDetails(OurSku.Iap.PRO_UPGRADE.id))),
+        )
+
+        val details = connection.querySkus(OurSku.Iap.PRO_UPGRADE, OurSku.Iap.PRO_UPGRADE)
+
+        details.map { it.sku } shouldBe listOf(OurSku.Iap.PRO_UPGRADE)
+    }
+
+    @Test fun `ITEM_UNAVAILABLE at query time maps to the offer problem`() = runTest2 {
+        val connection = BillingConnection(
+            client = skuClient(queryResponse = result(BillingResponseCode.ITEM_UNAVAILABLE)),
+        )
+
+        shouldThrow<OfferUnavailableBillingException> {
+            connection.querySkus(OurSku.Sub.PRO_UPGRADE)
+        }.sku shouldBe OurSku.Sub.PRO_UPGRADE
+    }
+
+    @Test fun `other query failures keep the generic client exception`() = runTest2 {
+        val connection = BillingConnection(client = skuClient(queryResponse = result(BillingResponseCode.ERROR)))
+
+        shouldThrow<BillingClientException> { connection.querySkus(OurSku.Iap.PRO_UPGRADE) }
+    }
+
+    @Test fun `an unfetched merchandising status surfaces as an offer problem`() = runTest2 {
+        val connection = BillingConnection(
+            client = skuClient(
+                unfetched = listOf(
+                    unfetchedProduct(OurSku.Sub.PRO_UPGRADE.id, UnfetchedProduct.StatusCode.NO_ELIGIBLE_OFFER),
+                ),
+            ),
+        )
+
+        shouldThrow<OfferUnavailableBillingException> {
+            connection.querySkus(OurSku.Sub.PRO_UPGRADE)
+        }.sku shouldBe OurSku.Sub.PRO_UPGRADE
+    }
+
+    @Test fun `an invalid product id format stays on the reportable path`() = runTest2 {
+        // Our own configuration defect: this one SHOULD reach the bug report, unlike the
+        // merchandising states.
+        val connection = BillingConnection(
+            client = skuClient(
+                unfetched = listOf(
+                    unfetchedProduct(
+                        OurSku.Sub.PRO_UPGRADE.id,
+                        UnfetchedProduct.StatusCode.INVALID_PRODUCT_ID_FORMAT,
+                    ),
+                ),
+            ),
+        )
+
+        shouldThrow<BillingClientException> {
+            connection.querySkus(OurSku.Sub.PRO_UPGRADE)
+        }.result.responseCode shouldBe BillingResponseCode.DEVELOPER_ERROR
+    }
+
+    @Test fun `a withheld offer at launch time is an offer problem, not a NoSuchElement`() = runTest2 {
+        // Play returns the subscription but not the offer we want (revoked/withheld): the strict
+        // single() used to blow up with an unmapped NoSuchElementException.
+        val connection = BillingConnection(
+            client = skuClient(
+                details = listOf(
+                    productDetails(
+                        id = OurSku.Sub.PRO_UPGRADE.id,
+                        type = BillingClient.ProductType.SUBS,
+                        offers = listOf(offerDetails(OurSku.Sub.PRO_UPGRADE.BASE_OFFER)),
+                    ),
+                ),
+            ),
+        )
+
+        val error = shouldThrow<OfferUnavailableBillingException> {
+            connection.launchBillingFlow(
+                activity = mockk(),
+                sku = OurSku.Sub.PRO_UPGRADE,
+                targetOffer = OurSku.Sub.PRO_UPGRADE.TRIAL_OFFER,
+            )
+        }
+        error.sku shouldBe OurSku.Sub.PRO_UPGRADE
+        error.offer shouldBe OurSku.Sub.PRO_UPGRADE.TRIAL_OFFER
+    }
+
+    @Test fun `duplicate offer rows at launch time are ambiguous, never guessed`() = runTest2 {
+        val connection = BillingConnection(
+            client = skuClient(
+                details = listOf(
+                    productDetails(
+                        id = OurSku.Sub.PRO_UPGRADE.id,
+                        type = BillingClient.ProductType.SUBS,
+                        offers = listOf(
+                            offerDetails(OurSku.Sub.PRO_UPGRADE.BASE_OFFER, token = "token-a"),
+                            offerDetails(OurSku.Sub.PRO_UPGRADE.BASE_OFFER, token = "token-b"),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        shouldThrow<OfferUnavailableBillingException> {
+            connection.launchBillingFlow(
+                activity = mockk(),
+                sku = OurSku.Sub.PRO_UPGRADE,
+                targetOffer = OurSku.Sub.PRO_UPGRADE.BASE_OFFER,
+            )
+        }.offer shouldBe OurSku.Sub.PRO_UPGRADE.BASE_OFFER
+    }
+
+    @Test fun `a missing subscriptionOfferDetails list at launch time is an offer problem`() = runTest2 {
+        val connection = BillingConnection(
+            client = skuClient(
+                details = listOf(
+                    productDetails(
+                        id = OurSku.Sub.PRO_UPGRADE.id,
+                        type = BillingClient.ProductType.SUBS,
+                        offers = null,
+                    ),
+                ),
+            ),
+        )
+
+        shouldThrow<OfferUnavailableBillingException> {
+            connection.launchBillingFlow(
+                activity = mockk(),
+                sku = OurSku.Sub.PRO_UPGRADE,
+                targetOffer = OurSku.Sub.PRO_UPGRADE.BASE_OFFER,
+            )
+        }
+    }
+
+    @Test fun `ITEM_UNAVAILABLE from the launch result maps to the offer problem`() = runTest2 {
+        val connection = BillingConnection(
+            client = skuClient(
+                details = listOf(productDetails(OurSku.Iap.PRO_UPGRADE.id)),
+                launchResult = result(BillingResponseCode.ITEM_UNAVAILABLE),
+            ),
+        )
+
+        shouldThrow<OfferUnavailableBillingException> {
+            connection.launchBillingFlow(mockk(), OurSku.Iap.PRO_UPGRADE, null)
+        }.sku shouldBe OurSku.Iap.PRO_UPGRADE
+    }
+
+    @Test fun `other launch failures keep the generic client exception`() = runTest2 {
+        val connection = BillingConnection(
+            client = skuClient(
+                details = listOf(productDetails(OurSku.Iap.PRO_UPGRADE.id)),
+                launchResult = result(BillingResponseCode.DEVELOPER_ERROR),
+            ),
+        )
+
+        shouldThrow<BillingClientException> {
+            connection.launchBillingFlow(mockk(), OurSku.Iap.PRO_UPGRADE, null)
+        }
     }
 
     // endregion

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingConnectionTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingConnectionTest.kt
@@ -566,6 +566,12 @@ class BillingConnectionTest : BaseTest() {
         every { offerToken } returns token
     }
 
+    // Play's QueryProductDetailsParams rejects a product list that mixes INAPP and SUBS, so an
+    // "omitted sku" fixture needs a second sku of the SAME type as the one Play does answer with.
+    private object OtherIap : Sku.Iap {
+        override val id: String = "eu.darken.sdmse.iap.other"
+    }
+
     private fun unfetchedProduct(
         id: String,
         status: Int,
@@ -605,15 +611,15 @@ class BillingConnectionTest : BaseTest() {
     }
 
     @Test fun `a requested sku omitted from the response throws for that sku`() = runTest2 {
-        // Iterating the response instead of the request would silently return only the IAP details
-        // and never notice that the subscription is missing.
+        // Iterating the response instead of the request would silently return only the details Play
+        // did send and never notice that the second requested sku is missing.
         val connection = BillingConnection(
             client = skuClient(details = listOf(productDetails(OurSku.Iap.PRO_UPGRADE.id))),
         )
 
         shouldThrow<OfferUnavailableBillingException> {
-            connection.querySkus(OurSku.Iap.PRO_UPGRADE, OurSku.Sub.PRO_UPGRADE)
-        }.sku shouldBe OurSku.Sub.PRO_UPGRADE
+            connection.querySkus(OurSku.Iap.PRO_UPGRADE, OtherIap)
+        }.sku shouldBe OtherIap
     }
 
     @Test fun `duplicate details for one requested sku are ambiguous, never guessed`() = runTest2 {


### PR DESCRIPTION
## What changed

If Google Play couldn't offer the exact product or trial the app asked for — for example a trial offer that was withdrawn between opening the upgrade screen and tapping buy, or a product temporarily unavailable in a region — the purchase attempt ended in a crash-style error dialog. It now shows a clear "Offer unavailable" message and nothing gets reported as an app error.

Additionally, the internal Pro check that guards Pro-only actions no longer risks blocking a paying user when Google Play is slow to respond: it now fails open in that situation, and its total wait time is properly capped.

## Technical Context

- Root cause 1: four strict `single`/`!!` lookups in the offer/product resolution turned normal Play merchandising states (withheld offer, duplicate offer row, omitted product) into unmapped exceptions on the bug-report path. They're now typed as a localized `OfferUnavailableBillingException`; `querySkus` iterates the *requested* skus so an omitted product is detected at all (iterating the response can't see what Play didn't send), and Billing 8.3's `unfetchedProductList` statuses split merchandising states from configuration defects (`INVALID_PRODUCT_ID_FORMAT` stays loudly reportable).
- Root cause 2: `isProSettled()` denied on an unsettled timeout despite documenting settle-based denial, and its refresh ran outside the advertised timeout (~35s worst case). The redesign puts refresh + wait on one budget and deliberately waits on `isPro` only — a settled-state predicate would consume the stale replayed emission right after `refresh()` and make the refresh decorative. The post-window decision: settled error → allow, settled non-Pro → deny, never settled → allow.
- Non-obvious side effect: tests expressing "definitely free user" must mock `upgradeInfo` as a **hot, settled** flow now — a finite `flowOf` completes the wait and trips the fail-open path (production is unaffected; both implementations end in `shareIn`). One existing fixture needed this treatment.
- Review guidance: the `querySkus` rewrite changes per-call semantics from partial results to all-or-nothing per requested sku — callers query product types separately, so partial-offer rendering in the UI is unaffected; the comment block in `querySkus` documents the exactly-one matching rule.
- Manual release-gate addition: disable the trial offer in Play Console, attempt the trial purchase → localized "Offer unavailable" dialog, no crash, no bug report.
