### PR TITLE
General: Let translators control the word order of the Pro app title

### DIFF
--- a/app/src/foss/res/values/strings.xml
+++ b/app/src/foss/res/values/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix" translatable="false">FOSS</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("FOSS"). -->
+    <string name="app_name_upgraded_template" translatable="false">%1$s %2$s</string>
 
 
     <string name="upgrades_dashcard_title">Upgrade SD Maid SE</string>

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeOwnership.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeOwnership.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.unit.dp
 import eu.darken.sdmse.R
 import eu.darken.sdmse.common.compose.preview.Preview2
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
-import eu.darken.sdmse.common.R as CommonR
 
 // Ownership presentation for users who already own a Pro entitlement. Subscribers without the
 // one-time purchase always see the switch offer — but LOCKED while the subscription still
@@ -168,7 +167,7 @@ private fun UpgradeOwnedHero(
                     text = stringResource(
                         if (ownership.hasIap) R.string.upgrade_screen_owned_hero_iap_body
                         else R.string.upgrade_screen_owned_hero_sub_body,
-                        "${stringResource(CommonR.string.app_name)} ${stringResource(R.string.app_name_upgrade_postfix)}",
+                        brandTitleText(includeQualifier = true),
                     ),
                     style = MaterialTheme.typography.bodyMedium,
                 )

--- a/app/src/gplay/res/values-af-rZA/strings.xml
+++ b/app/src/gplay/res/values-af-rZA/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Gradeer SD Maid SE op</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro bied beter resultate, meer funksies en opsies vir gevorderde gebruikers.</string>
     <string name="upgrades_dashcard_upgrade_action">Gradeer op</string>

--- a/app/src/gplay/res/values-am/strings.xml
+++ b/app/src/gplay/res/values-am/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE ያሻሽሉ</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro ለላቁ ተጠቃሚዎች የተሻሉ ውጤቶች፣ ተጨማሪ ባህሪያት እና አማራጮችን ይሰጣል።</string>
     <string name="upgrades_dashcard_upgrade_action">ያሻሽሉ</string>

--- a/app/src/gplay/res/values-ar/strings.xml
+++ b/app/src/gplay/res/values-ar/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">احترافي</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">ترقية SD Maid SE</string>
     <string name="upgrades_dashcard_body">يوفر SD Maid SE Pro نتائج أفضل وميزات وخيارات أكثر للمستخدمين المتقدمين.</string>
     <string name="upgrades_dashcard_upgrade_action">ترقية</string>

--- a/app/src/gplay/res/values-az/strings.xml
+++ b/app/src/gplay/res/values-az/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE-ni yüksəldin</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro daha yaxşı nəticələr, daha çox funksiya və güclü istifadəçilər üçün daha çox seçim təqdim edir.</string>
     <string name="upgrades_dashcard_upgrade_action">Yüksəlt</string>

--- a/app/src/gplay/res/values-be/strings.xml
+++ b/app/src/gplay/res/values-be/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Абнавіць SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro прапануе лепшыя вынікі, больш функцый і опцый для вопытных карыстальнікаў.</string>
     <string name="upgrades_dashcard_upgrade_action">Абнавіць</string>

--- a/app/src/gplay/res/values-bg/strings.xml
+++ b/app/src/gplay/res/values-bg/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Надстройте SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro предлага по-добри резултати, повече функции и опции за напреднали потребители.</string>
     <string name="upgrades_dashcard_upgrade_action">Надстройване</string>

--- a/app/src/gplay/res/values-bn-rBD/strings.xml
+++ b/app/src/gplay/res/values-bn-rBD/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE আপগ্রেড করুন</string>
     <string name="upgrades_dashcard_body">SD Maid SE প্রো আরও ভালো ফলাফল, আরও বেশি ফিচার এবং পাওয়ার ব্যবহারকারীদের জন্য আরও বিকল্প প্রদান করে।</string>
     <string name="upgrades_dashcard_upgrade_action">আপগ্রেড করুন</string>

--- a/app/src/gplay/res/values-ca/strings.xml
+++ b/app/src/gplay/res/values-ca/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Millora a l\'SD Maid SE</string>
     <string name="upgrades_dashcard_body">L\'SD Maid SE Pro ofereix millors resultats, més funcions i opcions per a usuaris avançats.</string>
     <string name="upgrades_dashcard_upgrade_action">Millora</string>

--- a/app/src/gplay/res/values-ckb-rIR/strings.xml
+++ b/app/src/gplay/res/values-ckb-rIR/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE نوێ بکەرەوە</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro ئەنجامی باشتر، تایبەتمەندی زیاتر و بژاردەی زیاتر بۆ بەکارهێنەرانی پیشکەوتوو پێشکەش دەکات.</string>
     <string name="upgrades_dashcard_upgrade_action">نوێکردنەوە</string>

--- a/app/src/gplay/res/values-cs/strings.xml
+++ b/app/src/gplay/res/values-cs/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Upgradovat SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE nabízí lepší výsledky, více funkcí a možností pro zkušené uživatele.</string>
     <string name="upgrades_dashcard_upgrade_action">Upgradovat</string>

--- a/app/src/gplay/res/values-da/strings.xml
+++ b/app/src/gplay/res/values-da/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Opgrader SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro giver bedre resultater, flere funktioner og muligheder for avancerede brugere.</string>
     <string name="upgrades_dashcard_upgrade_action">Opgrader</string>

--- a/app/src/gplay/res/values-de/strings.xml
+++ b/app/src/gplay/res/values-de/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE upgraden</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro bietet bessere Ergebnisse, mehr Funktionen und Optionen für Power-User.</string>
     <string name="upgrades_dashcard_upgrade_action">Upgrade</string>

--- a/app/src/gplay/res/values-el/strings.xml
+++ b/app/src/gplay/res/values-el/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Αναβάθμιση SD Maid SE</string>
     <string name="upgrades_dashcard_body">Το SD Maid SE Pro προσφέρει καλύτερα αποτελέσματα, περισσότερες δυνατότητες και επιλογές για προχωρημένους χρήστες.</string>
     <string name="upgrades_dashcard_upgrade_action">Αναβάθμιση</string>

--- a/app/src/gplay/res/values-es-rAR/strings.xml
+++ b/app/src/gplay/res/values-es-rAR/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Mejorar SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro ofrece mejores resultados, más funciones y opciones para usuarios avanzados.</string>
     <string name="upgrades_dashcard_upgrade_action">Mejorar</string>

