### PR TITLE
Fix: Stop endless loading when Shizuku or root fails to connect

### DIFF
--- a/app-common-adb/src/main/java/eu/darken/sdmse/common/adb/service/internal/AdbHostLauncher.kt
+++ b/app-common-adb/src/main/java/eu/darken/sdmse/common/adb/service/internal/AdbHostLauncher.kt
@@ -9,13 +9,14 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
-import eu.darken.sdmse.common.ipc.getInterface
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.channels.awaitClose
-import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
@@ -39,38 +40,36 @@ class AdbHostLauncher @Inject constructor(
     ): Flow<ConnectionWrapper<Service, Host>> = callbackFlow {
         if (serviceFactory.apiVersion() < 10) throw IllegalStateException("Shizuku API10+ required")
 
+        // Completed only once a connection was actually handed downstream, this is what the
+        // connect-watchdog below waits for.
+        val ready = CompletableDeferred<Unit>()
+
         val service = serviceFactory.create(
             hostClass = hostClass,
             options = options,
             onConnected = fun(binder: IBinder?) {
                 log(TAG) { "onServiceConnected(binder=$binder)" }
-
-                if (binder?.pingBinder() != true) {
-                    log(TAG) { "onServiceConnected(...) Invalid binder (ping failed)" }
-                    return
+                // Hop off Shizuku's callback thread (main): the handshake below does binder
+                // transactions, a wedged one would ANR and a DeadObjectException would crash the app
+                // uncaught. The producer scope runs on IO (see AdbServiceClient.parentScope).
+                this@callbackFlow.launch {
+                    try {
+                        log(TAG) { "Handshaking with the user service, options=$options" }
+                        val (userConnection, baseConnection) = serviceFactory.handshake<Service, Host>(
+                            binder = binder,
+                            serviceClass = serviceClass,
+                            options = options,
+                        )
+                        log(TAG) { "onServiceConnected(...) -> $userConnection" }
+                        send(ConnectionWrapper(userConnection, baseConnection))
+                        ready.complete(Unit)
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        log(TAG, WARN) { "User service handshake failed: ${e.asLog()}" }
+                        close(AdbException("Shizuku user service handshake failed", e))
+                    }
                 }
-
-                val baseConnection = try {
-                    AdbConnection.Stub.asInterface(binder)!!
-                } catch (e: Exception) {
-                    close(AdbException("Failed to get base connection", e))
-                    return
-                }
-
-                // Initial options, Shizuku has no init arguments through which these can be supplied earlier
-                log(TAG) { "Updating host options to $options" }
-                baseConnection.updateHostOptions(options)
-
-                val userConnection = try {
-                    baseConnection.userConnection.getInterface(serviceClass) as Service
-                } catch (e: Exception) {
-                    close(AdbException("Failed to get user connection (ADB)", e))
-                    return
-                }
-
-                log(TAG) { "onServiceConnected(...) -> $userConnection" }
-                @Suppress("UNCHECKED_CAST")
-                trySendBlocking(ConnectionWrapper(userConnection, baseConnection as Host))
             },
             onDisconnected = {
                 // Fires on an UNEXPECTED disconnect (Shizuku/host died outside our own unbind). Close the
@@ -83,6 +82,19 @@ class AdbHostLauncher @Inject constructor(
                 }
             },
         )
+
+        // Started BEFORE bind(): bindUserService() is itself a synchronous binder transaction that can
+        // wedge, and we can't interrupt that binder thread — but the watchdog still releases everyone
+        // waiting on this flow instead of leaving them hanging forever.
+        launch {
+            if (withTimeoutOrNull(CONNECT_TIMEOUT_MS) { ready.await() } == null) {
+                log(TAG, WARN) { "User service did not connect within ${CONNECT_TIMEOUT_MS}ms, closing" }
+                // Residual epsilon race: a send() completing concurrently with the deadline can tear
+                // down a connection that just came up. CompletableDeferred + withTimeoutOrNull narrows
+                // that window but can't close it; the next acquire re-binds.
+                close(AdbException("Shizuku user service did not connect within ${CONNECT_TIMEOUT_MS}ms"))
+            }
+        }
 
         var bound = false
         try {
@@ -120,5 +132,11 @@ class AdbHostLauncher @Inject constructor(
         // How long to wait for the Shizuku service to actually disconnect after unbinding before
         // giving up — bounded so teardown can't hang.
         private const val DISCONNECT_TIMEOUT_MS = 500L
+
+        // How long to wait for onServiceConnected after binding. Generous: a cold AdbHost start is a
+        // multi-second affair (see AdbServiceClient's keep-alive rationale). AppOpsNext uses 12s for
+        // the same probe against the same upstream Shizuku defect where bindUserService() returns but
+        // the connection callback never fires (MediaTek/HyperOS, Shizuku 13.6.0).
+        private const val CONNECT_TIMEOUT_MS = 15 * 1000L
     }
 }

--- a/app-common-adb/src/main/java/eu/darken/sdmse/common/adb/service/internal/AdbHostLauncherSeam.kt
+++ b/app-common-adb/src/main/java/eu/darken/sdmse/common/adb/service/internal/AdbHostLauncherSeam.kt
@@ -3,13 +3,16 @@ package eu.darken.sdmse.common.adb.service.internal
 import android.content.ComponentName
 import android.content.ServiceConnection
 import android.os.IBinder
+import android.os.IInterface
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import eu.darken.sdmse.common.BuildConfigWrap
+import eu.darken.sdmse.common.adb.AdbException
 import eu.darken.sdmse.common.adb.service.AdbHostOptions
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.ipc.getInterface
 import kotlinx.coroutines.CompletableDeferred
 import rikka.shizuku.Shizuku
 import rikka.shizuku.Shizuku.UserServiceArgs
@@ -42,6 +45,18 @@ interface ShizukuUserServiceFactory {
         onConnected: (IBinder?) -> Unit,
         onDisconnected: () -> Unit,
     ): ShizukuUserService
+
+    /**
+     * Post-connect handshake: validate the binder, wrap it, push the initial host options and resolve
+     * our user interface. Every failure is thrown to the caller (the launcher decides what to do with
+     * it), nothing is swallowed here. All of this does binder transactions, so the caller must not run
+     * it on Shizuku's main-thread callback.
+     */
+    fun <Service : IInterface, Host : AdbConnection> handshake(
+        binder: IBinder?,
+        serviceClass: KClass<Service>,
+        options: AdbHostOptions,
+    ): Pair<Service, Host>
 }
 
 internal class DefaultShizukuUserServiceFactory @Inject constructor() : ShizukuUserServiceFactory {
@@ -79,6 +94,25 @@ internal class DefaultShizukuUserServiceFactory @Inject constructor() : ShizukuU
                 disconnected.await()
             }
         }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <Service : IInterface, Host : AdbConnection> handshake(
+        binder: IBinder?,
+        serviceClass: KClass<Service>,
+        options: AdbHostOptions,
+    ): Pair<Service, Host> {
+        if (binder?.pingBinder() != true) throw AdbException("Invalid binder (ping failed)")
+
+        val baseConnection = AdbConnection.Stub.asInterface(binder)
+            ?: throw AdbException("Failed to get base connection")
+
+        // Initial options, Shizuku has no init arguments through which these can be supplied earlier
+        baseConnection.updateHostOptions(options)
+
+        val userConnection = baseConnection.userConnection.getInterface(serviceClass) as Service
+
+        return userConnection to (baseConnection as Host)
     }
 }
 

