### PR TITLE
General: Warn about short debug logs up to 10 seconds

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModule.kt
@@ -345,7 +345,15 @@ class RecorderModule @Inject constructor(
     companion object {
         internal val TAG = logTag("Debug", "Log", "Recorder", "Module")
         private const val FORCE_FILE = "force_debug_run"
-        private const val MIN_RECORDING_MS = 5_000L
+        /**
+         * Duration heuristic for "did you forget to reproduce the issue?". A recording stopped
+         * this quickly usually contains nothing but the recorder starting and stopping, which
+         * costs a support round-trip to re-request.
+         *
+         * It stays a prompt because short recordings can be perfectly valid: a crash is logged
+         * and flushed immediately, so the reproduction is already on disk. "Stop anyway" works.
+         */
+        private const val MIN_RECORDING_MS = 10_000L
 
         // Shared budget for ALL header reads, not per source: they run concurrently.
         private const val HEADER_READ_TIMEOUT_MS = 5_000L

--- a/app/src/test/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModuleTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModuleTest.kt
@@ -18,6 +18,7 @@ import eu.darken.sdmse.main.core.CurriculumVitae
 import io.kotest.matchers.longs.shouldBeLessThan
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -25,6 +26,7 @@ import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.slot
+import io.mockk.unmockkStatic
 import io.mockk.verify
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -37,6 +39,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
@@ -50,6 +53,12 @@ import testhelpers.BaseTest
 import testhelpers.coroutine.TestDispatcherProvider
 import java.io.File
 import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.BasicFileAttributes
+import java.nio.file.attribute.FileTime
+import java.time.Duration
+import java.time.Instant
 import java.util.concurrent.CopyOnWriteArrayList
 import javax.inject.Provider
 import kotlin.system.measureTimeMillis
@@ -117,7 +126,7 @@ class RecorderModuleTest : BaseTest() {
         every { context.getPackageInfo() } returns mockk(relaxed = true)
 
         mockkStatic(SystemClock::class)
-        every { SystemClock.elapsedRealtime() } returns 12345L
+        every { SystemClock.elapsedRealtime() } returns RECORDING_START
     }
 
     private fun createModule(scope: kotlinx.coroutines.CoroutineScope, dispatcher: CoroutineDispatcher) =
@@ -175,7 +184,7 @@ class RecorderModuleTest : BaseTest() {
             advanceUntilIdle()
 
             val state = module.state.first { it.isRecording }
-            state.recordingStartedAt shouldBe 12345L
+            state.recordingStartedAt shouldBe RECORDING_START
             val pathSlot = slot<(String?) -> String?>()
             coVerify { recorderPath.update(capture(pathSlot)) }
             pathSlot.captured("ignored") shouldNotBe null
@@ -289,6 +298,115 @@ class RecorderModuleTest : BaseTest() {
             val clearSlot = slot<(String?) -> String?>()
             coVerify(atLeast = 1) { recorderPath.update(capture(clearSlot)) }
             clearSlot.captured("ignored") shouldBe null
+        }
+    }
+
+    @Nested
+    inner class MinimumDuration {
+
+        private suspend fun TestScope.startFreshRecording(): RecorderModule {
+            File(externalDir, "force_debug_run").createNewFile()
+            coEvery { recorderPath.value() } returns null
+
+            val dispatcher = StandardTestDispatcher(testScheduler)
+            val module = createModule(backgroundScope, dispatcher)
+            advanceUntilIdle()
+
+            module.state.first { it.isRecording }.recordingStartedAt shouldBe RECORDING_START
+            return module
+        }
+
+        private suspend fun TestScope.startResumedRecording(): RecorderModule {
+            val existingDir = File(externalDir, "debug/logs/existing_session").apply { mkdirs() }
+            coEvery { recorderPath.value() } returns existingDir.path
+
+            val dispatcher = StandardTestDispatcher(testScheduler)
+            val module = createModule(backgroundScope, dispatcher)
+            advanceUntilIdle()
+
+            // No elapsedRealtime baseline survives a restart, so the fallback is used instead
+            module.state.first { it.isRecording }.recordingStartedAt shouldBe 0L
+            return module
+        }
+
+        /**
+         * A leaked [Files] mock breaks JUnit's own @TempDir handling in every later test,
+         * and there is no shared unmockkAll hook between tests here.
+         */
+        @AfterEach
+        fun releaseFilesMock() {
+            unmockkStatic(Files::class)
+        }
+
+        /** Makes the resumed-session fallback see a log dir created [age] ago. */
+        private fun stubLogDirAge(age: Duration) {
+            mockkStatic(Files::class)
+            every { Files.readAttributes(any<Path>(), BasicFileAttributes::class.java) } returns
+                    mockk<BasicFileAttributes>().apply {
+                        every { creationTime() } returns FileTime.from(Instant.now().minus(age))
+                    }
+        }
+
+        @Test
+        fun `an 8 second recording is caught`() = runTest {
+            val module = startFreshRecording()
+            every { SystemClock.elapsedRealtime() } returns RECORDING_START + 8_000L
+
+            module.requestStopRecorder() shouldBe RecorderModule.StopResult.TooShort
+        }
+
+        @Test
+        fun `a recording just below the threshold is caught`() = runTest {
+            val module = startFreshRecording()
+            every { SystemClock.elapsedRealtime() } returns RECORDING_START + 9_999L
+
+            module.requestStopRecorder() shouldBe RecorderModule.StopResult.TooShort
+        }
+
+        @Test
+        fun `a recording at the threshold stops without prompting`() = runTest {
+            val module = startFreshRecording()
+            every { SystemClock.elapsedRealtime() } returns RECORDING_START + 10_000L
+
+            module.requestStopRecorder().shouldBeInstanceOf<RecorderModule.StopResult.Stopped>()
+        }
+
+        @Test
+        fun `being caught keeps recording, it must not half-stop the recorder`() = runTest {
+            val module = startFreshRecording()
+            every { SystemClock.elapsedRealtime() } returns RECORDING_START + 8_000L
+
+            module.requestStopRecorder() shouldBe RecorderModule.StopResult.TooShort
+
+            module.state.first().isRecording shouldBe true
+            coVerify(exactly = 0) { mockRecorder.stop() }
+        }
+
+        @Test
+        fun `a resumed session younger than the threshold is caught`() = runTest {
+            val module = startResumedRecording()
+            stubLogDirAge(Duration.ofSeconds(3))
+
+            module.requestStopRecorder() shouldBe RecorderModule.StopResult.TooShort
+        }
+
+        @Test
+        fun `a resumed session older than the threshold stops without prompting`() = runTest {
+            val module = startResumedRecording()
+            stubLogDirAge(Duration.ofMinutes(5))
+
+            module.requestStopRecorder().shouldBeInstanceOf<RecorderModule.StopResult.Stopped>()
+        }
+
+        @Test
+        fun `an unreadable log dir fails open rather than trapping the user`() = runTest {
+            val module = startResumedRecording()
+            mockkStatic(Files::class)
+            every {
+                Files.readAttributes(any<Path>(), BasicFileAttributes::class.java)
+            } throws IOException("no attributes for you")
+
+            module.requestStopRecorder().shouldBeInstanceOf<RecorderModule.StopResult.Stopped>()
         }
     }
 
@@ -418,5 +536,10 @@ class RecorderModuleTest : BaseTest() {
                 logLines.any { it.startsWith("Upgrade diagnostics") } shouldBe false
             }
         }
+    }
+
+    companion object {
+        /** Arbitrary fixed [SystemClock.elapsedRealtime] value that recordings start at. */
+        private const val RECORDING_START = 12345L
     }
 }


