### PR TITLE
Fix: Review card could come back with disabled buttons

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/ReviewDashboardCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/ReviewDashboardCard.kt
@@ -13,7 +13,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -48,8 +48,12 @@ internal fun ReviewDashboardCard(item: ReviewDashboardCardItem) {
     // the review bookkeeping with a snooze) and a review after a dismiss. A repeated review tap is
     // harmless, the tool's single-flight lock absorbs it, and blocking it here would leave a dead
     // card whenever a Play request fails and nothing gets persisted.
-    var dismissLocked by rememberSaveable { mutableStateOf(false) }
-    var fullyLatched by rememberSaveable { mutableStateOf(false) }
+    // Plain remember, not rememberSaveable: the dashboard's lazy list retains saveable state per
+    // item key, so a latched card removed by a priority cycle would come back still latched. The
+    // latch only has to cover the sub-second window until the list drops the card, and disposal on
+    // removal is exactly the reset we want.
+    var dismissLocked by remember { mutableStateOf(false) }
+    var fullyLatched by remember { mutableStateOf(false) }
     val onReview = {
         if (!fullyLatched && activity != null) {
             dismissLocked = true

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/cards/ReviewDashboardCardTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/cards/ReviewDashboardCardTest.kt
@@ -3,7 +3,9 @@ package eu.darken.sdmse.main.ui.dashboard.cards
 import android.app.Activity
 import android.content.Context
 import androidx.activity.compose.LocalActivity
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
@@ -42,6 +44,24 @@ class ReviewDashboardCardTest : BaseComposeRobolectricTest() {
             PreviewWrapper {
                 CompositionLocalProvider(LocalActivity provides activity) {
                     ReviewDashboardCard(item = item)
+                }
+            }
+        }
+    }
+
+    private val cardVisible = mutableStateOf(true)
+
+    // Mirrors the dashboard host: a LazyColumn keyed by the item's stable id, which is constant for
+    // this card.
+    private fun setLazyContent(activity: Activity? = mockk<Activity>(relaxed = true)) {
+        composeRule.setContent {
+            PreviewWrapper {
+                CompositionLocalProvider(LocalActivity provides activity) {
+                    LazyColumn {
+                        if (cardVisible.value) {
+                            item(key = item.stableId) { ReviewDashboardCard(item = item) }
+                        }
+                    }
                 }
             }
         }
@@ -119,6 +139,28 @@ class ReviewDashboardCardTest : BaseComposeRobolectricTest() {
             reviews shouldBe 2
             dismisses shouldBe 0
         }
+    }
+
+    @Test
+    fun `a card that left the list comes back unlatched`() {
+        setLazyContent()
+
+        dismissButton().performClick()
+        composeRule.runOnIdle { dismisses shouldBe 1 }
+
+        // A priority cycle (MOTD, update or setup card taking the slot) removes the item and re-adds
+        // it later. The lazy host retains saveable state per item key, so a latch that survives
+        // disposal comes back with the card and leaves it dead.
+        cardVisible.value = false
+        composeRule.waitForIdle()
+        cardVisible.value = true
+        composeRule.waitForIdle()
+
+        dismissButton().assertIsEnabled()
+        reviewButton().assertIsEnabled()
+
+        cardBody().performSemanticsAction(SemanticsActions.OnClick)
+        composeRule.runOnIdle { reviews shouldBe 1 }
     }
 
     @Test


### PR DESCRIPTION
## What changed

Fixes a leftover from the recent review-prompt hardening (#2619): if the review card was temporarily pushed off the dashboard (by an MOTD, an update notice, or setup hints) after one of its buttons had been tapped, it could come back with its buttons still disabled — in the worst case a dead card that could neither be dismissed nor tapped for a review.

## Technical Context

- Root cause: the card's one-shot tap latch used `rememberSaveable`, and the dashboard renders it as a LazyColumn item with a constant stable key — the lazy host's saveable registry retains state for a removed item key and hands it back on re-add, so the latch survived removal cycles it was never meant to survive.
- Found during the fleet port review of the same hardening (the sibling apps' reviews caught it first); reproduced here test-first: the new remove/re-add regression test fails against the previous code with the dismiss button restored disabled, and passes after the fix.
- Fix: plain `remember` for both latch flags — disposal on item removal is exactly the intended reset, and the latch only needs to guard the sub-second window until the next state emission removes the card, so surviving activity recreation is not worth the retention defect.
