### PR TITLE
AppCleaner: Log which button the clear-cache DPAD navigation actually reaches

### DIFF
--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecs.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecs.kt
@@ -318,24 +318,17 @@ class AOSPSpecs @Inject constructor(
                 log(tag, INFO) { "DPAD_DOWN result=$steppedDown (source=quick-try)" }
                 logFocus("quick-try DOWN")
                 delay(stepDelayMs)
-                // A refused RIGHT does not mean navigation broke, it usually means focus is already
-                // at the rightmost element of the action row - which is the clear-cache button on
-                // both Android 16 and 17. DOWN from the header lands there directly (verified on a
-                // Pixel 7a and a Pixel 8), so the RIGHT is a no-op we do not depend on. Some builds
-                // return true for it anyway, others report the refusal honestly - pressing CENTER
-                // either way is what makes this work on both.
-                // We cannot confirm this by reading focus: the buttons are hidden from the
-                // accessibility service (NAF on 16, absent from our tree on 17), so the click has
-                // to be unconditional.
                 val moved = dpadRight()
                 if (!moved) {
-                    log(tag, WARN) { "DPAD_RIGHT refused (source=quick-try), assuming focus is already at the row end" }
-                    logFocus("quick-try refused RIGHT")
+                    log(tag, WARN) { "DPAD_RIGHT failed (source=quick-try)" }
+                    logFocus("quick-try failed RIGHT")
                 }
-                delay(stepDelayMs)
-                val clicked = if (Bugs.isDryRun) true else dpadCenter()
-                log(tag, INFO) { "DPAD_CENTER result=$clicked (source=quick-try, rightMoved=$moved)" }
-                if (clicked && validateWithDelta("quick-try", preSnapshot, sizeParser, timeoutMs = 800)) return true
+                if (moved) {
+                    delay(stepDelayMs)
+                    val clicked = if (Bugs.isDryRun) true else dpadCenter()
+                    log(tag, INFO) { "DPAD_CENTER result=$clicked (source=quick-try)" }
+                    if (clicked && validateWithDelta("quick-try", preSnapshot, sizeParser, timeoutMs = 800)) return true
+                }
                 // Check if anchor is still present before falling through to cycle loop.
                 // If anchor is gone, the click likely had an effect (UI changed) — don't double-click.
                 val anchorStillPresent = host.windowRoot()?.crawl()?.map { it.node }
@@ -350,7 +343,7 @@ class AOSPSpecs @Inject constructor(
             }
         }
 
