### PR TITLE
SystemCleaner: Tidy up the custom filter editor layout

### DIFF
--- a/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/CustomFilterEditorBody.kt
+++ b/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/CustomFilterEditorBody.kt
@@ -10,16 +10,24 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.Warning
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalMinimumInteractiveComponentSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -27,10 +35,16 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalViewConfiguration
+import androidx.compose.ui.platform.ViewConfiguration
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import eu.darken.sdmse.common.R as CommonR
 import eu.darken.sdmse.common.areas.DataArea
+import eu.darken.sdmse.common.compose.preview.Preview2
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import eu.darken.sdmse.common.compose.settings.dialogs.AgeInputDialog
 import eu.darken.sdmse.common.compose.settings.dialogs.SizeInputDialog
 import eu.darken.sdmse.common.files.FileType
@@ -148,17 +162,38 @@ internal fun CustomFilterEditorBody(
                 style = MaterialTheme.typography.labelLarge,
             )
             Spacer(Modifier.height(8.dp))
-            FlowRow(
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalArrangement = Arrangement.spacedBy(4.dp),
+            // The chips paint 32dp but Material's minimumInteractiveComponentSize inflates their
+            // measured height to the 48dp floor, leaving dead space between the rows. 32dp replaces
+            // that floor here. Both locals are needed: LocalMinimumInteractiveComponentSize is the
+            // layout floor, while pointer hit-testing separately expands each node to
+            // LocalViewConfiguration.minimumTouchTargetSize - without the second the pills would
+            // still claim 48dp of touch. Scope is exactly these area chips. The delegate is
+            // remembered because LocalViewConfiguration is a static composition local: Compose
+            // re-executes the whole provided subtree whenever the provided value is unequal to the
+            // previous one, and an anonymous object declares no equals - so every fresh instance
+            // counts as a change and would recompose all six chips on each keystroke in the label field.
+            val baseViewConfiguration = LocalViewConfiguration.current
+            val compactViewConfiguration = remember(baseViewConfiguration) {
+                object : ViewConfiguration by baseViewConfiguration {
+                    override val minimumTouchTargetSize: DpSize = DpSize(32.dp, 32.dp)
+                }
+            }
+            CompositionLocalProvider(
+                LocalMinimumInteractiveComponentSize provides 32.dp,
+                LocalViewConfiguration provides compactViewConfiguration,
             ) {
-                AREA_TYPES.forEach { type ->
-                    val selected = config.areas?.contains(type) == true
-                    FilterChip(
-                        selected = selected,
-                        onClick = { onToggleArea(type, !selected) },
-                        label = { Text(type.raw) },
-                    )
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    AREA_TYPES.forEach { type ->
+                        val selected = config.areas?.contains(type) == true
+                        FilterChip(
+                            selected = selected,
+                            onClick = { onToggleArea(type, !selected) },
+                            label = { Text(type.raw) },
+                        )
+                    }
                 }
             }
             Spacer(Modifier.height(8.dp))
@@ -243,10 +278,8 @@ internal fun CustomFilterEditorBody(
             )
         }
 
-        Text(
-            text = stringResource(SystemCleanerR.string.systemcleaner_customfilter_editor_warning),
-            style = MaterialTheme.typography.bodyMedium,
-            modifier = Modifier.padding(32.dp),
+        EditorWarningCard(
+            modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 32.dp),
         )
     }
 
@@ -344,11 +377,50 @@ private fun CheckboxRow(label: String, checked: Boolean, onClick: () -> Unit) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .toggleable(value = checked, onValueChange = { onClick() }, role = Role.Checkbox)
             .padding(vertical = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Checkbox(checked = checked, onCheckedChange = { onClick() })
+        // onCheckedChange = null hands the gesture to the row, so the merged semantics stay a single
+        // Role.Checkbox node. It also drops the Checkbox's own 48dp minimum size, hence the Spacer.
+        Checkbox(checked = checked, onCheckedChange = null)
+        Spacer(Modifier.width(8.dp))
         Text(label)
+    }
+}
+
+@Composable
+private fun EditorWarningCard(modifier: Modifier = Modifier) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+            contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+        ),
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = Icons.TwoTone.Warning,
+                contentDescription = null,
+                modifier = Modifier.size(24.dp),
+            )
+            Spacer(Modifier.width(12.dp))
+            Text(
+                text = stringResource(SystemCleanerR.string.systemcleaner_customfilter_editor_warning),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+    }
+}
+
+@Preview2
+@Composable
+private fun EditorWarningCardPreview() {
+    PreviewWrapper {
+        EditorWarningCard()
     }
 }
 

--- a/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/CustomFilterEditorBody.kt
+++ b/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/CustomFilterEditorBody.kt
@@ -35,11 +35,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalViewConfiguration
-import androidx.compose.ui.platform.ViewConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import eu.darken.sdmse.common.R as CommonR
 import eu.darken.sdmse.common.areas.DataArea
