### PR TITLE
Fix: Keep the supporter unlock and log recording reliable

### DIFF
--- a/app-common/src/main/java/eu/darken/sdmse/common/flow/DynamicStateFlow.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/flow/DynamicStateFlow.kt
@@ -5,7 +5,10 @@ import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.runBlocking
@@ -129,17 +132,27 @@ class DynamicStateFlow<T>(
      *
      * Any errors that occurred during [action] will be rethrown by this method.
      */
-    suspend fun updateBlocking(action: suspend T.() -> T): T {
+    suspend fun updateBlocking(action: suspend T.() -> T): T = coroutineScope {
         val update: Update<T> = Update(onModify = action)
+
+        // Subscribe BEFORE emitting: UNDISPATCHED runs the awaiter synchronously up to its first
+        // suspension inside first's collect, so the collector is registered on the shared flow
+        // before the update can be processed. Emitting first is a lost wakeup: a fast producer
+        // plus a reactive collector (RecorderModule reacts to every state with its own update)
+        // can process our update AND a successor before we subscribe, displacing our State from
+        // the replay-1 cache — the await then never completes.
+        val awaiter = async(start = CoroutineStart.UNDISPATCHED) {
+            internalFlow.first { it.updatedBy == update }
+        }
         updateActions.emit(update)
 
         lTag?.let { log(it, VERBOSE) { "Waiting for update." } }
-        val ourUpdate = internalFlow.first { it.updatedBy == update }
-        lTag?.let { log(it, VERBOSE) { "Finished waiting, got ${ourUpdate.value}" } }
+        val ourUpdate = awaiter.await()
+        lTag?.let { log(it, VERBOSE) { "Finished waiting, got $ourUpdate" } }
 
         ourUpdate.error?.let { throw it }
 
-        return ourUpdate.value
+        ourUpdate.value
     }
 
     private data class Update<T>(

--- a/app-common/src/test/java/eu/darken/sdmse/common/flow/DynamicStateFlowTest.kt
+++ b/app-common/src/test/java/eu/darken/sdmse/common/flow/DynamicStateFlowTest.kt
@@ -2,22 +2,30 @@ package eu.darken.sdmse.common.flow
 
 import eu.darken.sdmse.common.collections.mutate
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.runTest2
 import testhelpers.flow.test
 import java.io.IOException
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.concurrent.thread
 
 class DynamicStateFlowTest : BaseTest() {
@@ -274,6 +282,63 @@ class DynamicStateFlowTest : BaseTest() {
         testCollector.latestValues shouldBe listOf(2, 3, 0)
 
         testCollector.cancelAndJoin()
+    }
+
+    /**
+     * Pre-fix, [DynamicStateFlow.updateBlocking] emitted its update BEFORE subscribing to the
+     * shared flow. Under contention its awaited State could be displaced from the replay-1 cache
+     * by a successor update before the subscription existed, and the await then never completed
+     * (jstack-verified: the pre-fix suite wedged a CI runner until the 6h job timeout). This pins
+     * the subscribe-before-emit contract, and the timeout envelope turns any regression into a
+     * fast failure instead of another wedged runner.
+     */
+    @Test
+    fun `concurrent blocking updates survive a reactive collector`() {
+        val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+        try {
+            val hotData = DynamicStateFlow(
+                loggingTag = "tag",
+                parentScope = scope,
+                startValueProvider = { 0 },
+            )
+
+            // Mirrors RecorderModule: a collector that reacts to every state with an update of its
+            // own, keeping the producer busy between the other callers' updates. The echo updates
+            // are value-neutral so the final count stays exact, and capped so the echo terminates.
+            val echoes = AtomicInteger(0)
+            val subscribed = CompletableDeferred<Unit>()
+            scope.launch {
+                hotData.flow.collect { value ->
+                    subscribed.complete(Unit)
+                    if (value % 2 == 1 && echoes.getAndIncrement() < 100) {
+                        hotData.updateAsync { this + 0 }
+                    }
+                }
+            }
+
+            runBlocking {
+                withTimeout(20_000) {
+                    // The contention only means anything with the reactive collector actually
+                    // attached: its first received value proves the subscription exists.
+                    subscribed.await()
+
+                    val workers = (1..2).map {
+                        launch(Dispatchers.IO) {
+                            repeat(100) { hotData.updateBlocking { this + 1 } }
+                        }
+                    }
+                    workers.forEach { it.join() }
+                    workers.all { it.isCompleted } shouldBe true
+
+                    hotData.flow.first() shouldBe 200
+                    // Non-vacuity: without a single echo there was no successor update to displace
+                    // an awaited State, and the test would pass for the wrong reason.
+                    echoes.get() shouldBeGreaterThan 0
+                }
+            }
+        } finally {
+            scope.cancel()
+        }
     }
 
     @Test

--- a/app/src/foss/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoFoss.kt
+++ b/app/src/foss/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoFoss.kt
@@ -3,15 +3,20 @@ package eu.darken.sdmse.common.upgrade.core
 import eu.darken.sdmse.common.WebpageTool
 import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.flow.setupCommonEventHandlers
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.shareIn
 import java.time.Instant
 import java.util.UUID
@@ -31,20 +36,39 @@ class UpgradeRepoFoss @Inject constructor(
 
     private val refreshTrigger = MutableStateFlow(UUID.randomUUID())
 
-    override val upgradeInfo: Flow<UpgradeRepo.Info> = combine(
-        fossCache.upgrade.flow,
-        refreshTrigger
-    ) { data, _ ->
-        if (data == null) {
-            Info()
-        } else {
-            Info(
-                isPro = true,
-                upgradedAt = data.upgradedAt,
-                fossUpgradeType = data.upgradeType,
-            )
+    // Written only from the sharing coroutine (single collector) — no synchronization needed.
+    private var lastKnownInfo: Info? = null
+
+    override val upgradeInfo: Flow<UpgradeRepo.Info> = refreshTrigger
+        .flatMapLatest {
+            fossCache.upgrade.flow
+                .map { data ->
+                    if (data == null) {
+                        Info()
+                    } else {
+                        Info(
+                            isPro = true,
+                            upgradedAt = data.upgradedAt,
+                            fossUpgradeType = data.upgradeType,
+                        )
+                    }
+                }
+                .catch { e ->
+                    // A SharedFlow cannot fail: without this, a thrown cache read dies inside
+                    // shareIn's sharing coroutine and every collector hangs forever (VM state stuck
+                    // on Loading, checkSponsorReturn suspended mid-unlock). The catch sits INSIDE
+                    // flatMapLatest so the error completes only this inner subscription — refresh()
+                    // resubscribes the cache and recovery stays possible. Last-known preservation:
+                    // a late read failure must not revoke an entitlement we already saw; the error
+                    // rides on the previous Info instead. Contrast: gplay keeps a retryWhen loop
+                    // because billing re-settles in-place — the FOSS read is a local one-shot, and
+                    // refresh-driven resubscription IS the retry.
+                    if (e is CancellationException) throw e
+                    log(TAG, WARN) { "upgradeInfo read failed: ${e.asLog()}" }
+                    emit((lastKnownInfo ?: Info()).copy(error = e))
+                }
         }
-    }
+        .onEach { if (it.error == null) lastKnownInfo = it }
         .setupCommonEventHandlers(TAG) { "upgradeInfo" }
         .shareIn(appScope, SharingStarted.WhileSubscribed(3000L, 0L), replay = 1)
 
@@ -71,6 +95,9 @@ class UpgradeRepoFoss @Inject constructor(
                 upgradeType = FossUpgrade.Type.GITHUB_SPONSORS,
             )
         }
+        // A returned transaction proves the store is readable again: revive a possibly error-stuck
+        // inner flow so the record propagates to collectors still holding the error replay.
+        refresh()
         // Local binding: Updated.old is a public property from another module, so it can't smart cast.
         val previous = updated.old
         return if (previous == null) {

--- a/app/src/foss/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/foss/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
@@ -138,37 +138,44 @@ class UpgradeViewModel @Inject constructor(
     fun checkSponsorReturn() = launch {
         val pressedAt = handle.remove<Long>(KEY_SPONSOR_PRESSED_AT) ?: return@launch
 
-        // Evaluated before the duration: an already upgraded supporter (recurring donation button)
-        // has nothing left to unlock, so this fast path exists for the UX — return quietly, no
-        // redundant write attempt and no thanks toast for an unlock that already happened. Data
-        // integrity is not this guard's job: the repo's create-only transaction owns that.
-        if (upgradeRepo.upgradeInfo.first().isPro) {
-            log(TAG) { "checkSponsorReturn(): Already upgraded, staying quiet" }
-            return@launch
-        }
-
-        val elapsed = SystemClock.elapsedRealtime() - pressedAt
-        log(TAG) { "checkSponsorReturn(): elapsed=${elapsed}ms" }
-
-        if (elapsed < SPONSOR_DELAY_MS) {
-            log(TAG) { "checkSponsorReturn(): Too quick, showing snackbar" }
-            snackbarEvents.tryEmit(R.string.upgrade_screen_sponsor_return_too_quick)
-        } else {
-            log(TAG) { "checkSponsorReturn(): Delay passed, persisting upgrade" }
-            val created = try {
-                upgradeRepo.persistUpgrade()
-            } catch (e: Exception) {
-                // The marker was consumed above; a failed write must not eat the user's valid
-                // sponsor visit — restore it so the next return/resume can retry the unlock.
-                handle[KEY_SPONSOR_PRESSED_AT] = pressedAt
-                throw e
+        try {
+            // Evaluated before the duration: an already upgraded supporter (recurring donation button)
+            // has nothing left to unlock, so this fast path exists for the UX — return quietly, no
+            // redundant write attempt and no thanks toast for an unlock that already happened. Data
+            // integrity is not this guard's job: the repo's create-only transaction owns that.
+            if (upgradeRepo.upgradeInfo.first().isPro) {
+                log(TAG) { "checkSponsorReturn(): Already upgraded, staying quiet" }
+                return@launch
             }
-            if (created) {
-                toastEvents.tryEmit(R.string.upgrade_screen_thanks_toast)
+
+            val elapsed = SystemClock.elapsedRealtime() - pressedAt
+            log(TAG) { "checkSponsorReturn(): elapsed=${elapsed}ms" }
+
+            if (elapsed < SPONSOR_DELAY_MS) {
+                log(TAG) { "checkSponsorReturn(): Too quick, showing snackbar" }
+                snackbarEvents.tryEmit(R.string.upgrade_screen_sponsor_return_too_quick)
             } else {
-                // The isPro fast-path read a stale emission; the transaction kept the existing record.
-                log(TAG) { "checkSponsorReturn(): Record already existed, staying quiet" }
+                log(TAG) { "checkSponsorReturn(): Delay passed, persisting upgrade" }
+                val created = upgradeRepo.persistUpgrade()
+                if (created) {
+                    toastEvents.tryEmit(R.string.upgrade_screen_thanks_toast)
+                } else {
+                    // The isPro fast-path read a stale emission; the transaction kept the existing record.
+                    log(TAG) { "checkSponsorReturn(): Record already existed, staying quiet" }
+                }
             }
+        } catch (e: Exception) {
+            // The marker was consumed above; neither a failed entitlement read nor a failed write may
+            // eat the user's valid sponsor visit — restore it so the next return/resume can retry the
+            // unlock. Conditional: the user may have armed a NEWER launch while this attempt was
+            // suspended, and that one must survive. The contains-check has a small check-then-act
+            // window against a concurrent new arm; accepted — the create-only transaction owns data
+            // integrity, a wrong winner only changes which REAL visit's timestamp gates the unlock.
+            // Rethrow unconditionally: cancellation is not swallowed.
+            if (!handle.contains(KEY_SPONSOR_PRESSED_AT)) {
+                handle[KEY_SPONSOR_PRESSED_AT] = pressedAt
+            }
+            throw e
         }
     }
 

--- a/app/src/main/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModule.kt
@@ -69,6 +69,9 @@ class RecorderModule @Inject constructor(
     // advance the production bound. Same pattern as BillingCache.cacheTimeoutMs.
     internal var headerReadTimeoutMs: Long = HEADER_READ_TIMEOUT_MS
 
+    // Test seam: the resume fallback measures against the wall clock, which a test cannot move.
+    internal var wallClock: () -> Instant = { Instant.now() }
+
     private val triggerFile by lazy {
         try {
             File(context.getExternalFilesDir(null), FORCE_FILE)
@@ -128,7 +131,7 @@ class RecorderModule @Inject constructor(
                         copy(
                             recorder = newRecorder,
                             currentLogDir = logDir,
-                            recordingStartedAt = if (isResuming) 0L else SystemClock.elapsedRealtime(),
+                            recordingStartedAt = if (isResuming) null else SystemClock.elapsedRealtime(),
                         )
                     } else if (!shouldRecord && isRecording) {
                         log(TAG) { "Stopping log recorder for: $currentLogDir" }
@@ -142,7 +145,7 @@ class RecorderModule @Inject constructor(
                         copy(
                             recorder = null,
                             currentLogDir = null,
-                            recordingStartedAt = 0L,
+                            recordingStartedAt = null,
                         )
                     } else {
                         this
@@ -205,15 +208,28 @@ class RecorderModule @Inject constructor(
 
         val logDir = currentState.currentLogDir
         if (logDir != null) {
-            val elapsedMs = if (currentState.recordingStartedAt > 0) {
-                SystemClock.elapsedRealtime() - currentState.recordingStartedAt
+            // null discriminates a resumed session from a fresh one: elapsedRealtime() is a monotonic
+            // uptime that can legitimately BE 0 right after a boot, and a sentinel that a real
+            // timestamp can equal sends a fresh recording down the resume fallback.
+            val startedAt = currentState.recordingStartedAt
+            val elapsedMs = if (startedAt != null) {
+                SystemClock.elapsedRealtime() - startedAt
             } else {
                 // Fallback for resumed sessions — use file creation time
                 try {
                     val attrs = withContext(dispatcherProvider.IO) {
                         Files.readAttributes(logDir.toPath(), BasicFileAttributes::class.java)
                     }
-                    Duration.between(attrs.creationTime().toInstant(), Instant.now()).toMillis()
+                    val duration = Duration.between(attrs.creationTime().toInstant(), wallClock())
+                    if (duration.isNegative) {
+                        // The wall clock rolled back across the resume (NTP correction, manual change),
+                        // so the fallback can't measure this recording. Fail open like the read failure
+                        // below: a bogus "too short" prompt on a long recording is the worse outcome.
+                        log(TAG, WARN) { "Log dir creation time is in the future: ${attrs.creationTime()}" }
+                        Long.MAX_VALUE
+                    } else {
+                        duration.toMillis()
+                    }
                 } catch (e: Exception) {
                     log(TAG, WARN) { "Failed to read log dir creation time: ${e.asLog()}" }
                     Long.MAX_VALUE // Don't block stop on fallback failure
@@ -336,7 +352,7 @@ class RecorderModule @Inject constructor(
         val shouldRecord: Boolean = false,
         internal val recorder: Recorder? = null,
         val currentLogDir: File? = null,
-        val recordingStartedAt: Long = 0L,
+        internal val recordingStartedAt: Long? = null,
     ) {
         val isRecording: Boolean
             get() = recorder != null

--- a/app/src/test/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModuleTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModuleTest.kt
@@ -170,7 +170,7 @@ class RecorderModuleTest : BaseTest() {
 
             val state = module.state.first { it.isRecording }
             state.currentLogDir shouldBe existingDir
-            state.recordingStartedAt shouldBe 0L
+            state.recordingStartedAt shouldBe null
             coVerify { mockRecorder.start(existingDir) }
         }
 
@@ -274,7 +274,7 @@ class RecorderModuleTest : BaseTest() {
 
             val state = module.state.first { it.isRecording }
             state.currentLogDir shouldBe existingDir
-            state.recordingStartedAt shouldBe 0L
+            state.recordingStartedAt shouldBe null
         }
 
         @Test
@@ -325,7 +325,7 @@ class RecorderModuleTest : BaseTest() {
             advanceUntilIdle()
 
             // No elapsedRealtime baseline survives a restart, so the fallback is used instead
-            module.state.first { it.isRecording }.recordingStartedAt shouldBe 0L
+            module.state.first { it.isRecording }.recordingStartedAt shouldBe null
             return module
         }
 
@@ -405,6 +405,18 @@ class RecorderModuleTest : BaseTest() {
             every {
                 Files.readAttributes(any<Path>(), BasicFileAttributes::class.java)
             } throws IOException("no attributes for you")
+
+            module.requestStopRecorder().shouldBeInstanceOf<RecorderModule.StopResult.Stopped>()
+        }
+
+        @Test
+        fun `a clock rollback across a resume does not flag the recording as too short`() = runTest {
+            // The fallback measures a real log dir against the wall clock, and that clock can move
+            // backwards between the recording starting and the user stopping it (NTP correction,
+            // manual change). The resulting negative age must not be read as "just started" — that
+            // would nag a user who has been recording for hours to keep recording.
+            val module = startResumedRecording()
+            module.wallClock = { Instant.now().minus(Duration.ofHours(1)) }
 
             module.requestStopRecorder().shouldBeInstanceOf<RecorderModule.StopResult.Stopped>()
         }

--- a/app/src/testFoss/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoFossTest.kt
+++ b/app/src/testFoss/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoFossTest.kt
@@ -1,12 +1,32 @@
 package eu.darken.sdmse.common.upgrade.core
 
+import eu.darken.sdmse.common.datastore.DataStoreValue
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
+import java.io.IOException
 import java.time.Instant
+import java.util.concurrent.atomic.AtomicInteger
 
 class UpgradeRepoFossTest : BaseTest() {
 
@@ -19,6 +39,24 @@ class UpgradeRepoFossTest : BaseTest() {
     fun teardown() {
 
     }
+
+    private val record = FossUpgrade(
+        upgradedAt = Instant.EPOCH,
+        upgradeType = FossUpgrade.Type.GITHUB_SPONSORS,
+    )
+
+    private fun createUpgradeValue(cacheFlow: Flow<FossUpgrade?>) = mockk<DataStoreValue<FossUpgrade?>>().apply {
+        every { flow } returns cacheFlow
+        coEvery { update(any()) } returns DataStoreValue.Updated(old = null, new = record)
+    }
+
+    // Real dispatchers, not a test scheduler: the shareIn sharing coroutine and the collectors have
+    // to actually interleave here, and the whole point is that a failure settles instead of hanging.
+    private fun createRepo(appScope: CoroutineScope, upgradeValue: DataStoreValue<FossUpgrade?>) = UpgradeRepoFoss(
+        appScope = appScope,
+        fossCache = mockk<FossCache>().apply { every { upgrade } returns upgradeValue },
+        webpageTool = mockk(),
+    )
 
     @Test fun `test upgrade info pro status mapping`() {
         UpgradeRepoFoss.Info(
@@ -33,5 +71,83 @@ class UpgradeRepoFossTest : BaseTest() {
             isPro = true,
             upgradedAt = Instant.EPOCH,
         ).isPro shouldBe true
+    }
+
+    @Test fun `a failing cache read surfaces as a settled error Info instead of hanging`() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        try {
+            val repo = createRepo(scope, createUpgradeValue(flow { throw IOException("cache broken") }))
+
+            withTimeout(10_000) {
+                repo.upgradeInfo.first().apply {
+                    // Type and message: a bare non-null check would also pass on a swallow-and-wrap.
+                    error.shouldBeInstanceOf<IOException>().message shouldBe "cache broken"
+                    isPro shouldBe false
+                    // The UI must be able to render this: an unsettled error is an endless spinner.
+                    isSettled shouldBe true
+                }
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test fun `a late cache failure keeps the last known entitlement`() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        try {
+            val repo = createRepo(scope, createUpgradeValue(flow {
+                emit(record)
+                throw IOException("cache broken later")
+            }))
+
+            withTimeout(10_000) {
+                val infos = repo.upgradeInfo.take(2).toList()
+
+                infos[0].apply {
+                    isPro shouldBe true
+                    error shouldBe null
+                }
+                // The entitlement we already saw must survive the read failure - a revoked Pro
+                // status would kick a paying supporter back to the pitch.
+                infos[1].apply {
+                    isPro shouldBe true
+                    error.shouldBeInstanceOf<IOException>()
+                }
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test fun `a successful persist revives an error-stuck upgradeInfo`() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        try {
+            // First subscription fails, later ones read fine: the store recovered, but the shared
+            // flow is still replaying the error Info to everyone.
+            val subscriptions = AtomicInteger(0)
+            val upgradeValue = createUpgradeValue(flow {
+                if (subscriptions.getAndIncrement() == 0) throw IOException("cache broken")
+                emit(record)
+            })
+            val repo = createRepo(scope, upgradeValue)
+
+            val received = Channel<UpgradeRepo.Info>(Channel.UNLIMITED)
+            scope.launch { repo.upgradeInfo.collect { received.send(it) } }
+
+            withTimeout(10_000) {
+                received.receive().error.shouldBeInstanceOf<IOException>()
+
+                // No explicit refresh() from the test: persist has to do the reviving itself,
+                // otherwise the user's unlock never reaches the screen they are looking at.
+                repo.persistUpgrade() shouldBe true
+
+                received.receive().apply {
+                    isPro shouldBe true
+                    error shouldBe null
+                }
+            }
+        } finally {
+            scope.cancel()
+        }
     }
 }

--- a/app/src/testFoss/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoFossTest.kt
+++ b/app/src/testFoss/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoFossTest.kt
@@ -73,7 +73,7 @@ class UpgradeRepoFossTest : BaseTest() {
         ).isPro shouldBe true
     }
 
-    @Test fun `a failing cache read surfaces as a settled error Info instead of hanging`() = runBlocking {
+    @Test fun `a failing cache read surfaces as a settled error Info instead of hanging`(): Unit = runBlocking {
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
         try {
             val repo = createRepo(scope, createUpgradeValue(flow { throw IOException("cache broken") }))
@@ -92,7 +92,7 @@ class UpgradeRepoFossTest : BaseTest() {
         }
     }
 
-    @Test fun `a late cache failure keeps the last known entitlement`() = runBlocking {
+    @Test fun `a late cache failure keeps the last known entitlement`(): Unit = runBlocking {
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
         try {
             val repo = createRepo(scope, createUpgradeValue(flow {
@@ -119,7 +119,7 @@ class UpgradeRepoFossTest : BaseTest() {
         }
     }
 
-    @Test fun `a successful persist revives an error-stuck upgradeInfo`() = runBlocking {
+    @Test fun `a successful persist revives an error-stuck upgradeInfo`(): Unit = runBlocking {
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
         try {
             // First subscription fails, later ones read fine: the store recovered, but the shared

--- a/app/src/testFoss/java/eu/darken/sdmse/common/upgrade/ui/FossUpgradeViewModelTest.kt
+++ b/app/src/testFoss/java/eu/darken/sdmse/common/upgrade/ui/FossUpgradeViewModelTest.kt
@@ -1,5 +1,6 @@
 package eu.darken.sdmse.common.upgrade.ui
 
+import android.os.SystemClock
 import androidx.lifecycle.SavedStateHandle
 import eu.darken.sdmse.R
 import eu.darken.sdmse.common.navigation.NavEvent
@@ -14,11 +15,15 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -375,6 +380,103 @@ class FossUpgradeViewModelTest : BaseTest() {
         errors.single().shouldBeInstanceOf<IOException>()
 
         toastCollector.cancel()
+        errorCollector.cancel()
+    }
+
+    @Test
+    fun `a thrown entitlement read restores the pending sponsor launch`() = runTest2(context = testDispatcher) {
+        // The guard's entitlement read happens after the marker was consumed, so it can eat the
+        // sponsor visit just as a failed write can. Installed after arming: the ViewModel's own init
+        // collectors already hold the working flow, so the only failing read is the guard's.
+        val repo = mockRepo()
+        val vm = buildVm(repo = repo)
+
+        val thanks = mutableListOf<Int>()
+        val errors = mutableListOf<Throwable>()
+        val toastCollector = launch(start = CoroutineStart.UNDISPATCHED) { vm.toastEvents.collect { thanks.add(it) } }
+        val errorCollector = launch(start = CoroutineStart.UNDISPATCHED) { vm.errorEvents.collect { errors.add(it) } }
+
+        vm.goGithubSponsors()
+        advanceUntilIdle()
+        every { repo.upgradeInfo } returns flow { throw IOException("read failed") }
+
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+        vm.checkSponsorReturn()
+        advanceUntilIdle()
+
+        vm.hasPendingSponsorLaunch() shouldBe true
+        thanks.shouldBeEmpty()
+        coVerify(exactly = 0) { repo.persistUpgrade() }
+        errors.single().shouldBeInstanceOf<IOException>()
+
+        toastCollector.cancel()
+        errorCollector.cancel()
+    }
+
+    @Test
+    fun `a hung entitlement read releases the visit when the screen dies`() = runTest2(context = testDispatcher) {
+        // A read that never answers holds the check open with the marker already consumed. When the
+        // screen goes away the coroutine is cancelled — the catch's cancellation path has to hand
+        // the sponsor visit back, otherwise it is lost with nothing to retry from.
+        val repo = mockRepo()
+        val vm = buildVm(repo = repo)
+
+        vm.goGithubSponsors()
+        advanceUntilIdle()
+        every { repo.upgradeInfo } returns flow { awaitCancellation() }
+
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+        vm.checkSponsorReturn()
+        advanceUntilIdle()
+        // Suspended inside the guard's read, marker already consumed.
+        vm.hasPendingSponsorLaunch() shouldBe false
+
+        // The ViewModel going away: vmScope shares viewModelScope's job, so this is the cleared VM.
+        vm.vmScope.cancel()
+        advanceUntilIdle()
+
+        vm.hasPendingSponsorLaunch() shouldBe true
+        coVerify(exactly = 0) { repo.persistUpgrade() }
+    }
+
+    @Test
+    fun `a newer sponsor launch survives a failed older attempt`() = runTest2(context = testDispatcher) {
+        // The restore must not clobber a launch armed while the old attempt was still suspended:
+        // the newer visit is the one the user is actually waiting on.
+        val repo = mockRepo()
+        val gate = CompletableDeferred<Unit>()
+        coEvery { repo.persistUpgrade() } coAnswers {
+            gate.await()
+            throw IOException("write failed")
+        }
+        val handle = SavedStateHandle()
+        val vm = buildVm(repo = repo, handle = handle)
+
+        val errors = mutableListOf<Throwable>()
+        val errorCollector = launch(start = CoroutineStart.UNDISPATCHED) { vm.errorEvents.collect { errors.add(it) } }
+
+        vm.goGithubSponsors()
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+        vm.checkSponsorReturn()
+        advanceUntilIdle()
+        // Consumed and parked in the write.
+        vm.hasPendingSponsorLaunch() shouldBe false
+
+        // A second sponsor visit while the first attempt is still hanging.
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(30))
+        val newerPressedAt = SystemClock.elapsedRealtime()
+        vm.goGithubSponsors()
+        advanceUntilIdle()
+
+        gate.complete(Unit)
+        advanceUntilIdle()
+
+        vm.hasPendingSponsorLaunch() shouldBe true
+        // Mirrors the ViewModel's private KEY_SPONSOR_PRESSED_AT: the newer timestamp must still be
+        // the one stored, the failed older attempt must not have written its own back over it.
+        handle.get<Long>("sponsor_pressed_at") shouldBe newerPressedAt
+        errors.single().shouldBeInstanceOf<IOException>()
+
         errorCollector.cancel()
     }
 


### PR DESCRIPTION
## What changed

FOSS version: problems while checking or saving the supporter status can no longer swallow an unlock. If reading the status fails, the upgrade screen shows the error instead of loading forever, a user the app already knows is a supporter stays recognized, and a pending sponsor-page return is kept for a retry instead of being lost. A successful unlock now also reaches the screen immediately even if an earlier read had failed.

Both versions: the "that debug log looks too short" warning no longer misfires when the device clock changed while a resumed recording was running. Also fixed: a rare internal race that could hang state updates indefinitely (the same race that wedged a sibling project's CI runner for 6 hours before it was caught there).

## Technical Context

- `DynamicStateFlow.updateBlocking` emitted its update before subscribing to the replay-1 shared flow; a fast producer plus a reactive collector (exactly `RecorderModule`'s react-to-every-state pattern) could displace the awaited emission before the subscription existed, suspending the caller forever. Fixed with an `UNDISPATCHED` awaiter registered before the emit; the regression test uses a subscription barrier plus an echo non-vacuity assertion so the contention is guaranteed rather than probabilistic, and a 20s envelope so a regression fails fast instead of wedging a runner.
- FOSS `upgradeInfo` previously died inside `shareIn` when the cache read threw — a `SharedFlow` cannot fail, so every collector hung (the screen stuck on loading, `checkSponsorReturn` suspended with the marker already consumed). Read failures now surface as a settled error `Info`. The catch sits inside a `refreshTrigger.flatMapLatest` block so recovery stays possible: `refresh()` resubscribes the cache, and `persistUpgrade()` triggers one after a successful transaction, so an unlock propagates even to collectors still holding the error replay. A late failure attaches the error to the last known entitlement instead of revoking it. Entitlement gate semantics are deliberately unchanged — settled-error Infos follow the same documented contract the gplay flavor's already do.
- The pending sponsor-return marker restore now wraps everything after the marker consume (a thrown entitlement read could previously eat a valid visit; only the persist write was covered) and is conditional so a newer launch armed mid-failure survives. The small check-then-act window is documented as accepted — the create-only transaction owns data integrity.
- The recorder's in-band `0L` "resumed" sentinel became a nullable field: `elapsedRealtime()` is a monotonic uptime that can legitimately be 0 right after boot, which would have sent a fresh recording down the resume fallback. That fallback also measures wall-clock creation-time age, so a clock rollback across the resume produced a negative age that read as "too short" — it now fails open, with the negative check on the `Duration` so sub-millisecond rollbacks can't truncate to zero.
- Review guidance: the contention test runs real dispatchers deliberately (virtual time can't produce the race); the new repo tests likewise, with per-test cancelled scopes so the `shareIn` job never outlives a test. The 2-core `taskset --no-daemon` app-common run that reproduced the original hang class completes in ~1m.
