### PR TITLE
Fix: Operations hanging when an internal shell breaks down

### DIFF
--- a/app-common-shell/src/main/java/eu/darken/flowshell/core/cmd/FlowCmdShell.kt
+++ b/app-common-shell/src/main/java/eu/darken/flowshell/core/cmd/FlowCmdShell.kt
@@ -14,8 +14,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.dropWhile
 import kotlinx.coroutines.flow.filterNotNull
@@ -35,10 +37,12 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import java.util.UUID
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.coroutines.cancellation.CancellationException
 
 class FlowCmdShell(
-    flowShell: FlowShell
+    flowShell: FlowShell,
+    internal val deathDrainIdleMs: Long = DEATH_DRAIN_IDLE_MS,
 ) {
 
     constructor(shell: String = "sh") : this(FlowShell(shell))
@@ -47,7 +51,7 @@ class FlowCmdShell(
         .onStart { if (isDebug) log(TAG, VERBOSE) { "Starting session..." } }
         .map { shellSession ->
             if (isDebug) log(TAG, VERBOSE) { "Wrapping to command shell session..." }
-            Session(session = shellSession)
+            Session(session = shellSession, deathDrainIdleMs = deathDrainIdleMs)
         }
         .onEach { if (isDebug) log(TAG, VERBOSE) { "Emitting $it" } }
         .onCompletion {
@@ -64,6 +68,7 @@ class FlowCmdShell(
 
     data class Session(
         private val session: FlowShell.Session,
+        internal val deathDrainIdleMs: Long = DEATH_DRAIN_IDLE_MS,
     ) {
         private val _tag = "${TAG}:${session.session.id}"
         private val scope = CoroutineScope(Job() + Dispatchers.IO)
@@ -72,6 +77,14 @@ class FlowCmdShell(
         private var cmdCount = 0
         val counter: Int
             get() = cmdCount
+
+        @Volatile private var streamEnded = false
+
+        // The first failure that terminated one of the streams. Kept at session level so that
+        // rejections which have no per-command events (the entry guard) can still name the root
+        // cause instead of only reporting that the session is gone. Published before streamEnded,
+        // so anyone who sees the flag also sees the cause.
+        private val firstEndCause = AtomicReference<Throwable?>(null)
 
         suspend fun isAlive() = session.isAlive()
 
@@ -89,11 +102,39 @@ class FlowCmdShell(
             scope.cancel()
         }
 
-        private val sharedOutput = session.output.shareIn(scope, started = SharingStarted.Eagerly)
-        private val sharedErrors = session.error.shareIn(scope, started = SharingStarted.Eagerly)
+        private sealed interface StreamEvent {
+            data class Line(val value: String) : StreamEvent
+            data class End(val cause: Throwable?) : StreamEvent
+        }
+
+        // Materializes stream termination as an in-band event: SharedFlows don't propagate
+        // upstream completion to their subscribers, so without this a harvester could never
+        // tell "no output yet" from "there will never be output again".
+        private fun Flow<String>.withTerminalEvent(): Flow<StreamEvent> = this
+            .map<String, StreamEvent> { StreamEvent.Line(it) }
+            .onCompletion { cause ->
+                if (cause == null) {
+                    streamEnded = true
+                    emit(StreamEvent.End(null))
+                }
+            }
+            .catch { cause ->
+                firstEndCause.compareAndSet(null, cause)
+                streamEnded = true
+                emit(StreamEvent.End(cause))
+            }
+
+        private val sharedOutput = session.output
+            .withTerminalEvent()
+            .shareIn(scope, started = SharingStarted.Eagerly, replay = 1)
+        private val sharedErrors = session.error
+            .withTerminalEvent()
+            .shareIn(scope, started = SharingStarted.Eagerly, replay = 1)
 
         suspend fun execute(cmd: FlowCmd): FlowCmd.Result = withContext(Dispatchers.IO) {
             mutex.withLock {
+                if (streamEnded) throw IllegalStateException("Shell session stream has ended", firstEndCause.get())
+
                 cmdCount++
                 val id = UUID.randomUUID().toString()
                 val idStart = "$id-start"
@@ -101,12 +142,23 @@ class FlowCmdShell(
                 log(_tag, VERBOSE) { "submit($cmdCount): $cmd" }
 
                 val output = mutableListOf<String>()
+                var outputEnd: StreamEvent.End? = null
                 val outputReady = CompletableDeferred<Unit>()
                 val outputJob = sharedOutput
                     .onSubscription {
                         outputReady.complete(Unit)
                         if (isDebug) log(_tag, VERBOSE) { "Output monitor started ($id)" }
                     }
+                    .takeWhile { event ->
+                        if (event is StreamEvent.End) {
+                            outputEnd = event
+                            streamEnded = true
+                            false
+                        } else {
+                            true
+                        }
+                    }
+                    .map { (it as StreamEvent.Line).value }
                     .dropWhile { it != idStart }.drop(1)
                     .onEach {
                         if (isDebug) log(_tag, VERBOSE) { "Adding (output-$id) $it" }
@@ -117,14 +169,33 @@ class FlowCmdShell(
                     .launchIn(this + Dispatchers.IO)
 
                 val errors = mutableListOf<String>()
+                var errorEnd: StreamEvent.End? = null
+                var sawErrorMarker = false
                 val errorReady = CompletableDeferred<Unit>()
                 val errorJob = sharedErrors
                     .onSubscription {
                         errorReady.complete(Unit)
                         if (isDebug) log(_tag, VERBOSE) { "Error monitor started ($id)" }
                     }
+                    .takeWhile { event ->
+                        if (event is StreamEvent.End) {
+                            errorEnd = event
+                            streamEnded = true
+                            false
+                        } else {
+                            true
+                        }
+                    }
+                    .map { (it as StreamEvent.Line).value }
                     .dropWhile { it != idStart }.drop(1)
-                    .takeWhile { it != idEnd }
+                    .takeWhile {
+                        if (it == idEnd) {
+                            sawErrorMarker = true
+                            false
+                        } else {
+                            true
+                        }
+                    }
                     .onEach {
                         if (isDebug) log(_tag, VERBOSE) { "Adding (errors-$id) $it" }
                         errors.add(it)
@@ -132,20 +203,44 @@ class FlowCmdShell(
                     .onCompletion { if (isDebug) log(_tag, VERBOSE) { "Error monitor finished ($id)" } }
                     .launchIn(this + Dispatchers.IO)
 
-                // `sharedOutput`/`sharedErrors` are `shareIn(Eagerly)` SharedFlows — they
-                // do NOT propagate upstream completion to subscribers. If the shell
-                // process dies (typically because cmd contained `exec ...` which
-                // replaced the shell), `takeWhile` would suspend forever waiting for an
-                // idEnd marker that will never arrive. Watch for the underlying process
-                // exiting and cancel the harvesters so joinAll() can return.
+                // The in-band End events above only arrive while the streams are readable. If the
+                // process is killed while its pipes stay open (or a peer keeps a write end alive),
+                // no End is ever emitted and the harvesters would wait for markers that can't come.
+                // Once the process has exited, drain whatever is still buffered and cut the
+                // harvesters loose as soon as they go idle, so joinAll() can return.
                 val deathWatcher = launch(this.coroutineContext + Dispatchers.IO) {
                     session.exitCode.filterNotNull().first()
-                    if (isDebug) log(_tag, VERBOSE) { "Shell session died, cancelling harvesters ($id)" }
-                    outputJob.cancel()
-                    errorJob.cancel()
+                    if (isDebug) log(_tag, VERBOSE) { "Shell session died, draining harvesters ($id)" }
+                    while (true) {
+                        val progress = output.size + errors.size
+                        delay(deathDrainIdleMs)
+                        if (outputJob.isCompleted && errorJob.isCompleted) break
+                        if (output.size + errors.size != progress) continue
+                        if (isDebug) log(_tag, VERBOSE) { "Drain went idle, cancelling harvesters ($id)" }
+                        outputJob.cancel()
+                        errorJob.cancel()
+                        break
+                    }
                 }
 
                 listOf(outputReady, errorReady).awaitAll()
+
+                if (outputJob.isCompleted || errorJob.isCompleted || streamEnded) {
+                    // The streams are gone before a single byte was written, so this command was
+                    // never submitted: no markers can arrive and no replacement process exists to
+                    // wait for. Tear the harvesters down and fail instead of waiting for anything.
+                    log(_tag, WARN) { "Streams already ended, aborting ($id)" }
+
+                    outputJob.cancel()
+                    errorJob.cancel()
+                    deathWatcher.cancel()
+                    listOf(outputJob, errorJob).joinAll()
+
+                    throw IllegalStateException(
+                        "Shell session stream has ended",
+                        outputEnd?.cause ?: errorEnd?.cause ?: firstEndCause.get(),
+                    )
+                }
 
                 if (isDebug) log(_tag, VERBOSE) { "Harvesters are ready, writing commands... ($id)" }
 
@@ -162,27 +257,34 @@ class FlowCmdShell(
 
                 if (isDebug) log(_tag, VERBOSE) { "Determining exitcode ($id)" }
 
-                val lastLine = output.lastOrNull()
-                val sawEndMarker = lastLine != null && lastLine.startsWith(idEnd)
+                val endLine = output.lastOrNull()?.takeIf { it.startsWith(idEnd) }
                 val exitCode = when {
-                    sawEndMarker -> {
+                    endLine != null && sawErrorMarker -> {
                         output.removeAt(output.lastIndex)
-                        lastLine.split(" ")
+                        endLine.split(" ")
                             .let { it.getOrNull(1)?.toIntOrNull() }
                             ?.let { FlowProcess.ExitCode(it) }
-                            ?: throw IllegalArgumentException("Failed to determine exitcode from $lastLine")
+                            ?: throw IllegalArgumentException("Failed to determine exitcode from $endLine")
                     }
 
-                    cmd.instructions.any { EXEC_REGEX.containsMatchIn(it) } -> {
-                        // The caller asked the shell to `exec ...` something that replaces
-                        // the shell process — no idEnd marker will ever be echoed. Surface
-                        // a sentinel exit code so callers observe completion cleanly.
+                    endLine == null && !sawErrorMarker && cmd.instructions.any { EXEC_REGEX.containsMatchIn(it) } -> {
+                        // The caller asked the shell to `exec ...` something that replaces the shell
+                        // process — no idEnd marker will ever be echoed on either stream. The sentinel
+                        // only applies to such fully markerless results: if exactly one marker showed
+                        // up, the shell survived the `exec` (e.g. a redirection-only `exec 2>...`) and
+                        // waiting for an exit that never comes would hang, so that case throws below.
+                        // RootHostLauncher relies on this call staying blocked until the replacement
+                        // dies, so wait for the exit before surfacing a sentinel exit code. A non-null
+                        // End cause is deliberately absorbed here: the streams tearing down IS the
+                        // expected outcome.
                         if (isDebug) log(_tag, VERBOSE) { "No end marker after exec-replacement ($id)" }
+                        session.waitFor()
                         FlowProcess.ExitCode(-1)
                     }
 
                     else -> throw IllegalStateException(
-                        "Command $cmd ended without exit-code marker; shell session likely died externally"
+                        "Command $cmd ended without exit-code marker; shell session likely died externally",
+                        outputEnd?.cause ?: errorEnd?.cause,
                     )
                 }
 
@@ -204,5 +306,9 @@ class FlowCmdShell(
         // replaces itself with another process — no `echo idEnd` will be emitted in that
         // case, so execute() must surface completion as ExitCode(-1) instead of throwing.
         private val EXEC_REGEX = Regex("""(^|;|&&|\|\|)\s*(\w+=\S+\s+)*exec\s""")
+
+        // How long the post-mortem drain waits for further output before giving up on
+        // harvesters whose streams stayed open after the process died.
+        private const val DEATH_DRAIN_IDLE_MS = 500L
     }
 }

--- a/app-common-shell/src/test/java/eu/darken/flowshell/core/cmd/FlowCmdShellTest.kt
+++ b/app-common-shell/src/test/java/eu/darken/flowshell/core/cmd/FlowCmdShellTest.kt
@@ -1,16 +1,26 @@
 package eu.darken.flowshell.core.cmd
 
 
+import eu.darken.flowshell.core.FlowShell
 import eu.darken.flowshell.core.FlowShellDebug
 import eu.darken.flowshell.core.process.FlowProcess
 import eu.darken.sdmse.common.flow.replayingShare
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.longs.shouldBeGreaterThanOrEqual
 import io.kotest.matchers.longs.shouldBeLessThan
 import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.joinAll
@@ -19,11 +29,20 @@ import kotlinx.coroutines.plus
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.runTest2
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.Closeable
+import java.io.IOException
+import java.io.InputStream
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import java.util.concurrent.CopyOnWriteArrayList
 
 class FlowCmdShellTest : BaseTest() {
     @BeforeEach
@@ -203,4 +222,364 @@ class FlowCmdShellTest : BaseTest() {
         result.exitCode shouldBe FlowProcess.ExitCode(-1)
     }
 
+    @Test fun `execute fails fast when streams die while process lives`(): Unit = runBlocking {
+        LoopbackShell(closeStdoutAtStart = true, closeStderrAtStart = true).use { shell ->
+            val session = shell.cmdSession()
+
+            withTimeout(5_000) {
+                shouldThrowExactly<IllegalStateException> { session.execute(FlowCmd("echo hi")) }
+            }
+
+            shell.exitCode.value shouldBe null
+        }
+    }
+
+    @Test fun `second execute after stream death is rejected before writing`(): Unit = runBlocking {
+        LoopbackShell(closeStdoutAtStart = true, closeStderrAtStart = true).use { shell ->
+            val session = shell.cmdSession()
+
+            withTimeout(5_000) {
+                shouldThrowExactly<IllegalStateException> { session.execute(FlowCmd("echo first-command")) }
+            }
+
+            withTimeout(5_000) {
+                shouldThrowExactly<IllegalStateException> { session.execute(FlowCmd("echo second-command")) }
+            }
+
+            // Give the interpreter a chance to catch up on anything that was still in flight.
+            delay(100)
+            shell.consumedLines().none { it.contains("second-command") } shouldBe true
+        }
+    }
+
+    @Test fun `exec on a dead-stream session fails instead of waiting`(): Unit = runBlocking {
+        LoopbackShell(closeStdoutAtStart = true, closeStderrAtStart = true).use { shell ->
+            val session = shell.cmdSession()
+
+            // Nothing was submitted, so there is no replacement process whose exit could be awaited.
+            withTimeout(5_000) {
+                shouldThrowExactly<IllegalStateException> { session.execute(FlowCmd("exec sleep 999")) }
+            }
+
+            shell.exitCode.value shouldBe null
+        }
+    }
+
+    @Test fun `execute after single stream death is rejected deterministically`(): Unit = runBlocking {
+        LoopbackShell(closeStderrAtStart = true).use { shell ->
+            val session = shell.cmdSession()
+
+            // The End event is published by the eagerly started sharing coroutine, so the rejection
+            // does not depend on a command's harvester having observed it first.
+            delay(300)
+
+            withTimeout(5_000) {
+                shouldThrowExactly<IllegalStateException> { session.execute(FlowCmd("echo probe")) }
+            }
+
+            shell.consumedLines().none { it.contains("probe") } shouldBe true
+        }
+    }
+
+    @Test fun `redirection-only exec fails instead of waiting on the live shell`(): Unit = runBlocking {
+        val scope = CoroutineScope(Dispatchers.IO + Job())
+        val (session, _) = FlowCmdShell().openSession(scope)
+
+        // `exec 2>/dev/null` only rebinds stderr, it does not replace the shell: stdout still
+        // delivers its end marker while the stderr marker is redirected away. Waiting for an exit
+        // that never comes would hang here while holding the session mutex.
+        withTimeout(5_000) {
+            shouldThrowExactly<IllegalStateException> { session.execute(FlowCmd("exec 2>/dev/null")) }
+        }
+
+        session.cancel()
+        scope.cancel()
+    }
+
+    @Test fun `stderr dying mid-command does not fake success`(): Unit = runBlocking {
+        LoopbackShell(closeStderrBeforeEndMarker = true).use { shell ->
+            val session = shell.cmdSession()
+
+            withTimeout(5_000) {
+                shouldThrowExactly<IllegalStateException> {
+                    session.execute(FlowCmd("echo out", "echo err >&2"))
+                }
+            }
+        }
+    }
+
+    @Test fun `buffered markers win over stream end`(): Unit = runBlocking {
+        LoopbackShell(exitCodeValue = 7, closePipesAfterProtocol = true).use { shell ->
+            val session = shell.cmdSession()
+
+            val result = withTimeout(5_000) {
+                session.execute(FlowCmd("echo one", "echo two", "echo err >&2"))
+            }
+
+            result.output shouldBe listOf("one", "two")
+            result.errors shouldBe listOf("err")
+            result.exitCode shouldBe FlowProcess.ExitCode(7)
+        }
+    }
+
+    @Test fun `process death before drain does not truncate buffered output`(): Unit = runBlocking {
+        val lines = 120_000
+        // The payload has to outgrow the fixture's pipe buffer, otherwise the interpreter never
+        // blocks and the drain watcher's progress-reset branch isn't exercised.
+        (1..lines).sumOf { "bulk-$it\n".length } shouldBeGreaterThan (1 shl 20)
+        LoopbackShell(
+            exitCodeValue = 3,
+            dieAfterProtocol = true,
+            closePipesAfterProtocol = true,
+        ).use { shell ->
+            val session = shell.cmdSession()
+
+            val result = withTimeout(60_000) { session.execute(FlowCmd("bulk $lines")) }
+
+            result.output.size shouldBe lines
+            result.output.first() shouldBe "bulk-1"
+            result.output.last() shouldBe "bulk-$lines"
+            result.exitCode shouldBe FlowProcess.ExitCode(3)
+        }
+    }
+
+    @Test fun `death with silent open pipes cancels after the idle window`(): Unit = runBlocking {
+        LoopbackShell(mute = true, dieAfterProtocol = true).use { shell ->
+            val session = shell.cmdSession(deathDrainIdleMs = 100)
+
+            withTimeout(5_000) {
+                shouldThrowExactly<IllegalStateException> { session.execute(FlowCmd("echo hi")) }
+            }
+        }
+    }
+
+    @Test fun `submitted exec with dead streams waits for process exit`(): Unit = runBlocking {
+        LoopbackShell(closePipesOnExecLine = true).use { shell ->
+            val session = shell.cmdSession()
+
+            // The command reached the shell before the streams died, so no marker can arrive but
+            // the replacement process is real and execute() must stay blocked until it exits.
+            val execution = async(Dispatchers.IO) { session.execute(FlowCmd("exec sleep 999")) }
+
+            withTimeoutOrNull(500) { execution.await() } shouldBe null
+
+            shell.exitCode.value = FlowProcess.ExitCode(0)
+
+            withTimeout(5_000) { execution.await() }.exitCode shouldBe FlowProcess.ExitCode(-1)
+        }
+    }
+
+    @Test fun `upstream failure surfaces as the protocol exception cause`(): Unit = runBlocking {
+        val boom = StdoutBoom(marker = 42L)
+        val session = fakeCmdSession(
+            output = ExplodingInputStream("line1\nline2\n", boom),
+            errors = ByteArrayInputStream(ByteArray(0)),
+        )
+
+        // Let both sharing coroutines drain their streams first: stderr ends without a cause,
+        // stdout ends with the boom, so the rejection has a deterministic root cause to name.
+        delay(200)
+
+        val failure = withTimeout(5_000) {
+            shouldThrowExactly<IllegalStateException> { session.execute(FlowCmd("echo hi")) }
+        }
+
+        generateSequence<Throwable>(failure) { it.cause }.any { it === boom } shouldBe true
+
+        session.cancel()
+    }
+
+    private fun fakeCmdSession(
+        output: InputStream,
+        errors: InputStream,
+        exitCode: MutableStateFlow<FlowProcess.ExitCode?> = MutableStateFlow(null),
+    ): FlowCmdShell.Session {
+        val process = mockk<Process>().apply {
+            every { outputStream } returns ByteArrayOutputStream()
+            every { inputStream } returns output
+            every { errorStream } returns errors
+        }
+        return FlowCmdShell.Session(
+            session = FlowShell.Session(
+                session = FlowProcess.Session(
+                    id = "test",
+                    process = process,
+                    exitCode = exitCode,
+                    onKill = {},
+                ),
+            ),
+        )
+    }
+
+    // Deliberately not copyable by coroutine stacktrace recovery (no (String)/(Throwable)/()
+    // constructor), so the instance that reaches the exception cause is the one thrown here.
+    private class StdoutBoom(marker: Long) : RuntimeException("stdout stream exploded #$marker")
+
+    private class ExplodingInputStream(
+        payload: String,
+        private val boom: RuntimeException,
+    ) : InputStream() {
+        private val data = payload.toByteArray()
+        private var pos = 0
+
+        override fun read(): Int {
+            if (pos == data.size) throw boom
+            return data[pos++].toInt() and 0xFF
+        }
+
+        override fun read(b: ByteArray, off: Int, len: Int): Int {
+            if (pos == data.size) throw boom
+            val chunk = minOf(len, data.size - pos)
+            System.arraycopy(data, pos, b, off, chunk)
+            pos += chunk
+            return chunk
+        }
+    }
+
+    /**
+     * A loopback shell: an interpreter thread consumes what execute() writes to stdin and echoes
+     * back on the stdout/stderr pipes, so the marker protocol can be broken in specific ways.
+     */
+    private class LoopbackShell(
+        private val exitCodeValue: Int = 0,
+        private val mute: Boolean = false,
+        private val closeStdoutAtStart: Boolean = false,
+        private val closeStderrAtStart: Boolean = false,
+        private val closeStderrBeforeEndMarker: Boolean = false,
+        private val dieAfterProtocol: Boolean = false,
+        private val closePipesAfterProtocol: Boolean = false,
+        private val closePipesOnExecLine: Boolean = false,
+    ) : AutoCloseable {
+
+        val exitCode = MutableStateFlow<FlowProcess.ExitCode?>(null)
+
+        private val consumed = CopyOnWriteArrayList<String>()
+        private val sessions = mutableListOf<FlowCmdShell.Session>()
+
+        private val stdinSink = PipedOutputStream()
+        private val stdinSource = PipedInputStream(stdinSink, PIPE_BUFFER)
+        private val stdoutSource = PipedInputStream(PIPE_BUFFER)
+        private val stdoutSink = PipedOutputStream(stdoutSource)
+        private val stderrSource = PipedInputStream(PIPE_BUFFER)
+        private val stderrSink = PipedOutputStream(stderrSource)
+
+        @Volatile private var closing = false
+        @Volatile private var failure: Throwable? = null
+        @Volatile private var silenced = false
+
+        private val interpreter = Thread {
+            try {
+                stdinSource.bufferedReader().forEachLine { handle(it) }
+            } catch (e: Throwable) {
+                if (!closing) failure = e
+            }
+        }.apply {
+            name = "loopback-shell"
+            isDaemon = true
+        }
+
+        init {
+            if (closeStdoutAtStart) closeQuietly(stdoutSink)
+            if (closeStderrAtStart) closeQuietly(stderrSink)
+            interpreter.start()
+        }
+
+        fun consumedLines(): List<String> = consumed.toList()
+
+        fun cmdSession(deathDrainIdleMs: Long? = null): FlowCmdShell.Session {
+            val process = mockk<Process>().apply {
+                every { outputStream } returns stdinSink
+                every { inputStream } returns stdoutSource
+                every { errorStream } returns stderrSource
+            }
+            val shellSession = FlowShell.Session(
+                session = FlowProcess.Session(
+                    id = "loopback",
+                    process = process,
+                    exitCode = exitCode,
+                    onKill = {},
+                ),
+            )
+            val session = when (deathDrainIdleMs) {
+                null -> FlowCmdShell.Session(session = shellSession)
+                else -> FlowCmdShell.Session(session = shellSession, deathDrainIdleMs = deathDrainIdleMs)
+            }
+            return session.also { sessions.add(it) }
+        }
+
+        private fun handle(line: String) {
+            consumed.add(line)
+            val isProtocolEnd = END_MARKER_ECHO.matches(line)
+
+            if (isProtocolEnd && closeStderrBeforeEndMarker) closeQuietly(stderrSink)
+
+            if (!mute && !silenced) interpret(line)
+
+            if (closePipesOnExecLine && line.contains("exec ")) {
+                // The exec'd process took over: both stream ends die and nothing is echoed back,
+                // but the shell was already handed the command.
+                closeQuietly(stdoutSink)
+                closeQuietly(stderrSink)
+                silenced = true
+            }
+
+            if (isProtocolEnd) {
+                if (dieAfterProtocol) exitCode.value = FlowProcess.ExitCode(exitCodeValue)
+                if (closePipesAfterProtocol) {
+                    closeQuietly(stdoutSink)
+                    closeQuietly(stderrSink)
+                }
+            }
+        }
+
+        private fun interpret(line: String) {
+            when {
+                line.startsWith("bulk ") -> {
+                    val count = line.removePrefix("bulk ").trim().toInt()
+                    (1..count).forEach { writeTo(stdoutSink, "bulk-$it") }
+                }
+
+                line.startsWith("echo ") && line.endsWith(" >&2") -> {
+                    writeTo(stderrSink, line.removePrefix("echo ").removeSuffix(" >&2").resolveExitCode())
+                }
+
+                line.startsWith("echo ") -> writeTo(stdoutSink, line.removePrefix("echo ").resolveExitCode())
+            }
+        }
+
+        private fun String.resolveExitCode() = replace("\$?", exitCodeValue.toString())
+
+        private fun writeTo(sink: PipedOutputStream, line: String) {
+            try {
+                sink.write((line + "\n").toByteArray())
+                sink.flush()
+            } catch (e: IOException) {
+                // The script closed this pipe — stdin must keep being consumed regardless,
+                // otherwise the writer would break before the marker accounting runs.
+            }
+        }
+
+        private fun closeQuietly(target: Closeable) {
+            try {
+                target.close()
+            } catch (e: IOException) {
+                // Already closed or never connected
+            }
+        }
+
+        override fun close() {
+            closing = true
+            closeQuietly(stdinSink)
+            interpreter.join(2_000)
+            listOf(stdoutSink, stderrSink, stdinSource, stdoutSource, stderrSource).forEach { closeQuietly(it) }
+            interpreter.join(2_000)
+            runBlocking { sessions.forEach { it.cancel() } }
+            failure?.let { throw it }
+        }
+
+        companion object {
+            private const val PIPE_BUFFER = 1 shl 20
+            private val END_MARKER_ECHO = Regex("""^echo \S+-end >&2$""")
+        }
+    }
 }


### PR DESCRIPTION
## What changed

Fixed internal shell commands being able to get stuck forever when the shell's output stream broke while the shell process itself kept running. Affected operations would hang silently (for root operations this could stall the whole action) instead of failing with an error. Commands that legitimately produce huge output are no longer at risk of being cut short when the shell exits.

## Technical Context

- Root cause: `FlowCmdShell.execute()` waits for end markers on `shareIn`-shared harvester streams, and `SharedFlow` never propagates upstream completion to subscribers; the death-watcher only unblocked on process exit. A stream ending with the process alive (plain EOF, e.g. a redirection-only `exec` closing a pipe write-end) left the marker-wait suspended forever — while holding the session mutex, blocking all later commands.
- Fix: stream termination now travels in-band as `Line`/`End(cause)` events ordered after every buffered line, so termination can never overtake a legitimately echoed marker; a session whose stream ended rejects new commands before writing them into the still-live shell; success requires both streams' markers (no silent stderr truncation); the markerless-`exec` sentinel awaits process exit (preserves `RootHostLauncher`'s blocks-until-exit contract) and applies only to genuinely markerless results.
- The death-watcher now drains buffered output with an idle-reset window instead of cancelling collectors immediately on process exit — immediate cancel could discard valid buffered markers under load.
- All three hang scenarios were reproduced empirically before fixing (including a timing race that hung 5 of 20 runs) and are covered by deterministic regression tests on a scriptable loopback fake shell; those tests fail on the pre-fix code.
- Review pointer: the both-markers success accounting and the gated `exec` sentinel branch in `FlowCmdShell.execute()` are the behavior changes worth the closest read; the `AtomicReference` cause-retention ordering (store before flag) is deliberate.
