### PR TITLE
General: Show clearer errors when Google Play offers can't load

### DIFF
--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/error/ComposeErrorDialog.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/error/ComposeErrorDialog.kt
@@ -52,7 +52,14 @@ fun ComposeErrorDialog(
     // lambdas, so never equal) on every recomposition, which would wipe the message immediately.
     var actionError by remember(throwable) { mutableStateOf<CaString?>(null) }
 
-    fun dispatchAndDismiss(route: NavigationDestination?, action: ((Activity) -> Unit)?) {
+    // errorMessage is per-dispatch, NOT read from localizedError: this function serves both the fix
+    // and the info button, and fixActionErrorMessage describes only the fix action's failure. Each
+    // call site passes its own copy (or none), so no button can ever surface another one's message.
+    fun dispatchAndDismiss(
+        route: NavigationDestination?,
+        action: ((Activity) -> Unit)?,
+        errorMessage: CaString? = null,
+    ) {
         // Error actions are arbitrary third-party code (intent launches, navigation): a throw here
         // would crash the UI thread from inside a click handler, and skipping onDismiss() would
         // leave the dialog latched on the current error with no way out.
@@ -63,9 +70,9 @@ fun ComposeErrorDialog(
             }
         } catch (e: Exception) {
             log(TAG, ERROR) { "Error action failed: ${e.asLog()}" }
-            // An error that ships its own failure copy keeps the dialog open and shows it inline
+            // A dispatch that ships its own failure copy keeps the dialog open and shows it inline
             // (no length cap, unlike a Toast). Never latched: the dismiss button stays available.
-            localizedError.fixActionErrorMessage?.let {
+            errorMessage?.let {
                 actionError = it
                 return
             }
@@ -108,7 +115,13 @@ fun ComposeErrorDialog(
                     SdmDialogAction(
                         label = localizedError.fixActionLabel?.get(context)
                             ?: stringResource(android.R.string.ok),
-                        onClick = { dispatchAndDismiss(localizedError.fixActionRoute, localizedError.fixAction) },
+                        onClick = {
+                            dispatchAndDismiss(
+                                route = localizedError.fixActionRoute,
+                                action = localizedError.fixAction,
+                                errorMessage = localizedError.fixActionErrorMessage,
+                            )
+                        },
                     )
                 } else {
                     SdmDialogAction(
@@ -128,7 +141,14 @@ fun ComposeErrorDialog(
                     SdmDialogAction(
                         label = localizedError.infoActionLabel?.get(context)
                             ?: stringResource(R.string.general_show_details_action),
-                        onClick = { dispatchAndDismiss(localizedError.infoActionRoute, localizedError.infoAction) },
+                        // No errorMessage: the info action has no failure copy of its own, and it
+                        // must never borrow the fix action's.
+                        onClick = {
+                            dispatchAndDismiss(
+                                route = localizedError.infoActionRoute,
+                                action = localizedError.infoAction,
+                            )
+                        },
                     )
                 } else {
                     null

--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/error/ComposeErrorDialog.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/error/ComposeErrorDialog.kt
@@ -8,11 +8,16 @@ import eu.darken.sdmse.common.compose.dialog.SdmAlertDialog
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import eu.darken.sdmse.common.R
+import eu.darken.sdmse.common.ca.CaString
 import eu.darken.sdmse.common.compose.dialog.SdmDialogAction
 import eu.darken.sdmse.common.compose.dialog.SdmDialogButtonBar
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
@@ -43,6 +48,10 @@ fun ComposeErrorDialog(
     val hasFix = localizedError.fixActionRoute != null || localizedError.fixAction != null
     val hasInfo = localizedError.infoActionRoute != null || localizedError.infoAction != null
 
+    // Keyed on the throwable, not the LocalizedError: the latter is rebuilt (with fresh action
+    // lambdas, so never equal) on every recomposition, which would wipe the message immediately.
+    var actionError by remember(throwable) { mutableStateOf<CaString?>(null) }
+
     fun dispatchAndDismiss(route: NavigationDestination?, action: ((Activity) -> Unit)?) {
         // Error actions are arbitrary third-party code (intent launches, navigation): a throw here
         // would crash the UI thread from inside a click handler, and skipping onDismiss() would
@@ -54,9 +63,14 @@ fun ComposeErrorDialog(
             }
         } catch (e: Exception) {
             log(TAG, ERROR) { "Error action failed: ${e.asLog()}" }
-        } finally {
-            onDismiss()
+            // An error that ships its own failure copy keeps the dialog open and shows it inline
+            // (no length cap, unlike a Toast). Never latched: the dismiss button stays available.
+            localizedError.fixActionErrorMessage?.let {
+                actionError = it
+                return
+            }
         }
+        onDismiss()
     }
 
     SdmAlertDialog(
@@ -75,6 +89,16 @@ fun ComposeErrorDialog(
                         style = MaterialTheme.typography.bodyMedium,
                         modifier = Modifier.padding(vertical = 8.dp),
                     )
+                }
+                actionError?.let {
+                    SelectionContainer {
+                        Text(
+                            text = it.get(context),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.error,
+                            modifier = Modifier.padding(bottom = 8.dp),
+                        )
+                    }
                 }
             }
         },

--- a/app-common-ui/src/test/java/eu/darken/sdmse/common/error/ComposeErrorDialogTest.kt
+++ b/app-common-ui/src/test/java/eu/darken/sdmse/common/error/ComposeErrorDialogTest.kt
@@ -43,6 +43,7 @@ class ComposeErrorDialogTest : BaseComposeRobolectricTest() {
         private val fixLabel: String? = null,
         private val fixAction: ((Activity) -> Unit)? = null,
         private val fixRoute: NavigationDestination? = null,
+        private val fixErrorMessage: String? = null,
     ) : Exception(ERROR_BODY), HasLocalizedError {
         override fun getLocalizedError() = LocalizedError(
             throwable = this,
@@ -51,6 +52,7 @@ class ComposeErrorDialogTest : BaseComposeRobolectricTest() {
             fixActionLabel = fixLabel?.toCaString(),
             fixAction = fixAction,
             fixActionRoute = fixRoute,
+            fixActionErrorMessage = fixErrorMessage?.toCaString(),
         )
     }
 
@@ -137,6 +139,28 @@ class ComposeErrorDialogTest : BaseComposeRobolectricTest() {
     }
 
     @Test
+    fun `a throwing fix action with its own message keeps the dialog open and shows it inline`() {
+        // A Toast caps at 2 lines and clipped this kind of message; the dialog body has no cap.
+        show(
+            TestError(
+                fixLabel = FIX_LABEL,
+                fixAction = { throw IllegalStateException("fix action exploded") },
+                fixErrorMessage = FIX_ERROR_MESSAGE,
+            )
+        )
+
+        composeRule.onNodeWithText(FIX_LABEL).performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText(FIX_ERROR_MESSAGE).assertIsDisplayed()
+        dismissals shouldBe 0
+        // Not latched: the way out stays available while the message is shown.
+        composeRule.onNodeWithText(dismissLabel).performClick()
+        composeRule.waitForIdle()
+        dismissals shouldBe 1
+    }
+
+    @Test
     fun `a throwing route navigation still closes the dialog`() {
         val navController = mockk<NavigationController>(relaxed = true).apply {
             every { goTo(any(), any(), any()) } throws IllegalStateException("NavigationController not initialized")
@@ -155,3 +179,4 @@ class ComposeErrorDialogTest : BaseComposeRobolectricTest() {
 private const val ERROR_TITLE = "Test error title"
 private const val ERROR_BODY = "Test error description"
 private const val FIX_LABEL = "Fix it"
+private const val FIX_ERROR_MESSAGE = "Fixing it did not work"

--- a/app-common-ui/src/test/java/eu/darken/sdmse/common/error/ComposeErrorDialogTest.kt
+++ b/app-common-ui/src/test/java/eu/darken/sdmse/common/error/ComposeErrorDialogTest.kt
@@ -44,6 +44,8 @@ class ComposeErrorDialogTest : BaseComposeRobolectricTest() {
         private val fixAction: ((Activity) -> Unit)? = null,
         private val fixRoute: NavigationDestination? = null,
         private val fixErrorMessage: String? = null,
+        private val infoLabel: String? = null,
+        private val infoAction: ((Activity) -> Unit)? = null,
     ) : Exception(ERROR_BODY), HasLocalizedError {
         override fun getLocalizedError() = LocalizedError(
             throwable = this,
@@ -53,6 +55,8 @@ class ComposeErrorDialogTest : BaseComposeRobolectricTest() {
             fixAction = fixAction,
             fixActionRoute = fixRoute,
             fixActionErrorMessage = fixErrorMessage?.toCaString(),
+            infoActionLabel = infoLabel?.toCaString(),
+            infoAction = infoAction,
         )
     }
 
@@ -161,6 +165,27 @@ class ComposeErrorDialogTest : BaseComposeRobolectricTest() {
     }
 
     @Test
+    fun `a throwing info action never borrows the fix action's failure message`() {
+        // The failure copy belongs to the fix action's dispatch, not to the error: the info button
+        // dispatches without one and must keep the plain log-then-dismiss behaviour.
+        show(
+            TestError(
+                fixLabel = FIX_LABEL,
+                fixAction = {},
+                fixErrorMessage = FIX_ERROR_MESSAGE,
+                infoLabel = INFO_LABEL,
+                infoAction = { throw IllegalStateException("info action exploded") },
+            )
+        )
+
+        composeRule.onNodeWithText(INFO_LABEL).performClick()
+        composeRule.waitForIdle()
+
+        dismissals shouldBe 1
+        composeRule.onAllNodesWithText(FIX_ERROR_MESSAGE).assertCountEquals(0)
+    }
+
+    @Test
     fun `a throwing route navigation still closes the dialog`() {
         val navController = mockk<NavigationController>(relaxed = true).apply {
             every { goTo(any(), any(), any()) } throws IllegalStateException("NavigationController not initialized")
@@ -180,3 +205,4 @@ private const val ERROR_TITLE = "Test error title"
 private const val ERROR_BODY = "Test error description"
 private const val FIX_LABEL = "Fix it"
 private const val FIX_ERROR_MESSAGE = "Fixing it did not work"
+private const val INFO_LABEL = "Tell me more"

--- a/app-common/src/main/java/eu/darken/sdmse/common/error/LocalizedError.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/error/LocalizedError.kt
@@ -19,6 +19,8 @@ data class LocalizedError(
     val fixActionLabel: CaString? = null,
     val fixAction: ((Activity) -> Unit)? = null,
     val fixActionRoute: NavigationDestination? = null,
+    /** Shown inline in the error dialog if the fix action fails, instead of a length-capped toast. */
+    val fixActionErrorMessage: CaString? = null,
     val infoActionLabel: CaString? = null,
     val infoAction: ((Activity) -> Unit)? = null,
     val infoActionRoute: NavigationDestination? = null,

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/GplayServiceUnavailableException.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/GplayServiceUnavailableException.kt
@@ -1,11 +1,9 @@
 package eu.darken.sdmse.common.upgrade.core.billing
 
-import android.app.Activity
 import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
 import android.provider.Settings
-import android.widget.Toast
 import eu.darken.sdmse.R
 import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
@@ -34,18 +32,23 @@ class GplayServiceUnavailableException(cause: Throwable) :
             try {
                 activity.startActivity(intent)
             } catch (e: ActivityNotFoundException) {
-                onLaunchFailed(activity, e)
+                onLaunchFailed(e)
+                throw e
             } catch (e: SecurityException) {
                 // Play can be installed but unreachable: disabled app, work/restricted profile or a
                 // ROM that guards the settings screen. The launch is denied, not unresolvable.
-                onLaunchFailed(activity, e)
+                onLaunchFailed(e)
+                throw e
             }
-        }
+        },
+        // The failure is not presented here: it propagates to the dialog, which renders this inline.
+        // A Toast caps at 2 lines and clipped this message (in French mid-word, dropping a whole
+        // condition), so the container was the defect, not the wording.
+        fixActionErrorMessage = R.string.upgrades_gplay_not_installed_message.toCaString(),
     )
 
-    private fun onLaunchFailed(activity: Activity, e: Exception) {
+    private fun onLaunchFailed(e: Exception) {
         log(ERROR) { "Can't launch settings intent for Google Play: $e" }
-        Toast.makeText(activity, R.string.upgrades_gplay_not_installed_message, Toast.LENGTH_SHORT).show()
     }
 
     companion object {

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
@@ -18,6 +18,7 @@ import eu.darken.sdmse.common.uix.ViewModel4
 import eu.darken.sdmse.common.upgrade.core.OurSku
 import eu.darken.sdmse.common.upgrade.core.UpgradeRepoGplay
 import eu.darken.sdmse.common.upgrade.core.billing.GplayServiceUnavailableException
+import eu.darken.sdmse.common.upgrade.core.billing.OfferUnavailableBillingException
 import eu.darken.sdmse.common.upgrade.core.billing.Sku
 import eu.darken.sdmse.common.upgrade.core.billing.SkuDetails
 import eu.darken.sdmse.main.ui.navigation.SupportFormRoute
@@ -187,9 +188,22 @@ class UpgradeViewModel @Inject constructor(
 
         if (done != null) {
             if (iap == null && sub == null) {
-                val serviceUnavailableError = GplayServiceUnavailableException(
-                    done.iap.exceptionOrNull() ?: RuntimeException("IAP and SUB data request failed.")
-                )
+                val iapCause = done.iap.exceptionOrNull()
+                val subCause = done.sub.exceptionOrNull()
+                // Play answered fine and simply has nothing to sell here (region, account
+                // eligibility, pulled product): reporting that as a connectivity failure sends the
+                // user chasing futile advice (clear Play's cache, reboot). Only when BOTH causes
+                // are merchandising — a single connectivity failure can't rule out a real Play
+                // problem, so the conservative "can't reach Play" copy stays correct.
+                val queryError = if (
+                    iapCause is OfferUnavailableBillingException && subCause is OfferUnavailableBillingException
+                ) {
+                    iapCause
+                } else {
+                    GplayServiceUnavailableException(
+                        iapCause ?: RuntimeException("IAP and SUB data request failed.")
+                    )
+                }
                 // Grace users and owners are excluded: during an outage (exactly when grace
                 // matters) they must keep the Loaded presentation with their status/grace card,
                 // not an acquisition-style error state or dialog.
@@ -198,9 +212,9 @@ class UpgradeViewModel @Inject constructor(
                     // toggling) — emit once per failure episode, not once per recombination.
                     if (!hasShownServiceUnavailableError) {
                         hasShownServiceUnavailableError = true
-                        errorEvents.tryEmit(serviceUnavailableError)
+                        errorEvents.tryEmit(queryError)
                     }
-                    return@combine GplayUpgradeUiState.Unavailable(serviceUnavailableError)
+                    return@combine GplayUpgradeUiState.Unavailable(queryError)
                 }
             } else {
                 hasShownServiceUnavailableError = false

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/billing/GplayFixActionTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/billing/GplayFixActionTest.kt
@@ -5,6 +5,7 @@ import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.provider.Settings
 import eu.darken.sdmse.R
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import org.junit.Test
@@ -19,7 +20,8 @@ import testhelpers.TestApplication
 
 /**
  * The error dialog's "Google Play" button runs on an activity context: it has to stay inside the
- * caller's task, and a device where the launch is refused must get a toast, not a crash.
+ * caller's task, and a device where the launch is refused must get the failure reported through the
+ * dialog (which can show the full message), not a clipped toast and not a crash.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [33], application = TestApplication::class)
@@ -56,22 +58,32 @@ class GplayFixActionTest : BaseTest() {
     }
 
     @Test
-    fun `a denied launch shows the not-installed toast instead of crashing`() {
+    fun `a denied launch reports through the dialog instead of a toast`() {
         val activity = activityOf(DeniedLaunchActivity::class.java)
 
-        fixAction.invoke(activity)
+        shouldThrow<SecurityException> { fixAction.invoke(activity) }
 
-        ShadowToast.getTextOfLatestToast() shouldBe
-            activity.getString(R.string.upgrades_gplay_not_installed_message)
+        // A toast caps at 2 lines and clipped this message (French lost a whole condition
+        // mid-word) — the dialog renders it inline instead.
+        ShadowToast.getLatestToast() shouldBe null
     }
 
     @Test
-    fun `an unresolvable launch shows the not-installed toast instead of crashing`() {
+    fun `an unresolvable launch reports through the dialog instead of a toast`() {
         val activity = activityOf(UnresolvedLaunchActivity::class.java)
 
-        fixAction.invoke(activity)
+        shouldThrow<ActivityNotFoundException> { fixAction.invoke(activity) }
 
-        ShadowToast.getTextOfLatestToast() shouldBe
-            activity.getString(R.string.upgrades_gplay_not_installed_message)
+        ShadowToast.getLatestToast() shouldBe null
+    }
+
+    @Test
+    fun `the failure message travels with the error for the dialog to show`() {
+        val activity = activityOf(Activity::class.java)
+
+        val message = GplayServiceUnavailableException(RuntimeException("Play hiccup"))
+            .getLocalizedError().fixActionErrorMessage.shouldNotBeNull()
+
+        message.get(activity) shouldBe activity.getString(R.string.upgrades_gplay_not_installed_message)
     }
 }

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/ui/GplayUpgradeViewModelTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/ui/GplayUpgradeViewModelTest.kt
@@ -10,6 +10,7 @@ import eu.darken.sdmse.common.upgrade.core.OurSku
 import eu.darken.sdmse.common.upgrade.core.UpgradeRepoGplay
 import eu.darken.sdmse.common.upgrade.core.billing.BillingData
 import eu.darken.sdmse.common.upgrade.core.billing.GplayServiceUnavailableException
+import eu.darken.sdmse.common.upgrade.core.billing.OfferUnavailableBillingException
 import eu.darken.sdmse.common.upgrade.core.billing.Sku
 import eu.darken.sdmse.main.ui.navigation.SupportFormRoute
 import io.kotest.matchers.booleans.shouldBeTrue
@@ -182,6 +183,67 @@ class GplayUpgradeViewModelTest : BaseTest() {
         advanceUntilIdle()
 
         coVerify(exactly = 2) { repo.querySkus(any()) }
+    }
+
+    @Test
+    fun `both product types unavailable surfaces the merchandising error, not a connectivity one`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // Play answered OK and simply has no sellable offer here (region, account eligibility,
+        // pulled product). Reporting that as "can't connect to Google Play" tells the user to
+        // clear Play's cache and reboot, which cannot help.
+        val repo = mockRepo()
+        coEvery { repo.querySkus(OurSku.Iap.PRO_UPGRADE) } throws
+            OfferUnavailableBillingException(OurSku.Iap.PRO_UPGRADE, null)
+        coEvery { repo.querySkus(OurSku.Sub.PRO_UPGRADE) } throws
+            OfferUnavailableBillingException(OurSku.Sub.PRO_UPGRADE, null)
+        val vm = buildVm(repo)
+
+        val unavailableState = async { vm.state.first { it is GplayUpgradeUiState.Unavailable } }
+        val forwardedError = async { vm.errorEvents.first() }
+        advanceUntilIdle()
+
+        forwardedError.await().shouldBeInstanceOf<OfferUnavailableBillingException>()
+        val state = unavailableState.await().shouldBeInstanceOf<GplayUpgradeUiState.Unavailable>()
+        state.error.shouldBeInstanceOf<OfferUnavailableBillingException>()
+    }
+
+    @Test
+    fun `a mixed failure keeps the conservative connectivity error`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // One sku failed for a non-merchandising reason: a real Play problem can't be ruled out,
+        // so the conservative "can't reach Play" copy stays.
+        val repo = mockRepo()
+        coEvery { repo.querySkus(OurSku.Iap.PRO_UPGRADE) } throws
+            OfferUnavailableBillingException(OurSku.Iap.PRO_UPGRADE, null)
+        coEvery { repo.querySkus(OurSku.Sub.PRO_UPGRADE) } throws IllegalStateException("Play unavailable")
+        val vm = buildVm(repo)
+
+        val unavailableState = async { vm.state.first { it is GplayUpgradeUiState.Unavailable } }
+        val forwardedError = async { vm.errorEvents.first() }
+        advanceUntilIdle()
+
+        forwardedError.await().shouldBeInstanceOf<GplayServiceUnavailableException>()
+        val state = unavailableState.await().shouldBeInstanceOf<GplayUpgradeUiState.Unavailable>()
+        state.error.shouldBeInstanceOf<GplayServiceUnavailableException>()
+    }
+
+    @Test
+    fun `a connectivity failure on both product types stays a connectivity error`() = runTest2(
+        context = testDispatcher,
+    ) {
+        val repo = mockRepo()
+        coEvery { repo.querySkus(any()) } throws IllegalStateException("Play unavailable")
+        val vm = buildVm(repo)
+
+        val unavailableState = async { vm.state.first { it is GplayUpgradeUiState.Unavailable } }
+        val forwardedError = async { vm.errorEvents.first() }
+        advanceUntilIdle()
+
+        forwardedError.await().shouldBeInstanceOf<GplayServiceUnavailableException>()
+        val state = unavailableState.await().shouldBeInstanceOf<GplayUpgradeUiState.Unavailable>()
+        state.error.shouldBeInstanceOf<GplayServiceUnavailableException>()
     }
 
     @Test


### PR DESCRIPTION
## What changed

Two fixes to how the upgrade screen reports Google Play problems, both found during a device QA pass.

**The app no longer blames your connection when Google Play simply has nothing to offer.** If Play answers normally but returns no purchasable products — because there is no pricing for your region, a product was withdrawn, or your account isn't eligible — the app used to say it "can't connect to Google Play" and suggest clearing the Play Store cache and rebooting. That advice couldn't help, because nothing was wrong with the device or with Play. Those cases now show the existing "offer unavailable" message instead. A genuine connection problem still reports as one.

**Error messages are no longer cut off.** When the "Google Play" button on an error dialog couldn't open the Play Store page, the explanation was shown as a toast — and Android limits toasts to two lines. The end of the sentence was clipped in English, and in translated languages an entire clause could disappear: a French user saw "it may be missing, disabled or r…" and never learned that *restricted* was one of the possible causes. The message now appears inside the dialog itself, where it fits at any length, and the dialog stays open so the wording is readable.

## Technical Context

- The billing layer already threw a typed `OfferUnavailableBillingException` for the merchandising case, specifically so it would surface as user copy rather than a bug report. The upgrade ViewModel discarded that typing, wrapping *any* both-queries-failed outcome into `GplayServiceUnavailableException`. It now inspects both causes and only downgrades to the merchandising error when **both** are merchandising — a single connectivity failure can't rule out a real Play problem, so the conservative copy stays correct in mixed cases.
- The failure message moved out of `Toast` and into the error dialog. `LocalizedError` gained an optional `fixActionErrorMessage`; the exception now logs and rethrows instead of presenting, and the dialog renders the message inline and skips its dismiss.
- The dialog's dispatch helper takes the message **per dispatch** rather than reading it off the error. That helper serves both the fix and the info buttons, so reading it off the error would let a failing info action surface the fix action's copy. Call sites use named arguments so any future third dispatch site has to make that choice explicitly.
- Review guidance: the inline-message state is keyed on the *throwable*, not the `LocalizedError` — the latter is rebuilt with fresh action lambdas on every recomposition, so equality never holds and the message would be wiped the instant it was set.
- Unchanged on purpose: the once-per-failure-episode emission guard, the carve-out that keeps owners and grace-period users on their normal presentation during an outage, and the wording of the message itself.
