### PR TITLE
AppCleaner: Stop offering to delete caches that can never be cleared

### DIFF
--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
@@ -367,7 +367,14 @@ class AppCleaner @Inject constructor(
                 appJunk.copy(
                     expendables = updatedExpendables,
                     inaccessibleCache = updatedInaccessible,
-                    acsError = acsResult?.failed?.get(appJunk.identifier),
+                    acsError = when {
+                        acsResult == null -> appJunk.acsError
+                        acsResult.failed.containsKey(appJunk.identifier) -> acsResult.failed[appJunk.identifier]
+                        acsResult.succesful.contains(appJunk.identifier) -> null
+                        // Not attempted this run (e.g. a targeted delete of other apps): a fresh
+                        // null must not erase what the last actual attempt learned.
+                        else -> appJunk.acsError
+                    },
                 )
             }.filter { !it.isEmpty() }
         )
@@ -481,6 +488,14 @@ class AppCleaner @Inject constructor(
     ) {
         val totalSize: Long get() = junks.sumOf { it.size }
         val totalCount: Int get() = junks.sumOf { it.itemCount }
+
+        /**
+         * Like [totalSize]/[totalCount], but without junks that are [AppJunk.isUnclearable] —
+         * what a delete action can actually free. Unclearable junks stay visible in the tool
+         * itself (with the failure reason), they just must not be advertised as freeable.
+         */
+        val actionableSize: Long get() = junks.filterNot { it.isUnclearable }.sumOf { it.size }
+        val actionableCount: Int get() = junks.filterNot { it.isUnclearable }.sumOf { it.itemCount }
 
         /** Live scan summary. Single source of truth shared with [performScan] and the dashboard card. */
         fun toScanSuccess() = AppCleanerScanTask.Success(

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleanerExtensions.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleanerExtensions.kt
@@ -2,3 +2,10 @@ package eu.darken.sdmse.appcleaner.core
 
 val AppCleaner.Data?.hasData: Boolean
     get() = this?.junks?.isNotEmpty() ?: false
+
+/**
+ * Like [hasData], but ignoring junks that are [AppJunk.isUnclearable]. This is what delete
+ * actions should key on: unclearable junks would make them report "0 deleted" forever.
+ */
+val AppCleaner.Data?.hasActionableData: Boolean
+    get() = this?.junks?.any { !it.isUnclearable } ?: false

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/AppJunk.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/AppJunk.kt
@@ -1,9 +1,12 @@
 package eu.darken.sdmse.appcleaner.core
 
+import eu.darken.sdmse.appcleaner.core.automation.errors.LockedAppCacheException
 import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilter
 import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilterIdentifier
 import eu.darken.sdmse.appcleaner.core.forensics.filter.DefaultCachesPublicFilter
 import eu.darken.sdmse.appcleaner.core.scanner.InaccessibleCache
+import eu.darken.sdmse.automation.core.errors.DisabledAppException
+import eu.darken.sdmse.automation.core.errors.NoSettingsWindowException
 import eu.darken.sdmse.common.ca.CaString
 import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.pkgs.features.InstallId
@@ -60,6 +63,17 @@ data class AppJunk(
         } ?: 0L
         knownFiles + inaccessibleSize
     }
+
+    /**
+     * Retrying frees nothing here with the currently available backends: all that remains is the
+     * inaccessible cache, and the last clearing attempt failed for a reason that won't go away on
+     * its own (no settings page, disabled app, cache locked by the system). Transient failures
+     * (timeouts, interference) don't count. A rescan builds fresh junks and resets this.
+     */
+    val isUnclearable: Boolean
+        get() = (expendables.isNullOrEmpty() || expendables.values.all { it.isEmpty() }) &&
+            inaccessibleCache != null &&
+            (acsError is NoSettingsWindowException || acsError is DisabledAppException || acsError is LockedAppCacheException)
 
     fun isEmpty() =
         (expendables.isNullOrEmpty() || expendables.values.all { it.isEmpty() }) && inaccessibleCache == null

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/AppCleanerExtensionsTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/AppCleanerExtensionsTest.kt
@@ -1,6 +1,10 @@
 package eu.darken.sdmse.appcleaner.core
 
+import eu.darken.sdmse.appcleaner.core.automation.errors.LockedAppCacheException
 import eu.darken.sdmse.appcleaner.ui.preview.previewAppJunk
+import eu.darken.sdmse.automation.core.errors.DisabledAppException
+import eu.darken.sdmse.automation.core.errors.InvalidSystemStateException
+import eu.darken.sdmse.automation.core.errors.NoSettingsWindowException
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
@@ -23,5 +27,62 @@ class AppCleanerExtensionsTest : BaseTest() {
     fun `hasData is true when junks is non-empty`() {
         val data = AppCleaner.Data(junks = listOf(previewAppJunk()))
         data.hasData shouldBe true
+    }
+
+    private fun unclearableJunk(error: Exception = NoSettingsWindowException("no settings window")) =
+        previewAppJunk(expendables = null).copy(acsError = error)
+
+    @Test
+    fun `a permanently failed inaccessible-only junk is unclearable`() {
+        unclearableJunk(NoSettingsWindowException("no settings window")).isUnclearable shouldBe true
+        unclearableJunk(DisabledAppException("disabled")).isUnclearable shouldBe true
+        unclearableJunk(LockedAppCacheException("locked")).isUnclearable shouldBe true
+    }
+
+    @Test
+    fun `a junk without a clearing failure is not unclearable`() {
+        previewAppJunk(expendables = null).isUnclearable shouldBe false
+    }
+
+    @Test
+    fun `a transient clearing failure keeps the junk actionable`() {
+        // A plan abort caused by system state (screen off, interference) can succeed on retry.
+        unclearableJunk(InvalidSystemStateException("screen was off")).isUnclearable shouldBe false
+    }
+
+    @Test
+    fun `remaining accessible files keep the junk actionable`() {
+        previewAppJunk().copy(acsError = NoSettingsWindowException("no settings window")).isUnclearable shouldBe false
+    }
+
+    @Test
+    fun `hasData stays true while hasActionableData drops for unclearable-only data`() {
+        val data = AppCleaner.Data(junks = listOf(unclearableJunk()))
+        data.hasData shouldBe true
+        data.hasActionableData shouldBe false
+    }
+
+    @Test
+    fun `hasActionableData is true when at least one junk is actionable`() {
+        val data = AppCleaner.Data(junks = listOf(unclearableJunk(), previewAppJunk()))
+        data.hasActionableData shouldBe true
+    }
+
+    @Test
+    fun `hasActionableData is false when Data is null`() {
+        val data: AppCleaner.Data? = null
+        data.hasActionableData shouldBe false
+    }
+
+    @Test
+    fun `actionable aggregates exclude unclearable junks but the totals keep them`() {
+        val actionable = previewAppJunk()
+        val unclearable = unclearableJunk()
+        val data = AppCleaner.Data(junks = listOf(actionable, unclearable))
+
+        data.totalSize shouldBe actionable.size + unclearable.size
+        data.totalCount shouldBe actionable.itemCount + unclearable.itemCount
+        data.actionableSize shouldBe actionable.size
+        data.actionableCount shouldBe actionable.itemCount
     }
 }

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/AppCleanerTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/AppCleanerTest.kt
@@ -6,6 +6,8 @@ import eu.darken.sdmse.appcleaner.core.scanner.InaccessibleCache
 import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerProcessingTask
 import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerScanTask
 import eu.darken.sdmse.appcleaner.ui.preview.previewAppJunk
+import eu.darken.sdmse.automation.core.errors.InvalidSystemStateException
+import eu.darken.sdmse.automation.core.errors.NoSettingsWindowException
 import eu.darken.sdmse.appcleaner.ui.preview.previewExpendables
 import eu.darken.sdmse.appcleaner.ui.preview.previewInstalled
 import eu.darken.sdmse.common.adb.AdbManager
@@ -643,6 +645,99 @@ class AppCleanerTest : BaseTest() {
         result.shouldBeInstanceOf<AppCleanerProcessingTask.Success>()
         result.affectedCount shouldBe 0
         result.affectedPaths shouldBe emptySet()
+    }
+
+    @Test
+    fun `a junk untouched by a later targeted run keeps its acsError`() = runTest2 {
+        val stuck = installId("com.example.stuck")
+        val other = installId("com.example.other")
+        val setup = setupCleaner(
+            scanResults = listOf(
+                inaccJunk("com.example.stuck", itemCount = 2, theoreticalPaths = emptySet()),
+                inaccJunk("com.example.other", itemCount = 2, theoreticalPaths = emptySet()),
+            ),
+        )
+        val deleter = mockk<InaccessibleDeleter>(relaxUnitFun = true).apply {
+            every { progress } returns MutableStateFlow<Progress.Data?>(null)
+            every { updateProgress(any()) } just Runs
+            coEvery { deleteInaccessible(any(), any(), any(), any()) } returnsMany listOf(
+                // First run: "stuck" fails permanently, "other" is left over.
+                InaccessibleDeleter.InaccDelResult(
+                    succesful = emptySet(),
+                    failed = mapOf(stuck to NoSettingsWindowException("no settings window")),
+                ),
+                // Second run targets only "other" and succeeds; "stuck" is not attempted.
+                InaccessibleDeleter.InaccDelResult(succesful = setOf(other), failed = emptyMap()),
+            )
+        }
+        val rebuilt = rebuildWithDeleter(setup, deleter)
+
+        rebuilt.cleaner.submit(AppCleanerScanTask())
+        rebuilt.cleaner.submit(AppCleanerProcessingTask(onlyInaccessible = true))
+        rebuilt.cleaner.submit(AppCleanerProcessingTask(onlyInaccessible = true, targetPkgs = setOf(other)))
+
+        // The untargeted run must not wipe what the first attempt learned about "stuck".
+        val junk = rebuilt.cleaner.state.first().data!!.junks.single()
+        junk.identifier shouldBe stuck
+        junk.acsError.shouldBeInstanceOf<NoSettingsWindowException>()
+        junk.isUnclearable shouldBe true
+    }
+
+    @Test
+    fun `a new attempt's failure replaces the stored acsError`() = runTest2 {
+        val stuck = installId("com.example.stuck")
+        val setup = setupCleaner(
+            scanResults = listOf(inaccJunk("com.example.stuck", itemCount = 2, theoreticalPaths = emptySet())),
+        )
+        val deleter = mockk<InaccessibleDeleter>(relaxUnitFun = true).apply {
+            every { progress } returns MutableStateFlow<Progress.Data?>(null)
+            every { updateProgress(any()) } just Runs
+            coEvery { deleteInaccessible(any(), any(), any(), any()) } returnsMany listOf(
+                InaccessibleDeleter.InaccDelResult(
+                    succesful = emptySet(),
+                    failed = mapOf(stuck to NoSettingsWindowException("no settings window")),
+                ),
+                InaccessibleDeleter.InaccDelResult(
+                    succesful = emptySet(),
+                    failed = mapOf(stuck to InvalidSystemStateException("screen was off")),
+                ),
+            )
+        }
+        val rebuilt = rebuildWithDeleter(setup, deleter)
+
+        rebuilt.cleaner.submit(AppCleanerScanTask())
+        rebuilt.cleaner.submit(AppCleanerProcessingTask(onlyInaccessible = true))
+        rebuilt.cleaner.submit(AppCleanerProcessingTask(onlyInaccessible = true))
+
+        // The latest attempt speaks for the junk: a transient failure lifts the unclearable mark.
+        val junk = rebuilt.cleaner.state.first().data!!.junks.single()
+        junk.acsError.shouldBeInstanceOf<InvalidSystemStateException>()
+        junk.isUnclearable shouldBe false
+    }
+
+    @Test
+    fun `a run without inaccessible deletion preserves the stored acsError`() = runTest2 {
+        val stuck = installId("com.example.stuck")
+        val setup = setupCleaner(
+            scanResults = listOf(inaccJunk("com.example.stuck", itemCount = 2, theoreticalPaths = emptySet())),
+        )
+        val deleter = mockk<InaccessibleDeleter>(relaxUnitFun = true).apply {
+            every { progress } returns MutableStateFlow<Progress.Data?>(null)
+            every { updateProgress(any()) } just Runs
+            coEvery { deleteInaccessible(any(), any(), any(), any()) } returns InaccessibleDeleter.InaccDelResult(
+                succesful = emptySet(),
+                failed = mapOf(stuck to NoSettingsWindowException("no settings window")),
+            )
+        }
+        val rebuilt = rebuildWithDeleter(setup, deleter)
+
+        rebuilt.cleaner.submit(AppCleanerScanTask())
+        rebuilt.cleaner.submit(AppCleanerProcessingTask(onlyInaccessible = true))
+        rebuilt.cleaner.submit(AppCleanerProcessingTask(includeInaccessible = false))
+
+        val junk = rebuilt.cleaner.state.first().data!!.junks.single()
+        junk.acsError.shouldBeInstanceOf<NoSettingsWindowException>()
+        junk.isUnclearable shouldBe true
     }
 
     @Test

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionEngine.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionEngine.kt
@@ -1,6 +1,7 @@
 package eu.darken.sdmse.main.ui.dashboard
 
 import eu.darken.sdmse.appcleaner.core.AppCleaner
+import eu.darken.sdmse.appcleaner.core.hasActionableData
 import eu.darken.sdmse.appcleaner.core.hasData
 import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerOneClickTask
 import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerProcessingTask
@@ -759,9 +760,9 @@ class DashboardMainActionEngine(
                 BottomBarState.Action.WORKING_CANCELABLE -> taskManager.cancel(SDMTool.Type.APPCLEANER)
                 BottomBarState.Action.WORKING -> {}
                 BottomBarState.Action.DELETE -> {
-                    if (appCleaner.state.first().data != null && upgradeRepo.isProForUi()) {
+                    if (appCleaner.state.first().data.hasActionableData && upgradeRepo.isProForUi()) {
                         runCleanup(SDMTool.Type.APPCLEANER, AppCleanerProcessingTask())
-                    } else if (appCleaner.state.first().data.hasData && !freeToolsWillRun()) {
+                    } else if (appCleaner.state.first().data.hasActionableData && !freeToolsWillRun()) {
                         onUpgradeRequired()
                     }
                 }
@@ -769,7 +770,7 @@ class DashboardMainActionEngine(
                 BottomBarState.Action.ONECLICK -> {
                     if (upgradeRepo.isProForUi()) {
                         runCleanup(SDMTool.Type.APPCLEANER, AppCleanerOneClickTask())
-                    } else if (appCleaner.state.first().data.hasData && !freeToolsWillRun()) {
+                    } else if (appCleaner.state.first().data.hasActionableData && !freeToolsWillRun()) {
                         onUpgradeRequired()
                     }
                 }
@@ -899,7 +900,7 @@ class DashboardMainActionEngine(
             !taskState.isIdle -> BottomBarState.Action.WORKING
             corpse.hasData && oneClick.corpseFinderEnabled -> BottomBarState.Action.DELETE
             system.hasData && oneClick.systemCleanerEnabled -> BottomBarState.Action.DELETE
-            app.hasData && oneClick.appCleanerEnabled -> BottomBarState.Action.DELETE
+            app.hasActionableData && oneClick.appCleanerEnabled -> BottomBarState.Action.DELETE
             dedupe.hasData && oneClick.deduplicatorEnabled && isPro -> BottomBarState.Action.DELETE
             oneClickMode -> BottomBarState.Action.ONECLICK
             else -> BottomBarState.Action.SCAN
@@ -922,8 +923,8 @@ class DashboardMainActionEngine(
         ): List<HeroSummary.ToolSlice> {
             if (isPro) return emptyList()
             return buildList {
-                app?.takeIf { oneClick.appCleanerEnabled && it.hasData }?.let {
-                    add(HeroSummary.ToolSlice(SDMTool.Type.APPCLEANER, it.totalSize, it.totalCount))
+                app?.takeIf { oneClick.appCleanerEnabled && it.hasActionableData }?.let {
+                    add(HeroSummary.ToolSlice(SDMTool.Type.APPCLEANER, it.actionableSize, it.actionableCount))
                 }
                 dedupe?.takeIf { oneClick.deduplicatorEnabled && it.hasData }?.let {
                     add(HeroSummary.ToolSlice(SDMTool.Type.DEDUPLICATOR, it.redundantSize, it.redundantCount))
@@ -954,8 +955,8 @@ class DashboardMainActionEngine(
                 system?.takeIf { oneClick.systemCleanerEnabled && it.hasData }?.let {
                     add(HeroSummary.ToolSlice(SDMTool.Type.SYSTEMCLEANER, it.totalSize, it.totalCount))
                 }
-                app?.takeIf { oneClick.appCleanerEnabled && isPro && it.hasData }?.let {
-                    add(HeroSummary.ToolSlice(SDMTool.Type.APPCLEANER, it.totalSize, it.totalCount))
+                app?.takeIf { oneClick.appCleanerEnabled && isPro && it.hasActionableData }?.let {
+                    add(HeroSummary.ToolSlice(SDMTool.Type.APPCLEANER, it.actionableSize, it.actionableCount))
                 }
                 dedupe?.takeIf { oneClick.deduplicatorEnabled && isPro && it.hasData }?.let {
                     add(HeroSummary.ToolSlice(SDMTool.Type.DEDUPLICATOR, it.redundantSize, it.redundantCount))

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardHeroSummaryTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardHeroSummaryTest.kt
@@ -34,9 +34,15 @@ class DashboardHeroSummaryTest : BaseTest() {
     }
 
     private fun app(size: Long, count: Int) = mockk<AppCleaner.Data> {
-        every { junks } returns setOf(mockk())
+        every { junks } returns setOf(mockk { every { isUnclearable } returns false })
         every { totalSize } returns size
         every { totalCount } returns count
+        every { actionableSize } returns size
+        every { actionableCount } returns count
+    }
+
+    private fun unclearableApp() = mockk<AppCleaner.Data> {
+        every { junks } returns setOf(mockk { every { isUnclearable } returns true })
     }
 
     private fun dedupe(redundant: Long, removableCount: Int) = mockk<Deduplicator.Data> {
@@ -159,6 +165,30 @@ class DashboardHeroSummaryTest : BaseTest() {
 
         result.totalSize shouldBe 100L
         result.tools.map { it.type } shouldBe listOf(SDMTool.Type.CORPSEFINDER)
+    }
+
+    @Test
+    fun `unclearable-only AppCleaner data is neither freeable nor locked`() {
+        // Residue whose clearing permanently failed must not be advertised: not as freeable
+        // (a delete would report "0 deleted"), and not as a Pro upsell either (Pro would not
+        // unlock it). It stays visible in the tool itself.
+        DashboardMainActionEngine.buildHeroSummary(
+            corpse = null,
+            system = null,
+            app = unclearableApp(),
+            dedupe = null,
+            oneClick = oneClick(),
+            isPro = true,
+        ).shouldBeNull()
+
+        DashboardMainActionEngine.buildHeroSummary(
+            corpse = null,
+            system = null,
+            app = unclearableApp(),
+            dedupe = null,
+            oneClick = oneClick(),
+            isPro = false,
+        ).shouldBeNull()
     }
 
     @Test

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionEngineTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionEngineTest.kt
@@ -1,6 +1,8 @@
 package eu.darken.sdmse.main.ui.dashboard
 
 import eu.darken.sdmse.appcleaner.core.AppCleaner
+import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerOneClickTask
+import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerProcessingTask
 import eu.darken.sdmse.common.datastore.DataStoreValue
 import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
@@ -442,6 +444,48 @@ internal class DashboardMainActionEngineTest : BaseTest() {
 
             upgradeRequired shouldBe 1
             h.submittedTasks.shouldBeEmpty()
+        } finally {
+            h.engineScope.cancel()
+        }
+    }
+
+    @Test
+    fun `a DELETE armed by another tool skips AppCleaner when its data is unclearable-only`() {
+        // Residue whose clearing permanently failed must not be retried by DELETE: it would add
+        // a guaranteed "0 deleted" AppCleaner run to every cleanup another tool armed.
+        val appData = mockk<AppCleaner.Data>(relaxed = true) {
+            every { junks } returns setOf(mockk(relaxed = true) { every { isUnclearable } returns true })
+        }
+        val h = harness(
+            corpseData = corpseData(),
+            appData = appData,
+            appCleanerOneClick = true,
+            isPro = true,
+        )
+
+        try {
+            h.engine.mainAction(BottomBarState.Action.DELETE)
+
+            h.submittedTasks.filterIsInstance<AppCleanerProcessingTask>().shouldBeEmpty()
+            h.submittedTasks.filterIsInstance<CorpseFinderDeleteTask>().size shouldBe 1
+        } finally {
+            h.engineScope.cancel()
+        }
+    }
+
+    @Test
+    fun `one-tap still rescans AppCleaner despite unclearable-only data`() {
+        // Deliberate: ONECLICK means "scan and clean now". Stale unclearable residue must not
+        // suppress discovery of junk that accumulated since; the fresh scan resets it either way.
+        val appData = mockk<AppCleaner.Data>(relaxed = true) {
+            every { junks } returns setOf(mockk(relaxed = true) { every { isUnclearable } returns true })
+        }
+        val h = harness(appData = appData, appCleanerOneClick = true, isPro = true)
+
+        try {
+            h.engine.mainAction(BottomBarState.Action.ONECLICK)
+
+            h.submittedTasks.filterIsInstance<AppCleanerOneClickTask>().size shouldBe 1
         } finally {
             h.engineScope.cancel()
         }

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionTest.kt
@@ -30,8 +30,8 @@ class DashboardMainActionTest : BaseTest() {
         every { filterContents } returns setOf(mockk())
     }
 
-    private fun app() = mockk<AppCleaner.Data> {
-        every { junks } returns setOf(mockk())
+    private fun app(unclearable: Boolean = false) = mockk<AppCleaner.Data> {
+        every { junks } returns setOf(mockk { every { isUnclearable } returns unclearable })
     }
 
     private fun dedupe() = mockk<Deduplicator.Data> {
@@ -114,6 +114,17 @@ class DashboardMainActionTest : BaseTest() {
             app = app(),
             isPro = false,
         ) shouldBe BottomBarState.Action.DELETE
+    }
+
+    @Test
+    fun `unclearable-only AppCleaner data does not arm DELETE`() {
+        // Junks whose clearing permanently failed (no settings page, locked app) would make
+        // DELETE report "0 deleted" forever — the button falls back to SCAN/ONECLICK instead.
+        resolve(app = app(unclearable = true)) shouldBe BottomBarState.Action.SCAN
+        resolve(
+            app = app(unclearable = true),
+            oneClickMode = true,
+        ) shouldBe BottomBarState.Action.ONECLICK
     }
 
     @Test


### PR DESCRIPTION
## What changed

Some caches can never be cleared without root or Shizuku: certain system apps have no settings page for the automation to open, and some are locked by the OS (their "Clear cache" button is disabled). After a cleanup, these leftovers kept the dashboard's main button stuck on "Delete" and the summary kept promising that their space "can be freed". Pressing the button again just reported "0 objects deleted", every time, which reads as "cleaning stopped working".

The dashboard now ignores these un-clearable leftovers: the main button returns to Scan (or One-Tap), and the summary only counts space a delete can actually free. The entries stay visible inside AppCleaner itself, including the reason they can't be cleared, so they can still be inspected or excluded. A new scan re-evaluates them, so setting up Shizuku or root makes them count again.

## Technical Context

- Root cause: `performProcessing` keeps `AppJunk`s whose inaccessible-cache clear failed, `hasData` never empties, and `resolveMainAction` pins DELETE while `buildHeroSummary` re-advertises the bytes. This chain is unchanged since v1.7.5; it surfaced now because One UI 9 beta ships mainline/APEX packages that report non-zero caches but have no settings page (reported via support email with a debug log confirming the exact byte math).
- `AppJunk.isUnclearable` derives from the `acsError` already stored per junk; only backend-permanent failures count (`NoSettingsWindowException`, `DisabledAppException`, `LockedAppCacheException`). Transient failures (timeout, interference) stay retryable.
- `acsError` is now preserved for junks a later run did not attempt; previously any targeted delete of other packages wiped it to null, reviving the pinned DELETE.
- One-Tap deliberately still rescans AppCleaner when only unclearable data is on record: it means "scan and clean now" and must not skip discovery of newly accumulated junk. A test pins this.
- `residueOf` and the dashboard tool card intentionally keep the full (non-actionable) aggregates: the post-run "left" line and in-tool visibility must stay truthful to everything that remains.
