### PR TITLE
Fix: SD Maid kept watching screen activity after finishing automation

### DIFF
--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/AutomationService.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/AutomationService.kt
@@ -460,6 +460,13 @@ class AutomationService : AccessibilityService(), AutomationHost, AutomationServ
             } finally {
                 withContext(NonCancellable) {
                     updateProgress { null }
+                    // Mirror of the reset before the task: modules widen the accessibility config
+                    // (e.g. ClearCacheModule uses TYPES_ALL_MASK) and without this the service stays
+                    // subscribed to every event on the device for the rest of the process lifetime,
+                    // even though onAccessibilityEvent() drops them all while no task is active.
+                    // Before removing the controlView, so the overlay is hidden while still attached.
+                    runCatching { changeOptions { AutomationHost.Options() } }
+                        .onFailure { log(TAG, WARN) { "submit($id): Failed to restore options: ${it.asLog()}" } }
                     optionsLock.withLock {
                         val viewToRemove = controlView!!
                         val lifecycleToDispose = overlayLifecycle


### PR DESCRIPTION
## What changed

When SD Maid uses the accessibility service to do things for you, like tapping "Clear cache" on each app's settings page or force-stopping an app, it has to ask Android to send it everything happening on screen so it can find the right buttons.

It never asked Android to stop again once the job was finished. So for as long as SD Maid stayed running in the background afterwards, the system kept forwarding every screen event on the device to it, and SD Maid threw all of them away because it had nothing to do with them. That was pure wasted work, and on weaker devices wasted work costs battery.

SD Maid now returns to its idle, minimal configuration as soon as an automated job ends, whether the job succeeded, failed, or was cancelled.

## Technical Context

- Root cause is an asymmetry that crept in over two commits: `changeOptions()` originally configured only the overlay, and `56e01248f` added a reset at task *start* for overlay-lifecycle reasons. `fce96e653` had already threaded `serviceInfo` assignment into `changeOptions()` so the dynamic flags would apply at all, but no matching restore at task *end* was ever added. Three modules widen the config today (`ClearCacheModule`, `AppControlAutomation`, `DebugTaskModule`), all via the same central path.
- The restore reuses `AutomationHost.Options()`, the same default already applied at task start, rather than hand-rolling an "idle" config. A second definition of what idle means is exactly how this bug arose, and would let a future field added to `Options` regress it again.
- Placement before the controlView removal is deliberate: the overlay is then still attached, so `updateOverlay()` does its normal work. After removal it would log a misleading "controlView was null" warning into every debug log, and `changeOptions()`'s 200ms settle delay would have nothing to settle.
- The `runCatching` intentionally does not rethrow `CancellationException`. Rethrowing would skip the controlView removal and `currentTask` clearing immediately below it, trading a config leak for a window leak.
- Worth close review: this sits inside `withContext(NonCancellable)` and must stay *outside* the following `optionsLock.withLock` block, since `changeOptions()` takes that same non-reentrant mutex. Also unaddressed here and pre-existing: a cancelled `submit()` caller releases `taskLock` while its service-owned task keeps running, so two tasks can overlap and a finishing task's teardown can disturb its successor. That path already removes the successor's overlay today; this change adds the config reset to what it can disturb.
