### PR TITLE
Fix: Setup could get stuck on 'Loading' for Shizuku until a reboot

### DIFF
--- a/app-common-adb/build.gradle.kts
+++ b/app-common-adb/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
     addSerialization()
 
     addTesting()
+    testImplementation(project(":app-common-test"))
 
     implementation("dev.rikka.shizuku:api:13.1.5")
     implementation("dev.rikka.shizuku:provider:13.1.5")

--- a/app-common-adb/src/main/java/eu/darken/sdmse/common/adb/service/internal/AdbHostLauncher.kt
+++ b/app-common-adb/src/main/java/eu/darken/sdmse/common/adb/service/internal/AdbHostLauncher.kt
@@ -5,12 +5,15 @@ import android.os.IInterface
 import dagger.Reusable
 import eu.darken.sdmse.common.adb.AdbException
 import eu.darken.sdmse.common.adb.service.AdbHostOptions
+import eu.darken.sdmse.common.coroutine.AppScope
+import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.channels.awaitClose
@@ -19,6 +22,7 @@ import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
+import java.util.concurrent.atomic.AtomicReference
 import javax.inject.Inject
 import kotlin.reflect.KClass
 
@@ -30,6 +34,8 @@ import kotlin.reflect.KClass
 @Reusable
 class AdbHostLauncher @Inject constructor(
     private val serviceFactory: ShizukuUserServiceFactory,
+    @AppScope private val appScope: CoroutineScope,
+    private val dispatcherProvider: DispatcherProvider,
 ) {
 
     @OptIn(DelicateCoroutinesApi::class) // isClosedForSend, to skip the close() on intentional teardown
@@ -37,6 +43,7 @@ class AdbHostLauncher @Inject constructor(
         serviceClass: KClass<Service>,
         hostClass: KClass<Host>,
         options: AdbHostOptions,
+        connectTimeoutMs: Long = CONNECT_TIMEOUT_MS,
     ): Flow<ConnectionWrapper<Service, Host>> = callbackFlow {
         if (serviceFactory.apiVersion() < 10) throw IllegalStateException("Shizuku API10+ required")
 
@@ -87,38 +94,78 @@ class AdbHostLauncher @Inject constructor(
         // wedge, and we can't interrupt that binder thread — but the watchdog still releases everyone
         // waiting on this flow instead of leaving them hanging forever.
         launch {
-            if (withTimeoutOrNull(CONNECT_TIMEOUT_MS) { ready.await() } == null) {
-                log(TAG, WARN) { "User service did not connect within ${CONNECT_TIMEOUT_MS}ms, closing" }
+            if (withTimeoutOrNull(connectTimeoutMs) { ready.await() } == null) {
+                log(TAG, WARN) { "User service did not connect within ${connectTimeoutMs}ms, closing" }
                 // Residual epsilon race: a send() completing concurrently with the deadline can tear
                 // down a connection that just came up. CompletableDeferred + withTimeoutOrNull narrows
                 // that window but can't close it; the next acquire re-binds.
-                close(AdbException("Shizuku user service did not connect within ${CONNECT_TIMEOUT_MS}ms"))
+                close(AdbException("Shizuku user service did not connect within ${connectTimeoutMs}ms"))
             }
         }
 
-        var bound = false
-        try {
-            service.bind()
-            bound = true
+        // bindUserService() is a synchronous binder transaction that can wedge indefinitely
+        // (same upstream Shizuku defect family as the never-firing callback). It must run OUTSIDE
+        // the producer scope: channelFlow collection awaits all producer children, so a wedged
+        // bind launched in this scope would keep the watchdog's close() from ever releasing
+        // waiting collectors - exactly the eternal setup spinner this launcher guards against.
+        //
+        // Unbind ownership is handed over via CAS so no interleaving of (bind returns) and
+        // (teardown gives up waiting) can leak the binding or unbind twice: whoever loses the
+        // race for the state transition owns the cleanup.
+        val bindState = AtomicReference(BindState.BINDING)
+        val bindJob = appScope.launch(dispatcherProvider.IO) {
+            try {
+                service.bind()
+            } catch (e: Exception) {
+                // Synchronous bind failures keep propagating to collectors, like they did when
+                // bind() ran in the producer. State stays BINDING: there is nothing to unbind.
+                close(e)
+                return@launch
+            }
+            if (!bindState.compareAndSet(BindState.BINDING, BindState.BOUND)) {
+                // Teardown already claimed TEARDOWN while bind() was underway and skipped the
+                // unbind; without this late unbind the binding would leak.
+                log(TAG, WARN) { "bind() returned after teardown gave up waiting, unbinding late" }
+                runCatching { service.unbind() }
+                    .onFailure { log(TAG, WARN) { "Late unbindUserService() failed: ${it.asLog()}" } }
+            }
+        }
 
+        try {
             log(TAG) { "Waiting for flow to close" }
             awaitClose { log(TAG) { "awaitClose() reached, flow is closing…" } }
         } finally {
             // Runs on cancellation too. Mirrors RootHostLauncher: cleanup lives in the finally (not
-            // only in awaitClose) so a throw between bind and awaitClose can't leak the Shizuku
-            // binding, and unbind is best-effort so a DeadObjectException can't mask the cancellation.
-            if (bound) {
-                log(TAG) { "Unbinding Shizuku user service…" }
-                runCatching { service.unbind() }
-                    .onFailure { log(TAG, WARN) { "unbindUserService() failed: ${it.asLog()}" } }
-                // Bounded wait for the actual disconnect; without it, quick flow restarts can cause
-                // DeadObjectExceptions from our Shizuku service binder.
-                withContext(NonCancellable) {
+            // only in awaitClose) so a throw before awaitClose can't leak the Shizuku binding, and
+            // unbind is best-effort so a DeadObjectException can't mask the cancellation.
+            withContext(NonCancellable) {
+                // Bounded settle so a merely-slow (not wedged) bind() still gets its unbind here.
+                withTimeoutOrNull(BIND_SETTLE_TIMEOUT_MS) { bindJob.join() }
+                if (bindState.compareAndSet(BindState.BINDING, BindState.TEARDOWN)) {
+                    // bind() has not returned yet: nothing to unbind now, the late-unbind path
+                    // above owns the eventual cleanup.
+                } else if (bindState.get() == BindState.BOUND) {
+                    log(TAG) { "Unbinding Shizuku user service…" }
+                    runCatching { service.unbind() }
+                        .onFailure { log(TAG, WARN) { "unbindUserService() failed: ${it.asLog()}" } }
+                    // Bounded wait for the actual disconnect; without it, quick flow restarts can
+                    // cause DeadObjectExceptions from our Shizuku service binder.
                     withTimeoutOrNull(DISCONNECT_TIMEOUT_MS) { service.awaitDisconnect() }
+                    log(TAG) { "Shizuku user service unbound." }
                 }
-                log(TAG) { "Shizuku user service unbound." }
             }
         }
+    }
+
+    private enum class BindState {
+        /** bind() is still running (or failed, leaving nothing to clean up). */
+        BINDING,
+
+        /** bind() returned and the flow's teardown owns the unbind. */
+        BOUND,
+
+        /** Teardown ran while bind() was still wedged; the bind job owns a late unbind. */
+        TEARDOWN,
     }
 
     data class ConnectionWrapper<Service : IInterface, Host : AdbConnection>(
@@ -133,10 +180,14 @@ class AdbHostLauncher @Inject constructor(
         // giving up — bounded so teardown can't hang.
         private const val DISCONNECT_TIMEOUT_MS = 500L
 
+        // How long teardown waits for a still-running bind() before concluding it is wedged and
+        // leaving cleanup to the late-unbind path.
+        private const val BIND_SETTLE_TIMEOUT_MS = 500L
+
         // How long to wait for onServiceConnected after binding. Generous: a cold AdbHost start is a
         // multi-second affair (see AdbServiceClient's keep-alive rationale). AppOpsNext uses 12s for
         // the same probe against the same upstream Shizuku defect where bindUserService() returns but
         // the connection callback never fires (MediaTek/HyperOS, Shizuku 13.6.0).
-        private const val CONNECT_TIMEOUT_MS = 15 * 1000L
+        internal const val CONNECT_TIMEOUT_MS = 15 * 1000L
     }
 }

--- a/app-common-adb/src/test/java/eu/darken/sdmse/common/adb/service/internal/AdbHostLauncherTest.kt
+++ b/app-common-adb/src/test/java/eu/darken/sdmse/common/adb/service/internal/AdbHostLauncherTest.kt
@@ -15,16 +15,27 @@ import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.mockk
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.Test
+import testhelpers.coroutine.TestDispatcherProvider
+import java.util.concurrent.CountDownLatch
 import kotlin.reflect.KClass
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Unit coverage for [AdbHostLauncher.createConnection]'s teardown/orchestration. Shizuku is replaced
@@ -98,14 +109,21 @@ class AdbHostLauncherTest {
         }
     }
 
-    private fun launcher(factory: ShizukuUserServiceFactory) = AdbHostLauncher(factory)
+    private fun TestScope.launcher(factory: ShizukuUserServiceFactory) = AdbHostLauncher(
+        serviceFactory = factory,
+        appScope = backgroundScope,
+        dispatcherProvider = TestDispatcherProvider(),
+    )
 
-    private fun AdbHostLauncher.connect() = createConnection(
+    private fun AdbHostLauncher.connect(
+        connectTimeoutMs: Long = AdbHostLauncher.CONNECT_TIMEOUT_MS,
+    ) = createConnection(
         serviceClass = AdbConnection::class,
         hostClass = AdbConnection::class,
         // Explicit values: AdbHostOptions()'s default isDebug=BuildConfigWrap.DEBUG triggers
         // BuildConfigWrap's static init, which isn't available on a plain JVM.
         options = AdbHostOptions(isDebug = false, isTrace = false, isDryRun = false, recorderPath = null),
+        connectTimeoutMs = connectTimeoutMs,
     )
 
     @Test fun `unsupported shizuku version fails before binding`() = runTest {
@@ -222,6 +240,67 @@ class AdbHostLauncherTest {
         error.message!! shouldContain "handshake failed"
         events shouldContainInOrder listOf("bind", "handshake", "unbind")
         job.cancelAndJoin()
+    }
+
+    @Test fun `a bind wedged in its binder transaction still releases collectors after the timeout`() = runTest(
+        timeout = 10.seconds,
+    ) {
+        // Upstream Shizuku defect, second variant: bindUserService() itself never returns (wedged
+        // synchronous binder transaction). The blocked thread can't be interrupted, but the
+        // watchdog's close() must still release everyone waiting on this flow.
+        val bindEntered = CompletableDeferred<Unit>()
+        val bindWedge = CountDownLatch(1)
+        val unboundLate = CompletableDeferred<Unit>()
+        val service = object : ShizukuUserService {
+            override fun bind() {
+                bindEntered.complete(Unit)
+                bindWedge.await() // blocks the calling thread, unaffected by coroutine cancellation
+            }
+
+            override fun unbind() {
+                unboundLate.complete(Unit)
+            }
+
+            override suspend fun awaitDisconnect() {}
+        }
+        // Real scope + real IO dispatcher: the wedge blocks an actual thread, virtual time and
+        // Unconfined execution can't model it (Unconfined would block the producer's own thread).
+        val realScope = CoroutineScope(SupervisorJob())
+        val l = AdbHostLauncher(
+            serviceFactory = FakeFactory(service),
+            appScope = realScope,
+            dispatcherProvider = TestDispatcherProvider(Dispatchers.IO),
+        )
+
+        try {
+            // Collection runs in its own scope: on a regression the collector blocks forever, and
+            // it must do so in a coroutine the test only awaits WITH a timeout - a blocked child
+            // of the test coroutine itself would defeat runTest's timeout (non-cooperative
+            // cancellation) and hang the JVM.
+            val collectResult = realScope.async(Dispatchers.Default) {
+                runCatching { l.connect(connectTimeoutMs = 250L).collect { } }
+            }
+
+            withContext(Dispatchers.Default) {
+                // Only measure once the wedge is real: bind() has been entered and is blocked.
+                withTimeout(5_000L) { bindEntered.await() }
+
+                val error = withTimeout(5_000L) { collectResult.await() }.exceptionOrNull()
+                error.shouldBeInstanceOf<AdbException>()
+                error.message!! shouldContain "did not connect"
+
+                // While bind() is still wedged there is nothing to unbind yet.
+                unboundLate.isCompleted shouldBe false
+
+                // When the wedged transaction finally returns, the binding must not leak:
+                // teardown already gave up, so the late unbind is the only cleanup left.
+                bindWedge.countDown()
+                withTimeout(5_000L) { unboundLate.await() }
+            }
+        } finally {
+            bindWedge.countDown()
+            realScope.cancel()
+        }
     }
 
     @Test fun `watchdog does not fire after a successful connect`() = runTest {


### PR DESCRIPTION
## What changed

On some devices (seen on HyperOS/MediaTek tablets with Shizuku 13.6.0), the Setup screen could show endless "Loading" spinners for the Storage access framework and Shizuku cards, and only a device reboot fixed it. This happened when Shizuku's service connection got stuck in a way that also defeated the recovery timeout added in v2.0.2. The app now recovers from this variant too: after 15 seconds the setup cards report the connection failure instead of spinning forever.

## Technical Context

- The v2.0.2 watchdog covered "bindUserService() returns but onServiceConnected never fires". The second variant of the same upstream Shizuku defect, bindUserService() never returning from its synchronous binder transaction, was still unbounded: bind() ran inside the callbackFlow producer, channelFlow collection awaits all producer children, and a coroutine parked in a blocked native call never completes, so the watchdog's close() never released collectors. `SharedResource.get()` then parked forever. A new regression test reproducing the wedge hung the entire test JVM against the old code.
- bind() now runs detached in the injected `@AppScope` on the IO dispatcher, so the producer can complete independently of a wedged binder thread.
- Deserves close review: the unbind ownership handoff, a CAS state machine (`BINDING` to `BOUND` or `TEARDOWN`). Teardown does a bounded 500 ms join, then either unbinds (bind returned) or cedes cleanup to the bind job's late-unbind path (bind still wedged). No interleaving leaks the binding or unbinds twice; a plain flag had a lost-ownership window between "bind returned" and "flag set".
- `connectTimeoutMs` is now a `createConnection()` parameter (production default unchanged at 15 s) so the wedge test runs with real dispatchers and a 250 ms deadline. The test collects in an independently owned scope awaited with timeouts, so a regression fails the test rather than hanging the JVM.
