### PR TITLE
General: Share one upgraded-title pattern between both builds

### DIFF
--- a/app-common/src/main/res/values-af-rZA/strings.xml
+++ b/app-common/src/main/res/values-af-rZA/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">Tot u diens.</string>
     <string name="slogan_message_1">Skoon en netjies.</string>
     <string name="slogan_message_2">Voorkoming van chaos.</string>

--- a/app-common/src/main/res/values-am/strings.xml
+++ b/app-common/src/main/res/values-am/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">ለአገልግሎትዎ ዝግጁ።</string>
     <string name="slogan_message_1">ንፁህ እና ተደራጅቶ።</string>
     <string name="slogan_message_2">ትርምስ መከላከል።</string>

--- a/app-common/src/main/res/values-ar/strings.xml
+++ b/app-common/src/main/res/values-ar/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">في خدمتك.</string>
     <string name="slogan_message_1">نظيف ومرتب.</string>
     <string name="slogan_message_2">منع الفوضى.</string>

--- a/app-common/src/main/res/values-az/strings.xml
+++ b/app-common/src/main/res/values-az/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">Xidmətinizdə.</string>
     <string name="slogan_message_1">Təmiz və səliqəli.</string>
     <string name="slogan_message_2">Xaosun qarşısını alma.</string>

--- a/app-common/src/main/res/values-be/strings.xml
+++ b/app-common/src/main/res/values-be/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">Да Вашых паслуг.</string>
     <string name="slogan_message_1">Чысціня і парадак.</string>
     <string name="slogan_message_2">Прадухіленне хаосу.</string>

--- a/app-common/src/main/res/values-bg/strings.xml
+++ b/app-common/src/main/res/values-bg/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">На ваше разположение.</string>
     <string name="slogan_message_1">Чисто и подредено.</string>
     <string name="slogan_message_2">Предотвратява хаоса.</string>

--- a/app-common/src/main/res/values-bn-rBD/strings.xml
+++ b/app-common/src/main/res/values-bn-rBD/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">এসডি মেইড এসই</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">আপনার সেবায় নিয়োজিত।</string>
     <string name="slogan_message_1">পরিষ্কার ও পরিপাটি.</string>
     <string name="slogan_message_2">বিশৃঙ্খলা প্রতিরোধ।</string>

--- a/app-common/src/main/res/values-ca/strings.xml
+++ b/app-common/src/main/res/values-ca/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">Al vostre servei.</string>
     <string name="slogan_message_1">Tot ben net i polit.</string>
     <string name="slogan_message_2">Prevenció del caos.</string>

--- a/app-common/src/main/res/values-ckb-rIR/strings.xml
+++ b/app-common/src/main/res/values-ckb-rIR/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">لە خزمەتتداین.</string>
     <string name="slogan_message_1">خاوێن و ڕێکخراو.</string>
     <string name="slogan_message_2">ڕێگرتن لە پشێوی.</string>

--- a/app-common/src/main/res/values-cs/strings.xml
+++ b/app-common/src/main/res/values-cs/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">K vašim službám.</string>
     <string name="slogan_message_1">Čistota a pořádek.</string>
     <string name="slogan_message_2">Předcházení chaosu.</string>

--- a/app-common/src/main/res/values-da/strings.xml
+++ b/app-common/src/main/res/values-da/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">Til tjeneste.</string>
     <string name="slogan_message_1">Rent og ryddeligt.</string>
     <string name="slogan_message_2">Forhindrer kaos.</string>

--- a/app-common/src/main/res/values-de/strings.xml
+++ b/app-common/src/main/res/values-de/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">Stets zu Diensten.</string>
     <string name="slogan_message_1">Sauber und ordentlich.</string>
     <string name="slogan_message_2">Chaos verhindern.</string>

--- a/app-common/src/main/res/values-el/strings.xml
+++ b/app-common/src/main/res/values-el/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">Στη διάθεσή σας.</string>
     <string name="slogan_message_1">Καθαρό και τακτοποιημένο.</string>
     <string name="slogan_message_2">Αποτροπή χάους.</string>

--- a/app-common/src/main/res/values-es-rAR/strings.xml
+++ b/app-common/src/main/res/values-es-rAR/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">A tu servicio.</string>
     <string name="slogan_message_1">Limpio y ordenado.</string>
     <string name="slogan_message_2">Previniendo el caos.</string>

--- a/app-common/src/main/res/values-es-rMX/strings.xml
+++ b/app-common/src/main/res/values-es-rMX/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">A tu servicio.</string>
     <string name="slogan_message_1">Limpio y ordenado.</string>
     <string name="slogan_message_2">Previene el caos.</string>

--- a/app-common/src/main/res/values-es/strings.xml
+++ b/app-common/src/main/res/values-es/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">A tu servicio.</string>
     <string name="slogan_message_1">Limpio y ordenado.</string>
     <string name="slogan_message_2">Impedir el caos.</string>

--- a/app-common/src/main/res/values-et-rEE/strings.xml
+++ b/app-common/src/main/res/values-et-rEE/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">Teie teenistuses.</string>
     <string name="slogan_message_1">Puhastab ja korrastab.</string>
     <string name="slogan_message_2">Kaose ennetamine.</string>

--- a/app-common/src/main/res/values-eu-rES/strings.xml
+++ b/app-common/src/main/res/values-eu-rES/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">Zure zerbitzutan.</string>
     <string name="slogan_message_1">Garbi eta txukun.</string>
     <string name="slogan_message_2">Kaosa saihesten.</string>

--- a/app-common/src/main/res/values-fa/strings.xml
+++ b/app-common/src/main/res/values-fa/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">در خدمت شما.</string>
     <string name="slogan_message_1">تمیز و مرتب.</string>
     <string name="slogan_message_2">جلوگیری از هرج و مرج.</string>

--- a/app-common/src/main/res/values-fi/strings.xml
+++ b/app-common/src/main/res/values-fi/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">Palveluksessasi.</string>
     <string name="slogan_message_1">Puhdas ja järjestyksessä.</string>
     <string name="slogan_message_2">Estää kaaoksen.</string>

--- a/app-common/src/main/res/values-fil/strings.xml
+++ b/app-common/src/main/res/values-fil/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">Laging nakahandang maglingkod.</string>
     <string name="slogan_message_1">Napakalinis.</string>
     <string name="slogan_message_2">Pangontra-kalat.</string>

--- a/app-common/src/main/res/values-fr/strings.xml
+++ b/app-common/src/main/res/values-fr/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">À votre service.</string>
     <string name="slogan_message_1">Propre et bien rangé.</string>
     <string name="slogan_message_2">Prévient le chaos.</string>

--- a/app-common/src/main/res/values-gl-rES/strings.xml
+++ b/app-common/src/main/res/values-gl-rES/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">Ao teu servizo.</string>
     <string name="slogan_message_1">Limpo e ordenado.</string>
     <string name="slogan_message_2">Previnindo o caos.</string>