--- a/app/src/gplay/res/values-es-rMX/strings.xml
+++ b/app/src/gplay/res/values-es-rMX/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Actualizar SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro ofrece mejores resultados, más funciones y opciones para usuarios avanzados.</string>
     <string name="upgrades_dashcard_upgrade_action">Actualizar</string>

--- a/app/src/gplay/res/values-es/strings.xml
+++ b/app/src/gplay/res/values-es/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Actualizar SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro ofrece mejores resultados, más funciones y opciones para usuarios avanzados.</string>
     <string name="upgrades_dashcard_upgrade_action">Actualizar</string>

--- a/app/src/gplay/res/values-et-rEE/strings.xml
+++ b/app/src/gplay/res/values-et-rEE/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE täiendamine</string>
     <string name="upgrades_dashcard_body">SD Maid SE pakub paremaid tulemusi, rohkem võimalusi ja valikuid edasijõudnutele.</string>
     <string name="upgrades_dashcard_upgrade_action">Täienda</string>

--- a/app/src/gplay/res/values-eu-rES/strings.xml
+++ b/app/src/gplay/res/values-eu-rES/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Eguneratu SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro-k emaitza hobeak, ezaugarri gehiago eta erabiltzaile aurreratuentzako aukerak eskaintzen ditu.</string>
     <string name="upgrades_dashcard_upgrade_action">Goratu</string>

--- a/app/src/gplay/res/values-fa/strings.xml
+++ b/app/src/gplay/res/values-fa/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">حرفه‌ای</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">ارتقاء SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro نتایج بهتر، امکانات بیشتر و گزینه‌های بیشتری را برای کاربران حرفه‌ای ارائه می‌دهد.</string>
     <string name="upgrades_dashcard_upgrade_action">ارتقاء</string>

--- a/app/src/gplay/res/values-fi/strings.xml
+++ b/app/src/gplay/res/values-fi/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Päivitä SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro tarjoaa parempia tuloksia, enemmän ominaisuuksia ja vaihtoehtoja tehokäyttäjille.</string>
     <string name="upgrades_dashcard_upgrade_action">Päivitä</string>

--- a/app/src/gplay/res/values-fil/strings.xml
+++ b/app/src/gplay/res/values-fil/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">I-upgrade ang SD Maid SE</string>
     <string name="upgrades_dashcard_body">Ang SD Maid SE Pro ay nag-aalok ng mas magagandang resulta, mas maraming mga feature at mga opsyon para sa mga power user.</string>
     <string name="upgrades_dashcard_upgrade_action">I-upgrade</string>

--- a/app/src/gplay/res/values-fr/strings.xml
+++ b/app/src/gplay/res/values-fr/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Passer à SD Maid SE Pro</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro offre de meilleurs résultats, plus de fonctions et d’options pour les utilisateurs expérimentés.</string>
     <string name="upgrades_dashcard_upgrade_action">Passer Pro</string>

--- a/app/src/gplay/res/values-gl-rES/strings.xml
+++ b/app/src/gplay/res/values-gl-rES/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Actualizar SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro ofrece mellores resultados, máis funcións e opcións para usuarios avanzados.</string>
     <string name="upgrades_dashcard_upgrade_action">Actualizar</string>

--- a/app/src/gplay/res/values-hi-rIN/strings.xml
+++ b/app/src/gplay/res/values-hi-rIN/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">प्रो</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE को अपग्रेड करें</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro बेहतर परिणाम, अधिक सुविधाएं और पावर उपयोगकर्ताओं के लिए विकल्प प्रदान करता है।</string>
     <string name="upgrades_dashcard_upgrade_action">उन्नत करें</string>

--- a/app/src/gplay/res/values-hr/strings.xml
+++ b/app/src/gplay/res/values-hr/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Nadogradite SD Maid</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro nudi bolje rezultate, više značajki i opcija za napredne korisnike.</string>
     <string name="upgrades_dashcard_upgrade_action">Nadogradnja</string>

--- a/app/src/gplay/res/values-hu/strings.xml
+++ b/app/src/gplay/res/values-hu/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE frissítése</string>
     <string name="upgrades_dashcard_body">Az SD Maid SE Pro jobb eredményeket, több funkciót és lehetőséget kínál haladó felhasználóknak.</string>
     <string name="upgrades_dashcard_upgrade_action">Frissítés</string>

--- a/app/src/gplay/res/values-in/strings.xml
+++ b/app/src/gplay/res/values-in/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Tingkatkan SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro menawarkan hasil yang lebih baik, lebih banyak fitur dan opsi untuk pengguna tingkat lanjut.</string>
     <string name="upgrades_dashcard_upgrade_action">Tingkatkan</string>

--- a/app/src/gplay/res/values-is/strings.xml
+++ b/app/src/gplay/res/values-is/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Uppfæra SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro býður betri niðurstöður, fleiri eiginleika og valkosti fyrir vanareynda notendur.</string>
     <string name="upgrades_dashcard_upgrade_action">Uppfæra</string>

--- a/app/src/gplay/res/values-it/strings.xml
+++ b/app/src/gplay/res/values-it/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Aggiorna SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro offre risultati migliori, più funzionalità e opzioni per utenti esperti.</string>
     <string name="upgrades_dashcard_upgrade_action">Aggiorna</string>

--- a/app/src/gplay/res/values-iw/strings.xml
+++ b/app/src/gplay/res/values-iw/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">פרו</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">שדרג את SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro מציע תוצאות טובות יותר, יותר תכונות ואפשרויות למשתמשים מתקדמים.</string>
     <string name="upgrades_dashcard_upgrade_action">שדרוג</string>

--- a/app/src/gplay/res/values-ja/strings.xml
+++ b/app/src/gplay/res/values-ja/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SEをアップグレード</string>
     <string name="upgrades_dashcard_body">SD Maid SE Proはより良い結果、より多くの機能、パワーユーザー向けのオプションを提供します。</string>
     <string name="upgrades_dashcard_upgrade_action">アップグレード</string>

--- a/app/src/gplay/res/values-ka-rGE/strings.xml
+++ b/app/src/gplay/res/values-ka-rGE/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE-ის განახლება</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro გთავაზობთ უკეთეს შედეგებს, მეტ ფუნქციებს და ვარიანტებს მოწინავე მომხმარებლებისთვის.</string>
     <string name="upgrades_dashcard_upgrade_action">გარემონტება</string>

