### PR TITLE
General: Show progress while reading folders with many files

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/IndirectLocalWalker.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/IndirectLocalWalker.kt
@@ -8,8 +8,12 @@ import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.isDirectory
 import eu.darken.sdmse.common.files.isFile
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.AbstractFlow
 import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
 import java.util.LinkedList
 
 class IndirectLocalWalker(
@@ -45,26 +49,23 @@ class IndirectLocalWalker(
         while (!queue.isEmpty()) {
             val lookUp = queue.removeFirst()
 
-            val newBatch = try {
-                gateway.lookupFiles(lookUp.lookedUp, mode)
-            } catch (e: Exception) {
-                log(TAG, ERROR) { "Failed to read $lookUp: $e" }
-                if (onError(lookUp, e)) {
-                    emptyList()
-                } else {
-                    throw e
+            // Children are consumed as they stream in over the gateway, a huge directory no
+            // longer stalls the whole walk until its complete listing has materialized.
+            // The read-error handling is attached to the upstream flow only: exceptions from
+            // onFilter, downstream operators or collectors, and cancellation (e.g. Flow.first)
+            // must all propagate instead of being swallowed as read errors by onError.
+            flow { emitAll(gateway.lookupFilesFlow(lookUp.lookedUp, mode)) }
+                .catch { e ->
+                    if (e !is Exception || e is CancellationException) throw e
+                    log(TAG, ERROR) { "Failed to read $lookUp: $e" }
+                    if (!onError(lookUp, e)) throw e
                 }
-            }
-
-            newBatch
-                .filter {
-                    val allowed = onFilter(it)
-                    if (Bugs.isTrace) {
-                        if (!allowed) log(tag, VERBOSE) { "Skipping (filter): $it" }
+                .collect { child ->
+                    val allowed = onFilter(child)
+                    if (!allowed) {
+                        if (Bugs.isTrace) log(tag, VERBOSE) { "Skipping (filter): $child" }
+                        return@collect
                     }
-                    allowed
-                }
-                .forEach { child ->
                     if (child.isDirectory) {
                         if (Bugs.isTrace) log(tag, VERBOSE) { "Walking: $child" }
                         queue.addFirst(child)

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/IndirectLocalWalkerTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/IndirectLocalWalkerTest.kt
@@ -1,10 +1,17 @@
 package eu.darken.sdmse.common.files.local
 
 import eu.darken.sdmse.common.files.FileType
+import eu.darken.sdmse.common.files.ReadException
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
@@ -34,11 +41,11 @@ class IndirectLocalWalkerTest : BaseTest() {
         val mode = LocalGateway.Mode.ROOT
         val start = LocalPath.build("root")
         coEvery { gateway.lookup(start, mode) } returns lookup("root", FileType.DIRECTORY)
-        coEvery { gateway.lookupFiles(LocalPath.build("root"), mode) } returns listOf(
+        coEvery { gateway.lookupFilesFlow(LocalPath.build("root"), mode) } returns flowOf(
             lookup("root/sub", FileType.DIRECTORY),
             lookup("root/file.txt", FileType.FILE),
         )
-        coEvery { gateway.lookupFiles(LocalPath.build("root/sub"), mode) } returns listOf(
+        coEvery { gateway.lookupFilesFlow(LocalPath.build("root/sub"), mode) } returns flowOf(
             lookup("root/sub/nested.txt", FileType.FILE),
         )
 
@@ -55,7 +62,7 @@ class IndirectLocalWalkerTest : BaseTest() {
         val mode = LocalGateway.Mode.ROOT
         val start = LocalPath.build("root")
         coEvery { gateway.lookup(start, mode) } returns lookup("root", FileType.DIRECTORY)
-        coEvery { gateway.lookupFiles(LocalPath.build("root"), mode) } returns listOf(
+        coEvery { gateway.lookupFilesFlow(LocalPath.build("root"), mode) } returns flowOf(
             lookup("root/link", FileType.SYMBOLIC_LINK, target = LocalPath.build("elsewhere")),
         )
 
@@ -68,6 +75,118 @@ class IndirectLocalWalkerTest : BaseTest() {
 
         items.names() shouldContainAll setOf("link")
         // The symlink target must never be listed through the gateway (no descent).
-        coVerify(exactly = 0) { gateway.lookupFiles(LocalPath.build("root/link"), mode) }
+        coVerify(exactly = 0) { gateway.lookupFilesFlow(LocalPath.build("root/link"), mode) }
+    }
+
+    @Test
+    fun `downstream abort is not treated as a read error`() = runTest {
+        val mode = LocalGateway.Mode.ROOT
+        val start = LocalPath.build("root")
+        coEvery { gateway.lookup(start, mode) } returns lookup("root", FileType.DIRECTORY)
+        coEvery { gateway.lookupFilesFlow(LocalPath.build("root"), mode) } returns flowOf(
+            lookup("root/file1.txt", FileType.FILE),
+            lookup("root/file2.txt", FileType.FILE),
+        )
+
+        var onErrorCalled = false
+        val firstItem = IndirectLocalWalker(
+            gateway = gateway,
+            mode = mode,
+            start = start,
+            onError = { _, _ -> onErrorCalled = true; true },
+        ).first()
+
+        firstItem.lookedUp.name shouldBe "file1.txt"
+        onErrorCalled shouldBe false
+    }
+
+    @Test
+    fun `mid-stream error keeps prior children and consults onError`() = runTest {
+        val mode = LocalGateway.Mode.ROOT
+        val start = LocalPath.build("root")
+        coEvery { gateway.lookup(start, mode) } returns lookup("root", FileType.DIRECTORY)
+        coEvery { gateway.lookupFilesFlow(LocalPath.build("root"), mode) } returns flow {
+            emit(lookup("root/early.txt", FileType.FILE))
+            emit(lookup("root/earlydir", FileType.DIRECTORY))
+            throw ReadException(path = LocalPath.build("root"))
+        }
+        coEvery { gateway.lookupFilesFlow(LocalPath.build("root/earlydir"), mode) } returns flowOf(
+            lookup("root/earlydir/nested.txt", FileType.FILE),
+        )
+
+        val consulted = mutableListOf<LocalPathLookup>()
+        val items = IndirectLocalWalker(
+            gateway = gateway,
+            mode = mode,
+            start = start,
+            onError = { lookup, _ -> consulted.add(lookup); true },
+        ).toList()
+
+        // Children streamed before the error are kept, and directories among them are still walked
+        items.names() shouldContainAll setOf("early.txt", "earlydir", "nested.txt")
+        consulted.map { it.lookedUp.name } shouldBe listOf("root")
+    }
+
+    @Test
+    fun `an onFilter exception propagates and is not consulted as read error`() = runTest {
+        val mode = LocalGateway.Mode.ROOT
+        val start = LocalPath.build("root")
+        coEvery { gateway.lookup(start, mode) } returns lookup("root", FileType.DIRECTORY)
+        coEvery { gateway.lookupFilesFlow(LocalPath.build("root"), mode) } returns flowOf(
+            lookup("root/file.txt", FileType.FILE),
+        )
+
+        var onErrorCalled = false
+        shouldThrow<IllegalStateException> {
+            IndirectLocalWalker(
+                gateway = gateway,
+                mode = mode,
+                start = start,
+                onFilter = { throw IllegalStateException("filter boom") },
+                onError = { _, _ -> onErrorCalled = true; true },
+            ).toList()
+        }
+        onErrorCalled shouldBe false
+    }
+
+    @Test
+    fun `a downstream collector exception propagates and is not consulted as read error`() = runTest {
+        val mode = LocalGateway.Mode.ROOT
+        val start = LocalPath.build("root")
+        coEvery { gateway.lookup(start, mode) } returns lookup("root", FileType.DIRECTORY)
+        coEvery { gateway.lookupFilesFlow(LocalPath.build("root"), mode) } returns flowOf(
+            lookup("root/file.txt", FileType.FILE),
+        )
+
+        var onErrorCalled = false
+        shouldThrow<IllegalStateException> {
+            IndirectLocalWalker(
+                gateway = gateway,
+                mode = mode,
+                start = start,
+                onError = { _, _ -> onErrorCalled = true; true },
+            ).collect { throw IllegalStateException("collector boom") }
+        }
+        onErrorCalled shouldBe false
+    }
+
+    @Test
+    fun `mid-stream error aborts the walk when onError returns false`() = runTest {
+        val mode = LocalGateway.Mode.ROOT
+        val start = LocalPath.build("root")
+        coEvery { gateway.lookup(start, mode) } returns lookup("root", FileType.DIRECTORY)
+        coEvery { gateway.lookupFilesFlow(LocalPath.build("root"), mode) } returns flow {
+            emit(lookup("root/early.txt", FileType.FILE))
+            throw ReadException(path = LocalPath.build("root"))
+        }
+
+        shouldThrow<ReadException> {
+            IndirectLocalWalker(
+                gateway = gateway,
+                mode = mode,
+                start = start,
+                onError = { _, _ -> false },
+            ).toList()
+        }
     }
 }


### PR DESCRIPTION
## What changed

SystemCleaner (and other tools that scan with app-side filters) no longer sit motionless while a folder with a huge number of files is being read. Files are processed as they arrive instead of after the entire folder listing has been transferred, so scans of folders like AnkiDroid's media collection show continuous progress and use far less memory.

Stacked on #2647: this PR consumes the streaming `lookupFilesFlow()` primitive introduced there. Its base is the #2647 branch and it will be retargeted to `main` once #2647 merges (CI only runs against `main`-based PRs, so checks appear after retargeting).

## Technical Context

- Root cause: `IndirectLocalWalker` (used whenever `walk()` carries `onFilter`/`onError` callbacks, which can't cross the root/Shizuku IPC boundary) blocked on `gateway.lookupFiles()`, the complete stat-per-entry listing of each directory, before emitting anything. Measured: a 30k-file directory pinned the whole SystemCleaner area walk for ~37 s (emulator) / 130 s+ (reporter's tablet) with all 30k lookups held in memory.
- Deserves close review: the error-path restructuring. Read-error handling is attached to the upstream flow only (a `catch` on a wrapping flow), so exceptions from `onFilter`, downstream operators, and cancellation aborts (`Flow.first`) propagate instead of being fed to `onError`. The default `onError = true` would have silently swallowed them.
- Intentional behavior change: children streamed before a mid-stream read error are kept (and directories among them still walked) instead of discarding the whole batch. All indirect-walk consumers (SystemCrawler, SwiperScanner, DuplicatesScanner, SdcardCorpseFilter) already operate best-effort; the default read-error policy skips unreadable directories.
- New walker tests pin the streaming semantics: early downstream aborts are not read errors, mid-stream errors keep prior children and consult `onError`, filter/collector exceptions propagate without consulting `onError`.