--- a/app-common/src/main/res/values-hi-rIN/strings.xml
+++ b/app-common/src/main/res/values-hi-rIN/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD मेड SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">आपकी सेवा में।</string>
     <string name="slogan_message_1">स्वच्छ और व्यवस्थित।</string>
     <string name="slogan_message_2">अव्यवस्था पर रोक लगा रहा है।</string>

--- a/app-common/src/main/res/values-hr/strings.xml
+++ b/app-common/src/main/res/values-hr/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">Na usluzi.</string>
     <string name="slogan_message_1">Čisto i uredno.</string>
     <string name="slogan_message_2">Sprječava kaos.</string>

--- a/app-common/src/main/res/values-hu/strings.xml
+++ b/app-common/src/main/res/values-hu/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">Az Ön szolgálatában.</string>
     <string name="slogan_message_1">Tiszta és rendezett.</string>
     <string name="slogan_message_2">A káosz megelőzése.</string>

--- a/app-common/src/main/res/values-in/strings.xml
+++ b/app-common/src/main/res/values-in/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">Siap melayani anda.</string>
     <string name="slogan_message_1">Bersih dan rapi.</string>
     <string name="slogan_message_2">Menghindari kekacauan.</string>

--- a/app-common/src/main/res/values-is/strings.xml
+++ b/app-common/src/main/res/values-is/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">Til þjónustu.</string>
     <string name="slogan_message_1">Hreint og snyrtilegur.</string>
     <string name="slogan_message_2">Kemur í veg fyrir óreiðu.</string>

--- a/app-common/src/main/res/values-it/strings.xml
+++ b/app-common/src/main/res/values-it/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">Al tuo servizio.</string>
     <string name="slogan_message_1">Pulito e ordinato.</string>
     <string name="slogan_message_2">Prevenire il caos.</string>

--- a/app-common/src/main/res/values-iw/strings.xml
+++ b/app-common/src/main/res/values-iw/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">לשירותכם.</string>
     <string name="slogan_message_1">נקי ומסודר.</string>
     <string name="slogan_message_2">מונע כאוס.</string>

--- a/app-common/src/main/res/values-ja/strings.xml
+++ b/app-common/src/main/res/values-ja/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">喜んでお手伝いします。</string>
     <string name="slogan_message_1">清潔で整頓されています。</string>
     <string name="slogan_message_2">ごちゃごちゃを防ぐ。</string>

--- a/app-common/src/main/res/values-ka-rGE/strings.xml
+++ b/app-common/src/main/res/values-ka-rGE/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">Თქვენს სერვისში.</string>
     <string name="slogan_message_1">სუფთა და კოხტა.</string>
     <string name="slogan_message_2">Ქაოსის პრევენცია.</string>

--- a/app-common/src/main/res/values-kaa/strings.xml
+++ b/app-common/src/main/res/values-kaa/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">Xızmetińizde.</string>
     <string name="slogan_message_1">Taza hám retli.</string>
     <string name="slogan_message_2">Bulaǵannı aldın alaw.</string>

--- a/app-common/src/main/res/values-km-rKH/strings.xml
+++ b/app-common/src/main/res/values-km-rKH/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">នៅសេវាកម្មរបស់អ្នក។</string>
     <string name="slogan_message_1">ស្អាត និងរៀបរយ។</string>
     <string name="slogan_message_2">បញ្ជៀសពីការច្របូកច្របល់។</string>

--- a/app-common/src/main/res/values-ko/strings.xml
+++ b/app-common/src/main/res/values-ko/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">성심껏 돕겠습니다.</string>
     <string name="slogan_message_1">정리 완료</string>
     <string name="slogan_message_2">혼돈을 막습니다.</string>

--- a/app-common/src/main/res/values-lo-rLA/strings.xml
+++ b/app-common/src/main/res/values-lo-rLA/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">ໃຫ້ບໍລິການທ່ານ.</string>
     <string name="slogan_message_1">ສະອາດ ແລະ ເປັນລະບຽບ.</string>
     <string name="slogan_message_2">ປ້ອງກັນຄວາມສັບສົນ.</string>

--- a/app-common/src/main/res/values-lt/strings.xml
+++ b/app-common/src/main/res/values-lt/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">„SD Maid SE“</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">Jūsų paslaugoms.</string>
     <string name="slogan_message_1">Švariai ir tvarkingai.</string>
     <string name="slogan_message_2">Užkertame kelią chaosui.</string>

--- a/app-common/src/main/res/values-lv/strings.xml
+++ b/app-common/src/main/res/values-lv/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">Jūsu pakalpojumā.</string>
     <string name="slogan_message_1">Tīrs un kārtīgs.</string>
     <string name="slogan_message_2">Novērš haoss.</string>

--- a/app-common/src/main/res/values-mk-rMK/strings.xml
+++ b/app-common/src/main/res/values-mk-rMK/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">На ваша услуга.</string>
     <string name="slogan_message_1">Чисто и уредно.</string>
     <string name="slogan_message_2">Спречување на хаос.</string>

--- a/app-common/src/main/res/values-ml-rIN/strings.xml
+++ b/app-common/src/main/res/values-ml-rIN/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD മെയ്ഡ് SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">നിങ്ങളുടെ സേവനത്തിൽ.</string>
     <string name="slogan_message_1">വൃത്തിയും വെടിപ്പും.</string>
     <string name="slogan_message_2">അരാജകത്വം തടയുന്നു.</string>

--- a/app-common/src/main/res/values-mn-rMN/strings.xml
+++ b/app-common/src/main/res/values-mn-rMN/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">Таны үйлчилгээнд.</string>
     <string name="slogan_message_1">Цэвэр бөгөөд эмх цэгцтэй.</string>
     <string name="slogan_message_2">Эмх замбараагүй байдлаас сэргийлэх.</string>

--- a/app-common/src/main/res/values-ms/strings.xml
+++ b/app-common/src/main/res/values-ms/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">Berkhidmat untuk anda.</string>
     <string name="slogan_message_1">Bersih dan kemas.</string>
     <string name="slogan_message_2">Mencegah huru-hara.</string>

--- a/app-common/src/main/res/values-my-rMM/strings.xml
+++ b/app-common/src/main/res/values-my-rMM/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">သင့်ကိုအစေခံပါ။</string>
     <string name="slogan_message_1">သန့်ရှင်းပြီး စနစ်တကျ။</string>
     <string name="slogan_message_2">ရှုပ်ထွေးမှုကို ကာကွယ်ပါ။</string>

--- a/app-common/src/main/res/values-nb/strings.xml
+++ b/app-common/src/main/res/values-nb/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">Til tjeneste.</string>
     <string name="slogan_message_1">Ren og ryddig.</string>
     <string name="slogan_message_2">Forhindrer kaos.</string>

