### PR TITLE
General: Cover privileged file operations with tests

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/GatewaySwitch.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/GatewaySwitch.kt
@@ -210,6 +210,14 @@ class GatewaySwitch @Inject constructor(
     }
 
     override suspend fun createSymlink(linkPath: APath, targetPath: APath): Boolean {
+        // The gateway is picked by the link path, but the target is handed to it unchecked: a
+        // mismatched pair would reach the gateway as the wrong path type and fail there (or worse,
+        // be silently misinterpreted).
+        if (linkPath.pathType != targetPath.pathType) {
+            throw IllegalArgumentException(
+                "Can't create symlink across path types: linkPath is ${linkPath.pathType}, targetPath is ${targetPath.pathType}"
+            )
+        }
         return useGateway(linkPath) { createSymlink(linkPath, targetPath) }
     }
 

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/GatewaySwitchTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/GatewaySwitchTest.kt
@@ -257,6 +257,16 @@ class GatewaySwitchTest {
         coVerify { localGateway.createSymlink(otherLink, localPath) }
     }
 
+    @Test fun `createSymlink rejects mixed path types`() = runTest2(autoCancel = true) {
+        val switch = createSwitch()
+
+        shouldThrow<IllegalArgumentException> { switch.createSymlink(localPath, safPath) }
+        shouldThrow<IllegalArgumentException> { switch.createSymlink(safPath, localPath) }
+
+        verify { localGateway wasNot Called }
+        verify { safGateway wasNot Called }
+    }
+
     @Test fun `lookup CURRENT never falls back`() = runTest2(autoCancel = true) {
         val switch = createSwitch()
         coEvery { localGateway.lookup(localPath) } throws ReadException(message = "original", path = localPath)

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/GatewaySwitchTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/GatewaySwitchTest.kt
@@ -1,26 +1,40 @@
 package eu.darken.sdmse.common.files
 
+import androidx.core.net.toUri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import eu.darken.sdmse.common.files.local.LocalGateway
 import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.files.local.LocalPathLookup
 import eu.darken.sdmse.common.files.local.LocalPathLookupExtended
 import eu.darken.sdmse.common.files.saf.SAFGateway
 import eu.darken.sdmse.common.files.saf.SAFPath
+import eu.darken.sdmse.common.files.saf.SAFPathLookup
 import eu.darken.sdmse.common.files.saf.SAFPathLookupExtended
 import eu.darken.sdmse.common.sharedresource.SharedResource
 import eu.darken.sdmse.common.storage.PathMapper
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldNotBeSameInstanceAs
+import io.mockk.Called
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import okio.FileHandle
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import testhelper.EmptyApp
 import testhelpers.coroutine.TestDispatcherProvider
 import testhelpers.coroutine.runTest2
+import java.io.IOException
+import java.time.Instant
 
 @RunWith(AndroidJUnit4::class)
 @Config(sdk = [29], application = EmptyApp::class)
@@ -29,6 +43,13 @@ class GatewaySwitchTest {
     private val safGateway = mockk<SAFGateway>(relaxed = true)
     private val localGateway = mockk<LocalGateway>(relaxed = true)
     private val mapper = mockk<PathMapper>()
+
+    private val localPath = LocalPath.build("/data/data/com.some.app")
+    private val safPath = SAFPath.build(
+        "content://com.android.externalstorage.documents/tree/primary%3A".toUri(),
+        "Android",
+        "data",
+    )
 
     private fun CoroutineScope.createSwitch(): GatewaySwitch {
         every { localGateway.sharedResource } returns SharedResource.createKeepAlive("local", this)
@@ -82,5 +103,326 @@ class GatewaySwitchTest {
                 switch.lookupExtended(localPath, GatewaySwitch.Type.AUTO)
             }
             thrown shouldBe original
+        }
+
+    @Test fun `getGateway returns the gateway matching the path type`() = runTest2(autoCancel = true) {
+        val switch = createSwitch()
+
+        switch.getGateway(APath.PathType.LOCAL) shouldBe localGateway
+        switch.getGateway(APath.PathType.SAF) shouldBe safGateway
+    }
+
+    @Test fun `RAW paths have no gateway`() = runTest2(autoCancel = true) {
+        val switch = createSwitch()
+        val rawPath = RawPath.build("/some/raw/path")
+
+        shouldThrow<NotImplementedError> { switch.exists(rawPath) }
+        shouldThrow<NotImplementedError> { switch.canRead(rawPath) }
+        shouldThrow<NotImplementedError> { switch.getGateway(APath.PathType.RAW) }
+    }
+
+    @Test fun `plain operations route local paths to the local gateway`() = runTest2(autoCancel = true) {
+        val switch = createSwitch()
+        val modifiedAt = Instant.ofEpochMilli(1234)
+        val permissions = Permissions(0b111_101_101)
+        val ownership = Ownership(1000L, 1001L)
+        val fileHandle = mockk<FileHandle>()
+        val lookup = mockk<LocalPathLookup>()
+        val lookupExtended = mockk<LocalPathLookupExtended>()
+        coEvery { localGateway.listFiles(localPath) } returns flowOf(localPath)
+        coEvery { localGateway.du(localPath, any()) } returns 42L
+        coEvery { localGateway.canRead(localPath) } returns true
+        coEvery { localGateway.canWrite(localPath) } returns true
+        coEvery { localGateway.file(localPath, true) } returns fileHandle
+        coEvery { localGateway.createSymlink(localPath, localPath) } returns true
+        coEvery { localGateway.setModifiedAt(localPath, modifiedAt) } returns true
+        coEvery { localGateway.setPermissions(localPath, permissions) } returns true
+        coEvery { localGateway.setOwnership(localPath, ownership) } returns true
+        coEvery { localGateway.lookup(localPath) } returns lookup
+        coEvery { localGateway.lookupFiles(localPath) } returns flowOf(lookup)
+        coEvery { localGateway.lookupFilesExtended(localPath) } returns flowOf(lookupExtended)
+
+        switch.createDir(localPath)
+        switch.createFile(localPath)
+        switch.listFiles(localPath)
+        switch.walk(localPath, APathGateway.WalkOptions(pathDoesNotContain = setOf("skipme")))
+        switch.du(localPath, APathGateway.DuOptions(abortOnError = true)) shouldBe 42L
+        switch.canRead(localPath) shouldBe true
+        switch.canWrite(localPath) shouldBe true
+        switch.file(localPath, readWrite = true) shouldBe fileHandle
+        switch.delete(localPath, recursive = true)
+        switch.createSymlink(localPath, localPath) shouldBe true
+        switch.setModifiedAt(localPath, modifiedAt) shouldBe true
+        switch.setPermissions(localPath, permissions) shouldBe true
+        switch.setOwnership(localPath, ownership) shouldBe true
+        switch.lookup(localPath) shouldBe lookup
+        switch.lookupFiles(localPath)
+        switch.lookupFilesExtended(localPath)
+
+        val walkOptions = slot<APathGateway.WalkOptions<LocalPath, LocalPathLookup>>()
+        val duOptions = slot<APathGateway.DuOptions<LocalPath, LocalPathLookup>>()
+        coVerify {
+            localGateway.createDir(localPath)
+            localGateway.createFile(localPath)
+            localGateway.listFiles(localPath)
+            localGateway.walk(localPath, capture(walkOptions))
+            localGateway.du(localPath, capture(duOptions))
+            localGateway.canRead(localPath)
+            localGateway.canWrite(localPath)
+            localGateway.file(localPath, true)
+            localGateway.delete(localPath, true)
+            localGateway.createSymlink(localPath, localPath)
+            localGateway.setModifiedAt(localPath, modifiedAt)
+            localGateway.setPermissions(localPath, permissions)
+            localGateway.setOwnership(localPath, ownership)
+            localGateway.lookup(localPath)
+            localGateway.lookupFiles(localPath)
+            localGateway.lookupFilesExtended(localPath)
+        }
+        walkOptions.captured.pathDoesNotContain shouldBe setOf("skipme")
+        duOptions.captured.abortOnError shouldBe true
+        verify { safGateway wasNot Called }
+    }
+
+    @Test fun `plain operations route SAF paths to the SAF gateway`() = runTest2(autoCancel = true) {
+        val switch = createSwitch()
+        val modifiedAt = Instant.ofEpochMilli(1234)
+        val permissions = Permissions(0b111_101_101)
+        val ownership = Ownership(1000L, 1001L)
+        val fileHandle = mockk<FileHandle>()
+        val lookup = mockk<SAFPathLookup>()
+        val lookupExtended = mockk<SAFPathLookupExtended>()
+        coEvery { safGateway.listFiles(safPath) } returns flowOf(safPath)
+        coEvery { safGateway.du(safPath, any()) } returns 42L
+        coEvery { safGateway.canRead(safPath) } returns true
+        coEvery { safGateway.canWrite(safPath) } returns true
+        coEvery { safGateway.file(safPath, true) } returns fileHandle
+        coEvery { safGateway.createSymlink(safPath, safPath) } returns true
+        coEvery { safGateway.setModifiedAt(safPath, modifiedAt) } returns true
+        coEvery { safGateway.setPermissions(safPath, permissions) } returns true
+        coEvery { safGateway.setOwnership(safPath, ownership) } returns true
+        coEvery { safGateway.lookup(safPath) } returns lookup
+        coEvery { safGateway.lookupFiles(safPath) } returns flowOf(lookup)
+        coEvery { safGateway.lookupFilesExtended(safPath) } returns flowOf(lookupExtended)
+
+        switch.createDir(safPath)
+        switch.createFile(safPath)
+        switch.listFiles(safPath)
+        switch.walk(safPath, APathGateway.WalkOptions(pathDoesNotContain = setOf("skipme")))
+        switch.du(safPath, APathGateway.DuOptions(abortOnError = true)) shouldBe 42L
+        switch.canRead(safPath) shouldBe true
+        switch.canWrite(safPath) shouldBe true
+        switch.file(safPath, readWrite = true) shouldBe fileHandle
+        switch.delete(safPath, recursive = true)
+        switch.createSymlink(safPath, safPath) shouldBe true
+        switch.setModifiedAt(safPath, modifiedAt) shouldBe true
+        switch.setPermissions(safPath, permissions) shouldBe true
+        switch.setOwnership(safPath, ownership) shouldBe true
+        switch.lookup(safPath) shouldBe lookup
+        switch.lookupFiles(safPath)
+        switch.lookupFilesExtended(safPath)
+
+        val walkOptions = slot<APathGateway.WalkOptions<SAFPath, SAFPathLookup>>()
+        val duOptions = slot<APathGateway.DuOptions<SAFPath, SAFPathLookup>>()
+        coVerify {
+            safGateway.createDir(safPath)
+            safGateway.createFile(safPath)
+            safGateway.listFiles(safPath)
+            safGateway.walk(safPath, capture(walkOptions))
+            safGateway.du(safPath, capture(duOptions))
+            safGateway.canRead(safPath)
+            safGateway.canWrite(safPath)
+            safGateway.file(safPath, true)
+            safGateway.delete(safPath, true)
+            safGateway.createSymlink(safPath, safPath)
+            safGateway.setModifiedAt(safPath, modifiedAt)
+            safGateway.setPermissions(safPath, permissions)
+            safGateway.setOwnership(safPath, ownership)
+            safGateway.lookup(safPath)
+            safGateway.lookupFiles(safPath)
+            safGateway.lookupFilesExtended(safPath)
+        }
+        walkOptions.captured.pathDoesNotContain shouldBe setOf("skipme")
+        duOptions.captured.abortOnError shouldBe true
+        verify { localGateway wasNot Called }
+    }
+
+    @Test fun `createSymlink keys on the link path`() = runTest2(autoCancel = true) {
+        val switch = createSwitch()
+        val otherLink = LocalPath.build("/data/data/com.some.app/link")
+        coEvery { localGateway.createSymlink(otherLink, localPath) } returns true
+
+        switch.createSymlink(otherLink, localPath) shouldBe true
+
+        coVerify { localGateway.createSymlink(otherLink, localPath) }
+    }
+
+    @Test fun `lookup CURRENT never falls back`() = runTest2(autoCancel = true) {
+        val switch = createSwitch()
+        coEvery { localGateway.lookup(localPath) } throws ReadException(message = "original", path = localPath)
+
+        // mapper is a strict mock: any fallback attempt would blow up on an unstubbed call.
+        shouldThrow<ReadException> { switch.lookup(localPath, GatewaySwitch.Type.CURRENT) }
+        shouldThrow<ReadException> { switch.lookup(localPath) }
+    }
+
+    @Test fun `lookup AUTO maps to the alternative gateway`() = runTest2(autoCancel = true) {
+        val switch = createSwitch()
+        val safResult = mockk<SAFPathLookup>()
+        coEvery { localGateway.lookup(localPath) } throws ReadException(path = localPath)
+        coEvery { mapper.toSAFPath(localPath) } returns safPath
+        coEvery { safGateway.lookup(safPath) } returns safResult
+
+        switch.lookup(localPath, GatewaySwitch.Type.AUTO) shouldBe safResult
+    }
+
+    @Test fun `lookup AUTO rethrows the original error when the alternative fails too`() =
+        runTest2(autoCancel = true) {
+            val switch = createSwitch()
+            val original = ReadException(message = "original", path = localPath)
+            coEvery { localGateway.lookup(localPath) } throws original
+            coEvery { mapper.toSAFPath(localPath) } returns safPath
+            coEvery { safGateway.lookup(safPath) } throws ReadException(message = "alternative")
+
+            shouldThrow<ReadException> {
+                switch.lookup(localPath, GatewaySwitch.Type.AUTO)
+            } shouldBe original
+        }
+
+    @Test fun `lookup AUTO surfaces the mapping error when there is no alternative path`() =
+        runTest2(autoCancel = true) {
+            val switch = createSwitch()
+            val original = ReadException(message = "original", path = localPath)
+            coEvery { localGateway.lookup(localPath) } throws original
+            coEvery { mapper.toSAFPath(localPath) } returns null
+
+            // documents suspect behavior: toAlternative() builds its own ReadException outside the
+            // inner try (GatewaySwitch.kt:84-90), so an unmappable path replaces the original
+            // failure with "Can't map to SAF" and the actual reason the lookup failed is lost.
+            // Correct behavior would be to rethrow the original error like the failing-alternative
+            // case does.
+            val thrown = shouldThrow<ReadException> { switch.lookup(localPath, GatewaySwitch.Type.AUTO) }
+            thrown shouldNotBeSameInstanceAs original
+            thrown.message shouldBe "Can't map to SAF <-> ${localPath.path}"
+        }
+
+    @Test fun `lookupFiles AUTO falls back and discards partial emissions`() = runTest2(autoCancel = true) {
+        val switch = createSwitch()
+        val partial = mockk<LocalPathLookup>()
+        val safResult = mockk<SAFPathLookup>()
+        coEvery { localGateway.lookupFiles(localPath) } returns flow {
+            emit(partial)
+            throw ReadException(message = "mid-collection", path = localPath)
+        }
+        coEvery { mapper.toSAFPath(localPath) } returns safPath
+        coEvery { safGateway.lookupFiles(safPath) } returns flowOf(safResult)
+
+        // The failure only happens while the flow is collected, the fallback still kicks in and
+        // whatever the primary gateway already emitted is dropped.
+        switch.lookupFiles(localPath, GatewaySwitch.Type.AUTO) shouldContainExactly listOf(safResult)
+    }
+
+    @Test fun `lookupFiles AUTO rethrows the original when the alternative fails mid-collection`() =
+        runTest2(autoCancel = true) {
+            val switch = createSwitch()
+            val original = ReadException(message = "original", path = localPath)
+            coEvery { localGateway.lookupFiles(localPath) } returns flow { throw original }
+            coEvery { mapper.toSAFPath(localPath) } returns safPath
+            coEvery { safGateway.lookupFiles(safPath) } returns flow {
+                emit(mockk<SAFPathLookup>())
+                throw ReadException(message = "alternative")
+            }
+
+            shouldThrow<ReadException> {
+                switch.lookupFiles(localPath, GatewaySwitch.Type.AUTO)
+            } shouldBe original
+        }
+
+    @Test fun `lookupFilesExtended AUTO falls back on a collection-time failure`() = runTest2(autoCancel = true) {
+        val switch = createSwitch()
+        val safResult = mockk<SAFPathLookupExtended>()
+        coEvery { localGateway.lookupFilesExtended(localPath) } returns flow {
+            emit(mockk<LocalPathLookupExtended>())
+            throw ReadException(message = "mid-collection", path = localPath)
+        }
+        coEvery { mapper.toSAFPath(localPath) } returns safPath
+        coEvery { safGateway.lookupFilesExtended(safPath) } returns flowOf(safResult)
+
+        switch.lookupFilesExtended(localPath, GatewaySwitch.Type.AUTO) shouldContainExactly listOf(safResult)
+    }
+
+    @Test fun `lookupFilesExtended AUTO rethrows the original when the alternative fails too`() =
+        runTest2(autoCancel = true) {
+            val switch = createSwitch()
+            val original = ReadException(message = "original", path = localPath)
+            coEvery { localGateway.lookupFilesExtended(localPath) } returns flow { throw original }
+            coEvery { mapper.toSAFPath(localPath) } returns safPath
+            coEvery { safGateway.lookupFilesExtended(safPath) } returns flow {
+                throw ReadException(message = "alternative")
+            }
+
+            shouldThrow<ReadException> {
+                switch.lookupFilesExtended(localPath, GatewaySwitch.Type.AUTO)
+            } shouldBe original
+        }
+
+    @Test fun `exists AUTO falls back to the alternative gateway`() = runTest2(autoCancel = true) {
+        val switch = createSwitch()
+        coEvery { localGateway.exists(localPath) } throws ReadException(path = localPath)
+        coEvery { mapper.toSAFPath(localPath) } returns safPath
+        coEvery { safGateway.exists(safPath) } returns true
+
+        switch.exists(localPath, GatewaySwitch.Type.AUTO) shouldBe true
+    }
+
+    @Test fun `exists AUTO propagates the alternative error instead of the original`() =
+        runTest2(autoCancel = true) {
+            val switch = createSwitch()
+            val original = ReadException(message = "original", path = localPath)
+            coEvery { localGateway.exists(localPath) } throws original
+            coEvery { mapper.toSAFPath(localPath) } returns safPath
+            coEvery { safGateway.exists(safPath) } throws ReadException(message = "alternative")
+
+            // documents suspect behavior: exists() has no inner try (GatewaySwitch.kt:184-194), so
+            // unlike lookup/lookupFiles/lookupFilesExtended it surfaces the alternative's error
+            // rather than the original one. Callers see the SAF failure for a LOCAL path.
+            val thrown = shouldThrow<ReadException> { switch.exists(localPath, GatewaySwitch.Type.AUTO) }
+            thrown.message shouldBe "alternative"
+        }
+
+    @Test fun `FORCED_LOCAL maps a SAF path through the mapper`() = runTest2(autoCancel = true) {
+        val switch = createSwitch()
+        val result = mockk<LocalPathLookup>()
+        coEvery { mapper.toLocalPath(safPath) } returns localPath
+        coEvery { localGateway.lookup(localPath) } returns result
+
+        switch.lookup(safPath, GatewaySwitch.Type.FORCED_LOCAL) shouldBe result
+    }
+
+    @Test fun `FORCED_SAF maps a local path through the mapper`() = runTest2(autoCancel = true) {
+        val switch = createSwitch()
+        val result = mockk<SAFPathLookup>()
+        coEvery { mapper.toSAFPath(localPath) } returns safPath
+        coEvery { safGateway.lookup(safPath) } returns result
+
+        switch.lookup(localPath, GatewaySwitch.Type.FORCED_SAF) shouldBe result
+    }
+
+    @Test fun `a forced type that can't be mapped fails before any gateway is used`() =
+        runTest2(autoCancel = true) {
+            val switch = createSwitch()
+            coEvery { mapper.toSAFPath(localPath) } returns null
+            coEvery { mapper.toLocalPath(safPath) } returns null
+
+            shouldThrow<IOException> {
+                switch.lookup(localPath, GatewaySwitch.Type.FORCED_SAF)
+            }.message shouldBe "Can't map $localPath to SAF"
+
+            shouldThrow<IOException> {
+                switch.lookup(safPath, GatewaySwitch.Type.FORCED_LOCAL)
+            }.message shouldBe "Can't map $safPath to LOCAL"
+
+            coVerify(exactly = 0) { localGateway.lookup(any()) }
+            coVerify(exactly = 0) { safGateway.lookup(any()) }
         }
 }

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/ipc/FileOpsClientTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/ipc/FileOpsClientTest.kt
@@ -1,0 +1,354 @@
+package eu.darken.sdmse.common.files.local.ipc
+
+import android.os.DeadObjectException
+import eu.darken.sdmse.common.files.APathGateway
+import eu.darken.sdmse.common.files.FileType
+import eu.darken.sdmse.common.files.Ownership
+import eu.darken.sdmse.common.files.Permissions
+import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.files.local.LocalPathLookup
+import eu.darken.sdmse.common.files.local.LocalPathLookupExtended
+import eu.darken.sdmse.common.ipc.RemoteInputStream
+import eu.darken.sdmse.common.ipc.ServiceConnectionLostException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+import java.io.IOException
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Argument/return plumbing of the app-side [FileOpsClient]. Each test uses a fake connection that
+ * overrides only the method under test, so touching any other connection method would return the
+ * AIDL default instead of the expected value.
+ *
+ * The enumeration flows (listFiles/lookupFiles/lookupFilesExtended) have their own coverage in
+ * FileOpsClientStreamingTest.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class FileOpsClientTest : BaseTest() {
+
+    private fun path(name: String) = LocalPath.build("test", name)
+
+    private fun lookup(name: String) = LocalPathLookup(
+        lookedUp = path(name),
+        fileType = FileType.FILE,
+        size = 16L,
+        modifiedAt = Instant.EPOCH,
+        target = null,
+    )
+
+    private fun lookupExtended(name: String) = LocalPathLookupExtended(
+        lookup = lookup(name),
+        ownership = null,
+        permissions = null,
+    )
+
+    @Test
+    fun `lookUp is delegated`() {
+        val expected = lookup("file")
+        var seen: LocalPath? = null
+        val client = FileOpsClient(object : FileOpsConnection.Default() {
+            override fun lookUp(path: LocalPath?): LocalPathLookup {
+                seen = path
+                return expected
+            }
+        })
+
+        client.lookUp(path("file")) shouldBe expected
+        seen shouldBe path("file")
+    }
+
+    @Test
+    fun `lookUpExtended is delegated`() {
+        val expected = lookupExtended("file")
+        var seen: LocalPath? = null
+        val client = FileOpsClient(object : FileOpsConnection.Default() {
+            override fun lookUpExtended(path: LocalPath?): LocalPathLookupExtended {
+                seen = path
+                return expected
+            }
+        })
+
+        client.lookUpExtended(path("file")) shouldBe expected
+        seen shouldBe path("file")
+    }
+
+    @Test
+    fun `du is delegated`() {
+        var seen: LocalPath? = null
+        val client = FileOpsClient(object : FileOpsConnection.Default() {
+            override fun du(path: LocalPath?): Long {
+                seen = path
+                return 1234L
+            }
+        })
+
+        client.du(path("dir")) shouldBe 1234L
+        seen shouldBe path("dir")
+    }
+
+    @Test
+    fun `mkdirs is delegated`() {
+        var seen: LocalPath? = null
+        val client = FileOpsClient(object : FileOpsConnection.Default() {
+            override fun mkdirs(path: LocalPath?): Boolean {
+                seen = path
+                return true
+            }
+        })
+
+        client.mkdirs(path("dir")) shouldBe true
+        seen shouldBe path("dir")
+    }
+
+    @Test
+    fun `createNewFile is delegated`() {
+        var seen: LocalPath? = null
+        val client = FileOpsClient(object : FileOpsConnection.Default() {
+            override fun createNewFile(path: LocalPath?): Boolean {
+                seen = path
+                return true
+            }
+        })
+
+        client.createNewFile(path("file")) shouldBe true
+        seen shouldBe path("file")
+    }
+
+    @Test
+    fun `canRead is delegated`() {
+        var seen: LocalPath? = null
+        val client = FileOpsClient(object : FileOpsConnection.Default() {
+            override fun canRead(path: LocalPath?): Boolean {
+                seen = path
+                return true
+            }
+        })
+
+        client.canRead(path("file")) shouldBe true
+        seen shouldBe path("file")
+    }
+
+    @Test
+    fun `canWrite is delegated`() {
+        var seen: LocalPath? = null
+        val client = FileOpsClient(object : FileOpsConnection.Default() {
+            override fun canWrite(path: LocalPath?): Boolean {
+                seen = path
+                return true
+            }
+        })
+
+        client.canWrite(path("file")) shouldBe true
+        seen shouldBe path("file")
+    }
+
+    @Test
+    fun `exists is delegated`() {
+        var seen: LocalPath? = null
+        val client = FileOpsClient(object : FileOpsConnection.Default() {
+            override fun exists(path: LocalPath?): Boolean {
+                seen = path
+                return true
+            }
+        })
+
+        client.exists(path("file")) shouldBe true
+        seen shouldBe path("file")
+    }
+
+    @Test
+    fun `delete forwards the recursive and dryRun flags`() {
+        val seen = mutableListOf<Triple<LocalPath?, Boolean, Boolean>>()
+        val client = FileOpsClient(object : FileOpsConnection.Default() {
+            override fun delete(path: LocalPath?, recursive: Boolean, dryRun: Boolean): Boolean {
+                seen.add(Triple(path, recursive, dryRun))
+                return true
+            }
+        })
+
+        client.delete(path("file"), recursive = true, dryRun = false) shouldBe true
+        client.delete(path("file"), recursive = false, dryRun = true) shouldBe true
+
+        seen shouldContainExactly listOf(
+            Triple(path("file"), true, false),
+            Triple(path("file"), false, true),
+        )
+    }
+
+    @Test
+    fun `createSymlink forwards link and target in order`() {
+        var seenLink: LocalPath? = null
+        var seenTarget: LocalPath? = null
+        val client = FileOpsClient(object : FileOpsConnection.Default() {
+            override fun createSymlink(linkPath: LocalPath?, targetPath: LocalPath?): Boolean {
+                seenLink = linkPath
+                seenTarget = targetPath
+                return true
+            }
+        })
+
+        client.createSymlink(path("link"), path("target")) shouldBe true
+        seenLink shouldBe path("link")
+        seenTarget shouldBe path("target")
+    }
+
+    @Test
+    fun `setModifiedAt converts the Instant to epoch millis`() {
+        var seenPath: LocalPath? = null
+        var seenStamp: Long? = null
+        val client = FileOpsClient(object : FileOpsConnection.Default() {
+            override fun setModifiedAt(path: LocalPath?, modifiedAt: Long): Boolean {
+                seenPath = path
+                seenStamp = modifiedAt
+                return true
+            }
+        })
+
+        client.setModifiedAt(path("file"), Instant.ofEpochMilli(1_234_567_890L)) shouldBe true
+        seenPath shouldBe path("file")
+        seenStamp shouldBe 1_234_567_890L
+    }
+
+    @Test
+    fun `setPermissions is delegated`() {
+        var seenPath: LocalPath? = null
+        var seenPermissions: Permissions? = null
+        val client = FileOpsClient(object : FileOpsConnection.Default() {
+            override fun setPermissions(path: LocalPath?, permissions: Permissions?): Boolean {
+                seenPath = path
+                seenPermissions = permissions
+                return true
+            }
+        })
+
+        client.setPermissions(path("file"), Permissions(0b111_101_101)) shouldBe true
+        seenPath shouldBe path("file")
+        seenPermissions shouldBe Permissions(0b111_101_101)
+    }
+
+    @Test
+    fun `setOwnership is delegated`() {
+        var seenPath: LocalPath? = null
+        var seenOwnership: Ownership? = null
+        val client = FileOpsClient(object : FileOpsConnection.Default() {
+            override fun setOwnership(path: LocalPath?, ownership: Ownership?): Boolean {
+                seenPath = path
+                seenOwnership = ownership
+                return true
+            }
+        })
+
+        client.setOwnership(path("file"), Ownership(1000L, 1001L)) shouldBe true
+        seenPath shouldBe path("file")
+        seenOwnership shouldBe Ownership(1000L, 1001L)
+    }
+
+    @Test
+    fun `walk rejects options the host can't execute`() {
+        val opened = AtomicInteger()
+        val client = FileOpsClient(object : FileOpsConnection.Default() {
+            override fun walkStream(
+                path: LocalPath?,
+                pathDoesNotContain: MutableList<String>?,
+                followSymlinks: Boolean,
+            ): RemoteInputStream {
+                opened.incrementAndGet()
+                throw IllegalStateException("must not be reached")
+            }
+        })
+
+        // onFilter is a suspend callback, it can't cross the binder.
+        shouldThrow<IllegalArgumentException> {
+            client.walk(
+                path("dir"),
+                APathGateway.WalkOptions(onFilter = { true }),
+            )
+        }
+        opened.get() shouldBe 0
+    }
+
+    @Test
+    fun `walk forwards its options and opens the stream at call time`() {
+        val scope = CoroutineScope(Job() + Dispatchers.IO)
+        try {
+            runBlocking {
+                val lookups = listOf(lookup("file1"), lookup("file2"))
+                val opened = AtomicInteger()
+                var seenPath: LocalPath? = null
+                var seenFilter: List<String>? = null
+                var seenFollow: Boolean? = null
+                val client = FileOpsClient(object : FileOpsConnection.Default() {
+                    override fun walkStream(
+                        path: LocalPath?,
+                        pathDoesNotContain: MutableList<String>?,
+                        followSymlinks: Boolean,
+                    ): RemoteInputStream {
+                        opened.incrementAndGet()
+                        seenPath = path
+                        seenFilter = pathDoesNotContain
+                        seenFollow = followSymlinks
+                        return lookups.asFlow().toRemoteInputStream(scope)
+                    }
+                })
+
+                val flow = client.walk(
+                    path("dir"),
+                    APathGateway.WalkOptions(
+                        pathDoesNotContain = setOf("skipme"),
+                        followSymlinks = true,
+                    ),
+                )
+
+                // Unlike the enumeration flows, walk() reaches through the binder before anyone
+                // collects, so an unconsumed walk already holds an IPC stream.
+                opened.get() shouldBe 1
+                seenPath shouldBe path("dir")
+                seenFilter shouldBe listOf("skipme")
+                seenFollow shouldBe true
+
+                flow.toList() shouldContainExactly lookups
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `a dead binder surfaces as ServiceConnectionLostException`() {
+        val client = FileOpsClient(object : FileOpsConnection.Default() {
+            override fun exists(path: LocalPath?): Boolean = throw DeadObjectException("binder died")
+        })
+
+        shouldThrow<ServiceConnectionLostException> { client.exists(path("file")) }
+    }
+
+    @Test
+    fun `a wrapped host exception is unwrapped into its original type`() {
+        // What FileOpsHost sends over the binder for an IOException (IpcHostModule.wrapToPropagate).
+        val client = FileOpsClient(object : FileOpsConnection.Default() {
+            override fun mkdirs(path: LocalPath?): Boolean =
+                throw UnsupportedOperationException("java.io.IOException: Can't create dir")
+        })
+
+        val thrown = shouldThrow<IOException> { client.mkdirs(path("dir")) }
+        thrown.message shouldBe "Can't create dir"
+        thrown.shouldBeInstanceOf<IOException>()
+    }
+}

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/ipc/FileOpsHostTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/ipc/FileOpsHostTest.kt
@@ -1,0 +1,345 @@
+package eu.darken.sdmse.common.files.local.ipc
+
+import eu.darken.sdmse.common.files.FileType
+import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.funnel.IPCFunnel
+import eu.darken.sdmse.common.ipc.IpcClientModule
+import eu.darken.sdmse.common.pkgs.pkgops.LibcoreTool
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldStartWith
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+import testhelpers.coroutine.TestDispatcherProvider
+import java.io.File
+import java.io.IOException
+import java.nio.file.Files
+
+/**
+ * Covers the privileged-side [FileOpsHost] against a real temp directory.
+ *
+ * Robolectric is mandatory: [FileOpsHost] extends the generated AIDL Binder stub.
+ *
+ * Deliberately NOT covered here, because the underlying `android.system.Os` calls are unavailable
+ * or unshadowed on the JVM (device-only behavior):
+ * - setPermissions / setOwnership (Os.chmod / Os.lchown)
+ * - host-side createSymlink (Os.symlink) — symlink fixtures are created with NIO instead
+ * - symlink-safe recursive deletion (depends on Os.readlink inside deleteRecursivelySafe)
+ * - field-level assertions on lookUpExtended's ownership/permissions (Os.lstat)
+ * - file() handles (needs a ParcelFileDescriptor harness)
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class FileOpsHostTest : BaseTest() {
+
+    private val testDir = Files.createTempDirectory("fileopshost-test").toFile()
+    private val hostJob = Job()
+    private val hostScope = CoroutineScope(hostJob + Dispatchers.IO)
+
+    @After
+    fun cleanup() {
+        // BaseTest's @AfterAll is JUnit5-only. The streaming producers outlive collection, so the
+        // scope's job has to be cancelled AND joined before the fixtures are removed.
+        runBlocking { hostJob.cancelAndJoin() }
+        unmockkAll()
+        testDir.deleteRecursively()
+    }
+
+    private fun host() = FileOpsHost(
+        appScope = hostScope,
+        dispatcherProvider = TestDispatcherProvider(Dispatchers.IO),
+        libcoreTool = mockk<LibcoreTool> {
+            every { getNameForUid(any()) } returns null
+            every { getNameForGid(any()) } returns null
+        },
+        ipcFunnel = mockk<IPCFunnel>(),
+    )
+
+    private fun path(file: File) = LocalPath.build(file)
+
+    @Test
+    fun `mkdirs creates the whole hierarchy`() {
+        val target = File(testDir, "a/b/c")
+
+        host().mkdirs(path(target)) shouldBe true
+
+        target.isDirectory shouldBe true
+        // java.io.File.mkdirs() reports false when there was nothing left to create.
+        host().mkdirs(path(target)) shouldBe false
+    }
+
+    @Test
+    fun `createNewFile creates the file and its missing parents`() {
+        val target = File(testDir, "parent/child/new.txt")
+
+        host().createNewFile(path(target)) shouldBe true
+
+        target.isFile shouldBe true
+        target.parentFile!!.isDirectory shouldBe true
+        // Already there -> nothing created.
+        host().createNewFile(path(target)) shouldBe false
+    }
+
+    @Test
+    fun `delete removes a plain file`() {
+        val target = File(testDir, "victim.txt").apply { writeText("data") }
+
+        host().delete(path(target), recursive = false, dryRun = false) shouldBe true
+
+        target.exists() shouldBe false
+    }
+
+    @Test
+    fun `recursive delete removes a populated tree`() {
+        // Plain files/dirs only: the symlink-safety of deleteRecursivelySafe() rides on Os.readlink,
+        // which is device-only, so it can't be exercised here.
+        val root = File(testDir, "tree").apply { mkdirs() }
+        File(root, "sub/deeper").mkdirs()
+        File(root, "sub/deeper/leaf.txt").writeText("leaf")
+        File(root, "top.txt").writeText("top")
+
+        host().delete(path(root), recursive = true, dryRun = false) shouldBe true
+
+        root.exists() shouldBe false
+    }
+
+    @Test
+    fun `a non-recursive delete of a populated directory fails`() {
+        val root = File(testDir, "keeper").apply { mkdirs() }
+        File(root, "child.txt").writeText("child")
+
+        host().delete(path(root), recursive = false, dryRun = false) shouldBe false
+
+        root.exists() shouldBe true
+    }
+
+    @Test
+    fun `dryRun only probes write access and deletes nothing`() {
+        val target = File(testDir, "dryrun.txt").apply { writeText("data") }
+
+        host().delete(path(target), recursive = true, dryRun = true) shouldBe true
+
+        target.exists() shouldBe true
+        target.readText() shouldBe "data"
+    }
+
+    @Test
+    fun `deleting an absent path is reported as success`() {
+        val target = File(testDir, "never-existed.txt")
+
+        host().delete(path(target), recursive = false, dryRun = false) shouldBe true
+    }
+
+    @Test
+    fun `setModifiedAt applies the epoch millis`() {
+        val target = File(testDir, "touched.txt").apply { writeText("data") }
+        val stamp = 1_000_000_000_000L
+
+        host().setModifiedAt(path(target), stamp) shouldBe true
+
+        target.lastModified() shouldBe stamp
+    }
+
+    @Test
+    fun `exists canRead and canWrite reflect the filesystem`() {
+        val file = File(testDir, "probe.txt").apply { writeText("data") }
+        val dir = File(testDir, "probe-dir").apply { mkdirs() }
+        val missing = File(testDir, "probe-missing")
+        val host = host()
+
+        host.exists(path(file)) shouldBe true
+        host.canRead(path(file)) shouldBe true
+        host.canWrite(path(file)) shouldBe true
+
+        host.exists(path(dir)) shouldBe true
+        host.canRead(path(dir)) shouldBe true
+        host.canWrite(path(dir)) shouldBe true
+
+        host.exists(path(missing)) shouldBe false
+        host.canRead(path(missing)) shouldBe false
+        host.canWrite(path(missing)) shouldBe false
+    }
+
+    @Test
+    fun `du sums every node of the tree`() {
+        val root = File(testDir, "du").apply { mkdirs() }
+        val sub = File(root, "sub").apply { mkdirs() }
+        val fileA = File(root, "a.txt").apply { writeText("aaaa") }
+        val fileB = File(sub, "b.txt").apply { writeText("bbbbbbbb") }
+
+        // The payload byte count alone is not the expectation: directory entries have a
+        // platform-dependent length() that du() includes.
+        val expected = listOf(root, sub, fileA, fileB).sumOf { it.length() }
+
+        host().du(path(root)) shouldBe expected
+    }
+
+    @Test
+    fun `lookUp classifies files, directories and symlinks`() {
+        val file = File(testDir, "lookup.txt").apply { writeText("12345") }
+        val dir = File(testDir, "lookup-dir").apply { mkdirs() }
+        val link = File(testDir, "lookup-link")
+        Files.createSymbolicLink(link.toPath(), file.toPath())
+        val host = host()
+
+        host.lookUp(path(file)).apply {
+            fileType shouldBe FileType.FILE
+            size shouldBe 5L
+            lookedUp shouldBe path(file)
+        }
+
+        host.lookUp(path(dir)).fileType shouldBe FileType.DIRECTORY
+
+        host.lookUp(path(link)).apply {
+            fileType shouldBe FileType.SYMBOLIC_LINK
+            target shouldBe path(file)
+        }
+    }
+
+    @Test
+    fun `lookUp of a missing path fails`() {
+        val thrown = shouldThrow<UnsupportedOperationException> {
+            host().lookUp(path(File(testDir, "gone")))
+        }
+        thrown.message!! shouldStartWith "eu.darken.sdmse.common.files.ReadException: "
+    }
+
+    @Test
+    fun `listFilesStream streams the directory contents`() {
+        val dir = File(testDir, "listing").apply { mkdirs() }
+        File(dir, "a.txt").writeText("a")
+        File(dir, "b.txt").writeText("b")
+        File(dir, "sub").mkdirs()
+
+        runBlocking {
+            val collected = host().listFilesStream(path(dir)).toLocalPathFlow().toList()
+            collected.map { it.name } shouldContainExactlyInAnyOrder listOf("a.txt", "b.txt", "sub")
+        }
+    }
+
+    @Test
+    fun `lookupFilesStream streams lookups for the directory contents`() {
+        val dir = File(testDir, "lookup-listing").apply { mkdirs() }
+        File(dir, "a.txt").writeText("aa")
+        File(dir, "sub").mkdirs()
+
+        runBlocking {
+            val collected = host().lookupFilesStream(path(dir)).toLocalPathLookupFlow().toList()
+            collected.map { it.name } shouldContainExactlyInAnyOrder listOf("a.txt", "sub")
+            collected.single { it.name == "a.txt" }.apply {
+                fileType shouldBe FileType.FILE
+                size shouldBe 2L
+            }
+            collected.single { it.name == "sub" }.fileType shouldBe FileType.DIRECTORY
+        }
+    }
+
+    @Test
+    fun `lookupFilesExtendedStream produces frames for the directory contents`() {
+        val dir = File(testDir, "extended-listing").apply { mkdirs() }
+        File(dir, "a.txt").writeText("a")
+        File(dir, "b.txt").writeText("b")
+
+        runBlocking {
+            val collected = host().lookupFilesExtendedStream(path(dir)).toLocalPathLookupExtendedFlow().toList()
+            // Only the lookup part is asserted, ownership/permissions come from Os.lstat.
+            collected.map { it.name } shouldContainExactlyInAnyOrder listOf("a.txt", "b.txt")
+        }
+    }
+
+    @Test
+    fun `walkStream descends into subdirectories`() {
+        val root = File(testDir, "walk").apply { mkdirs() }
+        File(root, "sub/deeper").mkdirs()
+        File(root, "sub/deeper/leaf.txt").writeText("leaf")
+        File(root, "top.txt").writeText("top")
+
+        runBlocking {
+            val collected = host()
+                .walkStream(path(root), emptyList(), false)
+                .toLocalPathLookupFlow()
+                .toList()
+            collected.map { it.name } shouldContainExactlyInAnyOrder listOf("sub", "deeper", "leaf.txt", "top.txt")
+        }
+    }
+
+    @Test
+    fun `walkStream honors the pathDoesNotContain filter`() {
+        val root = File(testDir, "walk-filtered").apply { mkdirs() }
+        File(root, "skipme/deeper").mkdirs()
+        File(root, "skipme/deeper/leaf.txt").writeText("leaf")
+        File(root, "keep.txt").writeText("keep")
+
+        runBlocking {
+            val collected = host()
+                .walkStream(path(root), listOf("skipme"), false)
+                .toLocalPathLookupFlow()
+                .toList()
+            // Filtered entries are not descended into either.
+            collected.map { it.name } shouldContainExactlyInAnyOrder listOf("keep.txt")
+        }
+    }
+
+    @Test
+    fun `walkStream does not follow symlinked directories when disabled`() {
+        val root = File(testDir, "walk-symlink").apply { mkdirs() }
+        val outside = File(testDir, "outside").apply { mkdirs() }
+        File(outside, "hidden.txt").writeText("hidden")
+        Files.createSymbolicLink(File(root, "link").toPath(), outside.toPath())
+
+        runBlocking {
+            val collected = host()
+                .walkStream(path(root), emptyList(), false)
+                .toLocalPathLookupFlow()
+                .toList()
+            collected.map { it.name } shouldContainExactlyInAnyOrder listOf("link")
+        }
+    }
+
+    @Test
+    fun `an enumeration failure surfaces at collection time, not as a binder throw`() {
+        val missing = File(testDir, "not-a-directory")
+
+        runBlocking {
+            // The stream is handed out fine, the host-side listing only fails once it runs, so the
+            // failure travels as an error frame and is reconstructed by the decoder.
+            val stream = host().lookupFilesStream(path(missing))
+            val thrown = runCatching { stream.toLocalPathLookupFlow().toList() }.exceptionOrNull()
+            thrown.shouldBeInstanceOf<IOException>()
+            thrown.message shouldBe "File does not exist"
+        }
+    }
+
+    @Test
+    fun `host errors are wrapped for the binder and unwrap back into the original type`() {
+        val dir = File(testDir, "existing-dir").apply { mkdirs() }
+
+        // Parcel.writeException() only supports a handful of types, so the host encodes the original
+        // class + message into an UnsupportedOperationException (IpcHostModule.wrapToPropagate).
+        val thrown = shouldThrow<UnsupportedOperationException> {
+            host().createNewFile(path(dir))
+        }
+        thrown.message!! shouldStartWith "java.io.IOException: "
+
+        // ...which the client side turns back into the original exception type.
+        val refined = with(object : IpcClientModule {}) { thrown.refineException() }
+        refined.shouldBeInstanceOf<IOException>()
+        refined.message shouldBe "Can't create file, path exists and is directory: ${path(dir)}"
+    }
+}

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/storage/PathMapperTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/storage/PathMapperTest.kt
@@ -1,0 +1,278 @@
+package eu.darken.sdmse.common.storage
+
+import android.content.ContentResolver
+import android.content.Intent
+import android.content.UriPermission
+import android.net.Uri
+import androidx.core.net.toUri
+import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.files.saf.SAFPath
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import io.mockk.verifyOrder
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+import testhelpers.coroutine.runTest2
+import java.io.File
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class PathMapperTest : BaseTest() {
+
+    private val contentResolver = mockk<ContentResolver>()
+    private val storageManager2 = mockk<StorageManager2>()
+
+    private val primaryTreeUri = "content://com.android.externalstorage.documents/tree/primary%3A".toUri()
+    private val sdcardTreeUri = "content://com.android.externalstorage.documents/tree/1234-5678%3A".toUri()
+
+    private fun volume(directory: String?, treeUri: Uri) = mockk<StorageVolumeX> {
+        every { this@mockk.directory } returns directory?.let { File(it) }
+        every { this@mockk.treeUri } returns treeUri
+    }
+
+    private fun mapper(vararg volumes: StorageVolumeX): PathMapper {
+        every { storageManager2.storageVolumes } returns volumes.toList()
+        return PathMapper(contentResolver, storageManager2)
+    }
+
+    private fun permission(uri: Uri, read: Boolean = true, write: Boolean = true) = mockk<UriPermission> {
+        every { this@mockk.uri } returns uri
+        every { isReadPermission } returns read
+        every { isWritePermission } returns write
+    }
+
+    @Test fun `a path inside a volume maps to a SAF path with the prefix stripped`() = runTest2 {
+        val mapper = mapper(volume("/storage/emulated/0", primaryTreeUri))
+
+        mapper.toSAFPath(LocalPath.build("/storage/emulated/0/Android/data/some.pkg")) shouldBe
+            SAFPath.build(primaryTreeUri, "Android", "data", "some.pkg")
+    }
+
+    @Test fun `a path equal to the volume root maps to the bare tree uri`() = runTest2 {
+        val mapper = mapper(volume("/storage/emulated/0", primaryTreeUri))
+
+        mapper.toSAFPath(LocalPath.build("/storage/emulated/0")) shouldBe SAFPath.build(primaryTreeUri)
+    }
+
+    @Test fun `the matching volume decides the tree uri`() = runTest2 {
+        val mapper = mapper(
+            volume("/storage/emulated/0", primaryTreeUri),
+            volume("/storage/1234-5678", sdcardTreeUri),
+        )
+
+        mapper.toSAFPath(LocalPath.build("/storage/1234-5678/Music")) shouldBe
+            SAFPath.build(sdcardTreeUri, "Music")
+    }
+
+    @Test fun `volumes without a directory are skipped`() = runTest2 {
+        val mapper = mapper(
+            volume(null, sdcardTreeUri),
+            volume("/storage/emulated/0", primaryTreeUri),
+        )
+
+        mapper.toSAFPath(LocalPath.build("/storage/emulated/0/Music")) shouldBe
+            SAFPath.build(primaryTreeUri, "Music")
+    }
+
+    @Test fun `a path outside every volume does not map`() = runTest2 {
+        val mapper = mapper(volume("/storage/emulated/0", primaryTreeUri))
+
+        mapper.toSAFPath(LocalPath.build("/data/data/some.pkg")) shouldBe null
+    }
+
+    @Test fun `a failing volume listing does not map`() = runTest2 {
+        every { storageManager2.storageVolumes } throws IllegalStateException("no volumes for you")
+        val mapper = PathMapper(contentResolver, storageManager2)
+
+        mapper.toSAFPath(LocalPath.build("/storage/emulated/0/Music")) shouldBe null
+    }
+
+    @Test fun `a sibling volume name is matched as a prefix`() = runTest2 {
+        val mapper = mapper(volume("/storage/emulated/0", primaryTreeUri))
+
+        // documents suspect behavior: the volume match is a plain String.startsWith, so
+        // /storage/emulated/01 is treated as being inside /storage/emulated/0. The prefix strip then
+        // doesn't apply either (it looks for a trailing separator), and the whole absolute path ends
+        // up as SAF segments. Correct behavior would be a segment-boundary aware match that returns
+        // null for a sibling volume.
+        mapper.toSAFPath(LocalPath.build("/storage/emulated/01/file")) shouldBe
+            SAFPath.build(primaryTreeUri, "", "storage", "emulated", "01", "file")
+    }
+
+    @Test fun `traversal segments survive the mapping`() = runTest2 {
+        val mapper = mapper(volume("/storage/emulated/0", primaryTreeUri))
+
+        // documents suspect behavior: '..' segments are passed through verbatim instead of being
+        // normalized or rejected, so a path that leaves the volume still maps to a SAF path rooted
+        // at that volume's tree uri.
+        mapper.toSAFPath(LocalPath.build("/storage/emulated/0/Android/../../../etc/hosts")) shouldBe
+            SAFPath.build(primaryTreeUri, "Android", "..", "..", "..", "etc", "hosts")
+    }
+
+    @Test fun `overlapping volume roots are resolved by list order, not by specificity`() = runTest2 {
+        val mapper = mapper(
+            volume("/storage/emulated", sdcardTreeUri),
+            volume("/storage/emulated/0", primaryTreeUri),
+        )
+
+        // documents suspect behavior: firstOrNull() takes whichever volume comes first in the
+        // system's list, so the less specific root wins and the path maps to the wrong tree uri.
+        // Correct behavior would be to pick the longest matching volume root.
+        mapper.toSAFPath(LocalPath.build("/storage/emulated/0/Music")) shouldBe
+            SAFPath.build(sdcardTreeUri, "0", "Music")
+    }
+
+    @Test fun `a SAF path maps back to the volume directory plus its segments`() = runTest2 {
+        val mapper = mapper(volume("/storage/emulated/0", primaryTreeUri))
+
+        mapper.toLocalPath(SAFPath.build(primaryTreeUri, "Android", "data")) shouldBe
+            LocalPath.build("/storage/emulated/0/Android/data")
+    }
+
+    @Test fun `a SAF path without segments maps to the volume directory`() = runTest2 {
+        val mapper = mapper(volume("/storage/emulated/0", primaryTreeUri))
+
+        mapper.toLocalPath(SAFPath.build(primaryTreeUri)) shouldBe LocalPath.build("/storage/emulated/0")
+    }
+
+    @Test fun `an unknown tree uri does not map`() = runTest2 {
+        val mapper = mapper(volume("/storage/emulated/0", primaryTreeUri))
+
+        mapper.toLocalPath(SAFPath.build(sdcardTreeUri, "Music")) shouldBe null
+    }
+
+    @Test fun `a failing volume listing does not map back`() = runTest2 {
+        every { storageManager2.storageVolumes } throws IllegalStateException("no volumes for you")
+        val mapper = PathMapper(contentResolver, storageManager2)
+
+        mapper.toLocalPath(SAFPath.build(primaryTreeUri, "Music")) shouldBe null
+    }
+
+    @Test fun `traversal segments survive the mapping back`() = runTest2 {
+        val mapper = mapper(volume("/storage/emulated/0", primaryTreeUri))
+
+        // documents suspect behavior: the segments are appended verbatim, so a SAF path carrying
+        // '..' resolves to a local path outside the volume it is anchored to.
+        mapper.toLocalPath(SAFPath.build(primaryTreeUri, "..", "..", "etc", "hosts")) shouldBe
+            LocalPath.build("/storage/emulated/0/../../etc/hosts")
+    }
+
+    @Test fun `takePermission persists a read-write grant`() {
+        every { contentResolver.persistedUriPermissions } returns emptyList()
+        every { contentResolver.takePersistableUriPermission(any(), any()) } just runs
+        val mapper = PathMapper(contentResolver, storageManager2)
+
+        mapper.takePermission(primaryTreeUri)
+
+        verify {
+            contentResolver.takePersistableUriPermission(
+                primaryTreeUri,
+                Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION,
+            )
+        }
+    }
+
+    @Test fun `takePermission is skipped when the uri is already persisted`() {
+        every { contentResolver.persistedUriPermissions } returns listOf(permission(primaryTreeUri))
+        val mapper = PathMapper(contentResolver, storageManager2)
+
+        mapper.takePermission(primaryTreeUri)
+
+        verify(exactly = 0) { contentResolver.takePersistableUriPermission(any(), any()) }
+    }
+
+    @Test fun `a failed take releases the grant and rethrows`() {
+        every { contentResolver.persistedUriPermissions } returns emptyList()
+        every { contentResolver.takePersistableUriPermission(any(), any()) } throws SecurityException("nope")
+        every { contentResolver.releasePersistableUriPermission(any(), any()) } just runs
+        val mapper = PathMapper(contentResolver, storageManager2)
+
+        shouldThrow<SecurityException> { mapper.takePermission(primaryTreeUri) }
+
+        verifyOrder {
+            contentResolver.takePersistableUriPermission(primaryTreeUri, any())
+            contentResolver.releasePersistableUriPermission(primaryTreeUri, any())
+        }
+    }
+
+    @Test fun `a failing release during error handling is swallowed`() {
+        every { contentResolver.persistedUriPermissions } returns emptyList()
+        every { contentResolver.takePersistableUriPermission(any(), any()) } throws SecurityException("nope")
+        every {
+            contentResolver.releasePersistableUriPermission(any(), any())
+        } throws SecurityException("nope either")
+        val mapper = PathMapper(contentResolver, storageManager2)
+
+        // The original failure is what callers get to see, not the cleanup failure.
+        shouldThrow<SecurityException> { mapper.takePermission(primaryTreeUri) }.message shouldBe "nope"
+    }
+
+    @Test fun `releasePermission releases the tree root uri`() {
+        every { contentResolver.persistedUriPermissions } returns emptyList()
+        every { contentResolver.releasePersistableUriPermission(any(), any()) } just runs
+        val mapper = PathMapper(contentResolver, storageManager2)
+
+        mapper.releasePermission(SAFPath.build(primaryTreeUri, "Android", "data")) shouldBe true
+
+        verify {
+            contentResolver.releasePersistableUriPermission(
+                primaryTreeUri,
+                Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION,
+            )
+        }
+    }
+
+    @Test fun `getPermissions maps every persisted grant to a SAF path`() {
+        every { contentResolver.persistedUriPermissions } returns listOf(
+            permission(primaryTreeUri),
+            permission(sdcardTreeUri),
+        )
+        val mapper = PathMapper(contentResolver, storageManager2)
+
+        mapper.getPermissions() shouldContainExactly listOf(
+            SAFPath.build(primaryTreeUri),
+            SAFPath.build(sdcardTreeUri),
+        )
+    }
+
+    @Test fun `hasPermission only knows the persisted uris`() {
+        every { contentResolver.persistedUriPermissions } returns listOf(permission(primaryTreeUri))
+        val mapper = PathMapper(contentResolver, storageManager2)
+
+        mapper.hasPermission(primaryTreeUri) shouldBe true
+        mapper.hasPermission(sdcardTreeUri) shouldBe false
+    }
+
+    @Test fun `hasPermission ignores how strong the persisted grant is`() {
+        val mapper = PathMapper(contentResolver, storageManager2)
+
+        // documents suspect behavior: only the uri is compared, the grant's read/write flags are
+        // never looked at. A read-only (or write-only) grant therefore reports as "have permission",
+        // and takePermission() consequently skips upgrading it to the read-write grant the app
+        // needs. Correct behavior would be to require both flags before reporting true.
+        every { contentResolver.persistedUriPermissions } returns listOf(
+            permission(primaryTreeUri, read = true, write = false),
+        )
+        mapper.hasPermission(primaryTreeUri) shouldBe true
+
+        every { contentResolver.persistedUriPermissions } returns listOf(
+            permission(primaryTreeUri, read = false, write = true),
+        )
+        mapper.hasPermission(primaryTreeUri) shouldBe true
+
+        every { contentResolver.persistedUriPermissions } returns listOf(
+            permission(primaryTreeUri, read = true, write = true),
+        )
+        mapper.hasPermission(primaryTreeUri) shouldBe true
+    }
+}


### PR DESCRIPTION
## What changed

No user-facing behavior change. This adds test coverage for the previously untested half of the file access layer: the privileged process that executes root/ADB file operations, the client that talks to it, the gateway dispatcher, and the path mapping between normal and SAF storage access. One small behavior change: creating a symlink across mismatched path types now fails with a clear error instead of an undefined one (no real-world flow does this).

## Technical Context

- Stacked on #2668 (the streaming refactor) and reviewed against its tip; merge that one first.
- 81 new tests: the privileged-side host is tested against a real temp filesystem including its streaming producers and error encoding; the IPC client's full non-streaming surface is tested against a fake connection; the gateway dispatcher's routing and fallback branches are covered including collection-time flow failures; path mapping is covered in both directions.
- Several probes deliberately document current suspect behavior instead of asserting correct behavior, marked "documents suspect behavior" in the code. They confirmed six pre-existing defects kept out of this change's scope: sibling-volume prefix matching and unnormalized ".." traversal in the path mapper, list-order volume resolution, persisted-grant strength being ignored, and two fallback error-reporting inconsistencies in the dispatcher. Each such test flips into a regression test when its defect is fixed.
- Operations backed by android.system.Os (chmod, chown, symlink creation, symlink-safe recursion internals) cannot run under Robolectric; the test files document these as device-only.
- The mixed-path-type symlink guard is the only production change and sits in its own commit.
