### PR TITLE
General: Shrink issue screenshots uploaded as HTML img tags

### DIFF
--- a/.github/workflows/thumbnail-images.yml
+++ b/.github/workflows/thumbnail-images.yml
@@ -23,4 +23,4 @@ jobs:
   thumbnail:
     permissions:
       issues: write
-    uses: d4rken-org/.github/.github/workflows/thumbnail-images.yml@3756372c3c844e4817c03d27983691f9991a19f4
+    uses: d4rken-org/.github/.github/workflows/thumbnail-images.yml@94e36d9a67a887e24338f95fd0429925cea21c98


### PR DESCRIPTION
## What changed

Screenshots attached to GitHub issues get shrunk into small clickable thumbnails again. GitHub changed how uploaded screenshots are embedded in issue text (HTML image tags instead of Markdown images), and the thumbnail automation didn't recognize the new format — recent issues like #2632 kept huge full-size screenshots.

## Technical Context

- One-line pin bump of the shared thumbnail workflow (`d4rken-org/.github`): the analyze action now also rewrites GitHub-uploader-emitted `<img width=… height=… src=…>` tags (portrait, taller than 640px) into the same clickable `<a><img width>` thumbnails as Markdown images. The tag attributes carry the dimensions, so these rewrites make no network requests.
- The action change itself was reviewed and tested upstream in d4rken-org/.github#2 (48 unit tests including adversarial input cases; the analyze job still runs with zero token scopes).

Refs #2632
