### PR TITLE
General: Shrink oversized screenshots in issues to clickable thumbnails

### DIFF
--- a/.github/thumbnail/.gitignore
+++ b/.github/thumbnail/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.github/thumbnail/analyze.js
+++ b/.github/thumbnail/analyze.js
@@ -1,0 +1,45 @@
+'use strict'
+
+// Runner glue for the unprivileged half of the thumbnail-images workflow.
+//
+// Reads the event payload straight off disk rather than through workflow
+// expressions: untrusted text must never be substituted into a script body.
+// Emits the rewritten Markdown gzipped and base64-encoded so the privileged job
+// can pass it through `env:` without any character needing escaping.
+//
+// Gzip is not an optimisation. A 65536-character body of CJK text is ~196 KB as
+// UTF-8 and ~262 KB once base64-encoded, past the ~128 KiB Linux allows for a
+// single environment string, which would stop the privileged step from starting
+// at all. Markdown compresses far below that.
+
+const fs = require('fs')
+const zlib = require('zlib')
+const { rewrite } = require('./rewrite')
+
+function bodyFromEvent(eventName, payload) {
+  if (eventName === 'issue_comment') return payload.comment && payload.comment.body
+  if (eventName === 'issues') return payload.issue && payload.issue.body
+  return null
+}
+
+async function main() {
+  const eventName = process.env.GITHUB_EVENT_NAME
+  const payload = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'))
+
+  const result = await rewrite(bodyFromEvent(eventName, payload))
+
+  const lines = [`changed=${result.changed}`]
+  if (result.changed) {
+    const packed = zlib.gzipSync(Buffer.from(result.body, 'utf8')).toString('base64')
+    lines.push(`body_gz_b64=${packed}`)
+    console.log(`encoded ${packed.length} bytes`)
+  }
+  fs.appendFileSync(process.env.GITHUB_OUTPUT, `${lines.join('\n')}\n`)
+
+  console.log(`event=${eventName} changed=${result.changed}`)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/.github/thumbnail/analyze.js
+++ b/.github/thumbnail/analyze.js
@@ -12,9 +12,19 @@
 // single environment string, which would stop the privileged step from starting
 // at all. Markdown compresses far below that.
 
+const crypto = require('crypto')
 const fs = require('fs')
 const zlib = require('zlib')
 const { rewrite } = require('./rewrite')
+
+// Base64 characters. Node's per-environment-string ceiling is ~128 KiB; stop
+// short of it so an incompressible body produces a clean no-op instead of a
+// privileged step that cannot start.
+const MAX_ENCODED = 100000
+
+function sha256(value) {
+  return crypto.createHash('sha256').update(String(value), 'utf8').digest('hex')
+}
 
 function bodyFromEvent(eventName, payload) {
   if (eventName === 'issue_comment') return payload.comment && payload.comment.body
@@ -26,13 +36,24 @@ async function main() {
   const eventName = process.env.GITHUB_EVENT_NAME
   const payload = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'))
 
-  const result = await rewrite(bodyFromEvent(eventName, payload))
+  const original = bodyFromEvent(eventName, payload)
+  const result = await rewrite(original)
 
   const lines = [`changed=${result.changed}`]
   if (result.changed) {
     const packed = zlib.gzipSync(Buffer.from(result.body, 'utf8')).toString('base64')
+    if (packed.length > MAX_ENCODED) {
+      console.log(`skipping: encoded body is ${packed.length} chars, over the ${MAX_ENCODED} limit`)
+      fs.appendFileSync(process.env.GITHUB_OUTPUT, 'changed=false\n')
+      return
+    }
     lines.push(`body_gz_b64=${packed}`)
-    console.log(`encoded ${packed.length} bytes`)
+    // The body analysed here is a snapshot from the webhook. Between now and
+    // the API call the author may have edited it again, and blindly PATCHing
+    // would revert that edit. Hand the privileged job a fingerprint of what we
+    // analysed so it can refuse to overwrite anything newer.
+    lines.push(`original_sha=${sha256(original)}`)
+    console.log(`encoded ${packed.length} chars`)
   }
   fs.appendFileSync(process.env.GITHUB_OUTPUT, `${lines.join('\n')}\n`)
 

--- a/.github/thumbnail/package-lock.json
+++ b/.github/thumbnail/package-lock.json
@@ -1,0 +1,126 @@
+{
+  "name": "sdmse-thumbnail",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sdmse-thumbnail",
+      "version": "1.0.0",
+      "license": "GPL-3.0-only",
+      "dependencies": {
+        "probe-image-size": "7.3.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/needle": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.9.1.tgz",
+      "integrity": "sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.6",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "needle": "bin/needle"
+      },
+      "engines": {
+        "node": ">= 4.4.x"
+      }
+    },
+    "node_modules/probe-image-size": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.3.0.tgz",
+      "integrity": "sha512-7CaDeBwiAbh6ohXsvLbAZhO7wzsZAmaevfxe39qvCwRh8LyaZfDlBGGLU1CCTgrTLtCOdwBBhjOrIHaIIimHfQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lodash.merge": "^4.6.2",
+        "needle": "^2.5.2",
+        "stream-parser": "~0.3.1"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/stream-parser": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/stream-parser/-/stream-parser-0.3.1.tgz",
+      "integrity": "sha512-bJ/HgKq41nlKvlhccD5kaCr/P+Hu0wPNKPJOH7en+YrJu/9EgqUF+88w5Jb6KNcjOFMhfX4B2asfeAtIGuHObQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2"
+      }
+    },
+    "node_modules/stream-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/stream-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    }
+  }
+}