--- a/app/src/gplay/res/values-kaa/strings.xml
+++ b/app/src/gplay/res/values-kaa/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE ni jańalaw</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro jaqsıraq nátiyjelер, kóbirek múmkinshilikler hám quwatlı paydalanıwshılar ushın variantlar usınadı.</string>
     <string name="upgrades_dashcard_upgrade_action">Jańalaw</string>

--- a/app/src/gplay/res/values-km-rKH/strings.xml
+++ b/app/src/gplay/res/values-km-rKH/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">ប្រូ</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">ដំឡើង SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro ផ្តល់លទ្ធផលប្រសើរជាង មុខងារច្រើនជាង និងជម្រើសច្រើនសម្រាប់អ្នកប្រើប្រាស់កម្រិតខ្ពស់។</string>
     <string name="upgrades_dashcard_upgrade_action">វិសិដ្ឋកម្ម</string>

--- a/app/src/gplay/res/values-ko/strings.xml
+++ b/app/src/gplay/res/values-ko/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">프로</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE 업그레이드</string>
     <string name="upgrades_dashcard_body">SD Maid SE 프로는 더 나은 결과, 더 많은 기능 및 고급 사용자를 위한 옵션을 제공합니다.</string>
     <string name="upgrades_dashcard_upgrade_action">업그레이드</string>

--- a/app/src/gplay/res/values-lo-rLA/strings.xml
+++ b/app/src/gplay/res/values-lo-rLA/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">ອັບເກຣດ SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro ໃຫ້ຜົນລັບທີ່ດີກວ່າ, ຄຸນສົມບັດ ແລະຕົວເລືອກເພີ່ມເຕີມສຳລັບຜູ້ໃຊ້ຂັ້ນສູງ.</string>
     <string name="upgrades_dashcard_upgrade_action">ອັບເກຣດ</string>

--- a/app/src/gplay/res/values-lt/strings.xml
+++ b/app/src/gplay/res/values-lt/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Atnaujinti SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro siūlo geresnius rezultatus, daugiau funkcijų ir parinkčių pažengusiems naudotojams.</string>
     <string name="upgrades_dashcard_upgrade_action">Atnaujinti</string>

--- a/app/src/gplay/res/values-lv/strings.xml
+++ b/app/src/gplay/res/values-lv/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Uzlabojiet SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro piedāvā labākus rezultātus, vairāk funkciju un opcijas pieredzējušiem lietotājiem.</string>
     <string name="upgrades_dashcard_upgrade_action">Uzlabot</string>

--- a/app/src/gplay/res/values-mk-rMK/strings.xml
+++ b/app/src/gplay/res/values-mk-rMK/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Надградете го SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro нуди подобри резултати, повеќе функции и опции за напредни корисници.</string>
     <string name="upgrades_dashcard_upgrade_action">Надгради</string>

--- a/app/src/gplay/res/values-ml-rIN/strings.xml
+++ b/app/src/gplay/res/values-ml-rIN/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">പ്രോ</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE അപ്ഗ്രേഡ് ചെയ്യുക</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro മികച്ച ഫലങ്ങളും കൂടുതല്‍ ഫീച്ചറുകളും പവര്‍ ഉപയോക്താക്കള്‍ക്കുള്ള ഓപ്ഷനുകളും വാഗ്ദാനം ചെയ്യുന്നു.</string>
     <string name="upgrades_dashcard_upgrade_action">അപ്ഗ്രേഡുചെയ്യുക</string>

--- a/app/src/gplay/res/values-mn-rMN/strings.xml
+++ b/app/src/gplay/res/values-mn-rMN/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE шинэчлэх</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro нь илүү сайн үр дүн, олон боломж, ахисан хэрэглэгчдэд зориулсан нэмэлт сонголтуудыг санал болгодог.</string>
     <string name="upgrades_dashcard_upgrade_action">Шинэчлэх</string>

--- a/app/src/gplay/res/values-ms/strings.xml
+++ b/app/src/gplay/res/values-ms/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Naik taraf SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro menawarkan hasil yang lebih baik, lebih banyak ciri dan pilihan untuk pengguna berkuasa.</string>
     <string name="upgrades_dashcard_upgrade_action">Naik taraf</string>

--- a/app/src/gplay/res/values-my-rMM/strings.xml
+++ b/app/src/gplay/res/values-my-rMM/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE ကို အဆင့်မြှင့်ပါ</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro သည် ပိုမိုကောင်းမွန်သော ရလဒ်များ၊ အင်္ဂါရပ်များနှင့် အဆင့်မြင့်သုံးစွဲသူများအတွက် ရွေးချယ်စရာများကို ပေးဆောင်သည်။</string>
     <string name="upgrades_dashcard_upgrade_action">အဆင့်မြှင့်မည်</string>

--- a/app/src/gplay/res/values-nb/strings.xml
+++ b/app/src/gplay/res/values-nb/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Oppgrader SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro gir bedre resultater, flere funksjoner og alternativer for avanserte brukere.</string>
     <string name="upgrades_dashcard_upgrade_action">Oppgrader</string>

--- a/app/src/gplay/res/values-ne-rNP/strings.xml
+++ b/app/src/gplay/res/values-ne-rNP/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE अपग्रेड गर्नुहोस्</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro ले राम्रा परिणामहरू, थप सुविधाहरू र उन्नत प्रयोगकर्ताहरूका लागि विकल्पहरू प्रदान गर्दछ।</string>
     <string name="upgrades_dashcard_upgrade_action">अपग्रेड</string>

--- a/app/src/gplay/res/values-nl/strings.xml
+++ b/app/src/gplay/res/values-nl/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE upgraden</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro biedt betere resultaten, meer functies en opties voor gevorderde gebruikers.</string>
     <string name="upgrades_dashcard_upgrade_action">Upgraden</string>

--- a/app/src/gplay/res/values-or-rIN/strings.xml
+++ b/app/src/gplay/res/values-or-rIN/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE ଅପଗ୍ରେଡ୍ କରନ୍ତୁ</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro ଉନ୍ନତ ଫଳାଫଳ, ଅଧିକ ବୈଶିଷ୍ଟ୍ୟ ଏବଂ ପାୱାର ବ୍ୟବହାରକାରୀଙ୍କ ପାଇଁ ବିକଳ୍ପ ପ୍ରଦାନ କରେ।</string>
     <string name="upgrades_dashcard_upgrade_action">ଅପଗ୍ରେଡ୍</string>

