### PR TITLE
General: Stop the Shizuku setup card from loading forever

### DIFF
--- a/app-common-adb/src/main/java/eu/darken/sdmse/common/adb/service/internal/AdbHostLauncher.kt
+++ b/app-common-adb/src/main/java/eu/darken/sdmse/common/adb/service/internal/AdbHostLauncher.kt
@@ -7,6 +7,7 @@ import eu.darken.sdmse.common.adb.AdbException
 import eu.darken.sdmse.common.adb.service.AdbHostOptions
 import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
+import eu.darken.sdmse.common.coroutine.runDetachedWithTimeout
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
@@ -44,8 +45,16 @@ class AdbHostLauncher @Inject constructor(
         hostClass: KClass<Host>,
         options: AdbHostOptions,
         connectTimeoutMs: Long = CONNECT_TIMEOUT_MS,
+        apiVersionTimeoutMs: Long = API_VERSION_TIMEOUT_MS,
     ): Flow<ConnectionWrapper<Service, Host>> = callbackFlow {
-        if (serviceFactory.apiVersion() < 10) throw IllegalStateException("Shizuku API10+ required")
+        // Shizuku.getVersion() only returns a cached field once the server has pushed its version via
+        // bindApplication(); until then it is a synchronous binder transaction that wedges against an
+        // unresponsive server. This runs before the connect watchdog below is armed, so it needs its
+        // own bound. Detached: a wedged binder thread leaks rather than pinning every collector.
+        val apiVersion = appScope.runDetachedWithTimeout(dispatcherProvider.IO, apiVersionTimeoutMs) {
+            serviceFactory.apiVersion()
+        } ?: throw AdbException("Shizuku getVersion() did not respond within ${apiVersionTimeoutMs}ms")
+        if (apiVersion < 10) throw IllegalStateException("Shizuku API10+ required")
 
         // Completed only once a connection was actually handed downstream, this is what the
         // connect-watchdog below waits for.
@@ -189,5 +198,10 @@ class AdbHostLauncher @Inject constructor(
         // the same probe against the same upstream Shizuku defect where bindUserService() returns but
         // the connection callback never fires (MediaTek/HyperOS, Shizuku 13.6.0).
         internal const val CONNECT_TIMEOUT_MS = 15 * 1000L
+
+        // Budget for the getVersion() round-trip. Same size as CONNECT_TIMEOUT_MS on purpose: this only
+        // has to turn "never returns" into "eventually fails", and timing out a slow-but-working
+        // Shizuku would break a setup that currently works.
+        internal const val API_VERSION_TIMEOUT_MS = 15 * 1000L
     }
 }

--- a/app-common-adb/src/main/java/eu/darken/sdmse/common/adb/shizuku/ShizukuWrapper.kt
+++ b/app-common-adb/src/main/java/eu/darken/sdmse/common/adb/shizuku/ShizukuWrapper.kt
@@ -5,13 +5,16 @@ import android.content.pm.PackageManager
 import android.os.Handler
 import android.os.HandlerThread
 import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