--- a/app-common/src/main/res/values-ne-rNP/strings.xml
+++ b/app-common/src/main/res/values-ne-rNP/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">तपाईंको सेवामा।</string>
     <string name="slogan_message_1">सफा र व्यवस्थित।</string>
     <string name="slogan_message_2">अराजकता रोक्दै।</string>

--- a/app-common/src/main/res/values-nl/strings.xml
+++ b/app-common/src/main/res/values-nl/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">Tot uw dienst.</string>
     <string name="slogan_message_1">Schoon en netjes.</string>
     <string name="slogan_message_2">Chaos voorkomen.</string>

--- a/app-common/src/main/res/values-or-rIN/strings.xml
+++ b/app-common/src/main/res/values-or-rIN/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">ଆପଣଙ୍କ ସେବାରେ।</string>
     <string name="slogan_message_1">ପରିଷ୍କାର ଓ ସୁବ୍ୟବସ୍ଥିତ।</string>
     <string name="slogan_message_2">ବିଶୃଙ୍ଖଳା ରୋକିବା।</string>

--- a/app-common/src/main/res/values-pa-rIN/strings.xml
+++ b/app-common/src/main/res/values-pa-rIN/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">ਤੁਹਾਡੀ ਸੇਵਾ ਵਿੱਚ।</string>
     <string name="slogan_message_1">ਸਾਫ਼-ਸੁਥਰਾ।</string>
     <string name="slogan_message_2">ਖਲਾਰੇ ਪੈਣ ਤੋਂ ਰੋਕਦੇ ਹੋਏ।</string>

--- a/app-common/src/main/res/values-pl/strings.xml
+++ b/app-common/src/main/res/values-pl/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">Do twoich usług</string>
     <string name="slogan_message_1">Czysto i schludnie</string>
     <string name="slogan_message_2">Zapobiega chaosowi</string>

--- a/app-common/src/main/res/values-pt-rBR/strings.xml
+++ b/app-common/src/main/res/values-pt-rBR/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">A seu serviço.</string>
     <string name="slogan_message_1">Limpo e arrumado.</string>
     <string name="slogan_message_2">Prevenindo o caos.</string>

--- a/app-common/src/main/res/values-pt/strings.xml
+++ b/app-common/src/main/res/values-pt/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">Ao seu serviço.</string>
     <string name="slogan_message_1">Limpo e arrumado.</string>
     <string name="slogan_message_2">A impedir o caos.</string>

--- a/app-common/src/main/res/values-ro/strings.xml
+++ b/app-common/src/main/res/values-ro/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">La servirea dvs.</string>
     <string name="slogan_message_1">Curat şi maree.</string>
     <string name="slogan_message_2">Previne haosul.</string>

--- a/app-common/src/main/res/values-ru/strings.xml
+++ b/app-common/src/main/res/values-ru/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">К Вашим услугам.</string>
     <string name="slogan_message_1">Чистота и порядок.</string>
     <string name="slogan_message_2">Предотвращение хаоса.</string>

--- a/app-common/src/main/res/values-sc-rIT/strings.xml
+++ b/app-common/src/main/res/values-sc-rIT/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">A su servìtziu tuo.</string>
     <string name="slogan_message_1">Lìmpia e ordinada.</string>
     <string name="slogan_message_2">Impedende su caos.</string>

--- a/app-common/src/main/res/values-si-rLK/strings.xml
+++ b/app-common/src/main/res/values-si-rLK/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">ඔබගේ සේවයේ.</string>
     <string name="slogan_message_1">පිරිසිදු සහ තබා.</string>
     <string name="slogan_message_2">අවුල් වීම වළක්වමින්.</string>

--- a/app-common/src/main/res/values-sk/strings.xml
+++ b/app-common/src/main/res/values-sk/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">K vašim službám.</string>
     <string name="slogan_message_1">Čistý a uprataný.</string>
     <string name="slogan_message_2">Predchádzanie chaosu.</string>

--- a/app-common/src/main/res/values-sl/strings.xml
+++ b/app-common/src/main/res/values-sl/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">Pripravljen.</string>
     <string name="slogan_message_1">Čist in urejen.</string>
     <string name="slogan_message_2">Preprečevanje nereda.</string>

--- a/app-common/src/main/res/values-sq-rAL/strings.xml
+++ b/app-common/src/main/res/values-sq-rAL/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">Në shërbimin juaj.</string>
     <string name="slogan_message_1">I pastër dhe i rregullt.</string>
     <string name="slogan_message_2">Parandalimi i kaosit.</string>

--- a/app-common/src/main/res/values-sr/strings.xml
+++ b/app-common/src/main/res/values-sr/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">Вама на услузи.</string>
     <string name="slogan_message_1">Чисто и уредно.</string>
     <string name="slogan_message_2">Спречава хаос.</string>

--- a/app-common/src/main/res/values-sv/strings.xml
+++ b/app-common/src/main/res/values-sv/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">Till din tjänst.</string>
     <string name="slogan_message_1">Rent och fint.</string>
     <string name="slogan_message_2">Förhindra kaos.</string>

--- a/app-common/src/main/res/values-sw/strings.xml
+++ b/app-common/src/main/res/values-sw/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">Katika huduma yako.</string>
     <string name="slogan_message_1">Safi na mpangilio.</string>
     <string name="slogan_message_2">Kuzuia machafuko.</string>

--- a/app-common/src/main/res/values-ta-rIN/strings.xml
+++ b/app-common/src/main/res/values-ta-rIN/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">உங்கள் சேவையில்.</string>
     <string name="slogan_message_1">சுத்தமான மற்றும் ஒழுங்கான.</string>
     <string name="slogan_message_2">குழப்பத்தைத் தடுக்கிறது.</string>

--- a/app-common/src/main/res/values-te-rIN/strings.xml
+++ b/app-common/src/main/res/values-te-rIN/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">మీ సేవలో.</string>
     <string name="slogan_message_1">శుభ్రంగా మరియు క్రమబద్ధంగా.</string>
     <string name="slogan_message_2">గందరగోళాన్ని నివారిస్తుంది.</string>

--- a/app-common/src/main/res/values-th/strings.xml
+++ b/app-common/src/main/res/values-th/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">พร้อมรับใช้คุณ</string>
     <string name="slogan_message_1">สะอาดและเป็นระเบียบ</string>
     <string name="slogan_message_2">ป้องกันความยุ่งเหยิง</string>

--- a/app-common/src/main/res/values-tr/strings.xml
+++ b/app-common/src/main/res/values-tr/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">Hizmetinizde.</string>
     <string name="slogan_message_1">Temiz ve düzenli.</string>
     <string name="slogan_message_2">Kaosu önleme.</string>

--- a/app-common/src/main/res/values-uk/strings.xml
+++ b/app-common/src/main/res/values-uk/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">До ваших послуг.</string>
     <string name="slogan_message_1">Чисто й охайно.</string>
     <string name="slogan_message_2">Запобігання хаосу.</string>

