### PR TITLE
AppControl: Fix force stop not working on ColorOS devices

### DIFF
--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/automation/AppControlAutomation.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/automation/AppControlAutomation.kt
@@ -15,6 +15,7 @@ import eu.darken.sdmse.appcontrol.core.automation.specs.AppControlLabelDebugger
 import eu.darken.sdmse.appcontrol.core.automation.specs.AppControlSpecGenerator
 import eu.darken.sdmse.appcontrol.core.automation.specs.androidtv.AndroidTVSpecs
 import eu.darken.sdmse.appcontrol.core.automation.specs.aosp.AOSPSpecs
+import eu.darken.sdmse.appcontrol.core.automation.specs.coloros.ColorOSSpecs
 import eu.darken.sdmse.appcontrol.core.automation.specs.hyperos.HyperOsSpecs
 import eu.darken.sdmse.appcontrol.core.automation.specs.miui.MIUISpecs
 import eu.darken.sdmse.appcontrol.core.automation.specs.oneui.OneUISpecs
@@ -92,7 +93,7 @@ class AppControlAutomation @AssistedInject constructor(
 //                is RealmeSpecs -> 150
 //                is HuaweiSpecs -> 140
 //                is LGESpecs -> 130
-//                is ColorOSSpecs -> 110
+                is ColorOSSpecs -> 110
 //                is FlymeSpecs -> 100
                 is OriginOSSpecs -> 80
                 is AndroidTVSpecs -> 70

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/coloros/ColorOSSpecs.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/coloros/ColorOSSpecs.kt
@@ -1,0 +1,194 @@
+package eu.darken.sdmse.appcontrol.core.automation.specs.coloros
+
+import dagger.Binds
+import dagger.Module
+import dagger.Reusable
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoSet
+import eu.darken.sdmse.appcontrol.core.automation.specs.AppControlSpecGenerator
+import eu.darken.sdmse.appcontrol.core.automation.specs.aosp.AOSPLabels
+import eu.darken.sdmse.appcontrol.core.automation.specs.aosp.AOSPSpecs
+import eu.darken.sdmse.automation.core.common.crawl
+import eu.darken.sdmse.automation.core.common.isClickyButton
+import eu.darken.sdmse.automation.core.common.isEmpty
+import eu.darken.sdmse.automation.core.common.pkgId
+import eu.darken.sdmse.automation.core.common.stepper.AutomationStep
+import eu.darken.sdmse.automation.core.common.stepper.StepContext
+import eu.darken.sdmse.automation.core.common.stepper.Stepper
+import eu.darken.sdmse.automation.core.common.stepper.clickNormal
+import eu.darken.sdmse.automation.core.common.stepper.findClickableParent
+import eu.darken.sdmse.automation.core.common.stepper.findColumnAlignedClickable
+import eu.darken.sdmse.automation.core.common.stepper.findNode
+import eu.darken.sdmse.automation.core.common.textMatchesAny
+import eu.darken.sdmse.automation.core.specs.AutomationExplorer
+import eu.darken.sdmse.automation.core.specs.AutomationSpec
+import eu.darken.sdmse.automation.core.specs.defaultNodeRecovery
+import eu.darken.sdmse.automation.core.specs.windowCheck
+import eu.darken.sdmse.automation.core.specs.windowCheckDefaultSettings
+import eu.darken.sdmse.automation.core.specs.windowLauncherDefaultSettings
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.datastore.value
+import eu.darken.sdmse.common.debug.Bugs
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.device.DeviceDetective
+import eu.darken.sdmse.common.device.RomType
+import eu.darken.sdmse.common.funnel.IPCFunnel
+import eu.darken.sdmse.common.hasApiLevel
+import eu.darken.sdmse.common.pkgs.features.Installed
+import eu.darken.sdmse.common.pkgs.toPkgId
+import eu.darken.sdmse.common.progress.withProgress
+import eu.darken.sdmse.main.core.GeneralSettings
+import javax.inject.Inject
+
+@Reusable
+class ColorOSSpecs @Inject constructor(
+    private val ipcFunnel: IPCFunnel,
+    private val deviceDetective: DeviceDetective,
+    private val aospLabels: AOSPLabels,
+    private val aospSpecs: AOSPSpecs,
+    private val generalSettings: GeneralSettings,
+    private val stepper: Stepper,
+) : AppControlSpecGenerator {
+
+    override val tag: String = TAG
+
+    override suspend fun isResponsible(pkg: Installed): Boolean {
+        val romType = generalSettings.romTypeDetection.value()
+        if (romType == RomType.COLOROS) return true
+        if (romType != RomType.AUTO) return false
+
+        return deviceDetective.getROMType() == RomType.COLOROS
+    }
+
+    override suspend fun getForceStop(pkg: Installed): AutomationSpec = object : AutomationSpec.Explorer {
+        override val tag: String = TAG
+        override suspend fun createPlan(): suspend AutomationExplorer.Context.() -> Unit = {
+            forceStopPlan(pkg)
+        }
+    }
+
+    override suspend fun getArchive(pkg: Installed): AutomationSpec = aospSpecs.getArchive(pkg)
+
+    override suspend fun getRestore(pkg: Installed): AutomationSpec = aospSpecs.getRestore(pkg)
+
+    private val forceStopPlan: suspend AutomationExplorer.Context.(Installed) -> Unit = plan@{ pkg ->
+        log(TAG, INFO) { "Executing plan for ${pkg.installId} with context $this" }
+
+        val forceStopLabels = aospLabels.getForceStopButtonDynamic(this)
+        var wasDisabled = false
+
+        run {
+            val action: suspend StepContext.() -> Boolean = action@{
+                // ColorOS renders the action as a real Button (e.g. id/middle_button), so the
+                // label node itself is the click target.
+                val candidate = findNode { node ->
+                    node.textMatchesAny(forceStopLabels)
+                } ?: return@action false
+
+                var target = findClickableParent(maxNesting = 3, includeSelf = true, node = candidate)
+
+                // Android 15+: the action button's icon and label can be separate, unclickable
+                // nodes with the tappable wrapper as a sibling (AOSP action-row layout). Match ONLY
+                // a clickable in the SAME column as the label, so we never grab an adjacent action
+                // such as Uninstall.
+                if (target == null && hasApiLevel(35)) {
+                    log(TAG, WARN) { "No clickable parent found for $candidate" }
+                    target = findColumnAlignedClickable(candidate)
+                    if (target != null) {
+                        log(TAG, INFO) { "Column-aligned clickable found: $target" }
+                    } else if (!candidate.getScreenBounds().isEmpty()) {
+                        // On this action row a button is clickable iff enabled. A well-bounded Force
+                        // stop label with no column-aligned clickable therefore means the button is
+                        // disabled -> the app is already stopped. Bail cleanly instead of clicking a
+                        // neighbouring action.
+                        log(TAG, WARN) { "No Force stop button in its column, treating as already-stopped: $candidate" }
+                        wasDisabled = true
+                        return@action true
+                    }
+                }
+
+                if (target == null) {
+                    log(TAG, WARN) { "No clickable target found for $candidate" }
+                    return@action false
+                }
+
+                if (!target.isEnabled) {
+                    wasDisabled = true
+                    return@action true
+                }
+
+                clickNormal(node = target)
+            }
+
+            val step = AutomationStep(
+                source = TAG,
+                descriptionInternal = "Force stop button for $pkg",
+                label = eu.darken.sdmse.appcontrol.R.string.appcontrol_automation_progress_find_force_stop.toCaString(forceStopLabels),
+                windowLaunch = windowLauncherDefaultSettings(pkg),
+                windowCheck = windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg),
+                nodeRecovery = defaultNodeRecovery(pkg),
+                nodeAction = action,
+            )
+            stepper.withProgress(this) { process(this@plan, step) }
+        }
+
+        if (wasDisabled) {
+            log(TAG) { "Force stop button was disabled, app is already stopped." }
+            return@plan
+        }
+
+        run {
+            val titleLbl = aospLabels.getForceStopDialogTitleDynamic(this) + forceStopLabels.map { "$it?" }
+            val okLbl = aospLabels.getForceStopDialogOkDynamic(this)
+            val cancelLbl = aospLabels.getForceStopDialogCancelDynamic(this)
+
+            val windowCheck = windowCheck { _, root ->
+                if (root.pkgId != SETTINGS_PKG) return@windowCheck false
+                root.crawl().map { it.node }.any { subNode -> subNode.textMatchesAny(titleLbl) }
+            }
+
+            val action: suspend StepContext.() -> Boolean = action@{
+                // ColorOS repeats the action verb on the confirm button ("Force stop" instead of
+                // "OK"), and the dialog title can carry the same text. Prefer an actual Button
+                // (the title never is one), only then fall back to a non-title text match.
+                val labels = when (Bugs.isDryRun) {
+                    true -> cancelLbl
+                    false -> okLbl + forceStopLabels
+                }
+                val candidate = findNode { node -> node.isClickyButton() && node.textMatchesAny(labels) }
+                    ?: findNode { node -> node.textMatchesAny(labels) && !node.textMatchesAny(titleLbl) }
+                    ?: return@action false
+                val mapped = when {
+                    candidate.isClickyButton() -> candidate
+                    else -> findClickableParent(includeSelf = true, node = candidate) ?: return@action false
+                }
+                clickNormal(node = mapped)
+            }
+
+            val step = AutomationStep(
+                source = TAG,
+                descriptionInternal = "Confirm force stop for $pkg",
+                label = eu.darken.sdmse.automation.R.string.automation_progress_find_ok_confirmation.toCaString(titleLbl + okLbl + forceStopLabels),
+                windowCheck = windowCheck,
+                nodeAction = action,
+            )
+            stepper.withProgress(this) { process(this@plan, step) }
+        }
+    }
+
+    @Module @InstallIn(SingletonComponent::class)
+    abstract class DIM {
+        @Binds @IntoSet abstract fun mod(mod: ColorOSSpecs): AppControlSpecGenerator
+    }
+
+    companion object {
+        val SETTINGS_PKG = "com.android.settings".toPkgId()
+
+        val TAG: String = logTag("AppControl", "Automation", "ColorOS", "Specs")
+    }
+
+}

