### PR TITLE
SystemCleaner: Speed up scanning folders with a huge number of files

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathExtensions.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathExtensions.kt
@@ -192,6 +192,10 @@ suspend fun <P : APath, PL : APathLookup<P>, PLE : APathLookupExtended<P>> P.loo
     return gateway.lookupFiles(this)
 }
 
+suspend fun <P : APath, PL : APathLookup<P>, PLE : APathLookupExtended<P>> P.lookupFilesFlow(gateway: APathGateway<P, PL, PLE>): Flow<PL> {
+    return gateway.lookupFilesFlow(this)
+}
+
 suspend fun <P : APath, PL : APathLookup<P>, PLE : APathLookupExtended<P>> P.lookupFilesOrNull(gateway: APathGateway<P, PL, PLE>): Collection<PL>? {
     return if (exists(gateway)) gateway.lookupFiles(this) else null
 }

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathGateway.kt
@@ -2,6 +2,7 @@ package eu.darken.sdmse.common.files
 
 import eu.darken.sdmse.common.sharedresource.HasSharedResource
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import okio.FileHandle
 import java.time.Instant
 
@@ -22,6 +23,12 @@ interface APathGateway<
     suspend fun lookupExtended(path: P): PLUE
 
     suspend fun lookupFiles(path: P): Collection<PLU>
+
+    /**
+     * Like [lookupFiles], but children are emitted as they are enumerated, so consumers can
+     * abort early without paying for the complete listing of a huge directory.
+     */
+    suspend fun lookupFilesFlow(path: P): Flow<PLU> = flow { lookupFiles(path).forEach { emit(it) } }
 
     suspend fun lookupFilesExtended(path: P): Collection<PLUE>
 

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathLookupExtensions.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathLookupExtensions.kt
@@ -59,6 +59,10 @@ suspend fun <P : APath, PL : APathLookup<P>> PL.lookupFiles(
     gateway: APathGateway<P, out APathLookup<P>, out APathLookupExtended<P>>
 ): Collection<APathLookup<*>> = lookedUp.lookupFiles(gateway)
 
+suspend fun <P : APath, PL : APathLookup<P>> PL.lookupFilesFlow(
+    gateway: APathGateway<P, out APathLookup<P>, out APathLookupExtended<P>>
+): Flow<APathLookup<*>> = lookedUp.lookupFilesFlow(gateway)
+
 fun APathLookup<*>.matches(other: APath): Boolean = lookedUp.matches(other)
 fun APath.matches(other: APathLookup<*>): Boolean = matches(other.lookedUp)
 fun APathLookup<*>.matches(other: APathLookup<*>): Boolean = lookedUp.matches(other.lookedUp)

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/GatewaySwitch.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/GatewaySwitch.kt
@@ -135,6 +135,10 @@ class GatewaySwitch @Inject constructor(
         }
     }
 
