### PR TITLE
General: Show when a Google Play payment is still being processed

### DIFF
--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplay.kt
@@ -2,7 +2,6 @@ package eu.darken.sdmse.common.upgrade.core
 
 import android.app.Activity
 import com.android.billingclient.api.BillingClient.BillingResponseCode
-import com.android.billingclient.api.Purchase
 import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
@@ -18,6 +17,7 @@ import eu.darken.sdmse.common.upgrade.core.billing.BillingData
 import eu.darken.sdmse.common.upgrade.core.billing.BillingManager
 import eu.darken.sdmse.common.upgrade.core.billing.GplayServiceUnavailableException
 import eu.darken.sdmse.common.upgrade.core.billing.ItemAlreadyOwnedBillingException
+import eu.darken.sdmse.common.upgrade.core.billing.PendingPurchaseBillingException
 import eu.darken.sdmse.common.upgrade.core.billing.PurchasedSku
 import eu.darken.sdmse.common.upgrade.core.billing.Sku
 import eu.darken.sdmse.common.upgrade.core.billing.SkuDetails
@@ -284,9 +284,18 @@ class UpgradeRepoGplay @Inject constructor(
                     // Reconciled only if the restore actually returned the SKU Play claims is
                     // owned — a grace-only isPro doesn't count, the entitlement is still missing.
                     if (restored?.upgrades?.any { it.sku == sku } != true) {
-                        // Couldn't reconcile the entitlement (pending purchase, account mismatch,
-                        // Play quirk) — fall back to the already-owned dialog with restore tips.
-                        onError(e)
+                        if (restored?.pendingSkus?.isNotEmpty() == true) {
+                            // Play blocks re-purchasing a product whose payment it is still
+                            // processing. "Already owned" is technically what Play said, but the
+                            // dialog's restore tips are the wrong advice: nothing to restore, and
+                            // the entitlement lands by itself once the payment clears.
+                            log(TAG, INFO) { "Already-owned recovery found a pending payment" }
+                            onError(PendingPurchaseBillingException(e))
+                        } else {
+                            // Couldn't reconcile the entitlement (account mismatch, Play quirk) —
+                            // fall back to the already-owned dialog with restore tips.
+                            onError(e)
+                        }
                     }
                 }
 
