### PR TITLE
Fix: Dashboard card asking for a Play Store review never appeared

### DIFF
--- a/app/src/gplay/java/eu/darken/sdmse/common/review/GplayReviewTool.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/review/GplayReviewTool.kt
@@ -1,12 +1,10 @@
 package eu.darken.sdmse.common.review
 
 import android.app.Activity
-import android.content.Context
 import com.google.android.play.core.ktx.launchReview
 import com.google.android.play.core.ktx.requestReview
 import com.google.android.play.core.review.ReviewInfo
-import com.google.android.play.core.review.ReviewManagerFactory
-import dagger.hilt.android.qualifiers.ApplicationContext
+import com.google.android.play.core.review.ReviewManager
 import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
@@ -18,73 +16,102 @@ import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.flow.replayingShare
 import eu.darken.sdmse.common.flow.throttleLatest
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
-import eu.darken.sdmse.main.core.release.ReleaseSettings
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.sync.Mutex
 import java.time.Duration
 import java.time.Instant
-import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.system.measureTimeMillis
 
 @Singleton
 class GplayReviewTool @Inject constructor(
-    @ApplicationContext private val context: Context,
     @AppScope private val appScope: CoroutineScope,
     private val settings: ReviewSettings,
-    releaseSettings: ReleaseSettings,
+    private val manager: ReviewManager,
     upgradeRepo: UpgradeRepo,
 ) : ReviewTool {
-    private val manager by lazy { ReviewManagerFactory.create(context) }
-    private val reviewRefresh = MutableStateFlow(UUID.randomUUID())
-    private val gplayReviewState = reviewRefresh
-        .map {
-            try {
-                manager.requestReview().also {
-                    log(TAG) { "requestReview(): ${it.desc()}" }
+
+    // Test seam: the probe backoff runs on AppScope (a real dispatcher), so a virtual-time test
+    // cannot advance the production bound. Same pattern as UpgradeRepoGplay.launchTimeoutMs.
+    internal var probeRetryDelay: Duration = PROBE_RETRY_DELAY
+
+    // Local bookkeeping only: decided without talking to Play, so an ineligible user never
+    // triggers a Play round-trip.
+    private val isLocallyEligible: Flow<Boolean> = combine(
+        settings.lastDismissed.flow,
+        settings.reviewedAt.flow,
+        upgradeRepo.upgradeInfo,
+    ) { lastDismissed, reviewedAt, upgradeInfo ->
+        val now = Instant.now()
+
+        // Free trial is 14 days, only ask for review after the user has paid something
+        val hasPaidForPro = Duration.between(upgradeInfo.upgradedAt ?: now, now) > Duration.ofDays(21)
+        val isSnoozed = Duration.between(lastDismissed ?: Instant.EPOCH, now) < Duration.ofDays(14)
+        val hasReviewed = reviewedAt != null
+
+        log(TAG) { "Eligibility: hasPaidForPro=$hasPaidForPro (${upgradeInfo.upgradedAt})" }
+        log(TAG) { "Eligibility: isSnoozed=$isSnoozed ($lastDismissed), hasReviewed=$hasReviewed ($reviewedAt)" }
+
+        hasPaidForPro && !isSnoozed && !hasReviewed
+    }
+        .distinctUntilChanged()
+
+    // Only probed once the user is eligible: Play counts requests against the app's quota, and an
+    // `isNoOp` answer is Play's deliberate verdict, i.e. an answer and not a failure to retry.
+    private val isReviewAvailable: Flow<Boolean> = isLocallyEligible
+        .flatMapLatest { eligible ->
+            if (!eligible) return@flatMapLatest flowOf(false)
+
+            flow {
+                for (attempt in 1..PROBE_ATTEMPTS) {
+                    val info = try {
+                        manager.requestReview()
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        log(TAG, WARN) { "Probe $attempt/$PROBE_ATTEMPTS failed: ${e.asLog()}" }
+                        if (attempt < PROBE_ATTEMPTS) delay(probeRetryDelay.toMillis())
+                        continue
+                    }
+                    log(TAG) { "Probe $attempt/$PROBE_ATTEMPTS returned ${info.desc()}" }
+                    emit(info.canShow)
+                    return@flow
                 }
-            } catch (e: Exception) {
-                log(TAG, ERROR) { "Failed to get ReviewInfo: ${e.asLog()}" }
-                null
+                // Re-probed when eligibility changes or on the next process start
+                log(TAG, WARN) { "Probe gave up after $PROBE_ATTEMPTS attempts" }
+                emit(false)
             }
         }
         .replayingShare(appScope)
 
     override val state: Flow<ReviewTool.State> = combine(
-        settings.lastDismissed.flow,
+        isLocallyEligible,
+        isReviewAvailable,
         settings.reviewedAt.flow,
-        gplayReviewState,
-        upgradeRepo.upgradeInfo,
-        releaseSettings.releasePartyAt.flow,
-    ) { lastDismissed, reviewedAt, reviewInfo, upgradeInfo, releasePartyAt ->
-        val now = Instant.now()
-        val isSnoozed = Duration.between(lastDismissed ?: Instant.EPOCH, now) < Duration.ofDays(14)
-        val canShow = reviewInfo?.canShow == true
-        val hasReviewed = reviewedAt != null
-
-        // Free trial is 14 days, only ask for review after the user has paid something
-        val hasPaidForPro = Duration.between(upgradeInfo.upgradedAt ?: now, now) > Duration.ofDays(21)
-
-        // User may still be hangover from party, don't ask for review
-        val hasRecoveredFromParty = Duration.between(releasePartyAt ?: now, now) > Duration.ofDays(5)
-
-        log(TAG) { "State 1: canShow=$canShow, isSnoozed=$isSnoozed ($lastDismissed), reviewedAt=$reviewedAt" }
-        log(TAG) { "State 2: hasRecoveredFromParty=$hasRecoveredFromParty, hasPaidForPro=$hasPaidForPro" }
-
+    ) { eligible, available, reviewedAt ->
+        log(TAG) { "State: eligible=$eligible, available=$available, reviewedAt=$reviewedAt" }
         ReviewTool.State(
-            shouldAskForReview = hasRecoveredFromParty && hasPaidForPro && !isSnoozed && !hasReviewed && canShow,
-            hasReviewed = hasReviewed,
+            shouldAskForReview = eligible && available,
+            hasReviewed = reviewedAt != null,
         )
     }
         .throttleLatest(500)
         .onStart { emit(ReviewTool.State()) }
         .replayingShare(appScope)
+
+    // Single-flight: a second tap must not queue up behind the first, or Play's flow would be
+    // launched again the moment the user returns from it.
+    private val reviewLock = Mutex()
 
     override suspend fun dismiss() {
         log(TAG, INFO) { "dismiss()" }
@@ -92,31 +119,60 @@ class GplayReviewTool @Inject constructor(
     }
 
     override suspend fun reviewNow(activity: Activity) {
-        val reviewInfo = gplayReviewState.first()
-        log(TAG, INFO) { "reviewNow($activity, ${reviewInfo?.desc()})" }
+        log(TAG, INFO) { "reviewNow($activity)" }
 
-        if (reviewInfo == null) {
-            log(TAG, WARN) { "ReviewInfo is unavailable" }
+        if (!reviewLock.tryLock()) {
+            log(TAG, WARN) { "reviewNow(...) is already in progress, skipping" }
             return
         }
 
-        if (!reviewInfo.canShow) {
-            log(TAG, ERROR) { "ReviewInfo says we can't show the prompt, how did we get here?" }
-            return
-        }
+        try {
+            // ReviewInfo is short lived, Google wants it requested shortly before the launch,
+            // a token cached at process start is likely stale by the time the user taps.
+            val reviewInfo = try {
+                manager.requestReview()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                // A transient failure is not user intent: don't snooze the card, the next tap retries
+                log(TAG, ERROR) { "Failed to get a fresh ReviewInfo: ${e.asLog()}" }
+                return
+            }
+            log(TAG) { "reviewNow(...): Fresh ${reviewInfo.desc()}" }
 
-        val reviewTime = measureTimeMillis {
-            manager.launchReview(activity, reviewInfo)
-        }
-        log(TAG) { "Review completed after ${reviewTime}ms" }
-        reviewRefresh.value = UUID.randomUUID()
+            if (!reviewInfo.canShow) {
+                // Play's quota verdict, asking again right away would be pointless
+                log(TAG, WARN) { "Play says we can't show the prompt, snoozing" }
+                settings.lastDismissed.value(Instant.now())
+                return
+            }
 
-        if (Duration.ofMillis(reviewTime) >= Duration.ofSeconds(2)) {
-            log(TAG, INFO) { "Marking review as completed" }
-            settings.reviewedAt.value(Instant.now())
-        } else {
-            log(TAG, INFO) { "Review was too quick, counting as dismiss" }
-            settings.lastDismissed.value(Instant.now())
+            if (activity.isFinishing || activity.isDestroyed) {
+                log(TAG, WARN) { "Activity is gone, aborting: $activity" }
+                return
+            }
+
+            val reviewTime = measureTimeMillis {
+                try {
+                    manager.launchReview(activity, reviewInfo)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    log(TAG, ERROR) { "Failed to launch review flow: ${e.asLog()}" }
+                    return
+                }
+            }
+            log(TAG) { "Review completed after ${reviewTime}ms" }
+
+            if (Duration.ofMillis(reviewTime) >= Duration.ofSeconds(2)) {
+                log(TAG, INFO) { "Marking review as completed" }
+                settings.reviewedAt.value(Instant.now())
+            } else {
+                log(TAG, INFO) { "Review was too quick, counting as dismiss" }
+                settings.lastDismissed.value(Instant.now())
+            }
+        } finally {
+            reviewLock.unlock()
         }
     }
 
@@ -132,5 +188,7 @@ class GplayReviewTool @Inject constructor(
 
     companion object {
         private val TAG = logTag("Review", "Tool", "Gplay")
+        private const val PROBE_ATTEMPTS = 3
+        private val PROBE_RETRY_DELAY = Duration.ofSeconds(30)
     }
 }

--- a/app/src/gplay/java/eu/darken/sdmse/common/review/ReviewModule.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/review/ReviewModule.kt
@@ -1,8 +1,13 @@
 package eu.darken.sdmse.common.review
 
+import android.content.Context
+import com.google.android.play.core.review.ReviewManager
+import com.google.android.play.core.review.ReviewManagerFactory
 import dagger.Binds
 import dagger.Module
+import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 
@@ -13,4 +18,10 @@ abstract class ReviewModule {
     @Binds
     @Singleton
     abstract fun reviewTool(tool: GplayReviewTool): ReviewTool
+
+    companion object {
+        @Provides
+        @Singleton
+        fun reviewManager(@ApplicationContext context: Context): ReviewManager = ReviewManagerFactory.create(context)
+    }
 }

--- a/app/src/main/java/eu/darken/sdmse/main/core/release/ReleaseSettings.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/core/release/ReleaseSettings.kt
@@ -7,15 +7,12 @@ import androidx.datastore.preferences.preferencesDataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.sdmse.common.datastore.createValue
 import eu.darken.sdmse.common.debug.logging.logTag
-import kotlinx.serialization.json.Json
-import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class ReleaseSettings @Inject constructor(
     @ApplicationContext private val context: Context,
-    json: Json,
 ) {
 
     private val Context.dataStore by preferencesDataStore(name = "settings_release")
@@ -23,9 +20,6 @@ class ReleaseSettings @Inject constructor(
     val dataStore: DataStore<Preferences>
         get() = context.dataStore
 
-    // Was used during v1.0 migration
-    // See https://github.com/d4rken-org/sdmaid-se/blob/f52df69cb6c54b39775908952e7065796a1a5087/app/src/main/java/eu/darken/sdmse/main/core/release/ReleaseManager.kt#L38-L67
-    val releasePartyAt = dataStore.createValue("release.party.date", null as Instant?, json)
     val wantsBeta = dataStore.createValue("release.prerelease.consent", false)
     val earlyAdopter = dataStore.createValue("release.earlyadopter", null as Boolean?)
 

--- a/app/src/testGplay/java/eu/darken/sdmse/common/review/GplayReviewToolTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/review/GplayReviewToolTest.kt
@@ -1,0 +1,263 @@
+package eu.darken.sdmse.common.review
+
+import android.app.Activity
+import com.google.android.gms.tasks.OnFailureListener
+import com.google.android.gms.tasks.OnSuccessListener
+import com.google.android.gms.tasks.Task
+import com.google.android.gms.tasks.Tasks
+import com.google.android.play.core.review.ReviewInfo
+import com.google.android.play.core.review.ReviewManager
+import eu.darken.sdmse.common.datastore.DataStoreValue
+import eu.darken.sdmse.common.upgrade.UpgradeRepo
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.withTimeoutOrNull
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+import java.time.Duration
+import java.time.Instant
+
+class GplayReviewToolTest : BaseTest() {
+
+    private val manager = mockk<ReviewManager>()
+    private val settings = mockk<ReviewSettings>()
+    private val upgradeRepo = mockk<UpgradeRepo>()
+    private lateinit var lastDismissedMock: DataStoreValue<Instant?>
+    private lateinit var reviewedAtMock: DataStoreValue<Instant?>
+
+    // Relaxed so the `.value(new)` writes (which go through `update`) succeed and can be verified.
+    private fun <T> rwSetting(initial: T): DataStoreValue<T> = mockk<DataStoreValue<T>>(relaxed = true).apply {
+        every { flow } returns flowOf(initial)
+    }
+
+    // The tool's own scope has to run on the test scheduler, otherwise the probe backoff and the
+    // state throttle would burn real time.
+    private fun TestScope.tool(
+        upgradedAt: Instant? = Instant.now().minus(Duration.ofDays(30)),
+        lastDismissed: Instant? = null,
+        reviewedAt: Instant? = null,
+    ): GplayReviewTool {
+        lastDismissedMock = rwSetting(lastDismissed)
+        reviewedAtMock = rwSetting(reviewedAt)
+        every { settings.lastDismissed } returns lastDismissedMock
+        every { settings.reviewedAt } returns reviewedAtMock
+
+        val upgradeInfo = mockk<UpgradeRepo.Info>()
+        every { upgradeInfo.upgradedAt } returns upgradedAt
+        every { upgradeRepo.upgradeInfo } returns flowOf(upgradeInfo)
+
+        return GplayReviewTool(
+            appScope = backgroundScope,
+            settings = settings,
+            manager = manager,
+            upgradeRepo = upgradeRepo,
+        ).apply { probeRetryDelay = Duration.ofSeconds(1) }
+    }
+
+    private fun reviewInfo(canShow: Boolean = true): ReviewInfo {
+        val info = mockk<ReviewInfo>()
+        // There is no public accessor for the isNoOp flag, the tool sniffs the toString().
+        every { info.toString() } returns when {
+            canShow -> "ReviewInfo{pendingIntent=PendingIntent{1}, isNoOp=false}"
+            else -> "ReviewInfo{pendingIntent=null, isNoOp=true}"
+        }
+        return info
+    }
+
+    private fun activity(finishing: Boolean = false, destroyed: Boolean = false) = mockk<Activity>().apply {
+        every { isFinishing } returns finishing
+        every { isDestroyed } returns destroyed
+    }
+
+    private fun launchOk(): Task<Void?> = Tasks.forResult(null)
+
+    // The `onStart` seed is not a computed state, every assertion has to await the first real one.
+    private suspend fun GplayReviewTool.computedState() = state.drop(1).first()
+
+    @Test fun `an eligible user is asked for a review`() = runTest2 {
+        // Pins the fix: the old release-party gate could never open (nothing writes releasePartyAt
+        // anymore), so this state was unreachable for every post-v1_0 install.
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+
+        tool().computedState().apply {
+            shouldAskForReview shouldBe true
+            hasReviewed shouldBe false
+        }
+    }
+
+    @Test fun `a user who has not paid for pro long enough is never probed`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+
+        tool(upgradedAt = Instant.now().minus(Duration.ofDays(3)))
+            .computedState().shouldAskForReview shouldBe false
+
+        // Eligibility is decided locally first: Play's request quota is only spent on candidates.
+        verify(exactly = 0) { manager.requestReviewFlow() }
+    }
+
+    @Test fun `a recently dismissed card is not shown again`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+
+        tool(lastDismissed = Instant.now().minus(Duration.ofDays(3)))
+            .computedState().shouldAskForReview shouldBe false
+
+        verify(exactly = 0) { manager.requestReviewFlow() }
+    }
+
+    @Test fun `reviewNow launches with a freshly requested ReviewInfo`() = runTest2 {
+        // Pins the fix: ReviewInfo is short lived, the token used for the launch must not be the
+        // one the availability probe obtained (potentially hours) earlier.
+        val probeInfo = reviewInfo()
+        val freshInfo = reviewInfo()
+        every { manager.requestReviewFlow() } returnsMany listOf(
+            Tasks.forResult(probeInfo),
+            Tasks.forResult(freshInfo),
+        )
+        every { manager.launchReviewFlow(any(), any()) } returns launchOk()
+        val tool = tool()
+        val activity = activity()
+
+        tool.computedState().shouldAskForReview shouldBe true
+        tool.reviewNow(activity)
+
+        verify(exactly = 2) { manager.requestReviewFlow() }
+        verify(exactly = 1) { manager.launchReviewFlow(activity, freshInfo) }
+        verify(exactly = 0) { manager.launchReviewFlow(activity, probeInfo) }
+    }
+
+    @Test fun `a failed fresh request keeps the card and persists nothing`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forException(RuntimeException("Play unavailable"))
+        val tool = tool()
+
+        tool.reviewNow(activity())
+
+        verify(exactly = 0) { manager.launchReviewFlow(any(), any()) }
+        // A transient failure is not user intent, the next tap has to be able to retry.
+        coVerify(exactly = 0) { lastDismissedMock.update(any()) }
+        coVerify(exactly = 0) { reviewedAtMock.update(any()) }
+    }
+
+    @Test fun `a fresh isNoOp answer snoozes the card`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo(canShow = false))
+        val tool = tool()
+
+        tool.reviewNow(activity())
+
+        verify(exactly = 0) { manager.launchReviewFlow(any(), any()) }
+        // isNoOp is Play's quota verdict, asking again right away would be pointless.
+        coVerify(exactly = 1) { lastDismissedMock.update(any()) }
+        coVerify(exactly = 0) { reviewedAtMock.update(any()) }
+    }
+
+    @Test fun `a failed launch persists nothing and does not escape`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+        every { manager.launchReviewFlow(any(), any()) } returns Tasks.forException(RuntimeException("launch failed"))
+        val tool = tool()
+
+        tool.reviewNow(activity())
+
+        coVerify(exactly = 0) { lastDismissedMock.update(any()) }
+        coVerify(exactly = 0) { reviewedAtMock.update(any()) }
+    }
+
+    @Test fun `a dead activity aborts the launch without persisting`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+        every { manager.launchReviewFlow(any(), any()) } returns launchOk()
+        val tool = tool()
+
+        // The fresh request is a Play round-trip, the activity can be gone by the time it returns.
+        tool.reviewNow(activity(finishing = true))
+
+        verify(exactly = 0) { manager.launchReviewFlow(any(), any()) }
+        coVerify(exactly = 0) { lastDismissedMock.update(any()) }
+        coVerify(exactly = 0) { reviewedAtMock.update(any()) }
+    }
+
+    @Test fun `overlapping reviewNow calls launch the flow only once`() = runTest2 {
+        // Park the first call on an unresolved Play request, so the second genuinely overlaps it.
+        val successListener = slot<OnSuccessListener<in ReviewInfo>>()
+        val pendingRequest = mockk<Task<ReviewInfo>>().apply {
+            every { isComplete } returns false
+            every { addOnSuccessListener(capture(successListener)) } returns this
+            every { addOnFailureListener(any<OnFailureListener>()) } returns this
+        }
+        every { manager.requestReviewFlow() } returnsMany listOf(
+            pendingRequest,
+            // A second request would resolve instantly, so a broken guard shows up as a launch.
+            Tasks.forResult(reviewInfo()),
+        )
+        every { manager.launchReviewFlow(any(), any()) } returns launchOk()
+        val tool = tool()
+        val activity = activity()
+
+        val first = launch { tool.reviewNow(activity) }
+        advanceUntilIdle()
+
+        tool.reviewNow(activity)
+
+        successListener.captured.onSuccess(reviewInfo())
+        first.join()
+
+        // Without the single-flight guard the second tap would run its own request+launch, and
+        // Play's flow would pop up again the moment the user returned from the first one.
+        verify(exactly = 1) { manager.requestReviewFlow() }
+        verify(exactly = 1) { manager.launchReviewFlow(any(), any()) }
+    }
+
+    @Test fun `a probe that fails once still resolves within the retry budget`() = runTest2 {
+        every { manager.requestReviewFlow() } returnsMany listOf(
+            Tasks.forException(RuntimeException("Play unavailable")),
+            Tasks.forResult(reviewInfo()),
+        )
+
+        tool().computedState().shouldAskForReview shouldBe true
+
+        verify(exactly = 2) { manager.requestReviewFlow() }
+    }
+
+    @Test fun `a probe that keeps failing hides the card`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forException(RuntimeException("Play unavailable"))
+
+        tool().computedState().shouldAskForReview shouldBe false
+
+        verify(exactly = 3) { manager.requestReviewFlow() }
+    }
+
+    @Test fun `cancellation during reviewNow is not swallowed`() = runTest2 {
+        every { manager.requestReviewFlow() } throws CancellationException("scope died")
+        val tool = tool()
+
+        shouldThrow<CancellationException> { tool.reviewNow(activity()) }
+
+        // A cancelled coroutine is not a Play failure: no launch, no bookkeeping.
+        verify(exactly = 0) { manager.launchReviewFlow(any(), any()) }
+        coVerify(exactly = 0) { lastDismissedMock.update(any()) }
+        coVerify(exactly = 0) { reviewedAtMock.update(any()) }
+    }
+
+    @Test fun `cancellation during the probe is not swallowed into the retry path`() = runTest2 {
+        every { manager.requestReviewFlow() } throws CancellationException("scope died")
+        val tool = tool()
+
+        // Cancellation takes the probe down with its scope, no verdict is ever computed (virtual
+        // time, so the timeout costs nothing).
+        val computed = withTimeoutOrNull(Duration.ofMinutes(1).toMillis()) { tool.computedState() }
+
+        computed shouldBe null
+        // The general failure path would have burned all 3 attempts and settled on "unavailable".
+        verify(exactly = 1) { manager.requestReviewFlow() }
+    }
+}


### PR DESCRIPTION
## What changed

Google Play users who upgraded to Pro were supposed to eventually see a small dashboard card asking them to rate the app — but due to a leftover check from the v1.0 release it could never appear. The card now shows up for users who have been Pro for more than 3 weeks, can be dismissed (which snoozes it for 2 weeks), and stops appearing once a review was left. Tapping it is also more reliable now: the Play review dialog is requested freshly at that moment instead of reusing an expired handle.

## Technical Context

- Root cause: `shouldAskForReview` required `releasePartyAt` to be older than 5 days, but that setting's only writer was removed together with the v1.0-migration `ReleaseManager`. For every later install it is `null`, the fallback made the gate permanently false, and the card was unreachable.
- Second defect: `ReviewInfo` was requested once per process start and launched much later; Play documents it as short-lived, so stale launches completed as silent no-ops and were booked as user dismissals.
- The state pipeline is now eligibility-first: local gates (Pro >21d, not snoozed, not reviewed) are computed without touching Play, and Play is only probed for eligible users (max 3 attempts, 30s backoff, `internal` test seam). This stops spending review quota on ineligible users and no longer hides the card for the whole process lifetime after one transient failure.
- `reviewNow()` requests a fresh token at tap time behind a single-flight `tryLock` guard. Transient request/launch failures persist nothing (the next tap retries), Play's `isNoOp` quota verdict snoozes for 14 days, the activity is liveness-checked after the suspension point, and launch failures no longer escape into the ViewModel error dialog. `CancellationException` is rethrown everywhere.
- Deliberately unchanged: the 2s completion-time heuristic (Play's API exposes no completion signal) and the `isNoOp` `toString()` sniffing (no public accessor exists) — the latter is a watch item on `com.google.android.play:review` version bumps.
- Review guidance: `ReleaseSettings` lost its now-unused `json` parameter along with the dead property; the orphaned `release.party.date` DataStore key on legacy devices is harmless. On the release carrying this, every Pro user past the 21-day mark becomes eligible at once, so a one-time wave of review cards is expected.
