### PR TITLE
Fix: Prevent a crash when review reminder settings are corrupted

### DIFF
--- a/app/src/gplay/java/eu/darken/sdmse/common/review/GplayReviewTool.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/review/GplayReviewTool.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
@@ -45,6 +46,10 @@ class GplayReviewTool @Inject constructor(
     // cannot advance the production bound. Same pattern as UpgradeRepoGplay.launchTimeoutMs.
     internal var probeRetryDelay: Duration = PROBE_RETRY_DELAY
 
+    // Test seam: the launch duration is wall-clock measured, so a virtual-time test cannot reach
+    // the production bound either.
+    internal var reviewMinDuration: Duration = REVIEW_MIN_DURATION
+
     // Local bookkeeping only: decided without talking to Play, so an ineligible user never
     // triggers a Play round-trip.
     private val isLocallyEligible: Flow<Boolean> = combine(
@@ -65,6 +70,13 @@ class GplayReviewTool @Inject constructor(
         hasPaidForPro && !isSnoozed && !hasReviewed
     }
         .distinctUntilChanged()
+        // Upstream of the shares below: an exception there would kill the sharing coroutine on
+        // AppScope (crashing the process) instead of reaching any downstream `catch`.
+        .catch { e ->
+            if (e is CancellationException) throw e
+            log(TAG, ERROR) { "Eligibility failed: ${e.asLog()}" }
+            emit(false)
+        }
 
     // Only probed once the user is eligible: Play counts requests against the app's quota, and an
     // `isNoOp` answer is Play's deliberate verdict, i.e. an answer and not a failure to retry.
@@ -107,6 +119,11 @@ class GplayReviewTool @Inject constructor(
     }
         .throttleLatest(500)
         .onStart { emit(ReviewTool.State()) }
+        .catch { e ->
+            if (e is CancellationException) throw e
+            log(TAG, ERROR) { "State failed: ${e.asLog()}" }
+            emit(ReviewTool.State())
+        }
         .replayingShare(appScope)
 
     // Single-flight: a second tap must not queue up behind the first, or Play's flow would be
@@ -164,7 +181,7 @@ class GplayReviewTool @Inject constructor(
             }
             log(TAG) { "Review completed after ${reviewTime}ms" }
 
-            if (Duration.ofMillis(reviewTime) >= Duration.ofSeconds(2)) {
+            if (Duration.ofMillis(reviewTime) >= reviewMinDuration) {
                 log(TAG, INFO) { "Marking review as completed" }
                 settings.reviewedAt.value(Instant.now())
             } else {
@@ -190,5 +207,6 @@ class GplayReviewTool @Inject constructor(
         private val TAG = logTag("Review", "Tool", "Gplay")
         private const val PROBE_ATTEMPTS = 3
         private val PROBE_RETRY_DELAY = Duration.ofSeconds(30)
+        private val REVIEW_MIN_DURATION = Duration.ofSeconds(2)
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -349,7 +349,7 @@
 
     <string name="review_app_review_action">Review</string>
     <string name="review_app_dismiss_action">Maybe later</string>
-    <string name="review_app_body">Would you like to leave SD Maid a review?️ ❤️</string>
+    <string name="review_app_body">Would you like to leave SD Maid a review? ❤️</string>
 
     <string name="anniversary_card_title">Happy SD Maid Anniversary ❤️</string>
     <string name="anniversary_card_install_date">With you since %s</string>

--- a/app/src/testGplay/java/eu/darken/sdmse/common/review/GplayReviewToolTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/review/GplayReviewToolTest.kt
@@ -19,11 +19,15 @@ import io.mockk.verify
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.SerializationException
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.runTest2
@@ -43,15 +47,27 @@ class GplayReviewToolTest : BaseTest() {
         every { flow } returns flowOf(initial)
     }
 
+    // Stored data that can't be decoded: the settings are created without a default fallback, so
+    // reading them throws (see ReviewSettingsTest).
+    private fun <T> unreadableSetting(error: Throwable): DataStoreValue<T> =
+        mockk<DataStoreValue<T>>(relaxed = true).apply {
+            every { flow } returns flow { throw error }
+        }
+
     // The tool's own scope has to run on the test scheduler, otherwise the probe backoff and the
     // state throttle would burn real time.
     private fun TestScope.tool(
         upgradedAt: Instant? = Instant.now().minus(Duration.ofDays(30)),
         lastDismissed: Instant? = null,
         reviewedAt: Instant? = null,
+        reviewedAtError: Throwable? = null,
+        minDuration: Duration? = null,
     ): GplayReviewTool {
         lastDismissedMock = rwSetting(lastDismissed)
-        reviewedAtMock = rwSetting(reviewedAt)
+        reviewedAtMock = when (reviewedAtError) {
+            null -> rwSetting(reviewedAt)
+            else -> unreadableSetting(reviewedAtError)
+        }
         every { settings.lastDismissed } returns lastDismissedMock
         every { settings.reviewedAt } returns reviewedAtMock
 
@@ -64,7 +80,10 @@ class GplayReviewToolTest : BaseTest() {
             settings = settings,
             manager = manager,
             upgradeRepo = upgradeRepo,
-        ).apply { probeRetryDelay = Duration.ofSeconds(1) }
+        ).apply {
+            probeRetryDelay = Duration.ofSeconds(1)
+            minDuration?.let { reviewMinDuration = it }
+        }
     }
 
     private fun reviewInfo(canShow: Boolean = true): ReviewInfo {
@@ -113,6 +132,18 @@ class GplayReviewToolTest : BaseTest() {
 
         tool(lastDismissed = Instant.now().minus(Duration.ofDays(3)))
             .computedState().shouldAskForReview shouldBe false
+
+        verify(exactly = 0) { manager.requestReviewFlow() }
+    }
+
+    @Test fun `a user who already reviewed is never asked or probed again`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+
+        tool(reviewedAt = Instant.now().minus(Duration.ofDays(200))).computedState().apply {
+            shouldAskForReview shouldBe false
+            // The card is gone for good, but the fact stays readable for anything else that asks.
+            hasReviewed shouldBe true
+        }
 
         verify(exactly = 0) { manager.requestReviewFlow() }
     }
@@ -171,6 +202,33 @@ class GplayReviewToolTest : BaseTest() {
 
         coVerify(exactly = 0) { lastDismissedMock.update(any()) }
         coVerify(exactly = 0) { reviewedAtMock.update(any()) }
+    }
+
+    @Test fun `a launch the user dismissed instantly counts as a snooze`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+        every { manager.launchReviewFlow(any(), any()) } returns launchOk()
+        val tool = tool()
+
+        tool.reviewNow(activity())
+
+        // Play returns immediately when it decides not to show anything, that is not a review.
+        coVerify(exactly = 1) { lastDismissedMock.update(any()) }
+        coVerify(exactly = 0) { reviewedAtMock.update(any()) }
+    }
+
+    @Test fun `a launch the user stayed in counts as a completed review`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+        // Real sleep on purpose: the heuristic measures wall clock, virtual time cannot reach it.
+        every { manager.launchReviewFlow(any(), any()) } answers {
+            Thread.sleep(150)
+            launchOk()
+        }
+        val tool = tool(minDuration = Duration.ofMillis(50))
+
+        tool.reviewNow(activity())
+
+        coVerify(exactly = 1) { reviewedAtMock.update(any()) }
+        coVerify(exactly = 0) { lastDismissedMock.update(any()) }
     }
 
     @Test fun `a dead activity aborts the launch without persisting`() = runTest2 {
@@ -234,6 +292,25 @@ class GplayReviewToolTest : BaseTest() {
         tool().computedState().shouldAskForReview shouldBe false
 
         verify(exactly = 3) { manager.requestReviewFlow() }
+    }
+
+    @Test fun `an isNoOp probe answer is accepted instead of retried`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo(canShow = false))
+
+        tool().computedState().shouldAskForReview shouldBe false
+
+        // isNoOp is an answer, not a failure: burning the retry budget on it would just cost quota.
+        verify(exactly = 1) { manager.requestReviewFlow() }
+    }
+
+    @Test fun `unreadable settings fall back to the default state`() = runTest2 {
+        // `state` is shared on AppScope, which has no exception handler: an error escaping the
+        // pipeline would take the process down instead of reaching any collector, so a collector
+        // side `.catch` can never see it.
+        val tool = tool(reviewedAtError = SerializationException("Stored timestamp is corrupt"))
+
+        // The onStart seed plus the fallback the tool emits in place of the failure.
+        tool.state.take(2).toList() shouldBe listOf(ReviewTool.State(), ReviewTool.State())
     }
 
     @Test fun `cancellation during reviewNow is not swallowed`() = runTest2 {

--- a/app/src/testGplay/java/eu/darken/sdmse/common/review/ReviewSettingsTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/review/ReviewSettingsTest.kt
@@ -1,0 +1,75 @@
+package eu.darken.sdmse.common.review
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.sdmse.common.datastore.value
+import eu.darken.sdmse.common.serialization.SerializationAppModule
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerializationException
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+import java.time.Instant
+import java.time.format.DateTimeParseException
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class ReviewSettingsTest : BaseTest() {
+
+    // One test method on purpose: ReviewSettings owns its DataStore, and DataStore forbids two
+    // active instances on the same file -- a second ReviewSettings in this process would crash,
+    // not exercise anything real.
+    @Test
+    fun `the review timestamps round-trip through the DataStore`() = runTest {
+        // Real time on purpose: the real DataStore does its I/O off the test scheduler.
+        withContext(Dispatchers.IO) {
+            // Real DataStore + the production Json wiring, no mocks: this catches an encoding
+            // mismatch between what the settings write and what they read back, and it only works
+            // because the serializers module registers a contextual Instant serializer.
+            val settings = ReviewSettings(
+                context = ApplicationProvider.getApplicationContext<Context>(),
+                json = SerializationAppModule().json(),
+            )
+
+            // A fresh install has never dismissed and never reviewed -- both gates read "no".
+            settings.lastDismissed.value() shouldBe null
+            settings.reviewedAt.value() shouldBe null
+
+            val dismissedAt = Instant.parse("2024-01-01T00:00:00Z")
+            settings.lastDismissed.value(dismissedAt)
+            settings.lastDismissed.value() shouldBe dismissedAt
+
+            val reviewedAt = Instant.parse("2024-06-15T12:34:56Z")
+            settings.reviewedAt.value(reviewedAt)
+            settings.reviewedAt.value() shouldBe reviewedAt
+
+            // Pins the loud-failure behaviour: these values are created without fallbackToDefault,
+            // so unreadable data surfaces instead of silently reading as "never reviewed" (which
+            // would re-ask a user who already left a review).
+            settings.dataStore.edit { prefs ->
+                prefs[REVIEWED_KEY] = "{not-valid-json"
+            }
+            shouldThrow<SerializationException> { settings.reviewedAt.value() }
+
+            // The other corrupt class: valid JSON that the Instant serializer can't parse, which
+            // fails inside Instant.parse instead of inside the JSON decoder.
+            settings.dataStore.edit { prefs ->
+                prefs[REVIEWED_KEY] = "\"not-a-timestamp\""
+            }
+            shouldThrow<DateTimeParseException> { settings.reviewedAt.value() }
+        }
+    }
+
+    companion object {
+        private val REVIEWED_KEY = stringPreferencesKey("review.reviewedAt")
+    }
+}


### PR DESCRIPTION
## What changed

Hardens the new Google Play review prompt: corrupted review settings (for example from an edited backup file) could crash the app the moment the dashboard loaded — they now simply keep the review card hidden, and the app recovers on the next dashboard visit once the data is fixed. Also removes a stray invisible Unicode character from the review question text.

## Technical Context

- Root cause: exceptions from the review DataStore flows terminated the `shareIn` sharing coroutine inside the handler-less app scope — a process crash that no downstream `catch` can intercept (SharedFlow collectors never receive upstream failures). Reproduced here before the fix: removing the guards makes the new regression test fail with the exact predicted signature (`UncompletedCoroutinesError` carrying the suppressed `SerializationException`).
- The fix fails closed upstream of both `replayingShare` calls (eligibility falls back to "not eligible", state to the default), rethrowing `CancellationException`. This is the same guard already shipped in the CAPod/Octi/Permission Pilot/BVM/Butler ports — this backport makes the origin match its ports.
- The exposure is worse here than in the ports: the review settings participate in backup/restore, so an edited backup can inject arbitrary strings into the timestamps.
- The 2s launch-duration threshold moved behind an `internal` test seam (same pattern as the existing probe-retry seam), enabling tests for both timing branches without real 2s sleeps.
- Test coverage additions close gaps found during the port reviews: already-reviewed users are never probed, a Play quota verdict is accepted without retry, both timing branches persist correctly, and a new real-DataStore settings test pins the two corrupt-data classes (malformed JSON, valid JSON with an unparseable timestamp).
- Recovery semantics after a guard trip: the shared flow completes and restarts on the next subscription cycle (dashboard leave/return or process start) — deliberate, matching all five ports.
- Base-English string fix only; the same stray variation selector in 42 translated files is left to the translation workflow.
