### PR TITLE
General: Improve the reliability of the upgrade screens

### DIFF
--- a/app/src/foss/java/eu/darken/sdmse/common/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/foss/java/eu/darken/sdmse/common/upgrade/ui/UpgradeScreen.kt
@@ -54,7 +54,12 @@ fun UpgradeScreenHost(
 
     val context = LocalContext.current
     val snackbarHostState = remember { SnackbarHostState() }
-    val sponsorReturnTracker = remember { SponsorReturnTracker() }
+    // Seeded from the ViewModel's handle-backed pending launch: after a process death while the
+    // sponsor page was open, a blank tracker would swallow the very first return. The handle is the
+    // authority on whether a return is still expected, so it reconstructs the tracker's state.
+    val sponsorReturnTracker = remember(vm) {
+        SponsorReturnTracker(wentToBackground = vm.hasPendingSponsorLaunch())
+    }
 
     LaunchedEffect(Unit) {
         vm.snackbarEvents.collect { stringRes ->
@@ -257,8 +262,9 @@ private fun UpgradeStatusUpgradedContent(
     }
 }
 
-internal class SponsorReturnTracker {
-    private var wentToBackground = false
+internal class SponsorReturnTracker(
+    private var wentToBackground: Boolean = false,
+) {
 
     fun onStop() {
         wentToBackground = true

--- a/app/src/foss/java/eu/darken/sdmse/common/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/foss/java/eu/darken/sdmse/common/upgrade/ui/UpgradeScreen.kt
@@ -34,6 +34,10 @@ import eu.darken.sdmse.common.error.ErrorEventHandler
 import eu.darken.sdmse.common.navigation.NavigationEventHandler
 import eu.darken.sdmse.common.navigation.routes.UpgradeRoute
 import androidx.compose.ui.unit.dp
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
 
 // Which presentation the FOSS upgrade screen shows: the classic support pitch, or one of the
 // status views behind the settings "upgrade status" entry.
@@ -82,12 +86,13 @@ fun UpgradeScreenHost(
         }
     }
 
-    val view by vm.state.collectAsStateWithLifecycle()
+    val state by vm.state.collectAsStateWithLifecycle()
 
     UpgradeScreen(
         // Until the route binding lands (one frame): the default route keeps rendering the pitch
         // exactly as before, only the manage route waits for the status decision.
-        view = view ?: FossUpgradeView.PITCH.takeIf { !route.manage },
+        view = state.view ?: FossUpgradeView.PITCH.takeIf { !route.manage },
+        supporterSince = state.supporterSince,
         snackbarHostState = snackbarHostState,
         onGithubSponsors = vm::goGithubSponsors,
         onShowUpgradeOptions = vm::onShowUpgradeOptions,
@@ -98,6 +103,7 @@ fun UpgradeScreenHost(
 @Composable
 internal fun UpgradeScreen(
     view: FossUpgradeView? = FossUpgradeView.PITCH,
+    supporterSince: Instant? = null,
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     onGithubSponsors: () -> Unit = {},
     onShowUpgradeOptions: () -> Unit = {},
@@ -128,6 +134,7 @@ internal fun UpgradeScreen(
 
             FossUpgradeView.STATUS_UPGRADED -> UpgradeStatusUpgradedContent(
                 paddingValues = paddingValues,
+                supporterSince = supporterSince,
                 onGithubSponsors = onGithubSponsors,
             )
         }
@@ -221,6 +228,7 @@ private fun UpgradeStatusFreeContent(
 @Composable
 private fun UpgradeStatusUpgradedContent(
     paddingValues: PaddingValues,
+    supporterSince: Instant? = null,
     onGithubSponsors: () -> Unit,
 ) {
     UpgradeScreenContent(
@@ -243,6 +251,15 @@ private fun UpgradeStatusUpgradedContent(
                 text = stringResource(R.string.upgrade_screen_status_upgraded_body),
                 style = MaterialTheme.typography.bodyMedium,
             )
+            supporterSince?.let { since ->
+                val formatter = remember {
+                    DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withZone(ZoneId.systemDefault())
+                }
+                Text(
+                    text = stringResource(R.string.upgrade_screen_supporter_since, formatter.format(since)),
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
         }
 
         UpgradeSectionCard(
@@ -300,6 +317,9 @@ private fun UpgradeScreenStatusFreePreview() {
 @Composable
 private fun UpgradeScreenStatusUpgradedPreview() {
     PreviewWrapper {
-        UpgradeScreen(view = FossUpgradeView.STATUS_UPGRADED)
+        UpgradeScreen(
+            view = FossUpgradeView.STATUS_UPGRADED,
+            supporterSince = Instant.ofEpochMilli(1_700_000_000_000L),
+        )
     }
 }

--- a/app/src/foss/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/foss/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.take
+import java.time.Instant
 import javax.inject.Inject
 
 @HiltViewModel
@@ -43,20 +44,29 @@ class UpgradeViewModel @Inject constructor(
     // gets a status view first; the pitch only appears once a free user asks for the upgrade
     // options. Upgrading wins over that choice — completing the sponsor flow from the pitch must
     // land on the upgraded status, not back on the ask. null until the route is bound.
-    internal val state: StateFlow<FossUpgradeView?> = combine(
+    internal val state: StateFlow<State> = combine(
         routeFlow,
         upgradeRepo.upgradeInfo,
         handle.getStateFlow(KEY_SHOW_UPGRADE_OPTIONS, false),
     ) { route, info, showOptions ->
-        when {
+        val view = when {
             route == null -> null
             route.manage && info.isPro -> FossUpgradeView.STATUS_UPGRADED
             route.manage && !showOptions -> FossUpgradeView.STATUS_FREE
             else -> FossUpgradeView.PITCH
         }
+        // Derived in the same emission as the view on purpose: a sibling flow would let the
+        // upgraded status render for a frame without the date it is supposed to carry.
+        State(view = view, supporterSince = info.upgradedAt)
     }.safeStateIn(
-        initialValue = null,
-        onError = { FossUpgradeView.PITCH },
+        initialValue = State(),
+        onError = { State(view = FossUpgradeView.PITCH) },
+    )
+
+    // internal like FossUpgradeView: the view enum is a screen-local presentation detail.
+    internal data class State(
+        val view: FossUpgradeView? = null,
+        val supporterSince: Instant? = null,
     )
 
     init {

--- a/app/src/foss/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/foss/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
@@ -97,6 +97,15 @@ class UpgradeViewModel @Inject constructor(
         upgradeRepo.openGithubSponsorsPage()
     }
 
+    /**
+     * Whether a sponsor-page launch is still awaiting its return.
+     *
+     * Handle-backed, so it survives process recreation while the browser is in front — the screen's
+     * in-memory return tracker does not, and gating on that alone drops the first return after a
+     * recreation.
+     */
+    fun hasPendingSponsorLaunch(): Boolean = handle.contains(KEY_SPONSOR_PRESSED_AT)
+
     fun checkSponsorReturn() = launch {
         val pressedAt = handle.remove<Long>(KEY_SPONSOR_PRESSED_AT) ?: return@launch
         val elapsed = SystemClock.elapsedRealtime() - pressedAt

--- a/app/src/foss/res/values/strings.xml
+++ b/app/src/foss/res/values/strings.xml
@@ -23,6 +23,7 @@
     <string name="upgrade_screen_status_free_action">See upgrade options</string>
     <string name="upgrade_screen_status_upgraded_title">Upgrade active</string>
     <string name="upgrade_screen_status_upgraded_body">All extra features are unlocked. Thank you for supporting open-source development ❤️</string>
+    <string name="upgrade_screen_supporter_since">Supporter since %s</string>
     <string name="upgrade_screen_recurring_title">Keep it going</string>
     <string name="upgrade_screen_recurring_body">SD Maid keeps evolving through updates and fixes. If you\'d like to sustain that, consider a recurring donation via GitHub Sponsors.</string>
     <string name="upgrade_screen_recurring_action">Open GitHub Sponsors</string>

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/BillingCache.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/BillingCache.kt
@@ -11,19 +11,27 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.sdmse.common.datastore.basicReader
 import eu.darken.sdmse.common.datastore.basicWriter
 import eu.darken.sdmse.common.datastore.createValue
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeoutOrNull
+import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
 
+private val Context.billingCacheDataStore by preferencesDataStore(name = "settings_gplay")
+
 @Singleton
-class BillingCache @Inject constructor(
-    @ApplicationContext private val context: Context,
+class BillingCache internal constructor(
+    private val dataStore: DataStore<Preferences>,
 ) {
 
-    private val Context.dataStore by preferencesDataStore(name = "settings_gplay")
+    @Inject constructor(@ApplicationContext context: Context) : this(context.billingCacheDataStore)
 
-    private val dataStore: DataStore<Preferences>
-        get() = context.dataStore
+    // Test seam: the bounded reads/writes below run on real dispatchers, so a virtual-time test
+    // cannot advance the production bound. Same pattern as UpgradeRepoGplay.launchTimeoutMs.
+    internal var cacheTimeoutMs: Long = CACHE_TIMEOUT_MS
 
     // Raw keys shared between the DataStoreValues and stampLastProState's transaction — one
     // source of truth for key name and encoding.
@@ -60,8 +68,15 @@ class BillingCache @Inject constructor(
         val proUnconfirmedSince: Long,
     )
 
+    // Bounded on purpose: a wedged DataStore file lock would otherwise hang the caller forever.
+    // A timeout must NOT fall back to the default snapshot -- that would report "never bought"
+    // for an install whose evidence merely couldn't be read, which is the exact distinction the
+    // debug-log header exists to make.
     suspend fun snapshot(): Snapshot {
-        val prefs = dataStore.data.first()
+        val prefs = withTimeoutOrNull(cacheTimeoutMs) { dataStore.data.first() } ?: run {
+            log(TAG, WARN) { "snapshot() timed out after ${cacheTimeoutMs}ms" }
+            throw IOException("BillingCache snapshot timed out after ${cacheTimeoutMs}ms")
+        }
         return Snapshot(
             lastProStateAt = prefs[lastProStateAtKey] ?: 0L,
             lastProStateSku = prefs[lastProStateSkuKey] ?: "",
@@ -77,11 +92,19 @@ class BillingCache @Inject constructor(
     // entitlement layer out of order) opened a still-valid episode that this older confirmation must
     // not erase.
     suspend fun stampLastProState(skuId: String, at: Long) {
-        dataStore.edit { prefs ->
-            prefs[lastProStateSkuKey] = skuId
-            prefs[lastProStateAtKey] = at
-            val episodeStart = prefs[proUnconfirmedSinceKey] ?: 0L
-            if (episodeStart in 1..at) prefs[proUnconfirmedSinceKey] = 0L
-        }
+        // Fail-soft: this decorates the entitlement path, it must never be the thing that blocks it.
+        withTimeoutOrNull(cacheTimeoutMs) {
+            dataStore.edit { prefs ->
+                prefs[lastProStateSkuKey] = skuId
+                prefs[lastProStateAtKey] = at
+                val episodeStart = prefs[proUnconfirmedSinceKey] ?: 0L
+                if (episodeStart in 1..at) prefs[proUnconfirmedSinceKey] = 0L
+            }
+        } ?: log(TAG, WARN) { "stampLastProState($skuId, $at) timed out after ${cacheTimeoutMs}ms, write skipped" }
+    }
+
+    companion object {
+        private const val CACHE_TIMEOUT_MS = 2_000L
+        private val TAG = logTag("Upgrade", "Gplay", "BillingCache")
     }
 }

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeDiagnosticsGplay.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeDiagnosticsGplay.kt
@@ -1,31 +1,63 @@
 package eu.darken.sdmse.common.upgrade.core
 
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.asLog
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.upgrade.UpgradeDiagnostics
+import eu.darken.sdmse.main.core.CurriculumVitae
+import kotlinx.coroutines.CancellationException
 import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * Reports the local billing cache into the debug log header.
+ * Reports the local billing cache and the lifetime Pro-state history into the debug log header.
  *
  * `lastProStateAt > 0` is the "this install once confirmed a real Pro purchase" bit. It predates
  * the CurriculumVitae pro-state counters by years and lives in a DataStore that was never migrated
  * or renamed, so it survives update chains that the newer counters can't speak to. Without it in
  * the header, a purchase complaint can't be told apart from a never-bought install.
  *
- * Depends on [BillingCache] alone -- see [UpgradeDiagnostics] for why this must not pull in
- * UpgradeRepoGplay.
+ * Depends on [BillingCache] and [CurriculumVitae] alone -- see [UpgradeDiagnostics] for why this
+ * must not pull in UpgradeRepoGplay.
  */
 @Singleton
 class UpgradeDiagnosticsGplay @Inject constructor(
     private val billingCache: BillingCache,
+    private val curriculumVitae: CurriculumVitae,
 ) : UpgradeDiagnostics {
 
     override suspend fun debugInfo(): String {
-        val snapshot = billingCache.snapshot()
-        val lastProAt = snapshot.lastProStateAt.takeIf { it > 0 }?.let { Instant.ofEpochMilli(it) } ?: "never"
-        val lastProSku = snapshot.lastProStateSku.takeIf { it.isNotEmpty() } ?: "unknown/legacy"
-        val unconfirmedSince = snapshot.proUnconfirmedSince.takeIf { it > 0 }?.let { Instant.ofEpochMilli(it) } ?: "none"
-        return "BillingCache(lastProStateAt=$lastProAt, lastProStateSku=$lastProSku, proUnconfirmedSince=$unconfirmedSince)"
+        val cache = try {
+            val snapshot = billingCache.snapshot()
+            val lastProAt = snapshot.lastProStateAt.takeIf { it > 0 }?.let { Instant.ofEpochMilli(it) } ?: "never"
+            val lastProSku = snapshot.lastProStateSku.takeIf { it.isNotEmpty() } ?: "unknown/legacy"
+            val unconfirmedSince =
+                snapshot.proUnconfirmedSince.takeIf { it > 0 }?.let { Instant.ofEpochMilli(it) } ?: "none"
+            "BillingCache(lastProStateAt=$lastProAt, lastProStateSku=$lastProSku, " +
+                "proUnconfirmedSince=$unconfirmedSince)"
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, WARN) { "Billing cache unavailable: ${e.asLog()}" }
+            "BillingCache=unavailable"
+        }
+        // Separate boundary from the cache read above on purpose: these are different DataStores,
+        // and the counters only cover installs new enough to have them. A failure to read one must
+        // not suppress the other's independent evidence.
+        val history = try {
+            curriculumVitae.proHistory().toString()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, WARN) { "Pro history unavailable: ${e.asLog()}" }
+            "unavailable"
+        }
+        return "$cache, ProHistory=$history"
+    }
+
+    companion object {
+        private val TAG = logTag("Upgrade", "Gplay", "Diagnostics")
     }
 }

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -27,6 +28,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import eu.darken.sdmse.R
 import eu.darken.sdmse.common.compose.dialog.SdmConfirmDialog
@@ -50,8 +53,9 @@ fun UpgradeScreenHost(
     val context = LocalContext.current
     val activity = context as? android.app.Activity
 
-    // No screen-level resume refresh: MainActivity already refreshes the upgrade repo on every
-    // activity resume, which covers returning from Play after cancelling the subscription there.
+    // MainActivity's per-resume refresh only covers the entitlement, never the screen-local SKU
+    // query — so a transient Play outage would leave the retry card up until it's tapped by hand.
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) { vm.onResume() }
 
     // rememberSaveable, not remember: these are driven by one-shot events that are already consumed
     // from the flow, so a rotation while a dialog is up would drop it for good.
@@ -360,14 +364,24 @@ private fun UpgradeOffersBox(
         when (state) {
             GplayUpgradeUiState.Loading -> UpgradeActionCard { UpgradeLoadingBlock() }
             is GplayUpgradeUiState.Unavailable -> UpgradeInlineStateCard(
-                title = stringResource(R.string.upgrades_gplay_unavailable_error_title),
+                title = stringResource(R.string.upgrade_screen_offers_unavailable_title),
                 body = stringResource(R.string.upgrade_screen_offers_unavailable_message),
                 icon = Icons.TwoTone.WarningAmber,
             ) {
                 // Play can be slow rather than broken (cold store, first sign-in): let
                 // the user re-run the offer queries instead of leaving a dead screen.
+                // No reset needed: this composable unmounts the moment the state leaves Unavailable.
+                var retryTapped by remember { mutableStateOf(false) }
                 OutlinedButton(
-                    onClick = onRetry,
+                    // Guard inside the callback, not just via `enabled`: `enabled` only takes effect
+                    // after recomposition, so two taps in the same frame would both fire.
+                    onClick = {
+                        if (!retryTapped) {
+                            retryTapped = true
+                            onRetry()
+                        }
+                    },
+                    enabled = !retryTapped,
                     modifier = Modifier
                         .fillMaxWidth()
                         .testTag(UpgradeScreenTags.GPLAY_RETRY),

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
@@ -267,6 +267,14 @@ class UpgradeViewModel @Inject constructor(
         retryTrigger.update { it + 1 }
     }
 
+    // Returning to the screen is the user's own "try again": a transient Play outage would
+    // otherwise leave the retry card up until it's tapped by hand. Only re-queries from the
+    // unavailable state — a loaded or still-loading screen has nothing to retry.
+    fun onResume() {
+        log(TAG) { "onResume()" }
+        if (state.value is GplayUpgradeUiState.Unavailable) retrySkuQuery()
+    }
+
     // Acquires the single action slot. Rejects while ANY other entitlement action of this ViewModel
     // runs, and while the repo reports a Play launch in flight (which may belong to another VM
     // instance — the repo CAS remains the authoritative gate, this only avoids the pointless tap).

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -35,6 +35,7 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Renews yearly. Cancel anytime in Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">Buy once</string>
     <string name="upgrade_screen_iap_offer_body">One payment, no renewals.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Prices unavailable</string>
     <string name="upgrade_screen_offers_unavailable_message">Prices couldn\'t be loaded right now. Check Google Play and try again in a moment.</string>
     <string name="upgrade_screen_subscription_trial_action">Start free 14-day trial</string>
     <string name="upgrade_screen_subscription_action">Subscribe</string>

--- a/app/src/main/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModule.kt
@@ -27,6 +27,7 @@ import eu.darken.sdmse.common.upgrade.UpgradeDiagnostics
 import eu.darken.sdmse.main.core.CurriculumVitae
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.filter
@@ -99,9 +100,22 @@ class RecorderModule @Inject constructor(
 
                         val newRecorder = recorderProvider.get().apply { start(logDir) }
 
-                        if (!triggerFile.exists()) triggerFile.createNewFile()
+                        try {
+                            if (!triggerFile.exists()) triggerFile.createNewFile()
 
-                        logInfos()
+                            logInfos()
+                        } catch (e: Exception) {
+                            // The recorder is already live but not yet committed to the state: an exception escaping
+                            // the header would abandon it where stopRecorder() can't reach it.
+                            withContext(NonCancellable) {
+                                try {
+                                    newRecorder.stop()
+                                } catch (stopError: Exception) {
+                                    e.addSuppressed(stopError)
+                                }
+                            }
+                            throw e
+                        }
 
                         copy(
                             recorder = newRecorder,

--- a/app/src/main/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModule.kt
@@ -256,20 +256,7 @@ class RecorderModule @Inject constructor(
         log(TAG, INFO) { "Update history: ${curriculumVitae.history.firstOrNull()}" }
 
         try {
-            // Billing complaints usually arrive as debug logs: having the lifetime grace/Pro-loss
-            // history in the header saves a support round-trip.
-            log(TAG, INFO) { "Pro history: ${curriculumVitae.proHistory()}" }
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            // Diagnostics only — a broken history read must not stop the recorder from starting.
-            log(TAG, WARN) { "Pro history unavailable: ${e.asLog()}" }
-        }
-
-        // Separate boundary from the block above on purpose: these read different DataStores, and
-        // the counters above only cover installs new enough to have them. A failure to read one
-        // must not suppress the other's independent evidence.
-        try {
+            // Diagnostics only — a broken read must not stop the recorder from starting.
             upgradeDiagnostics.debugInfo()?.let { log(TAG, INFO) { "Upgrade diagnostics: $it" } }
         } catch (e: CancellationException) {
             throw e

--- a/app/src/test/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModuleTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModuleTest.kt
@@ -73,13 +73,6 @@ class RecorderModuleTest : BaseTest() {
         every { sdmId.id } returns "abcd"
         every { dataAreaManager.latestState } returns emptyFlow()
         every { curriculumVitae.history } returns emptyFlow()
-        coEvery { curriculumVitae.proHistory() } returns CurriculumVitae.ProHistory(
-            lastState = null,
-            graceEngagedCount = 0,
-            graceEngagedLast = null,
-            proLostCount = 0,
-            proLostLast = null,
-        )
 
         coEvery { upgradeDiagnostics.debugInfo() } returns "BillingCache(test)"
 
@@ -175,21 +168,6 @@ class RecorderModuleTest : BaseTest() {
         }
 
         @Test
-        fun `a failing pro history read does not prevent recording`() = runTest {
-            // The pro history line in the log header is diagnostics only -- a broken DataStore
-            // must not stop the recorder from starting.
-            File(externalDir, "force_debug_run").createNewFile()
-            coEvery { recorderPath.value() } returns null
-            coEvery { curriculumVitae.proHistory() } throws IOException("disk full")
-
-            val dispatcher = StandardTestDispatcher(testScheduler)
-            val module = createModule(backgroundScope, dispatcher)
-            advanceUntilIdle()
-
-            module.state.first { it.isRecording }.isRecording shouldBe true
-        }
-
-        @Test
         fun `a failing upgrade diagnostics read does not prevent recording`() = runTest {
             File(externalDir, "force_debug_run").createNewFile()
             coEvery { recorderPath.value() } returns null
@@ -200,23 +178,6 @@ class RecorderModuleTest : BaseTest() {
             advanceUntilIdle()
 
             module.state.first { it.isRecording }.isRecording shouldBe true
-        }
-
-        @Test
-        fun `a failing pro history read still reports upgrade diagnostics`() = runTest {
-            // Separate failure boundaries: these read different DataStores, and the pro-state
-            // counters are too new to speak for installs that predate them. One failing must not
-            // suppress the other's evidence.
-            File(externalDir, "force_debug_run").createNewFile()
-            coEvery { recorderPath.value() } returns null
-            coEvery { curriculumVitae.proHistory() } throws IOException("disk full")
-
-            val dispatcher = StandardTestDispatcher(testScheduler)
-            val module = createModule(backgroundScope, dispatcher)
-            advanceUntilIdle()
-
-            module.state.first { it.isRecording }
-            coVerify { upgradeDiagnostics.debugInfo() }
         }
 
         @Test

--- a/app/src/test/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModuleTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModuleTest.kt
@@ -25,9 +25,15 @@ import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.verify
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
@@ -178,6 +184,48 @@ class RecorderModuleTest : BaseTest() {
             advanceUntilIdle()
 
             module.state.first { it.isRecording }.isRecording shouldBe true
+        }
+
+        @Test
+        fun `a cancellation during the log header stops the uncommitted recorder`() = runTest {
+            // The recorder is started before the header is written but only committed to the state
+            // afterwards: a cancellation in between would orphan a running recorder that
+            // stopRecorder() can never reach.
+            File(externalDir, "force_debug_run").createNewFile()
+            coEvery { recorderPath.value() } returns null
+            coEvery { upgradeDiagnostics.debugInfo() } coAnswers { awaitCancellation() }
+
+            val dispatcher = UnconfinedTestDispatcher(testScheduler)
+            val moduleScope = CoroutineScope(dispatcher + Job())
+            val module = createModule(moduleScope, dispatcher)
+            advanceUntilIdle()
+
+            // Cancelling the module's scope cancels the in-flight header read.
+            moduleScope.cancel()
+            advanceUntilIdle()
+
+            coVerify { mockRecorder.start(any()) }
+            coVerify { mockRecorder.stop() }
+            module.state.first().isRecording shouldBe false
+        }
+
+        @Test
+        fun `a failing header read stops the uncommitted recorder`() = runTest {
+            // Same window as above, but for ordinary failures of the unguarded header reads.
+            File(externalDir, "force_debug_run").createNewFile()
+            coEvery { recorderPath.value() } returns null
+            every { curriculumVitae.history } returns flow { throw IOException("disk full") }
+
+            val dispatcher = UnconfinedTestDispatcher(testScheduler)
+            val moduleScope = CoroutineScope(dispatcher + Job())
+            val module = createModule(moduleScope, dispatcher)
+            advanceUntilIdle()
+
+            coVerify { mockRecorder.start(any()) }
+            coVerify { mockRecorder.stop() }
+            module.state.first().isRecording shouldBe false
+
+            moduleScope.cancel()
         }
 
         @Test

--- a/app/src/testFoss/java/eu/darken/sdmse/common/upgrade/ui/FossUpgradeScreenTest.kt
+++ b/app/src/testFoss/java/eu/darken/sdmse/common/upgrade/ui/FossUpgradeScreenTest.kt
@@ -16,6 +16,10 @@ import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import testhelpers.compose.BaseComposeRobolectricTest
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
 
 class FossUpgradeScreenTest : BaseComposeRobolectricTest() {
 
@@ -85,17 +89,37 @@ class FossUpgradeScreenTest : BaseComposeRobolectricTest() {
 
     @Test
     fun `upgraded status view thanks the supporter and offers a recurring donation`() {
+        val since = Instant.ofEpochMilli(1_700_000_000_000L)
         composeRule.setUpgradeContent {
-            UpgradeScreen(view = FossUpgradeView.STATUS_UPGRADED)
+            UpgradeScreen(view = FossUpgradeView.STATUS_UPGRADED, supporterSince = since)
         }
 
         composeRule.onAllNodesWithText("${context.getString(CommonR.string.app_name)} ${context.getString(R.string.app_name_upgrade_postfix)}").assertCountEquals(1)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_STATUS_UPGRADED).assertCountEquals(1)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_status_upgraded_body))
             .assertCountEquals(1)
+        val formatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withZone(ZoneId.systemDefault())
+        composeRule.onAllNodesWithText(
+            context.getString(R.string.upgrade_screen_supporter_since, formatter.format(since))
+        ).assertCountEquals(1)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_DONATE).assertCountEquals(1)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_SHOW_OPTIONS).assertCountEquals(0)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_SPONSOR).assertCountEquals(0)
+    }
+
+    @Test
+    fun `the supporter-since line stays away without a date`() {
+        // UpgradeRepoFoss can report an upgrade whose timestamp predates the field: no date line
+        // instead of a bogus one.
+        composeRule.setUpgradeContent {
+            UpgradeScreen(view = FossUpgradeView.STATUS_UPGRADED, supporterSince = null)
+        }
+
+        val formatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withZone(ZoneId.systemDefault())
+        composeRule.onAllNodesWithText(
+            context.getString(R.string.upgrade_screen_supporter_since, formatter.format(Instant.EPOCH))
+        ).assertCountEquals(0)
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_STATUS_UPGRADED).assertCountEquals(1)
     }
 
     @Test

--- a/app/src/testFoss/java/eu/darken/sdmse/common/upgrade/ui/FossUpgradeViewModelTest.kt
+++ b/app/src/testFoss/java/eu/darken/sdmse/common/upgrade/ui/FossUpgradeViewModelTest.kt
@@ -76,37 +76,53 @@ class FossUpgradeViewModelTest : BaseTest() {
     fun `manage route shows the free status to non-upgraded users`() = runTest2(context = testDispatcher) {
         val vm = buildVm()
 
-        val view = async { vm.state.first { it != null } }
+        val view = async { vm.state.first { it.view != null } }
         vm.bindRoute(UpgradeRoute(manage = true))
         advanceUntilIdle()
 
-        view.await() shouldBe FossUpgradeView.STATUS_FREE
+        view.await().view shouldBe FossUpgradeView.STATUS_FREE
     }
 
     @Test
     fun `manage route shows the upgraded status to supporters`() = runTest2(context = testDispatcher) {
         val vm = buildVm(repo = mockRepo(MutableStateFlow(upgradedInfo())))
 
-        val view = async { vm.state.first { it != null } }
+        val view = async { vm.state.first { it.view != null } }
         vm.bindRoute(UpgradeRoute(manage = true))
         advanceUntilIdle()
 
-        view.await() shouldBe FossUpgradeView.STATUS_UPGRADED
+        view.await().view shouldBe FossUpgradeView.STATUS_UPGRADED
+    }
+
+    @Test
+    fun `supporterSince reflects the repo's upgradedAt`() = runTest2(context = testDispatcher) {
+        // Derived in the same emission as the view: the upgraded status must never render a frame
+        // without the date it is supposed to carry.
+        val vm = buildVm(repo = mockRepo(MutableStateFlow(upgradedInfo())))
+
+        val state = async { vm.state.first { it.view != null } }
+        vm.bindRoute(UpgradeRoute(manage = true))
+        advanceUntilIdle()
+
+        state.await() shouldBe UpgradeViewModel.State(
+            view = FossUpgradeView.STATUS_UPGRADED,
+            supporterSince = Instant.EPOCH,
+        )
     }
 
     @Test
     fun `default and forced routes show the pitch`() = runTest2(context = testDispatcher) {
         val defaultVm = buildVm()
-        val defaultView = async { defaultVm.state.first { it != null } }
+        val defaultView = async { defaultVm.state.first { it.view != null } }
         defaultVm.bindRoute(UpgradeRoute())
 
         val forcedVm = buildVm()
-        val forcedView = async { forcedVm.state.first { it != null } }
+        val forcedView = async { forcedVm.state.first { it.view != null } }
         forcedVm.bindRoute(UpgradeRoute(forced = true))
         advanceUntilIdle()
 
-        defaultView.await() shouldBe FossUpgradeView.PITCH
-        forcedView.await() shouldBe FossUpgradeView.PITCH
+        defaultView.await().view shouldBe FossUpgradeView.PITCH
+        forcedView.await().view shouldBe FossUpgradeView.PITCH
     }
 
     @Test
@@ -114,15 +130,15 @@ class FossUpgradeViewModelTest : BaseTest() {
         val vm = buildVm()
         vm.bindRoute(UpgradeRoute(manage = true))
 
-        val freeView = async { vm.state.first { it != null } }
+        val freeView = async { vm.state.first { it.view != null } }
         advanceUntilIdle()
-        freeView.await() shouldBe FossUpgradeView.STATUS_FREE
+        freeView.await().view shouldBe FossUpgradeView.STATUS_FREE
 
-        val pitchView = async { vm.state.first { it == FossUpgradeView.PITCH } }
+        val pitchView = async { vm.state.first { it.view == FossUpgradeView.PITCH } }
         vm.onShowUpgradeOptions()
         advanceUntilIdle()
 
-        pitchView.await() shouldBe FossUpgradeView.PITCH
+        pitchView.await().view shouldBe FossUpgradeView.PITCH
     }
 
     @Test
@@ -135,11 +151,11 @@ class FossUpgradeViewModelTest : BaseTest() {
 
         // Same handle, fresh ViewModel — as after the process was killed on the pitch.
         val recreatedVm = buildVm(handle = handle)
-        val view = async { recreatedVm.state.first { it != null } }
+        val view = async { recreatedVm.state.first { it.view != null } }
         recreatedVm.bindRoute(UpgradeRoute(manage = true))
         advanceUntilIdle()
 
-        view.await() shouldBe FossUpgradeView.PITCH
+        view.await().view shouldBe FossUpgradeView.PITCH
     }
 
     @Test
@@ -151,15 +167,15 @@ class FossUpgradeViewModelTest : BaseTest() {
         vm.bindRoute(UpgradeRoute(manage = true))
         vm.onShowUpgradeOptions()
 
-        val pitchView = async { vm.state.first { it != null } }
+        val pitchView = async { vm.state.first { it.view != null } }
         advanceUntilIdle()
-        pitchView.await() shouldBe FossUpgradeView.PITCH
+        pitchView.await().view shouldBe FossUpgradeView.PITCH
 
-        val upgradedView = async { vm.state.first { it == FossUpgradeView.STATUS_UPGRADED } }
+        val upgradedView = async { vm.state.first { it.view == FossUpgradeView.STATUS_UPGRADED } }
         info.value = upgradedInfo()
         advanceUntilIdle()
 
-        upgradedView.await() shouldBe FossUpgradeView.STATUS_UPGRADED
+        upgradedView.await().view shouldBe FossUpgradeView.STATUS_UPGRADED
     }
 
     @Test

--- a/app/src/testFoss/java/eu/darken/sdmse/common/upgrade/ui/FossUpgradeViewModelTest.kt
+++ b/app/src/testFoss/java/eu/darken/sdmse/common/upgrade/ui/FossUpgradeViewModelTest.kt
@@ -237,4 +237,34 @@ class FossUpgradeViewModelTest : BaseTest() {
         thanks.await() shouldBe R.string.upgrade_screen_thanks_toast
         coVerify(exactly = 1) { repo.persistUpgrade() }
     }
+
+    /**
+     * Process death between the sponsor launch and the return: the screen's in-memory return
+     * tracker is gone, so the handle-backed pending launch has to carry the state across. Without
+     * it the very first return after a recreation is dropped and the supporter never gets unlocked.
+     */
+    @Test
+    fun `a sponsor return after process recreation still persists the upgrade`() = runTest2(
+        context = testDispatcher,
+    ) {
+        val handle = SavedStateHandle()
+        val firstVm = buildVm(handle = handle)
+        firstVm.goGithubSponsors()
+        advanceUntilIdle()
+
+        // Same handle, fresh ViewModel — as after the process was killed while the browser was up.
+        val repo = mockRepo()
+        val recreatedVm = buildVm(repo = repo, handle = handle)
+        recreatedVm.hasPendingSponsorLaunch() shouldBe true
+
+        val thanks = async { recreatedVm.toastEvents.first() }
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+        recreatedVm.checkSponsorReturn()
+        advanceUntilIdle()
+
+        thanks.await() shouldBe R.string.upgrade_screen_thanks_toast
+        coVerify(exactly = 1) { repo.persistUpgrade() }
+        // Consumed: a later resume must not re-run the unlock.
+        recreatedVm.hasPendingSponsorLaunch() shouldBe false
+    }
 }

--- a/app/src/testFoss/java/eu/darken/sdmse/common/upgrade/ui/SponsorReturnTrackerTest.kt
+++ b/app/src/testFoss/java/eu/darken/sdmse/common/upgrade/ui/SponsorReturnTrackerTest.kt
@@ -2,8 +2,9 @@ package eu.darken.sdmse.common.upgrade.ui
 
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
 
-class SponsorReturnTrackerTest {
+class SponsorReturnTrackerTest : BaseTest() {
 
     @Test
     fun `resume only counts after background transition`() {
@@ -12,6 +13,20 @@ class SponsorReturnTrackerTest {
         tracker.consumeResumeReturn() shouldBe false
 
         tracker.onStop()
+
+        tracker.consumeResumeReturn() shouldBe true
+        tracker.consumeResumeReturn() shouldBe false
+    }
+
+    /**
+     * The process can be killed while the sponsor page is in front, i.e. between the launch and the
+     * return. The recomposed screen gets a brand-new tracker that never saw the ON_STOP, so gating
+     * on in-memory state alone would swallow that first return for good. The handle-backed pending
+     * launch is the authority and seeds the tracker instead.
+     */
+    @Test
+    fun `a tracker seeded from a pending launch counts the first resume`() {
+        val tracker = SponsorReturnTracker(wentToBackground = true)
 
         tracker.consumeResumeReturn() shouldBe true
         tracker.consumeResumeReturn() shouldBe false

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/BillingCacheTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/BillingCacheTest.kt
@@ -1,15 +1,25 @@
 package eu.darken.sdmse.common.upgrade.core
 
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.sdmse.common.datastore.value
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import testhelpers.BaseTest
 import testhelpers.TestApplication
+import java.io.IOException
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [33], application = TestApplication::class)
@@ -20,50 +30,76 @@ class BillingCacheTest : BaseTest() {
     // would crash, not exercise anything real.
     @Test
     fun `stampLastProState round-trips through the DataStoreValues`() = runTest {
-        // Real DataStore, no mocks: this catches an encoding mismatch between the raw keys the
-        // atomic stamp transaction writes and the keys/types the DataStoreValues read.
-        val cache = BillingCache(ApplicationProvider.getApplicationContext())
+        // Real time on purpose: the reads/writes below are bounded by cacheTimeoutMs, and the real
+        // DataStore does its I/O off the test scheduler -- under virtual time the bound would fire
+        // instantly while nothing else is scheduled.
+        withContext(Dispatchers.IO) {
+            // Real DataStore, no mocks: this catches an encoding mismatch between the raw keys the
+            // atomic stamp transaction writes and the keys/types the DataStoreValues read.
+            val cache = BillingCache(ApplicationProvider.getApplicationContext<Context>())
 
-        cache.lastProStateAt.value() shouldBe 0L
-        cache.lastProStateSku.value() shouldBe ""
+            cache.lastProStateAt.value() shouldBe 0L
+            cache.lastProStateSku.value() shouldBe ""
 
-        // Defaults on a never-Pro install: this exact triple is what the debug-log header reports
-        // as "never / unknown-legacy / none", and it's the signal that separates a never-bought
-        // install from one whose entitlement went missing.
-        cache.snapshot() shouldBe BillingCache.Snapshot(
-            lastProStateAt = 0L,
-            lastProStateSku = "",
-            proUnconfirmedSince = 0L,
-        )
+            // Defaults on a never-Pro install: this exact triple is what the debug-log header reports
+            // as "never / unknown-legacy / none", and it's the signal that separates a never-bought
+            // install from one whose entitlement went missing.
+            cache.snapshot() shouldBe BillingCache.Snapshot(
+                lastProStateAt = 0L,
+                lastProStateSku = "",
+                proUnconfirmedSince = 0L,
+            )
 
-        cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 1234L)
+            cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 1234L)
 
-        cache.lastProStateAt.value() shouldBe 1234L
-        cache.lastProStateSku.value() shouldBe OurSku.Iap.PRO_UPGRADE.id
+            cache.lastProStateAt.value() shouldBe 1234L
+            cache.lastProStateSku.value() shouldBe OurSku.Iap.PRO_UPGRADE.id
 
-        cache.stampLastProState(OurSku.Sub.PRO_UPGRADE.id, 5678L)
+            cache.stampLastProState(OurSku.Sub.PRO_UPGRADE.id, 5678L)
 
-        cache.lastProStateAt.value() shouldBe 5678L
-        cache.lastProStateSku.value() shouldBe OurSku.Sub.PRO_UPGRADE.id
+            cache.lastProStateAt.value() shouldBe 5678L
+            cache.lastProStateSku.value() shouldBe OurSku.Sub.PRO_UPGRADE.id
 
-        // Occurrence-aware episode clear: a confirmation closes an episode that began at or before
-        // it, but must leave a NEWER episode intact — a connection failure that occurred after this
-        // confirmation but was processed out of order opened a still-valid episode.
-        cache.proUnconfirmedSince.value(4_000L)
-        cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 5_000L) // confirmation newer than episode
-        cache.proUnconfirmedSince.value() shouldBe 0L
+            // Occurrence-aware episode clear: a confirmation closes an episode that began at or before
+            // it, but must leave a NEWER episode intact — a connection failure that occurred after this
+            // confirmation but was processed out of order opened a still-valid episode.
+            cache.proUnconfirmedSince.value(4_000L)
+            cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 5_000L) // confirmation newer than episode
+            cache.proUnconfirmedSince.value() shouldBe 0L
 
-        cache.proUnconfirmedSince.value(9_000L)
-        cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 8_000L) // confirmation older than episode
-        cache.proUnconfirmedSince.value() shouldBe 9_000L
+            cache.proUnconfirmedSince.value(9_000L)
+            cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 8_000L) // confirmation older than episode
+            cache.proUnconfirmedSince.value() shouldBe 9_000L
 
-        // snapshot() must agree with the individual reads. It exists so the debug-log header reads
-        // all three in ONE DataStore emission: three separate reads can straddle a concurrent
-        // stampLastProState and report a combination that never existed.
-        cache.snapshot() shouldBe BillingCache.Snapshot(
-            lastProStateAt = 8_000L,
-            lastProStateSku = OurSku.Iap.PRO_UPGRADE.id,
-            proUnconfirmedSince = 9_000L,
-        )
+            // snapshot() must agree with the individual reads. It exists so the debug-log header reads
+            // all three in ONE DataStore emission: three separate reads can straddle a concurrent
+            // stampLastProState and report a combination that never existed.
+            cache.snapshot() shouldBe BillingCache.Snapshot(
+                lastProStateAt = 8_000L,
+                lastProStateSku = OurSku.Iap.PRO_UPGRADE.id,
+                proUnconfirmedSince = 9_000L,
+            )
+        }
     }
+
+    @Test
+    fun `a wedged datastore is bounded, reads fail loudly and writes fail soft`() = runTest {
+        // Fake store, no file: a second real DataStore on the same file would crash this process.
+        val cache = BillingCache(HangingPreferencesDataStore()).apply { cacheTimeoutMs = 50L }
+
+        // A timeout must not masquerade as a default snapshot -- "never bought" and "couldn't read
+        // the evidence" are the two things the debug-log header exists to tell apart.
+        shouldThrow<IOException> { cache.snapshot() }
+
+        // The write only decorates the entitlement path, it must never block it.
+        cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 1234L)
+    }
+}
+
+/** DataStore that never answers -- stands in for a wedged file lock. */
+internal class HangingPreferencesDataStore : DataStore<Preferences> {
+    override val data: Flow<Preferences> = flow { awaitCancellation() }
+
+    override suspend fun updateData(transform: suspend (Preferences) -> Preferences): Preferences =
+        awaitCancellation()
 }

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeDiagnosticsGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeDiagnosticsGplayTest.kt
@@ -4,6 +4,7 @@ import eu.darken.sdmse.main.core.CurriculumVitae
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.CancellationException
@@ -104,6 +105,22 @@ class UpgradeDiagnosticsGplayTest : BaseTest() {
                 history = { throw CancellationException("scope died") },
             ).debugInfo()
         }
+    }
+
+    @Test
+    fun `a wedged billing cache is reported as unavailable, not as a never-pro install`() = runTest {
+        // End-to-end over a real BillingCache whose store never answers: the bounded read throws,
+        // and the header must say the evidence is missing instead of claiming "never bought".
+        val diagnostics = UpgradeDiagnosticsGplay(
+            billingCache = BillingCache(HangingPreferencesDataStore()).apply { cacheTimeoutMs = 50L },
+            curriculumVitae = mockk<CurriculumVitae>().apply { coEvery { proHistory() } returns proHistory },
+        )
+
+        val info = diagnostics.debugInfo()
+
+        info shouldContain "BillingCache=unavailable"
+        info shouldNotContain "lastProStateAt=never"
+        info shouldContain "ProHistory=$proHistory"
     }
 
     @Test

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeDiagnosticsGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeDiagnosticsGplayTest.kt
@@ -1,17 +1,32 @@
 package eu.darken.sdmse.common.upgrade.core
 
+import eu.darken.sdmse.main.core.CurriculumVitae
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.mockk.coEvery
 import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 
 class UpgradeDiagnosticsGplayTest : BaseTest() {
 
-    private fun create(snapshot: BillingCache.Snapshot) = UpgradeDiagnosticsGplay(
-        billingCache = mockk<BillingCache>().apply { coEvery { this@apply.snapshot() } returns snapshot },
+    private val proHistory = CurriculumVitae.ProHistory(
+        lastState = CurriculumVitae.ProState.PURCHASED,
+        graceEngagedCount = 2,
+        graceEngagedLast = null,
+        proLostCount = 0,
+        proLostLast = null,
+    )
+
+    private fun create(
+        snapshot: () -> BillingCache.Snapshot,
+        history: () -> CurriculumVitae.ProHistory = { proHistory },
+    ) = UpgradeDiagnosticsGplay(
+        billingCache = mockk<BillingCache>().apply { coEvery { this@apply.snapshot() } answers { snapshot() } },
+        curriculumVitae = mockk<CurriculumVitae>().apply { coEvery { proHistory() } answers { history() } },
     )
 
     @Test
@@ -19,20 +34,88 @@ class UpgradeDiagnosticsGplayTest : BaseTest() {
         // The whole point of this line in the log header is telling "never bought" apart from
         // "bought once, entitlement now missing". A raw 0 reads as a 1970 timestamp.
         val info = create(
-            BillingCache.Snapshot(lastProStateAt = 0L, lastProStateSku = "", proUnconfirmedSince = 0L)
+            { BillingCache.Snapshot(lastProStateAt = 0L, lastProStateSku = "", proUnconfirmedSince = 0L) }
         ).debugInfo()
 
-        info shouldBe "BillingCache(lastProStateAt=never, lastProStateSku=unknown/legacy, proUnconfirmedSince=none)"
+        info shouldContain
+            "BillingCache(lastProStateAt=never, lastProStateSku=unknown/legacy, proUnconfirmedSince=none)"
+    }
+
+    @Test
+    fun `the pro history rides along so a complaint arrives with both records`() = runTest {
+        val info = create(
+            { BillingCache.Snapshot(lastProStateAt = 0L, lastProStateSku = "", proUnconfirmedSince = 0L) }
+        ).debugInfo()
+
+        info shouldContain "ProHistory=$proHistory"
+    }
+
+    @Test
+    fun `a broken history read still reports the billing cache`() = runTest {
+        // Different DataStores: one failing must not suppress the other's independent evidence.
+        val info = create(
+            snapshot = {
+                BillingCache.Snapshot(
+                    lastProStateAt = 1_700_000_000_000L,
+                    lastProStateSku = OurSku.Iap.PRO_UPGRADE.id,
+                    proUnconfirmedSince = 0L,
+                )
+            },
+            history = { throw IllegalStateException("storage is full") },
+        ).debugInfo()
+
+        info shouldContain "lastProStateSku=${OurSku.Iap.PRO_UPGRADE.id}"
+        info shouldContain "ProHistory=unavailable"
+    }
+
+    @Test
+    fun `a broken billing cache read still reports the pro history`() = runTest {
+        // Mirror image of the above: the billing cache DataStore failing must not suppress the
+        // lifetime pro-state counters, which live in a different store.
+        var historyReads = 0
+        val info = create(
+            snapshot = { throw IllegalStateException("datastore is corrupt") },
+            history = { historyReads++; proHistory },
+        ).debugInfo()
+
+        historyReads shouldBe 1
+        info shouldContain "BillingCache=unavailable"
+        info shouldContain "ProHistory=$proHistory"
+    }
+
+    @Test
+    fun `a cancelled billing cache read is not swallowed`() = runTest {
+        shouldThrow<CancellationException> {
+            create(
+                snapshot = { throw CancellationException("scope died") },
+            ).debugInfo()
+        }
+    }
+
+    @Test
+    fun `a cancelled history read is not swallowed`() = runTest {
+        // Symmetric to the cache read: cancellation is not a diagnostics failure, it means the
+        // caller's scope died and the header read must unwind with it.
+        shouldThrow<CancellationException> {
+            create(
+                snapshot = {
+                    BillingCache.Snapshot(lastProStateAt = 0L, lastProStateSku = "", proUnconfirmedSince = 0L)
+                },
+                history = { throw CancellationException("scope died") },
+            ).debugInfo()
+        }
     }
 
     @Test
     fun `a confirmed purchase reports an instant and the sku`() = runTest {
         val info = create(
-            BillingCache.Snapshot(
-                lastProStateAt = 1_700_000_000_000L,
-                lastProStateSku = OurSku.Iap.PRO_UPGRADE.id,
-                proUnconfirmedSince = 0L,
-            )
+            {
+                BillingCache.Snapshot(
+                    lastProStateAt = 1_700_000_000_000L,
+                    lastProStateSku = OurSku.Iap.PRO_UPGRADE.id,
+                    proUnconfirmedSince = 0L,
+                )
+            }
         ).debugInfo()
 
         info shouldContain "lastProStateAt=2023-11-14T22:13:20Z"
@@ -43,11 +126,13 @@ class UpgradeDiagnosticsGplayTest : BaseTest() {
     @Test
     fun `an open unconfirmed episode is reported as an instant`() = runTest {
         val info = create(
-            BillingCache.Snapshot(
-                lastProStateAt = 1_700_000_000_000L,
-                lastProStateSku = OurSku.Sub.PRO_UPGRADE.id,
-                proUnconfirmedSince = 1_700_000_500_000L,
-            )
+            {
+                BillingCache.Snapshot(
+                    lastProStateAt = 1_700_000_000_000L,
+                    lastProStateSku = OurSku.Sub.PRO_UPGRADE.id,
+                    proUnconfirmedSince = 1_700_000_500_000L,
+                )
+            }
         ).debugInfo()
 
         info shouldContain "proUnconfirmedSince=2023-11-14T22:21:40Z"

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/ui/GplayUpgradeScreenHostTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/ui/GplayUpgradeScreenHostTest.kt
@@ -1,0 +1,75 @@
+package eu.darken.sdmse.common.upgrade.ui
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.SavedStateHandle
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.common.upgrade.core.UpgradeRepoGplay
+import eu.darken.sdmse.common.upgrade.core.billing.GplayServiceUnavailableException
+import eu.darken.sdmse.common.upgrade.core.billing.Sku
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+import testhelpers.coroutine.TestDispatcherProvider
+
+/**
+ * Host-level counterpart to the ViewModel's `onResume` tests: those prove the ViewModel re-queries,
+ * they cannot prove the screen actually asks it to. Only a real lifecycle round-trip catches a
+ * missing or mis-scoped ON_RESUME effect.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class GplayUpgradeScreenHostTest : BaseTest() {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    private fun mockRepo(): UpgradeRepoGplay = mockk<UpgradeRepoGplay>(relaxed = true).apply {
+        every { upgradeInfo } returns MutableStateFlow(UpgradeRepoGplay.Info(false, null, null, isSettled = true))
+        every { wasEverPro } returns MutableStateFlow(false)
+        every { proUnconfirmedSince } returns MutableStateFlow(0L)
+        every { autoRestoreBusy } returns MutableStateFlow(false)
+        every { purchaseLaunchSku } returns MutableStateFlow<Sku?>(null)
+    }
+
+    @Test
+    fun `returning to the screen re-runs a failed offers query`() {
+        val repo = mockRepo()
+        var queries = 0
+        coEvery { repo.querySkus(any()) } coAnswers {
+            queries++
+            throw GplayServiceUnavailableException(RuntimeException("Play hiccup"))
+        }
+        val vm = UpgradeViewModel(
+            handle = SavedStateHandle(mapOf("forced" to false)),
+            dispatcherProvider = TestDispatcherProvider(),
+            upgradeRepo = repo,
+            webpageTool = mockk(relaxed = true),
+        )
+
+        // The real ViewModel instance, passed explicitly: hiltViewModel() has nothing to resolve here.
+        composeRule.setContent {
+            PreviewWrapper {
+                UpgradeScreenHost(vm = vm)
+            }
+        }
+
+        composeRule.waitUntil { vm.state.value is GplayUpgradeUiState.Unavailable }
+        val baseline = queries
+
+        composeRule.activityRule.scenario.moveToState(Lifecycle.State.STARTED)
+        composeRule.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
+        composeRule.waitForIdle()
+
+        composeRule.waitUntil { queries > baseline }
+    }
+}

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/ui/GplayUpgradeScreenTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/ui/GplayUpgradeScreenTest.kt
@@ -151,6 +151,12 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_UNAVAILABLE).assertCountEquals(1)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_offers_unavailable_message)).assertCountEquals(1)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_benefits_title)).assertCountEquals(1)
+        // The card is about the prices, not about Play as a whole -- the generic service-unavailable
+        // title contradicted its own body.
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_offers_unavailable_title))
+            .assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrades_gplay_unavailable_error_title))
+            .assertCountEquals(0)
     }
 
     @Test
@@ -300,6 +306,26 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
         // would silently miss the button.
         composeRule.onNodeWithTag(UpgradeScreenTags.GPLAY_RETRY).performScrollTo().performClick()
         composeRule.runOnIdle { check(retryClicks == 1) { "expected 1 retry click, got $retryClicks" } }
+    }
+
+    @Test
+    fun `the retry latches after the first tap`() {
+        var retryClicks = 0
+        composeRule.setUpgradeContent {
+            UpgradeScreen(
+                uiState = GplayUpgradeUiState.Unavailable(
+                    error = RuntimeException("Google Play services unavailable"),
+                ),
+                onRetry = { retryClicks++ },
+            )
+        }
+
+        val retry = composeRule.onNodeWithTag(UpgradeScreenTags.GPLAY_RETRY).performScrollTo()
+        retry.performClick()
+        retry.performClick()
+
+        composeRule.runOnIdle { check(retryClicks == 1) { "expected 1 retry click, got $retryClicks" } }
+        composeRule.onNodeWithTag(UpgradeScreenTags.GPLAY_RETRY).assertIsNotEnabled()
     }
 
     @Test

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/ui/GplayUpgradeViewModelTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/ui/GplayUpgradeViewModelTest.kt
@@ -140,6 +140,51 @@ class GplayUpgradeViewModelTest : BaseTest() {
     }
 
     @Test
+    fun `onResume retries the query after a failure`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // MainActivity's per-resume refresh only covers the entitlement -- coming back to the screen
+        // after a Play outage has to re-run the screen-local SKU query too.
+        val repo = mockRepo()
+        coEvery { repo.querySkus(any()) } throws GplayServiceUnavailableException(RuntimeException("Play hiccup"))
+        val vm = buildVm(repo)
+
+        // WhileSubscribed: without a live subscriber the retry has no upstream to re-run.
+        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { vm.state.collect { } }
+        advanceUntilIdle()
+
+        vm.state.value.shouldBeInstanceOf<GplayUpgradeUiState.Unavailable>()
+        coVerify(exactly = 1) { repo.querySkus(OurSku.Iap.PRO_UPGRADE) }
+        coVerify(exactly = 1) { repo.querySkus(OurSku.Sub.PRO_UPGRADE) }
+
+        vm.onResume()
+        advanceUntilIdle()
+
+        coVerify(exactly = 2) { repo.querySkus(OurSku.Iap.PRO_UPGRADE) }
+        coVerify(exactly = 2) { repo.querySkus(OurSku.Sub.PRO_UPGRADE) }
+    }
+
+    @Test
+    fun `onResume does not re-query when offers are already loaded`() = runTest2(
+        context = testDispatcher,
+    ) {
+        val repo = mockRepo()
+        coEvery { repo.querySkus(any()) } returns emptyList()
+        val vm = buildVm(repo)
+
+        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { vm.state.collect { } }
+        advanceUntilIdle()
+
+        vm.state.value.shouldBeInstanceOf<GplayUpgradeUiState.Loaded>()
+        coVerify(exactly = 2) { repo.querySkus(any()) }
+
+        vm.onResume()
+        advanceUntilIdle()
+
+        coVerify(exactly = 2) { repo.querySkus(any()) }
+    }
+
+    @Test
     fun `a single failed product type keeps the screen loaded and surfaces the error once`() = runTest2(
         context = testDispatcher,
     ) {


### PR DESCRIPTION
## What changed

A set of reliability improvements for the upgrade screens and Pro status handling, collected from the sibling apps that share this billing implementation.

On Google Play: if prices couldn't be loaded, simply returning to the upgrade screen now retries automatically instead of leaving the error card up until it's tapped by hand, the error card now says "Prices unavailable" instead of a generic "Google Play is unavailable" (the connection may be fine — it's the prices that didn't arrive), and the retry button can no longer be double-triggered.

On the FOSS version: completing a GitHub Sponsors donation is no longer lost if Android killed the app in the background while the browser was open — the return is now detected after the app restarts. The upgrade status screen also shows since when you've been a supporter.

For support: debug logs now always include the full purchase-state history alongside the billing cache snapshot, even when one of the two can't be read — and a broken or slow read can neither block log recording from starting nor leave an invisible recording running after a cancelled start.

## Technical Context

- These are backports collected while converging the app family on this shared billing implementation — each already ships (or shipped pre-convergence) in a sibling app: the combined diagnostics shape, the sponsor-return tracker seeding, the on-resume offers retry, the offers-unavailable title, and the supporter-since date.
- Recorder leak root cause: the log header runs suspending diagnostics reads *after* the recorder starts but *before* it is committed to module state; an exception escaping there (including cancellation, which two header reads deliberately rethrow) left a running recorder that `stopRecorder()` can never reach, because the state flow's error handling keeps the pre-update state. The guard stops the uncommitted recorder under `NonCancellable` (a plain catch would skip a suspending `stop()` in an already-cancelled job) and preserves the original exception via `addSuppressed`.
- Sponsor-return root cause: the pending-launch timestamp already survives process death in `SavedStateHandle`, but the screen-side return tracker's in-memory flag does not — after recreation, the first ON_RESUME found a blank tracker and the pending key was orphaned. The tracker is now seeded from the handle-backed state.
- On-resume retry: MainActivity's existing per-resume `refresh()` only reconciles entitlements; it never re-runs the screen-local SKU/offers query, so a transient Play outage stuck the screen on the retry card. The screen now re-queries on resume, only from the unavailable state.
- `BillingCache` reads/writes are bounded (2s): a timed-out `snapshot()` **throws** rather than returning defaults, so the debug-log header reports `BillingCache=unavailable` instead of misreporting a wedged cache as a never-Pro install. The constructor restructure (injectable `DataStore`) keeps the same backing file (`settings_gplay`) — no data migration.
- Review guidance: the diagnostics fold deliberately does not adopt the multibinding DI shape used by the sibling app it came from (its recorder lives in a separate module; ours compiles with exactly one flavor's binding). `GplayUpgradeScreenHostTest` introduces the repo's first lifecycle-driving compose host test, proving the ON_RESUME wiring itself fires.
