### PR TITLE
General: Add a setting to only open the dashboard summary on demand

### DIFF
--- a/app-common-data/src/main/java/eu/darken/sdmse/main/core/GeneralSettings.kt
+++ b/app-common-data/src/main/java/eu/darken/sdmse/main/core/GeneralSettings.kt
@@ -67,6 +67,11 @@ class GeneralSettings @Inject constructor(
     val oneClickDeduplicatorEnabled = dataStore.createValue("dashboard.oneclick.deduplicator.enabled", false)
     val shortcutOneClickEnabled = dataStore.createValue("shortcut.oneclick.enabled", false)
 
+    // Whether the dashboard summary (hero) card may open by itself as the outcome of a one-tap main
+    // action. When off the card never auto-opens; the bar's compact size chip stays the indicator and
+    // one tap on it still opens the card.
+    val dashboardHeroAutoShow = dataStore.createValue("dashboard.hero.autoshow.enabled", true)
+
     // Home-screen widget "Clean" one-tap consent. The widget's Clean button never scan+deletes
     // without opt-in: [widgetOneClickEnabled] must be on. [widgetOneClickConsentAsked] records
     // that the one-time in-app consent prompt has been shown (so it never reappears), regardless

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionEngine.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionEngine.kt
@@ -46,6 +46,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
@@ -58,6 +59,8 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.flow.updateAndGet
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration.Companion.minutes
@@ -230,10 +233,20 @@ class DashboardMainActionEngine(
     private val heroExpanded = MutableStateFlow(false)
 
     /**
+     * Orders the auto-expand resolution against collapse-on-disable, so a disable landing between
+     * the decision and the expand write cannot be overwritten by a stale expand.
+     */
+    private val expansionLock = Mutex()
+
+    /**
      * Whether the hero card is expanded. It only ever becomes true as the outcome of a one-tap main
      * action that produced something to show, or because the user expanded it from the bar's compact
      * chip — an operation started anywhere else (a tool card, an in-tool screen, the scheduler)
      * leaves it collapsed. Dismissing or discarding collapses it again. In-memory, resets with the VM.
+     *
+     * The auto-expansion half is additionally gated by [GeneralSettings.dashboardHeroAutoShow]: with
+     * the setting off no action opens the card by itself, the chip-expand path is unaffected, and
+     * turning the setting off collapses a card that is currently open.
      */
     val isHeroExpanded: StateFlow<Boolean> = heroExpanded
 
@@ -252,6 +265,8 @@ class DashboardMainActionEngine(
         val batchId: Long,
         /** All branches of that batch have folded in their results. */
         val isSettled: Boolean,
+        /** [GeneralSettings.dashboardHeroAutoShow] as of this snapshot; see [resolveAutoExpand]. */
+        val autoShowEnabled: Boolean,
     )
 
     /** Consecutive failures of the [heroState] derivation; 0 while it is healthy. */
@@ -291,6 +306,7 @@ class DashboardMainActionEngine(
                 oneClickOptionsState,
                 freedResult,
                 discarding,
+                generalSettings.dashboardHeroAutoShow.flow,
             ) { upgradeInfo,
                 taskState,
                 corpseState,
@@ -300,7 +316,8 @@ class DashboardMainActionEngine(
                 oneClickMode,
                 oneClickOptions,
                 freed,
-                isDiscarding ->
+                isDiscarding,
+                autoShowEnabled ->
 
                 val actionState = resolveMainAction(
                     taskState = taskState,
@@ -387,6 +404,7 @@ class DashboardMainActionEngine(
                     upgradeInfo = upgradeInfo,
                     batchId = phase.id,
                     isSettled = phase.isSettled,
+                    autoShowEnabled = autoShowEnabled,
                 )
             }
         }
@@ -447,19 +465,63 @@ class DashboardMainActionEngine(
         // by the next card-triggered scan and auto-expand it, which is the defect this closes.
         scope.launch {
             heroState.filterNotNull().collect { hero ->
-                val decision = resolveAutoExpand(
-                    snapshotBatchId = hero.batchId,
-                    isSettled = hero.isSettled,
-                    hasSummary = hero.heroSummary != null,
-                    batch = batchState.value,
-                )
-                when (decision) {
-                    AutoExpandDecision.IGNORE -> return@collect
-                    AutoExpandDecision.DISARM -> Unit
-                    AutoExpandDecision.EXPAND_AND_DISARM -> heroExpanded.value = true
+                // Under the lock as one unit — the batch read, the decision and the expand write:
+                // a disable arriving in between must not lose to a decision taken before it.
+                expansionLock.withLock {
+                    val decision = resolveAutoExpand(
+                        snapshotBatchId = hero.batchId,
+                        isSettled = hero.isSettled,
+                        hasSummary = hero.heroSummary != null,
+                        // From the same snapshot being judged, never read separately: the setting is a
+                        // combine input so it is causally consistent with the rest of the snapshot.
+                        autoShowEnabled = hero.autoShowEnabled,
+                        batch = batchState.value,
+                    )
+                    when (decision) {
+                        AutoExpandDecision.IGNORE -> return@withLock
+                        AutoExpandDecision.DISARM -> Unit
+                        AutoExpandDecision.EXPAND_AND_DISARM -> heroExpanded.value = true
+                    }
+                    batchState.update { if (it.id == hero.batchId) it.copy(autoExpandArmed = false) else it }
                 }
-                batchState.update { if (it.id == hero.batchId) it.copy(autoExpandArmed = false) else it }
             }
+        }
+        // Disabling auto-show collapses an open hero so the user does not return from settings to the
+        // exact card they just disabled. DataStoreValue.flow is distinctUntilChanged, so only real
+        // value changes arrive; the initial emission is a no-op (heroExpanded starts false).
+        scope.launch {
+            // Consecutive failures of this collector; 0 while it is healthy.
+            var failures = 0L
+            generalSettings.dashboardHeroAutoShow.flow
+                // Upstream of the retry: only a genuine emission ends an outage.
+                .onEach { failures = 0L }
+                // Same treatment as heroState: a settings read that blips must not silently take
+                // the collapse-on-disable behaviour away for the ViewModel's lifetime. Retrying
+                // resubscribes DataStoreValue.flow, which re-emits the current value on
+                // resubscription, so a disable that happened during the outage is delivered on
+                // recovery. Reported once per outage rather than per attempt, with backoff so a
+                // permanently broken source can't hot-loop.
+                .retryWhen { error, _ ->
+                    if (error is CancellationException) return@retryWhen false
+                    if (failures == 0L) {
+                        log(TAG, ERROR) { "dashboardHeroAutoShow collector failed: ${error.asLog()}" }
+                        onStateError(error)
+                    }
+                    val doublings = failures.coerceAtMost(HERO_STATE_RETRY_MAX_DOUBLINGS).toInt()
+                    val backoff = minOf(HERO_STATE_RETRY_MAX_MS, HERO_STATE_RETRY_BASE_MS shl doublings)
+                    failures++
+                    delay(backoff)
+                    true
+                }
+                .filter { !it }
+                .collect {
+                    expansionLock.withLock {
+                        heroExpanded.value = false
+                        // Mirrors dismissHero(): closes the small race where a snapshot derived before
+                        // the disable-write settles after it and re-opens the card.
+                        batchState.update { it.copy(autoExpandArmed = false) }
+                    }
+                }
         }
     }
 
@@ -793,16 +855,24 @@ class DashboardMainActionEngine(
          * A settled snapshot of the armed batch always consumes the arm, whether or not it had
          * anything to show: an arm left behind by a fruitless run would be inherited by the next
          * card-triggered scan and auto-expand it.
+         *
+         * [autoShowEnabled] is [GeneralSettings.dashboardHeroAutoShow], taken from the very snapshot
+         * being judged. With it off nothing auto-expands — but the row DISARMs rather than IGNOREs,
+         * because the arm still has to be consumed or a later card-triggered scan would inherit it.
+         * It deliberately sits *after* the settle check: an unsettled snapshot must stay IGNORE, or
+         * the setting would consume the arm before the run it belongs to has finished.
          */
         internal fun resolveAutoExpand(
             snapshotBatchId: Long,
             isSettled: Boolean,
             hasSummary: Boolean,
+            autoShowEnabled: Boolean,
             batch: BatchState,
         ): AutoExpandDecision = when {
             !isSettled -> AutoExpandDecision.IGNORE
             !batch.autoExpandArmed -> AutoExpandDecision.IGNORE
             batch.id != snapshotBatchId -> AutoExpandDecision.IGNORE
+            !autoShowEnabled -> AutoExpandDecision.DISARM
             hasSummary -> AutoExpandDecision.EXPAND_AND_DISARM
             else -> AutoExpandDecision.DISARM
         }

--- a/app/src/main/java/eu/darken/sdmse/main/ui/settings/general/GeneralSettingsScreen.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/settings/general/GeneralSettingsScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.icons.twotone.Language
 import androidx.compose.material.icons.automirrored.twotone.Message
 import androidx.compose.material.icons.twotone.Palette
 import androidx.compose.material.icons.twotone.PhoneAndroid
+import androidx.compose.material.icons.twotone.Summarize
 import androidx.compose.material.icons.twotone.SystemUpdate
 import androidx.compose.material.icons.twotone.TouchApp
 import androidx.compose.material.icons.twotone.Widgets
@@ -68,6 +69,7 @@ fun GeneralSettingsScreenHost(
         onThemeColorChanged = vm::setThemeColor,
         onOneClickChanged = vm::toggleOneClick,
         onShortcutOneClickChanged = vm::toggleShortcutOneClick,
+        onDashboardSummaryAutoShowChanged = vm::toggleDashboardSummaryAutoShow,
         onWidgetOneClickChanged = vm::toggleWidgetOneClick,
         onPreviewsChanged = vm::togglePreviews,
         onUpdateCheckChanged = vm::toggleUpdateCheck,
@@ -94,6 +96,7 @@ internal fun GeneralSettingsScreen(
     onThemeColorChanged: (ThemeColor) -> Unit = {},
     onOneClickChanged: (Boolean) -> Unit = {},
     onShortcutOneClickChanged: (Boolean) -> Unit = {},
+    onDashboardSummaryAutoShowChanged: (Boolean) -> Unit = {},
     onWidgetOneClickChanged: (Boolean) -> Unit = {},
     onPreviewsChanged: (Boolean) -> Unit = {},
     onUpdateCheckChanged: (Boolean) -> Unit = {},
@@ -206,6 +209,15 @@ internal fun GeneralSettingsScreen(
                     title = stringResource(R.string.dashboard_settings_oneclick_tools_title),
                     subtitle = stringResource(R.string.dashboard_settings_oneclick_tools_desc),
                     onClick = { showOneClickTools = true },
+                )
+            }
+            item {
+                SettingsSwitchItem(
+                    icon = Icons.TwoTone.Summarize,
+                    title = stringResource(R.string.dashboard_settings_summary_autoshow_title),
+                    subtitle = stringResource(R.string.dashboard_settings_summary_autoshow_summary),
+                    checked = state.dashboardSummaryAutoShow,
+                    onCheckedChange = onDashboardSummaryAutoShowChanged,
                 )
             }
             item {

--- a/app/src/main/java/eu/darken/sdmse/main/ui/settings/general/GeneralSettingsViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/settings/general/GeneralSettingsViewModel.kt
@@ -57,8 +57,10 @@ class GeneralSettingsViewModel @Inject constructor(
         generalSettings.oneClickAppCleanerEnabled.flow,
         generalSettings.oneClickDeduplicatorEnabled.flow,
         generalSettings.widgetOneClickEnabled.flow,
+        generalSettings.dashboardHeroAutoShow.flow,
     ) { isPro, isUpdateCheckSupported, oneClick, shortcut, theme, previews, romType, updateCheck, motd, debug, locales,
-        oneClickCorpseFinder, oneClickSystemCleaner, oneClickAppCleaner, oneClickDeduplicator, widgetOneClick ->
+        oneClickCorpseFinder, oneClickSystemCleaner, oneClickAppCleaner, oneClickDeduplicator, widgetOneClick,
+        summaryAutoShow ->
         State(
             isPro = isPro,
             isUpdateCheckSupported = isUpdateCheckSupported,
@@ -79,6 +81,7 @@ class GeneralSettingsViewModel @Inject constructor(
             oneClickAppCleanerEnabled = oneClickAppCleaner,
             oneClickDeduplicatorEnabled = oneClickDeduplicator,
             widgetOneClickEnabled = widgetOneClick,
+            dashboardSummaryAutoShow = summaryAutoShow,
         )
     }.safeStateIn(
         initialValue = State(),
@@ -91,6 +94,10 @@ class GeneralSettingsViewModel @Inject constructor(
 
     fun toggleShortcutOneClick(enabled: Boolean) = launch {
         generalSettings.shortcutOneClickEnabled.value(enabled)
+    }
+
+    fun toggleDashboardSummaryAutoShow(enabled: Boolean) = launch {
+        generalSettings.dashboardHeroAutoShow.value(enabled)
     }
 
     fun toggleWidgetOneClick(enabled: Boolean) = launch {
@@ -182,6 +189,7 @@ class GeneralSettingsViewModel @Inject constructor(
         val oneClickAppCleanerEnabled: Boolean = true,
         val oneClickDeduplicatorEnabled: Boolean = false,
         val widgetOneClickEnabled: Boolean = false,
+        val dashboardSummaryAutoShow: Boolean = true,
     )
 
     companion object {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,6 +49,8 @@
     <string name="dashboard_settings_oneclick_summary">Start scan and deletion for all tools with a tap on the dashboard\'s action button, no extra confirmations.</string>
     <string name="dashboard_settings_oneclick_tools_title">One-Tap Tools</string>
     <string name="dashboard_settings_oneclick_tools_desc">Which tools should be included in one-tap operations?</string>
+    <string name="dashboard_settings_summary_autoshow_title">Show summary automatically</string>
+    <string name="dashboard_settings_summary_autoshow_summary">Automatically open the results summary after using the dashboard action button. When disabled, tap the size chip in the bottom bar to open it.</string>
     <string name="dashboard_card_config_title">Dashboard cards</string>
     <string name="dashboard_card_config_desc">Configure which cards are shown and their order</string>
     <string name="dashboard_card_config_header_title">Drag to reorder, toggle to show/hide</string>

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardAutoExpandDecisionTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardAutoExpandDecisionTest.kt
@@ -20,11 +20,13 @@ internal class DashboardAutoExpandDecisionTest : BaseTest() {
         snapshotBatchId: Long = armed.id,
         isSettled: Boolean = true,
         hasSummary: Boolean = true,
+        autoShowEnabled: Boolean = true,
         batch: BatchState = armed,
     ) = DashboardMainActionEngine.resolveAutoExpand(
         snapshotBatchId = snapshotBatchId,
         isSettled = isSettled,
         hasSummary = hasSummary,
+        autoShowEnabled = autoShowEnabled,
         batch = batch,
     )
 
@@ -62,5 +64,26 @@ internal class DashboardAutoExpandDecisionTest : BaseTest() {
     @Test
     fun `a settled snapshot of the armed batch with a hero expands and disarms`() {
         decide() shouldBe AutoExpandDecision.EXPAND_AND_DISARM
+    }
+
+    @Test
+    fun `auto-show turned off disarms instead of expanding`() {
+        // The user opted out of the card opening by itself. DISARM rather than IGNORE: the arm still
+        // has to be consumed, or the next card-triggered scan would inherit it and — should the user
+        // re-enable the setting in between — pop the hero open by itself.
+        decide(autoShowEnabled = false) shouldBe AutoExpandDecision.DISARM
+    }
+
+    @Test
+    fun `auto-show turned off leaves the nothing-to-show outcome unchanged`() {
+        decide(autoShowEnabled = false, hasSummary = false) shouldBe AutoExpandDecision.DISARM
+    }
+
+    @Test
+    fun `auto-show turned off does not consume the arm before the run settles`() {
+        // The setting row sits after the settle check on purpose: consuming the arm early would drop
+        // it for the run it belongs to, which matters the moment the user re-enables auto-show while
+        // that run is still in flight.
+        decide(autoShowEnabled = false, isSettled = false) shouldBe AutoExpandDecision.IGNORE
     }
 }

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionEngineTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionEngineTest.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
@@ -43,7 +44,9 @@ import kotlinx.coroutines.test.runCurrent
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.runTest2
+import java.io.IOException
 import java.time.Instant
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 
@@ -65,6 +68,8 @@ internal class DashboardMainActionEngineTest : BaseTest() {
         val systemCleaner: SystemCleaner,
         val appCleaner: AppCleaner,
         val deduplicator: Deduplicator,
+        /** The auto-show setting, live: flip it to stage a user toggling it while the engine runs. */
+        val heroAutoShow: MutableStateFlow<Boolean>,
         val submittedTasks: MutableList<SDMTool.Task>,
         /** Branch failures the scope's handler caught — in production these reach `errorEvents`. */
         val branchErrors: List<Throwable>,
@@ -78,6 +83,11 @@ internal class DashboardMainActionEngineTest : BaseTest() {
 
     private fun mockBool(value: Boolean): DataStoreValue<Boolean> = mockk(relaxed = true) {
         every { flow } returns MutableStateFlow(value)
+    }
+
+    /** Backed by the caller's flow so a test can change the setting after the engine was built. */
+    private fun mockBool(source: Flow<Boolean>): DataStoreValue<Boolean> = mockk(relaxed = true) {
+        every { flow } returns source
     }
 
     private fun upgradeInfoMock(isPro: Boolean): UpgradeRepo.Info = mockk(relaxed = true) {
@@ -139,6 +149,8 @@ internal class DashboardMainActionEngineTest : BaseTest() {
         appData: AppCleaner.Data? = null,
         dedupeData: Deduplicator.Data? = null,
         isPro: Boolean = false,
+        /** Initial value of the "show summary automatically" setting; see [Harness.heroAutoShow]. */
+        heroAutoShow: Boolean = true,
         /**
          * What `isProForUi()` sees, which the branches consult instead of the combine's upgrade
          * flow. Defaults to [isPro]; set it apart to stage the fail-open mismatch between the two.
@@ -149,6 +161,8 @@ internal class DashboardMainActionEngineTest : BaseTest() {
         gate: CompletableDeferred<Unit>? = null,
         /** Replaces CorpseFinder's state flow; for tests that need a non-StateFlow source. */
         corpseStateSource: Flow<CorpseFinder.State>? = null,
+        /** Replaces the auto-show setting's flow; for tests that need a failing source. */
+        heroAutoShowSource: Flow<Boolean>? = null,
         /** Replaces the engine scope; for tests that need virtual time instead of eager execution. */
         scope: CoroutineScope? = null,
     ): Harness {
@@ -169,12 +183,14 @@ internal class DashboardMainActionEngineTest : BaseTest() {
         val deduplicator = mockk<Deduplicator>(relaxed = true).apply {
             every { state } returns MutableStateFlow(mockk(relaxed = true) { every { data } returns dedupeData })
         }
+        val heroAutoShowFlow = MutableStateFlow(heroAutoShow)
         val generalSettings = mockk<GeneralSettings>(relaxed = true).apply {
             every { oneClickCorpseFinderEnabled } returns mockBool(corpseFinderOneClick)
             every { oneClickSystemCleanerEnabled } returns mockBool(otherToolsOneClick)
             every { oneClickAppCleanerEnabled } returns mockBool(appCleanerOneClick)
             every { oneClickDeduplicatorEnabled } returns mockBool(deduplicatorOneClick)
             every { enableDashboardOneClick } returns mockBool(false)
+            every { dashboardHeroAutoShow } returns mockBool(heroAutoShowSource ?: heroAutoShowFlow)
         }
         val submittedTasks = mutableListOf<SDMTool.Task>()
         val branchErrors = mutableListOf<Throwable>()
@@ -221,6 +237,7 @@ internal class DashboardMainActionEngineTest : BaseTest() {
             systemCleaner,
             appCleaner,
             deduplicator,
+            heroAutoShowFlow,
             submittedTasks,
             branchErrors,
             stateErrors,
@@ -517,6 +534,53 @@ internal class DashboardMainActionEngineTest : BaseTest() {
     }
 
     @Test
+    fun `a transient auto-show settings failure still collapses the hero after recovery`() = runTest2 {
+        // Without a retry the collapse-on-disable collector dies on the first failed settings read and
+        // disabling auto-show would never close an open card again for the ViewModel's lifetime.
+        // The outage covers every subscription while [outage] is set, so this does not depend on which
+        // consumer of the setting subscribes first (the hero derivation reads the same flow).
+        val outage = AtomicBoolean(true)
+        val autoShow = MutableStateFlow(true)
+        val h = harness(
+            scope = CoroutineScope(SupervisorJob() + StandardTestDispatcher(testScheduler)),
+            heroAutoShowSource = flow {
+                if (outage.get()) throw IOException("auto-show blip")
+                emitAll(autoShow)
+            },
+        )
+
+        try {
+            runCurrent()
+
+            // Both consumers of the setting reported their own outage; nothing else yet.
+            h.stateErrors.map { it.message } shouldBe listOf("auto-show blip", "auto-show blip")
+
+            // A second failed attempt one backoff later must not report again — once per outage,
+            // not once per attempt.
+            advanceTimeBy(1_500L)
+            runCurrent()
+            h.stateErrors.size shouldBe 2
+
+            // Past the second backoff the collector resubscribes; DataStoreValue.flow re-emits the
+            // current value on resubscription, so the collector is live again.
+            outage.set(false)
+            advanceTimeBy(3_000L)
+            runCurrent()
+
+            h.engine.expandHero()
+            h.engine.isHeroExpanded.value shouldBe true
+
+            autoShow.value = false
+            runCurrent()
+
+            h.engine.isHeroExpanded.value shouldBe false
+            h.stateErrors.size shouldBe 2
+        } finally {
+            h.engineScope.cancel()
+        }
+    }
+
+    @Test
     fun `a one-tap scan that finds nothing does not expand the hero`() {
         val h = harness()
 
@@ -545,6 +609,117 @@ internal class DashboardMainActionEngineTest : BaseTest() {
 
             h.barState().heroSummary.shouldNotBeNull()
             h.engine.isHeroExpanded.value shouldBe false
+        } finally {
+            h.engineScope.cancel()
+        }
+    }
+
+    @Test
+    fun `a one-tap scan does not expand the hero when auto-show is off`() {
+        // The setting only takes the auto-opening away: the run still produces a summary and the bar
+        // still carries it, so the compact size chip stays the indicator and one tap opens the card.
+        val gate = CompletableDeferred<Unit>()
+        val h = harness(gate = gate, heroAutoShow = false)
+
+        try {
+            h.engine.mainAction(BottomBarState.Action.SCAN)
+
+            h.corpseState.value = corpseToolState(corpseData())
+            gate.complete(Unit)
+
+            h.barState().heroSummary.shouldNotBeNull()
+            h.engine.isHeroExpanded.value shouldBe false
+
+            // The arm was consumed (DISARM, not IGNORE): switching the setting back on must not let
+            // a later card-triggered scan inherit the arm and pop the hero open by itself.
+            h.heroAutoShow.value = true
+            h.corpseState.value = corpseToolState(corpseData(count = 2))
+
+            h.barState().heroSummary.shouldNotBeNull()
+            h.engine.isHeroExpanded.value shouldBe false
+        } finally {
+            h.engineScope.cancel()
+        }
+    }
+
+    @Test
+    fun `the chip still expands the hero when auto-show is off`() {
+        // On-demand expansion is untouched by the setting; only the automatic path is gated.
+        val h = harness(corpseData = corpseData(), heroAutoShow = false)
+
+        try {
+            h.barState().heroSummary.shouldNotBeNull()
+
+            h.engine.expandHero()
+
+            h.engine.isHeroExpanded.value shouldBe true
+        } finally {
+            h.engineScope.cancel()
+        }
+    }
+
+    @Test
+    fun `a manually opened hero survives a one-tap cleanup with auto-show off`() {
+        // Sticky expand: a card the user opened themselves may re-render with the outcome of an
+        // action they started. The setting suppresses opening, it does not force closing.
+        val h = harness(corpseData = corpseData(), heroAutoShow = false)
+
+        try {
+            h.engine.expandHero()
+
+            h.engine.mainAction(BottomBarState.Action.DELETE)
+
+            h.barState().heroSummary.shouldNotBeNull()
+            h.engine.isHeroExpanded.value shouldBe true
+        } finally {
+            h.engineScope.cancel()
+        }
+    }
+
+    @Test
+    fun `disabling auto-show collapses an open hero and clears the arm`() {
+        // The user should not come back from settings to the exact card they just disabled.
+        val gate = CompletableDeferred<Unit>()
+        val h = harness(gate = gate)
+
+        try {
+            h.engine.mainAction(BottomBarState.Action.SCAN)
+            h.engine.expandHero()
+            h.engine.isHeroExpanded.value shouldBe true
+
+            h.heroAutoShow.value = false
+
+            h.engine.isHeroExpanded.value shouldBe false
+
+            // The arm went with it: re-enabling and letting the in-flight run settle must not
+            // re-open the card the disable just closed.
+            h.heroAutoShow.value = true
+            h.corpseState.value = corpseToolState(corpseData())
+            gate.complete(Unit)
+
+            h.barState().heroSummary.shouldNotBeNull()
+            h.engine.isHeroExpanded.value shouldBe false
+        } finally {
+            h.engineScope.cancel()
+        }
+    }
+
+    @Test
+    fun `the settling snapshot decides, not the setting value at arm time`() {
+        // The setting is a combine input, so the resolution judges the value the snapshot it is
+        // looking at carries — here the user switched auto-show back on while the scan was running.
+        val gate = CompletableDeferred<Unit>()
+        val h = harness(gate = gate, heroAutoShow = false)
+
+        try {
+            h.engine.mainAction(BottomBarState.Action.SCAN)
+
+            h.heroAutoShow.value = true
+            h.corpseState.value = corpseToolState(corpseData())
+            gate.complete(Unit)
+
+            h.barState().heroSummary.shouldNotBeNull()
+            h.engine.isHeroExpanded.value shouldBe true
         } finally {
             h.engineScope.cancel()
         }
@@ -867,7 +1042,7 @@ internal class DashboardMainActionEngineTest : BaseTest() {
         }
     }
 
-    private fun dedupeDeleteSetup(): DedupeDeleteSetup {
+    private fun dedupeDeleteSetup(heroAutoShow: Boolean = true): DedupeDeleteSetup {
         val proInfo = mockk<UpgradeRepo.Info>(relaxed = true) {
             every { isPro } returns true
             every { isSettled } returns true
@@ -910,6 +1085,7 @@ internal class DashboardMainActionEngineTest : BaseTest() {
             every { oneClickAppCleanerEnabled } returns mockBool(false)
             every { oneClickDeduplicatorEnabled } returns mockBool(true)
             every { enableDashboardOneClick } returns mockBool(false)
+            every { dashboardHeroAutoShow } returns mockBool(heroAutoShow)
         }
         val deleteResult = DeduplicatorDeleteTask.Success(
             affectedSpace = DEDUPE_FREED_SPACE,
@@ -975,6 +1151,23 @@ internal class DashboardMainActionEngineTest : BaseTest() {
             hero.mode shouldBe HeroSummary.Mode.FREED
             // The cleanup's total, not the surviving cluster's DEDUPE_RESIDUE_SPACE.
             hero.totalSize shouldBe DEDUPE_FREED_SPACE
+        } finally {
+            setup.engineScope.cancel()
+        }
+    }
+
+    @Test
+    fun `a cleanup that freed data stays collapsed when auto-show is off`() {
+        // The ordinary post-scan cleanup path: the FREED outcome is still built and still reaches the
+        // bar's compact chip, it just does not throw the card open.
+        val setup = dedupeDeleteSetup(heroAutoShow = false)
+
+        try {
+            setup.engine.mainAction(BottomBarState.Action.DELETE)
+            setup.dedupState.value = Deduplicator.State(data = null, progress = null)
+
+            setup.hero().mode shouldBe HeroSummary.Mode.FREED
+            setup.engine.isHeroExpanded.value shouldBe false
         } finally {
             setup.engineScope.cancel()
         }

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModelResilienceTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModelResilienceTest.kt
@@ -151,6 +151,11 @@ internal class DashboardViewModelResilienceTest : BaseTest() {
             every { enableDashboardOneClick } returns mockk(relaxed = true) {
                 every { flow } returns MutableStateFlow(false)
             }
+            // A hero-derivation combine input: a relaxed mock's flow never emits, which would keep
+            // the bottom bar null forever.
+            every { dashboardHeroAutoShow } returns mockk(relaxed = true) {
+                every { flow } returns MutableStateFlow(true)
+            }
         }
         val spaceHistoryRepo = mockk<SpaceHistoryRepo>(relaxed = true).apply {
             every { getAllHistory(any()) } returns history

--- a/app/src/test/java/eu/darken/sdmse/main/ui/settings/general/GeneralSettingsScreenSummaryAutoShowRowTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/settings/general/GeneralSettingsScreenSummaryAutoShowRowTest.kt
@@ -1,0 +1,31 @@
+package eu.darken.sdmse.main.ui.settings.general
+
+import androidx.compose.ui.test.hasScrollAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+
+class GeneralSettingsScreenSummaryAutoShowRowTest : BaseComposeRobolectricTest() {
+
+    @Test
+    fun `Show summary automatically row renders and toggling it reports the new value`() {
+        val values = mutableListOf<Boolean>()
+        composeRule.setContent {
+            PreviewWrapper {
+                GeneralSettingsScreen(
+                    state = GeneralSettingsViewModel.State(dashboardSummaryAutoShow = true),
+                    onDashboardSummaryAutoShowChanged = { values.add(it) },
+                )
+            }
+        }
+        // The settings screen uses a LazyColumn — scroll it to the row before touching it.
+        composeRule.onNode(hasScrollAction()).performScrollToNode(hasText("Show summary automatically"))
+        composeRule.onNodeWithText("Show summary automatically").performClick()
+        composeRule.waitForIdle()
+        if (values != listOf(false)) error("expected onDashboardSummaryAutoShowChanged(false), got $values")
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/main/ui/settings/general/GeneralSettingsViewModelTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/settings/general/GeneralSettingsViewModelTest.kt
@@ -1,0 +1,143 @@
+package eu.darken.sdmse.main.ui.settings.general
+
+import android.os.LocaleList
+import eu.darken.sdmse.common.compose.tour.GuidedTourController
+import eu.darken.sdmse.common.datastore.DataStoreValue
+import eu.darken.sdmse.common.debug.DebugSettings
+import eu.darken.sdmse.common.device.RomType
+import eu.darken.sdmse.common.locale.LocaleManager
+import eu.darken.sdmse.common.theming.ThemeColor
+import eu.darken.sdmse.common.theming.ThemeMode
+import eu.darken.sdmse.common.theming.ThemeStyle
+import eu.darken.sdmse.common.updater.UpdateChecker
+import eu.darken.sdmse.common.upgrade.UpgradeRepo
+import eu.darken.sdmse.main.core.GeneralSettings
+import eu.darken.sdmse.main.core.motd.MotdSettings
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import testhelpers.coroutine.runTest2
+import testhelpers.mockDataStoreValue
+
+/**
+ * Render state and writes of [GeneralSettingsViewModel], focused on the "show summary automatically"
+ * setting: its state field maps from the right settings flow (the state combine is positional, so a
+ * neighbouring boolean landing in the wrong slot is the failure mode) and its toggle writes it.
+ */
+internal class GeneralSettingsViewModelTest : BaseTest() {
+
+    private class Harness(
+        val vm: GeneralSettingsViewModel,
+        val autoShowSetting: DataStoreValue<Boolean>,
+    )
+
+    /** Relaxed so `.value(x)` (which writes via `update {}`) answers and can be verified. */
+    private fun mockBool(value: Boolean): DataStoreValue<Boolean> = mockk(relaxed = true) {
+        every { flow } returns MutableStateFlow(value)
+    }
+
+    // TestScope extension: safeStateIn uses WhileSubscribed(5000), so without a live subscriber
+    // vm.state stays at its initialValue and every assertion below would read State() defaults.
+    private fun TestScope.harness(
+        summaryAutoShow: Boolean = true,
+    ): Harness {
+        val autoShowSetting = mockBool(summaryAutoShow)
+        val generalSettings = mockk<GeneralSettings>(relaxed = true).apply {
+            every { enableDashboardOneClick } returns mockDataStoreValue(true)
+            every { shortcutOneClickEnabled } returns mockDataStoreValue(true)
+            every { themeMode } returns mockDataStoreValue(ThemeMode.SYSTEM)
+            every { themeStyle } returns mockDataStoreValue(ThemeStyle.DEFAULT)
+            every { themeColor } returns mockDataStoreValue(ThemeColor.GREEN)
+            every { usePreviews } returns mockDataStoreValue(true)
+            every { romTypeDetection } returns mockDataStoreValue(RomType.AUTO)
+            every { isUpdateCheckEnabled } returns mockDataStoreValue(true)
+            every { oneClickCorpseFinderEnabled } returns mockDataStoreValue(true)
+            every { oneClickSystemCleanerEnabled } returns mockDataStoreValue(true)
+            every { oneClickAppCleanerEnabled } returns mockDataStoreValue(true)
+            every { oneClickDeduplicatorEnabled } returns mockDataStoreValue(true)
+            every { widgetOneClickEnabled } returns mockDataStoreValue(true)
+            every { dashboardHeroAutoShow } returns autoShowSetting
+        }
+        val debugSettings = mockk<DebugSettings>(relaxed = true).apply {
+            every { isDebugMode } returns mockDataStoreValue(true)
+        }
+        val motdSettings = mockk<MotdSettings>(relaxed = true).apply {
+            every { isMotdEnabled } returns mockDataStoreValue(true)
+        }
+        val updateChecker = mockk<UpdateChecker>(relaxed = true).apply {
+            coEvery { isCheckSupported() } returns true
+        }
+        val localeManager = mockk<LocaleManager>(relaxed = true).apply {
+            // A mock, not LocaleList.getDefault(): the android.jar on the unit test classpath throws
+            // on any real framework call.
+            every { currentLocales } returns MutableStateFlow(mockk<LocaleList>(relaxed = true))
+        }
+        val proInfo = mockk<UpgradeRepo.Info>(relaxed = true).apply {
+            every { isPro } returns true
+        }
+        val upgradeRepo = mockk<UpgradeRepo>(relaxed = true).apply {
+            every { upgradeInfo } returns MutableStateFlow(proInfo)
+        }
+
+        val vm = GeneralSettingsViewModel(
+            dispatcherProvider = TestDispatcherProvider(),
+            upgradeRepo = upgradeRepo,
+            generalSettings = generalSettings,
+            debugSettings = debugSettings,
+            motdSettings = motdSettings,
+            updateChecker = updateChecker,
+            localeManager = localeManager,
+            guidedTourController = mockk<GuidedTourController>(relaxed = true),
+        )
+
+        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            vm.state.collect { /* keep WhileSubscribed alive */ }
+        }
+
+        return Harness(vm = vm, autoShowSetting = autoShowSetting)
+    }
+
+    @Test
+    fun `dashboardSummaryAutoShow maps from the auto-show setting`() = runTest2 {
+        // Every neighbouring boolean is deliberately true, so the false can only come from the flow
+        // it is supposed to come from — the 17-input combine is positional.
+        val h = harness(summaryAutoShow = false)
+        advanceUntilIdle()
+
+        val state = h.vm.state.first()
+        state.dashboardSummaryAutoShow shouldBe false
+        state.enableDashboardOneClick shouldBe true
+        state.shortcutOneClickEnabled shouldBe true
+        state.widgetOneClickEnabled shouldBe true
+    }
+
+    @Test
+    fun `dashboardSummaryAutoShow is on when the setting is on`() = runTest2 {
+        val h = harness(summaryAutoShow = true)
+        advanceUntilIdle()
+
+        h.vm.state.first().dashboardSummaryAutoShow shouldBe true
+    }
+
+    @Test
+    fun `toggleDashboardSummaryAutoShow writes the setting`() = runTest2 {
+        val h = harness()
+
+        h.vm.toggleDashboardSummaryAutoShow(false)
+        advanceUntilIdle()
+
+        // .value(false) is an extension that writes through update {}.
+        coVerify(exactly = 1) { h.autoShowSetting.update(any()) }
+    }
+}


### PR DESCRIPTION
## What changed

New setting in Settings > General (Dashboard section): **"Show summary automatically"**, enabled by default. When disabled, the summary card that normally pops up above the bottom bar after one-tap scans and cleanups stays closed — the size chip in the bottom bar still shows the result, and tapping the chip opens the card on demand. Turning the setting off also closes an already-open card, so you don't return from settings straight to the card you just disabled.

This keeps the beginner-friendly default while letting users who found the new summary card intrusive turn the auto-opening off without losing the information.

## Technical Context

- The setting joins the existing hero-state combine instead of being read separately: the settle snapshot judges the setting value it was derived with (causally consistent), and settings-read failures share the combine's existing retry/error routing instead of needing their own.
- The auto-expand decision table gains a row that consumes the arm (DISARM) rather than ignoring it — an unconsumed arm would be inherited by a later card-triggered scan and pop the card open after the user re-enables the setting.
- A mutex orders auto-expand resolution against collapse-on-disable: without it, a disable landing between the expand decision and the expand write could be overwritten by the stale expand.
- The collapse-on-disable collector retries transient settings-read failures with the same capped backoff as the hero derivation — a one-off blip must not silently disable the collapse behavior for the ViewModel's lifetime.
- Sticky expand is deliberate: a card the user opened manually may re-render with the outcome of an action they start; only the automatic opening is gated.
- Verified on-device (fresh API 35 emulator): row placement and default, toggling, persistence across process death.
