### PR TITLE
Analyzer: Show live progress when scanning an app's storage

### DIFF
--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/AppStorageScanner.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/AppStorageScanner.kt
@@ -17,6 +17,7 @@ import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.files.APathLookup
 import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.ReadException
 import eu.darken.sdmse.common.files.core.local.File
@@ -104,6 +105,7 @@ class AppStorageScanner @AssistedInject constructor(
 
     suspend fun process(
         request: Request,
+        onItem: (suspend (APathLookup<APath>) -> Unit)? = null,
     ): Result {
         val appStorStats = try {
             statsManager.queryStatsForPkg(storage.id, request.pkg)
@@ -127,7 +129,7 @@ class AppStorageScanner @AssistedInject constructor(
                 ?.let { codeDir ->
                     if (!request.shallow && useRoot) {
                         try {
-                            return@let codeDir.walkContentItem(gatewaySwitch, maxItems = WALK_MAX_ITEMS)
+                            return@let codeDir.walkContentItem(gatewaySwitch, maxItems = WALK_MAX_ITEMS, onItem = onItem)
                         } catch (e: ReadException) {
                             log(TAG, ERROR) { "Failed to read $codeDir despire root access? ${e.asLog()}" }
                         }
@@ -162,7 +164,7 @@ class AppStorageScanner @AssistedInject constructor(
                     }
 
                     gatewaySwitch.exists(pubData, type = GatewaySwitch.Type.AUTO) -> try {
-                        pubData.walkContentItem(gatewaySwitch, maxItems = WALK_MAX_ITEMS)
+                        pubData.walkContentItem(gatewaySwitch, maxItems = WALK_MAX_ITEMS, onItem = onItem)
                     } catch (_: ReadException) {
                         ContentItem.fromInaccessible(pubData)
                     }
@@ -180,7 +182,7 @@ class AppStorageScanner @AssistedInject constructor(
                     return@run request.pkg
                         .getPrivateDataDirs(dataAreas)
                         .filter { gatewaySwitch.exists(it, type = GatewaySwitch.Type.CURRENT) }
-                        .map { it.walkContentItem(gatewaySwitch, maxItems = WALK_MAX_ITEMS) }
+                        .map { it.walkContentItem(gatewaySwitch, maxItems = WALK_MAX_ITEMS, onItem = onItem) }
                 } catch (e: ReadException) {
                     log(TAG, ERROR) { "Failed to read private data dirs for $request.pkg: ${e.asLog()}" }
                 }
@@ -215,7 +217,7 @@ class AppStorageScanner @AssistedInject constructor(
                     if (request.shallow) {
                         path.sizeContentItem(gatewaySwitch)
                     } else {
-                        path.walkContentItem(gatewaySwitch, maxItems = WALK_MAX_ITEMS)
+                        path.walkContentItem(gatewaySwitch, maxItems = WALK_MAX_ITEMS, onItem = onItem)
                     }
                 } catch (_: ReadException) {
                     null
@@ -236,7 +238,7 @@ class AppStorageScanner @AssistedInject constructor(
                     if (request.shallow) {
                         path.sizeContentItem(gatewaySwitch)
                     } else {
-                        path.walkContentItem(gatewaySwitch, maxItems = WALK_MAX_ITEMS)
+                        path.walkContentItem(gatewaySwitch, maxItems = WALK_MAX_ITEMS, onItem = onItem)
                     }
                 } catch (_: ReadException) {
                     null

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/StorageScanner.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/StorageScanner.kt
@@ -424,7 +424,9 @@ class StorageScanner @Inject constructor(
         val request = AppStorageScanner.Request.Reprocessing(
             pkgStat = app
         )
-        val rescanned = appScanner.process(request)
+        // Per-item progress: deep scans of apps with huge folders otherwise sit on a static
+        // "Searching" for minutes, looking like a hang (the progress host throttles updates)
+        val rescanned = appScanner.process(request) { updateProgressSecondary(it.userReadablePath) }
 
         log(TAG) { "Rescanned ${app.id}: $rescanned" }
 

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/StorageScannerExtensions.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/StorageScannerExtensions.kt
@@ -16,6 +16,7 @@ import eu.darken.sdmse.common.files.Segments
 import eu.darken.sdmse.common.files.du
 import eu.darken.sdmse.common.files.walk
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import java.util.LinkedList
@@ -99,6 +100,7 @@ suspend fun APath.walkContentItem(
     gatewaySwitch: GatewaySwitch,
     maxItems: Int = Int.MAX_VALUE,
     followSymlinks: Boolean = false,
+    onItem: (suspend (APathLookup<APath>) -> Unit)? = null,
 ): ContentItem {
     log(TAG, VERBOSE) { "Walking content items for $this" }
 
@@ -111,6 +113,7 @@ suspend fun APath.walkContentItem(
         val options = APathGateway.WalkOptions<APath, APathLookup<APath>>(followSymlinks = followSymlinks)
         val children = try {
             lookup.walk(gatewaySwitch, options)
+                .onEach { onItem?.invoke(it) }
                 .map { ContentItem.fromLookup(it) }
                 .let { flow -> if (maxItems < Int.MAX_VALUE) flow.take(maxItems + 1) else flow }
                 .toList()


### PR DESCRIPTION
## What changed

When drilling into an app in the Storage Analyzer, the "Searching" screen no longer sits on a static image while the app's storage is being read. It now shows each file path as it is scanned, so on apps with huge folders (e.g. AnkiDroid's media collection, tens of thousands of files read via Shizuku) it's visible that the scan is working rather than hung. Reported via support with a screenshot of exactly this screen.

## Technical Context

- `StorageScanner.deepScanApp()` set the progress label once ("Searching", no count) and `AppStorageScanner` had no progress reporting at all, so the overlay stayed static for the whole walk.
- `walkContentItem()` gains an optional `onItem` per-entry callback (invoked before the `take(maxItems + 1)` cap, so at most cap+1 times); `AppStorageScanner.process()` forwards it; `deepScanApp()` publishes each walked path through the existing 50 ms-throttled progress host. All other callers keep the default `null`.
- Same symptom family as #2648 (AppCleaner) but a separate progress surface; independent change.