--- a/app/src/test/java/eu/darken/sdmse/appcontrol/core/automation/specs/coloros/ColorOSSpecsTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcontrol/core/automation/specs/coloros/ColorOSSpecsTest.kt
@@ -1,0 +1,182 @@
+package eu.darken.sdmse.appcontrol.core.automation.specs.coloros
+
+import android.graphics.Rect
+import eu.darken.sdmse.appcontrol.core.automation.specs.aosp.AOSPLabels
+import eu.darken.sdmse.appcontrol.core.automation.specs.aosp.AOSPSpecs
+import eu.darken.sdmse.automation.core.common.ACSNodeInfo
+import eu.darken.sdmse.automation.core.common.stepper.AutomationStep
+import eu.darken.sdmse.automation.core.common.stepper.StepContext
+import eu.darken.sdmse.automation.core.common.stepper.Stepper
+import eu.darken.sdmse.automation.core.specs.AutomationExplorer
+import eu.darken.sdmse.automation.core.specs.AutomationSpec
+import eu.darken.sdmse.common.device.DeviceDetective
+import eu.darken.sdmse.common.funnel.IPCFunnel
+import eu.darken.sdmse.common.pkgs.features.InstallId
+import eu.darken.sdmse.common.pkgs.features.Installed
+import eu.darken.sdmse.common.pkgs.toPkgId
+import eu.darken.sdmse.common.progress.Progress
+import eu.darken.sdmse.common.user.UserHandle2
+import eu.darken.sdmse.main.core.GeneralSettings
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestACSNodeInfo
+import testhelpers.TestApplication
+import testhelpers.automation.TestAutomationHost
+
+/**
+ * Regression coverage for the ColorOS force-stop confirmation dialog, whose positive button
+ * repeats the action verb ("Force stop" / "Paksa berhenti") instead of the AOSP "OK" label.
+ * Under the previous AOSP fallback the confirmation step never matched and timed out.
+ *
+ * Robolectric so `android.graphics.Rect` (node bounds) actually works.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class ColorOSSpecsTest : BaseTest() {
+
+    private val ipcFunnel: IPCFunnel = mockk(relaxed = true)
+    private val deviceDetective: DeviceDetective = mockk(relaxed = true)
+    private val generalSettings: GeneralSettings = mockk(relaxed = true)
+    private val stepper: Stepper = mockk(relaxed = true)
+    private val aospSpecs: AOSPSpecs = mockk(relaxed = true)
+    private val labels: AOSPLabels = mockk {
+        every { getForceStopButtonDynamic(any()) } returns setOf("Paksa berhenti")
+        every { getForceStopDialogTitleDynamic(any()) } returns setOf("Paksa berhenti")
+        every { getForceStopDialogOkDynamic(any()) } returns setOf("Oke")
+        every { getForceStopDialogCancelDynamic(any()) } returns setOf("Batal")
+    }
+
+    private fun createSpec() = ColorOSSpecs(
+        ipcFunnel = ipcFunnel,
+        deviceDetective = deviceDetective,
+        aospLabels = labels,
+        aospSpecs = aospSpecs,
+        generalSettings = generalSettings,
+        stepper = stepper,
+    )
+
+    private fun createTestPkg(packageName: String = "com.superthomaslab.hueessentials"): Installed = mockk {
+        every { installId } returns InstallId(
+            pkgId = packageName.toPkgId(),
+            userHandle = mockk<UserHandle2> { every { handleId } returns 0 },
+        )
+        every { this@mockk.packageName } returns packageName
+        every { id } returns packageName.toPkgId()
+    }
+
+    /** App-info screen: the Force stop action is a plain clickable Button (id/middle_button). */
+    private fun appInfoScreen(): Pair<TestACSNodeInfo, TestACSNodeInfo> {
+        val root = TestACSNodeInfo(viewIdResourceName = "root", packageName = "com.android.settings", bounds = Rect(0, 0, 1080, 2400))
+        val forceStop = TestACSNodeInfo(
+            text = "Paksa berhenti",
+            className = "android.widget.Button",
+            viewIdResourceName = "com.android.settings:id/middle_button",
+            isClickable = true,
+            bounds = Rect(58, 691, 540, 755),
+        )
+        root.addChild(forceStop)
+        return root to forceStop
+    }
+
+    /**
+     * Runs the real force-stop plan: the App-info step's nodeAction runs against [appInfoRoot],
+     * then the window root swaps to [dialogRoot] and the confirmation step's nodeAction runs
+     * against it. Returns the descriptions of every step handed to the stepper.
+     */
+    private suspend fun runForceStopPlan(
+        scope: TestScope,
+        appInfoRoot: TestACSNodeInfo,
+        dialogRoot: TestACSNodeInfo,
+        pkg: Installed,
+    ): List<String> {
+        val testHost = TestAutomationHost(scope).apply { setWindowRoot(appInfoRoot) }
+        val context = object : AutomationExplorer.Context {
+            override val host get() = testHost
+            override val progress = emptyFlow<Progress.Data?>()
+            override fun updateProgress(update: (Progress.Data?) -> Progress.Data?) {}
+        }
+
+        val processed = mutableListOf<String>()
+        coEvery { stepper.process(any(), any()) } coAnswers {
+            val step = secondArg<AutomationStep>()
+            processed += step.descriptionInternal
+            val stepContext = StepContext(hostContext = context, tag = "test", stepAttempts = 0)
+            step.nodeAction?.invoke(stepContext)
+            if (step.descriptionInternal.startsWith("Force stop button")) {
+                testHost.setWindowRoot(dialogRoot)
+            }
+            Unit
+        }
+
+        val plan = (createSpec().getForceStop(pkg) as AutomationSpec.Explorer).createPlan()
+        plan.invoke(context)
+        return processed
+    }
+
+    @Test
+    fun `confirmation button labeled with the force-stop verb is clicked instead of OK`() = runTest {
+        val (appInfoRoot, _) = appInfoScreen()
+
+        // ColorOS dialog: title repeats the verb with a question mark, no "OK"/"Oke" anywhere.
+        val dialogRoot = TestACSNodeInfo(viewIdResourceName = "root", packageName = "com.android.settings", bounds = Rect(0, 0, 1080, 2400))
+        val title = TestACSNodeInfo(text = "Paksa berhenti?", className = "android.widget.TextView", bounds = Rect(100, 900, 980, 980))
+        val cancel = TestACSNodeInfo(text = "Batal", className = "android.widget.Button", isClickable = true, bounds = Rect(100, 1100, 500, 1180))
+        val confirm = TestACSNodeInfo(text = "Paksa berhenti", className = "android.widget.Button", isClickable = true, bounds = Rect(580, 1100, 980, 1180))
+        dialogRoot.addChildren(title, cancel, confirm)
+
+        val processed = runForceStopPlan(this, appInfoRoot, dialogRoot, createTestPkg())
+
+        confirm.performedActions shouldBe listOf(ACSNodeInfo.ACTION_CLICK)
+        cancel.performedActions shouldBe emptyList()
+        title.performedActions shouldBe emptyList()
+        processed.size shouldBe 2
+        processed[1].startsWith("Confirm force stop") shouldBe true
+    }
+
+    @Test
+    fun `dialog title carrying the exact button text does not shadow the confirm button`() = runTest {
+        val (appInfoRoot, _) = appInfoScreen()
+
+        // Title text is IDENTICAL to the button text (no question mark): a title-exclusion filter
+        // alone would reject both nodes; the button-first lookup must still find the Button.
+        val dialogRoot = TestACSNodeInfo(viewIdResourceName = "root", packageName = "com.android.settings", bounds = Rect(0, 0, 1080, 2400))
+        val title = TestACSNodeInfo(text = "Paksa berhenti", className = "android.widget.TextView", bounds = Rect(100, 900, 980, 980))
+        val cancel = TestACSNodeInfo(text = "Batal", className = "android.widget.Button", isClickable = true, bounds = Rect(100, 1100, 500, 1180))
+        val confirm = TestACSNodeInfo(text = "Paksa berhenti", className = "android.widget.Button", isClickable = true, bounds = Rect(580, 1100, 980, 1180))
+        dialogRoot.addChildren(title, cancel, confirm)
+
+        val processed = runForceStopPlan(this, appInfoRoot, dialogRoot, createTestPkg())
+
+        confirm.performedActions shouldBe listOf(ACSNodeInfo.ACTION_CLICK)
+        title.performedActions shouldBe emptyList()
+        processed.size shouldBe 2
+    }
+
+    @Test
+    fun `stock OK confirmation button still works`() = runTest {
+        val (appInfoRoot, _) = appInfoScreen()
+
+        // ColorOS builds that use the stock label: confirm button is "Oke".
+        val dialogRoot = TestACSNodeInfo(viewIdResourceName = "root", packageName = "com.android.settings", bounds = Rect(0, 0, 1080, 2400))
+        val title = TestACSNodeInfo(text = "Paksa berhenti?", className = "android.widget.TextView", bounds = Rect(100, 900, 980, 980))
+        val cancel = TestACSNodeInfo(text = "Batal", className = "android.widget.Button", isClickable = true, bounds = Rect(100, 1100, 500, 1180))
+        val confirm = TestACSNodeInfo(text = "Oke", className = "android.widget.Button", isClickable = true, bounds = Rect(580, 1100, 980, 1180))
+        dialogRoot.addChildren(title, cancel, confirm)
+
+        val processed = runForceStopPlan(this, appInfoRoot, dialogRoot, createTestPkg())
+
+        confirm.performedActions shouldBe listOf(ACSNodeInfo.ACTION_CLICK)
+        cancel.performedActions shouldBe emptyList()
+        processed.size shouldBe 2
+    }
+}


