### PR TITLE
General: Improve screen reader support for the main dashboard button

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -22,6 +22,7 @@
     "jvm-tools@claude-code-cafe": true,
     "frontend-design@claude-plugins-official": true,
     "kotlin-lsp@claude-plugins-official": true,
-    "support-investigator@claude-code-cafe": true
+    "support-investigator@claude-code-cafe": true,
+    "devtools@claude-code-cafe": true
   }
 }

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardBottomBar.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardBottomBar.kt
@@ -49,7 +49,10 @@ import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
@@ -430,6 +433,7 @@ private fun MainActionFab(
                 .fillMaxSize()
                 .combinedClickable(
                     enabled = enabled && actionState != BottomBarState.Action.WORKING,
+                    role = Role.Button,
                     onClick = onClick,
                     onLongClick = onLongClick,
                 ),
@@ -451,7 +455,10 @@ private fun MainActionFab(
                     contentDescription = stringResource(R.string.dashboard_settings_oneclick_tools_title),
                 )
 
-                BottomBarState.Action.WORKING -> Unit
+                BottomBarState.Action.WORKING -> {
+                    val workingLabel = stringResource(R.string.widget_home_working)
+                    Box(Modifier.semantics { contentDescription = workingLabel })
+                }
 
                 BottomBarState.Action.WORKING_CANCELABLE -> Icon(
                     painter = painterResource(UiR.drawable.ic_cancel),


### PR DESCRIPTION
## What changed

The big scan/delete button on the dashboard now works properly with screen readers: it announces itself as a button, and while SD Maid is busy it reads "Working…" instead of being an unlabeled element. This also helps accessibility-based automation tools (e.g. Tasker with AutoInput) find the button again after the UI redesign.

Also enables the devtools plugin in the checked-in assistant settings (repo tooling only, no app change).

## Technical Context

- Root cause: the main action FAB is a `Box` with `combinedClickable` and an icon-only child. No `role` was set, so the merged semantics node reported the generic `android.view.View` class, and the WORKING state renders no icon at all, leaving the clickable node without any label.
- Fix: pass `role = Role.Button` to `combinedClickable` and give the WORKING branch a merged `contentDescription`.
- The WORKING label reuses the already-translated `widget_home_working` string ("Working…") instead of introducing a new string that would start untranslated in all locales.
- Surfaced by a support report: a Tasker/AutoInput setup could no longer target the scan button after the Compose redesign, since the button's content description is the only property accessibility clients can match on (no view IDs in Compose, no visible text).
