### PR TITLE
Squeezer: Fix app silently closing when video compression fails

### DIFF
--- a/app-common/src/main/java/eu/darken/sdmse/main/core/taskmanager/TaskSubmitter.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/main/core/taskmanager/TaskSubmitter.kt
@@ -28,7 +28,7 @@ interface TaskSubmitter {
         val cancelledAt: Instant? = null,
         val completedAt: Instant? = null,
         val result: SDMTool.Task.Result? = null,
-        val error: Exception? = null,
+        val error: Throwable? = null,
         val notifyOnFinish: Boolean = true,
     ) {
         val isComplete: Boolean = completedAt != null

--- a/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/processor/VideoTranscoder.kt
+++ b/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/processor/VideoTranscoder.kt
@@ -54,6 +54,7 @@ class VideoTranscoder @Inject constructor(
         // Capture the source mvhd timestamps so we can inject them into the muxer output
         // (#2388). Best-effort: a failure here just disables date preservation, gallery sort
         // then falls back to filesystem mtime which FileTransaction already preserves.
+        log(TAG) { "transcode(): Extracting timestamps from ${inputFile.path}" }
         val sourceTimestamps: VideoTimestampPreserver.TimestampData? = try {
             videoTimestampPreserver.extract(inputFile)
         } catch (e: Exception) {
@@ -77,9 +78,36 @@ class VideoTranscoder @Inject constructor(
                 // before starting the export so it can bail early instead of writing to a
                 // file that will immediately be deleted.
                 val cancellationRequested = AtomicBoolean(false)
+                // Every callback below runs on a thread we don't own (handler thread, muxer thread).
+                // An escaping Throwable there would kill the process, so all of them funnel into
+                // settle(), which is total: it never throws and resumes the continuation exactly once.
+                val settled = AtomicBoolean(false)
+                val firstProgress = AtomicBoolean(true)
 
                 fun deleteOutput() {
                     if (outputFile.exists()) outputFile.delete()
+                }
+
+                fun settle(outcome: Result<Unit>) {
+                    if (!settled.compareAndSet(false, true)) return
+
+                    runCatching { pollerRef?.let { handler.removeCallbacks(it) } }
+                        .onFailure { log(TAG, WARN) { "settle(): Removing poller failed: ${it.message}" } }
+
+                    if (outcome.isFailure) {
+                        runCatching { transformerRef?.cancel() }
+                            .onFailure { log(TAG, WARN) { "settle(): transformer.cancel() failed: ${it.message}" } }
+                        runCatching { deleteOutput() }
+                            .onFailure { log(TAG, WARN) { "settle(): deleteOutput() failed: ${it.message}" } }
+                    }
+
+                    // Last act: no cleanup failure above may prevent the coroutine from settling.
+                    if (cont.isActive) {
+                        outcome.fold(
+                            onSuccess = { cont.resume(Unit) },
+                            onFailure = { cont.resumeWithException(it) },
+                        )
+                    }
                 }
 
                 handler.post {
@@ -101,16 +129,22 @@ class VideoTranscoder @Inject constructor(
                         // MetadataProvider runs at muxer close() time on the muxer thread.
                         // Strip the default Mp4TimestampData (Media3 seeds it with "now") and
                         // replace it with the source's mvhd values so gallery DATE_TAKEN sort
-                        // is preserved (#2388).
+                        // is preserved (#2388). A throw here would escape into a thread we don't
+                        // own: date preservation is best-effort, it must neither fail nor settle
+                        // the transcode.
                         val muxerFactory = InAppMp4Muxer.Factory { entries ->
-                            sourceTimestamps?.let { ts ->
-                                entries.removeAll { it is Mp4TimestampData }
-                                entries.add(
-                                    Mp4TimestampData(
-                                        ts.creationTimeMp4Seconds,
-                                        ts.modificationTimeMp4Seconds,
+                            try {
+                                sourceTimestamps?.let { ts ->
+                                    entries.removeAll { it is Mp4TimestampData }
+                                    entries.add(
+                                        Mp4TimestampData(
+                                            ts.creationTimeMp4Seconds,
+                                            ts.modificationTimeMp4Seconds,
+                                        )
                                     )
-                                )
+                                }
+                            } catch (e: Throwable) {
+                                log(TAG, WARN) { "Mp4 timestamp injection failed: ${e.asLog()}" }
                             }
                         }
 
@@ -127,14 +161,23 @@ class VideoTranscoder @Inject constructor(
                             .setLooper(handlerThread.looper)
                             .build()
                         transformerRef = transformer
+                        log(TAG) { "Transformer built for ${inputFile.path}" }
 
                         lateinit var poller: Runnable
                         poller = Runnable {
-                            val state = transformer.getProgress(progressHolder)
-                            if (state == Transformer.PROGRESS_STATE_AVAILABLE) {
-                                progressListener?.onProgress(progressHolder.progress)
+                            try {
+                                val state = transformer.getProgress(progressHolder)
+                                if (state == Transformer.PROGRESS_STATE_AVAILABLE) {
+                                    if (firstProgress.compareAndSet(true, false)) {
+                                        log(TAG) { "First progress poll: ${progressHolder.progress}%" }
+                                    }
+                                    progressListener?.onProgress(progressHolder.progress)
+                                }
+                                if (!settled.get()) handler.postDelayed(poller, PROGRESS_POLL_INTERVAL_MS)
+                            } catch (e: Throwable) {
+                                log(TAG, ERROR) { "Progress poller threw: ${e.asLog()}" }
+                                settle(Result.failure(e))
                             }
-                            handler.postDelayed(poller, PROGRESS_POLL_INTERVAL_MS)
                         }
                         pollerRef = poller
 
@@ -143,8 +186,11 @@ class VideoTranscoder @Inject constructor(
                                 composition: Composition,
                                 exportResult: ExportResult,
                             ) {
-                                handler.removeCallbacks(poller)
-                                if (cont.isActive) cont.resume(Unit)
+                                try {
+                                    settle(Result.success(Unit))
+                                } catch (e: Throwable) {
+                                    log(TAG, ERROR) { "onCompleted() threw: ${e.asLog()}" }
+                                }
                             }
 
                             override fun onError(
@@ -152,8 +198,14 @@ class VideoTranscoder @Inject constructor(
                                 exportResult: ExportResult,
                                 exportException: ExportException,
                             ) {
-                                handler.removeCallbacks(poller)
-                                if (cont.isActive) cont.resumeWithException(mapExportException(exportException))
+                                try {
+                                    val mapped = runCatching { mapExportException(exportException) }
+                                        .getOrElse { exportException }
+                                    settle(Result.failure(mapped))
+                                } catch (e: Throwable) {
+                                    log(TAG, ERROR) { "onError() threw: ${e.asLog()}" }
+                                    settle(Result.failure(exportException))
+                                }
                             }
                         })
 
@@ -174,7 +226,9 @@ class VideoTranscoder @Inject constructor(
                             .setTransmuxAudio(true)
                             .build()
 
+                        log(TAG) { "Starting transformer for ${inputFile.path} -> ${outputFile.path}" }
                         transformer.start(composition, outputFile.absolutePath)
+                        log(TAG) { "Transformer started for ${inputFile.path}" }
 
                         if (cancellationRequested.get()) {
                             // Cancellation may have fired while start() was executing. The
@@ -187,7 +241,7 @@ class VideoTranscoder @Inject constructor(
                         handler.postDelayed(poller, PROGRESS_POLL_INTERVAL_MS)
                     } catch (e: Throwable) {
                         log(TAG, ERROR) { "Transformer setup/start threw synchronously: ${e.asLog()}" }
-                        if (cont.isActive) cont.resumeWithException(e)
+                        settle(Result.failure(e))
                     }
                 }
 

--- a/app/src/main/java/eu/darken/sdmse/App.kt
+++ b/app/src/main/java/eu/darken/sdmse/App.kt
@@ -22,6 +22,7 @@ import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.error.installErrorDialogCustomizer
+import eu.darken.sdmse.common.debug.exit.ExitInfoLogger
 import eu.darken.sdmse.common.debug.memory.MemoryMonitor
 import eu.darken.sdmse.common.debug.recorder.core.RecorderModule
 import eu.darken.sdmse.common.storage.StorageRescue
@@ -57,6 +58,7 @@ open class App : Application(), Configuration.Provider {
     @Inject lateinit var theming: Theming
     @Inject lateinit var coilTempFiles: CoilTempFiles
     @Inject lateinit var memoryMonitor: MemoryMonitor
+    @Inject lateinit var exitInfoLogger: ExitInfoLogger
     @Inject lateinit var shortcutManager: ShortcutManager
     @Inject lateinit var spaceMonitorControl: SpaceMonitorControl
     @Inject lateinit var taskStatsCoordinator: TaskStatsCoordinator
@@ -108,6 +110,7 @@ open class App : Application(), Configuration.Provider {
         installErrorDialogCustomizer()
 
         memoryMonitor.register()
+        exitInfoLogger.logPreviousExits()
 
         appScope.launch { coilTempFiles.cleanUp() }
         appScope.launch { storageRescue.restoreIfPossible() }

--- a/app/src/main/java/eu/darken/sdmse/common/debug/exit/ExitInfoLogger.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/debug/exit/ExitInfoLogger.kt
@@ -1,0 +1,109 @@
+package eu.darken.sdmse.common.debug.exit
+
+import android.app.ActivityManager
+import android.app.ApplicationExitInfo
+import android.content.Context
+import android.os.Build
+import androidx.annotation.RequiresApi
+import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.sdmse.common.coroutine.AppScope
+import eu.darken.sdmse.common.coroutine.DispatcherProvider
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.asLog
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.hasApiLevel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.time.Instant
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Logs why the previous process instances died (crash, ANR, low memory, ...). A process that was
+ * killed can't log its own death, so this is the only source for it in a debug log.
+ */
+@Singleton
+class ExitInfoLogger @Inject constructor(
+    @ApplicationContext private val context: Context,
+    @AppScope private val appScope: CoroutineScope,
+    private val dispatcherProvider: DispatcherProvider,
+) {
+
+    private val cacheLock = Mutex()
+    private var cachedRecords: List<String>? = null
+
+    /**
+     * Logs the previous exit reasons. Idempotent and callable multiple times: the records are
+     * fetched once per process, so a repeat emission (e.g. into a recording started later) is
+     * identical to the first.
+     */
+    fun logPreviousExits() {
+        appScope.launch(dispatcherProvider.IO) {
+            val records = cacheLock.withLock {
+                cachedRecords ?: fetchRecords().also { cachedRecords = it }
+            }
+            records.forEach { record -> log(TAG, INFO) { record } }
+        }
+    }
+
+    private fun fetchRecords(): List<String> {
+        if (!hasApiLevel(30)) return emptyList()
+        return try {
+            val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+            activityManager
+                .getHistoricalProcessExitReasons(null, 0, MAX_RECORDS)
+                .map { it.describe() }
+        } catch (e: Exception) {
+            log(TAG, WARN) { "Failed to read historical process exit reasons: ${e.asLog()}" }
+            emptyList()
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.R)
+    private fun ApplicationExitInfo.describe(): String = listOf(
+        "Previous exit: ${Instant.ofEpochMilli(timestamp)}",
+        "process=$processName",
+        "reason=${exitReasonLabel(reason)}($reason)",
+        "status=$status",
+        "importance=$importance",
+        "pss=${pss}kB",
+        "rss=${rss}kB",
+        "description=$description",
+    ).joinToString(" ")
+
+    companion object {
+        private val TAG = logTag("Debug", "ExitInfo")
+        private const val MAX_RECORDS = 5
+    }
+}
+
+/**
+ * Maps an [ApplicationExitInfo] reason code to its constant name. The codes are spelled out as
+ * literals so the mapping stays pure (and testable on the JVM) and covers reasons that were added
+ * in later API levels than the one we compile against.
+ */
+internal fun exitReasonLabel(reason: Int): String = EXIT_REASONS[reason] ?: "UNKNOWN($reason)"
+
+private val EXIT_REASONS = mapOf(
+    0 to "REASON_UNKNOWN",
+    1 to "REASON_EXIT_SELF",
+    2 to "REASON_SIGNALED",
+    3 to "REASON_LOW_MEMORY",
+    4 to "REASON_CRASH",
+    5 to "REASON_CRASH_NATIVE",
+    6 to "REASON_ANR",
+    7 to "REASON_INITIALIZATION_FAILURE",
+    8 to "REASON_PERMISSION_CHANGE",
+    9 to "REASON_EXCESSIVE_RESOURCE_USAGE",
+    10 to "REASON_USER_REQUESTED",
+    11 to "REASON_USER_STOPPED",
+    12 to "REASON_DEPENDENCY_DIED",
+    13 to "REASON_OTHER",
+    14 to "REASON_FREEZER",
+    15 to "REASON_PACKAGE_STATE_CHANGE",
+    16 to "REASON_PACKAGE_UPDATED",
+)

--- a/app/src/main/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModule.kt
@@ -15,6 +15,7 @@ import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.DebugSettings
+import eu.darken.sdmse.common.debug.exit.ExitInfoLogger
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
@@ -66,6 +67,7 @@ class RecorderModule @Inject constructor(
     private val debugSettings: DebugSettings,
     private val curriculumVitae: CurriculumVitae,
     private val upgradeDiagnostics: UpgradeDiagnostics,
+    private val exitInfoLogger: ExitInfoLogger,
     private val recorderProvider: Provider<Recorder>,
 ) {
 
@@ -153,6 +155,9 @@ class RecorderModule @Inject constructor(
             // else can reach, so the rollback has to know about the candidate already.
             val newRecorder = recorderProvider.get().also { candidate = it }
             newRecorder.start(logDir)
+            // The file logger is installed now: re-emit the previous process exit reasons so they
+            // land in THIS recording too, including one started long after app launch.
+            exitInfoLogger.logPreviousExits()
 
             if (!triggerFile.exists() && triggerFile.createNewFile()) createdTriggerFile = true
 

--- a/app/src/main/java/eu/darken/sdmse/main/core/taskmanager/TaskFatalErrorException.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/core/taskmanager/TaskFatalErrorException.kt
@@ -1,0 +1,9 @@
+package eu.darken.sdmse.main.core.taskmanager
+
+/**
+ * Wraps a non-[Exception] [Throwable] (e.g. an [OutOfMemoryError]) that escaped a tool, so callers
+ * of `TaskManager.submit()` keep receiving an [Exception] while the original cause is preserved.
+ */
+class TaskFatalErrorException(
+    override val cause: Throwable,
+) : RuntimeException("Task failed with a fatal error: ${cause::class.simpleName}", cause)

--- a/app/src/main/java/eu/darken/sdmse/main/core/taskmanager/TaskManager.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/core/taskmanager/TaskManager.kt
@@ -7,6 +7,7 @@ import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
@@ -17,17 +18,15 @@ import eu.darken.sdmse.common.sharedresource.KeepAlive
 import eu.darken.sdmse.common.sharedresource.SharedResource
 import eu.darken.sdmse.main.core.SDMTool
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
@@ -69,7 +68,7 @@ class TaskManager @Inject constructor(
         val job: Job? = null,
         val resourceLock: KeepAlive? = null,
         val result: SDMTool.Task.Result? = null,
-        val error: Exception? = null,
+        val error: Throwable? = null,
         val notifyOnFinish: Boolean = true,
     ) {
         val toolType: SDMTool.Type
@@ -223,18 +222,25 @@ class TaskManager @Inject constructor(
         log(TAG, INFO) { "submit(): $task (notifyOnFinish=$notifyOnFinish)" }
         val taskId = rngString
 
+        // The task's outcome is signalled through this deferred, NOT through the task map: a failing
+        // bookkeeping step must not be able to strand a submit() caller waiting for a completion
+        // state that is never published.
+        val outcome = CompletableDeferred<Result<SDMTool.Task.Result>>()
+
         val job = appScope.launch(
             context = dispatcherProvider.IO,
             start = CoroutineStart.LAZY,
         ) {
             var result: SDMTool.Task.Result? = null
-            var error: Exception? = null
+            var error: Throwable? = null
             try {
                 stage(taskId)
                 result = execute(taskId)
 
                 log(TAG) { "Result for ${task.type}-$taskId is $result" }
-            } catch (e: Exception) {
+            } catch (e: Throwable) {
+                // Throwable, not Exception: AppScope has no CoroutineExceptionHandler, so an Error
+                // escaping a tool would take the process down with it.
                 if (e is CancellationException) {
                     log(TAG, INFO) { "execute(): Task was cancelled (${task.type}-$taskId): $task" }
                 } else {
@@ -242,20 +248,53 @@ class TaskManager @Inject constructor(
                 }
                 error = e
             } finally {
-                updateTasks {
-                    this[taskId]!!.tool.updateProgress { null }
-                    log(TAG) { "Releasing resource lock for ${task.type}-$taskId" }
-                    this[taskId]!!.resourceLock!!.close()
-                    this[taskId] = this[taskId]!!.copy(
-                        completedAt = Instant.now(),
-                        error = error,
-                        result = result,
-                    )
+                try {
+                    updateTasks {
+                        // Throwable, not Exception: an Error from a tool's progress reset must not
+                        // skip the resource lock release or the completion publish below.
+                        try {
+                            this[taskId]!!.tool.updateProgress { null }
+                        } catch (e: Throwable) {
+                            runCatching {
+                                log(TAG, WARN) { "Failed to reset progress for ${task.type}-$taskId: ${e.asLog()}" }
+                            }
+                        }
+                        runCatching { log(TAG) { "Releasing resource lock for ${task.type}-$taskId" } }
+                        try {
+                            this[taskId]!!.resourceLock!!.close()
+                        } catch (e: Throwable) {
+                            runCatching {
+                                log(TAG, WARN) { "Failed to release resource lock for ${task.type}-$taskId: ${e.asLog()}" }
+                            }
+                        }
+                        this[taskId] = this[taskId]!!.copy(
+                            completedAt = Instant.now(),
+                            error = error,
+                            result = result,
+                        )
+                    }
+                } catch (e: Throwable) {
+                    log(TAG, ERROR) { "Bookkeeping failed for ${task.type}-$taskId: ${e.asLog()}" }
                 }
+
+                outcome.complete(
+                    when {
+                        error != null -> Result.failure(error)
+                        result != null -> Result.success(result)
+                        else -> Result.failure(IllegalStateException("Task produced neither result nor error"))
+                    }
+                )
             }
         }
 
         job.invokeOnCompletion { log(TAG, VERBOSE) { "Task completion: ${taskEntries.value[taskId]}" } }
+        // Safety net for a LAZY job that is cancelled before its body (and with it the finally above)
+        // ever ran — nothing else would ever complete the deferred.
+        job.invokeOnCompletion { cause ->
+            if (!outcome.isCompleted) {
+                outcome.complete(Result.failure(cause ?: IllegalStateException("Task job completed without outcome")))
+            }
+        }
 
         withContext(NonCancellable) {
             // Any task causes the taskmanager to stay "alive" and with it any depending resources
@@ -283,12 +322,11 @@ class TaskManager @Inject constructor(
 
         job.join()
 
-        val endTask = taskEntries
-            .mapNotNull { it[taskId] }
-            .filter { it.isComplete }
-            .first()
-
-        return endTask.result ?: throw endTask.error!!
+        return outcome.await().getOrElse { error ->
+            // Callers expect an Exception: a CancellationException passes through raw, anything else
+            // that isn't an Exception (i.e. an Error) arrives wrapped with its cause preserved.
+            throw (error as? Exception ?: TaskFatalErrorException(error))
+        }
     }
 
     /** Drops completed task entries for [type], removing their results from [state]. */

--- a/app/src/test/java/eu/darken/sdmse/common/debug/exit/ExitInfoLoggerTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/common/debug/exit/ExitInfoLoggerTest.kt
@@ -1,0 +1,23 @@
+package eu.darken.sdmse.common.debug.exit
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class ExitInfoLoggerTest : BaseTest() {
+
+    @Test fun `known reason codes map to their constant names`() {
+        exitReasonLabel(0) shouldBe "REASON_UNKNOWN"
+        exitReasonLabel(3) shouldBe "REASON_LOW_MEMORY"
+        exitReasonLabel(4) shouldBe "REASON_CRASH"
+        exitReasonLabel(5) shouldBe "REASON_CRASH_NATIVE"
+        exitReasonLabel(6) shouldBe "REASON_ANR"
+        exitReasonLabel(9) shouldBe "REASON_EXCESSIVE_RESOURCE_USAGE"
+        exitReasonLabel(14) shouldBe "REASON_FREEZER"
+    }
+
+    @Test fun `an unknown reason code keeps its raw value`() {
+        exitReasonLabel(99) shouldBe "UNKNOWN(99)"
+        exitReasonLabel(-1) shouldBe "UNKNOWN(-1)"
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModuleTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/common/debug/recorder/core/RecorderModuleTest.kt
@@ -11,6 +11,7 @@ import eu.darken.sdmse.common.areas.DataAreaManager
 import eu.darken.sdmse.common.datastore.DataStoreValue
 import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.DebugSettings
+import eu.darken.sdmse.common.debug.exit.ExitInfoLogger
 import eu.darken.sdmse.common.debug.logging.Logging
 import eu.darken.sdmse.common.getPackageInfo
 import eu.darken.sdmse.common.upgrade.UpgradeDiagnostics
@@ -81,6 +82,7 @@ class RecorderModuleTest : BaseTest() {
     private val dataAreaManager: DataAreaManager = mockk()
     private val curriculumVitae: CurriculumVitae = mockk()
     private val upgradeDiagnostics: UpgradeDiagnostics = mockk()
+    private val exitInfoLogger: ExitInfoLogger = mockk(relaxed = true)
     private val recorderProvider: Provider<Recorder> = mockk()
     private val mockRecorder: Recorder = mockk()
 
@@ -144,6 +146,7 @@ class RecorderModuleTest : BaseTest() {
             debugSettings = debugSettings,
             curriculumVitae = curriculumVitae,
             upgradeDiagnostics = upgradeDiagnostics,
+            exitInfoLogger = exitInfoLogger,
             recorderProvider = recorderProvider,
         )
 

--- a/app/src/test/java/eu/darken/sdmse/main/core/taskmanager/TaskManagerTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/core/taskmanager/TaskManagerTest.kt
@@ -1,0 +1,139 @@
+package eu.darken.sdmse.main.core.taskmanager
+
+import eu.darken.sdmse.common.backup.BackupOperationGate
+import eu.darken.sdmse.common.sharedresource.SharedResource
+import eu.darken.sdmse.main.core.SDMTool
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.plus
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import testhelpers.coroutine.runTest2
+import java.io.IOException
+
+class TaskManagerTest : BaseTest() {
+
+    private val taskWorkerControl: TaskWorkerControl = mockk(relaxed = true)
+
+    private val task: SDMTool.Task = mockk<SDMTool.Task>(relaxed = true).apply {
+        every { type } returns SDMTool.Type.APPCLEANER
+    }
+    private val taskResult: SDMTool.Task.Result = mockk<SDMTool.Task.Result>(relaxed = true).apply {
+        every { type } returns SDMTool.Type.APPCLEANER
+    }
+
+    /**
+     * The shared resources close their leases through `runBlocking`, which would deadlock against a
+     * virtual-time-only scope, so every test scope is combined with [Dispatchers.IO].
+     */
+    private fun createTool(scope: CoroutineScope): SDMTool = mockk<SDMTool>(relaxed = true).apply {
+        every { type } returns SDMTool.Type.APPCLEANER
+        every { sharedResource } returns SharedResource.createKeepAlive("test-tool", scope)
+        coEvery { useRes<SDMTool.Task.Result>(any()) } coAnswers {
+            firstArg<suspend (Any) -> SDMTool.Task.Result>().invoke(Unit)
+        }
+    }
+
+    /**
+     * kotlinx' stacktrace recovery hands a caller that awaited across a suspension point a COPY of
+     * the failure that chains the original, so identity is asserted along the cause chain.
+     */
+    private fun Throwable.carries(original: Throwable): Boolean =
+        generateSequence(this) { it.cause }.any { it === original }
+
+    private fun createManager(scope: CoroutineScope, tool: SDMTool) = TaskManager(
+        appScope = scope,
+        dispatcherProvider = TestDispatcherProvider(),
+        tools = setOf(tool),
+        taskWorkerControl = taskWorkerControl,
+        backupGate = BackupOperationGate(),
+    )
+
+    @Test fun `a successful task returns its result`() = runTest2(autoCancel = true) {
+        val scope = this + Dispatchers.IO
+        val tool = createTool(scope)
+        coEvery { tool.submit(task) } returns taskResult
+
+        val manager = createManager(scope, tool)
+
+        manager.submit(task) shouldBeSameInstanceAs taskResult
+    }
+
+    @Test fun `an exception from the tool is rethrown to the caller`() = runTest2(autoCancel = true) {
+        val scope = this + Dispatchers.IO
+        val tool = createTool(scope)
+        val boom = IOException("Disk on fire")
+        coEvery { tool.submit(task) } throws boom
+
+        val manager = createManager(scope, tool)
+
+        shouldThrow<IOException> { manager.submit(task) }.carries(boom) shouldBe true
+    }
+
+    @Test fun `an error from the tool arrives wrapped instead of killing the process`() =
+        runTest2(autoCancel = true) {
+            val scope = this + Dispatchers.IO
+            val tool = createTool(scope)
+            val boom = OutOfMemoryError("Out of everything")
+            coEvery { tool.submit(task) } throws boom
+
+            val manager = createManager(scope, tool)
+
+            val thrown = shouldThrow<TaskFatalErrorException> { manager.submit(task) }
+            thrown.cause.shouldBeInstanceOf<OutOfMemoryError>()
+            thrown.carries(boom) shouldBe true
+        }
+
+    @Test fun `a failing progress reset during cleanup does not strand the caller`() =
+        runTest2(autoCancel = true) {
+            val scope = this + Dispatchers.IO
+            val tool = createTool(scope)
+            var failProgress = false
+            every { tool.updateProgress(any()) } answers {
+                if (failProgress) throw IllegalStateException("Progress is broken")
+            }
+            coEvery { tool.submit(task) } coAnswers {
+                failProgress = true
+                taskResult
+            }
+
+            val manager = createManager(scope, tool)
+
+            manager.submit(task) shouldBeSameInstanceAs taskResult
+            manager.state.first().tasks.single().let {
+                it.isComplete shouldBe true
+                it.result shouldBeSameInstanceAs taskResult
+            }
+        }
+
+    @Test fun `an error from the progress reset during cleanup does not strand the caller`() =
+        runTest2(autoCancel = true) {
+            val scope = this + Dispatchers.IO
+            val tool = createTool(scope)
+            var failProgress = false
+            every { tool.updateProgress(any()) } answers {
+                if (failProgress) throw AssertionError("Progress is very broken")
+            }
+            coEvery { tool.submit(task) } coAnswers {
+                failProgress = true
+                taskResult
+            }
+
+            val manager = createManager(scope, tool)
+
+            manager.submit(task) shouldBeSameInstanceAs taskResult
+            manager.state.first().tasks.single().let {
+                it.isComplete shouldBe true
+                it.result shouldBeSameInstanceAs taskResult
+            }
+        }
+}

--- a/buildSrc/.gitignore
+++ b/buildSrc/.gitignore
@@ -1,3 +1,4 @@
 .gradle/
 build/
 .kotlin/sessions
+.kotlin/errors


### PR DESCRIPTION
## What changed

Fixed cases where SD Maid could vanish to the launcher without any error message the moment Media Squeeze started compressing videos. Failures during compression — including out-of-memory situations on low-RAM devices — now surface as a normal error dialog instead of silently killing the whole app.

Additionally, debug logs now record *why* the app died the last time (crash, native crash, out-of-memory, system kill), so silent-crash reports become diagnosable from the reporter's next debug log.

Refs #2634

## Technical Context

- Root cause class (two verified in-app process-kill routes; the reporter's device-specific trigger remains unconfirmed without a log):
  - `VideoTranscoder`'s progress poller, `Transformer` listener callbacks, and the `InAppMp4Muxer` metadata lambda ran on a HandlerThread / Media3's muxer thread with no try/catch — any `Throwable` there reached the default uncaught handler and killed the process.
  - `TaskManager.submit()`'s job caught only `Exception` inside an `appScope` that has no `CoroutineExceptionHandler`, so any `Error` (e.g. `OutOfMemoryError` during codec/GL setup, which `VideoTranscoder` deliberately funnels into the coroutine) was guaranteed process death — and even if contained, the `finally` recorded `error = null`, making `submit()`'s `throw endTask.error!!` an NPE.
- Transcoder callbacks now converge on a single `settle(Result)` coordinator guarded by an atomic terminal flag: cleanup steps are individually guarded and the coroutine resume is always the last act, so a failing cleanup can't re-open the hole.
- Task completion is now signalled via a `CompletableDeferred` instead of waiting on the task-state map — previously a throwing cleanup step (progress reset, resource-lock close) skipped the completion publish and stranded the `submit()` caller forever. Cleanup steps are individually guarded against `Throwable`.
- Non-`Exception` throwables reach `submit()` callers wrapped in the new `TaskFatalErrorException`, so every existing `catch (Exception)` call site (external watcher receiver, one-tap cleaner, ViewModels) contains them; `ManagedTask.error` widened `Exception?` → `Throwable?`.
- `ExitInfoLogger` (API 30+) fetches the last 5 `ApplicationExitInfo` records once per process and logs reason label + raw code, status, importance, and PSS/RSS. It re-emits when a debug-log recording starts, because the file logger installs asynchronously and has no replay buffer — without the re-emit, launch-time-only lines would never land in a recording started later.
- Review guidance: the trickiest part is the settle/cancellation interplay in `VideoTranscoder` (the `invokeOnCancellation` block is deliberately unchanged; its cleanup is idempotent against `settle()`'s) and the completion-signalling swap in `TaskManager.submit()` (the `invokeOnCompletion` safety net covers a LAZY job cancelled before its body ran).
- Verified on an emulator: video compression end-to-end on the changed code (file replaced smaller, mtime preserved, no crash), and a forced crash + relaunch writes `Previous exit: … reason=REASON_CRASH(4)` into the recorded debug log.
