### PR TITLE
General: Make the supporter flow and debug logging more dependable

### DIFF
--- a/app-common/src/main/java/eu/darken/sdmse/common/WebpageTool.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/WebpageTool.kt
@@ -18,12 +18,12 @@ class WebpageTool @Inject constructor(
     @ApplicationContext private val context: Context,
 ) {
 
-    fun open(address: String) {
-        open(context, address)
-    }
+    // Returns whether an activity was actually started, so callers that gate behaviour on the page
+    // having opened (e.g. the FOSS sponsor unlock heuristic) don't fire when no browser handled it.
+    fun open(address: String): Boolean = open(context, address)
 
     companion object {
-        fun open(context: Context, address: String) {
+        fun open(context: Context, address: String): Boolean {
             val intent = Intent(Intent.ACTION_VIEW, address.toUri()).apply {
                 addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             }
@@ -32,17 +32,20 @@ class WebpageTool @Inject constructor(
             if (handler != null && handler.packageName in STUB_PACKAGES) {
                 log(ERROR) { "Failed to launch. Only stub handler ($handler) available for $address" }
                 showNoAppToast(context, address)
-                return
+                return false
             }
-            try {
+            return try {
                 context.startActivity(intent)
+                true
             } catch (e: ActivityNotFoundException) {
                 log(ERROR) { "Failed to launch. No compatible activity for $address" }
                 showNoAppToast(context, address)
+                false
             } catch (e: SecurityException) {
                 // Permission Denial: starting Intent { act=android.intent.action.VIEW dat=https://github.com/...
                 // flg=0x10000000 cmp=com.mxtech.videoplayer.pro/com.mxtech.videoplayer.ActivityWebBrowser }
                 log(ERROR) { "Failed to launch activity due to $e" }
+                false
             }
         }
 

--- a/app-common/src/test/java/eu/darken/sdmse/common/WebpageToolTest.kt
+++ b/app-common/src/test/java/eu/darken/sdmse/common/WebpageToolTest.kt
@@ -1,0 +1,80 @@
+package eu.darken.sdmse.common
+
+import android.app.Application
+import android.content.ActivityNotFoundException
+import android.content.ContextWrapper
+import android.content.Intent
+import android.content.pm.ActivityInfo
+import android.content.pm.ResolveInfo
+import androidx.core.net.toUri
+import androidx.test.core.app.ApplicationProvider
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+
+/**
+ * The return value is a contract, not a convenience: the FOSS sponsor unlock heuristic only arms
+ * when the page actually opened. Every swallow point has to report the failure back.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class WebpageToolTest : BaseTest() {
+
+    private val application: Application
+        get() = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `a launched page reports success`() {
+        WebpageTool(application).open(URL) shouldBe true
+
+        shadowOf(application).nextStartedActivity!!.data shouldBe URL.toUri()
+    }
+
+    @Test
+    fun `the android-tv stub handler is not a launch`() {
+        // Android TV has no browser; the system stub would consume the intent and show an unhelpful
+        // toast, so nothing is started at all.
+        val intent = Intent(Intent.ACTION_VIEW, URL.toUri())
+        shadowOf(application.packageManager).addResolveInfoForIntent(
+            intent,
+            ResolveInfo().apply {
+                activityInfo = ActivityInfo().apply {
+                    packageName = "com.android.tv.frameworkpackagestubs"
+                    name = "StubActivity"
+                }
+                isDefault = true
+            },
+        )
+
+        WebpageTool(application).open(URL) shouldBe false
+
+        shadowOf(application).nextStartedActivity shouldBe null
+    }
+
+    @Test
+    fun `a missing browser reports failure`() {
+        val context = object : ContextWrapper(application) {
+            override fun startActivity(intent: Intent) = throw ActivityNotFoundException("No browser")
+        }
+
+        WebpageTool(context).open(URL) shouldBe false
+    }
+
+    @Test
+    fun `a denied launch reports failure`() {
+        val context = object : ContextWrapper(application) {
+            override fun startActivity(intent: Intent) = throw SecurityException("Permission Denial")
+        }
+
+        WebpageTool(context).open(URL) shouldBe false
+    }
+
+    companion object {
+        private const val URL = "https://github.com/sponsors/d4rken"
+    }
+}

--- a/app/src/foss/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoFoss.kt
+++ b/app/src/foss/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoFoss.kt
@@ -13,7 +13,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.shareIn
-import kotlinx.coroutines.launch
 import java.time.Instant
 import java.util.UUID
 import javax.inject.Inject
@@ -49,9 +48,11 @@ class UpgradeRepoFoss @Inject constructor(
         .setupCommonEventHandlers(TAG) { "upgradeInfo" }
         .shareIn(appScope, SharingStarted.WhileSubscribed(3000L, 0L), replay = 1)
 
-    fun openGithubSponsorsPage() = appScope.launch {
+    // Synchronous so the caller learns whether the page actually opened: the FOSS unlock heuristic
+    // only arms on a successful launch, and a fire-and-forget coroutine can't report that back.
+    fun openGithubSponsorsPage(): Boolean {
         log(TAG) { "openGithubSponsorsPage()" }
-        webpageTool.open(upgradeSite)
+        return webpageTool.open(upgradeSite)
     }
 
     internal suspend fun persistUpgrade() {

--- a/app/src/foss/java/eu/darken/sdmse/common/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/foss/java/eu/darken/sdmse/common/upgrade/ui/UpgradeScreen.kt
@@ -95,6 +95,7 @@ fun UpgradeScreenHost(
         supporterSince = state.supporterSince,
         snackbarHostState = snackbarHostState,
         onGithubSponsors = vm::goGithubSponsors,
+        onOpenSponsors = vm::openSponsors,
         onShowUpgradeOptions = vm::onShowUpgradeOptions,
         onNavigateUp = vm::navUp,
     )
@@ -106,6 +107,7 @@ internal fun UpgradeScreen(
     supporterSince: Instant? = null,
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     onGithubSponsors: () -> Unit = {},
+    onOpenSponsors: () -> Unit = {},
     onShowUpgradeOptions: () -> Unit = {},
     onNavigateUp: () -> Unit = {},
 ) {
@@ -135,7 +137,7 @@ internal fun UpgradeScreen(
             FossUpgradeView.STATUS_UPGRADED -> UpgradeStatusUpgradedContent(
                 paddingValues = paddingValues,
                 supporterSince = supporterSince,
-                onGithubSponsors = onGithubSponsors,
+                onOpenSponsors = onOpenSponsors,
             )
         }
     }
@@ -229,7 +231,7 @@ private fun UpgradeStatusFreeContent(
 private fun UpgradeStatusUpgradedContent(
     paddingValues: PaddingValues,
     supporterSince: Instant? = null,
-    onGithubSponsors: () -> Unit,
+    onOpenSponsors: () -> Unit,
 ) {
     UpgradeScreenContent(
         paddingValues = paddingValues,
@@ -268,7 +270,7 @@ private fun UpgradeStatusUpgradedContent(
         ) {
             UpgradeSectionBody(text = stringResource(R.string.upgrade_screen_recurring_body))
             OutlinedButton(
-                onClick = onGithubSponsors,
+                onClick = onOpenSponsors,
                 modifier = Modifier
                     .fillMaxWidth()
                     .testTag(UpgradeScreenTags.FOSS_DONATE),

--- a/app/src/foss/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/foss/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
@@ -101,9 +101,28 @@ class UpgradeViewModel @Inject constructor(
         handle[KEY_SHOW_UPGRADE_OPTIONS] = true
     }
 
+    /** Armed variant: the pitch's sponsor button, which starts the return-after-5s unlock heuristic. */
     fun goGithubSponsors() {
         log(TAG) { "goGithubSponsors()" }
+        if (hasPendingSponsorLaunch()) {
+            log(TAG) { "A sponsor launch is already awaiting its return" }
+            return
+        }
+        // Only arm the heuristic if the page actually opened; otherwise an unrelated later
+        // background/foreground round-trip would grant supporter status with no page ever shown.
+        if (!upgradeRepo.openGithubSponsorsPage()) {
+            log(TAG) { "Sponsor page didn't open; not arming the unlock heuristic" }
+            return
+        }
         handle[KEY_SPONSOR_PRESSED_AT] = SystemClock.elapsedRealtime()
+    }
+
+    /**
+     * Unarmed variant: the status view's donate button. An existing supporter re-visiting the page
+     * must not re-arm the unlock heuristic — there is nothing left to unlock.
+     */
+    fun openSponsors() {
+        log(TAG) { "openSponsors()" }
         upgradeRepo.openGithubSponsorsPage()
     }
 
@@ -118,18 +137,21 @@ class UpgradeViewModel @Inject constructor(
 
     fun checkSponsorReturn() = launch {
         val pressedAt = handle.remove<Long>(KEY_SPONSOR_PRESSED_AT) ?: return@launch
+
+        // Evaluated before the duration: an already upgraded supporter (recurring donation button)
+        // has nothing left to unlock, and persisting again would rewrite their upgradedAt — visibly
+        // resetting the "supporter since" date the status screen shows them.
+        if (upgradeRepo.upgradeInfo.first().isPro) {
+            log(TAG) { "checkSponsorReturn(): Already upgraded, staying quiet" }
+            return@launch
+        }
+
         val elapsed = SystemClock.elapsedRealtime() - pressedAt
         log(TAG) { "checkSponsorReturn(): elapsed=${elapsed}ms" }
 
         if (elapsed < SPONSOR_DELAY_MS) {
-            // The nudge belongs to the unlock heuristic. An already upgraded user (recurring
-            // donation button) has nothing to unlock — peeking at the page needs no feedback.
-            if (upgradeRepo.upgradeInfo.first().isPro) {
-                log(TAG) { "checkSponsorReturn(): Too quick, but already upgraded, staying quiet" }
-            } else {
-                log(TAG) { "checkSponsorReturn(): Too quick, showing snackbar" }
-                snackbarEvents.tryEmit(R.string.upgrade_screen_sponsor_return_too_quick)
-            }
+            log(TAG) { "checkSponsorReturn(): Too quick, showing snackbar" }
+            snackbarEvents.tryEmit(R.string.upgrade_screen_sponsor_return_too_quick)
         } else {
             log(TAG) { "checkSponsorReturn(): Delay passed, persisting upgrade" }
             upgradeRepo.persistUpgrade()

--- a/app/src/foss/res/values-af-rZA/strings.xml
+++ b/app/src/foss/res/values-af-rZA/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">Gradeer SD Maid SE op</string>
     <string name="upgrades_dashcard_body">Ontsluit addisionele funksies en word \'n beskermheer om voortgesette ontwikkeling te ondersteun!</string>
     <string name="upgrades_dashcard_upgrade_action">Gradeer op</string>

--- a/app/src/foss/res/values-am/strings.xml
+++ b/app/src/foss/res/values-am/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE ያሻሽሉ</string>
     <string name="upgrades_dashcard_body">ተጨማሪ ባህሪያትን ይክፈቱ እና ቀጣይ ልማትን ለመደገፍ ደጋፊ ይሁኑ!</string>
     <string name="upgrades_dashcard_upgrade_action">ያሻሽሉ</string>

--- a/app/src/foss/res/values-ar/strings.xml
+++ b/app/src/foss/res/values-ar/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">البرمجيات الحرة (FOSS)</string>
     <string name="upgrades_dashcard_title">ترقية SD Maid SE</string>
     <string name="upgrades_dashcard_body">افتح ميزات إضافية وكن راعياً لدعم التطوير المستمر!</string>
     <string name="upgrades_dashcard_upgrade_action">ترقية</string>

--- a/app/src/foss/res/values-az/strings.xml
+++ b/app/src/foss/res/values-az/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">Açıq mənbəli proqram təminatı</string>
     <string name="upgrades_dashcard_title">SD Maid SE-ni yüksəldin</string>
     <string name="upgrades_dashcard_body">Əlavə xüsusiyyətləri açın və davamlı inkişafı dəstəkləmək üçün himayədar olun!</string>
     <string name="upgrades_dashcard_upgrade_action">Yüksəlt</string>

--- a/app/src/foss/res/values-be/strings.xml
+++ b/app/src/foss/res/values-be/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">Абнавіць SD Maid SE</string>
     <string name="upgrades_dashcard_body">Адкрыйце дадатковыя функцыі і станьце спонсарам, каб падтрымаць далейшую распрацоўку!</string>
     <string name="upgrades_dashcard_upgrade_action">Абнавіць</string>

--- a/app/src/foss/res/values-bg/strings.xml
+++ b/app/src/foss/res/values-bg/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">Надстройте SD Maid SE</string>
     <string name="upgrades_dashcard_body">Отключете допълнителни функции и станете покровител, за да подкрепите непрекъснатото развитие!</string>
     <string name="upgrades_dashcard_upgrade_action">Надстройване</string>

--- a/app/src/foss/res/values-bn-rBD/strings.xml
+++ b/app/src/foss/res/values-bn-rBD/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE আপগ্রেড করুন</string>
     <string name="upgrades_dashcard_body">অতিরিক্ত ফিচার আনলক করুন এবং ক্রমাগত বিকাশকে সমর্থন করার জন্য একজন পৃষ্ঠপোষক হন!</string>
     <string name="upgrades_dashcard_upgrade_action">আপগ্রেড করুন</string>

--- a/app/src/foss/res/values-ca/strings.xml
+++ b/app/src/foss/res/values-ca/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">Millora l\'SD Maid SE</string>
     <string name="upgrades_dashcard_body">Desbloquegeu funcions addicionals i convertiu-vos en mecenes per donar suport al continuïtat del suport!</string>
     <string name="upgrades_dashcard_upgrade_action">Millora</string>

--- a/app/src/foss/res/values-ckb-rIR/strings.xml
+++ b/app/src/foss/res/values-ckb-rIR/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">نوێکردنەوەی SD Maid SE</string>
     <string name="upgrades_dashcard_body">تایبەتمەندی زیاتر بکەرەوە و ببە بە سپۆنسەر بۆ پشتگیریکردنی پەرەپێدانی بەردەوام!</string>
     <string name="upgrades_dashcard_upgrade_action">نوێکردنەوە</string>

--- a/app/src/foss/res/values-cs/strings.xml
+++ b/app/src/foss/res/values-cs/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">Upgradovat SD Maid SE</string>
     <string name="upgrades_dashcard_body">Odemkněte další funkce a staňte se patronem, který podpoří další vývoj!</string>
     <string name="upgrades_dashcard_upgrade_action">Upgradovat</string>

--- a/app/src/foss/res/values-cy/strings.xml
+++ b/app/src/foss/res/values-cy/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
 
     <string name="upgrades_dashcard_title">Uwchraddio SD Maid</string>
     <string name="upgrades_dashcard_body">Datgloi nodweddion ychwanegol a dod yn noddwr i gefnogi datblygiad parhaus!</string>

--- a/app/src/foss/res/values-da/strings.xml
+++ b/app/src/foss/res/values-da/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">Opgrader SD Maid SE</string>
     <string name="upgrades_dashcard_body">Lås op for flere funktioner, og bliv patron for at støtte den fortsatte udvikling!</string>
     <string name="upgrades_dashcard_upgrade_action">Opgrader</string>

--- a/app/src/foss/res/values-de/strings.xml
+++ b/app/src/foss/res/values-de/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE upgraden</string>
     <string name="upgrades_dashcard_body">Schalte zusätzliche Funktionen frei und werde Unterstützer, um die weitere Entwicklung zu fördern!</string>
     <string name="upgrades_dashcard_upgrade_action">Upgrade</string>

--- a/app/src/foss/res/values-el/strings.xml
+++ b/app/src/foss/res/values-el/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">Αναβάθμιση SD Maid SE</string>
     <string name="upgrades_dashcard_body">Ξεκλειδώστε πρόσθετες δυνατότητες και γίνετε patron για να υποστηρίξετε τη συνεχή ανάπτυξη!</string>
     <string name="upgrades_dashcard_upgrade_action">Αναβάθμιση</string>

--- a/app/src/foss/res/values-eo/strings.xml
+++ b/app/src/foss/res/values-eo/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
 
     <string name="upgrades_dashcard_title">Ĝisdatigi SD Maid</string>
     <string name="upgrades_dashcard_body">Malŝlosu pliajn funkciojn kaj fariĝu patrono por subteni daŭran disvolvadon!</string>

--- a/app/src/foss/res/values-es-rAR/strings.xml
+++ b/app/src/foss/res/values-es-rAR/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">Mejorar SD Maid SE</string>
     <string name="upgrades_dashcard_body">¡Desbloqueá funciones adicionales y hacete patreon para ayudar a continuar el desarrollo!</string>
     <string name="upgrades_dashcard_upgrade_action">Mejorar</string>

--- a/app/src/foss/res/values-es-rMX/strings.xml
+++ b/app/src/foss/res/values-es-rMX/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">Actualizar SD Maid SE</string>
     <string name="upgrades_dashcard_body">¡Desbloquea funciones adicionales y conviértete en pratrocinador para apoyar el desarrollo continuo!</string>
     <string name="upgrades_dashcard_upgrade_action">Actualizar</string>

--- a/app/src/foss/res/values-es/strings.xml
+++ b/app/src/foss/res/values-es/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">Actualizar SD Maid SE</string>
     <string name="upgrades_dashcard_body">¡Desbloquea las funciones adicionales y conviértete en patrocinador para apoyar el desarrollo continuo!</string>
     <string name="upgrades_dashcard_upgrade_action">Actualizar</string>

--- a/app/src/foss/res/values-et-rEE/strings.xml
+++ b/app/src/foss/res/values-et-rEE/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE täiendamine</string>
     <string name="upgrades_dashcard_body">Lubage lisavõimalused ja hakake toetajaks, et edendada arendamist.</string>
     <string name="upgrades_dashcard_upgrade_action">Täienda</string>

--- a/app/src/foss/res/values-eu-rES/strings.xml
+++ b/app/src/foss/res/values-eu-rES/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">Eguneratu SD Maid SE</string>
     <string name="upgrades_dashcard_body">Eginbide gehigarriak desblokeatu eta babesle izan etengabeko garapena laguntzeko!</string>
     <string name="upgrades_dashcard_upgrade_action">Eguneratu</string>

--- a/app/src/foss/res/values-fa/strings.xml
+++ b/app/src/foss/res/values-fa/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">منبع‌آزاد</string>
     <string name="upgrades_dashcard_title">ارتقاء SD Maid SE</string>
     <string name="upgrades_dashcard_body">قفل ویژگی های اضافی را باز کنید و برای حمایت از توسعه مداوم، حامی شوید!</string>
     <string name="upgrades_dashcard_upgrade_action">ارتقاء</string>

--- a/app/src/foss/res/values-fi/strings.xml
+++ b/app/src/foss/res/values-fi/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">Päivitä SD Maid SE</string>
     <string name="upgrades_dashcard_body">Avaa lisäominaisuuksia ja ryhdy tukijaksi tukeaksesi jatkuvaa kehitystä!</string>
     <string name="upgrades_dashcard_upgrade_action">Päivitä</string>

--- a/app/src/foss/res/values-fil/strings.xml
+++ b/app/src/foss/res/values-fil/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">I-upgrade ang SD Maid SE</string>
     <string name="upgrades_dashcard_body">I-unlock ang mga karagdagang feature at maging patron para suportahan ang patuloy na development!</string>
     <string name="upgrades_dashcard_upgrade_action">I-upgrade</string>

--- a/app/src/foss/res/values-fr/strings.xml
+++ b/app/src/foss/res/values-fr/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">Logiciel libre</string>
     <string name="upgrades_dashcard_title">Passer à SD Maid SE Pro</string>
     <string name="upgrades_dashcard_body">Débloquez des fonctions supplémentaires et devenez mécène pour soutenir le développement continu.</string>
     <string name="upgrades_dashcard_upgrade_action">Passer Pro</string>

--- a/app/src/foss/res/values-ga/strings.xml
+++ b/app/src/foss/res/values-ga/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
 
     <string name="upgrades_dashcard_title">Uasghrádú SD Maid</string>
     <string name="upgrades_dashcard_body">Díghlasáil gnéithe breise agus bí i do phátrún chun tacú le forbairt leanúnach!</string>

--- a/app/src/foss/res/values-gl-rES/strings.xml
+++ b/app/src/foss/res/values-gl-rES/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">Actualizar SD Maid SE</string>
     <string name="upgrades_dashcard_body">Desbloquea características adicionais e convértete en mecenas para apoiar o desenvolvemento continuo!</string>
     <string name="upgrades_dashcard_upgrade_action">Actualizar</string>

--- a/app/src/foss/res/values-hi-rIN/strings.xml
+++ b/app/src/foss/res/values-hi-rIN/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE को उन्नत करें</string>
     <string name="upgrades_dashcard_body">अतिरिक्त सुविधाओं को अनलॉक करें और निरंतर विकास का समर्थन करने के लिए संरक्षक बनें!</string>
     <string name="upgrades_dashcard_upgrade_action">उन्नत करें</string>

--- a/app/src/foss/res/values-hr/strings.xml
+++ b/app/src/foss/res/values-hr/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">Nadogradite SD Maid</string>
     <string name="upgrades_dashcard_body">Otključajte dodatne značajke i postanite pokrovitelj kako biste podržali daljnji razvoj!</string>
     <string name="upgrades_dashcard_upgrade_action">Nadogradnja</string>

--- a/app/src/foss/res/values-hu/strings.xml
+++ b/app/src/foss/res/values-hu/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE frissítése</string>
     <string name="upgrades_dashcard_body">Fedezze fel a további funkciókat, és legyen patron támogató, hogy támogassa a folyamatos fejlesztést!</string>
     <string name="upgrades_dashcard_upgrade_action">Frissítés</string>

--- a/app/src/foss/res/values-in/strings.xml
+++ b/app/src/foss/res/values-in/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">Tingkatkan SD Maid SE</string>
     <string name="upgrades_dashcard_body">Buka fitur-fitur tambahan dan jadilah penyokong yang mendukung pengembangan yang berkelanjutan!</string>
     <string name="upgrades_dashcard_upgrade_action">Tingkatkan</string>

--- a/app/src/foss/res/values-is/strings.xml
+++ b/app/src/foss/res/values-is/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">Uppfæra SD Maid SE</string>
     <string name="upgrades_dashcard_body">Opnaðu viðbótareiginleika og vertu styrktaraðili til að styðja áframhaldandi þróun!</string>
     <string name="upgrades_dashcard_upgrade_action">Uppfæra</string>

--- a/app/src/foss/res/values-it/strings.xml
+++ b/app/src/foss/res/values-it/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">Aggiorna SD Maid SE</string>
     <string name="upgrades_dashcard_body">Sblocca funzioni aggiuntive e diventa un sostenitore per supportare lo sviluppo continuo!</string>
     <string name="upgrades_dashcard_upgrade_action">Aggiorna</string>

--- a/app/src/foss/res/values-iw/strings.xml
+++ b/app/src/foss/res/values-iw/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">שדרג את SD Maid SE</string>
     <string name="upgrades_dashcard_body">בטל נעילה של תכונות נוספות והפוך לפטרון לתמיכה בהמשך הפיתוח!</string>
     <string name="upgrades_dashcard_upgrade_action">שדרוג</string>

--- a/app/src/foss/res/values-ja/strings.xml
+++ b/app/src/foss/res/values-ja/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE をアップグレード</string>
     <string name="upgrades_dashcard_body">開発を続けるためパトロンになって追加機能を解除してください</string>
     <string name="upgrades_dashcard_upgrade_action">アップグレード</string>

--- a/app/src/foss/res/values-ka-rGE/strings.xml
+++ b/app/src/foss/res/values-ka-rGE/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE-ის განახლება</string>
     <string name="upgrades_dashcard_body">განბლოკეთ დამატებითი ფუნქციები და გახდით მფარველი მუდმივი განვითარების მხარდასაჭერად!</string>
     <string name="upgrades_dashcard_upgrade_action">გარემონტება</string>

--- a/app/src/foss/res/values-kaa/strings.xml
+++ b/app/src/foss/res/values-kaa/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE jańalaw</string>
     <string name="upgrades_dashcard_body">Qosımsha mümkinliklerdi ashıń hám uzlıksız rawajlanıwdı qollap-quwatlawshı úshin homiyshı bolıń!</string>
     <string name="upgrades_dashcard_upgrade_action">Jańalaw</string>

--- a/app/src/foss/res/values-km-rKH/strings.xml
+++ b/app/src/foss/res/values-km-rKH/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">ធ្វើឱ្យប្រសើរ SD Maid SE</string>
     <string name="upgrades_dashcard_body">ដោះសោមុខងារបន្ថែម និងក្លាយជាអ្នកឧបត្ថម្ភដើម្បីគាំទ្រការអភិវឌ្ឍន៍បន្ត!</string>
     <string name="upgrades_dashcard_upgrade_action">វិសិដ្ឋកម្ម</string>

--- a/app/src/foss/res/values-kmr-rTR/strings.xml
+++ b/app/src/foss/res/values-kmr-rTR/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
 
     <string name="upgrades_dashcard_title">SD Maid-ê bilind bike</string>
     <string name="upgrades_dashcard_body">Taybetmendiyên zêde vekin û bibe patronek ji bo piştgiriya pêşkeftina berdewam!</string>

--- a/app/src/foss/res/values-ko/strings.xml
+++ b/app/src/foss/res/values-ko/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE 업그레이드</string>
     <string name="upgrades_dashcard_body">후원자가 되어 앱 개발을 지원하고 추가 기능을 잠금해제 하세요!</string>
     <string name="upgrades_dashcard_upgrade_action">업그레이드</string>

--- a/app/src/foss/res/values-ku-rTR/strings.xml
+++ b/app/src/foss/res/values-ku-rTR/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
 
     <string name="upgrades_dashcard_title">SD Maid-ê bilind bike</string>
     <string name="upgrades_dashcard_body">Taybetmendiyên zêde vekin û bibe patronek ji bo piştgiriya pêşkeftina berdewam!</string>

--- a/app/src/foss/res/values-lo-rLA/strings.xml
+++ b/app/src/foss/res/values-lo-rLA/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">ອັບເກຣດ SD Maid SE</string>
     <string name="upgrades_dashcard_body">ປົດລັອກຄຸນສົມບັດເພີ່ມເຕີມ ແລະ ກາຍເປັນຜູ້ອຸປະຖໍາເພື່ອສະໜັບສະໜູນການພັດທະນາຢ່າງຕໍ່ເນື່ອງ!</string>
     <string name="upgrades_dashcard_upgrade_action">ອັບເກຣດ</string>

--- a/app/src/foss/res/values-lt/strings.xml
+++ b/app/src/foss/res/values-lt/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">Atnaujinti SD Maid SE</string>
     <string name="upgrades_dashcard_body">Atrakinkite papildomas funkcijas ir tapkite globėju, kad palaikytumėte tolesnį plėtojimą!</string>
     <string name="upgrades_dashcard_upgrade_action">Atnaujinti</string>

--- a/app/src/foss/res/values-lv/strings.xml
+++ b/app/src/foss/res/values-lv/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">Uzlabojiet SD Maid SE</string>
     <string name="upgrades_dashcard_body">Atslēdziet papildu funkcijas un kļūstiet par aizbildni, lai atbalstītu turpmāko attīstību!</string>
     <string name="upgrades_dashcard_upgrade_action">Uzlabot</string>

--- a/app/src/foss/res/values-mk-rMK/strings.xml
+++ b/app/src/foss/res/values-mk-rMK/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">Надградете го SD Maid SE</string>
     <string name="upgrades_dashcard_body">Отклучете дополнителни функции и станете покровител за да го поддржите континуираниот развој!</string>
     <string name="upgrades_dashcard_upgrade_action">Надградете</string>

--- a/app/src/foss/res/values-ml-rIN/strings.xml
+++ b/app/src/foss/res/values-ml-rIN/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE അപ്ഗ്രേഡ് ചെയ്യുക</string>
     <string name="upgrades_dashcard_body">കൂടുതൽ സവിശേഷതകൾ അൺലോക്കുചെയ്‌ത് തുടർ വികസനത്തെ പിന്തുണയ്ക്കുന്നതിന് ഒരു പാട്രോൺ ആകുക!</string>
     <string name="upgrades_dashcard_upgrade_action">അപ്ഗ്രേഡുചെയ്യുക</string>

--- a/app/src/foss/res/values-mn-rMN/strings.xml
+++ b/app/src/foss/res/values-mn-rMN/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE-г шинэчлэх</string>
     <string name="upgrades_dashcard_body">Нэмэлт боломжуудыг нээж, тасралтгүй хөгжлийг дэмжихийн тулд ивээн тэтгэгч болоорой!</string>
     <string name="upgrades_dashcard_upgrade_action">Шинэчлэх</string>

--- a/app/src/foss/res/values-ms/strings.xml
+++ b/app/src/foss/res/values-ms/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">Naik taraf SD Maid SE</string>
     <string name="upgrades_dashcard_body">Buka kunci ciri tambahan dan menjadi penaung untuk menyokong pembangunan berterusan!</string>
     <string name="upgrades_dashcard_upgrade_action">Naik taraf</string>

--- a/app/src/foss/res/values-mt/strings.xml
+++ b/app/src/foss/res/values-mt/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
 
     <string name="upgrades_dashcard_title">Aġġorna SD Maid</string>
     <string name="upgrades_dashcard_body">Iftaħ karatteristiċi addizzjonali u sir patrun biex tappoġġja l-iżvilupp kontinwu!</string>

--- a/app/src/foss/res/values-my-rMM/strings.xml
+++ b/app/src/foss/res/values-my-rMM/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE ကို အဆင့်မြှင့်ရန်</string>
     <string name="upgrades_dashcard_body">အပိုဝန်ဆောင်မှုများကို ဖွင့်ပြီး ဆက်လက်ဖွံ့ဖြိုးတိုးတက်မှုကို ပံ့ပိုးရန် ကူညီသူဖြစ်လာပါ!</string>
     <string name="upgrades_dashcard_upgrade_action">အဆင့်မြှင့်ရန်</string>

--- a/app/src/foss/res/values-nb/strings.xml
+++ b/app/src/foss/res/values-nb/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">Oppgrader SD Maid SE</string>
     <string name="upgrades_dashcard_body">Lås opp flere funksjoner og bli en patron for å støtte utviklingen videre!</string>
     <string name="upgrades_dashcard_upgrade_action">Oppgrader</string>

--- a/app/src/foss/res/values-ne-rNP/strings.xml
+++ b/app/src/foss/res/values-ne-rNP/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE अपग्रेड गर्नुहोस्</string>
     <string name="upgrades_dashcard_body">थप सुविधाहरू अनलक गर्नुहोस् र निरन्तर विकासलाई समर्थन गर्न संरक्षक बन्नुहोस्!</string>
     <string name="upgrades_dashcard_upgrade_action">अपग्रेड गर्नुहोस्</string>

--- a/app/src/foss/res/values-nl/strings.xml
+++ b/app/src/foss/res/values-nl/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE upgraden</string>
     <string name="upgrades_dashcard_body">Ontgrendel extra functies en word een patroon om verdere ontwikkeling te ondersteunen!</string>
     <string name="upgrades_dashcard_upgrade_action">Upgraden</string>

--- a/app/src/foss/res/values-or-rIN/strings.xml
+++ b/app/src/foss/res/values-or-rIN/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE ଅପଗ୍ରେଡ କରନ୍ତୁ</string>
     <string name="upgrades_dashcard_body">ଅତିରିକ୍ତ ବୈଶିଷ୍ଟ୍ୟଗୁଡ଼ିକ ଅନଲକ କରନ୍ତୁ ଏବଂ ନିରନ୍ତର ବିକାଶକୁ ସମର୍ଥନ କରିବା ପାଇଁ ଜଣେ ପୃଷ୍ଠପୋଷକ ହୋଇଯାଆନ୍ତୁ!</string>
     <string name="upgrades_dashcard_upgrade_action">ଅପଗ୍ରେଡ କରନ୍ତୁ</string>

--- a/app/src/foss/res/values-pa-rIN/strings.xml
+++ b/app/src/foss/res/values-pa-rIN/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE ਅੱਪਗ੍ਰੇਡ ਕਰੋ</string>
     <string name="upgrades_dashcard_body">ਵਾਧੂ ਵਿਸ਼ੇਸ਼ਤਾਵਾਂ ਨੂੰ ਅਨਲੌਕ ਕਰੋ ਅਤੇ ਨਿਰੰਤਰ ਵਿਕਾਸ ਦਾ ਸਮਰਥਨ ਕਰਨ ਲਈ ਸਰਪ੍ਰਸਤ ਬਣੋ!</string>
     <string name="upgrades_dashcard_upgrade_action">ਅੱਪਗ੍ਰੇਡ ਕਰੋ</string>

--- a/app/src/foss/res/values-pl/strings.xml
+++ b/app/src/foss/res/values-pl/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">Uaktualnij SD Maid SE</string>
     <string name="upgrades_dashcard_body">Odblokuj dodatkowe funkcje i zostań patronem, aby wesprzeć dalszy rozwój!</string>
     <string name="upgrades_dashcard_upgrade_action">Uaktualnij</string>

--- a/app/src/foss/res/values-pt-rBR/strings.xml
+++ b/app/src/foss/res/values-pt-rBR/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">Atualizar SD Maid SE</string>
     <string name="upgrades_dashcard_body">Desbloqueie recursos adicionais e torne-se um patrão para apoiar o desenvolvimento contínuo!</string>
     <string name="upgrades_dashcard_upgrade_action">Atualizar</string>

--- a/app/src/foss/res/values-pt/strings.xml
+++ b/app/src/foss/res/values-pt/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">Upgrade do SD Maid</string>
     <string name="upgrades_dashcard_body">Desbloqueie funcionalidades extra e torne-se um patrono para apoiar o desenvolvimento contínuo!</string>
     <string name="upgrades_dashcard_upgrade_action">Atualizar</string>

--- a/app/src/foss/res/values-ro/strings.xml
+++ b/app/src/foss/res/values-ro/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">Actualizați SD Maid SE</string>
     <string name="upgrades_dashcard_body">Deblochează funcții suplimentare și devino un patron pentru a suporta dezvoltarea continuată!</string>
     <string name="upgrades_dashcard_upgrade_action">Actualizează</string>

--- a/app/src/foss/res/values-ru/strings.xml
+++ b/app/src/foss/res/values-ru/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">Обновление SD Maid SE</string>
     <string name="upgrades_dashcard_body">Разблокируйте дополнительные возможности и станьте спонсором, чтобы поддержать разработку приложения!</string>
     <string name="upgrades_dashcard_upgrade_action">Обновить</string>

--- a/app/src/foss/res/values-sc-rIT/strings.xml
+++ b/app/src/foss/res/values-sc-rIT/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">Atualizare SD Maid SE</string>
     <string name="upgrades_dashcard_body">Aberri funtzionalidades addizionales e diventa patronu pro sustènnere su isvilupu continuadu!</string>
     <string name="upgrades_dashcard_upgrade_action">Atualizare</string>

--- a/app/src/foss/res/values-si-rLK/strings.xml
+++ b/app/src/foss/res/values-si-rLK/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE වැඩිදියුණු කරන්න</string>
     <string name="upgrades_dashcard_body">අමතර විශේෂාංග අඟුල හරිමින් අඛණ්ඩ සංවර්ධනයට සහාය වීමට අනුග්‍රාහකයෙකු වන්න!</string>
     <string name="upgrades_dashcard_upgrade_action">වැඩිදියුණු කරන්න</string>

--- a/app/src/foss/res/values-sk/strings.xml
+++ b/app/src/foss/res/values-sk/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">Inovovať SD Maid SE</string>
     <string name="upgrades_dashcard_body">Odomknite ďalšie funkcie a staňte sa patrónom na podporu ďalšieho vývoja!</string>
     <string name="upgrades_dashcard_upgrade_action">Inovovať</string>

--- a/app/src/foss/res/values-sl/strings.xml
+++ b/app/src/foss/res/values-sl/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">Nadgradi SD Maid SE</string>
     <string name="upgrades_dashcard_body">Odklenite dodatne funkcije in postanite pokrovitelj, da podprete nadaljnji razvoj!</string>
     <string name="upgrades_dashcard_upgrade_action">Nadgradi</string>

--- a/app/src/foss/res/values-sq-rAL/strings.xml
+++ b/app/src/foss/res/values-sq-rAL/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">Përmirëso SD Maid SE</string>
     <string name="upgrades_dashcard_body">Çelni veçori shtesë dhe bëhuni një mbrojtës për të mbështetur zhvillimin e vazhdueshëm!</string>
     <string name="upgrades_dashcard_upgrade_action">Përmirëso</string>

--- a/app/src/foss/res/values-sr/strings.xml
+++ b/app/src/foss/res/values-sr/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">Надогради SD Maid SE</string>
     <string name="upgrades_dashcard_body">Откључај додатне функције и постани покровитељ да подржиш континуирани развој!</string>
     <string name="upgrades_dashcard_upgrade_action">Надогради</string>

--- a/app/src/foss/res/values-sv/strings.xml
+++ b/app/src/foss/res/values-sv/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">Uppgradera SD Maid SE</string>
     <string name="upgrades_dashcard_body">Lås upp ytterligare funktioner och bli en beskyddare för att stödja fortsatt utveckling!</string>
     <string name="upgrades_dashcard_upgrade_action">Uppgradera</string>

--- a/app/src/foss/res/values-sw/strings.xml
+++ b/app/src/foss/res/values-sw/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">Boresha SD Maid SE</string>
     <string name="upgrades_dashcard_body">Fungua vipengele vya ziada na uwe mfumo wa kuunga mkono maendeleo ya kuendelea!</string>
     <string name="upgrades_dashcard_upgrade_action">Boresha</string>

--- a/app/src/foss/res/values-ta-rIN/strings.xml
+++ b/app/src/foss/res/values-ta-rIN/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE ஐ மேம்படுத்தவும்</string>
     <string name="upgrades_dashcard_body">கூடுதல் அம்சங்களைத் திறக்கவும் மற்றும் தொடர்ச்சியான மேம்பாட்டை ஆதரிக்க புரவலராக மாறவும்!</string>
     <string name="upgrades_dashcard_upgrade_action">மேம்படுத்தவும்</string>

--- a/app/src/foss/res/values-te-rIN/strings.xml
+++ b/app/src/foss/res/values-te-rIN/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE అప్‌గ్రేడ్ చేయండి</string>
     <string name="upgrades_dashcard_body">అదనపు ఫీచర్లను అన్‌లాక్ చేసి, నిరంతర అభివృద్ధికి మద్దతు ఇవ్వడానికి పేట్రన్ అవ్వండి!</string>
     <string name="upgrades_dashcard_upgrade_action">అప్‌గ్రేడ్ చేయండి</string>

--- a/app/src/foss/res/values-th/strings.xml
+++ b/app/src/foss/res/values-th/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">บังคับ</string>
     <string name="upgrades_dashcard_title">อัปเกรด SD Maid SE</string>
     <string name="upgrades_dashcard_body">ปลดล็อกฟีเจอร์เพิ่มเติมและเป็นผู้อุปถัมภ์เพื่อสนับสนุนการพัฒนาอย่างต่อเนื่อง!</string>
     <string name="upgrades_dashcard_upgrade_action">อัปเกรด</string>

--- a/app/src/foss/res/values-tr/strings.xml
+++ b/app/src/foss/res/values-tr/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE\'yi yükseltin</string>
     <string name="upgrades_dashcard_body">Ek özelliklerin kilidini açın ve sürekli gelişimi desteklemek için bir patron olun!</string>
     <string name="upgrades_dashcard_upgrade_action">Yükselt</string>

--- a/app/src/foss/res/values-uk/strings.xml
+++ b/app/src/foss/res/values-uk/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">Оновлення SD Maid SE</string>
     <string name="upgrades_dashcard_body">Розблокуйте додаткові функції та станьте спонсором, щоб підтримати подальший розвиток!</string>
     <string name="upgrades_dashcard_upgrade_action">Оновлення</string>

--- a/app/src/foss/res/values-ur-rIN/strings.xml
+++ b/app/src/foss/res/values-ur-rIN/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE اپگریڈ کریں</string>
     <string name="upgrades_dashcard_body">اضافی خصوصیات کو غیر مقفل کریں اور مسلسل ترقی کی حمایت کے لیے سرپرست بنیں!</string>
     <string name="upgrades_dashcard_upgrade_action">اپگریڈ کریں</string>

--- a/app/src/foss/res/values-uz/strings.xml
+++ b/app/src/foss/res/values-uz/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">SD Maid SE-ni yangilash</string>
     <string name="upgrades_dashcard_body">Qo\'shimcha xususiyatlarni oching va doimiy rivojlanishni qo\'llab-quvvatlash uchun homiy bo\'ling!</string>
     <string name="upgrades_dashcard_upgrade_action">Yangilash</string>

--- a/app/src/foss/res/values-vi/strings.xml
+++ b/app/src/foss/res/values-vi/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">Nâng cấp SD Maid SE</string>
     <string name="upgrades_dashcard_body">Mở khóa các tính năng bổ sung và trở thành người bảo trợ để hỗ trợ sự phát triển liên tục!</string>
     <string name="upgrades_dashcard_upgrade_action">Nâng cấp</string>

--- a/app/src/foss/res/values-zh-rCN/strings.xml
+++ b/app/src/foss/res/values-zh-rCN/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">升级 SD Maid SE</string>
     <string name="upgrades_dashcard_body">解锁附加功能，成为支持持续开发的赞助人！</string>
     <string name="upgrades_dashcard_upgrade_action">升级</string>

--- a/app/src/foss/res/values-zh-rHK/strings.xml
+++ b/app/src/foss/res/values-zh-rHK/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">升級 SD Maid SE</string>
     <string name="upgrades_dashcard_body">解鎖額外功能，並成為贊助者，以支持持續開發！</string>
     <string name="upgrades_dashcard_upgrade_action">升級</string>

--- a/app/src/foss/res/values-zh-rTW/strings.xml
+++ b/app/src/foss/res/values-zh-rTW/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">升級 SD Maid SE</string>
     <string name="upgrades_dashcard_body">解鎖額外功能，並成為贊助者，以支持持續開發！</string>
     <string name="upgrades_dashcard_upgrade_action">升級</string>

--- a/app/src/foss/res/values-zu/strings.xml
+++ b/app/src/foss/res/values-zu/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
     <string name="upgrades_dashcard_title">Thuthukisa SD Maid SE</string>
     <string name="upgrades_dashcard_body">Vula izici ezengeziwe futhi ube ngumnikazi ukuze usekele ukuthuthukiswa okuqhubekayo!</string>
     <string name="upgrades_dashcard_upgrade_action">Thuthukisa</string>

--- a/app/src/foss/res/values/strings.xml
+++ b/app/src/foss/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgrade_postfix">FOSS</string>
+    <string name="app_name_upgrade_postfix" translatable="false">FOSS</string>
 
 
     <string name="upgrades_dashcard_title">Upgrade SD Maid SE</string>

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/BillingCache.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/BillingCache.kt
@@ -12,8 +12,10 @@ import eu.darken.sdmse.common.datastore.basicReader
 import eu.darken.sdmse.common.datastore.basicWriter
 import eu.darken.sdmse.common.datastore.createValue
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withTimeoutOrNull
 import java.io.IOException
@@ -93,14 +95,24 @@ class BillingCache internal constructor(
     // not erase.
     suspend fun stampLastProState(skuId: String, at: Long) {
         // Fail-soft: this decorates the entitlement path, it must never be the thing that blocks it.
-        withTimeoutOrNull(cacheTimeoutMs) {
-            dataStore.edit { prefs ->
-                prefs[lastProStateSkuKey] = skuId
-                prefs[lastProStateAtKey] = at
-                val episodeStart = prefs[proUnconfirmedSinceKey] ?: 0L
-                if (episodeStart in 1..at) prefs[proUnconfirmedSinceKey] = 0L
-            }
-        } ?: log(TAG, WARN) { "stampLastProState($skuId, $at) timed out after ${cacheTimeoutMs}ms, write skipped" }
+        // A wedged file lock (timeout) and a broken write (IOException, corrupt file, no disk space)
+        // are the same to the caller — the stamp is lost, the bookkeeping around it carries on.
+        try {
+            withTimeoutOrNull(cacheTimeoutMs) {
+                dataStore.edit { prefs ->
+                    prefs[lastProStateSkuKey] = skuId
+                    prefs[lastProStateAtKey] = at
+                    val episodeStart = prefs[proUnconfirmedSinceKey] ?: 0L
+                    if (episodeStart in 1..at) prefs[proUnconfirmedSinceKey] = 0L
+                }
+            } ?: log(TAG, WARN) { "stampLastProState($skuId, $at) timed out after ${cacheTimeoutMs}ms, write skipped" }
+        } catch (e: CancellationException) {
+            // Caught before the general case on purpose: our caller going away is not a write
+            // failure, and swallowing it would break their structured concurrency.
+            throw e
+        } catch (e: Exception) {
+            log(TAG, WARN) { "stampLastProState($skuId, $at) failed, write skipped: ${e.asLog()}" }
+        }
     }
 
     companion object {

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeDiagnosticsGplay.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeDiagnosticsGplay.kt
@@ -7,6 +7,7 @@ import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.upgrade.UpgradeDiagnostics
 import eu.darken.sdmse.main.core.CurriculumVitae
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.withTimeoutOrNull
 import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -28,6 +29,10 @@ class UpgradeDiagnosticsGplay @Inject constructor(
     private val curriculumVitae: CurriculumVitae,
 ) : UpgradeDiagnostics {
 
+    // Test seam: the bounded read below runs on real dispatchers, so a virtual-time test cannot
+    // advance the production bound. Same pattern as BillingCache.cacheTimeoutMs.
+    internal var historyTimeoutMs: Long = HISTORY_TIMEOUT_MS
+
     override suspend fun debugInfo(): String {
         val cache = try {
             val snapshot = billingCache.snapshot()
@@ -47,7 +52,12 @@ class UpgradeDiagnosticsGplay @Inject constructor(
         // and the counters only cover installs new enough to have them. A failure to read one must
         // not suppress the other's independent evidence.
         val history = try {
-            curriculumVitae.proHistory().toString()
+            // Bounded like the cache read above: a wedged DataStore file lock would otherwise hold
+            // the debug-log header - and with it the start of the recording - forever.
+            withTimeoutOrNull(historyTimeoutMs) { curriculumVitae.proHistory().toString() } ?: run {
+                log(TAG, WARN) { "Pro history timed out after ${historyTimeoutMs}ms" }
+                "unavailable"
+            }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -58,6 +68,7 @@ class UpgradeDiagnosticsGplay @Inject constructor(
     }
 
     companion object {
+        private const val HISTORY_TIMEOUT_MS = 2_000L
         private val TAG = logTag("Upgrade", "Gplay", "Diagnostics")
     }
 }

--- a/app/src/main/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModule.kt
@@ -27,7 +27,10 @@ import eu.darken.sdmse.common.upgrade.UpgradeDiagnostics
 import eu.darken.sdmse.main.core.CurriculumVitae
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.filter
@@ -37,6 +40,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.attribute.BasicFileAttributes
@@ -60,6 +64,10 @@ class RecorderModule @Inject constructor(
     private val upgradeDiagnostics: UpgradeDiagnostics,
     private val recorderProvider: Provider<Recorder>,
 ) {
+
+    // Test seam: the header reads below are bounded on real dispatchers, a virtual-time test cannot
+    // advance the production bound. Same pattern as BillingCache.cacheTimeoutMs.
+    internal var headerReadTimeoutMs: Long = HEADER_READ_TIMEOUT_MS
 
     private val triggerFile by lazy {
         try {
@@ -263,20 +271,59 @@ class RecorderModule @Inject constructor(
         val locales = Resources.getSystem().configuration.locales
         log(TAG, INFO) { "App locales: $locales" }
 
-        val state = dataAreaManager.latestState.firstOrNull()
-        log(TAG, INFO) { "Data areas: (${state?.areas?.size})" }
-        state?.areas?.forEachIndexed { index, dataArea -> log(TAG, INFO) { "#$index $dataArea" } }
+        // The three remaining sources all talk to storage or the billing stack, and any of them can
+        // wedge. Debug recording is what a user reaches for when the app is ALREADY misbehaving, so
+        // they run concurrently under ONE shared deadline: a stuck or broken source degrades to
+        // "unavailable" and the recording still starts.
+        coroutineScope {
+            val deadline = System.nanoTime() + headerReadTimeoutMs * 1_000_000L
+            val areasRead = async { readHeader("Data areas") { dataAreaManager.latestState.firstOrNull() } }
+            val historyRead = async { readHeader("Update history") { curriculumVitae.history.firstOrNull() } }
+            val diagnosticsRead = async { readHeader("Upgrade diagnostics") { upgradeDiagnostics.debugInfo() } }
 
-        log(TAG, INFO) { "Update history: ${curriculumVitae.history.firstOrNull()}" }
+            areasRead.awaitHeader(deadline, "Data areas")?.let { areas ->
+                log(TAG, INFO) { "Data areas: (${areas.value?.areas?.size})" }
+                areas.value?.areas?.forEachIndexed { index, dataArea -> log(TAG, INFO) { "#$index $dataArea" } }
+            }
 
-        try {
-            // Diagnostics only — a broken read must not stop the recorder from starting.
-            upgradeDiagnostics.debugInfo()?.let { log(TAG, INFO) { "Upgrade diagnostics: $it" } }
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            log(TAG, WARN) { "Upgrade diagnostics unavailable: ${e.asLog()}" }
+            historyRead.awaitHeader(deadline, "Update history")?.let {
+                log(TAG, INFO) { "Update history: ${it.value}" }
+            }
+
+            diagnosticsRead.awaitHeader(deadline, "Upgrade diagnostics")?.value
+                ?.let { log(TAG, INFO) { "Upgrade diagnostics: $it" } }
         }
+    }
+
+    /**
+     * Completion marker for a header read: tells a source that legitimately has nothing to report
+     * (no data areas known yet, no diagnostics on FOSS) apart from one that failed or never answered.
+     */
+    private class HeaderRead<T>(val value: T)
+
+    private suspend fun <T> readHeader(source: String, read: suspend () -> T): HeaderRead<T>? = try {
+        HeaderRead(read())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        log(TAG, WARN) { "$source unavailable: ${e.asLog()}" }
+        null
+    }
+
+    private suspend fun <T> Deferred<HeaderRead<T>?>.awaitHeader(
+        deadlineNanos: Long,
+        source: String,
+    ): HeaderRead<T>? {
+        if (isCompleted) return await()
+        val remainingMs = (deadlineNanos - System.nanoTime()) / 1_000_000L
+        val result = if (remainingMs > 0) withTimeoutOrNull(remainingMs) { await() } else null
+        if (result == null && !isCompleted) {
+            // Cancelled, not abandoned: the surrounding scope would wait for it anyway, which is
+            // exactly the hang the deadline exists to prevent.
+            cancel()
+            log(TAG, WARN) { "$source unavailable, read did not finish within ${headerReadTimeoutMs}ms" }
+        }
+        return result
     }
 
     sealed class StopResult {
@@ -299,5 +346,8 @@ class RecorderModule @Inject constructor(
         internal val TAG = logTag("Debug", "Log", "Recorder", "Module")
         private const val FORCE_FILE = "force_debug_run"
         private const val MIN_RECORDING_MS = 5_000L
+
+        // Shared budget for ALL header reads, not per source: they run concurrently.
+        private const val HEADER_READ_TIMEOUT_MS = 5_000L
     }
 }

--- a/app/src/test/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModuleTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModuleTest.kt
@@ -11,9 +11,11 @@ import eu.darken.sdmse.common.areas.DataAreaManager
 import eu.darken.sdmse.common.datastore.DataStoreValue
 import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.DebugSettings
+import eu.darken.sdmse.common.debug.logging.Logging
 import eu.darken.sdmse.common.getPackageInfo
 import eu.darken.sdmse.common.upgrade.UpgradeDiagnostics
 import eu.darken.sdmse.main.core.CurriculumVitae
+import io.kotest.matchers.longs.shouldBeLessThan
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.mockk.coEvery
@@ -26,16 +28,20 @@ import io.mockk.slot
 import io.mockk.verify
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -44,7 +50,9 @@ import testhelpers.BaseTest
 import testhelpers.coroutine.TestDispatcherProvider
 import java.io.File
 import java.io.IOException
+import java.util.concurrent.CopyOnWriteArrayList
 import javax.inject.Provider
+import kotlin.system.measureTimeMillis
 
 class RecorderModuleTest : BaseTest() {
 
@@ -198,7 +206,9 @@ class RecorderModuleTest : BaseTest() {
             val dispatcher = UnconfinedTestDispatcher(testScheduler)
             val moduleScope = CoroutineScope(dispatcher + Job())
             val module = createModule(moduleScope, dispatcher)
-            advanceUntilIdle()
+            // runCurrent(), not advanceUntilIdle(): advancing would jump virtual time past the
+            // header's read deadline, and the cancellation has to arrive while the read is in flight.
+            runCurrent()
 
             // Cancelling the module's scope cancels the in-flight header read.
             moduleScope.cancel()
@@ -210,8 +220,10 @@ class RecorderModuleTest : BaseTest() {
         }
 
         @Test
-        fun `a failing header read stops the uncommitted recorder`() = runTest {
-            // Same window as above, but for ordinary failures of the unguarded header reads.
+        fun `a failing header read degrades to unavailable instead of aborting the recording`() = runTest {
+            // Deliberate contract: debug recording is what a user reaches for when the app is
+            // ALREADY misbehaving, so a broken header source must not be the thing that denies them
+            // the log. Only an outer cancellation (above) still rolls the uncommitted recorder back.
             File(externalDir, "force_debug_run").createNewFile()
             coEvery { recorderPath.value() } returns null
             every { curriculumVitae.history } returns flow { throw IOException("disk full") }
@@ -222,8 +234,8 @@ class RecorderModuleTest : BaseTest() {
             advanceUntilIdle()
 
             coVerify { mockRecorder.start(any()) }
-            coVerify { mockRecorder.stop() }
-            module.state.first().isRecording shouldBe false
+            coVerify(exactly = 0) { mockRecorder.stop() }
+            module.state.first().isRecording shouldBe true
 
             moduleScope.cancel()
         }
@@ -277,6 +289,134 @@ class RecorderModuleTest : BaseTest() {
             val clearSlot = slot<(String?) -> String?>()
             coVerify(atLeast = 1) { recorderPath.update(capture(clearSlot)) }
             clearSlot.captured("ignored") shouldBe null
+        }
+    }
+
+    @Nested
+    inner class HeaderReads {
+
+        private val logLines = CopyOnWriteArrayList<String>()
+        private val logCapture = object : Logging.Logger {
+            override fun log(priority: Logging.Priority, tag: String, message: String, metaData: Map<String, Any>?) {
+                logLines.add(message)
+            }
+        }
+
+        @BeforeEach
+        fun installLogCapture() {
+            Logging.install(logCapture)
+        }
+
+        @AfterEach
+        fun removeLogCapture() {
+            Logging.remove(logCapture)
+        }
+
+        /**
+         * Real dispatchers on purpose: the header deadline is wall-clock, a virtual-time test would
+         * skip it instead of exercising it. The recording is started via [RecorderModule.startRecorder]
+         * so the seam can be set before any header read runs.
+         */
+        private suspend fun withRealtimeModule(
+            headerTimeoutMs: Long = 300L,
+            block: suspend (RecorderModule) -> Unit,
+        ) {
+            coEvery { recorderPath.value() } returns null
+            val moduleScope = CoroutineScope(Dispatchers.IO + Job())
+            try {
+                val module = createModule(moduleScope, Dispatchers.IO)
+                module.headerReadTimeoutMs = headerTimeoutMs
+                block(module)
+            } finally {
+                moduleScope.cancel()
+            }
+        }
+
+        @Test
+        fun `a wedged data area read does not hold up the recording`() = runTest {
+            every { dataAreaManager.latestState } returns flow { awaitCancellation() }
+
+            withRealtimeModule { module ->
+                module.startRecorder()
+
+                module.state.first().isRecording shouldBe true
+                logLines.any { it.startsWith("Data areas unavailable") } shouldBe true
+                // The other sources are unaffected -- they were read concurrently.
+                logLines.any { it.startsWith("Update history:") } shouldBe true
+                logLines.any { it.startsWith("Upgrade diagnostics: ") } shouldBe true
+            }
+        }
+
+        @Test
+        fun `a wedged update history read does not hold up the recording`() = runTest {
+            every { curriculumVitae.history } returns flow { awaitCancellation() }
+
+            withRealtimeModule { module ->
+                module.startRecorder()
+
+                module.state.first().isRecording shouldBe true
+                logLines.any { it.startsWith("Update history unavailable") } shouldBe true
+                logLines.any { it.startsWith("Data areas: ") } shouldBe true
+                logLines.any { it.startsWith("Upgrade diagnostics: ") } shouldBe true
+            }
+        }
+
+        @Test
+        fun `a wedged upgrade diagnostics read does not hold up the recording`() = runTest {
+            coEvery { upgradeDiagnostics.debugInfo() } coAnswers { awaitCancellation() }
+
+            withRealtimeModule { module ->
+                module.startRecorder()
+
+                module.state.first().isRecording shouldBe true
+                logLines.any { it.startsWith("Upgrade diagnostics unavailable") } shouldBe true
+                logLines.any { it.startsWith("Data areas: ") } shouldBe true
+                logLines.any { it.startsWith("Update history:") } shouldBe true
+            }
+        }
+
+        @Test
+        fun `all header reads wedged at once still costs only one shared deadline`() = runTest {
+            every { dataAreaManager.latestState } returns flow { awaitCancellation() }
+            every { curriculumVitae.history } returns flow { awaitCancellation() }
+            coEvery { upgradeDiagnostics.debugInfo() } coAnswers { awaitCancellation() }
+
+            withRealtimeModule(headerTimeoutMs = 300L) { module ->
+                val elapsed = measureTimeMillis { module.startRecorder() }
+
+                // One budget for all three: they are read concurrently, so three wedged sources
+                // cost the same as one. Bounding each source separately would cost three times as
+                // much, and not bounding them at all would never return.
+                elapsed shouldBeLessThan 750L
+                module.state.first().isRecording shouldBe true
+            }
+        }
+
+        @Test
+        fun `a data area state that is not known yet is not reported as unavailable`() = runTest {
+            // latestState legitimately starts out null -- that is a normal header line, not a failure.
+            every { dataAreaManager.latestState } returns flowOf(null)
+
+            withRealtimeModule { module ->
+                module.startRecorder()
+
+                logLines.any { it == "Data areas: (null)" } shouldBe true
+                logLines.any { it.startsWith("Data areas unavailable") } shouldBe false
+            }
+        }
+
+        @Test
+        fun `a flavor without diagnostics is not reported as unavailable`() = runTest {
+            // FOSS has nothing to report and returns null: no diagnostics line at all, and above all
+            // not one claiming the read failed.
+            coEvery { upgradeDiagnostics.debugInfo() } returns null
+
+            withRealtimeModule { module ->
+                module.startRecorder()
+
+                module.state.first().isRecording shouldBe true
+                logLines.any { it.startsWith("Upgrade diagnostics") } shouldBe false
+            }
         }
     }
 }

--- a/app/src/test/java/eu/darken/sdmse/main/ui/areas/DataAreasViewModelTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/areas/DataAreasViewModelTest.kt
@@ -38,7 +38,7 @@ class DataAreasViewModelTest : BaseTest() {
 
         every { dataAreaManager.state } returns areaState
         every { taskManager.state } returns taskState
-        every { webpageTool.open(any()) } returns Unit
+        every { webpageTool.open(any()) } returns true
         coEvery { dataAreaManager.reloadAndAwait() } returns DataAreaManager.State(
             areas = emptySet(),
             refreshGeneration = 1L,

--- a/app/src/testFoss/java/eu/darken/sdmse/common/upgrade/ui/FossUpgradeScreenHostTest.kt
+++ b/app/src/testFoss/java/eu/darken/sdmse/common/upgrade/ui/FossUpgradeScreenHostTest.kt
@@ -1,0 +1,106 @@
+package eu.darken.sdmse.common.upgrade.ui
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.SavedStateHandle
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.common.navigation.routes.UpgradeRoute
+import eu.darken.sdmse.common.upgrade.core.UpgradeRepoFoss
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowSystemClock
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+import testhelpers.coroutine.TestDispatcherProvider
+import java.time.Duration
+
+/**
+ * Host-level counterpart to the ViewModel's sponsor-return tests: those prove the ViewModel reacts,
+ * they cannot prove the screen actually bridges the lifecycle to it. Only a real STOP/RESUME
+ * round-trip catches a missing or mis-scoped lifecycle effect, or a tracker that isn't seeded from
+ * the handle after a recreation.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class FossUpgradeScreenHostTest : BaseTest() {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    private var persisted = 0
+
+    private fun mockRepo(): UpgradeRepoFoss = mockk<UpgradeRepoFoss>(relaxed = true).apply {
+        every { upgradeInfo } returns MutableStateFlow(UpgradeRepoFoss.Info())
+        every { openGithubSponsorsPage() } returns true
+        coEvery { persistUpgrade() } answers { persisted++ }
+    }
+
+    private fun buildVm(
+        repo: UpgradeRepoFoss,
+        handle: SavedStateHandle = SavedStateHandle(),
+    ) = UpgradeViewModel(
+        handle = handle,
+        dispatcherProvider = TestDispatcherProvider(),
+        upgradeRepo = repo,
+    )
+
+    @Test
+    fun `a stop-resume round-trip after a sponsor launch runs the return check`() {
+        val repo = mockRepo()
+        // The real ViewModel instance, passed explicitly: hiltViewModel() has nothing to resolve here.
+        val vm = buildVm(repo)
+
+        composeRule.setContent {
+            PreviewWrapper {
+                UpgradeScreenHost(route = UpgradeRoute(), vm = vm)
+            }
+        }
+        composeRule.waitForIdle()
+
+        vm.goGithubSponsors()
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+
+        // CREATED, not STARTED: only that far down does the activity emit ON_STOP, which is what
+        // "the browser took the foreground" looks like to the return tracker.
+        composeRule.activityRule.scenario.moveToState(Lifecycle.State.CREATED)
+        composeRule.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
+        composeRule.waitForIdle()
+
+        composeRule.waitUntil { persisted == 1 }
+        vm.hasPendingSponsorLaunch() shouldBe false
+    }
+
+    @Test
+    fun `a recreated screen consumes the pending sponsor launch on the first resume`() {
+        // Process death while the browser was in front: the fresh screen's tracker never saw the
+        // ON_STOP, so it has to be seeded from the handle or the first return is swallowed.
+        val handle = SavedStateHandle()
+        buildVm(mockRepo(), handle).goGithubSponsors()
+
+        val repo = mockRepo()
+        val recreatedVm = buildVm(repo, handle)
+        recreatedVm.hasPendingSponsorLaunch() shouldBe true
+
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+
+        composeRule.setContent {
+            PreviewWrapper {
+                UpgradeScreenHost(route = UpgradeRoute(), vm = recreatedVm)
+            }
+        }
+        composeRule.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
+        composeRule.waitForIdle()
+
+        composeRule.waitUntil { persisted == 1 }
+        recreatedVm.hasPendingSponsorLaunch() shouldBe false
+    }
+}

--- a/app/src/testFoss/java/eu/darken/sdmse/common/upgrade/ui/FossUpgradeScreenTest.kt
+++ b/app/src/testFoss/java/eu/darken/sdmse/common/upgrade/ui/FossUpgradeScreenTest.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.semantics.SemanticsActions
 import eu.darken.sdmse.R
 import eu.darken.sdmse.common.R as CommonR
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import testhelpers.compose.BaseComposeRobolectricTest
@@ -125,9 +126,16 @@ class FossUpgradeScreenTest : BaseComposeRobolectricTest() {
     @Test
     fun `recurring donation button invokes the sponsors callback`() {
         var clicked = false
+        // The armed pitch callback must stay untouched here: a supporter donating again has nothing
+        // left to unlock, so the donate button goes through the unarmed callback.
+        var armed = false
 
         composeRule.setUpgradeContent {
-            UpgradeScreen(view = FossUpgradeView.STATUS_UPGRADED, onGithubSponsors = { clicked = true })
+            UpgradeScreen(
+                view = FossUpgradeView.STATUS_UPGRADED,
+                onGithubSponsors = { armed = true },
+                onOpenSponsors = { clicked = true },
+            )
         }
 
         composeRule.onNodeWithTag(UpgradeScreenTags.FOSS_DONATE)
@@ -135,6 +143,7 @@ class FossUpgradeScreenTest : BaseComposeRobolectricTest() {
 
         composeRule.runOnIdle {
             assertTrue(clicked)
+            assertFalse(armed)
         }
     }
 }

--- a/app/src/testFoss/java/eu/darken/sdmse/common/upgrade/ui/FossUpgradeViewModelTest.kt
+++ b/app/src/testFoss/java/eu/darken/sdmse/common/upgrade/ui/FossUpgradeViewModelTest.kt
@@ -11,6 +11,7 @@ import io.kotest.matchers.shouldBe
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -61,6 +62,7 @@ class FossUpgradeViewModelTest : BaseTest() {
         info: MutableStateFlow<UpgradeRepoFoss.Info> = MutableStateFlow(UpgradeRepoFoss.Info()),
     ): UpgradeRepoFoss = mockk<UpgradeRepoFoss>(relaxed = true).apply {
         every { upgradeInfo } returns info
+        every { openGithubSponsorsPage() } returns true
     }
 
     private fun buildVm(
@@ -282,5 +284,98 @@ class FossUpgradeViewModelTest : BaseTest() {
         coVerify(exactly = 1) { repo.persistUpgrade() }
         // Consumed: a later resume must not re-run the unlock.
         recreatedVm.hasPendingSponsorLaunch() shouldBe false
+    }
+
+    @Test
+    fun `a long sponsor visit by an already upgraded user does not re-persist the upgrade`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // Persisting again would rewrite upgradedAt and visibly reset the "supporter since" date the
+        // status screen shows — and the thanks toast belongs to the unlock, which already happened.
+        val repo = mockRepo(MutableStateFlow(upgradedInfo()))
+        val vm = buildVm(repo = repo)
+
+        val nudges = mutableListOf<Int>()
+        val thanks = mutableListOf<Int>()
+        val snackbarCollector = launch(start = CoroutineStart.UNDISPATCHED) {
+            vm.snackbarEvents.collect { nudges.add(it) }
+        }
+        val toastCollector = launch(start = CoroutineStart.UNDISPATCHED) { vm.toastEvents.collect { thanks.add(it) } }
+
+        vm.goGithubSponsors()
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+        vm.checkSponsorReturn()
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { repo.persistUpgrade() }
+        nudges.shouldBeEmpty()
+        thanks.shouldBeEmpty()
+        snackbarCollector.cancel()
+        toastCollector.cancel()
+    }
+
+    @Test
+    fun `a sponsor page that never opened arms nothing and a later retry still works`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // A silently failed launch must not leave the heuristic armed: an unrelated later
+        // background round-trip would otherwise hand out supporter status for free.
+        val repo = mockRepo()
+        every { repo.openGithubSponsorsPage() } returns false
+        val vm = buildVm(repo = repo)
+
+        vm.goGithubSponsors()
+        advanceUntilIdle()
+
+        vm.hasPendingSponsorLaunch() shouldBe false
+
+        // And the failure must not brick the button either — the next working attempt arms as usual.
+        every { repo.openGithubSponsorsPage() } returns true
+        vm.goGithubSponsors()
+        advanceUntilIdle()
+
+        vm.hasPendingSponsorLaunch() shouldBe true
+    }
+
+    @Test
+    fun `a second sponsor tap while a launch is pending opens the page only once`() = runTest2(
+        context = testDispatcher,
+    ) {
+        val repo = mockRepo()
+        val vm = buildVm(repo = repo)
+
+        vm.goGithubSponsors()
+        vm.goGithubSponsors()
+        advanceUntilIdle()
+
+        verify(exactly = 1) { repo.openGithubSponsorsPage() }
+    }
+
+    @Test
+    fun `a long donate visit from the status view does not re-persist the upgrade`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // The status view's donate button is unarmed on purpose: a supporter browsing the sponsors
+        // page for a while must not run the unlock heuristic again and rewrite their upgrade date.
+        val repo = mockRepo(MutableStateFlow(upgradedInfo()))
+        val vm = buildVm(repo = repo)
+
+        val state = async { vm.state.first { it.view != null } }
+        vm.bindRoute(UpgradeRoute(manage = true))
+        advanceUntilIdle()
+        state.await().supporterSince shouldBe Instant.EPOCH
+
+        vm.openSponsors()
+        advanceUntilIdle()
+
+        verify(exactly = 1) { repo.openGithubSponsorsPage() }
+        vm.hasPendingSponsorLaunch() shouldBe false
+
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+        vm.checkSponsorReturn()
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { repo.persistUpgrade() }
+        vm.state.value.supporterSince shouldBe Instant.EPOCH
     }
 }

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/BillingCacheTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/BillingCacheTest.kt
@@ -7,6 +7,7 @@ import androidx.test.core.app.ApplicationProvider
 import eu.darken.sdmse.common.datastore.value
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.Flow
@@ -94,6 +95,28 @@ class BillingCacheTest : BaseTest() {
         // The write only decorates the entitlement path, it must never block it.
         cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 1234L)
     }
+
+    @Test
+    fun `a failing datastore write does not abort the entitlement bookkeeping`() = runTest {
+        // A broken write (corrupt file, no disk space) is not the same failure as a wedged lock, and
+        // the timeout alone doesn't cover it -- the exception would propagate straight through the
+        // stamp into the caller that was only decorating its entitlement work.
+        val cache = BillingCache(ThrowingPreferencesDataStore())
+
+        cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 1234L)
+
+        // Reads stay loud: a snapshot that can't be read must not look like "never bought".
+        shouldThrow<IOException> { cache.snapshot() }
+    }
+
+    @Test
+    fun `a cancelled stamp still cancels`() = runTest {
+        // Fail-soft must not extend to cancellation -- swallowing it would break the structured
+        // concurrency of whatever entitlement work is being torn down.
+        val cache = BillingCache(CancellingPreferencesDataStore())
+
+        shouldThrow<CancellationException> { cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 1234L) }
+    }
 }
 
 /** DataStore that never answers -- stands in for a wedged file lock. */
@@ -102,4 +125,20 @@ internal class HangingPreferencesDataStore : DataStore<Preferences> {
 
     override suspend fun updateData(transform: suspend (Preferences) -> Preferences): Preferences =
         awaitCancellation()
+}
+
+/** DataStore whose I/O fails -- stands in for a corrupt file or a full disk. */
+internal class ThrowingPreferencesDataStore : DataStore<Preferences> {
+    override val data: Flow<Preferences> = flow { throw IOException("Preferences file is broken") }
+
+    override suspend fun updateData(transform: suspend (Preferences) -> Preferences): Preferences =
+        throw IOException("Preferences file is broken")
+}
+
+/** DataStore whose write is cancelled from the outside. */
+internal class CancellingPreferencesDataStore : DataStore<Preferences> {
+    override val data: Flow<Preferences> = flow { throw CancellationException("Torn down") }
+
+    override suspend fun updateData(transform: suspend (Preferences) -> Preferences): Preferences =
+        throw CancellationException("Torn down")
 }

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeDiagnosticsGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeDiagnosticsGplayTest.kt
@@ -8,6 +8,7 @@ import io.kotest.matchers.string.shouldNotContain
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
@@ -121,6 +122,29 @@ class UpgradeDiagnosticsGplayTest : BaseTest() {
         info shouldContain "BillingCache=unavailable"
         info shouldNotContain "lastProStateAt=never"
         info shouldContain "ProHistory=$proHistory"
+    }
+
+    @Test
+    fun `a wedged history is reported as unavailable`() = runTest {
+        // Counterpart to the wedged cache above: a never-answering CurriculumVitae store would hold
+        // the debug-log header -- and with it the start of the recording -- forever.
+        val diagnostics = UpgradeDiagnosticsGplay(
+            billingCache = mockk<BillingCache>().apply {
+                coEvery { snapshot() } returns BillingCache.Snapshot(
+                    lastProStateAt = 0L,
+                    lastProStateSku = "",
+                    proUnconfirmedSince = 0L,
+                )
+            },
+            curriculumVitae = mockk<CurriculumVitae>().apply {
+                coEvery { proHistory() } coAnswers { awaitCancellation() }
+            },
+        ).apply { historyTimeoutMs = 50L }
+
+        val info = diagnostics.debugInfo()
+
+        info shouldContain "BillingCache(lastProStateAt=never"
+        info shouldContain "ProHistory=unavailable"
     }
 
     @Test


### PR DESCRIPTION
## What changed

FOSS version: a supporter re-visiting the GitHub Sponsors page from their status screen can no longer accidentally reset their "supporter since" date — the donate button on the status screen now simply opens the page without re-running the unlock logic, and a returning supporter is never re-registered. Supporter status is also only granted when the sponsors page actually opened: if no browser could handle the link, coming back to the app later no longer counts as a donation visit. And the "FOSS" flavor label is no longer translatable — a handful of languages had it translated into regular words (the Thai one meant "compulsory"), so titles like "SD Maid SE FOSS" now show the brand name everywhere.

For support: debug-log recording now starts even when parts of the app are wedged. Previously the log header waited on three data sources one after another with no time limit — a stuck storage lock could silently prevent a debug log from ever being recorded, exactly when a user was trying to report a problem. The header sources now load concurrently under one shared time budget, and anything that doesn't answer is reported as unavailable instead of blocking the recording. A failed write to the purchase cache also no longer interrupts the surrounding entitlement bookkeeping.

## Technical Context

- Continuation of the upgrade-stack reliability work from #2592, folding back improvements that originated in the sibling apps.
- Sponsor flow: `WebpageTool.open()` now returns whether an activity was actually started (all three failure paths — stub-only handler, `ActivityNotFoundException`, `SecurityException` — report false); `UpgradeRepoFoss.openGithubSponsorsPage()` is synchronous so the ViewModel can arm the return-after-5s unlock heuristic only on a successful launch, with a single-flight guard against double taps. The status view's donate button uses a new unarmed path; `checkSponsorReturn()` additionally consumes the pending key and returns quietly for already-Pro users before the duration check — defense in depth for the date-reset scenario.
- Recorder: the three header reads (data areas, update history, upgrade diagnostics) run concurrently via `async` under a single 5s deadline with a completion marker distinguishing "timed out" from "legitimately nothing to report" (the data-area state starts null and FOSS has no upgrade diagnostics — both keep logging their normal lines). Deliberate behavior change: a failing header read used to abort the recording; it now degrades that source to "unavailable" and the recording starts. Cancellation semantics and the existing start-failure rollback are unchanged. The GPlay diagnostics' pro-history read gets the same 2s bound the billing-cache read already had.
- `BillingCache.stampLastProState()` was fail-soft for timeouts only; a thrown `IOException` escaped into the fresh-billing collector and skipped the pro-state counter update sharing its try-block. Non-cancellation write exceptions now degrade to a logged skip; reads stay loud, and cancellation is rethrown (covered by tests).
- Resources: `app_name_upgrade_postfix` (foss) is now `translatable="false"` and its 79 locale entries were removed — with the attribute set, any remaining locale entry would trip fatal `ExtraTranslation` in release lint, hence all of them. The GPlay "Pro" postfix remains intentionally translated.
- Review guidance: new host-level lifecycle test for the FOSS screen (real ViewModel, real STOP/RESUME transitions, recreation-seeding case that can only pass via constructor seeding); recorder hang tests run on real dispatchers with a short deadline seam, including an all-three-sources-wedged case asserting the shared (not stacked) budget; four-outcome `WebpageTool` contract test since the Boolean now gates entitlement arming.