--- a/app-common/src/main/res/values-ur-rIN/strings.xml
+++ b/app-common/src/main/res/values-ur-rIN/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">آپ کی خدمت میں۔</string>
     <string name="slogan_message_1">صاف اور منظم۔</string>
     <string name="slogan_message_2">افراتفری سے بچانا۔</string>

--- a/app-common/src/main/res/values-uz/strings.xml
+++ b/app-common/src/main/res/values-uz/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">Sizning xizmatingizda.</string>
     <string name="slogan_message_1">Toza va tartibli.</string>
     <string name="slogan_message_2">Betartiblikni oldini olish.</string>

--- a/app-common/src/main/res/values-vi/strings.xml
+++ b/app-common/src/main/res/values-vi/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">Hân hạnh phục vụ bạn.</string>
     <string name="slogan_message_1">Sạch sẽ và gọn gàng.</string>
     <string name="slogan_message_2">Ngăn chặn hỗn loạn.</string>

--- a/app-common/src/main/res/values-zh-rCN/strings.xml
+++ b/app-common/src/main/res/values-zh-rCN/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">为你服务。</string>
     <string name="slogan_message_1">干净整洁</string>
     <string name="slogan_message_2">预防于乱</string>

--- a/app-common/src/main/res/values-zh-rHK/strings.xml
+++ b/app-common/src/main/res/values-zh-rHK/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD 女僕 SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">為您服務</string>
     <string name="slogan_message_1">乾淨整潔</string>
     <string name="slogan_message_2">防止混亂</string>

--- a/app-common/src/main/res/values-zh-rTW/strings.xml
+++ b/app-common/src/main/res/values-zh-rTW/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD 女僕 SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">為您服務</string>
     <string name="slogan_message_1">乾淨整潔</string>
     <string name="slogan_message_2">防止混亂</string>

--- a/app-common/src/main/res/values-zu/strings.xml
+++ b/app-common/src/main/res/values-zu/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="slogan_message_0">Ekusizeni kwakho.</string>
     <string name="slogan_message_1">Kuhlanzekile futhi kuhlelekile.</string>
     <string name="slogan_message_2">Kuvimbela isiphithiphithi.</string>

--- a/app-common/src/main/res/values/strings.xml
+++ b/app-common/src/main/res/values/strings.xml
@@ -1,5 +1,7 @@
 <resources>
     <string name="app_name">SD Maid SE</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
 
     <string name="slogan_message_0">At your service.</string>
     <string name="slogan_message_1">Clean and tidy.</string>

--- a/app/src/foss/res/values/strings.xml
+++ b/app/src/foss/res/values/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix" translatable="false">FOSS</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("FOSS"). -->
-    <string name="app_name_upgraded_template" translatable="false">%1$s %2$s</string>
 
 
     <string name="upgrades_dashcard_title">Upgrade SD Maid SE</string>

--- a/app/src/gplay/res/values-af-rZA/strings.xml
+++ b/app/src/gplay/res/values-af-rZA/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Gradeer SD Maid SE op</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro bied beter resultate, meer funksies en opsies vir gevorderde gebruikers.</string>
     <string name="upgrades_dashcard_upgrade_action">Gradeer op</string>

--- a/app/src/gplay/res/values-am/strings.xml
+++ b/app/src/gplay/res/values-am/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE ያሻሽሉ</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro ለላቁ ተጠቃሚዎች የተሻሉ ውጤቶች፣ ተጨማሪ ባህሪያት እና አማራጮችን ይሰጣል።</string>
     <string name="upgrades_dashcard_upgrade_action">ያሻሽሉ</string>

--- a/app/src/gplay/res/values-ar/strings.xml
+++ b/app/src/gplay/res/values-ar/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">احترافي</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">ترقية SD Maid SE</string>
     <string name="upgrades_dashcard_body">يوفر SD Maid SE Pro نتائج أفضل وميزات وخيارات أكثر للمستخدمين المتقدمين.</string>
     <string name="upgrades_dashcard_upgrade_action">ترقية</string>

--- a/app/src/gplay/res/values-az/strings.xml
+++ b/app/src/gplay/res/values-az/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE-ni yüksəldin</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro daha yaxşı nəticələr, daha çox funksiya və güclü istifadəçilər üçün daha çox seçim təqdim edir.</string>
     <string name="upgrades_dashcard_upgrade_action">Yüksəlt</string>

--- a/app/src/gplay/res/values-be/strings.xml
+++ b/app/src/gplay/res/values-be/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Абнавіць SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro прапануе лепшыя вынікі, больш функцый і опцый для вопытных карыстальнікаў.</string>
     <string name="upgrades_dashcard_upgrade_action">Абнавіць</string>

--- a/app/src/gplay/res/values-bg/strings.xml
+++ b/app/src/gplay/res/values-bg/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Надстройте SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro предлага по-добри резултати, повече функции и опции за напреднали потребители.</string>
     <string name="upgrades_dashcard_upgrade_action">Надстройване</string>

--- a/app/src/gplay/res/values-bn-rBD/strings.xml
+++ b/app/src/gplay/res/values-bn-rBD/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE আপগ্রেড করুন</string>
     <string name="upgrades_dashcard_body">SD Maid SE প্রো আরও ভালো ফলাফল, আরও বেশি ফিচার এবং পাওয়ার ব্যবহারকারীদের জন্য আরও বিকল্প প্রদান করে।</string>
     <string name="upgrades_dashcard_upgrade_action">আপগ্রেড করুন</string>

--- a/app/src/gplay/res/values-ca/strings.xml
+++ b/app/src/gplay/res/values-ca/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Millora a l\'SD Maid SE</string>
     <string name="upgrades_dashcard_body">L\'SD Maid SE Pro ofereix millors resultats, més funcions i opcions per a usuaris avançats.</string>
     <string name="upgrades_dashcard_upgrade_action">Millora</string>

--- a/app/src/gplay/res/values-ckb-rIR/strings.xml
+++ b/app/src/gplay/res/values-ckb-rIR/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE نوێ بکەرەوە</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro ئەنجامی باشتر، تایبەتمەندی زیاتر و بژاردەی زیاتر بۆ بەکارهێنەرانی پیشکەوتوو پێشکەش دەکات.</string>
     <string name="upgrades_dashcard_upgrade_action">نوێکردنەوە</string>

--- a/app/src/gplay/res/values-cs/strings.xml
+++ b/app/src/gplay/res/values-cs/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Upgradovat SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE nabízí lepší výsledky, více funkcí a možností pro zkušené uživatele.</string>
     <string name="upgrades_dashcard_upgrade_action">Upgradovat</string>

--- a/app/src/gplay/res/values-da/strings.xml
+++ b/app/src/gplay/res/values-da/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Opgrader SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro giver bedre resultater, flere funktioner og muligheder for avancerede brugere.</string>
     <string name="upgrades_dashcard_upgrade_action">Opgrader</string>

