### PR TITLE
AppCleaner: Fix cache cleaning reporting success when it cleared nothing

### DIFF
--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/common/stepper/Stepper.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/common/stepper/Stepper.kt
@@ -93,6 +93,8 @@ class Stepper @Inject constructor(
                     } catch (e: StepAbortException) {
                         log(tag, WARN) { "ABORT Step due to ${e.asLog()}" }
                         logFailureNodes(tag, context)
+                        // Only a deliberate skip may continue the plan, a failure has to propagate
+                        if (!e.treatAsSuccess) throw e
                         break
                     } catch (e: Exception) {
                         log(tag, WARN) { "crawl(): Attempt $stepAttempts failed on $step:\n${e.asLog()}" }

--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/errors/StepAbortException.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/errors/StepAbortException.kt
@@ -1,5 +1,14 @@
 package eu.darken.sdmse.automation.core.errors
 
+/**
+ * Aborts the current step without retrying it.
+ *
+ * [treatAsSuccess] distinguishes a deliberate skip (the step is unnecessary because another path
+ * handles it) from a genuine failure (the step could not be completed). Only a skip may let the
+ * plan continue - a failure must propagate, otherwise the caller reports success for work that
+ * never happened.
+ */
 class StepAbortException(
     message: String,
+    val treatAsSuccess: Boolean = false,
 ) : AutomationException(message)

--- a/app-common-automation/src/test/java/eu/darken/sdmse/automation/core/common/stepper/StepperTest.kt
+++ b/app-common-automation/src/test/java/eu/darken/sdmse/automation/core/common/stepper/StepperTest.kt
@@ -1,0 +1,65 @@
+package eu.darken.sdmse.automation.core.common.stepper
+
+import eu.darken.sdmse.automation.core.ScreenState
+import eu.darken.sdmse.automation.core.common.ACSNodeInfo
+import eu.darken.sdmse.automation.core.errors.StepAbortException
+import eu.darken.sdmse.automation.core.specs.AutomationExplorer
+import eu.darken.sdmse.common.ca.toCaString
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+
+/**
+ * [StepAbortException] used to be swallowed unconditionally, which made a step that could not be
+ * completed indistinguishable from one that was deliberately skipped. Callers like the AppCleaner
+ * clear-cache module then recorded a failed run as a success.
+ */
+class StepperTest : BaseTest() {
+
+    // Hot flow that stays open like the production callbackFlow, so the screen guard is only
+    // torn down by Stepper's own cleanup and not by the source completing on its own.
+    private val screenState = mockk<ScreenState>().apply {
+        every { state } returns MutableStateFlow(ScreenState.State(isScreenOn = true, isUnlocked = true))
+    }
+    private val hostContext = mockk<AutomationExplorer.Context>(relaxed = true)
+    private val windowRoot = mockk<ACSNodeInfo>(relaxed = true)
+    private var nodeActions = 0
+
+    private fun createStep(abort: StepAbortException) = AutomationStep(
+        source = "test",
+        descriptionInternal = "Aborting step",
+        label = "Test".toCaString(),
+        windowCheck = { windowRoot },
+        nodeAction = {
+            nodeActions++
+            throw abort
+        },
+    )
+
+    @Test
+    fun `a skip continues the plan`() = runTest2 {
+        val step = createStep(StepAbortException("Skipped, handled elsewhere", treatAsSuccess = true))
+
+        Stepper(screenState).process(hostContext, step)
+
+        nodeActions shouldBe 1
+    }
+
+    @Test
+    fun `a failure propagates instead of being reported as success`() = runTest2 {
+        val abort = StepAbortException("Button not reachable")
+        abort.treatAsSuccess shouldBe false
+
+        val thrown = shouldThrow<StepAbortException> {
+            Stepper(screenState).process(hostContext, createStep(abort))
+        }
+
+        thrown shouldBe abort
+        nodeActions shouldBe 1
+    }
+}

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/hyperos/HyperOsSpecs.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/hyperos/HyperOsSpecs.kt
@@ -222,7 +222,10 @@ class HyperOsSpecs @Inject constructor(
                 if (clearDataTarget == null) {
                     findNode { it.isTextView() && it.textMatchesAny(clearCacheLabels) }?.let {
                         useAlternativeStep = true
-                        throw StepAbortException("Got 'Clear cache' instead of 'Clear data' skip the action dialog step.")
+                        throw StepAbortException(
+                            message = "Got 'Clear cache' instead of 'Clear data' skip the action dialog step.",
+                            treatAsSuccess = true,
+                        )
                     }
 
                     findNode { it.isTextView() && it.textMatchesAny(manageSpaceLabels) }?.let {

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/miui/MIUISpecs.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/miui/MIUISpecs.kt
@@ -217,7 +217,10 @@ class MIUISpecs @Inject constructor(
                 val altNode = findNodeByLabel(clearCacheLabels)
                 if (altNode != null) {
                     useAlternativeStep = true
-                    throw StepAbortException("Got 'Clear cache' instead of 'Clear data' skip the action dialog step.")
+                    throw StepAbortException(
+                        message = "Got 'Clear cache' instead of 'Clear data' skip the action dialog step.",
+                        treatAsSuccess = true,
+                    )
                 }
 
                 var target = findNodeByLabel(clearDataLabels) ?: return@action false


### PR DESCRIPTION
## What changed

When SD Maid could not reach the "Clear cache" button while cleaning an app, it marked that app as cleaned anyway. No error appeared, and the cache was untouched. Affected users saw a run that looked completely successful but freed nothing.

This is most visible on recent Pixel devices, where the clear-cache button is hidden from the accessibility service and SD Maid has to reach it with a keyboard-navigation workaround. When that workaround runs out of options, the failure is now reported as a failure instead of being silently counted as a success.

This does not make cache cleaning work in cases where it previously failed. It makes the failure visible.

## Technical Context

- Root cause: `StepAbortException` had one handler but two contradictory meanings. `Stepper.process` caught it, logged it, and `break`-ed out of the retry loop so `process()` returned normally. That is right for `MIUISpecs`/`HyperOsSpecs`, which throw it as a deliberate skip when the screen offers "Clear cache" instead of "Clear data" and an alternative step takes over. It is wrong for `AOSPSpecs`, which throws it when the DPAD fallback is exhausted and the button genuinely could not be reached. The plan lambda then completed, `AutomationExplorer` logged `// Success :)`, and `ClearCacheModule` added the target to `successful`.
- Chose `treatAsSuccess` over splitting into two exception types because `PlanAbortException` already solved exactly this problem in this codebase with that flag, and is consumed the same way in `ClearCacheModule`. Consistency beat a new type hierarchy.
- Default is `false` (fail-closed): a future throw site that forgets the flag gets treated as a failure, not as a silent success. The two real skip sites opt in explicitly, so their behaviour is unchanged.
- `AOSPSpecs` is deliberately not modified. With the handler fixed, its existing throw propagates on its own, gets retried by `AutomationExplorer` as any other plan failure would, and is finally recorded as failed. Retry count and timing are unchanged. Switching it to `PlanAbortException` for a faster, more precise failure was considered and rejected: focus/layout/input-injection failures can be transient, and `dpadExhausted` is plan-local so each plan retry is a genuine fresh attempt rather than a spin.
- Known limitation, unchanged by this PR: the exception ultimately recorded is a generic `AutomationTimeoutException`, because `AutomationExplorer` discards each plan-attempt exception when it retries. The specific reason survives only in the log. That applies to every plan failure, not just this one, and fixing it means touching the retry loop shared by all automation specs.
- Review guidance: the load-bearing change is the single `if (!e.treatAsSuccess) throw e` in `Stepper.kt`. Worth confirming the two `treatAsSuccess = true` sites really are skips and not failures in disguise.

Reviewed by Codex, which independently confirmed the propagation path, the default choice, and that no caller depended on the old swallow-everything behaviour.