### PR TITLE
Fix: Keep the review prompt working when Google Play hangs

### DIFF
--- a/app/src/gplay/java/eu/darken/sdmse/common/review/GplayReviewTool.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/review/GplayReviewTool.kt
@@ -113,6 +113,11 @@ class GplayReviewTool @Inject constructor(
     // the verdict doesn't change while the app runs. Survives eligibility flips, unlike the share.
     @Volatile private var cachedVerdict: Verdict? = null
 
+    // Process-wide on purpose: the eligibility flatMapLatest below restarts this branch on every
+    // input change (a billing flicker flipping upgradedAt is enough), and a restart must not hand
+    // out a fresh round budget.
+    @Volatile private var probeRoundsStarted: Int = 0
+
     // Only probed once the user is eligible: Play counts requests against the app's quota, and an
     // `isNoOp` answer is Play's deliberate verdict, i.e. an answer and not a failure to retry.
     // `null` means no probe ran (not eligible), which is not a Play answer and is never cached.
@@ -127,8 +132,16 @@ class GplayReviewTool @Inject constructor(
                     return@flow
                 }
 
-                for (round in 0..FAILURE_RETRY_ROUNDS) {
-                    if (round > 0) delay(probeFailureCooldown.toMillis())
+                while (true) {
+                    if (probeRoundsStarted == FAILURE_RETRY_ROUNDS + 1) {
+                        log(TAG, WARN) { "Probe failed in all ${FAILURE_RETRY_ROUNDS + 1} rounds, giving up" }
+                        emit(Verdict.TRANSIENT_FAILURE)
+                        return@flow
+                    }
+                    if (probeRoundsStarted > 0) delay(probeFailureCooldown.toMillis())
+
+                    val round = probeRoundsStarted
+                    probeRoundsStarted++
 
                     val verdict = probeRound(round)
                     emit(verdict)
@@ -139,7 +152,6 @@ class GplayReviewTool @Inject constructor(
                         return@flow
                     }
                 }
-                log(TAG, WARN) { "Probe failed in all ${FAILURE_RETRY_ROUNDS + 1} rounds, giving up" }
             }
         }
         // Lazily, not WhileSubscribed: a re-subscription must not spend another Play request on a

--- a/app/src/gplay/java/eu/darken/sdmse/common/review/GplayReviewTool.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/review/GplayReviewTool.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -27,7 +28,9 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.withTimeoutOrNull
 import java.time.Duration
 import java.time.Instant
 import javax.inject.Inject
