### PR TITLE
Fix: Crash when returning to the app with a picker or preview open

### DIFF
--- a/app-common-coil/src/test/java/eu/darken/sdmse/common/previews/PreviewRouteSavedStateTest.kt
+++ b/app-common-coil/src/test/java/eu/darken/sdmse/common/previews/PreviewRouteSavedStateTest.kt
@@ -1,0 +1,36 @@
+package eu.darken.sdmse.common.previews
+
+import androidx.savedstate.serialization.decodeFromSavedState
+import androidx.savedstate.serialization.encodeToSavedState
+import eu.darken.sdmse.common.files.local.LocalPath
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+
+/**
+ * A PreviewRoute on the Navigation3 back stack is persisted through the androidx savedstate codec.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class PreviewRouteSavedStateTest : BaseTest() {
+
+    @Test
+    fun `PreviewRoute saved state round-trip`() {
+        val original = PreviewRoute(
+            options = PreviewOptions(
+                paths = listOf(
+                    LocalPath.build("/test/image.jpg"),
+                    LocalPath.build("/test/photo.png"),
+                ),
+                position = 1,
+            ),
+        )
+
+        val savedState = encodeToSavedState(PreviewRoute.serializer(), original)
+        decodeFromSavedState(PreviewRoute.serializer(), savedState) shouldBe original
+    }
+}

--- a/app-common-data/src/test/java/eu/darken/sdmse/common/picker/PickerRouteSavedStateTest.kt
+++ b/app-common-data/src/test/java/eu/darken/sdmse/common/picker/PickerRouteSavedStateTest.kt
@@ -1,0 +1,72 @@
+package eu.darken.sdmse.common.picker
+
+import android.os.Parcel
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.serialization.NavBackStackSerializer
+import androidx.navigation3.runtime.serialization.NavKeySerializer
+import androidx.savedstate.serialization.decodeFromSavedState
+import androidx.savedstate.serialization.encodeToSavedState
+import eu.darken.sdmse.common.areas.DataArea
+import eu.darken.sdmse.common.files.RawPath
+import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.files.saf.SAFPath
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+
+/**
+ * A PickerRoute on the Navigation3 back stack is persisted through the androidx savedstate codec.
+ * This is the shape that crashed on process death restore in v2.0.2.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class PickerRouteSavedStateTest : BaseTest() {
+
+    private val route = PickerRoute(
+        request = PickerRequest(
+            requestKey = "test-key",
+            mode = PickerRequest.PickMode.DIRS,
+            allowedAreas = setOf(DataArea.Type.SDCARD, DataArea.Type.PUBLIC_DATA),
+            selectedPaths = listOf(
+                LocalPath.build("/storage/emulated/0/DCIM"),
+                SAFPath(
+                    "content://com.android.externalstorage.documents/tree/primary%3A",
+                    listOf("Pictures", "Wallpaper"),
+                ),
+                RawPath.build("/some/raw/path"),
+            ),
+        ),
+    )
+
+    @Test
+    fun `PickerRoute saved state round-trip`() {
+        val savedState = encodeToSavedState(PickerRoute.serializer(), route)
+        decodeFromSavedState(PickerRoute.serializer(), savedState) shouldBe route
+    }
+
+    @Test
+    fun `PickerRoute survives a full nav back stack save and restore`() {
+        val serializer = NavBackStackSerializer(NavKeySerializer<NavKey>())
+        val original = NavBackStack<NavKey>(route)
+
+        val savedState = encodeToSavedState(serializer, original)
+
+        val parcel = Parcel.obtain()
+        val restored = try {
+            parcel.writeBundle(savedState)
+            parcel.setDataPosition(0)
+            val marshalled = parcel.readBundle(javaClass.classLoader)!!
+            decodeFromSavedState(serializer, marshalled)
+        } finally {
+            parcel.recycle()
+        }
+
+        restored.size shouldBe 1
+        restored.first() shouldBe route
+    }
+}

--- a/app-common-exclusion/src/test/java/eu/darken/sdmse/exclusion/ui/PathExclusionEditorRouteSavedStateTest.kt
+++ b/app-common-exclusion/src/test/java/eu/darken/sdmse/exclusion/ui/PathExclusionEditorRouteSavedStateTest.kt
@@ -1,0 +1,34 @@
+package eu.darken.sdmse.exclusion.ui
+
+import androidx.savedstate.serialization.decodeFromSavedState
+import androidx.savedstate.serialization.encodeToSavedState
+import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.exclusion.ui.editor.path.PathExclusionEditorOptions
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+
+/**
+ * A PathExclusionEditorRoute on the Navigation3 back stack is persisted through the androidx savedstate codec.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class PathExclusionEditorRouteSavedStateTest : BaseTest() {
+
+    @Test
+    fun `PathExclusionEditorRoute saved state round-trip`() {
+        val original = PathExclusionEditorRoute(
+            exclusionId = "exc-123",
+            initial = PathExclusionEditorOptions(
+                targetPath = LocalPath.build("/storage/emulated/0/DCIM"),
+            ),
+        )
+
+        val savedState = encodeToSavedState(PathExclusionEditorRoute.serializer(), original)
+        decodeFromSavedState(PathExclusionEditorRoute.serializer(), savedState) shouldBe original
+    }
+}

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/serialization/APathSerializer.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/serialization/APathSerializer.kt
@@ -5,20 +5,67 @@ import eu.darken.sdmse.common.files.RawPath
 import eu.darken.sdmse.common.files.local.LocalPath
 import eu.darken.sdmse.common.files.saf.SAFPath
 import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerializationException
-import kotlinx.serialization.json.JsonContentPolymorphicSerializer
-import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.encoding.CompositeDecoder
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.encoding.decodeStructure
+import kotlinx.serialization.json.JsonDecoder
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import java.io.File
 
-object APathSerializer : JsonContentPolymorphicSerializer<APath>(APath::class) {
+/**
+ * Format agnostic serializer for the [APath] hierarchy.
+ *
+ * The written layout is the flat field-set of the concrete subtype (no type discriminator), identical in every format:
+ * `{file}` for [LocalPath], `{treeRoot, segments}` for [SAFPath], `{path}` for [RawPath].
+ *
+ * Reading dispatches on the present fields, so both JSON and non-JSON formats (e.g. the androidx SavedState codec used
+ * by the Navigation3 back stack) can restore an [APath].
+ */
+object APathSerializer : KSerializer<APath> {
 
-    override fun selectDeserializer(element: JsonElement): DeserializationStrategy<APath> {
+    private const val IDX_FILE = 0
+    private const val IDX_TREE_ROOT = 1
+    private const val IDX_SEGMENTS = 2
+    private const val IDX_PATH = 3
+
+    private val segmentsSerializer = ListSerializer(String.serializer())
+
+    override val descriptor: SerialDescriptor = buildClassSerialDescriptor("eu.darken.sdmse.common.files.APath") {
+        element("file", String.serializer().descriptor, isOptional = true)
+        element("treeRoot", String.serializer().descriptor, isOptional = true)
+        element("segments", segmentsSerializer.descriptor, isOptional = true)
+        element("path", String.serializer().descriptor, isOptional = true)
+    }
+
+    override fun serialize(encoder: Encoder, value: APath) {
+        when (value) {
+            is LocalPath -> encoder.encodeSerializableValue(LocalPath.serializer(), value)
+            is SAFPath -> encoder.encodeSerializableValue(SAFPath.serializer(), value)
+            is RawPath -> encoder.encodeSerializableValue(RawPath.serializer(), value)
+            else -> throw SerializationException("Unknown APath type: ${value::class}")
+        }
+    }
+
+    override fun deserialize(decoder: Decoder): APath = when (decoder) {
+        is JsonDecoder -> deserializeJson(decoder)
+        else -> deserializeStructured(decoder)
+    }
+
+    private fun deserializeJson(decoder: JsonDecoder): APath {
+        val element = decoder.decodeJsonElement()
         val keys = element.jsonObject.keys
         // Dispatch on pathType if present (backward compat with old Moshi JSON),
         // fall back to field-name dispatch
         val pathType = element.jsonObject["pathType"]?.jsonPrimitive?.content
-        return when {
+        val selected: DeserializationStrategy<APath> = when {
             pathType == "LOCAL" -> LocalPath.serializer()
             pathType == "RAW" -> RawPath.serializer()
             pathType == "SAF" -> SAFPath.serializer()
@@ -26,6 +73,40 @@ object APathSerializer : JsonContentPolymorphicSerializer<APath>(APath::class) {
             "treeRoot" in keys -> SAFPath.serializer()
             "path" in keys -> RawPath.serializer()
             else -> throw SerializationException("Unknown APath type, keys: $keys")
+        }
+        return decoder.json.decodeFromJsonElement(selected, element)
+    }
+
+    private fun deserializeStructured(decoder: Decoder): APath = decoder.decodeStructure(descriptor) {
+        var file: String? = null
+        var treeRoot: String? = null
+        var segments: List<String>? = null
+        var path: String? = null
+
+        while (true) {
+            when (val index = decodeElementIndex(descriptor)) {
+                IDX_FILE -> file = decodeStringElement(descriptor, index)
+                IDX_TREE_ROOT -> treeRoot = decodeStringElement(descriptor, index)
+                IDX_SEGMENTS -> segments = decodeSerializableElement(descriptor, index, segmentsSerializer)
+                IDX_PATH -> path = decodeStringElement(descriptor, index)
+                CompositeDecoder.DECODE_DONE -> break
+                else -> throw SerializationException("Unexpected APath element index: $index")
+            }
+        }
+
+        when {
+            file != null && treeRoot == null && segments == null && path == null -> LocalPath(File(file))
+            treeRoot != null && segments != null && file == null && path == null -> SAFPath(treeRoot, segments)
+            path != null && file == null && treeRoot == null && segments == null -> RawPath(path)
+            else -> {
+                val keys = listOfNotNull(
+                    "file".takeIf { file != null },
+                    "treeRoot".takeIf { treeRoot != null },
+                    "segments".takeIf { segments != null },
+                    "path".takeIf { path != null },
+                )
+                throw SerializationException("Unknown APath type, keys: $keys")
+            }
         }
     }
 }

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/serialization/APathSerializerSavedStateTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/serialization/APathSerializerSavedStateTest.kt
@@ -1,0 +1,91 @@
+package eu.darken.sdmse.common.serialization
+
+import android.os.Bundle
+import androidx.savedstate.serialization.decodeFromSavedState
+import androidx.savedstate.serialization.encodeToSavedState
+import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.files.RawPath
+import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.files.saf.SAFPath
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.SerializationException
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+
+/**
+ * The Navigation3 back stack is persisted through the androidx savedstate codec, not JSON.
+ * [APathSerializer] must therefore survive a round-trip through a non-JSON encoder/decoder pair.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class APathSerializerSavedStateTest : BaseTest() {
+
+    private val treeUri = "content://com.android.externalstorage.documents/tree/primary%3A"
+
+    private val localPath = LocalPath.build("/storage/emulated/0/DCIM")
+    private val safPath = SAFPath(treeUri, listOf("Pictures", "Wallpaper"))
+    private val rawPath = RawPath.build("/some/raw/path")
+
+    @Test
+    fun `LocalPath saved state round-trip`() {
+        val original: APath = localPath
+        decodeFromSavedState(APathSerializer, encodeToSavedState(APathSerializer, original)) shouldBe original
+    }
+
+    @Test
+    fun `SAFPath saved state round-trip`() {
+        val original: APath = safPath
+        decodeFromSavedState(APathSerializer, encodeToSavedState(APathSerializer, original)) shouldBe original
+    }
+
+    @Test
+    fun `RawPath saved state round-trip`() {
+        val original: APath = rawPath
+        decodeFromSavedState(APathSerializer, encodeToSavedState(APathSerializer, original)) shouldBe original
+    }
+
+    @Test
+    fun `LocalPath saved state written by the previous release still decodes`() {
+        val legacy = encodeToSavedState(LocalPath.serializer(), localPath)
+        decodeFromSavedState(APathSerializer, legacy) shouldBe localPath
+    }
+
+    @Test
+    fun `SAFPath saved state written by the previous release still decodes`() {
+        val legacy = encodeToSavedState(SAFPath.serializer(), safPath)
+        decodeFromSavedState(APathSerializer, legacy) shouldBe safPath
+    }
+
+    @Test
+    fun `RawPath saved state written by the previous release still decodes`() {
+        val legacy = encodeToSavedState(RawPath.serializer(), rawPath)
+        decodeFromSavedState(APathSerializer, legacy) shouldBe rawPath
+    }
+
+    @Test
+    fun `fields from multiple variants are rejected`() {
+        val mixed = Bundle().apply {
+            putString("file", "/a")
+            putString("path", "/b")
+        }
+        shouldThrow<SerializationException> { decodeFromSavedState(APathSerializer, mixed) }
+    }
+
+    @Test
+    fun `SAFPath without segments is rejected`() {
+        val incomplete = Bundle().apply {
+            putString("treeRoot", treeUri)
+        }
+        shouldThrow<SerializationException> { decodeFromSavedState(APathSerializer, incomplete) }
+    }
+
+    @Test
+    fun `empty saved state is rejected`() {
+        shouldThrow<SerializationException> { decodeFromSavedState(APathSerializer, Bundle()) }
+    }
+}


### PR DESCRIPTION
## What changed

Returning to the app after Android had killed it in the background could crash it if the file picker (for example the search-location selection), an image preview, or the path exclusion editor was the screen left open. This affected v2.0.2 and crashed reliably every time the system restored the app in that state. These screens now restore correctly, including state that was saved by v2.0.2 before updating.

## Technical Context

- Root cause: `APathSerializer` extended `JsonContentPolymorphicSerializer`, whose `deserialize` requires a JSON decoder. Navigation3 persists the `rememberNavBackStack` back stack through the androidx savedstate codec, so any restore with an `APath`-carrying route (`PickerRoute`, `PreviewRoute`, `PathExclusionEditorRoute`) threw `IllegalStateException` (two Play vitals issues, one root cause).
- The encode path is deliberately unchanged (pure delegation to the concrete subtype serializer): only `deserialize` was JSON-bound, meaning v2.0.2 already wrote flat subtype layouts into saved state, and that state survives app updates. Decode now reads the flat field union (`file` / `treeRoot`+`segments` / `path`), which covers both old and new saved state and keeps JSON output byte-identical for DataStore, Room, and exports.
- The saved-state decode path validates that exactly one complete subtype field-set is present and throws `SerializationException` otherwise, instead of silently picking a variant on corrupt input.
- Closest review scrutiny: `APathSerializerSavedStateTest` pins the v2.0.2 legacy-layout compatibility and malformed-state rejection; `PickerRouteSavedStateTest` reproduces the full crash envelope through `NavBackStackSerializer`/`NavKeySerializer` plus a `Parcel` round-trip.
- Verified on an API 36 emulator (which CI cannot cover): killing the process with the picker open and relaunching restores the picker screen with the selection intact and a clean logcat.