@@ -162,29 +159,14 @@ internal fun CustomFilterEditorBody(
                 style = MaterialTheme.typography.labelLarge,
             )
             Spacer(Modifier.height(8.dp))
-            // The chips paint 32dp but Material's minimumInteractiveComponentSize inflates their
-            // measured height to the 48dp floor, leaving dead space between the rows. 32dp replaces
-            // that floor here. Both locals are needed: LocalMinimumInteractiveComponentSize is the
-            // layout floor, while pointer hit-testing separately expands each node to
-            // LocalViewConfiguration.minimumTouchTargetSize - without the second the pills would
-            // still claim 48dp of touch. Scope is exactly these area chips. The delegate is
-            // remembered because LocalViewConfiguration is a static composition local: Compose
-            // re-executes the whole provided subtree whenever the provided value is unequal to the
-            // previous one, and an anonymous object declares no equals - so every fresh instance
-            // counts as a change and would recompose all six chips on each keystroke in the label field.
-            val baseViewConfiguration = LocalViewConfiguration.current
-            val compactViewConfiguration = remember(baseViewConfiguration) {
-                object : ViewConfiguration by baseViewConfiguration {
-                    override val minimumTouchTargetSize: DpSize = DpSize(32.dp, 32.dp)
-                }
-            }
-            CompositionLocalProvider(
-                LocalMinimumInteractiveComponentSize provides 32.dp,
-                LocalViewConfiguration provides compactViewConfiguration,
-            ) {
+            // Surface applies minimumInteractiveComponentSize(), so a 32dp chip occupies 48dp of
+            // layout and the rows drift far apart. 40dp replaces that floor, matching the criteria
+            // chips in TaggedInputField. Touch targets stay at the default 48dp on purpose - only
+            // the layout floor is lowered, and the scope is exactly these area chips.
+            CompositionLocalProvider(LocalMinimumInteractiveComponentSize provides 40.dp) {
                 FlowRow(
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    horizontalArrangement = Arrangement.spacedBy(2.dp),
+                    verticalArrangement = Arrangement.spacedBy(2.dp),
                 ) {
                     AREA_TYPES.forEach { type ->
                         val selected = config.areas?.contains(type) == true

--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/CustomFilterEditorScreenTest.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/CustomFilterEditorScreenTest.kt
@@ -245,12 +245,12 @@ class CustomFilterEditorScreenTest : BaseComposeRobolectricTest() {
         }
 
         val pitch = rowTops.zipWithNext { upper, lower -> lower - upper }.min()
-        // With the 48dp interactive floor in place each chip measures >= 48dp, so the pitch is >= 56dp.
-        // Without it the pitch is the chip's own height plus the 8dp spacing - measured at 44dp here,
-        // since the chip content is a little taller than the 32dp FilterChip container token. Anything
-        // >= 48dp means the floor is back; the gap to 44dp absorbs text-metric drift.
-        if (pitch >= 48.dp) {
-            throw AssertionError("Area chip rows are still $pitch apart, expected less than 48.dp")
+        // With the default 48dp interactive floor each chip measures >= 48dp, so the pitch would be
+        // >= 50dp. With the 40dp floor the chip measures max(content, 40dp) = 40dp, so the pitch is
+        // the 40dp chip plus the 2dp spacing - measured at 42dp here. 46dp is the midpoint: anything
+        // >= 46dp means the default floor is back, and the gap to 42dp absorbs text-metric drift.
+        if (pitch >= 46.dp) {
+            throw AssertionError("Area chip rows are still $pitch apart, expected less than 46.dp")
         }
     }
 }

--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/CustomFilterEditorScreenTest.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/CustomFilterEditorScreenTest.kt
@@ -10,8 +10,11 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.height
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.common.files.FileType
 import eu.darken.sdmse.common.sieve.SegmentCriterium
 import eu.darken.sdmse.systemcleaner.core.filter.custom.CustomFilterConfig
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -180,7 +183,82 @@ class CustomFilterEditorScreenTest : BaseComposeRobolectricTest() {
             )
         }
     }
+
+    @Test
+    fun `tapping the Files row label toggles the file type`() {
+        val toggled = mutableListOf<FileType>()
+        composeRule.setEditorContent {
+            CustomFilterEditorScreen(
+                stateSource = MutableStateFlow(editorState()),
+                onToggleFileType = { toggled.add(it) },
+            )
+        }
+
+        // The file type section sits below the initial viewport, and performClick() injects touch
+        // input without auto-scrolling. useUnmergedTree targets the label Text itself, so this
+        // actually exercises "tapping the label", not the merged row node's centre.
+        composeRule.onNodeWithText("Files", useUnmergedTree = true).performScrollTo().performClick()
+
+        if (toggled != listOf(FileType.FILE)) {
+            throw AssertionError("Expected a single FILE toggle, got $toggled")
+        }
+    }
+
+    @Test
+    fun `tapping the Folders row label toggles the file type`() {
+        val toggled = mutableListOf<FileType>()
+        composeRule.setEditorContent {
+            CustomFilterEditorScreen(
+                stateSource = MutableStateFlow(editorState()),
+                onToggleFileType = { toggled.add(it) },
+            )
+        }
+
+        composeRule.onNodeWithText("Folders", useUnmergedTree = true).performScrollTo().performClick()
+
+        if (toggled != listOf(FileType.DIRECTORY)) {
+            throw AssertionError("Expected a single DIRECTORY toggle, got $toggled")
+        }
+    }
+
+    @Test
+    fun `area chips no longer reserve the 48dp minimum interactive height`() {
+        composeRule.setEditorContent {
+            CustomFilterEditorScreen(stateSource = MutableStateFlow(editorState()))
+        }
+
+        val areaLabels = listOf("SDCARD", "PUBLIC_DATA", "PUBLIC_MEDIA", "PUBLIC_OBB", "PRIVATE_DATA", "PORTABLE")
+        // Scroll once, then measure: scrolling between measurements would mix different scroll
+        // offsets into the row tops and make the pitch meaningless.
+        composeRule.onNodeWithText(areaLabels.last()).performScrollTo()
+
+        // A single chip's height is not usable here: the semantics coordinator sits inside the
+        // minimumInteractiveComponentSize layout modifier, so it reads ~32dp before and after.
+        // The row pitch is what actually changes.
+        val rowTops = areaLabels
+            .map { composeRule.onNodeWithText(it).getUnclippedBoundsInRoot().top }
+            .distinct()
+            .sorted()
+
+        if (rowTops.size < 2) {
+            throw AssertionError("Expected the area chips to wrap over multiple rows, found ${rowTops.size} row(s)")
+        }
+
+        val pitch = rowTops.zipWithNext { upper, lower -> lower - upper }.min()
+        // With the 48dp interactive floor in place each chip measures >= 48dp, so the pitch is >= 56dp.
+        // Without it the pitch is the chip's own height plus the 8dp spacing - measured at 44dp here,
+        // since the chip content is a little taller than the 32dp FilterChip container token. Anything
+        // >= 48dp means the floor is back; the gap to 44dp absorbs text-metric drift.
+        if (pitch >= 48.dp) {
+            throw AssertionError("Area chip rows are still $pitch apart, expected less than 48.dp")
+        }
+    }
 }