--- a/app/src/gplay/res/values-de/strings.xml
+++ b/app/src/gplay/res/values-de/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE upgraden</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro bietet bessere Ergebnisse, mehr Funktionen und Optionen für Power-User.</string>
     <string name="upgrades_dashcard_upgrade_action">Upgrade</string>

--- a/app/src/gplay/res/values-el/strings.xml
+++ b/app/src/gplay/res/values-el/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Αναβάθμιση SD Maid SE</string>
     <string name="upgrades_dashcard_body">Το SD Maid SE Pro προσφέρει καλύτερα αποτελέσματα, περισσότερες δυνατότητες και επιλογές για προχωρημένους χρήστες.</string>
     <string name="upgrades_dashcard_upgrade_action">Αναβάθμιση</string>

--- a/app/src/gplay/res/values-es-rAR/strings.xml
+++ b/app/src/gplay/res/values-es-rAR/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Mejorar SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro ofrece mejores resultados, más funciones y opciones para usuarios avanzados.</string>
     <string name="upgrades_dashcard_upgrade_action">Mejorar</string>

--- a/app/src/gplay/res/values-es-rMX/strings.xml
+++ b/app/src/gplay/res/values-es-rMX/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Actualizar SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro ofrece mejores resultados, más funciones y opciones para usuarios avanzados.</string>
     <string name="upgrades_dashcard_upgrade_action">Actualizar</string>

--- a/app/src/gplay/res/values-es/strings.xml
+++ b/app/src/gplay/res/values-es/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Actualizar SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro ofrece mejores resultados, más funciones y opciones para usuarios avanzados.</string>
     <string name="upgrades_dashcard_upgrade_action">Actualizar</string>

--- a/app/src/gplay/res/values-et-rEE/strings.xml
+++ b/app/src/gplay/res/values-et-rEE/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE täiendamine</string>
     <string name="upgrades_dashcard_body">SD Maid SE pakub paremaid tulemusi, rohkem võimalusi ja valikuid edasijõudnutele.</string>
     <string name="upgrades_dashcard_upgrade_action">Täienda</string>

--- a/app/src/gplay/res/values-eu-rES/strings.xml
+++ b/app/src/gplay/res/values-eu-rES/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Eguneratu SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro-k emaitza hobeak, ezaugarri gehiago eta erabiltzaile aurreratuentzako aukerak eskaintzen ditu.</string>
     <string name="upgrades_dashcard_upgrade_action">Goratu</string>

--- a/app/src/gplay/res/values-fa/strings.xml
+++ b/app/src/gplay/res/values-fa/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">حرفه‌ای</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">ارتقاء SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro نتایج بهتر، امکانات بیشتر و گزینه‌های بیشتری را برای کاربران حرفه‌ای ارائه می‌دهد.</string>
     <string name="upgrades_dashcard_upgrade_action">ارتقاء</string>

--- a/app/src/gplay/res/values-fi/strings.xml
+++ b/app/src/gplay/res/values-fi/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Päivitä SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro tarjoaa parempia tuloksia, enemmän ominaisuuksia ja vaihtoehtoja tehokäyttäjille.</string>
     <string name="upgrades_dashcard_upgrade_action">Päivitä</string>

--- a/app/src/gplay/res/values-fil/strings.xml
+++ b/app/src/gplay/res/values-fil/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">I-upgrade ang SD Maid SE</string>
     <string name="upgrades_dashcard_body">Ang SD Maid SE Pro ay nag-aalok ng mas magagandang resulta, mas maraming mga feature at mga opsyon para sa mga power user.</string>
     <string name="upgrades_dashcard_upgrade_action">I-upgrade</string>

--- a/app/src/gplay/res/values-fr/strings.xml
+++ b/app/src/gplay/res/values-fr/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Passer à SD Maid SE Pro</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro offre de meilleurs résultats, plus de fonctions et d’options pour les utilisateurs expérimentés.</string>
     <string name="upgrades_dashcard_upgrade_action">Passer Pro</string>

--- a/app/src/gplay/res/values-gl-rES/strings.xml
+++ b/app/src/gplay/res/values-gl-rES/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Actualizar SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro ofrece mellores resultados, máis funcións e opcións para usuarios avanzados.</string>
     <string name="upgrades_dashcard_upgrade_action">Actualizar</string>

--- a/app/src/gplay/res/values-hi-rIN/strings.xml
+++ b/app/src/gplay/res/values-hi-rIN/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">प्रो</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE को अपग्रेड करें</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro बेहतर परिणाम, अधिक सुविधाएं और पावर उपयोगकर्ताओं के लिए विकल्प प्रदान करता है।</string>
     <string name="upgrades_dashcard_upgrade_action">उन्नत करें</string>

--- a/app/src/gplay/res/values-hr/strings.xml
+++ b/app/src/gplay/res/values-hr/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Nadogradite SD Maid</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro nudi bolje rezultate, više značajki i opcija za napredne korisnike.</string>
     <string name="upgrades_dashcard_upgrade_action">Nadogradnja</string>

--- a/app/src/gplay/res/values-hu/strings.xml
+++ b/app/src/gplay/res/values-hu/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE frissítése</string>
     <string name="upgrades_dashcard_body">Az SD Maid SE Pro jobb eredményeket, több funkciót és lehetőséget kínál haladó felhasználóknak.</string>
     <string name="upgrades_dashcard_upgrade_action">Frissítés</string>

--- a/app/src/gplay/res/values-in/strings.xml
+++ b/app/src/gplay/res/values-in/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Tingkatkan SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro menawarkan hasil yang lebih baik, lebih banyak fitur dan opsi untuk pengguna tingkat lanjut.</string>
     <string name="upgrades_dashcard_upgrade_action">Tingkatkan</string>

--- a/app/src/gplay/res/values-is/strings.xml
+++ b/app/src/gplay/res/values-is/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Uppfæra SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro býður betri niðurstöður, fleiri eiginleika og valkosti fyrir vanareynda notendur.</string>
     <string name="upgrades_dashcard_upgrade_action">Uppfæra</string>

--- a/app/src/gplay/res/values-it/strings.xml
+++ b/app/src/gplay/res/values-it/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Aggiorna SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro offre risultati migliori, più funzionalità e opzioni per utenti esperti.</string>
     <string name="upgrades_dashcard_upgrade_action">Aggiorna</string>

--- a/app/src/gplay/res/values-iw/strings.xml
+++ b/app/src/gplay/res/values-iw/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">פרו</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">שדרג את SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro מציע תוצאות טובות יותר, יותר תכונות ואפשרויות למשתמשים מתקדמים.</string>
     <string name="upgrades_dashcard_upgrade_action">שדרוג</string>