+    override suspend fun lookupFilesFlow(path: APath): Flow<APathLookup<APath>> {
+        return useGateway(path) { lookupFilesFlow(path) }
+    }
+
     override suspend fun lookupFilesExtended(path: APath): Collection<APathLookupExtended<APath>> {
         return lookupFilesExtended(path, Type.CURRENT)
     }

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalGateway.kt
@@ -41,6 +41,9 @@ import eu.darken.sdmse.common.storage.StorageEnvironment
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.withContext
@@ -387,6 +390,68 @@ class LocalGateway @Inject constructor(
             }
         } catch (e: IOException) {
             log(TAG, WARN) { "lookupFiles(path=$path, mode=$mode) failed:\n${e.asLog()}" }
+            throw ReadException(path = path, cause = e)
+        }
+    }
+
+    override suspend fun lookupFilesFlow(path: LocalPath): Flow<LocalPathLookup> = lookupFilesFlow(path, Mode.AUTO)
+
+    suspend fun lookupFilesFlow(path: LocalPath, mode: Mode = Mode.AUTO): Flow<LocalPathLookup> = runIO {
+        try {
+            val javaFile = path.asFile()
+            val nonRootList = try {
+                when (mode) {
+                    Mode.ROOT -> null
+                    Mode.ADB -> null
+                    else -> if (javaFile.canRead()) javaFile.listFiles2() else null
+                }
+            } catch (e: Exception) {
+                null
+            }
+
+            when {
+                mode == Mode.NORMAL || nonRootList != null && mode == Mode.AUTO -> {
+                    log(TAG, VERBOSE) { "lookupFilesFlow($mode->NORMAL): $path" }
+                    if (nonRootList == null) throw ReadException(path = path)
+                    flow {
+                        nonRootList.forEach { child ->
+                            val lookup = try {
+                                child.toLocalPath().performLookup()
+                            } catch (e: IOException) {
+                                log(TAG, WARN) { "lookupFilesFlow($path): Failed to lookup child $child: ${e.asLog()}" }
+                                null
+                            }
+                            lookup?.let { emit(it) }
+                        }
+                    }
+                }
+
+                hasRoot() && (mode == Mode.ROOT || nonRootList == null && mode == Mode.AUTO) -> {
+                    log(TAG, VERBOSE) { "lookupFilesFlow($mode->ROOT): $path" }
+                    // Lease + IPC stream are only created at collection time and the lease spans
+                    // the whole consumption; a built-but-never-collected flow must not hold either.
+                    flow<LocalPathLookup> { rootOps { emitAll(it.lookupFilesFlow(path)) } }
+                }
+
+                hasAdb() && (mode == Mode.ADB || nonRootList == null && mode == Mode.AUTO) -> {
+                    log(TAG, VERBOSE) { "lookupFilesFlow($mode->ADB): $path" }
+                    // Lease + IPC stream are only created at collection time and the lease spans
+                    // the whole consumption; a built-but-never-collected flow must not hold either.
+                    flow<LocalPathLookup> { adbOps { emitAll(it.lookupFilesFlow(path)) } }
+                }
+
+                else -> throw IOException("No matching mode available.")
+            }.catch { e ->
+                log(TAG, WARN) { "lookupFilesFlow(path=$path, mode=$mode) failed:\n${e.asLog()}" }
+                when (e) {
+                    is CancellationException -> throw e
+                    is ReadException -> throw e
+                    is IOException -> throw ReadException(path = path, cause = e)
+                    else -> throw e
+                }
+            }
+        } catch (e: IOException) {
+            log(TAG, WARN) { "lookupFilesFlow(path=$path, mode=$mode) failed:\n${e.asLog()}" }
             throw ReadException(path = path, cause = e)
         }
     }

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/FileOpsClient.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/FileOpsClient.kt
@@ -16,6 +16,8 @@ import eu.darken.sdmse.common.files.local.LocalPathLookupExtended
 import eu.darken.sdmse.common.ipc.IpcClientModule
 import eu.darken.sdmse.common.ipc.fileHandle
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import okio.FileHandle
@@ -65,6 +67,20 @@ class FileOpsClient @AssistedInject constructor(
         }
     } catch (e: Exception) {
         throw e.refineException()
+    }
+
+    /**
+     * Streams lookups as the host enumerates the directory. Consumers may cancel collection
+     * early and only pay for the chunks streamed so far, instead of the complete listing.
+     * The IPC stream is only opened once the flow is collected.
+     */
+    fun lookupFilesFlow(path: LocalPath): Flow<LocalPathLookup> = flow {
+        val output = try {
+            fileOpsConnection.lookupFilesStream(path)
+        } catch (e: Exception) {
+            throw e.refineException()
+        }
+        emitAll(output.toLocalPathLookupFlow())
     }
 
     /**

--- a/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/EmptyDirectoryFilter.kt
+++ b/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/EmptyDirectoryFilter.kt
@@ -21,7 +21,7 @@ import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APathLookup
 import eu.darken.sdmse.common.files.FileType
 import eu.darken.sdmse.common.files.GatewaySwitch
-import eu.darken.sdmse.common.files.lookupFiles
+import eu.darken.sdmse.common.files.lookupFilesFlow
 import eu.darken.sdmse.common.files.matches
 import eu.darken.sdmse.common.files.segs
 import eu.darken.sdmse.common.sieve.SegmentCriterium
@@ -31,6 +31,7 @@ import eu.darken.sdmse.systemcleaner.core.SystemCleanerSettings
 import eu.darken.sdmse.systemcleaner.core.filter.BaseSystemCleanerFilter
 import eu.darken.sdmse.systemcleaner.core.filter.SystemCleanerFilter
 import eu.darken.sdmse.systemcleaner.core.sieve.SystemCrawlerSieve
+import kotlinx.coroutines.flow.firstOrNull
 import javax.inject.Inject
 import javax.inject.Provider
 
@@ -125,12 +126,22 @@ class EmptyDirectoryFilter @Inject constructor(
             return null
         }
 
-        // Check for nested empty directories
-        val content = item.lookupFiles(gatewaySwitch)
+        // Check for nested empty directories. Stream the children and stop at the first file:
+        // huge directories (e.g. 30k+ files in AnkiDroid's collection.media) would otherwise be
+        // fully listed over IPC just to determine "not empty".
+        val subDirs = mutableListOf<APathLookup<*>>()
+        val blockingChild = item.lookupFilesFlow(gatewaySwitch).firstOrNull { child ->
+            if (child.fileType == FileType.DIRECTORY) {
+                subDirs.add(child)
+                false
+            } else {
+                true
+            }
+        }
         return when {
-            content.isEmpty() -> SystemCleanerFilter.Match.Deletion(item)
-            content.any { it.fileType != FileType.DIRECTORY } -> null
-            else -> if (content.all { match(it) != null }) SystemCleanerFilter.Match.Deletion(item) else null
+            blockingChild != null -> null
+            subDirs.all { match(it) != null } -> SystemCleanerFilter.Match.Deletion(item)
+            else -> null
         }
     }
 

--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/SystemCleanerFilterTest.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/SystemCleanerFilterTest.kt
@@ -37,6 +37,7 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -319,6 +320,11 @@ abstract class SystemCleanerFilterTest : BaseTest() {
         coEvery { gatewaySwitch.canRead(any()) } returns false
         coEvery { gatewaySwitch.lookupFiles(any()) } answers {
             throw ReadException(path = arg<APath>(0))
+        }
+        // Mirrors the real gateway: children stream lazily, errors surface at collection time
+        coEvery { gatewaySwitch.lookupFilesFlow(any()) } coAnswers {
+            val path = arg<APath>(0)
+            flow { gatewaySwitch.lookupFiles(path).forEach { emit(it) } }
         }
         every { storageEnvironment.dataDir } returns LocalPath.build("/data")
 

--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/EmptyDirectoryFilterTest.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/EmptyDirectoryFilterTest.kt
@@ -3,8 +3,13 @@ package eu.darken.sdmse.systemcleaner.core.filter.stock
 import eu.darken.sdmse.common.areas.DataArea.Type.PUBLIC_DATA
 import eu.darken.sdmse.common.areas.DataArea.Type.PUBLIC_MEDIA
 import eu.darken.sdmse.common.areas.DataArea.Type.SDCARD
+import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.common.files.isChildOf
 import eu.darken.sdmse.systemcleaner.core.filter.SystemCleanerFilterTest
 import eu.darken.sdmse.systemcleaner.core.sieve.SystemCrawlerSieve
+import io.mockk.coEvery
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -103,6 +108,29 @@ class EmptyDirectoryFilterTest : SystemCleanerFilterTest() {
         pos(SDCARD, "1", Flag.Dir, Flag.Size(262144))
         pos(SDCARD, "2", Flag.Dir, Flag.Size(524288))
         pos(SDCARD, "3", Flag.Dir, Flag.Size(1048576))
+
+        confirm(create())
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    @Test fun `huge directories - listing is aborted at the first blocking child`() = runTest {
+        val dirs = doMock(SDCARD, "huge", null, Flag.Dir)
+        negatives.addAll(dirs)
+        val blockers = doMock(SDCARD, "huge/blocker", null, Flag.File)
+        negatives.addAll(blockers)
+
+        dirs.forEach { dir ->
+            val blocker = blockers.single { it.lookedUp.isChildOf(dir.lookedUp) }
+            coEvery { gatewaySwitch.lookupFilesFlow(dir.lookedUp) } returns flow {
+                emit(blocker as APathLookup<APath>)
+                throw AssertionError("Should not enumerate past the first blocking child: ${dir.path}")
+            }
+            coEvery { gatewaySwitch.lookupFiles(dir.lookedUp) } answers {
+                throw AssertionError("Should stream via lookupFilesFlow, not materialize via lookupFiles: ${dir.path}")
+            }
+        }
+
+        pos(SDCARD, "empty", Flag.Dir)
 
         confirm(create())
     }


### PR DESCRIPTION
## What changed

Scans no longer stall for minutes on folders that contain a huge number of files (e.g. AnkiDroid's media collection with 30k+ files). The "Empty directories" filter now stops reading a folder as soon as it sees the first file, instead of reading the complete folder contents just to conclude "not empty".

## Technical Context

- Root cause: `EmptyDirectoryFilter.match()` materialized the full directory listing via `lookupFiles()` (a stat per entry, chunked over the root/Shizuku IPC stream) for every directory the crawler visited, on top of the crawler's own walk of the same tree. Measured on an API 36 emulator with 30k files: 36.8 s of a 51 s SystemCleaner scan, all in this one directory. A support report shows 130 s+ on a MediaTek tablet.
- Adds a streaming `APathGateway.lookupFilesFlow()` primitive: `FileOpsClient` exposes the already-chunked IPC stream as a `Flow` instead of collapsing it with `toList()`; `LocalGateway` overrides it mirroring `lookupFiles()`/`walk()` mode selection; other gateways fall back to a default wrapper.
- Deserves close review: `LocalGateway.lookupFilesFlow()`. The service lease and IPC stream are only created at collection time and the lease spans the whole consumption (`runSessionAction`'s `use{}`), so a built-but-never-collected flow holds nothing and early abort releases the privileged service.
- Deletion safety is unchanged: read errors still propagate as `ReadException` (the crawler treats that as no-match), and the recursive "only empty directory trees match" semantics are covered by the existing filter tests plus a new regression test that fails if the filter ever goes back to materializing listings.
- On-device behavior was verified in an emulator reproduction (Android 16, Shizuku ADB mode, 30k-file directory) that CI cannot cover.