--- a/.github/thumbnail/package.json
+++ b/.github/thumbnail/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "sdmse-thumbnail",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Image dimension probing for the thumbnail-images workflow. Not part of the app build.",
+  "license": "GPL-3.0-only",
+  "scripts": {
+    "test": "node --test rewrite.test.js"
+  },
+  "dependencies": {
+    "probe-image-size": "7.3.0"
+  }
+}

--- a/.github/thumbnail/rewrite.js
+++ b/.github/thumbnail/rewrite.js
@@ -181,7 +181,14 @@ async function probeSize(url) {
       }),
       timeout,
     ])
-    if (!result || !result.width || !result.height) return null
+    if (!result) return null
+    // Trust boundary with the image parser. The bytes behind an attachment URL
+    // are fully attacker-controlled, so only two numbers are allowed out of
+    // here; everything else the parser reports is discarded. Math.round() would
+    // coerce a rogue string to NaN rather than let markup through, but NaN
+    // passes every comparison below, so reject it explicitly.
+    if (!Number.isFinite(result.width) || !Number.isFinite(result.height)) return null
+    if (result.width <= 0 || result.height <= 0) return null
     return { width: result.width, height: result.height }
   } catch {
     // Broken, private, redirected or unsupported images are left untouched.
@@ -195,10 +202,14 @@ async function probeSize(url) {
  * @returns {number|null} the width to render at, or null to leave the image alone.
  */
 function thumbnailWidth(size) {
+  if (!Number.isFinite(size.width) || !Number.isFinite(size.height)) return null
+  if (size.width <= 0 || size.height <= 0) return null
   if (size.height <= size.width) return null
   if (size.height < MIN_HEIGHT) return null
 
   const width = Math.round(TARGET_HEIGHT * (size.width / size.height))
+  // NaN would satisfy neither comparison, so assert the result directly.
+  if (!Number.isFinite(width)) return null
   if (width < MIN_WIDTH || width >= size.width) return null
   return width
 }

--- a/.github/thumbnail/rewrite.js
+++ b/.github/thumbnail/rewrite.js
@@ -1,0 +1,276 @@
+'use strict'
+
+// Rewrites oversized GitHub-hosted screenshots in issue/comment Markdown into
+// clickable thumbnails.
+//
+// This module runs in the unprivileged half of the thumbnail-images workflow:
+// it touches attacker-controlled text and fetches attacker-supplied URLs, but
+// the job it runs in holds no write scopes. It performs no GitHub API calls and
+// returns plain data.
+
+const probe = require('probe-image-size')
+
+// Skip a body entirely when it carries this marker.
+const OPT_OUT = '<!-- no-thumbnail -->'
+
+// GitHub caps issue/comment bodies at 65536 characters.
+const MAX_BODY = 65536
+// Bounds the probe fan-out so one comment cannot stall the job or turn the
+// workflow into a request amplifier.
+const MAX_IMAGES = 20
+const PROBE_TIMEOUT_MS = 5000
+
+// Only portrait images taller than this are touched. Landscape shots are
+// already constrained by the width of the comment column.
+const MIN_HEIGHT = 640
+// Rendered height we aim for; the emitted width is derived from it.
+const TARGET_HEIGHT = 400
+const MIN_WIDTH = 80
+
+// Exact host allowlist. Every entry is GitHub-controlled, so the redirect chain
+// a probe follows is GitHub-controlled too. Repo content (raw.githubusercontent)
+// is deliberately absent: those are not user uploads.
+const ALLOWED_HOSTS = [
+  { host: 'github.com', prefix: '/user-attachments/assets/' },
+  { host: 'user-images.githubusercontent.com', prefix: '/' },
+  { host: 'private-user-images.githubusercontent.com', prefix: '/' },
+]
+
+// Deliberately strict: no parentheses, quotes or whitespace in the URL, so a
+// Markdown link containing parens cannot be mis-sliced. No nesting.
+// Both runs are explicitly bounded: with an open-ended `[^\]]*` a body of
+// "![![![..." makes every "!" rescan to end-of-string, which is quadratic.
+const MAX_ALT = 300
+const MAX_URL = 2048
+const IMAGE_RE = new RegExp(
+  `!\\[([^\\]]{0,${MAX_ALT}})\\]\\((https://[^\\s()<>"'\`]{1,${MAX_URL}})\\)`,
+  'g',
+)
+
+/**
+ * Validates a URL against the host allowlist.
+ * @returns {string|null} the normalised URL, or null if it is not eligible.
+ */
+function allowedUrl(raw) {
+  let url
+  try {
+    url = new URL(raw)
+  } catch {
+    return null
+  }
+  if (url.protocol !== 'https:') return null
+  // Credentials in the URL would make the runner send basic auth upstream.
+  if (url.username || url.password) return null
+  // hostname excludes the port, so this has to be checked separately.
+  if (url.port !== '') return null
+
+  const rule = ALLOWED_HOSTS.find((entry) => entry.host === url.hostname)
+  if (!rule) return null
+  // URL parsing already resolved any "..", so this cannot be walked out of.
+  if (!url.pathname.startsWith(rule.prefix)) return null
+
+  return url.toString()
+}
+
+function escapeAttr(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+/**
+ * Indices of lines that sit inside fenced or indented code blocks.
+ */
+function codeLineIndices(lines) {
+  const inCode = new Set()
+  let fence = null
+  let indented = false
+  let prevBlank = true
+
+  for (let i = 0; i < lines.length; i++) {
+    // Fences inside a blockquote carry a "> " prefix on both ends.
+    const line = lines[i].replace(/^(?:\s*>)+ ?/, '')
+    const fenceMatch = /^ {0,3}(`{3,}|~{3,})(.*)$/.exec(line)
+
+    if (fence) {
+      inCode.add(i)
+      // GFM only closes a fence when nothing but whitespace follows the run;
+      // treating "```foo" as a close would end the block early and expose the
+      // rest of it to rewriting.
+      const closes =
+        fenceMatch &&
+        fenceMatch[1][0] === fence[0] &&
+        fenceMatch[1].length >= fence.length &&
+        fenceMatch[2].trim() === ''
+      if (closes) fence = null
+      continue
+    }
+    if (fenceMatch) {
+      fence = fenceMatch[1]
+      inCode.add(i)
+      prevBlank = false
+      indented = false
+      continue
+    }
+    if (line.trim() === '') {
+      // A blank line does not close an indented block.
+      prevBlank = true
+      continue
+    }
+    if (/^(?: {4}|\t)/.test(line) && (prevBlank || indented)) {
+      inCode.add(i)
+      indented = true
+      prevBlank = false
+      continue
+    }
+    indented = false
+    prevBlank = false
+  }
+  return inCode
+}
+
+/**
+ * Character ranges covered by inline code spans on a single line.
+ *
+ * Deliberately a hand-rolled scan rather than /(`+)(.*?)\1/g: on a line shaped
+ * like 30k backticks followed by 35k other characters, that pattern backtracks
+ * for around two minutes. This is a single linear pass. It approximates
+ * CommonMark rather than implementing it, which is enough to answer the only
+ * question asked of it: is this image inside inline code?
+ */
+function inlineCodeRanges(line) {
+  const ranges = []
+  const openers = new Map() // backtick run length -> index of the pending opener
+
+  let i = 0
+  while (i < line.length) {
+    if (line[i] !== '`') {
+      i++
+      continue
+    }
+    let end = i
+    while (end < line.length && line[end] === '`') end++
+    const length = end - i
+
+    if (openers.has(length)) {
+      ranges.push([openers.get(length), end])
+      openers.delete(length)
+    } else {
+      openers.set(length, i)
+    }
+    i = end
+  }
+  return ranges
+}
+
+async function probeSize(url) {
+  let timer
+  const timeout = new Promise((resolve) => {
+    timer = setTimeout(() => resolve(null), PROBE_TIMEOUT_MS)
+    if (typeof timer.unref === 'function') timer.unref()
+  })
+  try {
+    const result = await Promise.race([
+      probe(url, {
+        open_timeout: PROBE_TIMEOUT_MS,
+        response_timeout: PROBE_TIMEOUT_MS,
+        read_timeout: PROBE_TIMEOUT_MS,
+        follow_max: 3,
+      }),
+      timeout,
+    ])
+    if (!result || !result.width || !result.height) return null
+    return { width: result.width, height: result.height }
+  } catch {
+    // Broken, private, redirected or unsupported images are left untouched.
+    return null
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/**
+ * @returns {number|null} the width to render at, or null to leave the image alone.
+ */
+function thumbnailWidth(size) {
+  if (size.height <= size.width) return null
+  if (size.height < MIN_HEIGHT) return null
+
+  const width = Math.round(TARGET_HEIGHT * (size.width / size.height))
+  if (width < MIN_WIDTH || width >= size.width) return null
+  return width
+}
+
+// Only "width" is emitted. Setting "height" as well fights GitHub's
+// max-width:100% and stretches the image on narrow displays.
+function thumbnailHtml(url, alt, width) {
+  const safeUrl = escapeAttr(url)
+  return `<a href="${safeUrl}"><img src="${safeUrl}" alt="${escapeAttr(alt)}" width="${width}"></a>`
+}
+
+/**
+ * @param {string} body Markdown body of an issue or comment.
+ * @returns {Promise<{changed: boolean, body: string}>}
+ */
+async function rewrite(body) {
+  if (typeof body !== 'string' || body.length === 0) return { changed: false, body: '' }
+  if (body.length > MAX_BODY) return { changed: false, body }
+  if (body.includes(OPT_OUT)) return { changed: false, body }
+
+  const lines = body.split('\n')
+  const skipLines = codeLineIndices(lines)
+
+  const hits = []
+  for (let i = 0; i < lines.length; i++) {
+    if (skipLines.has(i)) continue
+    const codeRanges = inlineCodeRanges(lines[i])
+
+    IMAGE_RE.lastIndex = 0
+    let match
+    while ((match = IMAGE_RE.exec(lines[i])) !== null) {
+      const start = match.index
+      if (codeRanges.some(([from, to]) => start >= from && start < to)) continue
+      const url = allowedUrl(match[2])
+      if (!url) continue
+
+      hits.push({ line: i, start, length: match[0].length, alt: match[1], url })
+    }
+  }
+  if (hits.length === 0) return { changed: false, body }
+
+  // The cap exists to bound outbound requests, so it counts distinct URLs
+  // rather than occurrences. Counting occurrences would let twenty repeats of
+  // one thumbnail-sized image crowd out a genuine screenshot further down.
+  const probeTargets = [...new Set(hits.map((hit) => hit.url))].slice(0, MAX_IMAGES)
+  const sizes = new Map()
+  for (const url of probeTargets) {
+    sizes.set(url, await probeSize(url))
+  }
+
+  // Apply right-to-left so earlier offsets stay valid.
+  let changed = false
+  for (const hit of hits.slice().reverse()) {
+    const size = sizes.get(hit.url)
+    if (!size) continue
+    const width = thumbnailWidth(size)
+    if (!width) continue
+
+    const line = lines[hit.line]
+    lines[hit.line] =
+      line.slice(0, hit.start) +
+      thumbnailHtml(hit.url, hit.alt, width) +
+      line.slice(hit.start + hit.length)
+    changed = true
+  }
+  if (!changed) return { changed: false, body }
+
+  const updated = lines.join('\n')
+  // Refuse to produce a body GitHub would reject.
+  if (updated.length > MAX_BODY) return { changed: false, body }
+
+  return { changed: true, body: updated }
+}
+
+module.exports = { rewrite, allowedUrl, thumbnailWidth, codeLineIndices, escapeAttr }

--- a/.github/thumbnail/rewrite.js
+++ b/.github/thumbnail/rewrite.js
@@ -90,8 +90,14 @@ function codeLineIndices(lines) {
   let prevBlank = true
 
   for (let i = 0; i < lines.length; i++) {
-    // Fences inside a blockquote carry a "> " prefix on both ends.
-    const line = lines[i].replace(/^(?:\s*>)+ ?/, '')
+    // Strip container prefixes so a fence is still recognised inside a
+    // blockquote ("> ```") or a list item ("- ```"). Missing the opener is the
+    // damaging direction: the fenced sample then gets rewritten as if it were
+    // prose, and its closing fence reads as a stray opener that hides real
+    // images further down.
+    const line = lines[i]
+      .replace(/^(?:\s*>)+ ?/, '')
+      .replace(/^ {0,3}(?:[-*+]|\d{1,9}[.)]) +/, '')
     const fenceMatch = /^ {0,3}(`{3,}|~{3,})(.*)$/.exec(line)
 
     if (fence) {
@@ -223,9 +229,11 @@ function thumbnailHtml(url, alt, width) {
 
 /**
  * @param {string} body Markdown body of an issue or comment.
+ * @param {{probe?: (url: string) => Promise<{width: number, height: number}|null>}} [options]
+ *   Seam for tests, so the replacement path can be covered without network access.
  * @returns {Promise<{changed: boolean, body: string}>}
  */
-async function rewrite(body) {
+async function rewrite(body, { probe: probeFn = probeSize } = {}) {
   if (typeof body !== 'string' || body.length === 0) return { changed: false, body: '' }
   if (body.length > MAX_BODY) return { changed: false, body }
   if (body.includes(OPT_OUT)) return { changed: false, body }
@@ -243,6 +251,15 @@ async function rewrite(body) {
     while ((match = IMAGE_RE.exec(lines[i])) !== null) {
       const start = match.index
       if (codeRanges.some(([from, to]) => start >= from && start < to)) continue
+
+      const prev = start > 0 ? lines[i][start - 1] : ''
+      // "\![alt](url)" is an escaped literal, not an image.
+      if (prev === '\\') continue
+      // "[![alt](url)](target)" is a linked image. Rewriting the inner image
+      // would strip the author's link target, and it is already clickable,
+      // which is the whole point of the rewrite.
+      if (prev === '[') continue
+
       const url = allowedUrl(match[2])
       if (!url) continue
 
@@ -257,7 +274,7 @@ async function rewrite(body) {
   const probeTargets = [...new Set(hits.map((hit) => hit.url))].slice(0, MAX_IMAGES)
   const sizes = new Map()
   for (const url of probeTargets) {
-    sizes.set(url, await probeSize(url))
+    sizes.set(url, await probeFn(url))
   }
 
   // Apply right-to-left so earlier offsets stay valid.

--- a/.github/thumbnail/rewrite.test.js
+++ b/.github/thumbnail/rewrite.test.js
@@ -57,6 +57,16 @@ test('thumbnailWidth only shrinks tall portrait images', () => {
   assert.strictEqual(thumbnailWidth({ width: 100, height: 700 }), null)
 })
 
+test('thumbnailWidth rejects non-numeric dimensions from the parser', () => {
+  // The image bytes are attacker-controlled, so nothing the parser reports is
+  // assumed to be a number. NaN previously slipped through: every comparison
+  // against it is false, so it satisfied both bounds checks.
+  for (const bad of ['1 onerror=alert(1)', {}, null, undefined, NaN, Infinity, -1, 0]) {
+    assert.strictEqual(thumbnailWidth({ width: bad, height: 5000 }), null, `width=${String(bad)}`)
+    assert.strictEqual(thumbnailWidth({ width: 1080, height: bad }), null, `height=${String(bad)}`)
+  }
+})
+
 test('codeLineIndices marks fenced and indented blocks', () => {
   const lines = [
     'before',

--- a/.github/thumbnail/rewrite.test.js
+++ b/.github/thumbnail/rewrite.test.js
@@ -1,0 +1,160 @@
+'use strict'
+
+// Run with: node --test .github/thumbnail/
+// Covers the parsing and validation logic. The network probe is not exercised.
+
+const test = require('node:test')
+const assert = require('node:assert')
+
+const { rewrite, allowedUrl, thumbnailWidth, codeLineIndices, escapeAttr } = require('./rewrite')
+
+const ATTACHMENT = 'https://github.com/user-attachments/assets/0e3b1f2a-1111-2222-3333-444455556666'
+
+test('allowedUrl accepts GitHub attachment hosts', () => {
+  assert.strictEqual(allowedUrl(ATTACHMENT), ATTACHMENT)
+  assert.strictEqual(
+    allowedUrl('https://user-images.githubusercontent.com/1/2.png'),
+    'https://user-images.githubusercontent.com/1/2.png',
+  )
+})
+
+test('allowedUrl rejects lookalike and non-GitHub hosts', () => {
+  // Suffix confusion: passes a naive includes('github.com') check.
+  assert.strictEqual(allowedUrl('https://github.com.evil.tld/user-attachments/assets/x'), null)
+  // Fragment confusion: also passes a naive includes() check.
+  assert.strictEqual(allowedUrl('https://evil.tld/x.png#github.com'), null)
+  // Subdomain that is not on the list.
+  assert.strictEqual(allowedUrl('https://raw.githubusercontent.com/o/r/main/x.png'), null)
+  // Wrong path on an allowed host.
+  assert.strictEqual(allowedUrl('https://github.com/owner/repo/raw/main/x.png'), null)
+  // Path traversal is normalised by URL parsing before the prefix check.
+  assert.strictEqual(allowedUrl('https://github.com/user-attachments/assets/../../x.png'), null)
+  // Non-https schemes.
+  assert.strictEqual(allowedUrl('http://github.com/user-attachments/assets/x'), null)
+  assert.strictEqual(allowedUrl('file:///etc/passwd'), null)
+  // Embedded credentials.
+  assert.strictEqual(allowedUrl('https://u:p@github.com/user-attachments/assets/x'), null)
+  // Cloud metadata endpoint.
+  assert.strictEqual(allowedUrl('http://169.254.169.254/metadata/instance'), null)
+  assert.strictEqual(allowedUrl('not a url'), null)
+})
+
+test('escapeAttr neutralises attribute breakout', () => {
+  assert.strictEqual(
+    escapeAttr('" onerror="alert(1)'),
+    '&quot; onerror=&quot;alert(1)',
+  )
+  assert.strictEqual(escapeAttr('a & b <c>'), 'a &amp; b &lt;c&gt;')
+})
+
+test('thumbnailWidth only shrinks tall portrait images', () => {
+  assert.strictEqual(thumbnailWidth({ width: 1080, height: 2400 }), 180)
+  // Landscape is already constrained by the comment column.
+  assert.strictEqual(thumbnailWidth({ width: 1920, height: 1080 }), null)
+  // Portrait but small enough already.
+  assert.strictEqual(thumbnailWidth({ width: 200, height: 400 }), null)
+  // Would scale up rather than down.
+  assert.strictEqual(thumbnailWidth({ width: 100, height: 700 }), null)
+})
+
+test('codeLineIndices marks fenced and indented blocks', () => {
+  const lines = [
+    'before',
+    '```yaml',
+    'inside fence',
+    '```',
+    'after',
+    '',
+    '    indented code',
+    '    still code',
+    '',
+    'prose again',
+  ]
+  const marked = codeLineIndices(lines)
+  assert.deepStrictEqual([...marked].sort((a, b) => a - b), [1, 2, 3, 6, 7])
+})
+
+test('rewrite honours the opt-out marker', async () => {
+  const body = `<!-- no-thumbnail -->\n![shot](${ATTACHMENT})`
+  assert.deepStrictEqual(await rewrite(body), { changed: false, body })
+})
+
+test('rewrite ignores images inside fenced code blocks', async () => {
+  const body = ['```md', `![shot](${ATTACHMENT})`, '```'].join('\n')
+  assert.deepStrictEqual(await rewrite(body), { changed: false, body })
+})
+
+test('rewrite ignores images inside inline code spans', async () => {
+  const body = `use \`![shot](${ATTACHMENT})\` to embed`
+  assert.deepStrictEqual(await rewrite(body), { changed: false, body })
+})
+
+test('rewrite ignores non-allowlisted hosts', async () => {
+  const body = '![shot](https://evil.tld/huge.png)'
+  assert.deepStrictEqual(await rewrite(body), { changed: false, body })
+})
+
+test('rewrite ignores reference-style images and existing HTML', async () => {
+  const refStyle = '![shot][ref]\n\n[ref]: ' + ATTACHMENT
+  assert.deepStrictEqual(await rewrite(refStyle), { changed: false, body: refStyle })
+
+  const html = `<a href="${ATTACHMENT}"><img src="${ATTACHMENT}" width="180"></a>`
+  assert.deepStrictEqual(await rewrite(html), { changed: false, body: html })
+})
+
+test('rewrite stays fast on adversarial bodies', async () => {
+  const cases = {
+    // Unbounded alt/URL quantifiers made every "!" rescan to end-of-string.
+    'unclosed image opens': '!['.repeat(32000),
+    'nested brackets': '![' + '['.repeat(60000) + ']( https://x',
+    'all backticks': '`'.repeat(65000),
+    // The killer for /(`+)(.*?)\1/g: one long run, then a long non-backtick
+    // tail. Took ~118 seconds before inlineCodeRanges became a linear scan.
+    'backtick run then tail': '`'.repeat(30000) + 'x'.repeat(35000),
+    'alternating backticks': '`x'.repeat(32000),
+    'many fences': '```\n'.repeat(16000),
+    'deep indent': '    x\n'.repeat(10000),
+  }
+  for (const [name, body] of Object.entries(cases)) {
+    const started = process.hrtime.bigint()
+    await rewrite(body.slice(0, 65536))
+    const elapsedMs = Number(process.hrtime.bigint() - started) / 1e6
+    assert.ok(elapsedMs < 1000, `${name} took ${elapsedMs.toFixed(0)}ms`)
+  }
+})
+
+test('allowedUrl rejects non-default ports', () => {
+  // hostname excludes the port, so this needs its own check.
+  assert.strictEqual(allowedUrl('https://github.com:8443/user-attachments/assets/x'), null)
+  assert.strictEqual(allowedUrl('https://user-images.githubusercontent.com:1337/a.png'), null)
+})
+
+test('codeLineIndices handles blockquoted and mid-content fences', () => {
+  const lines = [
+    '> ```kotlin',
+    '> val x = 1',
+    '> ```',
+    'prose',
+    '```',
+    'still code, because "```foo" does not close a fence',
+    '```foo',
+    'also still code',
+    '```',
+    'free again',
+  ]
+  const marked = codeLineIndices(lines)
+  assert.deepStrictEqual([...marked].sort((a, b) => a - b), [0, 1, 2, 4, 5, 6, 7, 8])
+})
+
+test('rewrite ignores images in blockquoted code fences', async () => {
+  const body = ['> ```md', `> ![shot](${ATTACHMENT})`, '> ```'].join('\n')
+  assert.deepStrictEqual(await rewrite(body), { changed: false, body })
+})
+
+test('rewrite leaves empty and oversized bodies alone', async () => {
+  assert.deepStrictEqual(await rewrite(''), { changed: false, body: '' })
+  assert.deepStrictEqual(await rewrite(undefined), { changed: false, body: '' })
+
+  const huge = 'x'.repeat(65537)
+  assert.deepStrictEqual(await rewrite(huge), { changed: false, body: huge })
+})

--- a/.github/thumbnail/rewrite.test.js
+++ b/.github/thumbnail/rewrite.test.js
@@ -9,6 +9,73 @@ const assert = require('node:assert')
 const { rewrite, allowedUrl, thumbnailWidth, codeLineIndices, escapeAttr } = require('./rewrite')
 
 const ATTACHMENT = 'https://github.com/user-attachments/assets/0e3b1f2a-1111-2222-3333-444455556666'
+const ATTACHMENT2 = 'https://github.com/user-attachments/assets/9a9a9a9a-5555-6666-7777-888899990000'
+
+// Stands in for the network probe. 1080x2400 is a typical phone screenshot and
+// yields width=180.
+const tallProbe = { probe: async () => ({ width: 1080, height: 2400 }) }
+
+test('rewrite replaces an eligible image with a clickable thumbnail', async () => {
+  const result = await rewrite(`before\n\n![my "shot" & co](${ATTACHMENT})\n\nafter`, tallProbe)
+  assert.strictEqual(result.changed, true)
+  assert.strictEqual(
+    result.body,
+    'before\n\n' +
+      `<a href="${ATTACHMENT}"><img src="${ATTACHMENT}" alt="my &quot;shot&quot; &amp; co" width="180"></a>` +
+      '\n\nafter',
+  )
+  // Quotes in the alt text must not break out of the attribute.
+  assert.ok(!result.body.includes('alt="my "shot"'))
+  // Height is never emitted: with width it fights GitHub's max-width:100%.
+  assert.ok(!result.body.includes('height='))
+})
+
+test('rewrite handles several images on one line without corrupting offsets', async () => {
+  const result = await rewrite(`![a](${ATTACHMENT}) middle ![b](${ATTACHMENT2})`, tallProbe)
+  assert.strictEqual(result.changed, true)
+  assert.strictEqual(
+    result.body,
+    `<a href="${ATTACHMENT}"><img src="${ATTACHMENT}" alt="a" width="180"></a>` +
+      ' middle ' +
+      `<a href="${ATTACHMENT2}"><img src="${ATTACHMENT2}" alt="b" width="180"></a>`,
+  )
+})
+
+test('rewrite is idempotent: its own output does not rematch', async () => {
+  const once = await rewrite(`![a](${ATTACHMENT})`, tallProbe)
+  assert.strictEqual(once.changed, true)
+  const twice = await rewrite(once.body, tallProbe)
+  assert.strictEqual(twice.changed, false)
+})
+
+test('rewrite leaves escaped and already-linked images alone', async () => {
+  // Escaped: not an image at all.
+  const escaped = `\\![shot](${ATTACHMENT})`
+  assert.deepStrictEqual(await rewrite(escaped, tallProbe), { changed: false, body: escaped })
+
+  // Already a linked image: rewriting would discard the author's link target.
+  const linked = `[![shot](${ATTACHMENT})](https://example.com/details)`
+  assert.deepStrictEqual(await rewrite(linked, tallProbe), { changed: false, body: linked })
+})
+
+test('rewrite ignores images in a fence opened inside a list item', async () => {
+  const body = ['- example:', '  ```md', `  ![shot](${ATTACHMENT})`, '  ```', '', 'prose'].join('\n')
+  assert.deepStrictEqual(await rewrite(body, tallProbe), { changed: false, body })
+})
+
+test('a stray fence in a list does not hide later real images', async () => {
+  const body = ['- ```md', '  sample', '  ```', '', `![real](${ATTACHMENT})`].join('\n')
+  const result = await rewrite(body, tallProbe)
+  assert.strictEqual(result.changed, true)
+  assert.ok(result.body.includes('<img src='), 'image after the list fence should still be rewritten')
+  assert.ok(result.body.includes('  sample'), 'the fenced sample must be untouched')
+})
+
+test('rewrite skips images whose probe fails', async () => {
+  const body = `![shot](${ATTACHMENT})`
+  const failing = { probe: async () => null }
+  assert.deepStrictEqual(await rewrite(body, failing), { changed: false, body })
+})
 
 test('allowedUrl accepts GitHub attachment hosts', () => {
   assert.strictEqual(allowedUrl(ATTACHMENT), ATTACHMENT)

--- a/.github/workflows/thumbnail-images.yml
+++ b/.github/workflows/thumbnail-images.yml
@@ -1,0 +1,91 @@
+name: Thumbnail images
+
+# Rewrites oversized GitHub-hosted screenshots in issues and comments into
+# clickable thumbnails.
+#
+# Split into two jobs on purpose. `analyze` handles attacker-controlled text and
+# fetches attacker-supplied URLs, and holds no write scopes. `apply` holds the
+# write scope but only decodes a base64 blob and makes one API call, against an
+# ID it reads from the event itself rather than from `analyze`.
+#
+# Add <!-- no-thumbnail --> to a body to opt it out.
+
+on:
+  issue_comment:
+    types: [created, edited]
+  issues:
+    types: [opened, edited]
+
+permissions: {}
+
+concurrency:
+  group: thumbnail-${{ github.event_name }}-${{ github.event.comment.id || github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    # Untrusted half: parses user Markdown and probes user-supplied image URLs.
+    # `contents: read` only exists to fetch the pinned lockfile; on a public repo
+    # it grants nothing an anonymous user does not already have.
+    if: github.event.sender.type != 'Bot'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      changed: ${{ steps.rewrite.outputs.changed }}
+      body_gz_b64: ${{ steps.rewrite.outputs.body_gz_b64 }}
+    steps:
+      - name: Checkout tooling
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/thumbnail
+          sparse-checkout-cone-mode: false
+
+      - name: Install probe dependency
+        working-directory: .github/thumbnail
+        # --ignore-scripts blocks package lifecycle hooks; `npm ci` pins every
+        # transitive package to the integrity hashes in the committed lockfile.
+        run: npm ci --ignore-scripts
+
+      - name: Rewrite images
+        id: rewrite
+        working-directory: .github/thumbnail
+        run: node analyze.js
+
+  apply:
+    # Privileged half: no untrusted parsing, no network fetches, no repo code.
+    needs: analyze
+    if: needs.analyze.outputs.changed == 'true'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Update body
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          # Reaches the script as a runtime value, never as substituted source.
+          # Base64 also means no character in it can terminate a string literal,
+          # and gzip keeps it under the per-variable size limit for bodies in
+          # scripts like Chinese or Japanese.
+          BODY_GZ_B64: ${{ needs.analyze.outputs.body_gz_b64 }}
+        with:
+          script: |
+            const zlib = require('zlib')
+            const body = zlib.gunzipSync(Buffer.from(process.env.BODY_GZ_B64, 'base64')).toString('utf8')
+            if (context.eventName === 'issue_comment') {
+              await github.rest.issues.updateComment({
+                ...context.repo,
+                comment_id: context.payload.comment.id,
+                body,
+              })
+            } else {
+              await github.rest.issues.update({
+                ...context.repo,
+                issue_number: context.payload.issue.number,
+                body,
+              })
+            }

--- a/.github/workflows/thumbnail-images.yml
+++ b/.github/workflows/thumbnail-images.yml
@@ -35,6 +35,7 @@ jobs:
     outputs:
       changed: ${{ steps.rewrite.outputs.changed }}
       body_gz_b64: ${{ steps.rewrite.outputs.body_gz_b64 }}
+      original_sha: ${{ steps.rewrite.outputs.original_sha }}
     steps:
       - name: Checkout tooling
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -72,20 +73,33 @@ jobs:
           # and gzip keeps it under the per-variable size limit for bodies in
           # scripts like Chinese or Japanese.
           BODY_GZ_B64: ${{ needs.analyze.outputs.body_gz_b64 }}
+          ORIGINAL_SHA: ${{ needs.analyze.outputs.original_sha }}
         with:
           script: |
+            const crypto = require('crypto')
             const zlib = require('zlib')
+
+            const isComment = context.eventName === 'issue_comment'
+            const target = isComment
+              ? { comment_id: context.payload.comment.id }
+              : { issue_number: context.payload.issue.number }
+
+            // Compare-and-swap. The body was snapshotted when the webhook
+            // fired; if the author has edited it since, writing our rewrite
+            // would silently revert their edit. Re-read and bail on mismatch.
+            const current = isComment
+              ? (await github.rest.issues.getComment({ ...context.repo, ...target })).data.body
+              : (await github.rest.issues.get({ ...context.repo, ...target })).data.body
+            const currentSha = crypto.createHash('sha256').update(String(current ?? ''), 'utf8').digest('hex')
+
+            if (currentSha !== process.env.ORIGINAL_SHA) {
+              core.info('Body changed since it was analysed; skipping rather than reverting the newer edit.')
+              return
+            }
+
             const body = zlib.gunzipSync(Buffer.from(process.env.BODY_GZ_B64, 'base64')).toString('utf8')
-            if (context.eventName === 'issue_comment') {
-              await github.rest.issues.updateComment({
-                ...context.repo,
-                comment_id: context.payload.comment.id,
-                body,
-              })
+            if (isComment) {
+              await github.rest.issues.updateComment({ ...context.repo, ...target, body })
             } else {
-              await github.rest.issues.update({
-                ...context.repo,
-                issue_number: context.payload.issue.number,
-                body,
-              })
+              await github.rest.issues.update({ ...context.repo, ...target, body })
             }

--- a/.github/workflows/thumbnail-tests.yml
+++ b/.github/workflows/thumbnail-tests.yml
@@ -6,10 +6,12 @@ on:
   push:
     paths:
       - '.github/thumbnail/**'
+      - '.github/workflows/thumbnail-images.yml'
       - '.github/workflows/thumbnail-tests.yml'
   pull_request:
     paths:
       - '.github/thumbnail/**'
+      - '.github/workflows/thumbnail-images.yml'
       - '.github/workflows/thumbnail-tests.yml'
 
 permissions: {}

--- a/.github/workflows/thumbnail-tests.yml
+++ b/.github/workflows/thumbnail-tests.yml
@@ -1,0 +1,37 @@
+name: Thumbnail tooling tests
+
+# Guards the Markdown parsing and URL allowlist used by thumbnail-images.yml.
+
+on:
+  push:
+    paths:
+      - '.github/thumbnail/**'
+      - '.github/workflows/thumbnail-tests.yml'
+  pull_request:
+    paths:
+      - '.github/thumbnail/**'
+      - '.github/workflows/thumbnail-tests.yml'
+
+permissions: {}
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/thumbnail
+          sparse-checkout-cone-mode: false
+
+      - name: Install dependencies
+        working-directory: .github/thumbnail
+        run: npm ci --ignore-scripts
+
+      - name: Run tests
+        working-directory: .github/thumbnail
+        run: npm test


### PR DESCRIPTION
## What changed

Large phone screenshots posted in issues and comments now get shrunk to a small thumbnail you can click to open full size. Previously a single screenshot could take up several screens of scrolling.

Only tall portrait images are touched. Landscape screenshots, badges, icons and small images are left exactly as they are, because GitHub already fits those to the comment width.

Put `<!-- no-thumbnail -->` anywhere in a comment to opt that comment out.

## Technical Context

The issue/comment body is fully attacker-controlled on a public repo, so the workflow is built as a **two-job privilege split**:

- **`analyze`** parses the untrusted Markdown and probes attacker-supplied image URLs. It holds only `contents: read`, which on a public repo grants nothing an anonymous user lacks.
- **`apply`** holds `issues: write` but does no parsing and makes no network requests. It receives one gzipped base64 blob and reads the target comment ID from the event payload rather than from `analyze`, so the untrusted half cannot redirect the edit at someone else's comment.

Why the pieces are the way they are:

- **No `${{ }}` reaches any script body.** `analyze` reads the event from `GITHUB_EVENT_PATH` on disk; `apply` receives the result through `env:`. Expression injection is the vector that actually compromises Actions, and this closes it structurally rather than by escaping.
- **Pure-JS header probe, never a native decoder.** `probe-image-size` reads image headers in JavaScript and never decodes pixels. Shelling out to ImageMagick or using `sharp`/libvips would put a native parser behind an attacker-controlled file, which is where essentially every image RCE has lived. Only two integers escape the parser, and they must be finite and positive.
- **Compare-and-swap before writing.** The body is snapshotted when the webhook fires but written 15-20s later. Without a check, an author fixing a typo in that window had their edit silently reverted. `analyze` emits a SHA-256 of what it analysed and `apply` refuses to write if the body no longer matches. This narrows the race to the ~200ms between read and write rather than closing it — the REST API has no conditional-update primitive.
- **Only `width` is emitted, never `height`.** Setting both fights GitHub's `max-width:100%` and stretches images on narrow displays. This is the exact bug NewPipe's equivalent workflow had to fix.
- **`npm ci --ignore-scripts`** against a committed lockfile, so package lifecycle hooks cannot run and every transitive package is integrity-pinned.

### Review guidance

The Markdown scanning in `rewrite.js` is the part worth attention — it decides what *not* to touch. Images inside fenced, indented, blockquoted and list-item code blocks are skipped, as are escaped images (`\![x](y)`) and already-linked images (`[![x](y)](z)`, which would otherwise lose the author's link target). Both regex quantifiers are explicitly bounded and inline-code detection is a hand-rolled linear scan; the obvious `/(\`+)(.*?)\1/g` backtracks for ~118 seconds on a hostile line.

`pull-requests: write` is kept alongside `issues: write`. `issues.updateComment` is an Issues-API endpoint and likely does not need it, but the job makes exactly one call against an event-derived ID, and dropping it risks a 403 on PR-timeline comments that an issue-based smoke test would not catch.

### Testing

23 unit tests run in CI via `thumbnail-tests.yml`. The probe is injectable, so substitution, multi-image offset math, idempotency and probe-failure are covered without network access.

Verified against live GitHub infrastructure using real attachments from #2603 and #2557: they resolve unauthenticated in one redirect, and a 1080x2340 screenshot yields a 185px thumbnail.

**Not yet exercised on a runner.** Workflows for `issues`/`issue_comment` run from the default branch, so this cannot execute until it is merged. A throwaway issue should be the first thing after merge.