### PR TITLE
Fix: Crash when the installed app list couldn't be refreshed

### DIFF
--- a/app-common-pkgs/src/main/java/eu/darken/sdmse/common/pkgs/PkgRepo.kt
+++ b/app-common-pkgs/src/main/java/eu/darken/sdmse/common/pkgs/PkgRepo.kt
@@ -8,6 +8,7 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.DEBUG
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
@@ -21,6 +22,7 @@ import eu.darken.sdmse.common.sharedresource.closeAll
 import eu.darken.sdmse.common.shell.ShellOps
 import eu.darken.sdmse.common.user.UserHandle2
 import eu.darken.sdmse.common.user.UserManager2
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -82,7 +84,15 @@ class PkgRepo @Inject constructor(
             .onEach {
                 log(TAG, INFO) { "Refreshing package cache due to event: $it" }
                 Bugs.leaveBreadCrumb("Installed package data has changed")
-                refresh()
+                try {
+                    refresh()
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    // The failure is stored in PkgData.error and surfaces on the next pkgs access,
+                    // rethrowing here would crash the app via the handler-less appScope.
+                    log(TAG, WARN) { "Package cache refresh failed: ${e.asLog()}" }
+                }
             }
             .launchIn(appScope)
     }


### PR DESCRIPTION
## What changed

Fixed a crash where SD Maid could suddenly close on its own. It happened when Android notified SD Maid that an app was installed or removed, and reloading the list of installed apps then failed — for example on devices that hide the app list from SD Maid, or while the system itself was briefly unstable. Instead of crashing, SD Maid now shows its normal error message the next time a tool needs the app list.

## Technical Context

- Root cause: `PkgRepo`'s init block refreshes the package cache on every `PackageEventListener` event via `launchIn(appScope)`. `refresh()` ends with `return after.pkgs`, which rethrows any error stored in `PkgData.error` — and `appScope` is a bare `SupervisorJob()` with no `CoroutineExceptionHandler`, so the rethrow killed the process. The diff shows the catch; this rethrow-into-an-unsupervised-scope chain is what caused the crash.
- Matches Play vitals: two `InvalidPkgInventoryException` crash clusters (72 reports, ~44 distinct users over 28 days), plus the `DeadSystemException` clusters from `PkgOps.queryPkgs` likely ride the same path whenever they hit during a background refresh — this fix absorbs those occurrences too.
- No new error surfacing was needed: the error stays in `PkgData.error`, tool tasks already fail with the localized dialog (`InvalidPkgInventoryException` implements `HasLocalizedError`), and the existing setup card covers the persistent faked-inventory case.
- Considered and rejected: keeping the last good cache when a background refresh fails. A stale cache that's missing a newly installed app could let CorpseFinder treat that app's data as a corpse — failing closed (error state, tools refuse with a dialog) is the safer semantic.
- `CancellationException` is rethrown to keep cancellation intact.
