### PR TITLE
General: Stream directory listings instead of collecting them first

### DIFF
--- a/app-common-data/src/main/java/eu/darken/sdmse/common/areas/modules/dalvik/ArtProfileModule.kt
+++ b/app-common-data/src/main/java/eu/darken/sdmse/common/areas/modules/dalvik/ArtProfileModule.kt
@@ -22,6 +22,7 @@ import eu.darken.sdmse.common.files.local.LocalGateway
 import eu.darken.sdmse.common.files.local.LocalPath
 import eu.darken.sdmse.common.hasApiLevel
 import eu.darken.sdmse.common.user.UserManager2
+import kotlinx.coroutines.flow.toList
 import javax.inject.Inject
 
 @Reusable
@@ -48,7 +49,7 @@ class ArtProfileModule @Inject constructor(
     }
 
     private suspend fun getMirror(gateway: LocalGateway): Collection<DataArea> {
-        val dataMirrorContent = gateway.listFiles(mirrorArea, mode = LocalGateway.Mode.ROOT)
+        val dataMirrorContent = gateway.listFiles(mirrorArea, mode = LocalGateway.Mode.ROOT).toList()
         log(TAG, VERBOSE) { "Items in data_mirror: $dataMirrorContent" }
 
         val users = userManager2.allUsers()

--- a/app-common-data/src/main/java/eu/darken/sdmse/common/areas/modules/priv/PrivateDataModule.kt
+++ b/app-common-data/src/main/java/eu/darken/sdmse/common/areas/modules/priv/PrivateDataModule.kt
@@ -22,6 +22,7 @@ import eu.darken.sdmse.common.files.local.LocalGateway
 import eu.darken.sdmse.common.files.local.LocalPath
 import eu.darken.sdmse.common.hasApiLevel
 import eu.darken.sdmse.common.user.UserManager2
+import kotlinx.coroutines.flow.toList
 import javax.inject.Inject
 
 @Reusable
@@ -64,7 +65,7 @@ class PrivateDataModule @Inject constructor(
      * and /data/user and /data/user_de will only show the current user/owner
      */
     private suspend fun getMirrored(gateway: LocalGateway): Collection<DataArea> {
-        val dataMirrorContent = gateway.listFiles(mirrorArea, mode = LocalGateway.Mode.ROOT)
+        val dataMirrorContent = gateway.listFiles(mirrorArea, mode = LocalGateway.Mode.ROOT).toList()
         log(TAG, VERBOSE) { "Items in mirror: $dataMirrorContent" }
 
         val users = userManager2.allUsers()

--- a/app-common-data/src/test/java/eu/darken/sdmse/common/forensics/csi/BaseCSITest.kt
+++ b/app-common-data/src/test/java/eu/darken/sdmse/common/forensics/csi/BaseCSITest.kt
@@ -25,6 +25,7 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.AfterEach
@@ -51,7 +52,7 @@ abstract class BaseCSITest : BaseTest() {
             MockKAnnotations.init(this)
         }
         coEvery { clutterRepo.match(any(), any()) } returns emptySet()
-        coEvery { gatewaySwitch.listFiles(any()) } returns emptyList()
+        coEvery { gatewaySwitch.listFiles(any()) } returns emptyFlow()
         coEvery { gatewaySwitch.exists(any()) } returns false
         coEvery { userManager2.currentUser() } returns UserProfile2(UserHandle2(0))
         every { storageEnvironment.dataDir } returns LocalPath.build("/data")

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathExtensions.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathExtensions.kt
@@ -14,6 +14,7 @@ import eu.darken.sdmse.common.files.saf.isAncestorOf
 import eu.darken.sdmse.common.files.saf.isParentOf
 import eu.darken.sdmse.common.files.saf.startsWith
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.toList
 import okio.FileHandle
 import java.io.File
 import java.io.IOException
@@ -126,7 +127,10 @@ suspend fun <T : APath> T.deleteWalk(
         val lookup = gateway.lookup(this)
 
         if (lookup.isDirectory) {
-            gateway.listFiles(this).forEach {
+            // Materialize before recursing: deleting entries while lazily enumerating the same
+            // directory over a live IPC stream risks skipped entries (readdir semantics) and would
+            // keep a nested stream/lease open for every level of the recursion.
+            gateway.listFiles(this).toList().forEach {
                 it.deleteWalk(gateway, filter) // Recursion enter
             }
         }
@@ -189,19 +193,19 @@ suspend fun <P : APath, PL : APathLookup<P>, PLE : APathLookupExtended<P>> P.loo
 }
 
 suspend fun <P : APath, PL : APathLookup<P>, PLE : APathLookupExtended<P>> P.lookupFiles(gateway: APathGateway<P, PL, PLE>): Collection<PL> {
-    return gateway.lookupFiles(this)
+    return gateway.lookupFiles(this).toList()
 }
 
 suspend fun <P : APath, PL : APathLookup<P>, PLE : APathLookupExtended<P>> P.lookupFilesFlow(gateway: APathGateway<P, PL, PLE>): Flow<PL> {
-    return gateway.lookupFilesFlow(this)
+    return gateway.lookupFiles(this)
 }
 
 suspend fun <P : APath, PL : APathLookup<P>, PLE : APathLookupExtended<P>> P.lookupFilesOrNull(gateway: APathGateway<P, PL, PLE>): Collection<PL>? {
-    return if (exists(gateway)) gateway.lookupFiles(this) else null
+    return if (exists(gateway)) gateway.lookupFiles(this).toList() else null
 }
 
 suspend fun <T : APath> T.listFiles(gateway: APathGateway<T, out APathLookup<T>, out APathLookupExtended<T>>): Collection<T> {
-    return gateway.listFiles(this)
+    return gateway.listFiles(this).toList()
 }
 
 suspend fun <T : APath> T.canRead(gateway: APathGateway<T, out APathLookup<T>, out APathLookupExtended<T>>): Boolean {

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathGateway.kt
@@ -2,7 +2,6 @@ package eu.darken.sdmse.common.files
 
 import eu.darken.sdmse.common.sharedresource.HasSharedResource
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import okio.FileHandle
 import java.time.Instant
 
@@ -16,21 +15,30 @@ interface APathGateway<
 
     suspend fun createFile(path: P)
 
-    suspend fun listFiles(path: P): Collection<P>
+    /**
+     * See [lookupFiles] for streaming and error semantics.
+     */
+    suspend fun listFiles(path: P): Flow<P>
 
     suspend fun lookup(path: P): PLU
 
     suspend fun lookupExtended(path: P): PLUE
 
-    suspend fun lookupFiles(path: P): Collection<PLU>
+    /**
+     * Children are emitted as they are enumerated, so consumers can abort early without paying
+     * for the complete listing of a huge directory.
+     *
+     * A [ReadException] can surface at call time or at collection time:
+     * - NORMAL mode enumerates the directory eagerly at call time (a snapshot), only the per-child
+     *   lookup work is lazy. Re-collecting replays that call-time snapshot.
+     * - ROOT/ADB mode enumerates fully lazily at collection time, each collection re-enumerates.
+     */
+    suspend fun lookupFiles(path: P): Flow<PLU>
 
     /**
-     * Like [lookupFiles], but children are emitted as they are enumerated, so consumers can
-     * abort early without paying for the complete listing of a huge directory.
+     * See [lookupFiles] for streaming and error semantics.
      */
-    suspend fun lookupFilesFlow(path: P): Flow<PLU> = flow { lookupFiles(path).forEach { emit(it) } }
-
-    suspend fun lookupFilesExtended(path: P): Collection<PLUE>
+    suspend fun lookupFilesExtended(path: P): Flow<PLUE>
 
     suspend fun walk(
         path: P,

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/GatewaySwitch.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/GatewaySwitch.kt
@@ -15,6 +15,7 @@ import eu.darken.sdmse.common.sharedresource.adoptChildResource
 import eu.darken.sdmse.common.storage.PathMapper
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.plus
 import okio.FileHandle
 import okio.IOException
@@ -113,21 +114,21 @@ class GatewaySwitch @Inject constructor(
         }
     }
 
-    override suspend fun lookupFiles(path: APath): Collection<APathLookup<APath>> {
-        return lookupFiles(path, Type.CURRENT)
+    override suspend fun lookupFiles(path: APath): Flow<APathLookup<APath>> {
+        return useGateway(path) { lookupFiles(path) }
     }
 
     suspend fun lookupFiles(path: APath, type: Type): Collection<APathLookup<APath>> {
         val mapped = path.toTargetType(type)
         return try {
-            useGateway(mapped) { lookupFiles(mapped) }
+            useGateway(mapped) { lookupFiles(mapped) }.toList()
         } catch (oge: ReadException) {
             if (type != Type.AUTO) throw oge
             log(TAG, WARN) { "lookupFiles(...): Original lookup failed, try alternative: ${oge.asLog()}" }
 
             val fallback = path.toAlternative()
             try {
-                useGateway(fallback) { lookupFiles(fallback) }
+                useGateway(fallback) { lookupFiles(fallback) }.toList()
             } catch (e: ReadException) {
                 log(TAG, WARN) { "lookupFiles(...): Alternative lookup failed either: ${e.asLog()}" }
                 throw oge
@@ -135,25 +136,21 @@ class GatewaySwitch @Inject constructor(
         }
     }
 
-    override suspend fun lookupFilesFlow(path: APath): Flow<APathLookup<APath>> {
-        return useGateway(path) { lookupFilesFlow(path) }
-    }
-
-    override suspend fun lookupFilesExtended(path: APath): Collection<APathLookupExtended<APath>> {
-        return lookupFilesExtended(path, Type.CURRENT)
+    override suspend fun lookupFilesExtended(path: APath): Flow<APathLookupExtended<APath>> {
+        return useGateway(path) { lookupFilesExtended(path) }
     }
 
     suspend fun lookupFilesExtended(path: APath, type: Type): Collection<APathLookupExtended<APath>> {
         val mapped = path.toTargetType(type)
         return try {
-            useGateway(mapped) { lookupFilesExtended(mapped) }
+            useGateway(mapped) { lookupFilesExtended(mapped) }.toList()
         } catch (oge: ReadException) {
             if (type != Type.AUTO) throw oge
             log(TAG, WARN) { "lookupFilesExtended(...): Original lookup failed, try alternative: ${oge.asLog()}" }
 
             val fallback = path.toAlternative()
             try {
-                useGateway(fallback) { lookupFilesExtended(fallback) }
+                useGateway(fallback) { lookupFilesExtended(fallback) }.toList()
             } catch (e: ReadException) {
                 log(TAG, WARN) { "lookupFilesExtended(...): Alternative lookup failed either: ${e.asLog()}" }
                 throw oge
@@ -176,7 +173,7 @@ class GatewaySwitch @Inject constructor(
         return useGateway(path) { du(path, options) }
     }
 
-    override suspend fun listFiles(path: APath): Collection<APath> {
+    override suspend fun listFiles(path: APath): Flow<APath> {
         return useGateway(path) { listFiles(path) }
     }
 

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/IndirectLocalWalker.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/IndirectLocalWalker.kt
@@ -54,7 +54,7 @@ class IndirectLocalWalker(
             // The read-error handling is attached to the upstream flow only: exceptions from
             // onFilter, downstream operators or collectors, and cancellation (e.g. Flow.first)
             // must all propagate instead of being swallowed as read errors by onError.
-            flow { emitAll(gateway.lookupFilesFlow(lookUp.lookedUp, mode)) }
+            flow { emitAll(gateway.lookupFiles(lookUp.lookedUp, mode)) }
                 .catch { e ->
                     if (e !is Exception || e is CancellationException) throw e
                     log(TAG, ERROR) { "Failed to read $lookUp: $e" }

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalGateway.kt
@@ -333,7 +333,6 @@ class LocalGateway @Inject constructor(
 
                 else -> throw IOException("No matching mode available.")
             }
-                .trace("listFiles($path, $mode)")
                 .refineErrors("listFiles", path, mode)
                 .flowOn(dispatcherProvider.IO)
         } catch (e: IOException) {

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalGateway.kt
@@ -462,7 +462,11 @@ class LocalGateway @Inject constructor(
         null
     }
 
-    private fun <T> Flow<T>.trace(label: String): Flow<T> = if (!Bugs.isTrace) this else flow {
+    private fun <T> Flow<T>.trace(label: String): Flow<T> = flow {
+        if (!Bugs.isTrace) {
+            emitAll(this@trace)
+            return@flow
+        }
         var count = 0
         emitAll(
             onEach { item ->

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/LocalGateway.kt
@@ -44,7 +44,9 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.withContext
 import okio.FileHandle
@@ -298,41 +300,42 @@ class LocalGateway @Inject constructor(
         }
     }
 
-    override suspend fun listFiles(path: LocalPath): Collection<LocalPath> = listFiles(path, Mode.AUTO)
+    override suspend fun listFiles(path: LocalPath): Flow<LocalPath> = listFiles(path, Mode.AUTO)
 
-    suspend fun listFiles(path: LocalPath, mode: Mode = Mode.AUTO): Collection<LocalPath> = runIO {
+    suspend fun listFiles(path: LocalPath, mode: Mode = Mode.AUTO): Flow<LocalPath> = runIO {
         try {
-            val javaFile = path.asFile()
-            val nonRootList: List<File>? = try {
-                when (mode) {
-                    Mode.ROOT -> null
-                    Mode.ADB -> null
-                    else -> if (javaFile.canRead()) javaFile.listFiles2() else null
-                }
-            } catch (e: Exception) {
+            val nonRootList = enumerateNormal(path, mode) { e ->
                 log(TAG) { "listFiles($path, $mode) failed: $e" }
-                null
             }
 
             when {
                 mode == Mode.NORMAL || nonRootList != null && mode == Mode.AUTO -> {
                     log(TAG, VERBOSE) { "listFiles($mode->NORMAL): $path" }
                     if (nonRootList == null) throw ReadException(path = path)
-                    nonRootList.map { LocalPath.build(it) }
+                    flow {
+                        nonRootList.forEach { child -> emit(LocalPath.build(child)) }
+                    }
                 }
 
                 hasRoot() && (mode == Mode.ROOT || nonRootList == null && mode == Mode.AUTO) -> {
                     log(TAG, VERBOSE) { "listFiles($mode->ROOT): $path" }
-                    rootOps { it.listFiles(path) }
+                    // Lease + IPC stream are only created at collection time and the lease spans
+                    // the whole consumption; a built-but-never-collected flow must not hold either.
+                    flow<LocalPath> { rootOps { emitAll(it.listFiles(path)) } }
                 }
 
                 hasAdb() && (mode == Mode.ADB || nonRootList == null && mode == Mode.AUTO) -> {
                     log(TAG, VERBOSE) { "listFiles($mode->ADB): $path" }
-                    adbOps { it.listFiles(path) }
+                    // Lease + IPC stream are only created at collection time and the lease spans
+                    // the whole consumption; a built-but-never-collected flow must not hold either.
+                    flow<LocalPath> { adbOps { emitAll(it.listFiles(path)) } }
                 }
 
                 else -> throw IOException("No matching mode available.")
             }
+                .trace("listFiles($path, $mode)")
+                .refineErrors("listFiles", path, mode)
+                .flowOn(dispatcherProvider.IO)
         } catch (e: IOException) {
             throw ReadException(path = path, cause = e).also {
                 log(TAG, WARN) { "listFiles(path=$path, mode=$mode) failed:\n${it.asLog()}" }
@@ -340,85 +343,22 @@ class LocalGateway @Inject constructor(
         }
     }
 
-    override suspend fun lookupFiles(path: LocalPath): Collection<LocalPathLookup> = lookupFiles(path, Mode.AUTO)
+    override suspend fun lookupFiles(path: LocalPath): Flow<LocalPathLookup> = lookupFiles(path, Mode.AUTO)
 
-    suspend fun lookupFiles(path: LocalPath, mode: Mode = Mode.AUTO): Collection<LocalPathLookup> = runIO {
+    suspend fun lookupFiles(path: LocalPath, mode: Mode = Mode.AUTO): Flow<LocalPathLookup> = runIO {
         try {
-            val javaFile = path.asFile()
-            val nonRootList = try {
-                when (mode) {
-                    Mode.ROOT -> null
-                    Mode.ADB -> null
-                    else -> if (javaFile.canRead()) javaFile.listFiles2() else null
-                }
-            } catch (e: Exception) {
-                null
-            }
+            val nonRootList = enumerateNormal(path, mode)
 
             when {
                 mode == Mode.NORMAL || nonRootList != null && mode == Mode.AUTO -> {
                     log(TAG, VERBOSE) { "lookupFiles($mode->NORMAL): $path" }
-                    if (nonRootList == null) throw ReadException(path = path)
-                    nonRootList
-                        .map { it.toLocalPath() }
-                        .mapNotNull {
-                            try {
-                                it.performLookup()
-                            } catch (e: IOException) {
-                                log(TAG, WARN) { "lookupFiles($path): Failed to lookup child $it: ${e.asLog()}" }
-                                null
-                            }
-                        }
-                }
-
-                hasRoot() && (mode == Mode.ROOT || nonRootList == null && mode == Mode.AUTO) -> {
-                    log(TAG, VERBOSE) { "lookupFiles($mode->ROOT): $path" }
-                    rootOps { it.lookupFiles(path) }
-                }
-
-                hasAdb() && (mode == Mode.ADB || nonRootList == null && mode == Mode.AUTO) -> {
-                    log(TAG, VERBOSE) { "lookupFiles($mode->ADB): $path" }
-                    adbOps { it.lookupFiles(path) }
-                }
-
-                else -> throw IOException("No matching mode available.")
-            }.also {
-                if (Bugs.isTrace) {
-                    log(TAG, VERBOSE) { "Looked up ${it.size} items:" }
-                    it.forEachIndexed { index, look -> log(TAG, VERBOSE) { "#$index $look" } }
-                }
-            }
-        } catch (e: IOException) {
-            log(TAG, WARN) { "lookupFiles(path=$path, mode=$mode) failed:\n${e.asLog()}" }
-            throw ReadException(path = path, cause = e)
-        }
-    }
-
-    override suspend fun lookupFilesFlow(path: LocalPath): Flow<LocalPathLookup> = lookupFilesFlow(path, Mode.AUTO)
-
-    suspend fun lookupFilesFlow(path: LocalPath, mode: Mode = Mode.AUTO): Flow<LocalPathLookup> = runIO {
-        try {
-            val javaFile = path.asFile()
-            val nonRootList = try {
-                when (mode) {
-                    Mode.ROOT -> null
-                    Mode.ADB -> null
-                    else -> if (javaFile.canRead()) javaFile.listFiles2() else null
-                }
-            } catch (e: Exception) {
-                null
-            }
-
-            when {
-                mode == Mode.NORMAL || nonRootList != null && mode == Mode.AUTO -> {
-                    log(TAG, VERBOSE) { "lookupFilesFlow($mode->NORMAL): $path" }
                     if (nonRootList == null) throw ReadException(path = path)
                     flow {
                         nonRootList.forEach { child ->
                             val lookup = try {
                                 child.toLocalPath().performLookup()
                             } catch (e: IOException) {
-                                log(TAG, WARN) { "lookupFilesFlow($path): Failed to lookup child $child: ${e.asLog()}" }
+                                log(TAG, WARN) { "lookupFiles($path): Failed to lookup child $child: ${e.asLog()}" }
                                 null
                             }
                             lookup?.let { emit(it) }
@@ -427,91 +367,124 @@ class LocalGateway @Inject constructor(
                 }
 
                 hasRoot() && (mode == Mode.ROOT || nonRootList == null && mode == Mode.AUTO) -> {
-                    log(TAG, VERBOSE) { "lookupFilesFlow($mode->ROOT): $path" }
+                    log(TAG, VERBOSE) { "lookupFiles($mode->ROOT): $path" }
                     // Lease + IPC stream are only created at collection time and the lease spans
                     // the whole consumption; a built-but-never-collected flow must not hold either.
-                    flow<LocalPathLookup> { rootOps { emitAll(it.lookupFilesFlow(path)) } }
+                    flow<LocalPathLookup> { rootOps { emitAll(it.lookupFiles(path)) } }
                 }
 
                 hasAdb() && (mode == Mode.ADB || nonRootList == null && mode == Mode.AUTO) -> {
-                    log(TAG, VERBOSE) { "lookupFilesFlow($mode->ADB): $path" }
+                    log(TAG, VERBOSE) { "lookupFiles($mode->ADB): $path" }
                     // Lease + IPC stream are only created at collection time and the lease spans
                     // the whole consumption; a built-but-never-collected flow must not hold either.
-                    flow<LocalPathLookup> { adbOps { emitAll(it.lookupFilesFlow(path)) } }
+                    flow<LocalPathLookup> { adbOps { emitAll(it.lookupFiles(path)) } }
                 }
 
                 else -> throw IOException("No matching mode available.")
-            }.catch { e ->
-                log(TAG, WARN) { "lookupFilesFlow(path=$path, mode=$mode) failed:\n${e.asLog()}" }
-                when (e) {
-                    is CancellationException -> throw e
-                    is ReadException -> throw e
-                    is IOException -> throw ReadException(path = path, cause = e)
-                    else -> throw e
-                }
             }
+                .trace("lookupFiles($path, $mode)")
+                .refineErrors("lookupFiles", path, mode)
+                .flowOn(dispatcherProvider.IO)
         } catch (e: IOException) {
-            log(TAG, WARN) { "lookupFilesFlow(path=$path, mode=$mode) failed:\n${e.asLog()}" }
+            log(TAG, WARN) { "lookupFiles(path=$path, mode=$mode) failed:\n${e.asLog()}" }
             throw ReadException(path = path, cause = e)
         }
     }
 
     override suspend fun lookupFilesExtended(
         path: LocalPath
-    ): Collection<LocalPathLookupExtended> = lookupFilesExtended(path, Mode.AUTO)
+    ): Flow<LocalPathLookupExtended> = lookupFilesExtended(path, Mode.AUTO)
 
-    suspend fun lookupFilesExtended(path: LocalPath, mode: Mode = Mode.AUTO): Collection<LocalPathLookupExtended> =
-        runIO {
-            try {
-                val javaFile = path.asFile()
-                val nonRootList = try {
-                    when (mode) {
-                        Mode.ROOT -> null
-                        Mode.ADB -> null
-                        else -> if (javaFile.canRead()) javaFile.listFiles2() else null
-                    }
-                } catch (e: Exception) {
-                    null
-                }
+    suspend fun lookupFilesExtended(path: LocalPath, mode: Mode = Mode.AUTO): Flow<LocalPathLookupExtended> = runIO {
+        try {
+            val nonRootList = enumerateNormal(path, mode)
 
-                when {
-                    mode == Mode.NORMAL || nonRootList != null && mode == Mode.AUTO -> {
-                        log(TAG, VERBOSE) { "lookupFilesExtended($mode->NORMAL): $path" }
-                        if (nonRootList == null) throw ReadException(path = path)
-                        nonRootList
-                            .map { it.toLocalPath() }
-                            .mapNotNull {
-                                try {
-                                    it.performLookupExtended(ipcFunnel, libcoreTool)
-                                } catch (e: IOException) {
-                                    log(TAG, WARN) { "lookupFilesExtended($path): Failed to lookup child $it: ${e.asLog()}" }
-                                    null
+            when {
+                mode == Mode.NORMAL || nonRootList != null && mode == Mode.AUTO -> {
+                    log(TAG, VERBOSE) { "lookupFilesExtended($mode->NORMAL): $path" }
+                    if (nonRootList == null) throw ReadException(path = path)
+                    flow {
+                        nonRootList.forEach { child ->
+                            val lookup = try {
+                                child.toLocalPath().performLookupExtended(ipcFunnel, libcoreTool)
+                            } catch (e: IOException) {
+                                log(TAG, WARN) {
+                                    "lookupFilesExtended($path): Failed to lookup child $child: ${e.asLog()}"
                                 }
+                                null
                             }
-                    }
-
-                    hasRoot() && (mode == Mode.ROOT || nonRootList == null && mode == Mode.AUTO) -> {
-                        log(TAG, VERBOSE) { "lookupFilesExtended($mode->ROOT): $path" }
-                        rootOps { it.lookupFilesExtendedStream(path) }
-                    }
-
-                    hasAdb() && (mode == Mode.ADB || nonRootList == null && mode == Mode.AUTO) -> {
-                        log(TAG, VERBOSE) { "lookupFilesExtended($mode->ADB): $path" }
-                        adbOps { it.lookupFilesExtendedStream(path) }
-                    }
-
-                    else -> throw IOException("No matching mode available.")
-                }.also {
-                    if (Bugs.isTrace) {
-                        log(TAG, VERBOSE) { "Looked up ${it.size} items:" }
-                        it.forEachIndexed { index, look -> log(TAG, VERBOSE) { "#$index $look" } }
+                            lookup?.let { emit(it) }
+                        }
                     }
                 }
-            } catch (e: IOException) {
-                log(TAG, WARN) { "lookupFilesExtended(path=$path, mode=$mode) failed:\n${e.asLog()}" }
-                throw ReadException(path = path, cause = e)
+
+                hasRoot() && (mode == Mode.ROOT || nonRootList == null && mode == Mode.AUTO) -> {
+                    log(TAG, VERBOSE) { "lookupFilesExtended($mode->ROOT): $path" }
+                    // Lease + IPC stream are only created at collection time and the lease spans
+                    // the whole consumption; a built-but-never-collected flow must not hold either.
+                    flow<LocalPathLookupExtended> { rootOps { emitAll(it.lookupFilesExtended(path)) } }
+                }
+
+                hasAdb() && (mode == Mode.ADB || nonRootList == null && mode == Mode.AUTO) -> {
+                    log(TAG, VERBOSE) { "lookupFilesExtended($mode->ADB): $path" }
+                    // Lease + IPC stream are only created at collection time and the lease spans
+                    // the whole consumption; a built-but-never-collected flow must not hold either.
+                    flow<LocalPathLookupExtended> { adbOps { emitAll(it.lookupFilesExtended(path)) } }
+                }
+
+                else -> throw IOException("No matching mode available.")
             }
+                .trace("lookupFilesExtended($path, $mode)")
+                .refineErrors("lookupFilesExtended", path, mode)
+                .flowOn(dispatcherProvider.IO)
+        } catch (e: IOException) {
+            log(TAG, WARN) { "lookupFilesExtended(path=$path, mode=$mode) failed:\n${e.asLog()}" }
+            throw ReadException(path = path, cause = e)
         }
+    }
+
+    /**
+     * App-side directory enumeration, `null` means "not available, escalate".
+     * This is eager: the listing is a snapshot taken while the enumeration flow is being built.
+     */
+    private fun enumerateNormal(
+        path: LocalPath,
+        mode: Mode,
+        onError: (Exception) -> Unit = {},
+    ): List<File>? = try {
+        val javaFile = path.asFile()
+        when (mode) {
+            Mode.ROOT -> null
+            Mode.ADB -> null
+            else -> if (javaFile.canRead()) javaFile.listFiles2() else null
+        }
+    } catch (e: Exception) {
+        onError(e)
+        null
+    }
+
+    private fun <T> Flow<T>.trace(label: String): Flow<T> = if (!Bugs.isTrace) this else flow {
+        var count = 0
+        emitAll(
+            onEach { item ->
+                count++
+                log(TAG, VERBOSE) { "$label #$count $item" }
+            }.onCompletion { cause ->
+                if (cause == null) log(TAG, VERBOSE) { "$label finished $count items" }
+                else log(TAG, VERBOSE) { "$label aborted after $count items: $cause" }
+            }
+        )
+    }
+
+    private fun <T> Flow<T>.refineErrors(label: String, path: LocalPath, mode: Mode): Flow<T> = catch { e ->
+        log(TAG, WARN) { "$label(path=$path, mode=$mode) failed:\n${e.asLog()}" }
+        when (e) {
+            is CancellationException -> throw e
+            is ReadException -> throw e
+            is IOException -> throw ReadException(path = path, cause = e)
+            else -> throw e
+        }
+    }
 
     override suspend fun walk(
         path: LocalPath,

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/FileOpsClient.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/FileOpsClient.kt
@@ -83,7 +83,11 @@ class FileOpsClient @AssistedInject constructor(
         emitAll(output.toLocalPathLookupExtendedFlow())
     }.traceCount("lookupFilesExtended($path)")
 
-    private fun <T> Flow<T>.traceCount(label: String): Flow<T> = if (!Bugs.isTrace) this else flow {
+    private fun <T> Flow<T>.traceCount(label: String): Flow<T> = flow {
+        if (!Bugs.isTrace) {
+            emitAll(this@traceCount)
+            return@flow
+        }
         var count = 0
         emitAll(
             onEach { count++ }.onCompletion { cause ->

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/FileOpsClient.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/FileOpsClient.kt
@@ -18,8 +18,8 @@ import eu.darken.sdmse.common.ipc.fileHandle
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onEach
 import okio.FileHandle
 import java.time.Instant
 
@@ -28,17 +28,17 @@ class FileOpsClient @AssistedInject constructor(
 ) : IpcClientModule {
 
     /**
-     * Doesn't run into IPC buffer overflows on large directories
+     * Doesn't run into IPC buffer overflows on large directories.
+     * The IPC stream is only opened once the flow is collected.
      */
-    fun listFiles(path: LocalPath): Collection<LocalPath> = try {
-        runBlocking {
-            fileOpsConnection.listFilesStream(path).toLocalPathFlow().toList()
-        }.also {
-            if (Bugs.isTrace) log(TAG) { "listFiles($path) finished streaming, ${it.size} items" }
+    fun listFiles(path: LocalPath): Flow<LocalPath> = flow {
+        val output = try {
+            fileOpsConnection.listFilesStream(path)
+        } catch (e: Exception) {
+            throw e.refineException()
         }
-    } catch (e: Exception) {
-        throw e.refineException()
-    }
+        emitAll(output.toLocalPathFlow())
+    }.traceCount("listFiles($path)")
 
     fun lookUp(path: LocalPath): LocalPathLookup = try {
         fileOpsConnection.lookUp(path).also {
@@ -57,46 +57,40 @@ class FileOpsClient @AssistedInject constructor(
     }
 
     /**
-     * Doesn't run into IPC buffer overflows on large directories
-     */
-    fun lookupFiles(path: LocalPath): Collection<LocalPathLookup> = try {
-        runBlocking {
-            fileOpsConnection.lookupFilesStream(path).toLocalPathLookupFlow().toList()
-        }.also {
-            if (Bugs.isTrace) log(TAG, VERBOSE) { "lookupFiles($path) finished streaming, ${it.size} items" }
-        }
-    } catch (e: Exception) {
-        throw e.refineException()
-    }
-
-    /**
      * Streams lookups as the host enumerates the directory. Consumers may cancel collection
      * early and only pay for the chunks streamed so far, instead of the complete listing.
      * The IPC stream is only opened once the flow is collected.
      */
-    fun lookupFilesFlow(path: LocalPath): Flow<LocalPathLookup> = flow {
+    fun lookupFiles(path: LocalPath): Flow<LocalPathLookup> = flow {
         val output = try {
             fileOpsConnection.lookupFilesStream(path)
         } catch (e: Exception) {
             throw e.refineException()
         }
         emitAll(output.toLocalPathLookupFlow())
-    }
+    }.traceCount("lookupFiles($path)")
 
     /**
-     * Doesn't run into IPC buffer overflows on large directories
+     * Doesn't run into IPC buffer overflows on large directories.
+     * The IPC stream is only opened once the flow is collected.
      */
-    fun lookupFilesExtendedStream(path: LocalPath): Collection<LocalPathLookupExtended> = try {
-        runBlocking {
-            fileOpsConnection.lookupFilesExtendedStream(path).toLocalPathLookupExtendedFlow().toList()
-        }.also {
-            if (Bugs.isTrace) log(
-                TAG,
-                VERBOSE
-            ) { "lookupFilesExtendedStream($path) finished streaming, ${it.size} items" }
+    fun lookupFilesExtended(path: LocalPath): Flow<LocalPathLookupExtended> = flow {
+        val output = try {
+            fileOpsConnection.lookupFilesExtendedStream(path)
+        } catch (e: Exception) {
+            throw e.refineException()
         }
-    } catch (e: Exception) {
-        throw e.refineException()
+        emitAll(output.toLocalPathLookupExtendedFlow())
+    }.traceCount("lookupFilesExtended($path)")
+
+    private fun <T> Flow<T>.traceCount(label: String): Flow<T> = if (!Bugs.isTrace) this else flow {
+        var count = 0
+        emitAll(
+            onEach { count++ }.onCompletion { cause ->
+                if (cause == null) log(TAG, VERBOSE) { "$label finished streaming, $count items" }
+                else log(TAG, VERBOSE) { "$label stopped after $count items: $cause" }
+            }
+        )
     }
 
     /**

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/saf/SAFGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/saf/SAFGateway.kt
@@ -22,11 +22,16 @@ import eu.darken.sdmse.common.files.WriteException
 import eu.darken.sdmse.common.files.isDirectory
 import eu.darken.sdmse.common.files.isFile
 import eu.darken.sdmse.common.sharedresource.SharedResource
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.withContext
 import okio.FileHandle
@@ -134,18 +139,13 @@ class SAFGateway @Inject constructor(
         return targetDocFile
     }
 
-    override suspend fun listFiles(path: SAFPath): List<SAFPath> = runIO {
-        try {
-            val docFile = findDocFile(path)
-            log(TAG, VERBOSE) { "listFiles(): $path -> $docFile" }
-            docFile.listFiles().map {
-                val name = it.name ?: it.uri.pathSegments.last().split('/').last()
-                path.child(name)
-            }
-        } catch (e: Exception) {
-            log(TAG, WARN) { "listFiles($path) failed." }
-            throw ReadException(path = path, cause = e)
+    override suspend fun listFiles(path: SAFPath): Flow<SAFPath> = runIO {
+        val children = childPaths(path, "listFiles")
+        flow {
+            children.forEach { emit(it) }
         }
+            .refineErrors("listFiles", path)
+            .flowOn(dispatcherProvider.IO)
     }
 
     override suspend fun exists(path: SAFPath): Boolean = runIO {
@@ -171,7 +171,7 @@ class SAFGateway @Inject constructor(
 
             if (lookUp.isDirectory) {
                 val newBatch = try {
-                    lookupFiles(lookUp.lookedUp)
+                    lookupFiles(lookUp.lookedUp).toList()
                 } catch (e: IOException) {
                     log(TAG, ERROR) { "Failed to read directory to delete $lookUp: $e" }
                     throw ReadException(path = path, cause = e)
@@ -251,50 +251,61 @@ class SAFGateway @Inject constructor(
         }
     }
 
-    override suspend fun lookupFiles(path: SAFPath): List<SAFPathLookup> = runIO {
-        try {
-            val docFile = findDocFile(path)
-            log(TAG, VERBOSE) { "lookupFiles($path) -> $docFile" }
-
-            docFile.listFiles()
-                .map {
-                    val name = it.name ?: it.uri.pathSegments.last().split('/').last()
-                    path.child(name)
-                }
-                .map { lookup(it) }
-                .also {
-                    if (Bugs.isTrace) {
-                        log(TAG, VERBOSE) { "Looked up ${it.size} items:" }
-                        it.forEachIndexed { index, look -> log(TAG, VERBOSE) { "#$index $look" } }
-                    }
-                }
-        } catch (e: Exception) {
-            log(TAG, WARN) { "lookupFiles($path) failed." }
-            throw ReadException(path = path, cause = e)
+    override suspend fun lookupFiles(path: SAFPath): Flow<SAFPathLookup> = runIO {
+        val children = childPaths(path, "lookupFiles")
+        flow {
+            children.forEach { emit(lookup(it)) }
         }
+            .trace("lookupFiles($path)")
+            .refineErrors("lookupFiles", path)
+            .flowOn(dispatcherProvider.IO)
     }
 
-    override suspend fun lookupFilesExtended(path: SAFPath): List<SAFPathLookupExtended> = runIO {
-        try {
-            val docFile = findDocFile(path)
-            log(TAG, VERBOSE) { "lookupFilesExtended($path) -> $docFile" }
+    override suspend fun lookupFilesExtended(path: SAFPath): Flow<SAFPathLookupExtended> = runIO {
+        val children = childPaths(path, "lookupFilesExtended")
+        flow {
+            children.forEach { emit(SAFPathLookupExtended(lookup(it))) }
+        }
+            .trace("lookupFilesExtended($path)")
+            .refineErrors("lookupFilesExtended", path)
+            .flowOn(dispatcherProvider.IO)
+    }
 
-            docFile.listFiles()
-                .map {
-                    val name = it.name ?: it.uri.pathSegments.last().split('/').last()
-                    path.child(name)
-                }
-                .map { lookup(it) }
-                .map { SAFPathLookupExtended(it) }
-                .also {
-                    if (Bugs.isTrace) {
-                        log(TAG, VERBOSE) { "Looked up ${it.size} items:" }
-                        it.forEachIndexed { index, look -> log(TAG, VERBOSE) { "#$index $look" } }
-                    }
-                }
-        } catch (e: Exception) {
-            log(TAG, WARN) { "lookupFilesExtended($path) failed." }
-            throw ReadException(path = path, cause = e)
+    /**
+     * The ContentResolver cursor enumeration can't be streamed, so the child listing is a snapshot
+     * taken at call time. The per-child lookups on top of it stay lazy.
+     */
+    private fun childPaths(path: SAFPath, label: String): List<SAFPath> = try {
+        val docFile = findDocFile(path)
+        log(TAG, VERBOSE) { "$label($path) -> $docFile" }
+        docFile.listFiles().map {
+            val name = it.name ?: it.uri.pathSegments.last().split('/').last()
+            path.child(name)
+        }
+    } catch (e: Exception) {
+        log(TAG, WARN) { "$label($path) failed." }
+        throw ReadException(path = path, cause = e)
+    }
+
+    private fun <T> Flow<T>.trace(label: String): Flow<T> = if (!Bugs.isTrace) this else flow {
+        var count = 0
+        emitAll(
+            onEach { item ->
+                count++
+                log(TAG, VERBOSE) { "$label #$count $item" }
+            }.onCompletion { cause ->
+                if (cause == null) log(TAG, VERBOSE) { "$label finished $count items" }
+                else log(TAG, VERBOSE) { "$label aborted after $count items: $cause" }
+            }
+        )
+    }
+
+    private fun <T> Flow<T>.refineErrors(label: String, path: SAFPath): Flow<T> = catch { e ->
+        log(TAG, WARN) { "$label($path) failed." }
+        when (e) {
+            is CancellationException -> throw e
+            is ReadException -> throw e
+            else -> throw ReadException(path = path, cause = e)
         }
     }
 
@@ -316,7 +327,7 @@ class SAFGateway @Inject constructor(
             val lookUp = queue.removeFirst()
 
             val newBatch = try {
-                lookupFiles(lookUp.lookedUp)
+                lookupFiles(lookUp.lookedUp).toList()
             } catch (e: IOException) {
                 log(TAG, ERROR) { "Failed to read $lookUp: $e" }
                 if (options.onError?.invoke(lookUp, e) != false) {
@@ -367,7 +378,7 @@ class SAFGateway @Inject constructor(
                 val lookUp = queue.removeFirst()
 
                 val newBatch = try {
-                    lookupFiles(lookUp.lookedUp)
+                    lookupFiles(lookUp.lookedUp).toList()
                 } catch (e: IOException) {
                     log(TAG, ERROR) { "Failed to read $lookUp: $e" }
                     emptyList()

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/saf/SAFGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/saf/SAFGateway.kt
@@ -287,7 +287,11 @@ class SAFGateway @Inject constructor(
         throw ReadException(path = path, cause = e)
     }
 
-    private fun <T> Flow<T>.trace(label: String): Flow<T> = if (!Bugs.isTrace) this else flow {
+    private fun <T> Flow<T>.trace(label: String): Flow<T> = flow {
+        if (!Bugs.isTrace) {
+            emitAll(this@trace)
+            return@flow
+        }
         var count = 0
         emitAll(
             onEach { item ->

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/IndirectLocalWalkerTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/IndirectLocalWalkerTest.kt
@@ -41,11 +41,11 @@ class IndirectLocalWalkerTest : BaseTest() {
         val mode = LocalGateway.Mode.ROOT
         val start = LocalPath.build("root")
         coEvery { gateway.lookup(start, mode) } returns lookup("root", FileType.DIRECTORY)
-        coEvery { gateway.lookupFilesFlow(LocalPath.build("root"), mode) } returns flowOf(
+        coEvery { gateway.lookupFiles(LocalPath.build("root"), mode) } returns flowOf(
             lookup("root/sub", FileType.DIRECTORY),
             lookup("root/file.txt", FileType.FILE),
         )
-        coEvery { gateway.lookupFilesFlow(LocalPath.build("root/sub"), mode) } returns flowOf(
+        coEvery { gateway.lookupFiles(LocalPath.build("root/sub"), mode) } returns flowOf(
             lookup("root/sub/nested.txt", FileType.FILE),
         )
 
@@ -62,7 +62,7 @@ class IndirectLocalWalkerTest : BaseTest() {
         val mode = LocalGateway.Mode.ROOT
         val start = LocalPath.build("root")
         coEvery { gateway.lookup(start, mode) } returns lookup("root", FileType.DIRECTORY)
-        coEvery { gateway.lookupFilesFlow(LocalPath.build("root"), mode) } returns flowOf(
+        coEvery { gateway.lookupFiles(LocalPath.build("root"), mode) } returns flowOf(
             lookup("root/link", FileType.SYMBOLIC_LINK, target = LocalPath.build("elsewhere")),
         )
 
@@ -75,7 +75,7 @@ class IndirectLocalWalkerTest : BaseTest() {
 
         items.names() shouldContainAll setOf("link")
         // The symlink target must never be listed through the gateway (no descent).
-        coVerify(exactly = 0) { gateway.lookupFilesFlow(LocalPath.build("root/link"), mode) }
+        coVerify(exactly = 0) { gateway.lookupFiles(LocalPath.build("root/link"), mode) }
     }
 
     @Test
@@ -83,7 +83,7 @@ class IndirectLocalWalkerTest : BaseTest() {
         val mode = LocalGateway.Mode.ROOT
         val start = LocalPath.build("root")
         coEvery { gateway.lookup(start, mode) } returns lookup("root", FileType.DIRECTORY)
-        coEvery { gateway.lookupFilesFlow(LocalPath.build("root"), mode) } returns flowOf(
+        coEvery { gateway.lookupFiles(LocalPath.build("root"), mode) } returns flowOf(
             lookup("root/file1.txt", FileType.FILE),
             lookup("root/file2.txt", FileType.FILE),
         )
@@ -105,12 +105,12 @@ class IndirectLocalWalkerTest : BaseTest() {
         val mode = LocalGateway.Mode.ROOT
         val start = LocalPath.build("root")
         coEvery { gateway.lookup(start, mode) } returns lookup("root", FileType.DIRECTORY)
-        coEvery { gateway.lookupFilesFlow(LocalPath.build("root"), mode) } returns flow {
+        coEvery { gateway.lookupFiles(LocalPath.build("root"), mode) } returns flow {
             emit(lookup("root/early.txt", FileType.FILE))
             emit(lookup("root/earlydir", FileType.DIRECTORY))
             throw ReadException(path = LocalPath.build("root"))
         }
-        coEvery { gateway.lookupFilesFlow(LocalPath.build("root/earlydir"), mode) } returns flowOf(
+        coEvery { gateway.lookupFiles(LocalPath.build("root/earlydir"), mode) } returns flowOf(
             lookup("root/earlydir/nested.txt", FileType.FILE),
         )
 
@@ -132,7 +132,7 @@ class IndirectLocalWalkerTest : BaseTest() {
         val mode = LocalGateway.Mode.ROOT
         val start = LocalPath.build("root")
         coEvery { gateway.lookup(start, mode) } returns lookup("root", FileType.DIRECTORY)
-        coEvery { gateway.lookupFilesFlow(LocalPath.build("root"), mode) } returns flowOf(
+        coEvery { gateway.lookupFiles(LocalPath.build("root"), mode) } returns flowOf(
             lookup("root/file.txt", FileType.FILE),
         )
 
@@ -154,7 +154,7 @@ class IndirectLocalWalkerTest : BaseTest() {
         val mode = LocalGateway.Mode.ROOT
         val start = LocalPath.build("root")
         coEvery { gateway.lookup(start, mode) } returns lookup("root", FileType.DIRECTORY)
-        coEvery { gateway.lookupFilesFlow(LocalPath.build("root"), mode) } returns flowOf(
+        coEvery { gateway.lookupFiles(LocalPath.build("root"), mode) } returns flowOf(
             lookup("root/file.txt", FileType.FILE),
         )
 
@@ -175,7 +175,7 @@ class IndirectLocalWalkerTest : BaseTest() {
         val mode = LocalGateway.Mode.ROOT
         val start = LocalPath.build("root")
         coEvery { gateway.lookup(start, mode) } returns lookup("root", FileType.DIRECTORY)
-        coEvery { gateway.lookupFilesFlow(LocalPath.build("root"), mode) } returns flow {
+        coEvery { gateway.lookupFiles(LocalPath.build("root"), mode) } returns flow {
             emit(lookup("root/early.txt", FileType.FILE))
             throw ReadException(path = LocalPath.build("root"))
         }

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/LocalGatewayTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/LocalGatewayTest.kt
@@ -4,11 +4,16 @@ import eu.darken.sdmse.common.adb.AdbManager
 import eu.darken.sdmse.common.adb.service.AdbServiceClient
 import eu.darken.sdmse.common.adb.service.runModuleAction
 import eu.darken.sdmse.common.files.FileType
+import eu.darken.sdmse.common.files.ReadException
 import eu.darken.sdmse.common.files.WriteException
+import eu.darken.sdmse.common.files.listFiles
 import eu.darken.sdmse.common.files.local.ipc.FileOpsClient
+import eu.darken.sdmse.common.files.lookupFiles
+import eu.darken.sdmse.common.pkgs.pkgops.LibcoreTool
 import eu.darken.sdmse.common.root.RootManager
 import eu.darken.sdmse.common.storage.StorageEnvironment
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.every
@@ -17,7 +22,10 @@ import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.verify
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.withContext
 import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -29,6 +37,8 @@ import testhelpers.coroutine.TestDispatcherProvider
 import testhelpers.coroutine.runTest2
 import java.io.File
 import java.nio.file.Files
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.Executors
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [29], application = EmptyApp::class)
@@ -222,5 +232,74 @@ class LocalGatewayTest : BaseTest() {
 
             gateway.hasRoot() shouldBe true // precondition: escalation WAS available
             gateway.lookup(LocalPath.build(link), LocalGateway.Mode.AUTO).fileType shouldBe FileType.SYMBOLIC_LINK
+        }
+
+    @Test
+    fun `NORMAL enumeration of an unreadable directory throws before the flow is collected`() =
+        runTest2(autoCancel = true) {
+            // The directory listing is taken eagerly while the flow is built, so callers still see
+            // the ReadException from the call itself, not only once they start collecting.
+            val missing = LocalPath.build(File(testDir, "not-there"))
+            val gateway = gateway()
+
+            shouldThrow<ReadException> { gateway.listFiles(missing, LocalGateway.Mode.NORMAL) }
+            shouldThrow<ReadException> { gateway.lookupFiles(missing, LocalGateway.Mode.NORMAL) }
+            shouldThrow<ReadException> { gateway.lookupFilesExtended(missing, LocalGateway.Mode.NORMAL) }
+        }
+
+    @Test
+    fun `NORMAL enumeration materialized via the compat extensions yields the directory contents`() =
+        runTest2(autoCancel = true) {
+            val dir = File(testDir, "listing").apply { mkdirs() }
+            File(dir, "a.txt").writeText("a")
+            File(dir, "b.txt").writeText("b")
+            File(dir, "sub").mkdirs()
+            val path = LocalPath.build(dir)
+            val gateway = gateway()
+
+            path.listFiles(gateway).map { it.name } shouldContainExactlyInAnyOrder listOf("a.txt", "b.txt", "sub")
+            path.lookupFiles(gateway).map { it.name } shouldContainExactlyInAnyOrder listOf("a.txt", "b.txt", "sub")
+            gateway.lookupFiles(path, LocalGateway.Mode.NORMAL).toList()
+                .map { it.name } shouldContainExactlyInAnyOrder listOf("a.txt", "b.txt", "sub")
+        }
+
+    @Test
+    fun `NORMAL per-child lookups run on the IO dispatcher, not on the collector`() =
+        runTest2(autoCancel = true) {
+            // runIO only builds the flow; without flowOn the per-child lookups would run wherever
+            // the (possibly main-thread) collector happens to be.
+            val ioExecutor = Executors.newSingleThreadExecutor { Thread(it, "gateway-io") }
+            val collectorExecutor = Executors.newSingleThreadExecutor { Thread(it, "gateway-collector") }
+            try {
+                val lookupThreads = CopyOnWriteArrayList<String>()
+                val gateway = LocalGateway(
+                    ipcFunnel = mockk(),
+                    libcoreTool = mockk<LibcoreTool> {
+                        every { getNameForUid(any()) } answers {
+                            lookupThreads += Thread.currentThread().name
+                            null
+                        }
+                        every { getNameForGid(any()) } returns null
+                    },
+                    appScope = this,
+                    dispatcherProvider = TestDispatcherProvider(ioExecutor.asCoroutineDispatcher()),
+                    storageEnvironment = mockk(),
+                    rootManager = mockk<RootManager> { every { useRoot } returns flowOf(false) },
+                    adbManager = mockk<AdbManager> { every { useAdb } returns flowOf(false) },
+                )
+
+                val dir = File(testDir, "flowon").apply { mkdirs() }
+                File(dir, "child.txt").writeText("x")
+
+                val collected = withContext(collectorExecutor.asCoroutineDispatcher()) {
+                    gateway.lookupFilesExtended(LocalPath.build(dir), LocalGateway.Mode.NORMAL).toList()
+                }
+
+                collected.map { it.name } shouldBe listOf("child.txt")
+                lookupThreads shouldBe listOf("gateway-io")
+            } finally {
+                ioExecutor.shutdownNow()
+                collectorExecutor.shutdownNow()
+            }
         }
 }

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/LocalGatewayTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/LocalGatewayTest.kt
@@ -296,7 +296,8 @@ class LocalGatewayTest : BaseTest() {
                 }
 
                 collected.map { it.name } shouldBe listOf("child.txt")
-                lookupThreads shouldBe listOf("gateway-io")
+                // The coroutines debug agent appends " @coroutine#N" to thread names, match the prefix.
+                lookupThreads.map { it.substringBefore(" @coroutine") } shouldBe listOf("gateway-io")
             } finally {
                 ioExecutor.shutdownNow()
                 collectorExecutor.shutdownNow()

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/ipc/FileOpsClientStreamingTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/ipc/FileOpsClientStreamingTest.kt
@@ -1,0 +1,162 @@
+package eu.darken.sdmse.common.files.local.ipc
+
+import eu.darken.sdmse.common.files.FileType
+import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.files.local.LocalPathLookup
+import eu.darken.sdmse.common.files.local.LocalPathLookupExtended
+import eu.darken.sdmse.common.ipc.RemoteInputStream
+import eu.darken.sdmse.common.ipc.ServiceConnectionLostException
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.ints.shouldBeLessThan
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicInteger
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class FileOpsClientStreamingTest : BaseTest() {
+
+    private fun makeScope() = CoroutineScope(Job() + Dispatchers.IO)
+
+    private fun path(name: String) = LocalPath.build("test", name)
+
+    private fun lookup(name: String) = LocalPathLookup(
+        lookedUp = path(name),
+        fileType = FileType.FILE,
+        size = 16L,
+        modifiedAt = Instant.EPOCH,
+        target = null,
+    )
+
+    private fun lookupExtended(name: String) = LocalPathLookupExtended(
+        lookup = lookup(name),
+        ownership = null,
+        permissions = null,
+    )
+
+    /**
+     * Stub that pretends to be an AIDL FileOpsConnection, counting how often each enumeration
+     * stream was opened. [FileOpsConnection.Default] supplies the unused members.
+     */
+    private class FakeConnection(
+        private val streamFactory: () -> RemoteInputStream,
+    ) : FileOpsConnection.Default() {
+        val opened = AtomicInteger()
+
+        override fun listFilesStream(path: LocalPath?): RemoteInputStream = open()
+
+        override fun lookupFilesStream(path: LocalPath?): RemoteInputStream = open()
+
+        override fun lookupFilesExtendedStream(path: LocalPath?): RemoteInputStream = open()
+
+        private fun open(): RemoteInputStream {
+            opened.incrementAndGet()
+            return streamFactory()
+        }
+    }
+
+    @Test
+    fun `enumeration streams are opened at collection time, not at call time`() {
+        val scope = makeScope()
+        try {
+            runBlocking {
+                val paths = listOf(path("file1"), path("file2"))
+                val lookups = listOf(lookup("file1"), lookup("file2"))
+                val extended = listOf(lookupExtended("file1"), lookupExtended("file2"))
+
+                val pathConnection = FakeConnection { paths.asFlow().toRemoteInputStream(scope) }
+                val lookupConnection = FakeConnection { lookups.asFlow().toRemoteInputStream(scope) }
+                val extendedConnection = FakeConnection { extended.asFlow().toRemoteInputStream(scope) }
+
+                val listFilesFlow = FileOpsClient(pathConnection).listFiles(path("dir"))
+                val lookupFilesFlow = FileOpsClient(lookupConnection).lookupFiles(path("dir"))
+                val lookupFilesExtendedFlow = FileOpsClient(extendedConnection).lookupFilesExtended(path("dir"))
+
+                // Building the flow must not touch the connection, otherwise an unconsumed flow
+                // would already hold an IPC stream (and the lease keeping the helper alive).
+                pathConnection.opened.get() shouldBe 0
+                lookupConnection.opened.get() shouldBe 0
+                extendedConnection.opened.get() shouldBe 0
+
+                listFilesFlow.toList() shouldContainExactly paths
+                lookupFilesFlow.toList() shouldContainExactly lookups
+                lookupFilesExtendedFlow.toList() shouldContainExactly extended
+
+                pathConnection.opened.get() shouldBe 1
+                lookupConnection.opened.get() shouldBe 1
+                extendedConnection.opened.get() shouldBe 1
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `cancelling mid-stream stops consuming the remaining items`() {
+        val supervisor = SupervisorJob()
+        val scope = CoroutineScope(supervisor + Dispatchers.IO)
+        try {
+            runBlocking {
+                val itemCount = 100_000
+                val emitted = AtomicInteger()
+                val source: Flow<LocalPathLookup> = flow {
+                    repeat(itemCount) {
+                        emitted.incrementAndGet()
+                        emit(lookup("file$it"))
+                    }
+                }
+                val client = FileOpsClient(FakeConnection { source.toRemoteInputStream(scope) })
+
+                val collected = client.lookupFiles(path("dir")).take(3).toList()
+                collected shouldContainExactly listOf(lookup("file0"), lookup("file1"), lookup("file2"))
+
+                // The host unwinds on the closed pipe instead of enumerating the whole directory.
+                withTimeout(10_000) { supervisor.children.toList().joinAll() }
+                emitted.get() shouldBeLessThan itemCount
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `a dead connection surfaces as ServiceConnectionLostException at collection time`() {
+        runBlocking {
+            val connection = FakeConnection { throw android.os.DeadObjectException("binder died") }
+            val client = FileOpsClient(connection)
+
+            // refineException() promotes DeadObjectException, which is what drives the
+            // "Service Connection Lost" handling instead of a generic crash.
+            val flows = listOf(
+                client.listFiles(path("dir")),
+                client.lookupFiles(path("dir")),
+                client.lookupFilesExtended(path("dir")),
+            )
+
+            flows.forEach { flow ->
+                val thrown = runCatching { flow.toList() }.exceptionOrNull()
+                thrown.shouldBeInstanceOf<ServiceConnectionLostException>()
+            }
+        }
+    }
+}

--- a/app-common-picker/src/test/java/eu/darken/sdmse/common/picker/PickerViewModelSelectAllTest.kt
+++ b/app-common-picker/src/test/java/eu/darken/sdmse/common/picker/PickerViewModelSelectAllTest.kt
@@ -20,6 +20,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import org.junit.jupiter.api.Test
@@ -55,7 +57,7 @@ class PickerViewModelSelectAllTest : BaseTest() {
         val gatewaySwitch = mockk<GatewaySwitch> {
             every { sharedResource } returns SharedResource.createKeepAlive("test:gateway", resourceScope)
             coEvery { lookup(any()) } answers { lookupOf(arg<APath>(0) as LocalPath) }
-            coEvery { lookupFiles(any()) } answers { listings[arg<APath>(0) as LocalPath] ?: emptyList() }
+            coEvery { lookupFiles(any()) } answers { listings[arg<APath>(0) as LocalPath]?.asFlow() ?: emptyFlow() }
         }
         val dataAreaManager = mockk<DataAreaManager> {
             every { state } returns flowOf(DataAreaManager.State(areas = setOf(area)))

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/SystemStorageScanner.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/SystemStorageScanner.kt
@@ -15,6 +15,7 @@ import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.ReadException
 import eu.darken.sdmse.common.files.local.LocalPath
 import eu.darken.sdmse.common.storage.StorageId
+import kotlinx.coroutines.flow.toList
 import dagger.Reusable
 import javax.inject.Inject
 
@@ -85,7 +86,7 @@ class SystemStorageScanner @Inject constructor(
         return try {
             val dataPath = LocalPath.build("data")
             val dataLookup = gatewaySwitch.lookup(dataPath, type = GatewaySwitch.Type.AUTO)
-            val dataChildren = gatewaySwitch.listFiles(dataPath)
+            val dataChildren = gatewaySwitch.listFiles(dataPath).toList()
             val filteredChildren = dataChildren.filter { it.name !in excludedDirs }
 
             log(TAG) { "walkData(): children=${dataChildren.map { it.name }}, filtered=${filteredChildren.map { it.name }}" }

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/storage/SystemStorageScannerTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/storage/SystemStorageScannerTest.kt
@@ -20,6 +20,7 @@ import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
@@ -228,7 +229,7 @@ class SystemStorageScannerTest : BaseTest() {
                     coEvery { target } returns null
                 } as APathLookup<APath>
             }
-            coEvery { listFiles(any()) } returns listOf(LocalPath.build("data", "some_app"))
+            coEvery { listFiles(any()) } returns flowOf(LocalPath.build("data", "some_app"))
             coEvery { walk(any(), capture(capturedOptions)) } returns emptyFlow()
         }
 

--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/SystemCleanerFilterTest.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/SystemCleanerFilterTest.kt
@@ -37,8 +37,11 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import testhelpers.BaseTest
@@ -315,16 +318,13 @@ abstract class SystemCleanerFilterTest : BaseTest() {
             )
         )
 
-        coEvery { gatewaySwitch.listFiles(any()) } returns emptyList()
+        coEvery { gatewaySwitch.listFiles(any()) } returns emptyFlow()
         coEvery { gatewaySwitch.exists(any()) } returns false
         coEvery { gatewaySwitch.canRead(any()) } returns false
-        coEvery { gatewaySwitch.lookupFiles(any()) } answers {
-            throw ReadException(path = arg<APath>(0))
-        }
         // Mirrors the real gateway: children stream lazily, errors surface at collection time
-        coEvery { gatewaySwitch.lookupFilesFlow(any()) } coAnswers {
+        coEvery { gatewaySwitch.lookupFiles(any()) } coAnswers {
             val path = arg<APath>(0)
-            flow { gatewaySwitch.lookupFiles(path).forEach { emit(it) } }
+            flow { throw ReadException(path = path) }
         }
         every { storageEnvironment.dataDir } returns LocalPath.build("/data")
 
@@ -350,7 +350,7 @@ abstract class SystemCleanerFilterTest : BaseTest() {
             val treeKey = TreeKey(area.path.segments, mockedLockup.fileType)
             pathTree[treeKey] = mockedLockup
             val pathCopy = area.path.child()
-            coEvery { gatewaySwitch.lookupFiles(pathCopy) } returns emptyList()
+            coEvery { gatewaySwitch.lookupFiles(pathCopy) } returns emptyFlow()
         }
     }
 
@@ -534,15 +534,15 @@ abstract class SystemCleanerFilterTest : BaseTest() {
                 coEvery { gatewaySwitch.canRead(mockPath) } returns true
 
                 if (flagsCollection.contains(Flag.Dir)) {
-                    coEvery { gatewaySwitch.lookupFiles(mockPath) } returns emptyList()
+                    coEvery { gatewaySwitch.lookupFiles(mockPath) } returns emptyFlow()
                 }
 
                 val treeKey = TreeKey(mockPath.segments, mockLookup.fileType)
                 val treeKeyParent = TreeKey(mockPath.segments.dropLast(1), FileType.DIRECTORY)
 
                 pathTree[treeKeyParent]?.let { parent ->
-                    val parentsChildren = gatewaySwitch.lookupFiles(parent.lookedUp)
-                    coEvery { gatewaySwitch.lookupFiles(parent.lookedUp) } returns parentsChildren + mockLookup
+                    val parentsChildren = gatewaySwitch.lookupFiles(parent.lookedUp).toList()
+                    coEvery { gatewaySwitch.lookupFiles(parent.lookedUp) } returns (parentsChildren + mockLookup).asFlow()
                 } ?: throw IllegalArgumentException("$mockPath has no mocked parent")
 
                 pathTree[treeKey]?.let {

--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/EmptyDirectoryFilterTest.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/EmptyDirectoryFilterTest.kt
@@ -121,12 +121,10 @@ class EmptyDirectoryFilterTest : SystemCleanerFilterTest() {
 
         dirs.forEach { dir ->
             val blocker = blockers.single { it.lookedUp.isChildOf(dir.lookedUp) }
-            coEvery { gatewaySwitch.lookupFilesFlow(dir.lookedUp) } returns flow {
+            // Materializing the listing (instead of aborting after the first child) trips the error.
+            coEvery { gatewaySwitch.lookupFiles(dir.lookedUp) } returns flow {
                 emit(blocker as APathLookup<APath>)
                 throw AssertionError("Should not enumerate past the first blocking child: ${dir.path}")
-            }
-            coEvery { gatewaySwitch.lookupFiles(dir.lookedUp) } answers {
-                throw AssertionError("Should stream via lookupFilesFlow, not materialize via lookupFiles: ${dir.path}")
             }
         }
 

--- a/app/src/main/java/eu/darken/sdmse/common/debug/DebugCardProvider.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/debug/DebugCardProvider.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
@@ -214,7 +215,7 @@ class DebugCardProvider @Inject constructor(
 
                 for (area in areas) {
                     val depth1Dirs = try {
-                        gatewaySwitch.lookupFiles(area.path).filter { it.isDirectory }
+                        gatewaySwitch.lookupFiles(area.path).toList().filter { it.isDirectory }
                     } catch (e: CancellationException) {
                         throw e
                     } catch (e: Exception) {
@@ -233,7 +234,7 @@ class DebugCardProvider @Inject constructor(
 
                         // Get depth-2 children
                         val depth2Dirs = try {
-                            gatewaySwitch.lookupFiles(dir.lookedUp).filter { it.isDirectory }
+                            gatewaySwitch.lookupFiles(dir.lookedUp).toList().filter { it.isDirectory }
                         } catch (e: CancellationException) {
                             throw e
                         } catch (e: Exception) {

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/BaseFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/BaseFilterTest.kt
@@ -29,6 +29,8 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -270,11 +272,12 @@ abstract class BaseFilterTest : BaseTest() {
             )
         )
 
-        coEvery { gatewaySwitch.listFiles(any()) } returns emptyList()
+        coEvery { gatewaySwitch.listFiles(any()) } returns emptyFlow()
         coEvery { gatewaySwitch.exists(any()) } returns false
         coEvery { gatewaySwitch.canRead(any()) } returns false
-        coEvery { gatewaySwitch.lookupFiles(any()) } answers {
-            throw ReadException(path = arg<APath>(0))
+        coEvery { gatewaySwitch.lookupFiles(any()) } coAnswers {
+            val path = arg<APath>(0)
+            flow { throw ReadException(path = path) }
         }
         storageEnvironment.apply {
             every { dataDir } returns LocalPath.build("/data")


### PR DESCRIPTION
## What changed

No user-facing behavior change. Internal refactor: the file access layer now streams directory listings instead of collecting them into full lists first. This applies to normal, root, and ADB access alike, and callers that still need complete lists convert at the call site.

## Technical Context

- The gateway interface's three enumeration methods now return flows, absorbing the previous separate streaming method. Collection access moved into the existing path extension wrappers, so most call sites compile unchanged.
- Root/ADB leases and IPC streams are opened at collection time and span the whole consumption. The IPC client no longer collects streams internally.
- Normal-mode enumeration stays an eager call-time snapshot (documented on the interface); per-child lookups and privileged-mode enumeration are lazy. Error timing moves accordingly: a read failure can now surface at collection instead of at the call, which is the part of the diff that deserves the closest review, together with the cancellation-safe catch discipline in the SAF flows.
- Recursive deletion deliberately materializes listings before deleting, since streaming a directory while deleting from it risks skipped entries and held leases. The unused gateway-switch fallback overloads stay Collection-returning.
- A scans-only smoke run on a rooted device covered the root-mode enumeration paths that CI cannot exercise; the streaming client lifecycle is additionally unit-tested against a fake connection.