--- a/app/src/gplay/res/values-ja/strings.xml
+++ b/app/src/gplay/res/values-ja/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SEをアップグレード</string>
     <string name="upgrades_dashcard_body">SD Maid SE Proはより良い結果、より多くの機能、パワーユーザー向けのオプションを提供します。</string>
     <string name="upgrades_dashcard_upgrade_action">アップグレード</string>

--- a/app/src/gplay/res/values-ka-rGE/strings.xml
+++ b/app/src/gplay/res/values-ka-rGE/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE-ის განახლება</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro გთავაზობთ უკეთეს შედეგებს, მეტ ფუნქციებს და ვარიანტებს მოწინავე მომხმარებლებისთვის.</string>
     <string name="upgrades_dashcard_upgrade_action">გარემონტება</string>

--- a/app/src/gplay/res/values-kaa/strings.xml
+++ b/app/src/gplay/res/values-kaa/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE ni jańalaw</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro jaqsıraq nátiyjelер, kóbirek múmkinshilikler hám quwatlı paydalanıwshılar ushın variantlar usınadı.</string>
     <string name="upgrades_dashcard_upgrade_action">Jańalaw</string>

--- a/app/src/gplay/res/values-km-rKH/strings.xml
+++ b/app/src/gplay/res/values-km-rKH/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">ប្រូ</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">ដំឡើង SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro ផ្តល់លទ្ធផលប្រសើរជាង មុខងារច្រើនជាង និងជម្រើសច្រើនសម្រាប់អ្នកប្រើប្រាស់កម្រិតខ្ពស់។</string>
     <string name="upgrades_dashcard_upgrade_action">វិសិដ្ឋកម្ម</string>

--- a/app/src/gplay/res/values-ko/strings.xml
+++ b/app/src/gplay/res/values-ko/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">프로</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE 업그레이드</string>
     <string name="upgrades_dashcard_body">SD Maid SE 프로는 더 나은 결과, 더 많은 기능 및 고급 사용자를 위한 옵션을 제공합니다.</string>
     <string name="upgrades_dashcard_upgrade_action">업그레이드</string>

--- a/app/src/gplay/res/values-lo-rLA/strings.xml
+++ b/app/src/gplay/res/values-lo-rLA/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">ອັບເກຣດ SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro ໃຫ້ຜົນລັບທີ່ດີກວ່າ, ຄຸນສົມບັດ ແລະຕົວເລືອກເພີ່ມເຕີມສຳລັບຜູ້ໃຊ້ຂັ້ນສູງ.</string>
     <string name="upgrades_dashcard_upgrade_action">ອັບເກຣດ</string>

--- a/app/src/gplay/res/values-lt/strings.xml
+++ b/app/src/gplay/res/values-lt/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Atnaujinti SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro siūlo geresnius rezultatus, daugiau funkcijų ir parinkčių pažengusiems naudotojams.</string>
     <string name="upgrades_dashcard_upgrade_action">Atnaujinti</string>

--- a/app/src/gplay/res/values-lv/strings.xml
+++ b/app/src/gplay/res/values-lv/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Uzlabojiet SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro piedāvā labākus rezultātus, vairāk funkciju un opcijas pieredzējušiem lietotājiem.</string>
     <string name="upgrades_dashcard_upgrade_action">Uzlabot</string>

--- a/app/src/gplay/res/values-mk-rMK/strings.xml
+++ b/app/src/gplay/res/values-mk-rMK/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Надградете го SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro нуди подобри резултати, повеќе функции и опции за напредни корисници.</string>
     <string name="upgrades_dashcard_upgrade_action">Надгради</string>

--- a/app/src/gplay/res/values-ml-rIN/strings.xml
+++ b/app/src/gplay/res/values-ml-rIN/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">പ്രോ</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE അപ്ഗ്രേഡ് ചെയ്യുക</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro മികച്ച ഫലങ്ങളും കൂടുതല്‍ ഫീച്ചറുകളും പവര്‍ ഉപയോക്താക്കള്‍ക്കുള്ള ഓപ്ഷനുകളും വാഗ്ദാനം ചെയ്യുന്നു.</string>
     <string name="upgrades_dashcard_upgrade_action">അപ്ഗ്രേഡുചെയ്യുക</string>

--- a/app/src/gplay/res/values-mn-rMN/strings.xml
+++ b/app/src/gplay/res/values-mn-rMN/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE шинэчлэх</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro нь илүү сайн үр дүн, олон боломж, ахисан хэрэглэгчдэд зориулсан нэмэлт сонголтуудыг санал болгодог.</string>
     <string name="upgrades_dashcard_upgrade_action">Шинэчлэх</string>

--- a/app/src/gplay/res/values-ms/strings.xml
+++ b/app/src/gplay/res/values-ms/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Naik taraf SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro menawarkan hasil yang lebih baik, lebih banyak ciri dan pilihan untuk pengguna berkuasa.</string>
     <string name="upgrades_dashcard_upgrade_action">Naik taraf</string>

--- a/app/src/gplay/res/values-my-rMM/strings.xml
+++ b/app/src/gplay/res/values-my-rMM/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE ကို အဆင့်မြှင့်ပါ</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro သည် ပိုမိုကောင်းမွန်သော ရလဒ်များ၊ အင်္ဂါရပ်များနှင့် အဆင့်မြင့်သုံးစွဲသူများအတွက် ရွေးချယ်စရာများကို ပေးဆောင်သည်။</string>
     <string name="upgrades_dashcard_upgrade_action">အဆင့်မြှင့်မည်</string>

--- a/app/src/gplay/res/values-nb/strings.xml
+++ b/app/src/gplay/res/values-nb/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Oppgrader SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro gir bedre resultater, flere funksjoner og alternativer for avanserte brukere.</string>
     <string name="upgrades_dashcard_upgrade_action">Oppgrader</string>

--- a/app/src/gplay/res/values-ne-rNP/strings.xml
+++ b/app/src/gplay/res/values-ne-rNP/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE अपग्रेड गर्नुहोस्</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro ले राम्रा परिणामहरू, थप सुविधाहरू र उन्नत प्रयोगकर्ताहरूका लागि विकल्पहरू प्रदान गर्दछ।</string>
     <string name="upgrades_dashcard_upgrade_action">अपग्रेड</string>

--- a/app/src/gplay/res/values-nl/strings.xml
+++ b/app/src/gplay/res/values-nl/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE upgraden</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro biedt betere resultaten, meer functies en opties voor gevorderde gebruikers.</string>
     <string name="upgrades_dashcard_upgrade_action">Upgraden</string>

--- a/app/src/gplay/res/values-or-rIN/strings.xml
+++ b/app/src/gplay/res/values-or-rIN/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE ଅପଗ୍ରେଡ୍ କରନ୍ତୁ</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro ଉନ୍ନତ ଫଳାଫଳ, ଅଧିକ ବୈଶିଷ୍ଟ୍ୟ ଏବଂ ପାୱାର ବ୍ୟବହାରକାରୀଙ୍କ ପାଇଁ ବିକଳ୍ପ ପ୍ରଦାନ କରେ।</string>
     <string name="upgrades_dashcard_upgrade_action">ଅପଗ୍ରେଡ୍</string>

