### PR TITLE
Fix: Random shell command failures right after a shell dies

### DIFF
--- a/app-common-shell/src/main/java/eu/darken/flowshell/core/cmd/FlowCmdShell.kt
+++ b/app-common-shell/src/main/java/eu/darken/flowshell/core/cmd/FlowCmdShell.kt
@@ -88,6 +88,18 @@ class FlowCmdShell(
 
         suspend fun isAlive() = session.isAlive()
 
+        // Whether execute() would still accept a command. The process exit code is published by a
+        // separate exit-monitor coroutine, so it lags behind the stream EOF that already made
+        // execute() reject everything: isAlive() alone can say "alive" for a session that throws on
+        // its very next command. Only ever a snapshot — EOF can always land right after the answer
+        // is given — but it must not be stale by construction, hence the re-read across the
+        // suspending liveness check.
+        suspend fun isUsable(): Boolean {
+            if (streamEnded) return false
+            if (!session.isAlive()) return false
+            return !streamEnded
+        }
+
         suspend fun waitFor() = session.waitFor()
 
         suspend fun cancel() = withContext(Dispatchers.IO) {

--- a/app-common-shell/src/main/java/eu/darken/sdmse/common/shell/SharedShell.kt
+++ b/app-common-shell/src/main/java/eu/darken/sdmse/common/shell/SharedShell.kt
@@ -67,9 +67,11 @@ class SharedShell(
         tag = aTag,
         parentScope = scope,
         source = source,
-        // A shell whose process has died must never be handed to a reuse: SharedResource caches the
-        // session and its async teardown can lag, so validate liveness and re-acquire a fresh shell.
-        isReusable = { it.isAlive() },
+        // A shell that can no longer run commands must never be handed to a reuse: SharedResource
+        // caches the session and its async teardown can lag, so validate usability and re-acquire a
+        // fresh shell. isUsable() rather than isAlive() so the check matches the condition execute()
+        // itself rejects on, instead of the exit code that is published a moment later.
+        isReusable = { it.isUsable() },
     )
 
     override val sharedResource: SharedResource<FlowCmdShell.Session> = session

--- a/app-common-shell/src/test/java/eu/darken/flowshell/core/cmd/FlowCmdShellTest.kt
+++ b/app-common-shell/src/test/java/eu/darken/flowshell/core/cmd/FlowCmdShellTest.kt
@@ -234,6 +234,22 @@ class FlowCmdShellTest : BaseTest() {
         }
     }
 
+    @Test fun `a stream-dead session is unusable while its exit code still reports alive`(): Unit = runBlocking {
+        LoopbackShell(closeStdoutAtStart = true, closeStderrAtStart = true).use { shell ->
+            val session = shell.cmdSession()
+
+            withTimeout(5_000) {
+                shouldThrowExactly<IllegalStateException> { session.execute(FlowCmd("echo hi")) }
+            }
+
+            // The exit code is published by a separate monitor, so it can still say "running" long
+            // after the streams ended. Anything deciding whether to hand this session to another
+            // caller (SharedShell's reuse check) has to ask isUsable(), not isAlive().
+            session.isAlive() shouldBe true
+            session.isUsable() shouldBe false
+        }
+    }
+
     @Test fun `second execute after stream death is rejected before writing`(): Unit = runBlocking {
         LoopbackShell(closeStdoutAtStart = true, closeStderrAtStart = true).use { shell ->
             val session = shell.cmdSession()


### PR DESCRIPTION
## What changed

Fixes rare, random command failures that could happen right after a shell session dies. When SD Maid's shell process went away mid-command (killed by the system, or ending on its own), the next operation could be handed that same dead shell instead of a fresh one, and would fail immediately for no reason the user could see. Affects everything that runs shell commands, including root operations.

The same race was making a shell test fail intermittently on CI.

## Technical Context

- Root cause: `SharedShell` validated a cached `FlowCmdShell.Session` for reuse with `isAlive()`, which resolves to "the process exit code has not been published yet". That exit code is written by a separate exit-monitor coroutine after `process.waitFor()` returns, whereas `execute()` rejects a session the moment the shared stdout/stderr flows emit their terminal End event and set `streamEnded`. Nothing orders the two, so EOF could win and the reuse check would wave through a session that threw on its very next command.
- `Session.isUsable()` combines both signals and the reuse check now uses it. They are complementary rather than redundant: when EOF lands first `streamEnded` catches it; when the exit code lands first (the path where the pipes stay open, so no End event is ever emitted) `isAlive()` catches it.
- `isUsable()` re-reads `streamEnded` after the suspending liveness check, since `isAlive()` awaits a `StateFlow` and EOF can land during that suspension. The remaining window (EOF landing after the predicate returns) cannot be closed without making validation and execution atomic, and it is not the failure mode here: a failed `execute()` publishes `streamEnded` before it returns.
- `isAlive()` deliberately keeps its process-liveness meaning; existing callers and tests assert exactly that. The new name draws the line between "process is running" and "command channel still works".
- Worth a close look: the new `FlowCmdShellTest` case pins the race deterministically using the existing `LoopbackShell` harness, which closes stdout/stderr while holding `exitCode` at null, reproducing on purpose the state CI hit by accident.
