### PR TITLE
AppCleaner: Stop waiting on a greyed-out clear cache button

### DIFF
--- a/app-common/src/test/java/eu/darken/sdmse/common/progress/ProgressCountTest.kt
+++ b/app-common/src/test/java/eu/darken/sdmse/common/progress/ProgressCountTest.kt
@@ -1,0 +1,38 @@
+package eu.darken.sdmse.common.progress
+
+import android.content.Context
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class ProgressCountTest : BaseTest() {
+
+    private val context = mockk<Context>(relaxed = true)
+
+    @Test
+    fun `percent rounds up`() {
+        // What the cache clearing overlay shows while stepping through three apps. Rounding up is
+        // why users report "0, then about 30, then about 60" rather than 0/33/66.
+        Progress.Count.Percent(0, 3).displayValue(context) shouldBe "0%"
+        Progress.Count.Percent(1, 3).displayValue(context) shouldBe "34%"
+        Progress.Count.Percent(2, 3).displayValue(context) shouldBe "67%"
+        Progress.Count.Percent(3, 3).displayValue(context) shouldBe "100%"
+    }
+
+    @Test
+    fun `percent handles an empty range`() {
+        Progress.Count.Percent(0, 0).displayValue(context) shouldBe "NaN"
+    }
+
+    @Test
+    fun `counter shows raw values`() {
+        Progress.Count.Counter(1, 3).displayValue(context) shouldBe "1/3"
+    }
+
+    @Test
+    fun `indeterminate and none have nothing to show`() {
+        Progress.Count.Indeterminate().displayValue(context) shouldBe ""
+        Progress.Count.None().displayValue(context) shouldBe null
+    }
+}

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPLabels.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPLabels.kt
@@ -30,8 +30,9 @@ class AOSPLabels @Inject constructor(
     fun getComputingSizeDynamic(acsContext: AutomationExplorer.Context): Set<String> =
         labels29Plus.getComputingSizeDynamic(acsContext)
 
-    // The storage page renders the cache size on every API level we support, the resource name
-    // has not changed, so there is no pre-29 variant to fall back to.
+    // No pre-29 variant: AOSPLabels14Plus has no cache size accessor to fall back to. Whether
+    // cache_size_label resolves on API 26-28 is untested; if it doesn't, the static default is
+    // used, and if that matches nothing the caller reads it as "unknown" and behaves as before.
     fun getCacheSizeLabelDynamic(acsContext: AutomationExplorer.Context): Set<String> =
         labels29Plus.getCacheSizeLabelDynamic(acsContext)
 

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPLabels.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPLabels.kt
@@ -30,6 +30,14 @@ class AOSPLabels @Inject constructor(
     fun getComputingSizeDynamic(acsContext: AutomationExplorer.Context): Set<String> =
         labels29Plus.getComputingSizeDynamic(acsContext)
 
+    // The storage page renders the cache size on every API level we support, the resource name
+    // has not changed, so there is no pre-29 variant to fall back to.
+    fun getCacheSizeLabelDynamic(acsContext: AutomationExplorer.Context): Set<String> =
+        labels29Plus.getCacheSizeLabelDynamic(acsContext)
+
+    fun getCacheSizeLabelStatic(acsContext: AutomationExplorer.Context): Set<String> =
+        labels29Plus.getCacheSizeLabelStatic(acsContext)
+
     fun getClearCacheDynamic(acsContext: AutomationExplorer.Context): Set<String> = when {
         hasApiLevel(29) -> labels29Plus.getClearCacheDynamic(acsContext)
         else -> labels14Plus.getClearCacheDynamic(acsContext)

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPLabels29Plus.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPLabels29Plus.kt
@@ -136,6 +136,17 @@ class AOSPLabels29Plus @Inject constructor(
         acsContext: AutomationExplorer.Context,
     ): Set<String> = acsContext.getStrings(SETTINGS_PKG, setOf("computing_size"))
 
+    // Title of the "Cache" row on an app's storage page, i.e. the label next to the cache size.
+    // Not a button, we only read it to locate the size value.
+    fun getCacheSizeLabelDynamic(
+        acsContext: AutomationExplorer.Context,
+    ): Set<String> = acsContext.getStrings(SETTINGS_PKG, setOf("cache_size_label"))
+
+    // Deliberately just the AOSP default: this only ever narrows down which row to read, and a
+    // label that matches nothing falls back to the existing behaviour. A speculative translation
+    // that matched the wrong row would instead make us read the wrong size.
+    fun getCacheSizeLabelStatic(acsContext: AutomationExplorer.Context): Set<String> = setOf("Cache")
+
     fun getClearCacheDynamic(acsContext: AutomationExplorer.Context): Set<String> =
         aospLabels14Plus.getClearCacheDynamic(acsContext)
 

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecs.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecs.kt
@@ -10,11 +10,11 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.appcleaner.R
+import eu.darken.sdmse.appcleaner.core.automation.errors.LockedAppCacheException
 import eu.darken.sdmse.appcleaner.core.automation.specs.AppCleanerSpecGenerator
 import eu.darken.sdmse.appcleaner.core.automation.specs.StorageEntryFinder
 import eu.darken.sdmse.appcleaner.core.automation.specs.clickClearCache
 import eu.darken.sdmse.automation.core.common.ACSNodeInfo
-import eu.darken.sdmse.automation.core.errors.StepAbortException
 import eu.darken.sdmse.automation.core.common.contentDescMatches
 import eu.darken.sdmse.automation.core.common.crawl
 import eu.darken.sdmse.automation.core.common.isClickyButton
@@ -29,6 +29,7 @@ import eu.darken.sdmse.automation.core.common.stepper.findNodeByContentDesc
 import eu.darken.sdmse.automation.core.common.stepper.findNodeByLabel
 import eu.darken.sdmse.automation.core.common.stepper.waitForLayoutStability
 import eu.darken.sdmse.automation.core.common.textMatches
+import eu.darken.sdmse.automation.core.errors.StepAbortException
 import eu.darken.sdmse.automation.core.input.InputInjector
 import eu.darken.sdmse.automation.core.specs.AutomationExplorer
 import eu.darken.sdmse.automation.core.specs.AutomationSpec
@@ -48,6 +49,7 @@ import eu.darken.sdmse.common.device.RomType
 import eu.darken.sdmse.common.funnel.IPCFunnel
 import eu.darken.sdmse.common.hasApiLevel
 import eu.darken.sdmse.common.pkgs.features.Installed
+import eu.darken.sdmse.common.pkgs.isSystemApp
 import eu.darken.sdmse.common.pkgs.toPkgId
 import eu.darken.sdmse.common.progress.withProgress
 import eu.darken.sdmse.common.ui.SizeParser
@@ -128,6 +130,34 @@ class AOSPSpecs @Inject constructor(
         }
 
         return null
+    }
+
+    /**
+     * Reads the cache size Settings itself shows on the app's storage page.
+     *
+     * Returns null when the row can't be located or its value can't be parsed, which includes the
+     * "still calculating" state, so callers must treat null as "don't know" and never as "not zero".
+     */
+    private suspend fun StepContext.readCacheRowSize(
+        cacheSizeLabels: Collection<String>,
+        sizeParser: SizeParser?,
+    ): Long? {
+        if (sizeParser == null) {
+            log(tag, WARN) { "readCacheRowSize(): SizeParser unavailable" }
+            return null
+        }
+        val title = findNodeByLabel(cacheSizeLabels) { it.viewIdResourceName == ROW_TITLE_ID }
+        if (title == null) {
+            log(tag, VERBOSE) { "readCacheRowSize(): no cache row title" }
+            return null
+        }
+        val raw = title.findRowSummaryText()
+        if (raw == null) {
+            log(tag, VERBOSE) { "readCacheRowSize(): cache row has no summary" }
+            return null
+        }
+        return runCatching { sizeParser.parse(raw) }.getOrNull()
+            .also { log(tag, INFO) { "readCacheRowSize(): '$raw' -> $it" } }
     }
 
     private suspend fun StepContext.validateClickEffect(
@@ -514,6 +544,10 @@ class AOSPSpecs @Inject constructor(
                 aospLabels.getClearCacheDynamic(this) + aospLabels.getClearCacheStatic(this)
             log(TAG) { "clearCacheButtonLabels=${clearCacheButtonLabels.toVisualStrings()}" }
 
+            val cacheSizeLabels =
+                aospLabels.getCacheSizeLabelDynamic(this) + aospLabels.getCacheSizeLabelStatic(this)
+            log(TAG) { "cacheSizeLabels=${cacheSizeLabels.toVisualStrings()}" }
+
             val canInjectInput = inputInjector.canInject()
             log(TAG, INFO) { "InputInjector available? (canInjectInput=$canInjectInput)" }
 
@@ -530,6 +564,8 @@ class AOSPSpecs @Inject constructor(
 
             var nodeActionAttempts = 0
             var dpadExhausted = false
+            var sizeParser: SizeParser? = null
+            val verdictConfirmer = VerdictConfirmer()
             val nodeAction: suspend StepContext.() -> Boolean = action@{
                 val attempt = nodeActionAttempts++
                 val candidate = findClearCacheCandidate(clearCacheButtonLabels)
@@ -541,6 +577,41 @@ class AOSPSpecs @Inject constructor(
                         return@action clickClearCache(isDryRun = Bugs.isDryRun, pkg = pkg, node = target)
                     }
                     log(tag, WARN) { "Could not resolve clickable target from: $candidate" }
+                }
+
+                // No clickable "Clear cache" anywhere. Settings renders the cache size on this very
+                // screen though, so read it instead of polling for a button that may not exist:
+                // an already empty cache leaves the button greyed out, or - as on Hello UI /
+                // Android 17 - collapsed to zero height with no text and no content-desc, in which
+                // case findClearCacheCandidate can never match it and we would just run out the
+                // step timeout. Unlike the DPAD fallback below this only reads the screen, never
+                // blind-clicks, so it is safe on every ROM.
+                // Both crawls are expensive and this loop runs ~10x/s, so don't do it every pass.
+                // A terminal verdict needs two of these in a row, so it lands after ~1.2s.
+                if (attempt >= CACHE_SIZE_CHECK_MIN_ATTEMPTS &&
+                    (attempt - CACHE_SIZE_CHECK_MIN_ATTEMPTS) % CACHE_SIZE_CHECK_INTERVAL == 0
+                ) {
+                    if (sizeParser == null) sizeParser = runCatching { SizeParser(host.service) }.getOrNull()
+                    val cacheSize = readCacheRowSize(cacheSizeLabels, sizeParser)
+                    val verdict = noButtonVerdict(cacheSize, pkg.isSystemApp, useDpadFallback)
+                    when (verdictConfirmer.confirm(verdict)) {
+                        NoButtonVerdict.KEEP_TRYING -> {
+                            log(tag, VERBOSE) { "$verdict, cacheSize=$cacheSize (attempt=$attempt)" }
+                        }
+
+                        NoButtonVerdict.ALREADY_EMPTY -> {
+                            log(tag, INFO) { "Settings reports an empty cache, nothing left to clear" }
+                            throw StepAbortException(
+                                "Cache is already empty for ${pkg.installId}",
+                                treatAsSuccess = true,
+                            )
+                        }
+
+                        NoButtonVerdict.NO_BUTTON -> {
+                            log(tag, WARN) { "No clear cache button, but $cacheSize bytes of cache" }
+                            throw LockedAppCacheException("No clear cache button: ${pkg.installId}")
+                        }
+                    }
                 }
 
                 // DPAD fallback: try text search a few times first for AOSP ROMs with accessible buttons,
@@ -579,6 +650,13 @@ class AOSPSpecs @Inject constructor(
 
     companion object {
         val SETTINGS_PKG = "com.android.settings".toPkgId()
+
+        // Give the button a couple of passes to show up before we start reading sizes, and then
+        // only read about once per second: nodeAction is retried every 100ms and each check
+        // crawls the whole window.
+        private const val CACHE_SIZE_CHECK_MIN_ATTEMPTS = 2
+        private const val CACHE_SIZE_CHECK_INTERVAL = 10
+
         private val TAG: String = logTag("AppCleaner", "Automation", "AOSP", "Specs")
     }
 

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/ClearCacheButtonVerdict.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/ClearCacheButtonVerdict.kt
@@ -1,0 +1,54 @@
+package eu.darken.sdmse.appcleaner.core.automation.specs.aosp
+
+internal enum class NoButtonVerdict {
+    /** Not enough information yet, let the step keep polling. */
+    KEEP_TRYING,
+
+    /** Settings says the cache is empty, so there is nothing left for us to click. */
+    ALREADY_EMPTY,
+
+    /** There is cache, the page has rendered, and the button still isn't there. */
+    NO_BUTTON,
+}
+
+/**
+ * Decides what to do when the storage page is up but no clickable "Clear cache" was found.
+ *
+ * [cacheSize] is what Settings itself prints in the cache row, null when that could not be read or
+ * parsed. Null must never be read as "not zero": it also covers the "calculating…" state.
+ */
+internal fun noButtonVerdict(
+    cacheSize: Long?,
+    isSystemApp: Boolean,
+    useDpadFallback: Boolean,
+): NoButtonVerdict = when {
+    cacheSize == null -> NoButtonVerdict.KEEP_TRYING
+    cacheSize == 0L -> NoButtonVerdict.ALREADY_EMPTY
+    // The DPAD fallback exists because the button is deliberately invisible to us on those
+    // devices, so its absence from the tree proves nothing until DPAD has had its turn.
+    useDpadFallback -> NoButtonVerdict.KEEP_TRYING
+    // Same verdict clickClearCache reaches when it does find a disabled button on a system app.
+    // For a normal app a missing button is more likely a screen we haven't understood, so we
+    // keep polling rather than declare it unclearable.
+    isSystemApp -> NoButtonVerdict.NO_BUTTON
+    else -> NoButtonVerdict.KEEP_TRYING
+}
+
+/**
+ * Holds a terminal verdict back until the same one is reached twice in a row.
+ *
+ * Finding the button and reading the size are two separate crawls of a screen that may still be
+ * settling, so a single observation can be stale in both directions: a button that renders a moment
+ * later would be declared missing, and a row still showing a placeholder zero would be declared
+ * empty. Requiring two passes costs about a second and means the button search ran again in
+ * between, since each pass starts with it.
+ */
+internal class VerdictConfirmer {
+    private var previous: NoButtonVerdict? = null
+
+    fun confirm(verdict: NoButtonVerdict): NoButtonVerdict {
+        val confirmed = verdict != NoButtonVerdict.KEEP_TRYING && verdict == previous
+        previous = verdict
+        return if (confirmed) verdict else NoButtonVerdict.KEEP_TRYING
+    }
+}

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/StorageRowReader.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/StorageRowReader.kt
@@ -1,0 +1,28 @@
+package eu.darken.sdmse.appcleaner.core.automation.specs.aosp
+
+import eu.darken.sdmse.automation.core.common.ACSNodeInfo
+import eu.darken.sdmse.automation.core.common.children
+
+internal const val ROW_TITLE_ID = "android:id/title"
+internal const val ROW_SUMMARY_ID = "android:id/summary"
+
+/**
+ * Reads the value of the storage row this title belongs to.
+ *
+ * Rows are usually `container(title, summary)`, but some ROMs wrap the title one level deeper (see
+ * StorageEntryFinderTest), so walk up until a container holds the summary. Only direct children are
+ * considered at each level, so a container holding several rows can't leak a neighbour's value: our
+ * own summary sits deeper and would have matched first.
+ */
+internal fun ACSNodeInfo.findRowSummaryText(maxAscend: Int = 2): String? {
+    var current: ACSNodeInfo? = parent
+    repeat(maxAscend) {
+        val container = current ?: return null
+        container.children()
+            .firstOrNull { it.viewIdResourceName == ROW_SUMMARY_ID }
+            ?.text?.toString()
+            ?.let { return it }
+        current = container.parent
+    }
+    return null
+}

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/AppScanner.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/AppScanner.kt
@@ -532,7 +532,9 @@ class AppScanner @Inject constructor(
             .filter { it.userHandle == currentUser.handle }
             .filterIsInstance<NormalPkg>()
 
-        updateProgressCount(Progress.Count.Percent(pkgs.size))
+        // targets, not pkgs: the loop below increments once per target, so sizing the bar by the
+        // unfiltered package count leaves it short of 100% before it disappears.
+        updateProgressCount(Progress.Count.Percent(targets.size))
 
         return targets
             .mapNotNull {

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/ClearCacheButtonVerdictTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/ClearCacheButtonVerdictTest.kt
@@ -1,0 +1,88 @@
+package eu.darken.sdmse.appcleaner.core.automation.specs.aosp
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+/**
+ * Covers what AOSPSpecs does when the app's storage page is up but no clickable "Clear cache"
+ * exists in the accessibility tree.
+ *
+ * Motivating report: a Motorola Hello UI device on Android 17 where four system apps whose caches
+ * were already empty each cost 30s. Settings printed "Cache / 0 byte" and rendered the clear-cache
+ * row as a disabled, zero-height LinearLayout with no text and no content-desc, so it could never
+ * be matched and the step just ran out its timeout.
+ */
+class ClearCacheButtonVerdictTest : BaseTest() {
+
+    @Test
+    fun `an empty cache means there is nothing left to click`() {
+        noButtonVerdict(cacheSize = 0L, isSystemApp = true, useDpadFallback = false) shouldBe
+            NoButtonVerdict.ALREADY_EMPTY
+    }
+
+    @Test
+    fun `an empty cache short-circuits before the DPAD fallback too`() {
+        noButtonVerdict(cacheSize = 0L, isSystemApp = false, useDpadFallback = true) shouldBe
+            NoButtonVerdict.ALREADY_EMPTY
+    }
+
+    @Test
+    fun `an unreadable cache size is never treated as non-empty`() {
+        noButtonVerdict(cacheSize = null, isSystemApp = true, useDpadFallback = false) shouldBe
+            NoButtonVerdict.KEEP_TRYING
+    }
+
+    @Test
+    fun `a system app with cache and no button is unclearable`() {
+        noButtonVerdict(cacheSize = 143360L, isSystemApp = true, useDpadFallback = false) shouldBe
+            NoButtonVerdict.NO_BUTTON
+    }
+
+    @Test
+    fun `a normal app with cache and no button keeps polling`() {
+        noButtonVerdict(cacheSize = 143360L, isSystemApp = false, useDpadFallback = false) shouldBe
+            NoButtonVerdict.KEEP_TRYING
+    }
+
+    @Test
+    fun `a missing button proves nothing while DPAD is still in play`() {
+        noButtonVerdict(cacheSize = 143360L, isSystemApp = true, useDpadFallback = true) shouldBe
+            NoButtonVerdict.KEEP_TRYING
+    }
+
+    @Test
+    fun `a terminal verdict is held back until it repeats`() {
+        val confirmer = VerdictConfirmer()
+
+        confirmer.confirm(NoButtonVerdict.ALREADY_EMPTY) shouldBe NoButtonVerdict.KEEP_TRYING
+        confirmer.confirm(NoButtonVerdict.ALREADY_EMPTY) shouldBe NoButtonVerdict.ALREADY_EMPTY
+    }
+
+    @Test
+    fun `a verdict that does not repeat is discarded`() {
+        val confirmer = VerdictConfirmer()
+
+        // The screen was still settling: first pass saw no cache row, second saw an empty one.
+        confirmer.confirm(NoButtonVerdict.ALREADY_EMPTY) shouldBe NoButtonVerdict.KEEP_TRYING
+        confirmer.confirm(NoButtonVerdict.KEEP_TRYING) shouldBe NoButtonVerdict.KEEP_TRYING
+        confirmer.confirm(NoButtonVerdict.ALREADY_EMPTY) shouldBe NoButtonVerdict.KEEP_TRYING
+        confirmer.confirm(NoButtonVerdict.ALREADY_EMPTY) shouldBe NoButtonVerdict.ALREADY_EMPTY
+    }
+
+    @Test
+    fun `two different terminal verdicts do not confirm each other`() {
+        val confirmer = VerdictConfirmer()
+
+        confirmer.confirm(NoButtonVerdict.ALREADY_EMPTY) shouldBe NoButtonVerdict.KEEP_TRYING
+        confirmer.confirm(NoButtonVerdict.NO_BUTTON) shouldBe NoButtonVerdict.KEEP_TRYING
+        confirmer.confirm(NoButtonVerdict.NO_BUTTON) shouldBe NoButtonVerdict.NO_BUTTON
+    }
+
+    @Test
+    fun `keep trying never confirms itself into an action`() {
+        val confirmer = VerdictConfirmer()
+
+        repeat(5) { confirmer.confirm(NoButtonVerdict.KEEP_TRYING) shouldBe NoButtonVerdict.KEEP_TRYING }
+    }
+}

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/StorageRowReaderTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/StorageRowReaderTest.kt
@@ -1,0 +1,90 @@
+package eu.darken.sdmse.appcleaner.core.automation.specs.aosp
+
+import eu.darken.sdmse.automation.core.common.ACSNodeInfo
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+/**
+ * Covers reading the value out of a Settings storage row.
+ *
+ * The shapes here are taken from real accessibility dumps: the flat one from the Motorola Hello UI
+ * (Android 17) report that motivated this, the nested one from the Samsung layout already modelled
+ * in StorageEntryFinderTest, where the title sits one level deeper than the summary.
+ */
+class StorageRowReaderTest : BaseTest() {
+
+    private fun textNode(viewId: String?, text: String?) = mockk<ACSNodeInfo>(relaxed = true).also {
+        every { it.viewIdResourceName } returns viewId
+        every { it.text } returns text
+        every { it.childCount } returns 0
+        every { it.getChild(any()) } returns null
+    }
+
+    private fun container(vararg kids: ACSNodeInfo) = mockk<ACSNodeInfo>(relaxed = true).also { parent ->
+        every { parent.viewIdResourceName } returns null
+        every { parent.text } returns null
+        every { parent.childCount } returns kids.size
+        every { parent.getChild(any()) } answers { kids.getOrNull(firstArg()) }
+        kids.forEach { kid -> every { kid.parent } returns parent }
+    }
+
+    @Test
+    fun `reads the value from a flat row`() {
+        val title = textNode(ROW_TITLE_ID, "Cache")
+        val summary = textNode(ROW_SUMMARY_ID, "0 byte")
+        container(title, summary)
+
+        title.findRowSummaryText() shouldBe "0 byte"
+    }
+
+    @Test
+    fun `reads the value when the title is nested one level deeper`() {
+        val title = textNode(ROW_TITLE_ID, "Cache")
+        val titleHolder = container(title)
+        val summary = textNode(ROW_SUMMARY_ID, "0 byte")
+        container(titleHolder, summary)
+
+        title.findRowSummaryText() shouldBe "0 byte"
+    }
+
+    @Test
+    fun `gives up rather than reaching further than allowed`() {
+        val title = textNode(ROW_TITLE_ID, "Cache")
+        val inner = container(title)
+        val middle = container(inner)
+        val summary = textNode(ROW_SUMMARY_ID, "0 byte")
+        container(middle, summary)
+
+        title.findRowSummaryText() shouldBe null
+    }
+
+    @Test
+    fun `returns null when the row has no value`() {
+        val title = textNode(ROW_TITLE_ID, "Cache")
+        container(title)
+
+        title.findRowSummaryText() shouldBe null
+    }
+
+    @Test
+    fun `returns null when the title has no parent at all`() {
+        val title = textNode(ROW_TITLE_ID, "Cache").also { every { it.parent } returns null }
+
+        title.findRowSummaryText() shouldBe null
+    }
+
+    @Test
+    fun `does not pick up a neighbouring row's value`() {
+        val title = textNode(ROW_TITLE_ID, "Cache")
+        val ownRow = container(title)
+        val otherTitle = textNode(ROW_TITLE_ID, "Total")
+        val otherSummary = textNode(ROW_SUMMARY_ID, "17,35 MB")
+        val otherRow = container(otherTitle, otherSummary)
+        container(ownRow, otherRow)
+
+        title.findRowSummaryText() shouldBe null
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/common/DashboardProgress.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/common/DashboardProgress.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -100,6 +101,7 @@ internal fun DashboardProgress(progress: Progress.Data) {
             is Progress.Count.Size -> {
                 Spacer(modifier = Modifier.width(12.dp))
                 val isDeterminate = count.current > 0L && count.max > 0L
+                val context = LocalContext.current
                 Box(modifier = Modifier.size(32.dp)) {
                     if (isDeterminate) {
                         val fraction = (count.current.toFloat() / count.max.toFloat()).coerceIn(0f, 1f)
@@ -108,8 +110,15 @@ internal fun DashboardProgress(progress: Progress.Data) {
                             modifier = Modifier.matchParentSize(),
                             strokeWidth = 2.5.dp,
                         )
+                        // Percent renders itself, so the card agrees with the tool screen and the
+                        // automation overlay instead of flooring where they round up. Counter and
+                        // Size display as "3/10" and "1.2 MB/5 MB", which doesn't fit inside the
+                        // ring, so they keep showing a percentage of their own.
                         Text(
-                            text = "${(count.current * 100 / count.max).toInt()}%",
+                            text = when (count) {
+                                is Progress.Count.Percent -> count.displayValue(context)
+                                else -> "${(count.current * 100 / count.max).toInt()}%"
+                            },
                             style = MaterialTheme.typography.labelSmall.copy(fontSize = 9.sp),
                             modifier = Modifier.align(Alignment.Center),
                         )

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecsTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecsTest.kt
@@ -51,6 +51,8 @@ class AOSPSpecsTest : BaseAppCleanerSpecTest<AOSPSpecs, AOSPLabels>() {
         every { labels.getComputingSizeDynamic(any()) } returns emptySet()
         every { labels.getClearCacheDynamic(any()) } returns emptySet()
         every { labels.getClearCacheStatic(any()) } returns setOf("Clear cache")
+        every { labels.getCacheSizeLabelDynamic(any()) } returns emptySet()
+        every { labels.getCacheSizeLabelStatic(any()) } returns setOf("Cache")
     }
 
     @BeforeEach


### PR DESCRIPTION
## What changed

When SD Maid clears caches through the accessibility service, it could get stuck for 30 seconds on every app whose cache Android had already emptied. It opened the app's Settings page, looked for a "Clear cache" button that Android greys out when there is nothing left to clear, and waited out its timeout before moving on. A user on a Motorola running Android 17 lost two minutes to four such apps in a single run, and the progress ring drawn over the Settings screen sat frozen on one value for each of them.

SD Maid now reads the cache size that Settings itself shows on that page, and moves on immediately when it says the cache is empty. Those apps also stop being advertised as having something left to free.

Two smaller progress display fixes come along with it: the app scan's ring could stop short of full before disappearing, and the dashboard card showed a slightly different percentage than the tool screen and the automation overlay for the same run.

## Technical Context

- Root cause: on this ROM the clear-cache row renders as a disabled, zero-height `LinearLayout` with no text and no content-desc, so `AOSPSpecs.findClearCacheCandidate` (text and content-desc only) can never match it. `nodeAction` returns false until the 15s step timeout, retries once, then hits the 30s plan timeout. Measured 30027/30033/30032/30029 ms across the four apps.
- The information needed to bail out was already on screen but out of reach: `takeStorageSnapshot` parses those size rows and `StorageSnapshotDelta` has a `SKIP_SUCCESS` "cache already zero" verdict, but both are reachable only from the DPAD fallback, which 382fa24f1 deliberately restricted to Google devices because that path blind-clicks and could hit "Clear storage" instead. The new check only reads the screen, so it is ROM-neutral and that gate is left alone.
- Reuses `LockedAppCacheException` rather than adding a type: `AppCleanerSpecGeneratorExtensions` already throws it for the same verdict via the route where a disabled button *is* found, and `AppJunk.isUnclearable` already accepts it, so the dashboard stops offering those bytes.
- Worth close review: `VerdictConfirmer` in `ClearCacheButtonVerdict.kt` and the two-level ascent in `findRowSummaryText`. Finding the button and reading the size are two separate crawls of a screen that may still be settling, so a terminal verdict has to repeat before it acts; and some ROMs nest the row title one level deeper than the summary (see `StorageEntryFinderTest`). On a Pixel 7a (Android 16), with the candidate search stubbed out to reproduce the textless-button tree, the reader resolved the label and parsed the live Settings values correctly at two unit scales (`'327 MB' -> 327000000`, `'803 kB' -> 803000`), picking the cache row rather than app size or total.
- Scope: the fast-fail verdict is limited to system apps, mirroring the existing disabled-button branch, so a user app with an unmatchable button still runs to the timeout as it does today. This also does not address why `StorageStatsManager` still reported non-zero `cacheBytes` after `trimCaches`, which is what routes these apps to automation in the first place; 423d84243 covers that separately.
