### PR TITLE
General: Fix the dashboard cleanup button appearing to do nothing

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionEngine.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionEngine.kt
@@ -44,6 +44,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.updateAndGet
 import kotlinx.coroutines.launch
 import java.time.Instant
 import kotlin.time.Duration.Companion.minutes
@@ -101,6 +102,20 @@ class DashboardMainActionEngine(
 
     /** In-flight main-action cleanup branches; the freed hero stays hidden until this reaches 0. */
     private val pendingMainCleanup = MutableStateFlow(0)
+
+    /**
+     * Whether the current cleanup actually submitted a deletion task, regardless of how much it
+     * freed. Distinguishes "ran and freed nothing" (worth telling the user about) from "every
+     * branch opted out or upsold instead", which produces no result by design.
+     */
+    private val cleanupRan = MutableStateFlow(false)
+
+    /**
+     * Whether any branch of the current cleanup failed or was cancelled. Such a run did not
+     * "finish with nothing to free" — the user gets an error dialog, or stopped it themselves —
+     * so the zero-result card must stay away and not contradict that.
+     */
+    private val cleanupFailed = MutableStateFlow(false)
 
     /** While [discardResults] clears the tools one by one, suppress the hero so it never shows partial data. */
     private val discarding = MutableStateFlow(false)
@@ -189,8 +204,10 @@ class DashboardMainActionEngine(
         val queuedTasks = taskState.tasks.filter { it.isQueued }.size
         // Post-scan "will be freed" takes priority; otherwise, once the action has settled, show the
         // "freed" result of the last main-action deletion/one-click. While working, both stay hidden
-        // and the bar carries progress.
-        val freeable = if (actionState == BottomBarState.Action.DELETE) {
+        // and the bar carries progress. [pendingCleanup] gates this too, not just [settled]: the
+        // task manager reports idle again before the branches fold in their results, and without
+        // the gate the identical "can be freed" card flashes in that window.
+        val freeable = if (actionState == BottomBarState.Action.DELETE && pendingCleanup == 0) {
             buildHeroSummary(
                 corpse = corpseState.data,
                 system = filterState.data,
@@ -203,7 +220,10 @@ class DashboardMainActionEngine(
         } else {
             null
         }
-        val heroSummary = (freeable ?: freed?.takeIf { taskState.isIdle && pendingCleanup == 0 })
+        val settled = freed?.takeIf { taskState.isIdle && pendingCleanup == 0 }
+        // A cleanup that freed nothing outranks [freeable]: the data survived, so FREEABLE rebuilds
+        // identically and would bury the fact that the deletion ran at all.
+        val heroSummary = (settled?.takeIf { it.mode == HeroSummary.Mode.NOTHING_FREED } ?: freeable ?: settled)
             .takeIf { !isDiscarding }
         BottomBarState(
             isReady = listReady,
@@ -278,11 +298,49 @@ class DashboardMainActionEngine(
     // Runs one main-action tool branch and, for cleanups, decrements the pending counter when it
     // settles — so the freed hero only appears once *all* branches are done (no partial flash).
     private fun launchMainBranch(isCleanup: Boolean, block: suspend () -> Unit) = scope.launch {
+        var failed = false
         try {
             block()
+        } catch (e: Throwable) {
+            // Cancellation counts too: a run the user stopped did not "finish".
+            failed = true
+            throw e
         } finally {
-            if (isCleanup) pendingMainCleanup.update { (it - 1).coerceAtLeast(0) }
+            if (isCleanup) {
+                if (failed) cleanupFailed.value = true
+                val remaining = pendingMainCleanup.updateAndGet { (it - 1).coerceAtLeast(0) }
+                // Last branch home. A cleanup that ran but freed nothing leaves the tools' data
+                // untouched, so the identical "can be freed" card would just re-render and the
+                // whole thing reads as "the button did nothing". Say so instead.
+                if (remaining == 0 && cleanupRan.value && !cleanupFailed.value) {
+                    val nothingFreed = HeroSummary(
+                        mode = HeroSummary.Mode.NOTHING_FREED,
+                        totalSize = 0L,
+                        itemCount = 0,
+                        tools = emptyList(),
+                        timestamp = Instant.now(),
+                    )
+                    // Fold rather than assign: a result arriving from an overlapping cleanup must
+                    // win over this placeholder, never be clobbered by it. The lambda stays pure —
+                    // `update` retries it on contention.
+                    val applied = freedResult.updateAndGet { current -> current ?: nothingFreed }
+                    if (applied === nothingFreed) log(TAG, INFO) { "Cleanup finished without freeing anything." }
+                }
+            }
         }
+    }
+
+    /**
+     * Whether a Pro-free tool will actually contribute to this cleanup: it has findings *and* is
+     * opted into one-click. The upgrade upsell is only appropriate when no free tool would run, so
+     * this has to mirror [resolveMainAction]'s arming conditions — testing raw scan data instead
+     * suppresses the upsell for a tool that is opted out and therefore about to be skipped, which
+     * leaves the whole cleanup doing nothing at all.
+     */
+    private suspend fun freeToolsWillRun(): Boolean {
+        val corpse = corpseFinder.state.first().data.hasData && generalSettings.oneClickCorpseFinderEnabled.value()
+        val system = systemCleaner.state.first().data.hasData && generalSettings.oneClickSystemCleanerEnabled.value()
+        return corpse || system
     }
 
     fun mainAction(actionState: BottomBarState.Action) {
@@ -290,8 +348,19 @@ class DashboardMainActionEngine(
         // Start a fresh "freed" tally for this deletion/one-click. The hero stays hidden until every
         // branch has settled (pendingMainCleanup == 0) so a partial per-tool result can't flash.
         val isCleanup = actionState == BottomBarState.Action.DELETE || actionState == BottomBarState.Action.ONECLICK
+        // Single-flight: a second cleanup would reset the batch tally under the branches still
+        // running on it, mixing their results and settling the hero early. It would also gain
+        // nothing — every task queues on its tool's resource lock, so it would just run again
+        // against tools the first pass already emptied. Safe without a lock: this is not a suspend
+        // function and only the main thread calls it, so taps serialize.
+        if (isCleanup && pendingMainCleanup.value > 0) {
+            log(TAG, WARN) { "mainAction($actionState): a cleanup is already in flight, ignoring." }
+            return
+        }
         if (isCleanup) {
             freedResult.value = null
+            cleanupRan.value = false
+            cleanupFailed.value = false
             // Stamp before any branch runs so it's <= every resulting report's end_at.
             freedResultSince = Instant.now()
             pendingMainCleanup.value = 4 // CorpseFinder + SystemCleaner + AppCleaner + Deduplicator
@@ -349,7 +418,7 @@ class DashboardMainActionEngine(
                 BottomBarState.Action.DELETE -> {
                     if (appCleaner.state.first().data != null && upgradeRepo.isProForUi()) {
                         accumulateFreed(SDMTool.Type.APPCLEANER, submitTask(AppCleanerProcessingTask()))
-                    } else if (appCleaner.state.first().data.hasData && !corpseFinder.state.first().data.hasData && !systemCleaner.state.first().data.hasData) {
+                    } else if (appCleaner.state.first().data.hasData && !freeToolsWillRun()) {
                         onUpgradeRequired()
                     }
                 }
@@ -357,7 +426,7 @@ class DashboardMainActionEngine(
                 BottomBarState.Action.ONECLICK -> {
                     if (upgradeRepo.isProForUi()) {
                         accumulateFreed(SDMTool.Type.APPCLEANER, submitTask(AppCleanerOneClickTask()))
-                    } else if (appCleaner.state.first().data.hasData && !corpseFinder.state.first().data.hasData && !systemCleaner.state.first().data.hasData) {
+                    } else if (appCleaner.state.first().data.hasData && !freeToolsWillRun()) {
                         onUpgradeRequired()
                     }
                 }
@@ -380,7 +449,7 @@ class DashboardMainActionEngine(
                 BottomBarState.Action.ONECLICK -> {
                     if (upgradeRepo.isProForUi()) {
                         accumulateFreed(SDMTool.Type.DEDUPLICATOR, submitTask(DeduplicatorOneClickTask()))
-                    } else if (deduplicator.state.first().data.hasData && !corpseFinder.state.first().data.hasData && !systemCleaner.state.first().data.hasData) {
+                    } else if (deduplicator.state.first().data.hasData && !freeToolsWillRun()) {
                         onUpgradeRequired()
                     }
                 }
@@ -390,6 +459,9 @@ class DashboardMainActionEngine(
 
     /** Folds a deletion/one-click result into [freedResult] so the hero can show what was freed. */
     private fun accumulateFreed(type: SDMTool.Type, result: SDMTool.Task.Result) {
+        // Reaching here means a deletion task ran for this tool, even if it turned out to free
+        // nothing; [launchMainBranch] needs that distinction to report a zero-result cleanup.
+        cleanupRan.value = true
         val space = (result as? ReportDetails.AffectedSpace)?.affectedSpace ?: 0L
         val count = (result as? ReportDetails.AffectedCount)?.affectedCount ?: 0
         if (space <= 0L && count <= 0) return
@@ -410,11 +482,12 @@ class DashboardMainActionEngine(
         private val TAG = logTag("Dashboard", "MainActionEngine")
 
         /**
-         * Resolves what the main dashboard button does. CorpseFinder/SystemCleaner/AppCleaner data
-         * arms DELETE unconditionally (AppCleaner upsells non-Pro users instead of deleting).
-         * Deduplicator arms DELETE only when it is opted into one-click AND the user is Pro —
-         * exactly the conditions under which [mainAction]'s DELETE branch will actually submit a
-         * deletion task for it; its primary delete flow remains in-tool cluster selection.
+         * Resolves what the main dashboard button does. Every tool arms DELETE only when it is
+         * opted into one-click, because [mainAction] skips a tool whose toggle is off — arming
+         * without that check offers a button that provably frees nothing. Deduplicator
+         * additionally requires Pro; its primary delete flow remains in-tool cluster selection.
+         * AppCleaner deliberately arms *without* Pro so [mainAction] can upsell instead of
+         * deleting, which is why no [isPro] check appears on its line.
          */
         internal fun resolveMainAction(
             taskState: TaskSubmitter.State,
@@ -428,7 +501,9 @@ class DashboardMainActionEngine(
         ): BottomBarState.Action = when {
             taskState.hasCancellable -> BottomBarState.Action.WORKING_CANCELABLE
             !taskState.isIdle -> BottomBarState.Action.WORKING
-            corpse.hasData || system.hasData || app.hasData -> BottomBarState.Action.DELETE
+            corpse.hasData && oneClick.corpseFinderEnabled -> BottomBarState.Action.DELETE
+            system.hasData && oneClick.systemCleanerEnabled -> BottomBarState.Action.DELETE
+            app.hasData && oneClick.appCleanerEnabled -> BottomBarState.Action.DELETE
             dedupe.hasData && oneClick.deduplicatorEnabled && isPro -> BottomBarState.Action.DELETE
             oneClickMode -> BottomBarState.Action.ONECLICK
             else -> BottomBarState.Action.SCAN

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionState.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionState.kt
@@ -39,8 +39,11 @@ data class HeroSummary(
     /** When the displayed data came to be: latest scan of the included tools (FREEABLE) or deletion end (FREED). */
     val timestamp: Instant? = null,
 ) {
-    /** FREEABLE = "X will be freed" (post-scan); FREED = "X freed" (post-delete/one-click). */
-    enum class Mode { FREEABLE, FREED }
+    /**
+     * FREEABLE = "X will be freed" (post-scan); FREED = "X freed" (post-delete/one-click);
+     * NOTHING_FREED = a cleanup ran but freed nothing, which carries no amounts and no [tools].
+     */
+    enum class Mode { FREEABLE, FREED, NOTHING_FREED }
 
     data class ToolSlice(
         val type: SDMTool.Type,

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModel.kt
@@ -564,6 +564,8 @@ class DashboardViewModel @Inject constructor(
         when (mode) {
             HeroSummary.Mode.FREED -> showToolReport(type)
             HeroSummary.Mode.FREEABLE -> showTool(type)
+            // Renders no chips, so there is nothing here to tap.
+            HeroSummary.Mode.NOTHING_FREED -> {}
         }
     }
 

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardHeroCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardHeroCard.kt
@@ -74,13 +74,17 @@ internal fun DashboardHeroCard(
     // (UP from the bar/FAB) lands on Discard when present, else on the X; UP from Discard and
     // the tool chips goes to the X; UP from the X falls out of the dock (back to the grid).
     val dismissFocusRequester = remember { FocusRequester() }
-    // Colour tracks the action: destructive (red) while a deletion is pending, positive once freed.
+    // Colour tracks the action: destructive (red) while a deletion is pending, positive once freed,
+    // neutral when the cleanup ran but came up empty (nothing was lost, nothing was gained).
     val (containerColor, contentColor) = when (summary.mode) {
         HeroSummary.Mode.FREEABLE ->
             MaterialTheme.colorScheme.error to MaterialTheme.colorScheme.onError
 
         HeroSummary.Mode.FREED ->
             MaterialTheme.colorScheme.tertiaryContainer to MaterialTheme.colorScheme.onTertiaryContainer
+
+        HeroSummary.Mode.NOTHING_FREED ->
+            MaterialTheme.colorScheme.surfaceVariant to MaterialTheme.colorScheme.onSurfaceVariant
     }
     Surface(
         modifier = modifier,
@@ -125,6 +129,9 @@ private fun HeroBody(
 ) {
     val context = LocalContext.current
     val modeRes = summary.mode.resources
+    // NOTHING_FREED carries no size and no item count, so its headline and caption are plain
+    // sentences rather than templates wrapped around a number.
+    val hasAmounts = summary.mode != HeroSummary.Mode.NOTHING_FREED
     Column(modifier = modifier) {
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -141,27 +148,34 @@ private fun HeroBody(
                 Text(
                     text = buildAnnotatedString {
                         val sizeAt = template.indexOf(SIZE_ARG)
-                        if (sizeAt == -1) {
-                            append(sizeText)
-                        } else {
-                            withStyle(labelSpan) { append(template.take(sizeAt)) }
-                            append(sizeText)
-                            withStyle(labelSpan) { append(template.substring(sizeAt + SIZE_ARG.length)) }
+                        when {
+                            !hasAmounts -> withStyle(labelSpan) { append(template) }
+                            sizeAt == -1 -> append(sizeText)
+                            else -> {
+                                withStyle(labelSpan) { append(template.take(sizeAt)) }
+                                append(sizeText)
+                                withStyle(labelSpan) { append(template.substring(sizeAt + SIZE_ARG.length)) }
+                            }
                         }
                     },
                     style = MaterialTheme.typography.headlineMedium,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )
-                val itemsText = pluralStringResource(
-                    CommonR.plurals.result_x_items,
-                    summary.itemCount,
-                    summary.itemCount,
-                )
+                val captionText = if (hasAmounts) {
+                    val itemsText = pluralStringResource(
+                        CommonR.plurals.result_x_items,
+                        summary.itemCount,
+                        summary.itemCount,
+                    )
+                    stringResource(modeRes.caption, itemsText)
+                } else {
+                    stringResource(modeRes.caption)
+                }
                 Text(
                     // Two lines so the item-count result reads fully at large font scales (the column
                     // is narrow next to the dismiss button); the card height grows to make room.
-                    text = stringResource(modeRes.caption, itemsText),
+                    text = captionText,
                     style = MaterialTheme.typography.bodyMedium,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
@@ -314,6 +328,13 @@ private val HeroSummary.Mode.resources: HeroModeResources
             hint = R.string.dashboard_hero_freed_hint,
             timestampDescription = R.string.dashboard_hero_freed_timestamp_description,
         )
+
+        HeroSummary.Mode.NOTHING_FREED -> HeroModeResources(
+            headline = R.string.dashboard_hero_nothing_freed_headline,
+            caption = R.string.dashboard_hero_nothing_freed_caption,
+            hint = R.string.dashboard_hero_nothing_freed_hint,
+            timestampDescription = R.string.dashboard_hero_nothing_freed_timestamp_description,
+        )
     }
 
 private fun previewSummary(
@@ -361,6 +382,12 @@ private fun DashboardHeroCardFreeablePreview() {
 @Composable
 private fun DashboardHeroCardFreedPreview() {
     HeroCardPreview(summary = previewSummary(mode = HeroSummary.Mode.FREED))
+}
+
+@Preview2
+@Composable
+private fun DashboardHeroCardNothingFreedPreview() {
+    HeroCardPreview(summary = previewSummary(mode = HeroSummary.Mode.NOTHING_FREED, tools = emptyList()))
 }
 
 // Worst case: all four tools (chips wrap to a second row) + the two-line freeable hint — validates

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,9 +6,14 @@
     <string name="dashboard_hero_freed_x_items">%1$s removed</string>
     <string name="dashboard_hero_freeable_hint">Tap the button to free space, or a chip to check first.</string>
     <string name="dashboard_hero_freed_hint">Tap a chip for details.</string>
+    <!-- Shown when a cleanup ran to completion but could not free any space -->
+    <string name="dashboard_hero_nothing_freed_headline">Nothing was freed</string>
+    <string name="dashboard_hero_nothing_freed_caption">The cleanup finished, but none of the found data could be removed.</string>
+    <string name="dashboard_hero_nothing_freed_hint">Some data can only be removed with extra access, such as the accessibility service or root.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->
     <string name="dashboard_hero_scanned_timestamp_description">Scanned %1$s</string>
     <string name="dashboard_hero_freed_timestamp_description">Freed %1$s</string>
+    <string name="dashboard_hero_nothing_freed_timestamp_description">Attempted %1$s</string>
     <string name="dashboard_settings_category">Dashboard</string>
     <string name="dashboard_motd_title">A message from the developer</string>
     <string name="dashboard_settings_oneclick_title">One-Tap Mode</string>

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionEngineTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionEngineTest.kt
@@ -12,11 +12,15 @@ import eu.darken.sdmse.main.core.SDMTool
 import eu.darken.sdmse.main.core.taskmanager.TaskManager
 import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
 import eu.darken.sdmse.systemcleaner.core.SystemCleaner
+import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerOneClickTask
 import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -45,28 +49,43 @@ internal class DashboardMainActionEngineTest : BaseTest() {
         val appCleaner: AppCleaner,
         val deduplicator: Deduplicator,
         val submittedTasks: MutableList<SDMTool.Task>,
+        /** Branch failures the scope's handler caught — in production these reach `errorEvents`. */
+        val branchErrors: List<Throwable>,
     )
 
     private fun mockBool(value: Boolean): DataStoreValue<Boolean> = mockk(relaxed = true) {
         every { flow } returns MutableStateFlow(value)
     }
 
+    private fun upgradeInfoMock(isPro: Boolean): UpgradeRepo.Info = mockk(relaxed = true) {
+        every { this@mockk.isPro } returns isPro
+        every { isSettled } returns true
+        every { error } returns null
+    }
+
     private fun harness(
         taskState: TaskSubmitter.State = TaskSubmitter.State(),
         corpseFinderOneClick: Boolean = true,
         otherToolsOneClick: Boolean = false,
+        appCleanerOneClick: Boolean = otherToolsOneClick,
+        corpseData: CorpseFinder.Data? = null,
+        appData: AppCleaner.Data? = null,
+        isPro: Boolean = false,
+        failingTaskType: Class<out SDMTool.Task>? = null,
+        onUpgradeRequired: () -> Unit = {},
+        gate: CompletableDeferred<Unit>? = null,
     ): Harness {
         val taskManager = mockk<TaskManager>(relaxed = true).apply {
             every { state } returns MutableStateFlow(taskState)
         }
         val corpseFinder = mockk<CorpseFinder>(relaxed = true).apply {
-            every { state } returns MutableStateFlow(mockk(relaxed = true) { every { data } returns null })
+            every { state } returns MutableStateFlow(mockk(relaxed = true) { every { data } returns corpseData })
         }
         val systemCleaner = mockk<SystemCleaner>(relaxed = true).apply {
             every { state } returns MutableStateFlow(mockk(relaxed = true) { every { data } returns null })
         }
         val appCleaner = mockk<AppCleaner>(relaxed = true).apply {
-            every { state } returns MutableStateFlow(mockk(relaxed = true) { every { data } returns null })
+            every { state } returns MutableStateFlow(mockk(relaxed = true) { every { data } returns appData })
         }
         val deduplicator = mockk<Deduplicator>(relaxed = true).apply {
             every { state } returns MutableStateFlow(mockk(relaxed = true) { every { data } returns null })
@@ -74,14 +93,19 @@ internal class DashboardMainActionEngineTest : BaseTest() {
         val generalSettings = mockk<GeneralSettings>(relaxed = true).apply {
             every { oneClickCorpseFinderEnabled } returns mockBool(corpseFinderOneClick)
             every { oneClickSystemCleanerEnabled } returns mockBool(otherToolsOneClick)
-            every { oneClickAppCleanerEnabled } returns mockBool(otherToolsOneClick)
+            every { oneClickAppCleanerEnabled } returns mockBool(appCleanerOneClick)
             every { oneClickDeduplicatorEnabled } returns mockBool(otherToolsOneClick)
             every { enableDashboardOneClick } returns mockBool(false)
         }
         val submittedTasks = mutableListOf<SDMTool.Task>()
+        val branchErrors = mutableListOf<Throwable>()
         // Production-like scope: supervised like vmScope, eager like TestDispatcherProvider's
-        // Unconfined; cancelled per test so the engine's internal collectors don't leak.
-        val engineScope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+        // Unconfined; cancelled per test so the engine's internal collectors don't leak. The
+        // handler mirrors vmScope's — without it a branch failure escapes to the JVM's default
+        // handler, which kotlinx-coroutines-test then blames on whichever test runs next.
+        val engineScope = CoroutineScope(
+            SupervisorJob() + Dispatchers.Unconfined + CoroutineExceptionHandler { _, e -> branchErrors.add(e) },
+        )
         val engine = DashboardMainActionEngine(
             scope = engineScope,
             taskManager = taskManager,
@@ -90,15 +114,33 @@ internal class DashboardMainActionEngineTest : BaseTest() {
             appCleaner = appCleaner,
             deduplicator = deduplicator,
             generalSettings = generalSettings,
-            upgradeRepo = mockk<UpgradeRepo>(relaxed = true),
-            upgradeInfo = flowOf(null),
+            upgradeRepo = mockk<UpgradeRepo>(relaxed = true) {
+                // isProForUi() reads isPro and isSettled off the same Info; an unsettled mock would
+                // make it wait out its timeout and then fail open to Pro.
+                every { upgradeInfo } returns flowOf(upgradeInfoMock(isPro))
+            },
+            upgradeInfo = flowOf(upgradeInfoMock(isPro)),
             submitTask = { task ->
                 submittedTasks.add(task)
+                // Mirrors TaskManager.submit rethrowing a recorded task error.
+                if (failingTaskType?.isInstance(task) == true) throw IllegalStateException("task failed")
+                // Stands in for the tool's resource lock, holding a branch in flight.
+                gate?.await()
                 mockk(relaxed = true)
             },
-            onUpgradeRequired = {},
+            onUpgradeRequired = onUpgradeRequired,
         )
-        return Harness(engine, engineScope, taskManager, corpseFinder, systemCleaner, appCleaner, deduplicator, submittedTasks)
+        return Harness(
+            engine,
+            engineScope,
+            taskManager,
+            corpseFinder,
+            systemCleaner,
+            appCleaner,
+            deduplicator,
+            submittedTasks,
+            branchErrors,
+        )
     }
 
     private inline fun withHarness(taskState: TaskSubmitter.State = TaskSubmitter.State(), block: (Harness) -> Unit) {
@@ -150,6 +192,160 @@ internal class DashboardMainActionEngineTest : BaseTest() {
 
         h.engine.freedResultSince shouldBe Instant.EPOCH
         h.submittedTasks.size shouldBe 1
+    }
+
+    @Test
+    fun `a cleanup that frees nothing says so instead of re-showing the freeable card`() {
+        // Regression for the "I press the button and nothing happens" report: a zero-result cleanup
+        // leaves the tools' data intact, so the identical FREEABLE hero rebuilds and buries the
+        // fact that the deletion ran at all. The relaxed task result is neither AffectedSpace nor
+        // AffectedCount, which is exactly the "freed 0" shape.
+        val corpseData = mockk<CorpseFinder.Data>(relaxed = true) {
+            every { corpses } returns setOf(mockk(relaxed = true))
+        }
+        val h = harness(corpseData = corpseData)
+
+        try {
+            h.engine.mainAction(BottomBarState.Action.DELETE)
+
+            val hero = runBlocking {
+                h.engine.bottomBarState(
+                    listIsReady = MutableStateFlow(true),
+                    oneClickOptionsState = MutableStateFlow(OneClickOptionsState()),
+                ).first().heroSummary!!
+            }
+
+            hero.mode shouldBe HeroSummary.Mode.NOTHING_FREED
+            hero.totalSize shouldBe 0L
+            hero.itemCount shouldBe 0
+            hero.tools.shouldBeEmpty()
+        } finally {
+            h.engineScope.cancel()
+        }
+    }
+
+    @Test
+    fun `a cleanup where every tool opted out shows no hero at all`() {
+        // Nothing ran, so there is no outcome to report — distinct from "ran and freed nothing".
+        val h = harness(corpseFinderOneClick = false, otherToolsOneClick = false)
+
+        try {
+            h.engine.mainAction(BottomBarState.Action.ONECLICK)
+
+            val state = runBlocking {
+                h.engine.bottomBarState(
+                    listIsReady = MutableStateFlow(true),
+                    oneClickOptionsState = MutableStateFlow(OneClickOptionsState()),
+                ).first()
+            }
+
+            h.submittedTasks.shouldBeEmpty()
+            state.heroSummary shouldBe null
+        } finally {
+            h.engineScope.cancel()
+        }
+    }
+
+    @Test
+    fun `a second cleanup is ignored while one is still in flight`() {
+        // A second batch would reset the tally under the branches still running on it. The gate
+        // stands in for the tool resource lock that keeps the first cleanup's task pending.
+        val gate = CompletableDeferred<Unit>()
+        val h = harness(gate = gate)
+
+        try {
+            h.engine.mainAction(BottomBarState.Action.ONECLICK)
+            h.submittedTasks.size shouldBe 1
+
+            h.engine.mainAction(BottomBarState.Action.ONECLICK)
+            h.submittedTasks.size shouldBe 1
+
+            // Once it settles, the button works again.
+            gate.complete(Unit)
+            h.engine.mainAction(BottomBarState.Action.ONECLICK)
+            h.submittedTasks.size shouldBe 2
+        } finally {
+            h.engineScope.cancel()
+        }
+    }
+
+    @Test
+    fun `scans are never blocked by an in-flight cleanup`() {
+        val gate = CompletableDeferred<Unit>()
+        val h = harness(gate = gate)
+
+        try {
+            h.engine.mainAction(BottomBarState.Action.ONECLICK)
+            h.engine.mainAction(BottomBarState.Action.SCAN)
+
+            h.submittedTasks.size shouldBe 2
+        } finally {
+            gate.complete(Unit)
+            h.engineScope.cancel()
+        }
+    }
+
+    @Test
+    fun `a failed branch suppresses the nothing-freed card`() {
+        // One branch frees nothing and another throws: the user already gets an error dialog, so
+        // claiming the cleanup "finished" on top of it would contradict it. The findings survived
+        // the failure, so the freeable card legitimately stays — it just must not be the
+        // NOTHING_FREED one.
+        val corpseData = mockk<CorpseFinder.Data>(relaxed = true) {
+            every { corpses } returns setOf(mockk(relaxed = true))
+        }
+        val h = harness(
+            corpseData = corpseData,
+            otherToolsOneClick = true,
+            failingTaskType = SystemCleanerOneClickTask::class.java,
+        )
+
+        try {
+            h.engine.mainAction(BottomBarState.Action.ONECLICK)
+
+            val state = runBlocking {
+                h.engine.bottomBarState(
+                    listIsReady = MutableStateFlow(true),
+                    oneClickOptionsState = MutableStateFlow(OneClickOptionsState()),
+                ).first()
+            }
+
+            state.heroSummary?.mode shouldBe HeroSummary.Mode.FREEABLE
+            // The failure isn't swallowed — in production this is the dialog the user sees.
+            h.branchErrors.map { it.message } shouldBe listOf("task failed")
+        } finally {
+            h.engineScope.cancel()
+        }
+    }
+
+    @Test
+    fun `a non-Pro AppCleaner upsell fires even when an opted-out free tool has data`() {
+        // The upsell guard used to test raw CorpseFinder/SystemCleaner data, so an opted-out tool
+        // with findings silently blocked it — the DELETE branch then did nothing whatsoever.
+        val corpseData = mockk<CorpseFinder.Data>(relaxed = true) {
+            every { corpses } returns setOf(mockk(relaxed = true))
+        }
+        val appData = mockk<AppCleaner.Data>(relaxed = true) {
+            every { junks } returns setOf(mockk(relaxed = true))
+        }
+        var upgradeRequired = 0
+        val h = harness(
+            corpseData = corpseData,
+            appData = appData,
+            corpseFinderOneClick = false,
+            appCleanerOneClick = true,
+            isPro = false,
+            onUpgradeRequired = { upgradeRequired++ },
+        )
+
+        try {
+            h.engine.mainAction(BottomBarState.Action.DELETE)
+
+            upgradeRequired shouldBe 1
+            h.submittedTasks.shouldBeEmpty()
+        } finally {
+            h.engineScope.cancel()
+        }
     }
 
     @Test

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionTest.kt
@@ -1,9 +1,11 @@
 package eu.darken.sdmse.main.ui.dashboard
 
+import eu.darken.sdmse.appcleaner.core.AppCleaner
 import eu.darken.sdmse.corpsefinder.core.CorpseFinder
 import eu.darken.sdmse.deduplicator.core.Deduplicator
 import eu.darken.sdmse.deduplicator.core.Duplicate
 import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
+import eu.darken.sdmse.systemcleaner.core.SystemCleaner
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
@@ -12,8 +14,9 @@ import testhelpers.BaseTest
 
 /**
  * Contract of [DashboardMainActionEngine.resolveMainAction]: which results arm the main button's DELETE
- * action (and thereby summon the hero card). Deduplicator only counts when it is opted into
- * one-click and the user is Pro — matching what the DELETE branch of mainAction will actually free.
+ * action (and thereby summon the hero card). A tool only counts when it is opted into one-click
+ * (Deduplicator additionally requires Pro) — matching what the DELETE branch of mainAction will
+ * actually free, so the button never offers a deletion that provably does nothing.
  */
 class DashboardMainActionTest : BaseTest() {
 
@@ -23,17 +26,35 @@ class DashboardMainActionTest : BaseTest() {
         every { corpses } returns setOf(mockk())
     }
 
+    private fun system() = mockk<SystemCleaner.Data> {
+        every { filterContents } returns setOf(mockk())
+    }
+
+    private fun app() = mockk<AppCleaner.Data> {
+        every { junks } returns setOf(mockk())
+    }
+
     private fun dedupe() = mockk<Deduplicator.Data> {
         every { clusters } returns setOf(mockk<Duplicate.Cluster>())
     }
 
-    private fun oneClick(dedupe: Boolean = false) = OneClickOptionsState(
+    private fun oneClick(
+        corpse: Boolean = true,
+        system: Boolean = true,
+        app: Boolean = true,
+        dedupe: Boolean = false,
+    ) = OneClickOptionsState(
+        corpseFinderEnabled = corpse,
+        systemCleanerEnabled = system,
+        appCleanerEnabled = app,
         deduplicatorEnabled = dedupe,
     )
 
     private fun resolve(
         taskState: TaskSubmitter.State = idle,
         corpse: CorpseFinder.Data? = null,
+        system: SystemCleaner.Data? = null,
+        app: AppCleaner.Data? = null,
         dedupe: Deduplicator.Data? = null,
         oneClick: OneClickOptionsState = oneClick(),
         isPro: Boolean = true,
@@ -41,8 +62,8 @@ class DashboardMainActionTest : BaseTest() {
     ) = DashboardMainActionEngine.resolveMainAction(
         taskState = taskState,
         corpse = corpse,
-        system = null,
-        app = null,
+        system = system,
+        app = app,
         dedupe = dedupe,
         oneClick = oneClick,
         isPro = isPro,
@@ -58,6 +79,41 @@ class DashboardMainActionTest : BaseTest() {
     @Test
     fun `default tool data arms DELETE`() {
         resolve(corpse = corpse()) shouldBe BottomBarState.Action.DELETE
+    }
+
+    @Test
+    fun `data does not arm DELETE when its one-click toggle is off`() {
+        // mainAction's DELETE branch returns early for a tool that is opted out, so arming here
+        // would offer a button that submits no task at all.
+        resolve(
+            corpse = corpse(),
+            oneClick = oneClick(corpse = false),
+        ) shouldBe BottomBarState.Action.SCAN
+        resolve(
+            system = system(),
+            oneClick = oneClick(system = false),
+        ) shouldBe BottomBarState.Action.SCAN
+        resolve(
+            app = app(),
+            oneClick = oneClick(app = false),
+        ) shouldBe BottomBarState.Action.SCAN
+    }
+
+    @Test
+    fun `an opted-in tool still arms DELETE when a different tool is opted out`() {
+        resolve(
+            corpse = corpse(),
+            app = app(),
+            oneClick = oneClick(corpse = false, app = true),
+        ) shouldBe BottomBarState.Action.DELETE
+    }
+
+    @Test
+    fun `AppCleaner data arms DELETE without Pro so mainAction can upsell`() {
+        resolve(
+            app = app(),
+            isPro = false,
+        ) shouldBe BottomBarState.Action.DELETE
     }
 
     @Test

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardHeroCardTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardHeroCardTest.kt
@@ -119,6 +119,36 @@ class DashboardHeroCardTest : BaseComposeRobolectricTest() {
     }
 
     @Test
+    fun `nothing-freed hero states the outcome without printing a zero size`() {
+        val nothingFreed = HeroSummary(
+            mode = HeroSummary.Mode.NOTHING_FREED,
+            totalSize = 0L,
+            itemCount = 0,
+            tools = emptyList(),
+        )
+        composeRule.setContent {
+            PreviewWrapper {
+                BottomBar(
+                    state = deleteState(nothingFreed),
+                    isVisible = true,
+                    heroVisible = true,
+                    onMainAction = {},
+                    onMainActionLongClick = {},
+                    onSettings = {},
+                    onUpgrade = {},
+                    onDismissHero = {},
+                )
+            }
+        }
+        composeRule.onNodeWithText(context.getString(R.string.dashboard_hero_nothing_freed_headline)).assertExists()
+        // The size-interpolating headline path would render "0 B" here; this mode must not.
+        composeRule.onNodeWithText(
+            ByteFormatter.formatSize(context, 0L).first,
+            substring = true,
+        ).assertDoesNotExist()
+    }
+
+    @Test
     fun `activating a tool chip invokes onToolClick with the rendered mode and tool`() {
         var clickedMode: HeroSummary.Mode? = null
         var clickedType: SDMTool.Type? = null


### PR DESCRIPTION
## What changed

Fixes two situations where the big cleanup button on the dashboard looked broken: it showed how much could be freed, you tapped it, confirmed, and then nothing visibly happened.

The first case: if the tools holding findings were all switched off for one-tap cleaning (in the dashboard's one-tap options), the button still armed itself and offered to delete. Confirming it did nothing at all, because every tool it would have cleaned was opted out. The button now only offers to delete what it will actually clean, and falls back to Scan otherwise.

The second case: a cleanup can run correctly and still free nothing, for example when the only findings are app caches that need the accessibility service or root to remove. The screen then redrew the exact same "78 MB can be freed" card, so there was no way to tell the cleanup had run. It now says so plainly, with a note that some data needs extra access to remove.

Also fixed along the way: a non-Pro user could get no upgrade prompt and no cleanup at all if a switched-off free tool happened to have findings, and rapid double-taps on the one-tap button could scramble the result card.

## Technical Context

- **Root cause (case 1)**: `resolveMainAction` armed DELETE on raw `corpse/system/app.hasData`, but every DELETE branch in `mainAction` returns early when its tool's one-click toggle is off. Only Deduplicator had the matching check. Each tool now gates on its own toggle; AppCleaner still arms without Pro so the upsell can fire.
- **Root cause (case 2)**: `accumulateFreed` early-returns on a zero result, leaving `freedResult` null. Since a zero-result cleanup leaves the tools' data intact, `actionState` stays DELETE and `buildHeroSummary` rebuilds an identical FREEABLE card. Recording the zero result alone was not enough — FREEABLE won at the `freeable ?: freed` site, so the new `NOTHING_FREED` mode needed a priority insert ahead of it. The existing FREED/FREEABLE ordering is untouched.
- The upsell guards tested raw `CorpseFinder`/`SystemCleaner` data, so an opted-out tool with findings suppressed `onUpgradeRequired()` for a cleanup that was about to skip it. Both AppCleaner guards and the Deduplicator one now go through `freeToolsWillRun()`, which mirrors the arming conditions. This was pre-existing, but it is the same defect class as case 1 and leaving it would have made that fix incomplete.
- `mainAction` is single-flighted rather than generation-tagged. A second cleanup reset the batch tally under branches still running on it, mixing their slices into the new `freedResult` and breaking chip-to-report routing via the restamped `freedResultSince`. Single-flighting also loses nothing: `TaskManager.execute` runs every task under a per-tool resource lock, so a queued second cleanup would only rerun against tools the first pass emptied — and would now report "Nothing was freed", which is a worse outcome for an accidental double-tap than ignoring it.
- **Review guidance**: the concurrency in `launchMainBranch` is the part worth close attention. `accumulateFreed` runs inside the branch body while the tally is decremented in `finally`, so observing `remaining == 0` means every sibling has finished accumulating. The synthesis still folds via `updateAndGet { current ?: … }` with a pure lambda (the CAS can retry) so it can never clobber a real result, and `cleanupFailed` keeps the card away from runs that threw or were cancelled, where an error dialog already explains things.
- `freeable` is now gated on `pendingCleanup` too, not just `settled` — `TaskManager` reports idle before the branches fold in results, and the identical card flashed in that window.
- The engine test harness scope gained a `CoroutineExceptionHandler` matching the `vmScope` its comment claimed to mirror. Without it a failing branch escaped to the JVM default handler and `kotlinx-coroutines-test` attributed it to an unrelated later test.

## Verification

1029 unit tests pass (confirmed with `--rerun-tasks` to rule out cross-test pollution), `lintVitalFossRelease` and `lintVitalGplayRelease` clean.

## Not verified

This originates from a support report (AppCleaner, Pixel 9 Pro, Android 17, 2.0.1-beta1) but is **not confirmed to be that user's cause** — no debug log was provided. Their state shows an AppCleaner chip in the hero card, which means the task did submit, so case 1 does not apply to them; the zero-byte path is plausible but unproven. The change makes that path visible rather than silent either way.