-        cycleLoop@ for (cycle in 1..maxCycles) {
+        for (cycle in 1..maxCycles) {
             val bootstrapped = bootstrapAnchor("cycle-$cycle")
             if (!bootstrapped) {
                 delay(120)
@@ -395,10 +388,7 @@ class AOSPSpecs @Inject constructor(
                 if (!moved) {
                     log(tag, WARN) { "DPAD_RIGHT cycle=$cycle step=$stepIdx failed" }
                     logFocus("cycle-$cycle failed RIGHT")
-                    // Retrying cycles cannot help - if focus won't move right it won't move right
-                    // next cycle either. Fall through to the blind sweep, which doesn't depend on
-                    // focus reporting, rather than giving up on the remaining strategies.
-                    break@cycleLoop
+                    return false
                 }
                 totalRightSteps++
                 delay(stepDelayMs)

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecs.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecs.kt
@@ -340,7 +340,7 @@ class AOSPSpecs @Inject constructor(
             }
         }
 
-        for (cycle in 1..maxCycles) {
+        cycleLoop@ for (cycle in 1..maxCycles) {
             val bootstrapped = bootstrapAnchor("cycle-$cycle")
             if (!bootstrapped) {
                 delay(120)
@@ -385,7 +385,10 @@ class AOSPSpecs @Inject constructor(
                 if (!moved) {
                     log(tag, WARN) { "DPAD_RIGHT cycle=$cycle step=$stepIdx failed" }
                     logFocus("cycle-$cycle failed RIGHT")
-                    return false
+                    // Retrying cycles cannot help - if focus won't move right it won't move right
+                    // next cycle either. Fall through to the blind sweep, which doesn't depend on
+                    // focus reporting, rather than giving up on the remaining strategies.
+                    break@cycleLoop
                 }
                 totalRightSteps++
                 delay(stepDelayMs)

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecs.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecs.kt
@@ -318,17 +318,24 @@ class AOSPSpecs @Inject constructor(
                 log(tag, INFO) { "DPAD_DOWN result=$steppedDown (source=quick-try)" }
                 logFocus("quick-try DOWN")
                 delay(stepDelayMs)
+                // A refused RIGHT does not mean navigation broke, it usually means focus is already
+                // at the rightmost element of the action row - which is the clear-cache button on
+                // both Android 16 and 17. DOWN from the header lands there directly (verified on a
+                // Pixel 7a and a Pixel 8), so the RIGHT is a no-op we do not depend on. Some builds
+                // return true for it anyway, others report the refusal honestly - pressing CENTER
+                // either way is what makes this work on both.
+                // We cannot confirm this by reading focus: the buttons are hidden from the
+                // accessibility service (NAF on 16, absent from our tree on 17), so the click has
+                // to be unconditional.
                 val moved = dpadRight()
                 if (!moved) {
-                    log(tag, WARN) { "DPAD_RIGHT failed (source=quick-try)" }
-                    logFocus("quick-try failed RIGHT")
+                    log(tag, WARN) { "DPAD_RIGHT refused (source=quick-try), assuming focus is already at the row end" }
+                    logFocus("quick-try refused RIGHT")
                 }
-                if (moved) {
-                    delay(stepDelayMs)
-                    val clicked = if (Bugs.isDryRun) true else dpadCenter()
-                    log(tag, INFO) { "DPAD_CENTER result=$clicked (source=quick-try)" }
-                    if (clicked && validateWithDelta("quick-try", preSnapshot, sizeParser, timeoutMs = 800)) return true
-                }
+                delay(stepDelayMs)
+                val clicked = if (Bugs.isDryRun) true else dpadCenter()
+                log(tag, INFO) { "DPAD_CENTER result=$clicked (source=quick-try, rightMoved=$moved)" }
+                if (clicked && validateWithDelta("quick-try", preSnapshot, sizeParser, timeoutMs = 800)) return true
                 // Check if anchor is still present before falling through to cycle loop.
                 // If anchor is gone, the click likely had an effect (UI changed) — don't double-click.
                 val anchorStillPresent = host.windowRoot()?.crawl()?.map { it.node }

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecs.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecs.kt
@@ -299,8 +299,11 @@ class AOSPSpecs @Inject constructor(
             return bootstrapInputFocusResult || bootstrapA11yFocusResult || alreadyInputFocused || alreadyA11yFocused
         }
 
-        // Where focus actually sits after a movement. Without this a failed DPAD_RIGHT is ambiguous:
-        // the preceding DOWN may have gone nowhere, landed on the button row, or overshot it.
+        // Best-effort reading of where focus sits after a movement. Treat it as a hint, not proof:
+        // the framework often does not report focus after a DPAD action, so this can show the
+        // pre-movement node even when the movement worked. Observed on a Pixel 8 that clears the
+        // cache successfully - DPAD_DOWN returns true and focus still reads as the anchor. Only a
+        // reading that differs from the anchor says anything; an unchanged one is inconclusive.
         suspend fun logFocus(step: String) {
             val focus = findFocusedNode()
             log(tag) {

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecs.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecs.kt
@@ -299,12 +299,27 @@ class AOSPSpecs @Inject constructor(
             return bootstrapInputFocusResult || bootstrapA11yFocusResult || alreadyInputFocused || alreadyA11yFocused
         }
 
+        // Where focus actually sits after a movement. Without this a failed DPAD_RIGHT is ambiguous:
+        // the preceding DOWN may have gone nowhere, landed on the button row, or overshot it.
+        suspend fun logFocus(step: String) {
+            val focus = findFocusedNode()
+            log(tag) {
+                "DPAD focus after $step: input=${focus.inputFocused}, a11y=${focus.accessibilityFocused}"
+            }
+        }
+
         run {
             val fastBootstrapped = bootstrapAnchor("quick-try")
             if (fastBootstrapped) {
-                dpadDown()
+                val steppedDown = dpadDown()
+                log(tag, INFO) { "DPAD_DOWN result=$steppedDown (source=quick-try)" }
+                logFocus("quick-try DOWN")
                 delay(stepDelayMs)
                 val moved = dpadRight()
+                if (!moved) {
+                    log(tag, WARN) { "DPAD_RIGHT failed (source=quick-try)" }
+                    logFocus("quick-try failed RIGHT")
+                }
                 if (moved) {
                     delay(stepDelayMs)
                     val clicked = if (Bugs.isDryRun) true else dpadCenter()
@@ -357,7 +372,9 @@ class AOSPSpecs @Inject constructor(
                 log(tag, INFO) { "Focus not on anchor in cycle $cycle, attempting DPAD traversal anyway" }
             }
 
-            dpadDown()
+            val steppedDown = dpadDown()
+            log(tag, INFO) { "DPAD_DOWN result=$steppedDown (cycle=$cycle)" }
+            logFocus("cycle-$cycle DOWN")
             delay(stepDelayMs)
 
             var stalledSteps = 0
@@ -367,6 +384,7 @@ class AOSPSpecs @Inject constructor(
                 val moved = dpadRight()
                 if (!moved) {
                     log(tag, WARN) { "DPAD_RIGHT cycle=$cycle step=$stepIdx failed" }
+                    logFocus("cycle-$cycle failed RIGHT")
                     return false
                 }
                 totalRightSteps++
@@ -429,12 +447,15 @@ class AOSPSpecs @Inject constructor(
                     return false
                 }
 
-                dpadDown()
+                val steppedDown = dpadDown()
+                log(tag, INFO) { "DPAD_DOWN result=$steppedDown (source=blind-sweep-$rightSteps)" }
                 delay(stepDelayMs)
-                repeat(rightSteps) {
-                    dpadRight()
+                repeat(rightSteps) { step ->
+                    val moved = dpadRight()
+                    if (!moved) log(tag, WARN) { "DPAD_RIGHT blind-sweep-$rightSteps step=${step + 1} failed" }
                     delay(stepDelayMs)
                 }
+                logFocus("blind-sweep-$rightSteps")
 
                 val clicked = if (Bugs.isDryRun) true else dpadCenter()
                 log(tag, INFO) { "DPAD_CENTER result=$clicked (source=blind-sweep-$rightSteps)" }

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecsTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecsTest.kt
@@ -299,41 +299,6 @@ class AOSPSpecsTest : BaseAppCleanerSpecTest<AOSPSpecs, AOSPLabels>() {
     }
 
     @Test
-    fun `a refused DPAD_RIGHT still clicks and still reaches the blind sweep`() = runTest {
-        // Regression guard for the Android 17 report. DOWN from the header lands directly on the
-        // clear-cache button (verified on a Pixel 7a and a Pixel 8), so the following RIGHT has
-        // nowhere to go. Some builds return true for it regardless, others report the refusal
-        // honestly - and we used to treat that honest answer as fatal, skipping the click while
-        // focus was sitting on the button, then abandoning the remaining strategies too.
-        setupTestScope(this)
-        mockkStatic(::hasApiLevel)
-        every { hasApiLevel(any()) } answers { firstArg<Int>() <= 36 }
-        mockkObject(BuildWrap)
-        every { BuildWrap.MANUFACTOR } returns "Google"
-        every { BuildWrap.PRODUCT } returns "lynx_beta"
-
-        coEvery { inputInjector.canInject() } returns false
-        every { testHost.service.performGlobalAction(any()) } answers {
-            firstArg<Int>() != android.accessibilityservice.AccessibilityService.GLOBAL_ACTION_DPAD_RIGHT
-        }
-
-        testRoot = buildTestTree(
-            """
-            ACS-DEBUG: 0: text='null', class=android.widget.FrameLayout, clickable=false, checkable=false enabled=true, id=null pkg=com.android.settings, identity=root, bounds=Rect(0, 0 - 1080, 2400)
-            ACS-DEBUG: -1: text='null', class=android.widget.LinearLayout, clickable=true, checkable=false enabled=true, id=com.android.settings:id/entity_header_content pkg=com.android.settings, identity=header, bounds=Rect(84, 328 - 996, 675)
-            """.trimIndent()
-        )
-
-        val result = captureAndRunClearCacheAction()
-
-        result shouldBe false
-        // 1 quick-try + 3 blind-sweep (positions 2-4) = 4 CENTER, matching the all-actions-succeed
-        // case above. A refused RIGHT must not change how many clicks we attempt. Before the fix
-        // this was 0: quick-try skipped its click and the sweep was never reached.
-        verify(exactly = 4) { testHost.service.performGlobalAction(android.accessibilityservice.AccessibilityService.GLOBAL_ACTION_DPAD_CENTER) }
-    }
-
-    @Test
     fun `clear cache DPAD validation fails when root package changes after click`() = runTest {
         setupTestScope(this)
         mockkStatic(::hasApiLevel)

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecsTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecsTest.kt
@@ -299,10 +299,12 @@ class AOSPSpecsTest : BaseAppCleanerSpecTest<AOSPSpecs, AOSPLabels>() {
     }
 
     @Test
-    fun `blind sweep still runs when DPAD_RIGHT is refused outright`() = runTest {
-        // Regression guard: a refused DPAD_RIGHT used to return from the whole navigation, which
-        // skipped the remaining cycles AND the blind sweep. The blind sweep does not depend on
-        // focus moving, so it has to stay reachable when the platform won't move focus at all.
+    fun `a refused DPAD_RIGHT still clicks and still reaches the blind sweep`() = runTest {
+        // Regression guard for the Android 17 report. DOWN from the header lands directly on the
+        // clear-cache button (verified on a Pixel 7a and a Pixel 8), so the following RIGHT has
+        // nowhere to go. Some builds return true for it regardless, others report the refusal
+        // honestly - and we used to treat that honest answer as fatal, skipping the click while
+        // focus was sitting on the button, then abandoning the remaining strategies too.
         setupTestScope(this)
         mockkStatic(::hasApiLevel)
         every { hasApiLevel(any()) } answers { firstArg<Int>() <= 36 }
@@ -325,9 +327,10 @@ class AOSPSpecsTest : BaseAppCleanerSpecTest<AOSPSpecs, AOSPLabels>() {
         val result = captureAndRunClearCacheAction()
 
         result shouldBe false
-        // Quick-try skips its CENTER because RIGHT never moved, so the 3 CENTERs are the blind
-        // sweep at positions 2-4. Before the fix this was 0 - the sweep was never reached.
-        verify(exactly = 3) { testHost.service.performGlobalAction(android.accessibilityservice.AccessibilityService.GLOBAL_ACTION_DPAD_CENTER) }
+        // 1 quick-try + 3 blind-sweep (positions 2-4) = 4 CENTER, matching the all-actions-succeed
+        // case above. A refused RIGHT must not change how many clicks we attempt. Before the fix
+        // this was 0: quick-try skipped its click and the sweep was never reached.
+        verify(exactly = 4) { testHost.service.performGlobalAction(android.accessibilityservice.AccessibilityService.GLOBAL_ACTION_DPAD_CENTER) }
     }
 
     @Test

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecsTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecsTest.kt
@@ -299,6 +299,38 @@ class AOSPSpecsTest : BaseAppCleanerSpecTest<AOSPSpecs, AOSPLabels>() {
     }
 
     @Test
+    fun `blind sweep still runs when DPAD_RIGHT is refused outright`() = runTest {
+        // Regression guard: a refused DPAD_RIGHT used to return from the whole navigation, which
+        // skipped the remaining cycles AND the blind sweep. The blind sweep does not depend on
+        // focus moving, so it has to stay reachable when the platform won't move focus at all.
+        setupTestScope(this)
+        mockkStatic(::hasApiLevel)
+        every { hasApiLevel(any()) } answers { firstArg<Int>() <= 36 }
+        mockkObject(BuildWrap)
+        every { BuildWrap.MANUFACTOR } returns "Google"
+        every { BuildWrap.PRODUCT } returns "lynx_beta"
+
+        coEvery { inputInjector.canInject() } returns false
+        every { testHost.service.performGlobalAction(any()) } answers {
+            firstArg<Int>() != android.accessibilityservice.AccessibilityService.GLOBAL_ACTION_DPAD_RIGHT
+        }
+
+        testRoot = buildTestTree(
+            """
+            ACS-DEBUG: 0: text='null', class=android.widget.FrameLayout, clickable=false, checkable=false enabled=true, id=null pkg=com.android.settings, identity=root, bounds=Rect(0, 0 - 1080, 2400)
+            ACS-DEBUG: -1: text='null', class=android.widget.LinearLayout, clickable=true, checkable=false enabled=true, id=com.android.settings:id/entity_header_content pkg=com.android.settings, identity=header, bounds=Rect(84, 328 - 996, 675)
+            """.trimIndent()
+        )
+
+        val result = captureAndRunClearCacheAction()
+
+        result shouldBe false
+        // Quick-try skips its CENTER because RIGHT never moved, so the 3 CENTERs are the blind
+        // sweep at positions 2-4. Before the fix this was 0 - the sweep was never reached.
+        verify(exactly = 3) { testHost.service.performGlobalAction(android.accessibilityservice.AccessibilityService.GLOBAL_ACTION_DPAD_CENTER) }
+    }
+
+    @Test
     fun `clear cache DPAD validation fails when root package changes after click`() = runTest {
         setupTestScope(this)
         mockkStatic(::hasApiLevel)


### PR DESCRIPTION
## What changed

No user-facing behaviour change. This adds logging only.

When AppCleaner cannot find the "Clear cache" button by name, it falls back to moving a keyboard-style focus cursor to reach it. Until now a debug log recorded almost nothing about that cursor, so a report of "the button was not pressed" was impossible to diagnose. This records what each movement returned and where focus ended up.

## Technical Context

- `dpadDown()`'s return value was discarded at all three call sites (quick-try, cycle loop, blind sweep), and a failed `dpadRight()` was logged only in the cycle loop. A refused RIGHT was therefore indistinguishable in a log from a dozen unrelated failures.
- Adds `DPAD_DOWN result=`, a `DPAD_RIGHT` failure line for quick-try and the blind sweep, and a best-effort focus reading after each DOWN and after a failed RIGHT.
- The focus reading is explicitly documented as a hint, not proof. On a Pixel 8 that clears caches successfully, `DPAD_DOWN` returns true and the focus read-back still reports the pre-movement anchor. The framework often does not report focus after a DPAD action, so only a reading that *differs* from the anchor says anything.

## History of this branch

It originally carried two behaviour changes, both since reverted in 3c17bac1c:

- pressing CENTER even when `dpadRight()` was refused
- letting a refused RIGHT fall through to the blind sweep instead of returning

Both rested on the assumption that a refused RIGHT means focus is already at the rightmost element of the action row, so clicking anyway is safe. Driving DPAD events and dumping focus on a Pixel 7a (Android 16) and a Pixel 8 (Android 17) refuted that. `button1` ("Clear storage") and `button2` ("Clear cache") sit *exactly* equidistant from the `entity_header_content` centre - ±238.5px at density 420, ±243 at 360 - so Android has a genuine tie to break, and at the smaller density DOWN lands on **Clear storage** every time.

Clicking unconditionally there presses Clear storage, which opens the delete-app-data confirmation. Nothing is deleted (the `anchorStillPresent` guard sees the dialog and aborts, verified on device), but it is the wrong button and cannot clear a cache.

## Related findings, not addressed here

- **The original Android 17 report was a platform bug.** The reporter's Pixel 9 refused `performGlobalAction(GLOBAL_ACTION_DPAD_RIGHT)` where a Pixel 8 on the same Android version returned true. An Android security update fixed it on their end.
- **The misclick is real and happens on release builds.** The same reporter, on a shipped version with none of these changes, sees the delete-app-data dialog appear occasionally mid-run. Fixing it means making the click target deterministic rather than a geometric tie-break. Not attempted here.
- On Android 17 `button2` carries `content-desc="Clear cache"` and is clickable, which `findClearCacheCandidate` should match, yet it returns null - so the accessibility service evidently sees a different tree than `uiautomator` does. If the service could see that node, none of the DPAD fallback would run.