### PR TITLE
Fix: Rare app freezes while the automation service is enabled

### DIFF
--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/AcsConsent.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/AcsConsent.kt
@@ -1,0 +1,49 @@
+package eu.darken.sdmse.automation.core
+
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.sdmse.common.debug.logging.asLog
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.retry
+import kotlinx.coroutines.flow.stateIn
+
+/**
+ * Caches the ACS consent setting so the accessibility service never has to read DataStore
+ * from the main thread (that blocking read showed up as ANRs in Play vitals).
+ */
+class AcsConsent(
+    source: Flow<Boolean?>,
+    scope: CoroutineScope,
+) {
+
+    /** The stored consent can legitimately be `null`, so "not loaded yet" needs its own wrapper level. */
+    data class Cached(val consent: Boolean?)
+
+    private val cache: StateFlow<Cached?> = source
+        .map { Cached(it) }
+        .retry {
+            log(TAG, ERROR) { "Consent read failed: ${it.asLog()}" }
+            delay(1000)
+            true
+        }
+        .stateIn(scope, SharingStarted.Eagerly, null)
+
+    /** Non-suspending, for the main-thread event hot path. null = not loaded yet OR stored null, both fail closed. */
+    val current: Boolean?
+        get() = cache.value?.consent
+
+    /** Suspends until the first real emission, so this can tell "not loaded" apart from "stored null". */
+    suspend fun await(): Boolean? = cache.filterNotNull().first().consent
+
+    companion object {
+        private val TAG = logTag("Automation", "Service", "AcsConsent")
+    }
+}

--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/AutomationService.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/AutomationService.kt
@@ -33,7 +33,6 @@ import eu.darken.sdmse.common.device.DeviceDetective
 import eu.darken.sdmse.common.theming.SdmSeTheme
 import eu.darken.sdmse.common.theming.ThemeState
 import eu.darken.sdmse.common.datastore.value
-import eu.darken.sdmse.common.datastore.valueBlocking
 import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
@@ -91,6 +90,10 @@ class AutomationService : AccessibilityService(), AutomationHost, AutomationServ
     private val automationProcessor: AutomationProcessor by lazy { automationProcessorFactory.create(this) }
 
     @Inject lateinit var generalSettings: GeneralSettings
+
+    /** `by lazy` because `generalSettings` is field-injected, i.e. not available at construction time. */
+    private val acsConsent by lazy { AcsConsent(generalSettings.hasAcsConsent.flow, serviceScope) }
+
     @Inject lateinit var automationManager: AutomationManager
     @Inject @SetupBinding(SetupModule.Type.AUTOMATION) lateinit var automationSetupModule: SetupModule
     @Inject lateinit var screenState: ScreenState
@@ -171,12 +174,15 @@ class AutomationService : AccessibilityService(), AutomationHost, AutomationServ
             return
         }
 
-        if (mightBeRestrictedDueToSideload() && !generalSettings.hasPassedAppOpsRestrictions.valueBlocking) {
-            log(TAG, INFO) { "We are not restricted by app ops." }
-            generalSettings.hasPassedAppOpsRestrictions.valueBlocking = true
-        }
+        log(TAG) { "Consent cache primed: ${acsConsent.current}" }
 
         serviceScope.launch {
+            if (withContext(dispatcher.IO) { mightBeRestrictedDueToSideload() }
+                && !generalSettings.hasPassedAppOpsRestrictions.value()
+            ) {
+                log(TAG, INFO) { "We are not restricted by app ops." }
+                generalSettings.hasPassedAppOpsRestrictions.value(true)
+            }
             delay(2000)
             automationSetupModule.refresh()
         }
@@ -244,11 +250,12 @@ class AutomationService : AccessibilityService(), AutomationHost, AutomationServ
         automationManager.setCurrentService(this)
         windowManager = getSystemService(WINDOW_SERVICE) as WindowManager
 
-        if (generalSettings.hasAcsConsent.valueBlocking != true) {
-            log(TAG, WARN) { "Missing consent for accessibility service, stopping service." }
-            // disableSelf() does not work if called within `onCreate()`
-            disableSelf()
-            return
+        serviceScope.launch {
+            if (acsConsent.await() != true) {
+                log(TAG, WARN) { "Missing consent for accessibility service, stopping service." }
+                // disableSelf() does not work if called within `onCreate()`
+                withContext(dispatcher.Main) { disableSelf() }
+            }
         }
     }
 
