### PR TITLE
General: Warn when dry-run mode is hiding that nothing was deleted, and stop claiming Shizuku setup is done when it isn't installed

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/adb/service/AdbServiceClient.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/adb/service/AdbServiceClient.kt
@@ -59,10 +59,14 @@ class AdbServiceClient @Inject constructor(
 
         if (adbSettings.useAdb.value() != true) throw AdbUnavailableException("ADB is not enabled")
 
+        // Mirror App.kt: trace and dry-run only apply while debug mode is on. Without this the host
+        // keeps dry-running after debug mode is switched off, while the toggle that turns it off is
+        // hidden with the debug card.
+        val isDebugInitial = debugSettings.isDebugMode.value()
         val optionsInitial = AdbHostOptions(
-            isDebug = debugSettings.isDebugMode.value(),
-            isTrace = debugSettings.isTraceMode.value(),
-            isDryRun = debugSettings.isDryRunMode.value(),
+            isDebug = isDebugInitial,
+            isTrace = isDebugInitial && debugSettings.isTraceMode.value(),
+            isDryRun = isDebugInitial && debugSettings.isDryRunMode.value(),
             recorderPath = debugSettings.recorderPath.value(),
         )
 
@@ -84,8 +88,8 @@ class AdbServiceClient @Inject constructor(
         ) { isDebug, isTrace, isDryRun, recorderPath, lastConnection ->
             val optionsDynamic = AdbHostOptions(
                 isDebug = isDebug,
-                isTrace = isTrace,
-                isDryRun = isDryRun,
+                isTrace = isDebug && isTrace,
+                isDryRun = isDebug && isDryRun,
                 recorderPath = recorderPath,
             )
             log(TAG) { "Updating debug settings: $optionsDynamic" }

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/root/service/RootServiceClient.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/root/service/RootServiceClient.kt
@@ -56,10 +56,14 @@ class RootServiceClient @Inject constructor(
         log(TAG) { "Instantiating Root launcher..." }
         if (rootSettings.useRoot.value() != true) throw RootUnavailableException("Root is not enabled")
 
+        // Mirror App.kt: trace and dry-run only apply while debug mode is on. Without this the host
+        // keeps dry-running after debug mode is switched off, while the toggle that turns it off is
+        // hidden with the debug card.
+        val isDebugInitial = debugSettings.isDebugMode.value()
         val initialOptions = RootHostOptions(
-            isDebug = debugSettings.isDebugMode.value(),
-            isTrace = debugSettings.isTraceMode.value(),
-            isDryRun = debugSettings.isDryRunMode.value(),
+            isDebug = isDebugInitial,
+            isTrace = isDebugInitial && debugSettings.isTraceMode.value(),
+            isDryRun = isDebugInitial && debugSettings.isDryRunMode.value(),
             recorderPath = debugSettings.recorderPath.value(),
         )
 
@@ -81,8 +85,8 @@ class RootServiceClient @Inject constructor(
         ) { isDebug, isTrace, isDryRun, recorderPath, lastConnection ->
             val dynamicOptions = RootHostOptions(
                 isDebug = isDebug,
-                isTrace = isTrace,
-                isDryRun = isDryRun,
+                isTrace = isDebug && isTrace,
+                isDryRun = isDebug && isDryRun,
                 recorderPath = recorderPath,
             )
             log(TAG) { "Updating debug settings: $dynamicOptions" }

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModel.kt
@@ -79,6 +79,7 @@ import eu.darken.sdmse.main.ui.dashboard.cards.DashboardItem
 import eu.darken.sdmse.main.ui.dashboard.cards.AnniversaryDashboardCardItem
 import eu.darken.sdmse.main.ui.dashboard.cards.AppControlDashboardCardItem
 import eu.darken.sdmse.main.ui.dashboard.cards.DebugDashboardCardItem
+import eu.darken.sdmse.main.ui.dashboard.cards.DryRunWarningDashboardCardItem
 import eu.darken.sdmse.main.ui.dashboard.cards.ErrorDataAreaDashboardCardItem
 import eu.darken.sdmse.main.ui.dashboard.cards.MotdDashboardCardItem
 import eu.darken.sdmse.main.ui.dashboard.cards.ReviewDashboardCardItem
@@ -387,6 +388,14 @@ class DashboardViewModel @Inject constructor(
         updateInfo?.let { items.add(it) }
         setupItem?.let { items.add(it) }
         dataAreaError?.let { items.add(it) }
+
+        // Dry-run makes every cleanup a no-op while still reporting freed space. The toggle lives at the
+        // bottom of the dashboard, so warn up top for as long as it's on. debugItem is null unless debug
+        // mode is on, which matches how App.kt gates Bugs.isDryRun.
+        debugItem
+            ?.takeIf { it.isDryRunEnabled }
+            ?.let { debug -> items.add(DryRunWarningDashboardCardItem(onDisable = { debug.onDryRunEnabled(false) })) }
+
         anniversaryItem?.let { items.add(it) }
 
         // Add tool cards based on user configuration

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/DashboardListCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/DashboardListCard.kt
@@ -30,6 +30,7 @@ internal fun DashboardListCard(
         is StatsDashboardCardItem -> StatsDashboardCard(item)
         is SwiperDashboardCardItem -> SwiperDashboardCard(modifier = modifier, item = item)
         is DebugDashboardCardItem -> DebugDashboardCard(item)
+        is DryRunWarningDashboardCardItem -> DryRunWarningDashboardCard(item)
         is ErrorDataAreaDashboardCardItem -> ErrorDataAreaDashboardCard(item)
     }
 }

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/DryRunWarningDashboardCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/DryRunWarningDashboardCard.kt
@@ -1,0 +1,67 @@
+package eu.darken.sdmse.main.ui.dashboard.cards
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.Cancel
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import eu.darken.sdmse.R
+import eu.darken.sdmse.common.compose.preview.Preview2
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.main.ui.dashboard.cards.common.DashboardActionIconSpacing
+import eu.darken.sdmse.main.ui.dashboard.cards.common.DashboardCard
+import eu.darken.sdmse.main.ui.dashboard.cards.common.DashboardFlatActionButton
+
+
+data class DryRunWarningDashboardCardItem(
+    val onDisable: () -> Unit,
+) : DashboardItem {
+    override val stableId: Long = this.javaClass.hashCode().toLong()
+}
+
+@Composable
+internal fun DryRunWarningDashboardCard(item: DryRunWarningDashboardCardItem) {
+    DashboardCard(containerColor = MaterialTheme.colorScheme.errorContainer) {
+        Text(
+            text = stringResource(R.string.dashboard_dryrun_warning_title),
+            style = MaterialTheme.typography.titleMedium,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = stringResource(R.string.dashboard_dryrun_warning_body),
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        DashboardFlatActionButton(
+            onClick = item.onDisable,
+            modifier = Modifier.align(Alignment.End),
+        ) {
+            Icon(
+                imageVector = Icons.TwoTone.Cancel,
+                contentDescription = null,
+            )
+            Spacer(modifier = Modifier.width(DashboardActionIconSpacing))
+            Text(text = stringResource(R.string.dashboard_dryrun_warning_disable_action))
+        }
+    }
+}
+
+@Preview2
+@Composable
+private fun DryRunWarningDashboardCardPreview() {
+    PreviewWrapper {
+        DryRunWarningDashboardCard(
+            item = DryRunWarningDashboardCardItem(
+                onDisable = {},
+            ),
+        )
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/setup/shizuku/ShizukuSetupCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/shizuku/ShizukuSetupCard.kt
@@ -56,12 +56,15 @@ internal fun ShizukuSetupCard(
                 .padding(horizontal = 16.dp),
         )
 
-        if (item.state.useShizuku == true && item.state.isInstalled) {
-            val ready = item.state.ourService
+        if (item.state.useShizuku == true) {
+            val ready = item.state.isInstalled && item.state.ourService
             Text(
                 text = stringResource(
-                    if (ready) R.string.setup_shizuku_state_ready_label
-                    else R.string.setup_shizuku_state_waiting_label,
+                    when {
+                        !item.state.isInstalled -> R.string.setup_shizuku_state_not_installed_label
+                        ready -> R.string.setup_shizuku_state_ready_label
+                        else -> R.string.setup_shizuku_state_waiting_label
+                    },
                 ),
                 style = MaterialTheme.typography.labelMedium,
                 color = if (ready) {
@@ -129,6 +132,29 @@ private fun ShizukuSetupCardPreview() {
                     isCompatible = true,
                     isInstalled = true,
                     basicService = true,
+                    ourService = false,
+                    alsoHasRoot = false,
+                ),
+                onToggleUseShizuku = {},
+                onOpen = {},
+                onHelp = {},
+            ),
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun ShizukuSetupCardNotInstalledPreview() {
+    PreviewWrapper {
+        ShizukuSetupCard(
+            item = ShizukuSetupCardItem(
+                state = ShizukuSetupModule.Result(
+                    pkg = "moe.shizuku.privileged.api".toPkgId(),
+                    useShizuku = true,
+                    isCompatible = true,
+                    isInstalled = false,
+                    basicService = false,
                     ourService = false,
                     alsoHasRoot = false,
                 ),

--- a/app/src/main/java/eu/darken/sdmse/setup/shizuku/ShizukuSetupModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/shizuku/ShizukuSetupModule.kt
@@ -165,8 +165,11 @@ class ShizukuSetupModule @Inject constructor(
 
         override val type: SetupModule.Type = SetupModule.Type.SHIZUKU
 
+        // "Wants Shizuku but it isn't installed" is NOT complete. Treating it as complete hid the card
+        // and rendered the whole setup screen as done, so users believed Shizuku was working while we
+        // silently fell back to the accessibility service.
         override val isComplete: Boolean =
-            useShizuku == false || !isCompatible || (useShizuku == true && (!isInstalled || ourService))
+            useShizuku == false || !isCompatible || (useShizuku == true && isInstalled && ourService)
     }
 
     @Module @InstallIn(SingletonComponent::class)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -253,6 +253,7 @@
     <string name="setup_shizuku_card_root_info">Shizuku in combination with root access does not enable additional features, but it improves reliability. SD Maid will use it as fallback method.</string>
     <string name="setup_shizuku_state_ready_label">Shizuku link is ready.</string>
     <string name="setup_shizuku_state_waiting_label">Waiting for link with Shizuku.</string>
+    <string name="setup_shizuku_state_not_installed_label">The Shizuku app is not installed.</string>
     <string name="setup_shizuku_enable_shizuku_use_label">Try to use Shizuku</string>
     <string name="setup_shizuku_disable_shizuku_use_label">Don\'t use Shizuku</string>
 
@@ -316,6 +317,10 @@
     <string name="debug_card_pkgs_reload_action">Reload apps</string>
     <string name="debug_card_root_test_action">Test root</string>
     <string name="debug_card_shizuku_test_action">Test Shizuku</string>
+    <!-- Dry-run warning card (dashboard) -->
+    <string name="dashboard_dryrun_warning_title">Dry-run mode is active</string>
+    <string name="dashboard_dryrun_warning_body">Cleanup is being simulated. Files are scanned and reported, but nothing is actually deleted.</string>
+    <string name="dashboard_dryrun_warning_disable_action">Turn off</string>
 
     <string name="data_area_public_app_data_official_label">Default public app data</string>
     <string name="data_area_public_app_assets_official_label">Default public app assets</string>


### PR DESCRIPTION
## What changed

Two separate problems that combined to make cleanups look like they worked when they did nothing at all.

**Dry-run mode had no warning.** Dry-run is a developer option that simulates a cleanup: files get scanned and counted, but nothing is deleted. Once switched on it stays on forever, across restarts and app updates, and nothing in the app ever mentions it again. Meanwhile every cleanup still reports the full "freed X GB" result, identical to a real one. A user can spend weeks cleaning up nothing and never get a hint. There is now a warning card at the top of the dashboard whenever dry-run is active, with a button to switch it straight off.

**Shizuku setup claimed to be finished when Shizuku wasn't installed.** If you picked "Try to use Shizuku" but never installed the Shizuku app, setup counted that as done, hid the Shizuku card, and showed the setup screen as fully complete. So you had every reason to believe Shizuku was working while SD Maid quietly used the slower accessibility service instead. The card now stays visible and says the Shizuku app isn't installed.

If you selected "Try to use Shizuku" without installing it, expect the setup prompt to come back after this update. That is the point, and you can dismiss it.

## Technical Context

- **Where this came from:** a support report (12 GB "deleted", 8.8 GB still there 10 minutes later). The debug log showed `debug.dryrun.enabled=true`, 2022 `DRYRUN: Not deleting` lines, and `AppCleanerProcessingTask.Success(8704424138, 1560 items, 1395 paths)` reported to the user from the same run. Both figures the user quoted reproduce exactly from the log.

- **Why the reported byte count is indistinguishable from a real run:** `AppCleaner` sums the pre-deletion scan's `expectedGain` over paths whose delete call returned success, and under dry-run `LocalGateway` returns `javaFile.canWrite()` as that success value. So a writable file counts as deleted. There is no post-hoc verification. `SpaceTracker` does record real free space and correctly saw no change, but nothing compares the two.

- **Why a warning card and not an auto-reset:** auto-resetting dry-run at startup would silently turn a *safe* state into a destructive one. Anyone who enables dry-run precisely because they are about to test something irreversible would get real deletions after any process death. A safety flag must not fail open.

- **Deliberately out of scope:** labelling the result figures themselves as simulated (snackbar, hero card, notifications), and suppressing/ tagging stats for dry-run runs. Both are real gaps; neither is addressed here.

- **The card needs no new plumbing:** it derives from the existing `DebugCardProvider` item, which is null exactly when debug mode is off — the same condition `App.kt` uses to gate `Bugs.isDryRun`. The item already carries the setter, so the off-switch is free.

- **Helper-process gating:** `RootServiceClient` / `AdbServiceClient` passed `isDryRun` and `isTrace` to the root/ADB hosts raw, while `App.kt` gates both on `isDebug`. Turning debug mode off with dry-run on stranded the flag: the helpers kept no-op'ing and the only toggle was hidden along with the debug card. Both the initial options and the dynamic update now match `App.kt`.

- **Shizuku `isComplete` review guidance:** the final clause went from `(useShizuku == true && (!isInstalled || ourService))` to `(useShizuku == true && isInstalled && ourService)`. Worth checking the truth table: opted-out and incompatible devices still complete, `useShizuku == null` is unchanged, installed-but-not-yet-bound stays incomplete as before. The `isInstalled` conjunct closes a case where a stale/racing `ourService=true` with `isInstalled=false` would have re-hidden the card. `ShizukuSetupCard`'s status `Text` previously only rendered when `isInstalled`, so without the new branch an incomplete card would have shown no explanation.

- **No wedge risk from the module going incomplete:** only `INVENTORY` has a setup heartbeat, `SetupHealer` doesn't touch Shizuku, and the dashboard setup card short-circuits on `isDismissed`.