### PR TITLE
General: Show how long SD Maid has been on your device

### DIFF
--- a/app-common-stats/src/main/java/eu/darken/sdmse/stats/ui/InstallElapsed.kt
+++ b/app-common-stats/src/main/java/eu/darken/sdmse/stats/ui/InstallElapsed.kt
@@ -1,0 +1,66 @@
+package eu.darken.sdmse.stats.ui
+
+import android.content.Context
+import eu.darken.sdmse.common.stats.R
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+
+object InstallElapsed {
+    enum class Span { DAYS, WEEKS, MONTHS, YEARS }
+    data class Value(val span: Span, val count: Int)
+
+    /**
+     * Largest sensible unit elapsed between [installedAt] and [now], or null below a full day —
+     * the caller renders no caption at all then rather than claim time that hasn't passed.
+     */
+    fun of(installedAt: Instant, now: Instant, zone: ZoneId = ZoneId.systemDefault()): Value? {
+        // Both guards are needed. The duration check stops "1 day" appearing minutes after a
+        // late-evening install once the clock rolls past midnight, and absorbs a backwards-
+        // corrected device clock (negative duration). The calendar check stops a "0 days" result
+        // on a 25-hour DST fall-back day, where 24h of real time can land on the same local date.
+        if (Duration.between(installedAt, now) < Duration.ofDays(1)) return null
+        val start = LocalDate.ofInstant(installedAt, zone)
+        val today = LocalDate.ofInstant(now, zone)
+        if (!start.isBefore(today)) return null
+
+        val years = wholeUnitsUntil(start, today, ChronoUnit.YEARS, LocalDate::plusYears)
+        if (years >= 1) return Value(Span.YEARS, years.toInt())
+
+        val months = wholeUnitsUntil(start, today, ChronoUnit.MONTHS, LocalDate::plusMonths)
+        if (months >= 1) return Value(Span.MONTHS, months.toInt())
+
+        val days = ChronoUnit.DAYS.between(start, today)
+        return if (days >= 7) Value(Span.WEEKS, (days / 7).toInt()) else Value(Span.DAYS, days.toInt())
+    }
+
+    // ChronoUnit.YEARS/MONTHS.between() compares day-of-month numerically, so it under-counts by
+    // exactly one whenever the end date is a clamped month-end: 2024-02-29 -> 2025-02-28 measures
+    // as 11 months (not 1 year), and 2025-01-31 -> 2025-02-28 as 0 months (not 1). plusYears /
+    // plusMonths clamp month-ends the same way CurriculumVitae.anniversaryOccurrenceOf does (a
+    // Feb-29 install has its anniversary on Feb 28 in non-leap years), so re-test the next-higher
+    // count against the actual date. Day-of-month truncation can only ever lose one unit, so a
+    // single fixup step is exact.
+    private fun wholeUnitsUntil(
+        start: LocalDate,
+        today: LocalDate,
+        unit: ChronoUnit,
+        plus: (LocalDate, Long) -> LocalDate,
+    ): Long {
+        val approx = unit.between(start, today)
+        return if (!plus(start, approx + 1).isAfter(today)) approx + 1 else approx
+    }
+
+    fun format(context: Context, value: Value): String = context.resources.getQuantityString(
+        when (value.span) {
+            Span.DAYS -> R.plurals.stats_dash_since_days
+            Span.WEEKS -> R.plurals.stats_dash_since_weeks
+            Span.MONTHS -> R.plurals.stats_dash_since_months
+            Span.YEARS -> R.plurals.stats_dash_since_years
+        },
+        value.count,
+        value.count,
+    )
+}

--- a/app-common-stats/src/main/res/values/strings.xml
+++ b/app-common-stats/src/main/res/values/strings.xml
@@ -8,6 +8,25 @@
         <item quantity="one">%s item processed since you invited SD Maid to your device.</item>
         <item quantity="other">%s items processed since you invited SD Maid to your device.</item>
     </plurals>