--- a/app/src/gplay/res/values-pa-rIN/strings.xml
+++ b/app/src/gplay/res/values-pa-rIN/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE ਅੱਪਗ੍ਰੇਡ ਕਰੋ</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro ਬਿਹਤਰ ਨਤੀਜੇ, ਵਧੇਰੇ ਵਿਸ਼ੇਸ਼ਤਾਵਾਂ ਅਤੇ ਪਾਵਰ ਉਪਭੋਗਤਾਵਾਂ ਲਈ ਵਿਕਲਪ ਪੇਸ਼ ਕਰਦਾ ਹੈ।</string>
     <string name="upgrades_dashcard_upgrade_action">ਅੱਪਗ੍ਰੇਡ ਕਰੋ</string>

--- a/app/src/gplay/res/values-pl/strings.xml
+++ b/app/src/gplay/res/values-pl/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Uaktualnij SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro oferuje lepsze wyniki, więcej funkcji i opcji dla zaawansowanych użytkowników.</string>
     <string name="upgrades_dashcard_upgrade_action">Uaktualnij</string>

--- a/app/src/gplay/res/values-pt-rBR/strings.xml
+++ b/app/src/gplay/res/values-pt-rBR/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Atualize o SD Maid SE</string>
     <string name="upgrades_dashcard_body">O SD Maid SE Pro oferece melhores resultados, mais recursos e opções para usuários avançados.</string>
     <string name="upgrades_dashcard_upgrade_action">Atualizar</string>

--- a/app/src/gplay/res/values-pt/strings.xml
+++ b/app/src/gplay/res/values-pt/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Atualizar o SD Maid SE</string>
     <string name="upgrades_dashcard_body">O SD Maid SE Pro oferece melhores resultados, mais funcionalidades e opções para utilizadores avançados.</string>
     <string name="upgrades_dashcard_upgrade_action">Atualizar</string>

--- a/app/src/gplay/res/values-ro/strings.xml
+++ b/app/src/gplay/res/values-ro/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Actualizați SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro oferă rezultate mai bune, mai multe caracteristici și opțiuni pentru utilizatorii de putere.</string>
     <string name="upgrades_dashcard_upgrade_action">Actualizează</string>

--- a/app/src/gplay/res/values-ru/strings.xml
+++ b/app/src/gplay/res/values-ru/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Обновление SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid Pro предлагает лучшие результаты, больше функций и опций для удобства пользователей.</string>
     <string name="upgrades_dashcard_upgrade_action">Обновить</string>

--- a/app/src/gplay/res/values-sc-rIT/strings.xml
+++ b/app/src/gplay/res/values-sc-rIT/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Agiorna SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro oferit risultados mègius, prus caraterìsticas e optziones pro sos utentes avanzados.</string>
     <string name="upgrades_dashcard_upgrade_action">Agiorna</string>

--- a/app/src/gplay/res/values-si-rLK/strings.xml
+++ b/app/src/gplay/res/values-si-rLK/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE උත්ශ්‍රේණි කරන්න</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro වැඩි ප්‍රතිඵල, වැඩි විශේෂාංග සහ බල පරිශීලකයින් සඳහා විකල්ප ලබා දෙයි.</string>
     <string name="upgrades_dashcard_upgrade_action">උත්ශ්‍රේණි කරන්න</string>

--- a/app/src/gplay/res/values-sk/strings.xml
+++ b/app/src/gplay/res/values-sk/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Inovovať SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro ponúka lepšie výsledky, viac funkcií a možností pre pokročilých používateľov.</string>
     <string name="upgrades_dashcard_upgrade_action">Inovovať</string>

--- a/app/src/gplay/res/values-sl/strings.xml
+++ b/app/src/gplay/res/values-sl/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Nadgradi SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro ponuja boljše rezultate, več funkcij in možnosti za napredne uporabnike.</string>
     <string name="upgrades_dashcard_upgrade_action">Nadgradi</string>

--- a/app/src/gplay/res/values-sq-rAL/strings.xml
+++ b/app/src/gplay/res/values-sq-rAL/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Përmirëso SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro ofron rezultate më të mira, më shumë veçori dhe opsione për përdoruesit e avancuar.</string>
     <string name="upgrades_dashcard_upgrade_action">Aktualizo</string>

--- a/app/src/gplay/res/values-sr/strings.xml
+++ b/app/src/gplay/res/values-sr/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Надоградите SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro нуди боље резултате, више функција и опција за напредне кориснике.</string>
     <string name="upgrades_dashcard_upgrade_action">Надогради</string>

--- a/app/src/gplay/res/values-sv/strings.xml
+++ b/app/src/gplay/res/values-sv/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Expert</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Uppgradera SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro erbjuder bättre resultat, fler funktioner och alternativ för avancerade användare.</string>
     <string name="upgrades_dashcard_upgrade_action">Uppgradera</string>

--- a/app/src/gplay/res/values-sw/strings.xml
+++ b/app/src/gplay/res/values-sw/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Boresha SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro inatoa matokeo bora zaidi, vipengele zaidi na chaguo kwa watumiaji wa hali ya juu.</string>
     <string name="upgrades_dashcard_upgrade_action">Boresha</string>

--- a/app/src/gplay/res/values-ta-rIN/strings.xml
+++ b/app/src/gplay/res/values-ta-rIN/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE-ஐ மேம்படுத்து</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro சிறந்த முடிவுகள், கூடுதல் அம்சங்கள் மற்றும் மேம்பட்ட பயனர்களுக்கான விருப்பங்களை வழங்குகிறது.</string>
     <string name="upgrades_dashcard_upgrade_action">மேம்படுத்து</string>

--- a/app/src/gplay/res/values-te-rIN/strings.xml
+++ b/app/src/gplay/res/values-te-rIN/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">ప్రొ</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE ను అప్‌గ్రేడ్ చేయండి</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro మెరుగైన ఫలితాలు, మరిన్ని ఫీచర్లు మరియు పవర్ వినియోగదారుల కోసం ఎంపికలను అందిస్తుంది.</string>
     <string name="upgrades_dashcard_upgrade_action">అప్‌గ్రేడ్ చేయండి</string>

