### PR TITLE
General: Show what a cleanup freed, not what it left behind

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardCardFlows.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardCardFlows.kt
@@ -113,7 +113,8 @@ internal fun DashboardViewModel.buildTitleCardItem(): Flow<TitleDashboardCardIte
  * live data (applying exclusions, the uninstall watcher pruning corpses) left the card advertising a
  * stale freeable size while the hero summary, which reads live data, disagreed. This prefers a summary
  * rebuilt from live tool [data] whenever a scan is on screen, while preserving frozen "freed X"
- * outcomes from a completed delete/one-click (those are not scan results).
+ * outcomes from a completed delete/one-click (those are not scan results) — including when that
+ * cleanup left residue behind, which is the common case rather than the exception.
  */
 internal inline fun <D : Any> resolveScanCardResult(
     isInitializing: Boolean,
@@ -126,14 +127,20 @@ internal inline fun <D : Any> resolveScanCardResult(
 ): SDMTool.Task.Result? = when {
     // Tool state not resolved yet, or a task is running (the card shows progress): keep the frozen result.
     isInitializing || isWorking -> lastResult
+    // A completed delete/one-click: keep its "freed X" outcome even when residual data survives it. Some
+    // junk can never be cleared — a locked system app's cache (com.google.android.gms is the usual one)
+    // fails with LockedAppCacheException on every run — so a successful cleanup routinely leaves a small
+    // remainder. Rebuilding from that remainder would advertise it as a fresh "can be freed" scan and hide
+    // what the cleanup actually did: a run that freed 1 GB and left 5 MB behind reported "5 MB can be freed".
+    lastResult != null && !lastResultIsScan -> lastResult
     // Live scan data was invalidated without a new task (e.g. Deduplicator arbiter-config change): drop a
     // now-stale scan result so the card falls back to its description instead of advertising vanished space.
-    data == null -> lastResult.takeUnless { lastResultIsScan }
+    data == null -> null
     // A scan is on screen — data present, or the last result is a scan even if data is now empty after
     // excluding everything: rebuild the freeable summary from live data (empty data yields Success(0, 0)).
     hasData || lastResultIsScan -> reconstruct(data)
-    // Empty data with a non-scan result (a completed delete's "freed X"): keep that outcome.
-    else -> lastResult
+    // No result recorded and nothing in live data: fall back to the tool's description.
+    else -> null
 }
 
 internal fun DashboardViewModel.buildCorpseFinderItem(): Flow<ToolDashboardCardItem> =

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionEngine.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionEngine.kt
@@ -140,6 +140,36 @@ class DashboardMainActionEngine(
      */
     private val branchesInFlight = AtomicInteger(0)
 
+    /** The task instance each branch of the current run submitted, accumulated as they go. */
+    private val submittedTasks = MutableStateFlow(emptyMap<SDMTool.Type, SDMTool.Task>())
+
+    /** Latest completed task instance on record per cleanup tool; the baseline a settle snapshots. */
+    @Volatile
+    private var tasksOnRecord: Map<SDMTool.Type, SDMTool.Task> = emptyMap()
+
+    /**
+     * Which task executions produced [freedResult], published once by the last branch of a cleanup.
+     *
+     * The task manager keeps exactly one completed entry per tool and hands back the very [SDMTool.Task]
+     * instance it was given, so referential identity answers "is the result currently on record for this
+     * tool still mine?" without a shared clock, an id plumbed through the task manager's API, or a
+     * snapshot taken at a moment that may not have settled. That matters because every timestamp-based
+     * answer to this question is wrong somewhere: wall clocks move, the tools' `replayingShare` states
+     * may not have published by the settle edge, and the task manager runs work this engine never
+     * submitted (a tool's own delete screen, the scheduler, the one-tap shortcut).
+     *
+     * Null whenever no cleanup outcome is being vouched for, which makes the check fail closed: an
+     * unvouched freed result is simply not shown, and the hero falls back to live data.
+     *
+     * Per cleanup tool this holds the instances that may legitimately be on record afterwards: the one
+     * the cleanup submitted, and the one already there when it settled. The latter covers two cases at
+     * once — a tool the cleanup never touched (its record must stay put, so an in-tool delete there is
+     * still caught) and a tool whose own result has not been published yet (the previous record is
+     * still acceptable, so a cleanup is never briefly judged stale on its own work).
+     */
+    @Volatile
+    private var freedProvenance: Map<SDMTool.Type, List<SDMTool.Task>>? = null
+
     /**
      * The current main-action batch, published as one atomic value: a settle edge must never become
      * visible apart from the [id] and the arm it belongs to.
@@ -291,12 +321,16 @@ class DashboardMainActionEngine(
                 } else {
                     null
                 }
-                val settled = freed?.takeIf { taskState.isIdle && phase.isSettled }
-                // A cleanup that freed nothing outranks [freeable]: the data survived, so FREEABLE
-                // rebuilds identically and would bury the fact that the deletion ran at all.
-                val heroSummary =
-                    (settled?.takeIf { it.mode == HeroSummary.Mode.NOTHING_FREED } ?: freeable ?: settled)
-                        .takeIf { !isDiscarding }
+                val settled = freed
+                    ?.takeIf { taskState.isIdle && phase.isSettled }
+                    ?.takeIf { taskState.vouchedFor(freedProvenance) }
+                // A settled cleanup outranks [freeable] whatever it freed: whatever data survived it
+                // rebuilds into a FREEABLE card that buries the fact the deletion ran at all. That is
+                // obvious when it freed nothing, but it also holds when it freed plenty and left a
+                // remainder — some junk can never be cleared (a locked system app's cache), so a
+                // cleanup routinely leaves one behind, and reporting only that remainder reads as if
+                // the run found almost nothing.
+                val heroSummary = (settled ?: freeable).takeIf { !isDiscarding }
                 HeroState(
                     actionState = actionState,
                     activeTasks = taskState.tasks.filter { it.isActive }.size,
@@ -333,6 +367,16 @@ class DashboardMainActionEngine(
         .shareIn(scope, SharingStarted.Eagerly, replay = 1)
 
     init {
+        // Baseline for the provenance a settle snapshots: which task execution is currently on record
+        // for each cleanup tool. Tracked continuously because the branch that settles cannot read the
+        // task manager's state flow synchronously.
+        scope.launch {
+            taskManager.state.collect { state ->
+                tasksOnRecord = state.tasks
+                    .filter { it.isComplete && it.toolType in CLEANUP_TOOLS }
+                    .associate { it.toolType to it.task }
+            }
+        }
         // A freshly completed *scan* clears any stale "freed" result. We must only react to a
         // *strictly newer* scan time: TaskManager keeps one task per tool, so a delete prunes that
         // tool's scan result and would otherwise make this "change" to an older/absent scan time
@@ -500,6 +544,16 @@ class DashboardMainActionEngine(
                     val applied = freedResult.updateAndGet { current -> current ?: nothingFreed }
                     if (applied === nothingFreed) log(TAG, INFO) { "Cleanup finished without freeing anything." }
                 }
+                // Published by the last branch, so it covers every task this cleanup submitted. Set
+                // after the fold above and before [batchState] settles, i.e. the outcome is never
+                // visible without the provenance that vouches for it.
+                if (isCleanup && remaining == 0) {
+                    val submitted = submittedTasks.value
+                    val baseline = tasksOnRecord
+                    freedProvenance = CLEANUP_TOOLS.associateWith { type ->
+                        listOfNotNull(baseline[type], submitted[type])
+                    }
+                }
                 // Every branch publishes its own decrement, so this reaches 0 only after the last
                 // one has been through the block above — no matter which got there first.
                 batchState.update { it.copy(pending = (it.pending - 1).coerceAtLeast(0)) }
@@ -550,6 +604,11 @@ class DashboardMainActionEngine(
             // belongs to. Counters before the cleanup bookkeeping below.
             branchesInFlight.set(4) // CorpseFinder + SystemCleaner + AppCleaner + Deduplicator
             batchState.update { BatchState(id = it.id + 1, pending = 4, autoExpandArmed = true) }
+            submittedTasks.value = emptyMap()
+            // Dropped for scans too, not just cleanups: a scan that is cancelled or submits nothing
+            // never completes, so the successful-scan collector below would not clear [freedResult]
+            // and an un-vouched outcome would otherwise linger unchallenged.
+            freedProvenance = null
         }
         if (isCleanup) {
             freedResult.value = null
@@ -569,13 +628,10 @@ class DashboardMainActionEngine(
                 BottomBarState.Action.WORKING_CANCELABLE -> taskManager.cancel(SDMTool.Type.CORPSEFINDER)
                 BottomBarState.Action.WORKING -> {}
                 BottomBarState.Action.DELETE -> if (corpseFinder.state.first().data != null) {
-                    accumulateFreed(SDMTool.Type.CORPSEFINDER, submitTask(CorpseFinderDeleteTask()))
+                    runCleanup(SDMTool.Type.CORPSEFINDER, CorpseFinderDeleteTask())
                 }
 
-                BottomBarState.Action.ONECLICK -> accumulateFreed(
-                    SDMTool.Type.CORPSEFINDER,
-                    submitTask(CorpseFinderOneClickTask()),
-                )
+                BottomBarState.Action.ONECLICK -> runCleanup(SDMTool.Type.CORPSEFINDER, CorpseFinderOneClickTask())
             }
         }
         launchMainBranch(isTracked = startsRun, isCleanup = isCleanup) {
@@ -589,13 +645,10 @@ class DashboardMainActionEngine(
                 BottomBarState.Action.WORKING_CANCELABLE -> taskManager.cancel(SDMTool.Type.SYSTEMCLEANER)
                 BottomBarState.Action.WORKING -> {}
                 BottomBarState.Action.DELETE -> if (systemCleaner.state.first().data != null) {
-                    accumulateFreed(SDMTool.Type.SYSTEMCLEANER, submitTask(SystemCleanerProcessingTask()))
+                    runCleanup(SDMTool.Type.SYSTEMCLEANER, SystemCleanerProcessingTask())
                 }
 
-                BottomBarState.Action.ONECLICK -> accumulateFreed(
-                    SDMTool.Type.SYSTEMCLEANER,
-                    submitTask(SystemCleanerOneClickTask()),
-                )
+                BottomBarState.Action.ONECLICK -> runCleanup(SDMTool.Type.SYSTEMCLEANER, SystemCleanerOneClickTask())
             }
         }
         launchMainBranch(isTracked = startsRun, isCleanup = isCleanup) {
@@ -610,7 +663,7 @@ class DashboardMainActionEngine(
                 BottomBarState.Action.WORKING -> {}
                 BottomBarState.Action.DELETE -> {
                     if (appCleaner.state.first().data != null && upgradeRepo.isProForUi()) {
-                        accumulateFreed(SDMTool.Type.APPCLEANER, submitTask(AppCleanerProcessingTask()))
+                        runCleanup(SDMTool.Type.APPCLEANER, AppCleanerProcessingTask())
                     } else if (appCleaner.state.first().data.hasData && !freeToolsWillRun()) {
                         onUpgradeRequired()
                     }
@@ -618,7 +671,7 @@ class DashboardMainActionEngine(
 
                 BottomBarState.Action.ONECLICK -> {
                     if (upgradeRepo.isProForUi()) {
-                        accumulateFreed(SDMTool.Type.APPCLEANER, submitTask(AppCleanerOneClickTask()))
+                        runCleanup(SDMTool.Type.APPCLEANER, AppCleanerOneClickTask())
                     } else if (appCleaner.state.first().data.hasData && !freeToolsWillRun()) {
                         onUpgradeRequired()
                     }
@@ -636,18 +689,27 @@ class DashboardMainActionEngine(
                 BottomBarState.Action.WORKING_CANCELABLE -> taskManager.cancel(SDMTool.Type.DEDUPLICATOR)
                 BottomBarState.Action.WORKING -> {}
                 BottomBarState.Action.DELETE -> if (deduplicator.state.first().data != null && upgradeRepo.isProForUi()) {
-                    accumulateFreed(SDMTool.Type.DEDUPLICATOR, submitTask(DeduplicatorDeleteTask()))
+                    runCleanup(SDMTool.Type.DEDUPLICATOR, DeduplicatorDeleteTask())
                 }
 
                 BottomBarState.Action.ONECLICK -> {
                     if (upgradeRepo.isProForUi()) {
-                        accumulateFreed(SDMTool.Type.DEDUPLICATOR, submitTask(DeduplicatorOneClickTask()))
+                        runCleanup(SDMTool.Type.DEDUPLICATOR, DeduplicatorOneClickTask())
                     } else if (deduplicator.state.first().data.hasData && !freeToolsWillRun()) {
                         onUpgradeRequired()
                     }
                 }
             }
         }
+    }
+
+    /**
+     * Submits one branch's cleanup task and folds its result in. Records the task instance first so
+     * [freedProvenance] can later tell this run's results apart from anyone else's.
+     */
+    private suspend fun runCleanup(type: SDMTool.Type, task: SDMTool.Task) {
+        submittedTasks.update { it + (type to task) }
+        accumulateFreed(type, submitTask(task))
     }
 
     /** Folds a deletion/one-click result into [freedResult] so the hero can show what was freed. */
@@ -673,6 +735,14 @@ class DashboardMainActionEngine(
 
     companion object {
         private val TAG = logTag("Dashboard", "MainActionEngine")
+
+        /** The tools the main action cleans, i.e. the ones whose data the freed hero summarises. */
+        private val CLEANUP_TOOLS = setOf(
+            SDMTool.Type.CORPSEFINDER,
+            SDMTool.Type.SYSTEMCLEANER,
+            SDMTool.Type.APPCLEANER,
+            SDMTool.Type.DEDUPLICATOR,
+        )
 
         /** Hero-derivation retry backoff: 1s, doubling per consecutive failure, capped at a minute. */
         private const val HERO_STATE_RETRY_BASE_MS = 1_000L
@@ -780,6 +850,33 @@ class DashboardMainActionEngine(
  * Single source of truth for "what counts as a dashboard scan" — used both to revive a dismissed
  * hero on fresh scans and to stamp [HeroSummary.timestamp].
  */
+/**
+ * Whether a freed hero backed by [provenance] still describes the current state.
+ *
+ * The task manager keeps one completed entry per tool, so for every tool the cleanup touched, that
+ * entry should still be the execution the cleanup submitted. If it is not, something else has since
+ * cleaned that tool — its own delete screen, the scheduler, the one-tap shortcut — and the freed
+ * total no longer matches what is on disk.
+ *
+ * Identity, not equality: the task types are data classes, so an externally submitted
+ * `CorpseFinderDeleteTask()` is `==` to ours and would otherwise vouch for a run it had nothing to
+ * do with. Tools whose entry has not landed yet are skipped rather than treated as foreign, so a
+ * cleanup is never briefly judged stale on its own results.
+ *
+ * A null [provenance] means nothing is vouching for the outcome, and the caller falls back to live
+ * data — the check fails closed.
+ */
+internal fun TaskSubmitter.State.vouchedFor(provenance: Map<SDMTool.Type, List<SDMTool.Task>>?): Boolean {
+    if (provenance == null) return false
+    return provenance.all { (type, acceptable) ->
+        val onRecord = tasks.filter { it.isComplete && it.toolType == type }
+        // `all`, not `any`: completion publishes the new entry before the task manager prunes the old
+        // one, so for a moment both are on record. Requiring every entry to be acceptable means that
+        // window cannot vouch for a foreign result just because the batch's own is still sitting there.
+        onRecord.isEmpty() || onRecord.all { entry -> acceptable.any { it === entry.task } }
+    }
+}
+
 internal fun TaskSubmitter.State.latestScanTimes(): Map<SDMTool.Type, Instant> = tasks
     .filter { task ->
         task.isComplete && when (task.result) {

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionEngine.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionEngine.kt
@@ -168,7 +168,17 @@ class DashboardMainActionEngine(
      * still acceptable, so a cleanup is never briefly judged stale on its own work).
      */
     @Volatile
-    private var freedProvenance: Map<SDMTool.Type, List<SDMTool.Task>>? = null
+    private var freedProvenance: FreedProvenance? = null
+
+    /**
+     * [acceptable] spans every cleanup tool, including ones this run never touched — their record
+     * must stay put too, or an in-tool delete there would go unnoticed. [submitted] is the narrower
+     * set the run actually ran, which is what leftovers are counted against.
+     */
+    internal data class FreedProvenance(
+        val acceptable: Map<SDMTool.Type, List<SDMTool.Task>>,
+        val submitted: Set<SDMTool.Type>,
+    )
 
     /**
      * The current main-action batch, published as one atomic value: a settle edge must never become
@@ -321,9 +331,25 @@ class DashboardMainActionEngine(
                 } else {
                     null
                 }
+                val provenance = freedProvenance
                 val settled = freed
                     ?.takeIf { taskState.isIdle && phase.isSettled }
-                    ?.takeIf { taskState.vouchedFor(freedProvenance) }
+                    ?.takeIf { taskState.vouchedFor(provenance) }
+                    ?.let { outcome ->
+                        // What the run left behind, across the tools it submitted to. Recomputed per
+                        // emission from live data, so it tracks later exclusions and per-tool deletes.
+                        val residue = residueOf(
+                            corpse = corpseState.data,
+                            system = filterState.data,
+                            app = junkState.data,
+                            dedupe = dedupeState.data,
+                            tools = provenance?.submitted.orEmpty(),
+                        )
+                        outcome.copy(
+                            residueSize = residue?.size ?: 0L,
+                            residueCount = residue?.count ?: 0,
+                        )
+                    }
                 // A settled cleanup outranks [freeable] whatever it freed: whatever data survived it
                 // rebuilds into a FREEABLE card that buries the fact the deletion ran at all. That is
                 // obvious when it freed nothing, but it also holds when it freed plenty and left a
@@ -550,9 +576,12 @@ class DashboardMainActionEngine(
                 if (isCleanup && remaining == 0) {
                     val submitted = submittedTasks.value
                     val baseline = tasksOnRecord
-                    freedProvenance = CLEANUP_TOOLS.associateWith { type ->
-                        listOfNotNull(baseline[type], submitted[type])
-                    }
+                    freedProvenance = FreedProvenance(
+                        acceptable = CLEANUP_TOOLS.associateWith { type ->
+                            listOfNotNull(baseline[type], submitted[type])
+                        },
+                        submitted = submitted.keys,
+                    )
                 }
                 // Every branch publishes its own decrement, so this reaches 0 only after the last
                 // one has been through the block above — no matter which got there first.
@@ -842,14 +871,47 @@ class DashboardMainActionEngine(
                 timestamp = tools.mapNotNull { scanTimes[it.type] }.maxOrNull(),
             )
         }
+
+        /**
+         * What is still on the books for [tools], i.e. the tools a settled cleanup submitted to.
+         *
+         * Scoped to those rather than to everything with data: a tool the run never touched — one
+         * switched off in the one-click options — has leftovers that this cleanup neither freed nor
+         * failed to free, and counting them would make an otherwise complete run look partial.
+         *
+         * Read live rather than snapshotted at the settle edge on purpose. This only feeds a
+         * displayed number, so a tool state that has not published its post-delete data yet simply
+         * corrects itself on the next emission. (A snapshot would be wrong here for the same reason
+         * it is unusable as a staleness signal — see [vouchedFor].)
+         */
+        internal data class Residue(val size: Long, val count: Int)
+
+        internal fun residueOf(
+            corpse: CorpseFinder.Data?,
+            system: SystemCleaner.Data?,
+            app: AppCleaner.Data?,
+            dedupe: Deduplicator.Data?,
+            tools: Set<SDMTool.Type>,
+        ): Residue? {
+            val slices = buildList {
+                corpse?.takeIf { SDMTool.Type.CORPSEFINDER in tools && it.hasData }?.let {
+                    add(HeroSummary.ToolSlice(SDMTool.Type.CORPSEFINDER, it.totalSize, it.totalCount))
+                }
+                system?.takeIf { SDMTool.Type.SYSTEMCLEANER in tools && it.hasData }?.let {
+                    add(HeroSummary.ToolSlice(SDMTool.Type.SYSTEMCLEANER, it.totalSize, it.totalCount))
+                }
+                app?.takeIf { SDMTool.Type.APPCLEANER in tools && it.hasData }?.let {
+                    add(HeroSummary.ToolSlice(SDMTool.Type.APPCLEANER, it.totalSize, it.totalCount))
+                }
+                dedupe?.takeIf { SDMTool.Type.DEDUPLICATOR in tools && it.hasData }?.let {
+                    add(HeroSummary.ToolSlice(SDMTool.Type.DEDUPLICATOR, it.redundantSize, it.redundantCount))
+                }
+            }
+            return Residue(size = slices.sumOf { it.size }, count = slices.sumOf { it.count })
+        }
     }
 }
 
-/**
- * Latest successful scan completion per tool, considering only the hero/main-action scan results.
- * Single source of truth for "what counts as a dashboard scan" — used both to revive a dismissed
- * hero on fresh scans and to stamp [HeroSummary.timestamp].
- */
 /**
  * Whether a freed hero backed by [provenance] still describes the current state.
  *
@@ -866,9 +928,9 @@ class DashboardMainActionEngine(
  * A null [provenance] means nothing is vouching for the outcome, and the caller falls back to live
  * data — the check fails closed.
  */
-internal fun TaskSubmitter.State.vouchedFor(provenance: Map<SDMTool.Type, List<SDMTool.Task>>?): Boolean {
+internal fun TaskSubmitter.State.vouchedFor(provenance: DashboardMainActionEngine.FreedProvenance?): Boolean {
     if (provenance == null) return false
-    return provenance.all { (type, acceptable) ->
+    return provenance.acceptable.all { (type, acceptable) ->
         val onRecord = tasks.filter { it.isComplete && it.toolType == type }
         // `all`, not `any`: completion publishes the new entry before the task manager prunes the old
         // one, so for a moment both are on record. Requiring every entry to be acceptable means that
@@ -877,6 +939,11 @@ internal fun TaskSubmitter.State.vouchedFor(provenance: Map<SDMTool.Type, List<S
     }
 }
 
+/**
+ * Latest successful scan completion per tool, considering only the hero/main-action scan results.
+ * Single source of truth for "what counts as a dashboard scan" — used both to revive a dismissed
+ * hero on fresh scans and to stamp [HeroSummary.timestamp].
+ */
 internal fun TaskSubmitter.State.latestScanTimes(): Map<SDMTool.Type, Instant> = tasks
     .filter { task ->
         task.isComplete && when (task.result) {

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionState.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionState.kt
@@ -38,6 +38,18 @@ data class HeroSummary(
     val tools: List<ToolSlice>,
     /** When the displayed data came to be: latest scan of the included tools (FREEABLE) or deletion end (FREED). */
     val timestamp: Instant? = null,
+    /**
+     * What the cleanup left behind, across the tools it actually submitted to. 0 unless [mode] is
+     * [Mode.FREED].
+     *
+     * Deliberately reported as "left", not "couldn't be freed": leftovers usually *are* junk that
+     * resisted deletion (a locked system app's cache fails on every run), but the tools don't record
+     * which items were attempted and failed versus never attempted at all — AppCleaner skips
+     * inaccessible caches outright when that option is off. Naming a cause would assert something
+     * only AppCleaner can currently substantiate.
+     */
+    val residueSize: Long = 0L,
+    val residueCount: Int = 0,
 ) {
     /**
      * FREEABLE = "X will be freed" (post-scan); FREED = "X freed" (post-delete/one-click);

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardHeroCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardHeroCard.kt
@@ -177,6 +177,20 @@ private fun HeroBody(
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
                 )
+                // What the run left behind, when it left anything. Muted and under the caption: it
+                // qualifies the freed total rather than competing with it.
+                if (summary.residueSize > 0L) {
+                    Text(
+                        text = stringResource(
+                            R.string.dashboard_hero_freed_residue,
+                            ByteFormatter.formatSize(context, summary.residueSize).first,
+                        ),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = LocalContentColor.current.copy(alpha = MUTED_ALPHA),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
             }
             IconButton(
                 onClick = onDismiss,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,6 +15,10 @@
     </plurals>
     <string name="dashboard_hero_freeable_hint">Tap the button to free space, or a chip to check first.</string>
     <string name="dashboard_hero_freed_hint">Tap a chip for details.</string>
+    <!-- Shown under a "freed" summary when the cleanup left something behind. Says "left", not
+         "couldn't be freed": the tools don't record whether an item was attempted and failed or
+         skipped, so naming a cause would claim more than is known. %1$s is a size, e.g. "5.8 MB" -->
+    <string name="dashboard_hero_freed_residue">%1$s left</string>
     <!-- Shown when a cleanup ran to completion but could not free any space -->
     <string name="dashboard_hero_nothing_freed_headline">Nothing was freed</string>
     <string name="dashboard_hero_nothing_freed_caption">The cleanup finished, but none of the found data could be removed.</string>

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardCardResultTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardCardResultTest.kt
@@ -136,6 +136,14 @@ class DashboardCardResultTest : BaseTest() {
     }
 
     @Test
+    fun `surviving live data with a non-scan result still keeps the freed outcome`() {
+        // Regression for "the cleanup freed 1 GB but the card said 5.8 MB can be freed": a delete that
+        // leaves residue behind (a locked system app's cache can never be cleared, so this is the norm)
+        // must not have that residue rebuilt into a fresh freeable summary over its own "freed X".
+        resolve(hasData = true, lastResultIsScan = false) shouldBe frozen
+    }
+
+    @Test
     fun `invalidated null data drops a stale scan result`() {
         resolve(data = null, hasData = false, lastResultIsScan = true) shouldBe null
     }

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionEngineTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionEngineTest.kt
@@ -654,6 +654,44 @@ internal class DashboardMainActionEngineTest : BaseTest() {
     }
 
     @Test
+    fun `a cleanup that leaves data behind reports it alongside what it freed`() {
+        // The freed total alone reads as "job done" when it isn't. corpseData() survives the relaxed
+        // delete here, which is exactly the shape of junk that resisted removal.
+        val h = harness(corpseData = corpseData(count = 3))
+
+        try {
+            h.engine.mainAction(BottomBarState.Action.DELETE)
+
+            val hero = h.barState().heroSummary!!
+            hero.residueCount shouldBe 3
+        } finally {
+            h.engineScope.cancel()
+        }
+    }
+
+    @Test
+    fun `residue ignores tools the cleanup never submitted to`() {
+        // AppCleaner is switched off for this run, so its leftovers were neither freed nor failed to
+        // free. Counting them would make an otherwise complete run look like it fell short.
+        val h = harness(
+            corpseData = corpseData(count = 2),
+            appData = AppCleaner.Data(
+                junks = listOf(mockk(relaxed = true) { every { size } returns 999L; every { itemCount } returns 7 }),
+            ),
+            appCleanerOneClick = false,
+        )
+
+        try {
+            h.engine.mainAction(BottomBarState.Action.DELETE)
+
+            val hero = h.barState().heroSummary!!
+            hero.residueCount shouldBe 2
+        } finally {
+            h.engineScope.cancel()
+        }
+    }
+
+    @Test
     fun `a cleanup on a tool this run never touched still clears the freed summary`() {
         // The batch only submits to CorpseFinder here. An in-tool AppCleaner deletion afterwards
         // changes storage just as much, so scoping the check to the tools the batch happened to

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionEngineTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionEngineTest.kt
@@ -6,8 +6,10 @@ import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
 import eu.darken.sdmse.corpsefinder.core.Corpse
 import eu.darken.sdmse.corpsefinder.core.CorpseFinder
+import eu.darken.sdmse.corpsefinder.core.tasks.CorpseFinderDeleteTask
 import eu.darken.sdmse.corpsefinder.core.tasks.CorpseFinderScanTask
 import eu.darken.sdmse.deduplicator.core.Deduplicator
+import eu.darken.sdmse.deduplicator.core.Duplicate
 import eu.darken.sdmse.deduplicator.core.tasks.DeduplicatorDeleteTask
 import eu.darken.sdmse.main.core.GeneralSettings
 import eu.darken.sdmse.main.core.SDMTool
@@ -101,6 +103,28 @@ internal class DashboardMainActionEngineTest : BaseTest() {
                 task = mockk(relaxed = true),
                 completedAt = at,
                 result = CorpseFinderScanTask.Success(itemCount = 1, recoverableSpace = 1L),
+            ),
+        ),
+    )
+
+    /**
+     * A completed *delete* on record for [toolType]. [task] is the instance the task manager hands back;
+     * pass one the engine submitted to represent its own work, or leave it a fresh mock to represent a
+     * cleanup run somewhere else.
+     */
+    private fun completedDeleteState(
+        toolType: SDMTool.Type = SDMTool.Type.CORPSEFINDER,
+        // A real instance, not a mock: CorpseFinderDeleteTask is a data class, so this is `==` to the
+        // one a cleanup submits and only differs by identity. That is what pins the `===` check.
+        task: SDMTool.Task = CorpseFinderDeleteTask(),
+    ): TaskSubmitter.State = TaskSubmitter.State(
+        tasks = listOf(
+            TaskSubmitter.ManagedTask(
+                id = "delete-${System.identityHashCode(task)}",
+                toolType = toolType,
+                task = task,
+                completedAt = Instant.now(),
+                result = CorpseFinderDeleteTask.Success(affectedSpace = 1L, affectedPaths = emptySet()),
             ),
         ),
     )
@@ -590,6 +614,84 @@ internal class DashboardMainActionEngineTest : BaseTest() {
     }
 
     @Test
+    fun `a cleanup run outside the main action clears the stale freed summary`() {
+        // The hero's freed outcome used to survive any number of deletes made from a tool's own
+        // screen, the scheduler, or the one-tap shortcut, because none of those submit a scan and
+        // only a scan invalidated it. It would then report an older run's total over data that had
+        // changed underneath it.
+        val h = harness(corpseData = corpseData())
+
+        try {
+            h.engine.mainAction(BottomBarState.Action.DELETE)
+            h.barState().heroSummary?.mode shouldBe HeroSummary.Mode.NOTHING_FREED
+
+            // A delete this engine never submitted is now the CorpseFinder result on record.
+            h.taskState.value = completedDeleteState()
+
+            h.barState().heroSummary?.mode shouldBe HeroSummary.Mode.FREEABLE
+        } finally {
+            h.engineScope.cancel()
+        }
+    }
+
+    @Test
+    fun `a cleanups own task on record keeps its freed summary`() {
+        // The counterpart to the test above, and the reason the check is by identity rather than by
+        // time or by task type: the task classes are data classes, so an external CorpseFinderDeleteTask
+        // is `==` to the one this cleanup submitted. Only the instance tells them apart.
+        val h = harness(corpseData = corpseData())
+
+        try {
+            h.engine.mainAction(BottomBarState.Action.DELETE)
+            val ourTask = h.submittedTasks.single { it is CorpseFinderDeleteTask }
+
+            h.taskState.value = completedDeleteState(task = ourTask)
+
+            h.barState().heroSummary?.mode shouldBe HeroSummary.Mode.NOTHING_FREED
+        } finally {
+            h.engineScope.cancel()
+        }
+    }
+
+    @Test
+    fun `a cleanup on a tool this run never touched still clears the freed summary`() {
+        // The batch only submits to CorpseFinder here. An in-tool AppCleaner deletion afterwards
+        // changes storage just as much, so scoping the check to the tools the batch happened to
+        // touch would let the old total sit there unchallenged.
+        val h = harness(corpseData = corpseData())
+
+        try {
+            h.engine.mainAction(BottomBarState.Action.DELETE)
+            h.barState().heroSummary?.mode shouldBe HeroSummary.Mode.NOTHING_FREED
+
+            h.taskState.value = completedDeleteState(toolType = SDMTool.Type.APPCLEANER)
+
+            h.barState().heroSummary?.mode shouldBe HeroSummary.Mode.FREEABLE
+        } finally {
+            h.engineScope.cancel()
+        }
+    }
+
+    @Test
+    fun `a task from a tool the cleanup did not touch leaves the freed summary alone`() {
+        // The task manager carries every tool's work, including read-only jobs like the Analyzer's
+        // storage scan. Counting those would discard a valid cleanup outcome the moment the user
+        // opened the storage overview — an everyday action right after cleaning.
+        val h = harness(corpseData = corpseData())
+
+        try {
+            h.engine.mainAction(BottomBarState.Action.DELETE)
+            h.barState().heroSummary?.mode shouldBe HeroSummary.Mode.NOTHING_FREED
+
+            h.taskState.value = completedDeleteState(toolType = SDMTool.Type.ANALYZER)
+
+            h.barState().heroSummary?.mode shouldBe HeroSummary.Mode.NOTHING_FREED
+        } finally {
+            h.engineScope.cancel()
+        }
+    }
+
+    @Test
     fun `a newer scan still clears a stale freed summary`() {
         val h = harness(corpseData = corpseData())
 
@@ -617,10 +719,23 @@ internal class DashboardMainActionEngineTest : BaseTest() {
         h.engine.isHeroExpanded.value shouldBe false
     }
 
-    @Test
-    fun `freed hero includes the deduplicator removable-file count`() {
-        // Regression for the post-delete path: a deduplicator-only cleanup must report the deleted
-        // file count, not 0. The FREED itemCount used to exclude the deduplicator entirely.
+    /**
+     * Deduplicator-only post-delete setup. Bespoke rather than [harness] because this path needs both
+     * deduplicator data and a real delete result, neither of which [harness] models.
+     */
+    private class DedupeDeleteSetup(
+        val engine: DashboardMainActionEngine,
+        val engineScope: CoroutineScope,
+        val dedupState: MutableStateFlow<Deduplicator.State>,
+    ) {
+        fun hero(): HeroSummary = runBlocking {
+            engine.bottomBarState(listIsReady = MutableStateFlow(true))
+                .first { it?.heroSummary != null }!!
+                .heroSummary!!
+        }
+    }
+
+    private fun dedupeDeleteSetup(): DedupeDeleteSetup {
         val proInfo = mockk<UpgradeRepo.Info>(relaxed = true) {
             every { isPro } returns true
             every { isSettled } returns true
@@ -640,7 +755,19 @@ internal class DashboardMainActionEngineTest : BaseTest() {
         val appCleaner = mockk<AppCleaner>(relaxed = true) {
             every { state } returns MutableStateFlow(mockk(relaxed = true) { every { data } returns null })
         }
-        val dedupData = mockk<Deduplicator.Data>(relaxed = true)
+        // Real Data with a populated cluster, NOT a relaxed mock: `hasData` reads `clusters.isNotEmpty()`,
+        // and a relaxed mock answers that with an empty set — which makes the main action resolve to SCAN
+        // and no FREEABLE hero gets built at all, so a residue test against a mock would pass vacuously.
+        val dedupData = Deduplicator.Data(
+            clusters = setOf(
+                mockk<Duplicate.Cluster>(relaxed = true) {
+                    // Deliberately different from DEDUPE_FREED_SPACE so a headline sourced from the
+                    // residue instead of the cleanup is distinguishable, not just a mode mismatch.
+                    every { redundantSize } returns DEDUPE_RESIDUE_SPACE
+                    every { redundantCount } returns 1
+                },
+            ),
+        )
         val dedupState = MutableStateFlow(Deduplicator.State(data = dedupData, progress = null))
         val deduplicator = mockk<Deduplicator>(relaxed = true) {
             every { state } returns dedupState
@@ -653,7 +780,7 @@ internal class DashboardMainActionEngineTest : BaseTest() {
             every { enableDashboardOneClick } returns mockBool(false)
         }
         val deleteResult = DeduplicatorDeleteTask.Success(
-            affectedSpace = 51L * 1024 * 1024,
+            affectedSpace = DEDUPE_FREED_SPACE,
             affectedPaths = setOf(mockk<APath>(relaxed = true), mockk<APath>(relaxed = true)),
         )
 
@@ -672,25 +799,57 @@ internal class DashboardMainActionEngineTest : BaseTest() {
             onUpgradeRequired = {},
             onStateError = {},
         )
+        return DedupeDeleteSetup(engine = engine, engineScope = engineScope, dedupState = dedupState)
+    }
+
+    @Test
+    fun `freed hero includes the deduplicator removable-file count`() {
+        // Regression for the post-delete path: a deduplicator-only cleanup must report the deleted
+        // file count, not 0. The FREED itemCount used to exclude the deduplicator entirely.
+        val setup = dedupeDeleteSetup()
 
         try {
-            engine.mainAction(BottomBarState.Action.DELETE)
-            // The real delete prunes the now-empty data; mirror that so the FREED hero surfaces
-            // instead of a fresh FREEABLE one.
-            dedupState.value = Deduplicator.State(data = null, progress = null)
+            setup.engine.mainAction(BottomBarState.Action.DELETE)
+            // A delete that clears everything prunes the now-empty data.
+            setup.dedupState.value = Deduplicator.State(data = null, progress = null)
 
-            val hero = runBlocking {
-                engine.bottomBarState(listIsReady = MutableStateFlow(true))
-                    .first { it?.heroSummary != null }!!
-                    .heroSummary!!
-            }
+            val hero = setup.hero()
 
             hero.mode shouldBe HeroSummary.Mode.FREED
-            hero.totalSize shouldBe 51L * 1024 * 1024
+            hero.totalSize shouldBe DEDUPE_FREED_SPACE
             hero.itemCount shouldBe 2
             hero.tools.single { it.type == SDMTool.Type.DEDUPLICATOR }.count shouldBe 2
         } finally {
-            engineScope.cancel()
+            setup.engineScope.cancel()
         }
+    }
+
+    @Test
+    fun `a cleanup that freed something still reports it when residue survives`() {
+        // Regression for "the one-click freed 1 GB but the card said 5.8 MB can be freed": some junk
+        // can never be cleared — a locked system app's cache fails on every run — so a successful
+        // cleanup routinely leaves data behind. That residue must not rebuild into a FREEABLE hero
+        // that outranks the FREED one and makes the run read as if it found almost nothing.
+        val setup = dedupeDeleteSetup()
+
+        try {
+            setup.engine.mainAction(BottomBarState.Action.DELETE)
+            // Deliberately no pruning: the data survives the delete, as it does whenever anything was
+            // un-clearable. The main action therefore still resolves to DELETE and a FREEABLE hero is
+            // built from the leftovers — it just must not outrank the FREED one.
+
+            val hero = setup.hero()
+
+            hero.mode shouldBe HeroSummary.Mode.FREED
+            // The cleanup's total, not the surviving cluster's DEDUPE_RESIDUE_SPACE.
+            hero.totalSize shouldBe DEDUPE_FREED_SPACE
+        } finally {
+            setup.engineScope.cancel()
+        }
+    }
+
+    companion object {
+        private const val DEDUPE_FREED_SPACE = 51L * 1024 * 1024
+        private const val DEDUPE_RESIDUE_SPACE = 5L * 1024 * 1024
     }
 }

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardHeroCardTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardHeroCardTest.kt
@@ -2,9 +2,13 @@ package eu.darken.sdmse.main.ui.dashboard.bottom
 
 import android.content.Context
 import android.text.format.DateUtils
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertHasNoClickAction
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
@@ -75,9 +79,13 @@ class DashboardHeroCardTest : BaseComposeRobolectricTest() {
         composeRule.onNodeWithText("can be removed", substring = true).assertExists()
     }
 
-    private fun renderHero(hero: HeroSummary) {
+    private fun renderHero(hero: HeroSummary, fontScale: Float = 1f) {
         composeRule.setContent {
-            PreviewWrapper {
+            val base = LocalDensity.current
+            CompositionLocalProvider(
+                LocalDensity provides Density(density = base.density, fontScale = fontScale),
+            ) {
+                PreviewWrapper {
                 BottomBar(
                     state = deleteState(hero),
                     isVisible = true,
@@ -87,7 +95,8 @@ class DashboardHeroCardTest : BaseComposeRobolectricTest() {
                     onSettings = {},
                     onUpgrade = {},
                     onDismissHero = {},
-                )
+                    )
+                }
             }
         }
     }
@@ -185,6 +194,32 @@ class DashboardHeroCardTest : BaseComposeRobolectricTest() {
         )
         renderHero(freed)
         composeRule.onNodeWithText("left", substring = true).assertExists()
+    }
+
+    @Test
+    fun `the leftover line survives the worst case the card is sized for`() {
+        // The card body is a fixed height that only scales with the font scale, so every line
+        // competes for the same budget. Worst case: all four tools charted (chips wrap to a second
+        // row), a leftover line, and Android's largest accessibility font scale. If the budget is
+        // too tight, the last things laid out drop off the bottom — so assert the leftover line and
+        // the hint below it are actually on screen, not merely composed.
+        val freed = HeroSummary(
+            mode = HeroSummary.Mode.FREED,
+            totalSize = 2L * 1024 * 1024 * 1024,
+            itemCount = 8147,
+            tools = listOf(
+                HeroSummary.ToolSlice(SDMTool.Type.CORPSEFINDER, 129L * 1024, 12),
+                HeroSummary.ToolSlice(SDMTool.Type.SYSTEMCLEANER, 852L * 1024 * 1024, 51),
+                HeroSummary.ToolSlice(SDMTool.Type.APPCLEANER, 87L * 1024 * 1024, 498),
+                HeroSummary.ToolSlice(SDMTool.Type.DEDUPLICATOR, 32L * 1024 * 1024, 60),
+            ),
+            residueSize = 5L * 1024 * 1024,
+            residueCount = 2,
+        )
+        renderHero(freed, fontScale = 2f)
+
+        composeRule.onNodeWithText("left", substring = true).assertIsDisplayed()
+        composeRule.onNodeWithText(context.getString(R.string.dashboard_hero_freed_hint)).assertIsDisplayed()
     }
 
     @Test

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardHeroCardTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardHeroCardTest.kt
@@ -172,6 +172,37 @@ class DashboardHeroCardTest : BaseComposeRobolectricTest() {
     }
 
     @Test
+    fun `freed-mode hero renders what the cleanup left behind`() {
+        val freed = HeroSummary(
+            mode = HeroSummary.Mode.FREED,
+            totalSize = 1L * 1024 * 1024 * 1024,
+            itemCount = 12,
+            tools = listOf(
+                HeroSummary.ToolSlice(SDMTool.Type.CORPSEFINDER, 1L * 1024 * 1024 * 1024, 12),
+            ),
+            residueSize = 5L * 1024 * 1024,
+            residueCount = 2,
+        )
+        renderHero(freed)
+        composeRule.onNodeWithText("left", substring = true).assertExists()
+    }
+
+    @Test
+    fun `freed-mode hero omits the leftover line when nothing was left`() {
+        // The common outcome is a clean sweep; a "0 B left" line would be noise on every one of them.
+        val freed = HeroSummary(
+            mode = HeroSummary.Mode.FREED,
+            totalSize = 1L * 1024 * 1024 * 1024,
+            itemCount = 12,
+            tools = listOf(
+                HeroSummary.ToolSlice(SDMTool.Type.CORPSEFINDER, 1L * 1024 * 1024 * 1024, 12),
+            ),
+        )
+        renderHero(freed)
+        composeRule.onNodeWithText("left", substring = true).assertDoesNotExist()
+    }
+
+    @Test
     fun `nothing-freed hero states the outcome without printing a zero size`() {
         val nothingFreed = HeroSummary(
             mode = HeroSummary.Mode.NOTHING_FREED,


### PR DESCRIPTION
## What changed

After a cleanup, the dashboard told you what was **left over** instead of what it had just **freed**.

Some junk can never be removed — a locked system app's cache (Google Play Services is the usual one) fails on every single run — so a successful cleanup almost always leaves a small remainder behind. The dashboard treated that remainder as a fresh scan result. A run that freed 1.05 GB and left 5.8 MB behind reported "5.8 MB can be freed", in the same red "you should clean this" styling as before the cleanup. The cleanup looked like it had found almost nothing.

Now both the tool card and the summary card above the bottom bar report what the run actually freed, and the summary card carries a second line with what it left, so the outcome is legible at a glance:

```
1.05 GB freed
383 items removed
5.8 MB left
```

That freed summary stops being shown once it no longer describes reality — a cleanup started somewhere else (a tool's own screen, the scheduler, the one-tap shortcut) retires it and the dashboard goes back to showing live data.

## Technical Context

- **Root cause (tool card):** `resolveScanCardResult` rebuilt the summary from live data whenever `hasData` was true, discarding the frozen result of a completed delete/one-click. A completed non-scan result now outranks rebuilding. The two branches below it are unchanged in behaviour — anything reaching them has `lastResult == null` or a scan result, for which both previously resolved to `null` anyway.

- **Root cause (hero):** only a `NOTHING_FREED` outcome outranked the rebuilt FREEABLE summary, so a run that freed plenty and left a remainder lost to its own leftovers. PR #2593 fixed the freed-nothing variant of this; this generalizes it to any settled cleanup.

- **Staleness is answered by task identity, not time.** The task manager keeps one completed entry per tool and hands back the very `SDMTool.Task` instance it was given, so referential identity answers "is the result on record for this tool still mine?". Identity rather than equality is load-bearing: the task classes are data classes, so an externally submitted `CorpseFinderDeleteTask()` is `==` to ours and would vouch for a run it had nothing to do with. There is a test that fails if `===` becomes `==`.

- **Three earlier designs were rejected**, each after review found a reachable defect — a wall-clock settle edge (cross-generation TOCTOU, permanently stranded hero after a cancelled scan, external-task-during-batch hole), and a data fingerprint snapshotted at the settle edge (the tools' `replayingShare` states may not have published by then, so it could capture pre-delete data and intermittently reintroduce the original bug). The identity approach is the only one that is both timing-independent and clock-free.

- **The check is read-only and fails closed.** There is no clearing write anywhere: an unvouched result is simply not shown and the hero falls back to live data, rather than a stale total outliving the bookkeeping meant to retire it.

- **Provenance carries two different scopes on purpose.** `acceptable` spans every cleanup tool, including ones the run never touched — their record must stay put too, or an in-tool delete there would go unnoticed. `submitted` is the narrower set the run actually ran, and is what leftovers are counted against; counting a tool the run skipped would make a complete run look like it fell short. A test pins that distinction.

- **Leftovers are worded "left", not "couldn't be freed".** They usually *are* junk that resisted removal, but only AppCleaner records why (`AppJunk.acsError`); CorpseFinder, SystemCleaner and Deduplicator catch their write failures and log them without keeping them, and AppCleaner skips inaccessible caches entirely when that option is off. Naming a cause would assert something three of the four tools can't currently back up.

- **The leftover line went into a fixed-height budget.** The card body only scales with font scale, and was sized for two chip rows plus a two-line hint. There's now a test pinning the worst case (four tools charted so chips wrap, leftover line present, at 200% font scale), verified to bite by shrinking `DASHBOARD_HERO_CONTENT_HEIGHT` to 90dp.

### Review guidance

`DashboardMainActionEngine` is where the risk concentrates. `freedProvenance` is a plain `@Volatile` published once by the last branch of a cleanup, after the nothing-freed fold and before `batchState` settles; single-flight prevents a new batch starting before that publish, and a new run resets it before launching branches.

### Verification

1081 unit tests and `lintVitalFossRelease` pass. Every added test was checked for vacuity by disabling the mechanism it guards.

Manually verified on a Pixel 7a (Android 16), in dry-run mode, by forcing the residue case:
- Freed summary wins over surviving leftovers — hero read "3.5 kB freed / 36 items removed / 424 MB left" where the old precedence would have shown a red "424 MB can be freed".
- An out-of-band delete from a tool's own card retired the freed summary and fell back to live data.
- The leftover line renders unclipped at both 100% and 200% font scale.

### Known gaps

- The **tool card's** residue branch (delete succeeds *and* leaves residue) is covered by a unit test that fails without the fix, but was never reproduced on a device — the only configuration that produces it is no-root with the accessibility service active, which I could not get the test device to reproduce.
- The cross-generation races are closed **structurally** (atomic publish, id guard), not exercised by a test — the engine test harness runs on `Dispatchers.Unconfined`, which serializes away the production interleavings.
- Unrelated to this change, but noticed while testing: at 200% font scale the hero's footer timestamp sits tight against the card edge. The footer lives in `DASHBOARD_CUTOUT_DEPTH`, a constant that does not scale with font size, so it predates this PR.
