### PR TITLE
Fix: Crash when no file picker app is available on the device

### DIFF
--- a/app-common-exclusion/src/main/java/eu/darken/sdmse/exclusion/ui/list/ExclusionListScreen.kt
+++ b/app-common-exclusion/src/main/java/eu/darken/sdmse/exclusion/ui/list/ExclusionListScreen.kt
@@ -1,6 +1,7 @@
 package eu.darken.sdmse.exclusion.ui.list
 
 import android.app.Activity
+import android.content.ActivityNotFoundException
 import android.net.Uri
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -63,6 +64,9 @@ import eu.darken.sdmse.common.compose.layout.SdmTopAppBar
 import eu.darken.sdmse.common.compose.preview.Preview2
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import eu.darken.sdmse.common.compose.selection.rememberSelectionState
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.error.ErrorEventHandler
 import eu.darken.sdmse.common.exclusion.R
 import eu.darken.sdmse.common.navigation.NavigationEventHandler
@@ -73,6 +77,8 @@ import eu.darken.sdmse.exclusion.ui.list.items.SegmentExclusionRow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+
+private val TAG = logTag("Exclusions", "List", "Screen")
 
 @Composable
 fun ExclusionListScreenHost(
@@ -101,7 +107,10 @@ fun ExclusionListScreenHost(
     val exportLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.StartActivityForResult(),
     ) { result ->
-        if (result.resultCode != Activity.RESULT_OK) return@rememberLauncherForActivityResult
+        if (result.resultCode != Activity.RESULT_OK) {
+            vm.onExportAborted()
+            return@rememberLauncherForActivityResult
+        }
         result.data?.data?.let { vm.performExport(it) }
     }
 
@@ -110,8 +119,19 @@ fun ExclusionListScreenHost(
     LaunchedEffect(vm) {
         vm.events.collect { event ->
             when (event) {
-                is ExclusionListViewModel.Event.ImportEvent -> importLauncher.launch(event.intent)
-                is ExclusionListViewModel.Event.ExportEvent -> exportLauncher.launch(event.intent)
+                is ExclusionListViewModel.Event.ImportEvent -> try {
+                    importLauncher.launch(event.intent)
+                } catch (e: ActivityNotFoundException) {
+                    log(TAG, WARN) { "Import picker unavailable: $e" }
+                    vm.errorEvents.emit(e)
+                }
+
+                is ExclusionListViewModel.Event.ExportEvent -> try {
+                    exportLauncher.launch(event.intent)
+                } catch (e: ActivityNotFoundException) {
+                    vm.onExportAborted(e)
+                }
+
                 is ExclusionListViewModel.Event.UndoRemove -> scope.launch {
                     val count = event.exclusions.size
                     val result = snackbarHostState.showSnackbar(

--- a/app-common-exclusion/src/main/java/eu/darken/sdmse/exclusion/ui/list/ExclusionListViewModel.kt
+++ b/app-common-exclusion/src/main/java/eu/darken/sdmse/exclusion/ui/list/ExclusionListViewModel.kt
@@ -265,6 +265,12 @@ class ExclusionListViewModel @Inject constructor(
         events.emit(Event.ExportEvent(intent))
     }
 
+    fun onExportAborted(error: Throwable? = null) = launch {
+        log(TAG) { "onExportAborted(error=$error)" }
+        stagedExportIds = null
+        error?.let { errorEvents.emit(it) }
+    }
+
     fun performExport(directoryUri: Uri?) = launch {
         if (directoryUri == null) {
             log(TAG, WARN) { "Export failed, no path picked" }

--- a/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/list/CustomFilterListScreen.kt
+++ b/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/list/CustomFilterListScreen.kt
@@ -56,6 +56,9 @@ import eu.darken.sdmse.common.compose.layout.SdmTooltipIconButton
 import eu.darken.sdmse.common.compose.preview.Preview2
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import eu.darken.sdmse.common.compose.selection.rememberSelectionState
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.error.ErrorEventHandler
 import eu.darken.sdmse.common.navigation.NavigationEventHandler
 import eu.darken.sdmse.systemcleaner.R
@@ -65,6 +68,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import java.time.Instant
+
+private val TAG = logTag("SystemCleaner", "CustomFilter", "List", "Screen")
 
 @Composable
 fun CustomFilterListScreenHost(
@@ -95,15 +100,29 @@ fun CustomFilterListScreenHost(
     val exportLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.StartActivityForResult(),
     ) { result ->
-        if (result.resultCode != Activity.RESULT_OK) return@rememberLauncherForActivityResult
+        if (result.resultCode != Activity.RESULT_OK) {
+            vm.onExportAborted()
+            return@rememberLauncherForActivityResult
+        }
         result.data?.data?.let { vm.performExport(it) }
     }
 
     LaunchedEffect(vm) {
         vm.events.collect { event ->
             when (event) {
-                is CustomFilterListViewModel.Event.LaunchImport -> importLauncher.launch(event.intent)
-                is CustomFilterListViewModel.Event.LaunchExport -> exportLauncher.launch(event.intent)
+                is CustomFilterListViewModel.Event.LaunchImport -> try {
+                    importLauncher.launch(event.intent)
+                } catch (e: ActivityNotFoundException) {
+                    log(TAG, WARN) { "Import picker unavailable: $e" }
+                    vm.errorEvents.emit(e)
+                }
+
+                is CustomFilterListViewModel.Event.LaunchExport -> try {
+                    exportLauncher.launch(event.intent)
+                } catch (e: ActivityNotFoundException) {
+                    vm.onExportAborted(e)
+                }
+
                 is CustomFilterListViewModel.Event.UndoRemove -> snackScope.launch {
                     val result = snackbarHostState.showSnackbar(
                         message = context.resources.getQuantityString(

--- a/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/list/CustomFilterListViewModel.kt
+++ b/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/customfilter/list/CustomFilterListViewModel.kt
@@ -148,6 +148,12 @@ class CustomFilterListViewModel @Inject constructor(
         events.tryEmit(Event.LaunchExport(intent))
     }
 
+    fun onExportAborted(error: Throwable? = null) = launch {
+        log(TAG) { "onExportAborted(error=$error)" }
+        stagedExport = null
+        error?.let { errorEvents.emit(it) }
+    }
+
     fun performExport(directoryUri: Uri?) = launch {
         if (directoryUri == null) {
             log(TAG, WARN) { "Export failed, no path picked" }

--- a/app/src/main/java/eu/darken/sdmse/main/ui/backup/BackupRestoreScreen.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/backup/BackupRestoreScreen.kt
@@ -1,6 +1,7 @@
 package eu.darken.sdmse.main.ui.backup
 
 import android.app.Activity
+import android.content.ActivityNotFoundException
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
@@ -56,10 +57,15 @@ import eu.darken.sdmse.common.compose.layout.SdmTooltipIconButton
 import eu.darken.sdmse.common.compose.preview.Preview2
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import eu.darken.sdmse.common.compose.settings.SettingsPreferenceItem
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.error.ErrorEventHandler
 import eu.darken.sdmse.common.navigation.NavigationEventHandler
 import eu.darken.sdmse.common.navigation.routes.UpgradeRoute
 import kotlinx.coroutines.launch
+
+private val TAG = logTag("Backup", "Restore", "Screen")
 
 @Composable
 fun BackupRestoreScreenHost(
@@ -91,8 +97,20 @@ fun BackupRestoreScreenHost(
     LaunchedEffect(vm) {
         vm.events.collect { event ->
             when (event) {
-                is BackupRestoreViewModel.Event.PickExportTarget -> exportLauncher.launch(event.intent)
-                is BackupRestoreViewModel.Event.PickImportSource -> importLauncher.launch(event.intent)
+                is BackupRestoreViewModel.Event.PickExportTarget -> try {
+                    exportLauncher.launch(event.intent)
+                } catch (e: ActivityNotFoundException) {
+                    log(TAG, WARN) { "Export target picker unavailable: $e" }
+                    vm.errorEvents.emit(e)
+                }
+
+                is BackupRestoreViewModel.Event.PickImportSource -> try {
+                    importLauncher.launch(event.intent)
+                } catch (e: ActivityNotFoundException) {
+                    log(TAG, WARN) { "Import source picker unavailable: $e" }
+                    vm.errorEvents.emit(e)
+                }
+
                 is BackupRestoreViewModel.Event.ConfirmRestore -> restoreConfirm = event.info
                 is BackupRestoreViewModel.Event.ExportDone -> scope.launch {
                     val msg = if (event.failedSections.isEmpty()) {


### PR DESCRIPTION
## What changed

On devices without a working system file picker (some stripped-down or heavily customized ROMs ship with the documents app disabled or removed), the app crashed when opening any file dialog: restoring or exporting a backup, importing or exporting SystemCleaner custom filters, and importing or exporting exclusions. These actions now show a "No compatible app found to handle this request" error message instead of crashing.

## Technical Context

- Root cause (Play vitals, e.g. moto e22 on Android 12): `ActivityResultLauncher.launch()` throws `ActivityNotFoundException` when no activity resolves the SAF `OPEN_DOCUMENT`/`CREATE_DOCUMENT`/`OPEN_DOCUMENT_TREE` intents. The guards follow the existing SetupScreen pattern (catch, log, route into `errorEvents`); `LocalizedError` already maps the exception to a localized message, so no new strings were needed.
- Both export flows stage their data before the picker opens (`CustomFilterListViewModel.stagedExport` holds full filter payloads). A failed launch, and previously also a cancelled picker, retained that state. The new `onExportAborted()` clears it on both paths, which is the part of the diff worth a closer look.
- The AppControl export launches already handle this via `runCatching` and were deliberately left unchanged.
- Verified on an emulator with the documents app disabled: the guarded paths show the error dialog instead of crashing, and the picker opens normally again once re-enabled (something CI cannot cover).
