### PR TITLE
AppCleaner: Stop spending minutes on system apps with nothing to clear

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/PackageManagerExtensions.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/PackageManagerExtensions.kt
@@ -155,6 +155,15 @@ suspend fun PackageManager.freeStorageAndNotify(
                     object : IPackageDataObserver.Stub() {
                         @Throws(RemoteException::class)
                         override fun onRemoveCompleted(packageName: String?, succeeded: Boolean) {
+                            // `succeeded` is deliberately logged but NOT propagated. It reports
+                            // whether the requested amount of space was freed, and we ask for
+                            // Long.MAX_VALUE, so it is false even when the trim cleared everything
+                            // it could. Observed on a device where caches provably went to zero
+                            // (including packages we have no filesystem access to) while this
+                            // still reported false. Turning it into a failure would send every
+                            // package to the accessibility fallback, minutes of automation for
+                            // work that already succeeded. Judge the outcome by re-reading the
+                            // cache sizes instead, as InaccessibleDeleter does.
                             log(VERBOSE) { "freeStorageAndNotify() $packageName -> $succeeded" }
                             continuation.resume(true)
                         }

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleter.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleter.kt
@@ -52,6 +52,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.timeout
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.isActive
+import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.seconds
 
@@ -353,18 +354,62 @@ class InaccessibleDeleter @Inject constructor(
                 }
             }
 
-            // Re-check system apps — trimCaches may have cleared their caches too
+            // Re-check system apps — trimCaches may have cleared their caches too.
+            // StorageStatsManager doesn't update instantly after a trim: a single immediate read
+            // can still report the pre-trim size, which would send an app whose cache is already
+            // empty into the automation fallback, where the "clear cache" button is disabled and
+            // every attempt burns the full step timeout. So wait for the numbers to settle.
             val systemTargets = targets.filter { it.pkg.isSystemApp }
             if (systemTargets.isNotEmpty()) {
                 log(TAG) { "Re-checking ${systemTargets.size} system app targets after trimCaches" }
-                for (junk in systemTargets) {
+                // Rounds rather than one coroutine per target: every target is sampled in every
+                // round, so none can be starved of polling by targets that never settle, and
+                // withTimeoutOrNull is a true wall-clock budget for the whole re-check.
+                val observed = mutableMapOf<InstallId, InaccessibleCache?>()
+                withTimeoutOrNull(SYSTEM_RECHECK_TIMEOUT) {
+                    val pending = systemTargets.toMutableList()
+                    while (pending.isNotEmpty()) {
+                        val settled = pending.filter { junk ->
+                            val beforeInfo = junk.inaccessibleCache!!
+                            val newInfo = inaccessibleCacheProvider.determineCache(junk.pkg)
+                            observed[junk.identifier] = newInfo
+                            // A failed query won't get better by asking again in a tight loop.
+                            // Zero is the end state we wait for, and a target that was already
+                            // zero would never satisfy the decrease check on its own.
+                            newInfo == null || newInfo.totalSize == 0L || newInfo.totalSize < beforeInfo.totalSize
+                        }
+                        pending.removeAll(settled)
+                        if (pending.isEmpty()) break
+                        log(TAG, VERBOSE) { "Waiting on ${pending.size} system app cache sizes to settle" }
+                        delay(500)
+                    }
+                } ?: log(TAG, WARN) { "System app re-check timed out after $SYSTEM_RECHECK_TIMEOUT" }
+
+                systemTargets.forEach { junk ->
                     val beforeInfo = junk.inaccessibleCache!!
-                    val newInfo = inaccessibleCacheProvider.determineCache(junk.pkg)
-                    if (newInfo != null && newInfo.totalSize < beforeInfo.totalSize) {
-                        log(TAG) { "System app cache decreased after trimCaches: ${junk.identifier}" }
-                        successTargets.add(junk.identifier)
-                    } else {
-                        log(TAG, VERBOSE) { "System app cache unchanged: ${junk.identifier}" }
+                    val identifier = junk.identifier
+                    if (!observed.containsKey(identifier)) {
+                        log(TAG, WARN) { "System app cache never sampled (re-check timed out): $identifier" }
+                        return@forEach
+                    }
+                    when (val newInfo = observed[identifier]) {
+                        null -> log(TAG, WARN) { "System app cache unknown (query failed): $identifier" }
+
+                        // An app whose cache is already empty has nothing left for automation to
+                        // clear, so accept it regardless of whether we observed a decrease.
+                        else -> when {
+                            newInfo.totalSize == 0L -> {
+                                log(TAG) { "System app cache is empty: $identifier" }
+                                successTargets.add(identifier)
+                            }
+
+                            newInfo.totalSize < beforeInfo.totalSize -> {
+                                log(TAG) { "System app cache decreased after trimCaches: $identifier" }
+                                successTargets.add(identifier)
+                            }
+
+                            else -> log(TAG, VERBOSE) { "System app cache unchanged: $identifier" }
+                        }
                     }
                 }
             }
@@ -388,5 +433,8 @@ class InaccessibleDeleter @Inject constructor(
 
     companion object {
         private val TAG = logTag("AppCleaner", "Deleter", "Inaccessible")
+
+        /** Wall-clock budget for waiting on StorageStatsManager to catch up after a trim. */
+        private val SYSTEM_RECHECK_TIMEOUT = 10.seconds
     }
 }

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleter.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleter.kt
@@ -414,6 +414,9 @@ class InaccessibleDeleter @Inject constructor(
                 }
             }
         } catch (e: Exception) {
+            // Don't swallow cancellation of our own scope (e.g. user cancelled the task).
+            // This block suspends for seconds, so a cancel landing inside it is not unlikely.
+            currentCoroutineContext().ensureActive()
             log(TAG, ERROR) { "Trimming caches failed: ${e.asLog()}" }
             trimCandidates.forEach {
                 failedTargets[it.identifier] = IllegalStateException("trimCache failed, multi:${it.identifier}")

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/InaccessibleCacheProvider.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/InaccessibleCacheProvider.kt
@@ -14,6 +14,8 @@ import eu.darken.sdmse.common.pkgs.features.Installed
 import eu.darken.sdmse.common.pkgs.isSystemApp
 import eu.darken.sdmse.common.storage.StorageId
 import eu.darken.sdmse.common.storage.StorageStatsManager2
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import javax.inject.Inject
 
 
@@ -39,6 +41,9 @@ class InaccessibleCacheProvider @Inject constructor(
             log(TAG, WARN) { "Don't have permission to query app size for ${pkg.id}: $e" }
             return null
         } catch (e: Exception) {
+            // Don't swallow cancellation of our own scope: callers poll this in a loop under a
+            // deadline, and a null here means "query failed", not "we gave up waiting".
+            currentCoroutineContext().ensureActive()
             log(TAG, ERROR) { "Unexpected error when querying app size for ${pkg.id}: ${e.asLog()}" }
             return null
         }

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleterTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleterTest.kt
@@ -226,31 +226,30 @@ class InaccessibleDeleterTest : BaseTest() {
     }
 
     @Test
-    fun `every system app is polled, not just the first batch`() = runTest {
-        // A per-target coroutine fan-out with a default concurrency limit would starve targets
-        // past the limit: they'd never be polled and would fall back to a single stale read.
-        val junks = (1..40).map { createAppJunk("com.example.system$it", cacheSize = 581632, isSystemApp = true) }
-        val snapshot = createSnapshot(*junks.toTypedArray())
+    fun `targets that never settle do not starve the rest of the batch`() = runTest {
+        // A per-target coroutine fan-out (flatMapMerge defaults to concurrency 16) would let the
+        // first 16 hold every slot until the deadline, so the remaining targets would never be
+        // sampled at all. Rounds must sample every pending target every time.
+        val stuck = (1..16).map { createAppJunk("com.example.stuck$it", cacheSize = 581632, isSystemApp = true) }
+        val settling = (1..24).map { createAppJunk("com.example.settling$it", cacheSize = 581632, isSystemApp = true) }
+        val snapshot = createSnapshot(*(stuck + settling).toTypedArray())
 
         every { adbManager.useAdb } returns flowOf(true)
-        every { settings.forceStopBeforeClearing } returns mockDataStoreValue(false)
         coEvery { pkgOps.trimCaches(any(), any(), any()) } returns Unit
-        coEvery { automationManager.submit(match { it is ClearCacheTask }) } returns ClearCacheTask.Result(
-            successful = emptySet(),
-            failed = emptyMap(),
-        )
 
-        // Each target reads stale twice, then settles at a smaller but NON-zero size. Non-zero
-        // matters: the caller's zero-only guard can't rescue a target that was never polled here.
         val reads = mutableMapOf<String, Int>()
         coEvery { inaccessibleCacheProvider.determineCache(any()) } answers {
             val pkg = firstArg<Installed>()
             val seen = reads.merge(pkg.packageName, 1, Int::plus)!!
+            // "stuck" never changes. "settling" drops to a smaller but NON-zero size after a few
+            // reads; non-zero matters because the caller's zero-only guard must not be what
+            // rescues them, otherwise this wouldn't be testing the polling at all.
+            val settled = pkg.packageName.startsWith("com.example.settling") && seen > 2
             InaccessibleCache(
                 identifier = InstallId(pkg.id, testHandle),
                 isSystemApp = true,
                 itemCount = 1,
-                totalSize = if (seen <= 2) 581632L else 1024L,
+                totalSize = if (settled) 1024L else 581632L,
                 publicSize = 0L,
                 theoreticalPaths = emptySet(),
             )
@@ -259,12 +258,12 @@ class InaccessibleDeleterTest : BaseTest() {
         val result = deleter.deleteInaccessible(
             snapshot = snapshot,
             targetPkgs = null,
-            useAutomation = true,
+            useAutomation = false,
             isBackground = false,
         )
 
-        junks.forEach { result.succesful shouldContain it.identifier }
-        coVerify(exactly = 0) { automationManager.submit(any()) }
+        settling.forEach { result.succesful shouldContain it.identifier }
+        stuck.forEach { result.succesful shouldNotContain it.identifier }
     }
 
     @Test

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleterTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleterTest.kt
@@ -11,6 +11,7 @@ import eu.darken.sdmse.common.adb.AdbManager
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.pkgs.NoSettingsDetector
 import eu.darken.sdmse.common.pkgs.Pkg
+import eu.darken.sdmse.common.pkgs.features.InstallDetails
 import eu.darken.sdmse.common.pkgs.features.InstallId
 import eu.darken.sdmse.common.pkgs.features.Installed
 import eu.darken.sdmse.common.pkgs.pkgops.PkgOps
@@ -95,18 +96,24 @@ class InaccessibleDeleterTest : BaseTest() {
     private fun createAppJunk(
         pkgName: String,
         cacheSize: Long,
+        isSystemApp: Boolean = false,
     ): AppJunk {
         val installId = InstallId(Pkg.Id(pkgName), testHandle)
-        val pkg = mockk<Installed> {
-            every { id } returns Pkg.Id(pkgName)
-            every { userHandle } returns testHandle
-            every { this@mockk.installId } returns installId
-            every { packageName } returns pkgName
-            every { label } returns null
+        // Pkg.isSystemApp is an extension: `(this is InstallDetails) && this.isSystemApp`.
+        // A plain Installed mock isn't an InstallDetails, so it already reads as a user app.
+        val pkg = when {
+            isSystemApp -> mockk<Installed>(moreInterfaces = arrayOf(InstallDetails::class))
+            else -> mockk<Installed>()
         }
+        every { pkg.id } returns Pkg.Id(pkgName)
+        every { pkg.userHandle } returns testHandle
+        every { pkg.installId } returns installId
+        every { pkg.packageName } returns pkgName
+        every { pkg.label } returns null
+        if (isSystemApp) every { (pkg as InstallDetails).isSystemApp } returns true
         val cache = InaccessibleCache(
             identifier = installId,
-            isSystemApp = false,
+            isSystemApp = isSystemApp,
             itemCount = 1,
             totalSize = cacheSize,
             publicSize = 0L,
@@ -171,6 +178,165 @@ class InaccessibleDeleterTest : BaseTest() {
         )
 
         // Not marked as success (useAutomation=false so no automation ran either)
+        result.succesful shouldNotContain junk.identifier
+    }
+
+    @Test
+    fun `system app cache is polled, a stale size does not send it to automation`() = runTest {
+        // Regression: StorageStatsManager keeps reporting the pre-trim size for a moment after
+        // trimCaches. A single immediate read made an already-cleared system app look untouched,
+        // which handed it to automation, where the "clear cache" button is disabled and every
+        // attempt burned the full step timeout.
+        val junk = createAppJunk("com.example.system", cacheSize = 581632, isSystemApp = true)
+        val snapshot = createSnapshot(junk)
+
+        every { adbManager.useAdb } returns flowOf(true)
+        every { settings.forceStopBeforeClearing } returns mockDataStoreValue(false)
+        coEvery { pkgOps.trimCaches(any(), any(), any()) } returns Unit
+        // Stubbed so that a regression fails on the coVerify below rather than on an unstubbed call.
+        coEvery { automationManager.submit(match { it is ClearCacheTask }) } returns ClearCacheTask.Result(
+            successful = emptySet(),
+            failed = emptyMap(),
+        )
+
+        // The first two reads are stale, the cache is actually already empty.
+        var reads = 0
+        coEvery { inaccessibleCacheProvider.determineCache(any()) } answers {
+            reads++
+            InaccessibleCache(
+                identifier = junk.identifier,
+                isSystemApp = true,
+                itemCount = if (reads <= 2) 1 else 0,
+                totalSize = if (reads <= 2) 581632L else 0L,
+                publicSize = 0L,
+                theoreticalPaths = emptySet(),
+            )
+        }
+
+        val result = deleter.deleteInaccessible(
+            snapshot = snapshot,
+            targetPkgs = null,
+            useAutomation = true,
+            isBackground = false,
+        )
+
+        result.succesful shouldContain junk.identifier
+        result.failed.shouldBeEmpty()
+        coVerify(exactly = 0) { automationManager.submit(any()) }
+    }
+
+    @Test
+    fun `every system app is polled, not just the first batch`() = runTest {
+        // A per-target coroutine fan-out with a default concurrency limit would starve targets
+        // past the limit: they'd never be polled and would fall back to a single stale read.
+        val junks = (1..40).map { createAppJunk("com.example.system$it", cacheSize = 581632, isSystemApp = true) }
+        val snapshot = createSnapshot(*junks.toTypedArray())
+
+        every { adbManager.useAdb } returns flowOf(true)
+        every { settings.forceStopBeforeClearing } returns mockDataStoreValue(false)
+        coEvery { pkgOps.trimCaches(any(), any(), any()) } returns Unit
+        coEvery { automationManager.submit(match { it is ClearCacheTask }) } returns ClearCacheTask.Result(
+            successful = emptySet(),
+            failed = emptyMap(),
+        )
+
+        // Each target reads stale twice, then settles at a smaller but NON-zero size. Non-zero
+        // matters: the caller's zero-only guard can't rescue a target that was never polled here.
+        val reads = mutableMapOf<String, Int>()
+        coEvery { inaccessibleCacheProvider.determineCache(any()) } answers {
+            val pkg = firstArg<Installed>()
+            val seen = reads.merge(pkg.packageName, 1, Int::plus)!!
+            InaccessibleCache(
+                identifier = InstallId(pkg.id, testHandle),
+                isSystemApp = true,
+                itemCount = 1,
+                totalSize = if (seen <= 2) 581632L else 1024L,
+                publicSize = 0L,
+                theoreticalPaths = emptySet(),
+            )
+        }
+
+        val result = deleter.deleteInaccessible(
+            snapshot = snapshot,
+            targetPkgs = null,
+            useAutomation = true,
+            isBackground = false,
+        )
+
+        junks.forEach { result.succesful shouldContain it.identifier }
+        coVerify(exactly = 0) { automationManager.submit(any()) }
+    }
+
+    @Test
+    fun `system app whose cache decreased is successful`() = runTest {
+        val junk = createAppJunk("com.example.system", cacheSize = 581632, isSystemApp = true)
+        val snapshot = createSnapshot(junk)
+
+        every { adbManager.useAdb } returns flowOf(true)
+        coEvery { pkgOps.trimCaches(any(), any(), any()) } returns Unit
+        coEvery { inaccessibleCacheProvider.determineCache(any()) } returns InaccessibleCache(
+            identifier = junk.identifier,
+            isSystemApp = true,
+            itemCount = 1,
+            totalSize = 1024L,
+            publicSize = 0L,
+            theoreticalPaths = emptySet(),
+        )
+
+        val result = deleter.deleteInaccessible(
+            snapshot = snapshot,
+            targetPkgs = null,
+            useAutomation = false,
+            isBackground = false,
+        )
+
+        result.succesful shouldContain junk.identifier
+    }
+
+    @Test
+    fun `system app with unchanged non-zero cache is not successful`() = runTest {
+        val junk = createAppJunk("com.example.system", cacheSize = 581632, isSystemApp = true)
+        val snapshot = createSnapshot(junk)
+
+        every { adbManager.useAdb } returns flowOf(true)
+        coEvery { pkgOps.trimCaches(any(), any(), any()) } returns Unit
+        // Still the same non-zero size: trimCaches genuinely did not clear this one.
+        coEvery { inaccessibleCacheProvider.determineCache(any()) } returns InaccessibleCache(
+            identifier = junk.identifier,
+            isSystemApp = true,
+            itemCount = 1,
+            totalSize = 581632,
+            publicSize = 0L,
+            theoreticalPaths = emptySet(),
+        )
+
+        val result = deleter.deleteInaccessible(
+            snapshot = snapshot,
+            targetPkgs = null,
+            useAutomation = false,
+            isBackground = false,
+        )
+
+        result.succesful shouldNotContain junk.identifier
+    }
+
+    @Test
+    fun `system app with a failing cache query is not successful`() = runTest {
+        val junk = createAppJunk("com.example.system", cacheSize = 581632, isSystemApp = true)
+        val snapshot = createSnapshot(junk)
+
+        every { adbManager.useAdb } returns flowOf(true)
+        coEvery { pkgOps.trimCaches(any(), any(), any()) } returns Unit
+        // A failed query must not be mistaken for an empty cache.
+        coEvery { inaccessibleCacheProvider.determineCache(any()) } returns null
+
+        val result = deleter.deleteInaccessible(
+            snapshot = snapshot,
+            targetPkgs = null,
+            useAutomation = false,
+            isBackground = false,
+        )
+
         result.succesful shouldNotContain junk.identifier
     }
 


### PR DESCRIPTION
## What changed

Cleaning could spend a couple of extra minutes at the end doing nothing visible. SD Maid would open the Settings screen of several system apps in turn, sit on each one for 30 seconds, and then report the run as successful anyway. Those apps had already been cleaned moments earlier, so their caches were empty, Android greys out the "Clear cache" button when there is nothing to clear, and there was never anything to tap. They also stayed on the list afterwards, so the next run repeated the same wait.

Cleaning now gives the system's storage figures a moment to catch up before deciding that an app still needs the slower settings-screen route.

## Technical Context

- Root cause: StorageStatsManager does not reflect a trim immediately. The system-app re-check after `trimCaches` read `cacheBytes` exactly once per package, roughly 5ms apart across the whole batch, so packages whose stats had not propagated yet still reported their pre-trim size and were treated as unchanged. That escalated them to the accessibility fallback, where the clear-cache button is disabled precisely because there is nothing to clear, costing a 15s poll plus one retry against the 30s plan timeout each.
- The caller's existing zero-cache guard could not catch this: it re-reads the same value at the same instant and only accepts an exact zero.
- Sampling now happens in rounds under one `withTimeoutOrNull` budget rather than one coroutine per target. A per-target `flatMapMerge` fan-out caps at its default concurrency of 16 and lets targets that never settle starve the rest out of being sampled at all, which is the same bug again on any device with more than 16 system app targets. `Flow.timeout` would also have been the wrong bound, since it measures the gap between emissions rather than elapsed time. An on-device run on Android 17 with 251 system app targets, 214 of which never settled, sampled every target in every round and returned after 10.0s total.
- Both catch sites around the re-check swallowed `CancellationException` (it is an `Exception`), turning a user cancel into trim failures, and `determineCache` did the same one level down. That matters more now that a null return there specifically means the query failed. Both call `ensureActive()` before handling.
- `freeStorageAndNotify`'s result is now documented as deliberately ignored. We request `Long.MAX_VALUE`, so it reports false even when the trim cleared everything it could; propagating it as a failure would route every package to the accessibility fallback.
