### PR TITLE
General: Fix anniversary card hiding after New Year dismissals

### DIFF
--- a/app-common-data/src/main/java/eu/darken/sdmse/main/core/GeneralSettings.kt
+++ b/app-common-data/src/main/java/eu/darken/sdmse/main/core/GeneralSettings.kt
@@ -78,7 +78,7 @@ class GeneralSettings @Inject constructor(
 
     val romTypeDetection = dataStore.createValue("core.romtype.detection", RomType.AUTO, json)
 
-    val anniversaryDismissedYear = dataStore.createValue<Int?>("core.anniversary.dismissed.year", null, json)
+    val anniversaryDismissedOrdinal = dataStore.createValue<Int?>(KEY_ANNIVERSARY_DISMISSED_ORDINAL, null)
 
     val dashboardCardConfig = dataStore.createValue(
         key = "dashboard.cards.config",
@@ -108,6 +108,8 @@ class GeneralSettings @Inject constructor(
 
     companion object {
         internal val TAG = logTag("Core", "Settings")
+
+        const val KEY_ANNIVERSARY_DISMISSED_ORDINAL = "core.anniversary.dismissed.ordinal"
     }
 }
 

--- a/app-common-data/src/main/java/eu/darken/sdmse/main/core/backup/GeneralSettingsBackupContributor.kt
+++ b/app-common-data/src/main/java/eu/darken/sdmse/main/core/backup/GeneralSettingsBackupContributor.kt
@@ -21,6 +21,12 @@ class GeneralSettingsBackupContributor @Inject constructor(
     override val excludedKeys = setOf(
         "core.appops.restrictions.passed",
         "core.appops.restrictions.triggered",
+        // The dismissal ordinal is anchored to THIS install's install date, which lives in the
+        // curriculum_vitae store and does not travel in config backups. Restoring it onto a
+        // different install would suppress that install's own anniversary. The legacy year key is
+        // orphaned junk from the pre-ordinal dismissal and must not be re-imported either.
+        GeneralSettings.KEY_ANNIVERSARY_DISMISSED_ORDINAL,
+        "core.anniversary.dismissed.year",
     )
 }
 

--- a/app-common/src/main/java/eu/darken/sdmse/main/core/CurriculumVitae.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/main/core/CurriculumVitae.kt
@@ -16,7 +16,6 @@ import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.datastore.createValue
 import eu.darken.sdmse.common.datastore.value
-import eu.darken.sdmse.common.datastore.valueBlocking
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
@@ -38,8 +37,6 @@ import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import java.time.Instant
 import java.time.LocalDate
-import java.time.Period
-import java.time.ZoneId
 import java.time.temporal.ChronoUnit
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -240,36 +237,13 @@ class CurriculumVitae @Inject constructor(
 
     internal enum class ProTransition { GRACE_ENGAGED, PRO_LOST }
 
-    fun isAnniversary(): Boolean {
-        val installedAt = _installedFirst.valueBlocking ?: return false
-        val now = LocalDate.now()
-        val installDate = LocalDate.ofInstant(installedAt, ZoneId.systemDefault())
-
-        // Check if it's been at least one year
-        val yearsSinceInstall = Period.between(installDate, now).years
-        if (yearsSinceInstall < 1) return false
-
-        // Calculate this year's anniversary date
-        val thisYearAnniversary = installDate.withYear(now.year)
-        val lastYearAnniversary = installDate.withYear(now.year - 1)
-
-        // Check if we're near an anniversary (within 14 days after)
-        val daysFromThisYear = ChronoUnit.DAYS.between(thisYearAnniversary, now)
-        val daysFromLastYear = ChronoUnit.DAYS.between(lastYearAnniversary, now)
-
-        // Show if:
-        // - 0 to 14 days after this year's anniversary
-        // - OR 0 to 14 days after last year's anniversary (for early January)
-        return (daysFromThisYear >= 0 && daysFromThisYear <= 14) ||
-                (daysFromLastYear >= 0 && daysFromLastYear <= 14)
-    }
-
-    fun getYearsSinceInstall(): Int {
-        val installedAt = _installedFirst.valueBlocking ?: return 0
-        val installDate = LocalDate.ofInstant(installedAt, ZoneId.systemDefault())
-        val now = LocalDate.now()
-        return Period.between(installDate, now).years
-    }
+    // A single anniversary celebration window: which anniversary it is ([ordinal], 1 = first),
+    // the calendar year that window is anchored in ([nominalYear]) and the date it started on.
+    data class AnniversaryOccurrence(
+        val ordinal: Int,
+        val nominalYear: Int,
+        val date: LocalDate,
+    )
 
     companion object {
         internal val TAG = logTag("Debug", "CurriculumVitae")
@@ -288,6 +262,27 @@ class CurriculumVitae @Inject constructor(
                 ProTransition.PRO_LOST
 
             else -> null
+        }
+
+        // The anniversary celebration window is the nominal anniversary date plus the following 14
+        // days, so an install date that falls on a day the user doesn't open the app isn't missed.
+        // Anchored on the NOMINAL date, not the calendar year: a late-December anniversary keeps the
+        // same occurrence into early January. Feb-29 installs celebrate on Feb 28 in non-leap years
+        // (withYear resolves the date that way) and on Feb 29 in leap years.
+        fun anniversaryOccurrenceOf(installDate: LocalDate, today: LocalDate): AnniversaryOccurrence? {
+            for (candidateYear in listOf(today.year, today.year - 1)) {
+                val nominalDate = installDate.withYear(candidateYear)
+                val days = ChronoUnit.DAYS.between(nominalDate, today)
+                val ordinal = candidateYear - installDate.year
+                if (days in 0..14 && ordinal >= 1) {
+                    return AnniversaryOccurrence(
+                        ordinal = ordinal,
+                        nominalYear = candidateYear,
+                        date = nominalDate,
+                    )
+                }
+            }
+            return null
         }
     }
 }

--- a/app-common/src/test/java/eu/darken/sdmse/main/core/CurriculumVitaeAnniversaryTest.kt
+++ b/app-common/src/test/java/eu/darken/sdmse/main/core/CurriculumVitaeAnniversaryTest.kt
@@ -1,0 +1,75 @@
+package eu.darken.sdmse.main.core
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.time.LocalDate
+
+class CurriculumVitaeAnniversaryTest : BaseTest() {
+
+    private fun occurrence(install: LocalDate, today: LocalDate) =
+        CurriculumVitae.anniversaryOccurrenceOf(install, today)
+
+    @Test fun `the install year itself is not an anniversary`() {
+        occurrence(LocalDate.of(2026, 8, 10), LocalDate.of(2026, 8, 20)) shouldBe null
+    }
+
+    @Test fun `the first anniversary starts on the nominal date`() {
+        occurrence(LocalDate.of(2024, 8, 10), LocalDate.of(2025, 8, 10)) shouldBe CurriculumVitae.AnniversaryOccurrence(
+            ordinal = 1,
+            nominalYear = 2025,
+            date = LocalDate.of(2025, 8, 10),
+        )
+    }
+
+    @Test fun `the window covers the nominal date plus 14 days`() {
+        val install = LocalDate.of(2024, 8, 10)
+
+        occurrence(install, LocalDate.of(2025, 8, 24))?.ordinal shouldBe 1
+        occurrence(install, LocalDate.of(2025, 8, 25)) shouldBe null
+        occurrence(install, LocalDate.of(2025, 8, 9)) shouldBe null
+    }
+
+    @Test fun `a late-December window keeps the same occurrence into January`() {
+        val install = LocalDate.of(2024, 12, 20)
+
+        occurrence(install, LocalDate.of(2026, 12, 25)) shouldBe CurriculumVitae.AnniversaryOccurrence(
+            ordinal = 2,
+            nominalYear = 2026,
+            date = LocalDate.of(2026, 12, 20),
+        )
+        occurrence(install, LocalDate.of(2027, 1, 2)) shouldBe CurriculumVitae.AnniversaryOccurrence(
+            ordinal = 2,
+            nominalYear = 2026,
+            date = LocalDate.of(2026, 12, 20),
+        )
+    }
+
+    @Test fun `a Feb-29 install celebrates on Feb 28 in non-leap years`() {
+        val install = LocalDate.of(2024, 2, 29)
+
+        occurrence(install, LocalDate.of(2026, 2, 28)) shouldBe CurriculumVitae.AnniversaryOccurrence(
+            ordinal = 2,
+            nominalYear = 2026,
+            date = LocalDate.of(2026, 2, 28),
+        )
+        // Still inside the 14 day window that started on Feb 28.
+        occurrence(install, LocalDate.of(2026, 3, 14))?.ordinal shouldBe 2
+        occurrence(install, LocalDate.of(2026, 3, 15)) shouldBe null
+    }
+
+    @Test fun `a Feb-29 install celebrates on Feb 29 in leap years`() {
+        occurrence(
+            LocalDate.of(2024, 2, 29),
+            LocalDate.of(2028, 2, 29),
+        ) shouldBe CurriculumVitae.AnniversaryOccurrence(
+            ordinal = 4,
+            nominalYear = 2028,
+            date = LocalDate.of(2028, 2, 29),
+        )
+    }
+
+    @Test fun `the ordinal counts full years since install`() {
+        occurrence(LocalDate.of(2020, 8, 10), LocalDate.of(2026, 8, 15))?.ordinal shouldBe 6
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/AnniversaryProvider.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/AnniversaryProvider.kt
@@ -20,7 +20,9 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import java.time.Instant
 import java.time.LocalDate
+import java.time.ZoneId
 import javax.inject.Inject
 
 class AnniversaryProvider @Inject constructor(
@@ -33,31 +35,39 @@ class AnniversaryProvider @Inject constructor(
 ) {
 
     val item: Flow<AnniversaryDashboardCardItem?> = combine(
-        generalSettings.anniversaryDismissedYear.flow,
+        generalSettings.anniversaryDismissedOrdinal.flow,
         curriculumVitae.installedAt,
         upgradeRepo.upgradeInfo,
-    ) { dismissedYear, installedAt, upgradeInfo ->
+    ) { dismissedOrdinal, installedAt, upgradeInfo ->
+        buildItem(dismissedOrdinal, installedAt, upgradeInfo)
+    }
+
+    internal suspend fun buildItem(
+        dismissedOrdinal: Int?,
+        installedAt: Instant,
+        upgradeInfo: UpgradeRepo.Info,
+        zone: ZoneId = ZoneId.systemDefault(),
+        today: LocalDate = LocalDate.now(zone),
+    ): AnniversaryDashboardCardItem? {
         if (!upgradeInfo.isPro) {
-            log(TAG, VERBOSE) { "User is not PRO, skipping anniverary check." }
-            return@combine null
+            log(TAG, VERBOSE) { "User is not PRO, skipping anniversary check." }
+            return null
         }
 
-        val currentYear = LocalDate.now().year
-        if (dismissedYear == currentYear) {
-            log(TAG, VERBOSE) { "Anniveray check already dismissed for this year." }
-            return@combine null
+        val installDate = LocalDate.ofInstant(installedAt, zone)
+        val occurrence = CurriculumVitae.anniversaryOccurrenceOf(installDate, today) ?: return null
+
+        if (dismissedOrdinal == occurrence.ordinal) {
+            log(TAG, VERBOSE) { "Anniversary already dismissed for this occurrence." }
+            return null
         }
 
-        if (!curriculumVitae.isAnniversary()) return@combine null
-
-        val years = curriculumVitae.getYearsSinceInstall()
-
-        log(TAG) { "Anniversary detected! Years: $years" }
+        log(TAG) { "Anniversary detected! $occurrence" }
 
         val spaceFreed = Formatter.formatShortFileSize(context, statsRepo.state.first().totalSpaceFreed)
 
-        AnniversaryDashboardCardItem(
-            years = years,
+        return AnniversaryDashboardCardItem(
+            years = occurrence.ordinal,
             installDate = installedAt,
             spaceFreed = spaceFreed,
             onShare = { yearsCount ->
@@ -79,8 +89,8 @@ class AnniversaryProvider @Inject constructor(
                 }
             },
             onDismiss = {
-                appScope.launch { generalSettings.anniversaryDismissedYear.value(currentYear) }
-            }
+                appScope.launch { generalSettings.anniversaryDismissedOrdinal.value(occurrence.ordinal) }
+            },
         )
     }
 

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/AnniversaryProviderTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/AnniversaryProviderTest.kt
@@ -1,0 +1,162 @@
+package eu.darken.sdmse.main.ui.dashboard
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.sdmse.common.datastore.DataStoreValue
+import eu.darken.sdmse.common.upgrade.UpgradeRepo
+import eu.darken.sdmse.main.core.CurriculumVitae
+import eu.darken.sdmse.main.core.GeneralSettings
+import eu.darken.sdmse.stats.core.StatsRepo
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.unmockkAll
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+import testhelpers.coroutine.runTest2
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZoneOffset
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class AnniversaryProviderTest : BaseTest() {
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    private val curriculumVitae = mockk<CurriculumVitae>()
+    private val generalSettings = mockk<GeneralSettings>()
+    private val upgradeRepo = mockk<UpgradeRepo>()
+    private val statsRepo = mockk<StatsRepo>()
+    private val dismissedSetting = mockk<DataStoreValue<Int?>>(relaxed = true)
+
+    @After fun teardown() {
+        unmockkAll()
+    }
+
+    private val zone: ZoneId = ZoneOffset.UTC
+
+    private fun instantOf(date: LocalDate): Instant = date.atStartOfDay(zone).toInstant()
+
+    private fun upgradeInfo(isPro: Boolean) = mockk<UpgradeRepo.Info>().apply {
+        every { this@apply.isPro } returns isPro
+    }
+
+    private fun stub(dismissedOrdinal: Int?, installedAt: Instant, isPro: Boolean = true) {
+        every { dismissedSetting.flow } returns flowOf(dismissedOrdinal)
+        every { generalSettings.anniversaryDismissedOrdinal } returns dismissedSetting
+        every { curriculumVitae.installedAt } returns flowOf(installedAt)
+        every { upgradeRepo.upgradeInfo } returns flowOf(upgradeInfo(isPro))
+        every { upgradeRepo.storeSite } returns "https://example.test"
+        every { statsRepo.state } returns flowOf(
+            StatsRepo.State(
+                reportsCount = 1,
+                snapshotsCount = 1,
+                totalSpaceFreed = 1024L,
+                itemsProcessed = 7L,
+                databaseSize = 128L,
+            ),
+        )
+    }
+
+    private fun TestScope.provider() = AnniversaryProvider(
+        appScope = this,
+        context = context,
+        curriculumVitae = curriculumVitae,
+        generalSettings = generalSettings,
+        upgradeRepo = upgradeRepo,
+        statsRepo = statsRepo,
+    )
+
+    @Test fun `dismissing a December window in January stores the occurrence ordinal`() = runTest2 {
+        // The dismissal must not be keyed on the calendar year: today is 2027 but the celebration
+        // running is still the 2026 (second) anniversary of a 2024-12-20 install.
+        val installedAt = instantOf(LocalDate.of(2024, 12, 20))
+        stub(dismissedOrdinal = null, installedAt = installedAt)
+
+        val item = provider().buildItem(
+            dismissedOrdinal = null,
+            installedAt = installedAt,
+            upgradeInfo = upgradeInfo(true),
+            zone = zone,
+            today = LocalDate.of(2027, 1, 2),
+        )
+
+        item.shouldNotBeNull()
+        item.years shouldBe 2
+
+        item.onDismiss()
+        advanceUntilIdle()
+
+        val update = slot<(Int?) -> Int?>()
+        coVerify { dismissedSetting.update(capture(update)) }
+        update.captured.invoke(null) shouldBe 2
+    }
+
+    @Test fun `a dismissed occurrence stays hidden`() = runTest2 {
+        val installedAt = instantOf(LocalDate.of(2024, 12, 20))
+        stub(dismissedOrdinal = 2, installedAt = installedAt)
+
+        provider().buildItem(
+            dismissedOrdinal = 2,
+            installedAt = installedAt,
+            upgradeInfo = upgradeInfo(true),
+            zone = zone,
+            today = LocalDate.of(2027, 1, 2),
+        ).shouldBeNull()
+    }
+
+    @Test fun `non-pro users never see the card`() = runTest2 {
+        val installedAt = instantOf(LocalDate.of(2024, 12, 20))
+        stub(dismissedOrdinal = null, installedAt = installedAt, isPro = false)
+
+        provider().buildItem(
+            dismissedOrdinal = null,
+            installedAt = installedAt,
+            upgradeInfo = upgradeInfo(false),
+            zone = zone,
+            today = LocalDate.of(2027, 1, 2),
+        ).shouldBeNull()
+    }
+
+    @Test fun `the next anniversary is shown again after a dismissal`() = runTest2 {
+        val installedAt = instantOf(LocalDate.of(2024, 12, 20))
+        stub(dismissedOrdinal = 2, installedAt = installedAt)
+
+        val item = provider().buildItem(
+            dismissedOrdinal = 2,
+            installedAt = installedAt,
+            upgradeInfo = upgradeInfo(true),
+            zone = zone,
+            today = LocalDate.of(2027, 12, 25),
+        )
+
+        item.shouldNotBeNull()
+        item.years shouldBe 3
+    }
+
+    @Test fun `the item flow reads the dismissal ordinal setting`() = runTest2 {
+        val installedAt = LocalDate.now(ZoneId.systemDefault())
+            .minusYears(1)
+            .atStartOfDay(ZoneId.systemDefault())
+            .toInstant()
+        stub(dismissedOrdinal = null, installedAt = installedAt)
+
+        provider().item.first().shouldNotBeNull()
+    }
+}


### PR DESCRIPTION
## What changed

The anniversary card on the dashboard (a Pro perk that celebrates each year with SD Maid) had two long-standing date bugs:

- Dismissing the card around New Year could silently hide the **next** year's card: anyone whose install anniversary falls in mid-to-late December and who dismissed the card in January would not see their following anniversary card for almost its entire two-week window.
- Installs made on February 29 got inconsistent behavior in non-leap years: the card's window and its "years together" count disagreed about when the anniversary actually is (Feb 28 vs Mar 1).

Both are fixed: dismissing the card now hides exactly the anniversary being celebrated (the next one always reappears), and leap-day installs celebrate consistently on Feb 28 in non-leap years.

## Technical Context

- **Root cause 1**: dismissal stored the calendar year, captured at card-build time. The celebration window spans New Year for December installs, so a January dismissal wrote the new year — which then matched the entire next December window and suppressed it.
- **Root cause 2**: the window check used `withYear()` (Feb 29 → Feb 28) while the displayed count used `Period.years` (boundary Mar 1), so the two disagreed around Feb 28.
- Fix: one pure occurrence calculation (`CurriculumVitae.anniversaryOccurrenceOf`) derives the anniversary ordinal, nominal date, and window from a single today/zone snapshot; dismissal stores the **ordinal** under a new primitive-Int key.
- Deliberately **no migration** of the old calendar-year value: it is ambiguous (a stored "2027" can't distinguish a Jan-2027 dismissal of the 2026 anniversary from a Dec-2027 dismissal of the 2027 one), so a correct migration is impossible. Worst case is one redundant dismiss for users updating inside a still-active window.
- Both dismissal keys are excluded from config backups: the install date lives in the `curriculum_vitae` store, which doesn't travel in backups, so a restored ordinal would suppress a *different* install's anniversary.
- Review guidance: the date semantics are in the pure function (unit-tested incl. New Year and Feb-29 windows); `AnniversaryProviderTest` covers the wiring — the ordinal written on dismiss, reappearance of the next occurrence, and the Pro gate.
- Verified end-to-end on an API 36 emulator: unlock → card content/visuals → share → dismiss → persistence across restart → next-year reappearance with the plural body text.
