### PR TITLE
Fix: Make error dialogs and the debug log survive rare failures

### DIFF
--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/error/ComposeErrorDialog.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/error/ComposeErrorDialog.kt
@@ -15,6 +15,10 @@ import androidx.compose.ui.unit.dp
 import eu.darken.sdmse.common.R
 import eu.darken.sdmse.common.compose.dialog.SdmDialogAction
 import eu.darken.sdmse.common.compose.dialog.SdmDialogButtonBar
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.sdmse.common.debug.logging.asLog
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.navigation.NavigationController
 import eu.darken.sdmse.common.navigation.NavigationDestination
 
@@ -40,11 +44,19 @@ fun ComposeErrorDialog(
     val hasInfo = localizedError.infoActionRoute != null || localizedError.infoAction != null
 
     fun dispatchAndDismiss(route: NavigationDestination?, action: ((Activity) -> Unit)?) {
-        when {
-            route != null -> navController?.goTo(route)
-            action != null && activity != null -> action(activity)
+        // Error actions are arbitrary third-party code (intent launches, navigation): a throw here
+        // would crash the UI thread from inside a click handler, and skipping onDismiss() would
+        // leave the dialog latched on the current error with no way out.
+        try {
+            when {
+                route != null -> navController?.goTo(route)
+                action != null && activity != null -> action(activity)
+            }
+        } catch (e: Exception) {
+            log(TAG, ERROR) { "Error action failed: ${e.asLog()}" }
+        } finally {
+            onDismiss()
         }
-        onDismiss()
     }
 
     SdmAlertDialog(
@@ -101,3 +113,5 @@ fun ComposeErrorDialog(
         },
     )
 }
+
+private val TAG = logTag("Error", "Dialog", "Compose")

--- a/app-common-ui/src/test/java/eu/darken/sdmse/common/error/ComposeErrorDialogTest.kt
+++ b/app-common-ui/src/test/java/eu/darken/sdmse/common/error/ComposeErrorDialogTest.kt
@@ -1,0 +1,157 @@
+package eu.darken.sdmse.common.error
+
+import android.app.Activity
+import android.content.Context
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.sdmse.common.R
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.common.navigation.NavigationController
+import eu.darken.sdmse.common.navigation.NavigationDestination
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+
+/**
+ * The shared error dialog: an error that offers a way out gets its own action plus a dismiss,
+ * everything else keeps the acknowledge-only shape, and a fix action that blows up must never take
+ * the UI - or the dialog's exit - down with it.
+ */
+class ComposeErrorDialogTest : BaseComposeRobolectricTest() {
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+    private val dismissLabel: String get() = context.getString(R.string.general_dismiss_action)
+    private val okLabel: String get() = context.getString(android.R.string.ok)
+
+    private var dismissals = 0
+
+    private enum class Dest : NavigationDestination { TARGET }
+
+    private class TestError(
+        private val fixLabel: String? = null,
+        private val fixAction: ((Activity) -> Unit)? = null,
+        private val fixRoute: NavigationDestination? = null,
+    ) : Exception(ERROR_BODY), HasLocalizedError {
+        override fun getLocalizedError() = LocalizedError(
+            throwable = this,
+            label = ERROR_TITLE.toCaString(),
+            description = ERROR_BODY.toCaString(),
+            fixActionLabel = fixLabel?.toCaString(),
+            fixAction = fixAction,
+            fixActionRoute = fixRoute,
+        )
+    }
+
+    /**
+     * Mirrors the host: the dialog is latched on the current error, so it only disappears when the
+     * dispatch actually calls back through [ComposeErrorDialog]'s onDismiss.
+     */
+    private fun show(error: Throwable, navController: NavigationController? = null) {
+        composeRule.setContent {
+            var visible by remember { mutableStateOf(true) }
+            PreviewWrapper {
+                if (visible) {
+                    ComposeErrorDialog(
+                        throwable = error,
+                        onDismiss = {
+                            dismissals++
+                            visible = false
+                        },
+                        navController = navController,
+                    )
+                }
+            }
+        }
+        composeRule.waitForIdle()
+    }
+
+    @Test
+    fun `a fixable error offers its action next to a dismiss`() {
+        show(TestError(fixLabel = FIX_LABEL, fixAction = {}))
+
+        composeRule.onNodeWithText(ERROR_TITLE).assertIsDisplayed()
+        composeRule.onNodeWithText(FIX_LABEL).assertIsDisplayed()
+        composeRule.onNodeWithText(dismissLabel).assertIsDisplayed()
+        // Nothing is merely acknowledged here, the error offers a way out.
+        composeRule.onAllNodesWithText(okLabel).assertCountEquals(0)
+    }
+
+    @Test
+    fun `dismissing closes the dialog without running the fix action`() {
+        var fixInvocations = 0
+        show(TestError(fixLabel = FIX_LABEL, fixAction = { fixInvocations++ }))
+
+        composeRule.onNodeWithText(dismissLabel).performClick()
+        composeRule.waitForIdle()
+
+        fixInvocations shouldBe 0
+        dismissals shouldBe 1
+        composeRule.onAllNodesWithText(FIX_LABEL).assertCountEquals(0)
+    }
+
+    @Test
+    fun `an ordinary error keeps the acknowledge-only dialog`() {
+        // The dialog backs every screen: the fix/dismiss pair must stay exclusive to errors that
+        // actually carry a fix action.
+        show(RuntimeException("something went wrong"))
+
+        composeRule.onNodeWithText(okLabel).assertIsDisplayed()
+        composeRule.onAllNodesWithText(dismissLabel).assertCountEquals(0)
+        composeRule.onAllNodesWithText(FIX_LABEL).assertCountEquals(0)
+    }
+
+    @Test
+    fun `a throwing fix action still closes the dialog`() {
+        var invoked = false
+        show(
+            TestError(
+                fixLabel = FIX_LABEL,
+                fixAction = {
+                    // Flag first: the assertion below has to distinguish "action ran and threw"
+                    // from "action was never dispatched".
+                    invoked = true
+                    throw IllegalStateException("fix action exploded")
+                },
+            )
+        )
+
+        composeRule.onNodeWithText(FIX_LABEL).performClick()
+        composeRule.waitForIdle()
+
+        invoked shouldBe true
+        // Exactly one dismissal: the throw must neither swallow it nor double it.
+        dismissals shouldBe 1
+        composeRule.onAllNodesWithText(FIX_LABEL).assertCountEquals(0)
+    }
+
+    @Test
+    fun `a throwing route navigation still closes the dialog`() {
+        val navController = mockk<NavigationController>(relaxed = true).apply {
+            every { goTo(any(), any(), any()) } throws IllegalStateException("NavigationController not initialized")
+        }
+        show(TestError(fixLabel = FIX_LABEL, fixRoute = Dest.TARGET), navController = navController)
+
+        composeRule.onNodeWithText(FIX_LABEL).performClick()
+        composeRule.waitForIdle()
+
+        verify { navController.goTo(Dest.TARGET, null, false) }
+        dismissals shouldBe 1
+        composeRule.onAllNodesWithText(FIX_LABEL).assertCountEquals(0)
+    }
+}
+
+private const val ERROR_TITLE = "Test error title"
+private const val ERROR_BODY = "Test error description"
+private const val FIX_LABEL = "Fix it"

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/hyperos/SecurityCenterMissingPermissionException.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/hyperos/SecurityCenterMissingPermissionException.kt
@@ -6,7 +6,10 @@ import androidx.core.net.toUri
 import eu.darken.sdmse.appcleaner.R
 import eu.darken.sdmse.automation.core.errors.InvalidSystemStateException
 import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.sdmse.common.debug.logging.asLog
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.error.HasLocalizedError
 import eu.darken.sdmse.common.error.LocalizedError
 
@@ -22,7 +25,7 @@ class SecurityCenterMissingPermissionException(
             try {
                 it.startActivity(Intent(Settings.ACTION_USAGE_ACCESS_SETTINGS))
             } catch (e: Exception) {
-                e.asLog()
+                log(TAG, ERROR) { "Failed to open usage access settings: ${e.asLog()}" }
             }
         },
         infoActionLabel = eu.darken.sdmse.common.R.string.general_help_action.toCaString(),
@@ -34,8 +37,12 @@ class SecurityCenterMissingPermissionException(
                 }
                 it.startActivity(intent)
             } catch (e: Exception) {
-                e.asLog()
+                log(TAG, ERROR) { "Failed to open the wiki page: ${e.asLog()}" }
             }
         }
     )