+    <!-- Dashboard statistics card caption: how long SD Maid has been installed. SD Maid is
+         personified as an invited houseguest (see stats_dash_body_count). Use the INFORMAL
+         register (du / tu / tú) in languages that distinguish it. %d is the count. -->
+    <plurals name="stats_dash_since_days">
+        <item quantity="one">Your guest for %d day.</item>
+        <item quantity="other">Your guest for %d days.</item>
+    </plurals>
+    <plurals name="stats_dash_since_weeks">
+        <item quantity="one">Your guest for %d week.</item>
+        <item quantity="other">Your guest for %d weeks.</item>
+    </plurals>
+    <plurals name="stats_dash_since_months">
+        <item quantity="one">Your guest for %d month.</item>
+        <item quantity="other">Your guest for %d months.</item>
+    </plurals>
+    <plurals name="stats_dash_since_years">
+        <item quantity="one">Your guest for %d year.</item>
+        <item quantity="other">Your guest for %d years.</item>
+    </plurals>
     <string name="stats_report_status_partial_success">Partial success</string>
     <string name="stats_report_status_partial_failure">Failure</string>
     <string name="stats_settings_desc">Configure SD Maid\'s statistics, reports and data retention.</string>

--- a/app-common-stats/src/test/java/eu/darken/sdmse/stats/ui/InstallElapsedTest.kt
+++ b/app-common-stats/src/test/java/eu/darken/sdmse/stats/ui/InstallElapsedTest.kt
@@ -1,0 +1,125 @@
+package eu.darken.sdmse.stats.ui
+
+import eu.darken.sdmse.stats.ui.InstallElapsed.Span
+import eu.darken.sdmse.stats.ui.InstallElapsed.Value
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZoneOffset
+
+class InstallElapsedTest : BaseTest() {
+
+    private fun elapsed(start: String, today: String): Value? = InstallElapsed.of(
+        installedAt = noon(start),
+        now = noon(today),
+        zone = ZoneOffset.UTC,
+    )
+
+    private fun noon(date: String): Instant = LocalDate.parse(date).atTime(12, 0).toInstant(ZoneOffset.UTC)
+
+    @Test
+    fun `nothing to show minutes after the install`() {
+        InstallElapsed.of(
+            installedAt = Instant.parse("2025-03-10T12:00:00Z"),
+            now = Instant.parse("2025-03-10T12:10:00Z"),
+            zone = ZoneOffset.UTC,
+        ).shouldBeNull()
+    }
+
+    @Test
+    fun `crossing midnight is not a day`() {
+        InstallElapsed.of(
+            installedAt = Instant.parse("2025-03-09T23:50:00Z"),
+            now = Instant.parse("2025-03-10T00:05:00Z"),
+            zone = ZoneOffset.UTC,
+        ).shouldBeNull()
+    }
+
+    @Test
+    fun `23 hours across a date boundary is not a day`() {
+        InstallElapsed.of(
+            installedAt = Instant.parse("2025-03-09T12:00:00Z"),
+            now = Instant.parse("2025-03-10T11:00:00Z"),
+            zone = ZoneOffset.UTC,
+        ).shouldBeNull()
+    }
+
+    @Test
+    fun `an install date in the future shows nothing`() {
+        InstallElapsed.of(
+            installedAt = Instant.parse("2025-03-11T12:00:00Z"),
+            now = Instant.parse("2025-03-10T12:00:00Z"),
+            zone = ZoneOffset.UTC,
+        ).shouldBeNull()
+    }
+
+    @Test
+    fun `24 hours on a DST fall-back day stays on the same local date`() {
+        val zone = ZoneId.of("America/New_York")
+        val installedAt = LocalDateTime.parse("2025-11-02T00:30:00").atZone(zone).toInstant()
+        InstallElapsed.of(
+            installedAt = installedAt,
+            now = installedAt.plus(Duration.ofHours(24)),
+            zone = zone,
+        ).shouldBeNull()
+    }
+
+    @Test
+    fun `single day`() {
+        elapsed("2025-03-09", "2025-03-10") shouldBe Value(Span.DAYS, 1)
+    }
+
+    @Test
+    fun `days until a full week`() {
+        elapsed("2025-03-04", "2025-03-10") shouldBe Value(Span.DAYS, 6)
+    }
+
+    @Test
+    fun `seven days is one week`() {
+        elapsed("2025-03-03", "2025-03-10") shouldBe Value(Span.WEEKS, 1)
+    }
+
+    @Test
+    fun `weeks are truncated not rounded`() {
+        elapsed("2025-02-25", "2025-03-10") shouldBe Value(Span.WEEKS, 1)
+        elapsed("2025-02-24", "2025-03-10") shouldBe Value(Span.WEEKS, 2)
+    }
+
+    @Test
+    fun `a month short of a month stays in weeks`() {
+        elapsed("2025-01-01", "2025-01-31") shouldBe Value(Span.WEEKS, 4)
+    }
+
+    @Test
+    fun `one month`() {
+        elapsed("2025-01-01", "2025-02-01") shouldBe Value(Span.MONTHS, 1)
+    }
+
+    @Test
+    fun `a month-end install rolls over on the clamped date`() {
+        elapsed("2025-01-31", "2025-02-27") shouldBe Value(Span.WEEKS, 3)
+        elapsed("2025-01-31", "2025-02-28") shouldBe Value(Span.MONTHS, 1)
+    }
+
+    @Test
+    fun `eleven months is not a year`() {
+        elapsed("2024-03-01", "2025-02-01") shouldBe Value(Span.MONTHS, 11)
+    }
+
+    @Test
+    fun `a leap-day install turns one on February 28th`() {
+        elapsed("2024-02-29", "2025-02-28") shouldBe Value(Span.YEARS, 1)
+        elapsed("2024-02-29", "2025-03-01") shouldBe Value(Span.YEARS, 1)
+    }
+
+    @Test
+    fun `two years`() {
+        elapsed("2023-03-10", "2025-03-10") shouldBe Value(Span.YEARS, 2)
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardCardFlows.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardCardFlows.kt
@@ -403,13 +403,18 @@ internal fun DashboardViewModel.buildMotdItem(): Flow<MotdDashboardCardItem?> = 
         )
     }
 
