### PR TITLE
AppCleaner: Fail faster when cache clearing can't work on a device

### DIFF
--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/specs/AutomationExplorer.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/specs/AutomationExplorer.kt
@@ -8,6 +8,7 @@ import eu.darken.sdmse.automation.core.AutomationHost
 import eu.darken.sdmse.automation.core.errors.AutomationOverlayException
 import eu.darken.sdmse.automation.core.errors.AutomationTimeoutException
 import eu.darken.sdmse.automation.core.errors.PlanAbortException
+import eu.darken.sdmse.automation.core.errors.StepAbortException
 import eu.darken.sdmse.common.R
 import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
@@ -62,6 +63,7 @@ class AutomationExplorer @AssistedInject constructor(
 
         try {
             withTimeout(spec.executionTimeout.toMillis()) {
+                var abortReplays = 0
                 while (currentCoroutineContext().isActive) {
                     try {
                         plan(context)
@@ -70,6 +72,26 @@ class AutomationExplorer @AssistedInject constructor(
                     } catch (e: PlanAbortException) {
                         log(TAG, WARN) { "ABORT Plan due to ${e.asLog()}" }
                         throw e
+                    } catch (e: StepAbortException) {
+                        // Stepper turns a deliberate skip into a `break`, so this should only ever be
+                        // a genuine failure. Mirror its semantics anyway if one does reach us.
+                        if (e.treatAsSuccess) {
+                            log(TAG, WARN) { "Plan finished early, step skipped: ${e.asLog()}" }
+                            return@withTimeout
+                        }
+                        // The step declared itself unretryable, so replaying the plan re-runs the
+                        // same failing step. Allow a bounded number of replays in case the screen
+                        // was merely in a bad state, but don't keep going until executionTimeout:
+                        // that turns a decided failure into a 30s stall per target.
+                        if (abortReplays >= spec.executionRetryCount) {
+                            log(TAG, WARN) { "Step aborted unretryably, out of replays:\n${e.asLog()}" }
+                            throw e
+                        }
+                        abortReplays++
+                        log(TAG, WARN) {
+                            "Step aborted unretryably, replay $abortReplays/${spec.executionRetryCount}:\n${e.asLog()}"
+                        }
+                        delay(300)
                     } catch (e: Exception) {
                         log(TAG, WARN) { "Plan failed, retrying:\n${e.asLog()}" }
                         delay(300)

--- a/app-common-automation/src/test/java/eu/darken/sdmse/automation/core/specs/AutomationExplorerTest.kt
+++ b/app-common-automation/src/test/java/eu/darken/sdmse/automation/core/specs/AutomationExplorerTest.kt
@@ -1,0 +1,113 @@
+package eu.darken.sdmse.automation.core.specs
+
+import eu.darken.sdmse.automation.core.AutomationHost
+import eu.darken.sdmse.automation.core.errors.AutomationTimeoutException
+import eu.darken.sdmse.automation.core.errors.StepAbortException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+import java.time.Duration
+
+/**
+ * A step that aborts without [StepAbortException.treatAsSuccess] has declared itself unretryable,
+ * but the explorer used to catch it in its generic retry branch and replay the whole plan until
+ * [AutomationSpec.Explorer.executionTimeout] expired. That re-ran the same failing step for 30s per
+ * target, so a decided failure looked like a hang: the AppCleaner clear-cache path spent 4.5 minutes
+ * relaunching Settings for nine apps before its give-up heuristic tripped.
+ */
+class AutomationExplorerTest : BaseTest() {
+
+    private val host = mockk<AutomationHost>(relaxed = true)
+
+    private fun spec(
+        retryCount: Int = 3,
+        timeout: Duration = Duration.ofSeconds(30),
+        plan: suspend (AutomationExplorer.Context) -> Unit,
+    ) = object : AutomationSpec.Explorer {
+        override val tag: String = "test"
+        override val executionTimeout: Duration = timeout
+        override val executionRetryCount: Int = retryCount
+        override suspend fun createPlan(): suspend (AutomationExplorer.Context) -> Unit = plan
+    }
+
+    @Test
+    fun `an unretryable step abort is replayed only within the retry budget`() = runTest2 {
+        var attempts = 0
+        val abort = StepAbortException("Button not reachable")
+        abort.treatAsSuccess shouldBe false
+
+        val thrown = shouldThrow<StepAbortException> {
+            AutomationExplorer(host).process(
+                spec(retryCount = 3) {
+                    attempts++
+                    throw abort
+                }
+            )
+        }
+
+        thrown shouldBe abort
+        // Initial attempt plus executionRetryCount replays, then it propagates instead of
+        // spinning until executionTimeout.
+        attempts shouldBe 4
+    }
+
+    @Test
+    fun `the retry budget is shared by the whole plan, not refreshed per replay`() = runTest2 {
+        var attempts = 0
+
+        shouldThrow<StepAbortException> {
+            AutomationExplorer(host).process(
+                spec(retryCount = 0) {
+                    attempts++
+                    throw StepAbortException("Button not reachable")
+                }
+            )
+        }
+
+        attempts shouldBe 1
+    }
+
+    @Test
+    fun `a step abort marked as success ends the plan without replaying`() = runTest2 {
+        var attempts = 0
+
+        AutomationExplorer(host).process(
+            spec {
+                attempts++
+                throw StepAbortException("Handled elsewhere", treatAsSuccess = true)
+            }
+        )
+
+        attempts shouldBe 1
+    }
+
+    @Test
+    fun `other failures keep retrying until the execution timeout`() = runTest2 {
+        var attempts = 0
+
+        shouldThrow<AutomationTimeoutException> {
+            AutomationExplorer(host).process(
+                spec(retryCount = 3, timeout = Duration.ofSeconds(3)) {
+                    attempts++
+                    throw IllegalStateException("Transient failure")
+                }
+            )
+        }
+
+        // The abort budget must not leak into the generic retry path.
+        attempts shouldBeGreaterThan 4
+    }
+
+    @Test
+    fun `a plan that succeeds runs exactly once`() = runTest2 {
+        var attempts = 0
+
+        AutomationExplorer(host).process(spec { attempts++ })
+
+        attempts shouldBe 1
+    }
+}

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/ClearCacheModule.kt
@@ -37,6 +37,7 @@ import eu.darken.sdmse.automation.core.errors.AutomationOverlayException
 import eu.darken.sdmse.automation.core.errors.AutomationTimeoutException
 import eu.darken.sdmse.automation.core.errors.InvalidSystemStateException
 import eu.darken.sdmse.automation.core.errors.PlanAbortException
+import eu.darken.sdmse.automation.core.errors.StepAbortException
 import eu.darken.sdmse.automation.core.errors.UserCancelledAutomationException
 import eu.darken.sdmse.automation.core.finishAutomation
 import eu.darken.sdmse.automation.core.specs.AutomationExplorer
@@ -150,9 +151,9 @@ class ClearCacheModule @AssistedInject constructor(
             result.failed.forEach { (id, e) -> log(TAG, WARN) { "$id failed with $e" } }
         }
 
-        val timeoutCount = result.failed.count { it.value is AutomationTimeoutException }
-        if (timeoutCount >= TIMEOUT_LIMIT && result.successful.isEmpty()) {
-            log(TAG, ERROR) { "Continued timeout errors, no successes so far, possible compatbility issue?" }
+        val unusableCount = result.failed.count { it.value.isAutomationUnusable() }
+        if (unusableCount >= FAILURE_LIMIT && result.successful.isEmpty()) {
+            log(TAG, ERROR) { "Continued automation failures, no successes so far, possible compatbility issue?" }
             throw AutomationCompatibilityException(
                 additionalHint = R.string.appcleaner_automation_compat_forcestop_hint.toCaString(),
             )
@@ -215,12 +216,12 @@ class ClearCacheModule @AssistedInject constructor(
                         throw e
                     }
 
-                    e is AutomationTimeoutException -> {
-                        log(TAG, WARN) { "Timeout while processing $installed" }
+                    e.isAutomationUnusable() -> {
+                        log(TAG, WARN) { "Automation unusable while processing $installed: ${e.asLog()}" }
                         task.onError(target, e)
                         failed[target] = e
-                        val timeouts = failed.count { it.value is AutomationTimeoutException }
-                        if (successful.isEmpty() && timeouts > TIMEOUT_LIMIT) break
+                        val unusable = failed.count { it.value.isAutomationUnusable() }
+                        if (successful.isEmpty() && unusable >= FAILURE_LIMIT) break
                     }
 
                     e is AutomationOverlayException -> {
@@ -314,7 +315,21 @@ class ClearCacheModule @AssistedInject constructor(
     }
 
     companion object {
-        private const val TIMEOUT_LIMIT = 8
+        /** How many targets may fail with an unusable automation path before we stop trying. */
+        private const val FAILURE_LIMIT = 8
+
+        /**
+         * Failures that mean we could not drive the Settings UI at all, as opposed to one app
+         * being uncooperative. A timeout is the slow form, an unretryable step abort the fast one
+         * (e.g. the DPAD fallback finding the clear-cache button unreachable). Both indicate the
+         * automation path itself is broken, so both feed the give-up heuristic.
+         */
+        private fun Throwable.isAutomationUnusable(): Boolean = when (this) {
+            is AutomationTimeoutException -> true
+            is StepAbortException -> !treatAsSuccess
+            else -> false
+        }
+
         val TAG: String = logTag("Automation", "AppCleaner", "ClearCacheModule")
     }
 }


### PR DESCRIPTION
## What changed

When automated cache clearing can't operate the Settings screen on a device, AppCleaner now gives up on each app after a few seconds instead of retrying it for a full 30 seconds. A run that previously spent four and a half minutes relaunching the Settings screen through nine apps before showing the compatibility error now reaches the same result in well under a minute. The error itself is unchanged, and so is which apps get cleared.

## Technical Context

- The clear-cache step throws `StepAbortException(treatAsSuccess=false)` about a second in when the button can't be reached, but `AutomationExplorer` caught it in its generic retry branch and replayed the entire plan until `executionTimeout`. Each replay re-ran the step that had already declared itself unretryable, and because the plan's attempt counters are locals, every replay reset them.
- `AutomationExplorer` now has a dedicated `StepAbortException` branch: a `treatAsSuccess` abort ends the plan as success, mirroring what `Stepper` does with its `break`, while a genuine one is replayed at most `executionRetryCount` times and then propagates. This is the first use of `executionRetryCount`, which was declared on `AutomationSpec.Explorer` and read nowhere.
- `ClearCacheModule`'s give-up heuristic had to broaden with it. It counted only `AutomationTimeoutException`, so once targets fail fast as aborts the counter would never advance and a run would walk every target without ever raising the compatibility error. Both call sites now count via `isAutomationUnusable()`. The `successful.isEmpty()` guard is unchanged, so a few individually uncooperative apps still can't trip it.
- Same lines, drive-by: the in-loop break used `>` while the post-loop throw used `>=` against the same constant, so it read as 8 but behaved as 9 and always processed one extra doomed target. Both are `>=` now, and `TIMEOUT_LIMIT` becomes `FAILURE_LIMIT`.
- Worth close review: the `when`-branch reorder in `ClearCacheModule`, from `e is AutomationTimeoutException` to `e.isAutomationUnusable()`. I checked that it shadows no later branch, but it's the part most able to hide a regression.

This came out of a support log from a device that couldn't drive the Settings UI at all because System UI had been force-stopped, which #2654 fixes. This PR doesn't address that cause, only what each failure costs.