--- a/app/src/gplay/res/values-pa-rIN/strings.xml
+++ b/app/src/gplay/res/values-pa-rIN/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE ਅੱਪਗ੍ਰੇਡ ਕਰੋ</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro ਬਿਹਤਰ ਨਤੀਜੇ, ਵਧੇਰੇ ਵਿਸ਼ੇਸ਼ਤਾਵਾਂ ਅਤੇ ਪਾਵਰ ਉਪਭੋਗਤਾਵਾਂ ਲਈ ਵਿਕਲਪ ਪੇਸ਼ ਕਰਦਾ ਹੈ।</string>
     <string name="upgrades_dashcard_upgrade_action">ਅੱਪਗ੍ਰੇਡ ਕਰੋ</string>

--- a/app/src/gplay/res/values-pl/strings.xml
+++ b/app/src/gplay/res/values-pl/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Uaktualnij SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro oferuje lepsze wyniki, więcej funkcji i opcji dla zaawansowanych użytkowników.</string>
     <string name="upgrades_dashcard_upgrade_action">Uaktualnij</string>

--- a/app/src/gplay/res/values-pt-rBR/strings.xml
+++ b/app/src/gplay/res/values-pt-rBR/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Atualize o SD Maid SE</string>
     <string name="upgrades_dashcard_body">O SD Maid SE Pro oferece melhores resultados, mais recursos e opções para usuários avançados.</string>
     <string name="upgrades_dashcard_upgrade_action">Atualizar</string>

--- a/app/src/gplay/res/values-pt/strings.xml
+++ b/app/src/gplay/res/values-pt/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Atualizar o SD Maid SE</string>
     <string name="upgrades_dashcard_body">O SD Maid SE Pro oferece melhores resultados, mais funcionalidades e opções para utilizadores avançados.</string>
     <string name="upgrades_dashcard_upgrade_action">Atualizar</string>

--- a/app/src/gplay/res/values-ro/strings.xml
+++ b/app/src/gplay/res/values-ro/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Actualizați SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro oferă rezultate mai bune, mai multe caracteristici și opțiuni pentru utilizatorii de putere.</string>
     <string name="upgrades_dashcard_upgrade_action">Actualizează</string>

--- a/app/src/gplay/res/values-ru/strings.xml
+++ b/app/src/gplay/res/values-ru/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Обновление SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid Pro предлагает лучшие результаты, больше функций и опций для удобства пользователей.</string>
     <string name="upgrades_dashcard_upgrade_action">Обновить</string>

--- a/app/src/gplay/res/values-sc-rIT/strings.xml
+++ b/app/src/gplay/res/values-sc-rIT/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Agiorna SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro oferit risultados mègius, prus caraterìsticas e optziones pro sos utentes avanzados.</string>
     <string name="upgrades_dashcard_upgrade_action">Agiorna</string>

--- a/app/src/gplay/res/values-si-rLK/strings.xml
+++ b/app/src/gplay/res/values-si-rLK/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE උත්ශ්‍රේණි කරන්න</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro වැඩි ප්‍රතිඵල, වැඩි විශේෂාංග සහ බල පරිශීලකයින් සඳහා විකල්ප ලබා දෙයි.</string>
     <string name="upgrades_dashcard_upgrade_action">උත්ශ්‍රේණි කරන්න</string>

--- a/app/src/gplay/res/values-sk/strings.xml
+++ b/app/src/gplay/res/values-sk/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Inovovať SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro ponúka lepšie výsledky, viac funkcií a možností pre pokročilých používateľov.</string>
     <string name="upgrades_dashcard_upgrade_action">Inovovať</string>

--- a/app/src/gplay/res/values-sl/strings.xml
+++ b/app/src/gplay/res/values-sl/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Nadgradi SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro ponuja boljše rezultate, več funkcij in možnosti za napredne uporabnike.</string>
     <string name="upgrades_dashcard_upgrade_action">Nadgradi</string>

--- a/app/src/gplay/res/values-sq-rAL/strings.xml
+++ b/app/src/gplay/res/values-sq-rAL/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Përmirëso SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro ofron rezultate më të mira, më shumë veçori dhe opsione për përdoruesit e avancuar.</string>
     <string name="upgrades_dashcard_upgrade_action">Aktualizo</string>

--- a/app/src/gplay/res/values-sr/strings.xml
+++ b/app/src/gplay/res/values-sr/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Надоградите SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro нуди боље резултате, више функција и опција за напредне кориснике.</string>
     <string name="upgrades_dashcard_upgrade_action">Надогради</string>

--- a/app/src/gplay/res/values-sv/strings.xml
+++ b/app/src/gplay/res/values-sv/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Expert</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Uppgradera SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro erbjuder bättre resultat, fler funktioner och alternativ för avancerade användare.</string>
     <string name="upgrades_dashcard_upgrade_action">Uppgradera</string>

--- a/app/src/gplay/res/values-sw/strings.xml
+++ b/app/src/gplay/res/values-sw/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Boresha SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro inatoa matokeo bora zaidi, vipengele zaidi na chaguo kwa watumiaji wa hali ya juu.</string>
     <string name="upgrades_dashcard_upgrade_action">Boresha</string>

--- a/app/src/gplay/res/values-ta-rIN/strings.xml
+++ b/app/src/gplay/res/values-ta-rIN/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE-ஐ மேம்படுத்து</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro சிறந்த முடிவுகள், கூடுதல் அம்சங்கள் மற்றும் மேம்பட்ட பயனர்களுக்கான விருப்பங்களை வழங்குகிறது.</string>
     <string name="upgrades_dashcard_upgrade_action">மேம்படுத்து</string>

--- a/app/src/gplay/res/values-te-rIN/strings.xml
+++ b/app/src/gplay/res/values-te-rIN/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">ప్రొ</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE ను అప్‌గ్రేడ్ చేయండి</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro మెరుగైన ఫలితాలు, మరిన్ని ఫీచర్లు మరియు పవర్ వినియోగదారుల కోసం ఎంపికలను అందిస్తుంది.</string>
     <string name="upgrades_dashcard_upgrade_action">అప్‌గ్రేడ్ చేయండి</string>

--- a/app/src/gplay/res/values-th/strings.xml
+++ b/app/src/gplay/res/values-th/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">โปร</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">อัปเกรด SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro ให้ผลลัพธ์ที่ดีกว่า มีฟีเจอร์และตัวเลือกมากขึ้นสำหรับผู้ใช้ขั้นสูง</string>
     <string name="upgrades_dashcard_upgrade_action">อัปเกรด</string>