@@ -329,12 +338,15 @@ class UpgradeRepoGplay @Inject constructor(
 
     suspend fun querySkus(vararg skus: Sku): Collection<SkuDetails> = billingManager.querySkus(*skus)
 
-    // Strict subscription lookup for the pre-purchase gate: fresh SUBS-only query with explicit
-    // failure. No grace substitution and no cross-product-type tolerance (unlike refresh() and
+    // Strict purchase-state lookup for the pre-purchase gates: a fresh COMPLETE round-trip with
+    // explicit failure. No grace substitution and no partial tolerance (unlike refresh() and
     // restorePurchaseNow()) — callers must treat any error as "couldn't verify" and fail closed.
-    suspend fun queryCurrentSubscriptions(): Collection<Purchase> {
-        log(TAG) { "queryCurrentSubscriptions()" }
-        return billingManager.querySubscriptions()
+    // Covers both product types and pending payments, because both can make a purchase wrong: a
+    // renewing subscription (double billing) and a payment Play is still processing (Play rejects
+    // the re-purchase).
+    suspend fun verifyPurchaseStateNow(): Info {
+        log(TAG) { "verifyPurchaseStateNow()" }
+        return Info(billingData = billingManager.refreshStrict(), isSettled = true)
     }
 
     override suspend fun refresh() {
@@ -496,8 +508,8 @@ class UpgradeRepoGplay @Inject constructor(
     // Shared Pro/grace mapping used by both the reactive upgradeInfo flow and restorePurchaseNow().
     // Only relinquishes Pro if we haven't had it for a while (grace period). READ-ONLY: this runs on
     // replayed shared-flow data too, so it must never stamp the grace cache — see recordProState().
-    // settled comes from the caller, never from billingData nullness: the grace branch returns an
-    // Info with billingData = null that may well be settled (built from a real empty snapshot).
+    // settled comes from the caller, never from billingData nullness: a null-data Info can be
+    // perfectly settled (a real empty snapshot), and the grace branch carries data through anyway.
     private suspend fun BillingData?.toUpgradeInfo(settled: Boolean): Info {
         // Branch on MAPPED upgrades, not raw purchases: a purchase list containing only products
         // this app doesn't know maps to zero upgrades and must fall through to the grace check —
@@ -513,7 +525,11 @@ class UpgradeRepoGplay @Inject constructor(
         return when {
             (now - lastProStateAt) < graceWindowMs() -> {
                 log(TAG, VERBOSE) { "We are not pro, but were recently, did GPlay try annoy us again?" }
-                Info(gracePeriod = true, billingData = null, isSettled = settled)
+                // billingData is carried through, not dropped: this branch is only reached when the
+                // mapped upgrades are empty, so entitlement stays empty either way — but a pending
+                // payment must stay visible, and a grace user waiting on one is exactly who needs
+                // the explanation.
+                Info(gracePeriod = true, billingData = this, isSettled = settled)
             }
 
             else -> mapped
@@ -553,6 +569,23 @@ class UpgradeRepoGplay @Inject constructor(
                         log(TAG) { "Mapped $productId to $sku (${purchase.redacted()})" }
                     }
                     PurchasedSku(sku, purchase)
+                }
+            }
+            ?.flatten()
+            ?: emptySet()
+
+        // Products with a payment Play is still processing. Deliberately NOT part of [isPro] or
+        // [upgrades]: a pending payment grants nothing. It exists so the UI can explain the wait
+        // and lock the purchase buttons — buying the alternative product now would double-charge.
+        val pendingSkus: Collection<Sku> = billingData?.pendingPurchases
+            ?.map { purchase ->
+                purchase.products.mapNotNull { productId ->
+                    val sku = OurSku.PRO_SKUS.singleOrNull { it.id == productId }
+                    if (sku == null) {
+                        log(TAG, WARN) { "Unknown pending product: $productId (${purchase.redacted()})" }
+                        return@mapNotNull null
+                    }
+                    sku
                 }
             }
             ?.flatten()

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplay.kt
@@ -591,6 +591,17 @@ class UpgradeRepoGplay @Inject constructor(
             ?.flatten()
             ?: emptySet()
 
+        // Any owned purchase Play still bills on a schedule. Deliberately computed from the RAW
+        // PURCHASED purchases instead of [upgrades]: the mapping drops products this app doesn't
+        // know, and the pre-purchase gate must keep blocking on a renewing subscription with an
+        // unknown or legacy product ID — being wrong there means billing the user twice for Pro.
+        // Both product types are scanned; a one-time purchase reports isAutoRenewing = false, so
+        // the broader input cannot produce a false positive.
+        // Computed on access, not in the initializer: an Info is built for every mapping pass, and
+        // only the purchase gate needs this.
+        val hasAutoRenewingSubscription: Boolean
+            get() = billingData?.purchases?.any { it.isAutoRenewing } == true
+
         override val isPro: Boolean = upgrades.isNotEmpty() || gracePeriod
 
         override val upgradedAt: Instant? = upgrades

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingData.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingData.kt
@@ -1,7 +1,28 @@
 package eu.darken.sdmse.common.upgrade.core.billing
 
 import com.android.billingclient.api.Purchase
+import eu.darken.sdmse.common.upgrade.core.billing.client.isPurchased
+import eu.darken.sdmse.common.upgrade.core.billing.client.isRelevant
 
+/**
+ * Play's purchase state, split by what it may be used for. [purchases] is the entitlement carrier
+ * and PURCHASED-only by construction, so no consumer can grant Pro (or stamp the grace cache) from
+ * a payment Play is still processing; [pendingPurchases] keeps that payment visible to the UI.
+ */
 data class BillingData(
-    val purchases: Collection<Purchase>
-)
+    val purchases: Collection<Purchase>,
+    val pendingPurchases: Collection<Purchase> = emptyList(),
+) {
+
+    companion object {
+        // The one place raw Play data becomes a BillingData: splitting here (instead of at each
+        // consumer) is what keeps "pending never grants Pro" a property of the type. Anything
+        // that is neither PURCHASED nor PENDING is dropped — it is not an entitlement and not a
+        // payment in progress.
+        fun from(raw: Collection<Purchase>): BillingData {
+            val relevant = raw.filter { it.isRelevant }
+            val (purchased, pending) = relevant.partition { it.isPurchased }
+            return BillingData(purchases = purchased, pendingPurchases = pending)
+        }
+    }
+}

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManager.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManager.kt
@@ -14,6 +14,7 @@ import eu.darken.sdmse.common.flow.setupCommonEventHandlers
 import eu.darken.sdmse.common.upgrade.core.billing.client.BillingClientException
 import eu.darken.sdmse.common.upgrade.core.billing.client.BillingConnection
 import eu.darken.sdmse.common.upgrade.core.billing.client.BillingConnectionProvider
+import eu.darken.sdmse.common.upgrade.core.billing.client.isPurchased
 import eu.darken.sdmse.common.upgrade.core.billing.client.redacted
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -73,13 +74,13 @@ class BillingManager @Inject constructor(
     private val failedOnce = MutableStateFlow(false)
     val isFailureSettled: Flow<Boolean> = failedOnce
 
-    // Fires once per failed connect-loop iteration: connection setup failure, the mandatory initial
-    // refreshPurchases erroring or timing out, an established connection dropping, an action-level
-    // invalidation (SERVICE_DISCONNECTED/SERVICE_TIMEOUT from any useConnection call), or an
-    // unexpected provider completion. Every one is a fresh reconciliation that couldn't confirm Pro.
-    // The connect loop retries these internally and downstream flows just go quiet, so without this
-    // explicit signal the grace episode clock (UpgradeRepoGplay.proUnconfirmedSince) would only
-    // advance on an explicit ON_RESUME refresh().
+    // Fires once per reconciliation that couldn't confirm Pro: a failed connect-loop iteration
+    // (connection setup failure, the mandatory initial refreshPurchases erroring or timing out, an
+    // established connection dropping, an action-level invalidation, an unexpected provider
+    // completion) — and, via processReconciliation, a refresh that COMPLETED but only partially,
+    // without a confirmed Pro purchase. The connect loop retries its failures internally and
+    // downstream flows just go quiet, so without this explicit signal the grace episode clock
+    // (UpgradeRepoGplay.proUnconfirmedSince) would only advance on an explicit ON_RESUME refresh().
     //
     // Each value is the failure's OCCURRENCE time (epoch millis). It has to be, not a bare Unit: the
     // channel buffers, and this feed and freshBillingData are separate flows with no cross-stream
@@ -121,13 +122,18 @@ class BillingManager @Inject constructor(
                                 // isFailureSettled forever with no retry. withTimeoutOrNull, NOT
                                 // withTimeout: TimeoutCancellationException is a
                                 // CancellationException and would kill this loop.
-                                withTimeoutOrNull(INITIAL_REFRESH_TIMEOUT_MS) {
+                                val initialRefresh = withTimeoutOrNull(INITIAL_REFRESH_TIMEOUT_MS) {
                                     connection.refreshPurchases()
                                 } ?: throw BillingException("Initial purchase refresh timed out")
 
                                 failStreak = 0
                                 connectionHolder.value = connection
                                 log(TAG, INFO) { "Billing connection established" }
+                                // AFTER publishing: a partial refresh is still a usable connection
+                                // (a pending-only cold start must not starve billingData), but its
+                                // bookkeeping — episode clock, dead-binder teardown — has to run,
+                                // and an invalidation may only tear down an INSTALLED connection.
+                                processReconciliation(initialRefresh)
                             }
                             // The provider flow stays open for the connection's lifetime; a normal
                             // completion means the connection is gone without an error — treat it
@@ -214,7 +220,7 @@ class BillingManager @Inject constructor(
         .shareIn(scope, WhileSubscribed(3000L, 0L), replay = 1)
 
     val billingData: Flow<BillingData> = purchases
-        .map { BillingData(purchases = it) }
+        .map { BillingData.from(it) }
         .shareIn(scope, WhileSubscribed(3000L, 0L), replay = 1)
 
     val purchaseFailures: Flow<BillingResult> = connectionHolder
@@ -235,7 +241,10 @@ class BillingManager @Inject constructor(
                 // every emission here is a real Play round-trip the grace bookkeeping needs.
                 .resubscribeOnFailure("freshBillingData")
         }
-        .map { FreshData(data = BillingData(purchases = it.purchases), isFullSnapshot = it.isFullSnapshot, occurredAt = it.occurredAt) }
+        // Through from() like every other exit, although the connection only ever puts PURCHASED
+        // purchases on this stream: if that invariant ever broke, splitting keeps the grace
+        // bookkeeping from stamping a pending payment as a confirmation.
+        .map { FreshData(data = BillingData.from(it.purchases), isFullSnapshot = it.isFullSnapshot, occurredAt = it.occurredAt) }
         .setupCommonEventHandlers(TAG) { "freshBillingData" }
         // Same belt as `purchases`: an Eagerly shared flow that dies stays dead, and this one feeds
         // both the grace bookkeeping and the ack collector's re-drive signal.
@@ -292,6 +301,14 @@ class BillingManager @Inject constructor(
     // -data signals.
     private suspend fun runAckPass(purchases: Collection<Purchase>) {
         val needAck = purchases.filter {
+            // The canonical list carries pending payments too. Play rejects acknowledging one
+            // PERMANENTLY, so an unfiltered pass would fire a bug report for every pending purchase,
+            // every pass — and there is nothing to acknowledge until the payment completes anyway.
+            if (!it.isPurchased) {
+                log(TAG) { "Not acknowledgeable yet: ${it.redacted()}" }
+                return@filter false
+            }
+
             val needsAck = !it.isAcknowledged
 
             if (needsAck) log(TAG) { "Needs ACK: ${it.redacted()}" }
@@ -401,6 +418,35 @@ class BillingManager @Inject constructor(
         }
     }
 
+    // Everything a COMPLETED refresh owes the rest of the app, in one place: both the connect loop's
+    // initial refresh and manual refresh() calls run through it, so a Restore tap during an outage
+    // feeds the same bookkeeping the connect loop does. Only reached when refreshPurchases returned
+    // (it still throws when it found nothing AND a query failed — that path is the connect loop's /
+    // useConnection's).
+    private fun processReconciliation(refresh: BillingConnection.PurchaseRefresh) {
+        // A partial refresh no longer reaches useConnection's dead-binder detection (it returns
+        // instead of throwing), so the teardown that used to ride the throw path happens here.
+        // Cause chain, not the exception itself: the failure arrives user-friendly-mapped.
+        // Deliberately no holder CAS: the failing connection may already have been replaced, and
+        // the accepted cost of that rare race is one extra failed action while the loop reconnects.
+        val clientError = refresh.partialError?.let {
+            (it as? BillingClientException) ?: (it.cause as? BillingClientException)
+        }
+        if (clientError != null && clientError.result.responseCode in INVALIDATING_CODES) {
+            log(TAG, WARN) { "Refresh reported the connection dead (${clientError.result.responseCode}), invalidating." }
+            invalidations.trySend(Unit)
+        }
+
+        if (!refresh.isComplete && !refresh.hasConfirmedProPurchase) {
+            // A reconciliation that couldn't confirm Pro. Stamped with the refresh's COMMIT time,
+            // never now-at-send: a confirmation that committed between this refresh and the send
+            // (e.g. a pending payment completing) must stay NEWER than this failure, or the grace
+            // episode it closed would be reopened.
+            log(TAG, WARN) { "Partial refresh without a confirmed Pro purchase at ${refresh.occurredAt}" }
+            connectionFailuresChannel.trySend(refresh.occurredAt)
+        }
+    }
+
     private suspend fun <T> useConnection(action: suspend BillingConnection.() -> T): T {
         // Every caller here is active demand (opening the upgrade screen, restore/buy taps,
         // purchase acks) — cut a pending reconnect backoff short. A no-op while healthy.
@@ -479,18 +525,24 @@ class BillingManager @Inject constructor(
         // shared upgradeInfo replay cache. The freshBillingData emission happens inside the
         // reducer's commit, in commit order — not here.
         val fresh = useConnection { refreshPurchases() }
-        return BillingData(purchases = fresh.purchases)
+        processReconciliation(fresh)
+        return BillingData.from(fresh.purchases)
     }
 
-    // Strict SUBS-only query for the pre-purchase subscription gate: unlike refresh(), a failure
-    // here propagates (user-friendly-mapped) instead of being masked by the other product type.
-    suspend fun querySubscriptions(): Collection<Purchase> = try {
-        useConnection { querySubscriptions() }
-    } catch (e: CancellationException) {
-        throw e
-    } catch (e: Exception) {
-        log(TAG, WARN) { "querySubscriptions() failed: ${e.asLog()}" }
-        throw e.tryMapUserFriendly()
+    // Strict variant for the pre-purchase gates: unlike refresh(), anything short of a COMPLETE
+    // reconciliation throws (user-friendly-mapped) instead of returning what it happened to find —
+    // a gate must be able to tell "not owned" apart from "couldn't verify" and fail closed.
+    suspend fun refreshStrict(): BillingData {
+        log(TAG) { "refreshStrict()" }
+        val fresh = useConnection { refreshPurchases() }
+        if (!fresh.isComplete) {
+            // partialError is set for every incomplete refresh; the fallback only exists so a
+            // future incompleteness without a captured cause still fails closed instead of passing.
+            val error = fresh.partialError ?: BillingException("Purchase refresh was incomplete")
+            log(TAG, WARN) { "refreshStrict() incomplete: ${error.asLog()}" }
+            throw error.tryMapUserFriendly()
+        }
+        return BillingData.from(fresh.purchases)
     }
 
     companion object {

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/PendingPurchaseBillingException.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/PendingPurchaseBillingException.kt
@@ -1,0 +1,11 @@
+package eu.darken.sdmse.common.upgrade.core.billing
+
+/**
+ * A purchase can't proceed because the account already has a payment Play is still processing.
+ *
+ * Typed so the UI can answer with the informational pending dialog instead of the already-owned
+ * error and its restore tips: restoring cannot help — Play refuses to re-sell a product with a
+ * pending payment, and the entitlement arrives on its own once the payment clears.
+ */
+class PendingPurchaseBillingException(cause: Throwable? = null) :
+    BillingException("A purchase with a pending payment already exists.", cause)

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingClientExtensions.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingClientExtensions.kt
@@ -9,6 +9,21 @@ internal val BillingResult.isSuccess: Boolean
     get() = responseCode == BillingClient.BillingResponseCode.OK
 
 /**
+ * Owned right now. The ONLY state that may grant an entitlement, stamp the Pro grace cache or be
+ * acknowledged — a PENDING purchase is a payment Play is still processing, and acknowledging one is
+ * rejected permanently.
+ */
+internal val Purchase.isPurchased: Boolean
+    get() = purchaseState == Purchase.PurchaseState.PURCHASED
+
+/**
+ * Worth carrying in our state at all: owned, or a payment in progress the user should see. Anything
+ * else (UNSPECIFIED_STATE) is dropped at ingestion — it is neither.
+ */
+internal val Purchase.isRelevant: Boolean
+    get() = isPurchased || purchaseState == Purchase.PurchaseState.PENDING
+
+/**
  * Log-safe rendering of a [Purchase].
  *
  * `Purchase.toString()` dumps the original response JSON, which carries the purchase token and the

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingConnection.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingConnection.kt
@@ -7,7 +7,6 @@ import com.android.billingclient.api.BillingClient.BillingResponseCode
 import com.android.billingclient.api.BillingFlowParams
 import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.Purchase
-import com.android.billingclient.api.Purchase.PurchaseState
 import com.android.billingclient.api.QueryProductDetailsParams
 import com.android.billingclient.api.QueryProductDetailsResult
 import com.android.billingclient.api.QueryPurchasesParams
@@ -41,11 +40,11 @@ class BillingConnection(
     private val skuTypeOf: (String) -> Sku.Type? = DEFAULT_SKU_TYPE_RESOLVER,
 ) {
 
-    // A purchase proven by an onPurchasesUpdated success event. Additive only: events prove
-    // ownership, never absence. `gen` orders it against queries (a query that STARTED before this
-    // event must not clear it); `type` is resolved at ingestion so a later per-type query that
-    // confirms absence can supersede it (null = product unknown to this app, only a complete
-    // refresh may clear it).
+    // A purchase (owned or with a pending payment) proven by an onPurchasesUpdated success event.
+    // Additive only: events prove existence, never absence. `gen` orders it against queries (a
+    // query that STARTED before this event must not clear it); `type` is resolved at ingestion so a
+    // later per-type query that confirms absence can supersede it (null = product unknown to this
+    // app, only a complete refresh may clear it).
     data class OverlayEntry(
         val purchase: Purchase,
         val gen: Long,
@@ -64,11 +63,11 @@ class BillingConnection(
     ) {
 
         internal fun withEvent(
-            purchased: Collection<Purchase>,
+            relevant: Collection<Purchase>,
             typeOf: (String) -> Sku.Type?,
         ): ReducerState {
             val gen = eventGen + 1
-            val entries = purchased.map { purchase ->
+            val entries = relevant.map { purchase ->
                 OverlayEntry(
                     purchase = purchase,
                     gen = gen,
@@ -169,10 +168,13 @@ class BillingConnection(
                 "onPurchasesUpdated(code=${result.responseCode}, message=${result.debugMessage}, " +
                     "purchases=${purchases?.redacted()})"
             }
-            // PENDING purchases must never surface as owned (or stamp the Pro grace cache).
-            val purchased = purchases.orEmpty().filter { it.purchaseState == PurchaseState.PURCHASED }
+            // The reducer carries PENDING purchases too (the UI must be able to show a payment in
+            // progress), but the fresh stream stays PURCHASED-only: it feeds the entitlement and
+            // grace bookkeeping, which must never see a payment Play hasn't completed.
+            val relevant = purchases.orEmpty().filter { it.isRelevant }
+            val purchased = relevant.filter { it.isPurchased }
             synchronized(reducerLock) {
-                state.value = state.value.withEvent(purchased, skuTypeOf)
+                state.value = state.value.withEvent(relevant, skuTypeOf)
                 if (purchased.isNotEmpty()) {
                     freshUpdatesChannel.trySend(FreshUpdate(purchased, isFullSnapshot = false))
                 }
@@ -193,12 +195,29 @@ class BillingConnection(
         failureChannel.close()
     }
 
-    // The purchases of a refresh plus whether it covered both product types: a partial result (one
-    // query failed) is still authoritative for what it FOUND, but must not be treated as proof of
-    // absence for the type that couldn't be checked.
+    // The full outcome of a refresh: what it committed, what it actually CONFIRMED, and how far it
+    // got. A partial result (one query failed) is still authoritative for what it found, but must
+    // not be treated as proof of absence for the type that couldn't be checked — so callers that
+    // need to fail closed, or to feed the grace episode clock, get the provenance instead of having
+    // to infer it from the merged view.
     data class PurchaseRefresh(
+        // The committed reducer state (queries merged with retained snapshots and surviving
+        // events) — the same view the reactive purchases flow emits.
         val purchases: Collection<Purchase>,
+        // ONLY what these queries returned: never retained state of a failed type, so a consumer
+        // can tell "Play said so just now" from "we still remember this".
+        val confirmed: Collection<Purchase> = emptyList(),
+        // A confirmed PURCHASED purchase of a product this app knows. Fail-safe default: "we
+        // couldn't confirm Pro" is the direction that keeps the grace bookkeeping honest.
+        val hasConfirmedProPurchase: Boolean = false,
         val isComplete: Boolean,
+        // Commit time under reducerLock — the same instant stamped on this refresh's FreshUpdate,
+        // so a confirmation and a later failure signal are ordered by when they HAPPENED.
+        val occurredAt: Long = System.currentTimeMillis(),
+        // Why the refresh is incomplete (the failed type's already user-friendly-mapped
+        // exception), null when complete. Carried rather than thrown: a partial refresh that found
+        // something is still useful, only the caller can decide whether partial is good enough.
+        val partialError: Throwable? = null,
     )
 
     // Serializes concurrent refreshes (manual, background, auto-restore): an older query that got
@@ -214,8 +233,8 @@ class BillingConnection(
         coroutineScope {
             log(TAG) { "refreshPurchases()" }
             val genAtQueryStart = state.value.eventGen
-            val iapJob = async { queryPurchasedProducts(BillingClient.ProductType.INAPP) }
-            val subJob = async { queryPurchasedProducts(BillingClient.ProductType.SUBS) }
+            val iapJob = async { queryRelevantProducts(BillingClient.ProductType.INAPP) }
+            val subJob = async { queryRelevantProducts(BillingClient.ProductType.SUBS) }
             val iap = iapJob.await()
             val sub = subJob.await()
             log(TAG) { "Refreshed IAPs=${iap.getOrNull()?.redacted()}, SUBs=${sub.getOrNull()?.redacted()}" }
@@ -224,6 +243,12 @@ class BillingConnection(
             // authoritative even when its sibling failed — verified absence (e.g. a refunded IAP)
             // must not be discarded just because the SUB query errored.
             val isComplete = iap.isSuccess && sub.isSuccess
+            // Only what the queries CONFIRMED as owned — retained stale data of a failed type, and
+            // pending payments, stay out (both would keep re-stamping the grace window).
+            val confirmed = (iap.getOrNull().orEmpty() + sub.getOrNull().orEmpty())
+                .filter { it.isPurchased }
+                .sortedByDescending { it.purchaseTime }
+            var committedAt = 0L
             val committed = synchronized(reducerLock) {
                 val next = state.value.withQueryResults(
                     iap = iap.getOrNull(),
@@ -231,17 +256,18 @@ class BillingConnection(
                     genAtQueryStart = genAtQueryStart,
                 )
                 state.value = next
+                committedAt = System.currentTimeMillis()
                 if (iap.isSuccess || sub.isSuccess) {
-                    // Only what the queries CONFIRMED — retained stale data of a failed type stays
-                    // out of the fresh stream (it would keep re-stamping the grace window).
-                    val confirmed = (iap.getOrNull().orEmpty() + sub.getOrNull().orEmpty())
-                        .sortedByDescending { it.purchaseTime }
-                    // A surviving overlay entry (purchase event newer than the query start, or of
-                    // a failed type) means this result does NOT prove total absence: it must not
-                    // count as a full snapshot, or an empty query racing a fresh purchase event
-                    // would start a false unconfirmed-grace episode.
-                    val provesAbsence = isComplete && next.overlay.isEmpty()
-                    freshUpdatesChannel.trySend(FreshUpdate(confirmed, isFullSnapshot = provesAbsence))
+                    // A surviving OWNED overlay entry (purchase event newer than the query start,
+                    // or of a failed type) means this result does NOT prove total absence: it must
+                    // not count as a full snapshot, or an empty query racing a fresh purchase event
+                    // would start a false unconfirmed-grace episode. A surviving PENDING entry
+                    // proves nothing about ownership, so it must not suppress the bookkeeping
+                    // either — a payment in progress would otherwise freeze the episode clock.
+                    val provesAbsence = isComplete && next.overlay.none { it.purchase.isPurchased }
+                    freshUpdatesChannel.trySend(
+                        FreshUpdate(confirmed, isFullSnapshot = provesAbsence, occurredAt = committedAt)
+                    )
                 }
                 next
             }
@@ -249,31 +275,42 @@ class BillingConnection(
             // Support-log anchor, at INFO because purchase complaints arrive as debug recordings.
             // Logs what these queries CONFIRMED, kept distinct from the committed view: merged()
             // retains a failed type's previous purchases, so reporting it as "what Play returned"
-            // would be the same false-certainty trap the copy elsewhere had to fix. Product IDs
-            // only -- never the Purchase, which carries order and token data.
+            // would be the same false-certainty trap the copy elsewhere had to fix. Pending ids are
+            // listed separately — "bought it, still not Pro" reports are exactly this state.
+            // Product IDs only -- never the Purchase, which carries order and token data.
             log(TAG, INFO) {
-                val confirmedIds = (iap.getOrNull().orEmpty() + sub.getOrNull().orEmpty()).flatMap { it.products }
-                "refreshPurchases(): confirmed=$confirmedIds, isComplete=$isComplete, " +
+                val returned = iap.getOrNull().orEmpty() + sub.getOrNull().orEmpty()
+                val confirmedIds = returned.filter { it.isPurchased }.flatMap { it.products }
+                val pendingIds = returned.filterNot { it.isPurchased }.flatMap { it.products }
+                "refreshPurchases(): confirmed=$confirmedIds, pending=$pendingIds, isComplete=$isComplete, " +
                     "iapOk=${iap.isSuccess}, subOk=${sub.isSuccess}, merged=${committed.merged().size}"
             }
 
             // Throws when nothing was found and a query failed, so the caller can tell "not
             // owned" apart from "couldn't verify".
-            combinePurchaseResults(iap, sub)
+            combinePurchaseResults(iap, sub, skuTypeOf)
 
             PurchaseRefresh(
                 purchases = committed.merged(),
+                confirmed = confirmed,
+                hasConfirmedProPurchase = confirmed.any { purchase ->
+                    purchase.products.any { skuTypeOf(it) != null }
+                },
                 isComplete = isComplete,
+                occurredAt = committedAt,
+                partialError = iap.exceptionOrNull() ?: sub.exceptionOrNull(),
             )
         }
     }
 
     // Never throws except on cancellation, so a single failing product-type query doesn't cancel
     // the sibling query (or the coroutineScope). The exception is already user-friendly-mapped.
-    private suspend fun queryPurchasedProducts(
+    // Returns owned AND pending purchases; the split by state happens where it matters (fresh
+    // stream, entitlement mapping), so a pending payment stays visible instead of vanishing here.
+    private suspend fun queryRelevantProducts(
         @BillingClient.ProductType type: String,
     ): Result<Collection<Purchase>> = try {
-        Result.success(queryPurchases(type).filter { it.purchaseState == PurchaseState.PURCHASED })
+        Result.success(queryPurchases(type).filter { it.isRelevant })
     } catch (e: CancellationException) {
         throw e
     } catch (e: Exception) {
@@ -307,37 +344,6 @@ class BillingConnection(
         return purchaseData
     }
 
-    // Strict SUBS-only query for the pre-purchase subscription gate: unlike refreshPurchases(),
-    // a failure propagates (no cross-type tolerance) — callers must be able to fail closed on
-    // "couldn't verify". Commits through the reducer like any query, so the reactive purchases
-    // flow picks up the fresh renewal state, and emits a partial fresh update: it proves what the
-    // SUBS query found, never the absence of anything it didn't cover.
-    suspend fun querySubscriptions(): Collection<Purchase> = refreshMutex.withLock {
-        log(TAG) { "querySubscriptions()" }
-        val genAtQueryStart = state.value.eventGen
-        val subs = queryPurchases(BillingClient.ProductType.SUBS)
-            .filter { it.purchaseState == PurchaseState.PURCHASED }
-        val committed = synchronized(reducerLock) {
-            val next = state.value.withQueryResults(
-                iap = null,
-                sub = subs,
-                genAtQueryStart = genAtQueryStart,
-            )
-            state.value = next
-            freshUpdatesChannel.trySend(FreshUpdate(subs, isFullSnapshot = false))
-            next
-        }
-        // The COMMITTED view, not the raw response: a purchase event that arrived after the query
-        // started survives the commit as a newer overlay and must reach the gate too — otherwise a
-        // just-purchased renewing sub could slip past the fail-closed double-billing check.
-        // Non-IAP overlays only; untyped (unknown product) entries stay in on the safe side.
-        val byToken = LinkedHashMap<String, Purchase>()
-        subs.forEach { byToken[it.purchaseToken] = it }
-        committed.overlay
-            .filter { it.type != Sku.Type.IAP }
-            .forEach { byToken[it.purchase.purchaseToken] = it.purchase }
-        byToken.values.sortedByDescending { it.purchaseTime }
-    }
     suspend fun acknowledgePurchase(purchase: Purchase): BillingResult {
         val ack = AcknowledgePurchaseParams.newBuilder().apply {
             setPurchaseToken(purchase.purchaseToken)
@@ -529,16 +535,22 @@ class BillingConnection(
             OurSku.PRO_SKUS.singleOrNull { it.id == productId }?.type
         }
 
-        // Combines the two product-type query results: a purchase found by either type is
-        // authoritative; an error is only propagated when nothing was found, so callers can tell
-        // "not owned" apart from "couldn't verify one product type". Treating any found purchase
-        // as authoritative is safe because every product this app sells is a Pro SKU (see
-        // OurSku.PRO_SKUS). Pure and unit-tested.
+        // Combines the two product-type query results: an error is only propagated when the refresh
+        // learned nothing usable, so callers can tell "not owned" apart from "couldn't verify one
+        // product type". A PURCHASED result of ANY product suppresses the error — every product
+        // this app sells is a Pro SKU (see OurSku.PRO_SKUS), so it is by construction relevant. A
+        // PENDING result only counts when it maps to a KNOWN Pro SKU: it grants nothing, and an
+        // unknown pending product says nothing about the type whose query failed, so treating it
+        // as a find would swallow a real "couldn't verify". Pure and unit-tested.
         internal fun combinePurchaseResults(
             iap: Result<Collection<Purchase>>,
             sub: Result<Collection<Purchase>>,
+            typeOf: (String) -> Sku.Type? = DEFAULT_SKU_TYPE_RESOLVER,
         ): Collection<Purchase> {
-            val found = iap.getOrNull().orEmpty() + sub.getOrNull().orEmpty()
+            val returned = iap.getOrNull().orEmpty() + sub.getOrNull().orEmpty()
+            val found = returned.filter { purchase ->
+                purchase.isPurchased || purchase.products.any { typeOf(it) != null }
+            }
             return when {
                 found.isNotEmpty() -> found.sortedByDescending { it.purchaseTime }
                 else -> {

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeEvents.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeEvents.kt
@@ -13,5 +13,14 @@ sealed class UpgradeEvents {
      */
     data object RestoreInconclusive : UpgradeEvents()
     data object SubscriptionStillRenewing : UpgradeEvents()
-    data object SubscriptionCheckFailed : UpgradeEvents()
+
+    /**
+     * Play answered, no completed purchase exists, but a payment is still being processed. Purely
+     * informational: nothing to fix, nothing to restore — Pro unlocks by itself once Play clears
+     * the payment, and a new purchase would be rejected (or double-charge) in the meantime.
+     */
+    data object PurchasePending : UpgradeEvents()
+
+    /** The pre-purchase check with Play didn't finish, so the purchase was not started. */
+    data object PurchaseCheckFailed : UpgradeEvents()
 }

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeOwnership.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeOwnership.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.Autorenew
+import androidx.compose.material.icons.twotone.HourglassTop
 import androidx.compose.material.icons.twotone.Verified
 import androidx.compose.material3.Button
 import androidx.compose.material3.CardDefaults
@@ -101,8 +102,10 @@ internal fun UpgradeOwnershipContent(
                 Button(
                     onClick = onIap,
                     // Not gated on iapEnabled: prices may have failed to load while the purchase
-                    // itself would work (the billing flow re-queries details on launch).
-                    enabled = switchUnlocked && uiState.busy == null,
+                    // itself would work (the billing flow re-queries details on launch). A pending
+                    // payment does lock it — Play would reject the purchase, and the pending card
+                    // above carries the explanation.
+                    enabled = switchUnlocked && uiState.busy == null && !uiState.hasPendingPurchase,
                     modifier = Modifier
                         .fillMaxWidth()
                         .testTag(UpgradeScreenTags.GPLAY_IAP),
@@ -235,6 +238,38 @@ internal fun UpgradeGraceCard(
                 Text(stringResource(R.string.upgrade_screen_restore_purchase_action))
             }
         }
+    }
+}
+
+// Shown to EVERY audience while Google Play is still processing a payment: an acquisition user who
+// just bought, an owner buying the other product, and a grace user whose Pro is running out — all
+// three have purchase actions locked and need the same explanation. Calm reassurance styling like
+// the grace card: nothing is wrong, the payment just isn't done.
+@Composable
+internal fun PendingPurchaseCard(
+    modifier: Modifier = Modifier,
+) {
+    UpgradeSectionCard(
+        title = stringResource(R.string.upgrade_screen_pending_card_title),
+        icon = Icons.TwoTone.HourglassTop,
+        modifier = modifier.testTag(UpgradeScreenTags.GPLAY_PENDING),
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+            contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        ),
+    ) {
+        Text(
+            text = stringResource(R.string.upgrade_screen_pending_card_body),
+            style = MaterialTheme.typography.bodyMedium,
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun PendingPurchaseCardPreview() {
+    PreviewWrapper {
+        PendingPurchaseCard()
     }
 }
 

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeScreen.kt
@@ -65,6 +65,7 @@ fun UpgradeScreenHost(
     var showRestoreInconclusive by rememberSaveable { mutableStateOf(false) }
     var showStillRenewing by rememberSaveable { mutableStateOf(false) }
     var showCheckFailed by rememberSaveable { mutableStateOf(false) }
+    var showPurchasePending by rememberSaveable { mutableStateOf(false) }
 
     LaunchedEffect(vm) {
         vm.events.collect { event ->
@@ -78,7 +79,8 @@ fun UpgradeScreenHost(
                 UpgradeEvents.RestoreFailed -> showRestoreFailed = true
                 UpgradeEvents.RestoreInconclusive -> showRestoreInconclusive = true
                 UpgradeEvents.SubscriptionStillRenewing -> showStillRenewing = true
-                UpgradeEvents.SubscriptionCheckFailed -> showCheckFailed = true
+                UpgradeEvents.PurchaseCheckFailed -> showCheckFailed = true
+                UpgradeEvents.PurchasePending -> showPurchasePending = true
             }
         }
     }
@@ -124,13 +126,17 @@ fun UpgradeScreenHost(
 
     if (showCheckFailed) {
         SdmConfirmDialog(
-            message = stringResource(R.string.upgrade_screen_sub_check_failed_message),
+            message = stringResource(R.string.upgrade_screen_purchase_check_failed_message),
             onDismissRequest = { showCheckFailed = false },
             positive = SdmDialogAction(
                 label = stringResource(CommonR.string.general_dismiss_action),
                 onClick = { showCheckFailed = false },
             ),
         )
+    }
+
+    if (showPurchasePending) {
+        PurchasePendingDialog(onDismiss = { showPurchasePending = false })
     }
 
     val uiState by vm.state.collectAsStateWithLifecycle()
@@ -173,6 +179,33 @@ internal fun RestoreFailedDialog(
             onClick = onDismiss,
         ),
     )
+}
+
+/**
+ * Shown when Play is still processing a payment. Purely informational: there is nothing to fix, no
+ * purchase to restore and no support case — the entitlement arrives on its own once the payment
+ * clears, so the dialog offers only a dismiss.
+ */
+@Composable
+internal fun PurchasePendingDialog(
+    onDismiss: () -> Unit = {},
+) {
+    SdmConfirmDialog(
+        message = stringResource(R.string.upgrade_screen_pending_dialog_message),
+        onDismissRequest = onDismiss,
+        positive = SdmDialogAction(
+            label = stringResource(CommonR.string.general_dismiss_action),
+            onClick = onDismiss,
+        ),
+    )
+}
+
+@Preview2
+@Composable
+private fun PurchasePendingDialogPreview() {
+    PreviewWrapper {
+        PurchasePendingDialog()
+    }
 }
 
 /**
@@ -266,6 +299,12 @@ internal fun UpgradeScreen(
                     )
                 }
             }
+
+            // Above the ownership/acquisition split, because a pending payment cuts across it: the
+            // buyer waiting for their first Pro purchase, the owner switching products and the
+            // grace user (whose offers box is hidden entirely) all need it, and it is the reason
+            // their purchase buttons are locked.
+            if (loaded?.hasPendingPurchase == true) PendingPurchaseCard()
 
             if (ownedState != null) {
                 UpgradeOwnershipContent(
@@ -467,6 +506,24 @@ private fun UpgradeScreenReturningBuyerPreview() {
                 iapEnabled = true,
                 iapPrice = "$24.99",
                 wasPreviouslyPro = true,
+            ),
+        )
+    }
+}
+
+// The acquisition variant of the pending state: card above the offers, both buy buttons locked.
+@Preview2
+@Composable
+private fun UpgradeScreenPendingPreview() {
+    PreviewWrapper {
+        UpgradeScreen(
+            uiState = GplayUpgradeUiState.Loaded(
+                subscriptionAction = SubscriptionAction.STANDARD,
+                subscriptionEnabled = false,
+                subscriptionPrice = "$12.99",
+                iapEnabled = false,
+                iapPrice = "$24.99",
+                hasPendingPurchase = true,
             ),
         )
     }

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeUiState.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeUiState.kt
@@ -23,6 +23,9 @@ internal sealed interface GplayUpgradeUiState {
         val ownership: Ownership = Ownership(),
         val grace: GraceHint? = null,
         val wasPreviouslyPro: Boolean = false,
+        // A payment Google Play is still processing. SKU-agnostic on purpose: the card explains the
+        // wait and both purchase actions lock, regardless of which product is pending.
+        val hasPendingPurchase: Boolean = false,
         val busy: BusyOp? = null,
     ) : GplayUpgradeUiState
 }
@@ -73,12 +76,18 @@ internal fun UpgradeRepoGplay.Info.toOwnership() = Ownership(
         ?.let { subs -> SubscriptionOwnership(isAutoRenewing = subs.any { it.purchase.isAutoRenewing }) },
 )
 
+// Any Pro payment Play is still processing. No per-product flag: the one-time purchase and the
+// subscription are alternatives, so a pending payment for either one must lock both — completing
+// both would charge the user twice for the same thing.
+internal fun UpgradeRepoGplay.Info.toPendingFlag(): Boolean = pendingSkus.isNotEmpty()
+
 internal fun toLoadedState(
     iap: SkuDetails?,
     sub: SkuDetails?,
     ownership: Ownership,
     grace: GraceHint? = null,
     wasPreviouslyPro: Boolean = false,
+    hasPendingPurchase: Boolean = false,
     busy: BusyOp? = null,
 ): GplayUpgradeUiState.Loaded {
     val iapOffer = iap?.details?.oneTimePurchaseOfferDetails
@@ -97,15 +106,18 @@ internal fun toLoadedState(
         },
         // Any running entitlement operation (restore, manual or the invisible already-owned
         // recovery, and purchases) pauses the buy actions too — starting a purchase while an
-        // entitlement is being reconciled just races Play into ITEM_ALREADY_OWNED.
+        // entitlement is being reconciled just races Play into ITEM_ALREADY_OWNED. A pending
+        // payment locks BOTH offers for the same reason the card explains: Play refuses the
+        // re-purchase, and the alternative product would double-charge for the same features.
         subscriptionEnabled = (subOffer != null || subOfferTrial != null) &&
-            ownership.subscription == null && busy == null,
+            ownership.subscription == null && busy == null && !hasPendingPurchase,
         subscriptionPrice = subOffer?.pricingPhases?.pricingPhaseList?.lastOrNull()?.formattedPrice,
-        iapEnabled = iapOffer != null && !ownership.hasIap && busy == null,
+        iapEnabled = iapOffer != null && !ownership.hasIap && busy == null && !hasPendingPurchase,
         iapPrice = iapOffer?.formattedPrice,
         ownership = ownership,
         grace = grace,
         wasPreviouslyPro = wasPreviouslyPro,
+        hasPendingPurchase = hasPendingPurchase,
         busy = busy,
     )
 }

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
@@ -19,6 +19,7 @@ import eu.darken.sdmse.common.upgrade.core.OurSku
 import eu.darken.sdmse.common.upgrade.core.UpgradeRepoGplay
 import eu.darken.sdmse.common.upgrade.core.billing.GplayServiceUnavailableException
 import eu.darken.sdmse.common.upgrade.core.billing.OfferUnavailableBillingException
+import eu.darken.sdmse.common.upgrade.core.billing.PendingPurchaseBillingException
 import eu.darken.sdmse.common.upgrade.core.billing.Sku
 import eu.darken.sdmse.common.upgrade.core.billing.SkuDetails
 import eu.darken.sdmse.main.ui.navigation.SupportFormRoute
@@ -162,8 +163,10 @@ class UpgradeViewModel @Inject constructor(
             null
         }
         // Owners and grace users don't depend on offer prices: their status and management
-        // actions render immediately and price problems are not their problem.
-        val priceIndependent = ownership.ownsAnything || grace != null
+        // actions render immediately and price problems are not their problem. A user waiting on a
+        // pending payment is in the same position — the card is their answer, and both offers are
+        // locked anyway, so a price failure must not replace it with an error screen.
+        val priceIndependent = ownership.ownsAnything || grace != null || current.pendingSkus.isNotEmpty()
 
         val done = queries as? SkuQueries.Done
         if (done == null) {
@@ -259,6 +262,7 @@ class UpgradeViewModel @Inject constructor(
             ownership = ownership,
             grace = grace,
             wasPreviouslyPro = wasEverPro && !current.isPro,
+            hasPendingPurchase = current.toPendingFlag(),
             // This ViewModel's own action wins; otherwise a launch started elsewhere (previous VM
             // instance, e.g. across a rotation — the launch lives on AppScope) or the repo's
             // invisible already-owned auto-restore still pauses the entitlement actions here.
@@ -304,44 +308,75 @@ class UpgradeViewModel @Inject constructor(
         return true
     }
 
+    // Outcome of the pre-purchase check with Play. Both purchase paths share it: they buy
+    // alternatives of the same entitlement from the same account, so a check only one of them runs
+    // is exactly how a double charge slips through. [Blocked] means the user was already told why.
+    private sealed interface PurchaseGate {
+        data class Clear(val info: UpgradeRepoGplay.Info) : PurchaseGate
+        data object Blocked : PurchaseGate
+    }
+
+    // Fails closed: no fresh, complete answer from Play (error, timeout) means no purchase. Bounded,
+    // because the repo waits for a healthy connection indefinitely and a tap must not park the
+    // single-flight guard through an outage.
+    private suspend fun runPurchaseGate(): PurchaseGate {
+        val info = try {
+            withTimeoutOrNull(VERIFY_TIMEOUT_MS) { upgradeRepo.verifyPurchaseStateNow() }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, WARN) { "Purchase verification errored: ${e.asLog()}" }
+            errorEvents.tryEmit(e)
+            return PurchaseGate.Blocked
+        }
+        if (info == null) {
+            log(TAG, WARN) { "Purchase verification timed out" }
+            events.tryEmit(UpgradeEvents.PurchaseCheckFailed)
+            return PurchaseGate.Blocked
+        }
+        if (info.pendingSkus.isNotEmpty()) {
+            // Play rejects a purchase while it is still processing a payment for this account, and
+            // the alternative product would charge twice for the same features.
+            log(TAG, INFO) { "Purchase blocked: a payment is still pending" }
+            events.tryEmit(UpgradeEvents.PurchasePending)
+            return PurchaseGate.Blocked
+        }
+        return PurchaseGate.Clear(info)
+    }
+
+    // A launch that failed on a pending payment is not an error the user can act on: it gets the
+    // informational dialog instead of the already-owned copy and its restore tips.
+    private fun onLaunchError(error: Throwable) {
+        if (error is PendingPurchaseBillingException) {
+            events.tryEmit(UpgradeEvents.PurchasePending)
+        } else {
+            errorEvents.tryEmit(error)
+        }
+    }
+
     fun onGoIap(activity: Activity) {
         log(TAG) { "onGoIap($activity)" }
         launch {
             // Single-flight: repeated taps must not stack verifications or billing launches.
             if (!acquireOp(BusyOp.IAP)) return@launch
             try {
-                // Hard gate against double-billing: verify against a FRESH SUBS-only query — the
-                // replayed upgradeInfo can be stale or built from partial results. Fails closed:
-                // no verified "not set to renew" (or no sub at all), no one-time purchase.
-                val subscriptions = try {
-                    withTimeoutOrNull(VERIFY_TIMEOUT_MS) { upgradeRepo.queryCurrentSubscriptions() }
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    log(TAG, WARN) { "Subscription verification errored: ${e.asLog()}" }
-                    errorEvents.tryEmit(e)
+                val gate = runPurchaseGate()
+                if (gate !is PurchaseGate.Clear) return@launch
+                // Hard gate against double-billing, against the FRESH result — the replayed
+                // upgradeInfo can be stale or built from partial results.
+                if (gate.info.upgrades.any { it.sku == OurSku.Sub.PRO_UPGRADE && it.purchase.isAutoRenewing }) {
+                    log(TAG, INFO) { "IAP purchase blocked: subscription is still set to renew" }
+                    events.tryEmit(UpgradeEvents.SubscriptionStillRenewing)
                     return@launch
                 }
-                when {
-                    subscriptions == null -> {
-                        log(TAG, WARN) { "Subscription verification timed out" }
-                        events.tryEmit(UpgradeEvents.SubscriptionCheckFailed)
-                    }
-
-                    subscriptions.any { it.isAutoRenewing } -> {
-                        log(TAG, INFO) { "IAP purchase blocked: subscription is still set to renew" }
-                        events.tryEmit(UpgradeEvents.SubscriptionStillRenewing)
-                    }
-
-                    // Suspends until the Play sheet launch resolved, so the single-flight guard
-                    // covers the whole tap-to-sheet window, not just the verification.
-                    else -> upgradeRepo.launchBillingFlowNow(
-                        activity,
-                        OurSku.Iap.PRO_UPGRADE,
-                        null,
-                        onError = errorEvents::tryEmit,
-                    )
-                }
+                // Suspends until the Play sheet launch resolved, so the single-flight guard covers
+                // the whole tap-to-sheet window, not just the verification.
+                upgradeRepo.launchBillingFlowNow(
+                    activity,
+                    OurSku.Iap.PRO_UPGRADE,
+                    null,
+                    onError = ::onLaunchError,
+                )
             } finally {
                 activeOp.value = null
             }
@@ -362,6 +397,9 @@ class UpgradeViewModel @Inject constructor(
         launch {
             if (!acquireOp(BusyOp.SUBSCRIPTION)) return@launch
             try {
+                // Same fresh check as the one-time path: a pending payment (for either product)
+                // must block this launch too — Play would reject it, or bill it on top.
+                if (runPurchaseGate() !is PurchaseGate.Clear) return@launch
                 // launchBillingFlowNow suspends until the launch resolved, so the guard covers the
                 // whole tap-to-sheet window. The flow itself still runs on AppScope, so closing the
                 // screen mid-launch doesn't abort the purchase.
@@ -369,7 +407,7 @@ class UpgradeViewModel @Inject constructor(
                     activity,
                     OurSku.Sub.PRO_UPGRADE,
                     offer,
-                    onError = errorEvents::tryEmit,
+                    onError = ::onLaunchError,
                 )
             } finally {
                 activeOp.value = null
@@ -431,6 +469,14 @@ class UpgradeViewModel @Inject constructor(
                     // Explicit feedback: on the ownership screen a successful restore changes
                     // nothing visible (the user already is Pro), so silence reads as "broken".
                     events.tryEmit(UpgradeEvents.RestoreSucceeded)
+                }
+
+                restored.info.pendingSkus.isNotEmpty() -> {
+                    // Play answered and found the purchase — it just hasn't been paid for yet.
+                    // RestoreFailed would send this user chasing account and support advice for
+                    // something that resolves itself.
+                    log(TAG, INFO) { "Restore found a purchase with a pending payment" }
+                    events.tryEmit(UpgradeEvents.PurchasePending)
                 }
 
                 else -> {

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
@@ -363,8 +363,11 @@ class UpgradeViewModel @Inject constructor(
                 val gate = runPurchaseGate()
                 if (gate !is PurchaseGate.Clear) return@launch
                 // Hard gate against double-billing, against the FRESH result — the replayed
-                // upgradeInfo can be stale or built from partial results.
-                if (gate.info.upgrades.any { it.sku == OurSku.Sub.PRO_UPGRADE && it.purchase.isAutoRenewing }) {
+                // upgradeInfo can be stale or built from partial results. Asked of the RAW
+                // purchases (see Info.hasAutoRenewingSubscription), never of the mapped upgrades:
+                // a renewing subscription with an unknown or legacy product ID must block the
+                // one-time purchase too, or the user pays for Pro twice.
+                if (gate.info.hasAutoRenewingSubscription) {
                     log(TAG, INFO) { "IAP purchase blocked: subscription is still set to renew" }
                     events.tryEmit(UpgradeEvents.SubscriptionStillRenewing)
                     return@launch

--- a/app/src/gplay/res/values-af-rZA/strings.xml
+++ b/app/src/gplay/res/values-af-rZA/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Dit is \'n aparte aankoop: dit kanselleer of gee nie terugbetaling vir jou inskrywing nie. Gebruik dieselfde Google-rekening vir beide.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Inskrywing nog aktief</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play rapporteer dat jou inskrywing nog steeds ingestel is om te vernuwe. Om die eenmalige opgradering te koop, kanselleer eers die inskrywing in Google Play, kom dan hierheen terug.\n\nNet gekanselleer? Gee Google Play \'n oomblik en probeer weer. Maak ook seker dat jy dieselfde Google-rekening gebruik.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Kon nie jou inskrywingstatus by Google Play nagaan nie. Probeer asseblief oor \'n oomblik weer.</string>
     <string name="upgrade_screen_restore_success_message">Aankoop herstel, jou Pro-opgradering is aktief.</string>
     <string name="upgrade_screen_grace_title">Bevestig jou aankoop</string>
     <string name="upgrade_screen_grace_body_short">Pro is nog aktief. Wag vir Google Play om jou aankoop te herbevestig, alle Pro-funksies bly ondertussen ontsluit.</string>

--- a/app/src/gplay/res/values-am/strings.xml
+++ b/app/src/gplay/res/values-am/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">ይህ ተለያይተ ግዢ ነው: ደንበኝነትዎን አትሰርዘውም ወይም አትመልስም። ለሁለቱ ተመሳሳይ Google ሂሳብ ተጠቀሙ።</string>
     <string name="upgrade_screen_sub_still_renewing_title">ደንበኝነት ገና ንቁ ነው</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play ደህና ዋስትናዎ አሁንም ራሱ ለመታደስ ተቀናብሮ እንደሆነ ይነግርዎታል። አንድ-ጊዜ ማሻሻያ ለመግዛት ፣ በመጀመሪያ Google Play ውስጥ ደህና ዋስትናውን ይሰርዙ ፣ ከዚያ ወደ እዚህ ይመለሱ።\n\nአሁን ሰርዘውታል? Google Play ትንሽ ጊዜ ሙታታ ሰጥተው እንደገና ሞክሩ። እንዲሁም ተመሳሳይ Google ሂሳብ ሲጠቀሙ ምልክት ያርጉ።</string>
-    <string name="upgrade_screen_sub_check_failed_message">Google Play ደንበኝነት ሁኔታ ሪምር አልቻለም። እባክህ ከአሁን በሪ ጊዜ ሞክር።</string>
     <string name="upgrade_screen_restore_success_message">ግዢ ተመልስ፣ የፕሮ ማሳሻ ንቁ ነው።</string>
     <string name="upgrade_screen_grace_title">ግዢ ከሚያረጋገጥ</string>
     <string name="upgrade_screen_grace_body_short">ፕሮ ገና ንቁ ነው። ግዢህን ለመክተር Google Play ን ጠብቅ፣ ሁሉም ፕሮ ባህሪ በጊዜው ይታጠቁ ይቀራሉ።</string>

--- a/app/src/gplay/res/values-ar/strings.xml
+++ b/app/src/gplay/res/values-ar/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">هذا شراء منفصل: إنه لا يلغي أو يسترجع اشتراكك. استخدم نفس حساب Google لكليهما.</string>
     <string name="upgrade_screen_sub_still_renewing_title">الاشتراك لا يزال نشطًا</string>
     <string name="upgrade_screen_sub_still_renewing_message">يُخبر Google Play أن اشتراكك لا يزال مضبوطًا للتجديد التلقائي. لشراء الترقية لمرة واحدة، ألغِ الاشتراك في Google Play أولاً، ثم عُد هنا.\n\nهل ألغيته للتو؟ أعطِ Google Play لحظة وحاول مرة أخرى. تأكد أيضًا من أنك تستخدم نفس حساب Google.</string>
-    <string name="upgrade_screen_sub_check_failed_message">لم نتمكن من التحقق من حالة اشتراكك لدى Google Play. يُرجى المحاولة مرة أخرى بعد قليل.</string>
     <string name="upgrade_screen_restore_success_message">تمت استعادة عملية الشراء، ترقيتك Pro نشطة الآن.</string>
     <string name="upgrade_screen_grace_title">جارٍ تأكيد عملية الشراء</string>
     <string name="upgrade_screen_grace_body_short">Pro لا يزال نشطًا. ننتظر Google Play لإعادة تأكيد عملية الشراء، جميع ميزات Pro تظل مفتوحة في غضون ذلك.</string>

--- a/app/src/gplay/res/values-az/strings.xml
+++ b/app/src/gplay/res/values-az/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Bu ayrı bir satınalmadır: abonəliyinizi ləğv etmir və ya geri qaytırmır. Hər ikisi üçün eyni Google hesabını istifadə edin.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Abonəlik hələ də aktiv</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play hesabat verir ki, abonəliyiniz hələ də yenilənməyə ayarlanmışdır. Bir dəfəlik yüksəltməni almaq üçün əvvəlcə Google Play-də abonəliyi ləğv edin, sonra buraya qayıdın.\n\nTəzə ləğv etdinizmi? Google Play-yə bir az vaxt verin və yenidən cəhd edin. Həmçinin eyni Google hesabını istifadə etdiyinizə əmin olun.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Google Play ilə abonəlik vəziyyətiniz yoxlanılmadı. Zəhmət olmasa bir az sonra yenidən cəhd edin.</string>
     <string name="upgrade_screen_restore_success_message">Satınalma bərpa edildi, Pro yüksəltməniz aktivdir.</string>
     <string name="upgrade_screen_grace_title">Satınalmanız təsdiqlənir</string>
     <string name="upgrade_screen_grace_body_short">Pro hələ də aktivdir. Google Play satınalmanızı yenidən təsdiq etməsini gözləyir, bu müddət ərzində bütün Pro xüsusiyyətləri açıq qalır.</string>

--- a/app/src/gplay/res/values-be/strings.xml
+++ b/app/src/gplay/res/values-be/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Гэта асобная купля: яна не скасоўвае і не вяртае грошы за вашу падпіску. Выкарыстоўвайце адзін і той жа ўліковы запіс Google для абодвух.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Падпіска ўсё яшчэ актыўная</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play паведамляе, што ваша падпіска ўсё яшчэ наладжана на аднаўленне. Каб купіць адзінаразовы Pro, спачатку скасуйце падпіску ў Google Play, а потым вярніцеся сюды.\n\nТолькі што скасавалі? Дайце Google Play крыху часу і паспрабуйце яшчэ раз. Таксама пераканайцеся, што выкарыстоўваеце той жа ўліковы запіс Google.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Не ўдалося праверыць статус вашай падпіскі ў Google Play. Паспрабуйце яшчэ раз праз хвіліну.</string>
     <string name="upgrade_screen_restore_success_message">Купля адноўлена, ваш Pro актыўны.</string>
     <string name="upgrade_screen_grace_title">Пацвярджэнне вашай куплі</string>
     <string name="upgrade_screen_grace_body_short">Pro ўсё яшчэ актыўны. Чакаем, пакуль Google Play паўторна пацвердзіць вашу куплю; усе функцыі Pro тым часам застаюцца разблакіраванымі.</string>

--- a/app/src/gplay/res/values-bg/strings.xml
+++ b/app/src/gplay/res/values-bg/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Това е отделна покупка: тя не отменя, нито възстановява вашия абонамент. Използвайте един и същи Google акаунт и за двете.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Абонаментът е все още активен</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play съобщава, че вашият абонамент все още е настроен да се подновява. За да закупите еднократното обновление, първо отменете абонамента в Google Play, след което се върнете тук.\n\nНаскоро го отменихте ли? Дайте на Google Play момент и опитайте отново. Също така проверете дали използвате един и същ Google акаунт.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Не можахме да проверим вашия статус на абонамент в Google Play. Моля, опитайте отново след момент.</string>
     <string name="upgrade_screen_restore_success_message">Покупката е възстановена, вашето Pro обновление е активно.</string>
     <string name="upgrade_screen_grace_title">Потвърждаване на вашата покупка</string>
     <string name="upgrade_screen_grace_body_short">Pro е все още активен. Изчаква се Google Play да потвърди повторно покупката ви, всички функции на Pro остават отключени междувременно.</string>

--- a/app/src/gplay/res/values-bn-rBD/strings.xml
+++ b/app/src/gplay/res/values-bn-rBD/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">এটি একটি আলাদা ক্রয়: এটি আপনার সাবস্ক্রিপশন বাতিল বা রিফান্ড করে না। উভয়ের জন্য একই Google অ্যাকাউন্ট ব্যবহার করুন।</string>
     <string name="upgrade_screen_sub_still_renewing_title">সাবস্ক্রিপশন এখনো সক্রিয়</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play জানায় যে আপনার সাবস্ক্রিপশন এখনো পুনর্নবীকরণের জন্য সেট আছে। এককালীন আপগ্রেড কিনতে, প্রথমে Google Play-তে সাবস্ক্রিপশন বাতিল করুন, তারপর এখানে ফিরে আসুন।\n\nশুধু এটি বাতিল করলেন? Google Play-কে একটু সময় দিন এবং আবার চেষ্টা করুন। এছাড়াও নিশ্চিত করুন যে আপনি একই Google অ্যাকাউন্ট ব্যবহার করছেন।</string>
-    <string name="upgrade_screen_sub_check_failed_message">Google Play-তে আপনার সাবস্ক্রিপশন স্থিতি পরীক্ষা করতে পারা গেল না। অনুগ্রহ করে একটু সময় পর আবার চেষ্টা করুন।</string>
     <string name="upgrade_screen_restore_success_message">ক্রয় পুনরুদ্ধার করা হয়েছে, আপনার Pro আপগ্রেড সক্রিয় আছে।</string>
     <string name="upgrade_screen_grace_title">আপনার ক্রয় নিশ্চিত করা হচ্ছে</string>
     <string name="upgrade_screen_grace_body_short">Pro এখনো সক্রিয় আছে। Google Play-তে আপনার ক্রয় পুনরায় নিশ্চিত করার জন্য অপেক্ষা করছে, এই সময়ে সমস্ত Pro ফিচার আনলক থাকে।</string>

--- a/app/src/gplay/res/values-ca/strings.xml
+++ b/app/src/gplay/res/values-ca/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Aquesta és una compra separada: no cancel·la ni reemborsa la vostra subscripció. Utilitzeu el mateix compte de Google per a ambdues.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Subscripció encara activa</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play informa que la vostra subscripció segueix configurada per renovar-se. Per comprar la millora d\'una sola vegada, cancel·leu primer la subscripció a Google Play i després torneu aquí.\n\nL\'acabeu de cancel·lar? Doneu a Google Play un moment i torneu a intentar-ho. Assegureu-vos també que utilitzeu el mateix compte de Google.</string>
-    <string name="upgrade_screen_sub_check_failed_message">No s\'ha pogut comprovar l\'estat de la vostra subscripció a Google Play. Si us plau, torneu a intentar-ho en un moment.</string>
     <string name="upgrade_screen_restore_success_message">Compra restaurada, la vostra millora Pro està activa.</string>
     <string name="upgrade_screen_grace_title">Confirmació de la vostra compra</string>
     <string name="upgrade_screen_grace_body_short">Pro segueix actiu. S\'està esperant que Google Play torni a confirmar la vostra compra, totes les funcions Pro romanen desbloquejades mentrestant.</string>

--- a/app/src/gplay/res/values-ckb-rIR/strings.xml
+++ b/app/src/gplay/res/values-ckb-rIR/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">ئەمە کڕینی جیاواز: بەشدارییەت ناچڵۆنێتەوە و پێشکەش نابات. ئەکاونتی گوگڵی یەکسانی بۆ هەردووک بەکاربێنە.</string>
     <string name="upgrade_screen_sub_still_renewing_title">بەشدارییە هێشتا چالاکە</string>
     <string name="upgrade_screen_sub_still_renewing_message">گوگڵ پلەی دەسگێڕێتەوە کە بەشدارییەت هێشتا ڕێکخستراوە بۆ نوێکاری. بۆ کڕینی نوێکاری یەک جار، لە سەرەتایی بەشدارییە لە گوگڵ پلەی ئەنجام بدە، پاشان وەکو نیگاری بگەڕێ.\n\nتازە ئەنجامدا؟ گوگڵ پلەی جەنجام بدە و دیسان هەوڵ بدە. هەروەها دڵنیا بکە کە ئەکاونتی گوگڵی یەکسانی بەکاردەهێنیت.</string>
-    <string name="upgrade_screen_sub_check_failed_message">نەتوانت باسکردنی بەشدارییەت بۆ گوگڵ پلەی. تکایە لە چوونێکدا دیسان هەوڵ بدە.</string>
     <string name="upgrade_screen_restore_success_message">کڕین گێڕدرایەوە، نوێکاری Pro تەکەت چالاکە.</string>
     <string name="upgrade_screen_grace_title">پشتڕاستکردنی کڕینی تۆ</string>
     <string name="upgrade_screen_grace_body_short">Pro هێشتا چالاکە. چاوچاوی گوگڵ پلەی بۆ دیسا پشتڕاستکردنی کڕینی تۆ، هەموو تایبەتمەندیەکانی Pro لە ئێستادا بێ قفڵ ماونەتەوە.</string>

--- a/app/src/gplay/res/values-cs/strings.xml
+++ b/app/src/gplay/res/values-cs/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Toto je samostatný nákup: nezruší ani nevrací vaše předplatné. Používejte pro obě možnosti stejný účet Google.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Předplatné je stále aktivní</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play hlásí, že je vaše předplatné stále nastaveno na obnovení. Chcete-li koupit jednorázový upgrade, zrušte nejdříve předplatné v Google Play a poté se vraťte sem.\n\nPrávě jste ho zrušili? Dejte Google Play chvíli a zkuste to znovu. Ujistěte se také, že používáte stejný účet Google.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Nepovedlo se ověřit stav vašeho předplatného u Google Play. Zkuste to prosím za chvíli.</string>
     <string name="upgrade_screen_restore_success_message">Nákup obnoven, váš upgrade Pro je aktivní.</string>
     <string name="upgrade_screen_grace_title">Potvrzování vašeho nákupu</string>
     <string name="upgrade_screen_grace_body_short">Pro je stále aktivní. Čekám na Google Play, aby znovu potvrdil váš nákup, všechny funkce Pro zůstávají mezitím odemčeny.</string>

--- a/app/src/gplay/res/values-da/strings.xml
+++ b/app/src/gplay/res/values-da/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Dette er et separat køb: det annullerer eller refunderer ikke dit abonnement. Brug den samme Google-konto til begge.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Abonnement stadig aktivt</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play rapporterer, at dit abonnement stadig er indstillet til at forny sig. For at købe engangskøbet skal du først annullere abonnementet i Google Play og derefter vende tilbage her.\n\nNetop annulleret det? Giv Google Play et øjeblik og prøv igen. Sørg også for at du bruger den samme Google-konto.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Kunne ikke kontrollere dit abonnementstatus hos Google Play. Prøv venligst igen om et øjeblik.</string>
     <string name="upgrade_screen_restore_success_message">Køb gendannet, din Pro-opgradering er aktiv.</string>
     <string name="upgrade_screen_grace_title">Bekræfter dit køb</string>
     <string name="upgrade_screen_grace_body_short">Pro er stadig aktiv. Venter på, at Google Play bekræfter dit køb igen, alle Pro-funktioner forbliver låst op i mellemtiden.</string>

--- a/app/src/gplay/res/values-de/strings.xml
+++ b/app/src/gplay/res/values-de/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Dies ist ein separater Kauf: Er kündigt weder dein Abo noch erstattet er die Kosten. Verwende für beides dasselbe Google-Konto.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Abo noch aktiv</string>
     <string name="upgrade_screen_sub_still_renewing_message">Laut Google Play verlängert sich dein Abo weiterhin. Um das einmalige Upgrade zu kaufen, kündige das Abo zuerst in Google Play und kehre dann hierher zurück.\n\nDu hast es gerade gekündigt? Gib Google Play einen Moment Zeit und versuche es erneut. Stelle außerdem sicher, dass du dasselbe Google-Konto verwendest.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Abo-Status konnte nicht bei Google Play überprüft werden. Bitte versuche es gleich noch einmal.</string>
     <string name="upgrade_screen_restore_success_message">Kauf wiederhergestellt, Dein Pro Upgrade ist aktiv.</string>
     <string name="upgrade_screen_grace_title">Dein Kauf wird bestätigt</string>
     <string name="upgrade_screen_grace_body_short">Pro ist weiterhin aktiv. Es wird darauf gewartet, dass Google Play deinen Kauf erneut bestätigt. Alle Pro-Funktionen bleiben in der Zwischenzeit freigeschaltet.</string>

--- a/app/src/gplay/res/values-el/strings.xml
+++ b/app/src/gplay/res/values-el/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Αυτή είναι ξεχωριστή αγορά: δεν ακυρώνει ούτε επιστρέφει τα χρήματα της συνδρομής σας. Χρησιμοποιήστε τον ίδιο λογαριασμό Google και για τα δύο.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Η συνδρομή είναι ακόμα ενεργή</string>
     <string name="upgrade_screen_sub_still_renewing_message">Το Google Play αναφέρει ότι η συνδρομή σας είναι ακόμα ρυθμισμένη για ανανέωση. Για να αγοράσετε την εφάπαξ αναβάθμιση, ακυρώστε πρώτα τη συνδρομή στο Google Play και έπειτα επιστρέψτε εδώ.\n\nΜόλις την ακυρώσατε; Δώστε στο Google Play λίγο χρόνο και δοκιμάστε ξανά. Βεβαιωθείτε επίσης ότι χρησιμοποιείτε τον ίδιο λογαριασμό Google.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Δεν ήταν δυνατόν να ελεγχθεί η κατάσταση της συνδρομής σας με το Google Play. Δοκιμάστε ξανά σε λίγο.</string>
     <string name="upgrade_screen_restore_success_message">Η αγορά επαναφέρθηκε, η αναβάθμιση Pro είναι ενεργή.</string>
     <string name="upgrade_screen_grace_title">Επιβεβαίωση της αγοράς σας</string>
     <string name="upgrade_screen_grace_body_short">Το Pro είναι ακόμα ενεργό. Γίνεται αναμονή ώστε το Google Play να επιβεβαιώσει ξανά την αγορά σας, όλες οι δυνατότητες Pro παραμένουν ξεκλείδωτες στο μεταξύ.</string>

--- a/app/src/gplay/res/values-es-rAR/strings.xml
+++ b/app/src/gplay/res/values-es-rAR/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Esta es una compra separada: no cancela ni reembolsa tu suscripción. Usá la misma cuenta de Google para ambas.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Suscripción aún activa</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play informa que tu suscripción sigue configurada para renovarse. Para comprar la actualización de un pago único, cancelá la suscripción en Google Play primero, luego volvé aquí.\n\n¿Acabás de cancelarla? Dale un momento a Google Play e intentá de nuevo. También asegurate de que estés usando la misma cuenta de Google.</string>
-    <string name="upgrade_screen_sub_check_failed_message">No se pudo verificar tu estado de suscripción con Google Play. Intentá de nuevo en un momento.</string>
     <string name="upgrade_screen_restore_success_message">Compra restaurada, tu actualización Pro está activa.</string>
     <string name="upgrade_screen_grace_title">Confirmando tu compra</string>
     <string name="upgrade_screen_grace_body_short">Pro sigue activo. Esperando a que Google Play reconfirme tu compra, todas las características Pro permanecen desbloqueadas mientras tanto.</string>

--- a/app/src/gplay/res/values-es-rMX/strings.xml
+++ b/app/src/gplay/res/values-es-rMX/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Esta es una compra separada: no cancela ni reembolsa tu suscripción. Usa la misma cuenta de Google para ambas.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Suscripción aún activa</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play informa que tu suscripción aún está configurada para renovarse. Para comprar la actualización única, cancela primero la suscripción en Google Play y luego vuelve aquí.\n\n¿Acabas de cancelarla? Dale un momento a Google Play e intenta de nuevo. Asegúrate también de usar la misma cuenta de Google.</string>
-    <string name="upgrade_screen_sub_check_failed_message">No se pudo verificar tu estado de suscripción en Google Play. Por favor, intenta de nuevo en un momento.</string>
     <string name="upgrade_screen_restore_success_message">Compra restaurada, tu actualización Pro está activa.</string>
     <string name="upgrade_screen_grace_title">Confirmando tu compra</string>
     <string name="upgrade_screen_grace_body_short">Pro sigue activo. Esperando a que Google Play confirme tu compra nuevamente, todas las funciones Pro permanecen desbloqueadas mientras tanto.</string>

--- a/app/src/gplay/res/values-es/strings.xml
+++ b/app/src/gplay/res/values-es/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Esta es una compra independiente: no cancela ni reembolsa tu suscripción. Usa la misma cuenta de Google para ambas.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Suscripción aún activa</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play informa que tu suscripción sigue configurada para renovarse. Para comprar la actualización de pago único, cancela la suscripción en Google Play primero, luego vuelve aquí.\n\n¿Acabas de cancelarla? Dale a Google Play un momento e intenta de nuevo. También asegúrate de que estés usando la misma cuenta de Google.</string>
-    <string name="upgrade_screen_sub_check_failed_message">No se pudo verificar el estado de tu suscripción con Google Play. Por favor, intenta de nuevo en un momento.</string>
     <string name="upgrade_screen_restore_success_message">Compra restaurada, tu actualización Pro está activa.</string>
     <string name="upgrade_screen_grace_title">Confirmando tu compra</string>
     <string name="upgrade_screen_grace_body_short">Pro sigue activo. Esperando a que Google Play reconfirme tu compra, todas las características Pro permanecen desbloqueadas mientras tanto.</string>

--- a/app/src/gplay/res/values-et-rEE/strings.xml
+++ b/app/src/gplay/res/values-et-rEE/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">See on eraldiseisev ost: see ei tühista ega tagasta teie tellimust. Kasutage mõlema jaoks sama Google\'i kontot.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Tellimus on endiselt kasutatav</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play teatab, et teie tellimus on endiselt seadistatud uuenema. Ühekordse ostu tegemiseks tühistage esmalt Google Plays tellimus ja seejärel naaske siia.\n\nJust tühistasite? Andke Google Playle hetk aega ja proovige uuesti. Samuti veenduge, et kasutate sama Google\'i kontot.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Ei saanud teie tellimuse olekut Google Playga kontrollida. Proovige hetke pärast uuesti.</string>
     <string name="upgrade_screen_restore_success_message">Ost taastatud, teie Pro-versioon on kasutusel.</string>
     <string name="upgrade_screen_grace_title">Teie ostu kinnitamine</string>
     <string name="upgrade_screen_grace_body_short">Pro on endiselt kasutusel. Oodatakse, et Google Play kinnitaks teie ostu uuesti, senikaua jäävad kõik Pro võimalused avatuks.</string>

--- a/app/src/gplay/res/values-eu-rES/strings.xml
+++ b/app/src/gplay/res/values-eu-rES/strings.xml
@@ -54,7 +54,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Hau erosketa bereizta da: ez du zure harpidetza etetzen, ezta itzulera ematen. Erabili Google kontu bera bientzat.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Harpidetza oraindik aktiboa</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play-k zure harpidetza oraindik berrituko dela adierazten du. Aldiz bateko eguneraketa erosi ahal izateko, Google Play-n utzi harpidetza aurrenekoz, eta bueltatu hemen.\n\nBertan utzi duzu? Une bat itxaron eta saia zaitez berriro. Egiaztatu Google kontu bera erabiltzen ari zarela.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Google Play-rekin zure harpidetzaren egoera egiaztatu ezin izan. Mesedez, saia zaitez berriro une baten ondoren.</string>
     <string name="upgrade_screen_restore_success_message">Erosketak berreskuratu, zure Pro eguneraketa aktiboa da.</string>
     <string name="upgrade_screen_grace_title">Zure erosketak berrestea</string>
     <string name="upgrade_screen_grace_body_short">Pro oraindik aktiboa da. Google Play-k zure erosketak berrestea itxaroten, Pro ezaugarri guztiak oraindik desblokezatuta daude.</string>

--- a/app/src/gplay/res/values-fa/strings.xml
+++ b/app/src/gplay/res/values-fa/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">این یک خرید جداگانه است: این‌کار اشتراک شما را لغو یا بازپرداخت نمی‌کند. از همان حساب Google برای هر دو استفاده کنید.</string>
     <string name="upgrade_screen_sub_still_renewing_title">اشتراک هنوز فعال است</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play گزارش می‌دهد که اشتراک شما هنوز برای تمدید تنظیم شده است. برای خرید ارتقاء یک‌بار، ابتدا اشتراک را در Google Play لغو کنید و سپس به اینجا بازگردید.\n\nتازه لغو کردید؟ به Google Play کمی زمان دهید و دوباره تلاش کنید. همچنین مطمئن شوید که از همان حساب Google استفاده می‌کنید.</string>
-    <string name="upgrade_screen_sub_check_failed_message">نمی‌توان وضعیت اشتراک شما را با Google Play بررسی کرد. لطفاً پس از لحظه‌ای دوباره تلاش کنید.</string>
     <string name="upgrade_screen_restore_success_message">خرید بازیابی شد، ارتقاء Pro شما فعال است.</string>
     <string name="upgrade_screen_grace_title">تأیید خرید شما</string>
     <string name="upgrade_screen_grace_body_short">Pro هنوز فعال است. در انتظار Google Play برای تأیید مجدد خرید شما، تمام ویژگی‌های Pro در این میان باقی می‌ماند.</string>

--- a/app/src/gplay/res/values-fi/strings.xml
+++ b/app/src/gplay/res/values-fi/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Tämä on erillinen osto: se ei peruuta tai palauta tilaustasi. Käytä samaa Google-tiliä molempiin.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Tilaus on edelleen aktiivinen</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play ilmoittaa, että tilauksesi on edelleen asetettu uusiutumaan. Osta kertaluonteinen päivitys peruuttamalla ensin tilaus Google Playssa ja palaa sitten tähän.\n\nJuuri peruuttanut? Anna Google Playlle hetki aikaa ja yritä uudelleen. Varmista myös, että käytät samaa Google-tiliä.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Tilauksesi tilan tarkistaminen Google Playssa epäonnistui. Yritä uudelleen hetken kuluttua.</string>
     <string name="upgrade_screen_restore_success_message">Osto palautettu, Pro-päivitys on aktiivinen.</string>
     <string name="upgrade_screen_grace_title">Vahvistetaan ostoasi</string>
     <string name="upgrade_screen_grace_body_short">Pro on edelleen aktiivinen. Odotetaan Google Playn vahvistusta ostokselle, kaikki Pro-ominaisuudet pysyvät käytettävissä sillä välin.</string>

--- a/app/src/gplay/res/values-fil/strings.xml
+++ b/app/src/gplay/res/values-fil/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Ito ay isang hiwalay na pagbili: hindi nito ikinakansela o nire-refund ang iyong subscription. Gamitin ang parehong Google account para sa dalawa.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Ang subscription ay aktibo pa rin</string>
     <string name="upgrade_screen_sub_still_renewing_message">Iniulat ng Google Play na naka-set pa rin ang iyong subscription na mag-renew. Upang bumili ng one-time na upgrade, i-cancel muna ang subscription sa Google Play, pagkatapos bumalik dito.\n\nKakakansela mo lang? Bigyan ng sandali ang Google Play at subukan ulit. Tiyakin din na ginagamit mo ang parehong Google account.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Hindi ma-check ang status ng iyong subscription sa Google Play. Subukan ulit sa loob ng ilang sandali.</string>
     <string name="upgrade_screen_restore_success_message">Na-restore na ang pagbili, aktibo na ang iyong Pro upgrade.</string>
     <string name="upgrade_screen_grace_title">Kino-confirm ang iyong pagbili</string>
     <string name="upgrade_screen_grace_body_short">Aktibo pa rin ang Pro. Naghihintay sa Google Play na muling kumpirmahin ang iyong pagbili, mananatiling naka-unlock ang lahat ng Pro features sa ngayon.</string>

--- a/app/src/gplay/res/values-fr/strings.xml
+++ b/app/src/gplay/res/values-fr/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">C’est un achat séparé : il n’annule ni ne rembourse votre abonnement. Utilisez le même compte Google pour les deux.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Abonnement toujours actif</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play signale que votre abonnement est toujours configuré pour se renouveler. Pour acheter la mise à niveau unique, annulez d’abord l’abonnement sur Google Play, puis revenez ici.\n\nVous venez de l’annuler ? Donnez un moment à Google Play et réessayez. Assurez-vous également que vous utilisez le même compte Google.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Impossible de vérifier votre statut d’abonnement avec Google Play. Veuillez réessayer dans un instant.</string>
     <string name="upgrade_screen_restore_success_message">Achat restauré, votre mise à niveau Pro est active.</string>
     <string name="upgrade_screen_grace_title">Confirmation de votre achat</string>
     <string name="upgrade_screen_grace_body_short">Pro est toujours actif. En attendant que Google Play reconfirme votre achat, toutes les fonctionnalités Pro restent déverrouillées.</string>

--- a/app/src/gplay/res/values-gl-rES/strings.xml
+++ b/app/src/gplay/res/values-gl-rES/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Esta é unha compra independente: non cancela nin reembolsa a túa subscrición. Usa a mesma conta de Google para as dúas.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Subscrición aínda activa</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play indica que a túa subscrición aínda está configurada para renovarse. Para comprar a actualización dun só pagamento, cancela a subscrición en Google Play primeiro, logo volta aquí.\n\nAcabas de cancelala? Dálle un momento a Google Play e tenta de novo. Asegúrate tamén de que estás usando a mesma conta de Google.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Non se puido comprobar o estado da túa subscrición con Google Play. Por favor, tenta de novo nun momento.</string>
     <string name="upgrade_screen_restore_success_message">Compra restaurada, a túa actualización Pro está activa.</string>
     <string name="upgrade_screen_grace_title">Confirmando a túa compra</string>
     <string name="upgrade_screen_grace_body_short">Pro aínda está activo. Agardando a que Google Play confirme de novo a túa compra, todas as características de Pro seguen desbloqueadas de momento.</string>

--- a/app/src/gplay/res/values-hi-rIN/strings.xml
+++ b/app/src/gplay/res/values-hi-rIN/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">यह एक अलग खरीद है: यह आपकी सदस्यता को रद्द या वापस नहीं करेगा। दोनों के लिए एक ही Google खाता इस्तेमाल करें।</string>
     <string name="upgrade_screen_sub_still_renewing_title">सदस्यता अभी भी सक्रिय है</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play की रिपोर्ट है कि आपकी सदस्यता अभी भी नवीनीकरण के लिए सेट है। एकबारी अपग्रेड खरीदने के लिए, पहले Google Play में सदस्यता को रद्द करें, फिर यहाँ वापस आएं।\n\nअभी रद्द किया? Google Play को एक क्षण दें और फिर से कोशिश करें। यह भी सुनिश्चित करें कि आप एक ही Google खाता इस्तेमाल कर रहे हैं।</string>
-    <string name="upgrade_screen_sub_check_failed_message">Google Play के साथ आपकी सदस्यता की स्थिति की जांच नहीं कर सके। कृपया एक क्षण में फिर से कोशिश करें।</string>
     <string name="upgrade_screen_restore_success_message">खरीद बहाल की गई, आपका Pro अपग्रेड सक्रिय है।</string>
     <string name="upgrade_screen_grace_title">आपकी खरीद की पुष्टि की जा रही है</string>
     <string name="upgrade_screen_grace_body_short">Pro अभी भी सक्रिय है। Google Play से आपकी खरीद की पुष्टि की प्रतीक्षा की जा रही है, इस बीच सभी Pro सुविधाएं अनलॉक रहती हैं।</string>

--- a/app/src/gplay/res/values-hr/strings.xml
+++ b/app/src/gplay/res/values-hr/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Ovo je zasebna kupnja: ne otkazuje niti vraća novac za vašu pretplatu. Koristite isti Google račun za oboje.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Pretplata je i dalje aktivna</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play javlja da je vaša pretplata i dalje postavljena za obnavljanje. Za kupnju jednokratne nadogradnje, prvo otkažite pretplatu putem Google Playa, a zatim se vratite ovdje.\n\nUpravo ste je otkazali? Pričekajte trenutak da Google Play obradi promjenu i pokušajte ponovno. Također provjerite koristite li isti Google račun.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Nije bilo moguće provjeriti status vaše pretplate putem Google Playa. Pokušajte ponovno za trenutak.</string>
     <string name="upgrade_screen_restore_success_message">Kupnja je vraćena, vaša Pro nadogradnja je aktivna.</string>
     <string name="upgrade_screen_grace_title">Potvrđivanje vaše kupnje</string>
     <string name="upgrade_screen_grace_body_short">Pro je i dalje aktivan. Čeka se da Google Play ponovno potvrdi vašu kupnju, a sve Pro značajke u međuvremenu ostaju otključane.</string>

--- a/app/src/gplay/res/values-hu/strings.xml
+++ b/app/src/gplay/res/values-hu/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Ez egy külön vásárlás: nem mondja le és nem térít vissza az előfizetésedet. Használd ugyanazt a Google-fiókot mindkettőhöz.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Az előfizetés még mindig aktív</string>
     <string name="upgrade_screen_sub_still_renewing_message">A Google Play szerint az előfizetésed még mindig meg fog újulni. Az egyszeri frissítés megvásárlásához először mondd le az előfizetést a Google Playen, majd térj vissza ide.\n\nMost mondtad le? Adj egy kis időt a Google Playnek, és próbáld újra. Győződj meg róla, hogy ugyanazt a Google-fiókot használod.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Nem sikerült ellenőrizni az előfizetésed állapotát a Google Playnél. Kérjük, próbáld újra egy kicsit később.</string>
     <string name="upgrade_screen_restore_success_message">A vásárlás visszaállítva, a Pro frissítésed aktív.</string>
     <string name="upgrade_screen_grace_title">Vásárlás megerősítése</string>
     <string name="upgrade_screen_grace_body_short">A Pro továbbra is aktív. A Google Play megerősítésére várunk, addig is minden Pro funkció feloldva marad.</string>

--- a/app/src/gplay/res/values-in/strings.xml
+++ b/app/src/gplay/res/values-in/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Ini adalah pembelian terpisah: tidak membatalkan atau mengembalikan dana langganan Anda. Gunakan akun Google yang sama untuk keduanya.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Langganan masih aktif</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play melaporkan bahwa langganan Anda masih diatur untuk diperbarui. Untuk membeli peningkatan sekali bayar, batalkan langganan di Google Play terlebih dahulu, lalu kembali ke sini.\n\nBaru saja membatalkannya? Beri Google Play sedikit waktu dan coba lagi. Pastikan juga Anda menggunakan akun Google yang sama.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Tidak dapat memeriksa status langganan Anda dengan Google Play. Silakan coba lagi sebentar.</string>
     <string name="upgrade_screen_restore_success_message">Pembelian dipulihkan, peningkatan Pro Anda aktif.</string>
     <string name="upgrade_screen_grace_title">Mengonfirmasi pembelian Anda</string>
     <string name="upgrade_screen_grace_body_short">Pro masih aktif. Menunggu Google Play mengonfirmasi ulang pembelian Anda, semua fitur Pro tetap terbuka sementara itu.</string>

--- a/app/src/gplay/res/values-is/strings.xml
+++ b/app/src/gplay/res/values-is/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Þetta er aðskilin kaup: það hættir ekki né endurgreiðir áskriftina þína. Notaðu sama Google reikning fyrir hvort tveggja.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Áskrift ennþá virk</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play tilkynnir að áskriftin þín sé ennþá sett til endurnýjunar. Til að kaupa einskiptis endurbótina, hættu áskriftinni í Google Play fyrst, komdu síðan aftur hingað.\n\nErtu búin að segja henni upp? Gefðu Google Play stund og reyndu aftur. Gakktu líka úr skugga um að þú notir sama Google reikning.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Gat ekki athugað stöðu áskriftarinnar þinnar með Google Play. Reyndu aftur eftir stund.</string>
     <string name="upgrade_screen_restore_success_message">Kaup endurheimt, Pro endurbótin þín er virk.</string>
     <string name="upgrade_screen_grace_title">Staðfesting kaupsins</string>
     <string name="upgrade_screen_grace_body_short">Pro er ennþá virk. Bið eftir að Google Play staðfesti kaupin þín aftur, allir Pro eiginleikar halda áfram að vera ólokaðir á meðan.</string>

--- a/app/src/gplay/res/values-it/strings.xml
+++ b/app/src/gplay/res/values-it/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Questo è un acquisto separato: non annulla né rimborsa il tuo abbonamento. Usa lo stesso account Google per entrambi.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Abbonamento ancora attivo</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play segnala che il tuo abbonamento è ancora impostato per il rinnovo. Per acquistare l’aggiornamento una tantum, annulla prima l’abbonamento su Google Play, poi torna qui.\n\nL’hai appena annullato? Dai un momento a Google Play e riprova. Assicurati anche di usare lo stesso account Google.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Impossibile verificare lo stato del tuo abbonamento con Google Play. Riprova tra un momento.</string>
     <string name="upgrade_screen_restore_success_message">Acquisto ripristinato, il tuo aggiornamento Pro è attivo.</string>
     <string name="upgrade_screen_grace_title">Conferma del tuo acquisto in corso</string>
     <string name="upgrade_screen_grace_body_short">Pro è ancora attivo. In attesa che Google Play riconfermi il tuo acquisto, tutte le funzionalità Pro restano sbloccate nel frattempo.</string>

--- a/app/src/gplay/res/values-iw/strings.xml
+++ b/app/src/gplay/res/values-iw/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">זו רכישה נפרדת: היא לא מבטלת או מחזירה כספים על המנוי שלך. השתמש באותו חשבון Google לשניהם.</string>
     <string name="upgrade_screen_sub_still_renewing_title">המנוי עדיין פעיל</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play מדווח שהמנוי שלך עדיין מוגדר להתחדש. כדי לקנות את השדרוג החד-פעמי, בטל תחילה את המנוי ב-Google Play, ואז חזור לכאן.\n\nבטלת זה עתה? תן ל-Google Play רגע ונסה שוב. ודא גם שאתה משתמש באותו חשבון Google.</string>
-    <string name="upgrade_screen_sub_check_failed_message">לא היה אפשר לבדוק את סטטוס המנוי שלך ב-Google Play. בבקשה נסה שוב בעוד רגע.</string>
     <string name="upgrade_screen_restore_success_message">הרכישה שוחזרה, השדרוג Pro שלך פעיל.</string>
     <string name="upgrade_screen_grace_title">מאשר את הרכישה שלך</string>
     <string name="upgrade_screen_grace_body_short">Pro עדיין פעיל. ממתין ל-Google Play לאישור חוזר של הרכישה שלך, כל התכונות של Pro נשארות פתוחות בינתיים.</string>

--- a/app/src/gplay/res/values-ja/strings.xml
+++ b/app/src/gplay/res/values-ja/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">これは別個の購入です。サブスクリプションの解約や返金は行われません。両方に同じGoogleアカウントを使用してください。</string>
     <string name="upgrade_screen_sub_still_renewing_title">サブスクリプションはまだ有効です</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Playによると、サブスクリプションはまだ更新するように設定されています。一度限りのアップグレードを購入するには、まず Google Play でサブスクリプションを解約してから、ここに戻ってきてください。\n\n解約したばかりですか? しばらく待ってからもう一度お試しください。また、同じGoogleアカウントを使用していることをご確認ください。</string>
-    <string name="upgrade_screen_sub_check_failed_message">Google Playでサブスクリプションの状態を確認できませんでした。しばらくしてからもう一度お試しください。</string>
     <string name="upgrade_screen_restore_success_message">購入が復元され、Proアップグレードが有効になりました。</string>
     <string name="upgrade_screen_grace_title">購入を確認しています</string>
     <string name="upgrade_screen_grace_body_short">Proはまだ有効です。Google Playが購入を再確認するのを待っている間も、Proの全機能のロックは解除されたままです。</string>

--- a/app/src/gplay/res/values-ka-rGE/strings.xml
+++ b/app/src/gplay/res/values-ka-rGE/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">ეს არის ცალკე ყიდვა: იგი არ გაუქმებს და არ დაბრუნებს თქვენს გამოწერას. გამოიყენეთ იგივე Google ანგარიში ორივესთვის.</string>
     <string name="upgrade_screen_sub_still_renewing_title">გამოწერა კვლავ აქტიური</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play იტყობინება, რომ თქვენი გამოწერა კვლავ დაყენებულია განახლებისთვის. ერთჯერადი განახლება რომ ვიყიდოთ, ჯერ გაუქმოთ გამოწერა Google Play-ში, შემდეგ დაბრუნდით აქ.\n\nახლახან გაუქმეთ? მოცემეთ Google Play-ს დრო და სცადეთ ხელახლა. ასევე დარწმუნდით, რომ იყენებთ იგივე Google ანგარიშს.</string>
-    <string name="upgrade_screen_sub_check_failed_message">ვერ შეძლო თქვენი გამოწერის სტატუსის შემოწმება Google Play-ში. გთხოვთ, მომენტში ხელახლა სცადეთ.</string>
     <string name="upgrade_screen_restore_success_message">ყიდვა აღდგა, თქვენი Pro განახლება აქტიური.</string>
     <string name="upgrade_screen_grace_title">თქვენი ყიდვის დადასტურება</string>
     <string name="upgrade_screen_grace_body_short">Pro კვლავ აქტიური. ველოდებთ, რომ Google Play ხელახლა დაადასტუროს თქვენი ყიდვა, ყველა Pro ფუნქცია განბლოკირებული რჩება ამ დროს.</string>

--- a/app/src/gplay/res/values-kaa/strings.xml
+++ b/app/src/gplay/res/values-kaa/strings.xml
@@ -53,7 +53,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Bul alohida satın alma: u sızding abonementıńızni bekor qilmaydu va pul qaytırma olmaydu. Ekilesin ushın bir xıl Google akkaunt paylanıńız.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Abonement heniz faoliy</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play xabar bergénde, sızding abonementıńız heniz yangilanshalı o\'rnatılgan. Bir marti upgrade satın almak ushın, birinche Google Play-da abonementıńızni bekor qilin, soñ bu yerge qaytıńız.\n\nBekor qildıńız ba? Google Play-ga bir az vaqıt berıńiz va qayta surınız. Sız bir xıl Google akkaunt paylanıp atingız.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Sızding abonement holatını Google Play bilen tekshiribe bolalmadi. Iltimas, bir az vaqıttan soñ qayta surınız.</string>
     <string name="upgrade_screen_restore_success_message">Satın alma tiklandi, sızding Pro upgrade faoliy.</string>
     <string name="upgrade_screen_grace_title">Sızding satın almashıńızni tastıqlaw</string>
     <string name="upgrade_screen_grace_body_short">Pro heniz faoliy. Google Play sızding satın almashıńızni qayta tastıqlaw kʼtilmoqde, bul vaqıtda barlıq Pro xususiyetleri oyıq qaladi.</string>

--- a/app/src/gplay/res/values-km-rKH/strings.xml
+++ b/app/src/gplay/res/values-km-rKH/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">នេះគឺជាការទិញដាច់ដោយឡែក៖ វាមិនលុបចោល ឬប្តូរប្រាក់ឱ្យលក់ឡើងវិញរបស់អ្នកទេ។ ប្រើគណនី Google ដូចគ្នាសម្រាប់ទាំងពីរ។</string>
     <string name="upgrade_screen_sub_still_renewing_title">ការលក់ឡើងវិញនៅតែសកម្ម</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play រាយការណ៍ថាការលក់ឡើងវិញរបស់អ្នកនៅតែកំណត់ដើម្បីឱ្យប្តូរ។ ដើម្បីទិញការលើកប្រទឹងម្តង សូមលុបចោលការលក់ឡើងវិញក្នុង Google Play ជាមុនសិន ហើយបន្ទាប់មកត្រឡប់មកទីនេះវិញ។\n\nទើសលុបចោលវាដែរ? ឱ្យពេលវេលាដល់ Google Play ហើយព្យាយាមម្តងទៀត។ ក៏ប្រាកដថាអ្នកកំពុងប្រើប្រាស់គណនី Google ដូចគ្នា។</string>
-    <string name="upgrade_screen_sub_check_failed_message">មិនអាចពិនិត្យស្ថានភាពការលក់ឡើងវិញរបស់អ្នកនៅក្នុង Google Play បានទេ។ សូមព្យាយាមម្តងទៀតក្នុងពេលឆាប់ៗ។</string>
     <string name="upgrade_screen_restore_success_message">ការទិញត្រូវបានស្ដារ ការលើកប្រទឹង Pro របស់អ្នកកំពុងដំណើរការ។</string>
     <string name="upgrade_screen_grace_title">ការបញ្ជាក់ការទិញរបស់អ្នក</string>
     <string name="upgrade_screen_grace_body_short">Pro នៅតែសកម្ម។ រង់ចាំដល់ Google Play ដើម្បីបញ្ជាក់ឡើងវិងក្នុងការទិញរបស់អ្នក មុខងារ Pro ទាំងអស់នៅតែដំណើរការ ក្នុងរយៈពេលនេះ។</string>

--- a/app/src/gplay/res/values-ko/strings.xml
+++ b/app/src/gplay/res/values-ko/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">이것은 별도의 구매입니다: 구독을 취소하거나 환불하지 않습니다. 두 경우 모두 동일한 Google 계정을 사용하세요.</string>
     <string name="upgrade_screen_sub_still_renewing_title">구독이 여전히 활성 상태입니다</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play에서 귀하의 구독이 여전히 자동 갱신으로 설정되어 있다고 보고합니다. 일회 업그레이드를 구매하려면 먼저 Google Play에서 구독을 취소한 후 여기로 돌아오세요.\n\n방금 취소했습니까? Google Play가 처리될 때까지 잠시 기다렸다가 다시 시도하세요. 동일한 Google 계정을 사용하고 있는지도 확인하세요.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Google Play로 구독 상태를 확인할 수 없습니다. 잠시 후 다시 시도해주세요.</string>
     <string name="upgrade_screen_restore_success_message">구매가 복구되었으며, Pro 업그레이드가 활성화되었습니다.</string>
     <string name="upgrade_screen_grace_title">구매 확인 중</string>
     <string name="upgrade_screen_grace_body_short">Pro가 여전히 활성입니다. Google Play가 구매를 다시 확인할 때까지 기다리는 중이며, 그동안 모든 Pro 기능은 잠금 해제 상태로 유지됩니다.</string>

--- a/app/src/gplay/res/values-lo-rLA/strings.xml
+++ b/app/src/gplay/res/values-lo-rLA/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">ນີ້ແມ່ນການຊື້ແຍກຕ່າງຫາກ: ມັນບໍ່ໄດ້ຍົກເລີກ ຫຼືຄືນເງິນທີ່ສະບັບຂອງທ່ານ. ໃຊ້ບັນຊີ Google ດຽວກັນສໍາລັບທັງສອງ.</string>
     <string name="upgrade_screen_sub_still_renewing_title">ການສະໝັກສະບັບຍັງຄົງໃຊ້ວຽກ</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play ລາຍງານວ່າການສະໝັກສະບັບຂອງທ່ານຍັງຄົງຕັ້ງໄວ້ເພື່ອຕໍ່ອາຍຸ. ເພື່ອຊື້ຕົວອັບເກຣດຄັ້ງດຽວ ໃຫ້ຍົກເລີກການສະໝັກສະບັບໃນ Google Play ກ່ອນ ແລ້ວກັບມາທີ່ນີ້.\n\nຫາກເພິ່ງຍົກເລີກ? ລໍ່ Google Play ສັກຈັກນາທີ ແລ້ວລອງອີກຄັ້ງ. ນອກຈາກນັ້ນໃຫ້ແນ່ໃຈວ່າທ່ານໃຊ້ບັນຊີ Google ດຽວກັນ.</string>
-    <string name="upgrade_screen_sub_check_failed_message">ບໍ່ສາມາດກວດສອບສະຖານະການສະໝັກສະບັບຂອງທ່ານກັບ Google Play. ກະລຸນາລອງອີກຄັ້ງຕໍ່ໄປ.</string>
     <string name="upgrade_screen_restore_success_message">ການຊື້ໄດ້ຮັບຟື້ນຟູ ການອັບເກຣດ Pro ຂອງທ່ານໄດ້ເປີດໃຊ້ງານ.</string>
     <string name="upgrade_screen_grace_title">ກໍາລັງຢືນຢັນການຊື້ຂອງທ່ານ</string>
     <string name="upgrade_screen_grace_body_short">Pro ຍັງຄົງໃຊ້ວຽກ. ກໍາລັງລໍ່ຕໍ່ Google Play ໃຫ້ຢືນຢັນການຊື້ຂອງທ່ານຄືນ, ທຸກລັກສະນະ Pro ຍັງຄົງປົດລັອກໃນລະຫວ່າງນີ້.</string>

--- a/app/src/gplay/res/values-lt/strings.xml
+++ b/app/src/gplay/res/values-lt/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Tai atskiras pirkinys: tai neatsauks jūsų prenumeratos ir nesugražins pinigų. Naudokite tą pačią „Google“ paskyrą abiem.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Prenumerata vis dar aktyvi</string>
     <string name="upgrade_screen_sub_still_renewing_message">„Google Play“ praneša, kad jūsų prenumerata vis dar nustatyta atsinaujinti. Norėdami įsigyti vienkartinį atnaujinimą, pirmiausia atšaukite prenumeratą programoje „Google Play“, tada grįžkite čia.\n\nJau atšaukėte? Leiskite „Google Play“ momentui ir bandykite dar kartą. Taip pat įsitikinkite, kad naudojate tą pačią „Google“ paskyrą.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Nepavyko patikrinti jūsų prenumeratos būsenos naudojant „Google Play“. Prašome bandyti dar kartą šiek tiek vėliau.</string>
     <string name="upgrade_screen_restore_success_message">Pirkinys atkurtas, jūsų „Pro“ atnaujinimas yra aktyvus.</string>
     <string name="upgrade_screen_grace_title">Patvirtinamas jūsų pirkinys</string>
     <string name="upgrade_screen_grace_body_short">„Pro“ vis dar aktyvus. Laukiame, kol „Google Play“ patvirtins jūsų pirkinį. Tuo tarpu visos „Pro“ funkcijos lieka atblokuotos.</string>

--- a/app/src/gplay/res/values-lv/strings.xml
+++ b/app/src/gplay/res/values-lv/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Šis ir atsevišķs pirkums: tas neatceļ un neatmaksā jūsu abonementu. Abiem izmantojiet vienu un to pašu Google kontu.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Abonements joprojām ir aktīvs</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play ziņo, ka jūsu abonements joprojām ir iestatīts uz atjaunošanu. Lai iegādātos vienreizējo jauninājumu, vispirms atceliet abonementu programmā Google Play, pēc tam atgriezieties šeit.\n\nTikko atcelts? Dodiet Google Play nedaudz laika un mēģiniet vēlreiz. Pārliecinieties arī, ka izmantojat vienu un to pašu Google kontu.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Nevarēja pārbaudīt jūsu abonementa statusu programmā Google Play. Lūdzu, mēģiniet vēlreiz pēc brīža.</string>
     <string name="upgrade_screen_restore_success_message">Pirkums atjaunots, jūsu Pro jauninājums ir aktīvs.</string>
     <string name="upgrade_screen_grace_title">Apstiprinām jūsu pirkumu</string>
     <string name="upgrade_screen_grace_body_short">Pro joprojām ir aktīvs. Gaidām uz Google Play apstiprinājumu, tikmēr visi Pro pakalpojumi paliek atbloķēti.</string>

--- a/app/src/gplay/res/values-mk-rMK/strings.xml
+++ b/app/src/gplay/res/values-mk-rMK/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Ова е одвоена куповина: таа не ја откажува или враќа вашата претплата. Користете иста Google сметка за обете.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Претплата е сеуште активна</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play пријавува дека вашата претплата е сеуште поставена да се обнови. За да го купите еднократното надградување, прво откажете ја претплатата во Google Play, потоа вратете се тука.\n\nШтотуку ја откажавте? Дајте му момент на Google Play и пробајте повторно. Исто така, проверете дека користите иста Google сметка.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Не можам да го проверам статусот на вашата претплата со Google Play. Ве молиме пробајте повторно за момент.</string>
     <string name="upgrade_screen_restore_success_message">Куповината е повратена, вашето Pro надградување е активно.</string>
     <string name="upgrade_screen_grace_title">Потврдување на вашата куповина</string>
     <string name="upgrade_screen_grace_body_short">Pro е сеуште активен. Чекам Google Play да ја потврди повторно вашата куповина, сите Pro функции остануваат отклучени до тогаш.</string>

--- a/app/src/gplay/res/values-ml-rIN/strings.xml
+++ b/app/src/gplay/res/values-ml-rIN/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">ഇത് വേറിട്ടുള്ള ഒരു വാങ്ങൽ ആണ്: ഇത് നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ റദ്ദാക്കുകയോ കാശ് തിരികെ നൽകുകയോ ചെയ്യുന്നില്ല. രണ്ടിനുമായി ഒറെ Google അക്കൗണ്ട് ഉപയോഗിക്കുക.</string>
     <string name="upgrade_screen_sub_still_renewing_title">സബ്സ്ക്രിപ്ഷൻ ഇപ്പോഴും സജീവമാണ്</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play റിപ്പോർട്ട് ചെയ്യുന്നത് നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ നവീകരിക്കാനായി സജ്ജീകരിച്ചിരിക്കുന്നുവെന്നാണ്. ഒറ്റത്തവണ അപ്‌ഗ്രേഡ് വാങ്ങാൻ, ആദ്യം Google Play-ൽ സബ്സ്ക്രിപ്ഷൻ റദ്ദാക്കുക, തുടർന്ന് ഇവിടെ തിരിച്ചുവരിക.\n\nഇതുവെച്ച് റദ്ദാക്കി? Google Play-യ്ക് കുറച്ച് സമയം കൊടുക്കുക കൂടാതെ വീണ്ടും ശ്രമിക്കുക. ഒറെ Google അക്കൗണ്ട് ഉപയോഗിക്കുന്നുവെന്ന് ഉറപ്പാക്കുക.</string>
-    <string name="upgrade_screen_sub_check_failed_message">നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ നില Google Play-ജംമായി പരിശോധിക്കാനായില്ല. കുറച്ച് സമയത്തിനിടയിൽ വീണ്ടും ശ്രമിക്കുക.</string>
     <string name="upgrade_screen_restore_success_message">വാങ്ങൽ പുനൃസ്ഥാപിതമായി, നിങ്ങളുടെ Pro അപ്‌ഗ്രേഡ് സജീവമാണ്.</string>
     <string name="upgrade_screen_grace_title">നിങ്ങളുടെ വാങ്ങൽ സ്ഥിരീകരിക്കുന്നു</string>
     <string name="upgrade_screen_grace_body_short">Pro ഇപ്പോഴും സജീവമാണ്. Google Play നിങ്ങളുടെ വാങ്ങൽ വീണ്ടും സ്ഥിരീകരിക്കാനായി കാത്തിരിക്കുന്നു, അതിനിടയ്ക്ക് എല്ലാ Pro ഫീച്ചറുകളും അൻലോക്ക് ആയതായി തുടരുന്നു.</string>

--- a/app/src/gplay/res/values-mn-rMN/strings.xml
+++ b/app/src/gplay/res/values-mn-rMN/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Энэ нь тусдаа худалдан авалт юм: энэ нь таны подпискийг цуцлахгүй, мөн буцаан авалт өгөхгүй. Хоёулангийн хувьд ижил Google акаунт ашиглаарай.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Подписк хэвээр идэвхтэй</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play-с таны подписк сунгахаар тохиргуулагдсан гэж мэдээлэлтэй байна. Нэг удаагийн худалдан авалтыг худалдахын тулд эхлээд Google Play-д подпискийг цуцлаад энд буцж ирээрэй.\n\nДөнгөж цуцласан уу? Google Play-д бага хугацаа өгөөд дахин оролдоно уу. Мөн та ижил Google акаунт ашиглаж байгаа эсэхийг шалгаарай.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Google Play-д таны подпискийн статусыг шалгаж чадсангүй. Та бага хугацаа хүлээгээд дахин оролдоно уу.</string>
     <string name="upgrade_screen_restore_success_message">Худалдан авалт сэргээгдсэн, таны Pro идэвхтэй байна.</string>
     <string name="upgrade_screen_grace_title">Таны худалдан авалтыг баталж байна</string>
     <string name="upgrade_screen_grace_body_short">Pro хэвээр идэвхтэй байна. Google Play таны худалдан авалтыг дахин баталахыг хүлээж байна, энэ хооронд Pro-ийн бүх функцууд нээлттэй хэвээр байна.</string>

--- a/app/src/gplay/res/values-ms/strings.xml
+++ b/app/src/gplay/res/values-ms/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Ini adalah pembelian yang berasingan: ia tidak membatalkan atau memulangkan bayaran langganan anda. Gunakan akaun Google yang sama untuk kedua-duanya.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Langganan masih aktif</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play melaporkan bahawa langganan anda masih ditetapkan untuk diperbaharui. Untuk membeli peningkatan sekali sahaja, batalkan langganan di Google Play terlebih dahulu, kemudian kembali ke sini.\n\nBaru saja membatalkannya? Tunggu sebentar lagi dan cuba lagi. Pastikan juga bahawa anda menggunakan akaun Google yang sama.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Tidak dapat memeriksa status langganan anda dengan Google Play. Sila cuba lagi sebentar lagi.</string>
     <string name="upgrade_screen_restore_success_message">Pembelian dipulihkan, peningkatan Pro anda aktif.</string>
     <string name="upgrade_screen_grace_title">Mengesahkan pembelian anda</string>
     <string name="upgrade_screen_grace_body_short">Pro masih aktif. Menunggu Google Play mengesahkan semula pembelian anda, semua ciri Pro kekal dibuka buat sementara waktu.</string>

--- a/app/src/gplay/res/values-my-rMM/strings.xml
+++ b/app/src/gplay/res/values-my-rMM/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">ဤသည်သည်သီးခြားဝယ်ယူမှုဖြစ်သည် - ၎င်းသည်သင်၏စာရင်းသွင်းမှုကိုဖျက်သိမ်းခြင်းသို့မဟုတ်အခြေခံငွေလည်ပတ်မှုမပြုလုပ်ပါ။ နှစ်ခုလုံးအတွက်တူညီသော Google အကောင့်ကိုအသုံးပြုပါ။</string>
     <string name="upgrade_screen_sub_still_renewing_title">စာရင်းသွင်းမှုယေဘုယျအားဖြင့်ရှင်သန်နေသည်</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play သည်သင်၏စာရင်းသွင်းမှုသည်အသစ်လည်ပတ်ရန်သတ်မှတ်ထားသည်ဟုအစီရင်ခံပြသည်။ အကြိမ်တစ်ကြိမ်အဆင့်မြှင့်တင်မှုကိုဝယ်ယူရန် Google Play တွင်စာရင်းသွင်းမှုကိုဦးတည်ဖျက်သိမ်းပါ၊ ထို့နောက်ဤနေရာသို့ပြန်လည်သွားရောက်ပါ။\n\nခုခုဖျက်သိမ်းလုပ်နေပါသလား။ Google Play ကိုအခွင့်အလမ်းပေးပြီးထပ်မံကြိုးစားပါ။ သင်သည်တူညီသော Google အကောင့်ကိုအသုံးပြုနေကြောင်းအတည်ပြုပါ။</string>
-    <string name="upgrade_screen_sub_check_failed_message">Google Play ဖြင့်သင်၏စာရင်းသွင်းမှုအခြေအနေကိုဆန်းစစ်နိုင်ခြင်းမရှိသည်။ အခွင့်အလမ်းပေးပြီးထပ်မံကြိုးစားပါ။</string>
     <string name="upgrade_screen_restore_success_message">ဝယ်ယူမှုပြန်လည်ရယူပြီးသည်။ သင်၏ Pro အဆင့်မြှင့်တင်မှုသည်ရှင်သန်ဖြစ်နေသည်။</string>
     <string name="upgrade_screen_grace_title">သင်၏ဝယ်ယူမှုကိုအတည်ပြုနေသည်</string>
     <string name="upgrade_screen_grace_body_short">Pro သည်ယေဘုယျအားဖြင့်ရှင်သန်နေသည်။ Google Play သည်သင်၏ဝယ်ယူမှုအတည်ပြုခြင်းအတွက်စောင့်ဆိုင်းနေသည်။ ယခုအချိန်တွင် Pro အင်္ဂါရပ်များအားလုံးသည်အခွင့်ပြုပြီးရှိသည်။</string>

--- a/app/src/gplay/res/values-nb/strings.xml
+++ b/app/src/gplay/res/values-nb/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Dette er et eget kjøp som verken kansellerer eller refunderer abonnementet ditt. Bruk samme Google-konto for begge.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Abonnement fortsatt aktivt</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play rapporterer at abonnementet ditt fortsatt er satt til å fornyes. For å kjøpe den permanente oppgraderingen må du først kansellere abonnementet i Google Play, deretter komme tilbake hit.\n\nAkkurat kansellert det? Gi Google Play et øyeblikk og prøv igjen. Pass også på at du bruker samme Google-konto.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Kunne ikke kontrollere abonnementstatusen din med Google Play. Vennligst prøv igjen om et øyeblikk.</string>
     <string name="upgrade_screen_restore_success_message">Kjøp gjenopprettet, Pro-oppgraderingen din er aktiv.</string>
     <string name="upgrade_screen_grace_title">Bekrefter kjøpet ditt</string>
     <string name="upgrade_screen_grace_body_short">Pro er fortsatt aktivt. Venter på at Google Play skal bekrefte kjøpet ditt på nytt. I mellomtiden forblir alle Pro-funksjoner tilgjengelige.</string>

--- a/app/src/gplay/res/values-ne-rNP/strings.xml
+++ b/app/src/gplay/res/values-ne-rNP/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">यो अलग खरिद हो: यसले तपाईंको सदस्यता रद्द वा फिर्ता गर्दैन। दुवैको लागि एउटै Google खाता प्रयोग गर्नुहोस्।</string>
     <string name="upgrade_screen_sub_still_renewing_title">सदस्यता अझै पनि सक्रिय छ</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play रिपोर्ट गर्छ कि तपाईंको सदस्यता अझै पनि नवीकरण गर्न सेट छ। एक पटकको अपग्रेड खरिद गर्न, पहिले Google Play मा सदस्यता रद्द गर्नुहोस्, त्यसपछि यहाँ फर्किनुहोस्।\n\nभर्खर रद्द गर्नुभयो? Google Play लाई एक क्षण दिनुहोस् र फेरि प्रयास गर्नुहोस्। साथै, तपाईं एउटै Google खाता प्रयोग गरिरहेको छ भन्ने कुरा सुनिश्चित गर्नुहोस्।</string>
-    <string name="upgrade_screen_sub_check_failed_message">Google Play सँग तपाईंको सदस्यता स्थिति जाँच गर्न सकिएन। कृपया एक क्षणपछि फेरि प्रयास गर्नुहोस्।</string>
     <string name="upgrade_screen_restore_success_message">खरिद पुनर्स्थापित गरिएको छ, तपाईंको Pro अपग्रेड सक्रिय छ।</string>
     <string name="upgrade_screen_grace_title">तपाईंको खरिद पुष्टि गरिँदै छ</string>
     <string name="upgrade_screen_grace_body_short">Pro अझै पनि सक्रिय छ। Google Play लाई तपाईंको खरिद पुनः पुष्टि गर्नको लागि प्रतीक्षा गरिँदै छ, यस बीचमा सबै Pro सुविधाहरु अनलक रहन्छ।</string>

--- a/app/src/gplay/res/values-nl/strings.xml
+++ b/app/src/gplay/res/values-nl/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Dit is een aparte aankoop: je abonnement wordt hiermee niet geannuleerd en het aankoopbedrag wordt niet terugbetaald. Gebruik voor beide aankopen hetzelfde Google-account.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Abonnement nog steeds actief</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play meldt dat je abonnement nog steeds automatisch verlengd moet worden. Om de eenmalige upgrade te kopen, moet je eerst je abonnement in Google Play annuleren en daarna hier terugkomen.\n\nNet geannuleerd? Geef Google Play even de tijd en probeer het opnieuw. Zorg er ook voor dat je hetzelfde Google-account gebruikt.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Kon je abonnementsstatus niet controleren met Google Play. Probeer het zo meteen opnieuw.</string>
     <string name="upgrade_screen_restore_success_message">Aankoop hersteld, je Pro-upgrade is actief.</string>
     <string name="upgrade_screen_grace_title">Je aankoop bevestigen</string>
     <string name="upgrade_screen_grace_body_short">Pro is nog steeds actief. Wachten tot Google Play je aankoop opnieuw bevestigt; alle Pro-functies blijven ondertussen ontgrendeld.</string>

--- a/app/src/gplay/res/values-or-rIN/strings.xml
+++ b/app/src/gplay/res/values-or-rIN/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">ଏଟି ଏକ ଭିନ୍ନ କ୍ରୟ: ଏହା ଆପଣଙ୍କ ସବସ୍କ୍ରିପ୍ସନକୁ ବାତିଲ କିମ୍ବା ରିଫଣ୍ଡ କରେ ନାହିଁ। ଉଭୟ ପାଇଁ ସମାନ Google ଖାତା ବ୍ୟବହାର କରନ୍ତୁ।</string>
     <string name="upgrade_screen_sub_still_renewing_title">ସବସ୍କ୍ରିପ୍ସନ ଅବିରତ ସକ୍ରିୟ</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play ରିପୋର୍ଟ କରେ ଯେ ଆପଣଙ୍କ ସବସ୍କ୍ରିପ୍ସନ ଅବିରତ ନବୀକରଣ ପାଇଁ ସେଟ ଅଛି। ଏକଥର ଅପଗ୍ରେଡ କିଣିବାକୁ, ପ୍ରଥମେ Google Play ରେ ସବସ୍କ୍ରିପ୍ସନ ବାତିଲ କରନ୍ତୁ, ତାପରେ ଏଠାକୁ ଫେରି ଆସନ୍ତୁ।\n\nଏହା ବର୍ତ୍ତମାନ ବାତିଲ କଲେ? Google Play କୁ ଏକ ମୁହୂର୍ତ୍ତ ଦିଅନ୍ତୁ ଓ ପୁନର୍ବାର ଚେଷ୍ଟା କରନ୍ତୁ। ଆଶ୍ୱାସ ଦିଅନ୍ତୁ ଯେ ଆପଣ ସମାନ Google ଖାତା ବ୍ୟବହାର କରୁଛନ୍ତି।</string>
-    <string name="upgrade_screen_sub_check_failed_message">Google Play ସହିତ ଆପଣଙ୍କ ସବସ୍କ୍ରିପ୍ସନ ସ୍ଥିତି ଯାଞ୍ଚ କରିପାରିଲି ନାହିଁ। ଦୟା କରି କିଛି ସମୟ ପରେ ପୁନର୍ବାର ଚେଷ୍ଟା କରନ୍ତୁ।</string>
     <string name="upgrade_screen_restore_success_message">କ୍ରୟ ପୁନରୁଦ୍ଧାର ହୋଇଛି, ଆପଣଙ୍କ Pro ଅପଗ୍ରେଡ ସକ୍ରିୟ।</string>
     <string name="upgrade_screen_grace_title">ଆପଣଙ୍କ କ୍ରୟ ନିଶ୍ଚିତ କରାଯାଉଛି</string>
     <string name="upgrade_screen_grace_body_short">Pro ଅବିରତ ସକ୍ରିୟ। Google Play ଆପଣଙ୍କ କ୍ରୟ ପୁନର୍ନିଶ୍ଚିତ କରିବାକୁ ଅପେକ୍ଷା କରୁଛି, ସମସ୍ତ Pro ବୈଶିଷ୍ଟ୍ୟ ଏହି ସମୟରେ ଅନଲକ୍ଡ ରହେ।</string>

--- a/app/src/gplay/res/values-pa-rIN/strings.xml
+++ b/app/src/gplay/res/values-pa-rIN/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">ਇਹ ਇੱਕ ਵੱਖ ਖਰੀਦ ਹੈ: ਇਹ ਤੁਹਾਡੀ ਸਬਸਕ੍ਰਿਪਸ਼ਨ ਨੂੰ ਰੱਦ ਨਹੀਂ ਕਰਦੀ ਜਾਂ ਰਿਫੰਡ ਨਹੀਂ ਕਰਦੀ। ਦੋਵਾਂ ਲਈ ਉਸੇ Google ਖਾਤੇ ਦੀ ਵਰਤੋਂ ਕਰੋ।</string>
     <string name="upgrade_screen_sub_still_renewing_title">ਸਬਸਕ੍ਰਿਪਸ਼ਨ ਅਜੇ ਸਰਗਰਮ ਹੈ</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play ਦੱਸਦਾ ਹੈ ਕਿ ਤੁਹਾਡੀ ਸਬਸਕ੍ਰਿਪਸ਼ਨ ਅਜੇ ਵੀ ਨਵਿਆਉਣ ਲਈ ਸੈਟ ਹੈ। ਇਕ-ਵਾਰ ਅਪਗ੍ਰੇਡ ਖਰੀਦਣ ਲਈ, ਪਹਿਲਾਂ Google Play ਵਿੱਚ ਸਬਸਕ੍ਰਿਪਸ਼ਨ ਨੂੰ ਰੱਦ ਕਰੋ, ਫਿਰ ਇਥੇ ਵਾਪਸ ਆਓ।\n\nਹੁਣੇ ਹੀ ਰੱਦ ਕੀਤਾ ਹੈ? Google Play ਨੂੰ ਇੱਕ ਪਲ ਦਿਓ ਅਤੇ ਫਿਰ ਕੋਸ਼ਿਸ਼ ਕਰੋ। ਇਹ ਵੀ ਯਕੀਨੀ ਬਣਾਓ ਕਿ ਤੁਸੀਂ ਉਸੇ Google ਖਾਤੇ ਦੀ ਵਰਤੋਂ ਕਰ ਰਹੇ ਹੋ।</string>
-    <string name="upgrade_screen_sub_check_failed_message">Google Play ਦੇ ਨਾਲ ਤੁਹਾਡੀ ਸਬਸਕ੍ਰਿਪਸ਼ਨ ਸਥਿਤੀ ਦੀ ਜਾਂਚ ਨਹੀਂ ਕਰ ਸਕਿਆ। ਕਿਰਪਾ ਕਰਕੇ ਇੱਕ ਪਲ ਵਿੱਚ ਦੁਬਾਰਾ ਕੋਸ਼ਿਸ਼ ਕਰੋ।</string>
     <string name="upgrade_screen_restore_success_message">ਖਰੀਦ ਬਹਾਲ ਕੀਤੀ, ਤੁਹਾਡਾ Pro ਅਪਗ੍ਰੇਡ ਸਰਗਰਮ ਹੈ।</string>
     <string name="upgrade_screen_grace_title">ਤੁਹਾਡੀ ਖਰੀਦ ਦੀ ਪੁ਷ਟੀ ਕਰ ਰਿਹਾ ਹੈ</string>
     <string name="upgrade_screen_grace_body_short">Pro ਅਜੇ ਵੀ ਸਰਗਰਮ ਹੈ। Google Play ਦੀ ਉਡੀਕ ਕਰ ਰਹੇ ਹਾਂ ਤੁਹਾਡੀ ਖਰੀਦ ਨੂੰ ਦੁਬਾਰਾ ਪੁ਷ਟੀ ਕਰਨ ਲਈ, ਇਸ ਦੌਰਾਨ ਸਾਰੀਆਂ Pro ਵਿਸ਼ੇਸ਼ਤਾਵਾਂ ਅਣਬੰਦ ਰਹਿੰਦੀਆਂ ਹਨ।</string>

--- a/app/src/gplay/res/values-pl/strings.xml
+++ b/app/src/gplay/res/values-pl/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">To oddzielny zakup: nie anuluje on ani nie zwraca twojej subskrypcji. Użyj tego samego konta Google do obu zakupów.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Subskrypcja nadal aktywna</string>
     <string name="upgrade_screen_sub_still_renewing_message">Sklep Google Play informuje, że twoja subskrypcja nadal jest ustawiona na odnowienie. Aby kupić jednorazową aktualizację, najpierw anuluj subskrypcję w Sklepie Google Play, a następnie wróć tutaj.\n\nWłaśnie ją anulowałeś? Daj Sklepowi Google Play chwilę i spróbuj ponownie. Upewnij się również, że używasz tego samego konta Google.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Nie udało się sprawdzić statusu subskrypcji w Sklepie Google Play. Spróbuj ponownie za chwilę.</string>
     <string name="upgrade_screen_restore_success_message">Zakup został przywrócony, aktualizacja Pro jest aktywna.</string>
     <string name="upgrade_screen_grace_title">Potwierdzanie twojego zakupu</string>
     <string name="upgrade_screen_grace_body_short">Wersja Pro jest nadal aktywna. Czekamy na ponowne potwierdzenie zakupu przez Sklep Google Play, a wszystkie funkcje wersji Pro pozostają odblokowane.</string>

--- a/app/src/gplay/res/values-pt-rBR/strings.xml
+++ b/app/src/gplay/res/values-pt-rBR/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Esta é uma compra separada: não cancela nem reembolsa sua assinatura. Use a mesma conta do Google para ambas.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Assinatura ainda ativa</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play informa que sua assinatura ainda está configurada para renovar. Para comprar a atualização única, cancele a assinatura no Google Play primeiro e depois volte aqui.\n\nAcabou de cancelar? Dê ao Google Play um momento e tente novamente. Certifique-se também de que está usando a mesma conta do Google.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Não foi possível verificar o status da sua assinatura no Google Play. Tente novamente em um momento.</string>
     <string name="upgrade_screen_restore_success_message">Compra restaurada, sua atualização Pro está ativa.</string>
     <string name="upgrade_screen_grace_title">Confirmando sua compra</string>
     <string name="upgrade_screen_grace_body_short">Pro ainda está ativo. Aguardando que o Google Play confirme novamente sua compra, todos os recursos Pro permanecem desbloqueados neste meio tempo.</string>

--- a/app/src/gplay/res/values-pt/strings.xml
+++ b/app/src/gplay/res/values-pt/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Esta é uma compra separada: não cancela nem reembolsa a subscrição. Use a mesma conta Google para ambas.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Subscrição ainda ativa</string>
     <string name="upgrade_screen_sub_still_renewing_message">O Google Play indica que a sua subscrição ainda está configurada para renovar. Para comprar a atualização de compra única, cancele primeiro a subscrição no Google Play e volte aqui.\n\nAcabou de a cancelar? Aguarde um momento e tente novamente. Confirme também que está a usar a mesma conta Google.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Não foi possível verificar o estado da sua subscrição no Google Play. Tente novamente dentro de alguns instantes.</string>
     <string name="upgrade_screen_restore_success_message">Compra restaurada; a sua atualização Pro está ativa.</string>
     <string name="upgrade_screen_grace_title">A confirmar a compra</string>
     <string name="upgrade_screen_grace_body_short">O Pro continua ativo. Enquanto o Google Play volta a confirmar a compra, todas as funcionalidades Pro permanecem desbloqueadas.</string>

--- a/app/src/gplay/res/values-ro/strings.xml
+++ b/app/src/gplay/res/values-ro/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Aceasta este o achiziție separată: nu anulează și nu ți se returnează banii din abonament. Folosește același cont Google pentru ambele.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Abonamentul este încă activ</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play raportează că abonamentul tău este încă setat să se reînnoiască. Pentru a cumpăra achiziția unică, anulează mai întâi abonamentul în Google Play, apoi revino aici.\n\nTocmai l-ai anulat? Dă-i Google Play un moment și încearcă din nou. De asemenea, asigură-te că folosești același cont Google.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Nu am putut verifica starea abonamentului tău cu Google Play. Te rog, încearcă din nou în câteva momente.</string>
     <string name="upgrade_screen_restore_success_message">Achiziția a fost restabilită, actualizarea ta Pro este activă.</string>
     <string name="upgrade_screen_grace_title">Se confirmă achiziția</string>
     <string name="upgrade_screen_grace_body_short">Pro este încă activ. Se așteaptă ca Google Play să confirme din nou achiziția ta; toate funcțiile Pro rămân deblocate în timp ce se așteaptă.</string>

--- a/app/src/gplay/res/values-ru/strings.xml
+++ b/app/src/gplay/res/values-ru/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Это отдельная покупка: она не отменяет и не возвращает средства за Вашу подписку. Используйте один и тот же аккаунт Google для обеих.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Подписка всё ещё активна</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play сообщает, что Ваша подписка по-прежнему установлена на автоматическое продление. Чтобы совершить единовременную покупку, сначала отмените подписку в Google Play, а затем вернитесь сюда.\n\nТолько что отменили? Дайте Google Play немного времени и попробуйте снова. Также убедитесь, что Вы используете один и тот же аккаунт Google.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Не удалось проверить статус подписки в Google Play. Пожалуйста, попробуйте ещё раз через некоторое время.</string>
     <string name="upgrade_screen_restore_success_message">Покупка восстановлена, Ваше обновление Pro активно.</string>
     <string name="upgrade_screen_grace_title">Подтверждение покупки</string>
     <string name="upgrade_screen_grace_body_short">Pro по-прежнему активен. Ожидаем повторного подтверждения покупки в Google Play, все функции Pro остаются разблокированы.</string>

--- a/app/src/gplay/res/values-sc-rIT/strings.xml
+++ b/app/src/gplay/res/values-sc-rIT/strings.xml
@@ -50,7 +50,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Custu est una iscanta separada: no at cancellare o restitùere sa sottoscritzione tua. Imprea s\'istessu contu Google pro ambos.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Sottoscritzione ancora attivu</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play nuntiat chi sa sottoscritzione tua est ancora impostada pro renovare. Pro cumparare s\'atibalzu ùnicu, cantzella prima sa sottoscritzione in Google Play, dopo torna chie.\n\nL\'as cantzellada oe? Astat un\'intziada a Google Play e tenta ancora. Asserta chi stais imprendu s\'istessu contu Google.</string>
-    <string name="upgrade_screen_sub_check_failed_message">No at podiddu contrallare s\'istadu de sa sottoscritzione tua in Google Play. Tenta ancora, perbai.</string>
     <string name="upgrade_screen_restore_success_message">Iscanta ripristinada, s\'atibalzu Pro tuu est attivu.</string>
     <string name="upgrade_screen_grace_title">Cunfirmande s\'iscanta tua</string>
     <string name="upgrade_screen_grace_body_short">Pro est ancora attivu. Ant\'aspettende chi Google Play cunfirmet de nou s\'iscanta tua, totu sas caraterìsticas Pro ant\'a restare desbloadas.</string>

--- a/app/src/gplay/res/values-si-rLK/strings.xml
+++ b/app/src/gplay/res/values-si-rLK/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">මෙය වෙනම ක්‍රයක්යයි: එය ඔබගේ දායකත්වය අවලංඝනය හෝ ප්‍රතිසිය නොකරයි. දෙකටම එකම Google ගිණුම භාවිතා කරන්න.</string>
     <string name="upgrade_screen_sub_still_renewing_title">දායකත්වය තවමත් ක්‍රියාකාරී ය</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play වාර්තා ගනුවේ ඔබගේ දායකත්වය තවමත් පුනරුත්ථාපනයට සකසා ඇති බවයි. එකවරක් උසස්කරණය ගැනීමට, පළමුව Google Play හිදී දායකත්වය අවලංඝනය කරන්න, ඉන්පසු මෙතැනට ආපසු පැමිණෙන්න.\n\nදැන් අවලංඝනය කර ඇතිද? Google Play ට ටිකක් බලා ගන්න සහ නැවතත් උත්සාහ කරන්න. එසේම ඔබ එකම Google ගිණුම භාවිතා කරන්නේ ඇතැයි තහවුරු කරන්න.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Google Play සමඟ ඔබගේ දායකත්වයේ තත්ත්වය පරීක්ෂා කිරීමට හැකි නොවිණි. කරුණාකර මොහොතකින් නැවතත් උත්සාහ කරන්න.</string>
     <string name="upgrade_screen_restore_success_message">ක්‍රයක් ප්‍රතිස්ථාපනය වුණි, ඔබගේ Pro උසස්කරණය සක්‍රිය ය.</string>
     <string name="upgrade_screen_grace_title">ඔබගේ ක්‍රයක් තහවුරු කරමින්</string>
     <string name="upgrade_screen_grace_body_short">Pro තවමත් ක්‍රියාකාරී ය. ඔබගේ ක්‍රයක් නැවතත් තහවුරු කිරීමට Google Play බලා ගනිමින්, සියලුම Pro ලක්ෂණ මධ්‍ය කාලයේ අගුලුවිරුද්ධ ඉතිරිව ඇත.</string>

--- a/app/src/gplay/res/values-sk/strings.xml
+++ b/app/src/gplay/res/values-sk/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Toto je samostatný nákup: nezruší ani nevráti vaše predplatné. Používajte rovnaký účet Google pre oba.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Predplatné je stále aktívne</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play hlási, že vaše predplatné je stále nastavené na obnovenie. Ak chcete kúpiť jednorazový upgrade, najskôr zrušte predplatné v Google Play a potom sa vráťte sem.\n\nPráve ste ho zrušili? Počkajte chvíľu a skúste znova. Tiež sa uistite, že používate rovnaký účet Google.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Nepodarilo sa skontrolovať stav vášho predplatného v Google Play. Skúste to prosím za chvíľu.</string>
     <string name="upgrade_screen_restore_success_message">Nákup obnovený, váš Pro upgrade je aktívny.</string>
     <string name="upgrade_screen_grace_title">Potvrdzovanie vášho nákupu</string>
     <string name="upgrade_screen_grace_body_short">Pro je stále aktívny. Čakáme na opätovné potvrdenie vášho nákupu od Google Play, všetky funkcie Pro zostávajú odomknuté.</string>

--- a/app/src/gplay/res/values-sl/strings.xml
+++ b/app/src/gplay/res/values-sl/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">To je ločen nakup: ne prekliče ali ne vrne vaše naročnine. Uporabite isti Google račun za oba.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Naročnina je še vedno aktivna</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play poroča, da je vaša naročnina še vedno nastavljena na obnovitev. Če želite kupiti enkratno nadgradnjo, najprej prekličite naročnino v Google Play, nato se vrnite sem.\n\nAli ste jo pravkar prekličali? Dajte Google Play trenutek in poskusite ponovno. Prepričajte se tudi, da uporabljate isti Google račun.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Ni mogoče preveriti stanja vaše naročnine pri Google Play. Prosimo, poskusite ponovno čez trenutek.</string>
     <string name="upgrade_screen_restore_success_message">Nakup je obnovljen, vaša Pro nadgradnja je aktivna.</string>
     <string name="upgrade_screen_grace_title">Potrditev vašega nakupa</string>
     <string name="upgrade_screen_grace_body_short">Pro je še vedno aktiven. Čakamo, da Google Play ponovno potrdi vaš nakup, v tem času pa so vse Pro funkcije dostopne.</string>

--- a/app/src/gplay/res/values-sq-rAL/strings.xml
+++ b/app/src/gplay/res/values-sq-rAL/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Ky është një blerje e veçantë: nuk anulon ose nuk kthen paratë për abonimin tuaj. Përdorni të njëjtën llogari Google për të dyja.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Abonimi ende aktiv</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play raporton se abonimi juaj është ende i caktuar për të rinovuar. Për të blerë përmirësimin një herë, anuloni abonimin në Google Play fillimisht, pastaj kthehuni këtu.\n\nSapo e anuluat atë? Jepini Google Play një çast dhe provoni përsëri. Gjithashtu sigurohuni që përdorni të njëjtën llogari Google.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Nuk mund të kontrollohej statusi i abonimit tuaj me Google Play. Ju lutemi provoni përsëri në një çast.</string>
     <string name="upgrade_screen_restore_success_message">Blerja u rikthye, përmirësimi juaj Pro është aktiv.</string>
     <string name="upgrade_screen_grace_title">Po konfirmohet blerja juaj</string>
     <string name="upgrade_screen_grace_body_short">Pro është ende aktiv. Duke pritur që Google Play të ri-konfirmojë blerjen tuaj, të gjitha veçoritë e Pro mbeten të disponueshëme në ndërkohë.</string>

--- a/app/src/gplay/res/values-sr/strings.xml
+++ b/app/src/gplay/res/values-sr/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Ово је одвојена куповина: она не отказује нити враћа вашу претплату. Користите исти Google налог за оба.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Претплата је још увек активна</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play пријављује да је ваша претплата још увек подешена да се обнови. Да бисте купили једнократну надоградњу, прво откажите претплату у Google Play-у, а затим се вратите овде.\n\nУправо сте је отказали? Дајте Google Play-у тренутак и покушајте поново. Такође, уверите се да користите исти Google налог.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Није било могуће проверити статус ваше претплате код Google Play-а. Молимо покушајте поново за тренутак.</string>
     <string name="upgrade_screen_restore_success_message">Куповина је враћена, ваша Pro надоградња је активна.</string>
     <string name="upgrade_screen_grace_title">Потврђивање ваше куповине</string>
     <string name="upgrade_screen_grace_body_short">Pro је још увек активан. Чекамо да Google Play поново потврди вашу куповину, све Pro функције остају откључане у међувремену.</string>

--- a/app/src/gplay/res/values-sv/strings.xml
+++ b/app/src/gplay/res/values-sv/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Det här är ett separat köp: det avbryter eller återbetalar inte din prenumeration. Använd samma Google-konto för båda.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Prenumeration fortfarande aktiv</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play rapporterar att din prenumeration fortfarande är inställd för att förnyas. För att köpa engångsuppgraderingen måste du först avbryta prenumerationen i Google Play och sedan komma tillbaka här.\n\nJust avbröt den? Ge Google Play ett ögonblick och försök igen. Se också till att du använder samma Google-konto.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Kunde inte kontrollera din prenumerationsstatus med Google Play. Försök igen om ett ögonblick.</string>
     <string name="upgrade_screen_restore_success_message">Köp återställt, din Pro-uppgradering är aktiv.</string>
     <string name="upgrade_screen_grace_title">Bekräftar ditt köp</string>
     <string name="upgrade_screen_grace_body_short">Pro är fortfarande aktiv. Väntar på att Google Play ska bekräfta ditt köp igen, alla Pro-funktioner förblir olåsta under tiden.</string>

--- a/app/src/gplay/res/values-sw/strings.xml
+++ b/app/src/gplay/res/values-sw/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Huu ni ununuzi tofauti: hauughairi wala kurudisha pesa za usajili wako. Tumia akaunti sawa ya Google kwa vyote viwili.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Usajili bado ni hai</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play inaripoti kwamba usajili wako bado umewekwa kurejeshwa. Ili kununua boresho la mara moja, ghairi usajili katika Google Play kwanza, kisha rudi hapa.\n\nUmeghairi hivi punde? Mpe Google Play muda kidogo kisha jaribu tena. Pia hakikisha unatumia akaunti sawa ya Google.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Imeshindwa kuangalia hali ya usajili wako na Google Play. Tafadhali jaribu tena baada ya muda.</string>
     <string name="upgrade_screen_restore_success_message">Ununuzi umerejeshwa, boresho lako la Pro ni hai.</string>
     <string name="upgrade_screen_grace_title">Inathibitisha ununuzi wako</string>
     <string name="upgrade_screen_grace_body_short">Pro bado ni hai. Inasubiri Google Play kuthibitisha tena ununuzi wako, vipengele vyote vya Pro vinabaki vimefunguliwa wakati huo huo.</string>

--- a/app/src/gplay/res/values-ta-rIN/strings.xml
+++ b/app/src/gplay/res/values-ta-rIN/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">இது ஒரு தனித்தனிய கொள்முதல்: இது உங்கள் சந்தாவை ரத்து செய்யாது அல்லது திரும்ப பெற்றுக்கொடுக்காது. இரண்டுக்கும் ஒரே Google கணக்கைப் பயன்படுத்தவும்.</string>
     <string name="upgrade_screen_sub_still_renewing_title">சந்தா இன்னும் செயல்பட்டுக்கொண்டிருக்கிறது</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play உங்கள் சந்தா இன்னும் புதுப்பிக்க அமைக்கப்பட்டுள்ளது என்று தெரிவிக்கிறது. ஒரு முறை மேம்பாட்டை வாங்குவதற்கு, முதலில் Google Play-ல் சந்தாவை ரத்து செய்து, பின்னர் இங்கே திரும்பவும்.\n\nஇப்போதுதான் ரத்து செய்துவிட்டீர்களா? Google Play க்கு ஒரு தருணம் கொடுங்கள் மற்றும் மீண்டும் முயற்சி செய்யவும். நீங்கள் ஒரே Google கணக்கைப் பயன்படுத்துகிறீர்கள் என்பதையும் உறுதிசெய்து கொள்ளவும்.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Google Play உடன் உங்கள் சந்தா நிலையைச் சரிபார்க்க முடியவில்லை. தயவுசெய்து சிறிதுநேரத்தில் மீண்டும் முயற்சி செய்யவும்.</string>
     <string name="upgrade_screen_restore_success_message">கொள்முதல் மீட்டெடுக்கப்பட்டது, உங்கள் Pro மேம்பாடு செயல்பட்டுக்கொண்டிருக்கிறது.</string>
     <string name="upgrade_screen_grace_title">உங்கள் கொள்முதலை உறுதிப்படுத்துகிறது</string>
     <string name="upgrade_screen_grace_body_short">Pro இன்னும் செயல்பட்டுக்கொண்டிருக்கிறது. Google Play உங்கள் கொள்முதலை மீண்டும் உறுதிப்படுத்த பொறுத்திருக்கிறது, இதற்குள் அனைத்து Pro அம்சங்களும் செயல்பட்டுக்கொண்டிருக்கிறது.</string>

--- a/app/src/gplay/res/values-te-rIN/strings.xml
+++ b/app/src/gplay/res/values-te-rIN/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">ఇది ప్రత్యేక కొనుగోలు: ఇది మీ సబ్‌స్క్రిప్షన్‌ను రద్దు చేయదు లేదా ద్రవ్యం తిరిగి ఇవ్వదు. రెండింటికీ ఒకే Google ఖాతాను ఉపయోగించండి.</string>
     <string name="upgrade_screen_sub_still_renewing_title">సబ్‌స్క్రిప్షన్ ఇప్పటికీ సక్రియమైనది</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play మీ సబ్‌స్క్రిప్షన్ ఇప్పటికూ పునరావృత్తం కోసం సెట్ చేయబడ్డ ఉందని నివేదిస్తుంది. ఒకసారి అప్‌గ్రేడ్‌ను కొనడానికి, ముందుగా Google Play లో సబ్‌స్క్రిప్షన్‌ను రద్దు చేసి, ఆ తర్వాత ఇక్కడికి తిరిగి రండి.\n\nఇప్పుడే రద్దు చేసారా? Google Play కు ఒక క్షణం ఇవ్వండి మరియు మళ్ళీ ప్రయత్నించండి. మీరు ఒకే Google ఖాతాను ఉపయోగిస్తున్నారని కూడా నిర్ధారించుకోండి.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Google Play తో మీ సబ్‌స్క్రిప్షన్ స్థితిని తనిఖీ చేయలేకపోయాము. దయచేసి ఒక క్షణం తర్వాత మళ్లీ ప్రయత్నించండి.</string>
     <string name="upgrade_screen_restore_success_message">కొనుగోలు పునరుద్ధరించబడింది, మీ Pro అప్‌గ్రేడ్ సక్రియమైనది.</string>
     <string name="upgrade_screen_grace_title">మీ కొనుగోలును నిర్ధారిస్తోంది</string>
     <string name="upgrade_screen_grace_body_short">Pro ఇప్పటికీ సక్రియమైనది. Google Play మీ కొనుగోలును తిరిగి నిర్ధారించటరానికి ఎదురుచూస్తోంది, ఈ సమయంలో అన్ని Pro లక్షణాలు అన్‌లాక్‌చేయబడినవిగా ఉంటాయి.</string>

--- a/app/src/gplay/res/values-th/strings.xml
+++ b/app/src/gplay/res/values-th/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">นี่คือการซื้อที่แยกต่างหาก จะไม่ยกเลิกหรือคืนเงินให้กับการสมัครสมาชิกของคุณ ใช้บัญชี Google เดียวกันสำหรับทั้งสอง</string>
     <string name="upgrade_screen_sub_still_renewing_title">การสมัครสมาชิกยังคงใช้งานอยู่</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play รายงานว่าการสมัครสมาชิกของคุณยังคงตั้งค่าให้ต่ออายุ ในการซื้อการอัปเกรดแบบครั้งเดียว ให้ยกเลิกการสมัครสมาชิกใน Google Play ก่อน แล้วกลับมาที่นี่\n\nเพิ่งยกเลิกไปแล้วหรือ? ให้เวลา Google Play สักครู่แล้วลองใหม่ นอกจากนี้ตรวจสอบว่าคุณใช้บัญชี Google เดียวกัน</string>
-    <string name="upgrade_screen_sub_check_failed_message">ไม่สามารถตรวจสอบสถานะการสมัครสมาชิกของคุณจาก Google Play ได้ โปรดลองใหม่อีกครั้งในอีกสักครู่</string>
     <string name="upgrade_screen_restore_success_message">กู้คืนการซื้อแล้ว การอัปเกรด Pro ของคุณใช้งานอยู่</string>
     <string name="upgrade_screen_grace_title">กำลังยืนยันการซื้อของคุณ</string>
     <string name="upgrade_screen_grace_body_short">Pro ยังคงใช้งานอยู่ รอให้ Google Play ยืนยันการซื้อของคุณอีกครั้ง ฟีเจอร์ Pro ทั้งหมดจะยังคงปลดล็อกในระหว่างนี้</string>

--- a/app/src/gplay/res/values-tr/strings.xml
+++ b/app/src/gplay/res/values-tr/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Bu ayrı bir satın almadır: aboneliğinizi iptal etmez veya geri ödeme yapmaz. Her ikisi için de aynı Google hesabını kullanın.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Abonelik hâlâ etkin</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play, aboneliğinizin hâlâ yenilenmek üzere ayarlı olduğunu bildiriyor. Tek seferlik yükseltmeyi satın almak için önce Google Play\'de aboneliği iptal edin, sonra buraya geri dönün.\n\nAz önce mi iptal ettiniz? Google Play\'e biraz zaman verin ve tekrar deneyin. Ayrıca aynı Google hesabını kullandığınızdan emin olun.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Abonelik durumunuz Google Play ile kontrol edilemedi. Lütfen biraz sonra tekrar deneyin.</string>
     <string name="upgrade_screen_restore_success_message">Satın alma geri yüklendi, Pro yükseltmeniz etkin.</string>
     <string name="upgrade_screen_grace_title">Satın alımınız onaylanıyor</string>
     <string name="upgrade_screen_grace_body_short">Pro hâlâ etkin. Google Play\'in satın alımınızı yeniden onaylaması bekleniyor, bu arada tüm Pro özellikleri açık kalmaya devam ediyor.</string>

--- a/app/src/gplay/res/values-uk/strings.xml
+++ b/app/src/gplay/res/values-uk/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Це окрема покупка: вона не скасовує та не повертає гроші за вашу підписку. Використовуйте один і той самий обліковий запис Google для обох.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Підписка все ще активна</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play повідомляє, що ваша підписка все ще встановлена на поновлення. Щоб купити одноразове оновлення, спочатку скасуйте підписку в Google Play, а потім повертайтеся сюди.\n\nТільки що скасували? Дайте Google Play хвилину і спробуйте знову. Також переконайтесь, що ви використовуєте один і той самий обліковий запис Google.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Не вдалося перевірити ваш статус підписки в Google Play. Будь ласка, спробуйте ще раз за хвилину.</string>
     <string name="upgrade_screen_restore_success_message">Покупку відновлено, ваше Pro активне.</string>
     <string name="upgrade_screen_grace_title">Підтвердження покупки</string>
     <string name="upgrade_screen_grace_body_short">Pro залишається активним. Очікуємо на повторне підтвердження вашої покупки від Google Play, всі функції Pro залишаються розблокованими тим часом.</string>

--- a/app/src/gplay/res/values-ur-rIN/strings.xml
+++ b/app/src/gplay/res/values-ur-rIN/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">یہ ایک الگ خریداری ہے: یہ آپ کی رکنیت کو منسوخ یا واپس نہیں کرتی۔ دونوں کے لیے ایک ہی Google اکاؤنٹ استعمال کریں۔</string>
     <string name="upgrade_screen_sub_still_renewing_title">رکنیت ابھی فعال ہے</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play رپورٹ کرتا ہے کہ آپ کی رکنیت ابھی تجدید کے لیے سیٹ ہے۔ ایک بار کی اپ گریڈ خریدنے کے لیے، پہلے Google Play میں رکنیت منسوخ کریں، پھر یہاں واپس آئیں۔\n\nابھی منسوخ کیا؟ Google Play کو ایک لمحہ دیں اور دوبارہ کوشش کریں۔ یہ بھی یقینی بنائیں کہ آپ ایک ہی Google اکاؤنٹ استعمال کر رہے ہیں۔</string>
-    <string name="upgrade_screen_sub_check_failed_message">Google Play کے ساتھ آپ کی رکنیت کی حالت چیک نہیں کی جا سکی۔ براہ کرم کچھ دیر میں دوبارہ کوشش کریں۔</string>
     <string name="upgrade_screen_restore_success_message">خریداری بحال کی گئی، آپ کی Pro اپ گریڈ فعال ہے۔</string>
     <string name="upgrade_screen_grace_title">آپ کی خریداری کی تصدیق کر رہے ہیں</string>
     <string name="upgrade_screen_grace_body_short">Pro ابھی فعال ہے۔ Google Play کے ذریعے آپ کی خریداری کی دوبارہ تصدیق کا انتظار کر رہے ہیں، تمام Pro خصوصیات اس دوران کھلی رہتی ہیں۔</string>

--- a/app/src/gplay/res/values-uz/strings.xml
+++ b/app/src/gplay/res/values-uz/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Bu alohida sotib olish: u sizning obunangizni bekor qilmaydi va qaytarish puli bermaydi. Ikkalasi uchun bir xil Google akkauntni ishlating.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Obuna hali aktiv</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play sizning obunangiz hali ham yangilanishga o\'rnatilganligini xabar beradi. Bir martalik yangilash sotib olish uchun, avval Google Play-da obunani bekor qiling, keyin bu yerga qaytavering.\n\nHozirgina bekor qildingizmi? Google Play-ga biroz vaqt bering va qayta urinib ko\'ring. Shuningdek, bir xil Google akkauntdan foydalanayotganingizni tekshiring.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Google Play bilan sizning obuna holatini tekshira olmadik. Iltimos, biroz vaqt o\'tib qayta urinib ko\'ring.</string>
     <string name="upgrade_screen_restore_success_message">Sotib olish tiklandi, sizning Pro yangilash aktiv.</string>
     <string name="upgrade_screen_grace_title">Sotib olishingizni tasdiqlash</string>
     <string name="upgrade_screen_grace_body_short">Pro hali aktiv. Google Play sizning sotib olishingizni qayta tasdiqlashini kutmoqda, shu vaqtda barcha Pro xususiyatlari qulfsiz qoladi.</string>

--- a/app/src/gplay/res/values-vi/strings.xml
+++ b/app/src/gplay/res/values-vi/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Đây là một lần mua hàng riêng biệt: nó không hủy hoặc hoàn lại đăng ký của bạn. Sử dụng cùng một tài khoản Google cho cả hai.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Đăng ký vẫn hoạt động</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play báo cáo rằng đăng ký của bạn vẫn được đặt để tự động gia hạn. Để mua bản nâng cấp thanh toán một lần, trước tiên hãy hủy đăng ký trong Google Play, sau đó quay lại đây.\n\nVừa hủy nó? Cho Google Play một chút thời gian và thử lại. Đồng thời đảm bảo rằng bạn đang sử dụng cùng một tài khoản Google.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Không thể kiểm tra trạng thái đăng ký của bạn với Google Play. Vui lòng thử lại sau một chút.</string>
     <string name="upgrade_screen_restore_success_message">Lần mua hàng đã được khôi phục, nâng cấp Pro của bạn đang hoạt động.</string>
     <string name="upgrade_screen_grace_title">Đang xác nhận lần mua hàng của bạn</string>
     <string name="upgrade_screen_grace_body_short">Pro vẫn hoạt động. Đang chờ Google Play xác nhận lại lần mua hàng của bạn, tất cả các tính năng Pro vẫn mở khóa trong khoảng thời gian này.</string>

--- a/app/src/gplay/res/values-zh-rCN/strings.xml
+++ b/app/src/gplay/res/values-zh-rCN/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">这是单独购买：它不会取消或退款您的订阅。两者请使用同一个 Google 账户。</string>
     <string name="upgrade_screen_sub_still_renewing_title">订阅仍处于活动状态</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play 报告您的订阅仍设置为续订。要购买一次性升级，请先在 Google Play 中取消订阅，然后返回此处。\n\n刚取消？请给 Google Play 一点时间，然后重试。另外请确保您使用的是同一个 Google 账户。</string>
-    <string name="upgrade_screen_sub_check_failed_message">无法通过 Google Play 检查您的订阅状态。请稍后重试。</string>
     <string name="upgrade_screen_restore_success_message">购买已恢复，您的 Pro 升级已激活。</string>
     <string name="upgrade_screen_grace_title">正在确认您的购买</string>
     <string name="upgrade_screen_grace_body_short">Pro 仍处于活动状态。等待 Google Play 重新确认您的购买，在此期间所有 Pro 功能保持解锁。</string>

--- a/app/src/gplay/res/values-zh-rHK/strings.xml
+++ b/app/src/gplay/res/values-zh-rHK/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">這是單獨的購買：不會取消或退款您的訂閱。請為兩者使用相同的 Google 帳戶。</string>
     <string name="upgrade_screen_sub_still_renewing_title">訂閱仍然有效</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play 報告您的訂閱仍設定為續期。要購買一次性升級，請先在 Google Play 中取消訂閱，然後回到此處。\n\n剛取消？給 Google Play 一些時間，然後重試。還要確保您使用相同的 Google 帳戶。</string>
-    <string name="upgrade_screen_sub_check_failed_message">無法透過 Google Play 檢查您的訂閱狀態。請稍後重試。</string>
     <string name="upgrade_screen_restore_success_message">購買已還原，您的 Pro 升級已啟動。</string>
     <string name="upgrade_screen_grace_title">確認您的購買</string>
     <string name="upgrade_screen_grace_body_short">Pro 仍然有效。等待 Google Play 重新確認您的購買，同時所有 Pro 功能保持解鎖狀態。</string>

--- a/app/src/gplay/res/values-zh-rTW/strings.xml
+++ b/app/src/gplay/res/values-zh-rTW/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">這是單獨的購買：不會取消或退款您的訂閱。請使用相同的 Google 帳戶進行兩次購買。</string>
     <string name="upgrade_screen_sub_still_renewing_title">訂閱仍作用中</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play 報告您的訂閱仍設定為自動續約。若要購買一次性升級，請先在 Google Play 中取消訂閱，然後回到此處。\n\n剛取消？請給 Google Play 一些時間，然後再試一次。同時確保您使用的是相同的 Google 帳戶。</string>
-    <string name="upgrade_screen_sub_check_failed_message">無法透過 Google Play 檢查您的訂閱狀態。請稍後再試。</string>
     <string name="upgrade_screen_restore_success_message">購買已復原，您的 Pro 升級已作用中。</string>
     <string name="upgrade_screen_grace_title">正在確認您的購買</string>
     <string name="upgrade_screen_grace_body_short">Pro 仍作用中。等待 Google Play 重新確認您的購買，在此期間所有 Pro 功能保持解鎖。</string>

--- a/app/src/gplay/res/values-zu/strings.xml
+++ b/app/src/gplay/res/values-zu/strings.xml
@@ -55,7 +55,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Loku kuthenga kuhlukahlukene: akukhanseleli noma akubuyi imali ye-subscription yakho. Sebenzisa i-akhawunti eyodwa ye-Google kubo bobabili.</string>
     <string name="upgrade_screen_sub_still_renewing_title">I-subscription isasebenza</string>
     <string name="upgrade_screen_sub_still_renewing_message">I-Google Play ikhaba ukuthi i-subscription yakho isahleliwe ukubuya. Ukuze kuthenga i-upgrade kube kanye, khansela i-subscription ku-Google Play okokuqala, ngemuva kwalokho buya lapha.\n\nUsanda uyakhansela? Nikeza i-Google Play isikhashana uzame futhi. Futhi qiniseka ukuthi usebenzisa i-akhawunti eyodwa ye-Google.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Ayikwazanga ukuhlola isimo se-subscription yakho ku-Google Play. Ngiyakucela uzame futhi esikhashana.</string>
     <string name="upgrade_screen_restore_success_message">Ukuthenga buyiselwe, i-Pro upgrade yakho isebenza.</string>
     <string name="upgrade_screen_grace_title">Iyacungula ukuthenga kwakho</string>
     <string name="upgrade_screen_grace_body_short">I-Pro isasebenza. Intandeka i-Google Play ukuze iphinde icungule ukuthenga kwakho. Zonke izilungiselelo ze-Pro zihlala zibukhishwe okwamanje.</string>

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -66,7 +66,7 @@
     <string name="upgrade_screen_sub_still_renewing_message">Google Play reports that your subscription is still set to renew. To buy the one-time upgrade, cancel the subscription in Google Play first, then come back here.\n\nJust cancelled it? Give Google Play a moment and try again. Also make sure you are using the same Google account.</string>
     <string name="upgrade_screen_purchase_check_failed_message">Couldn\'t check your purchases with Google Play. Please try again in a moment.</string>
     <string name="upgrade_screen_pending_card_title">Payment pending</string>
-    <string name="upgrade_screen_pending_card_body">Google Play is still processing your payment. Pro unlocks automatically once the payment goes through. Some payment methods take a while, there is nothing else to do.</string>
+    <string name="upgrade_screen_pending_card_body">Google Play is still processing your payment. Pro unlocks automatically once the payment goes through. Some payment methods can take a while. There is nothing else you need to do.</string>
     <string name="upgrade_screen_pending_dialog_message">Google Play found a purchase with a pending payment and is still processing it. Pro unlocks automatically once the payment goes through.</string>
     <string name="upgrade_screen_restore_success_message">Purchase restored, your Pro upgrade is active.</string>
     <string name="upgrade_screen_grace_title">Confirming your purchase</string>

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -64,7 +64,10 @@
     <string name="upgrade_screen_owned_iap_purchase_note">This is a separate purchase: it does not cancel or refund your subscription. Use the same Google account for both.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Subscription still active</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play reports that your subscription is still set to renew. To buy the one-time upgrade, cancel the subscription in Google Play first, then come back here.\n\nJust cancelled it? Give Google Play a moment and try again. Also make sure you are using the same Google account.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Couldn\'t check your subscription status with Google Play. Please try again in a moment.</string>
+    <string name="upgrade_screen_purchase_check_failed_message">Couldn\'t check your purchases with Google Play. Please try again in a moment.</string>
+    <string name="upgrade_screen_pending_card_title">Payment pending</string>
+    <string name="upgrade_screen_pending_card_body">Google Play is still processing your payment. Pro unlocks automatically once the payment goes through. Some payment methods take a while, there is nothing else to do.</string>
+    <string name="upgrade_screen_pending_dialog_message">Google Play found a purchase with a pending payment and is still processing it. Pro unlocks automatically once the payment goes through.</string>
     <string name="upgrade_screen_restore_success_message">Purchase restored, your Pro upgrade is active.</string>
     <string name="upgrade_screen_grace_title">Confirming your purchase</string>
     <string name="upgrade_screen_grace_body_short">Pro is still active. Waiting for Google Play to re-confirm your purchase, all Pro features stay unlocked in the meantime.</string>

--- a/app/src/main/java/eu/darken/sdmse/common/upgrade/ui/UpgradeContent.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/upgrade/ui/UpgradeContent.kt
@@ -89,6 +89,7 @@ internal object UpgradeScreenTags {
     const val GPLAY_OWNED_IAP = "upgrade_gplay_owned_iap"
     const val GPLAY_OWNED_SUB = "upgrade_gplay_owned_sub"
     const val GPLAY_MANAGE_SUB = "upgrade_gplay_manage_sub"
+    const val GPLAY_PENDING = "upgrade_gplay_pending"
     const val GPLAY_GRACE = "upgrade_gplay_grace"
     const val GPLAY_GRACE_SPINNER = "upgrade_gplay_grace_spinner"
     const val GPLAY_GRACE_RESTORE = "upgrade_gplay_grace_restore"

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplayTest.kt
@@ -10,6 +10,7 @@ import eu.darken.sdmse.common.upgrade.core.billing.BillingData
 import eu.darken.sdmse.common.upgrade.core.billing.BillingManager
 import eu.darken.sdmse.common.upgrade.core.billing.GplayServiceUnavailableException
 import eu.darken.sdmse.common.upgrade.core.billing.ItemAlreadyOwnedBillingException
+import eu.darken.sdmse.common.upgrade.core.billing.PendingPurchaseBillingException
 import eu.darken.sdmse.common.upgrade.core.billing.PurchasedSku
 import eu.darken.sdmse.common.upgrade.core.billing.UserCanceledBillingException
 import eu.darken.sdmse.main.core.CurriculumVitae
@@ -118,6 +119,13 @@ class UpgradeRepoGplayTest : BaseTest() {
         every { purchaseTime } returns Instant.parse("2024-01-01T00:00:00Z").toEpochMilli()
     }
 
+    // A payment Play is still processing. Lands in BillingData.pendingPurchases, never in
+    // purchases — the split happens at the billing layer, this is what the repo receives.
+    private fun pendingPurchase(productId: String = OurSku.Iap.PRO_UPGRADE.id) = mockk<Purchase>().apply {
+        every { products } returns listOf(productId)
+        every { purchaseTime } returns 1_000L
+    }
+
     @Test fun `test upgrade info pro status mapping`() {
         UpgradeRepoGplay.Info(
             gracePeriod = false,
@@ -147,6 +155,108 @@ class UpgradeRepoGplayTest : BaseTest() {
         info.upgradedAt shouldBe Instant.parse("2023-12-10T00:00:00Z")
         info.type
     }
+
+    // region pending payments
+
+    @Test fun `a pending payment is mapped but grants nothing`() {
+        val info = UpgradeRepoGplay.Info(
+            gracePeriod = false,
+            billingData = BillingData(purchases = emptySet(), pendingPurchases = setOf(pendingPurchase())),
+        )
+
+        info.pendingSkus shouldBe listOf(OurSku.Iap.PRO_UPGRADE)
+        // The whole point of the split: visible, never an entitlement.
+        info.upgrades shouldBe emptyList()
+        info.isPro shouldBe false
+        info.upgradedAt shouldBe null
+    }
+
+    @Test fun `a pending payment for an unknown product is dropped`() {
+        UpgradeRepoGplay.Info(
+            gracePeriod = false,
+            billingData = BillingData(
+                purchases = emptySet(),
+                pendingPurchases = setOf(pendingPurchase("some.unknown.product")),
+            ),
+        ).pendingSkus shouldBe emptyList()
+    }
+
+    @Test fun `the grace-substituted info keeps the pending payment visible`() = runTest2 {
+        // The audience that needs the explanation most: Pro is running on grace while Play is still
+        // processing the payment that will renew it. Dropping the data here (as the grace branch
+        // used to) left them with a silent screen.
+        coEvery { billingManager.refresh() } returns BillingData(emptySet(), setOf(pendingPurchase()))
+
+        val outcome = repo(lastProAt = System.currentTimeMillis() - 1_000).restorePurchaseNow()
+
+        outcome.info.isPro shouldBe true
+        outcome.info.pendingSkus shouldBe listOf(OurSku.Iap.PRO_UPGRADE)
+    }
+
+    @Test fun `a restore that only finds a pending payment reports it without pro`() = runTest2 {
+        coEvery { billingManager.refresh() } returns BillingData(emptySet(), setOf(pendingPurchase()))
+
+        val outcome = repo(lastProAt = 0L).restorePurchaseNow()
+
+        outcome.shouldBeInstanceOf<UpgradeRepoGplay.RestoreOutcome.Checked>()
+        outcome.info.isPro shouldBe false
+        outcome.info.pendingSkus shouldBe listOf(OurSku.Iap.PRO_UPGRADE)
+    }
+
+    @Test fun `a manual restore over a partial refresh still advances the unconfirmed episode`() = runTest2 {
+        // The restore itself succeeds (a pending payment IS an answer), so nothing on this path
+        // throws — the episode clock is fed by the manager's reconciliation signal instead, which
+        // carries the refresh's commit time.
+        val failures = MutableSharedFlow<Long>(extraBufferCapacity = 1)
+        val confirmedAt = System.currentTimeMillis() - 1_000
+        coEvery { billingManager.refresh() } returns BillingData(emptySet(), setOf(pendingPurchase()))
+        val repo = repo(lastProAt = confirmedAt, connectionFailures = failures)
+
+        repo.restorePurchaseNow().info.isPro shouldBe true
+        failures.emit(confirmedAt + 500)
+        advanceUntilIdle()
+
+        coVerify { proUnconfirmedMock.update(any()) }
+    }
+
+    @Test fun `verifyPurchaseStateNow fails closed instead of substituting grace`() = runTest2 {
+        val boom = GplayServiceUnavailableException(RuntimeException("one product type failed"))
+        coEvery { billingManager.refreshStrict() } throws boom
+
+        // Even a recent owner gets the error: a gate that can't verify must not let a purchase
+        // through on the strength of a grace window.
+        shouldThrow<GplayServiceUnavailableException> {
+            repo(lastProAt = System.currentTimeMillis() - 1_000).verifyPurchaseStateNow()
+        }
+    }
+
+    @Test fun `verifyPurchaseStateNow reports the fresh split state`() = runTest2 {
+        coEvery { billingManager.refreshStrict() } returns BillingData(
+            purchases = setOf(proPurchase()),
+            pendingPurchases = setOf(pendingPurchase(OurSku.Sub.PRO_UPGRADE.id)),
+        )
+
+        val info = repo(lastProAt = 0L).verifyPurchaseStateNow()
+
+        info.upgrades.map { it.sku } shouldBe OurSku.PRO_SKUS.toList()
+        info.pendingSkus shouldBe listOf(OurSku.Sub.PRO_UPGRADE)
+        info.isSettled shouldBe true
+    }
+
+    @Test fun `already-owned recovery reports a pending payment instead of restore tips`() = runTest2 {
+        // Play refuses to re-sell a product whose payment it is still processing. The already-owned
+        // dialog would tell the user to restore, which cannot help.
+        coEvery { billingManager.startIapFlow(any(), any(), null) } throws
+            ItemAlreadyOwnedBillingException(RuntimeException("launch result"))
+        coEvery { billingManager.refresh() } returns BillingData(emptySet(), setOf(pendingPurchase()))
+
+        val errors = mutableListOf<Throwable>()
+        repo(lastProAt = 0L).startLaunch { errors.add(it) }
+
+        errors.single().shouldBeInstanceOf<PendingPurchaseBillingException>()
+    }
+
+    // endregion
 
     @Test fun `grace period is 7 days`() {
         // Guards against the unit error where 7 * 24 * 60 * 1000 (2.8h) was used instead of 7 days,

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManagerTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManagerTest.kt
@@ -71,6 +71,15 @@ class BillingManagerTest : BaseTest() {
         every { isAcknowledged } returns true
     }
 
+    // A payment Play is still processing: carried by the state, but never owned and never ackable.
+    private fun pendingPurchase(token: String = "pending-token") = mockk<Purchase>().apply {
+        every { purchaseState } returns PurchaseState.PENDING
+        every { purchaseTime } returns 2_000L
+        every { purchaseToken } returns token
+        every { isAcknowledged } returns false
+        every { products } returns listOf(OurSku.Iap.PRO_UPGRADE.id)
+    }
+
     // An unacknowledged purchase with its own token: the ack bookkeeping (log level, permanent
     // failure reports) is keyed per token, so tests need distinguishable ones.
     private fun unackedPurchase(
@@ -89,16 +98,53 @@ class BillingManagerTest : BaseTest() {
     private fun connection(
         refreshResults: List<Collection<Purchase>> = listOf(emptyList()),
         refreshComplete: Boolean = true,
+        // Full refresh outcomes for the tests that care about provenance (confirmed set, commit
+        // time, partial error); overrides the plain refreshResults shorthand.
+        refreshes: List<BillingConnection.PurchaseRefresh>? = null,
         purchasesFlow: Flow<Collection<Purchase>> = flowOf(emptyList()),
         freshUpdatesFlow: Flow<BillingConnection.FreshUpdate> = emptyFlow(),
         failures: Flow<BillingResult> = emptyFlow(),
     ) = mockk<BillingConnection>().apply {
-        coEvery { refreshPurchases() } returnsMany
-            refreshResults.map { BillingConnection.PurchaseRefresh(it, isComplete = refreshComplete) }
+        coEvery { refreshPurchases() } returnsMany (
+            refreshes ?: refreshResults.map {
+                BillingConnection.PurchaseRefresh(
+                    purchases = it,
+                    confirmed = it,
+                    hasConfirmedProPurchase = it.isNotEmpty(),
+                    isComplete = refreshComplete,
+                )
+            }
+            )
         every { purchases } returns purchasesFlow
         every { freshUpdates } returns freshUpdatesFlow
         every { purchaseFailures } returns failures
     }
+
+    // An incomplete reconciliation: it committed what it found, but one product type couldn't be
+    // checked. The default cause is NON-invalidating — the dead-binder codes are opted into.
+    private fun partialRefresh(
+        purchases: Collection<Purchase> = emptyList(),
+        confirmed: Collection<Purchase> = emptyList(),
+        hasConfirmedPro: Boolean = false,
+        occurredAt: Long = 4242L,
+        error: Throwable = GplayServiceUnavailableException(
+            BillingClientException(result(BillingResponseCode.ERROR))
+        ),
+    ) = BillingConnection.PurchaseRefresh(
+        purchases = purchases,
+        confirmed = confirmed,
+        hasConfirmedProPurchase = hasConfirmedPro,
+        isComplete = false,
+        occurredAt = occurredAt,
+        partialError = error,
+    )
+
+    private fun completeRefresh(purchases: Collection<Purchase> = emptyList()) = BillingConnection.PurchaseRefresh(
+        purchases = purchases,
+        confirmed = purchases,
+        hasConfirmedProPurchase = purchases.isNotEmpty(),
+        isComplete = true,
+    )
 
     // The real provider flow emits one connection and stays open for its lifetime -- flowOf() would
     // complete immediately, which the connect loop rightly treats as a connection failure.
@@ -665,20 +711,194 @@ class BillingManagerTest : BaseTest() {
         failures.isNotEmpty() shouldBe true
     }
 
-    @Test fun `a non-invalidating action error does not emit`() = runTest2 {
-        // A strict querySubscriptions failure whose code is NOT invalidating leaves the connection
-        // installed, so no connect-loop iteration fails and nothing feeds the episode clock.
-        val conn = connection().apply {
-            coEvery { querySubscriptions() } throws BillingClientException(result(BillingResponseCode.ERROR))
-        }
+    @Test fun `a strict gate failure does not feed the episode clock`() = runTest2 {
+        // The gate surfaces its own failure to the user (fail-closed) and leaves the connection
+        // installed. The episode clock is fed by the connect loop and by refresh() — a gate that
+        // the user aborted mid-purchase is not a reconciliation outcome.
+        val conn = connection(refreshes = listOf(completeRefresh(), partialRefresh()))
         val manager = manager(conn)
         val failures = collectFailures(manager)
         runCurrent() // connection established
 
-        shouldThrow<Exception> { manager.querySubscriptions() }
+        shouldThrow<Exception> { manager.refreshStrict() }
         advanceUntilIdle()
 
         failures shouldBe emptyList()
+    }
+
+    @Test fun `a partial reconciliation without a confirmed pro purchase signals its commit time`() = runTest2 {
+        // The pending-only cold start: Play answered for one type with a payment in progress, the
+        // other failed. Nothing confirms Pro, so the grace episode clock must advance — stamped
+        // with the refresh's COMMIT time, so a confirmation landing in between stays newer.
+        val pending = pendingPurchase()
+        val conn = connection(
+            refreshes = listOf(partialRefresh(purchases = listOf(pending), occurredAt = 4242L)),
+            purchasesFlow = flowOf(listOf(pending)),
+        )
+        val manager = manager(conn)
+        val failures = collectFailures(manager)
+
+        runCurrent()
+
+        // Still published: a partial refresh is a usable connection, and starving billingData would
+        // leave the screen at Loading forever.
+        manager.billingData.first() shouldBe BillingData(
+            purchases = emptyList(),
+            pendingPurchases = listOf(pending),
+        )
+        failures shouldBe listOf(4242L)
+    }
+
+    @Test fun `a partial manual refresh signals too`() = runTest2 {
+        // Manual Restore runs the same reconciliation as the connect loop — before this it was the
+        // only path whose partial outcome silently vanished.
+        val conn = connection(refreshes = listOf(completeRefresh(), partialRefresh(occurredAt = 7_777L)))
+        val manager = manager(conn)
+        val failures = collectFailures(manager)
+        runCurrent()
+
+        manager.refresh()
+        advanceUntilIdle()
+
+        failures shouldBe listOf(7_777L)
+    }
+
+    @Test fun `a partial refresh that confirmed pro does not signal`() = runTest2 {
+        val owned = purchase()
+        val conn = connection(
+            refreshes = listOf(
+                completeRefresh(),
+                partialRefresh(purchases = listOf(owned), confirmed = listOf(owned), hasConfirmedPro = true),
+            ),
+        )
+        val manager = manager(conn)
+        val failures = collectFailures(manager)
+        runCurrent()
+
+        manager.refresh()
+        advanceUntilIdle()
+
+        // Pro WAS confirmed by this round-trip; the failed sibling type proves nothing against it.
+        failures shouldBe emptyList()
+    }
+
+    @Test fun `an invalidating partial refresh tears the connection down`() = runTest2 {
+        // The dead-binder teardown used to ride refreshPurchases' throw path through useConnection.
+        // A partial refresh returns instead of throwing, so without the explicit invalidation the
+        // dead connection would stay installed for every later caller.
+        val owned = purchase()
+        val dead = connection(
+            refreshes = listOf(
+                partialRefresh(
+                    purchases = listOf(owned),
+                    confirmed = listOf(owned),
+                    hasConfirmedPro = true,
+                    error = GplayServiceUnavailableException(
+                        BillingClientException(result(BillingResponseCode.SERVICE_DISCONNECTED))
+                    ),
+                ),
+            ),
+        )
+        val good = connection(refreshResults = listOf(emptyList(), listOf(owned)))
+        var attempts = 0
+        val provider = mockk<BillingConnectionProvider>().apply {
+            every { this@apply.connection } returns flow {
+                attempts++
+                emit(if (attempts == 1) dead else good)
+                awaitCancellation()
+            }
+        }
+        val manager = manager(provider)
+
+        advanceUntilIdle()
+
+        attempts shouldBe 2
+        manager.billingData.first() shouldBe BillingData(emptyList())
+    }
+
+    // endregion
+
+    // region pending purchases
+
+    @Test fun `billing data splits owned purchases from pending payments`() = runTest2 {
+        val owned = purchase()
+        val pending = pendingPurchase()
+        val manager = manager(connection(purchasesFlow = flowOf(listOf(owned, pending))))
+
+        // The split is what keeps a payment in progress out of every entitlement decision while
+        // still letting the UI show it.
+        manager.billingData.first() shouldBe BillingData(
+            purchases = listOf(owned),
+            pendingPurchases = listOf(pending),
+        )
+    }
+
+    @Test fun `a pending purchase is never acknowledged`() = runTest2 {
+        val pending = pendingPurchase()
+        val purchases = purchasesFlow()
+        val conn = connection(purchasesFlow = purchases)
+        val acks = conn.scriptAck { _, _ -> result(BillingResponseCode.OK) }
+        manager(conn)
+        runCurrent()
+
+        purchases.tryEmit(listOf(pending))
+        advanceTimeBy(400_000)
+        runCurrent()
+
+        // Play rejects acking a pending purchase permanently: an unfiltered pass would fire a bug
+        // report on every pass, forever, for a purchase that has nothing to acknowledge yet.
+        acks shouldBe emptyList()
+        verify(exactly = 0) { Bugs.report(any()) }
+    }
+
+    @Test fun `a follow-up refresh after a partial publish recovers the full state`() = runTest2 {
+        val pending = pendingPurchase()
+        val owned = purchase()
+        val purchases = purchasesFlow()
+        val conn = connection(
+            refreshes = listOf(
+                partialRefresh(purchases = listOf(pending)),
+                completeRefresh(listOf(owned)),
+            ),
+            purchasesFlow = purchases,
+        )
+        val manager = manager(conn)
+        runCurrent()
+
+        purchases.tryEmit(listOf(pending))
+        manager.billingData.first().pendingPurchases shouldBe listOf(pending)
+
+        // The payment completed: the next reconciliation returns the owned purchase, no reconnect
+        // needed (the partial one left a working connection installed).
+        manager.refresh() shouldBe BillingData(listOf(owned))
+    }
+
+    @Test fun `refreshStrict fails closed on an incomplete refresh`() = runTest2 {
+        val conn = connection(
+            refreshes = listOf(
+                completeRefresh(),
+                partialRefresh(purchases = listOf(purchase()), confirmed = listOf(purchase())),
+            ),
+        )
+        val manager = manager(conn)
+        runCurrent()
+
+        // A gate must not treat "one product type couldn't be checked" as "nothing else is owned":
+        // that is exactly how a double purchase gets through.
+        shouldThrow<GplayServiceUnavailableException> { manager.refreshStrict() }
+    }
+
+    @Test fun `refreshStrict returns the split data on a complete refresh`() = runTest2 {
+        val owned = purchase()
+        val pending = pendingPurchase()
+        val conn = connection(refreshes = listOf(completeRefresh(), completeRefresh(listOf(owned, pending))))
+        val manager = manager(conn)
+        runCurrent()
+
+        manager.refreshStrict() shouldBe BillingData(
+            purchases = listOf(owned),
+            pendingPurchases = listOf(pending),
+        )
     }
 
     // endregion

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManagerTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/billing/BillingManagerTest.kt
@@ -586,6 +586,10 @@ class BillingManagerTest : BaseTest() {
 
     // Drains the manager's connectionFailures (occurrence timestamps) into a list. Launched on
     // backgroundScope so it lives for the whole test.
+    //
+    // Drive it with runCurrent() (or a suspension of the test body), NEVER with advanceUntilIdle():
+    // that one stops as soon as no FOREGROUND event is left and never runs backgroundScope work, so
+    // a signal sent from the test body would sit unconsumed and the list would read empty.
     private fun TestScope.collectFailures(manager: BillingManager): List<Long> = mutableListOf<Long>().also { out ->
         backgroundScope.launch { manager.connectionFailures.collect { out.add(it) } }
     }
@@ -721,7 +725,7 @@ class BillingManagerTest : BaseTest() {
         runCurrent() // connection established
 
         shouldThrow<Exception> { manager.refreshStrict() }
-        advanceUntilIdle()
+        runCurrent()
 
         failures shouldBe emptyList()
     }
@@ -758,7 +762,7 @@ class BillingManagerTest : BaseTest() {
         runCurrent()
 
         manager.refresh()
-        advanceUntilIdle()
+        runCurrent() // the collector lives on backgroundScope, which advanceUntilIdle would skip
 
         failures shouldBe listOf(7_777L)
     }
@@ -776,7 +780,7 @@ class BillingManagerTest : BaseTest() {
         runCurrent()
 
         manager.refresh()
-        advanceUntilIdle()
+        runCurrent()
 
         // Pro WAS confirmed by this round-trip; the failed sibling type proves nothing against it.
         failures shouldBe emptyList()
@@ -809,11 +813,16 @@ class BillingManagerTest : BaseTest() {
             }
         }
         val manager = manager(provider)
+        runCurrent() // connection 1 established; its partial refresh signals the invalidation
 
+        // The next action is fresh demand: it skips the reconnect backoff and lands on connection 2.
+        // await() is what drives the connect loop here — it runs on backgroundScope, which
+        // advanceUntilIdle() alone would never touch.
+        val refreshed = async { manager.refresh() }
         advanceUntilIdle()
 
+        refreshed.await() shouldBe BillingData(listOf(owned))
         attempts shouldBe 2
-        manager.billingData.first() shouldBe BillingData(emptyList())
     }
 
     // endregion

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingConnectionTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/billing/client/BillingConnectionTest.kt
@@ -25,7 +25,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
-import io.mockk.verify
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -69,13 +68,20 @@ class BillingConnectionTest : BaseTest() {
         token: String = "token-$time",
         products: List<String> = listOf(OurSku.Iap.PRO_UPGRADE.id),
         acknowledged: Boolean = false,
+        state: Int = PurchaseState.PURCHASED,
     ) = mockk<Purchase>().apply {
         every { purchaseTime } returns time
         every { purchaseToken } returns token
         every { this@apply.products } returns products
-        every { purchaseState } returns PurchaseState.PURCHASED
+        every { purchaseState } returns state
         every { isAcknowledged } returns acknowledged
     }
+
+    private fun pendingPurchase(
+        time: Long,
+        token: String = "pending-$time",
+        products: List<String> = listOf(OurSku.Iap.PRO_UPGRADE.id),
+    ) = purchase(time = time, token = token, products = products, state = PurchaseState.PENDING)
 
     private fun result(code: Int): BillingResult = BillingResult.newBuilder().setResponseCode(code).build()
 
@@ -121,6 +127,42 @@ class BillingConnectionTest : BaseTest() {
                 sub = Result.failure(RuntimeException("SUBS query failed")),
             )
         }
+    }
+
+    @Test fun `a known pending purchase suppresses the couldn't-verify error`() {
+        // The user's payment is being processed: that IS a usable answer about this account, so a
+        // failing sibling query must not turn the screen into "can't reach Play".
+        val pending = pendingPurchase(1_000)
+
+        BillingConnection.combinePurchaseResults(
+            iap = Result.success(listOf(pending)),
+            sub = Result.failure(RuntimeException("SUBS query failed")),
+            typeOf = typeOf,
+        ) shouldBe listOf(pending)
+    }
+
+    @Test fun `an unknown pending purchase does not suppress the couldn't-verify error`() {
+        // A pending payment for a product this app doesn't sell says nothing about the type whose
+        // query failed — counting it as a find would swallow a real "couldn't verify".
+        shouldThrow<RuntimeException> {
+            BillingConnection.combinePurchaseResults(
+                iap = Result.success(listOf(pendingPurchase(1_000, products = listOf("some.unknown.product")))),
+                sub = Result.failure(RuntimeException("SUBS query failed")),
+                typeOf = typeOf,
+            )
+        }
+    }
+
+    @Test fun `an unknown PURCHASED product still suppresses the error`() {
+        // Ownership of anything is authoritative: every product this app sells is a Pro SKU, so an
+        // unrecognized owned product means our own SKU list is stale, not that Play failed.
+        val owned = purchase(1_000, products = listOf("some.unknown.product"))
+
+        BillingConnection.combinePurchaseResults(
+            iap = Result.success(listOf(owned)),
+            sub = Result.failure(RuntimeException("SUBS query failed")),
+            typeOf = typeOf,
+        ) shouldBe listOf(owned)
     }
 
     // endregion
@@ -423,13 +465,8 @@ class BillingConnectionTest : BaseTest() {
         connection.purchaseFailures.first().responseCode shouldBe BillingResponseCode.USER_CANCELED
     }
 
-    @Test fun `a pending purchase never surfaces as owned or as fresh data`() = runTest2 {
-        val pending = mockk<Purchase>().apply {
-            every { purchaseState } returns PurchaseState.PENDING
-            every { purchaseTime } returns 1_000L
-            every { purchaseToken } returns "pending"
-            every { this@apply.products } returns listOf(OurSku.Iap.PRO_UPGRADE.id)
-        }
+    @Test fun `a pending purchase event enters the state but never the fresh stream`() = runTest2 {
+        val pending = pendingPurchase(1_000, token = "pending")
         val connection = BillingConnection(
             client = clientReturning(
                 result(BillingResponseCode.OK) to emptyList(),
@@ -437,14 +474,169 @@ class BillingConnectionTest : BaseTest() {
             ),
         )
 
-        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(pending))
-        connection.refreshPurchases()
+        val freshUpdates = mutableListOf<BillingConnection.FreshUpdate>()
+        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            connection.freshUpdates.collect { freshUpdates.add(it) }
+        }
+        connection.refreshPurchases() // settles the state; predates the event
 
-        connection.purchases.first() shouldBe emptyList()
-        // Only the refresh's own emission — the PENDING event never produced one.
+        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(pending))
+        runCurrent()
+
+        // Visible as state (the UI must be able to show a payment in progress)...
+        connection.purchases.first().map { it.purchaseToken } shouldBe listOf("pending")
+        // ...but the fresh stream feeds the entitlement and grace bookkeeping, so only the
+        // refresh's own emission is on it — a pending payment confirms nothing.
+        freshUpdates.size shouldBe 1
+        freshUpdates.single().purchases shouldBe emptyList()
+    }
+
+    @Test fun `a pending query result enters the state but never the fresh stream`() = runTest2 {
+        val pending = pendingPurchase(1_000, token = "pending")
+        val connection = BillingConnection(
+            client = clientReturning(
+                result(BillingResponseCode.OK) to listOf(pending),
+                result(BillingResponseCode.OK) to emptyList(),
+            ),
+        )
+
+        val refresh = connection.refreshPurchases()
+
+        refresh.purchases.map { it.purchaseToken } shouldBe listOf("pending")
+        refresh.confirmed shouldBe emptyList()
+        refresh.hasConfirmedProPurchase shouldBe false
+        connection.purchases.first().map { it.purchaseToken } shouldBe listOf("pending")
         val update = connection.freshUpdates.first()
         update.purchases shouldBe emptyList()
         update.isFullSnapshot shouldBe true
+    }
+
+    @Test fun `a completing payment supersedes its own pending entry`() = runTest2 {
+        // Play delivers the same purchaseToken again once the payment cleared: the dedup must let
+        // the PURCHASED instance win instead of leaving the user with two records.
+        val pending = pendingPurchase(1_000, token = "same")
+        val purchased = purchase(1_000, token = "same")
+        val connection = BillingConnection(
+            client = clientReturning(
+                result(BillingResponseCode.OK) to emptyList(),
+                result(BillingResponseCode.OK) to emptyList(),
+            ),
+        )
+
+        connection.refreshPurchases() // settles the state; predates both events
+        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(pending))
+        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(purchased))
+
+        val merged = connection.purchases.first()
+        merged.size shouldBe 1
+        merged.single().purchaseState shouldBe PurchaseState.PURCHASED
+        // The completion is fresh Play data: it must reach the grace bookkeeping, unlike the
+        // pending event before it.
+        val updates = connection.freshUpdates.take(2).toList()
+        updates[0].purchases shouldBe emptyList()
+        updates[1].purchases shouldBe listOf(purchased)
+    }
+
+    @Test fun `an unspecified-state purchase is dropped everywhere`() = runTest2 {
+        val unspecified = purchase(1_000, token = "unspecified", state = PurchaseState.UNSPECIFIED_STATE)
+        val connection = BillingConnection(
+            client = clientReturning(
+                result(BillingResponseCode.OK) to listOf(unspecified),
+                result(BillingResponseCode.OK) to emptyList(),
+            ),
+        )
+        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(unspecified))
+
+        val refresh = connection.refreshPurchases()
+
+        // Neither owned nor a payment in progress: it must not reach state, refresh or UI.
+        refresh.purchases shouldBe emptyList()
+        connection.purchases.first() shouldBe emptyList()
+    }
+
+    @Test fun `a pending-only overlay survivor does not suppress absence bookkeeping`() = runTest2 {
+        // A pending payment arrives while a refresh is in flight: the queries verified empty, and
+        // the surviving PENDING overlay proves no ownership — the snapshot still proves absence,
+        // unlike the PURCHASED case (which must not start a false unconfirmed-grace episode).
+        val pendingListeners = mutableListOf<PurchasesResponseListener>()
+        val client = mockk<BillingClient>().apply {
+            every { queryPurchasesAsync(any<QueryPurchasesParams>(), any()) } answers {
+                pendingListeners.add(secondArg())
+            }
+        }
+        val connection = BillingConnection(client = client)
+
+        val refresh = async(start = CoroutineStart.UNDISPATCHED) { connection.refreshPurchases() }
+        runCurrent()
+        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(pendingPurchase(1_000)))
+        pendingListeners.forEach { it.onQueryPurchasesResponse(result(BillingResponseCode.OK), mutableListOf()) }
+        runCurrent()
+        refresh.await()
+
+        val update = connection.freshUpdates.first()
+        update.purchases shouldBe emptyList()
+        update.isFullSnapshot shouldBe true
+    }
+
+    @Test fun `a refresh reports only what its own queries confirmed`() = runTest2 {
+        val iapOwned = purchase(1_000, token = "iap")
+        val connection = BillingConnection(
+            client = clientReturning(
+                // Refresh 1: both succeed, IAP owned.
+                result(BillingResponseCode.OK) to listOf(iapOwned),
+                result(BillingResponseCode.OK) to emptyList(),
+                // Refresh 2: IAP fails (stale snapshot retained), SUB confirms a pending payment.
+                result(BillingResponseCode.ERROR) to emptyList(),
+                result(BillingResponseCode.OK) to listOf(
+                    pendingPurchase(2_000, token = "pending-sub", products = listOf(OurSku.Sub.PRO_UPGRADE.id))
+                ),
+            ),
+        )
+        connection.refreshPurchases()
+
+        val second = connection.refreshPurchases()
+
+        // The retained IAP purchase is in the committed view, but it is NOT something these
+        // queries confirmed — reporting it as confirmed Pro would keep the grace clock frozen
+        // through an indefinite outage.
+        second.purchases.map { it.purchaseToken } shouldContainExactly listOf("pending-sub", "iap")
+        second.confirmed shouldBe emptyList()
+        second.hasConfirmedProPurchase shouldBe false
+        second.isComplete shouldBe false
+        second.partialError.shouldNotBeNull()
+    }
+
+    @Test fun `a confirmed known purchase is reported as confirmed pro`() = runTest2 {
+        val connection = BillingConnection(
+            client = clientReturning(
+                result(BillingResponseCode.OK) to listOf(purchase(1_000, token = "iap")),
+                result(BillingResponseCode.ERROR) to emptyList(),
+            ),
+        )
+
+        val refresh = connection.refreshPurchases()
+
+        refresh.confirmed.map { it.purchaseToken } shouldBe listOf("iap")
+        refresh.hasConfirmedProPurchase shouldBe true
+        refresh.isComplete shouldBe false
+    }
+
+    @Test fun `a refresh is stamped with its commit time`() = runTest2 {
+        val before = System.currentTimeMillis()
+        val connection = BillingConnection(
+            client = clientReturning(
+                result(BillingResponseCode.OK) to emptyList(),
+                result(BillingResponseCode.OK) to emptyList(),
+            ),
+        )
+
+        val refresh = connection.refreshPurchases()
+        val after = System.currentTimeMillis()
+
+        (refresh.occurredAt in before..after) shouldBe true
+        // The same instant travels on the fresh update, so a confirmation and a later failure
+        // signal can be ordered against each other.
+        refresh.occurredAt shouldBe connection.freshUpdates.first().occurredAt
     }
 
     @Test fun `fresh updates arrive in commit order`() = runTest2 {
@@ -803,146 +995,6 @@ class BillingConnectionTest : BaseTest() {
         shouldThrow<BillingClientException> {
             connection.launchBillingFlow(mockk(), OurSku.Iap.PRO_UPGRADE, null)
         }
-    }
-
-    // endregion
-
-    // region querySubscriptions (pre-purchase gate)
-
-    @Test fun `querySubscriptions returns fresh subs and keeps the iap snapshot intact`() = runTest2 {
-        val iapOwned = purchase(1_000, token = "iap")
-        val subOwned = purchase(2_000, token = "sub", products = listOf(OurSku.Sub.PRO_UPGRADE.id))
-        val client = clientReturning(
-            // Refresh: IAP owned, no subs yet.
-            result(BillingResponseCode.OK) to listOf(iapOwned),
-            result(BillingResponseCode.OK) to emptyList(),
-            // SUBS-only gate query: sub found.
-            result(BillingResponseCode.OK) to listOf(subOwned),
-        )
-        val connection = BillingConnection(client = client)
-        connection.refreshPurchases()
-
-        val gateView = connection.querySubscriptions()
-
-        gateView shouldBe listOf(subOwned)
-        // The gate must have queried SUBS, not INAPP (clientReturning ignores the params, so this
-        // would otherwise go unnoticed). zza() is the params' only product-type accessor — a
-        // billing library upgrade renaming it breaks this line loudly at compile time.
-        verify(exactly = 2) {
-            client.queryPurchasesAsync(match<QueryPurchasesParams> { it.zza() == BillingClient.ProductType.SUBS }, any())
-        }
-        // The SUBS-only commit updates the reactive view WITHOUT disturbing the IAP snapshot —
-        // wiping it would briefly un-Pro a one-time-purchase owner.
-        connection.purchases.first().map { it.purchaseToken } shouldContainExactly listOf("sub", "iap")
-        val updates = connection.freshUpdates.take(2).toList()
-        // Partial by definition: it proves what the SUBS query found, never absence of the rest.
-        updates[1].purchases shouldBe listOf(subOwned)
-        updates[1].isFullSnapshot shouldBe false
-    }
-
-    @Test fun `a failed querySubscriptions propagates and commits nothing`() = runTest2 {
-        val iapOwned = purchase(1_000, token = "iap")
-        val subOwned = purchase(2_000, token = "sub", products = listOf(OurSku.Sub.PRO_UPGRADE.id))
-        val connection = BillingConnection(
-            client = clientReturning(
-                result(BillingResponseCode.OK) to listOf(iapOwned),
-                result(BillingResponseCode.OK) to listOf(subOwned),
-                result(BillingResponseCode.ERROR) to emptyList(),
-            ),
-        )
-        val freshUpdates = mutableListOf<BillingConnection.FreshUpdate>()
-        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) {
-            connection.freshUpdates.collect { freshUpdates.add(it) }
-        }
-        connection.refreshPurchases()
-
-        // Fail-closed contract: the gate must see the error, not an empty "no subscriptions".
-        shouldThrow<BillingClientException> { connection.querySubscriptions() }
-        runCurrent()
-
-        // No commit and no fresh emission from the failed query — only the refresh's own. Both
-        // snapshots survive, including the SUB one the failed query was about.
-        connection.purchases.first().map { it.purchaseToken } shouldContainExactly listOf("sub", "iap")
-        freshUpdates.size shouldBe 1
-    }
-
-    @Test fun `querySubscriptions clears an older sub overlay it could have seen`() = runTest2 {
-        // The sub arrived via purchase event, then the user refunded/cancelled it away: the gate
-        // query verifies empty and must supersede the stale event — otherwise the ghost sub keeps
-        // blocking the one-time purchase.
-        val subEvent = purchase(1_000, token = "sub-event", products = listOf(OurSku.Sub.PRO_UPGRADE.id))
-        val connection = BillingConnection(
-            client = clientReturning(result(BillingResponseCode.OK) to emptyList()),
-        )
-        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(subEvent))
-
-        connection.querySubscriptions() shouldBe emptyList()
-        connection.purchases.first() shouldBe emptyList()
-    }
-
-    @Test fun `querySubscriptions prefers a racing event's renewal state for the same token`() = runTest2 {
-        // The stale query result says the sub no longer renews, but a purchase event that landed
-        // while the query was in flight says it does (user just re-subscribed): the gate must see
-        // the overlay version, or the fail-closed double-billing check lets the buy through.
-        val queried = purchase(1_000, token = "same", products = listOf(OurSku.Sub.PRO_UPGRADE.id)).apply {
-            every { isAutoRenewing } returns false
-        }
-        val raced = purchase(1_000, token = "same", products = listOf(OurSku.Sub.PRO_UPGRADE.id)).apply {
-            every { isAutoRenewing } returns true
-        }
-        val pendingListeners = mutableListOf<PurchasesResponseListener>()
-        val client = mockk<BillingClient>().apply {
-            every { queryPurchasesAsync(any<QueryPurchasesParams>(), any()) } answers {
-                pendingListeners.add(secondArg())
-            }
-        }
-        val connection = BillingConnection(client = client)
-
-        val gate = async(start = CoroutineStart.UNDISPATCHED) { connection.querySubscriptions() }
-        runCurrent()
-        pendingListeners.size shouldBe 1
-
-        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(raced))
-        pendingListeners.single().onQueryPurchasesResponse(result(BillingResponseCode.OK), mutableListOf(queried))
-        runCurrent()
-
-        val gateView = gate.await()
-        gateView.single().isAutoRenewing shouldBe true
-    }
-
-    @Test fun `querySubscriptions excludes iap overlay entries but keeps untyped ones`() = runTest2 {
-        val iapEvent = purchase(1_000, token = "iap-event")
-        val unknownEvent = purchase(2_000, token = "unknown", products = listOf("some.unknown.product"))
-        val connection = BillingConnection(
-            client = clientReturning(result(BillingResponseCode.OK) to emptyList()),
-        )
-        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(iapEvent))
-        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(unknownEvent))
-
-        val gateView = connection.querySubscriptions()
-
-        // An IAP can't be the blocking subscription; an unknown product might be, so it stays in
-        // on the safe side.
-        gateView.map { it.purchaseToken } shouldBe listOf("unknown")
-        // Excluded from the gate view only — the reducer still owns both entries.
-        connection.purchases.first().map { it.purchaseToken } shouldContainExactly listOf("unknown", "iap-event")
-    }
-
-    @Test fun `querySubscriptions filters pending subscription results`() = runTest2 {
-        val pendingSub = mockk<Purchase>().apply {
-            every { purchaseState } returns PurchaseState.PENDING
-            every { purchaseTime } returns 1_000L
-            every { purchaseToken } returns "pending-sub"
-            every { this@apply.products } returns listOf(OurSku.Sub.PRO_UPGRADE.id)
-        }
-        val connection = BillingConnection(
-            client = clientReturning(result(BillingResponseCode.OK) to listOf(pendingSub)),
-        )
-
-        // A PENDING subscription is not an active one — it must neither block the gate nor
-        // surface as owned.
-        connection.querySubscriptions() shouldBe emptyList()
-        connection.purchases.first() shouldBe emptyList()
     }
 
     // endregion

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/ui/GplayUpgradeOwnershipTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/ui/GplayUpgradeOwnershipTest.kt
@@ -89,4 +89,38 @@ class GplayUpgradeOwnershipTest : BaseTest() {
 
         ownership.ownsAnything shouldBe false
     }
+
+    private fun pendingInfo(vararg pending: Purchase) = UpgradeRepoGplay.Info(
+        false,
+        BillingData(purchases = emptyList(), pendingPurchases = pending.toList()),
+        null,
+    )
+
+    @Test
+    fun `a pending payment sets the pending flag`() {
+        pendingInfo(mockPurchase("eu.darken.sdmse.iap.upgrade.pro")).toPendingFlag().shouldBeTrue()
+        pendingInfo(mockPurchase("upgrade.pro")).toPendingFlag().shouldBeTrue()
+    }
+
+    @Test
+    fun `no pending payment leaves the flag off`() {
+        info(mockPurchase("eu.darken.sdmse.iap.upgrade.pro")).toPendingFlag().shouldBeFalse()
+        pendingInfo().toPendingFlag().shouldBeFalse()
+    }
+
+    @Test
+    fun `an unknown pending product does not set the flag`() {
+        // Nothing to explain and nothing to lock: a product this app doesn't sell isn't the Pro
+        // upgrade the user is waiting for.
+        pendingInfo(mockPurchase("some.unknown.sku")).toPendingFlag().shouldBeFalse()
+    }
+
+    @Test
+    fun `a pending payment is not ownership`() {
+        val ownership = pendingInfo(mockPurchase("eu.darken.sdmse.iap.upgrade.pro")).toOwnership()
+
+        ownership.hasIap.shouldBeFalse()
+        ownership.subscription.shouldBeNull()
+        ownership.ownsAnything.shouldBeFalse()
+    }
 }

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/ui/GplayUpgradeScreenHostTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/ui/GplayUpgradeScreenHostTest.kt
@@ -2,8 +2,10 @@ package eu.darken.sdmse.common.upgrade.ui
 
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.SavedStateHandle
+import eu.darken.sdmse.R
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import eu.darken.sdmse.common.upgrade.core.UpgradeRepoGplay
 import eu.darken.sdmse.common.upgrade.core.billing.GplayServiceUnavailableException
@@ -39,6 +41,34 @@ class GplayUpgradeScreenHostTest : BaseTest() {
         every { proUnconfirmedSince } returns MutableStateFlow(0L)
         every { autoRestoreBusy } returns MutableStateFlow(false)
         every { purchaseLaunchSku } returns MutableStateFlow<Sku?>(null)
+    }
+
+    @Test
+    fun `a pending-purchase event puts the informational dialog on screen`() {
+        // Host-level wiring: the ViewModel tests prove the event is emitted, only a real
+        // composition proves it reaches a dialog (and survives as a rememberSaveable flag).
+        val repo = mockRepo()
+        coEvery { repo.querySkus(any()) } returns emptyList()
+        val vm = UpgradeViewModel(
+            handle = SavedStateHandle(mapOf("forced" to false)),
+            dispatcherProvider = TestDispatcherProvider(),
+            upgradeRepo = repo,
+            webpageTool = mockk(relaxed = true),
+        )
+
+        composeRule.setContent {
+            PreviewWrapper {
+                UpgradeScreenHost(vm = vm)
+            }
+        }
+        composeRule.waitForIdle()
+
+        vm.events.tryEmit(UpgradeEvents.PurchasePending)
+
+        val message = composeRule.activity.getString(R.string.upgrade_screen_pending_dialog_message)
+        composeRule.waitUntil {
+            composeRule.onAllNodesWithText(message, substring = true).fetchSemanticsNodes().isNotEmpty()
+        }
     }
 
     @Test

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/ui/GplayUpgradeScreenTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/ui/GplayUpgradeScreenTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
@@ -353,6 +354,88 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
         )
         check(idle.iapEnabled) { "IAP buy should be enabled when idle" }
         check(idle.subscriptionEnabled) { "Subscription buy should be enabled when idle" }
+
+        // A pending payment locks BOTH, whichever product it belongs to: Play rejects a second
+        // purchase of the pending product, and the alternative would charge twice for Pro.
+        val pending = toLoadedState(
+            iap = SkuDetails(OurSku.Iap.PRO_UPGRADE, iapDetails),
+            sub = SkuDetails(OurSku.Sub.PRO_UPGRADE, subDetails),
+            ownership = Ownership(),
+            hasPendingPurchase = true,
+        )
+        check(!pending.iapEnabled) { "IAP buy must be disabled while a payment is pending" }
+        check(!pending.subscriptionEnabled) { "Subscription buy must be disabled while a payment is pending" }
+    }
+
+    @Test
+    fun `a pending payment shows the card and locks the offers for acquisition`() {
+        composeRule.setUpgradeContent {
+            UpgradeScreen(
+                uiState = GplayUpgradeUiState.Loaded(
+                    subscriptionAction = SubscriptionAction.STANDARD,
+                    subscriptionEnabled = false,
+                    subscriptionPrice = "$12.99",
+                    iapEnabled = false,
+                    iapPrice = "$24.99",
+                    hasPendingPurchase = true,
+                ),
+            )
+        }
+
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_PENDING).assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_pending_card_body))
+            .assertCountEquals(1)
+        composeRule.onNodeWithTag(UpgradeScreenTags.GPLAY_SUBSCRIPTION).assertIsNotEnabled()
+        composeRule.onNodeWithTag(UpgradeScreenTags.GPLAY_IAP).assertIsNotEnabled()
+        // Restore stays available: re-checking with Play is exactly the right move for someone who
+        // believes the payment already went through.
+        composeRule.onNodeWithTag(UpgradeScreenTags.GPLAY_RESTORE).assertIsEnabled()
+    }
+
+    @Test
+    fun `a pending payment shows the card on the ownership screen and locks the switch`() {
+        composeRule.setUpgradeContent {
+            UpgradeScreen(
+                uiState = ownedState(Ownership(subscription = SubscriptionOwnership(isAutoRenewing = false)))
+                    .copy(hasPendingPurchase = true),
+            )
+        }
+
+        // The subscriber switching to the one-time purchase: the switch offer is unlocked by the
+        // non-renewing subscription, but a payment in progress must still hold it.
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_PENDING).assertCountEquals(1)
+        composeRule.onNodeWithTag(UpgradeScreenTags.GPLAY_IAP).assertIsNotEnabled()
+    }
+
+    @Test
+    fun `a pending payment shows the card during a young grace episode`() {
+        composeRule.setUpgradeContent {
+            UpgradeScreen(uiState = graceState(showDiagnostics = false).copy(hasPendingPurchase = true))
+        }
+
+        // The young grace stage hides the offers box entirely, so a card rendered inside it would
+        // never reach this audience — which is precisely the one waiting for a renewal payment.
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_PENDING).assertCountEquals(1)
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_GRACE).assertCountEquals(1)
+    }
+
+    @Test
+    fun `the pending dialog is informational only`() {
+        var dismissals = 0
+        composeRule.setUpgradeContent { PurchasePendingDialog(onDismiss = { dismissals++ }) }
+
+        composeRule.onNodeWithText(
+            context.getString(R.string.upgrade_screen_pending_dialog_message),
+            substring = true,
+        ).assertExists()
+        // No support escalation and no restore tips: there is nothing for the user to do.
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_contact_support_action))
+            .assertCountEquals(0)
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_restore_multiaccount_hint))
+            .assertCountEquals(0)
+
+        composeRule.onNodeWithText(context.getString(CommonR.string.general_dismiss_action)).performClick()
+        composeRule.runOnIdle { dismissals shouldBe 1 }
     }
 
     @Test

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/ui/GplayUpgradeViewModelTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/ui/GplayUpgradeViewModelTest.kt
@@ -571,6 +571,26 @@ class GplayUpgradeViewModelTest : BaseTest() {
     }
 
     @Test
+    fun `iap purchase is blocked by a renewing subscription with an unknown product`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // The gate reads the RAW purchases, never the mapped upgrades: a subscription whose product
+        // ID this build doesn't know (legacy SKU, renamed product) still renews and still bills, so
+        // letting the one-time purchase through here charges the user for Pro twice.
+        val repo = mockRepo()
+        coEvery { repo.verifyPurchaseStateNow() } returns
+            proInfo(mockPurchase("some.unknown.subscription", autoRenewing = true))
+        val vm = buildVm(repo)
+
+        val event = async { vm.events.first() }
+        vm.onGoIap(mockk<Activity>(relaxed = true))
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.SubscriptionStillRenewing
+        coVerify(exactly = 0) { repo.launchBillingFlowNow(any(), any(), any(), any()) }
+    }
+
+    @Test
     fun `iap purchase proceeds when the subscription is not set to renew`() = runTest2(context = testDispatcher) {
         val repo = mockRepo()
         coEvery { repo.verifyPurchaseStateNow() } returns

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/ui/GplayUpgradeViewModelTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/ui/GplayUpgradeViewModelTest.kt
@@ -24,6 +24,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
@@ -683,14 +684,19 @@ class GplayUpgradeViewModelTest : BaseTest() {
     fun `a pending-payment launch failure surfaces as the pending dialog`() = runTest2(context = testDispatcher) {
         // Play can only report this at launch time (the gate saw a clean state moments earlier):
         // the already-owned error dialog with its restore tips would be the wrong advice.
+        // The callback is captured and invoked from the test body rather than from inside the
+        // answer: on a suspend function the argument list carries the continuation, so grabbing the
+        // callback positionally there is a coin flip — and a wrong cast would surface as a hang.
         val repo = mockRepo()
-        coEvery { repo.launchBillingFlowNow(any(), any(), any(), any()) } coAnswers {
-            lastArg<(Throwable) -> Unit>().invoke(PendingPurchaseBillingException())
-        }
+        val onError = slot<(Throwable) -> Unit>()
+        coEvery { repo.launchBillingFlowNow(any(), any(), any(), capture(onError)) } returns Unit
         val vm = buildVm(repo)
 
         val event = async { vm.events.first() }
         vm.onGoIap(mockk<Activity>(relaxed = true))
+        advanceUntilIdle()
+
+        onError.captured(PendingPurchaseBillingException())
         advanceUntilIdle()
 
         event.await() shouldBe UpgradeEvents.PurchasePending

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/ui/GplayUpgradeViewModelTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/ui/GplayUpgradeViewModelTest.kt
@@ -11,6 +11,7 @@ import eu.darken.sdmse.common.upgrade.core.UpgradeRepoGplay
 import eu.darken.sdmse.common.upgrade.core.billing.BillingData
 import eu.darken.sdmse.common.upgrade.core.billing.GplayServiceUnavailableException
 import eu.darken.sdmse.common.upgrade.core.billing.OfferUnavailableBillingException
+import eu.darken.sdmse.common.upgrade.core.billing.PendingPurchaseBillingException
 import eu.darken.sdmse.common.upgrade.core.billing.Sku
 import eu.darken.sdmse.main.ui.navigation.SupportFormRoute
 import io.kotest.matchers.booleans.shouldBeTrue
@@ -298,6 +299,9 @@ class GplayUpgradeViewModelTest : BaseTest() {
         // Relaxed mocks return a no-op Flow that never emits -- the state combine would starve.
         every { autoRestoreBusy } returns MutableStateFlow(false)
         every { purchaseLaunchSku } returns MutableStateFlow<Sku?>(null)
+        // Both purchase paths run the pre-purchase gate: the default is a clean account (nothing
+        // owned, nothing pending), so tests only stub it when the gate IS the subject.
+        coEvery { verifyPurchaseStateNow() } returns UpgradeRepoGplay.Info(false, null, null, isSettled = true)
     }
 
     private fun buildVm(
@@ -321,6 +325,15 @@ class GplayUpgradeViewModelTest : BaseTest() {
         BillingData(purchases = purchases.toList()),
         null,
         // Ownership data implies a committed reconciliation -> always settled.
+        isSettled = true,
+    )
+
+    // Play is still processing a payment: nothing owned, nothing granted, but the purchase paths
+    // must treat it as a blocking answer.
+    private fun pendingInfo(skuId: String = OurSku.Iap.PRO_UPGRADE.id) = UpgradeRepoGplay.Info(
+        false,
+        BillingData(purchases = emptyList(), pendingPurchases = listOf(mockPurchase(skuId))),
+        null,
         isSettled = true,
     )
 
@@ -373,6 +386,22 @@ class GplayUpgradeViewModelTest : BaseTest() {
         advanceUntilIdle()
 
         event.await() shouldBe UpgradeEvents.RestoreFailed
+    }
+
+    @Test
+    fun `restore that finds a pending payment emits PurchasePending`() = runTest2(context = testDispatcher) {
+        // Play answered and DID find the purchase — it just isn't paid for yet. RestoreFailed would
+        // send this user through account troubleshooting and support for something that resolves
+        // itself.
+        val repo = mockRepo()
+        coEvery { repo.restorePurchaseNow() } returns checked(pendingInfo())
+        val vm = buildVm(repo)
+
+        val event = async { vm.events.first() }
+        vm.restorePurchase()
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.PurchasePending
     }
 
     @Test
@@ -528,7 +557,8 @@ class GplayUpgradeViewModelTest : BaseTest() {
     @Test
     fun `iap purchase is blocked while the subscription is still set to renew`() = runTest2(context = testDispatcher) {
         val repo = mockRepo()
-        coEvery { repo.queryCurrentSubscriptions() } returns listOf(mockPurchase("upgrade.pro", autoRenewing = true))
+        coEvery { repo.verifyPurchaseStateNow() } returns
+            proInfo(mockPurchase(OurSku.Sub.PRO_UPGRADE.id, autoRenewing = true))
         val vm = buildVm(repo)
 
         val event = async { vm.events.first() }
@@ -542,7 +572,8 @@ class GplayUpgradeViewModelTest : BaseTest() {
     @Test
     fun `iap purchase proceeds when the subscription is not set to renew`() = runTest2(context = testDispatcher) {
         val repo = mockRepo()
-        coEvery { repo.queryCurrentSubscriptions() } returns listOf(mockPurchase("upgrade.pro", autoRenewing = false))
+        coEvery { repo.verifyPurchaseStateNow() } returns
+            proInfo(mockPurchase(OurSku.Sub.PRO_UPGRADE.id, autoRenewing = false))
         val vm = buildVm(repo)
 
         vm.onGoIap(mockk<Activity>(relaxed = true))
@@ -554,7 +585,7 @@ class GplayUpgradeViewModelTest : BaseTest() {
     @Test
     fun `iap purchase proceeds without any subscription`() = runTest2(context = testDispatcher) {
         val repo = mockRepo()
-        coEvery { repo.queryCurrentSubscriptions() } returns emptyList()
+        coEvery { repo.verifyPurchaseStateNow() } returns UpgradeRepoGplay.Info(false, null, null, isSettled = true)
         val vm = buildVm(repo)
 
         vm.onGoIap(mockk<Activity>(relaxed = true))
@@ -564,12 +595,12 @@ class GplayUpgradeViewModelTest : BaseTest() {
     }
 
     @Test
-    fun `failing subscription verification blocks the purchase and forwards the error`() = runTest2(
+    fun `failing purchase verification blocks the purchase and forwards the error`() = runTest2(
         context = testDispatcher,
     ) {
         val repo = mockRepo()
         val boom = IllegalStateException("Play unavailable")
-        coEvery { repo.queryCurrentSubscriptions() } throws boom
+        coEvery { repo.verifyPurchaseStateNow() } throws boom
         val vm = buildVm(repo)
 
         val forwardedError = async { vm.errorEvents.first() }
@@ -581,13 +612,13 @@ class GplayUpgradeViewModelTest : BaseTest() {
     }
 
     @Test
-    fun `subscription verification timeout blocks the purchase with a check-failed event`() = runTest2(
+    fun `purchase verification timeout blocks the purchase with a check-failed event`() = runTest2(
         context = testDispatcher,
     ) {
         val repo = mockRepo()
-        coEvery { repo.queryCurrentSubscriptions() } coAnswers {
+        coEvery { repo.verifyPurchaseStateNow() } coAnswers {
             delay(30_000) // longer than the 10s verification timeout
-            emptyList()
+            UpgradeRepoGplay.Info(false, null, null, isSettled = true)
         }
         val vm = buildVm(repo)
 
@@ -595,16 +626,82 @@ class GplayUpgradeViewModelTest : BaseTest() {
         vm.onGoIap(mockk<Activity>(relaxed = true))
         advanceUntilIdle()
 
-        event.await() shouldBe UpgradeEvents.SubscriptionCheckFailed
+        event.await() shouldBe UpgradeEvents.PurchaseCheckFailed
         coVerify(exactly = 0) { repo.launchBillingFlowNow(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `a subscription gate timeout blocks that purchase too`() = runTest2(context = testDispatcher) {
+        // The subscription path used to launch unverified: a slow Play means we don't know whether
+        // a payment is already pending, so it must fail closed like the one-time path.
+        val repo = mockRepo()
+        coEvery { repo.verifyPurchaseStateNow() } coAnswers {
+            delay(30_000)
+            UpgradeRepoGplay.Info(false, null, null, isSettled = true)
+        }
+        val vm = buildVm(repo)
+
+        val event = async { vm.events.first() }
+        vm.onGoSubscription(mockk<Activity>(relaxed = true))
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.PurchaseCheckFailed
+        coVerify(exactly = 0) { repo.launchBillingFlowNow(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `a pending payment blocks the one-time purchase`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        coEvery { repo.verifyPurchaseStateNow() } returns pendingInfo()
+        val vm = buildVm(repo)
+
+        val event = async { vm.events.first() }
+        vm.onGoIap(mockk<Activity>(relaxed = true))
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.PurchasePending
+        coVerify(exactly = 0) { repo.launchBillingFlowNow(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `a pending payment blocks the subscription purchase`() = runTest2(context = testDispatcher) {
+        // SKU-agnostic on purpose: the two products are alternatives, so a pending payment for
+        // either one must block both — completing both charges the user twice.
+        val repo = mockRepo()
+        coEvery { repo.verifyPurchaseStateNow() } returns pendingInfo()
+        val vm = buildVm(repo)
+
+        val event = async { vm.events.first() }
+        vm.onGoSubscriptionTrial(mockk<Activity>(relaxed = true))
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.PurchasePending
+        coVerify(exactly = 0) { repo.launchBillingFlowNow(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `a pending-payment launch failure surfaces as the pending dialog`() = runTest2(context = testDispatcher) {
+        // Play can only report this at launch time (the gate saw a clean state moments earlier):
+        // the already-owned error dialog with its restore tips would be the wrong advice.
+        val repo = mockRepo()
+        coEvery { repo.launchBillingFlowNow(any(), any(), any(), any()) } coAnswers {
+            lastArg<(Throwable) -> Unit>().invoke(PendingPurchaseBillingException())
+        }
+        val vm = buildVm(repo)
+
+        val event = async { vm.events.first() }
+        vm.onGoIap(mockk<Activity>(relaxed = true))
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.PurchasePending
     }
 
     @Test
     fun `iap taps are single-flight while a verification is running`() = runTest2(context = testDispatcher) {
         val repo = mockRepo()
-        coEvery { repo.queryCurrentSubscriptions() } coAnswers {
+        coEvery { repo.verifyPurchaseStateNow() } coAnswers {
             delay(5_000)
-            emptyList()
+            UpgradeRepoGplay.Info(false, null, null, isSettled = true)
         }
         val vm = buildVm(repo)
 
@@ -613,7 +710,7 @@ class GplayUpgradeViewModelTest : BaseTest() {
         vm.onGoIap(mockk<Activity>(relaxed = true))
         advanceUntilIdle()
 
-        coVerify(exactly = 1) { repo.queryCurrentSubscriptions() }
+        coVerify(exactly = 1) { repo.verifyPurchaseStateNow() }
         coVerify(exactly = 1) { repo.launchBillingFlowNow(any(), eq(OurSku.Iap.PRO_UPGRADE), isNull(), any()) }
     }
 
@@ -650,8 +747,9 @@ class GplayUpgradeViewModelTest : BaseTest() {
         advanceUntilIdle()
 
         // One arbiter for all three: the purchase and the restore would otherwise run concurrent
-        // Play operations against the same account state.
-        coVerify(exactly = 0) { repo.queryCurrentSubscriptions() }
+        // Play operations against the same account state. Exactly one gate ran — the subscription's
+        // own; the blocked IAP tap never got to verify anything.
+        coVerify(exactly = 1) { repo.verifyPurchaseStateNow() }
         coVerify(exactly = 0) { repo.restorePurchaseNow() }
         coVerify(exactly = 1) { repo.launchBillingFlowNow(any(), any(), any(), any()) }
     }
@@ -674,7 +772,7 @@ class GplayUpgradeViewModelTest : BaseTest() {
 
         coVerify(exactly = 1) { repo.restorePurchaseNow() }
         coVerify(exactly = 0) { repo.launchBillingFlowNow(any(), any(), any(), any()) }
-        coVerify(exactly = 0) { repo.queryCurrentSubscriptions() }
+        coVerify(exactly = 0) { repo.verifyPurchaseStateNow() }
     }
 
     @Test
@@ -970,6 +1068,43 @@ class GplayUpgradeViewModelTest : BaseTest() {
         advanceUntilIdle()
 
         event.await() shouldBe UpgradeEvents.RestoreFailed
+    }
+
+    @Test
+    fun `a pending payment renders while the price queries are still running`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // Price-independent like owners and grace users: the pending card is this user's answer and
+        // both offers are locked anyway, so waiting on prices would hide it behind Loading.
+        val repo = mockRepo()
+        every { repo.upgradeInfo } returns MutableStateFlow(pendingInfo())
+        coEvery { repo.querySkus(any()) } coAnswers {
+            delay(60_000) // effectively never within this test
+            emptyList()
+        }
+        val vm = buildVm(repo)
+
+        val collector = launch(start = CoroutineStart.UNDISPATCHED) { vm.state.collect { } }
+        testScheduler.advanceTimeBy(1_000)
+
+        val loaded = vm.state.value.shouldBeInstanceOf<GplayUpgradeUiState.Loaded>()
+        loaded.hasPendingPurchase shouldBe true
+        collector.cancel()
+    }
+
+    @Test
+    fun `a pending payment keeps its card when both price queries fail`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        every { repo.upgradeInfo } returns MutableStateFlow(pendingInfo())
+        coEvery { repo.querySkus(any()) } throws IllegalStateException("Play unavailable")
+        val vm = buildVm(repo)
+
+        val loaded = async { awaitLoaded(vm) }
+        advanceUntilIdle()
+
+        // Not the acquisition-style Unavailable card: the pending explanation must survive a price
+        // outage, exactly like the grace card does.
+        loaded.await().hasPendingPurchase shouldBe true
     }
 
     @Test


### PR DESCRIPTION
## What changed

Paying for Pro with a slow payment method (cash codes, some cards) left the upgrade screen looking as if nothing had happened: the buy buttons stayed enabled and "Restore purchase" reported that nothing was found while Google Play was still processing the payment.

The upgrade screen now shows a "Payment pending" status card while a payment is being processed. All purchase buttons are locked during that time, since buying the other Pro variant on top would charge twice for the same features, and Google Play refuses to re-sell the product whose payment is pending anyway. "Restore purchase" now answers that the payment is still being processed instead of claiming nothing was found, and tapping a buy button before the app has caught up leads to the same explanation. Pro still only unlocks once Google Play completes the payment.

## Technical Context

- Pending purchases used to be filtered out at ingestion. They now enter the billing connection's reducer alongside completed ones and are split at the exits (`BillingData.from`), so entitlement, grace bookkeeping, and acknowledgement keep their PURCHASED-only views by construction, and the existing token dedup handles the pending-to-purchased transition on its own.
- Partial-refresh semantics changed deliberately: a pending purchase of a known Pro SKU counts as "found", so a cold start where one product-type query fails still publishes the connection and shows the pending state. The enriched `PurchaseRefresh` (commit-time timestamp, round-local confirmed evidence, partial error) feeds the grace-episode clock and dead-binder invalidation centrally from `BillingManager`, which also covers manual restores.
- Both purchase paths now run a fail-closed fresh pre-launch gate (`verifyPurchaseStateNow`) replacing the previous SUBS-only check. Review caught that narrowing the renewal check to known SKUs would let an auto-renewing subscription with an unknown or legacy product ID through to a double purchase, so the check reads the raw purchases (`Info.hasAutoRenewingSubscription`).
- Auto-renewing subscriptions never enter the pending state (pending purchases are only enabled for one-time products), so the realistic case is the one-time purchase; the handling stays SKU-agnostic. The subscription-specific check-failed string was replaced by a generic purchases one, so its stale entries were removed from all translated files and Crowdin will pick up the four new strings.
- On-device verification of the real pending flow (slow test card on a license-tester account) is still outstanding; the state handling and button gating are covered by unit tests.
