### PR TITLE
General: Show what SD Maid Pro could still clean up

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionEngine.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionEngine.kt
@@ -315,10 +315,19 @@ class DashboardMainActionEngine(
                 // Post-scan "will be freed" takes priority; otherwise, once the action has settled,
                 // show the "freed" result of the last main-action deletion/one-click. While working,
                 // both stay hidden and the bar carries progress. The settle edge gates this too, not
-                // just [settled]: the task manager reports idle again before the branches fold in
-                // their results, and without the gate the identical "can be freed" card flashes in
-                // that window.
-                val freeable = if (actionState == BottomBarState.Action.DELETE && phase.isSettled) {
+                // just the idle task manager: the latter reports idle again before the branches fold
+                // in their results, and without the gate the identical "can be freed" card flashes
+                // in that window.
+                //
+                // Deliberately NOT gated on DELETE: a non-Pro user whose only findings are locked
+                // resolves to SCAN/ONECLICK, and that is exactly the state the LOCKED_ONLY card
+                // exists for. Nothing else slips through — [resolveMainAction]'s DELETE conditions
+                // are [buildHeroSummary]'s inclusion conditions, so the builder is already the
+                // filter and returns null wherever the DELETE check used to.
+                val freeable = if (phase.isSettled &&
+                    actionState != BottomBarState.Action.WORKING &&
+                    actionState != BottomBarState.Action.WORKING_CANCELABLE
+                ) {
                     buildHeroSummary(
                         corpse = corpseState.data,
                         system = filterState.data,
@@ -345,9 +354,22 @@ class DashboardMainActionEngine(
                             dedupe = dedupeState.data,
                             tools = provenance?.submitted.orEmpty(),
                         )
+                        // Pro-gated findings that survived alongside the outcome, minus anything the
+                        // run submitted to. That filter is not cosmetic: isProForUi() fails open, so
+                        // a cleanup can submit a Pro-gated tool while this combine's [upgradeInfo]
+                        // still reports non-Pro — that tool's leftovers would then be counted by
+                        // [residueOf] *and* returned here, and the card would report the same bytes
+                        // twice under contradictory framing ("5 MB left" and "unlock 5 MB more").
+                        val locked = lockedSlices(
+                            app = junkState.data,
+                            dedupe = dedupeState.data,
+                            oneClick = oneClickOptions,
+                            isPro = upgradeInfo?.isPro == true,
+                        ).filterNot { it.type in provenance?.submitted.orEmpty() }
                         outcome.copy(
                             residueSize = residue?.size ?: 0L,
                             residueCount = residue?.count ?: 0,
+                            lockedTools = locked,
                         )
                     }
                 // A settled cleanup outranks [freeable] whatever it freed: whatever data survived it
@@ -814,10 +836,37 @@ class DashboardMainActionEngine(
         }
 
         /**
-         * Builds the action-truthful hero summary: only tools the main DELETE action will actually
-         * free (one-click toggle on, has data, AppCleaner and Deduplicator additionally require
-         * Pro). Returns null when nothing is one-tap-actionable for this user/config, even if raw
-         * scan data exists.
+         * The Pro-gated findings this user cannot act on: AppCleaner and Deduplicator, when they
+         * have data and are opted into one-click. Empty for a Pro user, whose findings are simply
+         * freeable.
+         *
+         * The one-click condition mirrors [buildHeroSummary]/[resolveMainAction] on purpose: a tool
+         * the user switched off is not locked, it is opted out, and claiming Pro would unlock it
+         * would be false.
+         */
+        internal fun lockedSlices(
+            app: AppCleaner.Data?,
+            dedupe: Deduplicator.Data?,
+            oneClick: OneClickOptionsState,
+            isPro: Boolean,
+        ): List<HeroSummary.ToolSlice> {
+            if (isPro) return emptyList()
+            return buildList {
+                app?.takeIf { oneClick.appCleanerEnabled && it.hasData }?.let {
+                    add(HeroSummary.ToolSlice(SDMTool.Type.APPCLEANER, it.totalSize, it.totalCount))
+                }
+                dedupe?.takeIf { oneClick.deduplicatorEnabled && it.hasData }?.let {
+                    add(HeroSummary.ToolSlice(SDMTool.Type.DEDUPLICATOR, it.redundantSize, it.redundantCount))
+                }
+            }
+        }
+
+        /**
+         * Builds the action-truthful hero summary: [HeroSummary.tools] holds only tools the main
+         * DELETE action will actually free (one-click toggle on, has data, AppCleaner and
+         * Deduplicator additionally require Pro), while Pro-gated findings this user cannot act on
+         * go to [HeroSummary.lockedTools] as an upsell. Returns null only when there is nothing at
+         * all to say — neither freeable nor locked.
          */
         internal fun buildHeroSummary(
             corpse: CorpseFinder.Data?,
@@ -842,7 +891,20 @@ class DashboardMainActionEngine(
                     add(HeroSummary.ToolSlice(SDMTool.Type.DEDUPLICATOR, it.redundantSize, it.redundantCount))
                 }
             }
-            if (tools.isEmpty()) return null
+            val locked = lockedSlices(app = app, dedupe = dedupe, oneClick = oneClick, isPro = isPro)
+            if (tools.isEmpty()) {
+                if (locked.isEmpty()) return null
+                // Nothing this user can free, but Pro-gated findings are sitting there. The amounts
+                // stay 0 — they are what the main action delivers, and it delivers nothing here.
+                return HeroSummary(
+                    mode = HeroSummary.Mode.LOCKED_ONLY,
+                    totalSize = 0L,
+                    itemCount = 0,
+                    tools = emptyList(),
+                    timestamp = locked.mapNotNull { scanTimes[it.type] }.maxOrNull(),
+                    lockedTools = locked,
+                )
+            }
             return HeroSummary(
                 mode = HeroSummary.Mode.FREEABLE,
                 totalSize = tools.sumOf { it.size },
@@ -853,6 +915,7 @@ class DashboardMainActionEngine(
                 // Only the *included* tools' scans: a newer scan of an absent tool must not make
                 // this summary's data look fresher than it is.
                 timestamp = tools.mapNotNull { scanTimes[it.type] }.maxOrNull(),
+                lockedTools = locked,
             )
         }
 

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionState.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionState.kt
@@ -24,12 +24,16 @@ data class BottomBarState(
 }
 
 /**
- * The one-tap-actionable cleanup summary surfaced by the hero card. Reflects exactly what the
- * main action ([DashboardMainActionEngine.mainAction] with [BottomBarState.Action.DELETE]) will
- * free: each tool is included only when its one-click toggle is enabled, it has data, and — for
- * AppCleaner and Deduplicator — the user is Pro. Deduplicator contributes its freeable
- * redundant size and the count of redundant files a keep-one delete removes, so [itemCount] is a
- * uniform discrete-file count across all tools.
+ * The one-tap-actionable cleanup summary surfaced by the hero card. [tools] (and with it
+ * [totalSize]/[itemCount]) reflects exactly what the main action
+ * ([DashboardMainActionEngine.mainAction] with [BottomBarState.Action.DELETE]) will free: each tool
+ * is included only when its one-click toggle is enabled, it has data, and — for AppCleaner and
+ * Deduplicator — the user is Pro. Deduplicator contributes its freeable redundant size and the count
+ * of redundant files a keep-one delete removes, so [itemCount] is a uniform discrete-file count
+ * across all tools.
+ *
+ * Findings a non-Pro user cannot act on are not dropped, they move to [lockedTools] — the card shows
+ * them as an upsell, kept strictly apart from the amounts the main action can actually deliver.
  */
 data class HeroSummary(
     val mode: Mode,
@@ -50,12 +54,23 @@ data class HeroSummary(
      */
     val residueSize: Long = 0L,
     val residueCount: Int = 0,
+    /**
+     * Findings a Pro-gated tool holds that this user cannot act on. Disjoint from [tools]: a tool is
+     * in one list or the other, never both.
+     */
+    val lockedTools: List<ToolSlice> = emptyList(),
 ) {
+    /** What Pro would additionally unlock. Not part of [totalSize]/[itemCount] — see [lockedTools]. */
+    val lockedSize: Long get() = lockedTools.sumOf { it.size }
+    val lockedCount: Int get() = lockedTools.sumOf { it.count }
+
     /**
      * FREEABLE = "X will be freed" (post-scan); FREED = "X freed" (post-delete/one-click);
-     * NOTHING_FREED = a cleanup ran but freed nothing, which carries no amounts and no [tools].
+     * NOTHING_FREED = a cleanup ran but freed nothing, which carries no amounts and no [tools];
+     * LOCKED_ONLY = every finding is Pro-gated, so [tools] is empty and [totalSize]/[itemCount] stay
+     * 0 — they mean "what the main action will free" everywhere else and must keep meaning that.
      */
-    enum class Mode { FREEABLE, FREED, NOTHING_FREED }
+    enum class Mode { FREEABLE, FREED, NOTHING_FREED, LOCKED_ONLY }
 
     data class ToolSlice(
         val type: SDMTool.Type,
@@ -64,6 +79,18 @@ data class HeroSummary(
         val count: Int,
     )
 }
+
+/**
+ * Whether the hero renders its nested upgrade block: only when free and Pro-gated findings coexist,
+ * so the block has something to be "additional" to. With no free chips the block would be the card's
+ * whole content, and those states stay flat (locked chips in the main row).
+ *
+ * Single source of truth on purpose — the card's render branch and the dock's height reservation
+ * both read this. If they ever disagreed, the card would clip or the dock would reserve dead space,
+ * and neither shows up in a unit test.
+ */
+internal val HeroSummary.showsUpgradeBlock: Boolean
+    get() = tools.isNotEmpty() && lockedTools.isNotEmpty()
 
 data class OneClickOptionsState(
     val corpseFinderEnabled: Boolean = true,

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardScreen.kt
@@ -183,6 +183,8 @@ fun DashboardScreenHost(
             }
         },
         onToolClick = vm::onHeroToolClick,
+        // A non-Pro user may browse a Pro tool's findings list; only deletion is gated.
+        onLockedToolClick = vm::showTool,
         onExpandHero = vm::expandHero,
         onDiscardResults = vm::discardResults,
         onSettings = { vm.navTo(SettingsRoute) },
@@ -199,6 +201,7 @@ internal fun DashboardScreen(
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     onMainAction: () -> Unit = {},
     onToolClick: (HeroSummary.Mode, SDMTool.Type) -> Unit = { _, _ -> },
+    onLockedToolClick: (SDMTool.Type) -> Unit = {},
     onExpandHero: () -> Unit = {},
     onDiscardResults: () -> Unit = {},
     onSettings: () -> Unit = {},
@@ -394,6 +397,20 @@ internal fun DashboardScreen(
     // Suppress the hero while a tour is active so it can't cover or fight tour targets.
     val heroVisible = bottomBarState?.heroSummary != null && isHeroExpanded && !dashboardTourActive
 
+    // A LOCKED_ONLY card states that the one-tap action frees nothing for this user, so its button
+    // routes to the upgrade screen instead of the delete-confirmation dialog.
+    //
+    // Decided here, from the rendered state, rather than by handing the tap back to the engine: the
+    // LOCKED_ONLY verdict comes from the dashboard's upgradeInfo flow, while the engine's branches
+    // re-check isProForUi(), which fails open to `true` on any exception. Re-entering the engine
+    // could therefore reach runCleanup() and delete for real on a screen that deliberately skipped
+    // the confirmation. Navigating is the only outcome the UI's own decision can justify.
+    val mainAction: () -> Unit = {
+        val lockedDelete = bottomBarState?.actionState == BottomBarState.Action.DELETE &&
+            bottomBarState?.heroSummary?.mode == HeroSummary.Mode.LOCKED_ONLY
+        if (lockedDelete) onUpgrade() else onMainAction()
+    }
+
     // Dismissing or discarding the hero with DPAD_CENTER removes the focused node from
     // composition and focus evaporates — the next key press would restart from the default.
     // Tracked at the screen root because the hero's own focus-event node leaves composition
@@ -464,11 +481,12 @@ internal fun DashboardScreen(
                 state = bottomBarState,
                 isVisible = dockVisible,
                 heroVisible = heroVisible,
-                onMainAction = onMainAction,
+                onMainAction = mainAction,
                 onSettings = onSettings,
                 onUpgrade = onUpgrade,
                 onDismissHero = onDismissHero,
                 onToolClick = onToolClick,
+                onLockedToolClick = onLockedToolClick,
                 onExpandHero = onExpandHero,
                 onDiscardResults = onDiscardResults,
                 canExpandHero = !dashboardTourActive,

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModel.kt
@@ -565,6 +565,8 @@ class DashboardViewModel @Inject constructor(
             HeroSummary.Mode.FREEABLE -> showTool(type)
             // Renders no chips, so there is nothing here to tap.
             HeroSummary.Mode.NOTHING_FREED -> {}
+            // Renders no *free* chips; its locked chips route through onLockedToolClick instead.
+            HeroSummary.Mode.LOCKED_ONLY -> {}
         }
     }
 

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardBottomBar.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardBottomBar.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.Role
@@ -74,6 +75,7 @@ import eu.darken.sdmse.common.easterEggProgressMsg
 import eu.darken.sdmse.common.ui.R as UiR
 import eu.darken.sdmse.main.ui.dashboard.BottomBarState
 import eu.darken.sdmse.main.ui.dashboard.HeroSummary
+import eu.darken.sdmse.main.ui.dashboard.showsUpgradeBlock
 import eu.darken.sdmse.main.core.SDMTool
 import java.time.Instant
 
@@ -100,6 +102,7 @@ internal fun BottomBar(
     onUpgrade: () -> Unit,
     onDismissHero: () -> Unit,
     onToolClick: (HeroSummary.Mode, SDMTool.Type) -> Unit = { _, _ -> },
+    onLockedToolClick: (SDMTool.Type) -> Unit = {},
     onExpandHero: () -> Unit = {},
     onDiscardResults: () -> Unit = {},
     canExpandHero: Boolean = false,
@@ -137,8 +140,11 @@ internal fun BottomBar(
     // Hero card + dock reservation grow with the font scale so large text doesn't clip the card's
     // caption/hint. One read each, reused below for the card height, the dock reservation, the
     // hidden-offset slide distance, and the swipe-to-dismiss threshold — they must stay in lockstep.
-    val heroCardHeight = dashboardHeroCardHeight
-    val dockHeightWithHero = dashboardDockHeightWithHero
+    // Read from the same predicate the card renders by, or the reservation and the layout disagree
+    // and the card either clips or leaves dead space behind it.
+    val heroShowsUpgradeBlock = heroSummary?.showsUpgradeBlock == true
+    val heroCardHeight = dashboardHeroCardHeight(heroShowsUpgradeBlock)
+    val dockHeightWithHero = dashboardDockHeightWithHero(heroShowsUpgradeBlock)
 
     // Reserved layout height drives the Scaffold's content padding. Elements are bottom-anchored, so
     // growing this only reflows the list above — it never moves the bar/FAB.
@@ -287,6 +293,8 @@ internal fun BottomBar(
                 onDiscard = onDiscardResults
                     .takeIf { heroSummary.mode == HeroSummary.Mode.FREEABLE },
                 onToolClick = onToolClick,
+                onLockedToolClick = onLockedToolClick,
+                onUpgrade = onUpgrade,
                 entryFocusRequester = heroEntryFocusRequester,
             )
         }
@@ -355,14 +363,28 @@ private fun BarContent(
             }
 
             compactSummary != null -> {
+                // A locked-only summary carries its amount in the locked slices — reading totalSize
+                // here would advertise "0 B". The star marks it as gated, and it has to be spelled
+                // out for TalkBack: the chip's icon is decorative unless described, so otherwise the
+                // announcement is a bare size with no hint that the space is out of reach.
+                val isLocked = compactSummary.mode == HeroSummary.Mode.LOCKED_ONLY
                 SdmInfoChip(
                     modifier = Modifier
                         .align(Alignment.CenterStart)
                         .padding(start = 12.dp),
-                    icon = painterResource(UiR.drawable.ic_baseline_delete_sweep_24),
-                    label = ByteFormatter.formatSize(context, compactSummary.totalSize).first,
+                    icon = if (isLocked) {
+                        rememberVectorPainter(Icons.TwoTone.Stars)
+                    } else {
+                        painterResource(UiR.drawable.ic_baseline_delete_sweep_24)
+                    },
+                    label = ByteFormatter.formatSize(
+                        context,
+                        if (isLocked) compactSummary.lockedSize else compactSummary.totalSize,
+                    ).first,
                     containerColor = MaterialTheme.colorScheme.primaryContainer,
                     contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    iconContentDescription = stringResource(R.string.dashboard_hero_locked_chip_description)
+                        .takeIf { isLocked },
                     // Tapping it expands the collapsed hero (null during a tour → passive chip).
                     onClick = onExpandHero,
                 )

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardDockGeometry.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardDockGeometry.kt
@@ -101,6 +101,14 @@ internal val DASHBOARD_HERO_BAR_GAP = 12.dp
  * via [dashboardHeroCardHeight] so the caption/hint don't clip — see that getter.
  */
 internal val DASHBOARD_HERO_CONTENT_HEIGHT = 156.dp
+
+/**
+ * Body height when the card also carries the nested upgrade block (its caption row + its own chip
+ * row + the block's padding), i.e. when free and Pro-gated findings coexist. Only that case gets the
+ * taller card: the block is what needs the room, and every other state keeps the original budget.
+ */
+internal val DASHBOARD_HERO_CONTENT_HEIGHT_WITH_BLOCK = 215.dp
+
 internal val DASHBOARD_HERO_CARD_HEIGHT = DASHBOARD_HERO_CONTENT_HEIGHT + DASHBOARD_CUTOUT_DEPTH
 internal val DASHBOARD_HERO_HORIZONTAL_MARGIN = 12.dp
 
@@ -117,26 +125,32 @@ internal val DASHBOARD_DOCK_HEIGHT_WITH_HERO =
 private const val HERO_MAX_FONT_SCALE = 2.0f
 
 /**
- * [DASHBOARD_HERO_CONTENT_HEIGHT] grown for the current font scale. The card's body is text, so its
+ * The applicable base height grown for the current font scale. The card's body is text, so its
  * height has to track the user's font size or the caption and the two-line tap-hint clip. Never
  * shrinks below the font-scale-1.0 worst-case height (coerced ≥ 1f).
+ *
+ * [withUpgradeBlock] must come from `HeroSummary.showsUpgradeBlock` — the single predicate the card
+ * also renders by. If the reservation and the render ever disagree, the card clips or the dock
+ * reserves dead space.
  */
-val dashboardHeroContentHeight: Dp
-    @Composable
-    @ReadOnlyComposable
-    get() = DASHBOARD_HERO_CONTENT_HEIGHT * LocalDensity.current.fontScale.coerceIn(1f, HERO_MAX_FONT_SCALE)
+@Composable
+@ReadOnlyComposable
+fun dashboardHeroContentHeight(withUpgradeBlock: Boolean): Dp {
+    val base = if (withUpgradeBlock) DASHBOARD_HERO_CONTENT_HEIGHT_WITH_BLOCK else DASHBOARD_HERO_CONTENT_HEIGHT
+    return base * LocalDensity.current.fontScale.coerceIn(1f, HERO_MAX_FONT_SCALE)
+}
 
 /** Font-scale-aware counterpart of [DASHBOARD_HERO_CARD_HEIGHT] (content + fixed cradle notch). */
-val dashboardHeroCardHeight: Dp
-    @Composable
-    @ReadOnlyComposable
-    get() = dashboardHeroContentHeight + DASHBOARD_CUTOUT_DEPTH
+@Composable
+@ReadOnlyComposable
+fun dashboardHeroCardHeight(withUpgradeBlock: Boolean): Dp =
+    dashboardHeroContentHeight(withUpgradeBlock) + DASHBOARD_CUTOUT_DEPTH
 
 /** Font-scale-aware counterpart of [DASHBOARD_DOCK_HEIGHT_WITH_HERO]. */
-val dashboardDockHeightWithHero: Dp
-    @Composable
-    @ReadOnlyComposable
-    get() = DASHBOARD_BAR_HEIGHT + DASHBOARD_HERO_BAR_GAP + dashboardHeroCardHeight
+@Composable
+@ReadOnlyComposable
+fun dashboardDockHeightWithHero(withUpgradeBlock: Boolean): Dp =
+    DASHBOARD_BAR_HEIGHT + DASHBOARD_HERO_BAR_GAP + dashboardHeroCardHeight(withUpgradeBlock)
 
 /**
  * The bar's shape. The FAB only exists once the dashboard is [isReady]; until then the bar must NOT

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardHeroCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardHeroCard.kt
@@ -3,6 +3,7 @@ package eu.darken.sdmse.main.ui.dashboard.bottom
 import android.text.format.DateUtils
 import androidx.annotation.PluralsRes
 import androidx.annotation.StringRes
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -14,9 +15,12 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.Close
+import androidx.compose.material.icons.twotone.Stars
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -28,14 +32,15 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.buildAnnotatedString
@@ -51,6 +56,7 @@ import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import eu.darken.sdmse.main.core.SDMTool
 import eu.darken.sdmse.main.ui.dashboard.HeroSummary
 import eu.darken.sdmse.main.ui.dashboard.cards.toolNameRes
+import eu.darken.sdmse.main.ui.dashboard.showsUpgradeBlock
 import java.time.Instant
 import eu.darken.sdmse.common.R as CommonR
 
@@ -68,6 +74,8 @@ internal fun DashboardHeroCard(
     onDismiss: () -> Unit = {},
     onDiscard: (() -> Unit)? = null,
     onToolClick: (HeroSummary.Mode, SDMTool.Type) -> Unit = { _, _ -> },
+    onLockedToolClick: (SDMTool.Type) -> Unit = {},
+    onUpgrade: () -> Unit = {},
     entryFocusRequester: FocusRequester? = null,
 ) {
     // Explicit D-pad ladder through the card — spatial search is unreliable here (the Dismiss X
@@ -76,7 +84,9 @@ internal fun DashboardHeroCard(
     // the tool chips goes to the X; UP from the X falls out of the dock (back to the grid).
     val dismissFocusRequester = remember { FocusRequester() }
     // Colour tracks the action: destructive (red) while a deletion is pending, positive once freed,
-    // neutral when the cleanup ran but came up empty (nothing was lost, nothing was gained).
+    // neutral when the cleanup ran but came up empty (nothing was lost, nothing was gained) — and
+    // neutral too when everything is locked, where the main action deletes nothing and the
+    // destructive red would be a lie.
     val (containerColor, contentColor) = when (summary.mode) {
         HeroSummary.Mode.FREEABLE ->
             MaterialTheme.colorScheme.error to MaterialTheme.colorScheme.onError
@@ -84,7 +94,7 @@ internal fun DashboardHeroCard(
         HeroSummary.Mode.FREED ->
             MaterialTheme.colorScheme.tertiaryContainer to MaterialTheme.colorScheme.onTertiaryContainer
 
-        HeroSummary.Mode.NOTHING_FREED ->
+        HeroSummary.Mode.NOTHING_FREED, HeroSummary.Mode.LOCKED_ONLY ->
             MaterialTheme.colorScheme.surfaceVariant to MaterialTheme.colorScheme.onSurfaceVariant
     }
     Surface(
@@ -96,12 +106,12 @@ internal fun DashboardHeroCard(
     ) {
         Column(modifier = Modifier.fillMaxSize()) {
             HeroBody(
-                modifier = Modifier
-                    .weight(1f)
-                    .padding(start = 20.dp, top = 12.dp, end = 8.dp),
+                modifier = Modifier.weight(1f),
                 summary = summary,
                 onDismiss = onDismiss,
                 onToolClick = onToolClick,
+                onLockedToolClick = onLockedToolClick,
+                onUpgrade = onUpgrade,
                 dismissFocusRequester = dismissFocusRequester,
                 dismissEntryRequester = entryFocusRequester.takeIf { onDiscard == null },
             )
@@ -125,6 +135,8 @@ private fun HeroBody(
     summary: HeroSummary,
     onDismiss: () -> Unit,
     onToolClick: (HeroSummary.Mode, SDMTool.Type) -> Unit,
+    onLockedToolClick: (SDMTool.Type) -> Unit = {},
+    onUpgrade: () -> Unit = {},
     dismissFocusRequester: FocusRequester = FocusRequester(),
     dismissEntryRequester: FocusRequester? = null,
 ) {
@@ -133,17 +145,40 @@ private fun HeroBody(
     // NOTHING_FREED carries no size and no item count, so its headline and caption are plain
     // sentences rather than templates wrapped around a number.
     val hasAmounts = summary.mode != HeroSummary.Mode.NOTHING_FREED
+    val isLockedOnly = summary.mode == HeroSummary.Mode.LOCKED_ONLY
+    val showsBlock = summary.showsUpgradeBlock
+    // Without free chips there is nothing for a nested block to be additional to, so the locked
+    // chips join the main row instead and the card keeps its normal height.
+    val flatLocked = if (showsBlock) emptyList() else summary.lockedTools
+    // Only LOCKED_ONLY turns its hint into a tappable unlock line: NOTHING_FREED's hint diagnoses
+    // why the cleanup came up empty and must not be displaced.
+    val showUnlockLine = flatLocked.isNotEmpty() && isLockedOnly
     Column(modifier = modifier) {
+        // Header insets are split between the row and the text column so the two can differ without
+        // either costing horizontal room. The dismiss button's inset is the row's (8.dp top, 8.dp
+        // end), keeping it square in the corner; the headline's extra 4.dp is the column's, so it
+        // still starts 12.dp below the card's top edge. Padding the *button* instead would come out
+        // of the text column's weight(1f) share, narrowing the headline and caption on a small
+        // display at a large font scale until the caption wraps onto a line the height has no room
+        // for.
         Row(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 20.dp, top = 8.dp, end = 8.dp),
             verticalAlignment = Alignment.Top,
         ) {
-            Column(modifier = Modifier.weight(1f)) {
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(top = 4.dp),
+            ) {
                 // One sentence with the size inline ("3.7 GB can be freed") — the smaller label
                 // text is spanned around the headline-sized number. Split on the placeholder so
                 // translations may put label text before and/or after the size.
                 val template = stringResource(modeRes.headline)
-                val sizeText = ByteFormatter.formatSize(context, summary.totalSize).first
+                // LOCKED_ONLY's amounts live in the locked slices; totalSize is 0 there by design.
+                val headlineSize = if (isLockedOnly) summary.lockedSize else summary.totalSize
+                val sizeText = ByteFormatter.formatSize(context, headlineSize).first
                 val labelSpan = MaterialTheme.typography.titleSmall.toSpanStyle()
                     .copy(color = LocalContentColor.current.copy(alpha = MUTED_ALPHA))
                 Text(
@@ -163,9 +198,10 @@ private fun HeroBody(
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )
+                val captionCount = if (isLockedOnly) summary.lockedCount else summary.itemCount
                 val captionText = when (val caption = modeRes.caption) {
                     is HeroCaption.Counted ->
-                        pluralStringResource(caption.id, summary.itemCount, summary.itemCount)
+                        pluralStringResource(caption.id, captionCount, captionCount)
 
                     is HeroCaption.Plain -> stringResource(caption.id)
                 }
@@ -207,11 +243,13 @@ private fun HeroBody(
 
         // The body is sized for the worst case (two chip rows + two-line hint); in smaller
         // configurations the slack collects here so chips + hint stay anchored above the footer.
-        Spacer(modifier = Modifier.height(12.dp))
+        Spacer(modifier = Modifier.height(8.dp))
 
         FlowRow(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp),
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
             verticalArrangement = Arrangement.spacedBy(4.dp),
         ) {
             summary.tools.forEach { slice ->
@@ -227,18 +265,166 @@ private fun HeroBody(
                     onClick = { onToolClick(summary.mode, slice.type) },
                 )
             }
+            flatLocked.forEach { slice ->
+                LockedToolChip(
+                    slice = slice,
+                    dismissFocusRequester = dismissFocusRequester,
+                    onLockedToolClick = onLockedToolClick,
+                )
+            }
         }
 
-        // Last, right above the footer strip: the hint references its direct neighbours — "the
-        // button below" and the category chips above.
-        Text(
-            modifier = Modifier.padding(top = 4.dp),
-            text = stringResource(modeRes.hint),
-            style = MaterialTheme.typography.labelSmall,
-            color = LocalContentColor.current.copy(alpha = MUTED_ALPHA),
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-        )
+        // Directly under the chips it talks about ("or a chip to check first"). LOCKED_ONLY shows the
+        // tappable unlock row below instead — the two are mutually exclusive, and are two separate
+        // conditions rather than one if/else only so that each keeps its own side of the block.
+        if (!showUnlockLine) {
+            Text(
+                modifier = Modifier.padding(top = 2.dp, start = 20.dp, end = 20.dp),
+                text = stringResource(modeRes.hint),
+                style = MaterialTheme.typography.labelSmall,
+                color = LocalContentColor.current.copy(alpha = MUTED_ALPHA),
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+
+        if (showsBlock) {
+            UpgradeBlock(
+                modifier = Modifier
+                    .padding(top = 8.dp, start = 20.dp, end = 20.dp),
+                lockedTools = summary.lockedTools,
+                dismissFocusRequester = dismissFocusRequester,
+                onLockedToolClick = onLockedToolClick,
+                onUpgrade = onUpgrade,
+            )
+        }
+
+        // LOCKED_ONLY's stand-in for the hint above: the same sentence, but the whole line is the
+        // upgrade target. Last, right above the footer strip. It never shares the card with the
+        // block — a LOCKED_ONLY summary has no free chips, so showsBlock is false whenever this is
+        // true — which is why the two conditions above and here can't both fire.
+        if (showUnlockLine) {
+            Row(
+                modifier = Modifier
+                    .padding(top = 4.dp, start = 20.dp, end = 20.dp)
+                    // The whole line is the target, not just the glyph run.
+                    .fillMaxWidth()
+                    // Reachable on TV, so it has to join the card's explicit D-pad ladder — a
+                    // focusable row outside it is a dead end there.
+                    .focusProperties { up = dismissFocusRequester }
+                    .clickable(role = Role.Button, onClick = onUpgrade),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    modifier = Modifier.size(14.dp),
+                    imageVector = Icons.TwoTone.Stars,
+                    contentDescription = null,
+                    tint = LocalContentColor.current.copy(alpha = MUTED_ALPHA),
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                Text(
+                    text = stringResource(R.string.dashboard_hero_locked_hint),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = LocalContentColor.current.copy(alpha = MUTED_ALPHA),
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * A Pro-gated finding, styled exactly like a free chip — same tool icon, same neutral pill. On device
+ * a star in place of the tool icon made it read as a different *kind* of object from the free chips
+ * beside it; what marks it as gated is where it sits (inside the [UpgradeBlock], or on a LOCKED_ONLY
+ * card), not a different glyph.
+ */
+@Composable
+private fun LockedToolChip(
+    modifier: Modifier = Modifier,
+    slice: HeroSummary.ToolSlice,
+    dismissFocusRequester: FocusRequester,
+    onLockedToolClick: (SDMTool.Type) -> Unit,
+) {
+    val context = LocalContext.current
+    SdmInfoChip(
+        modifier = modifier.focusProperties { up = dismissFocusRequester },
+        icon = slice.type.icon,
+        label = ByteFormatter.formatSize(context, slice.size).first,
+        containerColor = MaterialTheme.colorScheme.surface,
+        contentColor = contentColorFor(MaterialTheme.colorScheme.surface),
+        iconContentDescription = stringResource(toolNameRes(slice.type)),
+        // NOT onToolClick: in FREED mode that routes to a report, and a locked tool has none — it
+        // was never cleaned.
+        onClick = { onLockedToolClick(slice.type) },
+    )
+}
+
+/**
+ * The nested "more with Pro" block: a starred caption over its own row of locked tool chips. Shown
+ * only when free findings exist too (see [showsUpgradeBlock]), which is what makes a second,
+ * subordinate category meaningful.
+ *
+ * The caption carries no size — the chips sit directly below it and there is usually just one
+ * (Deduplicator is off by default in one-tap, leaving AppCleaner alone), so a total here would print
+ * the same figure twice.
+ *
+ * The whole block is one upgrade target; the chips inside stay individually clickable and consume
+ * their own taps, so tapping a chip opens that tool instead of the upgrade screen.
+ *
+ * The container is the hero's own content colour at a low alpha rather than a palette colour: the
+ * block has to read as nested on both the error-red FREEABLE card and the tertiary FREED one, and a
+ * translucent wash of what the card already uses is the one thing that works on both.
+ */
+@Composable
+private fun UpgradeBlock(
+    modifier: Modifier = Modifier,
+    lockedTools: List<HeroSummary.ToolSlice>,
+    dismissFocusRequester: FocusRequester,
+    onLockedToolClick: (SDMTool.Type) -> Unit,
+    onUpgrade: () -> Unit,
+) {
+    val blockContentColor = LocalContentColor.current
+    Surface(
+        modifier = modifier
+            .fillMaxWidth()
+            .focusProperties { up = dismissFocusRequester }
+            .clickable(role = Role.Button, onClick = onUpgrade),
+        color = blockContentColor.copy(alpha = BLOCK_CONTAINER_ALPHA),
+        contentColor = blockContentColor,
+        shape = RoundedCornerShape(12.dp),
+    ) {
+        Column(modifier = Modifier.padding(10.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    modifier = Modifier.size(14.dp),
+                    imageVector = Icons.TwoTone.Stars,
+                    contentDescription = null,
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                Text(
+                    text = stringResource(R.string.dashboard_hero_locked_block_caption),
+                    style = MaterialTheme.typography.labelSmall,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            Spacer(modifier = Modifier.height(4.dp))
+            FlowRow(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                lockedTools.forEach { slice ->
+                    LockedToolChip(
+                        slice = slice,
+                        dismissFocusRequester = dismissFocusRequester,
+                        onLockedToolClick = onLockedToolClick,
+                    )
+                }
+            }
+        }
     }
 }
 
@@ -316,6 +502,9 @@ private fun HeroFooter(
 private const val SIZE_ARG = "%1\$s"
 private const val MUTED_ALPHA = 0.8f
 
+/** Wash strength for the nested upgrade block; low enough to stay subordinate on every card colour. */
+private const val BLOCK_CONTAINER_ALPHA = 0.14f
+
 /**
  * A mode's caption is either driven by the item count or a plain sentence, and the two need different
  * resource types. Modelled rather than left as a bare id so a mode cannot be wired to the wrong one.
@@ -356,6 +545,14 @@ private val HeroSummary.Mode.resources: HeroModeResources
             hint = R.string.dashboard_hero_nothing_freed_hint,
             timestampDescription = R.string.dashboard_hero_nothing_freed_timestamp_description,
         )
+
+        HeroSummary.Mode.LOCKED_ONLY -> HeroModeResources(
+            headline = R.string.dashboard_hero_locked_headline,
+            caption = HeroCaption.Counted(R.plurals.dashboard_hero_locked_x_items),
+            hint = R.string.dashboard_hero_locked_hint,
+            // Scan data, same as FREEABLE — the timestamp means the same thing here.
+            timestampDescription = R.string.dashboard_hero_scanned_timestamp_description,
+        )
     }
 
 private fun previewSummary(
@@ -382,7 +579,7 @@ private fun HeroCardPreview(
         DashboardHeroCard(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(dashboardHeroCardHeight)
+                .height(dashboardHeroCardHeight(summary.showsUpgradeBlock))
                 .padding(horizontal = DASHBOARD_HERO_HORIZONTAL_MARGIN),
             summary = summary,
             onDiscard = onDiscard,
@@ -409,6 +606,167 @@ private fun DashboardHeroCardFreedPreview() {
 @Composable
 private fun DashboardHeroCardNothingFreedPreview() {
     HeroCardPreview(summary = previewSummary(mode = HeroSummary.Mode.NOTHING_FREED, tools = emptyList()))
+}
+
+// The one branch where locked chips render *without* the nested block: with no free chips there is
+// nothing for the block to be additional to, so the chips stay flat in the main row. It is also the
+// one mode whose hint is kept rather than turned into an unlock line — that sentence diagnoses why
+// the cleanup came up empty, and an upsell in its place would drop the explanation.
+@Preview2
+@Composable
+private fun DashboardHeroCardNothingFreedWithLockedPreview() {
+    HeroCardPreview(
+        summary = HeroSummary(
+            mode = HeroSummary.Mode.NOTHING_FREED,
+            totalSize = 0L,
+            itemCount = 0,
+            tools = emptyList(),
+            timestamp = Instant.now().minusSeconds(60),
+            lockedTools = listOf(
+                HeroSummary.ToolSlice(SDMTool.Type.APPCLEANER, 1_024L * 1_024L * 1_024L, 5),
+            ),
+        ),
+    )
+}
+
+@Preview2
+@Composable
+private fun DashboardHeroCardLockedOnlyPreview() {
+    HeroCardPreview(
+        summary = HeroSummary(
+            mode = HeroSummary.Mode.LOCKED_ONLY,
+            totalSize = 0L,
+            itemCount = 0,
+            tools = emptyList(),
+            timestamp = Instant.now().minusSeconds(5 * 60),
+            lockedTools = listOf(
+                HeroSummary.ToolSlice(SDMTool.Type.APPCLEANER, 1_024L * 1_024L * 1_024L, 5),
+                HeroSummary.ToolSlice(SDMTool.Type.DEDUPLICATOR, 1_024L * 1_024L * 512L, 3),
+            ),
+        ),
+    )
+}
+
+// The shape most non-Pro users actually get, and worth its own slot beside the two-tool variant: the
+// Deduplicator is off by default in one-tap, so AppCleaner is usually the only locked tool and the
+// card is carried by a single chip. A layout that only looks balanced with two chips fails here.
+@Preview2
+@Composable
+private fun DashboardHeroCardLockedOnlySingleToolPreview() {
+    HeroCardPreview(
+        summary = HeroSummary(
+            mode = HeroSummary.Mode.LOCKED_ONLY,
+            totalSize = 0L,
+            itemCount = 0,
+            tools = emptyList(),
+            timestamp = Instant.now().minusSeconds(5 * 60),
+            lockedTools = listOf(
+                HeroSummary.ToolSlice(SDMTool.Type.APPCLEANER, 1_024L * 1_024L * 1_024L, 5),
+            ),
+        ),
+    )
+}
+
+// The nested-block layout at its fullest: a freed result with a leftover line, its own chip row, and
+// the upgrade block below carrying two more chips. This is the case the taller
+// DASHBOARD_HERO_CONTENT_HEIGHT_WITH_BLOCK is sized for.
+@Preview2
+@Composable
+private fun DashboardHeroCardFreedWithLockedPreview() {
+    HeroCardPreview(
+        summary = HeroSummary(
+            mode = HeroSummary.Mode.FREED,
+            totalSize = 1_024L * 1_024L * 1_724L,
+            itemCount = 26,
+            tools = listOf(
+                HeroSummary.ToolSlice(SDMTool.Type.CORPSEFINDER, 1_024L * 1_024L * 1_024L, 12),
+                HeroSummary.ToolSlice(SDMTool.Type.SYSTEMCLEANER, 1_024L * 1_024L * 700L, 14),
+            ),
+            timestamp = Instant.now().minusSeconds(60),
+            residueSize = 1_024L * 1_024L * 5L,
+            residueCount = 2,
+            lockedTools = listOf(
+                HeroSummary.ToolSlice(SDMTool.Type.APPCLEANER, 1_024L * 1_024L * 1_024L, 5),
+                HeroSummary.ToolSlice(SDMTool.Type.DEDUPLICATOR, 1_024L * 1_024L * 512L, 3),
+            ),
+        ),
+    )
+}
+
+// The same block layout on the error-tinted FREEABLE card, where the nested wash has to read as
+// subordinate against a very different background than FREED's.
+//
+// For a FREEABLE summary two free chips is the maximum alongside the block: the block only appears
+// when the user is not Pro, and buildHeroSummary routes both Pro-gated tools (AppCleaner,
+// Deduplicator) into lockedTools in exactly that case, leaving tools with CorpseFinder and
+// SystemCleaner at most.
+//
+// That ceiling is FREEABLE-only — do not generalise it to the card. FREED summaries are not built by
+// buildHeroSummary at all: accumulateFreed assembles their tools from whichever tools actually ran a
+// cleanup, with no entitlement filter, and the settled path then attaches lockedTools filtered only
+// against the tools the run submitted to. So a tool that ran despite the combine reporting non-Pro
+// lands among the free chips while a still-gated tool that never ran stays locked — three free chips
+// plus the block. See DashboardHeroCardFreedWithThreeFreeAndLockedPreview.
+@Preview2
+@Composable
+private fun DashboardHeroCardFreeableWithLockedPreview() {
+    HeroCardPreview(
+        summary = HeroSummary(
+            mode = HeroSummary.Mode.FREEABLE,
+            totalSize = 1_024L * 1_024L * 1_724L,
+            itemCount = 26,
+            tools = listOf(
+                HeroSummary.ToolSlice(SDMTool.Type.CORPSEFINDER, 1_024L * 1_024L * 1_024L, 12),
+                HeroSummary.ToolSlice(SDMTool.Type.SYSTEMCLEANER, 1_024L * 1_024L * 700L, 14),
+            ),
+            timestamp = Instant.now().minusSeconds(5 * 60),
+            lockedTools = listOf(
+                HeroSummary.ToolSlice(SDMTool.Type.APPCLEANER, 1_024L * 1_024L * 1_024L, 5),
+                HeroSummary.ToolSlice(SDMTool.Type.DEDUPLICATOR, 1_024L * 1_024L * 512L, 3),
+            ),
+        ),
+        onDiscard = {},
+    )
+}
+
+// The most content the block layout can carry, and the reason the FREEABLE two-chip ceiling above
+// must not be read as a card-wide invariant: three free chips, a leftover line, and the block.
+//
+// One reachable path: a Pro user cleans CorpseFinder, SystemCleaner and AppCleaner while
+// Deduplicator is disabled in one-tap; afterward the entitlement lapses and Deduplicator is enabled
+// while its findings remain. The three cleaned slices stay in tools, while the never-submitted
+// Deduplicator enters lockedTools.
+//
+// Every clause of that is load-bearing. lockedSlices returns nothing at all while isPro, so the
+// lapse alone is not enough; and had Deduplicator been enabled with findings during the cleanup, the
+// DELETE branch would have submitted it, after which the settled path's filter against the run's
+// submitted set drops it from lockedTools again.
+//
+// The fail-open isProForUi() read reaches the same shape, but only when the dashboard's own upgrade
+// flow reports non-Pro AND Deduplicator independently satisfies lockedSlices: enabled, with
+// findings, never submitted.
+@Preview2
+@Composable
+private fun DashboardHeroCardFreedWithThreeFreeAndLockedPreview() {
+    val tools = listOf(
+        HeroSummary.ToolSlice(SDMTool.Type.CORPSEFINDER, 1_024L * 1_024L * 1_023L, 12),
+        HeroSummary.ToolSlice(SDMTool.Type.SYSTEMCLEANER, 1_024L * 1_024L * 700L, 14),
+        HeroSummary.ToolSlice(SDMTool.Type.APPCLEANER, 1_024L * 1_024L * 512L, 87),
+    )
+    HeroCardPreview(
+        summary = HeroSummary(
+            mode = HeroSummary.Mode.FREED,
+            totalSize = tools.sumOf { it.size },
+            itemCount = tools.sumOf { it.count },
+            tools = tools,
+            timestamp = Instant.now().minusSeconds(60),
+            residueSize = 1_024L * 1_024L * 5L,
+            residueCount = 2,
+            lockedTools = listOf(
+                HeroSummary.ToolSlice(SDMTool.Type.DEDUPLICATOR, 1_024L * 1_024L * 512L, 3),
+            ),
+        ),
+    )
 }
 
 // Worst case: all four tools (chips wrap to a second row) + the two-line freeable hint — validates

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,6 +23,22 @@
     <string name="dashboard_hero_nothing_freed_headline">Nothing was freed</string>
     <string name="dashboard_hero_nothing_freed_caption">The cleanup finished, but none of the found data could be removed.</string>
     <string name="dashboard_hero_nothing_freed_hint">Some data can only be removed with extra access, such as the accessibility service or root.</string>
+    <!-- Shown when every finding needs SD Maid Pro. Deliberately not "can be freed": the main action
+         will not free any of it. %1$s is the locked size, e.g. "3.7 GB" -->
+    <string name="dashboard_hero_locked_headline">%1$s found</string>
+    <plurals name="dashboard_hero_locked_x_items">
+        <item quantity="one">%d item needs SD Maid Pro</item>
+        <item quantity="other">%d items need SD Maid Pro</item>
+    </plurals>
+    <!-- Tappable line on the hero card, routing to the upgrade screen -->
+    <string name="dashboard_hero_locked_hint">Tap to unlock with SD Maid Pro.</string>
+    <!-- Caption of the nested block that collects Pro-gated findings sitting next to findings the
+         user can already free. "More" is load-bearing: it is on top of what the card's headline
+         already promises. Deliberately carries no size - the block's chips sit directly below it and
+         there is usually only one, so a total here would just print the same figure twice. -->
+    <string name="dashboard_hero_locked_block_caption">More can be freed with SD Maid Pro</string>
+    <!-- Accessibility name for the bar's collapsed summary chip when the space it shows needs Pro -->
+    <string name="dashboard_hero_locked_chip_description">Needs SD Maid Pro</string>
     <!-- Accessibility descriptions for the hero card's relative timestamp; %1$s is e.g. "5 min. ago" -->
     <string name="dashboard_hero_scanned_timestamp_description">Scanned %1$s</string>
     <string name="dashboard_hero_freed_timestamp_description">Freed %1$s</string>

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardHeroSummaryTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardHeroSummaryTest.kt
@@ -6,6 +6,7 @@ import eu.darken.sdmse.deduplicator.core.Deduplicator
 import eu.darken.sdmse.deduplicator.core.Duplicate
 import eu.darken.sdmse.main.core.SDMTool
 import eu.darken.sdmse.systemcleaner.core.SystemCleaner
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -161,16 +162,125 @@ class DashboardHeroSummaryTest : BaseTest() {
     }
 
     @Test
-    fun `returns null when nothing is one-tap-actionable for this user`() {
-        // AppCleaner has data but the user is not Pro, and it is the only tool with data.
+    fun `returns null when no tool has any data`() {
         DashboardMainActionEngine.buildHeroSummary(
+            corpse = null,
+            system = null,
+            app = null,
+            dedupe = null,
+            oneClick = oneClick(),
+            isPro = false,
+        ).shouldBeNull()
+    }
+
+    @Test
+    fun `a non-Pro user's only findings become a LOCKED_ONLY summary`() {
+        // AppCleaner has data but the user is not Pro, and it is the only tool with data. The
+        // findings used to vanish entirely — no card at all.
+        val result = DashboardMainActionEngine.buildHeroSummary(
             corpse = null,
             system = null,
             app = app(300, 7),
             dedupe = null,
             oneClick = oneClick(),
             isPro = false,
+        )!!
+
+        result.mode shouldBe HeroSummary.Mode.LOCKED_ONLY
+        result.tools.shouldBeEmpty()
+        // The amounts mean "what the main action will free", and it will free none of this.
+        result.totalSize shouldBe 0L
+        result.itemCount shouldBe 0
+        result.lockedSize shouldBe 300L
+        result.lockedCount shouldBe 7
+        result.lockedTools.map { it.type } shouldBe listOf(SDMTool.Type.APPCLEANER)
+    }
+
+    @Test
+    fun `a locked Deduplicator contributes its redundant size and file count`() {
+        val result = DashboardMainActionEngine.buildHeroSummary(
+            corpse = null,
+            system = null,
+            app = null,
+            dedupe = dedupe(redundant = 500, removableCount = 8),
+            oneClick = oneClick(dedupe = true),
+            isPro = false,
+        )!!
+
+        result.mode shouldBe HeroSummary.Mode.LOCKED_ONLY
+        result.lockedTools.single { it.type == SDMTool.Type.DEDUPLICATOR }.size shouldBe 500L
+        result.lockedTools.single { it.type == SDMTool.Type.DEDUPLICATOR }.count shouldBe 8
+    }
+
+    @Test
+    fun `freeable and locked findings coexist in one summary`() {
+        val result = DashboardMainActionEngine.buildHeroSummary(
+            corpse = corpse(100, 3),
+            system = null,
+            app = app(300, 7),
+            dedupe = dedupe(redundant = 500, removableCount = 8),
+            oneClick = oneClick(dedupe = true),
+            isPro = false,
+        )!!
+
+        result.mode shouldBe HeroSummary.Mode.FREEABLE
+        // The headline amounts stay exactly what the main action delivers.
+        result.totalSize shouldBe 100L
+        result.itemCount shouldBe 3
+        result.tools.map { it.type } shouldBe listOf(SDMTool.Type.CORPSEFINDER)
+        result.lockedTools.map { it.type } shouldBe listOf(
+            SDMTool.Type.APPCLEANER,
+            SDMTool.Type.DEDUPLICATOR,
+        )
+        result.lockedSize shouldBe 800L
+    }
+
+    @Test
+    fun `a Pro user has nothing locked`() {
+        val result = DashboardMainActionEngine.buildHeroSummary(
+            corpse = null,
+            system = null,
+            app = app(300, 7),
+            dedupe = dedupe(redundant = 500, removableCount = 8),
+            oneClick = oneClick(dedupe = true),
+            isPro = true,
+        )!!
+
+        result.mode shouldBe HeroSummary.Mode.FREEABLE
+        result.lockedTools.shouldBeEmpty()
+    }
+
+    @Test
+    fun `a Pro-gated tool with its one-click toggle off is opted out, not locked`() {
+        // Claiming Pro would unlock it would be false: the main action skips it either way.
+        DashboardMainActionEngine.buildHeroSummary(
+            corpse = null,
+            system = null,
+            app = app(300, 7),
+            dedupe = dedupe(redundant = 500, removableCount = 8),
+            oneClick = oneClick(app = false, dedupe = false),
+            isPro = false,
         ).shouldBeNull()
+    }
+
+    @Test
+    fun `a LOCKED_ONLY timestamp comes from the locked tools' scans`() {
+        val older = Instant.parse("2026-06-10T10:00:00Z")
+        val newer = Instant.parse("2026-06-10T11:00:00Z")
+        val result = DashboardMainActionEngine.buildHeroSummary(
+            corpse = null,
+            system = null,
+            app = app(300, 7),
+            dedupe = dedupe(redundant = 500, removableCount = 8),
+            oneClick = oneClick(dedupe = true),
+            isPro = false,
+            scanTimes = mapOf(
+                SDMTool.Type.APPCLEANER to older,
+                SDMTool.Type.DEDUPLICATOR to newer,
+            ),
+        )!!
+
+        result.timestamp shouldBe newer
     }
 
     @Test

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardLockedMainActionTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardLockedMainActionTest.kt
@@ -1,0 +1,136 @@
+package eu.darken.sdmse.main.ui.dashboard
+
+import android.content.Context
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.sdmse.common.R as CommonR
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.common.compose.tour.GuidedTourController
+import eu.darken.sdmse.common.compose.tour.LocalGuidedTourController
+import eu.darken.sdmse.common.compose.tour.LocalTourTargetRegistry
+import eu.darken.sdmse.common.compose.tour.TourTargetRegistry
+import eu.darken.sdmse.main.core.SDMTool
+import eu.darken.sdmse.main.ui.dashboard.cards.ToolDashboardCardItem
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+
+/**
+ * The main action button for a LOCKED_ONLY hero must navigate to the upgrade screen, never re-enter
+ * the engine. The card's verdict comes from the dashboard's upgrade flow, while the engine's
+ * branches re-check `isProForUi()`, which fails open to `true` on any exception — so handing the tap
+ * back could reach a real deletion on a screen that deliberately skipped the confirmation dialog.
+ */
+class DashboardLockedMainActionTest : BaseComposeRobolectricTest() {
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+    private val deleteLabel get() = context.getString(CommonR.string.general_delete_action)
+
+    private fun items() = listOf(
+        ToolDashboardCardItem(
+            toolType = SDMTool.Type.CORPSEFINDER,
+            isInitializing = false,
+            result = null,
+            progress = null,
+            showProRequirement = false,
+            onScan = {},
+            onDelete = {},
+            onViewTool = {},
+            onViewDetails = {},
+            onCancel = {},
+        ),
+    )
+
+    private fun barState(hero: HeroSummary) = BottomBarState(
+        isReady = true,
+        actionState = BottomBarState.Action.DELETE,
+        activeTasks = 0,
+        queuedTasks = 0,
+        heroSummary = hero,
+        upgradeInfo = null,
+    )
+
+    private fun lockedOnlyHero() = HeroSummary(
+        mode = HeroSummary.Mode.LOCKED_ONLY,
+        totalSize = 0L,
+        itemCount = 0,
+        tools = emptyList(),
+        lockedTools = listOf(HeroSummary.ToolSlice(SDMTool.Type.APPCLEANER, 512L * 1024 * 1024, 9)),
+    )
+
+    private fun freeableHero() = HeroSummary(
+        mode = HeroSummary.Mode.FREEABLE,
+        totalSize = 1024L * 1024L,
+        itemCount = 3,
+        tools = listOf(HeroSummary.ToolSlice(SDMTool.Type.CORPSEFINDER, 1024L * 1024L, 3)),
+    )
+
+    private fun setContent(
+        hero: HeroSummary,
+        onMainAction: () -> Unit,
+        onUpgrade: () -> Unit,
+    ) {
+        val controller = mockk<GuidedTourController>(relaxed = true).also {
+            coEvery { it.shouldStart(any()) } returns false
+            every { it.session } returns MutableStateFlow(null)
+        }
+        composeRule.setContent {
+            PreviewWrapper {
+                CompositionLocalProvider(
+                    LocalTourTargetRegistry provides TourTargetRegistry(),
+                    LocalGuidedTourController provides controller,
+                ) {
+                    DashboardScreen(
+                        listState = DashboardViewModel.ListState(items = items()),
+                        bottomBarState = barState(hero),
+                        isHeroExpanded = true,
+                        onMainAction = onMainAction,
+                        onUpgrade = onUpgrade,
+                    )
+                }
+            }
+        }
+        composeRule.waitForIdle()
+    }
+
+    @Test
+    fun `the main action upsells instead of deleting when everything is locked`() {
+        var mainActions = 0
+        var upgrades = 0
+        setContent(lockedOnlyHero(), onMainAction = { mainActions++ }, onUpgrade = { upgrades++ })
+
+        composeRule.onNodeWithContentDescription(deleteLabel)
+            .assertHasClickAction()
+            .performSemanticsAction(SemanticsActions.OnClick)
+
+        composeRule.runOnIdle {
+            assertEquals(1, upgrades)
+            // Not even the confirmation dialog: there is nothing here this user can delete.
+            assertEquals(0, mainActions)
+        }
+    }
+
+    @Test
+    fun `the main action still deletes when there is something freeable`() {
+        var mainActions = 0
+        var upgrades = 0
+        setContent(freeableHero(), onMainAction = { mainActions++ }, onUpgrade = { upgrades++ })
+
+        composeRule.onNodeWithContentDescription(deleteLabel)
+            .assertHasClickAction()
+            .performSemanticsAction(SemanticsActions.OnClick)
+
+        composeRule.runOnIdle {
+            assertEquals(1, mainActions)
+            assertEquals(0, upgrades)
+        }
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionEngineTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionEngineTest.kt
@@ -134,9 +134,16 @@ internal class DashboardMainActionEngineTest : BaseTest() {
         corpseFinderOneClick: Boolean = true,
         otherToolsOneClick: Boolean = false,
         appCleanerOneClick: Boolean = otherToolsOneClick,
+        deduplicatorOneClick: Boolean = otherToolsOneClick,
         corpseData: CorpseFinder.Data? = null,
         appData: AppCleaner.Data? = null,
+        dedupeData: Deduplicator.Data? = null,
         isPro: Boolean = false,
+        /**
+         * What `isProForUi()` sees, which the branches consult instead of the combine's upgrade
+         * flow. Defaults to [isPro]; set it apart to stage the fail-open mismatch between the two.
+         */
+        repoIsPro: Boolean = isPro,
         failingTaskType: Class<out SDMTool.Task>? = null,
         onUpgradeRequired: () -> Unit = {},
         gate: CompletableDeferred<Unit>? = null,
@@ -160,13 +167,13 @@ internal class DashboardMainActionEngineTest : BaseTest() {
             every { state } returns MutableStateFlow(mockk(relaxed = true) { every { data } returns appData })
         }
         val deduplicator = mockk<Deduplicator>(relaxed = true).apply {
-            every { state } returns MutableStateFlow(mockk(relaxed = true) { every { data } returns null })
+            every { state } returns MutableStateFlow(mockk(relaxed = true) { every { data } returns dedupeData })
         }
         val generalSettings = mockk<GeneralSettings>(relaxed = true).apply {
             every { oneClickCorpseFinderEnabled } returns mockBool(corpseFinderOneClick)
             every { oneClickSystemCleanerEnabled } returns mockBool(otherToolsOneClick)
             every { oneClickAppCleanerEnabled } returns mockBool(appCleanerOneClick)
-            every { oneClickDeduplicatorEnabled } returns mockBool(otherToolsOneClick)
+            every { oneClickDeduplicatorEnabled } returns mockBool(deduplicatorOneClick)
             every { enableDashboardOneClick } returns mockBool(false)
         }
         val submittedTasks = mutableListOf<SDMTool.Task>()
@@ -190,7 +197,7 @@ internal class DashboardMainActionEngineTest : BaseTest() {
             upgradeRepo = mockk<UpgradeRepo>(relaxed = true) {
                 // isProForUi() reads isPro and isSettled off the same Info; an unsettled mock would
                 // make it wait out its timeout and then fail open to Pro.
-                every { upgradeInfo } returns flowOf(upgradeInfoMock(isPro))
+                every { upgradeInfo } returns flowOf(upgradeInfoMock(repoIsPro))
             },
             upgradeInfo = flowOf(upgradeInfoMock(isPro)),
             submitTask = { task ->
@@ -741,6 +748,93 @@ internal class DashboardMainActionEngineTest : BaseTest() {
             h.taskState.value = completedScanState(Instant.now())
 
             h.barState().heroSummary?.mode shouldBe HeroSummary.Mode.FREEABLE
+        } finally {
+            h.engineScope.cancel()
+        }
+    }
+
+    @Test
+    fun `a non-Pro Deduplicator-only scan produces a locked-only hero`() {
+        // The case the old DELETE-only hero gate swallowed: without Pro the Deduplicator never arms
+        // DELETE, so the main action resolves to SCAN and buildHeroSummary was never reached — the
+        // findings were invisible with no card at all. A builder unit test cannot catch that.
+        val lockedSpace = 42L * 1024 * 1024
+        val dedupeData = Deduplicator.Data(
+            clusters = setOf(
+                mockk<Duplicate.Cluster>(relaxed = true) {
+                    every { redundantSize } returns lockedSpace
+                    every { redundantCount } returns 4
+                },
+            ),
+        )
+        val h = harness(
+            corpseFinderOneClick = false,
+            deduplicatorOneClick = true,
+            dedupeData = dedupeData,
+            isPro = false,
+        )
+
+        try {
+            val bar = h.barState()
+
+            bar.actionState shouldBe BottomBarState.Action.SCAN
+            val hero = bar.heroSummary!!
+            hero.mode shouldBe HeroSummary.Mode.LOCKED_ONLY
+            hero.totalSize shouldBe 0L
+            hero.lockedSize shouldBe lockedSpace
+            hero.lockedTools.map { it.type } shouldBe listOf(SDMTool.Type.DEDUPLICATOR)
+        } finally {
+            h.engineScope.cancel()
+        }
+    }
+
+    @Test
+    fun `a zero-result cleanup still reports what stayed locked`() {
+        // The cleanup ran on the free tool and freed nothing, while AppCleaner's findings sat there
+        // unclaimed behind Pro — exactly the moment worth surfacing the upsell.
+        val h = harness(
+            corpseData = corpseData(),
+            appData = AppCleaner.Data(
+                junks = listOf(mockk(relaxed = true) { every { size } returns 999L; every { itemCount } returns 7 }),
+            ),
+            appCleanerOneClick = true,
+            isPro = false,
+        )
+
+        try {
+            h.engine.mainAction(BottomBarState.Action.DELETE)
+
+            val hero = h.barState().heroSummary!!
+            hero.mode shouldBe HeroSummary.Mode.NOTHING_FREED
+            hero.lockedTools.map { it.type } shouldBe listOf(SDMTool.Type.APPCLEANER)
+            hero.lockedSize shouldBe 999L
+        } finally {
+            h.engineScope.cancel()
+        }
+    }
+
+    @Test
+    fun `a tool the cleanup did submit to is residue, never also locked`() {
+        // isProForUi() fails open to true, so a cleanup can submit a Pro-gated tool while the
+        // combine's upgrade flow still reports non-Pro. Without the submitted-set filter the same
+        // bytes would be counted twice under contradictory framing: "999 B left" next to
+        // "unlock 999 B more with Pro".
+        val h = harness(
+            corpseFinderOneClick = false,
+            appData = AppCleaner.Data(
+                junks = listOf(mockk(relaxed = true) { every { size } returns 999L; every { itemCount } returns 7 }),
+            ),
+            appCleanerOneClick = true,
+            isPro = false,
+            repoIsPro = true,
+        )
+
+        try {
+            h.engine.mainAction(BottomBarState.Action.DELETE)
+
+            val hero = h.barState().heroSummary!!
+            hero.residueCount shouldBe 7
+            hero.lockedTools.shouldBeEmpty()
         } finally {
             h.engineScope.cancel()
         }

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardHeroCardTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardHeroCardTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertHasNoClickAction
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -22,8 +23,11 @@ import eu.darken.sdmse.common.R as CommonR
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import eu.darken.sdmse.main.ui.dashboard.BottomBarState
 import eu.darken.sdmse.main.ui.dashboard.HeroSummary
+import eu.darken.sdmse.main.ui.dashboard.showsUpgradeBlock
 import eu.darken.sdmse.main.core.SDMTool
+import io.kotest.matchers.shouldBe
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.robolectric.annotation.Config
 import testhelpers.compose.BaseComposeRobolectricTest
@@ -78,7 +82,13 @@ class DashboardHeroCardTest : BaseComposeRobolectricTest() {
         composeRule.onNodeWithText("can be removed", substring = true).assertExists()
     }
 
-    private fun renderHero(hero: HeroSummary, fontScale: Float = 1f) {
+    private fun renderHero(
+        hero: HeroSummary,
+        fontScale: Float = 1f,
+        now: Instant = Instant.EPOCH,
+        onUpgrade: () -> Unit = {},
+        onLockedToolClick: (SDMTool.Type) -> Unit = {},
+    ) {
         composeRule.setContent {
             val base = LocalDensity.current
             CompositionLocalProvider(
@@ -86,13 +96,14 @@ class DashboardHeroCardTest : BaseComposeRobolectricTest() {
             ) {
                 PreviewWrapper {
                 BottomBar(
-                    state = deleteState(hero),
+                    state = deleteState(hero, now = now),
                     isVisible = true,
                     heroVisible = true,
                     onMainAction = {},
                     onSettings = {},
-                    onUpgrade = {},
+                    onUpgrade = onUpgrade,
                     onDismissHero = {},
+                    onLockedToolClick = onLockedToolClick,
                     )
                 }
             }
@@ -199,6 +210,15 @@ class DashboardHeroCardTest : BaseComposeRobolectricTest() {
         // row), a leftover line, and Android's largest accessibility font scale. If the budget is
         // too tight, the last things laid out drop off the bottom — so assert the leftover line and
         // the hint below it are actually on screen, not merely composed.
+        //
+        // Font scale 2.0 ONLY — do NOT add a 1.0 sibling. One was written and removed after being
+        // measured: this harness has stub font metrics, so it cannot answer that question. A
+        // bodyMedium line measures 36.0dp here against a real line height of 20dp, and text width is
+        // a flat 1.0dp-per-character stub that ignores the font scale entirely (the headline
+        // "2.00 GB freed" measures 13.0dp wide), so nothing ever wraps. At 1.0 those inflated line
+        // heights push the hint off the card in the harness while it renders fine on a device — the
+        // test would fail for a reason that does not exist. At 2.0 the fixed-dp parts of the body
+        // are proportionally small enough that the distortion no longer decides the outcome.
         val freed = HeroSummary(
             mode = HeroSummary.Mode.FREED,
             totalSize = 2L * 1024 * 1024 * 1024,
@@ -536,6 +556,313 @@ class DashboardHeroCardTest : BaseComposeRobolectricTest() {
             }
         }
         composeRule.onNodeWithText("ago", substring = true).assertDoesNotExist()
+    }
+
+    private val appCleanerName get() = context.getString(CommonR.string.appcleaner_tool_name)
+    private val deduplicatorName get() = context.getString(CommonR.string.deduplicator_tool_name)
+
+    private fun lockedOnly(lockedSize: Long = 512L * 1024 * 1024, lockedCount: Int = 9) = HeroSummary(
+        mode = HeroSummary.Mode.LOCKED_ONLY,
+        totalSize = 0L,
+        itemCount = 0,
+        tools = emptyList(),
+        lockedTools = listOf(HeroSummary.ToolSlice(SDMTool.Type.APPCLEANER, lockedSize, lockedCount)),
+    )
+
+    @Test
+    fun `locked findings render as a chip identified by the tool name`() {
+        val locked = lockedOnly()
+        renderHero(locked)
+
+        composeRule.onNodeWithContentDescription(appCleanerName).assertIsDisplayed()
+        composeRule.onNodeWithText(ByteFormatter.formatSize(context, locked.lockedSize).first).assertExists()
+    }
+
+    @Test
+    fun `a locked chip routes through onLockedToolClick, not the mode-routed tool click`() {
+        // A locked tool has no report to open — it was never cleaned — so it must not share the
+        // chip callback that routes FREED chips to reports.
+        var lockedClicks = 0
+        var clickedType: SDMTool.Type? = null
+        renderHero(lockedOnly(), onLockedToolClick = { lockedClicks++; clickedType = it })
+
+        composeRule.onNodeWithContentDescription(appCleanerName)
+            .assertHasClickAction()
+            .performSemanticsAction(SemanticsActions.OnClick)
+        composeRule.runOnIdle {
+            assertEquals(1, lockedClicks)
+            assertEquals(SDMTool.Type.APPCLEANER, clickedType)
+        }
+    }
+
+    @Test
+    fun `the locked-only hero headlines the locked size and shows no freeable chips`() {
+        val locked = lockedOnly()
+        renderHero(locked)
+
+        // The headline splices in the *locked* size — totalSize is 0 in this mode by design, and
+        // the size-interpolating path would otherwise print "0 B".
+        composeRule.onNodeWithText(
+            context.getString(
+                R.string.dashboard_hero_locked_headline,
+                ByteFormatter.formatSize(context, locked.lockedSize).first,
+            ),
+        ).assertExists()
+        composeRule.onNodeWithContentDescription(
+            context.getString(CommonR.string.corpsefinder_tool_name),
+        ).assertDoesNotExist()
+    }
+
+    @Test
+    fun `tapping the upsell line opens the upgrade screen`() {
+        var upgrades = 0
+        renderHero(lockedOnly(), onUpgrade = { upgrades++ })
+
+        composeRule.onNodeWithText(context.getString(R.string.dashboard_hero_locked_hint))
+            .assertHasClickAction()
+            .performSemanticsAction(SemanticsActions.OnClick)
+        composeRule.runOnIdle { assertEquals(1, upgrades) }
+    }
+
+    @Test
+    fun `a nothing-freed hero keeps its own hint while still showing locked chips`() {
+        // That hint diagnoses why the cleanup came up empty; an unlock line must not displace it.
+        // With no free chips there is nothing for a nested block to be additional to, so the locked
+        // chips stay flat in the main row and the card keeps its base height.
+        val nothingFreed = HeroSummary(
+            mode = HeroSummary.Mode.NOTHING_FREED,
+            totalSize = 0L,
+            itemCount = 0,
+            tools = emptyList(),
+            lockedTools = listOf(HeroSummary.ToolSlice(SDMTool.Type.APPCLEANER, 512L * 1024 * 1024, 9)),
+        )
+        nothingFreed.showsUpgradeBlock shouldBe false
+        renderHero(nothingFreed)
+
+        composeRule.onNodeWithText(context.getString(R.string.dashboard_hero_nothing_freed_hint)).assertExists()
+        composeRule.onNodeWithContentDescription(appCleanerName).assertIsDisplayed()
+        composeRule.onNodeWithText(blockCaption).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a locked-only hero renders flat, without the nested block`() {
+        val locked = lockedOnly()
+        locked.showsUpgradeBlock shouldBe false
+        renderHero(locked)
+
+        composeRule.onNodeWithContentDescription(appCleanerName).assertIsDisplayed()
+        composeRule.onNodeWithText(blockCaption).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the collapsed bar chip shows the locked size instead of zero`() {
+        val locked = lockedOnly()
+        composeRule.setContent {
+            PreviewWrapper {
+                BottomBar(
+                    state = deleteState(locked),
+                    isVisible = true,
+                    heroVisible = false,
+                    canExpandHero = true,
+                    onMainAction = {},
+                    onSettings = {},
+                    onUpgrade = {},
+                    onDismissHero = {},
+                )
+            }
+        }
+        composeRule.onNodeWithText(ByteFormatter.formatSize(context, locked.lockedSize).first).assertExists()
+        composeRule.onNodeWithText(ByteFormatter.formatSize(context, 0L).first).assertDoesNotExist()
+        // The star is not decorative here: without this the chip announces a bare size with no
+        // indication that the space is out of reach.
+        composeRule.onNodeWithContentDescription(
+            context.getString(R.string.dashboard_hero_locked_chip_description),
+            substring = true,
+        ).assertExists()
+    }
+
+    private val blockCaption get() = context.getString(R.string.dashboard_hero_locked_block_caption)
+
+    private val freedAt = Instant.parse("2026-06-10T12:00:00Z")
+
+    private fun freedWithLocked() = HeroSummary(
+        mode = HeroSummary.Mode.FREED,
+        totalSize = 2L * 1024 * 1024 * 1024,
+        itemCount = 8147,
+        tools = listOf(
+            HeroSummary.ToolSlice(SDMTool.Type.CORPSEFINDER, 129L * 1024, 12),
+            HeroSummary.ToolSlice(SDMTool.Type.SYSTEMCLEANER, 852L * 1024 * 1024, 51),
+        ),
+        timestamp = freedAt,
+        residueSize = 5L * 1024 * 1024,
+        residueCount = 2,
+        lockedTools = listOf(
+            HeroSummary.ToolSlice(SDMTool.Type.APPCLEANER, 87L * 1024 * 1024, 498),
+            HeroSummary.ToolSlice(SDMTool.Type.DEDUPLICATOR, 32L * 1024 * 1024, 60),
+        ),
+    )
+
+    @Test
+    fun `the nested upgrade block and everything under it survive the largest font scale`() {
+        // The fullest the card ever gets: a freed result with a leftover line and its own chip row,
+        // plus the nested block with two more chips, at Android's largest accessibility font scale.
+        // The block is what the taller base height exists for, so assert its caption, its chips, the
+        // leftover line above it and the footer below it are all on screen rather than merely
+        // composed. Font scale 2.0 only — see the note on the sibling test above.
+        val hero = freedWithLocked()
+        val now = freedAt.plusSeconds(5 * 60)
+        hero.showsUpgradeBlock shouldBe true
+        renderHero(hero, fontScale = 2f, now = now)
+
+        composeRule.onNodeWithText(blockCaption).assertIsDisplayed()
+        composeRule.onNodeWithContentDescription(appCleanerName).assertIsDisplayed()
+        composeRule.onNodeWithContentDescription(
+            context.getString(CommonR.string.deduplicator_tool_name),
+        ).assertIsDisplayed()
+        composeRule.onNodeWithText("left", substring = true).assertIsDisplayed()
+        // The footer sits below everything; if the block overran the budget this is what it buries.
+        val relativeTime = DateUtils.getRelativeTimeSpanString(
+            freedAt.toEpochMilli(),
+            now.toEpochMilli(),
+            DateUtils.MINUTE_IN_MILLIS,
+        ).toString()
+        composeRule.onNodeWithText(relativeTime).assertIsDisplayed()
+    }
+
+    /**
+     * A FREED summary carrying three free chips beside the block. Reachable despite the two-chip
+     * ceiling that holds for FREEABLE: FREED summaries are not built by `buildHeroSummary` at all —
+     * `accumulateFreed` assembles their tools from whichever tools ran, with no entitlement filter,
+     * and `lockedTools` is recomputed from live inputs on every emission, filtered only against the
+     * tools the run submitted to.
+     *
+     * One reachable path: a Pro user cleans CorpseFinder, SystemCleaner and AppCleaner while
+     * Deduplicator is disabled in one-tap; afterward the entitlement lapses and Deduplicator is
+     * enabled while its findings remain. The three cleaned slices stay in `tools`, while the
+     * never-submitted Deduplicator enters `lockedTools`.
+     *
+     * Every clause of that is load-bearing. `lockedSlices` returns nothing at all while `isPro`, so
+     * the lapse alone is not enough; and had Deduplicator been enabled with findings during the
+     * cleanup, the DELETE branch would have submitted it, after which the settled path's filter
+     * against the run's submitted set drops it from `lockedTools` again.
+     *
+     * The fail-open `isProForUi()` read reaches the same shape, but only when the dashboard's own
+     * upgrade flow reports non-Pro AND Deduplicator independently satisfies `lockedSlices`: enabled,
+     * with findings, never submitted.
+     */
+    private fun freedWithThreeFreeAndLocked(): HeroSummary {
+        val tools = listOf(
+            HeroSummary.ToolSlice(SDMTool.Type.CORPSEFINDER, 129L * 1024, 12),
+            HeroSummary.ToolSlice(SDMTool.Type.SYSTEMCLEANER, 852L * 1024 * 1024, 51),
+            HeroSummary.ToolSlice(SDMTool.Type.APPCLEANER, 512L * 1024 * 1024, 87),
+        )
+        return HeroSummary(
+            mode = HeroSummary.Mode.FREED,
+            totalSize = tools.sumOf { it.size },
+            itemCount = tools.sumOf { it.count },
+            tools = tools,
+            timestamp = freedAt,
+            residueSize = 5L * 1024 * 1024,
+            residueCount = 2,
+            lockedTools = listOf(
+                HeroSummary.ToolSlice(SDMTool.Type.DEDUPLICATOR, 32L * 1024 * 1024, 60),
+            ),
+        )
+    }
+
+    @Test
+    fun `three free chips beside the block still fit at the largest font scale`() {
+        // The free chip row is capped at two chips only for FREEABLE summaries; a FREED one can carry
+        // three and still show the block, which is more content than the taller height was first
+        // rendered against. Same assertions as the sibling above: the block, the leftover line above
+        // it and the footer below it must all be on screen, not merely composed.
+        val hero = freedWithThreeFreeAndLocked()
+        val now = freedAt.plusSeconds(5 * 60)
+        hero.showsUpgradeBlock shouldBe true
+        renderHero(hero, fontScale = 2f, now = now)
+
+        composeRule.onNodeWithText(blockCaption).assertIsDisplayed()
+        composeRule.onNodeWithContentDescription(
+            context.getString(CommonR.string.deduplicator_tool_name),
+        ).assertIsDisplayed()
+        composeRule.onNodeWithText("left", substring = true).assertIsDisplayed()
+        val relativeTime = DateUtils.getRelativeTimeSpanString(
+            freedAt.toEpochMilli(),
+            now.toEpochMilli(),
+            DateUtils.MINUTE_IN_MILLIS,
+        ).toString()
+        composeRule.onNodeWithText(relativeTime).assertIsDisplayed()
+    }
+
+    @Test
+    @Config(qualifiers = "w350dp-h900dp")
+    fun `the block clears the footer on a narrow display at the largest font scale`() {
+        // The header's geometry has to live on the header Row: padding on the dismiss button comes
+        // out of the text column's weight(1f) share, and on a narrow display at a large font scale
+        // that is enough to wrap the caption onto an extra line and push the block into the footer.
+        //
+        // Compared by bounds rather than assertIsDisplayed(): that assertion passes on any sliver of
+        // visibility, so it would happily accept the block's last row sitting half under the footer.
+        val hero = freedWithThreeFreeAndLocked()
+        val now = freedAt.plusSeconds(5 * 60)
+        renderHero(hero, fontScale = 2f, now = now)
+
+        val relativeTime = DateUtils.getRelativeTimeSpanString(
+            freedAt.toEpochMilli(),
+            now.toEpochMilli(),
+            DateUtils.MINUTE_IN_MILLIS,
+        ).toString()
+        val chipBottom = composeRule.onNodeWithContentDescription(deduplicatorName)
+            .getUnclippedBoundsInRoot().bottom
+        val footerTop = composeRule.onNodeWithText(relativeTime).getUnclippedBoundsInRoot().top
+        assertTrue(
+            "locked chip bottom=$chipBottom must sit strictly above footer top=$footerTop",
+            chipBottom < footerTop,
+        )
+    }
+
+    @Test
+    fun `a chip inside the block opens its tool and does not trigger the upgrade`() {
+        var upgrades = 0
+        var clickedType: SDMTool.Type? = null
+        renderHero(
+            freedWithLocked(),
+            fontScale = 2f,
+            onUpgrade = { upgrades++ },
+            onLockedToolClick = { clickedType = it },
+        )
+
+        composeRule.onNodeWithContentDescription(appCleanerName)
+            .assertHasClickAction()
+            .performSemanticsAction(SemanticsActions.OnClick)
+        composeRule.runOnIdle {
+            assertEquals(SDMTool.Type.APPCLEANER, clickedType)
+            // The chip consumes its own tap; the block's upgrade action must not fire as well.
+            assertEquals(0, upgrades)
+        }
+    }
+
+    @Test
+    fun `tapping the block outside a chip opens the upgrade screen`() {
+        var upgrades = 0
+        var lockedClicks = 0
+        val hero = freedWithLocked()
+        renderHero(
+            hero,
+            fontScale = 2f,
+            onUpgrade = { upgrades++ },
+            onLockedToolClick = { lockedClicks++ },
+        )
+
+        // The caption belongs to the block's own (merging) clickable node, so activating it is the
+        // "tapped the block, not a chip" case.
+        composeRule.onNodeWithText(blockCaption)
+            .assertHasClickAction()
+            .performSemanticsAction(SemanticsActions.OnClick)
+        composeRule.runOnIdle {
+            assertEquals(1, upgrades)
+            assertEquals(0, lockedClicks)
+        }
     }
 
     @Test

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardHeroHeightScalingTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardHeroHeightScalingTest.kt
@@ -17,17 +17,29 @@ class DashboardHeroHeightScalingTest : BaseComposeRobolectricTest() {
 
     private data class Heights(val card: Dp, val dock: Dp)
 
+    /** Both card variants at one font scale: without the nested upgrade block, and with it. */
+    private data class ScaleHeights(val flat: Heights, val withBlock: Heights)
+
     /**
-     * Reads the @Composable height getters under each [fontScale] in a single composition —
+     * Reads the @Composable height functions under each [fontScale] in a single composition —
      * [androidx.compose.ui.test.junit4.ComposeContentTestRule.setContent] may only be called once
      * per test, so every scale a test needs is captured here together.
      */
-    private fun heightsAt(vararg fontScales: Float): Map<Float, Heights> {
-        val out = linkedMapOf<Float, Heights>()
+    private fun heightsAt(vararg fontScales: Float): Map<Float, ScaleHeights> {
+        val out = linkedMapOf<Float, ScaleHeights>()
         composeRule.setContent {
             fontScales.forEach { scale ->
                 CompositionLocalProvider(LocalDensity provides Density(density = 2.75f, fontScale = scale)) {
-                    out[scale] = Heights(card = dashboardHeroCardHeight, dock = dashboardDockHeightWithHero)
+                    out[scale] = ScaleHeights(
+                        flat = Heights(
+                            card = dashboardHeroCardHeight(withUpgradeBlock = false),
+                            dock = dashboardDockHeightWithHero(withUpgradeBlock = false),
+                        ),
+                        withBlock = Heights(
+                            card = dashboardHeroCardHeight(withUpgradeBlock = true),
+                            dock = dashboardDockHeightWithHero(withUpgradeBlock = true),
+                        ),
+                    )
                 }
             }
         }
@@ -36,30 +48,55 @@ class DashboardHeroHeightScalingTest : BaseComposeRobolectricTest() {
     }
 
     private val baselineCard = DASHBOARD_HERO_CONTENT_HEIGHT + DASHBOARD_CUTOUT_DEPTH
+    private val baselineBlockCard = DASHBOARD_HERO_CONTENT_HEIGHT_WITH_BLOCK + DASHBOARD_CUTOUT_DEPTH
 
     @Test
     fun `card height tracks font scale`() {
         val h = heightsAt(1.0f, 1.5f)
-        h.getValue(1.0f).card shouldBe baselineCard
-        h.getValue(1.5f).card shouldBe DASHBOARD_HERO_CONTENT_HEIGHT * 1.5f + DASHBOARD_CUTOUT_DEPTH
+        h.getValue(1.0f).flat.card shouldBe baselineCard
+        h.getValue(1.5f).flat.card shouldBe DASHBOARD_HERO_CONTENT_HEIGHT * 1.5f + DASHBOARD_CUTOUT_DEPTH
     }
 
     @Test
     fun `growth is clamped at 2x`() {
         val h = heightsAt(2.0f, 2.5f)
-        h.getValue(2.0f).card shouldBe DASHBOARD_HERO_CONTENT_HEIGHT * 2.0f + DASHBOARD_CUTOUT_DEPTH
+        h.getValue(2.0f).flat.card shouldBe DASHBOARD_HERO_CONTENT_HEIGHT * 2.0f + DASHBOARD_CUTOUT_DEPTH
         // Past the 2.0 ceiling the card stops growing instead of eating the screen.
-        h.getValue(2.5f).card shouldBe h.getValue(2.0f).card
+        h.getValue(2.5f).flat.card shouldBe h.getValue(2.0f).flat.card
     }
 
     @Test
     fun `never shrinks below the font-scale-1 baseline`() {
-        heightsAt(0.85f).getValue(0.85f).card shouldBe baselineCard
+        heightsAt(0.85f).getValue(0.85f).flat.card shouldBe baselineCard
     }
 
     @Test
     fun `dock reservation is bar plus gap plus the scaled card`() {
-        val h = heightsAt(1.5f).getValue(1.5f)
+        val h = heightsAt(1.5f).getValue(1.5f).flat
         h.dock shouldBe DASHBOARD_BAR_HEIGHT + DASHBOARD_HERO_BAR_GAP + h.card
+    }
+
+    @Test
+    fun `the upgrade block gets the taller base, scaled the same way`() {
+        // Only the base height differs; the font-scale multiplier and the fixed cradle notch are the
+        // same, so the two variants can never drift apart in how they respond to font size.
+        val h = heightsAt(1.0f, 1.5f)
+        h.getValue(1.0f).withBlock.card shouldBe baselineBlockCard
+        h.getValue(1.5f).withBlock.card shouldBe DASHBOARD_HERO_CONTENT_HEIGHT_WITH_BLOCK * 1.5f + DASHBOARD_CUTOUT_DEPTH
+    }
+
+    @Test
+    fun `the block variant is taller than the flat one at every scale`() {
+        val h = heightsAt(1.0f, 2.0f)
+        h.values.forEach { (flat, withBlock) ->
+            (withBlock.card > flat.card) shouldBe true
+            withBlock.dock shouldBe DASHBOARD_BAR_HEIGHT + DASHBOARD_HERO_BAR_GAP + withBlock.card
+        }
+    }
+
+    @Test
+    fun `the block variant is also clamped at 2x`() {
+        val h = heightsAt(2.0f, 2.5f)
+        h.getValue(2.5f).withBlock.card shouldBe h.getValue(2.0f).withBlock.card
     }
 }


### PR DESCRIPTION
## What changed

Without SD Maid Pro, anything AppCleaner or the Deduplicator found was left out of the dashboard's result card completely. The card only counted what the one-tap button could actually delete, so those results simply vanished — and if they were the only things found, no card appeared at all. The button still turned red, still asked you to confirm a deletion, and then opened the upgrade screen without deleting anything.

Now those results are shown. When there is also something to clean for free, they appear in their own "More can be freed with SD Maid Pro" section underneath the normal results, each with its tool's icon and size. When they are the only thing found, the card says so directly instead of staying hidden. Tapping that section opens the upgrade screen; tapping a result still opens its tool, so you can look at what was found before deciding anything.

The one-tap button no longer offers a deletion it cannot perform — in that state it goes straight to the upgrade screen, with no confirmation dialog in between.

## Technical Context

- `HeroSummary` gains `lockedTools` and a `LOCKED_ONLY` mode. `totalSize`/`itemCount` deliberately stay `0` in that mode: they mean "what the main action will free" everywhere else, and the bar's collapsed chip reads `totalSize` directly.

- **The hunk most worth reviewing** is the hero gate in `heroState`, relaxed from `actionState == DELETE && phase.isSettled` to `phase.isSettled` plus a not-working check. This is required rather than cosmetic: a non-Pro Deduplicator-only state resolves to `SCAN`, never `DELETE`, so the old gate would have kept the new card permanently hidden for it. It is behaviour-preserving for the free-tool case because `resolveMainAction`'s DELETE conditions are exactly `buildHeroSummary`'s inclusion conditions — the builder was already the filter — but it is a change to a heavily-commented state machine and deserves a careful read.

- A DELETE tap on a `LOCKED_ONLY` card navigates directly instead of re-entering the engine. That is a safety property, not a shortcut: the card's verdict comes from the dashboard's `upgradeInfo` flow, while the engine's branches re-check `isProForUi()`, which **fails open to `true` on any exception**. Handing the tap back could therefore reach `runCleanup()` and delete for real on a screen that had just skipped the confirmation dialog.

- The same fail-open path is why the freed card's locked slices are filtered against `provenance.submitted`. Without it, a tool submitted under a failed entitlement read would be counted by both `residueOf` and `lockedSlices`, reporting the same bytes twice under contradictory framing ("5 MB left" next to "unlock 5 MB more"). The filter makes them disjoint by construction rather than by argument.

- Card body height becomes conditional: 156dp normally, 215dp only when the nested block is present. `DashboardHeroCard`'s render branch and `DashboardBottomBar`'s height reservation both read a single predicate, `HeroSummary.showsUpgradeBlock`, so they cannot diverge and leave the card clipped or the dock reserving dead space.

### On the tests

Two rendered font-scale-1.0 bounds tests were **deleted**, with the reason recorded in the surviving test so they are not reintroduced. Robolectric measures text at roughly 1dp per character and inflates `bodyMedium` line height to 36dp against a real ~20dp, so those assertions failed against content that already ships on `main` — they were measuring the harness, not the layout.

Related caveat, stated rather than buried: the 350dp/font-scale-2 bounds test accompanying the header-width change is a **gross-overflow guard only**. It was mutation-tested — the regression was reintroduced and the test still passed — because a 16dp column-width change cannot move the wrap point of a string the harness thinks is 18dp wide. The code change is verifiable by reading the layout; genuine automated cover for it would need the `screenshotTest` source set.

Verified by hand on a non-Pro FOSS build on an emulator: both card shapes render un-clipped, and both the upgrade block and the main action reach the upgrade screen.