@@ -273,7 +280,7 @@ class AutomationService : AccessibilityService(), AutomationHost, AutomationServ
     }
 
     override fun onAccessibilityEvent(event: AccessibilityEvent) {
-        if (generalSettings.hasAcsConsent.valueBlocking != true) {
+        if (acsConsent.current != true) {
             log(TAG, WARN) { "Missing consent for accessibility service, skipping event." }
             return
         }
@@ -389,7 +396,7 @@ class AutomationService : AccessibilityService(), AutomationHost, AutomationServ
         val id = task.hashCode()
         log(TAG, INFO) { "submit($id): $task" }
 
-        if (generalSettings.hasAcsConsent.valueBlocking != true) {
+        if (acsConsent.await() != true) {
             log(TAG, WARN) { "submit($id): Missing consent for accessibility service, skipping task." }
             throw AutomationNoConsentException()
         }

--- a/app-common-automation/src/test/java/eu/darken/sdmse/automation/core/AcsConsentTest.kt
+++ b/app-common-automation/src/test/java/eu/darken/sdmse/automation/core/AcsConsentTest.kt
@@ -1,0 +1,75 @@
+package eu.darken.sdmse.automation.core
+
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+import java.io.IOException
+
+class AcsConsentTest : BaseTest() {
+
+    @Test
+    fun `current is null and await suspends until the first emission`() = runTest2 {
+        val source = MutableSharedFlow<Boolean?>()
+        val consent = AcsConsent(source, backgroundScope)
+        runCurrent()
+
+        consent.current shouldBe null
+
+        val awaited = async { consent.await() }
+        runCurrent()
+        awaited.isCompleted shouldBe false
+
+        source.emit(true)
+        runCurrent()
+
+        awaited.await() shouldBe true
+        consent.current shouldBe true
+    }
+
+    @Test
+    fun `a stored null is not mistaken for not-loaded-yet`() = runTest2 {
+        val consent = AcsConsent(flowOf(null), backgroundScope)
+
+        consent.await() shouldBe null
+        consent.current shouldBe null
+    }
+
+    @Test
+    fun `a failing source is retried and recovers`() = runTest2 {
+        var attempts = 0
+        val source = flow {
+            attempts++
+            if (attempts == 1) throw IOException("Read failed")
+            emit(true)
+        }
+        val consent = AcsConsent(source, backgroundScope)
+
+        advanceTimeBy(1001)
+        runCurrent()
+
+        consent.current shouldBe true
+        consent.await() shouldBe true
+        attempts shouldBe 2
+    }
+
+    @Test
+    fun `later emissions are propagated`() = runTest2 {
+        val source = MutableStateFlow<Boolean?>(true)
+        val consent = AcsConsent(source, backgroundScope)
+
+        consent.await() shouldBe true
+
+        source.value = false
+        runCurrent()
+
+        consent.current shouldBe false
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/common/theming/Theming.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/theming/Theming.kt
@@ -32,6 +32,9 @@ class Theming @Inject constructor(
             .setupCommonEventHandlers(TAG) { "setup" }
             .launchIn(appScope)
 
+        // Deliberately blocking: the night mode has to be set before the first frame, otherwise the app
+        // flashes the wrong theme and AppCompat recreates the activity to correct it. This cold read also
+        // warms the shared `settings_core` DataStore for the main-thread reads that follow it.
         generalSettings.themeMode.valueBlocking.let {
             log(TAG) { "Applying initial themeMode setting: $it" }
             it.applyMode()


### PR DESCRIPTION
## What changed

Android could report SD Maid as unresponsive (ANR) while the automation service was enabled, most often when the screen turned off under heavy device load. Play vitals for v2.0.2 show a cluster of these freezes. The automation service no longer performs blocking settings reads on the main thread, which removes the freeze source. Consent handling behaves the same from the user's perspective: without consent the service still refuses events, tasks, and disables itself.

## Technical Context

- Root cause: `AutomationService.onAccessibilityEvent` runs on the main thread for every accessibility event and read `hasAcsConsent` via `valueBlocking` (`runBlocking { flow.first() }` over DataStore). A cold or I/O-pressured DataStore read there exceeds the ANR deadline (vitals issues `5f4340b3`, `8735765b`; the SCREEN_OFF broadcast in the ANR title is just the queued victim). `onServiceConnected`, `submit()`, and the app-ops block in `onCreate` had the same pattern.
- Consent now comes from `AcsConsent`, an eagerly collected StateFlow cache: non-suspending `current` in the event hot path, suspending `await()` in `onServiceConnected`/`submit()`. The `Cached` wrapper keeps "not loaded yet" distinguishable from "stored null" (both fail closed), and a retry stops a transient DataStore IOException from permanently killing the collector. `submit()` awaiting the cache also guarantees the event path's cache is hot before any task starts.
- The app-ops check/write moved into the existing startup coroutine rather than its own, keeping the write ordered before `automationSetupModule.refresh()`; the setup module only re-reads that value on refresh, so a concurrent write could have left it stale indefinitely.
- `Theming.setup` (the second vitals stack, from v1.7.5) deliberately keeps its blocking read and now documents why: applying the theme asynchronously would flash the wrong theme and recreate activities on every cold start for users with an explicit dark/light setting. Other remaining `valueBlocking` call sites were reviewed and left unchanged (low frequency, no vitals evidence).
- Manual on-device QA covered what CI cannot: consent-gate negative/positive behavior and an end-to-end automation cache-clear on an API 35 emulator.
