### PR TITLE
Fix: Sponsor screen looked unchanged after successfully sponsoring

### DIFF
--- a/app/src/foss/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/foss/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
@@ -42,8 +42,10 @@ class UpgradeViewModel @Inject constructor(
 
     // Which presentation the screen shows. The manage route (settings "upgrade status" entry)
     // gets a status view first; the pitch only appears once a free user asks for the upgrade
-    // options. Upgrading wins over that choice — completing the sponsor flow from the pitch must
-    // land on the upgraded status, not back on the ask. null until the route is bound.
+    // options. Upgrading wins on EVERY route, not just manage: forced routes (Pro-locked settings)
+    // stay open after the sponsor flow completes, and the pitch with its live sponsor button reads
+    // as "sponsoring didn't work" to a fresh supporter — the toast alone is too transient for a
+    // money moment without a receipt behind it. null until the route is bound.
     internal val state: StateFlow<State> = combine(
         routeFlow,
         upgradeRepo.upgradeInfo,
@@ -51,7 +53,7 @@ class UpgradeViewModel @Inject constructor(
     ) { route, info, showOptions ->
         val view = when {
             route == null -> null
-            route.manage && info.isPro -> FossUpgradeView.STATUS_UPGRADED
+            info.isPro -> FossUpgradeView.STATUS_UPGRADED
             route.manage && !showOptions -> FossUpgradeView.STATUS_FREE
             else -> FossUpgradeView.PITCH
         }

--- a/app/src/testFoss/java/eu/darken/sdmse/common/upgrade/ui/FossUpgradeViewModelTest.kt
+++ b/app/src/testFoss/java/eu/darken/sdmse/common/upgrade/ui/FossUpgradeViewModelTest.kt
@@ -192,6 +192,35 @@ class FossUpgradeViewModelTest : BaseTest() {
     }
 
     @Test
+    fun `forced route lands on the upgraded status when the sponsor flow completes`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // Forced routes (Pro-locked settings entry) deliberately don't auto-close, so the screen is
+        // still up when the unlock lands — it must flip to the supporter status instead of keeping
+        // the sales pitch, which reads as "sponsoring didn't work".
+        val info = MutableStateFlow(UpgradeRepoFoss.Info())
+        val vm = buildVm(repo = mockRepo(info))
+
+        val navEvents = mutableListOf<NavEvent>()
+        val collector = launch(start = CoroutineStart.UNDISPATCHED) { vm.navEvents.collect { navEvents.add(it) } }
+
+        val pitchView = async { vm.state.first { it.view != null } }
+        vm.bindRoute(UpgradeRoute(forced = true))
+        advanceUntilIdle()
+        pitchView.await().view shouldBe FossUpgradeView.PITCH
+
+        val upgradedView = async { vm.state.first { it.view == FossUpgradeView.STATUS_UPGRADED } }
+        info.value = upgradedInfo()
+        advanceUntilIdle()
+
+        upgradedView.await().view shouldBe FossUpgradeView.STATUS_UPGRADED
+        // The don't-auto-close semantics of forced routes are unchanged — status, not navigation,
+        // is what acknowledges the upgrade here.
+        navEvents.shouldBeEmpty()
+        collector.cancel()
+    }
+
+    @Test
     fun `default route bounces an upgraded user out of the screen`() = runTest2(context = testDispatcher) {
         val vm = buildVm(repo = mockRepo(MutableStateFlow(upgradedInfo())))
 


### PR DESCRIPTION
## What changed

On the open-source version, sponsoring via GitHub from a Pro-locked setting (for example a locked theme option) looked like it hadn't worked: after returning from the sponsor page the screen kept showing the sales pitch with an active sponsor button, and the only confirmation was a brief toast. The unlock itself always went through.

The screen now switches to the "You're a supporter" status view the moment the upgrade lands, on every way into the screen. The Google Play version already behaved this way, showing the ownership view after a purchase on the same path.

## Technical Context

- Root cause: the view mapping only allowed the upgraded-status view on the manage route (`route.manage && info.isPro`). Entries from Pro-locked settings use a forced route, which deliberately never auto-closes, so it was the one path where a fresh supporter could sit on the stale pitch indefinitely. The comment above the mapping already promised "upgrading wins over that choice"; the code only honored it for manage.
- Status-first was chosen over auto-closing the forced route: a sponsorship is a payment without a receipt behind it, so a durable on-screen confirmation beats a 3-second toast followed by a vanishing screen, and it matches both the gplay flavor's route-independent ownership rendering and the app's stay-open-and-explain pattern (grace card, pending-payment card). The forced route's don't-auto-close semantics are unchanged and now pinned by a test.