+
+    companion object {
+        private val TAG = logTag("AppCleaner", "Automation", "HyperOS", "SecurityCenter")
+    }
 }

--- a/app/src/foss/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoFoss.kt
+++ b/app/src/foss/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoFoss.kt
@@ -37,6 +37,9 @@ class UpgradeRepoFoss @Inject constructor(
     private val refreshTrigger = MutableStateFlow(UUID.randomUUID())
 
     // Written only from the sharing coroutine (single collector) — no synchronization needed.
+    // Recorded INSIDE the flatMapLatest block, upstream of its channel buffer: a downstream onEach
+    // can still be waiting on a buffered emission when the inner flow throws, and the catch below
+    // would then read a stale (null) value and revoke an entitlement we already saw.
     private var lastKnownInfo: Info? = null
 
     override val upgradeInfo: Flow<UpgradeRepo.Info> = refreshTrigger
@@ -53,6 +56,10 @@ class UpgradeRepoFoss @Inject constructor(
                         )
                     }
                 }
+                // Same coroutine as the throw below, so the ordering is guaranteed. Only
+                // successfully mapped elements pass here — catch emissions go straight downstream
+                // and never record themselves as a last known state.
+                .onEach { lastKnownInfo = it }
                 .catch { e ->
                     // A SharedFlow cannot fail: without this, a thrown cache read dies inside
                     // shareIn's sharing coroutine and every collector hangs forever (VM state stuck
@@ -68,7 +75,6 @@ class UpgradeRepoFoss @Inject constructor(
                     emit((lastKnownInfo ?: Info()).copy(error = e))
                 }
         }
-        .onEach { if (it.error == null) lastKnownInfo = it }
         .setupCommonEventHandlers(TAG) { "upgradeInfo" }
         .shareIn(appScope, SharingStarted.WhileSubscribed(3000L, 0L), replay = 1)
 

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/GplayServiceUnavailableException.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/GplayServiceUnavailableException.kt
@@ -1,5 +1,6 @@
 package eu.darken.sdmse.common.upgrade.core.billing
 
+import android.app.Activity
 import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
@@ -19,22 +20,33 @@ class GplayServiceUnavailableException(cause: Throwable) :
         throwable = this,
         label = R.string.upgrades_gplay_unavailable_error_title.toCaString(),
         description = R.string.upgrades_gplay_unavailable_error_description.toCaString(),
+        // Deliberately untranslated brand name.
         fixActionLabel = "Google Play".toCaString(),
+        // BillingManager also maps transient timeout/network failures onto this exception, so the
+        // action is a GENERIC troubleshooting affordance (open Play's app info), not a diagnosis of
+        // the cause. Harmless for a transient blip, and it matches the fleet's dialog.
         fixAction = { activity ->
-            try {
-                val intent = Intent().apply {
-                    action = Settings.ACTION_APPLICATION_DETAILS_SETTINGS
-                    data = Uri.fromParts("package", GPLAY_PKG, null)
-                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                }
+            val intent = Intent().apply {
+                action = Settings.ACTION_APPLICATION_DETAILS_SETTINGS
+                data = Uri.fromParts("package", GPLAY_PKG, null)
+            }
 
+            try {
                 activity.startActivity(intent)
             } catch (e: ActivityNotFoundException) {
-                log(ERROR) { "Can't launch settings intent for Google Play: $e" }
-                Toast.makeText(activity, "Google Play is not installed", Toast.LENGTH_SHORT).show()
+                onLaunchFailed(activity, e)
+            } catch (e: SecurityException) {
+                // Play can be installed but unreachable: disabled app, work/restricted profile or a
+                // ROM that guards the settings screen. The launch is denied, not unresolvable.
+                onLaunchFailed(activity, e)
             }
         }
     )