### PR DESCRIPTION
## What changed

When you stop a debug log recording almost immediately, SD Maid asks whether you really meant to, because a recording that short usually doesn't contain the problem you were trying to capture. That warning only appeared below 5 seconds, which was short enough that genuinely empty recordings still slipped through. It now covers anything under 10 seconds.

It's still only a prompt. "Stop anyway" works exactly as before.

## Technical Context

- **Motivation**: an actual support log came in at 8 seconds. It contained the recorder starting, the recorder stopping, and nothing in between: no tool run, no errors, not a single line about the reported problem. It sailed past the 5s threshold and cost an email round-trip to re-request.

- **Why it stays a prompt, not a block**: a short recording can be entirely valid. `App.kt` logs `UNCAUGHT EXCEPTION` through the same logging facade, and `FileLogger` calls `flush()` after every line, so a crash-on-launch reproduction is on disk within seconds. The threshold is a heuristic about user intent, not a claim about log content, and the code comment now says so.

- **Why not check log content instead**: warning when the session recorded no tool activity would be more precise, but the recorder has no notion of what ran during a session, so that's a feature rather than a threshold change. A naive line count would be unreliable since startup headers and background activity already produce noise.

- **Resume path**: when `recordingStartedAt` is 0 (session resumed after an app restart) elapsed time comes from the log dir's creation time, and an unreadable attribute read still returns `Long.MAX_VALUE` so it fails open and can't trap the user. The only newly-warned range is 5s through 9.999s; older sessions are unaffected.

- **Dialog copy unchanged**: "The recording was very short. Debug logs are recordings, not snapshots…" reads correctly at 10s, so no strings changed and no re-translation is needed.

## Testing

- New `RecorderModuleTest.MinimumDuration`, 7 cases: 8s caught, 9.999s caught, 10s passes through as `Stopped`, being caught leaves `isRecording == true` and never calls `Recorder.stop()`, plus three resumed-session cases (young dir caught, old dir stops, unreadable attributes fail open)
- The nested class unmocks `Files` in an `@AfterEach`; a leaked static mock there breaks JUnit's own `@TempDir` in every later test
- Replaced the magic `12345L` clock value with a named `RECORDING_START` constant
- `:app:testFossDebugUnitTest --tests RecorderModuleTest` 22/22
