### PR TITLE
Fix: Use correct grammar for item counts in other languages

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardHeroCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardHeroCard.kt
@@ -1,6 +1,7 @@
 package eu.darken.sdmse.main.ui.dashboard.bottom
 
 import android.text.format.DateUtils
+import androidx.annotation.PluralsRes
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -162,15 +163,11 @@ private fun HeroBody(
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )
-                val captionText = if (hasAmounts) {
-                    val itemsText = pluralStringResource(
-                        CommonR.plurals.result_x_items,
-                        summary.itemCount,
-                        summary.itemCount,
-                    )
-                    stringResource(modeRes.caption, itemsText)
-                } else {
-                    stringResource(modeRes.caption)
+                val captionText = when (val caption = modeRes.caption) {
+                    is HeroCaption.Counted ->
+                        pluralStringResource(caption.id, summary.itemCount, summary.itemCount)
+
+                    is HeroCaption.Plain -> stringResource(caption.id)
                 }
                 Text(
                     // Two lines so the item-count result reads fully at large font scales (the column
@@ -305,10 +302,20 @@ private fun HeroFooter(
 private const val SIZE_ARG = "%1\$s"
 private const val MUTED_ALPHA = 0.8f
 
+/**
+ * A mode's caption is either driven by the item count or a plain sentence, and the two need different
+ * resource types. Modelled rather than left as a bare id so a mode cannot be wired to the wrong one.
+ */
+private sealed interface HeroCaption {
+    /** Must be a `<plurals>`: languages with verb agreement need a different form per quantity. */
+    data class Counted(@PluralsRes val id: Int) : HeroCaption
+    data class Plain(@StringRes val id: Int) : HeroCaption
+}
+
 /** Per-mode string resources, kept together so each mode is defined in one place. */
 private data class HeroModeResources(
     @StringRes val headline: Int,
-    @StringRes val caption: Int,
+    val caption: HeroCaption,
     @StringRes val hint: Int,
     @StringRes val timestampDescription: Int,
 )
@@ -317,21 +324,21 @@ private val HeroSummary.Mode.resources: HeroModeResources
     get() = when (this) {
         HeroSummary.Mode.FREEABLE -> HeroModeResources(
             headline = R.string.dashboard_hero_freeable_headline,
-            caption = R.string.dashboard_hero_freeable_x_items,
+            caption = HeroCaption.Counted(R.plurals.dashboard_hero_freeable_x_items),
             hint = R.string.dashboard_hero_freeable_hint,
             timestampDescription = R.string.dashboard_hero_scanned_timestamp_description,
         )
 
         HeroSummary.Mode.FREED -> HeroModeResources(
             headline = R.string.dashboard_hero_freed_headline,
-            caption = R.string.dashboard_hero_freed_x_items,
+            caption = HeroCaption.Counted(R.plurals.dashboard_hero_freed_x_items),
             hint = R.string.dashboard_hero_freed_hint,
             timestampDescription = R.string.dashboard_hero_freed_timestamp_description,
         )
 
         HeroSummary.Mode.NOTHING_FREED -> HeroModeResources(
             headline = R.string.dashboard_hero_nothing_freed_headline,
-            caption = R.string.dashboard_hero_nothing_freed_caption,
+            caption = HeroCaption.Plain(R.string.dashboard_hero_nothing_freed_caption),
             hint = R.string.dashboard_hero_nothing_freed_hint,
             timestampDescription = R.string.dashboard_hero_nothing_freed_timestamp_description,
         )

--- a/app/src/main/res/values-af-rZA/strings.xml
+++ b/app/src/main/res/values-af-rZA/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Skrap resultate in alle gereedskap?</string>
     <string name="dashboard_hero_freeable_headline">%1$s kan vrygestel word</string>
     <string name="dashboard_hero_freed_headline">%1$s vrygestel</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s kan verwyder word</string>
-    <string name="dashboard_hero_freed_x_items">%1$s verwyder</string>
     <string name="dashboard_hero_freeable_hint">Tik die knop om plek vry te maak, of \'n knoppie om eers na te gaan.</string>
     <string name="dashboard_hero_freed_hint">Tik \'n chip vir besonderhede.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">በሁሉም መሳሪያዎች ውስጥ ያሉ ውጤቶችን ይሰረዙ?</string>
     <string name="dashboard_hero_freeable_headline">%1$s ነፃ ሊሆን ይችላል</string>
     <string name="dashboard_hero_freed_headline">%1$s ተገለለ</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s ሊወገድ ይችላል</string>
-    <string name="dashboard_hero_freed_x_items">%1$s ተወግዷል</string>
     <string name="dashboard_hero_freeable_hint">ቦታ ለመክፈት ቁልፍ ይጫኑ ወይም መጀመሪያ ለመመርመር ሪባ ይጫኑ።</string>
     <string name="dashboard_hero_freed_hint">ዝርዝሮች ለማየት ሊባ ታች ያድርጉ።</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">حذف النتائج في كل الأدوات؟</string>
     <string name="dashboard_hero_freeable_headline">%1$s يمكن تحريره</string>
     <string name="dashboard_hero_freed_headline">%1$s محررة</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s يمكن إزالته</string>
-    <string name="dashboard_hero_freed_x_items">%1$s تمت إزالته</string>
     <string name="dashboard_hero_freeable_hint">اضغط على الزر لتحرير مساحة، أو على شريحة للفحص أولاً</string>
     <string name="dashboard_hero_freed_hint">اضغط على شريط للاطلاع على التفاصيل.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Bütün alətlərdəki nəticələr silinsin?</string>
     <string name="dashboard_hero_freeable_headline">%1$s azad edilə bilər</string>
     <string name="dashboard_hero_freed_headline">%1$s azad edildi</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s silinə bilər</string>
-    <string name="dashboard_hero_freed_x_items">%1$s silindi</string>
     <string name="dashboard_hero_freeable_hint">Yeri azaltmaq üçün düyməyə basın, ya da əvvəl yoxlamaq üçün chip-ə toxunun.</string>
     <string name="dashboard_hero_freed_hint">Detallar üçün çipə toxunun.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Выдаліць рэзультаты ва ўсіх інструментах?</string>
     <string name="dashboard_hero_freeable_headline">%1$s можна вызваліць</string>
     <string name="dashboard_hero_freed_headline">Вызвалена %1$s</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s можна выдаліць</string>
-    <string name="dashboard_hero_freed_x_items">Выдалена %1$s</string>
     <string name="dashboard_hero_freeable_hint">Дакніце на кнопку, каб вызваліць месца, або на чып для праверкі спачатку.</string>
     <string name="dashboard_hero_freed_hint">Кацніце чып для дэталяў.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Изтриване на резултатите във всички инструменти?</string>
     <string name="dashboard_hero_freeable_headline">%1$s може да бъде освободено</string>
     <string name="dashboard_hero_freed_headline">%1$s е освободено</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s може да бъде премахнато</string>
-    <string name="dashboard_hero_freed_x_items">%1$s е премахнато</string>
     <string name="dashboard_hero_freeable_hint">Натиснете бутона за освобождаване на място или категория за проверка първо.</string>
     <string name="dashboard_hero_freed_hint">Докоснете чип за детайли.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">সব টুলের ফলাফল মুছে ফেলবেন?</string>
     <string name="dashboard_hero_freeable_headline">%1$s মুক্ত করা যেতে পারে</string>
     <string name="dashboard_hero_freed_headline">%1$s খালি হয়েছে</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s সরানো যেতে পারে</string>
-    <string name="dashboard_hero_freed_x_items">%1$s সরানো হয়েছে</string>
     <string name="dashboard_hero_freeable_hint">স্থান খালি করতে বোতামটি ট্যাপ করুন, বা আগে যাচাই করতে একটি চিপ ট্যাপ করুন।</string>
     <string name="dashboard_hero_freed_hint">বিবরণের জন্য একটি চিপ ট্যাপ করুন।</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Voleu suprimir els resultats de totes les eines?</string>
     <string name="dashboard_hero_freeable_headline">%1$s es pot alliberar</string>
     <string name="dashboard_hero_freed_headline">%1$s alliberat</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s es pot eliminar</string>
-    <string name="dashboard_hero_freed_x_items">%1$s eliminat</string>
     <string name="dashboard_hero_freeable_hint">Toca el botó per alliberar espai, o una fitxa per comprovar primer.</string>
     <string name="dashboard_hero_freed_hint">Toca un xip per a detalls.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-ckb-rIR/strings.xml
+++ b/app/src/main/res/values-ckb-rIR/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">ئەنجامەکان لە هەموو ئامرازەکاندا بسڕدرێنەوە؟</string>
     <string name="dashboard_hero_freeable_headline">%1$s دەتوانرێت خالی بکرێت</string>
     <string name="dashboard_hero_freed_headline">%1$s خالی کرا</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s دەتوانرێت سڕاوە</string>
-    <string name="dashboard_hero_freed_x_items">%1$s سڕاوە</string>
     <string name="dashboard_hero_freeable_hint">دکمە کۆتایی بکە بۆ فریکردنی جێگا، یان چپیلێک بۆ پێشتر پشکنین.</string>
     <string name="dashboard_hero_freed_hint">سەتێک لێدە بۆ وردەکاری</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Smazat výsledky ve všech nástrojích?</string>
     <string name="dashboard_hero_freeable_headline">Je možné uvolnit %1$s</string>
     <string name="dashboard_hero_freed_headline">Uvolněno %1$s</string>
-    <string name="dashboard_hero_freeable_x_items">Je možné odstranit %1$s</string>
-    <string name="dashboard_hero_freed_x_items">Odstraněno %1$s</string>
     <string name="dashboard_hero_freeable_hint">Klepnutím na tlačítko uvolněte místo, nebo klepnutím na prvek nejdříve zkontrolujte.</string>
     <string name="dashboard_hero_freed_hint">Klepnutím na prvek zobrazíte podrobnosti.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Slet resultater i alle værktøjer?</string>
     <string name="dashboard_hero_freeable_headline">%1$s kan frigøres</string>
     <string name="dashboard_hero_freed_headline">%1$s frigjort</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s kan fjernes</string>
-    <string name="dashboard_hero_freed_x_items">%1$s fjernet</string>
     <string name="dashboard_hero_freeable_hint">Tryk på knappen for at frigøre plads, eller tryk på et chip for at kontrollere først.</string>
     <string name="dashboard_hero_freed_hint">Tryk på et chip for detaljer.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -3,8 +3,14 @@
     <string name="dashboard_delete_all_message">Ergebnisse in allen Tools löschen?</string>
     <string name="dashboard_hero_freeable_headline">%1$s kann freigegeben werden</string>
     <string name="dashboard_hero_freed_headline">%1$s freigegeben</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s kann entfernt werden</string>
-    <string name="dashboard_hero_freed_x_items">%1$s entfernt</string>
+    <plurals name="dashboard_hero_freeable_x_items">
+        <item quantity="one">%d Element kann entfernt werden</item>
+        <item quantity="other">%d Elemente können entfernt werden</item>
+    </plurals>
+    <plurals name="dashboard_hero_freed_x_items">
+        <item quantity="one">%d Element entfernt</item>
+        <item quantity="other">%d Elemente entfernt</item>
+    </plurals>
     <string name="dashboard_hero_freeable_hint">Tippe auf den Button, um Speicher freizugeben, oder auf einen Chip, um zunächst zu prüfen.</string>
     <string name="dashboard_hero_freed_hint">Tippe auf einen Chip für Details.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Διαγραφή αποτελεσμάτων σε όλα τα εργαλεία;</string>
     <string name="dashboard_hero_freeable_headline">%1$s μπορεί να απελευθερωθεί</string>
     <string name="dashboard_hero_freed_headline">%1$s απελευθερώθηκε</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s μπορεί να καταργηθεί</string>
-    <string name="dashboard_hero_freed_x_items">%1$s καταργήθηκε</string>
     <string name="dashboard_hero_freeable_hint">Πατήστε το κουμπί για να ελευθερώσετε χώρο, ή ένα chip για να ελέγξετε πρώτα.</string>
     <string name="dashboard_hero_freed_hint">Πατήστε ένα chip για λεπτομέρειες.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-es-rAR/strings.xml
+++ b/app/src/main/res/values-es-rAR/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">¿Borrar los resultados en todas las herramientas?</string>
     <string name="dashboard_hero_freeable_headline">%1$s se puede liberar</string>
     <string name="dashboard_hero_freed_headline">%1$s liberado</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s se puede remover</string>
-    <string name="dashboard_hero_freed_x_items">%1$s removido</string>
     <string name="dashboard_hero_freeable_hint">Tocá el botón para liberar espacio, o un chip para verificar primero.</string>
     <string name="dashboard_hero_freed_hint">Presioná un chip para ver detalles.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">¿Borrar los resultados en todas las herramientas?</string>
     <string name="dashboard_hero_freeable_headline">Se puede liberar %1$s</string>
     <string name="dashboard_hero_freed_headline">%1$s liberado</string>
-    <string name="dashboard_hero_freeable_x_items">Se puede eliminar %1$s</string>
-    <string name="dashboard_hero_freed_x_items">%1$s eliminado</string>
     <string name="dashboard_hero_freeable_hint">Toca el botón para liberar espacio, o un chip para verificar primero.</string>
     <string name="dashboard_hero_freed_hint">Toca una opción para más detalles.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">¿Borrar los resultados en todas las herramientas?</string>
     <string name="dashboard_hero_freeable_headline">Se pueden liberar %1$s</string>
     <string name="dashboard_hero_freed_headline">%1$s liberados</string>
-    <string name="dashboard_hero_freeable_x_items">Se pueden eliminar %1$s</string>
-    <string name="dashboard_hero_freed_x_items">%1$s eliminados</string>
     <string name="dashboard_hero_freeable_hint">Toca el botón para liberar espacio, o un chip para verificar primero.</string>
     <string name="dashboard_hero_freed_hint">Toca un chip para obtener detalles.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-et-rEE/strings.xml
+++ b/app/src/main/res/values-et-rEE/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Kustutada kõikide vahendite tulemused?</string>
     <string name="dashboard_hero_freeable_headline">%1$s saab vabastada</string>
     <string name="dashboard_hero_freed_headline">%1$s vabastatud</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s saab eemaldada</string>
-    <string name="dashboard_hero_freed_x_items">%1$s eemaldatud</string>
     <string name="dashboard_hero_freeable_hint">Puuduta nuppu ruumi vabastamiseks, või puuduta kiipi esmalt kontrollimiseks.</string>
     <string name="dashboard_hero_freed_hint">Vajuta kiibi peale täpsemalt.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-eu-rES/strings.xml
+++ b/app/src/main/res/values-eu-rES/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Erraminta guztietako emaitzak ezabatu?</string>
     <string name="dashboard_hero_freeable_headline">%1$s askatu daiteke</string>
     <string name="dashboard_hero_freed_headline">%1$s askatuta</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s kendu daiteke</string>
-    <string name="dashboard_hero_freed_x_items">%1$s kenduta</string>
     <string name="dashboard_hero_freeable_hint">Sakatu botoia espazioa libratzeko, edo txipa aurrenekoa egiaztatzeko.</string>
     <string name="dashboard_hero_freed_hint">Sakatu txipa detaleak ikusteko.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">نتایج در همه ابزارها حذف شود؟</string>
     <string name="dashboard_hero_freeable_headline">%1$s قابل آزادسازی است</string>
     <string name="dashboard_hero_freed_headline">%1$s آزادسازی شده</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s قابل حذف است</string>
-    <string name="dashboard_hero_freed_x_items">%1$s حذف شده</string>
     <string name="dashboard_hero_freeable_hint">برای آزادسازی فضا روی دکمه ضربه بزنید یا روی یک برچسب برای بررسی اول ضربه بزنید.</string>
     <string name="dashboard_hero_freed_hint">برای جزئیات روی یک چیپ ضربه بزنید.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Poista tulokset kaikista työkaluista?</string>
     <string name="dashboard_hero_freeable_headline">%1$s voidaan vapauttaa</string>
     <string name="dashboard_hero_freed_headline">%1$s vapautettu</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s voidaan poistaa</string>
-    <string name="dashboard_hero_freed_x_items">%1$s poistettu</string>
     <string name="dashboard_hero_freeable_hint">Napauta painiketta vapauttaaksesi tilaa, tai napauta sirua tarkistaaksesi ensin.</string>
     <string name="dashboard_hero_freed_hint">Napauta sirua saadaksesi lisätietoja.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Burahin ang mga resulta sa lahat ng mga kagamitan?</string>
     <string name="dashboard_hero_freeable_headline">%1$s ay maaaring ma-free</string>
     <string name="dashboard_hero_freed_headline">Napakawalan ang %1$s</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s ay maaaring ma-alisin</string>
-    <string name="dashboard_hero_freed_x_items">Naalis ang %1$s</string>
     <string name="dashboard_hero_freeable_hint">I-tap ang button upang magbigay ng espasyo, o ang chip upang munang suriin.</string>
     <string name="dashboard_hero_freed_hint">I-tap ang chip para sa mga detalye.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Supprimer les résultats pour tous les outils ?</string>
     <string name="dashboard_hero_freeable_headline">%1$s peut être libéré</string>
     <string name="dashboard_hero_freed_headline">%1$s libéré</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s peut être supprimé</string>
-    <string name="dashboard_hero_freed_x_items">%1$s supprimé</string>
     <string name="dashboard_hero_freeable_hint">Appuyez sur le bouton pour libérer de l’espace, ou sur une puce pour vérifier d’abord.</string>
     <string name="dashboard_hero_freed_hint">Appuyez sur une puce pour les détails.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Eliminar os resultados de todas as ferramentas?</string>
     <string name="dashboard_hero_freeable_headline">%1$s pódese liberar</string>
     <string name="dashboard_hero_freed_headline">%1$s liberado</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s pódese eliminar</string>
-    <string name="dashboard_hero_freed_x_items">%1$s eliminado</string>
     <string name="dashboard_hero_freeable_hint">Toca o botón para liberar espazo, ou un chip para comprobar primeiro.</string>
     <string name="dashboard_hero_freed_hint">Toca un chip para máis detalles.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">सभी टूल में परिणाम मिटाएं?</string>
     <string name="dashboard_hero_freeable_headline">%1$s मुक्त किया जा सकता है</string>
     <string name="dashboard_hero_freed_headline">%1$s खाली की गई</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s हटाया जा सकता है</string>
-    <string name="dashboard_hero_freed_x_items">%1$s हटा दी गई</string>
     <string name="dashboard_hero_freeable_hint">स्पेस फ्री करने के लिए बटन दबाएं, या पहले जांचने के लिए एक चिप दबाएं।</string>
     <string name="dashboard_hero_freed_hint">विवरण के लिए एक चिप पर टैप करें।</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Izbrisati rezultate u svim alatima?</string>
     <string name="dashboard_hero_freeable_headline">%1$s može biti oslobođeno</string>
     <string name="dashboard_hero_freed_headline">%1$s oslobođeno</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s može biti uklonjeno</string>
-    <string name="dashboard_hero_freed_x_items">%1$s uklonjeno</string>
     <string name="dashboard_hero_freeable_hint">Dodirnite gumb za oslobađanje prostora ili čip za prethodnu provjeru.</string>
     <string name="dashboard_hero_freed_hint">Dodirnite čip za detalje.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Törli az eredményeket az összes eszközben?</string>
     <string name="dashboard_hero_freeable_headline">%1$s felszabadítható</string>
     <string name="dashboard_hero_freed_headline">%1$s felszabadult</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s eltávolítható</string>
-    <string name="dashboard_hero_freed_x_items">%1$s eltávolítva</string>
     <string name="dashboard_hero_freeable_hint">Nyomd meg a gombot a hely felszabadításához, vagy egy gombot az ellenőrzéshez.</string>
     <string name="dashboard_hero_freed_hint">Koppints egy chipre a részletekért.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Hapus hasil di semua alat?</string>
     <string name="dashboard_hero_freeable_headline">%1$s dapat dibebaskan</string>
     <string name="dashboard_hero_freed_headline">%1$s dibebaskan</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s dapat dihapus</string>
-    <string name="dashboard_hero_freed_x_items">%1$s dihapus</string>
     <string name="dashboard_hero_freeable_hint">Ketuk tombol untuk membebaskan ruang, atau chip untuk memeriksa terlebih dahulu.</string>
     <string name="dashboard_hero_freed_hint">Ketuk chip untuk detail.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Eyða niðurstöðum í öllum tækjum?</string>
     <string name="dashboard_hero_freeable_headline">%1$s má losa</string>
     <string name="dashboard_hero_freed_headline">%1$s losað</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s má fjarlægja</string>
-    <string name="dashboard_hero_freed_x_items">%1$s fjarlægð</string>
     <string name="dashboard_hero_freeable_hint">Ýttu á hnappinn til að losa um pláss, eða á flís til að athuga fyrst.</string>
     <string name="dashboard_hero_freed_hint">Ýttu á flís fyrir upplýsingar.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Eliminare i risultati in tutti gli strumenti?</string>
     <string name="dashboard_hero_freeable_headline">%1$s può essere liberato</string>
     <string name="dashboard_hero_freed_headline">%1$s liberato</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s può essere rimosso</string>
-    <string name="dashboard_hero_freed_x_items">%1$s rimosso</string>
     <string name="dashboard_hero_freeable_hint">Tocca il pulsante per liberare spazio, oppure un chip per controllare prima.</string>
     <string name="dashboard_hero_freed_hint">Tocca una scheda per i dettagli.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">למחוק תוצאות בכל הכלים?</string>
     <string name="dashboard_hero_freeable_headline">ניתן לפנות %1$s</string>
     <string name="dashboard_hero_freed_headline">%1$s שוחרר</string>
-    <string name="dashboard_hero_freeable_x_items">ניתן להסיר %1$s</string>
-    <string name="dashboard_hero_freed_x_items">הוסר %1$s</string>
     <string name="dashboard_hero_freeable_hint">הקש על הכפתור כדי לשחרר מקום, או על שבב לבדיקה תחילה.</string>
     <string name="dashboard_hero_freed_hint">הקש על שבב לפרטים.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">すべてのツールの結果を削除しますか？</string>
     <string name="dashboard_hero_freeable_headline">%1$sを解放できます</string>
     <string name="dashboard_hero_freed_headline">%1$s解放されました</string>
-    <string name="dashboard_hero_freeable_x_items">%1$sを削除できます</string>
-    <string name="dashboard_hero_freed_x_items">%1$s削除されました</string>
     <string name="dashboard_hero_freeable_hint">ボタンをタップしてスペースを解放するか、チップをタップして最初に確認してください。</string>
     <string name="dashboard_hero_freed_hint">詳細を確認するにはチップをタップしてください。</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-ka-rGE/strings.xml
+++ b/app/src/main/res/values-ka-rGE/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">წაშალოთ შედეგები ყველა ხელსაწყოში?</string>
     <string name="dashboard_hero_freeable_headline">%1$s შეიძლება განთავისუფლდეს</string>
     <string name="dashboard_hero_freed_headline">%1$s განთავისუფლდა</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s შეიძლება წაიშალოს</string>
-    <string name="dashboard_hero_freed_x_items">%1$s წაშლილია</string>
     <string name="dashboard_hero_freeable_hint">დააჭირეთ ღილაკს ადგილის გასაწყობლად ან ჯერ ჩიპს შეამოწმეთ.</string>
     <string name="dashboard_hero_freed_hint">შეეხეთ ჩიპს დეტალებისთვის.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-kaa/strings.xml
+++ b/app/src/main/res/values-kaa/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Nátiyjeler barlıq ásbaplardan óshirilsin be?</string>
     <string name="dashboard_hero_freeable_headline">%1$s bostatıla alması múmkin</string>
     <string name="dashboard_hero_freed_headline">%1$s bostatıldı</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s óshirile alması múmkin</string>
-    <string name="dashboard_hero_freed_x_items">%1$s óshirildi</string>
     <string name="dashboard_hero_freeable_hint">Jorlama ushun tugmani basıp qosıń, yaki avval teksheriw ushun chipni basıń.</string>
     <string name="dashboard_hero_freed_hint">Detallar ushın chipti basıń.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-km-rKH/strings.xml
+++ b/app/src/main/res/values-km-rKH/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">លុបលទ្ធផលនៅក្នុងឧបករណ៍ទាំងអស់ឬ?</string>
     <string name="dashboard_hero_freeable_headline">%1$s អាចនៅទំនេរ</string>
     <string name="dashboard_hero_freed_headline">លុបចោល %1$s</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s អាចដកចេញបាន</string>
-    <string name="dashboard_hero_freed_x_items">ដកចេញ %1$s</string>
     <string name="dashboard_hero_freeable_hint">ចុចប៉ោលដើម្បីលាតលំហ ឬចុចឈីបដើម្បីពិនិត្យមើលដំបូង។</string>
     <string name="dashboard_hero_freed_hint">ចុចបន្ទះដើម្បីមើលព័ត៌មានលម្អិត។</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">모든 도구의 결과를 삭제할까요?</string>
     <string name="dashboard_hero_freeable_headline">%1$s를 확보할 수 있습니다</string>
     <string name="dashboard_hero_freed_headline">%1$s 확보됨</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s를 제거할 수 있습니다</string>
-    <string name="dashboard_hero_freed_x_items">%1$s 제거됨</string>
     <string name="dashboard_hero_freeable_hint">버튼을 탭하여 공간을 확보하거나 먼저 확인하려면 칩을 탭하세요.</string>
     <string name="dashboard_hero_freed_hint">칩을 눌러 자세한 정보를 확인하세요.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-lo-rLA/strings.xml
+++ b/app/src/main/res/values-lo-rLA/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">ລຶບຜົນລັບໃນທຸກເຄື່ອງມືບໍ?</string>
     <string name="dashboard_hero_freeable_headline">%1$s ສາມາດປົດປ່ອຍໄດ້</string>
     <string name="dashboard_hero_freed_headline">%1$s ຖືກປົດປ່ອຍ</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s ສາມາດລຶບອອກໄດ້</string>
-    <string name="dashboard_hero_freed_x_items">%1$s ຖືກລຶບອອກແລ້ວ</string>
     <string name="dashboard_hero_freeable_hint">ແຕະປຸ່ມເພື່ອເຮັດຄວາມສະອາດ ຫຼືແຕະສະຫຸ່ນເພື່ອກວດສອບກ່ອນ</string>
     <string name="dashboard_hero_freed_hint">ແຕະຊິບສໍາລັບລາຍລະອຽດ.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Ištrinti visų įrankių rezultatus?</string>
     <string name="dashboard_hero_freeable_headline">%1$s gali būti atlaisvinta</string>
     <string name="dashboard_hero_freed_headline">%1$s atlaisvinta</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s gali būti pašalinta</string>
-    <string name="dashboard_hero_freed_x_items">%1$s pašalinta</string>
     <string name="dashboard_hero_freeable_hint">Paspauskite mygtuką laisvai atlaisvinti, arba žetoną norėdami iš pradžios patikrinti.</string>
     <string name="dashboard_hero_freed_hint">Palieskite lustą, kad sužinotumėte daugiau.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Dzēst rezultātus visos rīkos?</string>
     <string name="dashboard_hero_freeable_headline">%1$s var tikt atbrīvots</string>
     <string name="dashboard_hero_freed_headline">%1$s atbrīvots</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s var tikt noņemts</string>
-    <string name="dashboard_hero_freed_x_items">%1$s noņemts</string>
     <string name="dashboard_hero_freeable_hint">Nospiediet pogu, lai atbrīvotu vietu, vai čipu, lai vispirms pārbaudītu.</string>
     <string name="dashboard_hero_freed_hint">Nospiediet žetonu sīkumiem.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-mk-rMK/strings.xml
+++ b/app/src/main/res/values-mk-rMK/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Избриши ги резултатите од сите алатки?</string>
     <string name="dashboard_hero_freeable_headline">%1$s може да се ослободи</string>
     <string name="dashboard_hero_freed_headline">%1$s слободно</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s може да се отстрани</string>
-    <string name="dashboard_hero_freed_x_items">%1$s отстрането</string>
     <string name="dashboard_hero_freeable_hint">Допрете го копчето за да ослободите простор, или фишка за прво проверка.</string>
     <string name="dashboard_hero_freed_hint">Притиснете чип за детали.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-ml-rIN/strings.xml
+++ b/app/src/main/res/values-ml-rIN/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">എല്ലാ ടൂളുകളിലെ ഫലങ്ങൾ ഇല്ലാതാക്കണോ?</string>
     <string name="dashboard_hero_freeable_headline">%1$s സ്വതന്ത്രമാക്കാം</string>
     <string name="dashboard_hero_freed_headline">%1$s ഫ്രീ ആക്കി</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s നീക്കം ചെയ്യാം</string>
-    <string name="dashboard_hero_freed_x_items">%1$s നീക്കം ചെയ്യപ്പെട്ടു</string>
     <string name="dashboard_hero_freeable_hint">സ്ഥലം സ്വതന്ത്ര ചെയ്യാൻ ബട്ടൺ തൊടുക, അല്ലെങ്കിൽ ആദ്യം പരിശോധിക്കാൻ ഒരു ചിപ് തൊടുക.</string>
     <string name="dashboard_hero_freed_hint">വിശദാംശങ്ങൾക്കായി ചിപ്പ് ടാപ്പ് ചെയ്യുക.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-mn-rMN/strings.xml
+++ b/app/src/main/res/values-mn-rMN/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Бүх хэрэгслийн үр дүнг устгах уу?</string>
     <string name="dashboard_hero_freeable_headline">%1$s-ийг чөлөөлөх боломжтой</string>
     <string name="dashboard_hero_freed_headline">%1$s чөлөөлөгдсөн</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s-ийг хасах боломжтой</string>
-    <string name="dashboard_hero_freed_x_items">%1$s хасагдсан</string>
     <string name="dashboard_hero_freeable_hint">Сансар чөлөөлөхийн тулд товчийг дарах, эсвэл эхлээд шалгахын тулд сонголтыг сонгох.</string>
     <string name="dashboard_hero_freed_hint">Дэлгэрэнгүй үзэхийн тулд цэгийг дараарай.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Padamkan hasil dalam semua alatan?</string>
     <string name="dashboard_hero_freeable_headline">%1$s boleh dibebaskan</string>
     <string name="dashboard_hero_freed_headline">%1$s dibebaskan</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s boleh dibuang</string>
-    <string name="dashboard_hero_freed_x_items">%1$s dibuang</string>
     <string name="dashboard_hero_freeable_hint">Ketuk butang untuk membebaskan ruang, atau cip untuk menyemak terlebih dahulu.</string>
     <string name="dashboard_hero_freed_hint">Tekan cip untuk butiran.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-my-rMM/strings.xml
+++ b/app/src/main/res/values-my-rMM/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">ကိရိယာအားလုံးရှိ ရလဒ်များကို ဖျက်မလား?</string>
     <string name="dashboard_hero_freeable_headline">%1$s ကို လွတ်လပ်စေနိုင်ပါသည်</string>
     <string name="dashboard_hero_freed_headline">%1$s လွတ်လပ်စေပြီးပါပြီ</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s ကို ဖျက်သိမ်းနိုင်ပါသည်</string>
-    <string name="dashboard_hero_freed_x_items">%1$s ဖျက်သိမ်းပြီးပါပြီ</string>
     <string name="dashboard_hero_freeable_hint">ခလုတ်ကို နှိပ်ပြီး နေရာ လွတ်ရန် သို့မဟုတ် ဦးစွာ စစ်ဆေးရန် အညွှန်းကို နှိပ်ပါ။</string>
     <string name="dashboard_hero_freed_hint">အချက်အလက်အတွက် အညွှန်းကို နှိပ်ပါ။</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Slette resultater i alle verktøy?</string>
     <string name="dashboard_hero_freeable_headline">%1$s kan frigjøres</string>
     <string name="dashboard_hero_freed_headline">%1$s frigjort</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s kan fjernes</string>
-    <string name="dashboard_hero_freed_x_items">%1$s fjernet</string>
     <string name="dashboard_hero_freeable_hint">Trykk på knappen for å frigjøre plass, eller en brikke for å sjekke først.</string>
     <string name="dashboard_hero_freed_hint">Trykk på en brikke for detaljer.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-ne-rNP/strings.xml
+++ b/app/src/main/res/values-ne-rNP/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">सबै उपकरणहरूमा परिणामहरू मेटाउने?</string>
     <string name="dashboard_hero_freeable_headline">%1$s खाली गर्न सकिन्छ</string>
     <string name="dashboard_hero_freed_headline">%1$s खाली गरिएको छ</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s हटाउन सकिन्छ</string>
-    <string name="dashboard_hero_freed_x_items">%1$s हटाइएको छ</string>
     <string name="dashboard_hero_freeable_hint">स्पेस खाली गर्न बटन दबाउनुहोस्, वा पहिले जाँच गर्न एक चिप दबाउनुहोस्।</string>
     <string name="dashboard_hero_freed_hint">विवरणका लागि चिप ट्याप गर्नुहोस्।</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Resultaten in alle hulpmiddelen verwijderen?</string>
     <string name="dashboard_hero_freeable_headline">%1$s kan worden vrijgemaakt</string>
     <string name="dashboard_hero_freed_headline">%1$s vrijgemaakt</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s kan worden verwijderd</string>
-    <string name="dashboard_hero_freed_x_items">%1$s verwijderd</string>
     <string name="dashboard_hero_freeable_hint">Tik op de knop om ruimte vrij te maken, of op een chip om eerst te controleren.</string>
     <string name="dashboard_hero_freed_hint">Raak een chip aan voor details.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-or-rIN/strings.xml
+++ b/app/src/main/res/values-or-rIN/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">ସମସ୍ତ ଟୁଲ୍‌ର ଫଳାଫଳ ଡିଲିଟ୍ କରିବେ?</string>
     <string name="dashboard_hero_freeable_headline">%1$s ମୁକ୍ତ କରିହେବ</string>
     <string name="dashboard_hero_freed_headline">%1$s ମୁକ୍ତ କରାଗଲା</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s ଅପସାରଣ କରିହେବ</string>
-    <string name="dashboard_hero_freed_x_items">%1$s ଅପସାରଣ କରାଗଲା</string>
     <string name="dashboard_hero_freeable_hint">ସ୍ଥାନ ମୁକ୍ତ କରିବାକୁ ବଟନକୁ ଟ୍ୟାପ୍ କରନ୍ତୁ, ଅଥବା ପ୍ରଥମେ ଚେକ୍ କରିବାକୁ ଏକ ଚିପକୁ ଟ୍ୟାପ୍ କରନ୍ତୁ।</string>
     <string name="dashboard_hero_freed_hint">ବିବରଣୀ ପାଇଁ ଏକ ଚିପ୍ ଟ୍ୟାପ କରନ୍ତୁ।</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-pa-rIN/strings.xml
+++ b/app/src/main/res/values-pa-rIN/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">ਕੀ ਸਾਰੇ ਸੰਦਾਂ ਵਿੱਚੋਂ ਨਤੀਜੇ ਮਿਟਾਉਣੇ ਹਨ?</string>
     <string name="dashboard_hero_freeable_headline">%1$s ਮੁਫਤ ਕੀਤਾ ਜਾ ਸਕਦਾ ਹੈ</string>
     <string name="dashboard_hero_freed_headline">%1$s ਮੁਕਤ ਕੀਤਾ ਗਿਆ</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s ਹਟਾਇਆ ਜਾ ਸਕਦਾ ਹੈ</string>
-    <string name="dashboard_hero_freed_x_items">%1$s ਹਟਾਇਆ ਗਿਆ</string>
     <string name="dashboard_hero_freeable_hint">ਸਪੇਸ ਖਾਲੀ ਕਰਨ ਲਈ ਬਟਨ \'ਤੇ ਟੈਪ ਕਰੋ, ਜਾਂ ਪਹਿਲਾਂ ਚੈਕ ਕਰਨ ਲਈ ਚਿਪ \'ਤੇ ਟੈਪ ਕਰੋ।</string>
     <string name="dashboard_hero_freed_hint">ਵਿਸਥਾਰ ਲਈ ਚਿਪ ਨੂੰ ਦਬਾਓ।</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Usunąć wyniki we wszystkich narzędziach?</string>
     <string name="dashboard_hero_freeable_headline">Można zwolnić %1$s</string>
     <string name="dashboard_hero_freed_headline">Zwolniono %1$s</string>
-    <string name="dashboard_hero_freeable_x_items">Można usunąć %1$s</string>
-    <string name="dashboard_hero_freed_x_items">%1$s usunięto</string>
     <string name="dashboard_hero_freeable_hint">Naciśnij przycisk, aby zwolnić miejsce, lub znacznik, aby najpierw sprawdzić.</string>
     <string name="dashboard_hero_freed_hint">Naciśnij znacznik, aby wyświetlić szczegóły.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Excluir resultados em todas as ferramentas?</string>
     <string name="dashboard_hero_freeable_headline">%1$s pode ser liberado</string>
     <string name="dashboard_hero_freed_headline">%1$s liberado</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s pode ser removido</string>
-    <string name="dashboard_hero_freed_x_items">%1$s removido</string>
     <string name="dashboard_hero_freeable_hint">Toque o botão para liberar espaço, ou um chip para verificar primeiro.</string>
     <string name="dashboard_hero_freed_hint">Toque um chip para obter detalhes.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Apagar os resultados em todas as ferramentas?</string>
     <string name="dashboard_hero_freeable_headline">Pode libertar %1$s</string>
     <string name="dashboard_hero_freed_headline">%1$s livre</string>
-    <string name="dashboard_hero_freeable_x_items">Pode remover %1$s</string>
-    <string name="dashboard_hero_freed_x_items">%1$s removido</string>
     <string name="dashboard_hero_freeable_hint">Toque no botão para libertar espaço, ou numa pastilha para verificar primeiro.</string>
     <string name="dashboard_hero_freed_hint">Toque numa etiqueta para detalhes.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Ștergeți rezultatele din toate instrumentele?</string>
     <string name="dashboard_hero_freeable_headline">%1$s poate fi eliberat</string>
     <string name="dashboard_hero_freed_headline">%1$s eliberat</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s poate fi eliminat</string>
-    <string name="dashboard_hero_freed_x_items">%1$s eliminat</string>
     <string name="dashboard_hero_freeable_hint">Atingeți butonul pentru a elibera spațiu, sau o etichetă pentru a verifica mai întâi.</string>
     <string name="dashboard_hero_freed_hint">Apasă o etichetă pentru detalii.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Удалить результаты во всех инструментах?</string>
     <string name="dashboard_hero_freeable_headline">Можно освободить: %1$s</string>
     <string name="dashboard_hero_freed_headline">%1$s освобождено</string>
-    <string name="dashboard_hero_freeable_x_items">Можно удалить: %1$s</string>
-    <string name="dashboard_hero_freed_x_items">%1$s удалено</string>
     <string name="dashboard_hero_freeable_hint">Коснитесь кнопки, чтобы освободить место, или чипа для предварительной проверки.</string>
     <string name="dashboard_hero_freed_hint">Коснитесь чипа для получения подробной информации.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-sc-rIT/strings.xml
+++ b/app/src/main/res/values-sc-rIT/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Cantzellare is risultados in totu is ainas?</string>
     <string name="dashboard_hero_freeable_headline">%1$s si podet isberare</string>
     <string name="dashboard_hero_freed_headline">%1$s isberadu</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s si podet tòllere</string>
-    <string name="dashboard_hero_freed_x_items">%1$s tollidu</string>
     <string name="dashboard_hero_freeable_hint">Toca su butone pro liberare spazzu, o un chip pro controlare subprima.</string>
     <string name="dashboard_hero_freed_hint">Toca un chip pro dettallus.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-si-rLK/strings.xml
+++ b/app/src/main/res/values-si-rLK/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">සියලුම මෙවලම්වල ප්‍රතිඵල මකා දමන්නද?</string>
     <string name="dashboard_hero_freeable_headline">%1$s නිදහස් කළ හැක</string>
     <string name="dashboard_hero_freed_headline">%1$s නිදහස් කරගෙන ඇත</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s ඉවත් කළ හැක</string>
-    <string name="dashboard_hero_freed_x_items">%1$s ඉවත් කරගෙන ඇත</string>
     <string name="dashboard_hero_freeable_hint">ඉතිරි පිටපතක් ගිණීමට බොත්තම තට්ටු කරන්න, හෝ පළමුව පරීක්ෂා කිරීමට ඡිපය තට්ටු කරන්න.</string>
     <string name="dashboard_hero_freed_hint">විස්තර සඳහා චිප ටැප් කරන්න.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Odstrániť výsledky vo všetkých nástrojoch?</string>
     <string name="dashboard_hero_freeable_headline">%1$s sa dá uvoľniť</string>
     <string name="dashboard_hero_freed_headline">%1$s uvoľnené</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s sa dá odstrániť</string>
-    <string name="dashboard_hero_freed_x_items">%1$s odstránené</string>
     <string name="dashboard_hero_freeable_hint">Klepnite na tlačidlo, aby ste uvoľnili miesto, alebo na čip, ak chcete najskôr skontrolovať.</string>
     <string name="dashboard_hero_freed_hint">Klepnite na štítok pre podrobnosti.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Izbriši rezultate v vseh orodjih?</string>
     <string name="dashboard_hero_freeable_headline">Sprostite lahko %1$s.</string>
     <string name="dashboard_hero_freed_headline">Sproščeno je bilo %1$s.</string>
-    <string name="dashboard_hero_freeable_x_items">Odstraniti je mogoče %1$s.</string>
-    <string name="dashboard_hero_freed_x_items">Odstranjeno je bilo %1$s.</string>
     <string name="dashboard_hero_freeable_hint">Pritisnite gumb, da sprostite prostor, ali oznako za preverjanje najprej.</string>
     <string name="dashboard_hero_freed_hint">Tapnite čip za podrobnosti.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-sq-rAL/strings.xml
+++ b/app/src/main/res/values-sq-rAL/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Të fshihen rezultatet në të gjitha mjetet?</string>
     <string name="dashboard_hero_freeable_headline">%1$s mund të lirohet</string>
     <string name="dashboard_hero_freed_headline">%1$s u lirua</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s mund të hiqet</string>
-    <string name="dashboard_hero_freed_x_items">%1$s u hoq</string>
     <string name="dashboard_hero_freeable_hint">Prekni butonin për të liruar hapësirë, ose një çip për të kontrolluar fillimisht.</string>
     <string name="dashboard_hero_freed_hint">Prek një çip për më shumë detaje.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Избрисати резултате у свим алаткама?</string>
     <string name="dashboard_hero_freeable_headline">%1$s се може ослободити</string>
     <string name="dashboard_hero_freed_headline">%1$s ослобођено</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s се може уклонити</string>
-    <string name="dashboard_hero_freed_x_items">%1$s уклоњено</string>
     <string name="dashboard_hero_freeable_hint">Притисните дугме да ослободите простор, или чип да прво проверите.</string>
     <string name="dashboard_hero_freed_hint">Додирните чип за детаље.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Ta bort resultat i alla verktyg?</string>
     <string name="dashboard_hero_freeable_headline">%1$s kan frigöras</string>
     <string name="dashboard_hero_freed_headline">%1$s frigjord</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s kan tas bort</string>
-    <string name="dashboard_hero_freed_x_items">%1$s borttagen</string>
     <string name="dashboard_hero_freeable_hint">Tryck på knappen för att frigöra utrymme, eller på ett chip för att kontrollera först.</string>
     <string name="dashboard_hero_freed_hint">Tryck på en chip för detaljer.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Futa matokeo katika zana zote?</string>
     <string name="dashboard_hero_freeable_headline">%1$s inaweza kuachiliwa</string>
     <string name="dashboard_hero_freed_headline">Kuachiliwa %1$s</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s inaweza kuondolewa</string>
-    <string name="dashboard_hero_freed_x_items">Kuondolewa %1$s</string>
     <string name="dashboard_hero_freeable_hint">Gusa kitufe ili kuachia nafasi, au chip ili kuangalia kwanza.</string>
     <string name="dashboard_hero_freed_hint">Gusa kiambishi kwa maelezo.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-ta-rIN/strings.xml
+++ b/app/src/main/res/values-ta-rIN/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">அனைத்து கருவிகளிலும் முடிவுகளை நீக்கவா?</string>
     <string name="dashboard_hero_freeable_headline">%1$s விடுவிக்கப்படலாம்</string>
     <string name="dashboard_hero_freed_headline">%1$s விடுவிக்கப்பட்டது</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s நீக்கப்படலாம்</string>
-    <string name="dashboard_hero_freed_x_items">%1$s நீக்கப்பட்டது</string>
     <string name="dashboard_hero_freeable_hint">பொத்தானைத் தட்டி இடைவெளியை விடுவிக்க, அல்லது முதலில் சரிபார்க்க ஒரு சிப்பைத் தட்டவும்.</string>
     <string name="dashboard_hero_freed_hint">விவரங்களுக்கு ஒரு சிப்பை தட்டவும்.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-te-rIN/strings.xml
+++ b/app/src/main/res/values-te-rIN/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">అన్ని టూల్స్‌లోని ఫలితాలను తొలగించాలా?</string>
     <string name="dashboard_hero_freeable_headline">%1$s విడిపించవచ్చు</string>
     <string name="dashboard_hero_freed_headline">%1$s విడిపించబడింది</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s తొలగించవచ్చు</string>
-    <string name="dashboard_hero_freed_x_items">%1$s తొలగించబడింది</string>
     <string name="dashboard_hero_freeable_hint">స్థలాన్ని విడిపించడానికి బటన్‌ను నొక్కండి లేదా ముందుగా చెక్ చేయడానికి చిప్‌ను నొక్కండి.</string>
     <string name="dashboard_hero_freed_hint">వివరాల కోసం చిప్‌ను నొక్కండి.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">ลบการรายงานผลทั้งหมดหรือไม่?</string>
     <string name="dashboard_hero_freeable_headline">%1$s สามารถปล่อยออกได้</string>
     <string name="dashboard_hero_freed_headline">%1$s ปล่อยออก</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s สามารถลบออกได้</string>
-    <string name="dashboard_hero_freed_x_items">%1$s ลบออก</string>
     <string name="dashboard_hero_freeable_hint">แตะปุ่มเพื่อเพิ่มพื้นที่ว่าง หรือแตะชิปเพื่อตรวจสอบก่อน</string>
     <string name="dashboard_hero_freed_hint">แตะชิปเพื่อดูรายละเอียด</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Tüm sonuçlar silinsin mi?</string>
     <string name="dashboard_hero_freeable_headline">%1$s serbest bırakılabilir</string>
     <string name="dashboard_hero_freed_headline">%1$s serbest bırakıldı</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s kaldırılabilir</string>
-    <string name="dashboard_hero_freed_x_items">%1$s kaldırıldı</string>
     <string name="dashboard_hero_freeable_hint">Alan boşaltmak için düğmeye dokunun veya önce kontrol etmek için bir çipe dokunun.</string>
     <string name="dashboard_hero_freed_hint">Ayrıntılar için bir çipe dokunun.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Видалити результати в усіх інструментах?</string>
     <string name="dashboard_hero_freeable_headline">Можна звільнити %1$s</string>
     <string name="dashboard_hero_freed_headline">Звільнено %1$s</string>
-    <string name="dashboard_hero_freeable_x_items">Можна видалити %1$s</string>
-    <string name="dashboard_hero_freed_x_items">Видалено %1$s</string>
     <string name="dashboard_hero_freeable_hint">Натисніть кнопку для звільнення місця або чіп для попередньої перевірки.</string>
     <string name="dashboard_hero_freed_hint">Торкніться чіпа для деталей.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-ur-rIN/strings.xml
+++ b/app/src/main/res/values-ur-rIN/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">تمام ٹولز میں نتائج کو حذف کریں؟</string>
     <string name="dashboard_hero_freeable_headline">%1$s خالی کیا جا سکتا ہے</string>
     <string name="dashboard_hero_freed_headline">%1$s خالی کیا گیا</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s ہٹایا جا سکتا ہے</string>
-    <string name="dashboard_hero_freed_x_items">%1$s ہٹایا گیا</string>
     <string name="dashboard_hero_freeable_hint">جگہ خالی کرنے کے لیے بٹن دبائیں یا پہلے چیک کرنے کے لیے ایک چپ دبائیں</string>
     <string name="dashboard_hero_freed_hint">تفصیلات کے لیے ایک چپ کو تھپتھپائیں۔</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-uz/strings.xml
+++ b/app/src/main/res/values-uz/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Barcha vositalardan natijalarni o\'chirish kerakmi?</string>
     <string name="dashboard_hero_freeable_headline">%1$s bo\'shatish mumkin</string>
     <string name="dashboard_hero_freed_headline">%1$s bo\'shatildi</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s o\'chirish mumkin</string>
-    <string name="dashboard_hero_freed_x_items">%1$s o\'chirildi</string>
     <string name="dashboard_hero_freeable_hint">Maydonni bo\'shatish uchun tugmani bosing yoki birinchi tekshirish uchun chipni bosing.</string>
     <string name="dashboard_hero_freed_hint">Batafsil uchun chipni bosing.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Xóa kết quả trong tất cả công cụ?</string>
     <string name="dashboard_hero_freeable_headline">%1$s có thể được giải phóng</string>
     <string name="dashboard_hero_freed_headline">Đã giải phóng %1$s</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s có thể được xóa</string>
-    <string name="dashboard_hero_freed_x_items">Đã xóa %1$s</string>
     <string name="dashboard_hero_freeable_hint">Nhấn nút để giải phóng dung lượng, hoặc nhấn một chip để kiểm tra trước.</string>
     <string name="dashboard_hero_freed_hint">Nhấn một chip để xem chi tiết.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">是否删除所有功能的结果？</string>
     <string name="dashboard_hero_freeable_headline">可释放 %1$s 空间</string>
     <string name="dashboard_hero_freed_headline">已释放 %1$s 空间</string>
-    <string name="dashboard_hero_freeable_x_items">可删除 %1$s</string>
-    <string name="dashboard_hero_freed_x_items">已删除 %1$s</string>
     <string name="dashboard_hero_freeable_hint">点按按钮释放空间，或点按标签先检查。</string>
     <string name="dashboard_hero_freed_hint">点击标签查看详情。</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">在所有工具中刪除結果？</string>
     <string name="dashboard_hero_freeable_headline">%1$s 可以釋放</string>
     <string name="dashboard_hero_freed_headline">%1$s 已釋出</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s 可以移除</string>
-    <string name="dashboard_hero_freed_x_items">%1$s 已移除</string>
     <string name="dashboard_hero_freeable_hint">點擊按鈕釋放空間，或先點擊標籤以檢查。</string>
     <string name="dashboard_hero_freed_hint">點擊卡片以查看詳細資料。</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">在所有工具中刪除結果？</string>
     <string name="dashboard_hero_freeable_headline">%1$s 可釋出</string>
     <string name="dashboard_hero_freed_headline">%1$s 已釋出</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s 可移除</string>
-    <string name="dashboard_hero_freed_x_items">%1$s 已移除</string>
     <string name="dashboard_hero_freeable_hint">點擊按鈕以釋放空間，或點擊標籤先檢查。</string>
     <string name="dashboard_hero_freed_hint">點擊標籤以取得詳細資訊。</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values-zu/strings.xml
+++ b/app/src/main/res/values-zu/strings.xml
@@ -3,8 +3,6 @@
     <string name="dashboard_delete_all_message">Susa imiphumela kuwo wonke amathuluzi?</string>
     <string name="dashboard_hero_freeable_headline">%1$s ingakhululwa</string>
     <string name="dashboard_hero_freed_headline">%1$s khululiwe</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s ingasuswa</string>
-    <string name="dashboard_hero_freed_x_items">%1$s susuliwe</string>
     <string name="dashboard_hero_freeable_hint">Cisha inkinobho ukuze kukhululeke indawo, noma ichips ukuze uhlole kuqala.</string>
     <string name="dashboard_hero_freed_hint">Thinta ichip ukuthola imininingwane.</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,8 +2,17 @@
     <string name="dashboard_delete_all_message">Delete results in all tools?</string>
     <string name="dashboard_hero_freeable_headline">%1$s can be freed</string>
     <string name="dashboard_hero_freed_headline">%1$s freed</string>
-    <string name="dashboard_hero_freeable_x_items">%1$s can be removed</string>
-    <string name="dashboard_hero_freed_x_items">%1$s removed</string>
+    <!-- Full sentences with the count inlined, not a count spliced into a separate string: languages
+         with verb agreement (de, it, fr, …) need a different verb form per quantity, and a plain
+         <string> can only ever offer the translator one. -->
+    <plurals name="dashboard_hero_freeable_x_items">
+        <item quantity="one">%d item can be removed</item>
+        <item quantity="other">%d items can be removed</item>
+    </plurals>
+    <plurals name="dashboard_hero_freed_x_items">
+        <item quantity="one">%d item removed</item>
+        <item quantity="other">%d items removed</item>
+    </plurals>
     <string name="dashboard_hero_freeable_hint">Tap the button to free space, or a chip to check first.</string>
     <string name="dashboard_hero_freed_hint">Tap a chip for details.</string>
     <!-- Shown when a cleanup ran to completion but could not free any space -->

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardHeroCardTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardHeroCardTest.kt
@@ -20,6 +20,7 @@ import eu.darken.sdmse.main.ui.dashboard.HeroSummary
 import eu.darken.sdmse.main.core.SDMTool
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import org.robolectric.annotation.Config
 import testhelpers.compose.BaseComposeRobolectricTest
 import java.time.Instant
 
@@ -27,10 +28,13 @@ class DashboardHeroCardTest : BaseComposeRobolectricTest() {
 
     private val context: Context get() = ApplicationProvider.getApplicationContext()
 
-    private fun summary(timestamp: Instant? = null) = HeroSummary(
+    private fun summary(
+        timestamp: Instant? = null,
+        itemCount: Int = 37,
+    ) = HeroSummary(
         mode = HeroSummary.Mode.FREEABLE,
         totalSize = 2L * 1024 * 1024 * 1024,
-        itemCount = 37,
+        itemCount = itemCount,
         tools = listOf(
             HeroSummary.ToolSlice(SDMTool.Type.CORPSEFINDER, 1L * 1024 * 1024 * 1024, 12),
             HeroSummary.ToolSlice(SDMTool.Type.SYSTEMCLEANER, 1L * 1024 * 1024 * 1024, 25),
@@ -68,6 +72,54 @@ class DashboardHeroCardTest : BaseComposeRobolectricTest() {
             }
         }
         composeRule.onNodeWithText("can be removed", substring = true).assertExists()
+    }
+
+    private fun renderHero(hero: HeroSummary) {
+        composeRule.setContent {
+            PreviewWrapper {
+                BottomBar(
+                    state = deleteState(hero),
+                    isVisible = true,
+                    heroVisible = true,
+                    onMainAction = {},
+                    onMainActionLongClick = {},
+                    onSettings = {},
+                    onUpgrade = {},
+                    onDismissHero = {},
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `freeable caption uses the singular form for a single item`() {
+        renderHero(summary(itemCount = 1))
+        composeRule.onNodeWithText("1 item can be removed", substring = true).assertExists()
+    }
+
+    // Regression: the caption used to splice an already-pluralized noun phrase into a plain <string>,
+    // so German was locked to the singular verb and rendered "10 Elemente kann entfernt werden".
+    //
+    // Expected text is resolved through the resources rather than hardcoded — values-de is a Crowdin
+    // download target, so pinning wording would make a translator reword or a crowdin pull fail CI.
+    // Matching is exact and positive-only: a substring check can spuriously fail when one form
+    // legitimately contains the other, and asserting the absence of the opposing form breaks on the
+    // impersonal rephrasings that make both forms identical (several locales already do this). An
+    // exact match on the form for the real count already fails if the wrong form is selected.
+    @Test
+    @Config(qualifiers = "de")
+    fun `german caption picks the plural form for multiple items`() {
+        val expected = context.resources.getQuantityString(R.plurals.dashboard_hero_freeable_x_items, 10, 10)
+        renderHero(summary(itemCount = 10))
+        composeRule.onNodeWithText(expected).assertExists()
+    }
+
+    @Test
+    @Config(qualifiers = "de")
+    fun `german caption picks the singular form for a single item`() {
+        val expected = context.resources.getQuantityString(R.plurals.dashboard_hero_freeable_x_items, 1, 1)
+        renderHero(summary(itemCount = 1))
+        composeRule.onNodeWithText(expected).assertExists()
     }
 
     @Test


### PR DESCRIPTION
## What changed

The dashboard card that reports what can be cleaned showed the item count with the wrong grammar in
many languages. In German it read "10 Elemente kann entfernt werden" instead of "10 Elemente **können**
entfernt werden" — the singular verb, no matter how many items there were.

This was not a bad translation. The text was assembled in a way that gave translators only one verb
form to work with, so no German translation could have been correct for both "1 Element" and
"10 Elemente". The same was true for Italian, French, Dutch, Croatian, Romanian, Serbian, Brazilian
Portuguese, Danish, Swedish and Norwegian. Several other languages had quietly worked around it by
rephrasing the sentence impersonally.

Reported by a user over support, with a screenshot.

## Technical Context

- **Root cause**: the caption nested two resources. `result_x_items` produced an already-pluralized
  noun phrase ("10 Elemente"), which was then substituted into a plain `<string>`, `"%1$s can be
  removed"`. English is number-agnostic here, so the defect was invisible in the base language, but a
  `<string>` exposes exactly one form per locale.
- **Fix**: both captions become full-sentence `<plurals>` with the count inlined as `%d`, matching the
  convention already used by `appcleaner_result_x_items_deleted`. The nested composition is gone.
- **This one is exact, not best-effort**: the quantity is an item count, so it is always an integer and
  CLDR categorises it unambiguously.
- **Translations**: the resource type changed, so the previous translations of these two keys are
  removed from the other locales and Crowdin will re-translate them. Those locales fall back to English
  until it does. German is written here so the reported string is correct on the next build — note this
  means the German plurals need adding/approving in Crowdin too, since `values-de` is a download target
  and would otherwise be overwritten on the next pull.

### Deliberately out of scope

The headline on the same card ("78 MB can be freed") has the same symptom, and is **not** fixed here.
It is keyed on a formatted size rather than a count, and `getQuantityString` takes an `Int` while CLDR
categorises a decimal using its integer part *and* its visible fraction digits. A rendered "1.1 GB" is
`other` in German but `one` in French, and Polish reaches `other` only through fractional values, so no
integer can stand in for it. Attempting it either way trades one language's correctness for another's.

That limitation applies to roughly 26 existing size-keyed call sites app-wide, not just this card, and
it is already visible in English: `stats_dash_body_size` currently renders "1.1 GB has been freed."
where CLDR wants "have". Worth its own change — either keying those messages on an item count the way
`swiper_delete_confirmation_message` already does, or making the forms number-invariant.

### Review guidance

- 72 of the 76 changed files are the identical mechanical removal of the same two keys. The real
  changes are `values/strings.xml`, `values-de/strings.xml`, `DashboardHeroCard.kt` and its test.
- The tests assert *which* plural form the card selects and resolve the expected text through the
  resources rather than hardcoding German copy. `values-de` is a Crowdin download target, so pinning
  wording would break CI on any reword or pull. Matching is exact and positive-only: a substring check
  can spuriously fail when one form legitimately contains the other, and asserting the absence of the
  opposing form breaks on the impersonal rephrasings that make both forms identical.