--- a/app-common-adb/src/main/java/eu/darken/sdmse/common/adb/shizuku/ShizukuWrapper.kt
+++ b/app-common-adb/src/main/java/eu/darken/sdmse/common/adb/shizuku/ShizukuWrapper.kt
@@ -118,8 +118,14 @@ class ShizukuWrapper @Inject constructor(
         val grantResult: Int,
     )
 
+    // Seams for the two Shizuku statics behind isGranted(). Mirrors the AdbHostLauncher seam: the
+    // Shizuku statics are untouchable in JVM unit tests, even via mockkStatic, because the class
+    // initializer builds a Handler on the main Looper. Overridden in tests, never in production.
+    internal var pingBinderAction: () -> Boolean = { Shizuku.pingBinder() }
+    internal var checkSelfPermissionAction: () -> Int = { Shizuku.checkSelfPermission() }
+
     private fun pingBinderSafe(): Boolean = try {
-        Shizuku.pingBinder()
+        pingBinderAction()
     } catch (e: NullPointerException) {
         // Upstream race: the binder can be nulled between Shizuku's null check and the ping.
         false
@@ -134,7 +140,7 @@ class ShizukuWrapper @Inject constructor(
             return@withContext null
         }
         val granted = try {
-            Shizuku.checkSelfPermission() == PackageManager.PERMISSION_GRANTED
+            checkSelfPermissionAction() == PackageManager.PERMISSION_GRANTED
         } catch (e: IllegalStateException) {
             log(TAG, WARN) { "isGranted(): $e" }
             null

--- a/app-common-adb/src/main/java/eu/darken/sdmse/common/adb/shizuku/ShizukuWrapper.kt
+++ b/app-common-adb/src/main/java/eu/darken/sdmse/common/adb/shizuku/ShizukuWrapper.kt
@@ -118,7 +118,21 @@ class ShizukuWrapper @Inject constructor(
         val grantResult: Int,
     )
 
+    private fun pingBinderSafe(): Boolean = try {
+        Shizuku.pingBinder()
+    } catch (e: NullPointerException) {
+        // Upstream race: the binder can be nulled between Shizuku's null check and the ping.
+        false
+    }
+
     suspend fun isGranted(): Boolean? = withContext(dispatcherProvider.IO) {
+        // Shizuku.checkSelfPermission() latches its granted state process-wide and never clears it on
+        // binder death, so without this gate it reports a stale `true` with no live binder behind it.
+        // null already means "cannot know" (see the ISE catch below), which covers this case too.
+        if (!pingBinderSafe()) {
+            log(TAG) { "isGranted()=null (binder not alive)" }
+            return@withContext null
+        }
         val granted = try {
             Shizuku.checkSelfPermission() == PackageManager.PERMISSION_GRANTED
         } catch (e: IllegalStateException) {

--- a/app-common-adb/src/test/java/eu/darken/sdmse/common/adb/service/internal/AdbHostLauncherTest.kt
+++ b/app-common-adb/src/test/java/eu/darken/sdmse/common/adb/service/internal/AdbHostLauncherTest.kt
@@ -94,7 +94,7 @@ class AdbHostLauncherTest {
         ): Pair<Service, Host> {
             events += "handshake"
             handshakeError?.let { throw it }
-            return mockk<AdbConnection>() as Service to mockk<AdbConnection>() as Host
+            return (mockk<AdbConnection>() as Service) to (mockk<AdbConnection>() as Host)
         }
     }
 

--- a/app-common-adb/src/test/java/eu/darken/sdmse/common/adb/service/internal/AdbHostLauncherTest.kt
+++ b/app-common-adb/src/test/java/eu/darken/sdmse/common/adb/service/internal/AdbHostLauncherTest.kt
@@ -1,20 +1,27 @@
 package eu.darken.sdmse.common.adb.service.internal
 
 import android.os.IBinder
+import android.os.IInterface
 import eu.darken.sdmse.common.adb.AdbException
 import eu.darken.sdmse.common.adb.service.AdbHostOptions
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainInOrder
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.mockk
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import kotlin.reflect.KClass
@@ -50,9 +57,13 @@ class AdbHostLauncherTest {
         val service: ShizukuUserService = FakeService(),
         val version: Int = 11,
         val bindError: Throwable? = null,
+        val handshakeError: Throwable? = null,
     ) : ShizukuUserServiceFactory {
         /** Captured so a test can simulate an unexpected onServiceDisconnected. */
         var disconnectCallback: (() -> Unit)? = null
+
+        /** Captured so a test can simulate onServiceConnected. */
+        var connectedCallback: ((IBinder?) -> Unit)? = null
 
         override fun apiVersion(): Int = version
         override fun <Host : AdbConnection> create(
@@ -61,6 +72,7 @@ class AdbHostLauncherTest {
             onConnected: (IBinder?) -> Unit,
             onDisconnected: () -> Unit,
         ): ShizukuUserService {
+            connectedCallback = onConnected
             disconnectCallback = onDisconnected
             return if (bindError != null) {
                 object : ShizukuUserService by service {
@@ -72,6 +84,17 @@ class AdbHostLauncherTest {
             } else {
                 service
             }
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <Service : IInterface, Host : AdbConnection> handshake(
+            binder: IBinder?,
+            serviceClass: KClass<Service>,
+            options: AdbHostOptions,
+        ): Pair<Service, Host> {
+            events += "handshake"
+            handshakeError?.let { throw it }
+            return mockk<AdbConnection>() as Service to mockk<AdbConnection>() as Host
         }
     }
 
@@ -97,7 +120,9 @@ class AdbHostLauncherTest {
         val l = launcher(FakeFactory(FakeService()))
 
         val job = launch { l.connect().collect { } }
-        advanceUntilIdle() // reach awaitClose (bound)
+        // runCurrent, not advanceUntilIdle: the fakes never connect, so advancing virtual time would
+        // trip the connect-watchdog instead of testing the cancellation teardown.
+        runCurrent() // reach awaitClose (bound)
         job.cancelAndJoin()
 
         events shouldContainInOrder listOf("bind", "unbind", "awaitDisconnect")
@@ -107,7 +132,7 @@ class AdbHostLauncherTest {
         val l = launcher(FakeFactory(FakeService(onUnbind = { throw IllegalStateException("unbind boom") })))
 
         val job = launch { l.connect().collect { } }
-        advanceUntilIdle()
+        runCurrent()
         job.cancelAndJoin() // must not throw
 
         events shouldContainInOrder listOf("bind", "unbind", "awaitDisconnect")
@@ -117,7 +142,7 @@ class AdbHostLauncherTest {
         val l = launcher(FakeFactory(FakeService(onAwait = { awaitCancellation() }))) // never disconnects
 
         val job = launch { l.connect().collect { } }
-        advanceUntilIdle()
+        runCurrent()
         job.cancelAndJoin() // runTest advances virtual time through the bounded await
 
         events shouldContainInOrder listOf("bind", "unbind", "awaitDisconnect")
@@ -135,7 +160,7 @@ class AdbHostLauncherTest {
                 caught.complete(e)
             }
         }
-        advanceUntilIdle() // reach awaitClose (bound)
+        runCurrent() // reach awaitClose (bound)
 
         factory.disconnectCallback!!.invoke() // simulate an unexpected onServiceDisconnected
         advanceUntilIdle()
@@ -152,5 +177,77 @@ class AdbHostLauncherTest {
 
         events shouldBe listOf("bind") // bound never became true -> no unbind
         events shouldNotContain "unbind"
+    }
+
+    @Test fun `a bind that never connects fails with AdbException after the timeout`() = runTest {
+        // Upstream Shizuku defect: bindUserService() returns fine but onServiceConnected never fires.
+        val l = launcher(FakeFactory(FakeService()))
+
+        val caught = CompletableDeferred<Throwable>()
+        val job = launch {
+            try {
+                l.connect().collect { }
+            } catch (e: Throwable) {
+                caught.complete(e)
+            }
+        }
+        advanceUntilIdle() // past the connect deadline
+
+        val error = caught.await()
+        error.shouldBeInstanceOf<AdbException>()
+        error.message!! shouldContain "did not connect"
+        events shouldContainInOrder listOf("bind", "unbind", "awaitDisconnect") // teardown still ran
+        job.cancelAndJoin()
+    }
+
+    @Test fun `a failing handshake closes the flow bounded`() = runTest {
+        val factory = FakeFactory(FakeService(), handshakeError = IllegalStateException("handshake boom"))
+        val l = launcher(factory)
+
+        val caught = CompletableDeferred<Throwable>()
+        val job = launch {
+            try {
+                l.connect().collect { }
+            } catch (e: Throwable) {
+                caught.complete(e)
+            }
+        }
+        runCurrent() // without this the callback isn't captured yet and this degrades to a timeout test
+
+        factory.connectedCallback.shouldNotBeNull().invoke(mockk<IBinder>())
+        advanceUntilIdle()
+
+        val error = caught.await()
+        error.shouldBeInstanceOf<AdbException>()
+        error.message!! shouldContain "handshake failed"
+        events shouldContainInOrder listOf("bind", "handshake", "unbind")
+        job.cancelAndJoin()
+    }
+
+    @Test fun `watchdog does not fire after a successful connect`() = runTest {
+        val factory = FakeFactory(FakeService())
+        val l = launcher(factory)
+
+        val emitted = mutableListOf<AdbHostLauncher.ConnectionWrapper<AdbConnection, AdbConnection>>()
+        val caught = CompletableDeferred<Throwable>()
+        val job = launch {
+            try {
+                l.connect().collect { emitted += it }
+            } catch (e: Throwable) {
+                caught.complete(e)
+            }
+        }
+        runCurrent()
+
+        factory.connectedCallback.shouldNotBeNull().invoke(mockk<IBinder>())
+        runCurrent()
+        emitted shouldHaveSize 1
+
+        advanceTimeBy(60 * 1000L) // way past the connect deadline
+        advanceUntilIdle()
+
+        caught.isCompleted shouldBe false // still connected, nothing was torn down
+        emitted shouldHaveSize 1
+        job.cancelAndJoin()
     }
 }

--- a/app-common-adb/src/test/java/eu/darken/sdmse/common/adb/shizuku/ShizukuWrapperTest.kt
+++ b/app-common-adb/src/test/java/eu/darken/sdmse/common/adb/shizuku/ShizukuWrapperTest.kt
@@ -7,13 +7,10 @@ import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkStatic
-import io.mockk.unmockkStatic
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import rikka.shizuku.Shizuku
 
 /**
  * Covers [ShizukuWrapper.getManagerPackage] — permission-based Shizuku detection that survives
@@ -78,44 +75,37 @@ class ShizukuWrapperTest {
 
     @Test
     fun `isGranted returns null when the binder is not alive`() = runTest {
-        mockkStatic(Shizuku::class)
-        try {
-            every { Shizuku.pingBinder() } returns false
+        val wrapper = wrapper().apply {
+            pingBinderAction = { false }
             // checkSelfPermission() latches process-wide and would still claim a grant here.
-            every { Shizuku.checkSelfPermission() } returns PackageManager.PERMISSION_GRANTED
-
-            wrapper().isGranted() shouldBe null
-        } finally {
-            unmockkStatic(Shizuku::class)
+            checkSelfPermissionAction = { PackageManager.PERMISSION_GRANTED }
         }
+
+        wrapper.isGranted() shouldBe null
     }
 
     @Test
     fun `isGranted returns null when pingBinder throws the null-race NPE`() = runTest {
-        mockkStatic(Shizuku::class)
-        try {
-            every { Shizuku.pingBinder() } throws NullPointerException("binder went away")
-            every { Shizuku.checkSelfPermission() } returns PackageManager.PERMISSION_GRANTED
-
-            wrapper().isGranted() shouldBe null
-        } finally {
-            unmockkStatic(Shizuku::class)
+        val wrapper = wrapper().apply {
+            pingBinderAction = { throw NullPointerException("binder went away") }
+            checkSelfPermissionAction = { PackageManager.PERMISSION_GRANTED }
         }
+
+        wrapper.isGranted() shouldBe null
     }
 
     @Test
     fun `isGranted reflects checkSelfPermission when the binder is alive`() = runTest {
-        mockkStatic(Shizuku::class)
-        try {
-            every { Shizuku.pingBinder() } returns true
+        val wrapper = wrapper().apply { pingBinderAction = { true } }
 
-            every { Shizuku.checkSelfPermission() } returns PackageManager.PERMISSION_GRANTED
-            wrapper().isGranted() shouldBe true
+        wrapper.checkSelfPermissionAction = { PackageManager.PERMISSION_GRANTED }
+        wrapper.isGranted() shouldBe true
 
-            every { Shizuku.checkSelfPermission() } returns PackageManager.PERMISSION_DENIED
-            wrapper().isGranted() shouldBe false
-        } finally {
-            unmockkStatic(Shizuku::class)
-        }
+        wrapper.checkSelfPermissionAction = { PackageManager.PERMISSION_DENIED }
+        wrapper.isGranted() shouldBe false
+
+        // Shizuku itself throws when it has no binder to ask, which also means "cannot know".
+        wrapper.checkSelfPermissionAction = { throw IllegalStateException("binder haven't been received") }
+        wrapper.isGranted() shouldBe null
     }
 }

--- a/app-common-adb/src/test/java/eu/darken/sdmse/common/adb/shizuku/ShizukuWrapperTest.kt
+++ b/app-common-adb/src/test/java/eu/darken/sdmse/common/adb/shizuku/ShizukuWrapperTest.kt
@@ -7,14 +7,18 @@ import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
+import rikka.shizuku.Shizuku
 
 /**
  * Covers [ShizukuWrapper.getManagerPackage] — permission-based Shizuku detection that survives
- * "Hide Shizuku from other apps" mode and forks that rename their package (issue #2405).
+ * "Hide Shizuku from other apps" mode and forks that rename their package (issue #2405) — and
+ * [ShizukuWrapper.isGranted]'s binder-liveness gate.
  */
 class ShizukuWrapperTest {
 
@@ -70,5 +74,48 @@ class ShizukuWrapperTest {
         every { packageManager.getPermissionInfo(any(), any<Int>()) } returns permissionInfo("")
 
         wrapper().getManagerPackage() shouldBe null
+    }
+
+    @Test
+    fun `isGranted returns null when the binder is not alive`() = runTest {
+        mockkStatic(Shizuku::class)
+        try {
+            every { Shizuku.pingBinder() } returns false
+            // checkSelfPermission() latches process-wide and would still claim a grant here.
+            every { Shizuku.checkSelfPermission() } returns PackageManager.PERMISSION_GRANTED
+
+            wrapper().isGranted() shouldBe null
+        } finally {
+            unmockkStatic(Shizuku::class)
+        }
+    }
+
+    @Test
+    fun `isGranted returns null when pingBinder throws the null-race NPE`() = runTest {
+        mockkStatic(Shizuku::class)
+        try {
+            every { Shizuku.pingBinder() } throws NullPointerException("binder went away")
+            every { Shizuku.checkSelfPermission() } returns PackageManager.PERMISSION_GRANTED
+
+            wrapper().isGranted() shouldBe null
+        } finally {
+            unmockkStatic(Shizuku::class)
+        }
+    }
+
+    @Test
+    fun `isGranted reflects checkSelfPermission when the binder is alive`() = runTest {
+        mockkStatic(Shizuku::class)
+        try {
+            every { Shizuku.pingBinder() } returns true
+
+            every { Shizuku.checkSelfPermission() } returns PackageManager.PERMISSION_GRANTED
+            wrapper().isGranted() shouldBe true
+
+            every { Shizuku.checkSelfPermission() } returns PackageManager.PERMISSION_DENIED
+            wrapper().isGranted() shouldBe false
+        } finally {
+            unmockkStatic(Shizuku::class)
+        }
     }
 }

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/adb/shizuku/ShizukuManagerTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/adb/shizuku/ShizukuManagerTest.kt
@@ -1,11 +1,13 @@
 package eu.darken.sdmse.common.adb.shizuku
 
 import eu.darken.sdmse.common.adb.AdbSettings
+import eu.darken.sdmse.common.adb.AdbUnavailableException
 import eu.darken.sdmse.common.adb.service.AdbServiceClient
 import eu.darken.sdmse.common.datastore.DataStoreValue
 import eu.darken.sdmse.common.pkgs.toPkgId
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
@@ -136,6 +138,25 @@ class ShizukuManagerTest : BaseTest() {
         val mgr = manager()
 
         runBlocking { mgr.getManagerId() } shouldBe forkPkg.toPkgId()
+    }
+
+    @Test fun `isOurServiceAvailable is false when isGranted is null`() {
+        // null = "cannot know", e.g. no live Shizuku binder. Probing the service would block on the
+        // host connection instead of failing fast.
+        coEvery { shizukuWrapper.isGranted() } returns null
+        val mgr = manager()
+
+        runBlocking { mgr.isOurServiceAvailable() } shouldBe false
+
+        coVerify(exactly = 0) { serviceClient.get() }
+    }
+
+    @Test fun `isOurServiceAvailable is false when the service client fails`() {
+        coEvery { shizukuWrapper.isGranted() } returns true
+        coEvery { serviceClient.get() } throws AdbUnavailableException("test")
+        val mgr = manager()
+
+        runBlocking { mgr.isOurServiceAvailable() } shouldBe false
     }
 
     @Test fun `managerIds always includes the reference package plus any detected fork`() {

--- a/app-common-root/src/main/java/eu/darken/sdmse/common/root/service/internal/RootHostLauncher.kt
+++ b/app-common-root/src/main/java/eu/darken/sdmse/common/root/service/internal/RootHostLauncher.kt
@@ -12,11 +12,13 @@ import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.ipc.getInterface
 import eu.darken.sdmse.common.root.RootException
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import java.util.UUID
@@ -53,6 +55,9 @@ class RootHostLauncher @Inject constructor(
 
         val pairingCode = UUID.randomUUID().toString()
         val connected = AtomicBoolean(false)
+        // Completed once the host actually bound, this is what the bind-watchdog below waits for.
+        // `connected` stays as-is, it drives the relocation-retry decision.
+        val ready = CompletableDeferred<Unit>()
 
         val ipcReceiver = receiverFactory.create(
             pairingCode = pairingCode,
@@ -69,6 +74,7 @@ class RootHostLauncher @Inject constructor(
                 log(iTag, INFO) { "onServiceConnected(...) got our interface: $userConnection" }
                 connected.set(true)
                 trySendBlocking(ConnectionWrapper(userConnection, connection))
+                ready.complete(Unit)
             },
             onDisconnect = { connection ->
                 log(iTag, INFO) { "onDisconnect(ipc=$connection), closing channel..." }
@@ -91,6 +97,15 @@ class RootHostLauncher @Inject constructor(
                 throw RootException("Failed to open root session.", e)
             }
 
+            // Started as soon as the su session is open (so a Magisk grant prompt doesn't eat the
+            // budget) and before the --mount-master call, which can park in execute() indefinitely.
+            launch {
+                if (withTimeoutOrNull(CONNECT_TIMEOUT_MS) { ready.await() } == null) {
+                    log(iTag, WARN) { "Root host did not bind within ${CONNECT_TIMEOUT_MS}ms, closing" }
+                    close(RootException("Root host did not bind within ${CONNECT_TIMEOUT_MS}ms"))
+                }
+            }
+
             if (useMountMaster) {
                 try {
                     log(iTag, INFO) { "Using --mount-master" }
@@ -98,6 +113,7 @@ class RootHostLauncher @Inject constructor(
                     log(iTag) { "--mount-master result: $result" }
                     if (!result.isSuccessful) throw IllegalStateException("--mount-master command was unsuccessful")
                 } catch (e: Exception) {
+                    if (e is CancellationException) throw e
                     log(iTag) { "Failed to use --mount-master" }
                 }
             }
@@ -188,5 +204,11 @@ class RootHostLauncher @Inject constructor(
         // How long to wait for a graceful session close (write `exit` + await) before forcefully
         // cancelling/killing the root session shell.
         private const val SESSION_CLOSE_TIMEOUT_MS = 10 * 1000L
+
+        // BACKSTOP above the host protocol's own self-timeouts, not a competing deadline: each exec
+        // attempt's host self-terminates after a 30s client-wait (RootIPC), so the worst legitimate
+        // case (both attempts losing the broadcast) is ~60s plus launch overhead. This only catches
+        // hosts that wedge before ever reaching that protocol wait.
+        private const val CONNECT_TIMEOUT_MS = 90 * 1000L
     }
 }

--- a/app-common-root/src/test/java/eu/darken/sdmse/common/root/service/internal/RootHostLauncherTest.kt
+++ b/app-common-root/src/test/java/eu/darken/sdmse/common/root/service/internal/RootHostLauncherTest.kt
@@ -8,14 +8,19 @@ import io.kotest.matchers.collections.shouldContainInOrder
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
@@ -101,9 +106,10 @@ class RootHostLauncherTest {
         commandFactory: RootLaunchCommandFactory = FakeCommandFactory(),
     ) = RootHostLauncher(sessionFactory, receiverFactory, commandFactory)
 
-    private fun RootHostLauncher.connect() = createConnection(
+    private fun RootHostLauncher.connect(useMountMaster: Boolean = false) = createConnection(
         serviceClass = RootConnection::class,
         hostClass = BaseRootHost::class,
+        useMountMaster = useMountMaster,
         options = RootHostOptions(),
     )
 
@@ -125,7 +131,9 @@ class RootHostLauncherTest {
         val l = launcher(FakeSessionFactory(session), FakeReceiverFactory(), cmds)
 
         val job = launch { l.connect().collect { } }
-        advanceUntilIdle() // reach the parked execute()
+        // runCurrent, not advanceUntilIdle: the host never binds here, so advancing virtual time
+        // would trip the bind-watchdog instead of testing the cancellation teardown.
+        runCurrent() // reach the parked execute()
         job.cancelAndJoin()
 
         events shouldContainInOrder listOf("connect", "execute", "release", "close")
@@ -141,7 +149,7 @@ class RootHostLauncherTest {
         val l = launcher(FakeSessionFactory(session), FakeReceiverFactory())
 
         val job = launch { l.connect().collect { } }
-        advanceUntilIdle()
+        runCurrent()
         job.cancelAndJoin()
 
         events shouldContainInOrder listOf("release", "close", "cancel")
@@ -155,7 +163,7 @@ class RootHostLauncherTest {
         val l = launcher(FakeSessionFactory(session), FakeReceiverFactory())
 
         val job = launch { l.connect().collect { } }
-        advanceUntilIdle()
+        runCurrent()
         job.cancelAndJoin() // runTest advances virtual time through the close timeout
 
         events shouldContainInOrder listOf("release", "close", "cancel")
@@ -173,7 +181,7 @@ class RootHostLauncherTest {
         )
 
         val job = launch { l.connect().collect { } }
-        advanceUntilIdle()
+        runCurrent()
         job.cancelAndJoin() // must not throw despite every cleanup step throwing
 
         events shouldContainInOrder listOf("release", "close", "cancel")
@@ -209,6 +217,80 @@ class RootHostLauncherTest {
 
         cmds.relocations shouldBe listOf(false) // connected -> relocation retry skipped
         emitted shouldHaveSize 1 // factory-routed callback sent the connection into the flow
+    }
+
+    @Test fun `a host that neither binds nor exits is closed by the watchdog`() = runTest {
+        // The host process wedges before it ever reaches the protocol's own self-timeout, so the
+        // exec never returns and no connection is delivered.
+        val session = FakeSession(onExecute = { awaitCancellation() })
+        val l = launcher(FakeSessionFactory(session), FakeReceiverFactory())
+
+        val caught = CompletableDeferred<Throwable>()
+        val job = launch {
+            try {
+                l.connect().collect { }
+            } catch (e: Throwable) {
+                caught.complete(e)
+            }
+        }
+        advanceUntilIdle() // past the bind deadline
+
+        val error = caught.await()
+        error.shouldBeInstanceOf<RootException>()
+        error.message!! shouldContain "did not bind within"
+        events shouldContainInOrder listOf("connect", "execute", "release", "close") // teardown ran
+        job.cancelAndJoin()
+    }
+
+    @Test fun `a hanging mount-master exec is bounded by the watchdog`() = runTest {
+        val session = FakeSession(onExecute = { cmd ->
+            if (cmd.instructions.any { it.contains("--mount-master") }) awaitCancellation() else ok(cmd)
+        })
+        val l = launcher(FakeSessionFactory(session), FakeReceiverFactory())
+
+        val caught = CompletableDeferred<Throwable>()
+        val job = launch {
+            try {
+                l.connect(useMountMaster = true).collect { }
+            } catch (e: Throwable) {
+                caught.complete(e)
+            }
+        }
+        advanceUntilIdle()
+
+        val error = caught.await()
+        error.shouldBeInstanceOf<RootException>()
+        error.message!! shouldContain "did not bind within"
+        events shouldContainInOrder listOf("connect", "execute", "release", "close") // teardown ran
+        job.cancelAndJoin()
+    }
+
+    @Test fun `a slow connect within the protocol window is not killed`() = runTest {
+        // The watchdog is a backstop ABOVE the host protocol's own 30s-per-attempt self-timeout,
+        // a late-but-legitimate bind must survive it.
+        val receiverFactory = FakeReceiverFactory()
+        val connection = mockk<RootConnection> { every { userConnection } returns mockk(relaxed = true) }
+        val session = FakeSession(onExecute = {
+            delay(40 * 1000L)
+            receiverFactory.receiver.deliverConnect?.invoke(connection)
+            ok(it)
+        })
+        val l = launcher(FakeSessionFactory(session), receiverFactory)
+
+        val emitted = mutableListOf<RootHostLauncher.ConnectionWrapper<RootConnection>>()
+        val caught = CompletableDeferred<Throwable>()
+        val job = launch {
+            try {
+                l.connect().collect { emitted += it }
+            } catch (e: Throwable) {
+                caught.complete(e)
+            }
+        }
+        advanceUntilIdle()
+
+        caught.isCompleted shouldBe false
+        emitted shouldHaveSize 1
+        job.cancelAndJoin()
     }
 
     companion object {


### PR DESCRIPTION
## What changed

When Shizuku (or root) accepts the connection request but never answers — which happens on many MediaTek/HyperOS devices because of a bug in Shizuku v13.6.0 — the setup screen used to show a loading spinner forever, with no error and nothing useful in the debug log. Now the app gives up after a short wait and shows the regular "not available" state instead, and the debug log states clearly what happened.

Refs #2603, Refs #1816

## Technical Context

- Root cause of the hang: `Shizuku.bindUserService()` returns normally but `onServiceConnected` never fires (upstream RikkaApps/Shizuku#1171; the fix RikkaApps/Shizuku-API#299 is unmerged and OG Shizuku is unmaintained). Nothing on our probe path (`ShizukuSetupModule` → `ShizukuManager.isOurServiceAvailable()` → `AdbServiceClient.get()`) had a timeout, so the SharedResource generation never became ready and the setup card stayed on Loading indefinitely.
- Shizuku side: 15s connect watchdog in `AdbHostLauncher` (a `CompletableDeferred` raced via `withTimeoutOrNull`), started before `bind()` so even a wedged synchronous bind transaction releases waiting consumers. The connect handshake moved off Shizuku's main-thread callback into the IO producer scope behind the existing test seam — previously `updateHostOptions()` ran uncovered on the main thread, so a host dying mid-handshake was an uncaught `DeadObjectException` crash, and a wedged transaction an ANR.
- Root side: 90s backstop deliberately above the root protocol's own 30s-per-attempt self-timeout (`RootIPC`'s client-wait makes a broadcast-lost host exit on its own), so the watchdog only catches hosts that wedge before reaching the protocol wait and can never suppress the relocation retry. The mount-master exec is now inside the watchdog window, and its catch rethrows `CancellationException` instead of swallowing it.
- `ShizukuWrapper.isGranted()` now returns `null` when the binder is not alive: `Shizuku.checkSelfPermission()` latches its granted state process-wide and never clears it on binder death, so debug logs used to show a misleading `isGranted()=true` against a dead binder — which is exactly what derailed triage in #2603.
- Review guidance: the residual race between a completing handshake and the deadline is documented in-code (a just-established connection can be torn down at the boundary; the next acquire re-binds). The test migrations from `advanceUntilIdle()` to `runCurrent()` are deliberate — the watchdog is a scheduled task the old idiom would trip.
- Smoke-tested on a Pixel 7a (Android 16, rooted, real Shizuku): Shizuku setup completes ~1.8s after the grant, root in ~2.0s — no false timeouts on healthy devices.
