### PR TITLE
Fix: Upgrade partial storage grants and report the right access error

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/GatewaySwitch.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/GatewaySwitch.kt
@@ -60,6 +60,34 @@ class GatewaySwitch @Inject constructor(
         return resolveGatewayType(type)
     }
 
+    /**
+     * Runs [operation] on the type-mapped path, on [Type.AUTO] a [ReadException] retries it on the alternative path.
+     * The original failure is what callers see, the fallback failure (including an unmappable alternative) is
+     * attached as a suppressed exception.
+     */
+    private suspend fun <R> withFallback(
+        path: APath,
+        type: Type,
+        label: String,
+        operation: suspend (APath) -> R,
+    ): R {
+        val mapped = path.toTargetType(type)
+        return try {
+            operation(mapped)
+        } catch (oge: ReadException) {
+            if (type != Type.AUTO) throw oge
+            log(TAG, WARN) { "$label(...): Original access failed, try alternative: ${oge.asLog()}" }
+
+            try {
+                operation(path.toAlternative())
+            } catch (e: ReadException) {
+                log(TAG, WARN) { "$label(...): Alternative access failed either: ${e.asLog()}" }
+                if (e !== oge) oge.addSuppressed(e)
+                throw oge
+            }
+        }
+    }
+
     override val sharedResource = SharedResource.createKeepAlive(TAG, appScope + dispatcherProvider.IO)
 
     override suspend fun createDir(path: APath) {
@@ -74,89 +102,36 @@ class GatewaySwitch @Inject constructor(
         return lookup(path, Type.CURRENT)
     }
 
-    suspend fun lookup(path: APath, type: Type): APathLookup<APath> {
-        val mapped = path.toTargetType(type)
-        return try {
-            useGateway(mapped) { lookup(mapped) }
-        } catch (oge: ReadException) {
-            if (type != Type.AUTO) throw oge
-            log(TAG, WARN) { "lookup(...): Original lookup failed, try alternative: ${oge.asLog()}" }
-
-            val fallback = path.toAlternative()
-            try {
-                useGateway(fallback) { lookup(fallback) }
-            } catch (e: ReadException) {
-                log(TAG, WARN) { "lookup(...): Alternative lookup failed either: ${e.asLog()}" }
-                throw oge
-            }
-        }
+    suspend fun lookup(path: APath, type: Type): APathLookup<APath> = withFallback(path, type, "lookup") { target ->
+        useGateway(target) { lookup(target) }
     }
 
     override suspend fun lookupExtended(path: APath): APathLookupExtended<APath> {
         return lookupExtended(path, Type.CURRENT)
     }
 
-    suspend fun lookupExtended(path: APath, type: Type): APathLookupExtended<APath> {
-        val mapped = path.toTargetType(type)
-        return try {
-            useGateway(mapped) { lookupExtended(mapped) }
-        } catch (oge: ReadException) {
-            if (type != Type.AUTO) throw oge
-            log(TAG, WARN) { "lookupExtended(...): Original lookup failed, try alternative: ${oge.asLog()}" }
-
-            val fallback = path.toAlternative()
-            try {
-                useGateway(fallback) { lookupExtended(fallback) }
-            } catch (e: ReadException) {
-                log(TAG, WARN) { "lookupExtended(...): Alternative lookup failed either: ${e.asLog()}" }
-                throw oge
-            }
+    suspend fun lookupExtended(path: APath, type: Type): APathLookupExtended<APath> =
+        withFallback(path, type, "lookupExtended") { target ->
+            useGateway(target) { lookupExtended(target) }
         }
-    }
 
     override suspend fun lookupFiles(path: APath): Flow<APathLookup<APath>> {
         return useGateway(path) { lookupFiles(path) }
     }
 
-    suspend fun lookupFiles(path: APath, type: Type): Collection<APathLookup<APath>> {
-        val mapped = path.toTargetType(type)
-        return try {
-            useGateway(mapped) { lookupFiles(mapped) }.toList()
-        } catch (oge: ReadException) {
-            if (type != Type.AUTO) throw oge
-            log(TAG, WARN) { "lookupFiles(...): Original lookup failed, try alternative: ${oge.asLog()}" }
-
-            val fallback = path.toAlternative()
-            try {
-                useGateway(fallback) { lookupFiles(fallback) }.toList()
-            } catch (e: ReadException) {
-                log(TAG, WARN) { "lookupFiles(...): Alternative lookup failed either: ${e.asLog()}" }
-                throw oge
-            }
+    suspend fun lookupFiles(path: APath, type: Type): Collection<APathLookup<APath>> =
+        withFallback(path, type, "lookupFiles") { target ->
+            useGateway(target) { lookupFiles(target) }.toList()
         }
-    }
 
     override suspend fun lookupFilesExtended(path: APath): Flow<APathLookupExtended<APath>> {
         return useGateway(path) { lookupFilesExtended(path) }
     }
 
-    suspend fun lookupFilesExtended(path: APath, type: Type): Collection<APathLookupExtended<APath>> {
-        val mapped = path.toTargetType(type)
-        return try {
-            useGateway(mapped) { lookupFilesExtended(mapped) }.toList()
-        } catch (oge: ReadException) {
-            if (type != Type.AUTO) throw oge
-            log(TAG, WARN) { "lookupFilesExtended(...): Original lookup failed, try alternative: ${oge.asLog()}" }
-
-            val fallback = path.toAlternative()
-            try {
-                useGateway(fallback) { lookupFilesExtended(fallback) }.toList()
-            } catch (e: ReadException) {
-                log(TAG, WARN) { "lookupFilesExtended(...): Alternative lookup failed either: ${e.asLog()}" }
-                throw oge
-            }
+    suspend fun lookupFilesExtended(path: APath, type: Type): Collection<APathLookupExtended<APath>> =
+        withFallback(path, type, "lookupFilesExtended") { target ->
+            useGateway(target) { lookupFilesExtended(target) }.toList()
         }
-    }
 
     override suspend fun walk(
         path: APath,
@@ -181,16 +156,8 @@ class GatewaySwitch @Inject constructor(
         return exists(path, Type.CURRENT)
     }
 
-    suspend fun exists(path: APath, type: Type): Boolean {
-        val mapped = path.toTargetType(type)
-        return try {
-            useGateway(mapped) { exists(mapped) }
-        } catch (e: ReadException) {
-            if (type != Type.AUTO) throw e
-
-            val fallback = path.toAlternative()
-            useGateway(fallback) { exists(fallback) }
-        }
+    suspend fun exists(path: APath, type: Type): Boolean = withFallback(path, type, "exists") { target ->
+        useGateway(target) { exists(target) }
     }
 
     override suspend fun canWrite(path: APath): Boolean {

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/storage/PathMapper.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/storage/PathMapper.kt
@@ -1,6 +1,7 @@
 package eu.darken.sdmse.common.storage
 
 import android.content.ContentResolver
+import android.content.Intent
 import android.net.Uri
 import dagger.Reusable
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
@@ -109,14 +110,21 @@ class PathMapper @Inject constructor(
 
         log(TAG, INFO) { "Taking uri permission for $uri" }
 
+        // A partial grant (read-only or write-only) can already exist here, we are upgrading it.
+        // Cleanup after a failed upgrade must only drop what the failed take could have added.
+        val heldFlags = heldFlags(uri)
+
         try {
             contentResolver.takePersistableUriPermission(uri, SAFGateway.RW_FLAGSINT)
         } catch (e: SecurityException) {
             log(TAG, ERROR) { "Failed to take permission ${e.asLog()}" }
-            try {
-                contentResolver.releasePersistableUriPermission(uri, SAFGateway.RW_FLAGSINT)
-            } catch (e2: SecurityException) {
-                log(TAG, ERROR) { "Error while releasing during error... ${e2.asLog()}" }
+            val releaseFlags = SAFGateway.RW_FLAGSINT and heldFlags.inv()
+            if (releaseFlags != 0) {
+                try {
+                    contentResolver.releasePersistableUriPermission(uri, releaseFlags)
+                } catch (e2: SecurityException) {
+                    log(TAG, ERROR) { "Error while releasing during error... ${e2.asLog()}" }
+                }
             }
             throw e
         }
@@ -143,9 +151,19 @@ class PathMapper @Inject constructor(
         return contentResolver.persistedUriPermissions.map { SAFPath.build(it.uri) }
     }
 
-    fun hasPermission(uri: Uri): Boolean {
-        return getPermissions().any { it.pathUri == uri }
-    }
+    /**
+     * The app needs read AND write, a partial grant is not good enough and has to be upgraded.
+     */
+    fun hasPermission(uri: Uri): Boolean = heldFlags(uri) == SAFGateway.RW_FLAGSINT
+
+    private fun heldFlags(uri: Uri): Int = contentResolver.persistedUriPermissions
+        .filter { it.uri == uri }
+        .fold(0) { flags, permission ->
+            var updated = flags
+            if (permission.isReadPermission) updated = updated or Intent.FLAG_GRANT_READ_URI_PERMISSION
+            if (permission.isWritePermission) updated = updated or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+            updated
+        }
 
     companion object {
         val TAG: String = logTag("SAF", "Mapper")

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/GatewaySwitchTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/GatewaySwitchTest.kt
@@ -15,7 +15,7 @@ import eu.darken.sdmse.common.storage.PathMapper
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.types.shouldNotBeSameInstanceAs
+import io.kotest.matchers.types.shouldBeSameInstanceAs
 import io.mockk.Called
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -294,26 +294,59 @@ class GatewaySwitchTest {
             coEvery { mapper.toSAFPath(localPath) } returns safPath
             coEvery { safGateway.lookup(safPath) } throws ReadException(message = "alternative")
 
-            shouldThrow<ReadException> {
-                switch.lookup(localPath, GatewaySwitch.Type.AUTO)
-            } shouldBe original
+            val thrown = shouldThrow<ReadException> { switch.lookup(localPath, GatewaySwitch.Type.AUTO) }
+            thrown shouldBeSameInstanceAs original
+            thrown.suppressed.single().message shouldBe "alternative"
         }
 
-    @Test fun `lookup AUTO surfaces the mapping error when there is no alternative path`() =
+    @Test fun `lookup AUTO rethrows the original error when there is no alternative path`() =
         runTest2(autoCancel = true) {
             val switch = createSwitch()
             val original = ReadException(message = "original", path = localPath)
             coEvery { localGateway.lookup(localPath) } throws original
             coEvery { mapper.toSAFPath(localPath) } returns null
 
-            // documents suspect behavior: toAlternative() builds its own ReadException outside the
-            // inner try (GatewaySwitch.kt:84-90), so an unmappable path replaces the original
-            // failure with "Can't map to SAF" and the actual reason the lookup failed is lost.
-            // Correct behavior would be to rethrow the original error like the failing-alternative
-            // case does.
+            // An unmappable alternative must not mask why the primary access failed.
             val thrown = shouldThrow<ReadException> { switch.lookup(localPath, GatewaySwitch.Type.AUTO) }
-            thrown shouldNotBeSameInstanceAs original
-            thrown.message shouldBe "Can't map to SAF <-> ${localPath.path}"
+            thrown shouldBeSameInstanceAs original
+            thrown.suppressed.single().message shouldBe "Can't map to SAF <-> ${localPath.path}"
+            coVerify(exactly = 0) { safGateway.lookup(any()) }
+        }
+
+    @Test fun `lookup AUTO falls back from SAF to the local gateway`() = runTest2(autoCancel = true) {
+        val switch = createSwitch()
+        val localResult = mockk<LocalPathLookup>()
+        coEvery { safGateway.lookup(safPath) } throws ReadException(path = safPath)
+        coEvery { mapper.toLocalPath(safPath) } returns localPath
+        coEvery { localGateway.lookup(localPath) } returns localResult
+
+        switch.lookup(safPath, GatewaySwitch.Type.AUTO) shouldBe localResult
+    }
+
+    @Test fun `lookup AUTO rethrows the original SAF error when there is no local path`() =
+        runTest2(autoCancel = true) {
+            val switch = createSwitch()
+            val original = ReadException(message = "original", path = safPath)
+            coEvery { safGateway.lookup(safPath) } throws original
+            coEvery { mapper.toLocalPath(safPath) } returns null
+
+            val thrown = shouldThrow<ReadException> { switch.lookup(safPath, GatewaySwitch.Type.AUTO) }
+            thrown shouldBeSameInstanceAs original
+            thrown.suppressed.single().message shouldBe "Can't map to LOCAL <-> ${safPath.path}"
+            coVerify(exactly = 0) { localGateway.lookup(any()) }
+        }
+
+    @Test fun `lookupExtended AUTO rethrows the original error when there is no alternative path`() =
+        runTest2(autoCancel = true) {
+            val switch = createSwitch()
+            val original = ReadException(message = "original", path = localPath)
+            coEvery { localGateway.lookupExtended(localPath) } throws original
+            coEvery { mapper.toSAFPath(localPath) } returns null
+
+            shouldThrow<ReadException> {
+                switch.lookupExtended(localPath, GatewaySwitch.Type.AUTO)
+            } shouldBeSameInstanceAs original
+            coVerify(exactly = 0) { safGateway.lookupExtended(any()) }
         }
 
     @Test fun `lookupFiles AUTO falls back and discards partial emissions`() = runTest2(autoCancel = true) {
@@ -348,6 +381,19 @@ class GatewaySwitchTest {
             } shouldBe original
         }
 
+    @Test fun `lookupFiles AUTO rethrows the original error when there is no alternative path`() =
+        runTest2(autoCancel = true) {
+            val switch = createSwitch()
+            val original = ReadException(message = "original", path = localPath)
+            coEvery { localGateway.lookupFiles(localPath) } returns flow { throw original }
+            coEvery { mapper.toSAFPath(localPath) } returns null
+
+            shouldThrow<ReadException> {
+                switch.lookupFiles(localPath, GatewaySwitch.Type.AUTO)
+            } shouldBeSameInstanceAs original
+            coVerify(exactly = 0) { safGateway.lookupFiles(any()) }
+        }
+
     @Test fun `lookupFilesExtended AUTO falls back on a collection-time failure`() = runTest2(autoCancel = true) {
         val switch = createSwitch()
         val safResult = mockk<SAFPathLookupExtended>()
@@ -376,6 +422,19 @@ class GatewaySwitchTest {
             } shouldBe original
         }
 
+    @Test fun `lookupFilesExtended AUTO rethrows the original error when there is no alternative path`() =
+        runTest2(autoCancel = true) {
+            val switch = createSwitch()
+            val original = ReadException(message = "original", path = localPath)
+            coEvery { localGateway.lookupFilesExtended(localPath) } returns flow { throw original }
+            coEvery { mapper.toSAFPath(localPath) } returns null
+
+            shouldThrow<ReadException> {
+                switch.lookupFilesExtended(localPath, GatewaySwitch.Type.AUTO)
+            } shouldBeSameInstanceAs original
+            coVerify(exactly = 0) { safGateway.lookupFilesExtended(any()) }
+        }
+
     @Test fun `exists AUTO falls back to the alternative gateway`() = runTest2(autoCancel = true) {
         val switch = createSwitch()
         coEvery { localGateway.exists(localPath) } throws ReadException(path = localPath)
@@ -385,7 +444,7 @@ class GatewaySwitchTest {
         switch.exists(localPath, GatewaySwitch.Type.AUTO) shouldBe true
     }
 
-    @Test fun `exists AUTO propagates the alternative error instead of the original`() =
+    @Test fun `exists AUTO rethrows the original error when the alternative fails too`() =
         runTest2(autoCancel = true) {
             val switch = createSwitch()
             val original = ReadException(message = "original", path = localPath)
@@ -393,11 +452,22 @@ class GatewaySwitchTest {
             coEvery { mapper.toSAFPath(localPath) } returns safPath
             coEvery { safGateway.exists(safPath) } throws ReadException(message = "alternative")
 
-            // documents suspect behavior: exists() has no inner try (GatewaySwitch.kt:184-194), so
-            // unlike lookup/lookupFiles/lookupFilesExtended it surfaces the alternative's error
-            // rather than the original one. Callers see the SAF failure for a LOCAL path.
             val thrown = shouldThrow<ReadException> { switch.exists(localPath, GatewaySwitch.Type.AUTO) }
-            thrown.message shouldBe "alternative"
+            thrown shouldBeSameInstanceAs original
+            thrown.suppressed.single().message shouldBe "alternative"
+        }
+
+    @Test fun `exists AUTO rethrows the original error when there is no alternative path`() =
+        runTest2(autoCancel = true) {
+            val switch = createSwitch()
+            val original = ReadException(message = "original", path = localPath)
+            coEvery { localGateway.exists(localPath) } throws original
+            coEvery { mapper.toSAFPath(localPath) } returns null
+
+            shouldThrow<ReadException> {
+                switch.exists(localPath, GatewaySwitch.Type.AUTO)
+            } shouldBeSameInstanceAs original
+            coVerify(exactly = 0) { safGateway.exists(any()) }
         }
 
     @Test fun `FORCED_LOCAL maps a SAF path through the mapper`() = runTest2(autoCancel = true) {

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/storage/PathMapperTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/storage/PathMapperTest.kt
@@ -309,26 +309,105 @@ class PathMapperTest : BaseTest() {
         mapper.hasPermission(sdcardTreeUri) shouldBe false
     }
 
-    @Test fun `hasPermission ignores how strong the persisted grant is`() {
+    @Test fun `hasPermission requires a read-write grant`() {
         val mapper = PathMapper(contentResolver, storageManager2)
 
-        // documents suspect behavior: only the uri is compared, the grant's read/write flags are
-        // never looked at. A read-only (or write-only) grant therefore reports as "have permission",
-        // and takePermission() consequently skips upgrading it to the read-write grant the app
-        // needs. Correct behavior would be to require both flags before reporting true.
         every { contentResolver.persistedUriPermissions } returns listOf(
             permission(primaryTreeUri, read = true, write = false),
         )
-        mapper.hasPermission(primaryTreeUri) shouldBe true
+        mapper.hasPermission(primaryTreeUri) shouldBe false
 
         every { contentResolver.persistedUriPermissions } returns listOf(
             permission(primaryTreeUri, read = false, write = true),
         )
-        mapper.hasPermission(primaryTreeUri) shouldBe true
+        mapper.hasPermission(primaryTreeUri) shouldBe false
 
         every { contentResolver.persistedUriPermissions } returns listOf(
             permission(primaryTreeUri, read = true, write = true),
         )
         mapper.hasPermission(primaryTreeUri) shouldBe true
+    }
+
+    @Test fun `takePermission upgrades a read-only grant`() {
+        every { contentResolver.persistedUriPermissions } returns listOf(
+            permission(primaryTreeUri, read = true, write = false),
+        )
+        every { contentResolver.takePersistableUriPermission(any(), any()) } just runs
+        val mapper = PathMapper(contentResolver, storageManager2)
+
+        mapper.takePermission(primaryTreeUri)
+
+        verify {
+            contentResolver.takePersistableUriPermission(
+                primaryTreeUri,
+                Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION,
+            )
+        }
+    }
+
+    @Test fun `takePermission upgrades a write-only grant`() {
+        every { contentResolver.persistedUriPermissions } returns listOf(
+            permission(primaryTreeUri, read = false, write = true),
+        )
+        every { contentResolver.takePersistableUriPermission(any(), any()) } just runs
+        val mapper = PathMapper(contentResolver, storageManager2)
+
+        mapper.takePermission(primaryTreeUri)
+
+        verify {
+            contentResolver.takePersistableUriPermission(
+                primaryTreeUri,
+                Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION,
+            )
+        }
+    }
+
+    @Test fun `a failed upgrade keeps the grant we already had`() {
+        every { contentResolver.persistedUriPermissions } returns listOf(
+            permission(primaryTreeUri, read = true, write = false),
+        )
+        every { contentResolver.takePersistableUriPermission(any(), any()) } throws SecurityException("nope")
+        every { contentResolver.releasePersistableUriPermission(any(), any()) } just runs
+        val mapper = PathMapper(contentResolver, storageManager2)
+
+        shouldThrow<SecurityException> { mapper.takePermission(primaryTreeUri) }
+
+        // Only the mode the failed take could have added is released, the pre-existing read survives.
+        verify {
+            contentResolver.releasePersistableUriPermission(
+                primaryTreeUri,
+                Intent.FLAG_GRANT_WRITE_URI_PERMISSION,
+            )
+        }
+        verify(exactly = 0) {
+            contentResolver.releasePersistableUriPermission(
+                primaryTreeUri,
+                match { it and Intent.FLAG_GRANT_READ_URI_PERMISSION != 0 },
+            )
+        }
+    }
+
+    @Test fun `a failed upgrade of a write-only grant only releases the read mode`() {
+        every { contentResolver.persistedUriPermissions } returns listOf(
+            permission(primaryTreeUri, read = false, write = true),
+        )
+        every { contentResolver.takePersistableUriPermission(any(), any()) } throws SecurityException("nope")
+        every { contentResolver.releasePersistableUriPermission(any(), any()) } just runs
+        val mapper = PathMapper(contentResolver, storageManager2)
+
+        shouldThrow<SecurityException> { mapper.takePermission(primaryTreeUri) }
+
+        verify {
+            contentResolver.releasePersistableUriPermission(
+                primaryTreeUri,
+                Intent.FLAG_GRANT_READ_URI_PERMISSION,
+            )
+        }
+        verify(exactly = 0) {
+            contentResolver.releasePersistableUriPermission(
+                primaryTreeUri,
+                match { it and Intent.FLAG_GRANT_WRITE_URI_PERMISSION != 0 },
+            )
+        }
     }
 }


### PR DESCRIPTION
## What changed

Two fixes for problems documented by the earlier test-coverage work. First, SAF setup: if the app somehow ended up holding a read-only storage grant, it considered that good enough and never asked for the read-write access it actually needs, so later write operations through SAF would fail; it now recognizes partial grants and upgrades them, and a failed upgrade no longer throws away the partial grant that was already there. Second, error reporting: when automatic fallback between normal and SAF access fails, the error shown now always describes the original failure instead of the less useful fallback error, across all affected operations.

## Technical Context

- Stacked on #2674; merge that one first (this PR retargets to main automatically when its base merges, and CI runs then).
- The grant gate sat inside takePermission itself: hasPermission matched persisted grants by URI only, discarding the read/write flags. It now checks both modes directly against persistedUriPermissions; the failed-take cleanup computes the modes held beforehand and releases only what the attempt could have added.
- The five near-identical AUTO-fallback blocks in the gateway dispatcher (which had already drifted apart, which is how exists() got different error behavior) are consolidated into one helper; the fallback failure is attached to the rethrown original as a suppressed exception rather than being dropped.
- Both "documents suspect behavior" characterization tests flipped to regression tests, with added coverage for the unmappable-alternative case on every operation and for the SAF-to-local mapping direction.
- One behavior that unit tests cannot prove: whether Android upgrades an existing partial persisted grant when the same tree is re-selected. Mocks verify the flags we request and release; a one-time manual check on a device (start from a read-only grant, redo SAF setup, confirm read-write access and a successful SAF write) would close that gap.