+
+private fun editorState() = CustomFilterEditorViewModel.State(
+    original = null,
+    current = CustomFilterConfig(identifier = "abc", label = "Test"),
+)
 
 private fun ComposeContentTestRule.setEditorContent(content: @Composable () -> Unit) {
     setContent { PreviewWrapper { content() } }


### PR DESCRIPTION
## What changed

The custom filter editor got a tidy-up:

- The data area chips no longer sit in tall, mostly-empty rows — they now use the same compact spacing as the criteria chips above them.
- The **Files** and **Folders** checkboxes now toggle when you tap anywhere on their row, instead of only on the small box itself.
- The warning at the bottom is now a card with an icon, so it's easier to notice without looking alarming.

## Technical Context

- **Root cause of the chip gap**: Material3's `minimumInteractiveComponentSize`, which `FilterChip` picks up via `Surface(selected =, onClick =)`. Its modifier node reports `max(childSize, 48dp)` as the **layout** size, so each 32dp chip occupied a 48dp box. The wasted space was an invisible layout floor, not a spacing value — which is why it wasn't visible in the `FlowRow` arrangement.
- **Scoping the composition local rather than hand-rolling a chip** keeps `FilterChip`'s selected checkmark, ripple, colors and `Role.Checkbox` semantics instead of re-implementing them. The 40dp floor and 2dp spacing deliberately match what `TaggedInputField` already does for the criteria chips on the same screen, so the two chip groups share one rhythm. Only the layout floor is lowered — touch targets stay at the default 48dp.
- **`Checkbox(onCheckedChange = null)` is required, not cosmetic**: it removes the checkbox's own click node so the row owns a single `Role.Checkbox` gesture and the merged semantics stay one node. It also drops the checkbox's own 48dp floor, which is what shrinks the rows and why an explicit spacer was added. Mirrors the existing `TagToggle` pattern in the exclusion editors.
- **The chip geometry test measures row *pitch*, not chip height, on purpose** — a `SemanticsNode`'s bounds come from the coordinator *inside* the min-interactive layout modifier, so a single chip reads the same before and after the change and a height assertion would pass against unfixed code. It also fails loudly if the chips ever stop wrapping, so it cannot pass vacuously.
- The warning card's 32dp bottom padding preserves the trailing scroll space the old `padding(32.dp)` provided, keeping the end of the form reachable above the collapsed live-search sheet.