-internal fun DashboardViewModel.buildStatsItem(): Flow<StatsDashboardCardItem?> = combine(
+internal fun DashboardViewModel.buildStatsItem(): Flow<StatsDashboardCardItem?> = eu.darken.sdmse.common.flow.combine(
     statsRepo.state,
     upgradeInfo.map { it?.isPro ?: false },
     statsSettings.retentionReports.flow,
     statsSettings.retentionPaths.flow,
     statsSettings.retentionSnapshots.flow,
-) { state, isPro, retentionReports, retentionPaths, retentionSnapshots ->
+    // CurriculumVitae.installedAt is filterNotNull() and stays silent until updateAppLaunch()
+    // has written the install date, which on a first-ever launch waits on upgrade state (5s
+    // timeout). As a bare combine source that would hide the whole Stats card for that window,
+    // so prime it with null and treat null as "no caption yet".
+    (curriculumVitae.installedAt as Flow<Instant?>).onStart { emit(null) },
+) { state, isPro, retentionReports, retentionPaths, retentionSnapshots, installedAt ->
     // Hide card if all retention settings are disabled
     if (retentionReports == Duration.ZERO && retentionPaths == Duration.ZERO && retentionSnapshots == Duration.ZERO) {
         return@combine null
@@ -419,6 +424,7 @@ internal fun DashboardViewModel.buildStatsItem(): Flow<StatsDashboardCardItem?> 
     StatsDashboardCardItem(
         state = state,
         showProRequirement = !isPro,
+        installedAt = installedAt,
         onViewAction = {
             if (isPro) {
                 navTo(ReportsRoute)

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModel.kt
@@ -65,6 +65,7 @@ import eu.darken.sdmse.deduplicator.core.tasks.DeduplicatorDeleteTask
 import eu.darken.sdmse.deduplicator.core.tasks.DeduplicatorOneClickTask
 import eu.darken.sdmse.deduplicator.core.tasks.DeduplicatorScanTask
 import eu.darken.sdmse.deduplicator.core.tasks.DeduplicatorTask
+import eu.darken.sdmse.main.core.CurriculumVitae
 import eu.darken.sdmse.main.core.DashboardCardConfig
 import eu.darken.sdmse.main.core.DashboardCardType
 import eu.darken.sdmse.main.core.GeneralSettings
@@ -165,6 +166,7 @@ class DashboardViewModel @Inject constructor(
     anniversaryProvider: AnniversaryProvider,
     internal val statsRepo: StatsRepo,
     internal val statsSettings: StatsSettings,
+    internal val curriculumVitae: CurriculumVitae,
     internal val spaceHistoryRepo: SpaceHistoryRepo,
     deviceDetective: DeviceDetective,
 ) : ViewModel4(dispatcherProvider, TAG) {

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/StatsDashboardCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/StatsDashboardCard.kt
@@ -33,10 +33,14 @@ import eu.darken.sdmse.main.ui.dashboard.cards.common.DashboardActionIconSpacing
 import eu.darken.sdmse.main.ui.dashboard.cards.common.DashboardCard
 import eu.darken.sdmse.main.ui.dashboard.cards.common.DashboardFlatActionButton
 import eu.darken.sdmse.stats.core.StatsRepo
+import eu.darken.sdmse.stats.ui.InstallElapsed
+import java.time.Duration
+import java.time.Instant
 
 data class StatsDashboardCardItem(
     val state: StatsRepo.State,
     val showProRequirement: Boolean,
+    val installedAt: Instant?,
     val onViewAction: () -> Unit,
 ) : DashboardItem {
     override val stableId: Long = this.javaClass.hashCode().toLong()
@@ -99,6 +103,23 @@ internal fun StatsDashboardCard(item: StatsDashboardCardItem) {
             style = MaterialTheme.typography.bodyMedium,
         )
 
+        // Deliberately not remembered: the result depends on Instant.now() as well as installedAt, so any
+        // remember key that omits the current date would pin a stale caption across midnight. The
+        // computation is a handful of LocalDate ops plus one resource lookup.
+        // Null means either "install date not yet known" or "less than a day old" — no caption either way.
+        val elapsedText = item.installedAt
+            ?.let { InstallElapsed.of(it, Instant.now()) }
+            ?.let { InstallElapsed.format(context, it) }
+
+        if (elapsedText != null) {
+            Spacer(modifier = Modifier.height(2.dp))
+            Text(
+                text = elapsedText,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
         Spacer(modifier = Modifier.height(4.dp))
 
         Row(
@@ -131,6 +152,7 @@ private fun StatsDashboardCardPreview() {
                     databaseSize = 256L * 1024L,
                 ),
                 showProRequirement = false,
+                installedAt = Instant.now().minus(Duration.ofDays(95)),
                 onViewAction = {},
             ),
         )

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardDiscardTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardDiscardTest.kt
@@ -13,6 +13,7 @@ import eu.darken.sdmse.common.updater.UpdateService
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
 import eu.darken.sdmse.corpsefinder.core.CorpseFinder
 import eu.darken.sdmse.deduplicator.core.Deduplicator
+import eu.darken.sdmse.main.core.CurriculumVitae
 import eu.darken.sdmse.main.core.GeneralSettings
 import eu.darken.sdmse.main.core.SDMTool
 import eu.darken.sdmse.main.core.motd.MotdRepo
@@ -110,6 +111,7 @@ internal class DashboardDiscardTest : BaseTest() {
             anniversaryProvider = mockk<AnniversaryProvider>(relaxed = true).apply { every { item } returns emptyFlow() },
             statsRepo = mockk<StatsRepo>(relaxed = true).apply { every { state } returns emptyFlow() },
             statsSettings = statsSettings,
+            curriculumVitae = mockk<CurriculumVitae>(relaxed = true).apply { every { installedAt } returns emptyFlow() },
             spaceHistoryRepo = mockk<SpaceHistoryRepo>(relaxed = true).apply {
                 every { getAllHistory(any()) } returns emptyFlow()
             },

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardHeroToolRoutingTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardHeroToolRoutingTest.kt
@@ -15,6 +15,7 @@ import eu.darken.sdmse.common.upgrade.UpgradeRepo
 import eu.darken.sdmse.corpsefinder.core.CorpseFinder
 import eu.darken.sdmse.corpsefinder.ui.CorpseFinderListRoute
 import eu.darken.sdmse.deduplicator.core.Deduplicator
+import eu.darken.sdmse.main.core.CurriculumVitae
 import eu.darken.sdmse.main.core.GeneralSettings
 import eu.darken.sdmse.main.core.SDMTool
 import eu.darken.sdmse.main.core.motd.MotdRepo
@@ -110,6 +111,9 @@ internal class DashboardHeroToolRoutingTest : BaseTest() {
         val spaceHistoryRepo = mockk<SpaceHistoryRepo>(relaxed = true).apply {
             every { getAllHistory(any()) } returns emptyFlow()
         }
+        val curriculumVitae = mockk<CurriculumVitae>(relaxed = true).apply {
+            every { installedAt } returns emptyFlow()
+        }
 
         return DashboardViewModel(
             context = mockk(relaxed = true),
@@ -138,6 +142,7 @@ internal class DashboardHeroToolRoutingTest : BaseTest() {
             anniversaryProvider = anniversaryProvider,
             statsRepo = statsRepo,
             statsSettings = statsSettings,
+            curriculumVitae = curriculumVitae,
             spaceHistoryRepo = spaceHistoryRepo,
             deviceDetective = mockk(relaxed = true),
         )

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModelResilienceTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModelResilienceTest.kt
@@ -16,6 +16,7 @@ import eu.darken.sdmse.common.upgrade.UpgradeRepo
 import eu.darken.sdmse.corpsefinder.core.CorpseFinder
 import eu.darken.sdmse.corpsefinder.core.tasks.CorpseFinderScanTask
 import eu.darken.sdmse.deduplicator.core.Deduplicator
+import eu.darken.sdmse.main.core.CurriculumVitae
 import eu.darken.sdmse.main.core.DashboardCardConfig
 import eu.darken.sdmse.main.core.DashboardCardType
 import eu.darken.sdmse.main.core.GeneralSettings
@@ -29,6 +30,7 @@ import eu.darken.sdmse.setup.SetupManager
 import eu.darken.sdmse.squeezer.core.Squeezer
 import eu.darken.sdmse.main.ui.dashboard.cards.AnalyzerDashboardCardItem
 import eu.darken.sdmse.main.ui.dashboard.cards.SchedulerDashboardCardItem
+import eu.darken.sdmse.main.ui.dashboard.cards.StatsDashboardCardItem
 import eu.darken.sdmse.main.ui.dashboard.cards.SwiperDashboardCardItem
 import eu.darken.sdmse.main.ui.dashboard.cards.ToolDashboardCardItem
 import eu.darken.sdmse.stats.core.SpaceHistoryRepo
@@ -85,6 +87,9 @@ internal class DashboardViewModelResilienceTest : BaseTest() {
         appCleanerState: Flow<AppCleaner.State>? = null,
         corpseFinderState: Flow<CorpseFinder.State>? = null,
         taskManagerState: Flow<TaskSubmitter.State>? = null,
+        statsState: Flow<StatsRepo.State> = emptyFlow(),
+        statsRetention: java.time.Duration = java.time.Duration.ZERO,
+        installedAt: Flow<Instant> = emptyFlow(),
     ): DashboardViewModel {
         fun <T> srcOr(name: String, default: Flow<T>): Flow<T> = if (stall == name) stalled() else default
 
@@ -127,7 +132,10 @@ internal class DashboardViewModelResilienceTest : BaseTest() {
         val motdRepo = mockk<MotdRepo>(relaxed = true).apply { every { motd } returns srcOr("motd", emptyFlow()) }
         val reviewTool = mockk<ReviewTool>(relaxed = true).apply { every { state } returns srcOr("review", emptyFlow()) }
         val anniversaryProvider = mockk<AnniversaryProvider>(relaxed = true).apply { every { item } returns srcOr("anniversary", emptyFlow()) }
-        val statsRepo = mockk<StatsRepo>(relaxed = true).apply { every { state } returns srcOr("stats", emptyFlow()) }
+        val statsRepo = mockk<StatsRepo>(relaxed = true).apply { every { state } returns srcOr("stats", statsState) }
+        val curriculumVitae = mockk<CurriculumVitae>(relaxed = true).also {
+            every { it.installedAt } returns installedAt
+        }
         val swiper = mockk<Swiper>(relaxed = true).apply {
             every { getSessionsWithStats() } returns srcOr("swiper", emptyFlow())
             every { progress } returns emptyFlow()
@@ -140,9 +148,9 @@ internal class DashboardViewModelResilienceTest : BaseTest() {
             every { create(any(), any(), any(), any()) } returns srcOr("debug", emptyFlow())
         }
         val statsSettings = mockk<StatsSettings>(relaxed = true).apply {
-            every { retentionReports } returns mockDuration()
-            every { retentionPaths } returns mockDuration()
-            every { retentionSnapshots } returns mockDuration()
+            every { retentionReports } returns mockDuration(statsRetention)
+            every { retentionPaths } returns mockDuration(statsRetention)
+            every { retentionSnapshots } returns mockDuration(statsRetention)
         }
         val generalSettings = mockk<GeneralSettings>(relaxed = true).apply {
             every { dashboardCardConfig } returns mockk(relaxed = true) {
@@ -188,6 +196,7 @@ internal class DashboardViewModelResilienceTest : BaseTest() {
             anniversaryProvider = anniversaryProvider,
             statsRepo = statsRepo,
             statsSettings = statsSettings,
+            curriculumVitae = curriculumVitae,
             spaceHistoryRepo = spaceHistoryRepo,
             deviceDetective = mockk(relaxed = true),
         )
@@ -197,9 +206,10 @@ internal class DashboardViewModelResilienceTest : BaseTest() {
         return vm
     }
 
-    private fun mockDuration(): DataStoreValue<java.time.Duration> = mockk(relaxed = true) {
-        every { flow } returns MutableStateFlow(java.time.Duration.ZERO)
-    }
+    private fun mockDuration(value: java.time.Duration = java.time.Duration.ZERO): DataStoreValue<java.time.Duration> =
+        mockk(relaxed = true) {
+            every { flow } returns MutableStateFlow(value)
+        }
 
     @Test
     fun `listState emits when all sources behave`() = runTest2 {
@@ -311,6 +321,31 @@ internal class DashboardViewModelResilienceTest : BaseTest() {
                 list?.items?.filterIsInstance<ToolDashboardCardItem>()?.firstOrNull { it.toolType == SDMTool.Type.CORPSEFINDER }
             }
             .first { it.result == CorpseFinderScanTask.Success(itemCount = 0, recoverableSpace = 0L) }
+    }
+
+    @Test
+    fun `stats card still renders when the install date never arrives`() = runTest2 {
+        // CurriculumVitae.installedAt only emits after the install date has been written, which on a
+        // first-ever launch waits on upgrade state. The card must render captionless meanwhile.
+        val vm = harness(
+            statsState = MutableStateFlow(
+                StatsRepo.State(
+                    reportsCount = 3,
+                    snapshotsCount = 2,
+                    totalSpaceFreed = 1024L,
+                    itemsProcessed = 12,
+                    databaseSize = 4096L,
+                )
+            ),
+            statsRetention = java.time.Duration.ofDays(30),
+            installedAt = emptyFlow(),
+        )
+
+        val card = vm.listState
+            .mapNotNull { it?.items?.filterIsInstance<StatsDashboardCardItem>()?.singleOrNull() }
+            .first()
+
+        card.installedAt shouldBe null
     }
 
     @Test


### PR DESCRIPTION
## What changed

The Statistics card on the dashboard already told you how much space has been freed and how many items were processed "since you invited SD Maid to your device", but never said when that actually was. It now shows the elapsed time as well, on a small line under the card text: "Your guest for 3 months."

The line picks whichever unit reads best, from days up to years. It stays hidden for the first full day after installing, because there is nothing meaningful to say yet, and saying "1 day" to someone who installed ten minutes ago would just be wrong.

Anyone who has reinstalled does not get reset to zero. The line uses the same first-invite date the anniversary card already uses, which is backdated to the original purchase for Pro users.

## Technical Context

- Unit selection uses a `plusYears`/`plusMonths` fixup rather than `Period.between`. `ChronoUnit.YEARS/MONTHS.between()` compares day-of-month numerically and under-counts clamped month-ends, so a Feb-29 install would have read "11 months" on the exact day `CurriculumVitae.anniversaryOccurrenceOf` celebrates its first anniversary. `InstallElapsed.wholeUnitsUntil` is the part worth reviewing closely; it relies on that undercount never exceeding one unit.
- Suppressing the line below one day needs both an elapsed-24h check and a crossed-calendar-date check, not either alone. Duration alone breaks on a 25-hour DST fall-back day, where 24h of real time can land on the same local date and the ladder would compute zero days. Date alone would show "1 day" at 00:05 to someone who installed at 23:50.
- `buildStatsItem()` fully qualifies the project's `combine` helper instead of switching the file's import. `DashboardCardFlows.kt` also contains genuine two-source `combine` calls and the helper's two-arg overload is commented out, so switching the import would not compile.
- `CurriculumVitae.installedAt` is `filterNotNull()` and stays silent until the install date has been written, so it is primed with `null` via `onStart`. Without that priming a silent upstream would hide the entire Statistics card, not merely the new line.
- Four new plural resources carry the text, one per unit, with the number inside the sentence so translators can inflect it rather than receiving a pre-formatted quantity. An XML comment above them asks for the informal register. No existing string was modified, so all current translations stay valid.