+import eu.darken.sdmse.common.coroutine.runDetachedWithTimeout
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.flow.setupCommonEventHandlers
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.flow.Flow
@@ -27,6 +30,7 @@ import javax.inject.Singleton
 @Singleton
 class ShizukuWrapper @Inject constructor(
     @ApplicationContext private val context: Context,
+    @AppScope private val appScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
 ) {
 
@@ -124,6 +128,9 @@ class ShizukuWrapper @Inject constructor(
     internal var pingBinderAction: () -> Boolean = { Shizuku.pingBinder() }
     internal var checkSelfPermissionAction: () -> Int = { Shizuku.checkSelfPermission() }
 
+    /** Overridden in tests to keep the wedge case fast, never in production. */
+    internal var ipcTimeoutMs: Long = IPC_TIMEOUT_MS
+
     private fun pingBinderSafe(): Boolean = try {
         pingBinderAction()
     } catch (e: NullPointerException) {
@@ -131,24 +138,44 @@ class ShizukuWrapper @Inject constructor(
         false
     }
 
-    suspend fun isGranted(): Boolean? = withContext(dispatcherProvider.IO) {
-        // Shizuku.checkSelfPermission() latches its granted state process-wide and never clears it on
-        // binder death, so without this gate it reports a stale `true` with no live binder behind it.
-        // null already means "cannot know" (see the ISE catch below), which covers this case too.
-        if (!pingBinderSafe()) {
-            log(TAG) { "isGranted()=null (binder not alive)" }
-            return@withContext null
+    suspend fun isGranted(): Boolean? {
+        // Both statics below are synchronous binder transactions that can wedge against a Shizuku
+        // server that is alive but not servicing requests: pingBinder() is a PING_TRANSACTION, and
+        // checkSelfPermission() does a real round-trip whenever its granted state was not latched yet
+        // (first connection). Neither is covered by AdbHostLauncher's connect watchdog, because both
+        // run before it is armed, so an unbounded wedge here reproduces the eternal setup spinner that
+        // watchdog exists to prevent. Detached + bounded: a wedged binder thread leaks, we don't hang.
+        // GrantState (not Boolean?) so the helper's `null` stays reserved for "timed out".
+        val state = appScope.runDetachedWithTimeout(dispatcherProvider.IO, ipcTimeoutMs) {
+            // Shizuku.checkSelfPermission() latches its granted state process-wide and never clears it
+            // on binder death, so without this gate it reports a stale `true` with no live binder
+            // behind it. UNKNOWN already means "cannot know" (see the ISE catch below), which covers
+            // this case too.
+            if (!pingBinderSafe()) {
+                log(TAG) { "isGranted()=null (binder not alive)" }
+                return@runDetachedWithTimeout GrantState.UNKNOWN
+            }
+            val granted = try {
+                checkSelfPermissionAction() == PackageManager.PERMISSION_GRANTED
+            } catch (e: IllegalStateException) {
+                log(TAG, WARN) { "isGranted(): $e" }
+                log(TAG) { "isGranted()=null" }
+                return@runDetachedWithTimeout GrantState.UNKNOWN
+            }
+            log(TAG) { "isGranted()=$granted" }
+            if (granted) GrantState.GRANTED else GrantState.DENIED
         }
-        val granted = try {
-            checkSelfPermissionAction() == PackageManager.PERMISSION_GRANTED
-        } catch (e: IllegalStateException) {
-            log(TAG, WARN) { "isGranted(): $e" }
-            null
+        if (state == null) {
+            log(TAG, WARN) { "isGranted()=null (Shizuku did not respond within ${ipcTimeoutMs}ms)" }
         }
-        log(TAG) { "isGranted()=$granted" }
-        granted
+        return when (state) {
+            GrantState.GRANTED -> true
+            GrantState.DENIED -> false
+            GrantState.UNKNOWN, null -> null
+        }
     }
 
+    private enum class GrantState { GRANTED, DENIED, UNKNOWN }
 
     suspend fun isCompatible(): Boolean {
         return !Shizuku.isPreV11()
@@ -161,6 +188,16 @@ class ShizukuWrapper @Inject constructor(
 
     companion object {
         private val TAG = logTag("ADB", "Shizuku", "Wrapper")
+
+        /**
+         * Combined budget for the two binder round-trips behind [isGranted].
+         *
+         * Deliberately generous rather than tight: the job here is only to turn "never returns" into
+         * "eventually gives up". A too-tight bound would report a slow-but-working Shizuku as
+         * unavailable, and low-end devices under memory pressure (the exact hardware this defect shows
+         * up on) are where both a real wedge and a slow answer are most likely.
+         */
+        internal const val IPC_TIMEOUT_MS = 15 * 1000L
     }
 
 }

--- a/app-common-adb/src/test/java/eu/darken/sdmse/common/adb/service/internal/AdbHostLauncherTest.kt
+++ b/app-common-adb/src/test/java/eu/darken/sdmse/common/adb/service/internal/AdbHostLauncherTest.kt
@@ -69,6 +69,9 @@ class AdbHostLauncherTest {
         val version: Int = 11,
         val bindError: Throwable? = null,
         val handshakeError: Throwable? = null,
+        /** Blocks apiVersion() to model a wedged Shizuku.getVersion() binder transaction. */
+        val versionWedge: CountDownLatch? = null,
+        val versionEntered: CompletableDeferred<Unit>? = null,
     ) : ShizukuUserServiceFactory {
         /** Captured so a test can simulate an unexpected onServiceDisconnected. */
         var disconnectCallback: (() -> Unit)? = null
@@ -76,7 +79,12 @@ class AdbHostLauncherTest {
         /** Captured so a test can simulate onServiceConnected. */
         var connectedCallback: ((IBinder?) -> Unit)? = null
 
-        override fun apiVersion(): Int = version
+        override fun apiVersion(): Int {
+            versionEntered?.complete(Unit)
+            versionWedge?.await() // blocks the calling thread, like a wedged binder transaction
+            return version
+        }
+
         override fun <Host : AdbConnection> create(
             hostClass: KClass<Host>,
             options: AdbHostOptions,
@@ -117,7 +125,9 @@ class AdbHostLauncherTest {
 
     private fun AdbHostLauncher.connect(
         connectTimeoutMs: Long = AdbHostLauncher.CONNECT_TIMEOUT_MS,
+        apiVersionTimeoutMs: Long = AdbHostLauncher.API_VERSION_TIMEOUT_MS,
     ) = createConnection(
+        apiVersionTimeoutMs = apiVersionTimeoutMs,
         serviceClass = AdbConnection::class,
         hostClass = AdbConnection::class,
         // Explicit values: AdbHostOptions()'s default isDebug=BuildConfigWrap.DEBUG triggers
@@ -299,6 +309,46 @@ class AdbHostLauncherTest {
             }
         } finally {
             bindWedge.countDown()
+            realScope.cancel()
+        }
+    }
+
+    @Test fun `a getVersion wedged in its binder transaction fails instead of hanging`() = runTest(
+        timeout = 10.seconds,
+    ) {
+        // Shizuku.getVersion() only returns a cached field once the server has pushed its version via
+        // bindApplication(); until then it is a synchronous binder transaction. It runs before the
+        // connect watchdog is armed, so without its own bound a wedge here hangs every collector -
+        // the same eternal setup spinner, just one step earlier than the bind wedge above.
+        val versionEntered = CompletableDeferred<Unit>()
+        val versionWedge = CountDownLatch(1)
+        // Real scope + real IO dispatcher: the wedge blocks an actual thread, virtual time and
+        // Unconfined execution can't model it (Unconfined would block the producer's own thread).
+        val realScope = CoroutineScope(SupervisorJob())
+        val l = AdbHostLauncher(
+            serviceFactory = FakeFactory(versionWedge = versionWedge, versionEntered = versionEntered),
+            appScope = realScope,
+            dispatcherProvider = TestDispatcherProvider(Dispatchers.IO),
+        )
+
+        try {
+            val collectResult = realScope.async(Dispatchers.Default) {
+                runCatching { l.connect(apiVersionTimeoutMs = 250L).collect { } }
+            }
+
+            withContext(Dispatchers.Default) {
+                // Only measure once the wedge is real: apiVersion() has been entered and is blocked.
+                withTimeout(5_000L) { versionEntered.await() }
+
+                val error = withTimeout(5_000L) { collectResult.await() }.exceptionOrNull()
+                error.shouldBeInstanceOf<AdbException>()
+                error.message!! shouldContain "getVersion"
+
+                // Bailed out before binding, so there is nothing to unbind.
+                events.shouldBeEmpty()
+            }
+        } finally {
+            versionWedge.countDown()
             realScope.cancel()
         }
     }

--- a/app-common-adb/src/test/java/eu/darken/sdmse/common/adb/shizuku/ShizukuWrapperTest.kt
+++ b/app-common-adb/src/test/java/eu/darken/sdmse/common/adb/shizuku/ShizukuWrapperTest.kt
@@ -7,10 +7,21 @@ import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import io.kotest.matchers.nulls.shouldNotBeNull
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.Test
+import testhelpers.coroutine.TestDispatcherProvider
+import java.util.concurrent.CountDownLatch
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Covers [ShizukuWrapper.getManagerPackage] — permission-based Shizuku detection that survives
@@ -26,9 +37,12 @@ class ShizukuWrapperTest {
         override val IO: CoroutineDispatcher = Dispatchers.Unconfined
     }
 
-    private fun wrapper(): ShizukuWrapper {
+    private fun wrapper(
+        scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined),
+        dispatchers: DispatcherProvider = dispatcherProvider,
+    ): ShizukuWrapper {
         every { context.packageManager } returns packageManager
-        return ShizukuWrapper(context, dispatcherProvider)
+        return ShizukuWrapper(context, scope, dispatchers)
     }
 
     // mockk gives us a real (Objenesis-instantiated) PermissionInfo whose inherited public
@@ -107,5 +121,60 @@ class ShizukuWrapperTest {
         // Shizuku itself throws when it has no binder to ask, which also means "cannot know".
         wrapper.checkSelfPermissionAction = { throw IllegalStateException("binder haven't been received") }
         wrapper.isGranted() shouldBe null
+    }
+
+    @Test
+    fun `isGranted gives up when the Shizuku binder wedges`() = runTest(timeout = 10.seconds) {
+        // Shizuku.checkSelfPermission() does a real binder round-trip until its granted state has been
+        // latched (first connection). Against a server that is alive but not servicing requests that
+        // transaction never returns, and it runs before AdbHostLauncher's connect watchdog is armed,
+        // so without a bound here the setup card spins forever.
+        val entered = CompletableDeferred<Unit>()
+        val wedge = CountDownLatch(1)
+        // Real scope + real IO dispatcher: the wedge blocks an actual thread, Unconfined would run the
+        // block inline and block the caller before the timeout could ever be applied.
+        val realScope = CoroutineScope(SupervisorJob())
+        val wrapper = wrapper(realScope, TestDispatcherProvider(Dispatchers.IO)).apply {
+            ipcTimeoutMs = 250L
+            pingBinderAction = { true }
+            checkSelfPermissionAction = {
+                entered.complete(Unit)
+                wedge.await() // blocks the calling thread, unaffected by coroutine cancellation
+                PackageManager.PERMISSION_GRANTED
+            }
+        }
+
+        try {
+            // The call runs in its OWN scope, not as a child of the test coroutine: on a regression
+            // it blocks a thread non-cooperatively, and a blocked child would make the enclosing
+            // withContext wait for it forever, deadlocking the JVM instead of failing the test.
+            val result = realScope.async(Dispatchers.Default) { wrapper.isGranted() }
+
+            withContext(Dispatchers.Default) {
+                // Only assert once the wedge is real: the call has been entered and is blocked.
+                withTimeout(5_000L) { entered.await() }
+                withTimeout(5_000L) { result.await() } shouldBe null
+            }
+        } finally {
+            wedge.countDown()
+            realScope.cancel()
+        }
+    }
+
+    @Test
+    fun `isGranted still answers normally when the binder responds`() = runTest(timeout = 10.seconds) {
+        // Guards the happy path against the detach+timeout wrapper: a prompt answer must survive it.
+        val realScope = CoroutineScope(SupervisorJob())
+        val wrapper = wrapper(realScope, TestDispatcherProvider(Dispatchers.IO)).apply {
+            pingBinderAction = { true }
+            checkSelfPermissionAction = { PackageManager.PERMISSION_GRANTED }
+        }
+        try {
+            withContext(Dispatchers.Default) {
+                withTimeout(5_000L) { wrapper.isGranted() }.shouldNotBeNull() shouldBe true
+            }
+        } finally {
+            realScope.cancel()
+        }
     }
 }

--- a/app-common/src/main/java/eu/darken/sdmse/common/coroutine/CoroutineExtensions.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/coroutine/CoroutineExtensions.kt
@@ -1,8 +1,44 @@
 package eu.darken.sdmse.common.coroutine
 
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.withTimeoutOrNull
 import java.io.Closeable
 
+
+/**
+ * Runs [block] detached on this scope and waits at most [timeoutMs] for its result, `null` on timeout.
+ *
+ * For *synchronous* calls that can wedge (binder transactions against an alive-but-unresponsive
+ * process), [withTimeoutOrNull] on its own is not enough: it only unwinds at suspension points, so a
+ * thread blocked inside the call keeps pinning the caller anyway. Detaching the call means a wedged
+ * thread leaks instead of the caller hanging forever, the same trade-off
+ * `AdbHostLauncher.createConnection` makes for `bindUserService()`.
+ *
+ * [T] is non-nullable so a `null` return unambiguously means "timed out". Exceptions thrown by
+ * [block] propagate to the caller.
+ *
+ * The receiver MUST be a scope independent of the caller (e.g. `@AppScope`). Passing a scope the
+ * caller is a child of defeats the whole point: the wedge would pin the caller again.
+ */
+suspend fun <T : Any> CoroutineScope.runDetachedWithTimeout(
+    dispatcher: CoroutineDispatcher,
+    timeoutMs: Long,
+    block: () -> T,
+): T? {
+    val deferred = async(dispatcher) { block() }
+    return try {
+        withTimeoutOrNull(timeoutMs) { deferred.await() }
+    } finally {
+        // In the finally, not just on the timeout branch: withTimeoutOrNull only converts its OWN
+        // timeout, so a cancelled caller propagates out of await() and would otherwise leave the
+        // detached coroutine running unobserved on the long-lived scope. Cancelling can't interrupt a
+        // thread already blocked in a binder transaction, but it does drop queued/cooperative work.
+        deferred.cancel()
+    }
+}
 
 suspend fun <T> Job.cancelAfterRun(action: suspend () -> T): T = try {
     action()

--- a/app/src/main/java/eu/darken/sdmse/setup/shizuku/ShizukuSetupModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/shizuku/ShizukuSetupModule.kt
@@ -9,6 +9,8 @@ import eu.darken.sdmse.common.adb.AdbSettings
 import eu.darken.sdmse.common.adb.shizuku.ShizukuManager
 import eu.darken.sdmse.common.areas.DataAreaManager
 import eu.darken.sdmse.common.coroutine.AppScope
+import eu.darken.sdmse.common.coroutine.DispatcherProvider
+import eu.darken.sdmse.common.coroutine.runDetachedWithTimeout
 import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
@@ -39,6 +41,7 @@ import javax.inject.Singleton
 @Singleton
 class ShizukuSetupModule @Inject constructor(
     @AppScope private val appScope: CoroutineScope,
+    private val dispatcherProvider: DispatcherProvider,
     private val adbSettings: AdbSettings,
     private val shizukuManager: ShizukuManager,
     private val dataAreaManager: DataAreaManager,
@@ -46,6 +49,9 @@ class ShizukuSetupModule @Inject constructor(
 ) : SetupModule {
 
     private val refreshTrigger = MutableStateFlow(rngString)
+
+    /** Overridden in tests to keep the wedge case fast, never in production. */
+    internal var pingTimeoutMs: Long = PING_TIMEOUT_MS
 
     // Last known concrete Result, kept so re-subscription (e.g. returning to the dashboard) can emit it
     // immediately instead of regressing to Loading and flickering the setup card while the availability
@@ -85,9 +91,18 @@ class ShizukuSetupModule @Inject constructor(
             shizukuManager.permissionGrantEvents.map { }.onStart { emit(Unit) },
             shizukuManager.shizukuBinder.onStart { emit(null) },
         ) { _, _, binder ->
+            // pingBinder() is a synchronous PING_TRANSACTION: against a Shizuku server that is alive
+            // but not servicing requests it never returns, and an unbounded wedge here stalls this
+            // combine so the card stays on Loading forever - the exact symptom the ADB-side timeouts
+            // guard against. Detached + bounded, same trade as ShizukuWrapper.isGranted().
+            val basicService = binder?.let { b ->
+                appScope.runDetachedWithTimeout(dispatcherProvider.IO, pingTimeoutMs) { b.pingBinder() }
+                    ?: false.also { log(TAG) { "pingBinder() did not respond within ${pingTimeoutMs}ms" } }
+            } ?: false
+
             @Suppress("USELESS_CAST")
             baseState.copy(
-                basicService = binder?.pingBinder() ?: false,
+                basicService = basicService,
                 ourService = shizukuManager.isOurServiceAvailable(),
             ) as SetupModule.State
         }
@@ -179,5 +194,9 @@ class ShizukuSetupModule @Inject constructor(
 
     companion object {
         private val TAG = logTag("Setup", "ADB", "Shizuku", "Module")
+
+        // Generous on purpose: a false timeout would report a working Shizuku as unavailable, which is
+        // worse than waiting. This only has to turn "never" into "eventually".
+        internal const val PING_TIMEOUT_MS = 15 * 1000L
     }
 }

--- a/app/src/test/java/eu/darken/sdmse/setup/shizuku/ShizukuSetupModuleTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/setup/shizuku/ShizukuSetupModuleTest.kt
@@ -3,6 +3,8 @@ package eu.darken.sdmse.setup.shizuku
 import eu.darken.sdmse.common.adb.AdbSettings
 import eu.darken.sdmse.common.adb.shizuku.ShizukuManager
 import eu.darken.sdmse.common.areas.DataAreaManager
+import eu.darken.sdmse.common.adb.shizuku.ShizukuBaseServiceBinder
+import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.datastore.DataStoreValue
 import eu.darken.sdmse.common.pkgs.toPkgId
 import eu.darken.sdmse.common.root.RootManager
@@ -26,7 +28,9 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
 import testhelpers.flow.test
+import java.util.concurrent.CountDownLatch
 
 class ShizukuSetupModuleTest : BaseTest() {
 
@@ -65,7 +69,10 @@ class ShizukuSetupModuleTest : BaseTest() {
         scope.cancel()
     }
 
-    private fun module() = ShizukuSetupModule(scope, adbSettings, shizukuManager, dataAreaManager, rootManager)
+    private fun module(
+        moduleScope: CoroutineScope = scope,
+        dispatchers: DispatcherProvider = TestDispatcherProvider(),
+    ) = ShizukuSetupModule(moduleScope, dispatchers, adbSettings, shizukuManager, dataAreaManager, rootManager)
 
     @Test fun `first subscription emits Loading then Result`() {
         val mod = module()
@@ -148,5 +155,33 @@ class ShizukuSetupModuleTest : BaseTest() {
         probeCount shouldBeGreaterThan before
 
         runBlocking { collector.cancelAndJoin() }
+    }
+
+    @Test fun `a wedged pingBinder still produces a Result`() {
+        // pingBinder() is a synchronous PING_TRANSACTION. Against a Shizuku server that is alive but
+        // not servicing requests it never returns, and unbounded it would stall this module's combine
+        // so the setup card sits on Loading forever.
+        val wedge = CountDownLatch(1)
+        val binder = mockk<ShizukuBaseServiceBinder>()
+        every { binder.pingBinder() } answers { wedge.await(); true }
+        every { shizukuManager.shizukuBinder } returns flowOf(binder)
+
+        // Real scope + real IO dispatcher: the wedge blocks an actual thread, Unconfined would run it
+        // inline and block the collector before any timeout could apply.
+        val realScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+        try {
+            val mod = module(realScope, TestDispatcherProvider(Dispatchers.IO)).apply { pingTimeoutMs = 250L }
+
+            val collector = mod.state.test(tag = "wedge", scope = realScope)
+            collector.await { values, _ -> values.any { it is ShizukuSetupModule.Result } }
+
+            val result = collector.latestValues.filterIsInstance<ShizukuSetupModule.Result>().last()
+            result.basicService shouldBe false
+
+            runBlocking { collector.cancelAndJoin() }
+        } finally {
+            wedge.countDown()
+            realScope.cancel()
+        }
     }
 }


### PR DESCRIPTION
## What changed

When Shizuku is installed and permitted but its service stops answering, the Shizuku entry on the setup screen could sit on "Loading" forever, with nothing to indicate what was wrong. The Storage Access Framework entry got stuck behind it too, because it waits on the same check.

SD Maid now gives up after 15 seconds and shows Shizuku as unavailable instead of spinning indefinitely. This does not make an unresponsive Shizuku work. It means you get an answer instead of an endless spinner, and the rest of the setup screen keeps working.

Refs #1816

## Technical Context

- Root cause: three Shizuku calls perform a *synchronous* binder transaction on code paths that run before `AdbHostLauncher`'s existing 15s connect watchdog is armed, so none of them were covered by it: `ShizukuSetupModule`'s `pingBinder()`, `ShizukuWrapper.isGranted()` (both `pingBinder()` and `checkSelfPermission()`), and `AdbHostLauncher`'s `apiVersion()`. Against a Shizuku server that is alive but not servicing requests, any of the three wedges forever and reproduces the same eternal spinner the watchdog was added to prevent.
- `getVersion()` and `checkSelfPermission()` are *conditionally* blocking, which is why this is not obvious from the call sites. Decompiling `dev.rikka.shizuku:api:13.1.5` shows each returns a latched static field once the server has pushed it via `bindApplication()`, and otherwise does a real `transact(..., flags=0)`. `getVersion()`'s blocking state is reachable whenever a binder has been received but its `bindApplication` has not landed yet, because `onBinderReceived(null)` clears the version cache and the service reference together; `checkSelfPermission()` blocks on a first-ever connection.
- `withTimeoutOrNull` alone cannot fix this, which drives the design: it only unwinds at suspension points, so a thread blocked inside a binder transaction keeps pinning its caller regardless. The new `runDetachedWithTimeout` helper runs the call on `@AppScope` and bounds only the await, letting a wedged thread leak rather than hanging the caller. That is the same trade `createConnection` already makes for `bindUserService()`. Rejected alternative: wrapping the calls in `withTimeout` directly, which compiles and reads fine but does nothing against a non-cooperative block.
- Timeouts are 15s rather than something tighter on purpose. The goal is only to turn "never returns" into "eventually gives up", and a bound tight enough to misfire would report a slow-but-working Shizuku as unavailable. Low-end devices under memory pressure are both where the wedge appears and where a slow-but-valid answer is most likely.
- Worth close review: `isGranted()` now maps through a private `GrantState` enum so the helper's `null` (timed out) does not collide with the pre-existing `null` (cannot know); and `runDetachedWithTimeout` cancels its deferred in a `finally`, not only on the timeout branch, so a cancelled caller cannot leave work running unobserved on the long-lived scope.
- Two related gaps are deliberately **not** addressed here, both pre-existing and neither triggered by this defect: the post-connect handshake does further synchronous IPC inside the `callbackFlow` producer, where a wedge can still keep collection from completing; and nothing bounds how many wedged threads can accumulate across repeated probes.
