### PR TITLE
AppCleaner: Stop stalling on disabled apps when cleaning caches on Samsung

### DIFF
--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/errors/DisabledAppException.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/errors/DisabledAppException.kt
@@ -1,0 +1,21 @@
+package eu.darken.sdmse.automation.core.errors
+
+import eu.darken.sdmse.automation.R
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.error.HasLocalizedError
+import eu.darken.sdmse.common.error.LocalizedError
+
+/**
+ * The app's settings page exists but can't be opened while the app is disabled.
+ * Unlike [NoSettingsWindowException] this is recoverable: enabling the app, or using
+ * root/ADB instead of the accessibility service, makes the cache clearable again.
+ */
+class DisabledAppException(
+    message: String,
+) : PlanAbortException(message), HasLocalizedError {
+    override fun getLocalizedError() = LocalizedError(
+        throwable = this,
+        label = R.string.automation_error_disabled_app_title.toCaString(),
+        description = R.string.automation_error_disabled_app_body.toCaString()
+    )
+}

--- a/app-common-automation/src/main/res/values/strings.xml
+++ b/app-common-automation/src/main/res/values/strings.xml
@@ -23,6 +23,8 @@
     <string name="automation_error_scheduler_body">A scheduled task tried to use the accessibility service, but it was unavailable. If you don\'t need this, disable the \"Accessibility service\" option in the scheduler settings.</string>
     <string name="automation_error_no_settings_title">Settings screen unavailable</string>
     <string name="automation_error_no_settings_body">This system app has no settings screen. Cache clearing via accessibility service is not possible. Exclude it to speed up cache clearing.</string>
+    <string name="automation_error_disabled_app_title">App is disabled</string>
+    <string name="automation_error_disabled_app_body">Your device won\'t open the settings screen of disabled apps, so the cache can\'t be cleared via accessibility service. Enable the app, or use root or Shizuku/ADB instead.</string>
     <string name="automation_error_interference_title">Settings screen blocked</string>
     <string name="automation_error_interference_body">Another app (%1$s) is blocking the system settings screen, so SD Maid can\'t continue. Disable that app\'s app-lock or screen protection for the system settings, then try again.</string>
     <string name="automation_loading">Preparing automation via accessibility service</string>

--- a/app-common-pkgs/src/main/java/eu/darken/sdmse/common/pkgs/NoSettingsDetector.kt
+++ b/app-common-pkgs/src/main/java/eu/darken/sdmse/common/pkgs/NoSettingsDetector.kt
@@ -4,22 +4,49 @@ import dagger.Reusable
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.device.DeviceDetective
+import eu.darken.sdmse.common.device.RomType
+import eu.darken.sdmse.common.device.RomTypeProvider
 import eu.darken.sdmse.common.pkgs.features.Installed
 import javax.inject.Inject
 
 /**
- * Single seam for detecting packages whose Android Settings details page can't be opened.
- * Currently delegates to [Installed.hasNoSettings] (structural APEX/mainline check).
- * Designed as an injectable so smarter detection can replace the implementation later
- * without touching call sites.
+ * Single seam for detecting packages whose Android Settings details page can't be opened,
+ * i.e. packages that accessibility based automation can never reach.
+ *
+ * Covers the structural [Installed.hasNoSettings] check (APEX/mainline) plus ROM specific
+ * limitations. This is deliberately an automation-only concern: other deletion backends
+ * (root, ADB) don't go through the Settings UI and must not be restricted by it.
  */
 @Reusable