--- a/app/src/gplay/res/values-th/strings.xml
+++ b/app/src/gplay/res/values-th/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">โปร</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">อัปเกรด SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro ให้ผลลัพธ์ที่ดีกว่า มีฟีเจอร์และตัวเลือกมากขึ้นสำหรับผู้ใช้ขั้นสูง</string>
     <string name="upgrades_dashcard_upgrade_action">อัปเกรด</string>

--- a/app/src/gplay/res/values-tr/strings.xml
+++ b/app/src/gplay/res/values-tr/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE\'yi Yükselt</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro daha iyi sonuçlar, daha fazla özellik ve ileri düzey kullanıcılar için seçenekler sunar.</string>
     <string name="upgrades_dashcard_upgrade_action">Yükselt</string>

--- a/app/src/gplay/res/values-uk/strings.xml
+++ b/app/src/gplay/res/values-uk/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Оновити SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro пропонує кращі результати, більше функцій та опцій для досвідчених користувачів.</string>
     <string name="upgrades_dashcard_upgrade_action">Оновлення</string>

--- a/app/src/gplay/res/values-ur-rIN/strings.xml
+++ b/app/src/gplay/res/values-ur-rIN/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE کو اپ گریڈ کریں</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro بہتر نتائج، زیادہ خصوصیات اور طاقتور صارفین کے لیے اختیارات پیش کرتا ہے۔</string>
     <string name="upgrades_dashcard_upgrade_action">اپ گریڈ</string>

--- a/app/src/gplay/res/values-uz/strings.xml
+++ b/app/src/gplay/res/values-uz/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE ni yangilash</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro yaxshiroq natijalar, ko\'proq funksiyalar va ilg\'or foydalanuvchilar uchun variantlarni taqdim etadi.</string>
     <string name="upgrades_dashcard_upgrade_action">Yangilash</string>

--- a/app/src/gplay/res/values-vi/strings.xml
+++ b/app/src/gplay/res/values-vi/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Nâng cấp SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro mang lại kết qủa tốt hơn, nhiều tính năng và tùy chọn hơn cho người dùng.</string>
     <string name="upgrades_dashcard_upgrade_action">Nâng cấp</string>

--- a/app/src/gplay/res/values-zh-rCN/strings.xml
+++ b/app/src/gplay/res/values-zh-rCN/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">专业版</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">升级 SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE 专业版提供更好的结果、更多功能以及面向高级用户的更多选项。</string>
     <string name="upgrades_dashcard_upgrade_action">升级</string>

--- a/app/src/gplay/res/values-zh-rHK/strings.xml
+++ b/app/src/gplay/res/values-zh-rHK/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">專業版</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">升級 SD 女僕 SE</string>
     <string name="upgrades_dashcard_body">SD 女僕 SE 專業版提供更好的結果、更多功能及進階使用者選項。</string>
     <string name="upgrades_dashcard_upgrade_action">升級</string>

--- a/app/src/gplay/res/values-zh-rTW/strings.xml
+++ b/app/src/gplay/res/values-zh-rTW/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">專業版</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">升級 SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE 專業版提供更好的結果、更多功能以及進階使用者的更多選項。</string>
     <string name="upgrades_dashcard_upgrade_action">升級</string>

--- a/app/src/gplay/res/values-zu/strings.xml
+++ b/app/src/gplay/res/values-zu/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Thuthukisa i-SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro inikeza imiphumela engcono, izici eziningi kanye nezinketho zabasebenzisi abaphezulu.</string>
     <string name="upgrades_dashcard_upgrade_action">Thuthukisa</string>

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
 
     <string name="upgrades_dashcard_title">Upgrade SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro offers better results, more features and options for power users.</string>

--- a/app/src/main/java/eu/darken/sdmse/common/upgrade/ui/UpgradeContent.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/upgrade/ui/UpgradeContent.kt
@@ -94,21 +94,58 @@ internal object UpgradeScreenTags {
     const val GPLAY_GRACE_RESTORE = "upgrade_gplay_grace_restore"
 }
 
+// The app's brand title, composed through the flavor's title template so translators own the word
+// order and punctuation instead of the code assuming "name, space, qualifier".
+//
+// The two flags are deliberately separate. `includeQualifier` decides whether the tier word is part
+// of the title at all (the dashboard drops it while free); `highlightQualifier` only decides whether
+// it is colored. The FOSS status-free view needs "SD Maid SE FOSS" in plain text, so it passes
+// (true, false) — collapsing these into one flag would silently drop FOSS from that screen.
+@Composable
+internal fun brandTitle(includeQualifier: Boolean, highlightQualifier: Boolean): AnnotatedString {
+    val name = AnnotatedString(stringResource(CommonR.string.app_name))
+    if (!includeQualifier) return name
+
+    val qualifier = buildAnnotatedString {
+        if (highlightQualifier) pushStyle(SpanStyle(color = colorResource(R.color.colorUpgraded)))
+        append(stringResource(R.string.app_name_upgrade_postfix))
+        if (highlightQualifier) pop()
+    }
+    return spliceTitleTemplate(
+        formatted = stringResource(
+            R.string.app_name_upgraded_template,
+            BRAND_TITLE_MARKER,
+            BRAND_QUALIFIER_MARKER,
+        ),
+        name = name,
+        qualifier = qualifier,
+    )
+}
+
+// Same composition for the call sites that need a plain String (the settings components take
+// String, not AnnotatedString). Routed through brandTitle so the two forms cannot drift apart.
+@Composable
+internal fun brandTitleText(includeQualifier: Boolean): String =
+    brandTitle(includeQualifier = includeQualifier, highlightQualifier = false).text
+
 // Composed app title with the flavor postfix highlighted in the upgraded color while Pro is
 // active — the same treatment the dashboard title card uses.
 @Composable
-internal fun upgradeScreenTitle(upgraded: Boolean): AnnotatedString = buildAnnotatedString {
-    append(stringResource(CommonR.string.app_name))
-    append(" ")
-    if (upgraded) pushStyle(SpanStyle(color = colorResource(R.color.colorUpgraded)))
-    append(stringResource(R.string.app_name_upgrade_postfix))
-    if (upgraded) pop()
-}
+internal fun upgradeScreenTitle(upgraded: Boolean): AnnotatedString = brandTitle(
+    // Unconditional: this title names the flavor even when the screen is showing the free state.
+    includeQualifier = true,
+    highlightQualifier = upgraded,
+)
 
 // Marker char for brand-title splicing: formatted into the translated pattern via the normal
 // Android format path (so %1$s vs %s, argument reordering, and %% all behave), then replaced
 // with the styled brand. U+FFFC (object replacement) cannot occur in a real translation.
 internal const val BRAND_TITLE_MARKER = "￼"
