### PR TITLE
AppCleaner: Fix extra scrolling when clearing caches on One UI

### DIFF
--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/specs/SpecGeneratorExtensions.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/specs/SpecGeneratorExtensions.kt
@@ -7,6 +7,7 @@ import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.content.res.Resources
+import android.view.accessibility.AccessibilityEvent
 import eu.darken.sdmse.automation.core.errors.NoSettingsWindowException
 import eu.darken.sdmse.automation.core.AutomationEvent
 import eu.darken.sdmse.automation.core.common.ACSNodeInfo
@@ -31,12 +32,16 @@ import eu.darken.sdmse.common.pkgs.features.Installed
 import eu.darken.sdmse.common.pkgs.getLabel2
 import eu.darken.sdmse.common.pkgs.getPackageInfo2
 import eu.darken.sdmse.common.pkgs.getSettingsIntent
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.withTimeoutOrNull
 
 fun SpecGenerator.windowLauncherDefaultSettings(
     pkgInfo: Installed
@@ -228,46 +233,88 @@ private const val BUSY_NODE_MAX_LENGTH = 30
 fun SpecGenerator.defaultNodeRecovery(
     pkg: Installed,
     extraBusyLabels: Collection<String> = emptySet(),
-): suspend StepContext.(ACSNodeInfo) -> Boolean = recovery@{ root ->
-    log(tag) { "Performing node recovery for ${pkg.id}" }
+): suspend StepContext.(ACSNodeInfo) -> Boolean {
+    // One state holder per call: tracks scrolling across the stepper's inner retry loop.
+    // A new step attempt relaunches the target window and resets its scroll position.
+    var lastAttempt = -1
+    var lastScrolledForward = false
+    return recovery@{ root ->
+        log(tag) { "Performing node recovery for ${pkg.id}" }
 
-    // Check for busy/loading indicators: "...", "…", or any text containing them (e.g. "Computing…")
-    val busyNode = root.crawl().firstOrNull { crawled ->
-        val text = crawled.node.text?.toString() ?: return@firstOrNull false
-        if (text.length > BUSY_NODE_MAX_LENGTH) return@firstOrNull false
-        crawled.node.textContainsAny(listOf("...", "…")) ||
-                (extraBusyLabels.isNotEmpty() && crawled.node.textMatchesAny(extraBusyLabels))
-    }
-    if (busyNode != null) {
-        log(tag, VERBOSE) { "Found a busy-node, attempting recovery via delay: $busyNode" }
-        delay(1000)
-        root.refresh()
-        return@recovery true
-    }
-
-    // Try scrolling forward first
-    var scrolled = false
-    val scrollableNodes = root.crawl().filter { it.node.isScrollable }.toList()
-
-    for (crawled in scrollableNodes) {
-        val success = crawled.node.scrollNode()
-        if (success) {
-            scrolled = true
-            crawled.node.refresh()
+        if (stepAttempts != lastAttempt) {
+            lastAttempt = stepAttempts
+            lastScrolledForward = false
         }
-    }
 
-    // If forward scroll failed (already at bottom), try scrolling backward
-    if (!scrolled) {
-        log(tag, VERBOSE) { "Forward scroll failed, trying backward scroll" }
-        for (crawled in scrollableNodes) {
-            val success = crawled.node.scrollNodeBackward()
-            if (success) {
-                scrolled = true
-                crawled.node.refresh()
+        // Check for busy/loading indicators: "...", "…", or any text containing them (e.g. "Computing…")
+        val busyNode = root.crawl().firstOrNull { crawled ->
+            val text = crawled.node.text?.toString() ?: return@firstOrNull false
+            if (text.length > BUSY_NODE_MAX_LENGTH) return@firstOrNull false
+            crawled.node.textContainsAny(listOf("...", "…")) ||
+                    (extraBusyLabels.isNotEmpty() && crawled.node.textMatchesAny(extraBusyLabels))
+        }
+        if (busyNode != null) {
+            log(tag, VERBOSE) { "Found a busy-node, attempting recovery via delay: $busyNode" }
+            delay(1000)
+            root.refresh()
+            return@recovery true
+        }
+
+        var scrolled = false
+        var scrolledForward = false
+        val scrollableNodes = root.crawl().filter { it.node.isScrollable }.toList()
+
+        coroutineScope {
+            // A successful scroll action returns before the node tree reflects it (e.g. OneUI serves
+            // stale nodes for another ~50-250ms). Arm the settle watcher before scrolling, the event
+            // stream has no replay and the content change may arrive before we'd get to subscribe.
+            val settleWatcher = async(start = CoroutineStart.UNDISPATCHED) {
+                host.events.first {
+                    (it.eventType == AccessibilityEvent.TYPE_VIEW_SCROLLED ||
+                            it.eventType == AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED) &&
+                            it.pkgId == root.pkgId
+                }
             }
-        }
-    }
 
-    scrolled
+            // Try scrolling forward first
+            for (crawled in scrollableNodes) {
+                val success = crawled.node.scrollNode()
+                if (success) {
+                    scrolled = true
+                    scrolledForward = true
+                    crawled.node.refresh()
+                }
+            }
+
+            if (!scrolled) {
+                if (lastScrolledForward) {
+                    // We just scrolled to the end of the list ourselves, the target should be on screen
+                    // and the previous look may have hit a stale tree. Scrolling backward now would undo
+                    // our own scrolling, so give the finder one more look first.
+                    log(tag, VERBOSE) { "Forward scroll failed right after a successful one, we are at the list end" }
+                } else {
+                    // The screen may have opened already scrolled past the target
+                    log(tag, VERBOSE) { "Forward scroll failed, trying backward scroll" }
+                    for (crawled in scrollableNodes) {
+                        val success = crawled.node.scrollNodeBackward()
+                        if (success) {
+                            scrolled = true
+                            crawled.node.refresh()
+                        }
+                    }
+                }
+            }
+
+            if (scrolled) {
+                val settleEvent = withTimeoutOrNull(1000) { settleWatcher.await() }
+                log(tag, VERBOSE) { "Scrolled, settled after event: $settleEvent" }
+            }
+            // Timing out the await() does not cancel the watcher itself
+            settleWatcher.cancel()
+        }
+
+        lastScrolledForward = scrolledForward
+
+        scrolled
+    }
 }

--- a/app/src/test/java/eu/darken/sdmse/automation/core/specs/DefaultNodeRecoveryTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/automation/core/specs/DefaultNodeRecoveryTest.kt
@@ -1,5 +1,6 @@
 package eu.darken.sdmse.automation.core.specs
 
+import android.view.accessibility.AccessibilityEvent
 import eu.darken.sdmse.automation.core.common.ACSNodeInfo
 import eu.darken.sdmse.automation.core.common.stepper.StepContext
 import eu.darken.sdmse.common.pkgs.features.Installed
@@ -8,11 +9,15 @@ import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.common.user.UserHandle2
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.longs.shouldBeLessThan
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.currentTime
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -209,6 +214,85 @@ class DefaultNodeRecoveryTest : BaseTest() {
         result shouldBe true
         scrollable.performedActions shouldContain ACSNodeInfo.ACTION_SCROLL_FORWARD
         scrollable.performedActions shouldNotContain ACSNodeInfo.ACTION_SCROLL_BACKWARD
+    }
+
+    @Test
+    fun `skips backward scroll only once right after a successful forward scroll`() = runTest {
+        val recovery = testSpec.defaultNodeRecovery(testPkg)
+
+        val scrollable = TestACSNodeInfo(isScrollable = true)
+        recovery.invoke(stepContext, TestACSNodeInfo().addChild(scrollable)) shouldBe true
+        scrollable.performedActions shouldContain ACSNodeInfo.ACTION_SCROLL_FORWARD
+
+        // We reached the end of the list ourselves and the previous look may have hit a stale tree.
+        // Scrolling backward would undo our own scrolling, the finder gets another look first.
+        val atEnd1 = TestACSNodeInfo(isScrollable = true, performActionResult = false)
+        recovery.invoke(stepContext, TestACSNodeInfo().addChild(atEnd1)) shouldBe false
+        atEnd1.performedActions shouldContain ACSNodeInfo.ACTION_SCROLL_FORWARD
+        atEnd1.performedActions shouldNotContain ACSNodeInfo.ACTION_SCROLL_BACKWARD
+
+        // Target still not found on a fresh look: backward paging is legitimate again
+        val atEnd2 = TestACSNodeInfo(isScrollable = true, performActionResult = false)
+        recovery.invoke(stepContext, TestACSNodeInfo().addChild(atEnd2)) shouldBe false
+        atEnd2.performedActions shouldContain ACSNodeInfo.ACTION_SCROLL_BACKWARD
+    }
+
+    @Test
+    fun `backward scroll is available again on a new step attempt`() = runTest {
+        val recovery = testSpec.defaultNodeRecovery(testPkg)
+
+        val scrollable = TestACSNodeInfo(isScrollable = true)
+        recovery.invoke(stepContext, TestACSNodeInfo().addChild(scrollable)) shouldBe true
+
+        // A new step attempt relaunches the window, resetting its scroll position
+        val retryContext = stepContext.copy(stepAttempts = 1)
+        val scrollableAtEnd = TestACSNodeInfo(isScrollable = true, performActionResult = false)
+        recovery.invoke(retryContext, TestACSNodeInfo().addChild(scrollableAtEnd))
+
+        scrollableAtEnd.performedActions shouldContain ACSNodeInfo.ACTION_SCROLL_FORWARD
+        scrollableAtEnd.performedActions shouldContain ACSNodeInfo.ACTION_SCROLL_BACKWARD
+    }
+
+    // ============================================================
+    // Post-scroll settling on window events
+    // ============================================================
+
+    @Test
+    fun `scroll settle completes on content change event from the scrolled window`() = runTest {
+        val scrollable = TestACSNodeInfo(isScrollable = true)
+        val root = TestACSNodeInfo(packageName = "com.android.settings").addChild(scrollable)
+
+        val recovery = testSpec.defaultNodeRecovery(testPkg)
+        val job = launch { recovery.invoke(stepContext, root) shouldBe true }
+        runCurrent()
+
+        testHost.emitEvent(
+            pkgId = "com.android.settings",
+            eventType = AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED,
+        )
+        job.join()
+
+        // Settled via the event, not by running into the timeout
+        currentTime shouldBeLessThan 1000L
+    }
+
+    @Test
+    fun `scroll settle ignores events from other windows`() = runTest {
+        val scrollable = TestACSNodeInfo(isScrollable = true)
+        val root = TestACSNodeInfo(packageName = "com.android.settings").addChild(scrollable)
+
+        val recovery = testSpec.defaultNodeRecovery(testPkg)
+        val job = launch { recovery.invoke(stepContext, root) shouldBe true }
+        runCurrent()
+
+        testHost.emitEvent(
+            pkgId = "some.other.app",
+            eventType = AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED,
+        )
+        job.join()
+
+        // Foreign event does not count as settled, the timeout has to expire
+        currentTime shouldBe 1000L
     }
 
     @Test


### PR DESCRIPTION
## What changed

On Samsung One UI devices, AppCleaner's accessibility automation could visibly scroll the Settings screen down, back up to the top, and down again for the same app while clearing caches. Every clear still succeeded, but the bounce roughly tripled the time spent per app and looked broken. The automation now waits for the screen to actually update after it scrolls and no longer undoes its own scrolling.

## Technical Context

- Root cause (from a reporter's debug log, Galaxy A34, Android 14): after `ACTION_SCROLL_FORWARD` reports success, One UI's Settings keeps serving the pre-scroll node tree via `rootInActiveWindow` for ~50-250 ms. The finder re-crawled after a flat 200 ms, missed the now-visible storage row, and the next recovery pass's backward-scroll fallback then reversed the scroll back to the top.
- The backward fallback itself dates to 1.7.1-rc0 (d8d1899c9). The trigger is environmental (the storage row still showing "Computing…" routes the run into this path), which is why the reporter perceived it as a 1.7.5-rc0 regression.
- The post-scroll settle is event-based rather than a longer fixed delay: a watcher is armed before the scroll action (the event stream has no replay), filtered to the scrolled window's package, capped at 1 s.
- Backward suppression is a one-shot grace, not a permanent latch: it only skips the invocation right after a successful forward scroll (the stale-tree case). Backward paging still works when a fresh crawl misses the target, and after a step-attempt relaunch. The closure state in `defaultNodeRecovery` is the part of the diff that deserves the closest look.
- The changed code is shared: all AppCleaner ROM specs and AppControl's One UI spec use `defaultNodeRecovery`.
