### PR TITLE
Fix: Rare app crash during shell session shutdown

### DIFF
--- a/app-common-shell/src/main/java/eu/darken/flowshell/core/FlowShell.kt
+++ b/app-common-shell/src/main/java/eu/darken/flowshell/core/FlowShell.kt
@@ -18,8 +18,8 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
-import kotlinx.coroutines.stream.consumeAsFlow
 import kotlinx.coroutines.withContext
+import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStreamWriter
 import java.nio.charset.StandardCharsets
@@ -67,10 +67,23 @@ class FlowShell(
 
         private fun InputStream.lineHarvester(tag: String) = flow {
             if (isDebug) log(_tag, VERBOSE) { "Harverster($tag) is active" }
-            bufferedReader().use { reader ->
-                reader.lines().consumeAsFlow().collect {
-                    if (isDebug) log(_tag, VERBOSE) { "Harverster($tag) -> $it" }
-                    emit(it)
+            val reader = bufferedReader()
+            try {
+                while (true) {
+                    val line = try {
+                        reader.readLine() ?: break
+                    } catch (e: IOException) {
+                        if (isDebug) log(_tag, WARN) { "Harvester($tag) stream ended: $e" }
+                        break
+                    }
+                    if (isDebug) log(_tag, VERBOSE) { "Harvester($tag) -> $line" }
+                    emit(line)
+                }
+            } finally {
+                try {
+                    reader.close()
+                } catch (e: IOException) {
+                    if (isDebug) log(_tag, WARN) { "Harvester($tag) close failed: $e" }
                 }
             }
             if (isDebug) log(_tag, VERBOSE) { "Harverster($tag) is finished" }

--- a/app-common-shell/src/test/java/eu/darken/flowshell/core/FlowShellTest.kt
+++ b/app-common-shell/src/test/java/eu/darken/flowshell/core/FlowShellTest.kt
@@ -4,24 +4,37 @@ package eu.darken.flowshell.core
 import eu.darken.flowshell.core.process.FlowProcess
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.flow.replayingShare
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.takeWhile
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.runTest2
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.io.InputStream
+import java.io.InterruptedIOException
 import java.util.Base64
 import java.util.UUID
 
@@ -151,6 +164,83 @@ class FlowShellTest : BaseTest() {
             decode(outputData.toString()).size shouldBe expectedSize
             decode(errorData.toString()).size shouldBe expectedSize
             outputData shouldNotBe errorData
+        }
+    }
+
+    @Test fun `harvester treats stream teardown as end of stream`() = runTest {
+        val session = fakeSession(TornDownInputStream("line1\nline2\n"))
+
+        session.output.toList() shouldBe listOf("line1", "line2")
+    }
+
+    @Test fun `killing session while output is collected does not throw`() = runTest2(autoCancel = true) {
+        val sharedSession = FlowShell().session.replayingShare(this)
+        sharedSession.launchIn(this + Dispatchers.IO)
+
+        val session = sharedSession.first()
+        val lineArrived = CompletableDeferred<Unit>()
+
+        val outputJob = session.output
+            .onEach { if (it == "marker") lineArrived.complete(Unit) }
+            .launchIn(this + Dispatchers.IO)
+        val errorJob = session.error.launchIn(this + Dispatchers.IO)
+
+        session.write("echo marker")
+        lineArrived.await()
+
+        session.cancel()
+
+        withContext(Dispatchers.IO) {
+            withTimeout(10_000) { listOf(outputJob, errorJob).joinAll() }
+        }
+    }
+
+    @Test fun `collector exceptions propagate through the harvester`() = runTest {
+        val session = fakeSession(EndlessInputStream("line"))
+
+        shouldThrow<IllegalStateException> {
+            session.output.collect { throw IllegalStateException("collector boom") }
+        }.message shouldBe "collector boom"
+    }
+
+    private fun fakeSession(output: InputStream): FlowShell.Session {
+        val process = mockk<Process>().apply {
+            every { outputStream } returns ByteArrayOutputStream()
+            every { inputStream } returns output
+            every { errorStream } returns ByteArrayInputStream(ByteArray(0))
+        }
+        return FlowShell.Session(
+            session = FlowProcess.Session(
+                id = "test",
+                process = process,
+                exitCode = MutableStateFlow<FlowProcess.ExitCode?>(null),
+                onKill = {},
+            ),
+        )
+    }
+
+    private class TornDownInputStream(payload: String) : InputStream() {
+        private val data = payload.toByteArray()
+        private var pos = 0
+
+        override fun read(): Int {
+            if (pos == data.size) throw InterruptedIOException("read interrupted by close() on another thread")
+            return data[pos++].toInt() and 0xFF
+        }
+
+        override fun close() {
+            throw IOException("close() failed")
+        }
+    }
+
+    private class EndlessInputStream(line: String) : InputStream() {
+        private val data = (line + "\n").toByteArray()
+        private var pos = 0
+
+        override fun read(): Int {
+            val byte = data[pos]
+            pos = (pos + 1) % data.size
+            return byte.toInt() and 0xFF
         }
     }
 }


### PR DESCRIPTION
## What changed

Fixed a rare crash that could kill the app when an internal shell session was shut down while its output was still being read. Surfaced via Play crash reports on the v2.0.2 beta (Android 16).

## Technical Context

- Root cause: shell output is read via `BufferedReader.lines()`, whose iterator wraps any `IOException` from `readLine()` in `UncheckedIOException`. When session teardown races an in-flight read (Android interrupts a blocked read when the stream is closed on another thread), that unchecked exception escaped the harvester flow into `FlowCmdShell`'s unsupervised `shareIn` scope and reached the default uncaught handler.
- The fix rewrites `lineHarvester` as a manual `readLine()` loop treating `IOException` on read or close as end-of-stream — a dead process pipe can never produce another line. `emit` stays outside the catch, so collector and cancellation exceptions propagate unchanged.
- Deliberately not addressed here: a pre-existing stall class in `FlowCmdShell` where a command's marker-wait can hang if a stream ends while the process stays alive — tracked separately to keep this change minimal.
- Review pointer: the regression test simulates the Android interrupted-read with a scripted `InputStream` (deterministic, fails pre-fix); the real-shell test is a teardown smoke test only, since desktop JVMs usually deliver clean EOF instead of the interrupted read.
