### PR TITLE
Fix: Match storage paths to the correct volume during SAF access

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/storage/PathMapper.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/storage/PathMapper.kt
@@ -6,6 +6,7 @@ import dagger.Reusable
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
@@ -27,24 +28,34 @@ class PathMapper @Inject constructor(
 
     suspend fun toSAFPath(localPath: LocalPath): SAFPath? {
         return try {
-            val osStorage = storageManager2.storageVolumes
+            // StorageVolumeX.directory is a live reflection backed getter, a second read can race an unmount
+            val volumes = storageManager2.storageVolumes
                 .onEach { log(TAG, VERBOSE) { "Trying to match volume $it against $localPath" } }
-                .filter { it.directory != null }
-                .firstOrNull { localPath.path.startsWith(it.directory!!.path) }
-                ?.also { log(TAG, VERBOSE) { "Target storageVolumes for $localPath is $it" } }
+                .mapNotNull { volume -> volume.directory?.let { volume to it } }
+
+            // Most specific volume wins. Volumes sharing a directory resolve to the first of them (list order).
+            // A volume directory of "/" isn't covered by the containment check, no storage volume mounts there.
+            val (osStorage, directory) = volumes
+                .filter { (_, dir) ->
+                    localPath.path == dir.path || localPath.path.startsWith("${dir.path}${File.separatorChar}")
+                }
+                .maxByOrNull { (_, dir) -> dir.path.length }
+                ?.also { log(TAG, VERBOSE) { "Target storageVolumes for $localPath is ${it.first}" } }
                 ?: return null
 
-            val prefixFreeFile = if (osStorage.directory!!.path != localPath.path) {
-                localPath.path.replace("${osStorage.directory!!.path}${File.separatorChar}", "")
-            } else {
-                // Permission is equal to path
-                ""
-            }
+            val prefixFreeFile = localPath.path
+                .substring(directory.path.length)
+                .trimStart(File.separatorChar)
 
             val segments = if (prefixFreeFile.isEmpty()) {
                 emptyList()
             } else {
                 prefixFreeFile.split(File.separator)
+            }
+
+            if (segments.hasTraversal()) {
+                log(TAG, WARN) { "Traversal components in $localPath, refusing to map" }
+                return null
             }
 
             SAFPath.build(
@@ -68,12 +79,25 @@ class PathMapper @Inject constructor(
                 ?.also { log(TAG) { "Target storageVolumes for $safPath is $it" } }
                 ?: return null
 
+            if (safPath.segments.hasTraversal()) {
+                log(TAG, WARN) { "Traversal components in $safPath, refusing to map" }
+                return null
+            }
+
             osStorage.directory?.toLocalPath()?.child(*safPath.segments.toTypedArray())
         } catch (e: Exception) {
             log(TAG, ERROR) { "Failed to map $safPath:${e.asLog()}" }
             null
         }
     }
+
+    /**
+     * A single segment can carry embedded separators, java.io.File acts on those, so check the effective components.
+     */
+    private fun List<String>.hasTraversal(): Boolean = this
+        .flatMap { it.split(File.separatorChar) }
+        .filter { it.isNotEmpty() }
+        .any { it == ".." || it == "." }
 
     fun takePermission(uri: Uri) {
         log(TAG, VERBOSE) { "takePermission(path=$uri)" }

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/storage/PathMapperTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/storage/PathMapperTest.kt
@@ -97,39 +97,58 @@ class PathMapperTest : BaseTest() {
         mapper.toSAFPath(LocalPath.build("/storage/emulated/0/Music")) shouldBe null
     }
 
-    @Test fun `a sibling volume name is matched as a prefix`() = runTest2 {
+    @Test fun `a sibling volume name is not matched as a prefix`() = runTest2 {
         val mapper = mapper(volume("/storage/emulated/0", primaryTreeUri))
 
-        // documents suspect behavior: the volume match is a plain String.startsWith, so
-        // /storage/emulated/01 is treated as being inside /storage/emulated/0. The prefix strip then
-        // doesn't apply either (it looks for a trailing separator), and the whole absolute path ends
-        // up as SAF segments. Correct behavior would be a segment-boundary aware match that returns
-        // null for a sibling volume.
-        mapper.toSAFPath(LocalPath.build("/storage/emulated/01/file")) shouldBe
-            SAFPath.build(primaryTreeUri, "", "storage", "emulated", "01", "file")
+        mapper.toSAFPath(LocalPath.build("/storage/emulated/01/file")) shouldBe null
     }
 
-    @Test fun `traversal segments survive the mapping`() = runTest2 {
+    @Test fun `a sibling user volume is not matched as a prefix`() = runTest2 {
+        val mapper = mapper(volume("/storage/emulated/1", primaryTreeUri))
+
+        mapper.toSAFPath(LocalPath.build("/storage/emulated/10/x")) shouldBe null
+    }
+
+    @Test fun `the volume prefix is only stripped from the front`() = runTest2 {
         val mapper = mapper(volume("/storage/emulated/0", primaryTreeUri))
 
-        // documents suspect behavior: '..' segments are passed through verbatim instead of being
-        // normalized or rejected, so a path that leaves the volume still maps to a SAF path rooted
-        // at that volume's tree uri.
-        mapper.toSAFPath(LocalPath.build("/storage/emulated/0/Android/../../../etc/hosts")) shouldBe
-            SAFPath.build(primaryTreeUri, "Android", "..", "..", "..", "etc", "hosts")
+        mapper.toSAFPath(LocalPath.build("/storage/emulated/0/backup/storage/emulated/0/f")) shouldBe
+            SAFPath.build(primaryTreeUri, "backup", "storage", "emulated", "0", "f")
     }
 
-    @Test fun `overlapping volume roots are resolved by list order, not by specificity`() = runTest2 {
+    @Test fun `a path with traversal segments does not map`() = runTest2 {
+        val mapper = mapper(volume("/storage/emulated/0", primaryTreeUri))
+
+        mapper.toSAFPath(LocalPath.build("/storage/emulated/0/Android/../../../etc/hosts")) shouldBe null
+    }
+
+    @Test fun `a path with a compound traversal segment does not map`() = runTest2 {
+        val mapper = mapper(volume("/storage/emulated/0", primaryTreeUri))
+
+        mapper.toSAFPath(LocalPath.build("/storage/emulated/0", "safe/../../etc")) shouldBe null
+    }
+
+    @Test fun `a path with a current directory segment does not map`() = runTest2 {
+        val mapper = mapper(volume("/storage/emulated/0", primaryTreeUri))
+
+        mapper.toSAFPath(LocalPath.build("/storage/emulated/0/./Music")) shouldBe null
+    }
+
+    @Test fun `names that only look like traversal still map`() = runTest2 {
+        val mapper = mapper(volume("/storage/emulated/0", primaryTreeUri))
+
+        mapper.toSAFPath(LocalPath.build("/storage/emulated/0/foo..bar/.../.nomedia")) shouldBe
+            SAFPath.build(primaryTreeUri, "foo..bar", "...", ".nomedia")
+    }
+
+    @Test fun `overlapping volume roots are resolved by specificity`() = runTest2 {
         val mapper = mapper(
             volume("/storage/emulated", sdcardTreeUri),
             volume("/storage/emulated/0", primaryTreeUri),
         )
 
-        // documents suspect behavior: firstOrNull() takes whichever volume comes first in the
-        // system's list, so the less specific root wins and the path maps to the wrong tree uri.
-        // Correct behavior would be to pick the longest matching volume root.
         mapper.toSAFPath(LocalPath.build("/storage/emulated/0/Music")) shouldBe
-            SAFPath.build(sdcardTreeUri, "0", "Music")
+            SAFPath.build(primaryTreeUri, "Music")
     }
 
     @Test fun `a SAF path maps back to the volume directory plus its segments`() = runTest2 {
@@ -158,13 +177,50 @@ class PathMapperTest : BaseTest() {
         mapper.toLocalPath(SAFPath.build(primaryTreeUri, "Music")) shouldBe null
     }
 
-    @Test fun `traversal segments survive the mapping back`() = runTest2 {
+    @Test fun `a SAF path with traversal segments does not map back`() = runTest2 {
         val mapper = mapper(volume("/storage/emulated/0", primaryTreeUri))
 
-        // documents suspect behavior: the segments are appended verbatim, so a SAF path carrying
-        // '..' resolves to a local path outside the volume it is anchored to.
-        mapper.toLocalPath(SAFPath.build(primaryTreeUri, "..", "..", "etc", "hosts")) shouldBe
-            LocalPath.build("/storage/emulated/0/../../etc/hosts")
+        mapper.toLocalPath(SAFPath.build(primaryTreeUri, "..", "..", "etc", "hosts")) shouldBe null
+    }
+
+    @Test fun `a SAF path with a compound traversal segment does not map back`() = runTest2 {
+        val mapper = mapper(volume("/storage/emulated/0", primaryTreeUri))
+
+        mapper.toLocalPath(SAFPath.build(primaryTreeUri, "safe/../../etc")) shouldBe null
+        mapper.toLocalPath(SAFPath.build(primaryTreeUri, "Android", "../etc")) shouldBe null
+    }
+
+    @Test fun `a SAF path with a current directory segment does not map back`() = runTest2 {
+        val mapper = mapper(volume("/storage/emulated/0", primaryTreeUri))
+
+        mapper.toLocalPath(SAFPath.build(primaryTreeUri, ".", "Music")) shouldBe null
+    }
+
+    @Test fun `SAF names that only look like traversal still map back`() = runTest2 {
+        val mapper = mapper(volume("/storage/emulated/0", primaryTreeUri))
+
+        mapper.toLocalPath(SAFPath.build(primaryTreeUri, "foo..bar", "...", ".nomedia")) shouldBe
+            LocalPath.build("/storage/emulated/0/foo..bar/.../.nomedia")
+    }
+
+    @Test fun `a local path round-trips through the SAF mapping`() = runTest2 {
+        val mapper = mapper(volume("/storage/emulated/0", primaryTreeUri))
+
+        val nested = LocalPath.build("/storage/emulated/0/Android/data/some.pkg")
+        mapper.toLocalPath(mapper.toSAFPath(nested)!!) shouldBe nested
+
+        val volumeRoot = LocalPath.build("/storage/emulated/0")
+        mapper.toLocalPath(mapper.toSAFPath(volumeRoot)!!) shouldBe volumeRoot
+    }
+
+    @Test fun `a SAF path round-trips through the local mapping`() = runTest2 {
+        val mapper = mapper(volume("/storage/emulated/0", primaryTreeUri))
+
+        val nested = SAFPath.build(primaryTreeUri, "Android", "data", "some.pkg")
+        mapper.toSAFPath(mapper.toLocalPath(nested)!!) shouldBe nested
+
+        val volumeRoot = SAFPath.build(primaryTreeUri)
+        mapper.toSAFPath(mapper.toLocalPath(volumeRoot)!!) shouldBe volumeRoot
     }
 
     @Test fun `takePermission persists a read-write grant`() {


### PR DESCRIPTION
## What changed

Fixes how paths are matched to storage volumes when SD Maid falls back to SAF (storage access framework) access. Previously, a path could be matched to the wrong volume when one volume's name was a prefix of another (for example on multi-user devices, where user 10's storage looks like a prefix match for user 1's volume), nested volume roots resolved to whichever the system listed first, and paths containing ".." were passed through unchecked. Wrong matches now either resolve to the correct volume or are treated as "no SAF access available", which every feature already handles.

## Technical Context

- These defects were documented (not fixed) by the characterization tests merged in #2669; this PR flips those four tests into regression tests and widens the matrix (compound segments carrying embedded separators, "." components, lookalike names such as .nomedia, round-trips).
- Volume containment is now segment-boundary aware and picks the longest matching root; the prefix strip is positional (the old code used String.replace, which removed the prefix substring anywhere in the path).
- Traversal rejection checks effective components: each segment is split on the separator first, so a single segment like "safe/../../etc" cannot bypass the guard.
- Volume directories are read once per mapping into immutable pairs; the platform getter is reflection-backed and live, so repeated reads could race an unmount into an NPE that the catch-all would mask.
- Callers were audited: everything null-checks the mapping, so newly-rejected paths degrade to the existing "no SAF route" handling (dropped candidates, skipped media-scan notification, omitted setup entry, or a thrown ReadException in the gateway fallback) instead of operating on a wrong tree.