### PR DESCRIPTION
## What changed

Force stopping apps now works on OPPO/ColorOS devices when SD Maid has to use the accessibility service. ColorOS labels the confirmation dialog's confirm button "Force stop" (e.g. "Paksa berhenti" in Indonesian) instead of "OK", so SD Maid never found the button and the operation timed out. This also affects AppCleaner's "force stop apps" option when neither root nor Shizuku is available.

## Technical Context

- Root cause: AppControl automation had no ColorOS spec generator, so ColorOS devices fell through to `AOSPSpecs`. Its confirmation step only matches the `okay`/`dlg_ok` labels, and `defaultFindAndClick` resolves the click target via a clickable-parent search that excludes the matched node itself — dialog buttons are clickable themselves, so even a text match would have been discarded.
- The new ColorOS spec follows the confirmation-matching pattern already proven on OneUI and OriginOS: accept the force-stop verb as a confirm label, prefer an actual `Button` (the dialog title can carry the same text), and resolve clicks including the matched node. The App info screen step keeps AOSP's Android 15+ action-row handling so newer ColorOS builds don't regress versus the old fallback.
- Archive and restore delegate to the injected `AOSPSpecs`, which is behaviorally identical to the previous fallback path for those operations.
- Evidence: a support debug log from an OPPO CPH2113 (ColorOS 12, Indonesian locale) shows `force_stop` resolving to "Paksa berhenti" as a plain clickable `Button`. The failing confirmation step itself is not in the log (it was recorded with Shizuku active, which bypasses accessibility force-stop), so the confirm matching rests on the user's report plus the OneUI/OriginOS precedent.
