### PR TITLE
Fix: Stop the cleanup summary card appearing on its own

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionEngine.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionEngine.kt
@@ -6,9 +6,11 @@ import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerOneClickTask
 import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerProcessingTask
 import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerScanTask
 import eu.darken.sdmse.common.datastore.value
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.flow.intervalFlow
@@ -34,19 +36,30 @@ import eu.darken.sdmse.systemcleaner.core.hasData
 import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerOneClickTask
 import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerProcessingTask
 import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerScanTask
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.retryWhen
+import kotlinx.coroutines.flow.shareIn
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.flow.updateAndGet
 import kotlinx.coroutines.launch
 import java.time.Instant
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration.Companion.minutes
 
 /**
@@ -72,10 +85,16 @@ class DashboardMainActionEngine(
     private val submitTask: suspend (SDMTool.Task) -> SDMTool.Task.Result,
     /** Invoked when a non-Pro user triggers a Pro-gated cleanup; the VM navigates to upgrade. */
     private val onUpgradeRequired: () -> Unit,
+    /**
+     * Invoked when a state flow this engine owns fails and falls back. The VM routes it to
+     * `errorEvents` — without this the user would silently get fallback state (e.g. default
+     * one-click toggles) with no indication that their settings couldn't be read.
+     */
+    private val onStateError: (Throwable) -> Unit,
 ) {
 
-    /** Cold per-setting combine; the VM turns this into the shared [OneClickOptionsState] StateFlow. */
-    val oneClickOptions: Flow<OneClickOptionsState> = combine(
+    /** Cold per-setting combine; [oneClickOptionsState] is the single shared collection of it. */
+    private val oneClickOptions: Flow<OneClickOptionsState> = combine(
         generalSettings.oneClickCorpseFinderEnabled.flow,
         generalSettings.oneClickSystemCleanerEnabled.flow,
         generalSettings.oneClickAppCleanerEnabled.flow,
@@ -89,6 +108,20 @@ class DashboardMainActionEngine(
         )
     }
 
+    /**
+     * The one-click toggles, shared: both [heroState] and the VM's options dialog read this single
+     * collection instead of subscribing to the four settings flows twice. Upstream failures fall
+     * back to the defaults rather than freezing the dashboard.
+     */
+    val oneClickOptionsState: StateFlow<OneClickOptionsState> = oneClickOptions
+        .catch { e ->
+            if (e is CancellationException) throw e
+            log(TAG, ERROR) { "oneClickOptions failed: ${e.asLog()}" }
+            onStateError(e)
+            emit(OneClickOptionsState())
+        }
+        .stateIn(scope, SharingStarted.Eagerly, OneClickOptionsState())
+
     /** Aggregated "freed" result of the most recent main-action deletion/one-click; null otherwise. */
     private val freedResult = MutableStateFlow<HeroSummary?>(null)
 
@@ -100,8 +133,40 @@ class DashboardMainActionEngine(
     var freedResultSince: Instant = Instant.EPOCH
         private set
 
-    /** In-flight main-action cleanup branches; the freed hero stays hidden until this reaches 0. */
-    private val pendingMainCleanup = MutableStateFlow(0)
+    /**
+     * Branch bookkeeping for the current main action, deliberately NOT observed by anything. Its
+     * only job is to tell the last returning branch that it *is* the last one, while it still has
+     * results to write; [batchState] is published afterwards. See [launchMainBranch].
+     */
+    private val branchesInFlight = AtomicInteger(0)
+
+    /**
+     * The current main-action batch, published as one atomic value: a settle edge must never become
+     * visible apart from the [id] and the arm it belongs to.
+     *
+     * [id] identifies the run. A resolution derived from batch A can still be in flight when batch B
+     * starts, and both arms are the same indistinguishable `true` — the id is what stops A's late
+     * resolution from consuming B's arm.
+     */
+    internal data class BatchState(
+        val id: Long = 0L,
+        /** In-flight branches; gates the freed hero and the settle edge [heroState] carries. */
+        val pending: Int = 0,
+        /** A one-tap main action is running and its hero, if it produces one, should auto-expand. */
+        val autoExpandArmed: Boolean = false,
+    )
+
+    /** What the settle collector does with one hero snapshot; see [resolveAutoExpand]. */
+    internal enum class AutoExpandDecision {
+        IGNORE,
+        DISARM,
+        EXPAND_AND_DISARM,
+    }
+
+    private val batchState = MutableStateFlow(BatchState())
+
+    /** The part of [BatchState] the hero derivation keys on; see [heroState]. */
+    private data class BatchPhase(val id: Long, val isSettled: Boolean)
 
     /**
      * Whether the current cleanup actually submitted a deletion task, regardless of how much it
@@ -122,16 +187,156 @@ class DashboardMainActionEngine(
 
     private val nowTicks: Flow<Instant> = intervalFlow(1.minutes).map { Instant.now() }
 
-    private val heroDismissed = MutableStateFlow(false)
+    private val heroExpanded = MutableStateFlow(false)
 
-    /** Whether the user dismissed the hero for the current results. In-memory; resets on a fresh scan. */
-    val isHeroDismissed: StateFlow<Boolean> = heroDismissed
+    /**
+     * Whether the hero card is expanded. It only ever becomes true as the outcome of a one-tap main
+     * action that produced something to show, or because the user expanded it from the bar's compact
+     * chip — an operation started anywhere else (a tool card, an in-tool screen, the scheduler)
+     * leaves it collapsed. Dismissing or discarding collapses it again. In-memory, resets with the VM.
+     */
+    val isHeroExpanded: StateFlow<Boolean> = heroExpanded
+
+    /**
+     * One consistent snapshot of everything the hero/main action derives from; null once the
+     * derivation has failed and fallen back. Shared eagerly because the auto-expand resolution has
+     * to observe it too, and both consumers must judge the *same* snapshot.
+     */
+    private data class HeroState(
+        val actionState: BottomBarState.Action,
+        val activeTasks: Int,
+        val queuedTasks: Int,
+        val heroSummary: HeroSummary?,
+        val upgradeInfo: UpgradeRepo.Info?,
+        /** The batch this snapshot was derived under; see [BatchState.id]. */
+        val batchId: Long,
+        /** All branches of that batch have folded in their results. */
+        val isSettled: Boolean,
+    )
+
+    /** Consecutive failures of the [heroState] derivation; 0 while it is healthy. */
+    private var heroStateFailures = 0L
+
+    /**
+     * The batch phase is applied by *re-deriving* rather than as another combine input: a branch
+     * writes its tool state before it decrements, but the two reach a combine through independent
+     * per-source collectors, so a plain combine can pair the settled counter with a tool state it
+     * hasn't picked up yet — and the auto-expand resolution would judge that stale pairing. Keying
+     * the restart on the phase makes every source re-read at (re)subscription, after the decrement.
+     *
+     * Keyed on [BatchPhase], NOT on the raw counter: the intermediate 4→3→2→1 decrements are not
+     * phase changes, so a run costs two re-subscriptions (start and settle) instead of five.
+     *
+     * ACCEPTED RESIDUAL — do not "fix" this without asking: re-subscribing does not *force* the
+     * tools to recompute. Each tool's `state` is a `replayingShare` projection, so a re-read returns
+     * its replay cache; if a tool's own projection hasn't published the scan it just finished by the
+     * time the settle edge arrives, the run resolves against data that doesn't include it and
+     * disarms without expanding. Effect is benign and rare: the hero doesn't auto-open, the bar
+     * still shows the compact summary chip, and one tap opens it. Closing it would mean exposing
+     * each tool's internal data as a new public StateFlow across the four app-tool-* modules; that
+     * API cost was weighed against this miss and deliberately declined.
+     */
+    private val heroState: Flow<HeroState?> = batchState
+        .map { BatchPhase(id = it.id, isSettled = it.pending == 0) }
+        .distinctUntilChanged()
+        .flatMapLatest<BatchPhase, HeroState?> { phase ->
+            eu.darken.sdmse.common.flow.combine(
+                upgradeInfo,
+                taskManager.state,
+                corpseFinder.state,
+                systemCleaner.state,
+                appCleaner.state,
+                deduplicator.state,
+                generalSettings.enableDashboardOneClick.flow,
+                oneClickOptionsState,
+                freedResult,
+                discarding,
+            ) { upgradeInfo,
+                taskState,
+                corpseState,
+                filterState,
+                junkState,
+                dedupeState,
+                oneClickMode,
+                oneClickOptions,
+                freed,
+                isDiscarding ->
+
+                val actionState = resolveMainAction(
+                    taskState = taskState,
+                    corpse = corpseState.data,
+                    system = filterState.data,
+                    app = junkState.data,
+                    dedupe = dedupeState.data,
+                    oneClick = oneClickOptions,
+                    isPro = upgradeInfo?.isPro == true,
+                    oneClickMode = oneClickMode,
+                )
+                // Post-scan "will be freed" takes priority; otherwise, once the action has settled,
+                // show the "freed" result of the last main-action deletion/one-click. While working,
+                // both stay hidden and the bar carries progress. The settle edge gates this too, not
+                // just [settled]: the task manager reports idle again before the branches fold in
+                // their results, and without the gate the identical "can be freed" card flashes in
+                // that window.
+                val freeable = if (actionState == BottomBarState.Action.DELETE && phase.isSettled) {
+                    buildHeroSummary(
+                        corpse = corpseState.data,
+                        system = filterState.data,
+                        app = junkState.data,
+                        dedupe = dedupeState.data,
+                        oneClick = oneClickOptions,
+                        isPro = upgradeInfo?.isPro == true,
+                        scanTimes = taskState.latestScanTimes(),
+                    )
+                } else {
+                    null
+                }
+                val settled = freed?.takeIf { taskState.isIdle && phase.isSettled }
+                // A cleanup that freed nothing outranks [freeable]: the data survived, so FREEABLE
+                // rebuilds identically and would bury the fact that the deletion ran at all.
+                val heroSummary =
+                    (settled?.takeIf { it.mode == HeroSummary.Mode.NOTHING_FREED } ?: freeable ?: settled)
+                        .takeIf { !isDiscarding }
+                HeroState(
+                    actionState = actionState,
+                    activeTasks = taskState.tasks.filter { it.isActive }.size,
+                    queuedTasks = taskState.tasks.filter { it.isQueued }.size,
+                    heroSummary = heroSummary,
+                    upgradeInfo = upgradeInfo,
+                    batchId = phase.id,
+                    isSettled = phase.isSettled,
+                )
+            }
+        }
+        // Upstream of the retry on purpose: only a real snapshot ends an outage. The fallback the
+        // retry emits below goes straight downstream and must not clear the counter.
+        .onEach { heroStateFailures = 0L }
+        // The share below is eager and permanently subscribed, so there is no later subscription
+        // cycle to restart this on — a terminating operator (`catch`, or a bounded retry) would cost
+        // the dashboard its whole bottom bar for the ViewModel's lifetime over one DataStore blip.
+        // Retry without a bound instead, emitting the null fallback (the bar's "not ready" state)
+        // so the outage is visible, reporting it once per outage rather than per attempt, and
+        // backing off so a permanently broken source can't hot-loop.
+        .retryWhen { error, _ ->
+            if (error is CancellationException) return@retryWhen false
+            if (heroStateFailures == 0L) {
+                log(TAG, ERROR) { "heroState failed: ${error.asLog()}" }
+                onStateError(error)
+            }
+            emit(null)
+            val doublings = heroStateFailures.coerceAtMost(HERO_STATE_RETRY_MAX_DOUBLINGS).toInt()
+            val backoff = minOf(HERO_STATE_RETRY_MAX_MS, HERO_STATE_RETRY_BASE_MS shl doublings)
+            heroStateFailures++
+            delay(backoff)
+            true
+        }
+        .shareIn(scope, SharingStarted.Eagerly, replay = 1)
 
     init {
-        // A freshly completed *scan* clears any stale "freed" result and revives a dismissed hero.
-        // We must only react to a *strictly newer* scan time: TaskManager keeps one task per tool,
-        // so a delete prunes that tool's scan result and would otherwise make this "change" to an
-        // older/absent scan time and wrongly clear the freed hero we just produced.
+        // A freshly completed *scan* clears any stale "freed" result. We must only react to a
+        // *strictly newer* scan time: TaskManager keeps one task per tool, so a delete prunes that
+        // tool's scan result and would otherwise make this "change" to an older/absent scan time
+        // and wrongly clear the freed hero we just produced.
         scope.launch {
             var latestSeenScan: Instant? = null
             taskManager.state
@@ -141,110 +346,67 @@ class DashboardMainActionEngine(
                     if (prev == null || scanCompletedAt.isAfter(prev)) {
                         latestSeenScan = scanCompletedAt
                         freedResult.value = null
-                        heroDismissed.value = false
                     }
                 }
         }
-        // A freshly produced "freed" result also revives a dismissed hero so the outcome is shown.
+        // Auto-expand is a one-shot armed by a one-tap main action and resolved when that action's
+        // branches have all settled: expand if it produced something to show, otherwise just disarm.
+        // Resolving either way is the point — an arm left set by a fruitless scan would be inherited
+        // by the next card-triggered scan and auto-expand it, which is the defect this closes.
         scope.launch {
-            freedResult
-                .map { it != null }
-                .distinctUntilChanged()
-                .collect { hasFreed -> if (hasFreed) heroDismissed.value = false }
+            heroState.filterNotNull().collect { hero ->
+                val decision = resolveAutoExpand(
+                    snapshotBatchId = hero.batchId,
+                    isSettled = hero.isSettled,
+                    hasSummary = hero.heroSummary != null,
+                    batch = batchState.value,
+                )
+                when (decision) {
+                    AutoExpandDecision.IGNORE -> return@collect
+                    AutoExpandDecision.DISARM -> Unit
+                    AutoExpandDecision.EXPAND_AND_DISARM -> heroExpanded.value = true
+                }
+                batchState.update { if (it.id == hero.batchId) it.copy(autoExpandArmed = false) else it }
+            }
         }
     }
 
     /**
-     * Cold bottom bar state assembly. [listIsReady] and [oneClickOptionsState] are the VM's shared
-     * flows (list readiness derives from its listState; the options StateFlow is built from
-     * [oneClickOptions]) so their upstreams aren't collected twice.
+     * Cold bottom bar state assembly on top of the shared [heroState]; null while the hero
+     * derivation has no (or no longer a) usable snapshot. [listIsReady] is the VM's shared flow
+     * (derived from its listState) so its upstream isn't collected twice.
      */
     fun bottomBarState(
         listIsReady: Flow<Boolean>,
-        oneClickOptionsState: Flow<OneClickOptionsState>,
-    ): Flow<BottomBarState> = eu.darken.sdmse.common.flow.combine(
-        upgradeInfo,
-        taskManager.state,
-        corpseFinder.state,
-        systemCleaner.state,
-        appCleaner.state,
-        deduplicator.state,
-        generalSettings.enableDashboardOneClick.flow,
-        oneClickOptionsState,
-        freedResult,
-        pendingMainCleanup,
+    ): Flow<BottomBarState?> = combine(
+        heroState,
         listIsReady,
-        discarding,
         nowTicks,
-    ) { upgradeInfo,
-        taskState,
-        corpseState,
-        filterState,
-        junkState,
-        dedupeState,
-        oneClickMode,
-        oneClickOptions,
-        freed,
-        pendingCleanup,
-        listReady,
-        isDiscarding,
-        now ->
-
-        val actionState = resolveMainAction(
-            taskState = taskState,
-            corpse = corpseState.data,
-            system = filterState.data,
-            app = junkState.data,
-            dedupe = dedupeState.data,
-            oneClick = oneClickOptions,
-            isPro = upgradeInfo?.isPro == true,
-            oneClickMode = oneClickMode,
-        )
-        val activeTasks = taskState.tasks.filter { it.isActive }.size
-        val queuedTasks = taskState.tasks.filter { it.isQueued }.size
-        // Post-scan "will be freed" takes priority; otherwise, once the action has settled, show the
-        // "freed" result of the last main-action deletion/one-click. While working, both stay hidden
-        // and the bar carries progress. [pendingCleanup] gates this too, not just [settled]: the
-        // task manager reports idle again before the branches fold in their results, and without
-        // the gate the identical "can be freed" card flashes in that window.
-        val freeable = if (actionState == BottomBarState.Action.DELETE && pendingCleanup == 0) {
-            buildHeroSummary(
-                corpse = corpseState.data,
-                system = filterState.data,
-                app = junkState.data,
-                dedupe = dedupeState.data,
-                oneClick = oneClickOptions,
-                isPro = upgradeInfo?.isPro == true,
-                scanTimes = taskState.latestScanTimes(),
+    ) { hero, listReady, now ->
+        hero?.let {
+            BottomBarState(
+                isReady = listReady,
+                actionState = it.actionState,
+                activeTasks = it.activeTasks,
+                queuedTasks = it.queuedTasks,
+                heroSummary = it.heroSummary,
+                upgradeInfo = it.upgradeInfo,
+                now = now,
             )
-        } else {
-            null
         }
-        val settled = freed?.takeIf { taskState.isIdle && pendingCleanup == 0 }
-        // A cleanup that freed nothing outranks [freeable]: the data survived, so FREEABLE rebuilds
-        // identically and would bury the fact that the deletion ran at all.
-        val heroSummary = (settled?.takeIf { it.mode == HeroSummary.Mode.NOTHING_FREED } ?: freeable ?: settled)
-            .takeIf { !isDiscarding }
-        BottomBarState(
-            isReady = listReady,
-            actionState = actionState,
-            activeTasks = activeTasks,
-            queuedTasks = queuedTasks,
-            heroSummary = heroSummary,
-            upgradeInfo = upgradeInfo,
-            now = now,
-        )
     }
 
     fun dismissHero() {
         log(TAG) { "dismissHero()" }
-        heroDismissed.value = true
+        heroExpanded.value = false
+        // An action still in flight must not re-open what the user just closed.
+        batchState.update { it.copy(autoExpandArmed = false) }
     }
 
-    /** Re-shows a hero the user dismissed (via the compact summary chip in the bar). */
-    fun restoreHero() {
-        log(TAG) { "restoreHero()" }
-        heroDismissed.value = false
+    /** Expands a collapsed hero (via the compact summary chip in the bar). */
+    fun expandHero() {
+        log(TAG) { "expandHero()" }
+        heroExpanded.value = true
     }
 
     /**
@@ -273,7 +435,10 @@ class DashboardMainActionEngine(
             taskManager.forgetCompleted(SDMTool.Type.SYSTEMCLEANER)
             taskManager.forgetCompleted(SDMTool.Type.APPCLEANER)
             taskManager.forgetCompleted(SDMTool.Type.DEDUPLICATOR)
-            heroDismissed.value = false
+            // Discard returns the dashboard to its pristine state; the next card-triggered scan
+            // must not inherit this run's auto-expand and pop the hero open by itself.
+            heroExpanded.value = false
+            batchState.update { it.copy(autoExpandArmed = false) }
         } finally {
             discarding.value = false
         }
@@ -295,9 +460,12 @@ class DashboardMainActionEngine(
         generalSettings.oneClickDeduplicatorEnabled.value(enabled)
     }
 
-    // Runs one main-action tool branch and, for cleanups, decrements the pending counter when it
-    // settles — so the freed hero only appears once *all* branches are done (no partial flash).
-    private fun launchMainBranch(isCleanup: Boolean, block: suspend () -> Unit) = scope.launch {
+    /**
+     * Runs one main-action tool branch. A branch of a run that opened a batch ([isTracked]) also
+     * closes its share of it, so the freed hero only appears — and auto-expand only resolves — once
+     * *all* branches are done. Cancel taps don't open a batch and must not decrement someone else's.
+     */
+    private fun launchMainBranch(isTracked: Boolean, isCleanup: Boolean, block: suspend () -> Unit) = scope.launch {
         var failed = false
         try {
             block()
@@ -306,13 +474,19 @@ class DashboardMainActionEngine(
             failed = true
             throw e
         } finally {
-            if (isCleanup) {
-                if (failed) cleanupFailed.value = true
-                val remaining = pendingMainCleanup.updateAndGet { (it - 1).coerceAtLeast(0) }
+            if (isTracked) {
+                if (isCleanup && failed) cleanupFailed.value = true
+                // Two counters on purpose, do NOT merge them back into one: the observed
+                // [batchState] is published *last*, after this branch wrote everything it produces.
+                // Its pending == 0 is the settle edge [heroState] snapshots and auto-expand acts on,
+                // so a result written after that edge would arrive too late to be part of that
+                // snapshot. [branchesInFlight] is the unobserved bookkeeping that tells us we are
+                // the last branch while there is still time to write.
+                val remaining = branchesInFlight.updateAndGet { (it - 1).coerceAtLeast(0) }
                 // Last branch home. A cleanup that ran but freed nothing leaves the tools' data
                 // untouched, so the identical "can be freed" card would just re-render and the
                 // whole thing reads as "the button did nothing". Say so instead.
-                if (remaining == 0 && cleanupRan.value && !cleanupFailed.value) {
+                if (isCleanup && remaining == 0 && cleanupRan.value && !cleanupFailed.value) {
                     val nothingFreed = HeroSummary(
                         mode = HeroSummary.Mode.NOTHING_FREED,
                         totalSize = 0L,
@@ -326,6 +500,9 @@ class DashboardMainActionEngine(
                     val applied = freedResult.updateAndGet { current -> current ?: nothingFreed }
                     if (applied === nothingFreed) log(TAG, INFO) { "Cleanup finished without freeing anything." }
                 }
+                // Every branch publishes its own decrement, so this reaches 0 only after the last
+                // one has been through the block above — no matter which got there first.
+                batchState.update { it.copy(pending = (it.pending - 1).coerceAtLeast(0)) }
             }
         }
     }
@@ -343,19 +520,36 @@ class DashboardMainActionEngine(
         return corpse || system
     }
 
+    /**
+     * Runs the one-tap main action. Only the dashboard FAB (and the DELETE confirmation dialog it
+     * opens) may call this — that FAB-only origin is what makes arming the auto-expand here correct.
+     * Scans and deletions started from a tool card, an in-tool screen or the scheduler must not.
+     */
     fun mainAction(actionState: BottomBarState.Action) {
         log(TAG) { "mainAction(actionState=$actionState)" }
         // Start a fresh "freed" tally for this deletion/one-click. The hero stays hidden until every
-        // branch has settled (pendingMainCleanup == 0) so a partial per-tool result can't flash.
+        // branch has settled (batch pending == 0) so a partial per-tool result can't flash.
         val isCleanup = actionState == BottomBarState.Action.DELETE || actionState == BottomBarState.Action.ONECLICK
-        // Single-flight: a second cleanup would reset the batch tally under the branches still
-        // running on it, mixing their results and settling the hero early. It would also gain
-        // nothing — every task queues on its tool's resource lock, so it would just run again
-        // against tools the first pass already emptied. Safe without a lock: this is not a suspend
-        // function and only the main thread calls it, so taps serialize.
-        if (isCleanup && pendingMainCleanup.value > 0) {
-            log(TAG, WARN) { "mainAction($actionState): a cleanup is already in flight, ignoring." }
+        // WORKING/WORKING_CANCELABLE are the cancel tap, not a new run: they neither open a batch
+        // nor arm anything.
+        val startsRun = isCleanup || actionState == BottomBarState.Action.SCAN
+        // Single-flight across *every* run, scans included: a second batch would reset the tally
+        // under the branches still running on the first, so both counters would hit 0 after any
+        // four of the eight branches returned — settling the hero while tasks are still going and
+        // attributing results to the wrong batch. Reachable by double-tapping SCAN before the task
+        // manager reports non-idle, which is the window in which the FAB still offers SCAN. A
+        // second run would also gain nothing: every task queues on its tool's resource lock. Safe
+        // without a lock — this is not a suspend function and only the main thread calls it, so
+        // taps serialize.
+        if (startsRun && batchState.value.pending > 0) {
+            log(TAG, WARN) { "mainAction($actionState): a main action is already in flight, ignoring." }
             return
+        }
+        if (startsRun) {
+            // One atomic publish: a settle edge must never be visible without the id and arm it
+            // belongs to. Counters before the cleanup bookkeeping below.
+            branchesInFlight.set(4) // CorpseFinder + SystemCleaner + AppCleaner + Deduplicator
+            batchState.update { BatchState(id = it.id + 1, pending = 4, autoExpandArmed = true) }
         }
         if (isCleanup) {
             freedResult.value = null
@@ -363,9 +557,8 @@ class DashboardMainActionEngine(
             cleanupFailed.value = false
             // Stamp before any branch runs so it's <= every resulting report's end_at.
             freedResultSince = Instant.now()
-            pendingMainCleanup.value = 4 // CorpseFinder + SystemCleaner + AppCleaner + Deduplicator
         }
-        launchMainBranch(isCleanup) {
+        launchMainBranch(isTracked = startsRun, isCleanup = isCleanup) {
             if (!generalSettings.oneClickCorpseFinderEnabled.value()) {
                 log(VERBOSE) { "CorpseFinder is disabled one-click mode." }
                 return@launchMainBranch
@@ -385,7 +578,7 @@ class DashboardMainActionEngine(
                 )
             }
         }
-        launchMainBranch(isCleanup) {
+        launchMainBranch(isTracked = startsRun, isCleanup = isCleanup) {
             if (!generalSettings.oneClickSystemCleanerEnabled.value()) {
                 log(VERBOSE) { "SystemCleaner is disabled one-click mode." }
                 return@launchMainBranch
@@ -405,7 +598,7 @@ class DashboardMainActionEngine(
                 )
             }
         }
-        launchMainBranch(isCleanup) {
+        launchMainBranch(isTracked = startsRun, isCleanup = isCleanup) {
             if (!generalSettings.oneClickAppCleanerEnabled.value()) {
                 log(VERBOSE) { "AppCleaner is disabled one-click mode." }
                 return@launchMainBranch
@@ -432,7 +625,7 @@ class DashboardMainActionEngine(
                 }
             }
         }
-        launchMainBranch(isCleanup) {
+        launchMainBranch(isTracked = startsRun, isCleanup = isCleanup) {
             if (!generalSettings.oneClickDeduplicatorEnabled.value()) {
                 log(VERBOSE) { "Deduplicator is disabled one-click mode." }
                 return@launchMainBranch
@@ -480,6 +673,34 @@ class DashboardMainActionEngine(
 
     companion object {
         private val TAG = logTag("Dashboard", "MainActionEngine")
+
+        /** Hero-derivation retry backoff: 1s, doubling per consecutive failure, capped at a minute. */
+        private const val HERO_STATE_RETRY_BASE_MS = 1_000L
+        private const val HERO_STATE_RETRY_MAX_MS = 60_000L
+        private const val HERO_STATE_RETRY_MAX_DOUBLINGS = 6L
+
+        /**
+         * What to do with one hero snapshot the settle collector sees. Pure so the whole table can
+         * be tested — in particular the id-mismatch row, whose timing (a resolution derived from an
+         * earlier run arriving after the next run armed, the two arms being indistinguishable
+         * booleans) only occurs across threads and cannot be staged on a test dispatcher.
+         *
+         * A settled snapshot of the armed batch always consumes the arm, whether or not it had
+         * anything to show: an arm left behind by a fruitless run would be inherited by the next
+         * card-triggered scan and auto-expand it.
+         */
+        internal fun resolveAutoExpand(
+            snapshotBatchId: Long,
+            isSettled: Boolean,
+            hasSummary: Boolean,
+            batch: BatchState,
+        ): AutoExpandDecision = when {
+            !isSettled -> AutoExpandDecision.IGNORE
+            !batch.autoExpandArmed -> AutoExpandDecision.IGNORE
+            batch.id != snapshotBatchId -> AutoExpandDecision.IGNORE
+            hasSummary -> AutoExpandDecision.EXPAND_AND_DISARM
+            else -> AutoExpandDecision.DISARM
+        }
 
         /**
          * Resolves what the main dashboard button does. Every tool arms DELETE only when it is

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardScreen.kt
@@ -85,7 +85,7 @@ fun DashboardScreenHost(
     val listState by vm.listState.collectAsStateWithLifecycle()
     val bottomBarState by vm.bottomBarState.collectAsStateWithLifecycle()
     val oneClickOptionsState by vm.oneClickOptionsState.collectAsStateWithLifecycle()
-    val isHeroDismissed by vm.isHeroDismissed.collectAsStateWithLifecycle()
+    val isHeroExpanded by vm.isHeroExpanded.collectAsStateWithLifecycle()
 
     var dialogState by remember { mutableStateOf<DashboardDialogState?>(null) }
 
@@ -173,7 +173,7 @@ fun DashboardScreenHost(
         bottomBarState = bottomBarState,
         isTv = vm.isTvDevice,
         oneClickOptionsState = oneClickOptionsState,
-        isHeroDismissed = isHeroDismissed,
+        isHeroExpanded = isHeroExpanded,
         snackbarHostState = snackbarHostState,
         onDismissHero = vm::dismissHero,
         onMainAction = {
@@ -186,7 +186,7 @@ fun DashboardScreenHost(
             }
         },
         onToolClick = vm::onHeroToolClick,
-        onRestoreHero = vm::restoreHero,
+        onExpandHero = vm::expandHero,
         onDiscardResults = vm::discardResults,
         onSettings = { vm.navTo(SettingsRoute) },
         onUpgrade = { vm.navTo(UpgradeRoute()) },
@@ -203,11 +203,11 @@ internal fun DashboardScreen(
     bottomBarState: BottomBarState? = null,
     isTv: Boolean = false,
     oneClickOptionsState: OneClickOptionsState = OneClickOptionsState(),
-    isHeroDismissed: Boolean = false,
+    isHeroExpanded: Boolean = false,
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     onMainAction: () -> Unit = {},
     onToolClick: (HeroSummary.Mode, SDMTool.Type) -> Unit = { _, _ -> },
-    onRestoreHero: () -> Unit = {},
+    onExpandHero: () -> Unit = {},
     onDiscardResults: () -> Unit = {},
     onSettings: () -> Unit = {},
     onUpgrade: () -> Unit = {},
@@ -413,7 +413,7 @@ internal fun DashboardScreen(
     }
 
     // Suppress the hero while a tour is active so it can't cover or fight tour targets.
-    val heroVisible = bottomBarState?.heroSummary != null && !isHeroDismissed && !dashboardTourActive
+    val heroVisible = bottomBarState?.heroSummary != null && isHeroExpanded && !dashboardTourActive
 
     // Dismissing or discarding the hero with DPAD_CENTER removes the focused node from
     // composition and focus evaporates — the next key press would restart from the default.
@@ -491,9 +491,9 @@ internal fun DashboardScreen(
                 onUpgrade = onUpgrade,
                 onDismissHero = onDismissHero,
                 onToolClick = onToolClick,
-                onRestoreHero = onRestoreHero,
+                onExpandHero = onExpandHero,
                 onDiscardResults = onDiscardResults,
-                isHeroDismissed = isHeroDismissed,
+                canExpandHero = !dashboardTourActive,
                 mainActionModifier = Modifier.guidedTourTarget(DashboardTour.MAIN_ACTION_TARGET),
                 settingsModifier = Modifier.guidedTourTarget(DashboardTour.SETTINGS_TARGET),
             )

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModel.kt
@@ -474,28 +474,28 @@ class DashboardViewModel @Inject constructor(
         upgradeInfo = upgradeInfo,
         submitTask = ::submitTask,
         onUpgradeRequired = { navTo(UpgradeRoute()) },
+        onStateError = { errorEvents.tryEmit(it) },
     )
 
-    val oneClickOptionsState: StateFlow<OneClickOptionsState> = mainActionEngine.oneClickOptions.safeStateIn(
-        initialValue = OneClickOptionsState(),
-        onError = { OneClickOptionsState() },
-    )
+    val oneClickOptionsState: StateFlow<OneClickOptionsState> = mainActionEngine.oneClickOptionsState
 
     val bottomBarState: StateFlow<BottomBarState?> = mainActionEngine.bottomBarState(
         listIsReady = listState.map { state -> state?.items?.any { it is MainActionItem } == true },
-        oneClickOptionsState = oneClickOptionsState,
     ).safeStateIn(
         initialValue = null,
         onError = { null },
     )
 
-    /** Whether the user dismissed the hero for the current results. In-memory; resets on a fresh scan. */
-    val isHeroDismissed: StateFlow<Boolean> = mainActionEngine.isHeroDismissed
+    /**
+     * Whether the hero card is expanded. Auto-expands only for a one-tap main action that produced
+     * a result; anything started elsewhere leaves it collapsed and reachable via the bar's chip.
+     */
+    val isHeroExpanded: StateFlow<Boolean> = mainActionEngine.isHeroExpanded
 
     fun dismissHero() = mainActionEngine.dismissHero()
 
-    /** Re-shows a hero the user dismissed (via the compact summary chip in the bar). */
-    fun restoreHero() = mainActionEngine.restoreHero()
+    /** Expands a collapsed hero (via the compact summary chip in the bar). */
+    fun expandHero() = mainActionEngine.expandHero()
 
     /**
      * Drops all pending scan results, returning the dashboard to its pristine SCAN state. Unlike

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardBottomBar.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardBottomBar.kt
@@ -97,9 +97,9 @@ internal fun BottomBar(
     onUpgrade: () -> Unit,
     onDismissHero: () -> Unit,
     onToolClick: (HeroSummary.Mode, SDMTool.Type) -> Unit = { _, _ -> },
-    onRestoreHero: () -> Unit = {},
+    onExpandHero: () -> Unit = {},
     onDiscardResults: () -> Unit = {},
-    isHeroDismissed: Boolean = false,
+    canExpandHero: Boolean = false,
     mainActionModifier: Modifier = Modifier,
     settingsModifier: Modifier = Modifier,
     upgradeModifier: Modifier = Modifier,
@@ -238,9 +238,10 @@ internal fun BottomBar(
                 compactSummary = heroSummary?.takeIf { !showHero },
                 onSettings = onSettings,
                 onUpgrade = onUpgrade,
-                // Only the user-dismissed compact chip restores the hero; during a tour the same
-                // chip stays a passive info chip (the tour suppresses the floating hero on purpose).
-                onRestoreHero = onRestoreHero.takeIf { isHeroDismissed },
+                // The chip expands the hero whenever one is available and collapsed — never
+                // auto-shown (card-triggered) or dismissed by the user. During a tour it stays a
+                // passive info chip (the tour suppresses the floating hero on purpose).
+                onExpandHero = onExpandHero.takeIf { canExpandHero },
                 contentBottomPadding = navBottom,
                 settingsModifier = settingsModifier,
                 upgradeModifier = upgradeModifier,
@@ -313,7 +314,7 @@ private fun BarContent(
     compactSummary: HeroSummary?,
     onSettings: () -> Unit,
     onUpgrade: () -> Unit,
-    onRestoreHero: (() -> Unit)? = null,
+    onExpandHero: (() -> Unit)? = null,
     contentBottomPadding: Dp = 0.dp,
     settingsModifier: Modifier = Modifier,
     upgradeModifier: Modifier = Modifier,
@@ -358,8 +359,8 @@ private fun BarContent(
                     label = ByteFormatter.formatSize(context, compactSummary.totalSize).first,
                     containerColor = MaterialTheme.colorScheme.primaryContainer,
                     contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                    // Tapping it re-shows a dismissed hero (null during a tour → passive chip).
-                    onClick = onRestoreHero,
+                    // Tapping it expands the collapsed hero (null during a tour → passive chip).
+                    onClick = onExpandHero,
                 )
             }
 

--- a/app/src/screenshotTest/kotlin/eu/darken/sdmse/screenshots/DashboardScreenshots.kt
+++ b/app/src/screenshotTest/kotlin/eu/darken/sdmse/screenshots/DashboardScreenshots.kt
@@ -76,6 +76,9 @@ fun DashboardScreenshot() {
                 ),
                 upgradeInfo = null,
             ),
+            // The hero starts collapsed unless a one-tap action expanded it; without this the card
+            // would silently vanish from the store screenshot.
+            isHeroExpanded = true,
         )
     }
 }

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardAutoExpandDecisionTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardAutoExpandDecisionTest.kt
@@ -1,0 +1,66 @@
+package eu.darken.sdmse.main.ui.dashboard
+
+import eu.darken.sdmse.main.ui.dashboard.DashboardMainActionEngine.AutoExpandDecision
+import eu.darken.sdmse.main.ui.dashboard.DashboardMainActionEngine.BatchState
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+/**
+ * Contract of [DashboardMainActionEngine.resolveAutoExpand]: whether a hero snapshot arriving at the
+ * settle collector expands the card, merely consumes the batch's one-shot arm, or is none of its
+ * business. The arm is consumed by any settled snapshot of the armed batch — including one with
+ * nothing to show, or the next card-triggered scan would inherit it and pop the hero open by itself.
+ */
+internal class DashboardAutoExpandDecisionTest : BaseTest() {
+
+    private val armed = BatchState(id = 7L, pending = 0, autoExpandArmed = true)
+
+    private fun decide(
+        snapshotBatchId: Long = armed.id,
+        isSettled: Boolean = true,
+        hasSummary: Boolean = true,
+        batch: BatchState = armed,
+    ) = DashboardMainActionEngine.resolveAutoExpand(
+        snapshotBatchId = snapshotBatchId,
+        isSettled = isSettled,
+        hasSummary = hasSummary,
+        batch = batch,
+    )
+
+    @Test
+    fun `an unsettled snapshot is ignored`() {
+        decide(isSettled = false) shouldBe AutoExpandDecision.IGNORE
+        decide(isSettled = false, hasSummary = false) shouldBe AutoExpandDecision.IGNORE
+    }
+
+    @Test
+    fun `a settled snapshot without an arm is ignored`() {
+        // Results the user didn't ask for with the one-tap button: a tool card's scan, an in-tool
+        // screen, the scheduler. They render into the bar, they never open the hero.
+        val disarmed = armed.copy(autoExpandArmed = false)
+
+        decide(batch = disarmed) shouldBe AutoExpandDecision.IGNORE
+        decide(batch = disarmed, hasSummary = false) shouldBe AutoExpandDecision.IGNORE
+    }
+
+    @Test
+    fun `a settled snapshot from a superseded batch is ignored`() {
+        // The ABA row: batch A's resolution can still arrive after batch B armed, and the two arms
+        // are the same indistinguishable `true`. Without the id check, A consumes B's arm and B's
+        // result — the one the user is waiting for — never expands.
+        decide(snapshotBatchId = armed.id - 1) shouldBe AutoExpandDecision.IGNORE
+        decide(snapshotBatchId = armed.id - 1, hasSummary = false) shouldBe AutoExpandDecision.IGNORE
+        decide(snapshotBatchId = armed.id + 1) shouldBe AutoExpandDecision.IGNORE
+    }
+
+    @Test
+    fun `a settled snapshot of the armed batch with nothing to show only disarms`() {
+        decide(hasSummary = false) shouldBe AutoExpandDecision.DISARM
+    }
+
+    @Test
+    fun `a settled snapshot of the armed batch with a hero expands and disarms`() {
+        decide() shouldBe AutoExpandDecision.EXPAND_AND_DISARM
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardDiscardTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardDiscardTest.kt
@@ -149,16 +149,17 @@ internal class DashboardDiscardTest : BaseTest() {
     }
 
     @Test
-    fun `discardResults revives a previously dismissed hero state`() = runTest2 {
+    fun `discardResults collapses the hero`() = runTest2 {
         val h = harness()
-        h.vm.dismissHero()
-        h.vm.isHeroDismissed.value shouldBe true
+        h.vm.expandHero()
+        h.vm.isHeroExpanded.value shouldBe true
 
         h.vm.discardResults()
         advanceUntilIdle()
 
-        // Clean slate for the next scan cycle: no leftover dismissal (and thus no restore chip).
-        h.vm.isHeroDismissed.value shouldBe false
+        // Clean slate for the next scan cycle: discarding is a full reset, so the card goes away
+        // and a later card-triggered scan doesn't inherit an expanded hero.
+        h.vm.isHeroExpanded.value shouldBe false
     }
 
     @Test

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionDialogTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionDialogTest.kt
@@ -1,0 +1,74 @@
+package eu.darken.sdmse.main.ui.dashboard
+
+import android.content.Context
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.sdmse.common.R as CommonR
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+
+/**
+ * The one-tap DELETE goes through a confirmation dialog, and only its confirm button may reach
+ * `mainAction` — which is what keeps the hero's auto-expand armed by FAB-initiated runs only.
+ */
+class DashboardMainActionDialogTest : BaseComposeRobolectricTest() {
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    private fun setDialog(onConfirmMainAction: (BottomBarState.Action) -> Unit) {
+        composeRule.setContent {
+            PreviewWrapper {
+                DashboardEventDialogs(
+                    state = DashboardDialogState.MainActionDelete(BottomBarState.Action.DELETE),
+                    onDismiss = {},
+                    onConfirmCorpseFinder = {},
+                    onShowCorpseFinder = {},
+                    onConfirmSystemCleaner = {},
+                    onShowSystemCleaner = {},
+                    onConfirmAppCleaner = {},
+                    onShowAppCleaner = {},
+                    onConfirmDeduplicator = {},
+                    onShowDeduplicator = {},
+                    onPreviewDeduplicator = {},
+                    onStopShortRecording = {},
+                    onConfirmMainAction = onConfirmMainAction,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `merely opening the dialog does not run the action`() {
+        var confirmed: BottomBarState.Action? = null
+        setDialog { confirmed = it }
+
+        composeRule.onNodeWithText(context.getString(CommonR.string.general_delete_confirmation_title))
+            .assertIsDisplayed()
+        composeRule.runOnIdle { assertNull(confirmed) }
+    }
+
+    @Test
+    fun `confirming the dialog runs the main action`() {
+        var confirmed: BottomBarState.Action? = null
+        setDialog { confirmed = it }
+
+        composeRule.onNodeWithText(context.getString(CommonR.string.general_delete_action)).performClick()
+
+        composeRule.runOnIdle { assertEquals(BottomBarState.Action.DELETE, confirmed) }
+    }
+
+    @Test
+    fun `cancelling the dialog does not run the main action`() {
+        var confirmed: BottomBarState.Action? = null
+        setDialog { confirmed = it }
+
+        composeRule.onNodeWithText(context.getString(CommonR.string.general_cancel_action)).performClick()
+
+        composeRule.runOnIdle { assertNull(confirmed) }
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionEngineTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionEngineTest.kt
@@ -4,7 +4,9 @@ import eu.darken.sdmse.appcleaner.core.AppCleaner
 import eu.darken.sdmse.common.datastore.DataStoreValue
 import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
+import eu.darken.sdmse.corpsefinder.core.Corpse
 import eu.darken.sdmse.corpsefinder.core.CorpseFinder
+import eu.darken.sdmse.corpsefinder.core.tasks.CorpseFinderScanTask
 import eu.darken.sdmse.deduplicator.core.Deduplicator
 import eu.darken.sdmse.deduplicator.core.tasks.DeduplicatorDeleteTask
 import eu.darken.sdmse.main.core.GeneralSettings
@@ -15,6 +17,7 @@ import eu.darken.sdmse.systemcleaner.core.SystemCleaner
 import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerOneClickTask
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.mockk.coVerify
 import io.mockk.every
@@ -24,19 +27,29 @@ import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
 import java.time.Instant
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Direct contract tests for [DashboardMainActionEngine]: discarding clears both the tools' data and
- * the task manager's completed results, and cleanups stamp [DashboardMainActionEngine.freedResultSince]
- * so freed-hero chips resolve to *this* cleanup's reports.
+ * the task manager's completed results, cleanups stamp [DashboardMainActionEngine.freedResultSince]
+ * so freed-hero chips resolve to *this* cleanup's reports, and the hero only auto-expands as the
+ * outcome of a one-tap main action that actually produced something.
  */
 internal class DashboardMainActionEngineTest : BaseTest() {
 
@@ -44,14 +57,22 @@ internal class DashboardMainActionEngineTest : BaseTest() {
         val engine: DashboardMainActionEngine,
         val engineScope: CoroutineScope,
         val taskManager: TaskManager,
+        val taskState: MutableStateFlow<TaskSubmitter.State>,
         val corpseFinder: CorpseFinder,
+        val corpseState: MutableStateFlow<CorpseFinder.State>,
         val systemCleaner: SystemCleaner,
         val appCleaner: AppCleaner,
         val deduplicator: Deduplicator,
         val submittedTasks: MutableList<SDMTool.Task>,
         /** Branch failures the scope's handler caught — in production these reach `errorEvents`. */
         val branchErrors: List<Throwable>,
-    )
+        /** State-flow failures the engine reported — in production these reach `errorEvents`. */
+        val stateErrors: List<Throwable>,
+    ) {
+        fun barState(): BottomBarState = runBlocking {
+            engine.bottomBarState(listIsReady = MutableStateFlow(true)).first()!!
+        }
+    }
 
     private fun mockBool(value: Boolean): DataStoreValue<Boolean> = mockk(relaxed = true) {
         every { flow } returns MutableStateFlow(value)
@@ -62,6 +83,27 @@ internal class DashboardMainActionEngineTest : BaseTest() {
         every { isSettled } returns true
         every { error } returns null
     }
+
+    private fun corpseToolState(data: CorpseFinder.Data?): CorpseFinder.State = mockk(relaxed = true) {
+        every { this@mockk.data } returns data
+    }
+
+    /** Real [CorpseFinder.Data] so `hasData` and the hero's tool slice behave like production. */
+    private fun corpseData(count: Int = 1): CorpseFinder.Data = CorpseFinder.Data(
+        corpses = (0 until count).map { mockk<Corpse>(relaxed = true) },
+    )
+
+    private fun completedScanState(at: Instant): TaskSubmitter.State = TaskSubmitter.State(
+        tasks = listOf(
+            TaskSubmitter.ManagedTask(
+                id = "scan-$at",
+                toolType = SDMTool.Type.CORPSEFINDER,
+                task = mockk(relaxed = true),
+                completedAt = at,
+                result = CorpseFinderScanTask.Success(itemCount = 1, recoverableSpace = 1L),
+            ),
+        ),
+    )
 
     private fun harness(
         taskState: TaskSubmitter.State = TaskSubmitter.State(),
@@ -74,12 +116,18 @@ internal class DashboardMainActionEngineTest : BaseTest() {
         failingTaskType: Class<out SDMTool.Task>? = null,
         onUpgradeRequired: () -> Unit = {},
         gate: CompletableDeferred<Unit>? = null,
+        /** Replaces CorpseFinder's state flow; for tests that need a non-StateFlow source. */
+        corpseStateSource: Flow<CorpseFinder.State>? = null,
+        /** Replaces the engine scope; for tests that need virtual time instead of eager execution. */
+        scope: CoroutineScope? = null,
     ): Harness {
+        val taskStateFlow = MutableStateFlow(taskState)
         val taskManager = mockk<TaskManager>(relaxed = true).apply {
-            every { state } returns MutableStateFlow(taskState)
+            every { state } returns taskStateFlow
         }
+        val corpseStateFlow = MutableStateFlow(corpseToolState(corpseData))
         val corpseFinder = mockk<CorpseFinder>(relaxed = true).apply {
-            every { state } returns MutableStateFlow(mockk(relaxed = true) { every { data } returns corpseData })
+            every { state } returns (corpseStateSource ?: corpseStateFlow)
         }
         val systemCleaner = mockk<SystemCleaner>(relaxed = true).apply {
             every { state } returns MutableStateFlow(mockk(relaxed = true) { every { data } returns null })
@@ -99,11 +147,12 @@ internal class DashboardMainActionEngineTest : BaseTest() {
         }
         val submittedTasks = mutableListOf<SDMTool.Task>()
         val branchErrors = mutableListOf<Throwable>()
+        val stateErrors = mutableListOf<Throwable>()
         // Production-like scope: supervised like vmScope, eager like TestDispatcherProvider's
         // Unconfined; cancelled per test so the engine's internal collectors don't leak. The
         // handler mirrors vmScope's — without it a branch failure escapes to the JVM's default
         // handler, which kotlinx-coroutines-test then blames on whichever test runs next.
-        val engineScope = CoroutineScope(
+        val engineScope = scope ?: CoroutineScope(
             SupervisorJob() + Dispatchers.Unconfined + CoroutineExceptionHandler { _, e -> branchErrors.add(e) },
         )
         val engine = DashboardMainActionEngine(
@@ -129,17 +178,21 @@ internal class DashboardMainActionEngineTest : BaseTest() {
                 mockk(relaxed = true)
             },
             onUpgradeRequired = onUpgradeRequired,
+            onStateError = { stateErrors.add(it) },
         )
         return Harness(
             engine,
             engineScope,
             taskManager,
+            taskStateFlow,
             corpseFinder,
+            corpseStateFlow,
             systemCleaner,
             appCleaner,
             deduplicator,
             submittedTasks,
             branchErrors,
+            stateErrors,
         )
     }
 
@@ -200,25 +253,19 @@ internal class DashboardMainActionEngineTest : BaseTest() {
         // leaves the tools' data intact, so the identical FREEABLE hero rebuilds and buries the
         // fact that the deletion ran at all. The relaxed task result is neither AffectedSpace nor
         // AffectedCount, which is exactly the "freed 0" shape.
-        val corpseData = mockk<CorpseFinder.Data>(relaxed = true) {
-            every { corpses } returns setOf(mockk(relaxed = true))
-        }
-        val h = harness(corpseData = corpseData)
+        val h = harness(corpseData = corpseData())
 
         try {
             h.engine.mainAction(BottomBarState.Action.DELETE)
 
-            val hero = runBlocking {
-                h.engine.bottomBarState(
-                    listIsReady = MutableStateFlow(true),
-                    oneClickOptionsState = MutableStateFlow(OneClickOptionsState()),
-                ).first().heroSummary!!
-            }
+            val hero = h.barState().heroSummary!!
 
             hero.mode shouldBe HeroSummary.Mode.NOTHING_FREED
             hero.totalSize shouldBe 0L
             hero.itemCount shouldBe 0
             hero.tools.shouldBeEmpty()
+            // A NOTHING_FREED card IS a hero, so this one-tap cleanup auto-expands it.
+            h.engine.isHeroExpanded.value shouldBe true
         } finally {
             h.engineScope.cancel()
         }
@@ -232,15 +279,8 @@ internal class DashboardMainActionEngineTest : BaseTest() {
         try {
             h.engine.mainAction(BottomBarState.Action.ONECLICK)
 
-            val state = runBlocking {
-                h.engine.bottomBarState(
-                    listIsReady = MutableStateFlow(true),
-                    oneClickOptionsState = MutableStateFlow(OneClickOptionsState()),
-                ).first()
-            }
-
             h.submittedTasks.shouldBeEmpty()
-            state.heroSummary shouldBe null
+            h.barState().heroSummary shouldBe null
         } finally {
             h.engineScope.cancel()
         }
@@ -270,7 +310,10 @@ internal class DashboardMainActionEngineTest : BaseTest() {
     }
 
     @Test
-    fun `scans are never blocked by an in-flight cleanup`() {
+    fun `a second tracked run is ignored while the first is still in flight`() {
+        // Scans open the batch counters too, so a second run of any kind would reset them under the
+        // branches still on the first: both counters would hit 0 after any four of the eight
+        // branches returned, settling the hero while tasks are still running.
         val gate = CompletableDeferred<Unit>()
         val h = harness(gate = gate)
 
@@ -278,9 +321,30 @@ internal class DashboardMainActionEngineTest : BaseTest() {
             h.engine.mainAction(BottomBarState.Action.ONECLICK)
             h.engine.mainAction(BottomBarState.Action.SCAN)
 
-            h.submittedTasks.size shouldBe 2
+            h.submittedTasks.size shouldBe 1
         } finally {
             gate.complete(Unit)
+            h.engineScope.cancel()
+        }
+    }
+
+    @Test
+    fun `a rapid double tap on scan starts a single run`() {
+        // Until the task manager reports non-idle the FAB still resolves to SCAN, so both taps of a
+        // double tap reach mainAction.
+        val gate = CompletableDeferred<Unit>()
+        val h = harness(gate = gate)
+
+        try {
+            h.engine.mainAction(BottomBarState.Action.SCAN)
+            h.engine.mainAction(BottomBarState.Action.SCAN)
+            h.submittedTasks.size shouldBe 1
+
+            // Once the batch settles, the button works again.
+            gate.complete(Unit)
+            h.engine.mainAction(BottomBarState.Action.SCAN)
+            h.submittedTasks.size shouldBe 2
+        } finally {
             h.engineScope.cancel()
         }
     }
@@ -291,11 +355,8 @@ internal class DashboardMainActionEngineTest : BaseTest() {
         // claiming the cleanup "finished" on top of it would contradict it. The findings survived
         // the failure, so the freeable card legitimately stays — it just must not be the
         // NOTHING_FREED one.
-        val corpseData = mockk<CorpseFinder.Data>(relaxed = true) {
-            every { corpses } returns setOf(mockk(relaxed = true))
-        }
         val h = harness(
-            corpseData = corpseData,
+            corpseData = corpseData(),
             otherToolsOneClick = true,
             failingTaskType = SystemCleanerOneClickTask::class.java,
         )
@@ -303,14 +364,7 @@ internal class DashboardMainActionEngineTest : BaseTest() {
         try {
             h.engine.mainAction(BottomBarState.Action.ONECLICK)
 
-            val state = runBlocking {
-                h.engine.bottomBarState(
-                    listIsReady = MutableStateFlow(true),
-                    oneClickOptionsState = MutableStateFlow(OneClickOptionsState()),
-                ).first()
-            }
-
-            state.heroSummary?.mode shouldBe HeroSummary.Mode.FREEABLE
+            h.barState().heroSummary?.mode shouldBe HeroSummary.Mode.FREEABLE
             // The failure isn't swallowed — in production this is the dialog the user sees.
             h.branchErrors.map { it.message } shouldBe listOf("task failed")
         } finally {
@@ -322,15 +376,12 @@ internal class DashboardMainActionEngineTest : BaseTest() {
     fun `a non-Pro AppCleaner upsell fires even when an opted-out free tool has data`() {
         // The upsell guard used to test raw CorpseFinder/SystemCleaner data, so an opted-out tool
         // with findings silently blocked it — the DELETE branch then did nothing whatsoever.
-        val corpseData = mockk<CorpseFinder.Data>(relaxed = true) {
-            every { corpses } returns setOf(mockk(relaxed = true))
-        }
         val appData = mockk<AppCleaner.Data>(relaxed = true) {
             every { junks } returns setOf(mockk(relaxed = true))
         }
         var upgradeRequired = 0
         val h = harness(
-            corpseData = corpseData,
+            corpseData = corpseData(),
             appData = appData,
             corpseFinderOneClick = false,
             appCleanerOneClick = true,
@@ -346,6 +397,224 @@ internal class DashboardMainActionEngineTest : BaseTest() {
         } finally {
             h.engineScope.cancel()
         }
+    }
+
+    @Test
+    fun `a one-tap scan that finds data expands the hero`() {
+        // The gate holds the branches in flight so the findings land while the batch is still open,
+        // mirroring a real scan where the tool's data fills before its task returns.
+        val gate = CompletableDeferred<Unit>()
+        val h = harness(gate = gate)
+
+        try {
+            h.engine.mainAction(BottomBarState.Action.SCAN)
+            h.engine.isHeroExpanded.value shouldBe false
+
+            h.corpseState.value = corpseToolState(corpseData())
+            gate.complete(Unit)
+
+            h.barState().heroSummary.shouldNotBeNull()
+            h.engine.isHeroExpanded.value shouldBe true
+        } finally {
+            h.engineScope.cancel()
+        }
+    }
+
+    @Test
+    fun `the settled snapshot re-reads the tool states`() {
+        // Regression for the settle-edge race: the batch phase is applied by re-deriving the hero,
+        // so the settled snapshot reads every source *after* the branches decremented, instead of
+        // pairing the settled counter with whatever a long-lived per-source collector happened to
+        // have picked up. This source only reveals its value at (re)subscription — standing in for
+        // one whose update the previous subscription hadn't seen yet — so a settle edge that does
+        // not re-read leaves the hero collapsed.
+        val gate = CompletableDeferred<Unit>()
+        val corpseHolder = AtomicReference(corpseToolState(null))
+        val h = harness(
+            gate = gate,
+            corpseStateSource = flow {
+                emit(corpseHolder.get())
+                awaitCancellation()
+            },
+        )
+
+        try {
+            h.engine.mainAction(BottomBarState.Action.SCAN)
+
+            // The scan's findings, published where only a re-subscription can pick them up.
+            corpseHolder.set(corpseToolState(corpseData()))
+            gate.complete(Unit)
+
+            h.barState().heroSummary.shouldNotBeNull()
+            h.engine.isHeroExpanded.value shouldBe true
+        } finally {
+            h.engineScope.cancel()
+        }
+    }
+
+    @Test
+    fun `a transient derivation failure falls back and then recovers`() = runTest2 {
+        // The share is eager and permanently subscribed, so nothing would ever resubscribe it: a
+        // terminating operator here would cost the dashboard its bottom bar — the app's primary
+        // action — for the ViewModel's lifetime, over one failed settings read.
+        val attempts = AtomicInteger(0)
+        val h = harness(
+            scope = CoroutineScope(SupervisorJob() + StandardTestDispatcher(testScheduler)),
+            corpseStateSource = flow {
+                if (attempts.getAndIncrement() == 0) throw IllegalStateException("upstream blip")
+                emit(corpseToolState(corpseData()))
+                awaitCancellation()
+            },
+        )
+
+        try {
+            runCurrent()
+
+            // The outage is visible as the bar's not-ready state, and reported once.
+            h.engine.bottomBarState(listIsReady = MutableStateFlow(true)).first() shouldBe null
+            h.stateErrors.map { it.message } shouldBe listOf("upstream blip")
+
+            // Past the first backoff the derivation resubscribes and the bar comes back.
+            advanceTimeBy(2 * 1_000L)
+            runCurrent()
+
+            h.engine.bottomBarState(listIsReady = MutableStateFlow(true)).first().shouldNotBeNull()
+            h.stateErrors.size shouldBe 1
+        } finally {
+            h.engineScope.cancel()
+        }
+    }
+
+    @Test
+    fun `a one-tap scan that finds nothing does not expand the hero`() {
+        val h = harness()
+
+        try {
+            h.engine.mainAction(BottomBarState.Action.SCAN)
+
+            h.barState().heroSummary shouldBe null
+            h.engine.isHeroExpanded.value shouldBe false
+        } finally {
+            h.engineScope.cancel()
+        }
+    }
+
+    @Test
+    fun `a fruitless one-tap scan does not arm a later foreign scan`() {
+        // The leak this design closes: a one-tap scan that produced no hero must still consume its
+        // arm, or the next card-triggered scan inherits it and pops the hero open by itself.
+        val h = harness()
+
+        try {
+            h.engine.mainAction(BottomBarState.Action.SCAN)
+            h.engine.isHeroExpanded.value shouldBe false
+
+            // A tool card's own scan finding something — no mainAction() involved.
+            h.corpseState.value = corpseToolState(corpseData())
+
+            h.barState().heroSummary.shouldNotBeNull()
+            h.engine.isHeroExpanded.value shouldBe false
+        } finally {
+            h.engineScope.cancel()
+        }
+    }
+
+    @Test
+    fun `a card-triggered scan leaves the hero collapsed`() {
+        // The reported defect: results the user didn't ask for with the one-tap button must not
+        // throw the hero card over the dashboard.
+        val h = harness()
+
+        try {
+            h.corpseState.value = corpseToolState(corpseData())
+
+            h.barState().heroSummary.shouldNotBeNull()
+            h.engine.isHeroExpanded.value shouldBe false
+        } finally {
+            h.engineScope.cancel()
+        }
+    }
+
+    @Test
+    fun `a card-triggered scan does not re-expand a dismissed hero`() {
+        val h = harness(corpseData = corpseData())
+
+        try {
+            h.engine.expandHero()
+            h.engine.dismissHero()
+
+            h.corpseState.value = corpseToolState(corpseData(count = 2))
+
+            h.barState().heroSummary.shouldNotBeNull()
+            h.engine.isHeroExpanded.value shouldBe false
+        } finally {
+            h.engineScope.cancel()
+        }
+    }
+
+    @Test
+    fun `cancelling via the main action does not arm auto-expand`() {
+        // WORKING/WORKING_CANCELABLE taps stop the current run; they start nothing and must not
+        // leave an arm behind for whatever produces the next hero.
+        val h = harness()
+
+        try {
+            h.engine.mainAction(BottomBarState.Action.WORKING_CANCELABLE)
+            h.engine.mainAction(BottomBarState.Action.WORKING)
+
+            h.corpseState.value = corpseToolState(corpseData())
+
+            h.barState().heroSummary.shouldNotBeNull()
+            h.engine.isHeroExpanded.value shouldBe false
+        } finally {
+            h.engineScope.cancel()
+        }
+    }
+
+    @Test
+    fun `dismissing mid-flight is respected when the result arrives`() {
+        val gate = CompletableDeferred<Unit>()
+        val h = harness(corpseData = corpseData(), gate = gate)
+
+        try {
+            h.engine.mainAction(BottomBarState.Action.ONECLICK)
+            h.engine.dismissHero()
+
+            gate.complete(Unit)
+
+            h.barState().heroSummary.shouldNotBeNull()
+            h.engine.isHeroExpanded.value shouldBe false
+        } finally {
+            h.engineScope.cancel()
+        }
+    }
+
+    @Test
+    fun `a newer scan still clears a stale freed summary`() {
+        val h = harness(corpseData = corpseData())
+
+        try {
+            h.engine.mainAction(BottomBarState.Action.DELETE)
+            h.barState().heroSummary?.mode shouldBe HeroSummary.Mode.NOTHING_FREED
+
+            // A newer scan supersedes the last cleanup's outcome; the bar goes back to "freeable".
+            h.taskState.value = completedScanState(Instant.now())
+
+            h.barState().heroSummary?.mode shouldBe HeroSummary.Mode.FREEABLE
+        } finally {
+            h.engineScope.cancel()
+        }
+    }
+
+    @Test
+    fun `expandHero and dismissHero toggle the flag`() = withHarness { h ->
+        h.engine.isHeroExpanded.value shouldBe false
+
+        h.engine.expandHero()
+        h.engine.isHeroExpanded.value shouldBe true
+
+        h.engine.dismissHero()
+        h.engine.isHeroExpanded.value shouldBe false
     }
 
     @Test
@@ -401,6 +670,7 @@ internal class DashboardMainActionEngineTest : BaseTest() {
             upgradeInfo = MutableStateFlow(proInfo),
             submitTask = { task -> if (task is DeduplicatorDeleteTask) deleteResult else mockk(relaxed = true) },
             onUpgradeRequired = {},
+            onStateError = {},
         )
 
         try {
@@ -410,10 +680,9 @@ internal class DashboardMainActionEngineTest : BaseTest() {
             dedupState.value = Deduplicator.State(data = null, progress = null)
 
             val hero = runBlocking {
-                engine.bottomBarState(
-                    listIsReady = MutableStateFlow(true),
-                    oneClickOptionsState = MutableStateFlow(OneClickOptionsState(deduplicatorEnabled = true)),
-                ).first { it.heroSummary != null }.heroSummary!!
+                engine.bottomBarState(listIsReady = MutableStateFlow(true))
+                    .first { it?.heroSummary != null }!!
+                    .heroSummary!!
             }
 
             hero.mode shouldBe HeroSummary.Mode.FREED

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardScreenDpadWrapTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardScreenDpadWrapTest.kt
@@ -389,12 +389,12 @@ class DashboardScreenDpadWrapTest : BaseComposeRobolectricTest() {
                     LocalTourTargetRegistry provides TourTargetRegistry(),
                     LocalGuidedTourController provides controller,
                 ) {
-                    var dismissed by remember { mutableStateOf(false) }
+                    var expanded by remember { mutableStateOf(true) }
                     DashboardScreen(
                         listState = DashboardViewModel.ListState(items = defaultItems()),
                         bottomBarState = bottomBarState(heroSummary = heroSummary()),
-                        isHeroDismissed = dismissed,
-                        onDismissHero = { dismissed = true },
+                        isHeroExpanded = expanded,
+                        onDismissHero = { expanded = false },
                     )
                 }
             }
@@ -459,6 +459,9 @@ private fun ComposeContentTestRule.setDashboardContent(
                 DashboardScreen(
                     listState = listState,
                     bottomBarState = bottomBarState,
+                    // These tests are about focus travel through a *shown* hero; expand whenever the
+                    // state carries one, since the hero is collapsed by default now.
+                    isHeroExpanded = bottomBarState.heroSummary != null,
                 )
             }
         }

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardHeroCardTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardHeroCardTest.kt
@@ -5,6 +5,7 @@ import android.text.format.DateUtils
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertHasNoClickAction
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -306,23 +307,23 @@ class DashboardHeroCardTest : BaseComposeRobolectricTest() {
     }
 
     @Test
-    fun `tapping the compact bar chip restores a dismissed hero`() {
-        var restored = 0
+    fun `tapping the compact bar chip expands a collapsed hero`() {
+        var expanded = 0
         val hero = summary()
         composeRule.setContent {
             PreviewWrapper {
                 BottomBar(
                     state = deleteState(hero),
                     isVisible = true,
-                    // Dismissed: the floating hero is gone and the bar shows the compact chip instead.
+                    // Collapsed: the floating hero is gone and the bar shows the compact chip instead.
                     heroVisible = false,
-                    isHeroDismissed = true,
+                    canExpandHero = true,
                     onMainAction = {},
                     onMainActionLongClick = {},
                     onSettings = {},
                     onUpgrade = {},
                     onDismissHero = {},
-                    onRestoreHero = { restored++ },
+                    onExpandHero = { expanded++ },
                 )
             }
         }
@@ -330,7 +331,60 @@ class DashboardHeroCardTest : BaseComposeRobolectricTest() {
         composeRule.onNodeWithText(label)
             .assertHasClickAction()
             .performSemanticsAction(SemanticsActions.OnClick)
-        composeRule.runOnIdle { assertEquals(1, restored) }
+        composeRule.runOnIdle { assertEquals(1, expanded) }
+    }
+
+    @Test
+    fun `the compact chip is clickable for a hero that was never expanded`() {
+        // Card-triggered results never auto-show the hero; the chip is the way back to it, and it
+        // must not depend on the user having dismissed something first.
+        var expanded = 0
+        val hero = summary()
+        composeRule.setContent {
+            PreviewWrapper {
+                BottomBar(
+                    state = deleteState(hero),
+                    isVisible = true,
+                    heroVisible = false,
+                    canExpandHero = true,
+                    onMainAction = {},
+                    onMainActionLongClick = {},
+                    onSettings = {},
+                    onUpgrade = {},
+                    onDismissHero = {},
+                    onExpandHero = { expanded++ },
+                )
+            }
+        }
+        composeRule.onNodeWithText(ByteFormatter.formatSize(context, hero.totalSize).first)
+            .assertHasClickAction()
+            .performSemanticsAction(SemanticsActions.OnClick)
+        composeRule.runOnIdle { assertEquals(1, expanded) }
+    }
+
+    @Test
+    fun `the compact chip is passive during a tour`() {
+        // The tour suppresses the floating hero on purpose, so the chip must not be able to bring
+        // it back and fight the tour's targets.
+        val hero = summary()
+        composeRule.setContent {
+            PreviewWrapper {
+                BottomBar(
+                    state = deleteState(hero),
+                    isVisible = true,
+                    heroVisible = false,
+                    canExpandHero = false,
+                    onMainAction = {},
+                    onMainActionLongClick = {},
+                    onSettings = {},
+                    onUpgrade = {},
+                    onDismissHero = {},
+                    onExpandHero = {},
+                )
+            }
+        }
+        composeRule.onNodeWithText(ByteFormatter.formatSize(context, hero.totalSize).first)
+            .assertHasNoClickAction()
     }
 
     @Test


### PR DESCRIPTION
## What changed

The summary card above the bottom bar — the big one showing how much can be freed — used to appear
whenever any tool had scan results, no matter how you started the scan. Tapping "Scan" on a single
tool's card would throw the summary over the whole dashboard unprompted, and it would also bring
itself back after you had explicitly swiped it away.

Now it only opens by itself as the result of something you started with the main button at the
bottom (including its delete confirmation). Anything started elsewhere — a tool card's Scan or
Delete, a tool's own screen, or the scheduler — leaves it collapsed, and the small size chip in the
bottom bar opens it with one tap whenever you want it. That chip now works whenever a summary
exists, not only after you had dismissed the card once.

## Technical Context

- **Auto-expand is a one-shot armed intent resolved when the action's branches settle**, not a flag
  set when the button is tapped. Arming on tap alone leaks: a one-tap scan that finds nothing never
  consumes the arm, so the next card-triggered scan inherits it and reopens the original defect.
  Resolving at settle consumes the arm either way.
- **The hero derivation moved into a shared `heroState`** so the settle resolution and the bottom bar
  judge the same snapshot. The batch phase drives it through `flatMapLatest` — a settled snapshot
  therefore re-reads its sources instead of pairing a settled counter with a tool state the combine
  had not picked up yet, which is a real interleaving on `Dispatchers.Default`. It is keyed on the
  phase rather than the raw counter deliberately: the intermediate 4→3→2→1 decrements are not phase
  changes, so a run costs two re-subscriptions instead of five.
- **`BatchState` publishes the run id, pending count and arm atomically.** The id is an ABA guard —
  it stops a late resolution from one run consuming the next run's arm, the two arms being
  indistinguishable booleans otherwise.
- **Single-flight now covers scans, not just cleanups.** A double-tapped scan previously reset the
  batch counters under still-running branches, so eight branches decremented a counter that started
  at four. This replaces the old `scans are never blocked by an in-flight cleanup` test, whose
  contract is now wrong. Nothing reachable changes — `resolveMainAction` returns WORKING while a
  cleanup runs, so the button cannot offer Scan then.
- **The derivation retries with capped backoff instead of terminating.** It is eagerly shared with a
  permanent subscriber, so a terminating operator would cost the dashboard its whole bottom bar for
  the ViewModel's lifetime over one settings-read blip. State-flow failures also now reach the error
  channel instead of silently falling back to default one-click toggles.

### Known accepted residual

The tools' `state` flows are `replayingShare` projections, so re-subscribing reads a replay cache
rather than forcing recomputation. If a tool has not published its results by the settle edge, the
hero will not auto-open — the bar chip still opens it. Closing this would mean exposing each tool's
internal data as new public API across the four `app-tool-*` modules; that was weighed and declined
as too much API surface for a rare, benign miss. It is documented in the code so it is not
"fixed" later without the same discussion.

### Review guidance

The concurrency in `DashboardMainActionEngine` is where the risk concentrates. The two-counter scheme
is deliberate: the unobserved `branchesInFlight` tells the last branch that it *is* last while it
still has results to write, and the observed `BatchState` is published only afterwards — so the
settle edge never becomes visible before the results it is supposed to include.

Locally passing at this SHA: `:app:testFossDebugUnitTest` (1058 tests), `:app:compileFossDebugScreenshotTestSources`,
`:app:assembleFossDebug`, `:app:updateFossDebugScreenshotTest`. The Play Store dashboard reference
screenshot was rendered and visually confirmed to still show the card.
