### PR TITLE
Fix: Stop the FOSS supporter date from resetting

### DIFF
--- a/app/src/foss/java/eu/darken/sdmse/common/upgrade/core/FossCache.kt
+++ b/app/src/foss/java/eu/darken/sdmse/common/upgrade/core/FossCache.kt
@@ -10,21 +10,24 @@ import kotlinx.serialization.json.Json
 import javax.inject.Inject
 import javax.inject.Singleton
 
+private val Context.fossCacheDataStore by preferencesDataStore(name = "settings_foss")
+
 @Singleton
-class FossCache @Inject constructor(
-    @ApplicationContext private val context: Context,
+class FossCache internal constructor(
+    // Test seam: the store is handed in so a test can supply its own DataStore instead of the
+    // Context-bound production delegate. Same pattern as BillingCache.
+    private val dataStore: DataStore<Preferences>,
     json: Json,
 ) {
 
-    private val Context.dataStore by preferencesDataStore(name = "settings_foss")
-
-    private val dataStore: DataStore<Preferences>
-        get() = context.dataStore
+    @Inject constructor(
+        @ApplicationContext context: Context,
+        json: Json,
+    ) : this(context.fossCacheDataStore, json)
 
     val upgrade = dataStore.createValue<FossUpgrade?>(
         key = "foss.upgrade",
         json = json,
         defaultValue = null,
     )
-
 }

--- a/app/src/foss/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoFoss.kt
+++ b/app/src/foss/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoFoss.kt
@@ -2,7 +2,7 @@ package eu.darken.sdmse.common.upgrade.core
 
 import eu.darken.sdmse.common.WebpageTool
 import eu.darken.sdmse.common.coroutine.AppScope
-import eu.darken.sdmse.common.datastore.value
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.flow.setupCommonEventHandlers
@@ -55,14 +55,30 @@ class UpgradeRepoFoss @Inject constructor(
         return webpageTool.open(upgradeSite)
     }
 
-    internal suspend fun persistUpgrade() {
+    /**
+     * Create-only-if-absent inside the store transaction: an existing record (and its upgradedAt —
+     * the user-visible "supporter since" date) is never replaced. The VM-level isPro guard alone is
+     * not race-free: it reads a shareIn replay that can be stale. Note the kept record is still
+     * re-encoded through the current schema — decoded fields are preserved exactly.
+     *
+     * @return true if a new record was created, false if an existing record was kept.
+     */
+    internal suspend fun persistUpgrade(): Boolean {
         log(TAG) { "persistUpgrade()" }
-        fossCache.upgrade.value(
-            FossUpgrade(
+        val updated = fossCache.upgrade.update { existing ->
+            existing ?: FossUpgrade(
                 upgradedAt = Instant.now(),
                 upgradeType = FossUpgrade.Type.GITHUB_SPONSORS,
             )
-        )
+        }
+        // Local binding: Updated.old is a public property from another module, so it can't smart cast.
+        val previous = updated.old
+        return if (previous == null) {
+            true
+        } else {
+            log(TAG, WARN) { "persistUpgrade(): Record already exists (upgradedAt=${previous.upgradedAt}), keeping it" }
+            false
+        }
     }
 
     override suspend fun refresh() {

--- a/app/src/foss/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/foss/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
@@ -139,8 +139,9 @@ class UpgradeViewModel @Inject constructor(
         val pressedAt = handle.remove<Long>(KEY_SPONSOR_PRESSED_AT) ?: return@launch
 
         // Evaluated before the duration: an already upgraded supporter (recurring donation button)
-        // has nothing left to unlock, and persisting again would rewrite their upgradedAt — visibly
-        // resetting the "supporter since" date the status screen shows them.
+        // has nothing left to unlock, so this fast path exists for the UX — return quietly, no
+        // redundant write attempt and no thanks toast for an unlock that already happened. Data
+        // integrity is not this guard's job: the repo's create-only transaction owns that.
         if (upgradeRepo.upgradeInfo.first().isPro) {
             log(TAG) { "checkSponsorReturn(): Already upgraded, staying quiet" }
             return@launch
@@ -154,8 +155,20 @@ class UpgradeViewModel @Inject constructor(
             snackbarEvents.tryEmit(R.string.upgrade_screen_sponsor_return_too_quick)
         } else {
             log(TAG) { "checkSponsorReturn(): Delay passed, persisting upgrade" }
-            upgradeRepo.persistUpgrade()
-            toastEvents.tryEmit(R.string.upgrade_screen_thanks_toast)
+            val created = try {
+                upgradeRepo.persistUpgrade()
+            } catch (e: Exception) {
+                // The marker was consumed above; a failed write must not eat the user's valid
+                // sponsor visit — restore it so the next return/resume can retry the unlock.
+                handle[KEY_SPONSOR_PRESSED_AT] = pressedAt
+                throw e
+            }
+            if (created) {
+                toastEvents.tryEmit(R.string.upgrade_screen_thanks_toast)
+            } else {
+                // The isPro fast-path read a stale emission; the transaction kept the existing record.
+                log(TAG) { "checkSponsorReturn(): Record already existed, staying quiet" }
+            }
         }
     }
 

--- a/app/src/testFoss/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoFossPersistTest.kt
+++ b/app/src/testFoss/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoFossPersistTest.kt
@@ -1,0 +1,82 @@
+package eu.darken.sdmse.common.upgrade.core
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.sdmse.common.datastore.value
+import eu.darken.sdmse.common.serialization.SerializationAppModule
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+import java.time.Instant
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class UpgradeRepoFossPersistTest : BaseTest() {
+
+    // One test method on purpose: FossCache is a @Singleton in production, and DataStore forbids
+    // two active instances on the same file — a second FossCache on `settings_foss` in this
+    // process would crash, not exercise anything real.
+    @Test
+    fun `persistUpgrade is create-only-if-absent`() = runTest {
+        // backgroundScope belongs to the test scope, capture it before switching dispatchers.
+        val repoScope = backgroundScope
+        // Real time on purpose: the real DataStore does its I/O off the test scheduler, so virtual
+        // time would let the assertions run past writes that haven't happened yet.
+        withContext(Dispatchers.IO) {
+            // Real DataStore, no mocks: the point is the transaction inside the store, a mocked
+            // DataStoreValue would only replay whatever this test told it to.
+            val cache = FossCache(ApplicationProvider.getApplicationContext<Context>(), SerializationAppModule().json())
+            val repo = UpgradeRepoFoss(
+                appScope = repoScope,
+                fossCache = cache,
+                webpageTool = mockk(),
+            )
+
+            cache.upgrade.value() shouldBe null
+
+            // An existing supporter: this record and its date are what the status screen shows.
+            cache.upgrade.value(
+                FossUpgrade(upgradedAt = Instant.EPOCH, upgradeType = FossUpgrade.Type.GITHUB_SPONSORS)
+            )
+
+            // The regression: a persist call on an existing record must keep it, not overwrite it
+            // with a fresh "supporter since" timestamp.
+            repo.persistUpgrade() shouldBe false
+            cache.upgrade.value() shouldBe FossUpgrade(
+                upgradedAt = Instant.EPOCH,
+                upgradeType = FossUpgrade.Type.GITHUB_SPONSORS,
+            )
+
+            repo.upgradeInfo.first().apply {
+                isPro shouldBe true
+                upgradedAt shouldBe Instant.EPOCH
+            }
+
+            cache.upgrade.value(null)
+
+            // Create path: a fresh unlock stamps "now", bracketed so the assertion doesn't depend
+            // on a fixed clock.
+            val before = Instant.now()
+            repo.persistUpgrade() shouldBe true
+            val after = Instant.now()
+
+            val created = cache.upgrade.value()!!
+            created.upgradeType shouldBe FossUpgrade.Type.GITHUB_SPONSORS
+            (created.upgradedAt >= before && created.upgradedAt <= after) shouldBe true
+
+            // Keep-branch proof via the returned Boolean: immune to a timestamp collision making
+            // the record comparison vacuously true.
+            repo.persistUpgrade() shouldBe false
+            cache.upgrade.value() shouldBe created
+        }
+    }
+}

--- a/app/src/testFoss/java/eu/darken/sdmse/common/upgrade/ui/FossUpgradeScreenHostTest.kt
+++ b/app/src/testFoss/java/eu/darken/sdmse/common/upgrade/ui/FossUpgradeScreenHostTest.kt
@@ -41,7 +41,7 @@ class FossUpgradeScreenHostTest : BaseTest() {
     private fun mockRepo(): UpgradeRepoFoss = mockk<UpgradeRepoFoss>(relaxed = true).apply {
         every { upgradeInfo } returns MutableStateFlow(UpgradeRepoFoss.Info())
         every { openGithubSponsorsPage() } returns true
-        coEvery { persistUpgrade() } answers { persisted++ }
+        coEvery { persistUpgrade() } answers { persisted++; true }
     }
 
     private fun buildVm(

--- a/app/src/testFoss/java/eu/darken/sdmse/common/upgrade/ui/FossUpgradeViewModelTest.kt
+++ b/app/src/testFoss/java/eu/darken/sdmse/common/upgrade/ui/FossUpgradeViewModelTest.kt
@@ -8,6 +8,8 @@ import eu.darken.sdmse.common.upgrade.core.FossUpgrade
 import eu.darken.sdmse.common.upgrade.core.UpgradeRepoFoss
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
@@ -33,6 +35,7 @@ import testhelpers.BaseTest
 import testhelpers.TestApplication
 import testhelpers.coroutine.TestDispatcherProvider
 import testhelpers.coroutine.runTest2
+import java.io.IOException
 import java.time.Duration
 import java.time.Instant
 
@@ -63,6 +66,9 @@ class FossUpgradeViewModelTest : BaseTest() {
     ): UpgradeRepoFoss = mockk<UpgradeRepoFoss>(relaxed = true).apply {
         every { upgradeInfo } returns info
         every { openGithubSponsorsPage() } returns true
+        // Explicit: a relaxed mock would answer the Boolean with false, i.e. "record already
+        // existed", silently turning every thanks-toast assertion below into a no-op.
+        coEvery { persistUpgrade() } returns true
     }
 
     private fun buildVm(
@@ -290,8 +296,8 @@ class FossUpgradeViewModelTest : BaseTest() {
     fun `a long sponsor visit by an already upgraded user does not re-persist the upgrade`() = runTest2(
         context = testDispatcher,
     ) {
-        // Persisting again would rewrite upgradedAt and visibly reset the "supporter since" date the
-        // status screen shows — and the thanks toast belongs to the unlock, which already happened.
+        // The store transaction keeps the existing record either way, so this is about the feedback:
+        // no redundant write attempt, and no thanks toast for an unlock that already happened.
         val repo = mockRepo(MutableStateFlow(upgradedInfo()))
         val vm = buildVm(repo = repo)
 
@@ -312,6 +318,64 @@ class FossUpgradeViewModelTest : BaseTest() {
         thanks.shouldBeEmpty()
         snackbarCollector.cancel()
         toastCollector.cancel()
+    }
+
+    @Test
+    fun `a sponsor return whose record already existed stays quiet`() = runTest2(context = testDispatcher) {
+        // The isPro fast path reads a shareIn replay that can be stale, so a supporter's return can
+        // get past it. Only the store transaction knows the record is already there — it keeps it and
+        // reports "not created", and there is no unlock to thank anyone for.
+        val repo = mockRepo()
+        coEvery { repo.persistUpgrade() } returns false
+        val vm = buildVm(repo = repo)
+
+        val nudges = mutableListOf<Int>()
+        val thanks = mutableListOf<Int>()
+        val snackbarCollector = launch(start = CoroutineStart.UNDISPATCHED) {
+            vm.snackbarEvents.collect { nudges.add(it) }
+        }
+        val toastCollector = launch(start = CoroutineStart.UNDISPATCHED) { vm.toastEvents.collect { thanks.add(it) } }
+
+        vm.goGithubSponsors()
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+        vm.checkSponsorReturn()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { repo.persistUpgrade() }
+        thanks.shouldBeEmpty()
+        nudges.shouldBeEmpty()
+        // Consumed: the visit was evaluated, there is nothing left to retry.
+        vm.hasPendingSponsorLaunch() shouldBe false
+
+        snackbarCollector.cancel()
+        toastCollector.cancel()
+    }
+
+    @Test
+    fun `a failed persist restores the pending sponsor launch`() = runTest2(context = testDispatcher) {
+        // The marker is consumed before the write. If the write then fails, dropping it would eat a
+        // valid sponsor visit for good — the next return/resume has to be able to retry the unlock.
+        val repo = mockRepo()
+        coEvery { repo.persistUpgrade() } throws IOException("write failed")
+        val vm = buildVm(repo = repo)
+
+        val thanks = mutableListOf<Int>()
+        val errors = mutableListOf<Throwable>()
+        val toastCollector = launch(start = CoroutineStart.UNDISPATCHED) { vm.toastEvents.collect { thanks.add(it) } }
+        val errorCollector = launch(start = CoroutineStart.UNDISPATCHED) { vm.errorEvents.collect { errors.add(it) } }
+
+        vm.goGithubSponsors()
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+        vm.checkSponsorReturn()
+        advanceUntilIdle()
+
+        vm.hasPendingSponsorLaunch() shouldBe true
+        thanks.shouldBeEmpty()
+        // Rethrown, not swallowed: the failure still travels the normal error path.
+        errors.single().shouldBeInstanceOf<IOException>()
+
+        toastCollector.cancel()
+        errorCollector.cancel()
     }
 
     @Test
@@ -356,7 +420,7 @@ class FossUpgradeViewModelTest : BaseTest() {
         context = testDispatcher,
     ) {
         // The status view's donate button is unarmed on purpose: a supporter browsing the sponsors
-        // page for a while must not run the unlock heuristic again and rewrite their upgrade date.
+        // page for a while must not run the unlock heuristic again — no write attempt, no toast.
         val repo = mockRepo(MutableStateFlow(upgradedInfo()))
         val vm = buildVm(repo = repo)
 


### PR DESCRIPTION
## What changed

FOSS version: an existing supporter's "supporter since" date is now protected by the storage layer itself and can no longer be reset. The previous protection checked the entitlement state before saving, which left a narrow timing window where a supporter returning from the GitHub Sponsors page could still get their date overwritten with "today". Two smaller fixes in the same flow: the "thanks for supporting" toast now only appears when supporter status was actually newly granted, and if saving the supporter status fails (e.g. storage trouble), the pending unlock is no longer lost — the next return to the app retries it instead of demanding another sponsor-page visit.

## Technical Context

- Root cause: `persistUpgrade()` unconditionally overwrote the `FossUpgrade` record. The VM-level already-Pro guard reads `upgradeInfo.first()` off a `shareIn(replay = 1)` flow, and a stale replayed emission can report `isPro=false` for an upgraded user — reachable because forced routes show the pitch (with the armed sponsor button) to Pro users.
- The persist is now a create-only-if-absent transaction inside `DataStoreValue.update {}` (atomic read-modify-write in `updateData`): an existing record is kept regardless of what the UI layer saw. It returns whether a record was created; the VM emits the thanks toast only on `true`. The isPro guard stays as a UX fast path — data integrity no longer depends on it.
- The pending-return marker (`KEY_SPONSOR_PRESSED_AT`) was consumed before the write; a thrown write failure now restores it before rethrowing (cancellation not swallowed), so a failed write can't permanently eat a valid sponsor visit.
- `FossCache` gains the same constructor-injected DataStore seam `BillingCache` has (file-level delegate + internal ctor); same file name and key, no migration.
- Review guidance: keeping an existing record still re-encodes it through the current schema — decoded fields are preserved exactly, which is the property the defect concerns. The new repo test is a single Robolectric method on purpose (DataStore forbids two active instances on `settings_foss` in one process); the create path is timestamp-bracketed and the keep branch is proven via the returned Boolean, immune to timestamp-collision vacuity. The VM tests stub `persistUpgrade()` explicitly — a relaxed mock's default `false` would silently vacate the toast assertions.
