### PR TITLE
General: Don't block Pro users when Google Play answers late

### DIFF
--- a/app-common/src/main/java/eu/darken/sdmse/common/upgrade/UpgradeRepoExtensions.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/upgrade/UpgradeRepoExtensions.kt
@@ -50,6 +50,7 @@ suspend fun UpgradeRepo.isProSettled(timeout: Duration = 5.seconds): Boolean = t
             // Full window elapsed after the refresh started — the pipeline has caught up by now.
             val current = upgradeInfo.first()
             when {
+                current.isPro -> true           // pro landed as the window closed: never deny a known pro
                 current.error != null -> true   // settled error state: fail open
                 current.isSettled -> false      // settled and still no purchase: the documented deny
                 else -> true                    // never settled within the budget: documented fail-open

--- a/app-common/src/test/java/eu/darken/sdmse/common/upgrade/UpgradeRepoExtensionsTest.kt
+++ b/app-common/src/test/java/eu/darken/sdmse/common/upgrade/UpgradeRepoExtensionsTest.kt
@@ -127,6 +127,21 @@ class UpgradeRepoExtensionsTest : BaseTest() {
     }
 
     @Test
+    fun `a pro state published by a hanging refresh still resolves true`() = runTest {
+        // The refresh publishes the purchase to the pipeline but its round-trip never returns, so
+        // the isPro wait (which only starts after refresh()) never runs: the post-window read is
+        // the only place that can see the pro state — it must honor it, not deny off isSettled.
+        val repo = FakeRepo(pro = false, settled = true)
+        repo.onRefresh = {
+            settle(pro = true)
+            awaitCancellation()
+        }
+
+        repo.isProSettled() shouldBe true
+        currentTime shouldBe 5_000
+    }
+
+    @Test
     fun `a hanging refresh fails open within the supplied budget`() = runTest {
         // The timeout covers refresh + wait: the old shape started the wait only AFTER an unbounded
         // refresh, so a hanging Play call could park a task-submit gate far past the window.

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplay.kt
@@ -41,7 +41,6 @@ import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.flow.runningReduce
 import kotlinx.coroutines.flow.shareIn
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeoutOrNull
@@ -204,15 +203,6 @@ class UpgradeRepoGplay @Inject constructor(
     // self-healing Play blips never surface it.
     val proUnconfirmedSince: Flow<Long> = billingCache.proUnconfirmedSince.flow
         .distinctUntilChanged()
-
-    fun launchBillingFlow(
-        activity: Activity,
-        sku: Sku,
-        offer: Sku.Subscription.Offer?,
-        onError: (Throwable) -> Unit,
-    ) {
-        scope.launch { launchBillingFlowInternal(activity, sku, offer, onError) }
-    }
 
     // Suspends until the Play launch resolved (sheet up, or failed) — callers holding an
     // in-progress guard (e.g. the IAP verification single-flight) stay guarded through the

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
@@ -340,9 +340,9 @@ class UpgradeViewModel @Inject constructor(
         launch {
             if (!acquireOp(BusyOp.SUBSCRIPTION)) return@launch
             try {
-                // launchBillingFlowNow, not the fire-and-forget launchBillingFlow: the guard has to
-                // cover the whole tap-to-sheet window. The flow itself still runs on AppScope, so
-                // closing the screen mid-launch doesn't abort the purchase.
+                // launchBillingFlowNow suspends until the launch resolved, so the guard covers the
+                // whole tap-to-sheet window. The flow itself still runs on AppScope, so closing the
+                // screen mid-launch doesn't abort the purchase.
                 upgradeRepo.launchBillingFlowNow(
                     activity,
                     OurSku.Sub.PRO_UPGRADE,

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplayTest.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
@@ -98,6 +99,13 @@ class UpgradeRepoGplayTest : BaseTest() {
     }
 
     private fun result(code: Int): BillingResult = BillingResult.newBuilder().setResponseCode(code).build()
+
+    // Starts a launch without blocking the test body: launchBillingFlowNow suspends until the
+    // launch resolved, but these tests drive gates/async events while it is in flight. The
+    // Unconfined scope keeps the old eager semantics (runs until the first real suspension).
+    private fun UpgradeRepoGplay.startLaunch(onError: (Throwable) -> Unit = {}) {
+        scope.launch { launchBillingFlowNow(mockk<Activity>(), OurSku.Iap.PRO_UPGRADE, null, onError) }
+    }
 
     private fun proPurchase() = mockk<Purchase>().apply {
         every { products } returns OurSku.PRO_SKUS.map { it.id }
@@ -311,7 +319,7 @@ class UpgradeRepoGplayTest : BaseTest() {
         coEvery { billingManager.refresh() } returns BillingData(setOf(proPurchase()))
 
         val errors = mutableListOf<Throwable>()
-        repo(lastProAt = 0L).launchBillingFlow(mockk<Activity>(), OurSku.Iap.PRO_UPGRADE, null) { errors.add(it) }
+        repo(lastProAt = 0L).startLaunch { errors.add(it) }
 
         errors shouldBe emptyList()
     }
@@ -323,7 +331,7 @@ class UpgradeRepoGplayTest : BaseTest() {
 
         val errors = mutableListOf<Throwable>()
         // Grace expired -> the restore can't rescue the entitlement either.
-        repo(lastProAt = 0L).launchBillingFlow(mockk<Activity>(), OurSku.Iap.PRO_UPGRADE, null) { errors.add(it) }
+        repo(lastProAt = 0L).startLaunch { errors.add(it) }
 
         errors.single().shouldBeInstanceOf<ItemAlreadyOwnedBillingException>()
     }
@@ -334,7 +342,7 @@ class UpgradeRepoGplayTest : BaseTest() {
         coEvery { billingManager.refresh() } throws RuntimeException("Play unavailable")
 
         val errors = mutableListOf<Throwable>()
-        repo(lastProAt = 0L).launchBillingFlow(mockk<Activity>(), OurSku.Iap.PRO_UPGRADE, null) { errors.add(it) }
+        repo(lastProAt = 0L).startLaunch { errors.add(it) }
 
         errors.single().shouldBeInstanceOf<ItemAlreadyOwnedBillingException>()
     }
@@ -344,7 +352,7 @@ class UpgradeRepoGplayTest : BaseTest() {
             UserCanceledBillingException(RuntimeException("launch result"))
 
         val errors = mutableListOf<Throwable>()
-        repo(lastProAt = 0L).launchBillingFlow(mockk<Activity>(), OurSku.Iap.PRO_UPGRADE, null) { errors.add(it) }
+        repo(lastProAt = 0L).startLaunch { errors.add(it) }
 
         errors shouldBe emptyList()
     }
@@ -354,7 +362,7 @@ class UpgradeRepoGplayTest : BaseTest() {
         coEvery { billingManager.startIapFlow(any(), any(), null) } throws CancellationException("scope died")
 
         val errors = mutableListOf<Throwable>()
-        repo(lastProAt = 0L).launchBillingFlow(mockk<Activity>(), OurSku.Iap.PRO_UPGRADE, null) { errors.add(it) }
+        repo(lastProAt = 0L).startLaunch { errors.add(it) }
 
         errors shouldBe emptyList()
     }
@@ -364,7 +372,7 @@ class UpgradeRepoGplayTest : BaseTest() {
         coEvery { billingManager.startIapFlow(any(), any(), null) } throws failure
 
         val errors = mutableListOf<Throwable>()
-        repo(lastProAt = 0L).launchBillingFlow(mockk<Activity>(), OurSku.Iap.PRO_UPGRADE, null) { errors.add(it) }
+        repo(lastProAt = 0L).startLaunch { errors.add(it) }
 
         errors.single() shouldBe failure
     }
@@ -539,7 +547,7 @@ class UpgradeRepoGplayTest : BaseTest() {
         // Grace is active: the restore's Info reports isPro=true, but no actual purchase came
         // back — the entitlement Play claims is owned is still missing, so the dialog must show.
         repo(lastProAt = System.currentTimeMillis() - 1_000)
-            .launchBillingFlow(mockk<Activity>(), OurSku.Iap.PRO_UPGRADE, null) { errors.add(it) }
+            .startLaunch { errors.add(it) }
 
         errors.single().shouldBeInstanceOf<ItemAlreadyOwnedBillingException>()
     }
@@ -555,7 +563,7 @@ class UpgradeRepoGplayTest : BaseTest() {
 
         val errors = mutableListOf<Throwable>()
         // The restore found the SUB, but Play claimed the IAP is owned — not reconciled.
-        repo(lastProAt = 0L).launchBillingFlow(mockk<Activity>(), OurSku.Iap.PRO_UPGRADE, null) { errors.add(it) }
+        repo(lastProAt = 0L).startLaunch { errors.add(it) }
 
         errors.single().shouldBeInstanceOf<ItemAlreadyOwnedBillingException>()
     }
@@ -596,7 +604,7 @@ class UpgradeRepoGplayTest : BaseTest() {
         val repo = repo(lastProAt = 0L, purchaseFailureFlow = asyncFailures)
 
         // Trigger 1: a buy tap whose launch result comes back ITEM_ALREADY_OWNED.
-        repo.launchBillingFlow(mockk<Activity>(), OurSku.Iap.PRO_UPGRADE, null) { errors.add(it) }
+        repo.startLaunch { errors.add(it) }
         repo.autoRestoreBusy.first() shouldBe true
 
         // Trigger 2: Play's async already-owned event lands while that restore is still in flight.
@@ -874,7 +882,7 @@ class UpgradeRepoGplayTest : BaseTest() {
         val repo = repo(lastProAt = 0L)
         repo.autoRestoreBusy.first() shouldBe false
 
-        repo.launchBillingFlow(mockk<Activity>(), OurSku.Iap.PRO_UPGRADE, null) { }
+        repo.startLaunch()
         repo.autoRestoreBusy.first() shouldBe true
 
         gate.complete(Unit)


### PR DESCRIPTION
## What changed

No user-facing behavior change in practice. A rare timing edge in the Pro check could briefly treat a paying user as free even though their purchase had just been confirmed; the check now always honors a purchase it can see. Also removes an internal purchase-launch helper that no longer had any callers.

## Technical Context

Follow-ups from reviewing the recent billing hardening batch.

- `isProSettled`'s post-window read only inspected `error` and `isSettled`, so an Info already reporting `isPro = true` (a refresh outcome published to the pipeline while the round-trip itself hung, or landing just as the timeout fired) was denied off its settledness. The deny branch now re-checks `isPro` first, matching the gate's documented "never deny a paying user" contract. Pinned by a test where a hanging refresh publishes the purchase before the window closes.
- The fire-and-forget `launchBillingFlow` lost its last production caller in the single-flight rework (all ViewModel paths go through `launchBillingFlowNow`), leaving it test-only surface. `UpgradeRepoGplayTest` keeps its non-blocking shape via a local `startLaunch` helper that launches `launchBillingFlowNow` on the test's Unconfined scope — identical eager semantics, since the wrapper was just `scope.launch` around the same internal.