@@ -46,9 +49,22 @@ class GplayReviewTool @Inject constructor(
     // cannot advance the production bound. Same pattern as UpgradeRepoGplay.launchTimeoutMs.
     internal var probeRetryDelay: Duration = PROBE_RETRY_DELAY
 
+    // Test seam: same reason, the cooldown between failed probe rounds is a production sized wait.
+    internal var probeFailureCooldown: Duration = PROBE_FAILURE_COOLDOWN
+
     // Test seam: the launch duration is wall-clock measured, so a virtual-time test cannot reach
     // the production bound either.
     internal var reviewMinDuration: Duration = REVIEW_MIN_DURATION
+
+    // Test seam: a hung Play call would otherwise have to be waited out for the production bound.
+    internal var requestTimeout: Duration = REQUEST_TIMEOUT
+
+    // Test seam: same reason, the review sheet bound is minutes long.
+    internal var launchTimeout: Duration = LAUNCH_TIMEOUT
+
+    // Test seam: eligibility is a function of wall-clock time, a virtual-time test needs to be able
+    // to move "now" itself. Only used for eligibility, the persisted timestamps stay real.
+    internal var nowProvider: () -> Instant = Instant::now
 
     // Local bookkeeping only: decided without talking to Play, so an ineligible user never
     // triggers a Play round-trip.
@@ -57,18 +73,33 @@ class GplayReviewTool @Inject constructor(
         settings.reviewedAt.flow,
         upgradeRepo.upgradeInfo,
     ) { lastDismissed, reviewedAt, upgradeInfo ->
-        val now = Instant.now()
-
-        // Free trial is 14 days, only ask for review after the user has paid something
-        val hasPaidForPro = Duration.between(upgradeInfo.upgradedAt ?: now, now) > Duration.ofDays(21)
-        val isSnoozed = Duration.between(lastDismissed ?: Instant.EPOCH, now) < Duration.ofDays(14)
-        val hasReviewed = reviewedAt != null
-
-        log(TAG) { "Eligibility: hasPaidForPro=$hasPaidForPro (${upgradeInfo.upgradedAt})" }
-        log(TAG) { "Eligibility: isSnoozed=$isSnoozed ($lastDismissed), hasReviewed=$hasReviewed ($reviewedAt)" }
-
-        hasPaidForPro && !isSnoozed && !hasReviewed
+        EligibilityInputs(
+            lastDismissed = lastDismissed,
+            reviewedAt = reviewedAt,
+            upgradedAt = upgradeInfo.upgradedAt,
+        )
     }
+        // Eligibility depends on time, not just on the inputs: a snooze that runs out while the
+        // process is alive has to flip the verdict, otherwise the card only reappears after a
+        // restart. Re-evaluated at the upcoming boundaries, an input change restarts the whole
+        // schedule via flatMapLatest.
+        .flatMapLatest { inputs ->
+            flow {
+                var wakes = 0
+                while (true) {
+                    val now = nowProvider()
+                    emit(inputs.isEligibleAt(now))
+
+                    val nextBoundary = inputs.boundariesAfter(now).minOrNull()
+                    if (nextBoundary == null || wakes == MAX_BOUNDARY_WAKES) break
+
+                    wakes++
+                    val wakeIn = Duration.between(now, nextBoundary) + BOUNDARY_WAKE_MARGIN
+                    log(TAG) { "Eligibility: Re-evaluating in $wakeIn (boundary $nextBoundary)" }
+                    delay(wakeIn.toMillis())
+                }
+            }
+        }
         .distinctUntilChanged()
         // Upstream of the shares below: an exception there would kill the sharing coroutine on
         // AppScope (crashing the process) instead of reaching any downstream `catch`.
@@ -78,42 +109,81 @@ class GplayReviewTool @Inject constructor(
             emit(false)
         }
 
+    // Play's definitive answers are worth exactly one round-trip per process: quota is limited and
+    // the verdict doesn't change while the app runs. Survives eligibility flips, unlike the share.
+    @Volatile private var cachedVerdict: Verdict? = null
+
     // Only probed once the user is eligible: Play counts requests against the app's quota, and an
     // `isNoOp` answer is Play's deliberate verdict, i.e. an answer and not a failure to retry.
-    private val isReviewAvailable: Flow<Boolean> = isLocallyEligible
+    // `null` means no probe ran (not eligible), which is not a Play answer and is never cached.
+    private val reviewAvailability: Flow<Verdict?> = isLocallyEligible
         .flatMapLatest { eligible ->
-            if (!eligible) return@flatMapLatest flowOf(false)
+            if (!eligible) return@flatMapLatest flowOf<Verdict?>(null)
 
             flow {
-                for (attempt in 1..PROBE_ATTEMPTS) {
-                    val info = try {
-                        manager.requestReview()
-                    } catch (e: CancellationException) {
-                        throw e
-                    } catch (e: Exception) {
-                        log(TAG, WARN) { "Probe $attempt/$PROBE_ATTEMPTS failed: ${e.asLog()}" }
-                        if (attempt < PROBE_ATTEMPTS) delay(probeRetryDelay.toMillis())
-                        continue
-                    }
-                    log(TAG) { "Probe $attempt/$PROBE_ATTEMPTS returned ${info.desc()}" }
-                    emit(info.canShow)
+                cachedVerdict?.let {
+                    log(TAG) { "Reusing cached probe verdict: $it" }
+                    emit(it)
                     return@flow
                 }
-                // Re-probed when eligibility changes or on the next process start
-                log(TAG, WARN) { "Probe gave up after $PROBE_ATTEMPTS attempts" }
-                emit(false)
+
+                for (round in 0..FAILURE_RETRY_ROUNDS) {
+                    if (round > 0) delay(probeFailureCooldown.toMillis())
+
+                    val verdict = probeRound(round)
+                    emit(verdict)
+
+                    if (verdict != Verdict.TRANSIENT_FAILURE) {
+                        // Play answered, that answer holds for the rest of the process
+                        cachedVerdict = verdict
+                        return@flow
+                    }
+                }
+                log(TAG, WARN) { "Probe failed in all ${FAILURE_RETRY_ROUNDS + 1} rounds, giving up" }
             }
         }
-        .replayingShare(appScope)
+        // Lazily, not WhileSubscribed: a re-subscription must not spend another Play request on a
+        // question that was already answered (or given up on) in this process.
+        .shareIn(appScope, SharingStarted.Lazily, replay = 1)
+
+    private suspend fun probeRound(round: Int): Verdict {
+        for (attempt in 1..PROBE_ATTEMPTS) {
+            val info = try {
+                // withTimeoutOrNull, never withTimeout: TimeoutCancellationException IS-A
+                // CancellationException and would escape through the rethrow below.
+                withTimeoutOrNull(requestTimeout.toMillis()) { manager.requestReview() }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                log(TAG, WARN) { "Probe $round:$attempt/$PROBE_ATTEMPTS failed: ${e.asLog()}" }
+                if (attempt < PROBE_ATTEMPTS) delay(probeRetryDelay.toMillis())
+                continue
+            }
+
+            if (info == null) {
+                // Our timeout does not cancel the underlying Play Task: an immediate retry would
+                // stack concurrent quota-consuming requests against an already hung service, so the
+                // whole round is abandoned. The orphaned Task is tolerated, its completion resumes
+                // a cancelled continuation and is discarded.
+                log(TAG, WARN) { "Probe $round:$attempt/$PROBE_ATTEMPTS timed out, abandoning the round" }
+                return Verdict.TRANSIENT_FAILURE
+            }
+
+            log(TAG) { "Probe $round:$attempt/$PROBE_ATTEMPTS returned ${info.desc()}" }
+            return if (info.canShow) Verdict.AVAILABLE else Verdict.UNAVAILABLE_BY_PLAY
+        }
+        log(TAG, WARN) { "Probe round $round gave up after $PROBE_ATTEMPTS attempts" }
+        return Verdict.TRANSIENT_FAILURE
+    }
 
     override val state: Flow<ReviewTool.State> = combine(
         isLocallyEligible,
-        isReviewAvailable,
+        reviewAvailability,
         settings.reviewedAt.flow,
-    ) { eligible, available, reviewedAt ->
-        log(TAG) { "State: eligible=$eligible, available=$available, reviewedAt=$reviewedAt" }
+    ) { eligible, verdict, reviewedAt ->
+        log(TAG) { "State: eligible=$eligible, verdict=$verdict, reviewedAt=$reviewedAt" }
         ReviewTool.State(
-            shouldAskForReview = eligible && available,
+            shouldAskForReview = eligible && verdict == Verdict.AVAILABLE,
             hasReviewed = reviewedAt != null,
         )
     }
@@ -130,8 +200,15 @@ class GplayReviewTool @Inject constructor(
     // launched again the moment the user returns from it.
     private val reviewLock = Mutex()
 
+    // Tap race backstop: a dismiss can land while a reviewNow is waiting on Play. In-memory on
+    // purpose, re-reading the persisted timestamp would race the write it is supposed to observe.
+    @Volatile private var dismissGeneration: Int = 0
+
     override suspend fun dismiss() {
         log(TAG, INFO) { "dismiss()" }
+        // Bumped before the write: an in-flight reviewNow has to see the dismiss immediately,
+        // not once DataStore has persisted it.
+        dismissGeneration++
         settings.lastDismissed.value(Instant.now())
     }
 
@@ -144,10 +221,12 @@ class GplayReviewTool @Inject constructor(
         }
 
         try {
+            val generation = dismissGeneration
+
             // ReviewInfo is short lived, Google wants it requested shortly before the launch,
             // a token cached at process start is likely stale by the time the user taps.
             val reviewInfo = try {
-                manager.requestReview()
+                withTimeoutOrNull(requestTimeout.toMillis()) { manager.requestReview() }
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
@@ -155,7 +234,18 @@ class GplayReviewTool @Inject constructor(
                 log(TAG, ERROR) { "Failed to get a fresh ReviewInfo: ${e.asLog()}" }
                 return
             }
+
+            if (reviewInfo == null) {
+                // A hang is not user intent either: persist nothing, the next tap retries
+                log(TAG, ERROR) { "Timed out requesting a fresh ReviewInfo" }
+                return
+            }
             log(TAG) { "reviewNow(...): Fresh ${reviewInfo.desc()}" }
+
+            if (dismissGeneration != generation) {
+                log(TAG, WARN) { "Dismissed while we were requesting a fresh ReviewInfo, aborting" }
+                return
+            }
 
             if (!reviewInfo.canShow) {
                 // Play's quota verdict, asking again right away would be pointless
@@ -169,13 +259,28 @@ class GplayReviewTool @Inject constructor(
                 return
             }
 
+            if (dismissGeneration != generation) {
+                log(TAG, WARN) { "Dismissed before we could launch, aborting" }
+                return
+            }
+
             val reviewTime = measureTimeMillis {
-                try {
-                    manager.launchReview(activity, reviewInfo)
+                val launched = try {
+                    // withTimeoutOrNull for the same reason as the probe: a withTimeout would be
+                    // rethrown as cancellation by the branch below.
+                    withTimeoutOrNull(launchTimeout.toMillis()) { manager.launchReview(activity, reviewInfo) }
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Exception) {
                     log(TAG, ERROR) { "Failed to launch review flow: ${e.asLog()}" }
+                    return
+                }
+
+                if (launched == null) {
+                    // Far beyond any real review session: the sheet's Task is hung and must not hold
+                    // the single-flight lock forever. The outcome is unknown, so nothing is persisted
+                    // and the duration heuristic below is skipped.
+                    log(TAG, WARN) { "Timed out waiting for the review flow to finish" }
                     return
                 }
             }
@@ -193,6 +298,29 @@ class GplayReviewTool @Inject constructor(
         }
     }
 
+    private data class EligibilityInputs(
+        val lastDismissed: Instant?,
+        val reviewedAt: Instant?,
+        val upgradedAt: Instant?,
+    )
+
+    private fun EligibilityInputs.isEligibleAt(now: Instant): Boolean {
+        // Free trial is 14 days, only ask for review after the user has paid something
+        val hasPaidForPro = Duration.between(upgradedAt ?: now, now) > PRO_GRACE_PERIOD
+        val isSnoozed = Duration.between(lastDismissed ?: Instant.EPOCH, now) < SNOOZE_PERIOD
+        val hasReviewed = reviewedAt != null
+
+        log(TAG) { "Eligibility: hasPaidForPro=$hasPaidForPro ($upgradedAt)" }
+        log(TAG) { "Eligibility: isSnoozed=$isSnoozed ($lastDismissed), hasReviewed=$hasReviewed ($reviewedAt)" }
+
+        return hasPaidForPro && !isSnoozed && !hasReviewed
+    }
+
+    private fun EligibilityInputs.boundariesAfter(now: Instant): List<Instant> = listOfNotNull(
+        lastDismissed?.plus(SNOOZE_PERIOD),
+        upgradedAt?.plus(PRO_GRACE_PERIOD),
+    ).filter { it > now }
+
     private val ReviewInfo.canShow: Boolean
         get() = when {
             toString().contains("isNoOp=true") -> false
@@ -203,10 +331,29 @@ class GplayReviewTool @Inject constructor(
         return "ReviewInfo(canShow=$canShow, ${toString()})"
     }
 
+    private enum class Verdict {
+        // Play answered with a usable ReviewInfo
+        AVAILABLE,
+
+        // Play answered with an isNoOp ReviewInfo, i.e. a deliberate "no"
+        UNAVAILABLE_BY_PLAY,
+
+        // No answer: attempts exhausted by exceptions, or the round was abandoned on a timeout
+        TRANSIENT_FAILURE,
+    }
+
     companion object {
         private val TAG = logTag("Review", "Tool", "Gplay")
         private const val PROBE_ATTEMPTS = 3
+        private const val FAILURE_RETRY_ROUNDS = 3
         private val PROBE_RETRY_DELAY = Duration.ofSeconds(30)
+        private val PROBE_FAILURE_COOLDOWN = Duration.ofMinutes(15)
         private val REVIEW_MIN_DURATION = Duration.ofSeconds(2)
+        private val REQUEST_TIMEOUT = Duration.ofSeconds(10)
+        private val LAUNCH_TIMEOUT = Duration.ofMinutes(10)
+        private val SNOOZE_PERIOD = Duration.ofDays(14)
+        private val PRO_GRACE_PERIOD = Duration.ofDays(21)
+        private const val MAX_BOUNDARY_WAKES = 4
+        private val BOUNDARY_WAKE_MARGIN = Duration.ofSeconds(1)
     }
 }

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/ReviewDashboardCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/ReviewDashboardCard.kt
@@ -11,6 +11,10 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -39,9 +43,19 @@ data class ReviewDashboardCardItem(
 @Composable
 internal fun ReviewDashboardCard(item: ReviewDashboardCardItem) {
     val activity = LocalActivity.current
+    // The card has three tap targets that all remove it, but the removal only arrives with the next
+    // state emission. Until then a second tap would reach a second callback (dismiss after review
+    // overwrites the review bookkeeping with a snooze), so the first action consumes all of them.
+    var actionTaken by rememberSaveable { mutableStateOf(false) }
+    val onReview = {
+        if (!actionTaken && activity != null) {
+            actionTaken = true
+            item.onReview(activity)
+        }
+    }
     DashboardCard(
         containerColor = MaterialTheme.colorScheme.secondaryContainer,
-        onClick = { activity?.let(item.onReview) },
+        onClick = onReview,
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Icon(
@@ -63,14 +77,22 @@ internal fun ReviewDashboardCard(item: ReviewDashboardCardItem) {
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            DashboardFlatActionButton(onClick = item.onDismiss) {
+            DashboardFlatActionButton(
+                onClick = {
+                    if (!actionTaken) {
+                        actionTaken = true
+                        item.onDismiss()
+                    }
+                },
+                enabled = !actionTaken,
+            ) {
                 Text(text = stringResource(R.string.review_app_dismiss_action))
             }
             Spacer(modifier = Modifier.width(8.dp))
             DashboardFilledActionButton(
                 modifier = Modifier.weight(1f),
-                onClick = { activity?.let(item.onReview) },
-                enabled = activity != null,
+                onClick = onReview,
+                enabled = !actionTaken && activity != null,
             ) {
                 Icon(
                     imageVector = SdmIcons.GooglePlay,

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/ReviewDashboardCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/ReviewDashboardCard.kt
@@ -43,13 +43,16 @@ data class ReviewDashboardCardItem(
 @Composable
 internal fun ReviewDashboardCard(item: ReviewDashboardCardItem) {
     val activity = LocalActivity.current
-    // The card has three tap targets that all remove it, but the removal only arrives with the next
-    // state emission. Until then a second tap would reach a second callback (dismiss after review
-    // overwrites the review bookkeeping with a snooze), so the first action consumes all of them.
-    var actionTaken by rememberSaveable { mutableStateOf(false) }
+    // The card only disappears with the next state emission, so the tap targets need a latch. It is
+    // asymmetric on purpose: the harmful orderings are a dismiss after a review (which overwrites
+    // the review bookkeeping with a snooze) and a review after a dismiss. A repeated review tap is
+    // harmless, the tool's single-flight lock absorbs it, and blocking it here would leave a dead
+    // card whenever a Play request fails and nothing gets persisted.
+    var dismissLocked by rememberSaveable { mutableStateOf(false) }
+    var fullyLatched by rememberSaveable { mutableStateOf(false) }
     val onReview = {
-        if (!actionTaken && activity != null) {
-            actionTaken = true
+        if (!fullyLatched && activity != null) {
+            dismissLocked = true
             item.onReview(activity)
         }
     }
@@ -79,12 +82,13 @@ internal fun ReviewDashboardCard(item: ReviewDashboardCardItem) {
         ) {
             DashboardFlatActionButton(
                 onClick = {
-                    if (!actionTaken) {
-                        actionTaken = true
+                    if (!fullyLatched && !dismissLocked) {
+                        dismissLocked = true
+                        fullyLatched = true
                         item.onDismiss()
                     }
                 },
-                enabled = !actionTaken,
+                enabled = !fullyLatched && !dismissLocked,
             ) {
                 Text(text = stringResource(R.string.review_app_dismiss_action))
             }
@@ -92,7 +96,7 @@ internal fun ReviewDashboardCard(item: ReviewDashboardCardItem) {
             DashboardFilledActionButton(
                 modifier = Modifier.weight(1f),
                 onClick = onReview,
-                enabled = !actionTaken && activity != null,
+                enabled = !fullyLatched && activity != null,
             ) {
                 Icon(
                     imageVector = SdmIcons.GooglePlay,

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/cards/ReviewDashboardCardTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/cards/ReviewDashboardCardTest.kt
@@ -1,0 +1,120 @@
+package eu.darken.sdmse.main.ui.dashboard.cards
+
+import android.app.Activity
+import android.content.Context
+import androidx.activity.compose.LocalActivity
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.sdmse.R
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+
+/**
+ * The card only disappears once the next state emission arrives, so its three tap targets (card
+ * body, dismiss, review) have to be one-shot: whichever the user hits first wins and the others
+ * become no-ops. Otherwise a dismiss landing after a review overwrites the completed-review
+ * bookkeeping with a snooze.
+ */
+class ReviewDashboardCardTest : BaseComposeRobolectricTest() {
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    private var reviews = 0
+    private var dismisses = 0
+
+    private val item = ReviewDashboardCardItem(
+        onReview = { reviews++ },
+        onDismiss = { dismisses++ },
+    )
+
+    private fun setContent(activity: Activity? = mockk<Activity>(relaxed = true)) {
+        composeRule.setContent {
+            PreviewWrapper {
+                CompositionLocalProvider(LocalActivity provides activity) {
+                    ReviewDashboardCard(item = item)
+                }
+            }
+        }
+    }
+
+    // The card merges its descendants, so the body text resolves to the clickable card itself.
+    private fun cardBody() = composeRule.onNodeWithText(context.getString(R.string.review_app_body))
+
+    private fun dismissButton() = composeRule.onNodeWithText(context.getString(R.string.review_app_dismiss_action))
+
+    private fun reviewButton() = composeRule.onNodeWithText(context.getString(R.string.review_app_review_action))
+
+    @Test
+    fun `a dismissed card ignores a later review tap`() {
+        setContent()
+
+        dismissButton().performClick()
+        composeRule.runOnIdle { dismisses shouldBe 1 }
+
+        reviewButton().assertIsNotEnabled()
+        reviewButton().performClick()
+        cardBody().performSemanticsAction(SemanticsActions.OnClick)
+
+        composeRule.runOnIdle {
+            reviews shouldBe 0
+            dismisses shouldBe 1
+        }
+    }
+
+    @Test
+    fun `a reviewed card ignores a later dismiss tap`() {
+        setContent()
+
+        reviewButton().performClick()
+        composeRule.runOnIdle { reviews shouldBe 1 }
+
+        dismissButton().assertIsNotEnabled()
+        dismissButton().performClick()
+
+        composeRule.runOnIdle {
+            reviews shouldBe 1
+            dismisses shouldBe 0
+        }
+    }
+
+    @Test
+    fun `a tap on the card body counts as a review`() {
+        setContent()
+
+        cardBody().performSemanticsAction(SemanticsActions.OnClick)
+        composeRule.runOnIdle { reviews shouldBe 1 }
+
+        cardBody().performSemanticsAction(SemanticsActions.OnClick)
+        dismissButton().performClick()
+
+        composeRule.runOnIdle {
+            reviews shouldBe 1
+            dismisses shouldBe 0
+        }
+    }
+
+    @Test
+    fun `a review tap without an activity does not consume the gate`() {
+        setContent(activity = null)
+
+        reviewButton().assertIsNotEnabled()
+        reviewButton().performClick()
+        cardBody().performSemanticsAction(SemanticsActions.OnClick)
+        composeRule.runOnIdle { reviews shouldBe 0 }
+
+        // Nothing was handed to the caller, so the card must still be dismissable
+        dismissButton().assertIsEnabled()
+        dismissButton().performClick()
+
+        composeRule.runOnIdle { dismisses shouldBe 1 }
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/cards/ReviewDashboardCardTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/cards/ReviewDashboardCardTest.kt
@@ -20,9 +20,10 @@ import testhelpers.compose.BaseComposeRobolectricTest
 
 /**
  * The card only disappears once the next state emission arrives, so its three tap targets (card
- * body, dismiss, review) have to be one-shot: whichever the user hits first wins and the others
- * become no-ops. Otherwise a dismiss landing after a review overwrites the completed-review
- * bookkeeping with a snooze.
+ * body, dismiss, review) need a latch: a dismiss after a review would overwrite the
+ * completed-review bookkeeping with a snooze, a review after a dismiss would re-open what the user
+ * just closed. The latch is asymmetric — repeated review taps stay allowed, because a Play request
+ * can fail without persisting anything, which leaves the card on screen and in need of a retry.
  */
 class ReviewDashboardCardTest : BaseComposeRobolectricTest() {
 
@@ -93,7 +94,7 @@ class ReviewDashboardCardTest : BaseComposeRobolectricTest() {
         cardBody().performSemanticsAction(SemanticsActions.OnClick)
         composeRule.runOnIdle { reviews shouldBe 1 }
 
-        cardBody().performSemanticsAction(SemanticsActions.OnClick)
+        dismissButton().assertIsNotEnabled()
         dismissButton().performClick()
 
         composeRule.runOnIdle {
@@ -103,7 +104,25 @@ class ReviewDashboardCardTest : BaseComposeRobolectricTest() {
     }
 
     @Test
-    fun `a review tap without an activity does not consume the gate`() {
+    fun `repeated review taps are not absorbed by the card`() {
+        setContent()
+
+        reviewButton().performClick()
+        composeRule.runOnIdle { reviews shouldBe 1 }
+
+        // A failed Play request persists nothing and leaves the card up, so the retry has to work.
+        // Duplicates are the tool's problem, it holds a single-flight lock for exactly this.
+        reviewButton().assertIsEnabled()
+        reviewButton().performClick()
+
+        composeRule.runOnIdle {
+            reviews shouldBe 2
+            dismisses shouldBe 0
+        }
+    }
+
+    @Test
+    fun `a review tap without an activity consumes neither latch`() {
         setContent(activity = null)
 
         reviewButton().assertIsNotEnabled()

--- a/app/src/testGplay/java/eu/darken/sdmse/common/review/GplayReviewToolTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/review/GplayReviewToolTest.kt
@@ -544,7 +544,7 @@ class GplayReviewToolTest : BaseTest() {
 
     @Test fun `the probe retry rounds are bounded`() = runTest2 {
         every { manager.requestReviewFlow() } returns Tasks.forException(RuntimeException("Play unavailable"))
-        val tool = tool()
+        val tool = tool(hotSettings = true)
         val states = collectStates(tool)
 
         advanceBy(PROBE_FAILURE_COOLDOWN.multipliedBy(4))
@@ -554,6 +554,15 @@ class GplayReviewToolTest : BaseTest() {
         states.last().shouldAskForReview shouldBe false
 
         advanceBy(PROBE_FAILURE_COOLDOWN.multipliedBy(20))
+
+        verify(exactly = 12) { manager.requestReviewFlow() }
+
+        // The budget is spent for the process: an eligibility flicker restarts the probe branch,
+        // but it must not hand out a fresh set of rounds.
+        lastDismissedFlow.value = Instant.now()
+        advanceBy(Duration.ofSeconds(1))
+        lastDismissedFlow.value = null
+        advanceBy(PROBE_FAILURE_COOLDOWN.multipliedBy(10))
 
         verify(exactly = 12) { manager.requestReviewFlow() }
     }

--- a/app/src/testGplay/java/eu/darken/sdmse/common/review/GplayReviewToolTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/review/GplayReviewToolTest.kt
@@ -17,6 +17,9 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
@@ -24,8 +27,10 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestScope
-import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.SerializationException
 import org.junit.jupiter.api.Test
@@ -41,10 +46,17 @@ class GplayReviewToolTest : BaseTest() {
     private val upgradeRepo = mockk<UpgradeRepo>()
     private lateinit var lastDismissedMock: DataStoreValue<Instant?>
     private lateinit var reviewedAtMock: DataStoreValue<Instant?>
+    private lateinit var lastDismissedFlow: MutableStateFlow<Instant?>
 
     // Relaxed so the `.value(new)` writes (which go through `update`) succeed and can be verified.
     private fun <T> rwSetting(initial: T): DataStoreValue<T> = mockk<DataStoreValue<T>>(relaxed = true).apply {
         every { flow } returns flowOf(initial)
+    }
+
+    // Hot variant: a value written after the tool started collecting has to reach the pipeline,
+    // which a one-shot `flowOf` can't do.
+    private fun <T> hotSetting(source: Flow<T>): DataStoreValue<T> = mockk<DataStoreValue<T>>(relaxed = true).apply {
+        every { flow } returns source
     }
 
     // Stored data that can't be decoded: the settings are created without a default fallback, so
@@ -62,8 +74,13 @@ class GplayReviewToolTest : BaseTest() {
         reviewedAt: Instant? = null,
         reviewedAtError: Throwable? = null,
         minDuration: Duration? = null,
+        hotSettings: Boolean = false,
     ): GplayReviewTool {
-        lastDismissedMock = rwSetting(lastDismissed)
+        lastDismissedFlow = MutableStateFlow(lastDismissed)
+        lastDismissedMock = when {
+            hotSettings -> hotSetting(lastDismissedFlow)
+            else -> rwSetting(lastDismissed)
+        }
         reviewedAtMock = when (reviewedAtError) {
             null -> rwSetting(reviewedAt)
             else -> unreadableSetting(reviewedAtError)
@@ -81,7 +98,10 @@ class GplayReviewToolTest : BaseTest() {
             manager = manager,
             upgradeRepo = upgradeRepo,
         ).apply {
-            probeRetryDelay = Duration.ofSeconds(1)
+            probeRetryDelay = PROBE_RETRY_DELAY
+            probeFailureCooldown = PROBE_FAILURE_COOLDOWN
+            requestTimeout = REQUEST_TIMEOUT
+            launchTimeout = LAUNCH_TIMEOUT
             minDuration?.let { reviewMinDuration = it }
         }
     }
@@ -103,8 +123,29 @@ class GplayReviewToolTest : BaseTest() {
 
     private fun launchOk(): Task<Void?> = Tasks.forResult(null)
 
+    // A Play call that never comes back: the ktx wrapper suspends on the listeners it registers
+    // with the Task, and a relaxed mock never invokes them.
+    private fun <T> hangingTask(): Task<T> = mockk<Task<T>>(relaxed = true).apply {
+        every { isComplete } returns false
+    }
+
     // The `onStart` seed is not a computed state, every assertion has to await the first real one.
     private suspend fun GplayReviewTool.computedState() = state.drop(1).first()
+
+    // Live view of everything the tool emitted so far, for assertions that have to move the clock
+    // between emissions instead of awaiting a single one.
+    private fun TestScope.collectStates(tool: GplayReviewTool): List<ReviewTool.State> {
+        val states = mutableListOf<ReviewTool.State>()
+        backgroundScope.launch { tool.state.collect { states += it } }
+        return states
+    }
+
+    // The tool's flows all run on the background scope, and `advanceUntilIdle` only advances while
+    // there is foreground work, so every wait has to name the span it is waiting for.
+    private fun TestScope.advanceBy(duration: Duration) {
+        advanceTimeBy(duration.toMillis())
+        runCurrent()
+    }
 
     @Test fun `an eligible user is asked for a review`() = runTest2 {
         // Pins the fix: the old release-party gate could never open (nothing writes releasePartyAt
@@ -261,8 +302,10 @@ class GplayReviewToolTest : BaseTest() {
         val tool = tool()
         val activity = activity()
 
+        // runCurrent, not advanceUntilIdle: the first call has to be parked on the request when the
+        // second tap arrives, an unbounded time advance would trip the request timeout first.
         val first = launch { tool.reviewNow(activity) }
-        advanceUntilIdle()
+        runCurrent()
 
         tool.reviewNow(activity)
 
@@ -336,5 +379,284 @@ class GplayReviewToolTest : BaseTest() {
         computed shouldBe null
         // The general failure path would have burned all 3 attempts and settled on "unavailable".
         verify(exactly = 1) { manager.requestReviewFlow() }
+    }
+
+    @Test fun `a probe that times out abandons the whole round`() = runTest2 {
+        var hanging = true
+        every { manager.requestReviewFlow() } answers {
+            if (hanging) hangingTask() else Tasks.forResult(reviewInfo())
+        }
+        val tool = tool()
+        val states = collectStates(tool)
+
+        advanceBy(REQUEST_TIMEOUT.multipliedBy(2))
+
+        // Our timeout does not cancel the Play Task: an in-round retry would stack concurrent
+        // quota-consuming requests against a service that is already hung.
+        verify(exactly = 1) { manager.requestReviewFlow() }
+        states.last().shouldAskForReview shouldBe false
+
+        hanging = false
+        advanceBy(PROBE_FAILURE_COOLDOWN.multipliedBy(2))
+
+        // Recovery comes from the next cooldown round, not from the abandoned one.
+        verify(exactly = 2) { manager.requestReviewFlow() }
+        states.last().shouldAskForReview shouldBe true
+    }
+
+    @Test fun `a probe exception is still retried inside the round`() = runTest2 {
+        // Only a timeout abandons the round, the exception path keeps its 3 attempt budget.
+        every { manager.requestReviewFlow() } returnsMany listOf(
+            Tasks.forException(RuntimeException("Play unavailable")),
+            Tasks.forResult(reviewInfo()),
+        )
+        val tool = tool()
+        val states = collectStates(tool)
+
+        advanceBy(PROBE_RETRY_DELAY.multipliedBy(4))
+
+        verify(exactly = 2) { manager.requestReviewFlow() }
+        states.last().shouldAskForReview shouldBe true
+    }
+
+    @Test fun `a hanging fresh request releases the lock without persisting`() = runTest2 {
+        var hanging = true
+        every { manager.requestReviewFlow() } answers {
+            if (hanging) hangingTask() else Tasks.forResult(reviewInfo())
+        }
+        every { manager.launchReviewFlow(any(), any()) } returns launchOk()
+        val tool = tool()
+        val activity = activity()
+
+        tool.reviewNow(activity)
+
+        // A hang is not user intent: no launch, no bookkeeping, the next tap has to be able to retry.
+        verify(exactly = 0) { manager.launchReviewFlow(any(), any()) }
+        coVerify(exactly = 0) { lastDismissedMock.update(any()) }
+        coVerify(exactly = 0) { reviewedAtMock.update(any()) }
+
+        hanging = false
+        tool.reviewNow(activity)
+
+        // Without the timeout the single-flight lock would still be held by the first tap.
+        verify(exactly = 1) { manager.launchReviewFlow(activity, any()) }
+    }
+
+    @Test fun `a hanging launch releases the lock without persisting`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+        var hanging = true
+        every { manager.launchReviewFlow(any(), any()) } answers {
+            if (hanging) hangingTask() else launchOk()
+        }
+        val tool = tool()
+        val activity = activity()
+
+        tool.reviewNow(activity)
+
+        // The outcome is unknown, so neither the review nor the snooze may be recorded, and the
+        // duration heuristic must not treat the timeout as a completed review.
+        coVerify(exactly = 0) { reviewedAtMock.update(any()) }
+        coVerify(exactly = 0) { lastDismissedMock.update(any()) }
+
+        hanging = false
+        tool.reviewNow(activity)
+
+        verify(exactly = 2) { manager.launchReviewFlow(activity, any()) }
+    }
+
+    @Test fun `a dismiss racing the fresh request aborts the launch`() = runTest2 {
+        val tool = tool()
+        every { manager.requestReviewFlow() } answers {
+            // The user hits "maybe later" while Play is still answering the review tap.
+            runBlocking { tool.dismiss() }
+            Tasks.forResult(reviewInfo())
+        }
+        every { manager.launchReviewFlow(any(), any()) } returns launchOk()
+
+        tool.reviewNow(activity())
+
+        verify(exactly = 0) { manager.launchReviewFlow(any(), any()) }
+        // Only the dismiss' own write, reviewNow must not add bookkeeping on top of it.
+        coVerify(exactly = 1) { lastDismissedMock.update(any()) }
+        coVerify(exactly = 0) { reviewedAtMock.update(any()) }
+    }
+
+    @Test fun `a definitive probe answer is not requested twice`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+        val tool = tool()
+
+        val first = mutableListOf<ReviewTool.State>()
+        val firstJob = backgroundScope.launch { tool.state.collect { first += it } }
+        advanceBy(Duration.ofSeconds(1))
+        first.last().shouldAskForReview shouldBe true
+        firstJob.cancelAndJoin()
+
+        val second = mutableListOf<ReviewTool.State>()
+        val secondJob = backgroundScope.launch { tool.state.collect { second += it } }
+        advanceBy(Duration.ofSeconds(1))
+        second.last().shouldAskForReview shouldBe true
+        secondJob.cancelAndJoin()
+
+        // Play's answer holds for the rest of the process, a re-subscription must not cost quota.
+        verify(exactly = 1) { manager.requestReviewFlow() }
+    }
+
+    @Test fun `an isNoOp answer is not requested twice either`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo(canShow = false))
+        val tool = tool()
+
+        val first = mutableListOf<ReviewTool.State>()
+        val firstJob = backgroundScope.launch { tool.state.collect { first += it } }
+        advanceBy(Duration.ofSeconds(1))
+        first.last().shouldAskForReview shouldBe false
+        firstJob.cancelAndJoin()
+
+        val second = mutableListOf<ReviewTool.State>()
+        val secondJob = backgroundScope.launch { tool.state.collect { second += it } }
+        advanceBy(Duration.ofSeconds(1))
+        second.last().shouldAskForReview shouldBe false
+        secondJob.cancelAndJoin()
+
+        // isNoOp is a verdict, not a failure: it is cached like any other answer.
+        verify(exactly = 1) { manager.requestReviewFlow() }
+    }
+
+    @Test fun `a transient probe failure is retried after the cooldown`() = runTest2 {
+        var healthy = false
+        every { manager.requestReviewFlow() } answers {
+            if (healthy) Tasks.forResult(reviewInfo()) else Tasks.forException(RuntimeException("Play unavailable"))
+        }
+        val tool = tool()
+        val states = collectStates(tool)
+
+        advanceBy(PROBE_FAILURE_COOLDOWN.dividedBy(2))
+
+        verify(exactly = 3) { manager.requestReviewFlow() }
+        states.last().shouldAskForReview shouldBe false
+
+        healthy = true
+        advanceBy(PROBE_FAILURE_COOLDOWN)
+
+        // A failure is not an answer, so Play gets asked again once the cooldown is over.
+        verify(exactly = 4) { manager.requestReviewFlow() }
+        states.last().shouldAskForReview shouldBe true
+    }
+
+    @Test fun `the probe retry rounds are bounded`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forException(RuntimeException("Play unavailable"))
+        val tool = tool()
+        val states = collectStates(tool)
+
+        advanceBy(PROBE_FAILURE_COOLDOWN.multipliedBy(4))
+
+        // The initial round plus 3 cooldown rounds, 3 attempts each, then the process gives up.
+        verify(exactly = 12) { manager.requestReviewFlow() }
+        states.last().shouldAskForReview shouldBe false
+
+        advanceBy(PROBE_FAILURE_COOLDOWN.multipliedBy(20))
+
+        verify(exactly = 12) { manager.requestReviewFlow() }
+    }
+
+    @Test fun `a snooze running out flips the card on without a restart`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+        var fakeNow = BASE_NOW
+        val tool = tool(
+            upgradedAt = BASE_NOW.minus(Duration.ofDays(60)),
+            lastDismissed = BASE_NOW.minus(Duration.ofDays(13)),
+        ).apply { nowProvider = { fakeNow } }
+        val states = collectStates(tool)
+
+        advanceBy(Duration.ofSeconds(1))
+        states.last().shouldAskForReview shouldBe false
+
+        // The snooze ends a day later: the scheduled re-evaluation has to re-read the clock.
+        fakeNow = BASE_NOW.plus(Duration.ofDays(2))
+        advanceBy(Duration.ofDays(2))
+
+        states.last().shouldAskForReview shouldBe true
+    }
+
+    @Test fun `the pro grace period boundary is strict`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+        var fakeNow = BASE_NOW
+        val upgradedAt = BASE_NOW.minus(Duration.ofDays(21))
+
+        val atBoundary = tool(upgradedAt = upgradedAt).apply { nowProvider = { fakeNow } }
+        val atBoundaryStates = collectStates(atBoundary)
+        advanceBy(Duration.ofSeconds(1))
+        // 21 days have to have passed, not just been reached
+        atBoundaryStates.last().shouldAskForReview shouldBe false
+
+        // A second instance because nothing is pending on the first one: the wake schedule only
+        // keeps boundaries strictly after "now", and this one is exactly "now".
+        fakeNow = BASE_NOW.plus(Duration.ofSeconds(1))
+        val pastBoundary = tool(upgradedAt = upgradedAt).apply { nowProvider = { fakeNow } }
+        val pastBoundaryStates = collectStates(pastBoundary)
+        advanceBy(Duration.ofSeconds(1))
+
+        pastBoundaryStates.last().shouldAskForReview shouldBe true
+    }
+
+    @Test fun `a new dismiss reschedules the boundary re-evaluation`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+        var fakeNow = BASE_NOW
+        val tool = tool(
+            upgradedAt = BASE_NOW.minus(Duration.ofDays(60)),
+            lastDismissed = BASE_NOW.minus(Duration.ofDays(13)),
+            hotSettings = true,
+        ).apply { nowProvider = { fakeNow } }
+        val states = collectStates(tool)
+
+        advanceBy(Duration.ofSeconds(1))
+        states.last().shouldAskForReview shouldBe false
+
+        // Dismissed again while the old snooze end was still scheduled
+        lastDismissedFlow.value = BASE_NOW
+        advanceBy(Duration.ofSeconds(1))
+
+        fakeNow = BASE_NOW.plus(Duration.ofDays(2))
+        advanceBy(Duration.ofDays(3))
+        // The stale boundary must not flip the card back on, the new snooze governs now
+        states.last().shouldAskForReview shouldBe false
+
+        fakeNow = BASE_NOW.plus(Duration.ofDays(15))
+        advanceBy(Duration.ofDays(15))
+
+        states.last().shouldAskForReview shouldBe true
+    }
+
+    @Test fun `a clock that moved backwards re-evaluates instead of flipping`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+        var fakeNow = BASE_NOW
+        val tool = tool(
+            upgradedAt = BASE_NOW.minus(Duration.ofDays(60)),
+            lastDismissed = BASE_NOW.minus(Duration.ofDays(13)),
+        ).apply { nowProvider = { fakeNow } }
+        val states = collectStates(tool)
+
+        advanceBy(Duration.ofSeconds(1))
+        states.last().shouldAskForReview shouldBe false
+
+        // The device clock moved back: the wake fires on schedule, but the snooze is still running
+        fakeNow = BASE_NOW.minus(Duration.ofDays(5))
+        advanceBy(Duration.ofDays(30))
+
+        states.last().shouldAskForReview shouldBe false
+        verify(exactly = 0) { manager.requestReviewFlow() }
+
+        // Rescheduling is capped, so a backwards clock cannot keep the process waking forever
+        fakeNow = BASE_NOW.plus(Duration.ofDays(2))
+        advanceBy(Duration.ofDays(30))
+
+        states.last().shouldAskForReview shouldBe false
+    }
+
+    companion object {
+        private val BASE_NOW: Instant = Instant.parse("2024-06-01T12:00:00Z")
+        private val PROBE_RETRY_DELAY: Duration = Duration.ofSeconds(1)
+        private val PROBE_FAILURE_COOLDOWN: Duration = Duration.ofMinutes(5)
+        private val REQUEST_TIMEOUT: Duration = Duration.ofSeconds(5)
+        private val LAUNCH_TIMEOUT: Duration = Duration.ofMinutes(1)
     }
 }


### PR DESCRIPTION
## What changed

Hardens the Google Play review prompt against a misbehaving Play Store. If Play hung while the app was checking review availability or launching the review sheet, the review feature could silently stop working until the next app restart — those calls now time out and the next tap simply retries. Fast double-taps on the review card can no longer trigger conflicting actions (like a "Maybe later" erasing a just-completed review). The app also asks Play about review availability only once per app start instead of on every dashboard visit, and the card now appears on time when a snooze or the post-purchase waiting period runs out while the app is open.

## Technical Context

- Root cause of the headline fix: the `ReviewManager` suspend calls are unbounded over Play IPC. A hang either stalls the availability probe forever or leaves `reviewNow` holding its single-flight mutex, after which every later tap is silently dropped until process death. All three call sites are now bounded via `withTimeoutOrNull` (10s for requests, a deliberately generous 10min for the sheet itself) — not `withTimeout`, whose `TimeoutCancellationException` is a `CancellationException` and would escape the deliberate cancellation rethrows.
- A probe timeout abandons the whole probe round instead of retrying in-loop: our timeout does not cancel the underlying Play Task, so immediate retries would stack concurrent quota-consuming requests against an already hung service. Failed rounds retry on a 15-minute cooldown with a process-wide budget — the budget survives eligibility-driven flow restarts, so a billing flicker cannot hand out fresh rounds.
- Definitive availability verdicts (usable ReviewInfo, or Play's `isNoOp` refusal) are cached for the process lifetime; transient failures are never cached. This makes the previously inaccurate "re-probed on next process start" comment true and stops dashboard re-visits from re-spending Play's request quota.
- Eligibility is now a function of time, not only of stored inputs: the flow schedules bounded re-evaluations at the upcoming boundaries (snooze end, post-purchase grace end), re-reading the clock after every wake so wall-clock adjustments cannot strand it. A `nowProvider` seam makes the boundary behavior testable under virtual time.
- Tap race: dismissals persist asynchronously and the card state is throttled, so "Maybe later" followed by a fast "Review" could still launch Play's flow. Fixed in two layers: an in-memory dismiss generation checked after the fresh request and again right before launch, plus an asymmetric latch in the card — a review tap locks only the dismiss action (repeat review taps stay allowed so a transient Play failure remains retryable; the tool's single-flight lock absorbs duplicates), while a dismiss locks everything.
- Review guidance: the Compose test drives the card's full latch matrix; the process-wide-budget test was falsified during development (shadowing the budget per-restart yields 24 requests where 12 are asserted), so the assertion is known to be non-vacuous.
