### PR TITLE
SystemCleaner: Edit custom filter entries without deleting the others

### DIFF
--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/dialog/SdmDialogButtonBar.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/dialog/SdmDialogButtonBar.kt
@@ -34,6 +34,9 @@ private val VerticalSpacing = 2.dp
  * wins (first in positive/negative/neutral order), otherwise the negative (cancel) when present,
  * else the positive. Without this the framework picks spatially, i.e. whatever button happens to
  * sit leftmost — for destructive confirms the safe default must be the cancel action.
+ *
+ * Dialogs whose content owns focus (anything with a text field) must pass [autoFocus] = false,
+ * otherwise the bar takes the focus the field just requested and typing goes nowhere.
  */
 @Composable
 fun SdmDialogButtonBar(
@@ -41,6 +44,7 @@ fun SdmDialogButtonBar(
     positive: SdmDialogAction,
     negative: SdmDialogAction? = null,
     neutral: SdmDialogAction? = null,
+    autoFocus: Boolean = true,
 ) {
     val focusTarget = listOfNotNull(positive, negative, neutral).firstOrNull { it.initialFocus }
         ?: negative
@@ -50,9 +54,15 @@ fun SdmDialogButtonBar(
     // and would re-yank focus from wherever the user moved it. In touch mode the request fails
     // silently (buttons aren't touch-focusable); the first remote/keyboard key flips the mode
     // and re-runs this to claim focus properly.
+    //
+    // That re-claim is also why [autoFocus] exists: a dialog with a text field flips the mode on
+    // every keystroke typed on a hardware keyboard, so the re-claim would fire per letter and
+    // drag focus off the field mid-word. Those dialogs opt out rather than the bar guessing.
     val inputModeManager = LocalInputModeManager.current
-    LaunchedEffect(inputModeManager.inputMode) {
-        runCatching { focusRequester.requestFocus() }
+    if (autoFocus) {
+        LaunchedEffect(inputModeManager.inputMode) {
+            runCatching { focusRequester.requestFocus() }
+        }
     }
     Layout(
         modifier = modifier.fillMaxWidth(),

--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/focus/DpadFieldEscape.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/focus/DpadFieldEscape.kt
@@ -1,0 +1,40 @@
+package eu.darken.sdmse.common.compose.focus
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.LocalFocusManager
+
+/**
+ * Lets D-pad UP/DOWN move focus out of a single-line text field.
+ *
+ * A focused text field consumes the vertical keys for caret movement, so on a device with no TAB
+ * key — i.e. every TV remote — a field that holds focus is a trap: the user can type and can back
+ * out, but can never reach the dialog's buttons. Handled as a *preview* event so it runs before
+ * the field's own key handling, which would otherwise swallow the key first.
+ *
+ * ONLY for `singleLine` fields, where vertical keys have no legitimate caret use. On a multi-line
+ * field this would steal line-to-line navigation.
+ *
+ * Consumes the key only when focus actually moved, matching the convention used elsewhere for
+ * D-pad bridging: with nothing to move to, the key falls through to the default handling rather
+ * than being silently eaten.
+ */
+@Composable
+fun Modifier.dpadVerticalFieldEscape(): Modifier {
+    val focusManager = LocalFocusManager.current
+    return onPreviewKeyEvent { event ->
+        if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
+        val direction = when (event.key) {
+            Key.DirectionUp -> FocusDirection.Up
+            Key.DirectionDown -> FocusDirection.Down
+            else -> return@onPreviewKeyEvent false
+        }
+        focusManager.moveFocus(direction)
+    }
+}

--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/settings/dialogs/AgeInputDialog.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/settings/dialogs/AgeInputDialog.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.unit.dp
 import eu.darken.sdmse.common.R
 import eu.darken.sdmse.common.compose.dialog.SdmDialogAction
 import eu.darken.sdmse.common.compose.dialog.SdmDialogButtonBar
+import eu.darken.sdmse.common.compose.focus.dpadVerticalFieldEscape
 import eu.darken.sdmse.common.compose.preview.Preview2
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import eu.darken.sdmse.common.getQuantityString2
@@ -93,7 +94,11 @@ fun AgeInputDialog(
                     isError = error != null,
                     supportingText = { error?.let { Text(it) } },
                     singleLine = true,
-                    modifier = Modifier.fillMaxWidth(),
+                    // Without this the field swallows D-pad UP/DOWN and a TV remote can never
+                    // reach the buttons below.
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .dpadVerticalFieldEscape(),
                 )
                 Spacer(Modifier.height(8.dp))
                 Slider(
@@ -112,6 +117,8 @@ fun AgeInputDialog(
         },
         confirmButton = {
             SdmDialogButtonBar(
+                // The text field owns the focus here; a button claiming it swallows the typing.
+                autoFocus = false,
                 positive = SdmDialogAction(
                     label = stringResource(R.string.general_save_action),
                     enabled = saveEnabled,

--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/settings/dialogs/SizeInputDialog.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/settings/dialogs/SizeInputDialog.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.unit.dp
 import eu.darken.sdmse.common.R
 import eu.darken.sdmse.common.compose.dialog.SdmDialogAction
 import eu.darken.sdmse.common.compose.dialog.SdmDialogButtonBar
+import eu.darken.sdmse.common.compose.focus.dpadVerticalFieldEscape
 import eu.darken.sdmse.common.compose.preview.Preview2
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import eu.darken.sdmse.common.ui.SizeParser
@@ -83,7 +84,11 @@ fun SizeInputDialog(
                     isError = error != null,
                     supportingText = { error?.let { Text(it) } },
                     singleLine = true,
-                    modifier = Modifier.fillMaxWidth(),
+                    // Without this the field swallows D-pad UP/DOWN and a TV remote can never
+                    // reach the buttons below.
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .dpadVerticalFieldEscape(),
                 )
                 Spacer(Modifier.height(8.dp))
                 Slider(
@@ -102,6 +107,8 @@ fun SizeInputDialog(
         },
         confirmButton = {
             SdmDialogButtonBar(
+                // The text field owns the focus here; a button claiming it swallows the typing.
+                autoFocus = false,
                 positive = SdmDialogAction(
                     label = stringResource(R.string.general_save_action),
                     enabled = saveEnabled,

--- a/app-common-ui/src/test/java/eu/darken/sdmse/common/compose/dialog/SdmDialogButtonBarTest.kt
+++ b/app-common-ui/src/test/java/eu/darken/sdmse/common/compose/dialog/SdmDialogButtonBarTest.kt
@@ -1,10 +1,20 @@
 package eu.darken.sdmse.common.compose.dialog
 
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.InputMode
+import androidx.compose.ui.input.InputModeManager
+import androidx.compose.ui.platform.LocalInputModeManager
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
@@ -12,8 +22,10 @@ import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertIsNotFocused
 import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.requestFocus
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
@@ -34,6 +46,7 @@ class SdmDialogButtonBarTest : BaseComposeRobolectricTest() {
         positive: SdmDialogAction = SdmDialogAction(label = positiveLabel, onClick = {}),
         negative: SdmDialogAction? = SdmDialogAction(label = negativeLabel, onClick = {}),
         neutral: SdmDialogAction? = SdmDialogAction(label = neutralLabel, onClick = {}),
+        autoFocus: Boolean = true,
     ) {
         composeRule.setContent {
             PreviewWrapper {
@@ -44,6 +57,7 @@ class SdmDialogButtonBarTest : BaseComposeRobolectricTest() {
                             positive = positive,
                             negative = negative,
                             neutral = neutral,
+                            autoFocus = autoFocus,
                         )
                     }
                 }
@@ -227,5 +241,81 @@ class SdmDialogButtonBarTest : BaseComposeRobolectricTest() {
         setBar(containerWidth = 120)
 
         composeRule.onNodeWithText(negativeLabel).assertIsFocused()
+    }
+
+    @Test
+    fun `autoFocus false leaves focus untouched for dialogs whose content owns it`() {
+        setBar(containerWidth = 400, autoFocus = false)
+
+        composeRule.onNodeWithText(negativeLabel).assertIsNotFocused()
+        composeRule.onNodeWithText(positiveLabel).assertIsNotFocused()
+        composeRule.onNodeWithText(neutralLabel).assertIsNotFocused()
+    }
+
+    @Test
+    fun `a touch to keyboard transition re-claims focus for the safe default`() {
+        val inputModes = FakeInputModeManager(InputMode.Touch)
+        setBarWithInputMode(inputModes, autoFocus = true)
+
+        // Focus sitting on other content, as it would after the user reached it by touch.
+        composeRule.onNodeWithTag(outsideTag).requestFocus()
+        composeRule.onNodeWithTag(outsideTag).assertIsFocused()
+
+        // Picking up a remote or keyboard has to pull focus back onto the safe default action,
+        // otherwise the first D-pad press acts on whatever the framework picks spatially.
+        composeRule.runOnIdle { inputModes.inputMode = InputMode.Keyboard }
+
+        composeRule.onNodeWithText(negativeLabel).assertIsFocused()
+    }
+
+    @Test
+    fun `autoFocus false ignores a touch to keyboard transition`() {
+        val inputModes = FakeInputModeManager(InputMode.Touch)
+        setBarWithInputMode(inputModes, autoFocus = false)
+
+        composeRule.onNodeWithTag(outsideTag).requestFocus()
+
+        // A dialog with a text field flips the mode on every hardware-keyboard keystroke; re-claiming
+        // here would drag focus off the field after every letter.
+        composeRule.runOnIdle { inputModes.inputMode = InputMode.Keyboard }
+
+        composeRule.onNodeWithTag(outsideTag).assertIsFocused()
+        composeRule.onNodeWithText(negativeLabel).assertIsNotFocused()
+    }
+
+    private val outsideTag = "outside.focusable"
+
+    /** Lets a test drive the input mode that [SdmDialogButtonBar] reads, independent of the host. */
+    private class FakeInputModeManager(initial: InputMode) : InputModeManager {
+        override var inputMode: InputMode by mutableStateOf(initial)
+
+        override fun requestInputMode(inputMode: InputMode): Boolean {
+            this.inputMode = inputMode
+            return true
+        }
+    }
+
+    private fun setBarWithInputMode(inputModes: FakeInputModeManager, autoFocus: Boolean) {
+        composeRule.setContent {
+            PreviewWrapper {
+                CompositionLocalProvider(LocalInputModeManager provides inputModes) {
+                    Column {
+                        Box(
+                            modifier = Modifier
+                                .size(10.dp)
+                                .focusable()
+                                .testTag(outsideTag),
+                        )
+                        Box(modifier = Modifier.width(400.dp)) {
+                            SdmDialogButtonBar(
+                                positive = SdmDialogAction(label = positiveLabel, onClick = {}),
+                                negative = SdmDialogAction(label = negativeLabel, onClick = {}),
+                                autoFocus = autoFocus,
+                            )
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/app-common-ui/src/test/java/eu/darken/sdmse/common/compose/focus/DpadFieldEscapeTest.kt
+++ b/app-common-ui/src/test/java/eu/darken/sdmse/common/compose/focus/DpadFieldEscapeTest.kt
@@ -1,0 +1,143 @@
+package eu.darken.sdmse.common.compose.focus
+
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.assertIsNotFocused
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.pressKey
+import androidx.compose.ui.test.requestFocus
+import androidx.compose.ui.unit.dp
+import eu.darken.sdmse.common.R
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.common.compose.settings.dialogs.AgeInputDialog
+import eu.darken.sdmse.common.compose.settings.dialogs.SizeInputDialog
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+import java.time.Duration
+
+/**
+ * A focused text field consumes D-pad UP/DOWN for caret movement. Remotes have no TAB key, so a
+ * dialog field that holds focus without [dpadVerticalFieldEscape] is a dead end on TV: the buttons
+ * below it are unreachable.
+ */
+@OptIn(ExperimentalTestApi::class)
+class DpadFieldEscapeTest : BaseComposeRobolectricTest() {
+
+    private val aboveTag = "above"
+    private val belowTag = "below"
+
+    private fun field() = composeRule.onNode(hasSetTextAction())
+
+    @Composable
+    private fun Harness(escape: Boolean) {
+        var value by remember { mutableStateOf("") }
+        Column {
+            Box(Modifier.size(10.dp).focusable().testTag(aboveTag))
+            OutlinedTextField(
+                value = value,
+                onValueChange = { value = it },
+                singleLine = true,
+                modifier = if (escape) Modifier.dpadVerticalFieldEscape() else Modifier,
+            )
+            Box(Modifier.size(10.dp).focusable().testTag(belowTag))
+        }
+    }
+
+    private fun setHarness(escape: Boolean) {
+        composeRule.setContent { PreviewWrapper { Harness(escape = escape) } }
+        field().requestFocus()
+        field().assertIsFocused()
+    }
+
+    @Test
+    fun `dpad down moves focus out of the field`() {
+        setHarness(escape = true)
+
+        field().performKeyInput { pressKey(Key.DirectionDown) }
+
+        field().assertIsNotFocused()
+        composeRule.onNodeWithTag(belowTag).assertIsFocused()
+    }
+
+    @Test
+    fun `dpad up moves focus out of the field`() {
+        setHarness(escape = true)
+
+        field().performKeyInput { pressKey(Key.DirectionUp) }
+
+        field().assertIsNotFocused()
+        composeRule.onNodeWithTag(aboveTag).assertIsFocused()
+    }
+
+    /**
+     * The control: proves the two tests above are not vacuous. Without the modifier the field eats
+     * the key and focus never leaves — exactly the trap reported from the device.
+     */
+    @Test
+    fun `without the escape the field swallows the vertical keys`() {
+        setHarness(escape = false)
+
+        field().performKeyInput { pressKey(Key.DirectionDown) }
+        field().assertIsFocused()
+
+        field().performKeyInput { pressKey(Key.DirectionUp) }
+        field().assertIsFocused()
+    }
+
+    @Test
+    fun `the size dialog's field releases dpad down`() {
+        composeRule.setContent {
+            PreviewWrapper {
+                SizeInputDialog(
+                    titleRes = R.string.general_save_action,
+                    currentSize = 16 * 1024L,
+                    onSave = {},
+                    onReset = {},
+                    onDismiss = {},
+                )
+            }
+        }
+        field().requestFocus()
+        field().assertIsFocused()
+
+        field().performKeyInput { pressKey(Key.DirectionDown) }
+
+        field().assertIsNotFocused()
+    }
+
+    @Test
+    fun `the age dialog's field releases dpad down`() {
+        composeRule.setContent {
+            PreviewWrapper {
+                AgeInputDialog(
+                    titleRes = R.string.general_save_action,
+                    currentAge = Duration.ofDays(3),
+                    onSave = {},
+                    onReset = {},
+                    onDismiss = {},
+                )
+            }
+        }
+        field().requestFocus()
+        field().assertIsFocused()
+
+        field().performKeyInput { pressKey(Key.DirectionDown) }
+
+        field().assertIsNotFocused()
+    }
+}

--- a/app-common/src/main/res/values/strings.xml
+++ b/app-common/src/main/res/values/strings.xml
@@ -29,6 +29,8 @@
     <string name="general_set_up_action">Set up</string>
     <string name="general_unavailable_label">Unavailable</string>
     <string name="general_edit_action">Edit</string>
+    <string name="general_edit_x_action">Edit %s</string>
+    <string name="general_add_action">Add</string>
     <string name="general_na_label">N/A</string>
     <string name="general_empty_label">Empty</string>
     <string name="general_new_badge_label">New</string>
@@ -111,6 +113,7 @@
     </plurals>
 
     <string name="general_remove_action">Remove</string>
+    <string name="general_remove_x_action">Remove %s</string>
     <plurals name="general_remove_success_x_items">
         <item quantity="one">One item was removed</item>
         <item quantity="other">%d items were removed</item>

--- a/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/ChipModeSwitcherDialog.kt
+++ b/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/ChipModeSwitcherDialog.kt
@@ -1,11 +1,11 @@
 package eu.darken.sdmse.systemcleaner.ui.customfilter.editor
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import eu.darken.sdmse.common.compose.dialog.SdmAlertDialog
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -14,39 +14,79 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
-import eu.darken.sdmse.common.R as CommonR
+import eu.darken.sdmse.common.compose.dialog.SdmAlertDialog
+import eu.darken.sdmse.common.compose.preview.Preview2
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.common.sieve.SegmentCriterium
 import eu.darken.sdmse.common.sieve.SieveCriterium
+import eu.darken.sdmse.common.R as CommonR
+import eu.darken.sdmse.systemcleaner.R as SystemCleanerR
 
+/**
+ * Picks the matching mode for a criterium.
+ *
+ * [unavailableModes] renders those options disabled: a mode that another entry already uses for
+ * the same text would produce an exact duplicate, which the criteria set collapses — the entry
+ * would silently disappear with no dialog left to warn in.
+ */
 @Composable
 internal fun ChipModeSwitcherDialog(
-    criterium: SieveCriterium,
+    type: TagType,
+    selectedMode: SieveCriterium.Mode,
     onModeSelected: (SieveCriterium.Mode) -> Unit,
     onDismiss: () -> Unit,
+    unavailableModes: Set<SieveCriterium.Mode> = emptySet(),
 ) {
-    val modes = remember(criterium) { availableModesFor(criterium) }
-    val selectedIndex = remember(criterium) {
-        modes.indexOfFirst { it.first::class.isInstance(criterium.mode) }.coerceAtLeast(0)
+    val modes = remember(type) { availableModesFor(type) }
+    val selectedIndex = remember(type, selectedMode) {
+        modes.indexOfFirst { it.first::class.isInstance(selectedMode) }.coerceAtLeast(0)
     }
 
     SdmAlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text(stringResource(modeSwitcherTitleRes(criterium))) },
+        title = { Text(stringResource(modeSwitcherTitleRes(type))) },
         text = {
             Column {
                 modes.forEachIndexed { index, (mode, labelRes) ->
+                    val enabled = !unavailableModes.contains(mode)
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clickable { onModeSelected(mode) }
+                            .selectable(
+                                selected = index == selectedIndex,
+                                enabled = enabled,
+                                role = Role.RadioButton,
+                                onClick = { onModeSelected(mode) },
+                            )
                             .padding(vertical = 4.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         RadioButton(
                             selected = index == selectedIndex,
-                            onClick = { onModeSelected(mode) },
+                            enabled = enabled,
+                            onClick = null,
                         )
-                        Text(stringResource(labelRes))
+                        Column(modifier = Modifier.padding(start = 8.dp)) {
+                            Text(
+                                text = stringResource(labelRes),
+                                color = if (enabled) {
+                                    MaterialTheme.colorScheme.onSurface
+                                } else {
+                                    MaterialTheme.colorScheme.onSurfaceVariant
+                                },
+                            )
+                            if (!enabled) {
+                                Text(
+                                    text = stringResource(
+                                        SystemCleanerR.string.systemcleaner_customfilter_editor_criterium_mode_taken_label,
+                                    ),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        }
                     }
                 }
             }
@@ -58,4 +98,18 @@ internal fun ChipModeSwitcherDialog(
             }
         },
     )
+}
+
+@Preview2
+@Composable
+private fun ChipModeSwitcherDialogPreview() {
+    PreviewWrapper {
+        ChipModeSwitcherDialog(
+            type = TagType.SEGMENTS,
+            selectedMode = SegmentCriterium.Mode.Contain(allowPartial = true),
+            unavailableModes = setOf(SegmentCriterium.Mode.Equal()),
+            onModeSelected = {},
+            onDismiss = {},
+        )
+    }
 }

--- a/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/CriteriumEditorDialog.kt
+++ b/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/CriteriumEditorDialog.kt
@@ -1,0 +1,263 @@
+package eu.darken.sdmse.systemcleaner.ui.customfilter.editor
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.error
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
+import eu.darken.sdmse.common.compose.dialog.SdmAlertDialog
+import eu.darken.sdmse.common.compose.dialog.SdmDialogAction
+import eu.darken.sdmse.common.compose.dialog.SdmDialogButtonBar
+import eu.darken.sdmse.common.compose.focus.dpadVerticalFieldEscape
+import eu.darken.sdmse.common.compose.preview.Preview2
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.common.sieve.SegmentCriterium
+import eu.darken.sdmse.common.sieve.SieveCriterium
+import eu.darken.sdmse.common.R as CommonR
+import eu.darken.sdmse.systemcleaner.R as SystemCleanerR
+
+internal const val CRITERIUM_EDITOR_INPUT_TEST_TAG = "customfilter.editor.criterium_input"
+internal const val CRITERIUM_EDITOR_MODE_ROW_TEST_TAG = "customfilter.editor.criterium_mode_row"
+
+/** What the dialog's positive button does for the draft as it currently stands. */
+private enum class PositiveAction {
+    SAVE,
+    REMOVE,
+    CLOSE,
+}
+
+/**
+ * Creates or edits exactly one criterium.
+ *
+ * The candidate criterium is built exactly once via [buildCriterium] and that same instance is
+ * used for the duplicate check and handed to [onSave] — validating one construction while saving
+ * a differently built one is how a "saved" edit ends up not matching what was checked.
+ *
+ * [original] is the entry being edited, or null when creating a new one. [siblings] are the other
+ * criteria of the same section (i.e. excluding [original]).
+ */
+@Composable
+internal fun CriteriumEditorDialog(
+    section: CriteriaSection,
+    type: TagType,
+    original: SieveCriterium?,
+    value: TextFieldValue,
+    mode: SieveCriterium.Mode,
+    siblings: List<SieveCriterium>,
+    onValueChange: (TextFieldValue) -> Unit,
+    onChangeMode: () -> Unit,
+    onSave: (SieveCriterium) -> Unit,
+    onRemove: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val isNew = original == null
+    // Gated on the RAW text, not the trimmed one: a whitespace-only draft is a legitimate
+    // criterium (buildCriterium keeps it verbatim), only a truly empty field has nothing to save.
+    val candidate = remember(value.text, type, mode) {
+        value.text.takeIf { it.isNotEmpty() }?.let { buildCriterium(it, type, mode) }
+    }
+    val isDuplicate = candidate != null && siblings.contains(candidate)
+    val canSave = candidate != null && !isDuplicate
+    // Editing an existing entry gives the positive button two extra jobs, because "Save" is a lie
+    // in both cases: an emptied field means the user wants the entry gone, and an untouched draft
+    // has nothing to write. Creating keeps the plain disabled-until-valid Save.
+    val positiveAction = when {
+        isNew -> PositiveAction.SAVE
+        value.text.isEmpty() -> PositiveAction.REMOVE
+        candidate == original -> PositiveAction.CLOSE
+        else -> PositiveAction.SAVE
+    }
+    val duplicateError = stringResource(
+        SystemCleanerR.string.systemcleaner_customfilter_editor_criterium_duplicate_error,
+    )
+    val modeLabel = stringResource(modeLabelRes(mode))
+    // Display form, so a whitespace draft names itself as "2 spaces" rather than being spoken as
+    // the dangling "for   ,".
+    val draft = criteriumDisplayText(normaliseCriteriumInput(value.text))
+    // A new entry has no text to name in "Change match mode for X": formatting it with an empty X
+    // would have TalkBack announce a dangling "for ,". Without a click label the row falls back to
+    // its own visible content (the mode label) plus the standard activation hint, which is complete.
+    val modeClickLabel = when {
+        draft.isEmpty() -> null
+        else -> stringResource(
+            SystemCleanerR.string.systemcleaner_customfilter_editor_criterium_mode_x_action,
+            draft,
+            modeLabel,
+        )
+    }
+
+    val focusRequester = remember { FocusRequester() }
+
+    SdmAlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Column {
+                Text(stringResource(criteriumEditorTitleRes(isNew)))
+                // The title stays generic; which list is being edited is the subtitle, reusing the
+                // section's own label from the editor screen.
+                Text(
+                    text = stringResource(criteriumSectionLabelRes(section)),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        },
+        text = {
+            // The focus request MUST live inside this slot: the slot is composed in the dialog
+            // window's own subcomposition, so an effect declared in the dialog function's body runs
+            // while Modifier.focusRequester below is still unattached. requestFocus() then fails
+            // ("FocusRequester is not initialized"), and the field silently opens unfocused — key
+            // events go to whatever else the dialog focuses instead of into the text field.
+            LaunchedEffect(Unit) { runCatching { focusRequester.requestFocus() } }
+            Column(modifier = Modifier.fillMaxWidth()) {
+                OutlinedTextField(
+                    value = value,
+                    onValueChange = { onValueChange(if (type == TagType.NAME) stripSlashes(it) else it) },
+                    label = {
+                        Text(
+                            stringResource(
+                                SystemCleanerR.string.systemcleaner_customfilter_editor_criterium_value_label,
+                            ),
+                        )
+                    },
+                    isError = isDuplicate,
+                    supportingText = { if (isDuplicate) Text(duplicateError) },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = KeyboardType.Text,
+                        imeAction = ImeAction.Done,
+                    ),
+                    keyboardActions = KeyboardActions(
+                        onDone = {
+                            when (positiveAction) {
+                                PositiveAction.SAVE -> if (canSave) onSave(candidate!!)
+                                PositiveAction.CLOSE -> onDismiss()
+                                // Deleting an entry stays an explicit button press; the IME's Done
+                                // key is far too easy to hit by accident for a destructive action.
+                                PositiveAction.REMOVE -> Unit
+                            }
+                        },
+                    ),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .focusRequester(focusRequester)
+                        // Without this the field swallows D-pad UP/DOWN, and since it now holds
+                        // the initial focus a TV remote could never reach the mode row or buttons.
+                        .dpadVerticalFieldEscape()
+                        // Without this the field swallows D-pad UP/DOWN, and since it now holds
+                        // the initial focus a TV remote could never reach the mode row or buttons.
+                        .testTag(CRITERIUM_EDITOR_INPUT_TEST_TAG)
+                        // M3 only sets a generic "invalid input" error, so screen readers would
+                        // never learn WHY the entry is rejected.
+                        .semantics { if (isDuplicate) error(duplicateError) },
+                )
+                Spacer(Modifier.height(8.dp))
+                // The row that shows the mode IS the control for changing it — no separate button.
+                // clickable() also makes it D-pad focusable.
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(MaterialTheme.shapes.small)
+                        .clickable(
+                            role = Role.Button,
+                            onClickLabel = modeClickLabel,
+                            onClick = onChangeMode,
+                        )
+                        .heightIn(min = 48.dp)
+                        .padding(horizontal = 4.dp)
+                        .testTag(CRITERIUM_EDITOR_MODE_ROW_TEST_TAG),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(
+                        imageVector = modeIcon(mode),
+                        contentDescription = null,
+                        modifier = Modifier.size(20.dp),
+                    )
+                    Text(
+                        text = modeLabel,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(start = 8.dp),
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            SdmDialogButtonBar(
+                // The text field owns the focus here; a button claiming it swallows the typing.
+                autoFocus = false,
+                positive = SdmDialogAction(
+                    label = stringResource(
+                        when (positiveAction) {
+                            PositiveAction.SAVE -> CommonR.string.general_save_action
+                            PositiveAction.REMOVE -> CommonR.string.general_remove_action
+                            PositiveAction.CLOSE -> CommonR.string.general_close_action
+                        },
+                    ),
+                    enabled = positiveAction != PositiveAction.SAVE || canSave,
+                    onClick = {
+                        when (positiveAction) {
+                            PositiveAction.SAVE -> candidate?.let { onSave(it) }
+                            PositiveAction.REMOVE -> onRemove()
+                            PositiveAction.CLOSE -> onDismiss()
+                        }
+                    },
+                ),
+                negative = SdmDialogAction(
+                    label = stringResource(CommonR.string.general_cancel_action),
+                    onClick = onDismiss,
+                ),
+            )
+        },
+    )
+}
+
+@Preview2
+@Composable
+private fun CriteriumEditorDialogPreview() {
+    PreviewWrapper {
+        CriteriumEditorDialog(
+            section = CriteriaSection.PATH,
+            type = TagType.SEGMENTS,
+            original = SegmentCriterium(
+                segments = listOf("Downloads"),
+                mode = SegmentCriterium.Mode.Contain(allowPartial = true),
+            ),
+            value = TextFieldValue("Downloads/oldapks"),
+            mode = SegmentCriterium.Mode.Contain(allowPartial = true),
+            siblings = emptyList(),
+            onValueChange = {},
+            onChangeMode = {},
+            onSave = {},
+            onRemove = {},
+            onDismiss = {},
+        )
+    }
+}

--- a/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/CustomFilterEditorBody.kt
+++ b/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/CustomFilterEditorBody.kt
@@ -72,7 +72,6 @@ internal fun CustomFilterEditorBody(
     onUpdateSizeMax: (Long?) -> Unit,
     onUpdateAgeMin: (Duration?) -> Unit,
     onUpdateAgeMax: (Duration?) -> Unit,
-    onTaggedFieldFocused: () -> Unit,
 ) {
     val context = LocalContext.current
 
@@ -101,12 +100,12 @@ internal fun CustomFilterEditorBody(
             taggedField = {
                 TaggedInputField(
                     type = TagType.SEGMENTS,
+                    section = CriteriaSection.PATH,
                     hint = stringResource(SystemCleanerR.string.systemcleaner_customfilter_editor_path_label),
                     tags = (config.pathCriteria ?: emptySet()).toList(),
                     onAdd = { onAddPath(it as SegmentCriterium) },
                     onRemove = { onRemovePath(it as SegmentCriterium) },
-                    onModeChange = onSwapPath,
-                    onFocusChange = { hasFocus -> if (hasFocus) onTaggedFieldFocused() },
+                    onSwap = onSwapPath,
                 )
             },
             explanation = stringResource(SystemCleanerR.string.systemcleaner_customfilter_editor_path_explanation),
@@ -116,12 +115,12 @@ internal fun CustomFilterEditorBody(
             taggedField = {
                 TaggedInputField(
                     type = TagType.NAME,
+                    section = CriteriaSection.NAME,
                     hint = stringResource(SystemCleanerR.string.systemcleaner_customfilter_editor_name_label),
                     tags = (config.nameCriteria ?: emptySet()).toList(),
                     onAdd = { onAddName(it as NameCriterium) },
                     onRemove = { onRemoveName(it as NameCriterium) },
-                    onModeChange = onSwapName,
-                    onFocusChange = { hasFocus -> if (hasFocus) onTaggedFieldFocused() },
+                    onSwap = onSwapName,
                 )
             },
             explanation = stringResource(SystemCleanerR.string.systemcleaner_customfilter_editor_name_explanation),
@@ -131,12 +130,12 @@ internal fun CustomFilterEditorBody(
             taggedField = {
                 TaggedInputField(
                     type = TagType.SEGMENTS,
+                    section = CriteriaSection.EXCLUSION,
                     hint = stringResource(SystemCleanerR.string.systemcleaner_customfilter_editor_exclusions_label),
                     tags = (config.exclusionCriteria ?: emptySet()).toList(),
                     onAdd = { onAddExclusion(it as SegmentCriterium) },
                     onRemove = { onRemoveExclusion(it as SegmentCriterium) },
-                    onModeChange = onSwapExclusion,
-                    onFocusChange = { hasFocus -> if (hasFocus) onTaggedFieldFocused() },
+                    onSwap = onSwapExclusion,
                 )
             },
             explanation = stringResource(SystemCleanerR.string.systemcleaner_customfilter_editor_exclusions_explanation),

--- a/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/CustomFilterEditorScreen.kt
+++ b/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/CustomFilterEditorScreen.kt
@@ -273,11 +273,6 @@ internal fun CustomFilterEditorScreen(
                     onUpdateSizeMax = onUpdateSizeMax,
                     onUpdateAgeMin = onUpdateAgeMin,
                     onUpdateAgeMax = onUpdateAgeMax,
-                    onTaggedFieldFocused = {
-                        if (sheetState.currentValue == SheetValue.Expanded) {
-                            scope.launch { sheetState.partialExpand() }
-                        }
-                    },
                 )
             }
         }

--- a/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/TaggedChip.kt
+++ b/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/TaggedChip.kt
@@ -1,60 +1,126 @@
 package eu.darken.sdmse.systemcleaner.ui.customfilter.editor
 
-import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.Close
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.InputChip
 import androidx.compose.material3.InputChipDefaults
+import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import eu.darken.sdmse.common.sieve.SieveCriterium
+import eu.darken.sdmse.common.R as CommonR
+import eu.darken.sdmse.systemcleaner.R as SystemCleanerR
+
+/** The leading mode target. Deliberately not an IconButton: that applies
+ * `minimumInteractiveComponentSize()` (48dp) and the overhang eats the chip body on short labels. */
+private val MODE_TARGET_SIZE = 32.dp
+
+/**
+ * Reference string for the label's minimum width. A one-character entry otherwise renders as a
+ * sliver between the two icons and reads as broken next to its neighbours.
+ *
+ * Measured rather than hardcoded as dp so it tracks the system font scale and the locale's actual
+ * glyphs. Digits are the reference because they are visually uniform — a letter-based one would
+ * swing wildly between "iii" and "WWW" and the minimum would mean something different per locale.
+ */
+private const val MIN_LABEL_REFERENCE = "000"
 
 @Composable
 internal fun TaggedChip(
     modifier: Modifier = Modifier,
     criterium: SieveCriterium,
+    onEdit: () -> Unit,
     onRemove: () -> Unit,
-    onLongClick: () -> Unit,
+    onShowModeSwitcher: () -> Unit,
 ) {
+    // Display form: a whitespace-only value would otherwise be a blank chip, and every label built
+    // from it ("Edit  ") would be read out as a dangling fragment.
+    val label = criteriumDisplayText(criteriumValue(criterium))
+    val editLabel = stringResource(CommonR.string.general_edit_x_action, label)
+    val modeLabel = stringResource(
+        SystemCleanerR.string.systemcleaner_customfilter_editor_criterium_mode_x_action,
+        label,
+        stringResource(criteriumModeLabelRes(criterium)),
+    )
     InputChip(
         selected = false,
-        onClick = {},
-        modifier = modifier.combinedClickable(onClick = {}, onLongClick = onLongClick),
-        label = { Text(criteriumValue(criterium)) },
-        leadingIcon = {
-            CriteriumLeadingIcon(
-                criterium = criterium,
-                modifier = Modifier.size(InputChipDefaults.IconSize),
+        // The gesture has to be the chip's own onClick: InputChip renders a Surface that appends its
+        // own selectable AFTER whatever modifier we pass in. That inner node sees the bubbling pointer
+        // pass first and consumes the down, so an outer clickable/combinedClickable never fires.
+        onClick = onEdit,
+        // SelectableChip advertises Role.Checkbox, which is wrong now that a tap opens the editor.
+        // Applied before the chip's own semantics so these outermost values win (collapsePeer keeps
+        // the outermost value for a plain key, and the outermost non-null label for an action key).
+        modifier = modifier.semantics {
+            role = Role.Button
+            onClick(label = editLabel, action = null)
+        },
+        label = {
+            // Inside the label slot LocalTextStyle is the chip's own labelTextStyle, so the
+            // reference is measured with exactly the style the label below renders with.
+            val measurer = rememberTextMeasurer()
+            val labelStyle = LocalTextStyle.current
+            val density = LocalDensity.current
+            val minLabelWidth = remember(measurer, labelStyle, density) {
+                with(density) { measurer.measure(MIN_LABEL_REFERENCE, labelStyle).size.width.toDp() }
+            }
+            Text(
+                text = label,
+                modifier = Modifier.widthIn(min = minLabelWidth),
+                // Only bites below the minimum, where it centres the label instead of leaving it
+                // hugging the leading edge with dead space trailing it.
+                textAlign = TextAlign.Center,
             )
         },
+        leadingIcon = {
+            Box(
+                modifier = Modifier
+                    .size(MODE_TARGET_SIZE)
+                    .clickable(role = Role.Button, onClick = onShowModeSwitcher),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = criteriumIcon(criterium),
+                    contentDescription = modeLabel,
+                    modifier = Modifier.size(InputChipDefaults.IconSize),
+                )
+            }
+        },
         trailingIcon = {
+            // Pinned to 24dp: without it the button expands to LocalMinimumInteractiveComponentSize
+            // (40dp here) and drags the whole chip taller than the neighbouring Add chip. The size
+            // only constrains layout — the touch target still overhangs the chip bounds (measured
+            // 44x48dp on device), so reachability is unaffected.
             IconButton(
                 onClick = onRemove,
                 modifier = Modifier.size(24.dp),
             ) {
                 Icon(
                     imageVector = Icons.TwoTone.Close,
-                    contentDescription = null,
+                    // Not the "Remove %s filter" wording: these are the filter's entries, and
+                    // announcing one as a filter contradicts the rest of the screen.
+                    contentDescription = stringResource(CommonR.string.general_remove_x_action, label),
                     modifier = Modifier.size(InputChipDefaults.IconSize),
                 )
             }
         },
-    )
-}
-
-@Composable
-private fun CriteriumLeadingIcon(
-    criterium: SieveCriterium,
-    modifier: Modifier = Modifier,
-) {
-    Icon(
-        imageVector = criteriumIcon(criterium),
-        contentDescription = null,
-        modifier = modifier,
     )
 }

--- a/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/TaggedInputField.kt
+++ b/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/TaggedInputField.kt
@@ -5,60 +5,122 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.Add
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalMinimumInteractiveComponentSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.mapSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.input.key.Key
-import androidx.compose.ui.input.key.KeyEventType
-import androidx.compose.ui.input.key.key
-import androidx.compose.ui.input.key.onPreviewKeyEvent
-import androidx.compose.ui.input.key.type
-import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextRange
-import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
+import eu.darken.sdmse.common.compose.preview.Preview2
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.common.sieve.SegmentCriterium
 import eu.darken.sdmse.common.sieve.SieveCriterium
+import eu.darken.sdmse.common.R as CommonR
 
-internal const val TAGGED_INPUT_FIELD_TEST_TAG = "customfilter.editor.tagged_input"
+internal enum class EditorStep {
+    EDITOR,
+    MODE,
+}
 
+/**
+ * A single create-or-edit interaction with one criterium.
+ *
+ * [original] is the identity of the entry being edited and is NEVER replaced by the draft: `null`
+ * means create (Save adds), otherwise Save swaps `original -> candidate`. Targeting the draft
+ * instead would make Save a silent no-op, because [swapPreservingOrder] returns the set unchanged
+ * when `old` isn't in it. Visiting the mode dialog mutates [draftMode] and [step] only.
+ */
+internal data class EditorSession(
+    val original: SieveCriterium?,
+    val draftText: TextFieldValue,
+    val draftMode: SieveCriterium.Mode,
+    val step: EditorStep = EditorStep.EDITOR,
+)
+
+private const val SESSION_KEY_ORIGINAL = "original"
+private const val SESSION_KEY_TEXT = "text"
+private const val SESSION_KEY_SELECTION_START = "selectionStart"
+private const val SESSION_KEY_SELECTION_END = "selectionEnd"
+private const val SESSION_KEY_MODE = "mode"
+private const val SESSION_KEY_STEP = "step"
+
+/**
+ * [rememberSaveable] can't save an arbitrary data class, and [TextFieldValue] isn't Parcelable,
+ * so the session is stored field-wise (criterium and mode are Parcelable, the rest primitives).
+ */
+internal val EditorSessionSaver: Saver<EditorSession?, Any> = mapSaver(
+    save = { session ->
+        if (session == null) {
+            emptyMap()
+        } else {
+            mapOf(
+                SESSION_KEY_ORIGINAL to session.original,
+                SESSION_KEY_TEXT to session.draftText.text,
+                SESSION_KEY_SELECTION_START to session.draftText.selection.start,
+                SESSION_KEY_SELECTION_END to session.draftText.selection.end,
+                SESSION_KEY_MODE to session.draftMode,
+                SESSION_KEY_STEP to session.step.name,
+            )
+        }
+    },
+    restore = { saved ->
+        if (saved.isEmpty()) {
+            null
+        } else {
+            EditorSession(
+                original = saved[SESSION_KEY_ORIGINAL] as SieveCriterium?,
+                draftText = TextFieldValue(
+                    text = saved[SESSION_KEY_TEXT] as String,
+                    selection = TextRange(
+                        saved[SESSION_KEY_SELECTION_START] as Int,
+                        saved[SESSION_KEY_SELECTION_END] as Int,
+                    ),
+                ),
+                draftMode = saved[SESSION_KEY_MODE] as SieveCriterium.Mode,
+                step = EditorStep.valueOf(saved[SESSION_KEY_STEP] as String),
+            )
+        }
+    },
+)
+
+/**
+ * Renders one criteria section: the existing entries as chips plus an add button. Every mutation
+ * goes through a dialog — there is no inline text field, because its limbo state (a chip popped
+ * into the input) could destroy entries without any visible trace.
+ */
 @Composable
 internal fun TaggedInputField(
     modifier: Modifier = Modifier,
     type: TagType,
+    section: CriteriaSection,
     hint: String,
     tags: List<SieveCriterium>,
     onAdd: (SieveCriterium) -> Unit,
     onRemove: (SieveCriterium) -> Unit,
-    onModeChange: (old: SieveCriterium, new: SieveCriterium) -> Unit,
-    onFocusChange: ((Boolean) -> Unit)? = null,
+    onSwap: (old: SieveCriterium, new: SieveCriterium) -> Unit,
 ) {
-    // Saveable: a config change mid-edit of a backspace-popped chip must not lose the chip — it
-    // was already removed from the draft, so the in-progress text is its only remaining copy.
-    var typedText by rememberSaveable(stateSaver = TextFieldValue.Saver) { mutableStateOf(TextFieldValue("")) }
-    // The chip that was popped back into the input for editing (null while typing a fresh entry).
-    var editingCriterium by rememberSaveable { mutableStateOf<SieveCriterium?>(null) }
-    var modeSwitcherFor by rememberSaveable { mutableStateOf<SieveCriterium?>(null) }
-
-    fun commit() {
-        val text = typedText.text.trim()
-        if (text.isNotEmpty()) onAdd(inputTextToChipTag(text, type, editingCriterium))
-        editingCriterium = null
-        typedText = TextFieldValue("")
+    var session by rememberSaveable(stateSaver = EditorSessionSaver) {
+        mutableStateOf<EditorSession?>(null)
     }
+    var modeSwitcherFor by rememberSaveable { mutableStateOf<SieveCriterium?>(null) }
 
     Column(modifier = modifier.fillMaxWidth()) {
         Text(
@@ -66,83 +128,144 @@ internal fun TaggedInputField(
             style = MaterialTheme.typography.labelLarge,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
-        FlowRow(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 8.dp),
-            horizontalArrangement = Arrangement.spacedBy(4.dp),
-            verticalArrangement = Arrangement.spacedBy(4.dp),
-        ) {
-            tags.forEach { criterium ->
-                TaggedChip(
-                    criterium = criterium,
-                    onRemove = { onRemove(criterium) },
-                    onLongClick = { modeSwitcherFor = criterium },
+        // Surface applies minimumInteractiveComponentSize(), so a 32dp chip occupies 48dp of layout
+        // and the rows drift far apart. 40dp keeps the remove target comfortably tappable.
+        CompositionLocalProvider(LocalMinimumInteractiveComponentSize provides 40.dp) {
+            FlowRow(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(2.dp),
+                verticalArrangement = Arrangement.spacedBy(2.dp),
+            ) {
+                tags.forEach { criterium ->
+                    TaggedChip(
+                        criterium = criterium,
+                        onEdit = {
+                            val text = criteriumValue(criterium)
+                            session = EditorSession(
+                                original = criterium,
+                                draftText = TextFieldValue(text, TextRange(text.length)),
+                                draftMode = criteriumMode(criterium),
+                            )
+                        },
+                        onRemove = { onRemove(criterium) },
+                        onShowModeSwitcher = { modeSwitcherFor = criterium },
+                    )
+                }
+                AddCriteriumChip(
+                    section = section,
+                    onClick = {
+                        session = EditorSession(
+                            original = null,
+                            draftText = TextFieldValue(""),
+                            draftMode = defaultModeFor(type),
+                        )
+                    },
                 )
             }
-            BasicTextField(
-                value = typedText,
-                onValueChange = { newValue ->
-                    typedText = if (type == TagType.NAME) stripSlashes(newValue) else newValue
+        }
+    }
+
+    session?.let { active ->
+        val original = active.original
+        val siblings = tags.filter { it != original }
+        when (active.step) {
+            EditorStep.EDITOR -> CriteriumEditorDialog(
+                section = section,
+                type = type,
+                original = original,
+                value = active.draftText,
+                mode = active.draftMode,
+                siblings = siblings,
+                onValueChange = { session = active.copy(draftText = it) },
+                onChangeMode = { session = active.copy(step = EditorStep.MODE) },
+                onSave = { candidate ->
+                    if (original == null) onAdd(candidate) else onSwap(original, candidate)
+                    session = null
                 },
-                modifier = Modifier
-                    .widthIn(min = 80.dp)
-                    .padding(horizontal = 4.dp, vertical = 8.dp)
-                    .testTag(TAGGED_INPUT_FIELD_TEST_TAG)
-                    .onFocusChanged { focusState ->
-                        if (!focusState.isFocused) {
-                            // Don't silently drop an in-progress edit of a popped chip — re-commit it
-                            // (preserving its matching mode). Fresh, un-submitted drafts are discarded.
-                            if (editingCriterium != null) {
-                                commit()
-                            } else if (typedText.text.isNotEmpty()) {
-                                typedText = TextFieldValue("")
-                            }
-                        }
-                        onFocusChange?.invoke(focusState.isFocused)
-                    }
-                    .onPreviewKeyEvent { event ->
-                        if (event.type == KeyEventType.KeyDown &&
-                            event.key == Key.Backspace &&
-                            typedText.text.isEmpty() &&
-                            tags.isNotEmpty()
-                        ) {
-                            val last = tags.last()
-                            onRemove(last)
-                            editingCriterium = last
-                            val value = criteriumValue(last)
-                            // Caret at the end so cursor keys move within the text instead of escaping focus.
-                            typedText = TextFieldValue(value, selection = TextRange(value.length))
-                            true
-                        } else {
-                            false
-                        }
-                    },
-                singleLine = true,
-                cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
-                textStyle = MaterialTheme.typography.bodyMedium.copy(
-                    color = MaterialTheme.colorScheme.onSurface,
-                ),
-                keyboardOptions = KeyboardOptions(
-                    keyboardType = KeyboardType.Text,
-                    imeAction = ImeAction.Done,
-                ),
-                keyboardActions = KeyboardActions(
-                    onDone = { commit() },
-                    onSearch = { commit() },
-                ),
+                // Only offered while editing, so original is non-null; routed through the same
+                // remove path as the chip's own remove button.
+                onRemove = {
+                    original?.let { onRemove(it) }
+                    session = null
+                },
+                onDismiss = { session = null },
+            )
+
+            EditorStep.MODE -> ChipModeSwitcherDialog(
+                type = type,
+                selectedMode = active.draftMode,
+                unavailableModes = collidingModes(active.draftText.text, type, siblings),
+                // Only the mode changes: the draft text and the edited entry's identity survive.
+                onModeSelected = { session = active.copy(draftMode = it, step = EditorStep.EDITOR) },
+                onDismiss = { session = active.copy(step = EditorStep.EDITOR) },
             )
         }
     }
 
-    modeSwitcherFor?.let { active ->
+    modeSwitcherFor?.let { target ->
+        val siblings = tags.filter { it != target }
+        // The candidate that gets validated MUST be the one that gets saved. Rebuilding it from the
+        // chip's text (which trims/normalises) while saving a withMode() copy (which doesn't) lets a
+        // collision slip past the check for entries carrying e.g. surrounding whitespace — the save
+        // then writes an exact duplicate and swapPreservingOrder collapses it, losing a chip.
+        val candidatesByMode = availableModesFor(type)
+            .map { it.first }
+            .associateWith { withMode(target, it) }
         ChipModeSwitcherDialog(
-            criterium = active,
+            type = type,
+            selectedMode = criteriumMode(target),
+            unavailableModes = candidatesByMode.filterValues { siblings.contains(it) }.keys,
             onModeSelected = { newMode ->
-                onModeChange(active, withMode(active, newMode))
+                onSwap(target, candidatesByMode.getValue(newMode))
                 modeSwitcherFor = null
             },
             onDismiss = { modeSwitcherFor = null },
+        )
+    }
+}
+
+@Composable
+private fun AddCriteriumChip(
+    section: CriteriaSection,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val description = stringResource(criteriumAddDescriptionRes(section))
+    AssistChip(
+        onClick = onClick,
+        // The visible label stays short so the chip row keeps its density; screen readers get the
+        // section-specific wording instead of a bare "Add".
+        modifier = modifier.semantics { contentDescription = description },
+        label = {
+            Text(stringResource(CommonR.string.general_add_action))
+        },
+        leadingIcon = {
+            Icon(
+                imageVector = Icons.TwoTone.Add,
+                contentDescription = null,
+                modifier = Modifier.size(AssistChipDefaults.IconSize),
+            )
+        },
+    )
+}
+
+@Preview2
+@Composable
+private fun TaggedInputFieldPreview() {
+    PreviewWrapper {
+        TaggedInputField(
+            type = TagType.SEGMENTS,
+            section = CriteriaSection.PATH,
+            hint = "Path criteria",
+            tags = listOf(
+                SegmentCriterium(listOf("Downloads"), SegmentCriterium.Mode.Contain(allowPartial = true)),
+                SegmentCriterium(listOf("tmp"), SegmentCriterium.Mode.Equal()),
+            ),
+            onAdd = {},
+            onRemove = {},
+            onSwap = { _, _ -> },
         )
     }
 }

--- a/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/TaggedInputHelpers.kt
+++ b/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/TaggedInputHelpers.kt
@@ -1,7 +1,9 @@
 package eu.darken.sdmse.systemcleaner.ui.customfilter.editor
 
 import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import eu.darken.sdmse.common.compose.icons.ApproximatelyEqual
@@ -14,6 +16,7 @@ import eu.darken.sdmse.common.files.toSegs
 import eu.darken.sdmse.common.sieve.NameCriterium
 import eu.darken.sdmse.common.sieve.SegmentCriterium
 import eu.darken.sdmse.common.sieve.SieveCriterium
+import eu.darken.sdmse.common.R as CommonR
 import eu.darken.sdmse.systemcleaner.R as SystemCleanerR
 
 internal enum class TagType {
@@ -21,16 +24,61 @@ internal enum class TagType {
     NAME,
 }
 
+/**
+ * Which criteria list a chip row belongs to. [TagType] can't carry this: path criteria and
+ * exclusions are both [TagType.SEGMENTS], so it can't tell an exclusion editor from a path editor.
+ * [TagType] keeps driving criterium construction, this drives the user-facing wording.
+ */
+internal enum class CriteriaSection {
+    PATH,
+    NAME,
+    EXCLUSION,
+}
+
+// The edit case reuses the plain "Edit": the section subtitle right below supplies the object, so
+// the dialog reads "Edit / Path criteria". Creating keeps its own title — "New" alone is a badge,
+// not a heading.
+@StringRes
+internal fun criteriumEditorTitleRes(isNew: Boolean): Int = if (isNew) {
+    SystemCleanerR.string.systemcleaner_customfilter_editor_criterium_create_title
+} else {
+    CommonR.string.general_edit_action
+}
+
+/** Which list the editor is working on, shown as the dialog's subtitle — the section's own label. */
+@StringRes
+internal fun criteriumSectionLabelRes(section: CriteriaSection): Int = when (section) {
+    CriteriaSection.PATH -> SystemCleanerR.string.systemcleaner_customfilter_editor_path_label
+    CriteriaSection.NAME -> SystemCleanerR.string.systemcleaner_customfilter_editor_name_label
+    CriteriaSection.EXCLUSION -> SystemCleanerR.string.systemcleaner_customfilter_editor_exclusions_label
+}
+
+@StringRes
+internal fun criteriumAddDescriptionRes(section: CriteriaSection): Int = when (section) {
+    CriteriaSection.PATH -> SystemCleanerR.string.systemcleaner_customfilter_editor_path_criterium_add_action
+    CriteriaSection.NAME -> SystemCleanerR.string.systemcleaner_customfilter_editor_name_criterium_add_action
+    CriteriaSection.EXCLUSION -> SystemCleanerR.string.systemcleaner_customfilter_editor_exclusion_criterium_add_action
+}
+
+private val SEGMENTS_DEFAULT_MODE = SegmentCriterium.Mode.Contain(allowPartial = true)
+private val NAME_DEFAULT_MODE = NameCriterium.Mode.Contain()
+
 internal fun inputTextToChipTag(input: String, type: TagType): SieveCriterium = when (type) {
     TagType.SEGMENTS -> SegmentCriterium(
         segments = input.toSegs(),
-        mode = SegmentCriterium.Mode.Contain(allowPartial = true),
+        mode = SEGMENTS_DEFAULT_MODE,
     )
 
     TagType.NAME -> NameCriterium(
         name = input,
-        mode = NameCriterium.Mode.Contain(),
+        mode = NAME_DEFAULT_MODE,
     )
+}
+
+/** Mode a freshly created criterium starts out with. */
+internal fun defaultModeFor(type: TagType): SieveCriterium.Mode = when (type) {
+    TagType.SEGMENTS -> SEGMENTS_DEFAULT_MODE
+    TagType.NAME -> NAME_DEFAULT_MODE
 }
 
 /**
@@ -41,6 +89,65 @@ internal fun inputTextToChipTag(input: String, type: TagType): SieveCriterium = 
 internal fun inputTextToChipTag(input: String, type: TagType, basedOn: SieveCriterium?): SieveCriterium {
     val fresh = inputTextToChipTag(input, type)
     return if (basedOn != null) withMode(fresh, criteriumMode(basedOn)) else fresh
+}
+
+/**
+ * Surrounding whitespace is noise the user did not mean to type — except when whitespace is ALL
+ * they typed, which is a legitimate criterium: a name criterium of `" "` with *contains* matches
+ * every file whose name has a space in it, and there is no other way to express that. Trimming it
+ * to nothing is what made such entries impossible to create.
+ */
+internal fun normaliseCriteriumInput(input: String): String = if (input.isBlank()) input else input.trim()
+
+/**
+ * The single canonical way to turn editor input into a criterium: the same normalisation, the same
+ * `/`-handling and the same mode for validation and for saving. Building it twice (once to check
+ * for duplicates, once to emit) is how a validated candidate and a saved candidate drift apart.
+ */
+internal fun buildCriterium(input: String, type: TagType, mode: SieveCriterium.Mode): SieveCriterium =
+    withMode(inputTextToChipTag(normaliseCriteriumInput(input), type), mode)
+
+/**
+ * What the user SEES for a criterium value. Identical to the stored value except for whitespace,
+ * which is rendered as its own count ("2 spaces").
+ *
+ * Display only — the stored criterium keeps the exact whitespace, [criteriumValue] keeps returning
+ * it raw (it seeds the editor's text field), and duplicate detection stays exact. Without this a
+ * whitespace chip renders as a blank box that reads as a rendering fault, `" "` and `"  "` look
+ * identical while being distinct criteria, and screen readers announce a dangling "Edit ".
+ */
+@Composable
+internal fun criteriumDisplayText(value: String): String = when {
+    value.isEmpty() || value.isNotBlank() -> value
+    else -> pluralStringResource(
+        SystemCleanerR.plurals.systemcleaner_customfilter_editor_criterium_whitespace_label,
+        value.length,
+        value.length,
+    )
+}
+
+/**
+ * Modes that [input] must not be switched to because an existing sibling criterium already uses
+ * them. Switching anyway would produce an exact duplicate, and [swapPreservingOrder] collapses
+ * duplicates — the chip would silently vanish.
+ */
+internal fun collidingModes(
+    input: String,
+    type: TagType,
+    siblings: List<SieveCriterium>,
+): Set<SieveCriterium.Mode> {
+    // isEmpty, not isBlank: whitespace is a real value now, and skipping its collision check would
+    // let two identical whitespace criteria collapse into one when a mode is switched.
+    if (input.isEmpty() || siblings.isEmpty()) return emptySet()
+    return availableModesFor(type)
+        .map { it.first }
+        .filter { mode -> siblings.contains(buildCriterium(input, type, mode)) }
+        .toSet()
+}
+
+internal fun tagTypeOf(criterium: SieveCriterium): TagType = when (criterium) {
+    is NameCriterium -> TagType.NAME
+    is SegmentCriterium -> TagType.SEGMENTS
 }
 
 internal fun criteriumMode(criterium: SieveCriterium): SieveCriterium.Mode = when (criterium) {
@@ -72,58 +179,61 @@ internal fun criteriumValue(criterium: SieveCriterium): String = when (criterium
     is SegmentCriterium -> criterium.segments.joinSegments()
 }
 
-internal fun criteriumIcon(criterium: SieveCriterium): ImageVector = when (criterium) {
-    is NameCriterium -> when (criterium.mode) {
-        is NameCriterium.Mode.Contain -> SdmIcons.Contain
-        is NameCriterium.Mode.End -> SdmIcons.ContainEnd
-        is NameCriterium.Mode.Equal -> SdmIcons.ApproximatelyEqual
-        is NameCriterium.Mode.Start -> SdmIcons.ContainStart
-    }
+internal fun criteriumIcon(criterium: SieveCriterium): ImageVector = modeIcon(criterium.mode)
 
-    is SegmentCriterium -> when (criterium.mode) {
-        is SegmentCriterium.Mode.Contain -> SdmIcons.Contain
-        is SegmentCriterium.Mode.End -> SdmIcons.ContainEnd
-        is SegmentCriterium.Mode.Equal -> SdmIcons.ApproximatelyEqual
-        is SegmentCriterium.Mode.Start -> SdmIcons.ContainStart
-        is SegmentCriterium.Mode.Ancestor -> throw IllegalArgumentException("Ancestor not supported")
-        is SegmentCriterium.Mode.Specific -> throw IllegalArgumentException("Specific not supported")
-    }
+internal fun modeIcon(mode: SieveCriterium.Mode): ImageVector = when (mode) {
+    is NameCriterium.Mode.Contain -> SdmIcons.Contain
+    is NameCriterium.Mode.End -> SdmIcons.ContainEnd
+    is NameCriterium.Mode.Equal -> SdmIcons.ApproximatelyEqual
+    is NameCriterium.Mode.Start -> SdmIcons.ContainStart
+
+    is SegmentCriterium.Mode.Contain -> SdmIcons.Contain
+    is SegmentCriterium.Mode.End -> SdmIcons.ContainEnd
+    is SegmentCriterium.Mode.Equal -> SdmIcons.ApproximatelyEqual
+    is SegmentCriterium.Mode.Start -> SdmIcons.ContainStart
+    is SegmentCriterium.Mode.Ancestor -> throw IllegalArgumentException("Ancestor not supported")
+    is SegmentCriterium.Mode.Specific -> throw IllegalArgumentException("Specific not supported")
 }
 
 @StringRes
-internal fun criteriumModeLabelRes(criterium: SieveCriterium): Int = when (criterium) {
-    is NameCriterium -> when (criterium.mode) {
-        is NameCriterium.Mode.Start -> SystemCleanerR.string.systemcleaner_customfilter_editor_name_matching_mode_start_label
-        is NameCriterium.Mode.Contain -> SystemCleanerR.string.systemcleaner_customfilter_editor_name_matching_mode_contains_label
-        is NameCriterium.Mode.End -> SystemCleanerR.string.systemcleaner_customfilter_editor_name_matching_mode_end_label
-        is NameCriterium.Mode.Equal -> SystemCleanerR.string.systemcleaner_customfilter_editor_name_matching_mode_equal_label
-    }
+internal fun criteriumModeLabelRes(criterium: SieveCriterium): Int = modeLabelRes(criterium.mode)
 
-    is SegmentCriterium -> when (criterium.mode) {
-        is SegmentCriterium.Mode.Start -> SystemCleanerR.string.systemcleaner_customfilter_editor_segments_matching_mode_start_label
-        is SegmentCriterium.Mode.Contain -> SystemCleanerR.string.systemcleaner_customfilter_editor_segments_matching_mode_contains_label
-        is SegmentCriterium.Mode.End -> SystemCleanerR.string.systemcleaner_customfilter_editor_segments_matching_mode_end_label
-        is SegmentCriterium.Mode.Equal -> SystemCleanerR.string.systemcleaner_customfilter_editor_segments_matching_mode_equal_label
-        is SegmentCriterium.Mode.Ancestor -> throw IllegalArgumentException("Ancestor not supported")
-        is SegmentCriterium.Mode.Specific -> throw IllegalArgumentException("Specific not supported")
-    }
+@StringRes
+internal fun modeLabelRes(mode: SieveCriterium.Mode): Int = when (mode) {
+    is NameCriterium.Mode.Start -> SystemCleanerR.string.systemcleaner_customfilter_editor_name_matching_mode_start_label
+    is NameCriterium.Mode.Contain -> SystemCleanerR.string.systemcleaner_customfilter_editor_name_matching_mode_contains_label
+    is NameCriterium.Mode.End -> SystemCleanerR.string.systemcleaner_customfilter_editor_name_matching_mode_end_label
+    is NameCriterium.Mode.Equal -> SystemCleanerR.string.systemcleaner_customfilter_editor_name_matching_mode_equal_label
+
+    is SegmentCriterium.Mode.Start -> SystemCleanerR.string.systemcleaner_customfilter_editor_segments_matching_mode_start_label
+    is SegmentCriterium.Mode.Contain -> SystemCleanerR.string.systemcleaner_customfilter_editor_segments_matching_mode_contains_label
+    is SegmentCriterium.Mode.End -> SystemCleanerR.string.systemcleaner_customfilter_editor_segments_matching_mode_end_label
+    is SegmentCriterium.Mode.Equal -> SystemCleanerR.string.systemcleaner_customfilter_editor_segments_matching_mode_equal_label
+    is SegmentCriterium.Mode.Ancestor -> throw IllegalArgumentException("Ancestor not supported")
+    is SegmentCriterium.Mode.Specific -> throw IllegalArgumentException("Specific not supported")
 }
 
 @StringRes
-internal fun modeSwitcherTitleRes(criterium: SieveCriterium): Int = when (criterium) {
-    is SegmentCriterium -> SystemCleanerR.string.systemcleaner_customfilter_editor_segments_matching_mode_label
-    is NameCriterium -> SystemCleanerR.string.systemcleaner_customfilter_editor_name_matching_mode_label
+internal fun modeSwitcherTitleRes(criterium: SieveCriterium): Int = modeSwitcherTitleRes(tagTypeOf(criterium))
+
+@StringRes
+internal fun modeSwitcherTitleRes(type: TagType): Int = when (type) {
+    TagType.SEGMENTS -> SystemCleanerR.string.systemcleaner_customfilter_editor_segments_matching_mode_label
+    TagType.NAME -> SystemCleanerR.string.systemcleaner_customfilter_editor_name_matching_mode_label
 }
 
-internal fun availableModesFor(criterium: SieveCriterium): List<Pair<SieveCriterium.Mode, Int>> = when (criterium) {
-    is NameCriterium -> listOf(
+internal fun availableModesFor(criterium: SieveCriterium): List<Pair<SieveCriterium.Mode, Int>> =
+    availableModesFor(tagTypeOf(criterium))
+
+internal fun availableModesFor(type: TagType): List<Pair<SieveCriterium.Mode, Int>> = when (type) {
+    TagType.NAME -> listOf(
         NameCriterium.Mode.Start() to SystemCleanerR.string.systemcleaner_customfilter_editor_name_matching_mode_start_label,
         NameCriterium.Mode.Contain() to SystemCleanerR.string.systemcleaner_customfilter_editor_name_matching_mode_contains_label,
         NameCriterium.Mode.End() to SystemCleanerR.string.systemcleaner_customfilter_editor_name_matching_mode_end_label,
         NameCriterium.Mode.Equal() to SystemCleanerR.string.systemcleaner_customfilter_editor_name_matching_mode_equal_label,
     )
 
-    is SegmentCriterium -> listOf(
+    TagType.SEGMENTS -> listOf(
         SegmentCriterium.Mode.Start(allowPartial = true) to SystemCleanerR.string.systemcleaner_customfilter_editor_segments_matching_mode_start_label,
         SegmentCriterium.Mode.Contain(allowPartial = true) to SystemCleanerR.string.systemcleaner_customfilter_editor_segments_matching_mode_contains_label,
         SegmentCriterium.Mode.End(allowPartial = true) to SystemCleanerR.string.systemcleaner_customfilter_editor_segments_matching_mode_end_label,

--- a/app-tool-systemcleaner/src/main/res/values/strings.xml
+++ b/app-tool-systemcleaner/src/main/res/values/strings.xml
@@ -74,11 +74,23 @@
     <string name="systemcleaner_customfilter_editor_filetypes_directories_label">Folders</string>
     <string name="systemcleaner_customfilter_editor_filetypes_hint">If no type is selected, then all types will be matched.</string>
     <string name="systemcleaner_customfilter_editor_path_label">Path criteria</string>
-    <string name="systemcleaner_customfilter_editor_path_explanation">The target path needs to match at least one entry (e.g. \"Downloads/oldapks/game-\"). Long press entries for more options.</string>
+    <string name="systemcleaner_customfilter_editor_path_explanation">The target path needs to match at least one entry (e.g. \"Downloads/oldapks/game-\"). Tap an entry to edit it, or its icon to change how it is matched.</string>
     <string name="systemcleaner_customfilter_editor_name_label">Name criteria</string>
-    <string name="systemcleaner_customfilter_editor_name_explanation">The target name must contain at least one of the keywords (e.g. \"-receipt\"). Long press entries for more options.</string>
+    <string name="systemcleaner_customfilter_editor_name_explanation">The target name must contain at least one of the keywords (e.g. \"-receipt\"). Tap an entry to edit it, or its icon to change how it is matched.</string>
     <string name="systemcleaner_customfilter_editor_exclusions_label">Exclusions</string>
-    <string name="systemcleaner_customfilter_editor_exclusions_explanation">The result will be excluded if the path matches any entry (e.g. \"DCIM\"). Long press entries for more options.</string>
+    <string name="systemcleaner_customfilter_editor_exclusions_explanation">The result will be excluded if the path matches any entry (e.g. \"DCIM\"). Tap an entry to edit it, or its icon to change how it is matched.</string>
+    <string name="systemcleaner_customfilter_editor_path_criterium_add_action">Add path entry</string>
+    <string name="systemcleaner_customfilter_editor_name_criterium_add_action">Add name entry</string>
+    <string name="systemcleaner_customfilter_editor_exclusion_criterium_add_action">Add exclusion entry</string>
+    <string name="systemcleaner_customfilter_editor_criterium_create_title">New entry</string>
+    <string name="systemcleaner_customfilter_editor_criterium_value_label">Keyword</string>
+    <string name="systemcleaner_customfilter_editor_criterium_duplicate_error">This entry already exists.</string>
+    <plurals name="systemcleaner_customfilter_editor_criterium_whitespace_label">
+        <item quantity="one">%d space</item>
+        <item quantity="other">%d spaces</item>
+    </plurals>
+    <string name="systemcleaner_customfilter_editor_criterium_mode_taken_label">Already used by another entry</string>
+    <string name="systemcleaner_customfilter_editor_criterium_mode_x_action">Change match mode for %1$s, currently: %2$s</string>
     <string name="systemcleaner_customfilter_editor_segments_matching_mode_label">Path comparison mode</string>
     <string name="systemcleaner_customfilter_editor_segments_matching_mode_start_label">Path starts with keyword</string>
     <string name="systemcleaner_customfilter_editor_segments_matching_mode_contains_label">Path contains keyword</string>

--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/TaggedInputFieldTest.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/TaggedInputFieldTest.kt
@@ -1,110 +1,850 @@
 package eu.darken.sdmse.systemcleaner.ui.customfilter.editor
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.text.BasicTextField
+import android.content.Context
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateListOf
-import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.key.Key
-import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsFocused
-import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.assertIsNotFocused
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.hasAnyDescendant
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.StateRestorationTester
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.performTextReplacement
+import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.pressKey
-import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.TextRange
+import androidx.test.core.app.ApplicationProvider
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.common.sieve.NameCriterium
 import eu.darken.sdmse.common.sieve.SegmentCriterium
 import eu.darken.sdmse.common.sieve.SieveCriterium
+import io.kotest.assertions.withClue
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.types.shouldBeInstanceOf
+import io.kotest.matchers.shouldNotBe
 import org.junit.Test
 import testhelpers.compose.BaseComposeRobolectricTest
+import eu.darken.sdmse.common.R as CommonR
+import eu.darken.sdmse.systemcleaner.R as SystemCleanerR
 
 @OptIn(ExperimentalTestApi::class)
 class TaggedInputFieldTest : BaseComposeRobolectricTest() {
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
 
     private val downloads = SegmentCriterium(
         segments = listOf("Downloads"),
         mode = SegmentCriterium.Mode.Contain(allowPartial = true),
     )
 
+    /** Which section the field under test renders — drives the section-specific add button. */
+    private var renderedSection: CriteriaSection = CriteriaSection.PATH
+
     @Test
-    fun `backspace pops the last chip and arrow keys then edit the draft in place`() {
-        // Stateful tags so onRemove actually drops the chip and recomposes, mirroring production.
-        val tags = mutableStateListOf<SieveCriterium>(downloads)
-        composeRule.setContent {
-            PreviewWrapper {
-                TaggedInputField(
-                    type = TagType.SEGMENTS,
-                    hint = "Path",
-                    tags = tags,
-                    onAdd = { tags += it },
-                    onRemove = { tags.remove(it) },
-                    onModeChange = { _, _ -> },
-                )
-            }
-        }
+    fun `tapping the chip body opens the criterium editor`() {
+        renderField(tags = listOf(downloads))
 
-        val field = composeRule.onNodeWithTag(TAGGED_INPUT_FIELD_TEST_TAG)
-        field.performClick()
-        field.performKeyInput { pressKey(Key.Backspace) }
+        tapChipBody(downloads)
 
-        // The chip is gone from state and its value is now the editable draft.
-        composeRule.runOnIdle { tags.toList() shouldBe emptyList() }
-        field.assertTextEquals("Downloads")
-
-        // Caret started at the end; one left + typing must insert mid-string (not escape focus).
-        field.performKeyInput { pressKey(Key.DirectionLeft) }
-        field.assertIsFocused()
-        field.performTextInput("X")
-        field.assertTextEquals("DownloadXs")
+        composeRule
+            .onNodeWithText(string(CommonR.string.general_edit_action))
+            .assertIsDisplayed()
+        composeRule
+            .onNodeWithTag(CRITERIUM_EDITOR_INPUT_TEST_TAG)
+            .assertTextContains("Downloads")
     }
 
     @Test
-    fun `losing focus while editing a popped chip re-commits it preserving the matching mode`() {
-        val endChip = SegmentCriterium(
-            segments = listOf("Pictures"),
-            mode = SegmentCriterium.Mode.End(allowPartial = true),
+    fun `tapping the leading icon opens the matching mode dialog`() {
+        renderField(tags = listOf(downloads))
+
+        tapModeTarget(downloads)
+
+        composeRule
+            .onNodeWithText(string(SystemCleanerR.string.systemcleaner_customfilter_editor_segments_matching_mode_label))
+            .assertIsDisplayed()
+        // Not the editor: the icon is a shortcut, not a detour.
+        composeRule
+            .onAllNodesWithText(string(CommonR.string.general_edit_action))
+            .fetchSemanticsNodes().size shouldBe 0
+    }
+
+    @Test
+    fun `selecting a mode via the leading icon swaps the criterium`() {
+        val swaps = mutableListOf<Pair<SieveCriterium, SieveCriterium>>()
+        renderField(
+            tags = listOf(downloads),
+            onSwap = { old, new -> swaps += old to new },
         )
-        val tags = mutableStateListOf<SieveCriterium>(endChip)
+
+        tapModeTarget(downloads)
+        composeRule
+            .onNodeWithText(string(SystemCleanerR.string.systemcleaner_customfilter_editor_segments_matching_mode_end_label))
+            .performClick()
+
+        composeRule.runOnIdle {
+            val (old, new) = swaps.single()
+            old shouldBe downloads
+            new shouldBe SegmentCriterium(
+                segments = listOf("Downloads"),
+                mode = SegmentCriterium.Mode.End(allowPartial = true),
+            )
+        }
+    }
+
+    @Test
+    fun `tapping the remove icon removes the chip without opening a dialog`() {
+        val removed = mutableListOf<SieveCriterium>()
+        // Static tags: the chip stays rendered, so a tap leaking to the chip would surface as a dialog.
+        renderField(
+            tags = listOf(downloads),
+            onRemove = { removed += it },
+        )
+
+        removeNode(downloads).performClick()
+
+        composeRule.runOnIdle { removed shouldBe listOf(downloads) }
+        composeRule
+            .onAllNodesWithText(string(SystemCleanerR.string.systemcleaner_customfilter_editor_segments_matching_mode_label))
+            .fetchSemanticsNodes().size shouldBe 0
+        composeRule
+            .onAllNodesWithText(string(CommonR.string.general_edit_action))
+            .fetchSemanticsNodes().size shouldBe 0
+    }
+
+    @Test
+    fun `a name-criterium chip opens the name comparison mode dialog`() {
+        val receipt = NameCriterium(name = "receipt", mode = NameCriterium.Mode.Contain())
+        renderField(type = TagType.NAME, section = CriteriaSection.NAME, tags = listOf(receipt))
+
+        tapModeTarget(receipt)
+
+        composeRule
+            .onNodeWithText(string(SystemCleanerR.string.systemcleaner_customfilter_editor_name_matching_mode_label))
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `the chip exposes a Button role`() {
+        renderField(tags = listOf(downloads))
+
+        val chip = chipNode(downloads).fetchSemanticsNode()
+
+        chip.config[SemanticsProperties.Role] shouldBe Role.Button
+    }
+
+    @Test
+    fun `a criteria chip is no taller than the add chip`() {
+        renderField(tags = listOf(downloads))
+
+        // Both heights come from the measured layout, not from dp constants: what matters is that
+        // the rows stay flush, whatever the chip defaults happen to be. A remove button that takes
+        // its size from LocalMinimumInteractiveComponentSize instead of a fixed 24dp inflates the
+        // whole chip and makes the criteria row visibly taller than the Add chip next to it.
+        val chipHeight = chipNode(downloads).fetchSemanticsNode().size.height
+        val addHeight = addNode().fetchSemanticsNode().size.height
+
+        withClue("criteria chip height $chipHeight vs add chip height $addHeight") {
+            (chipHeight <= addHeight) shouldBe true
+        }
+    }
+
+    @Test
+    fun `a short chip label is padded out to a three character minimum`() {
+        val oneChar = SegmentCriterium(listOf("a"), SegmentCriterium.Mode.Contain(allowPartial = true))
+        val threeChar = SegmentCriterium(listOf("abc"), SegmentCriterium.Mode.Contain(allowPartial = true))
+        renderField(tags = listOf(oneChar, threeChar, downloads))
+
+        // A single-character entry renders as a sliver between the two icons and reads as broken
+        // next to its neighbours, so its label is floored at the width of three characters.
+        val oneCharWidth = labelWidth(oneChar)
+        val threeCharWidth = labelWidth(threeChar)
+        val longWidth = labelWidth(downloads)
+
+        withClue("1-char label $oneCharWidth vs 3-char label $threeCharWidth") {
+            (oneCharWidth >= threeCharWidth) shouldBe true
+        }
+        // The floor is a minimum, not a fixed width: longer labels still size to their content.
+        withClue("long label $longWidth vs 3-char label $threeCharWidth") {
+            (longWidth > threeCharWidth) shouldBe true
+        }
+    }
+
+    @Test
+    fun `the add button opens the editor in create mode`() {
+        renderField(tags = listOf(downloads))
+
+        tapAdd()
+
+        composeRule
+            .onNodeWithText(string(SystemCleanerR.string.systemcleaner_customfilter_editor_criterium_create_title))
+            .assertIsDisplayed()
+        // Empty draft: nothing to save yet.
+        saveNode().assertIsNotEnabled()
+    }
+
+    @Test
+    fun `create then mode then save adds instead of swapping`() {
         val added = mutableListOf<SieveCriterium>()
-        composeRule.setContent {
+        val swaps = mutableListOf<Pair<SieveCriterium, SieveCriterium>>()
+        renderField(
+            tags = listOf(downloads),
+            onAdd = { added += it },
+            onSwap = { old, new -> swaps += old to new },
+        )
+
+        tapAdd()
+        typeCriterium("Pictures")
+        tapModeRow()
+        composeRule
+            .onNodeWithText(string(SystemCleanerR.string.systemcleaner_customfilter_editor_segments_matching_mode_end_label))
+            .performClick()
+        // Back in the editor: the draft survived the detour.
+        composeRule.onNodeWithTag(CRITERIUM_EDITOR_INPUT_TEST_TAG).assertTextContains("Pictures")
+        tapSave()
+
+        composeRule.runOnIdle {
+            swaps shouldBe emptyList()
+            added shouldBe listOf(
+                SegmentCriterium(listOf("Pictures"), SegmentCriterium.Mode.End(allowPartial = true)),
+            )
+        }
+    }
+
+    @Test
+    fun `editing then mode then save swaps the original entry`() {
+        val added = mutableListOf<SieveCriterium>()
+        val swaps = mutableListOf<Pair<SieveCriterium, SieveCriterium>>()
+        renderField(
+            tags = listOf(downloads),
+            onAdd = { added += it },
+            onSwap = { old, new -> swaps += old to new },
+        )
+
+        tapChipBody(downloads)
+        typeCriterium("Pictures")
+        tapModeRow()
+        composeRule
+            .onNodeWithText(string(SystemCleanerR.string.systemcleaner_customfilter_editor_segments_matching_mode_equal_label))
+            .performClick()
+        tapSave()
+
+        composeRule.runOnIdle {
+            added shouldBe emptyList()
+            val (old, new) = swaps.single()
+            // The ORIGINAL chip, not the draft — swapPreservingOrder silently no-ops on a stranger.
+            old shouldBe downloads
+            new shouldBe SegmentCriterium(listOf("Pictures"), SegmentCriterium.Mode.Equal())
+        }
+    }
+
+    @Test
+    fun `cancelling the mode dialog keeps the draft and the previous mode`() {
+        val added = mutableListOf<SieveCriterium>()
+        renderField(tags = emptyList(), onAdd = { added += it })
+
+        tapAdd()
+        typeCriterium("Pictures")
+        tapModeRow()
+        composeRule.onNodeWithText(string(CommonR.string.general_cancel_action)).performClick()
+
+        composeRule
+            .onNodeWithText(string(SystemCleanerR.string.systemcleaner_customfilter_editor_criterium_create_title))
+            .assertIsDisplayed()
+        composeRule.onNodeWithTag(CRITERIUM_EDITOR_INPUT_TEST_TAG).assertTextContains("Pictures")
+        tapSave()
+
+        composeRule.runOnIdle {
+            added shouldBe listOf(
+                SegmentCriterium(listOf("Pictures"), SegmentCriterium.Mode.Contain(allowPartial = true)),
+            )
+        }
+    }
+
+    @Test
+    fun `an exact duplicate blocks saving but the same text with another mode does not`() {
+        val swaps = mutableListOf<Pair<SieveCriterium, SieveCriterium>>()
+        val other = SegmentCriterium(listOf("Pictures"), SegmentCriterium.Mode.Contain(allowPartial = true))
+        renderField(
+            tags = listOf(downloads, other),
+            onSwap = { old, new -> swaps += old to new },
+        )
+
+        tapChipBody(downloads)
+        typeCriterium("Pictures")
+
+        // Identical text AND mode as the sibling -> exact duplicate.
+        saveNode().assertIsNotEnabled()
+        composeRule
+            .onNodeWithText(string(SystemCleanerR.string.systemcleaner_customfilter_editor_criterium_duplicate_error))
+            .assertIsDisplayed()
+
+        // Same text, different mode -> a legitimately distinct criterium.
+        tapModeRow()
+        composeRule
+            .onNodeWithText(string(SystemCleanerR.string.systemcleaner_customfilter_editor_segments_matching_mode_end_label))
+            .performClick()
+        saveNode().assertIsEnabled()
+        tapSave()
+
+        composeRule.runOnIdle {
+            val (old, new) = swaps.single()
+            old shouldBe downloads
+            new shouldBe SegmentCriterium(listOf("Pictures"), SegmentCriterium.Mode.End(allowPartial = true))
+        }
+    }
+
+    @Test
+    fun `a mode that would collide with a sibling is disabled`() {
+        val pictures = SegmentCriterium(listOf("Pictures"), SegmentCriterium.Mode.Contain(allowPartial = true))
+        val picturesEqual = SegmentCriterium(listOf("Pictures"), SegmentCriterium.Mode.Equal())
+        renderField(tags = listOf(pictures, picturesEqual))
+
+        tapModeTarget(pictures)
+
+        // Switching Contain -> Equal would produce an exact duplicate, which the criteria set
+        // collapses: one chip would vanish with no dialog left to warn in.
+        composeRule
+            .onNodeWithText(string(SystemCleanerR.string.systemcleaner_customfilter_editor_segments_matching_mode_equal_label))
+            .assertIsNotEnabled()
+        composeRule
+            .onNodeWithText(string(SystemCleanerR.string.systemcleaner_customfilter_editor_segments_matching_mode_end_label))
+            .assertIsEnabled()
+    }
+
+    @Test
+    fun `a colliding mode is blocked for an entry whose text is not normalised`() {
+        // Surrounding whitespace survives an import: rebuilding the candidate from the chip text
+        // trims it away, so the collision check would look for "foo" while the save writes " foo ".
+        val padded = NameCriterium(name = " foo ", mode = NameCriterium.Mode.Contain())
+        val paddedEqual = NameCriterium(name = " foo ", mode = NameCriterium.Mode.Equal())
+        val swaps = mutableListOf<Pair<SieveCriterium, SieveCriterium>>()
+        renderField(
+            type = TagType.NAME,
+            section = CriteriaSection.NAME,
+            tags = listOf(padded, paddedEqual),
+            onSwap = { old, new -> swaps += old to new },
+        )
+
+        tapModeTarget(padded)
+
+        composeRule
+            .onNodeWithText(string(SystemCleanerR.string.systemcleaner_customfilter_editor_name_matching_mode_equal_label))
+            .assertIsNotEnabled()
+
+        // The mode that IS offered saves exactly the criterium that was validated: untrimmed.
+        composeRule
+            .onNodeWithText(string(SystemCleanerR.string.systemcleaner_customfilter_editor_name_matching_mode_end_label))
+            .performClick()
+
+        composeRule.runOnIdle {
+            val (old, new) = swaps.single()
+            old shouldBe padded
+            new shouldBe NameCriterium(name = " foo ", mode = NameCriterium.Mode.End())
+        }
+    }
+
+    @Test
+    fun `tapping the mode row opens the mode dialog and returns with the draft intact`() {
+        val added = mutableListOf<SieveCriterium>()
+        renderField(tags = emptyList(), onAdd = { added += it })
+
+        tapAdd()
+        typeCriterium("Pictures")
+        composeRule.onNodeWithTag(CRITERIUM_EDITOR_MODE_ROW_TEST_TAG).assertHasClickAction()
+        tapModeRow()
+
+        composeRule
+            .onNodeWithText(string(SystemCleanerR.string.systemcleaner_customfilter_editor_segments_matching_mode_label))
+            .assertIsDisplayed()
+        composeRule
+            .onNodeWithText(string(SystemCleanerR.string.systemcleaner_customfilter_editor_segments_matching_mode_end_label))
+            .performClick()
+
+        // Back in the editor: same draft, and the row now displays the freshly picked mode.
+        composeRule.onNodeWithTag(CRITERIUM_EDITOR_INPUT_TEST_TAG).assertTextContains("Pictures")
+        composeRule
+            .onNodeWithText(string(SystemCleanerR.string.systemcleaner_customfilter_editor_segments_matching_mode_end_label))
+            .assertIsDisplayed()
+        tapSave()
+
+        composeRule.runOnIdle {
+            added shouldBe listOf(
+                SegmentCriterium(listOf("Pictures"), SegmentCriterium.Mode.End(allowPartial = true)),
+            )
+        }
+    }
+
+    @Test
+    fun `the mode row has no click label while the draft is empty`() {
+        renderField(tags = listOf(downloads))
+
+        tapAdd()
+
+        // Formatting the label with an empty draft yields "...for , currently: ..." — TalkBack would
+        // read the dangling "for ,". No label means the row announces its own visible mode instead.
+        modeRowClickLabel() shouldBe null
+    }
+
+    @Test
+    fun `the mode row names the entry once the draft has text`() {
+        renderField(tags = listOf(downloads))
+
+        tapChipBody(downloads)
+
+        modeRowClickLabel() shouldBe string(
+            SystemCleanerR.string.systemcleaner_customfilter_editor_criterium_mode_x_action,
+            "Downloads",
+            string(criteriumModeLabelRes(downloads)),
+        )
+    }
+
+    @Test
+    fun `typing one character at a time keeps the caret at the end`() {
+        renderField(tags = emptyList())
+
+        tapAdd()
+        // One call per character: a per-keystroke recomposition that drops focus or resets the
+        // selection only shows up between keystrokes, never in a single performTextReplacement.
+        criteriumInput().performTextInput("a")
+        criteriumInput().performTextInput("b")
+        criteriumInput().performTextInput("c")
+
+        criteriumText() shouldBe "abc"
+        criteriumSelection() shouldBe TextRange(3)
+    }
+
+    @Test
+    fun `typing on a hardware keyboard keeps the caret at the end`() {
+        renderField(tags = emptyList())
+
+        tapAdd()
+        // The reporter typed on the emulator's keyboard: key events go through the focused node,
+        // so a focus loss between keystrokes silently swallows the rest of the word.
+        criteriumInput().performKeyInput { pressKey(Key.A) }
+        criteriumInput().performKeyInput { pressKey(Key.B) }
+        criteriumInput().performKeyInput { pressKey(Key.C) }
+
+        criteriumText() shouldBe "abc"
+        criteriumSelection() shouldBe TextRange(3)
+    }
+
+    @Test
+    fun `clearing the text while editing turns the positive action into Remove`() {
+        val removed = mutableListOf<SieveCriterium>()
+        val added = mutableListOf<SieveCriterium>()
+        val swaps = mutableListOf<Pair<SieveCriterium, SieveCriterium>>()
+        renderField(
+            tags = listOf(downloads),
+            onAdd = { added += it },
+            onRemove = { removed += it },
+            onSwap = { old, new -> swaps += old to new },
+        )
+
+        tapChipBody(downloads)
+        criteriumInput().performTextClearance()
+
+        composeRule.onNodeWithText(string(CommonR.string.general_remove_action)).performClick()
+
+        composeRule.runOnIdle {
+            removed shouldBe listOf(downloads)
+            added shouldBe emptyList()
+            swaps shouldBe emptyList()
+        }
+    }
+
+    @Test
+    fun `an empty draft in create mode keeps a disabled Save`() {
+        renderField(tags = listOf(downloads))
+
+        tapAdd()
+
+        // Nothing to remove when nothing exists yet — the create flow keeps its plain Save.
+        saveNode().assertIsNotEnabled()
+        composeRule
+            .onAllNodesWithText(string(CommonR.string.general_remove_action))
+            .fetchSemanticsNodes().size shouldBe 0
+    }
+
+    @Test
+    fun `an unchanged edit offers Close and neither adds nor swaps`() {
+        val added = mutableListOf<SieveCriterium>()
+        val swaps = mutableListOf<Pair<SieveCriterium, SieveCriterium>>()
+        val removed = mutableListOf<SieveCriterium>()
+        renderField(
+            tags = listOf(downloads),
+            onAdd = { added += it },
+            onRemove = { removed += it },
+            onSwap = { old, new -> swaps += old to new },
+        )
+
+        tapChipBody(downloads)
+
+        composeRule.onNodeWithText(string(CommonR.string.general_close_action)).performClick()
+
+        composeRule.runOnIdle {
+            added shouldBe emptyList()
+            swaps shouldBe emptyList()
+            removed shouldBe emptyList()
+        }
+        // Dismissed, not left open.
+        composeRule
+            .onAllNodesWithText(string(CommonR.string.general_edit_action))
+            .fetchSemanticsNodes().size shouldBe 0
+    }
+
+    @Test
+    fun `changing the text of an existing entry restores Save`() {
+        val swaps = mutableListOf<Pair<SieveCriterium, SieveCriterium>>()
+        renderField(tags = listOf(downloads), onSwap = { old, new -> swaps += old to new })
+
+        tapChipBody(downloads)
+        typeCriterium("Pictures")
+
+        composeRule
+            .onAllNodesWithText(string(CommonR.string.general_close_action))
+            .fetchSemanticsNodes().size shouldBe 0
+        tapSave()
+
+        composeRule.runOnIdle {
+            val (old, new) = swaps.single()
+            old shouldBe downloads
+            new shouldBe SegmentCriterium(listOf("Pictures"), SegmentCriterium.Mode.Contain(allowPartial = true))
+        }
+    }
+
+    @Test
+    fun `changing only the mode of an existing entry restores Save`() {
+        val swaps = mutableListOf<Pair<SieveCriterium, SieveCriterium>>()
+        renderField(tags = listOf(downloads), onSwap = { old, new -> swaps += old to new })
+
+        tapChipBody(downloads)
+        // Same text, different mode: still a real edit, so Close would strand the change.
+        tapModeRow()
+        composeRule
+            .onNodeWithText(string(SystemCleanerR.string.systemcleaner_customfilter_editor_segments_matching_mode_end_label))
+            .performClick()
+
+        composeRule
+            .onAllNodesWithText(string(CommonR.string.general_close_action))
+            .fetchSemanticsNodes().size shouldBe 0
+        tapSave()
+
+        composeRule.runOnIdle {
+            val (old, new) = swaps.single()
+            old shouldBe downloads
+            new shouldBe SegmentCriterium(listOf("Downloads"), SegmentCriterium.Mode.End(allowPartial = true))
+        }
+    }
+
+    @Test
+    fun `dpad down moves focus off the keyword field`() {
+        renderField(tags = listOf(downloads))
+
+        tapChipBody(downloads)
+        criteriumInput().assertIsFocused()
+
+        // A remote has no TAB key, and the field now holds the initial focus. Without an explicit
+        // escape it eats the vertical keys for caret movement and Save is unreachable on TV.
+        criteriumInput().performKeyInput { pressKey(Key.DirectionDown) }
+
+        criteriumInput().assertIsNotFocused()
+    }
+
+    @Test
+    fun `a whitespace-only entry can be saved and keeps its exact value`() {
+        val added = mutableListOf<SieveCriterium>()
+        renderField(
+            type = TagType.NAME,
+            section = CriteriaSection.NAME,
+            tags = emptyList(),
+            onAdd = { added += it },
+        )
+
+        tapAdd()
+        typeCriterium("  ")
+
+        // A name criterium of " " with *contains* matches every file whose name has a space in it,
+        // and there is no other way to express that.
+        saveNode().assertIsEnabled()
+        tapSave()
+
+        composeRule.runOnIdle {
+            added shouldBe listOf(NameCriterium("  ", NameCriterium.Mode.Contain()))
+        }
+    }
+
+    @Test
+    fun `surrounding whitespace is still trimmed off a normal entry`() {
+        val added = mutableListOf<SieveCriterium>()
+        renderField(tags = emptyList(), onAdd = { added += it })
+
+        tapAdd()
+        typeCriterium("Downloads ")
+        tapSave()
+
+        // Only an all-whitespace value is kept verbatim; stray padding around real text is noise.
+        composeRule.runOnIdle {
+            added shouldBe listOf(
+                SegmentCriterium(listOf("Downloads"), SegmentCriterium.Mode.Contain(allowPartial = true)),
+            )
+        }
+    }
+
+    @Test
+    fun `whitespace chips render their count so they stay legible and distinct`() {
+        val oneSpace = NameCriterium(" ", NameCriterium.Mode.Contain())
+        val twoSpaces = NameCriterium("  ", NameCriterium.Mode.Contain())
+        renderField(type = TagType.NAME, section = CriteriaSection.NAME, tags = listOf(oneSpace, twoSpaces))
+
+        // Rendering the raw value would give two identically blank chips for two distinct criteria.
+        composeRule.onNodeWithText(whitespaceLabel(1)).assertIsDisplayed()
+        composeRule.onNodeWithText(whitespaceLabel(2)).assertIsDisplayed()
+        whitespaceLabel(1) shouldNotBe whitespaceLabel(2)
+    }
+
+    @Test
+    fun `a whitespace chip's edit and remove labels use the count`() {
+        val twoSpaces = NameCriterium("  ", NameCriterium.Mode.Contain())
+        renderField(type = TagType.NAME, section = CriteriaSection.NAME, tags = listOf(twoSpaces))
+
+        // Built from the raw value these would be spoken as a dangling "Edit  " / "Remove  ".
+        chipNode(twoSpaces).fetchSemanticsNode().config.getOrNull(SemanticsActions.OnClick)?.label shouldBe
+            string(CommonR.string.general_edit_x_action, whitespaceLabel(2))
+        removeNode(twoSpaces).assertIsDisplayed()
+    }
+
+    @Test
+    fun `editing a whitespace chip puts the raw whitespace back in the field`() {
+        val twoSpaces = NameCriterium("  ", NameCriterium.Mode.Contain())
+        renderField(type = TagType.NAME, section = CriteriaSection.NAME, tags = listOf(twoSpaces))
+
+        tapChipBody(twoSpaces)
+
+        // The count label is display only — the editor has to hand back the actual characters.
+        criteriumText() shouldBe "  "
+    }
+
+    @Test
+    fun `name input strips path separators`() {
+        val added = mutableListOf<SieveCriterium>()
+        renderField(
+            type = TagType.NAME,
+            section = CriteriaSection.NAME,
+            tags = emptyList(),
+            onAdd = { added += it },
+        )
+
+        tapAdd()
+        typeCriterium("a/b/c")
+        tapSave()
+
+        composeRule.runOnIdle {
+            added shouldBe listOf(NameCriterium("abc", NameCriterium.Mode.Contain()))
+        }
+    }
+
+    @Test
+    fun `the open editor survives a state restoration`() {
+        val restorationTester = StateRestorationTester(composeRule)
+        val added = mutableListOf<SieveCriterium>()
+        restorationTester.setContent {
             PreviewWrapper {
-                Column {
-                    TaggedInputField(
-                        type = TagType.SEGMENTS,
-                        hint = "Path",
-                        tags = tags,
-                        onAdd = {
-                            added += it
-                            tags += it
-                        },
-                        onRemove = { tags.remove(it) },
-                        onModeChange = { _, _ -> },
-                    )
-                    // A sibling focus target so we can pull focus away from the input.
-                    BasicTextField(
-                        value = TextFieldValue(""),
-                        onValueChange = {},
-                        modifier = Modifier.testTag("focus-sink"),
-                    )
-                }
+                FieldUnderTest(tags = mutableStateListOf(downloads), onAdd = { added += it })
             }
         }
 
-        val field = composeRule.onNodeWithTag(TAGGED_INPUT_FIELD_TEST_TAG)
-        field.performClick()
-        field.performKeyInput { pressKey(Key.Backspace) }
-        // Move focus away mid-edit — the draft must be re-committed, not silently dropped.
-        composeRule.onNodeWithTag("focus-sink").performClick()
+        tapChipBody(downloads)
+        typeCriterium("Pictures")
+        restorationTester.emulateSavedInstanceStateRestore()
 
-        composeRule.runOnIdle {
-            val committed = added.single().shouldBeInstanceOf<SegmentCriterium>()
-            committed.segments shouldBe listOf("Pictures")
-            committed.mode.shouldBeInstanceOf<SegmentCriterium.Mode.End>()
+        composeRule
+            .onNodeWithText(string(CommonR.string.general_edit_action))
+            .assertIsDisplayed()
+        composeRule.onNodeWithTag(CRITERIUM_EDITOR_INPUT_TEST_TAG).assertTextContains("Pictures")
+    }
+
+    @Test
+    fun `the open mode dialog survives a state restoration and returns to the editor`() {
+        val restorationTester = StateRestorationTester(composeRule)
+        restorationTester.setContent {
+            PreviewWrapper {
+                FieldUnderTest(tags = mutableStateListOf(downloads))
+            }
+        }
+
+        tapChipBody(downloads)
+        typeCriterium("Pictures")
+        tapModeRow()
+        restorationTester.emulateSavedInstanceStateRestore()
+
+        composeRule
+            .onNodeWithText(string(SystemCleanerR.string.systemcleaner_customfilter_editor_segments_matching_mode_label))
+            .assertIsDisplayed()
+        composeRule.onNodeWithText(string(CommonR.string.general_cancel_action)).performClick()
+        composeRule.onNodeWithTag(CRITERIUM_EDITOR_INPUT_TEST_TAG).assertTextContains("Pictures")
+    }
+
+    private fun string(resId: Int, vararg args: Any): String =
+        if (args.isEmpty()) context.getString(resId) else context.getString(resId, *args)
+
+    /** "N spaces" for an all-whitespace value, the raw value otherwise — what the chip renders. */
+    private fun whitespaceLabel(count: Int): String = context.resources.getQuantityString(
+        SystemCleanerR.plurals.systemcleaner_customfilter_editor_criterium_whitespace_label,
+        count,
+        count,
+    )
+
+    private fun displayLabel(criterium: SieveCriterium): String {
+        val raw = criteriumValue(criterium)
+        return if (raw.isNotEmpty() && raw.isBlank()) whitespaceLabel(raw.length) else raw
+    }
+
+    private fun chipNode(criterium: SieveCriterium) = composeRule
+        .onAllNodes(hasClickAction() and hasAnyDescendant(hasText(displayLabel(criterium))), useUnmergedTree = true)
+        .onFirst()
+
+    private fun modeNode(criterium: SieveCriterium) = composeRule.onNodeWithContentDescription(
+        string(
+            SystemCleanerR.string.systemcleaner_customfilter_editor_criterium_mode_x_action,
+            displayLabel(criterium),
+            string(criteriumModeLabelRes(criterium)),
+        ),
+        useUnmergedTree = true,
+    )
+
+    private fun removeNode(criterium: SieveCriterium) = composeRule.onNodeWithContentDescription(
+        string(CommonR.string.general_remove_x_action, displayLabel(criterium)),
+        useUnmergedTree = true,
+    )
+
+    private fun saveNode() = composeRule.onNodeWithText(string(CommonR.string.general_save_action))
+
+    /** The accessibility click label of the editor's mode row, or null if it exposes none. */
+    private fun modeRowClickLabel(): String? = composeRule
+        .onNodeWithTag(CRITERIUM_EDITOR_MODE_ROW_TEST_TAG)
+        .fetchSemanticsNode()
+        .config
+        .getOrNull(SemanticsActions.OnClick)
+        ?.label
+
+    /**
+     * Real touch injection (never a semantics action): what has to hold is that a pointer landing
+     * on the chip body reaches the editor. The target is computed from the measured gap between
+     * the mode target and the remove button, and the assertion that a gap exists at all is the
+     * point — Robolectric's stub text metrics make labels a few px wide, which is the worst case.
+     */
+    private fun tapChipBody(criterium: SieveCriterium) {
+        val chipBounds = chipNode(criterium).fetchSemanticsNode().boundsInRoot
+        val modeBounds = modeNode(criterium).fetchSemanticsNode().touchBoundsInRoot
+        val removeBounds = removeNode(criterium).fetchSemanticsNode().touchBoundsInRoot
+        if (modeBounds.right >= removeBounds.left) {
+            throw AssertionError(
+                "No tappable chip body: mode target ends at ${modeBounds.right}, " +
+                    "remove target starts at ${removeBounds.left}",
+            )
+        }
+        val x = (modeBounds.right + removeBounds.left) / 2f - chipBounds.left
+        chipNode(criterium).performTouchInput { click(Offset(x, chipBounds.height / 2f)) }
+    }
+
+    private fun tapModeTarget(criterium: SieveCriterium) = modeNode(criterium).performTouchInput {
+        click(center)
+    }
+
+    /** Width of the chip's own label node, i.e. excluding the mode target and remove button. */
+    private fun labelWidth(criterium: SieveCriterium) = composeRule
+        .onNodeWithText(criteriumValue(criterium), useUnmergedTree = true)
+        .fetchSemanticsNode()
+        .size
+        .width
+
+    private fun addNode() = composeRule
+        .onNodeWithContentDescription(string(criteriumAddDescriptionRes(renderedSection)))
+
+    private fun tapAdd() = addNode().performClick()
+
+    private fun criteriumInput() = composeRule.onNodeWithTag(CRITERIUM_EDITOR_INPUT_TEST_TAG)
+
+    private fun criteriumText(): String = criteriumInput()
+        .fetchSemanticsNode()
+        .config[SemanticsProperties.EditableText]
+        .text
+
+    private fun criteriumSelection(): TextRange = criteriumInput()
+        .fetchSemanticsNode()
+        .config[SemanticsProperties.TextSelectionRange]
+
+    private fun typeCriterium(text: String) = composeRule
+        .onNodeWithTag(CRITERIUM_EDITOR_INPUT_TEST_TAG)
+        .performTextReplacement(text)
+
+    private fun tapModeRow() = composeRule
+        .onNodeWithTag(CRITERIUM_EDITOR_MODE_ROW_TEST_TAG)
+        .performClick()
+
+    private fun tapSave() = saveNode().performClick()
+
+    @Composable
+    private fun FieldUnderTest(
+        tags: List<SieveCriterium>,
+        type: TagType = TagType.SEGMENTS,
+        section: CriteriaSection = renderedSection,
+        onAdd: (SieveCriterium) -> Unit = {},
+        onRemove: (SieveCriterium) -> Unit = {},
+        onSwap: (old: SieveCriterium, new: SieveCriterium) -> Unit = { _, _ -> },
+    ) = TaggedInputField(
+        type = type,
+        section = section,
+        hint = "Criteria",
+        tags = tags,
+        onAdd = onAdd,
+        onRemove = onRemove,
+        onSwap = onSwap,
+    )
+
+    private fun renderField(
+        tags: List<SieveCriterium>,
+        type: TagType = TagType.SEGMENTS,
+        section: CriteriaSection = CriteriaSection.PATH,
+        onAdd: (SieveCriterium) -> Unit = {},
+        onRemove: (SieveCriterium) -> Unit = {},
+        onSwap: (old: SieveCriterium, new: SieveCriterium) -> Unit = { _, _ -> },
+    ) {
+        renderedSection = section
+        composeRule.setContent {
+            PreviewWrapper {
+                FieldUnderTest(
+                    tags = tags,
+                    type = type,
+                    section = section,
+                    onAdd = onAdd,
+                    onRemove = onRemove,
+                    onSwap = onSwap,
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## What changed

Custom filter entries are now edited through a dialog. Tap an entry to change its text, tap its icon to change how it matches, tap the X to remove it, and use the new Add button to create one.

Previously there was no way to edit a *specific* entry. The only route was backspacing from the text field, which always popped the **last** entry — so correcting the first of several meant deleting and retyping everything after it.

This also fixes the reported bug where tapping an entry did nothing at all, leaving the matching-strategy option unreachable.

Other improvements along the way:

- Clearing an entry's text while editing offers **Remove**; opening an entry and changing nothing offers **Close** instead of Save.
- Entering a value that already exists is refused with an explanation, instead of silently collapsing into the existing entry.
- Changing an entry's match mode can no longer make it silently vanish by colliding with another entry.
- Very short entries are no longer rendered as tiny chips.
- The entry rows sit closer together.
- Screen-reader support: the match-mode icon, the entry itself, the remove button and Add are now four separately labelled, individually reachable targets, and the duplicate warning is announced rather than only shown in red.
- Fixes a typing bug in the size and age input dialogs in Settings, where every keystroke moved focus off the text field.

## Technical Context

- **Root cause of #2629:** `TaggedChip` put its gesture on an outer `combinedClickable`, but `InputChip` → `SelectableChip` → `Surface` appends its own `.selectable(...)` *after* the caller's modifier. The inner node takes the bubbling pointer pass first and consumes the down, so the outer long-press never started — and the chip's own `onClick` was a no-op `{}`. No configuration of `InputChip` permits an outer long-press; the handler has to be the chip's own `onClick`.
- **Reordering was deliberately not added.** Criteria are evaluated with `any {}` over a `Set` (`FileSieve.kt`), so chip order has no functional effect — drag-to-reorder would have been cosmetic only, while forcing a hand-rolled chip and a custom `FlowRow` drag implementation.
- **The inline text field was removed rather than kept alongside the dialog.** Its edit flow had a state where an entry existed only as text in a field, having already been removed from the set; any interruption destroyed it silently. This also deletes the backspace-pop and focus-loss re-commit behaviours, and their two tests, since the behaviour they covered is gone.
- **`swapPreservingOrder` returns the set unchanged when `old` is absent.** That is why the editor tracks the original criterium separately and never replaces it — targeting the in-progress draft instead would make Save a silent no-op. The same reasoning drives building the candidate criterium exactly once and using that identical instance for both the duplicate check and the save: validating a trimmed value while saving an untrimmed one produced an exact duplicate that `swapPreservingOrder` then collapsed, deleting an entry.
- **Shared-component change worth reviewer attention.** `SdmDialogButtonBar` claimed focus via `LaunchedEffect(inputModeManager.inputMode)`. That key flips on every Touch→Keyboard transition — i.e. once per keystroke when alternating between tapping a field and typing on a hardware keyboard — yanking focus onto the negative button after every letter. Text-input dialogs now opt out through a new `autoFocus` parameter; the touch-to-remote focus re-claim is preserved unchanged for every other dialog, and is now covered by a test that had never existed. `AgeInputDialog` and `SizeInputDialog` had the same defect and opt out too.
- **Translation note.** The three reworded explanation strings keep their existing keys, so the 77 localized overrides stay stale until Crowdin re-syncs. Renaming them would have orphaned 231 translations, and `ExtraTranslation` is a fatal lint outside beta builds. Three generic strings (`Add`, `Edit %s`, `Remove %s`) were promoted to `app-common` rather than duplicated per module.

## Review guidance

- **The dialog state machine is the trickiest part** — specifically create-vs-edit identity surviving the detour out to the mode dialog and back. `original` must never be replaced by the draft, and Save branches add-vs-swap on `original == null`.
- **The `app-common-ui` focus change affects 5 dialogs app-wide**, including the shared confirm dialog. Behaviour is intentionally unchanged for all of them except the three that host a text field.
- Editor state survives configuration change; unsaved edits still do not survive process death, which is pre-existing (the ViewModel keeps the edited config in `DynamicStateFlow` with no `SavedStateHandle`).

## Validation

- `:app-tool-systemcleaner:testDebugUnitTest` — 357/357
- `:app-common-ui:testDebugUnitTest` — 182/182
- `:app:assembleFossDebug`, `:app:lintVitalFossRelease` — clean
- Manually exercised on an emulator; the chip-height, per-keystroke-focus, Remove-on-clear and Close-when-unchanged behaviours were all found by hand-testing and fixed.

Closes #2629
