### PR TITLE
SystemCleaner: Fix search preview hidden behind the navigation bar

### DIFF
--- a/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/CustomFilterEditorScreen.kt
+++ b/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/CustomFilterEditorScreen.kt
@@ -5,14 +5,18 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.Close
 import androidx.compose.material.icons.twotone.Delete
 import androidx.compose.material.icons.twotone.Save
+import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.BottomSheetScaffold
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
@@ -31,6 +35,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -55,6 +61,29 @@ internal sealed interface EditorPendingDialog {
     data object Remove : EditorPendingDialog
     data object UnsavedChanges : EditorPendingDialog
 }
+
+/** First-frame guess for the live-search summary row, replaced by the measured height. */
+private val LIVESEARCH_SUMMARY_FALLBACK = 56.dp
+
+/**
+ * Strictly less than [LiveSearchRow]'s 36dp single-line height (20dp icon + 2x8dp padding), so the
+ * hinted match row is always visibly clipped. A fully visible row would read as "that's all of
+ * them" instead of "there is more, drag up".
+ */
+private val LIVESEARCH_MATCH_ROW_PEEK = 24.dp
+
+/**
+ * [BottomSheetScaffold] measures the peek band from the physical window bottom and applies no
+ * window insets, so the navigation bar inset has to be part of the peek height, as does the drag
+ * handle that is rendered above the sheet content.
+ */
+internal fun liveSearchPeekHeight(
+    dragHandleHeight: Dp,
+    summaryHeight: Dp,
+    hasMatches: Boolean,
+    navigationBarBottom: Dp,
+    matchRowPeek: Dp = LIVESEARCH_MATCH_ROW_PEEK,
+): Dp = dragHandleHeight + summaryHeight + (if (hasMatches) matchRowPeek else 0.dp) + navigationBarBottom
 
 @Composable
 fun CustomFilterEditorScreenHost(
@@ -172,14 +201,19 @@ internal fun CustomFilterEditorScreen(
     )
     val scaffoldState = rememberBottomSheetScaffoldState(bottomSheetState = sheetState)
 
-    val peekHeight: Dp = remember(liveSearch) {
-        when {
-            liveSearch.firstInit -> 64.dp
-            liveSearch.progress != null -> 96.dp
-            liveSearch.matches.isNotEmpty() -> 128.dp
-            else -> 64.dp
-        }
+    val density = LocalDensity.current
+    val navigationBarBottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+    var dragHandleHeight by remember { mutableStateOf(48.dp) }
+    var summaryHeight by remember(density.fontScale) {
+        mutableStateOf(LIVESEARCH_SUMMARY_FALLBACK * density.fontScale)
     }
+
+    val peekHeight: Dp = liveSearchPeekHeight(
+        dragHandleHeight = dragHandleHeight,
+        summaryHeight = summaryHeight,
+        hasMatches = liveSearch.matches.isNotEmpty(),
+        navigationBarBottom = navigationBarBottom,
+    )
 
     val isExpanded by remember { derivedStateOf { sheetState.currentValue == SheetValue.Expanded } }
 
@@ -194,11 +228,22 @@ internal fun CustomFilterEditorScreen(
         scaffoldState = scaffoldState,
         sheetPeekHeight = peekHeight,
         sheetSwipeEnabled = !liveSearch.firstInit,
+        sheetDragHandle = {
+            Box(
+                modifier = Modifier.onSizeChanged { size ->
+                    val measured = with(density) { size.height.toDp() }
+                    if (measured != dragHandleHeight) dragHandleHeight = measured
+                },
+            ) {
+                BottomSheetDefaults.DragHandle()
+            }
+        },
         sheetContent = {
             BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
                 LiveSearchSheetContent(
                     state = liveSearch,
                     modifier = Modifier.heightIn(max = maxHeight * 0.7f),
+                    onSummaryHeightChanged = { summaryHeight = it },
                 )
             }
         },
@@ -256,7 +301,7 @@ internal fun CustomFilterEditorScreen(
             } else {
                 CustomFilterEditorBody(
                     config = current,
-                    contentBottomPadding = peekHeight + 16.dp,
+                    contentBottomPadding = 16.dp,
                     onLabelChange = onLabelChange,
                     onAddPath = onAddPath,
                     onRemovePath = onRemovePath,

--- a/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/LiveSearchSheetContent.kt
+++ b/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/LiveSearchSheetContent.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -17,10 +18,13 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import eu.darken.sdmse.common.R as CommonR
 import eu.darken.sdmse.common.compose.icons.icon
@@ -30,13 +34,22 @@ import eu.darken.sdmse.systemcleaner.R as SystemCleanerR
 internal fun LiveSearchSheetContent(
     modifier: Modifier = Modifier,
     state: CustomFilterEditorViewModel.LiveSearchState,
+    onSummaryHeightChanged: (Dp) -> Unit = {},
 ) {
     val context = LocalContext.current
+    val density = LocalDensity.current
 
-    Column(modifier = modifier.fillMaxWidth()) {
+    // The scaffold's sheet container draws the background edge-to-edge (incl. behind the nav bar);
+    // navigationBarsPadding keeps the content above the system nav bar instead of being obscured.
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .navigationBarsPadding(),
+    ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
+                .onSizeChanged { onSummaryHeightChanged(with(density) { it.height.toDp() }) }
                 .padding(horizontal = 16.dp, vertical = 8.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {

--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/CustomFilterEditorPeekHeightTest.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/CustomFilterEditorPeekHeightTest.kt
@@ -1,0 +1,76 @@
+package eu.darken.sdmse.systemcleaner.ui.customfilter.editor
+
+import androidx.compose.ui.unit.dp
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class CustomFilterEditorPeekHeightTest : BaseTest() {
+
+    @Test
+    fun `peek height covers drag handle, summary and navigation bar`() {
+        liveSearchPeekHeight(
+            dragHandleHeight = 48.dp,
+            summaryHeight = 56.dp,
+            hasMatches = false,
+            navigationBarBottom = 48.dp,
+        ) shouldBe 152.dp
+    }
+
+    @Test
+    fun `navigation bar inset is part of the peek band`() {
+        val withoutInset = liveSearchPeekHeight(
+            dragHandleHeight = 48.dp,
+            summaryHeight = 56.dp,
+            hasMatches = false,
+            navigationBarBottom = 0.dp,
+        )
+        val withInset = liveSearchPeekHeight(
+            dragHandleHeight = 48.dp,
+            summaryHeight = 56.dp,
+            hasMatches = false,
+            navigationBarBottom = 24.dp,
+        )
+
+        (withInset - withoutInset) shouldBe 24.dp
+    }
+
+    @Test
+    fun `drag handle height is part of the peek band`() {
+        val small = liveSearchPeekHeight(
+            dragHandleHeight = 0.dp,
+            summaryHeight = 56.dp,
+            hasMatches = false,
+            navigationBarBottom = 24.dp,
+        )
+        val large = liveSearchPeekHeight(
+            dragHandleHeight = 48.dp,
+            summaryHeight = 56.dp,
+            hasMatches = false,
+            navigationBarBottom = 24.dp,
+        )
+
+        (large - small) shouldBe 48.dp
+    }
+
+    @Test
+    fun `match row hint is only added when there are matches`() {
+        val noMatches = liveSearchPeekHeight(
+            dragHandleHeight = 48.dp,
+            summaryHeight = 56.dp,
+            hasMatches = false,
+            navigationBarBottom = 24.dp,
+            matchRowPeek = 24.dp,
+        )
+        val withMatches = liveSearchPeekHeight(
+            dragHandleHeight = 48.dp,
+            summaryHeight = 56.dp,
+            hasMatches = true,
+            navigationBarBottom = 24.dp,
+            matchRowPeek = 24.dp,
+        )
+
+        noMatches shouldBe 128.dp
+        withMatches shouldBe 152.dp
+    }
+}

--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/CustomFilterEditorScreenTest.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/CustomFilterEditorScreenTest.kt
@@ -2,11 +2,15 @@ package eu.darken.sdmse.systemcleaner.ui.customfilter.editor
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.height
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import eu.darken.sdmse.common.sieve.SegmentCriterium
 import eu.darken.sdmse.systemcleaner.core.filter.custom.CustomFilterConfig
@@ -143,6 +147,37 @@ class CustomFilterEditorScreenTest : BaseComposeRobolectricTest() {
         // The label appears as the toolbar subtitle.
         composeRule.onAllNodesWithText("Typed name").fetchSemanticsNodes().size.let {
             if (it == 0) throw AssertionError("Expected typed label visible as subtitle for new filter")
+        }
+    }
+
+    @Test
+    fun `collapsed sheet peek exposes the whole live-search summary`() {
+        val state = CustomFilterEditorViewModel.State(
+            original = null,
+            current = CustomFilterConfig(identifier = "abc", label = "Test"),
+        )
+        composeRule.setEditorContent {
+            CustomFilterEditorScreen(
+                stateSource = MutableStateFlow(state),
+                liveSearchSource = MutableStateFlow(
+                    CustomFilterEditorViewModel.LiveSearchState(firstInit = true),
+                ),
+            )
+        }
+
+        val root = composeRule.onRoot().getUnclippedBoundsInRoot()
+        // firstInit renders "Live search" over "Ready"; "Ready" is the lowest element of the summary row.
+        val summary = composeRule.onNodeWithText("Ready").getUnclippedBoundsInRoot()
+
+        // The peek must cover drag handle + summary. Under the old 64dp peek the summary's bottom sat
+        // ~36dp below the window edge; 1dp of tolerance separates that from the exact-fit success case.
+        // Window insets are zero under Robolectric, so this covers the drag-handle/summary half of
+        // the peek calculation only.
+        if (summary.bottom.value >= root.height.value + 1f) {
+            throw AssertionError(
+                "Live search summary is clipped by the collapsed sheet peek: " +
+                    "summary bottom=${summary.bottom}, window height=${root.height}",
+            )
         }
     }
 }


### PR DESCRIPTION
## What changed

When creating or editing a custom filter in SystemCleaner, the search preview at the bottom of the screen was hidden behind the system navigation bar. With three-button navigation none of it was visible at all, so there was no way to see how many files the filter currently matches without first dragging the sheet open. Its summary now sits above the navigation bar, and the last results stay reachable when the preview is expanded.

The preview also grows with the system font size, so the summary stays fully visible at large accessibility font scales.

## Technical Context

- Root cause: `BottomSheetScaffold` applies no window insets. It anchors the collapsed sheet at `layoutHeight - sheetPeekHeight` measured from the physical window bottom, and the default drag handle occupies 48dp at the top of that band. The old peek was 64dp, so with a 48dp three-button navigation bar the summary row ended up 32dp *below* the screen edge.
- The peek is now composed as `measured drag handle + measured summary row + (24dp hint row when there are matches) + navigationBars bottom inset`, extracted into `liveSearchPeekHeight(...)` so the arithmetic is unit-testable. Handle and summary are measured via `onSizeChanged` rather than hardcoded — a hardcoded content height is what produced the bug in the first place, and it would have reappeared at larger font scales.
- The old three-branch peek table (64dp idle / 96dp scanning / 128dp with matches) is dropped deliberately: the summary row renders the same two lines in every state, so its measured height already covers the scanning case.
- `navigationBarsPadding()` on the sheet content fixes a second, separate symptom — the last rows of the *expanded* match list drawing under the navigation bar. The sheet's container intentionally stays edge-to-edge (Material 3 convention, matching `PickerScreen`), so rows scrolled past the hint still pass behind the transparent bar; only the summary and the hint row are guaranteed to clear it.
- `contentBottomPadding` drops from `peekHeight + 16.dp` to `16.dp`: the scaffold already hands the body `PaddingValues(bottom = sheetPeekHeight)` and the screen already applies it, so the peek was counted twice in the form's bottom gap — and correcting the peek would have made that dead space grow.
- Review guidance: the two `onSizeChanged` callbacks write Compose state from layout. They converge because assigning an identical `Dp` does not invalidate state, and the summary row's height depends on its text rather than on the peek, so there is no feedback loop.
- The Robolectric test covers the drag-handle/summary half only — window insets are zero under Robolectric. The inset half was checked on an emulator in three configurations (three-button navigation, gesture navigation, and 200% font scale), comparing the collapsed summary, the expanded list's last row, and the form's bottom gap against the navigation bar frame measured from `dumpsys window` in each.
