### PR TITLE
Fix: Force-stopping System UI broke cleaning automation until reboot

### DIFF
--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/ForceStopAutomationTask.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/ForceStopAutomationTask.kt
@@ -7,6 +7,9 @@ import eu.darken.sdmse.common.pkgs.toPkgId
 
 class ForceStopAutomationTask(
     val targets: List<InstallId>,
+    // An explicit user decision for a specific app may target packages that automated
+    // (multi-app) force-stops must skip, e.g. System UI.
+    val allowOffLimits: Boolean = false,
 ) : AutomationTask {
 
     data class Result(

--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/ForceStopAutomationTask.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/ForceStopAutomationTask.kt
@@ -1,7 +1,9 @@
 package eu.darken.sdmse.automation.core
 
-import eu.darken.sdmse.automation.core.AutomationTask
+import eu.darken.sdmse.common.BuildConfigWrap
+import eu.darken.sdmse.common.pkgs.Pkg
 import eu.darken.sdmse.common.pkgs.features.InstallId
+import eu.darken.sdmse.common.pkgs.toPkgId
 
 class ForceStopAutomationTask(
     val targets: List<InstallId>,
@@ -11,4 +13,24 @@ class ForceStopAutomationTask(
         val successful: Collection<InstallId>,
         val failed: Collection<InstallId>,
     ) : AutomationTask.Result
+
+    companion object {
+        /**
+         * Packages that must never be force-stopped by us.
+         *
+         * Force-stopping System UI cancels the PendingIntents it registered for accessibility
+         * system actions (BACK/HOME/DPAD), while its persistent process keeps running and never
+         * re-registers them. All performGlobalAction calls then fail until System UI restarts
+         * (usually via reboot). Force-stopping ourselves kills our own accessibility service
+         * mid-run.
+         */
+        // BuildConfigWrap can't initialize on the plain JVM unit test classpath (reflection on
+        // BuildConfig); tolerate that so production code using this filter stays JVM-testable.
+        val OFF_LIMIT_PKGS: Set<Pkg.Id> by lazy {
+            setOfNotNull(
+                "com.android.systemui".toPkgId(),
+                runCatching { BuildConfigWrap.APPLICATION_ID.toPkgId() }.getOrNull(),
+            )
+        }
+    }
 }

--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/errors/AutomationCompatibilityException.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/errors/AutomationCompatibilityException.kt
@@ -5,6 +5,7 @@ import android.os.Build
 import androidx.core.net.toUri
 import eu.darken.sdmse.automation.R
 import eu.darken.sdmse.common.BuildConfigWrap
+import eu.darken.sdmse.common.ca.CaString
 import eu.darken.sdmse.common.ca.caString
 import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.error.HasLocalizedError
@@ -14,21 +15,29 @@ import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 
 open class AutomationCompatibilityException(
-    override val message: String = "SD Maid couldn’t figure out the screen layout. If this keeps happening, your language or setup might not be fully supported. Check for updates or reach out to me so I can fix it."
+    override val message: String = "SD Maid couldn’t figure out the screen layout. If this keeps happening, your language or setup might not be fully supported. Check for updates or reach out to me so I can fix it.",
+    private val additionalHint: CaString? = null,
 ) : AutomationException(), HasLocalizedError {
 
     override fun getLocalizedError(): LocalizedError = LocalizedError(
         throwable = this,
         label = R.string.automation_error_compatibility_title.toCaString(),
         description = caString {
-            """
-                ${getString(R.string.automation_error_compatibility_body)}
-                
-               
-                ${getString(eu.darken.sdmse.common.R.string.general_information_for_the_developer)}:
-                v${BuildConfigWrap.VERSION_NAME} (${BuildConfigWrap.VERSION_CODE}) ${BuildConfigWrap.FLAVOR} [${BuildConfigWrap.BUILD_TYPE}]
-                ${Build.FINGERPRINT}
-            """.trimIndent()
+            val sb = StringBuilder()
+            sb.append(getString(R.string.automation_error_compatibility_body))
+            additionalHint?.let { hint ->
+                sb.append("\n\n")
+                sb.append(hint.get(this))
+            }
+            sb.append("\n\n\n")
+            sb.append(
+                """
+                    ${getString(eu.darken.sdmse.common.R.string.general_information_for_the_developer)}:
+                    v${BuildConfigWrap.VERSION_NAME} (${BuildConfigWrap.VERSION_CODE}) ${BuildConfigWrap.FLAVOR} [${BuildConfigWrap.BUILD_TYPE}]
+                    ${Build.FINGERPRINT}
+                """.trimIndent()
+            )
+            sb.toString()
         },
         infoActionLabel = eu.darken.sdmse.common.R.string.general_error_report_bug_action.toCaString(),
         infoAction = {

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleter.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleter.kt
@@ -231,7 +231,16 @@ class InaccessibleDeleter @Inject constructor(
         )
     }
 
-    private suspend fun forceStopApps(targets: List<InstallId>) {
+    private suspend fun forceStopApps(rawTargets: List<InstallId>) {
+        val targets = rawTargets.filter { target ->
+            val offLimits = ForceStopAutomationTask.OFF_LIMIT_PKGS.contains(target.pkgId)
+            if (offLimits) log(TAG, WARN) { "Skipping $target: force-stopping it would break accessibility automation" }
+            !offLimits
+        }
+        if (targets.isEmpty()) {
+            log(TAG) { "No force-stoppable apps in ${rawTargets.size} targets" }
+            return
+        }
         log(TAG, INFO) { "Force-stopping ${targets.size} apps before clearing cache" }
 
         updateProgressPrimary(eu.darken.sdmse.appcleaner.R.string.appcleaner_progress_force_stopping)

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
@@ -11,6 +11,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.appcleaner.R
+import eu.darken.sdmse.appcleaner.core.AppCleanerSettings
 import eu.darken.sdmse.appcleaner.core.automation.specs.AppCleanerSpecGenerator
 import eu.darken.sdmse.appcleaner.core.automation.specs.LabelDebugger
 import eu.darken.sdmse.appcleaner.core.automation.specs.alcatel.AlcatelSpecs
@@ -44,6 +45,7 @@ import eu.darken.sdmse.automation.core.specs.AutomationSpec
 import eu.darken.sdmse.common.OpsCounter
 import eu.darken.sdmse.common.ca.CaString
 import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
@@ -83,6 +85,7 @@ class ClearCacheModule @AssistedInject constructor(
     private val deviceDetective: DeviceDetective,
     private val romTypeProvider: RomTypeProvider,
     private val automationReturnHelper: AutomationReturnHelper,
+    private val settings: AppCleanerSettings,
 ) : AutomationModule(automationHost) {
 
     private fun getPriotizedSpecGenerators(): List<AppCleanerSpecGenerator> = specGenerators
@@ -153,7 +156,13 @@ class ClearCacheModule @AssistedInject constructor(
         val timeoutCount = result.failed.count { it.value is AutomationTimeoutException }
         if (timeoutCount >= TIMEOUT_LIMIT && result.successful.isEmpty()) {
             log(TAG, ERROR) { "Continued timeout errors, no successes so far, possible compatbility issue?" }
-            throw AutomationCompatibilityException()
+            throw AutomationCompatibilityException(
+                additionalHint = if (settings.forceStopBeforeClearing.value()) {
+                    R.string.appcleaner_automation_compat_forcestop_hint.toCaString()
+                } else {
+                    null
+                },
+            )
         }
 
         return ClearCacheTask.Result(

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
@@ -11,7 +11,6 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.appcleaner.R
-import eu.darken.sdmse.appcleaner.core.AppCleanerSettings
 import eu.darken.sdmse.appcleaner.core.automation.specs.AppCleanerSpecGenerator
 import eu.darken.sdmse.appcleaner.core.automation.specs.LabelDebugger
 import eu.darken.sdmse.appcleaner.core.automation.specs.alcatel.AlcatelSpecs
@@ -45,7 +44,6 @@ import eu.darken.sdmse.automation.core.specs.AutomationSpec
 import eu.darken.sdmse.common.OpsCounter
 import eu.darken.sdmse.common.ca.CaString
 import eu.darken.sdmse.common.ca.toCaString
-import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
@@ -85,7 +83,6 @@ class ClearCacheModule @AssistedInject constructor(
     private val deviceDetective: DeviceDetective,
     private val romTypeProvider: RomTypeProvider,
     private val automationReturnHelper: AutomationReturnHelper,
-    private val settings: AppCleanerSettings,
 ) : AutomationModule(automationHost) {
 
     private fun getPriotizedSpecGenerators(): List<AppCleanerSpecGenerator> = specGenerators
@@ -157,11 +154,7 @@ class ClearCacheModule @AssistedInject constructor(
         if (timeoutCount >= TIMEOUT_LIMIT && result.successful.isEmpty()) {
             log(TAG, ERROR) { "Continued timeout errors, no successes so far, possible compatbility issue?" }
             throw AutomationCompatibilityException(
-                additionalHint = if (settings.forceStopBeforeClearing.value()) {
-                    R.string.appcleaner_automation_compat_forcestop_hint.toCaString()
-                } else {
-                    null
-                },
+                additionalHint = R.string.appcleaner_automation_compat_forcestop_hint.toCaString(),
             )
         }
 

--- a/app-tool-appcleaner/src/main/res/values/strings.xml
+++ b/app-tool-appcleaner/src/main/res/values/strings.xml
@@ -86,6 +86,7 @@
     <string name="appcleaner_automation_error_locked_appcache_body">The system has disabled the "Clear cache" button for this app. Exclude it to speed up cache clearing.</string>
     <string name="appcleaner_automation_error_securitycenter_permission_title">System app misconfigured</string>
     <string name="appcleaner_automation_error_securitycenter_permission_body">HyperOS\'s Security app (com.miui.securitycenter) is missing the Usage Stats permission (GET_USAGE_STATS). This breaks features like "Clear Data" in app details and cache clearing via accessibility. Grant the permission to restore full functionality.</string>
+    <string name="appcleaner_automation_compat_forcestop_hint">This can also happen after force-stopping many apps in one run. That can make Android block SD Maid\'s automated input until you restart the device. If you have \"Force-stop before clearing\" turned on, try rebooting, or turn that option off.</string>
     <string name="appcleaner_forcestop_before_clearing_label">Force-stop before clearing</string>
     <string name="appcleaner_forcestop_before_clearing_summary">Force-stop apps before clearing their cache. It can help clear some apps\' caches, but may cause apps to misbehave and require manual restart.</string>
     <string name="appcleaner_progress_force_stopping">Force-stopping apps…</string>

--- a/app-tool-appcleaner/src/main/res/values/strings.xml
+++ b/app-tool-appcleaner/src/main/res/values/strings.xml
@@ -86,7 +86,7 @@
     <string name="appcleaner_automation_error_locked_appcache_body">The system has disabled the "Clear cache" button for this app. Exclude it to speed up cache clearing.</string>
     <string name="appcleaner_automation_error_securitycenter_permission_title">System app misconfigured</string>
     <string name="appcleaner_automation_error_securitycenter_permission_body">HyperOS\'s Security app (com.miui.securitycenter) is missing the Usage Stats permission (GET_USAGE_STATS). This breaks features like "Clear Data" in app details and cache clearing via accessibility. Grant the permission to restore full functionality.</string>
-    <string name="appcleaner_automation_compat_forcestop_hint">This can also happen after force-stopping many apps in one run. That can make Android block SD Maid\'s automated input until you restart the device. If you have \"Force-stop before clearing\" turned on, try rebooting, or turn that option off.</string>
+    <string name="appcleaner_automation_compat_forcestop_hint">This can also happen if the \"System UI\" system app was recently force-stopped, e.g. by an app cleaning tool. Android then blocks SD Maid\'s automated button presses until you restart the device.</string>
     <string name="appcleaner_forcestop_before_clearing_label">Force-stop before clearing</string>
     <string name="appcleaner_forcestop_before_clearing_summary">Force-stop apps before clearing their cache. It can help clear some apps\' caches, but may cause apps to misbehave and require manual restart.</string>
     <string name="appcleaner_progress_force_stopping">Force-stopping apps…</string>

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/AppControl.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/AppControl.kt
@@ -342,7 +342,7 @@ class AppControl @Inject constructor(
         forceStopper.useRes {
             forceStopper.withProgress(this) {
                 val mappedTargets = task.targets.map { id -> snapshot.apps.single { it.installId == id } }
-                val result = forceStop(mappedTargets)
+                val result = forceStop(mappedTargets, allowOffLimits = task.allowOffLimits)
                 successful.addAll(result.success)
                 failed.addAll(result.failed)
             }

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/automation/AppControlAutomation.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/automation/AppControlAutomation.kt
@@ -165,7 +165,7 @@ class AppControlAutomation @AssistedInject constructor(
                     throw UnsupportedOperationException("ACS based force-stop is not support for other users ($target)")
                 }
 
-                if (ForceStopAutomationTask.OFF_LIMIT_PKGS.contains(target.pkgId)) {
+                if (!task.allowOffLimits && ForceStopAutomationTask.OFF_LIMIT_PKGS.contains(target.pkgId)) {
                     log(TAG, WARN) { "Skipping $target: force-stopping it would break accessibility automation" }
                     failed.add(target)
                     continue

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/automation/AppControlAutomation.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/automation/AppControlAutomation.kt
@@ -165,6 +165,12 @@ class AppControlAutomation @AssistedInject constructor(
                     throw UnsupportedOperationException("ACS based force-stop is not support for other users ($target)")
                 }
 
+                if (ForceStopAutomationTask.OFF_LIMIT_PKGS.contains(target.pkgId)) {
+                    log(TAG, WARN) { "Skipping $target: force-stopping it would break accessibility automation" }
+                    failed.add(target)
+                    continue
+                }
+
                 val installed = pkgRepo.get(target.pkgId, target.userHandle)
 
                 if (installed == null) {

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/forcestop/ForceStopTask.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/forcestop/ForceStopTask.kt
@@ -14,6 +14,9 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 data class ForceStopTask(
     val targets: Set<InstallId> = emptySet(),
+    // An explicit user decision for a specific app may target packages that automated
+    // (multi-app) force-stops must skip, e.g. System UI.
+    val allowOffLimits: Boolean = false,
 ) : AppControlTask, Reportable {
 
     @Parcelize

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/forcestop/ForceStopper.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/forcestop/ForceStopper.kt
@@ -59,15 +59,18 @@ class ForceStopper @Inject constructor(
 
     override val sharedResource = SharedResource.createKeepAlive(TAG, appScope + dispatcherProvider.IO)
 
-    suspend fun forceStop(apps: List<AppInfo>): Result {
-        log(TAG, INFO) { "forceStop(${apps.size})" }
+    suspend fun forceStop(apps: List<AppInfo>, allowOffLimits: Boolean = false): Result {
+        log(TAG, INFO) { "forceStop(${apps.size}, allowOffLimits=$allowOffLimits)" }
         adoptChildResource(pkgOps)
 
 
         val successful = mutableSetOf<InstallId>()
         val failed = mutableSetOf<InstallId>()
 
-        val (offLimits, targets) = apps.partition { ForceStopAutomationTask.OFF_LIMIT_PKGS.contains(it.installId.pkgId) }
+        val (offLimits, targets) = when {
+            allowOffLimits -> emptyList<AppInfo>() to apps
+            else -> apps.partition { ForceStopAutomationTask.OFF_LIMIT_PKGS.contains(it.installId.pkgId) }
+        }
         offLimits.forEach {
             log(TAG, WARN) { "Skipping ${it.installId}: force-stopping it would break accessibility automation" }
             failed.add(it.installId)
@@ -97,7 +100,7 @@ class ForceStopper @Inject constructor(
             }
         } else if (automationSetupModule.isComplete()) {
             log(TAG) { "Using Automation..." }
-            val task = ForceStopAutomationTask(targets.map { it.installId }.toList())
+            val task = ForceStopAutomationTask(targets.map { it.installId }.toList(), allowOffLimits = allowOffLimits)
             val result = automation.submit(task) as ForceStopAutomationTask.Result
             successful.addAll(result.successful)
             failed.addAll(result.failed)

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/forcestop/ForceStopper.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/forcestop/ForceStopper.kt
@@ -12,6 +12,7 @@ import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
@@ -66,10 +67,19 @@ class ForceStopper @Inject constructor(
         val successful = mutableSetOf<InstallId>()
         val failed = mutableSetOf<InstallId>()
 
+        val (offLimits, targets) = apps.partition { ForceStopAutomationTask.OFF_LIMIT_PKGS.contains(it.installId.pkgId) }
+        offLimits.forEach {
+            log(TAG, WARN) { "Skipping ${it.installId}: force-stopping it would break accessibility automation" }
+            failed.add(it.installId)
+        }
+        if (targets.isEmpty()) {
+            return Result(success = successful, failed = failed)
+        }
+
         if (rootManager.canUseRootNow() || adbManager.canUseAdbNow()) {
             log(TAG) { "Using ROOT/ADB..." }
-            updateProgressCount(Progress.Count.Percent(apps.size))
-            apps.forEach {
+            updateProgressCount(Progress.Count.Percent(targets.size))
+            targets.forEach {
                 log(TAG) { "Force stopping ${it.installId} " }
                 updateProgressPrimary { ctx ->
                     ctx.getString(R.string.general_progress_processing_x, it.label.get(ctx))
@@ -87,7 +97,7 @@ class ForceStopper @Inject constructor(
             }
         } else if (automationSetupModule.isComplete()) {
             log(TAG) { "Using Automation..." }
-            val task = ForceStopAutomationTask(apps.map { it.installId }.toList())
+            val task = ForceStopAutomationTask(targets.map { it.installId }.toList())
             val result = automation.submit(task) as ForceStopAutomationTask.Result
             successful.addAll(result.successful)
             failed.addAll(result.failed)

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/actions/AppActionViewModel.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/actions/AppActionViewModel.kt
@@ -226,7 +226,7 @@ class AppActionViewModel @Inject constructor(
 
     private suspend fun submitForceStop() {
         val appInfo = currentAppInfoOrNull() ?: return
-        val task = ForceStopTask(setOf(appInfo.installId))
+        val task = ForceStopTask(setOf(appInfo.installId), allowOffLimits = true)
         val result = taskManager.submit(task) as ForceStopTask.Result
         events.emit(Event.ShowResult(result))
     }

--- a/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/ui/list/actions/AppActionViewModelTest.kt
+++ b/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/ui/list/actions/AppActionViewModelTest.kt
@@ -337,7 +337,7 @@ class AppActionViewModelTest : BaseTest() {
         h.vm.onActionTapped(AppActionItem.Action.ForceStop(installId))
         advanceUntilIdle()
 
-        val expectedTask = ForceStopTask(setOf(installId))
+        val expectedTask = ForceStopTask(setOf(installId), allowOffLimits = true)
         coVerify(exactly = 1) { h.taskSubmitter.submit(expectedTask) }
     }
 


### PR DESCRIPTION
## What changed

SD Maid no longer force-stops Android's "System UI" app (or SD Maid itself) during automated force-stops, i.e. AppCleaner's "Force-stop before clearing" and AppControl's multi-app force stop. Force-stopping System UI put Android into a state where all of SD Maid's automated button presses were rejected until the device was rebooted. On Pixel devices this made every cache clearing in the same run fail and show the "Automation compatibility" error, whose text blamed language or setup incompatibility. That error now also names this cause and points to a device restart, which matters when another tool force-stopped System UI.

## Technical Context

- Root cause, isolated on a Pixel 8 (Android 17): `performGlobalAction` system actions (BACK/HOME/DPAD) are PendingIntents registered by SystemUI. `forceStopPackage` cancels a package's PendingIntents but does not kill SystemUI's persistent process, so nothing re-registers them and every call fails with `PendingIntent$CanceledException` in `SystemActionPerformer` until SystemUI restarts. Verified in both directions: one targeted force-stop of `com.android.systemui` breaks the DPAD clear-cache path instantly, and restarting the SystemUI process heals it without a reboot. No count or threshold is involved; the earlier "many force-stops" framing was an artifact of full sweeps inevitably including System UI.
- The skip lives in `ForceStopAutomationTask.OFF_LIMIT_PKGS` and is enforced in `AppControlAutomation.processForceStop`, `ForceStopper` (root/ADB and automation), and `InaccessibleDeleter.forceStopApps` (root/ADB and automation). Skipped apps are reported as failed. `OFF_LIMIT_PKGS` resolves `BuildConfigWrap` lazily and tolerantly because it cannot initialize on the plain JVM test classpath.
- SD Maid's own package is skipped too: AppControl's select-all included SD Maid, and the automation force-stopped its own accessibility service mid-run, stranding the remaining targets (reproduced).
- Deliberate scope: the explicit single-app Force stop action in AppControl's app sheet passes `allowOffLimits = true` through `ForceStopTask`/`ForceStopper`/`ForceStopAutomationTask` and can still target System UI, since that is a deliberate per-app user decision; automated and multi-app paths keep the skip.
- `AutomationCompatibilityException` gained an optional `additionalHint` that is inserted between the body text and the developer-info block; the null-hint rendering is byte-identical to before. The hint is not gated on any setting because the remaining cause is external to SD Maid.
- On-device verification on the Pixel 8 covered what CI cannot: the poisoning mechanism, recovery via SystemUI restart, and the skip path (force-stop task on System UI returns skipped in 30 ms with no automation session and no PendingIntent errors).