+
+    private fun onLaunchFailed(activity: Activity, e: Exception) {
+        log(ERROR) { "Can't launch settings intent for Google Play: $e" }
+        Toast.makeText(activity, R.string.upgrades_gplay_not_installed_message, Toast.LENGTH_SHORT).show()
+    }
 
     companion object {
         private const val GPLAY_PKG = "com.android.vending"

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -20,6 +20,9 @@
     <string name="upgrades_gplay_offer_unavailable_title">Offer unavailable</string>
     <string name="upgrades_gplay_offer_unavailable_description">Google Play is currently not offering this upgrade option. Please try again later or check the Google Play Store.</string>
 
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Play is not installed.</string>
+
     <string name="upgrades_gplay_already_owned_error_title">Already purchased</string>
     <string name="upgrades_gplay_already_owned_error_description">Use the \"Restore purchase\" option to restore your purchase. If the issue persists, try clearing Google Play cache and restarting your device.</string>
 

--- a/app/src/main/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModule.kt
@@ -31,6 +31,8 @@ import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.filter
@@ -39,6 +41,8 @@ import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.plus
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import java.io.File
@@ -83,6 +87,11 @@ class RecorderModule @Inject constructor(
         }
     }
 
+    // Serializes the public start/stop API: each caller holds it from publishing its request through
+    // observing the outcome, so a second caller can neither clear a failure the first one is still
+    // waiting for nor adopt one that isn't theirs.
+    private val requestLock = Mutex()
+
     private val internalState = DynamicStateFlow(TAG, appScope + dispatcherProvider.IO) {
         val triggerFileExists = triggerFile.exists()
         val savedPath = debugSettings.recorderPath.value()
@@ -98,62 +107,156 @@ class RecorderModule @Inject constructor(
                 log(TAG) { "New Recorder state: $it" }
 
                 internalState.updateBlocking {
-                    if (!isRecording && shouldRecord) {
-                        val savedPath = debugSettings.recorderPath.value()
-                        val isResuming = savedPath != null
-                        val logDir = savedPath?.let {
-                            log(TAG) { "Continuing existing log: $it" }
-                            File(it)
-                        } ?: createRecordingDir().also {
-                            log(TAG) { "Starting new log: $it" }
-                            debugSettings.recorderPath.value(it.path)
-                        }
-
-                        val newRecorder = recorderProvider.get().apply { start(logDir) }
-
-                        try {
-                            if (!triggerFile.exists()) triggerFile.createNewFile()
-
-                            logInfos()
-                        } catch (e: Exception) {
-                            // The recorder is already live but not yet committed to the state: an exception escaping
-                            // the header would abandon it where stopRecorder() can't reach it.
-                            withContext(NonCancellable) {
-                                try {
-                                    newRecorder.stop()
-                                } catch (stopError: Exception) {
-                                    e.addSuppressed(stopError)
-                                }
-                            }
-                            throw e
-                        }
-
-                        copy(
-                            recorder = newRecorder,
-                            currentLogDir = logDir,
-                            recordingStartedAt = if (isResuming) null else SystemClock.elapsedRealtime(),
-                        )
-                    } else if (!shouldRecord && isRecording) {
-                        log(TAG) { "Stopping log recorder for: $currentLogDir" }
-                        requireNotNull(recorder) { "Recorder was null despite isRecording" }.stop()
-
-                        debugSettings.recorderPath.value(null)
-                        if (triggerFile.exists() && !triggerFile.delete()) {
-                            log(TAG, ERROR) { "Failed to delete trigger file" }
-                        }
-
-                        copy(
-                            recorder = null,
-                            currentLogDir = null,
-                            recordingStartedAt = null,
-                        )
-                    } else {
-                        this
+                    when {
+                        !isRecording && shouldRecord -> startAttempt()
+                        !shouldRecord && isRecording -> stopAttempt()
+                        else -> this
                     }
                 }
             }
+            // Start and stop failures are handled per iteration above, so only the state flow ending
+            // or the scope dying gets here. A failure that reached this catch would end the reactive
+            // loop for the rest of the process: no later request would ever be served again, and
+            // every caller awaiting a state transition would wait forever.
             .catch { log(TAG, ERROR) { "Log recording failed: ${it.asLog()}" } }
             .launchIn(appScope)
+    }
+
+    /**
+     * Starts a recorder and returns the committed state. A failure anywhere in here (including
+     * [Recorder.start] itself) is rolled back and recorded in the state instead of being thrown at
+     * the collector: it must stay alive, and [startRecorder] needs something to observe.
+     */
+    private suspend fun State.startAttempt(): State {
+        val savedPath = debugSettings.recorderPath.value()
+        val isResuming = savedPath != null
+        // Only what THIS attempt created may be rolled back: a resume marker or log dir from an
+        // earlier session belongs to that session and must survive a failed start.
+        var createdLogDir: File? = null
+        var createdTriggerFile = false
+        var candidate: Recorder? = null
+
+        try {
+            val logDir = savedPath?.let {
+                log(TAG) { "Continuing existing log: $it" }
+                File(it)
+            } ?: createRecordingDir().also {
+                log(TAG) { "Starting new log: $it" }
+                createdLogDir = it
+                debugSettings.recorderPath.value(it.path)
+            }
+
+            // Bound BEFORE start(): a throw from start() itself leaves a live recorder that nothing
+            // else can reach, so the rollback has to know about the candidate already.
+            val newRecorder = recorderProvider.get().also { candidate = it }
+            newRecorder.start(logDir)
+
+            if (!triggerFile.exists() && triggerFile.createNewFile()) createdTriggerFile = true
+
+            logInfos()
+
+            return copy(
+                recorder = newRecorder,
+                currentLogDir = logDir,
+                recordingStartedAt = if (isResuming) null else SystemClock.elapsedRealtime(),
+                startFailure = null,
+            )
+        } catch (e: Exception) {
+            rollbackFailedStart(e, candidate, createdLogDir, createdTriggerFile)
+
+            // Genuine cancellation of our scope: the collector dying with it is correct.
+            currentCoroutineContext().ensureActive()
+
+            // A FOREIGN CancellationException (e.g. a withTimeout inside the header work) is just a
+            // failed start. Rethrowing it because of its type would kill the collector, which is the
+            // exact wedge this guard exists to prevent.
+            log(TAG, ERROR) { "Failed to start recording: ${e.asLog()}" }
+            return copy(
+                shouldRecord = false,
+                recorder = null,
+                currentLogDir = null,
+                recordingStartedAt = null,
+                startFailure = e,
+            )
+        }
+    }
+
+    /**
+     * Undoes a failed start attempt. Runs [NonCancellable] because the failure may BE a cancellation,
+     * and every step is guarded on its own so one broken cleanup can't skip the rest.
+     */
+    private suspend fun rollbackFailedStart(
+        cause: Exception,
+        candidate: Recorder?,
+        createdLogDir: File?,
+        createdTriggerFile: Boolean,
+    ) = withContext(NonCancellable) {
+        if (candidate != null) {
+            try {
+                candidate.stop()
+            } catch (e: Exception) {
+                cause.addSuppressed(e)
+            }
+        }
+
+        if (createdTriggerFile) {
+            try {
+                if (triggerFile.exists() && !triggerFile.delete()) {
+                    log(TAG, ERROR) { "Failed to delete trigger file during rollback" }
+                }
+            } catch (e: Exception) {
+                cause.addSuppressed(e)
+            }
+        }
+
+        if (createdLogDir != null) {
+            try {
+                debugSettings.recorderPath.value(null)
+            } catch (e: Exception) {
+                cause.addSuppressed(e)
+            }
+            try {
+                if (!createdLogDir.deleteRecursively()) {
+                    log(TAG, WARN) { "Failed to delete $createdLogDir during rollback" }
+                }
+            } catch (e: Exception) {
+                cause.addSuppressed(e)
+            }
+        }
+    }
+
+    /**
+     * Stops the recorder and returns the cleared state. The transition COMPLETES even when a step
+     * fails: a [stopRecorder] caller is waiting on it, and a state that still claims to be recording
+     * could never be stopped again. A leaked recorder is the lesser evil, so it is logged here.
+     */
+    private suspend fun State.stopAttempt(): State {
+        log(TAG) { "Stopping log recorder for: $currentLogDir" }
+
+        try {
+            requireNotNull(recorder) { "Recorder was null despite isRecording" }.stop()
+        } catch (e: Exception) {
+            currentCoroutineContext().ensureActive()
+            log(TAG, ERROR) { "Failed to stop the recorder cleanly: ${e.asLog()}" }
+        }
+
+        try {
+            // Independent of the stop above: a recorder that failed to close must not leave the
+            // resume marker behind, or the next app start silently resumes into a dead session.
+            debugSettings.recorderPath.value(null)
+            if (triggerFile.exists() && !triggerFile.delete()) {
+                log(TAG, ERROR) { "Failed to delete trigger file" }
+            }
+        } catch (e: Exception) {
+            currentCoroutineContext().ensureActive()
+            log(TAG, ERROR) { "Failed to clear the recording markers: ${e.asLog()}" }
+        }
+
+        return copy(
+            recorder = null,
+            currentLogDir = null,
+            recordingStartedAt = null,
+        )
     }
 
     private fun createRecordingDir(): File {
@@ -194,12 +297,17 @@ class RecorderModule @Inject constructor(
         }
     }
 
-    suspend fun startRecorder(): File {
+    suspend fun startRecorder(): File = requestLock.withLock {
+        // The previous attempt's failure is cleared with the request it belongs to, so this call can
+        // only ever observe the outcome of its own attempt.
         internalState.updateBlocking {
-            copy(shouldRecord = true)
+            copy(shouldRecord = true, startFailure = null)
         }
-        val state = internalState.flow.filter { it.isRecording }.first()
-        return requireNotNull(state.currentLogDir) { "currentLogDir was null despite isRecording" }
+        // Both outcomes are terminal for this request: waiting on isRecording ALONE is what turned a
+        // failed start into a caller that waits forever.
+        val state = internalState.flow.filter { it.isRecording || it.startFailure != null }.first()
+        state.startFailure?.let { throw it }
+        requireNotNull(state.currentLogDir) { "currentLogDir was null despite isRecording" }
     }
 
     suspend fun requestStopRecorder(): StopResult {
@@ -245,13 +353,14 @@ class RecorderModule @Inject constructor(
         return StopResult.Stopped(sessionId = SessionId.derive(stoppedDir), logDir = stoppedDir)
     }
 
-    suspend fun stopRecorder(): File? {
-        val currentPath = internalState.value().currentLogDir ?: return null
+    suspend fun stopRecorder(): File? = requestLock.withLock {
+        val currentPath = internalState.value().currentLogDir ?: return@withLock null
         internalState.updateBlocking {
             copy(shouldRecord = false)
         }
+        // The stop transition always commits, even on a failing recorder, so this always settles.
         internalState.flow.filter { !it.isRecording }.first()
-        return currentPath
+        currentPath
     }
 
     suspend fun getCurrentLogDir(): File? = internalState.value().currentLogDir
@@ -353,6 +462,12 @@ class RecorderModule @Inject constructor(
         internal val recorder: Recorder? = null,
         val currentLogDir: File? = null,
         internal val recordingStartedAt: Long? = null,
+        /**
+         * Outcome of the last start attempt, cleared by the next start request. Without it a failed
+         * attempt is invisible to [startRecorder], which would then wait for a recording that is
+         * never coming.
+         */
+        internal val startFailure: Exception? = null,
     ) {
         val isRecording: Boolean
             get() = recorder != null

--- a/app/src/main/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModule.kt
@@ -198,7 +198,7 @@ class RecorderModule @Inject constructor(
             try {
                 candidate.stop()
             } catch (e: Exception) {
-                cause.addSuppressed(e)
+                cause.recordSuppressed(e)
             }
         }
 
@@ -208,7 +208,7 @@ class RecorderModule @Inject constructor(
                     log(TAG, ERROR) { "Failed to delete trigger file during rollback" }
                 }
             } catch (e: Exception) {
-                cause.addSuppressed(e)
+                cause.recordSuppressed(e)
             }
         }
 
@@ -216,15 +216,30 @@ class RecorderModule @Inject constructor(
             try {
                 debugSettings.recorderPath.value(null)
             } catch (e: Exception) {
-                cause.addSuppressed(e)
+                cause.recordSuppressed(e)
             }
             try {
                 if (!createdLogDir.deleteRecursively()) {
                     log(TAG, WARN) { "Failed to delete $createdLogDir during rollback" }
                 }
             } catch (e: Exception) {
-                cause.addSuppressed(e)
+                cause.recordSuppressed(e)
             }
+        }
+    }
+
+    /**
+     * Attaches a rollback failure to the failure being reported. The very same throwable can come
+     * back out of the rollback — a recorder that fails to start and rethrows on its teardown line —
+     * and [Throwable.addSuppressed] rejects self-suppression with an [IllegalArgumentException],
+     * which would abort the rollback before the failure state is ever committed.
+     */
+    private fun Throwable.recordSuppressed(other: Throwable) {
+        if (other === this) return
+        try {
+            addSuppressed(other)
+        } catch (_: Throwable) {
+            // Bookkeeping only: nothing about the report may replace the failure being reported.
         }
     }
 

--- a/app/src/main/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModule.kt
@@ -128,8 +128,6 @@ class RecorderModule @Inject constructor(
      * the collector: it must stay alive, and [startRecorder] needs something to observe.
      */
     private suspend fun State.startAttempt(): State {
-        val savedPath = debugSettings.recorderPath.value()
-        val isResuming = savedPath != null
         // Only what THIS attempt created may be rolled back: a resume marker or log dir from an
         // earlier session belongs to that session and must survive a failed start.
         var createdLogDir: File? = null
@@ -137,6 +135,11 @@ class RecorderModule @Inject constructor(
         var candidate: Recorder? = null
 
         try {
+            // Inside the guard: this read talks to DataStore, so it can throw like every other step
+            // here, and outside the guard that throw would end the collector instead of the attempt.
+            val savedPath = debugSettings.recorderPath.value()
+            val isResuming = savedPath != null
+
             val logDir = savedPath?.let {
                 log(TAG) { "Continuing existing log: $it" }
                 File(it)
@@ -306,13 +309,27 @@ class RecorderModule @Inject constructor(
         // Both outcomes are terminal for this request: waiting on isRecording ALONE is what turned a
         // failed start into a caller that waits forever.
         val state = internalState.flow.filter { it.isRecording || it.startFailure != null }.first()
-        state.startFailure?.let { throw it }
+        state.startFailure?.let { throw it.asCallerFailure() }
         requireNotNull(state.currentLogDir) { "currentLogDir was null despite isRecording" }
     }
 
-    suspend fun requestStopRecorder(): StopResult {
+    /**
+     * A stored failure is never our own scope's cancellation (`ensureActive` rethrows that one), but
+     * it can still BE a [CancellationException] from somewhere inside the attempt. Handing that to
+     * the caller as-is unwinds them as if THEY had been cancelled: the ViewModel's exception handler
+     * ignores it and the user is told nothing at all. The original stays in the state.
+     */
+    private fun Exception.asCallerFailure(): Exception = when (this) {
+        is CancellationException -> StartFailedException(this)
+        else -> this
+    }
+
+    suspend fun requestStopRecorder(): StopResult = requestLock.withLock {
+        // The whole transition is serialized against the start path: checking the state outside the
+        // lock let a stop request answer "not recording" for a start that was already in flight and
+        // committed right after, leaving a recording nobody wanted running.
         val currentState = internalState.value()
-        if (!currentState.isRecording) return StopResult.NotRecording
+        if (!currentState.isRecording) return@withLock StopResult.NotRecording
 
         val logDir = currentState.currentLogDir
         if (logDir != null) {
@@ -345,22 +362,25 @@ class RecorderModule @Inject constructor(
             }
             if (elapsedMs < MIN_RECORDING_MS) {
                 log(TAG) { "Recording too short: ${elapsedMs}ms < ${MIN_RECORDING_MS}ms" }
-                return StopResult.TooShort
+                return@withLock StopResult.TooShort
             }
         }
 
-        val stoppedDir = stopRecorder() ?: return StopResult.NotRecording
-        return StopResult.Stopped(sessionId = SessionId.derive(stoppedDir), logDir = stoppedDir)
+        val stoppedDir = stopRecorderLocked() ?: return@withLock StopResult.NotRecording
+        StopResult.Stopped(sessionId = SessionId.derive(stoppedDir), logDir = stoppedDir)
     }
 
-    suspend fun stopRecorder(): File? = requestLock.withLock {
-        val currentPath = internalState.value().currentLogDir ?: return@withLock null
+    suspend fun stopRecorder(): File? = requestLock.withLock { stopRecorderLocked() }
+
+    /** Callers must already hold [requestLock] — it is not reentrant. */
+    private suspend fun stopRecorderLocked(): File? {
+        val currentPath = internalState.value().currentLogDir ?: return null
         internalState.updateBlocking {
             copy(shouldRecord = false)
         }
         // The stop transition always commits, even on a failing recorder, so this always settles.
         internalState.flow.filter { !it.isRecording }.first()
-        currentPath
+        return currentPath
     }
 
     suspend fun getCurrentLogDir(): File? = internalState.value().currentLogDir
@@ -450,6 +470,12 @@ class RecorderModule @Inject constructor(
         }
         return result
     }
+
+    /** Carries a start failure that is itself a cancellation out to a caller as an ordinary error. */
+    class StartFailedException(cause: CancellationException) : IllegalStateException(
+        "Failed to start the recorder: ${cause.message}",
+        cause,
+    )
 
     sealed class StopResult {
         data object TooShort : StopResult()

--- a/app/src/test/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModuleTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModuleTest.kt
@@ -29,6 +29,8 @@ import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.unmockkStatic
 import io.mockk.verify
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -606,9 +608,14 @@ class RecorderModuleTest : BaseTest() {
             coVerify { mockRecorder.stop() }
             File(externalDir, "force_debug_run").exists() shouldBe false
             File(externalDir, "debug/logs").listFiles()?.toList() shouldBe emptyList()
-            val clearSlot = slot<(String?) -> String?>()
-            coVerify(atLeast = 1) { recorderPath.update(capture(clearSlot)) }
-            clearSlot.captured("ignored") shouldBe null
+            // A single slot only keeps the LAST matching call, and the order is the point here: the
+            // attempt saves its new dir as the resume marker, the rollback has to clear it again.
+            val pathUpdates = mutableListOf<(String?) -> String?>()
+            coVerify(atLeast = 1) { recorderPath.update(capture(pathUpdates)) }
+            val applied = pathUpdates.map { it("ignored") }
+            applied.size shouldBe 2
+            applied.first() shouldNotBe null
+            applied.last() shouldBe null
         }
 
         @Test
@@ -616,17 +623,105 @@ class RecorderModuleTest : BaseTest() {
             val existingDir = File(externalDir, "debug/logs/existing_session").apply { mkdirs() }
             val triggerFile = File(externalDir, "force_debug_run").apply { createNewFile() }
             coEvery { recorderPath.value() } returns existingDir.path
-            every { context.getPackageInfo() } throws IOException("no package info")
+            // Fail the resume at the recorder itself: it is the one step a resume definitely takes.
+            coEvery { mockRecorder.start(any()) } throws IOException("recorder broken")
 
             val module = createModule(backgroundScope, StandardTestDispatcher(testScheduler))
             advanceUntilIdle()
 
+            val state = module.state.first()
+            state.startFailure.shouldBeInstanceOf<IOException>()
+            state.isRecording shouldBe false
+
             coVerify { mockRecorder.stop() }
-            module.state.first().isRecording shouldBe false
             // None of this was created by the failed attempt, so the session stays resumable.
             triggerFile.exists() shouldBe true
             existingDir.exists() shouldBe true
             coVerify(exactly = 0) { recorderPath.update(any()) }
+        }
+
+        @Test
+        fun `a failing saved-path read fails the attempt, not the loop`() = runTest {
+            // The read decides whether the attempt is a resume, so it belongs to the attempt: while
+            // it sat outside the guard, a throwing DataStore ended the collector for good.
+            val boom = IOException("datastore unreachable")
+            var reads = 0
+            coEvery { recorderPath.value() } coAnswers {
+                reads++
+                // 1st read is the state initializer, 2nd is the attempt this test fails.
+                if (reads == 2) throw boom
+                null
+            }
+
+            val module = createModule(backgroundScope, StandardTestDispatcher(testScheduler))
+            advanceUntilIdle()
+
+            val error = withTimeout(START_ENVELOPE_MS) {
+                shouldThrow<IOException> { module.startRecorder() }
+            }
+            error shouldBe boom
+            module.state.first().shouldRecord shouldBe false
+
+            withTimeout(START_ENVELOPE_MS) { module.startRecorder() }
+            module.state.first().isRecording shouldBe true
+        }
+
+        @Test
+        fun `a foreign cancellation reaches the caller as a start failure`() = runTest {
+            // Not our scope being cancelled (ensureActive covers that one) but a cancellation from
+            // inside the attempt, e.g. a timeout. Rethrown as-is it unwinds the caller as if THEY
+            // had been cancelled, which the ViewModel error handler ignores: nothing is reported.
+            coEvery { recorderPath.value() } returns null
+            val foreign = CancellationException("header read timed out")
+            coEvery { mockRecorder.start(any()) } throws foreign
+
+            val module = createModule(backgroundScope, StandardTestDispatcher(testScheduler))
+            advanceUntilIdle()
+
+            val error = withTimeout(START_ENVELOPE_MS) {
+                shouldThrow<RecorderModule.StartFailedException> { module.startRecorder() }
+            }
+            error.cause shouldBe foreign
+            // The state keeps the original untouched.
+            module.state.first().startFailure shouldBe foreign
+
+            coEvery { mockRecorder.start(any()) } returns Unit
+
+            withTimeout(START_ENVELOPE_MS) { module.startRecorder() }
+            module.state.first().isRecording shouldBe true
+        }
+
+        @Test
+        fun `a stop request during an in-flight start waits for it`() = runTest {
+            coEvery { recorderPath.value() } returns null
+            val startGate = CompletableDeferred<Unit>()
+            coEvery { mockRecorder.start(any()) } coAnswers { startGate.await() }
+            // Second read is the stop request's duration check: long enough to actually stop.
+            every { SystemClock.elapsedRealtime() } returnsMany listOf(
+                RECORDING_START,
+                RECORDING_START + 20_000L,
+            )
+
+            val module = createModule(backgroundScope, StandardTestDispatcher(testScheduler))
+            advanceUntilIdle()
+
+            val starting = async { module.startRecorder() }
+            advanceUntilIdle()
+
+            val stopping = async { module.requestStopRecorder() }
+            advanceUntilIdle()
+
+            // Reading the state outside the lock answered "not recording" here, and the start
+            // committed right afterwards - a recording the user had already asked to stop.
+            stopping.isCompleted shouldBe false
+
+            startGate.complete(Unit)
+
+            withTimeout(START_ENVELOPE_MS) {
+                stopping.await().shouldBeInstanceOf<RecorderModule.StopResult.Stopped>()
+                starting.await()
+            }
+            module.state.first().isRecording shouldBe false
         }
 
         @Test

--- a/app/src/test/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModuleTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModuleTest.kt
@@ -648,6 +648,37 @@ class RecorderModuleTest : BaseTest() {
         }
 
         @Test
+        fun `a rollback that gets the start failure handed back to it still completes`() = runTest {
+            // A recorder that rethrows the VERY instance its start() failed with when the rollback
+            // stops it: addSuppressed rejects self-suppression with an IllegalArgumentException, and
+            // that throw escaped the rollback before the failure was ever committed -- ending the
+            // loop, which is the exact wedge this whole guard exists to prevent.
+            File(externalDir, "force_debug_run").createNewFile()
+            coEvery { recorderPath.value() } returns null
+            val boom = IOException("recorder broken")
+            val selfSuppressing: Recorder = mockk()
+            coEvery { selfSuppressing.start(any()) } throws boom
+            coEvery { selfSuppressing.stop() } throws boom
+            every { recorderProvider.get() } returns selfSuppressing
+
+            val module = createModule(backgroundScope, StandardTestDispatcher(testScheduler))
+            advanceUntilIdle()
+
+            // Bounded: without the guard the failure is never committed and this waits forever.
+            val state = withTimeout(START_ENVELOPE_MS) { module.state.first { it.startFailure != null } }
+            state.startFailure shouldBe boom
+            state.shouldRecord shouldBe false
+            state.isRecording shouldBe false
+            coVerify { selfSuppressing.stop() }
+
+            // The loop survived the rollback and still serves the next request.
+            every { recorderProvider.get() } returns mockRecorder
+
+            withTimeout(START_ENVELOPE_MS) { module.startRecorder() }
+            module.state.first().isRecording shouldBe true
+        }
+
+        @Test
         fun `a failing saved-path read fails the attempt, not the loop`() = runTest {
             // The read decides whether the attempt is a resume, so it belongs to the attempt: while
             // it sat outside the guard, a throwing DataStore ended the collector for good.

--- a/app/src/test/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModuleTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModuleTest.kt
@@ -624,16 +624,23 @@ class RecorderModuleTest : BaseTest() {
             val triggerFile = File(externalDir, "force_debug_run").apply { createNewFile() }
             coEvery { recorderPath.value() } returns existingDir.path
             // Fail the resume at the recorder itself: it is the one step a resume definitely takes.
-            coEvery { mockRecorder.start(any()) } throws IOException("recorder broken")
+            // Its own mock, stubbed on the exact resume dir -- the shared mockRecorder carries a
+            // permissive start(any()) stub from setup that would otherwise answer this call.
+            val boom = IOException("recorder broken")
+            val resumeRecorder: Recorder = mockk()
+            coEvery { resumeRecorder.start(existingDir) } throws boom
+            coEvery { resumeRecorder.stop() } returns Unit
+            every { recorderProvider.get() } returns resumeRecorder
 
             val module = createModule(backgroundScope, StandardTestDispatcher(testScheduler))
             advanceUntilIdle()
 
-            val state = module.state.first()
-            state.startFailure.shouldBeInstanceOf<IOException>()
+            // Bounded: a resume that never fails would otherwise hang here instead of failing.
+            val state = withTimeout(START_ENVELOPE_MS) { module.state.first { it.startFailure != null } }
+            state.startFailure shouldBe boom
             state.isRecording shouldBe false
 
-            coVerify { mockRecorder.stop() }
+            coVerify { resumeRecorder.stop() }
             // None of this was created by the failed attempt, so the session stays resumable.
             triggerFile.exists() shouldBe true
             existingDir.exists() shouldBe true

--- a/app/src/test/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModuleTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModuleTest.kt
@@ -15,6 +15,7 @@ import eu.darken.sdmse.common.debug.logging.Logging
 import eu.darken.sdmse.common.getPackageInfo
 import eu.darken.sdmse.common.upgrade.UpgradeDiagnostics
 import eu.darken.sdmse.main.core.CurriculumVitae
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.longs.shouldBeLessThan
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -32,6 +33,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.emptyFlow
@@ -44,6 +46,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -550,8 +553,120 @@ class RecorderModuleTest : BaseTest() {
         }
     }
 
+    /**
+     * A start that fails must not take the reactive loop with it: the loop is the only thing that
+     * ever serves a start or stop request, so killing it wedges every later caller forever.
+     */
+    @Nested
+    inner class StartFailures {
+
+        private fun TestScope.moduleWith(startThrows: Boolean = false): RecorderModule {
+            coEvery { recorderPath.value() } returns null
+            if (startThrows) coEvery { mockRecorder.start(any()) } throws IOException("recorder broken")
+
+            val module = createModule(backgroundScope, StandardTestDispatcher(testScheduler))
+            advanceUntilIdle()
+            return module
+        }
+
+        @Test
+        fun `a failed start surfaces to the caller instead of hanging`() = runTest {
+            val module = moduleWith(startThrows = true)
+
+            // Bounded: before the fix this call never returned at all.
+            val error = withTimeout(START_ENVELOPE_MS) {
+                shouldThrow<IOException> { module.startRecorder() }
+            }
+
+            error.message shouldBe "recorder broken"
+            module.state.first().isRecording shouldBe false
+        }
+
+        @Test
+        fun `a failed start leaves the loop alive for the next request`() = runTest {
+            val module = moduleWith(startThrows = true)
+
+            shouldThrow<IOException> { module.startRecorder() }
+
+            coEvery { mockRecorder.start(any()) } returns Unit
+
+            withTimeout(START_ENVELOPE_MS) { module.startRecorder() }
+
+            module.state.first().isRecording shouldBe true
+        }
+
+        @Test
+        fun `a failed start rolls back everything the attempt created`() = runTest {
+            every { context.getPackageInfo() } throws IOException("no package info")
+            val module = moduleWith()
+
+            shouldThrow<IOException> { module.startRecorder() }
+
+            // The recorder was already live: leaving it running orphans it where nothing can reach it.
+            coVerify { mockRecorder.stop() }
+            File(externalDir, "force_debug_run").exists() shouldBe false
+            File(externalDir, "debug/logs").listFiles()?.toList() shouldBe emptyList()
+            val clearSlot = slot<(String?) -> String?>()
+            coVerify(atLeast = 1) { recorderPath.update(capture(clearSlot)) }
+            clearSlot.captured("ignored") shouldBe null
+        }
+
+        @Test
+        fun `a failed resume keeps the markers of the session it was resuming`() = runTest {
+            val existingDir = File(externalDir, "debug/logs/existing_session").apply { mkdirs() }
+            val triggerFile = File(externalDir, "force_debug_run").apply { createNewFile() }
+            coEvery { recorderPath.value() } returns existingDir.path
+            every { context.getPackageInfo() } throws IOException("no package info")
+
+            val module = createModule(backgroundScope, StandardTestDispatcher(testScheduler))
+            advanceUntilIdle()
+
+            coVerify { mockRecorder.stop() }
+            module.state.first().isRecording shouldBe false
+            // None of this was created by the failed attempt, so the session stays resumable.
+            triggerFile.exists() shouldBe true
+            existingDir.exists() shouldBe true
+            coVerify(exactly = 0) { recorderPath.update(any()) }
+        }
+
+        @Test
+        fun `concurrent start requests each get their own failure`() = runTest {
+            val module = moduleWith(startThrows = true)
+
+            withTimeout(START_ENVELOPE_MS) {
+                val first = async { runCatching { module.startRecorder() } }
+                val second = async { runCatching { module.startRecorder() } }
+
+                // Serialized: neither request can clear the failure the other one is waiting for and
+                // leave it hanging on a recording that is never coming.
+                first.await().exceptionOrNull().shouldBeInstanceOf<IOException>()
+                second.await().exceptionOrNull().shouldBeInstanceOf<IOException>()
+            }
+        }
+
+        @Test
+        fun `a throwing recorder stop still completes the stop request`() = runTest {
+            val existingDir = File(externalDir, "debug/logs/existing_session").apply { mkdirs() }
+            coEvery { recorderPath.value() } returns existingDir.path
+
+            val module = createModule(backgroundScope, StandardTestDispatcher(testScheduler))
+            advanceUntilIdle()
+            module.state.first { it.isRecording }
+
+            coEvery { mockRecorder.stop() } throws IOException("cannot close")
+
+            // A leaked recorder is logged, but the transition still commits - otherwise the state
+            // keeps claiming to record and can never be stopped again.
+            withTimeout(START_ENVELOPE_MS) { module.stopRecorder() } shouldBe existingDir
+            module.state.first().isRecording shouldBe false
+        }
+    }
+
     companion object {
         /** Arbitrary fixed [SystemClock.elapsedRealtime] value that recordings start at. */
         private const val RECORDING_START = 12345L
+
+        /** Virtual-time bound: a wedged request would otherwise only fail via the suite timeout. */
+        private const val START_ENVELOPE_MS = 30_000L
     }
 }

--- a/app/src/testFoss/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoFossTest.kt
+++ b/app/src/testFoss/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoFossTest.kt
@@ -10,6 +10,7 @@ import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -26,6 +27,7 @@ import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import java.io.IOException
 import java.time.Instant
+import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicInteger
 
 class UpgradeRepoFossTest : BaseTest() {
@@ -116,6 +118,36 @@ class UpgradeRepoFossTest : BaseTest() {
             }
         } finally {
             scope.cancel()
+        }
+    }
+
+    @Test fun `the last known entitlement is recorded upstream of the flatMapLatest buffer`(): Unit = runBlocking {
+        // The barrier that holds downstream consumption is the single-threaded pipeline: the
+        // collecting coroutine (and with it anything downstream of flatMapLatest) can only run once
+        // the producing coroutine suspends or completes. The Pro emission is therefore provably
+        // still sitting in the flatMapLatest channel buffer when the inner flow throws - a tracker
+        // placed downstream of that buffer has not seen it yet and the catch reads a null state.
+        val executor = Executors.newSingleThreadExecutor()
+        val scope = CoroutineScope(SupervisorJob() + executor.asCoroutineDispatcher())
+        try {
+            val repo = createRepo(scope, createUpgradeValue(flow {
+                emit(record)
+                // Deliberately no suspension point between emission and throw.
+                throw IOException("cache broken after the buffered emission")
+            }))
+
+            withTimeout(10_000) {
+                val infos = repo.upgradeInfo.take(2).toList()
+
+                infos[0].isPro shouldBe true
+                infos[1].apply {
+                    isPro shouldBe true
+                    error.shouldBeInstanceOf<IOException>()
+                }
+            }
+        } finally {
+            scope.cancel()
+            executor.shutdownNow()
         }
     }
 

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/billing/GplayFixActionTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/billing/GplayFixActionTest.kt
@@ -1,0 +1,61 @@
+package eu.darken.sdmse.common.upgrade.core.billing
+
+import android.app.Activity
+import android.content.Intent
+import android.provider.Settings
+import eu.darken.sdmse.R
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowToast
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+
+/**
+ * The error dialog's "Google Play" button runs on an activity context: it has to stay inside the
+ * caller's task, and a device where the launch is refused must get a toast, not a crash.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class GplayFixActionTest : BaseTest() {
+
+    /** Play is installed but unreachable: disabled app, restricted profile or a guarding ROM. */
+    class DeniedLaunchActivity : Activity() {
+        override fun startActivity(intent: Intent): Unit = throw SecurityException("Permission Denial")
+    }
+
+    private val fixAction: (Activity) -> Unit
+        get() = GplayServiceUnavailableException(RuntimeException("Play hiccup"))
+            .getLocalizedError().fixAction.shouldNotBeNull()
+
+    private fun <T : Activity> activityOf(clazz: Class<T>): T = Robolectric.buildActivity(clazz).setup().get()
+
+    @Test
+    fun `the fix action opens Google Play's app info inside the current task`() {
+        val activity = activityOf(Activity::class.java)
+
+        fixAction.invoke(activity)
+
+        val started = shadowOf(activity).nextStartedActivity.shouldNotBeNull()
+        started.action shouldBe Settings.ACTION_APPLICATION_DETAILS_SETTINGS
+        started.data.toString() shouldBe "package:com.android.vending"
+        // NEW_TASK on an activity context detaches Play's app info from our task: the user loses the
+        // back path to the screen they came from and the settings screen lingers in recents.
+        (started.flags and Intent.FLAG_ACTIVITY_NEW_TASK) shouldBe 0
+    }
+
+    @Test
+    fun `a denied launch shows the not-installed toast instead of crashing`() {
+        val activity = activityOf(DeniedLaunchActivity::class.java)
+
+        fixAction.invoke(activity)
+
+        ShadowToast.getTextOfLatestToast() shouldBe
+            activity.getString(R.string.upgrades_gplay_not_installed_message)
+    }
+}


### PR DESCRIPTION
## What changed

Three reliability fixes. FOSS version: a rare timing window could briefly show a supporter as not upgraded while the app was having trouble reading its data — the last confirmed status now always wins. Both versions: the "Google Play" button on the billing error dialog now opens Play's app info within the app's own task, survives devices that block that settings screen (a clear message instead of a crash), and a failing dialog action can no longer crash the app or leave the dialog stuck. The debug log recorder no longer becomes permanently unusable when a recording fails to start — the failure now shows as a normal error and the next attempt works.

## Technical Context

- The FOSS `lastKnownInfo` recording moved inside the `flatMapLatest` block, upstream of its channel buffer: the downstream `onEach` could still be waiting on a buffered emission when the inner flow threw, letting the catch read a stale value and revoke a seen entitlement. A new single-thread-confined test makes the ordering deterministic (it fails on the old placement).
- Fix-action hardening: `FLAG_ACTIVITY_NEW_TASK` dropped from an Activity-context intent, `SecurityException` handled alongside `ActivityNotFoundException`, the fallback toast moved to a string resource, and the dialog's dispatch wrapped so a throwing action logs and dismisses instead of propagating to the UI thread. Two catch blocks that computed `e.asLog()` and discarded it now actually log.
- Recorder: the saved-path read moved inside the start guard; failures are committed to state (`startFailure`) instead of killing the reactive collector; `startRecorder()` awaits recording-or-failure and rethrows (a foreign `CancellationException` is wrapped in `StartFailedException` so ViewModel error handlers see it); `requestStopRecorder()` now runs entirely under the new request mutex — its pre-lock read could previously report `NotRecording` while an in-flight start then committed.
- First test coverage for the compose error dialog (including the throwing-action guard) and the Play fix-intent (asserting the NEW_TASK flag is absent).