-class NoSettingsDetector @Inject constructor() {
+class NoSettingsDetector @Inject constructor(
+    private val deviceDetective: DeviceDetective,
+    private val romTypeProvider: RomTypeProvider,
+) {
 
-    fun hasNoSettings(pkg: Installed): Boolean {
-        val skip = pkg.hasNoSettings
-        if (skip) log(TAG, VERBOSE) { "hasNoSettings=true for ${pkg.installId}" }
-        return skip
+    /**
+     * Why the settings page is unreachable. The distinction matters to the user:
+     * [NO_SETTINGS_PAGE] is permanent, [DISABLED_APP] goes away by enabling the app.
+     */
+    enum class Reason {
+        NO_SETTINGS_PAGE,
+        DISABLED_APP,
+    }
+
+    suspend fun getUnreachableReason(pkg: Installed): Reason? = when {
+        pkg.hasNoSettings -> Reason.NO_SETTINGS_PAGE
+        // On One UI (Samsung) the settings page of disabled apps can't be opened
+        !pkg.isEnabled && effectiveRomType() == RomType.ONEUI -> Reason.DISABLED_APP
+        else -> null
+    }.also { if (it != null) log(TAG, VERBOSE) { "Unreachable ($it): ${pkg.installId}" } }
+
+    /**
+     * The manual override wins: it exists so users can correct a misdetected OS when
+     * accessibility automation misbehaves, which is exactly what this check feeds into.
+     */
+    private suspend fun effectiveRomType(): RomType {
+        val override = romTypeProvider.getRomType()
+        return if (override != RomType.AUTO) override else deviceDetective.getROMType()
     }
 
     companion object {

--- a/app-common-pkgs/src/test/java/eu/darken/sdmse/common/pkgs/NoSettingsDetectorTest.kt
+++ b/app-common-pkgs/src/test/java/eu/darken/sdmse/common/pkgs/NoSettingsDetectorTest.kt
@@ -1,0 +1,102 @@
+package eu.darken.sdmse.common.pkgs
+
+import eu.darken.sdmse.common.device.DeviceDetective
+import eu.darken.sdmse.common.device.RomType
+import eu.darken.sdmse.common.device.RomTypeProvider
+import eu.darken.sdmse.common.pkgs.container.NormalPkg
+import eu.darken.sdmse.common.pkgs.features.InstallId
+import eu.darken.sdmse.common.user.UserHandle2
+import io.kotest.matchers.shouldBe
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class NoSettingsDetectorTest : BaseTest() {
+
+    @MockK lateinit var deviceDetective: DeviceDetective
+    @MockK lateinit var romTypeProvider: RomTypeProvider
+
+    @BeforeEach
+    fun setup() {
+        MockKAnnotations.init(this)
+        coEvery { romTypeProvider.getRomType() } returns RomType.AUTO
+    }
+
+    private fun create() = NoSettingsDetector(
+        deviceDetective = deviceDetective,
+        romTypeProvider = romTypeProvider,
+    )
+
+    private fun mockPkg(
+        enabled: Boolean = true,
+        hasNoSettings: Boolean = false,
+    ): NormalPkg = mockk<NormalPkg>().apply {
+        val pkgId = "some.pkg".toPkgId()
+        every { id } returns pkgId
+        every { installId } returns InstallId(pkgId, UserHandle2(handleId = 0))
+        // MockK intercepts the getters, the InstallDetails/Installed default impls never run
+        every { isEnabled } returns enabled
+        every { this@apply.hasNoSettings } returns hasNoSettings
+    }
+
+    @Test
+    fun `structurally unreachable packages are flagged on any ROM`() = runTest {
+        every { deviceDetective.getROMType() } returns RomType.AOSP
+
+        create().getUnreachableReason(mockPkg(hasNoSettings = true)) shouldBe
+                NoSettingsDetector.Reason.NO_SETTINGS_PAGE
+    }
+
+    @Test
+    fun `disabled apps are unreachable on One UI`() = runTest {
+        every { deviceDetective.getROMType() } returns RomType.ONEUI
+
+        create().getUnreachableReason(mockPkg(enabled = false)) shouldBe
+                NoSettingsDetector.Reason.DISABLED_APP
+    }
+
+    @Test
+    fun `enabled apps are reachable on One UI`() = runTest {
+        every { deviceDetective.getROMType() } returns RomType.ONEUI
+
+        create().getUnreachableReason(mockPkg(enabled = true)) shouldBe null
+    }
+
+    @Test
+    fun `disabled apps are reachable on other ROMs`() = runTest {
+        every { deviceDetective.getROMType() } returns RomType.AOSP
+
+        create().getUnreachableReason(mockPkg(enabled = false)) shouldBe null
+    }
+
+    @Test
+    fun `manual One UI override applies the rule on an undetected ROM`() = runTest {
+        every { deviceDetective.getROMType() } returns RomType.AOSP
+        coEvery { romTypeProvider.getRomType() } returns RomType.ONEUI
+
+        create().getUnreachableReason(mockPkg(enabled = false)) shouldBe
+                NoSettingsDetector.Reason.DISABLED_APP
+    }
+
+    @Test
+    fun `manual non-One UI override drops the rule on a detected Samsung`() = runTest {
+        every { deviceDetective.getROMType() } returns RomType.ONEUI
+        coEvery { romTypeProvider.getRomType() } returns RomType.AOSP
+
+        create().getUnreachableReason(mockPkg(enabled = false)) shouldBe null
+    }
+
+    @Test
+    fun `structural check wins over the disabled check`() = runTest {
+        every { deviceDetective.getROMType() } returns RomType.ONEUI
+
+        create().getUnreachableReason(mockPkg(enabled = false, hasNoSettings = true)) shouldBe
+                NoSettingsDetector.Reason.NO_SETTINGS_PAGE
+    }
+}

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleter.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleter.kt
@@ -7,6 +7,7 @@ import eu.darken.sdmse.appcleaner.core.scanner.InaccessibleCacheProvider
 import eu.darken.sdmse.automation.core.AutomationSubmitter
 import eu.darken.sdmse.automation.core.ForceStopAutomationTask
 import eu.darken.sdmse.automation.core.errors.AutomationUnavailableException
+import eu.darken.sdmse.automation.core.errors.DisabledAppException
 import eu.darken.sdmse.automation.core.errors.NoSettingsWindowException
 import eu.darken.sdmse.automation.core.errors.UserCancelledAutomationException
 import eu.darken.sdmse.common.adb.AdbManager
@@ -151,17 +152,25 @@ class InaccessibleDeleter @Inject constructor(
             updateProgressSecondary(CaString.EMPTY)
             updateProgressCount(Progress.Count.Indeterminate())
 
-            // Pre-flight: packages we know have no settings page can never be cleared via ACS.
-            // Mark them as failed upfront so we don't waste ~4-10s per package discovering this
-            // reactively inside the automation flow.
-            val (preFailedNoSettings, automationCandidates) = remainingTargets.partition { junk ->
-                noSettingsDetector.hasNoSettings(junk.pkg)
-            }
-            preFailedNoSettings.forEach { junk ->
-                log(TAG, INFO) { "Pre-flight: no settings page, marking failed: ${junk.identifier}" }
-                failedTargets[junk.identifier] = NoSettingsWindowException(
-                    "${junk.identifier.pkgId.name} has no settings window (pre-flight)."
-                )
+            // Pre-flight: packages whose settings page we know we can't reach can never be cleared
+            // via ACS. Mark them as failed upfront so we don't waste ~4-10s per package discovering
+            // this reactively inside the automation flow.
+            val automationCandidates = remainingTargets.filter { junk ->
+                val reason = noSettingsDetector.getUnreachableReason(junk.pkg)
+                if (reason != null) {
+                    log(TAG, INFO) { "Pre-flight: unreachable ($reason), marking failed: ${junk.identifier}" }
+                    val pkgName = junk.identifier.pkgId.name
+                    failedTargets[junk.identifier] = when (reason) {
+                        NoSettingsDetector.Reason.NO_SETTINGS_PAGE -> NoSettingsWindowException(
+                            "$pkgName has no settings window (pre-flight)."
+                        )
+
+                        NoSettingsDetector.Reason.DISABLED_APP -> DisabledAppException(
+                            "$pkgName is disabled, its settings window can't be opened (pre-flight)."
+                        )
+                    }
+                }
+                reason == null
             }
 
             log(TAG) { "Processing ${automationCandidates.size} remaining inaccessible caches" }

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/AppScanner.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/AppScanner.kt
@@ -8,7 +8,6 @@ import eu.darken.sdmse.appcleaner.core.AppJunk
 import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilter
 import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilterIdentifier
 import eu.darken.sdmse.appcleaner.core.forensics.filter.DefaultCachesPublicFilter
-import eu.darken.sdmse.common.BuildWrap
 import eu.darken.sdmse.common.ModeUnavailableException
 import eu.darken.sdmse.common.areas.DataArea
 import eu.darken.sdmse.common.areas.DataAreaManager
@@ -51,7 +50,6 @@ import eu.darken.sdmse.common.pkgs.current
 import eu.darken.sdmse.common.pkgs.features.InstallId
 import eu.darken.sdmse.common.pkgs.features.Installed
 import eu.darken.sdmse.common.pkgs.getPrivateDataDirs
-import eu.darken.sdmse.common.pkgs.isEnabled
 import eu.darken.sdmse.common.pkgs.isSystemApp
 import eu.darken.sdmse.common.pkgs.pkgops.PkgOps
 import eu.darken.sdmse.common.pkgs.pkgops.PkgOpsException
@@ -515,17 +513,14 @@ class AppScanner @Inject constructor(
         updateProgressSecondary(CaString.EMPTY)
         updateProgressCount(Progress.Count.Indeterminate())
 
-        // If we skip detection if ACS is disable, users might not be aware of the ACS option's capabilities?
-        settings.useAccessibilityService.value()
-        val isSamsungRom = BuildWrap.MANUFACTOR == "Samsung"
         val currentUser = userManager.currentUser()
 
+        // Detection deliberately runs even when ACS is off, otherwise users would never see what
+        // the ACS option could do for them. It is also backend-neutral: ROM specific limitations
+        // (e.g. One UI can't open the settings page of disabled apps) only affect ACS automation
+        // and are handled by NoSettingsDetector during deletion. Root/ADB clean those just fine.
         val targets = pkgs
             .filter { it.userHandle == currentUser.handle }
-            .filter { pkg ->
-                // On Samsung ROMs, we can't open the settings page for disabled apps
-                !isSamsungRom || pkg.isEnabled
-            }
             .filterIsInstance<NormalPkg>()
 
         updateProgressCount(Progress.Count.Percent(pkgs.size))

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleterTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleterTest.kt
@@ -76,7 +76,7 @@ class InaccessibleDeleterTest : BaseTest() {
         coEvery { userManager.currentUser() } returns testUser
         every { adbManager.useAdb } returns flowOf(false)
         // Default: no package is flagged as having no settings. Individual tests override as needed.
-        every { noSettingsDetector.hasNoSettings(any()) } returns false
+        coEvery { noSettingsDetector.getUnreachableReason(any()) } returns null
 
         deleter = InaccessibleDeleter(
             dispatcherProvider = dispatcherProvider,
@@ -172,6 +172,36 @@ class InaccessibleDeleterTest : BaseTest() {
 
         // Not marked as success (useAutomation=false so no automation ran either)
         result.succesful shouldNotContain junk.identifier
+    }
+
+    @Test
+    fun `ADB runs before reachability is considered, so unreachable targets still get cleaned`() = runTest {
+        val junk = createAppJunk("com.example.disabled", cacheSize = 50000)
+        val snapshot = createSnapshot(junk)
+
+        every { adbManager.useAdb } returns flowOf(true)
+        coEvery { pkgOps.trimCaches(any(), any(), any()) } returns Unit
+        // ADB cleared it: the re-query reports a smaller cache than the scan did
+        coEvery { inaccessibleCacheProvider.determineCache(any()) } returns InaccessibleCache(
+            identifier = junk.identifier,
+            isSystemApp = false,
+            itemCount = 0,
+            totalSize = 0L,
+            publicSize = 0L,
+            theoreticalPaths = emptySet(),
+        )
+
+        val result = deleter.deleteInaccessible(
+            snapshot = snapshot,
+            targetPkgs = null,
+            useAutomation = true,
+            isBackground = false,
+        )
+
+        result.succesful shouldContain junk.identifier
+        // The ACS-only reachability check must never gate the ADB backend
+        coVerify(exactly = 0) { noSettingsDetector.getUnreachableReason(any()) }
+        coVerify(exactly = 0) { automationManager.submit(any()) }
     }
 
     @Test
@@ -290,7 +320,7 @@ class InaccessibleDeleterTest : BaseTest() {
         val snapshot = createSnapshot(junk)
 
         coEvery { inaccessibleCacheProvider.determineCache(any()) } returns nonZeroCache(junk)
-        every { noSettingsDetector.hasNoSettings(junk.pkg) } returns true
+        coEvery { noSettingsDetector.getUnreachableReason(junk.pkg) } returns NoSettingsDetector.Reason.NO_SETTINGS_PAGE
         every { settings.forceStopBeforeClearing } returns mockDataStoreValue(false)
 
         val result = deleter.deleteInaccessible(
@@ -313,7 +343,7 @@ class InaccessibleDeleterTest : BaseTest() {
         val snapshot = createSnapshot(junk)
 
         coEvery { inaccessibleCacheProvider.determineCache(any()) } returns nonZeroCache(junk)
-        every { noSettingsDetector.hasNoSettings(junk.pkg) } returns true
+        coEvery { noSettingsDetector.getUnreachableReason(junk.pkg) } returns NoSettingsDetector.Reason.NO_SETTINGS_PAGE
 
         val result = deleter.deleteInaccessible(
             snapshot = snapshot,
@@ -337,8 +367,8 @@ class InaccessibleDeleterTest : BaseTest() {
 
         coEvery { inaccessibleCacheProvider.determineCache(junkNoSettings.pkg) } returns nonZeroCache(junkNoSettings)
         coEvery { inaccessibleCacheProvider.determineCache(junkNormal.pkg) } returns nonZeroCache(junkNormal)
-        every { noSettingsDetector.hasNoSettings(junkNoSettings.pkg) } returns true
-        every { noSettingsDetector.hasNoSettings(junkNormal.pkg) } returns false
+        coEvery { noSettingsDetector.getUnreachableReason(junkNoSettings.pkg) } returns NoSettingsDetector.Reason.NO_SETTINGS_PAGE
+        coEvery { noSettingsDetector.getUnreachableReason(junkNormal.pkg) } returns null
         every { settings.forceStopBeforeClearing } returns mockDataStoreValue(false)
 
         val capturedTask = slot<ClearCacheTask>()
@@ -372,7 +402,7 @@ class InaccessibleDeleterTest : BaseTest() {
 
         coEvery { inaccessibleCacheProvider.determineCache(junk1.pkg) } returns nonZeroCache(junk1)
         coEvery { inaccessibleCacheProvider.determineCache(junk2.pkg) } returns nonZeroCache(junk2)
-        every { noSettingsDetector.hasNoSettings(any()) } returns true
+        coEvery { noSettingsDetector.getUnreachableReason(any()) } returns NoSettingsDetector.Reason.NO_SETTINGS_PAGE
         every { settings.forceStopBeforeClearing } returns mockDataStoreValue(false)
 
         val result = deleter.deleteInaccessible(


### PR DESCRIPTION
## What changed

On Samsung phones, SD Maid tried to clear the cache of apps you had disabled. That can never work, because Samsung's settings app refuses to open the settings screen of a disabled app. Every disabled app still cost up to 30 seconds of the cleaning run waiting for something that was never going to happen, which is why cleaning could feel like it took forever and finished with little to show for it.

Disabled apps are now skipped up front when cleaning runs through the accessibility service, and you get a clear "App is disabled" message for them instead of a silent stall. They still show up in the AppCleaner list, and root or Shizuku/ADB can still clear them as before.

## Technical Context

- **Root cause**: `AppScanner` compared `BuildWrap.MANUFACTOR` (i.e. `Build.MANUFACTURER`, which is lowercase `samsung` on device) against the literal `"Samsung"`. The comparison is case-sensitive, so the guard evaluated to `false` on every real Samsung device and disabled apps were never excluded. `git log -L` shows the line unchanged since it was introduced, so this has never worked.

- **Why not just fix the comparison**: the scan result feeds *all* deletion backends, and `InaccessibleDeleter.deleteInaccessible()` attempts ADB `trimCaches` **before** any accessibility work. ADB doesn't go through the Settings UI, so a scan-time filter would have silently robbed ADB users of caches their backend can actually clear. That would have been a real regression, introduced by activating a guard that had never fired.

- **Where it lives now**: `NoSettingsDetector`, the ACS pre-flight seam at `InaccessibleDeleter.kt:157`, which runs after the ADB attempt and has exactly one production caller. Its KDoc already described it as the seam for "packages whose Settings details page can't be opened". ROM detection is delegated to `DeviceDetective` rather than re-implementing manufacturer string matching — it is already case-insensitive and already unit-tested for `samsung` → `RomType.ONEUI`, and it correctly returns `LINEAGE` for LineageOS-on-Samsung (where the AOSP-style settings app has no such limitation).

- **ROM-type override is honored**: `effectiveRomType()` checks `RomTypeProvider` before falling back to detection, matching the ~19 automation spec classes. The setting's own description is explicitly scoped to this: *"Accessibility based automation may fail if SD Maid doesn't detect your OS correctly. Use this setting to override the detected OS."*

- **Error copy**: `hasNoSettings(): Boolean` became `getUnreachableReason(): Reason?`. Reusing `NoSettingsWindowException` for disabled apps would have shown *"This system app has no settings screen. Cache clearing via accessibility service is not possible. Exclude it to speed up cache clearing."* — wrong on both counts (the app needn't be a system app, and its settings screen exists), and it recommends exclusion when enabling the app or using ADB is the actual remedy. Disabled apps now get `DisabledAppException` with its own copy. Two new base strings need translation.

- **Behavior note**: on a Samsung with many disabled apps, users now see a batch of explicit per-app failures where they previously saw a very slow run. These are attached as `AppJunk.acsError`; they never reach `ClearCacheModule`, are not counted as `AutomationTimeoutException`, and there is no downstream failure-ratio threshold, so they cannot trigger a spurious `AutomationCompatibilityException`.

- **Incidental**: removed a discarded `settings.useAccessibilityService.value()` call in the same function. That setting has no other reader or writer anywhere in the codebase; the declaration itself is left alone since it is a persisted key.

- **Review guidance**: the ordering in `deleteInaccessible` is the crux — ADB first, reachability check second. `InaccessibleDeleterTest` pins it with a test asserting the detector is never consulted when ADB succeeds.

- **Origin**: found while investigating a support report (Galaxy A16, Android 16, One UI, German locale). The user's debug log contained no reproduction, so this is **not confirmed as the cause of that report** — it is a defect found on its own merits while looking. The reporter's actual issue is still open pending a usable log.

## Testing

- New `NoSettingsDetectorTest`: 7 cases (structural, disabled+ONEUI, enabled+ONEUI, disabled+AOSP, both override directions, structural-wins precedence)
- New `InaccessibleDeleterTest` case pinning ADB-before-reachability ordering
- `:app-common-pkgs:testDebugUnitTest` 26/26, `:app-tool-appcleaner:testDebugUnitTest` 160/160
- `:app:assembleFossDebug`, `lintVitalFossRelease`, `lintVitalGplayRelease` all pass