+
+// The title template's second slot. U+FFF9 (interlinear annotation anchor) is likewise absent from
+// real translations, and being distinct from BRAND_TITLE_MARKER is what lets the splice tell the
+// two slots apart after the formatter has reordered them.
+internal const val BRAND_QUALIFIER_MARKER = "￹"
 
 internal fun spliceBrandTitle(formatted: String, brand: AnnotatedString): AnnotatedString = buildAnnotatedString {
     var rest = formatted
@@ -129,6 +166,45 @@ internal fun spliceBrandTitle(formatted: String, brand: AnnotatedString): Annota
     }
 }
 
+// Splices the two title slots into an already-formatted template. Stricter than spliceBrandTitle on
+// purpose: that one splices a brand into a *sentence*, where a repeated marker is a legitimate (if
+// odd) translation. A *title* template has exactly two slots, so anything else is damage — and once
+// a slot is missing or doubled the template can no longer tell us the intended order or
+// punctuation, which is the whole reason it exists. So a broken template is discarded whole and the
+// default title is rebuilt from the parts; patching it up piecewise would emit a title no
+// translator wrote.
+internal fun spliceTitleTemplate(
+    formatted: String,
+    name: AnnotatedString,
+    qualifier: AnnotatedString,
+): AnnotatedString {
+    val slots = listOf(
+        BRAND_TITLE_MARKER to name,
+        BRAND_QUALIFIER_MARKER to qualifier,
+    ).map { (marker, value) -> Triple(formatted.indexOf(marker), marker, value) }
+
+    val intact = slots.all { (index, marker, _) ->
+        index >= 0 && formatted.indexOf(marker, index + marker.length) < 0
+    }
+    if (!intact) {
+        return buildAnnotatedString {
+            append(name)
+            append(" ")
+            append(qualifier)
+        }
+    }
+
+    return buildAnnotatedString {
+        var cursor = 0
+        slots.sortedBy { it.first }.forEach { (index, marker, value) ->
+            append(formatted.substring(cursor, index))
+            append(value)
+            cursor = index + marker.length
+        }
+        append(formatted.substring(cursor))
+    }
+}
+
 @Preview2
 @Composable
 private fun UpgradeScreenTitlePreview() {
@@ -139,6 +215,25 @@ private fun UpgradeScreenTitlePreview() {
         ) {
             Text(text = upgradeScreenTitle(upgraded = false))
             Text(text = upgradeScreenTitle(upgraded = true))
+        }
+    }
+}
+
+// All three flag combinations the app actually uses, in one place — the pair (true, false) is the
+// one that reads as a mistake at a glance, so seeing it render "SD Maid SE FOSS" in plain text is
+// what documents it.
+@Preview2
+@Composable
+private fun BrandTitlePreview() {
+    PreviewWrapper {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(text = brandTitle(includeQualifier = false, highlightQualifier = false))
+            Text(text = brandTitle(includeQualifier = true, highlightQualifier = false))
+            Text(text = brandTitle(includeQualifier = true, highlightQualifier = true))
+            Text(text = brandTitleText(includeQualifier = true))
         }
     }
 }

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/TitleDashboardCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/TitleDashboardCard.kt
@@ -38,17 +38,13 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
-import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import eu.darken.sdmse.R
 import eu.darken.sdmse.common.BuildConfigWrap
 import eu.darken.sdmse.common.R as CommonR
 import eu.darken.sdmse.common.WebpageTool
