### PR TITLE
General: Fix pink tint on cards and dialogs in the default theme

### DIFF
--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/settings/dialogs/AgeInputDialog.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/settings/dialogs/AgeInputDialog.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import eu.darken.sdmse.common.compose.dialog.SdmAlertDialog
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Slider
@@ -111,7 +110,6 @@ fun AgeInputDialog(
                         saveEnabled = true
                     },
                     valueRange = minHours.toFloat()..maxHours.toFloat(),
-                    modifier = Modifier.padding(horizontal = 8.dp),
                 )
             }
         },

--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/settings/dialogs/SizeInputDialog.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/settings/dialogs/SizeInputDialog.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import eu.darken.sdmse.common.compose.dialog.SdmAlertDialog
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Slider
@@ -101,7 +100,6 @@ fun SizeInputDialog(
                         saveEnabled = true
                     },
                     valueRange = minKb.toFloat()..maxKb.toFloat(),
-                    modifier = Modifier.padding(horizontal = 8.dp),
                 )
             }
         },

--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/error/ComposeErrorDialog.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/error/ComposeErrorDialog.kt
@@ -94,7 +94,7 @@ fun ComposeErrorDialog(
                     Text(
                         text = localizedError.description.get(context),
                         style = MaterialTheme.typography.bodyMedium,
-                        modifier = Modifier.padding(vertical = 8.dp),
+                        modifier = Modifier.padding(top = 8.dp),
                     )
                 }
                 actionError?.let {

--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/theming/SdmSeColorsGreen.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/theming/SdmSeColorsGreen.kt
@@ -36,6 +36,14 @@ object SdmSeColorsGreen {
         inverseSurface = Color(0xFF2C322C),
         inverseOnSurface = Color(0xFFECF2EA),
         inversePrimary = Color(0xFF7CDA9A),
+        surfaceTint = Color(0xFF006D36),
+        surfaceBright = Color(0xFFF5FBF2),
+        surfaceContainer = Color(0xFFEAF0E7),
+        surfaceContainerHigh = Color(0xFFE4EAE1),
+        surfaceContainerHighest = Color(0xFFDEE4DC),
+        surfaceContainerLow = Color(0xFFEFF5ED),
+        surfaceContainerLowest = Color(0xFFFFFFFF),
+        surfaceDim = Color(0xFFD6DCD3),
     )
 
     val DarkDefault = darkColorScheme(
@@ -67,6 +75,14 @@ object SdmSeColorsGreen {
         inverseSurface = Color(0xFFDEE4DC),
         inverseOnSurface = Color(0xFF2C322C),
         inversePrimary = Color(0xFF006D36),
+        surfaceTint = Color(0xFF7CDA9A),
+        surfaceBright = Color(0xFF353B35),
+        surfaceContainer = Color(0xFF1B211C),
+        surfaceContainerHigh = Color(0xFF252B26),
+        surfaceContainerHighest = Color(0xFF303631),
+        surfaceContainerLow = Color(0xFF171D18),
+        surfaceContainerLowest = Color(0xFF0A100B),
+        surfaceDim = Color(0xFF0F1510),
     )
 
     val LightMediumContrast = lightColorScheme(
@@ -98,6 +114,14 @@ object SdmSeColorsGreen {
         inverseSurface = Color(0xFF2C322C),
         inverseOnSurface = Color(0xFFECF2EA),
         inversePrimary = Color(0xFF7CDA9A),
+        surfaceTint = Color(0xFF004E25),
+        surfaceBright = Color(0xFFF5FBF2),
+        surfaceContainer = Color(0xFFEAF0E7),
+        surfaceContainerHigh = Color(0xFFE4EAE1),
+        surfaceContainerHighest = Color(0xFFDEE4DC),
+        surfaceContainerLow = Color(0xFFEFF5ED),
+        surfaceContainerLowest = Color(0xFFFFFFFF),
+        surfaceDim = Color(0xFFD6DCD3),
     )
 
     val DarkMediumContrast = darkColorScheme(
@@ -129,6 +153,14 @@ object SdmSeColorsGreen {
         inverseSurface = Color(0xFFDEE4DC),
         inverseOnSurface = Color(0xFF262B26),
         inversePrimary = Color(0xFF005028),
+        surfaceTint = Color(0xFF92F1AF),
+        surfaceBright = Color(0xFF353B35),
+        surfaceContainer = Color(0xFF1B211C),
+        surfaceContainerHigh = Color(0xFF252B26),
+        surfaceContainerHighest = Color(0xFF303631),
+        surfaceContainerLow = Color(0xFF171D18),
+        surfaceContainerLowest = Color(0xFF0A100B),
+        surfaceDim = Color(0xFF0F1510),
     )
 
     val LightHighContrast = lightColorScheme(
@@ -160,6 +192,14 @@ object SdmSeColorsGreen {
         inverseSurface = Color(0xFF2C322C),
         inverseOnSurface = Color(0xFFFFFFFF),
         inversePrimary = Color(0xFF7CDA9A),
+        surfaceTint = Color(0xFF00421E),
+        surfaceBright = Color(0xFFF5FBF2),
+        surfaceContainer = Color(0xFFEAF0E7),
+        surfaceContainerHigh = Color(0xFFE4EAE1),
+        surfaceContainerHighest = Color(0xFFDEE4DC),
+        surfaceContainerLow = Color(0xFFEFF5ED),
+        surfaceContainerLowest = Color(0xFFFFFFFF),
+        surfaceDim = Color(0xFFD6DCD3),
     )
 
     val DarkHighContrast = darkColorScheme(
@@ -191,6 +231,14 @@ object SdmSeColorsGreen {
         inverseSurface = Color(0xFFDEE4DC),
         inverseOnSurface = Color(0xFF000000),
         inversePrimary = Color(0xFF005028),
+        surfaceTint = Color(0xFFB0FFCA),
+        surfaceBright = Color(0xFF353B35),
+        surfaceContainer = Color(0xFF1B211C),
+        surfaceContainerHigh = Color(0xFF252B26),
+        surfaceContainerHighest = Color(0xFF303631),
+        surfaceContainerLow = Color(0xFF171D18),
+        surfaceContainerLowest = Color(0xFF0A100B),
+        surfaceDim = Color(0xFF0F1510),
     )
 
     fun lightScheme(style: ThemeStyle): ColorScheme = when (style) {

--- a/app-common-ui/src/test/java/eu/darken/sdmse/common/theming/ThemeColorProviderTest.kt
+++ b/app-common-ui/src/test/java/eu/darken/sdmse/common/theming/ThemeColorProviderTest.kt
@@ -1,5 +1,9 @@
 package eu.darken.sdmse.common.theming
 
+import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import io.kotest.assertions.withClue
 import io.kotest.matchers.shouldNotBe
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
@@ -22,5 +26,42 @@ class ThemeColorProviderTest : BaseTest() {
                 ThemeColorProvider.getDarkColorScheme(color, style) shouldNotBe null
             }
         }
+    }
+
+    @Test
+    fun `surface container roles are not left at M3 baseline defaults`() {
+        val baselineLight = lightColorScheme()
+        val baselineDark = darkColorScheme()
+        for (color in ThemeColor.entries) {
+            for (style in ThemeStyle.entries) {
+                checkSurfaceRoles(
+                    label = "$color/$style/light",
+                    scheme = ThemeColorProvider.getLightColorScheme(color, style),
+                    baseline = baselineLight,
+                    // Light schemes legitimately use pure white for surfaceContainerLowest, same as the baseline.
+                    checkLowest = false,
+                )
+                checkSurfaceRoles(
+                    label = "$color/$style/dark",
+                    scheme = ThemeColorProvider.getDarkColorScheme(color, style),
+                    baseline = baselineDark,
+                    checkLowest = true,
+                )
+            }
+        }
+    }
+
+    private fun checkSurfaceRoles(label: String, scheme: ColorScheme, baseline: ColorScheme, checkLowest: Boolean) {
+        // Schemes built via lightColorScheme()/darkColorScheme() silently fill unspecified roles
+        // with the purple-seeded M3 baseline palette.
+        if (checkLowest) {
+            withClue("$label surfaceContainerLowest") { scheme.surfaceContainerLowest shouldNotBe baseline.surfaceContainerLowest }
+        }
+        withClue("$label surfaceDim") { scheme.surfaceDim shouldNotBe baseline.surfaceDim }
+        withClue("$label surfaceBright") { scheme.surfaceBright shouldNotBe baseline.surfaceBright }
+        withClue("$label surfaceContainerLow") { scheme.surfaceContainerLow shouldNotBe baseline.surfaceContainerLow }
+        withClue("$label surfaceContainer") { scheme.surfaceContainer shouldNotBe baseline.surfaceContainer }
+        withClue("$label surfaceContainerHigh") { scheme.surfaceContainerHigh shouldNotBe baseline.surfaceContainerHigh }
+        withClue("$label surfaceContainerHighest") { scheme.surfaceContainerHighest shouldNotBe baseline.surfaceContainerHighest }
     }
 }

--- a/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/settings/arbiter/ArbiterConfigScreen.kt
+++ b/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/settings/arbiter/ArbiterConfigScreen.kt
@@ -19,13 +19,15 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -198,15 +200,22 @@ private fun ModeSelectionDialog(
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clickable { onSelected(mode) }
-                            .padding(vertical = 12.dp),
+                            .selectable(
+                                selected = mode == currentMode,
+                                role = Role.RadioButton,
+                                onClick = { onSelected(mode) },
+                            )
+                            .heightIn(min = 48.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         RadioButton(
                             selected = mode == currentMode,
-                            onClick = { onSelected(mode) },
+                            onClick = null,
                         )
-                        Text(text = stringResource(mode.labelRes))
+                        Text(
+                            text = stringResource(mode.labelRes),
+                            modifier = Modifier.padding(start = 8.dp),
+                        )
                     }
                 }
             }

--- a/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/sessions/SwiperSessionsScreen.kt
+++ b/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/sessions/SwiperSessionsScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -38,6 +39,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -443,17 +445,20 @@ private fun SortOrderDialog(
                             .fillMaxWidth()
                             .selectable(
                                 selected = order == current,
+                                role = Role.RadioButton,
                                 onClick = { onSelect(order) },
-                            ),
+                            )
+                            .heightIn(min = 48.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         RadioButton(
                             selected = order == current,
-                            onClick = { onSelect(order) },
+                            onClick = null,
                         )
                         Text(
                             text = order.label.get(context),
                             style = MaterialTheme.typography.bodyMedium,
+                            modifier = Modifier.padding(start = 8.dp),
                         )
                     }
                 }

--- a/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/ChipModeSwitcherDialog.kt
+++ b/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/editor/ChipModeSwitcherDialog.kt
@@ -3,6 +3,7 @@ package eu.darken.sdmse.systemcleaner.ui.customfilter.editor
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.material3.MaterialTheme
@@ -60,7 +61,8 @@ internal fun ChipModeSwitcherDialog(
                                 role = Role.RadioButton,
                                 onClick = { onModeSelected(mode) },
                             )
-                            .padding(vertical = 4.dp),
+                            // RadioButton has onClick = null, so no 48dp minimum applies implicitly.
+                            .heightIn(min = 48.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         RadioButton(

--- a/app/src/main/java/eu/darken/sdmse/common/debug/logviewer/ui/FloatingLogPanel.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/debug/logviewer/ui/FloatingLogPanel.kt
@@ -11,12 +11,14 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
@@ -62,6 +64,7 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
@@ -524,19 +527,20 @@ private fun LogLevelDialog(
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clickable {
-                                onSelect(level)
-                                onDismiss()
-                            }
-                            .padding(vertical = 8.dp),
+                            .selectable(
+                                selected = level == current,
+                                role = Role.RadioButton,
+                                onClick = {
+                                    onSelect(level)
+                                    onDismiss()
+                                },
+                            )
+                            .heightIn(min = 48.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         RadioButton(
                             selected = level == current,
-                            onClick = {
-                                onSelect(level)
-                                onDismiss()
-                            },
+                            onClick = null,
                         )
                         Spacer(modifier = Modifier.width(8.dp))
                         Text(level.displayName())

--- a/app/src/main/java/eu/darken/sdmse/main/ui/settings/general/OneClickOptionsDialog.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/settings/general/OneClickOptionsDialog.kt
@@ -39,7 +39,7 @@ fun OneClickOptionsDialog(
             onClick = onDismiss,
         ),
     ) {
-        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Column {
             Text(
                 text = stringResource(R.string.dashboard_settings_oneclick_tools_desc),
                 style = MaterialTheme.typography.bodyMedium,

--- a/app/src/main/java/eu/darken/sdmse/main/ui/settings/general/ThemePickerDialogs.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/settings/general/ThemePickerDialogs.kt
@@ -2,7 +2,7 @@ package eu.darken.sdmse.main.ui.settings.general
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -27,6 +27,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import eu.darken.sdmse.R
 import eu.darken.sdmse.common.device.RomType
@@ -56,12 +57,17 @@ fun ThemeModePickerDialog(
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clickable { onModeSelected(mode) },
+                            .selectable(
+                                selected = mode == currentMode,
+                                role = Role.RadioButton,
+                                onClick = { onModeSelected(mode) },
+                            )
+                            .heightIn(min = 48.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         RadioButton(
                             selected = mode == currentMode,
-                            onClick = { onModeSelected(mode) },
+                            onClick = null,
                         )
                         Text(
                             text = label,
@@ -100,12 +106,17 @@ fun ThemeStylePickerDialog(
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clickable { onStyleSelected(style) },
+                            .selectable(
+                                selected = style == currentStyle,
+                                role = Role.RadioButton,
+                                onClick = { onStyleSelected(style) },
+                            )
+                            .heightIn(min = 48.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         RadioButton(
                             selected = style == currentStyle,
-                            onClick = { onStyleSelected(style) },
+                            onClick = null,
                         )
                         Text(
                             text = label,
@@ -143,18 +154,20 @@ fun RomTypePickerDialog(
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clickable {
-                                onRomTypeSelected(rom)
-                                onDismiss()
-                            },
+                            .selectable(
+                                selected = rom == currentRomType,
+                                role = Role.RadioButton,
+                                onClick = {
+                                    onRomTypeSelected(rom)
+                                    onDismiss()
+                                },
+                            )
+                            .heightIn(min = 48.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         RadioButton(
                             selected = rom == currentRomType,
-                            onClick = {
-                                onRomTypeSelected(rom)
-                                onDismiss()
-                            },
+                            onClick = null,
                         )
                         Text(
                             text = rom.label.get(context),
@@ -192,12 +205,17 @@ fun ThemeColorPickerDialog(
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clickable { onColorSelected(color) },
+                            .selectable(
+                                selected = color == currentColor,
+                                role = Role.RadioButton,
+                                onClick = { onColorSelected(color) },
+                            )
+                            .heightIn(min = 48.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         RadioButton(
                             selected = color == currentColor,
-                            onClick = { onColorSelected(color) },
+                            onClick = null,
                         )
                         Spacer(modifier = Modifier.width(8.dp))
                         ColorSwatch(color)

--- a/app/src/main/java/eu/darken/sdmse/main/ui/settings/general/ThemePickerDialogs.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/settings/general/ThemePickerDialogs.kt
@@ -56,8 +56,7 @@ fun ThemeModePickerDialog(
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clickable { onModeSelected(mode) }
-                            .padding(vertical = 8.dp),
+                            .clickable { onModeSelected(mode) },
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         RadioButton(
@@ -101,8 +100,7 @@ fun ThemeStylePickerDialog(
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clickable { onStyleSelected(style) }
-                            .padding(vertical = 8.dp),
+                            .clickable { onStyleSelected(style) },
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         RadioButton(
@@ -148,8 +146,7 @@ fun RomTypePickerDialog(
                             .clickable {
                                 onRomTypeSelected(rom)
                                 onDismiss()
-                            }
-                            .padding(vertical = 8.dp),
+                            },
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         RadioButton(
@@ -195,8 +192,7 @@ fun ThemeColorPickerDialog(
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clickable { onColorSelected(color) }
-                            .padding(vertical = 8.dp),
+                            .clickable { onColorSelected(color) },
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         RadioButton(


### PR DESCRIPTION
## What changed

Since v2.0.1, the default green theme showed cards, dialogs, pop-up/drop-down menus, and inactive switch toggles with a pink/purple tint instead of the familiar green-tinted look from v1 (reported via support email with before/after screenshots from multiple devices). Buttons and active elements were unaffected. This restores the pre-v2 green appearance in both light and dark mode.

Also restores pre-v2 dialog density across the app, which had grown noticeably airier after the v2 update: selection dialogs (theme mode/style/color, ROM type, log level, Deduplicator arbiter, Swiper sort order, One-Tap Tools) get their old row height and radio alignment back, the size/age slider dialogs get their wider slider track back, and error dialogs lose extra trailing whitespace.

## Technical Context

- Root cause: `SdmSeColorsGreen`'s six color schemes never set the M3 surface roles (`surfaceDim`, `surfaceBright`, `surfaceContainerLowest/Low/-/High/Highest`), so `lightColorScheme()`/`darkColorScheme()` silently filled them from the purple-seeded Material 3 baseline palette. Cards, dialogs, menus, and unchecked switch tracks all resolve through exactly these roles. Sunset and AMOLED define the full ramp and were unaffected.
- The added values were regenerated from the green scheme's own neutral tonal palette (HCT hue 155.76 / chroma 6.77, reconstructed from the scheme's defined anchors) at the M3 spec tones; they match the pre-v2 View theme's `md_theme_*` colors within 1/255 per channel. One container ramp is intentionally reused across DEFAULT/MEDIUM/HIGH contrast styles, matching how Sunset and AMOLED are structured.
- The new `ThemeColorProviderTest` case fails if any palette leaves surface-container roles at the M3 baseline defaults; `surfaceContainerLowest` is only asserted for dark schemes since light schemes legitimately use pure white there.
- The dialog density fixes come from a systematic v1.7.5-vs-current audit of every dialog's padding: the Compose port had stacked explicit row padding (4-12dp) on top of the widgets' 48dp minimum touch boxes and added slider/message insets v1 didn't have. Radio rows now use `selectable` + `RadioButton(onClick = null)` + 48dp min height, which also restores the radio to the dialog's 24dp inset and gives TalkBack/D-pad one focus stop per row. Touch targets are unchanged (48dp everywhere).
- Deliberately not "fixed": Compose M3 `AlertDialog` spec paddings/width (slightly different from the old View dialogs by design) and the Deduplicator delete-preview redesign (fixed 148dp thumbnail became full-width in v2, which looks intentional).
- Verified on two API 35 emulators running main vs this branch side by side: sampled pixels confirm cards `#1D1B20`→`#171D18`, dialogs `#2B2930`→`#252B26`, unchecked switch tracks `#36343B`→`#303631` (baseline purple → green ramp) — something CI cannot cover.