--- a/app/src/gplay/res/values-tr/strings.xml
+++ b/app/src/gplay/res/values-tr/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE\'yi Yükselt</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro daha iyi sonuçlar, daha fazla özellik ve ileri düzey kullanıcılar için seçenekler sunar.</string>
     <string name="upgrades_dashcard_upgrade_action">Yükselt</string>

--- a/app/src/gplay/res/values-uk/strings.xml
+++ b/app/src/gplay/res/values-uk/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Оновити SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro пропонує кращі результати, більше функцій та опцій для досвідчених користувачів.</string>
     <string name="upgrades_dashcard_upgrade_action">Оновлення</string>

--- a/app/src/gplay/res/values-ur-rIN/strings.xml
+++ b/app/src/gplay/res/values-ur-rIN/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE کو اپ گریڈ کریں</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro بہتر نتائج، زیادہ خصوصیات اور طاقتور صارفین کے لیے اختیارات پیش کرتا ہے۔</string>
     <string name="upgrades_dashcard_upgrade_action">اپ گریڈ</string>

--- a/app/src/gplay/res/values-uz/strings.xml
+++ b/app/src/gplay/res/values-uz/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">SD Maid SE ni yangilash</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro yaxshiroq natijalar, ko\'proq funksiyalar va ilg\'or foydalanuvchilar uchun variantlarni taqdim etadi.</string>
     <string name="upgrades_dashcard_upgrade_action">Yangilash</string>

--- a/app/src/gplay/res/values-vi/strings.xml
+++ b/app/src/gplay/res/values-vi/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Nâng cấp SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro mang lại kết qủa tốt hơn, nhiều tính năng và tùy chọn hơn cho người dùng.</string>
     <string name="upgrades_dashcard_upgrade_action">Nâng cấp</string>

--- a/app/src/gplay/res/values-zh-rCN/strings.xml
+++ b/app/src/gplay/res/values-zh-rCN/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">专业版</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">升级 SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE 专业版提供更好的结果、更多功能以及面向高级用户的更多选项。</string>
     <string name="upgrades_dashcard_upgrade_action">升级</string>

--- a/app/src/gplay/res/values-zh-rHK/strings.xml
+++ b/app/src/gplay/res/values-zh-rHK/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">專業版</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">升級 SD 女僕 SE</string>
     <string name="upgrades_dashcard_body">SD 女僕 SE 專業版提供更好的結果、更多功能及進階使用者選項。</string>
     <string name="upgrades_dashcard_upgrade_action">升級</string>

--- a/app/src/gplay/res/values-zh-rTW/strings.xml
+++ b/app/src/gplay/res/values-zh-rTW/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">專業版</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">升級 SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE 專業版提供更好的結果、更多功能以及進階使用者的更多選項。</string>
     <string name="upgrades_dashcard_upgrade_action">升級</string>

--- a/app/src/gplay/res/values-zu/strings.xml
+++ b/app/src/gplay/res/values-zu/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_dashcard_title">Thuthukisa i-SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro inikeza imiphumela engcono, izici eziningi kanye nezinketho zabasebenzisi abaphezulu.</string>
     <string name="upgrades_dashcard_upgrade_action">Thuthukisa</string>

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
 
     <string name="upgrades_dashcard_title">Upgrade SD Maid SE</string>
     <string name="upgrades_dashcard_body">SD Maid SE Pro offers better results, more features and options for power users.</string>

--- a/app/src/main/java/eu/darken/sdmse/common/upgrade/ui/UpgradeContent.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/upgrade/ui/UpgradeContent.kt
@@ -113,7 +113,7 @@ internal fun brandTitle(includeQualifier: Boolean, highlightQualifier: Boolean):
     }
     return spliceTitleTemplate(
         formatted = stringResource(
-            R.string.app_name_upgraded_template,
+            CommonR.string.app_name_upgraded_template,
             BRAND_TITLE_MARKER,
             BRAND_QUALIFIER_MARKER,
         ),

--- a/app/src/test/java/eu/darken/sdmse/common/upgrade/ui/BrandTitleTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/common/upgrade/ui/BrandTitleTest.kt
@@ -31,7 +31,7 @@ class BrandTitleTest : BaseComposeRobolectricTest() {
         get() = context.getString(R.string.app_name_upgrade_postfix)
 
     private val composed: String
-        get() = context.getString(R.string.app_name_upgraded_template, name, qualifier)
+        get() = context.getString(CommonR.string.app_name_upgraded_template, name, qualifier)
 
     private fun capture(block: @androidx.compose.runtime.Composable () -> AnnotatedString): AnnotatedString {
         lateinit var captured: AnnotatedString


### PR DESCRIPTION
## What changed

The pattern that arranges the upgraded app title — the app name plus its "Pro" or "FOSS" qualifier — is now a single translatable entry shared by both builds, instead of being declared separately for each one.

Arrangement is a property of the language, not of which build you installed. A language that wants the qualifier first, or a dash instead of a space, wants that in both builds. Declaring it per build meant translating it twice and letting the two drift apart.

No visible change in English. The open-source build now follows the language's arrangement instead of being frozen at "name, then qualifier", which is the point of the move.

## Technical Context

- **Placement rule:** each key lives where its variation actually lives. `app_name` varies by language → shared and translated. `app_name_upgrade_postfix` varies by *flavour* ("FOSS" vs "Pro") → stays flavour-specific and is deliberately untouched here. The arrangement template varies by language, so it joins `app_name`.
- **The migration is staged across two commits on purpose.** Crowdin identifies strings by key *within a source file*, so moving one between source files does not carry its translations across. The first commit only adds the shared declaration while both flavour copies remain — behaviour is unchanged, since the flavour copies still win the resource merge for their own builds. Only after Crowdin had the translations on the new source file were the old copies removed.
- **The removal includes all 73 gplay locale overrides, not just the base declaration.** A surviving locale override keeps winning the merge for gplay builds: harmless while the values agree, and a silent divergence the moment someone edits one. That duplication is what this change exists to remove. FOSS had no locale overrides to remove — `translatable="false"` kept the string out of Crowdin's FOSS exports entirely, verified rather than assumed.
- **The two `R` → `CommonR` edits are load-bearing, not cosmetic.** `android.nonTransitiveRClass=true` means the app module's `R` class is generated from app-module declarations only; library resources are reachable solely through the owning library's `R`. Deleting the app-module declaration removes the `R.string.app_name_upgraded_template` *symbol*, so the code does not compile until it reads the symbol from the shared module. Resource *merging* is unaffected — this is a compile-time symbol change, not a resolution change, and the distinction is easy to get backwards. Both files keep their own `R` import; other app-module strings there still need it.
- **Review guidance:** the 73-file translation commit is mechanical and identical line-for-line. The commit worth reading is the removal, specifically that the deletion and the symbol repoint are inseparable.
- Verified with `testGplayDebugUnitTest`, `testFossDebugUnitTest`, `assembleGplayDebug` and `assembleFossDebug`.