@@ -56,6 +52,7 @@ import eu.darken.sdmse.common.compose.SdmMascot
 import eu.darken.sdmse.common.compose.preview.Preview2
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
+import eu.darken.sdmse.common.upgrade.ui.brandTitle
 
 @StringRes
 private fun getRngSlogan() = when ((0..8).random()) {
@@ -88,19 +85,8 @@ internal fun TitleDashboardCard(
 ) {
     val slogan = remember { getRngSlogan() }
     val sloganText = stringResource(slogan)
-    val titleText = if (item.upgradeInfo?.isPro == true) {
-        buildAnnotatedString {
-            append(stringResource(CommonR.string.app_name))
-            append(" ")
-            pushStyle(SpanStyle(color = colorResource(R.color.colorUpgraded)))
-            append(stringResource(R.string.app_name_upgrade_postfix))
-            pop()
-        }
-    } else {
-        buildAnnotatedString {
-            append(stringResource(CommonR.string.app_name))
-        }
-    }
+    val isPro = item.upgradeInfo?.isPro == true
+    val titleText = brandTitle(includeQualifier = isPro, highlightQualifier = isPro)
 
     val mascotRotation = remember { Animatable(0f) }
     val mascotImpact = remember { Animatable(0f) }

--- a/app/src/main/java/eu/darken/sdmse/main/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/settings/SettingsScreen.kt
@@ -51,6 +51,7 @@ import eu.darken.sdmse.common.compose.settings.SettingsCategoryHeader
 import eu.darken.sdmse.common.compose.settings.SettingsPreferenceItem
 import eu.darken.sdmse.common.error.ErrorEventHandler
 import eu.darken.sdmse.common.navigation.NavigationEventHandler
+import eu.darken.sdmse.common.upgrade.ui.brandTitleText
 import eu.darken.sdmse.appcleaner.ui.AppCleanerSettingsRoute
 import eu.darken.sdmse.appcontrol.ui.AppControlSettingsRoute
 import eu.darken.sdmse.corpsefinder.ui.CorpseFinderSettingsRoute
@@ -287,9 +288,10 @@ internal fun SettingsScreen(
             item {
                 SettingsPreferenceItem(
                     icon = Icons.TwoTone.Stars,
-                    // Composed like the dashboard title card: the postfix string carries the
-                    // flavor-correct upgrade branding ("Pro" on GPLAY, "FOSS" on FOSS).
-                    title = "${stringResource(CommonR.string.app_name)} ${stringResource(R.string.app_name_upgrade_postfix)}",
+                    // Composed like the dashboard title card: the flavor's title template carries
+                    // the upgrade branding ("Pro" on GPLAY, "FOSS" on FOSS). Plain String because
+                    // that is what the settings item takes.
+                    title = brandTitleText(includeQualifier = true),
                     subtitle = stringResource(R.string.settings_upgrade_description),
                     onClick = onProClick,
                 )

--- a/app/src/test/java/eu/darken/sdmse/common/upgrade/ui/BrandTitleTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/common/upgrade/ui/BrandTitleTest.kt
@@ -1,0 +1,94 @@
+package eu.darken.sdmse.common.upgrade.ui
+
+import android.content.Context
+import androidx.compose.ui.text.AnnotatedString
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.sdmse.R
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotContain
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+import eu.darken.sdmse.common.R as CommonR
+
+/**
+ * Resolves the real flavor resources rather than a sample pattern, so this also proves the two
+ * markers survive Android's format path and never reach the user.
+ *
+ * Flavor-agnostic on purpose: it asserts against whatever this variant's qualifier resource says
+ * ("Pro" on GPLAY, "FOSS" on FOSS) so the one test guards both. The resources are flavor-owned, so
+ * a variant that compiles proves nothing about the other.
+ */
+class BrandTitleTest : BaseComposeRobolectricTest() {
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    private val name: String
+        get() = context.getString(CommonR.string.app_name)
+
+    private val qualifier: String
+        get() = context.getString(R.string.app_name_upgrade_postfix)
+
+    private val composed: String
+        get() = context.getString(R.string.app_name_upgraded_template, name, qualifier)
+
+    private fun capture(block: @androidx.compose.runtime.Composable () -> AnnotatedString): AnnotatedString {
+        lateinit var captured: AnnotatedString
+        composeRule.setContent {
+            PreviewWrapper { captured = block() }
+        }
+        composeRule.waitForIdle()
+        return captured
+    }
+
+    @Test
+    fun `without the qualifier the title is the bare app name`() {
+        val result = capture { brandTitle(includeQualifier = false, highlightQualifier = false) }
+
+        result.text shouldBe name
+        result.spanStyles.size shouldBe 0
+    }
+
+    // The regression guard for the two-flag split: this is the FOSS status-free view, which needs
+    // the qualifier present but NOT colored. Collapsing the flags drops it; highlighting on
+    // `includeQualifier` alone colors it. Both would still produce plausible-looking text, so the
+    // span count is the assertion that matters.
+    @Test
+    fun `an included but unhighlighted qualifier is present and carries no span`() {
+        val result = capture { brandTitle(includeQualifier = true, highlightQualifier = false) }
+
+        result.text shouldBe composed
+        result.text.contains(qualifier) shouldBe true
+        result.spanStyles.size shouldBe 0
+    }
+
+    @Test
+    fun `a highlighted qualifier carries exactly one span covering the qualifier only`() {
+        val result = capture { brandTitle(includeQualifier = true, highlightQualifier = true) }
+
+        result.text shouldBe composed
+        result.spanStyles.size shouldBe 1
+        val span = result.spanStyles.single()
+        // Not just "a span exists" — the bug class this replaces put the highlight on the app name
+        // while rendering perfectly correct text.
+        result.text.substring(span.start, span.end) shouldBe qualifier
+    }
+
+    // The markers are injected as format arguments, so a template or formatter that mangled them
+    // would leak U+FFFC / U+FFF9 into the toolbar.
+    @Test
+    fun `neither splice marker survives into the rendered title`() {
+        val result = capture { brandTitle(includeQualifier = true, highlightQualifier = true) }
+
+        result.text shouldNotContain BRAND_TITLE_MARKER
+        result.text shouldNotContain BRAND_QUALIFIER_MARKER
+    }
+
+    @Test
+    fun `the string form matches the annotated form`() {
+        val result = capture { AnnotatedString(brandTitleText(includeQualifier = true)) }
+
+        result.text shouldBe composed
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/common/upgrade/ui/TitleTemplateSpliceTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/common/upgrade/ui/TitleTemplateSpliceTest.kt
@@ -1,0 +1,155 @@
+package eu.darken.sdmse.common.upgrade.ui
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+/**
+ * The title template lets translators own word order and punctuation, so the styled qualifier has
+ * to land on the right offsets wherever they put it. Assertions are on span boundaries, not just on
+ * the concatenated text: the failure this guards against renders the correct characters with the
+ * highlight sitting on the wrong word.
+ */
+class TitleTemplateSpliceTest : BaseTest() {
+
+    private val qualifierColor = Color.Red
+
+    private val name = AnnotatedString("SD Maid SE")
+
+    private val qualifier: AnnotatedString = buildAnnotatedString {
+        pushStyle(SpanStyle(color = qualifierColor))
+        append("Pro")
+        pop()
+    }
+
+    private fun template(pattern: String) = pattern
+        .replace("%1\$s", BRAND_TITLE_MARKER)
+        .replace("%2\$s", BRAND_QUALIFIER_MARKER)
+
+    @Test
+    fun `the default order highlights the trailing qualifier`() {
+        val result = spliceTitleTemplate(template("%1\$s %2\$s"), name, qualifier)
+
+        result.text shouldBe "SD Maid SE Pro"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().item.color shouldBe qualifierColor
+        result.spanStyles.single().start shouldBe 11
+        result.spanStyles.single().end shouldBe 14
+        result.text.substring(11, 14) shouldBe "Pro"
+    }
+
+    @Test
+    fun `a reordered template highlights the leading qualifier`() {
+        val result = spliceTitleTemplate(template("%2\$s %1\$s"), name, qualifier)
+
+        result.text shouldBe "Pro SD Maid SE"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().start shouldBe 0
+        result.spanStyles.single().end shouldBe 3
+        result.text.substring(0, 3) shouldBe "Pro"
+    }
+
+    @Test
+    fun `a custom separator shifts the qualifier without entering the span`() {
+        val result = spliceTitleTemplate(template("%1\$s – %2\$s"), name, qualifier)
+
+        result.text shouldBe "SD Maid SE – Pro"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().start shouldBe 13
+        result.spanStyles.single().end shouldBe 16
+        result.text.substring(13, 16) shouldBe "Pro"
+    }
+
+    @Test
+    fun `a multi-word qualifier is highlighted whole`() {
+        val multiWord = buildAnnotatedString {
+            pushStyle(SpanStyle(color = qualifierColor))
+            append("النسخة الاحترافية")
+            pop()
+        }
+
+        val result = spliceTitleTemplate(template("%1\$s – %2\$s"), AnnotatedString("كابود"), multiWord)
+
+        result.text shouldBe "كابود – النسخة الاحترافية"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().start shouldBe 8
+        result.spanStyles.single().end shouldBe 25
+        result.text.substring(8, 25) shouldBe "النسخة الاحترافية"
+    }
+
+    // Span offsets are UTF-16 indices, so a supplementary character ahead of a slot shifts it by
+    // two. Pins that the splice arithmetic counts code units and not code points.
+    @Test
+    fun `a supplementary character before the slots shifts the span by two`() {
+        val result = spliceTitleTemplate(template("🧹 %1\$s %2\$s"), name, qualifier)
+
+        result.text shouldBe "🧹 SD Maid SE Pro"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().start shouldBe 14
+        result.spanStyles.single().end shouldBe 17
+        result.text.substring(14, 17) shouldBe "Pro"
+    }
+
+    @Test
+    fun `a duplicated name marker falls back to the complete default title`() {
+        val result = spliceTitleTemplate(
+            "$BRAND_TITLE_MARKER $BRAND_TITLE_MARKER $BRAND_QUALIFIER_MARKER",
+            name,
+            qualifier,
+        )
+
+        result.text shouldBe "SD Maid SE Pro"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().start shouldBe 11
+        result.spanStyles.single().end shouldBe 14
+    }
+
+    @Test
+    fun `a duplicated qualifier marker falls back to the complete default title`() {
+        val result = spliceTitleTemplate(
+            "$BRAND_TITLE_MARKER $BRAND_QUALIFIER_MARKER $BRAND_QUALIFIER_MARKER",
+            name,
+            qualifier,
+        )
+
+        result.text shouldBe "SD Maid SE Pro"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().start shouldBe 11
+        result.spanStyles.single().end shouldBe 14
+    }
+
+    @Test
+    fun `a missing name marker falls back rather than rendering the qualifier alone`() {
+        val result = spliceTitleTemplate("Get $BRAND_QUALIFIER_MARKER", name, qualifier)
+
+        result.text shouldBe "SD Maid SE Pro"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().start shouldBe 11
+        result.spanStyles.single().end shouldBe 14
+    }
+
+    @Test
+    fun `a missing qualifier marker falls back rather than dropping the tier`() {
+        val result = spliceTitleTemplate("Get $BRAND_TITLE_MARKER", name, qualifier)
+
+        result.text shouldBe "SD Maid SE Pro"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().start shouldBe 11
+        result.spanStyles.single().end shouldBe 14
+    }
+
+    @Test
+    fun `a template with neither marker falls back to the complete default title`() {
+        val result = spliceTitleTemplate("SD Maid SE Pro", name, qualifier)
+
+        result.text shouldBe "SD Maid SE Pro"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().item.color shouldBe qualifierColor
+        result.spanStyles.single().start shouldBe 11
+        result.spanStyles.single().end shouldBe 14
+    }
+}

--- a/fastlane/metadata/android/sl/full_description.txt
+++ b/fastlane/metadata/android/sl/full_description.txt
@@ -41,7 +41,7 @@ Izberi mapo in pregleduj datoteke eno za drugo s preprostimi drsnimi potezami �
 
 🗄️ Prihrani prostor brez brisanja fotografij
 
-Fotografije lahko zasedejo veliko prostora za shranjevanje, vendar jih ne želiš vedno odstraniti. Orodje »Media Squeeze« stisne tvoje slike z nastavljivo kakovostjo, da sprosti prostor, ne da bi izgubil fotografije.
+Fotografije lahko zasedejo veliko prostora za shranjevanje, vendar jih ne želiš vedno odstraniti. Orodje »Stiskalnik predstavnosti« stisne vaše slike z nastavljivo kakovostjo, da sprosti prostor, ne da bi izgubil fotografije.
 
 Ta program je brez oglasov.  Nekatere značilnosti zahtevajo plačljivo nadgradnjo.
 


### PR DESCRIPTION
## What changed

The upgraded app title — "SD Maid SE Pro" on Google Play, "SD Maid SE FOSS" on the open-source build — is now built from a translatable template instead of being glued together in code.

Until now the title was always assembled as "name, space, qualifier", and the qualifier was coloured because the code assumed it came last. Translators had no say in either. A language that wants a different word order, or a dash instead of a space, could not express it, and any language that did would end up with the wrong word highlighted.

Now each language gets a pattern it can rearrange and repunctuate, and the colour follows the qualifier wherever the translator puts it.

Nothing looks different in English today. This is the mechanism, not a visual change.

## Technical Context

- **Two splicers, not one generalised one.** `spliceBrandTitle` is untouched. It splices a brand into a *sentence* and is deliberately permissive — a duplicated marker renders the brand twice, a missing one appends it, both pinned by `BrandTitleSpliceTest`. A *title* template has exactly two slots, so the new `spliceTitleTemplate` requires each marker exactly once and otherwise discards the template whole and rebuilds the default title. Once a slot is missing or doubled the template can no longer convey the intended order or punctuation, so patching it piecewise would emit a title no translator wrote. That is why there is no "append what's missing" fallback.
- **`includeQualifier` and `highlightQualifier` are separate flags on purpose.** They look redundant. They are not: the FOSS status-free view needs the qualifier *present but uncoloured*, so it passes `(true, false)`. A single `upgraded` flag would silently drop "FOSS" from that screen. `FossUpgradeScreenTest` is the regression guard and passes unchanged.
- **A `String` form is required, not a convenience.** `SettingsPreferenceItem` and the ownership body take `String`, so `brandTitleText` exists for them; it routes through `brandTitle` so the two forms cannot drift. The settings component hierarchy was deliberately not widened to `AnnotatedString`.
- **Marker choice.** The qualifier slot uses U+FFF9, distinct from the existing U+FFFC brand marker — being distinguishable after formatting is what lets the splice tell the two slots apart once a translator has reordered them.
- **Review guidance.** Assertions are on *span boundaries*, not concatenated text. The failure mode this design prevents renders perfectly correct characters with the highlight sitting on the wrong word, so a text-only assertion would not catch it. `BrandTitleTest` resolves the real flavour resources and runs under both variants, since the template and qualifier are flavour-owned.
- Verified with `testGplayDebugUnitTest`, `testFossDebugUnitTest`, `assembleGplayDebug` and `assembleFossDebug`.
