### PR TITLE
CorpseFinder: Fix sdcard scan crashing on unidentifiable files

### DIFF
--- a/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/SdcardCorpseFilter.kt
+++ b/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/SdcardCorpseFilter.kt
@@ -111,10 +111,11 @@ class SdcardCorpseFilter @Inject constructor(
             val content = area.path.listFiles(gatewaySwitch)
 
             updateProgressCount(Progress.Count.Percent(content.size))
-            content.map {
-                fileForensics.findOwners(it)!!.also {
-                    increaseProgress()
-                }
+            content.mapNotNull { item ->
+                val ownerInfo = fileForensics.findOwners(item)
+                if (ownerInfo == null) log(TAG, WARN) { "Failed to identify $item, skipping" }
+                increaseProgress()
+                ownerInfo
             }
         }
 
@@ -321,7 +322,7 @@ class SdcardCorpseFilter @Inject constructor(
                 ownerInfo = ownerInfo,
                 lookup = lookup,
                 content = content,
-                isWriteProtected = ownerInfo.item.canWrite(gatewaySwitch),
+                isWriteProtected = !ownerInfo.item.canWrite(gatewaySwitch),
                 riskLevel = when {
                     ownerInfo.isKeeper -> RiskLevel.KEEPER
                     ownerInfo.isCommon -> RiskLevel.COMMON

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/AppAsecFileCorpseFilterTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/AppAsecFileCorpseFilterTest.kt
@@ -1,0 +1,38 @@
+package eu.darken.sdmse.corpsefinder.core.filter
+
+import eu.darken.sdmse.common.areas.DataArea
+import org.junit.jupiter.api.Test
+import testhelpers.coroutine.runTest2
+
+class AppAsecFileCorpseFilterTest : StandardCorpseFilterTest() {
+
+    override val areaType = DataArea.Type.APP_ASEC
+    override val filterClass = AppAsecFileCorpseFilter::class
+
+    override fun create() = AppAsecFileCorpseFilter(
+        areaManager = areaManager,
+        gatewaySwitch = gatewaySwitch,
+        fileForensics = fileForensics,
+        corpseFinderSettings = corpseFinderSettings,
+        exclusionManager = exclusionManager,
+    )
+
+    @Test fun `without root nothing is scanned`() = runTest2 {
+        hasRoot(false)
+        hasAdb(true)
+
+        assertSkipsScan()
+    }
+
+    @Test fun `scans on API 34`() = runTest2 {
+        fakeSdk(34)
+
+        assertScans()
+    }
+
+    @Test fun `bails on API 35`() = runTest2 {
+        fakeSdk(35)
+
+        assertSkipsScan()
+    }
+}

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/AppAsecFileCorpseFilterTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/AppAsecFileCorpseFilterTest.kt
@@ -9,6 +9,10 @@ class AppAsecFileCorpseFilterTest : StandardCorpseFilterTest() {
     override val areaType = DataArea.Type.APP_ASEC
     override val filterClass = AppAsecFileCorpseFilter::class
 
+    // AppSourceAsecCSI always ends up with owners: if neither the asec filename nor the clutter DB
+    // resolves one, it adds the file name itself as owner. An ownerless asec corpse cannot happen.
+    override val defaultPreset = Preset.StaleOwner()
+
     override fun create() = AppAsecFileCorpseFilter(
         areaManager = areaManager,
         gatewaySwitch = gatewaySwitch,
@@ -16,6 +20,14 @@ class AppAsecFileCorpseFilterTest : StandardCorpseFilterTest() {
         corpseFinderSettings = corpseFinderSettings,
         exclusionManager = exclusionManager,
     )
+
+    @Test fun `keeper risk gating`() = runTest2 {
+        assertKeeperGating()
+    }
+
+    @Test fun `common risk gating`() = runTest2 {
+        assertCommonGating()
+    }
 
     @Test fun `without root nothing is scanned`() = runTest2 {
         hasRoot(false)

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/AppLibCorpseFilterTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/AppLibCorpseFilterTest.kt
@@ -1,0 +1,38 @@
+package eu.darken.sdmse.corpsefinder.core.filter
+
+import eu.darken.sdmse.common.areas.DataArea
+import org.junit.jupiter.api.Test
+import testhelpers.coroutine.runTest2
+
+class AppLibCorpseFilterTest : StandardCorpseFilterTest() {
+
+    override val areaType = DataArea.Type.APP_LIB
+    override val filterClass = AppLibCorpseFilter::class
+
+    override fun create() = AppLibCorpseFilter(
+        areaManager = areaManager,
+        gatewaySwitch = gatewaySwitch,
+        fileForensics = fileForensics,
+        corpseFinderSettings = corpseFinderSettings,
+        exclusionManager = exclusionManager,
+    )
+
+    @Test fun `without root nothing is scanned`() = runTest2 {
+        hasRoot(false)
+        hasAdb(true)
+
+        assertSkipsScan()
+    }
+
+    @Test fun `scans on API 34`() = runTest2 {
+        fakeSdk(34)
+
+        assertScans()
+    }
+
+    @Test fun `bails on API 35`() = runTest2 {
+        fakeSdk(35)
+
+        assertSkipsScan()
+    }
+}

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/AppLibCorpseFilterTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/AppLibCorpseFilterTest.kt
@@ -9,6 +9,10 @@ class AppLibCorpseFilterTest : StandardCorpseFilterTest() {
     override val areaType = DataArea.Type.APP_LIB
     override val filterClass = AppLibCorpseFilter::class
 
+    // AppSourceLibCSI leaves the owner set empty when neither the dirname, a native library dir nor
+    // the clutter DB claims the directory.
+    override val defaultPreset = Preset.BlacklistOrphan
+
     override fun create() = AppLibCorpseFilter(
         areaManager = areaManager,
         gatewaySwitch = gatewaySwitch,
@@ -16,6 +20,19 @@ class AppLibCorpseFilterTest : StandardCorpseFilterTest() {
         corpseFinderSettings = corpseFinderSettings,
         exclusionManager = exclusionManager,
     )
+
+    @Test fun `an item with a stale clutter owner is a corpse`() = runTest2 {
+        // AppSourceLibCSI falls back to clutter matches, which are not install-verified.
+        assertStaleOwnerIsCorpse()
+    }
+
+    @Test fun `keeper risk gating`() = runTest2 {
+        assertKeeperGating()
+    }
+
+    @Test fun `common risk gating`() = runTest2 {
+        assertCommonGating()
+    }
 
     @Test fun `without root nothing is scanned`() = runTest2 {
         hasRoot(false)

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/AppSourceCorpseFilterTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/AppSourceCorpseFilterTest.kt
@@ -9,6 +9,9 @@ class AppSourceCorpseFilterTest : StandardCorpseFilterTest() {
     override val areaType = DataArea.Type.APP_APP
     override val filterClass = AppSourceCorpseFilter::class
 
+    // AppSourceMainCSI aggregates its checks and can come back with no owner at all.
+    override val defaultPreset = Preset.BlacklistOrphan
+
     override fun create() = AppSourceCorpseFilter(
         areaManager = areaManager,
         gatewaySwitch = gatewaySwitch,
@@ -16,6 +19,24 @@ class AppSourceCorpseFilterTest : StandardCorpseFilterTest() {
         corpseFinderSettings = corpseFinderSettings,
         exclusionManager = exclusionManager,
     )
+
+    @Test fun `an item with a stale clutter owner is a corpse`() = runTest2 {
+        // AppSourceClutterCheck contributes owners that were never install-verified.
+        assertStaleOwnerIsCorpse()
+    }
+
+    @Test fun `an item with an unknown owner is not a corpse`() = runTest2 {
+        // The source checks can report hasKnownUnknownOwner.
+        assertUnknownOwnerIsNotCorpse()
+    }
+
+    @Test fun `keeper risk gating`() = runTest2 {
+        assertKeeperGating()
+    }
+
+    @Test fun `common risk gating`() = runTest2 {
+        assertCommonGating()
+    }
 
     @Test fun `without root nothing is scanned`() = runTest2 {
         hasRoot(false)

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/AppSourceCorpseFilterTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/AppSourceCorpseFilterTest.kt
@@ -1,0 +1,38 @@
+package eu.darken.sdmse.corpsefinder.core.filter
+
+import eu.darken.sdmse.common.areas.DataArea
+import org.junit.jupiter.api.Test
+import testhelpers.coroutine.runTest2
+
+class AppSourceCorpseFilterTest : StandardCorpseFilterTest() {
+
+    override val areaType = DataArea.Type.APP_APP
+    override val filterClass = AppSourceCorpseFilter::class
+
+    override fun create() = AppSourceCorpseFilter(
+        areaManager = areaManager,
+        gatewaySwitch = gatewaySwitch,
+        fileForensics = fileForensics,
+        corpseFinderSettings = corpseFinderSettings,
+        exclusionManager = exclusionManager,
+    )
+
+    @Test fun `without root nothing is scanned`() = runTest2 {
+        hasRoot(false)
+        hasAdb(true)
+
+        assertSkipsScan()
+    }
+
+    @Test fun `scans on API 36`() = runTest2 {
+        fakeSdk(36)
+
+        assertScans()
+    }
+
+    @Test fun `bails on API 37`() = runTest2 {
+        fakeSdk(37)
+
+        assertSkipsScan()
+    }
+}

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/AppSourcePrivateCorpseFilterTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/AppSourcePrivateCorpseFilterTest.kt
@@ -1,0 +1,38 @@
+package eu.darken.sdmse.corpsefinder.core.filter
+
+import eu.darken.sdmse.common.areas.DataArea
+import org.junit.jupiter.api.Test
+import testhelpers.coroutine.runTest2
+
+class AppSourcePrivateCorpseFilterTest : StandardCorpseFilterTest() {
+
+    override val areaType = DataArea.Type.APP_APP_PRIVATE
+    override val filterClass = AppSourcePrivateCorpseFilter::class
+
+    override fun create() = AppSourcePrivateCorpseFilter(
+        areaManager = areaManager,
+        gatewaySwitch = gatewaySwitch,
+        fileForensics = fileForensics,
+        corpseFinderSettings = corpseFinderSettings,
+        exclusionManager = exclusionManager,
+    )
+
+    @Test fun `without root nothing is scanned`() = runTest2 {
+        hasRoot(false)
+        hasAdb(true)
+
+        assertSkipsScan()
+    }
+
+    @Test fun `scans on API 34`() = runTest2 {
+        fakeSdk(34)
+
+        assertScans()
+    }
+
+    @Test fun `bails on API 35`() = runTest2 {
+        fakeSdk(35)
+
+        assertSkipsScan()
+    }
+}

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/AppSourcePrivateCorpseFilterTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/AppSourcePrivateCorpseFilterTest.kt
@@ -9,6 +9,9 @@ class AppSourcePrivateCorpseFilterTest : StandardCorpseFilterTest() {
     override val areaType = DataArea.Type.APP_APP_PRIVATE
     override val filterClass = AppSourcePrivateCorpseFilter::class
 
+    // AppSourcePrivateCSI aggregates its checks and can come back with no owner at all.
+    override val defaultPreset = Preset.BlacklistOrphan
+
     override fun create() = AppSourcePrivateCorpseFilter(
         areaManager = areaManager,
         gatewaySwitch = gatewaySwitch,
@@ -16,6 +19,24 @@ class AppSourcePrivateCorpseFilterTest : StandardCorpseFilterTest() {
         corpseFinderSettings = corpseFinderSettings,
         exclusionManager = exclusionManager,
     )
+
+    @Test fun `an item with a stale clutter owner is a corpse`() = runTest2 {
+        // AppSourceClutterCheck contributes owners that were never install-verified.
+        assertStaleOwnerIsCorpse()
+    }
+
+    @Test fun `an item with an unknown owner is not a corpse`() = runTest2 {
+        // The source checks can report hasKnownUnknownOwner.
+        assertUnknownOwnerIsNotCorpse()
+    }
+
+    @Test fun `keeper risk gating`() = runTest2 {
+        assertKeeperGating()
+    }
+
+    @Test fun `common risk gating`() = runTest2 {
+        assertCommonGating()
+    }
 
     @Test fun `without root nothing is scanned`() = runTest2 {
         hasRoot(false)

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/ArtProfilesCorpseFilterTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/ArtProfilesCorpseFilterTest.kt
@@ -1,0 +1,38 @@
+package eu.darken.sdmse.corpsefinder.core.filter
+
+import eu.darken.sdmse.common.areas.DataArea
+import org.junit.jupiter.api.Test
+import testhelpers.coroutine.runTest2
+
+class ArtProfilesCorpseFilterTest : StandardCorpseFilterTest() {
+
+    override val areaType = DataArea.Type.ART_PROFILE
+    override val filterClass = ArtProfilesCorpseFilter::class
+
+    override fun create() = ArtProfilesCorpseFilter(
+        areaManager = areaManager,
+        gatewaySwitch = gatewaySwitch,
+        fileForensics = fileForensics,
+        corpseFinderSettings = corpseFinderSettings,
+        exclusionManager = exclusionManager,
+    )
+
+    @Test fun `without root nothing is scanned`() = runTest2 {
+        hasRoot(false)
+        hasAdb(true)
+
+        assertSkipsScan()
+    }
+
+    @Test fun `scans on API 36`() = runTest2 {
+        fakeSdk(36)
+
+        assertScans()
+    }
+
+    @Test fun `bails on API 37`() = runTest2 {
+        fakeSdk(37)
+
+        assertSkipsScan()
+    }
+}

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/ArtProfilesCorpseFilterTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/ArtProfilesCorpseFilterTest.kt
@@ -9,6 +9,11 @@ class ArtProfilesCorpseFilterTest : StandardCorpseFilterTest() {
     override val areaType = DataArea.Type.ART_PROFILE
     override val filterClass = ArtProfilesCorpseFilter::class
 
+    // ArtProfileCSI runs a single DirNameCheck: an owner exists only when that package is installed.
+    // So the only corpse shape it can produce is "no owners at all" - a stale owner, an unknown
+    // owner and clutter flags (keeper/common) are all unreachable here, hence no such tests below.
+    override val defaultPreset = Preset.BlacklistOrphan
+
     override fun create() = ArtProfilesCorpseFilter(
         areaManager = areaManager,
         gatewaySwitch = gatewaySwitch,

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/CorpseFilterTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/CorpseFilterTest.kt
@@ -155,6 +155,13 @@ abstract class CorpseFilterTest : BaseTest() {
     /** The two roots we register for [type], in a stable order. */
     fun areasOf(type: DataArea.Type): List<DataArea> = dataAreas.filter { it.type == type }
 
+    /**
+     * Mirrors the CSIs: every area a corpse filter scans is a blacklist location, except SDCARD
+     * where content has to be whitelisted through the clutter DB (see `SdcardCSI`).
+     */
+    val DataArea.Type.isBlackListLocation: Boolean
+        get() = this != DataArea.Type.SDCARD
+
     private val areaContents = mutableMapOf<APath, MutableList<APath>>()
     private val installedExclusions = mutableListOf<Exclusion>()
     private var fakeSdkLevel: Int = 0
@@ -223,15 +230,21 @@ abstract class CorpseFilterTest : BaseTest() {
         every { exclusionManager.exclusions } returns flowOf(holders)
     }
 
-    /** Ownership fixtures. The resulting [OwnerInfo] predicates are computed, never stubbed. */
+    /**
+     * Ownership fixtures. The resulting [OwnerInfo] predicates are computed, never stubbed.
+     *
+     * Not every shape is reachable in every area - the CSI that owns an area decides whether it can
+     * report no owner at all, an unknown owner, or clutter flags. Pick the preset that the area's
+     * CSI can actually produce.
+     */
     sealed interface Preset {
-        /** Blacklist area, nobody claims it -> corpse. */
+        /** Nobody claims it, not even a stale owner -> corpse in a blacklist area. */
         data object BlacklistOrphan : Preset
 
-        /** Whitelist area with a known but uninstalled owner -> corpse. */
-        data class WhitelistStale(val pkg: String = "com.stale.owner") : Preset
+        /** A known but uninstalled owner -> corpse. */
+        data class StaleOwner(val pkg: String = "com.stale.owner") : Preset
 
-        /** Blacklist area, CSI couldn't attribute it -> not a corpse. */
+        /** CSI knows someone owns it but can't name them -> not a corpse. */
         data object UnknownOwner : Preset
 
         /** Owner is currently installed -> not a corpse. */
@@ -263,7 +276,7 @@ abstract class CorpseFilterTest : BaseTest() {
         fileType: FileType = FileType.DIRECTORY,
         children: List<String> = emptyList(),
         forensicArea: DataArea = area,
-        blacklistArea: Boolean = preset !is Preset.WhitelistStale,
+        blacklistArea: Boolean = forensicArea.type.isBlackListLocation,
     ): Candidate {
         val path = area.path.child(name) as LocalPath
         registerContent(area, path)
@@ -305,7 +318,7 @@ abstract class CorpseFilterTest : BaseTest() {
         path: LocalPath,
         preset: Preset,
         area: DataArea,
-        blacklistArea: Boolean = preset !is Preset.WhitelistStale,
+        blacklistArea: Boolean = area.type.isBlackListLocation,
     ): OwnerInfo {
         val areaInfo = AreaInfo(
             file = path,
@@ -326,7 +339,7 @@ abstract class CorpseFilterTest : BaseTest() {
                 hasUnknownOwner = false,
             )
 
-            is Preset.WhitelistStale -> OwnerInfo(
+            is Preset.StaleOwner -> OwnerInfo(
                 areaInfo = areaInfo,
                 owners = setOf(owner(preset.pkg)),
                 installedOwners = emptySet(),

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/CorpseFilterTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/CorpseFilterTest.kt
@@ -1,0 +1,373 @@
+package eu.darken.sdmse.corpsefinder.core.filter
+
+import eu.darken.sdmse.common.areas.DataArea
+import eu.darken.sdmse.common.areas.DataAreaManager
+import eu.darken.sdmse.common.clutter.Marker
+import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.files.FileType
+import eu.darken.sdmse.common.files.GatewaySwitch
+import eu.darken.sdmse.common.files.local.LocalGateway
+import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.files.local.LocalPathLookup
+import eu.darken.sdmse.common.forensics.AreaInfo
+import eu.darken.sdmse.common.forensics.FileForensics
+import eu.darken.sdmse.common.forensics.Owner
+import eu.darken.sdmse.common.forensics.OwnerInfo
+import eu.darken.sdmse.common.hasApiLevel
+import eu.darken.sdmse.common.pkgs.Pkg
+import eu.darken.sdmse.common.user.UserHandle2
+import eu.darken.sdmse.corpsefinder.core.Corpse
+import eu.darken.sdmse.corpsefinder.core.CorpseFinderSettings
+import eu.darken.sdmse.corpsefinder.core.RiskLevel
+import eu.darken.sdmse.exclusion.core.ExclusionManager
+import eu.darken.sdmse.exclusion.core.types.Exclusion
+import eu.darken.sdmse.exclusion.core.types.ExclusionHolder
+import eu.darken.sdmse.exclusion.core.types.PathExclusion
+import eu.darken.sdmse.exclusion.core.types.UserExclusion
+import io.kotest.matchers.shouldBe
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import testhelpers.BaseTest
+import testhelpers.mockDataStoreValue
+import java.time.Instant
+import kotlin.reflect.KClass
+
+/**
+ * Shared harness for the [CorpseFilter] implementations.
+ *
+ * The mocked world is intentionally shallow: data areas exist, the gateway lists whatever a test
+ * registered, and [FileForensics] answers with REAL [OwnerInfo] objects. The corpse-relevant
+ * predicates ([OwnerInfo.isCorpse], [OwnerInfo.isOwned], [OwnerInfo.isKeeper], [OwnerInfo.isCommon])
+ * are derived, so they are never mocked - mocking them would allow states the production CSI can
+ * never produce.
+ */
+@Suppress("MemberVisibilityCanBePrivate")
+abstract class CorpseFilterTest : BaseTest() {
+
+    @MockK lateinit var areaManager: DataAreaManager
+    @MockK lateinit var gatewaySwitch: GatewaySwitch
+    @MockK lateinit var fileForensics: FileForensics
+    @MockK lateinit var corpseFinderSettings: CorpseFinderSettings
+    @MockK lateinit var exclusionManager: ExclusionManager
+
+    lateinit var localGateway: LocalGateway
+
+    /** SDCARD area root, overridable so tests can point it at a real (temp) directory. */
+    open val sdcardRoot: LocalPath get() = LocalPath.build("/storage", "emulated", "0")
+
+    /** SDK level the fake [hasApiLevel] reports unless a test calls [fakeSdk]. */
+    open val defaultSdk: Int = 34
+
+    val dataRoot1: LocalPath = LocalPath.build("/data")
+    val dataRoot2: LocalPath = LocalPath.build("/mnt", "expand", "1a2b3c4d")
+
+    val appSource1 = dataArea(DataArea.Type.APP_APP, dataRoot1.child("app"), primary = true)
+    val appSource2 = dataArea(DataArea.Type.APP_APP, dataRoot2.child("app"))
+
+    val appSourcePrivate1 = dataArea(DataArea.Type.APP_APP_PRIVATE, dataRoot1.child("app-private"), primary = true)
+    val appSourcePrivate2 = dataArea(DataArea.Type.APP_APP_PRIVATE, dataRoot2.child("app-private"))
+
+    val appLib1 = dataArea(DataArea.Type.APP_LIB, dataRoot1.child("app-lib"), primary = true)
+    val appLib2 = dataArea(DataArea.Type.APP_LIB, dataRoot2.child("app-lib"))
+
+    val appAsec1 = dataArea(DataArea.Type.APP_ASEC, dataRoot1.child("app-asec"), primary = true)
+    val appAsec2 = dataArea(DataArea.Type.APP_ASEC, dataRoot2.child("app-asec"))
+
+    val artProfile1 = dataArea(DataArea.Type.ART_PROFILE, dataRoot1.child("misc", "profiles", "cur", "0"), primary = true)
+    val artProfile2 = dataArea(DataArea.Type.ART_PROFILE, dataRoot2.child("misc", "profiles", "cur", "0"))
+
+    val dalvikProfile1 = dataArea(DataArea.Type.DALVIK_PROFILE, dataRoot1.child("dalvik-cache", "profiles"), primary = true)
+    val dalvikProfile2 = dataArea(DataArea.Type.DALVIK_PROFILE, dataRoot2.child("dalvik-cache", "profiles"))
+
+    val dalvikDex1 = dataArea(DataArea.Type.DALVIK_DEX, dataRoot1.child("dalvik-cache", "arm64"), primary = true)
+    val dalvikDex2 = dataArea(DataArea.Type.DALVIK_DEX, dataRoot2.child("dalvik-cache", "arm64"))
+
+    val privateData1 = dataArea(
+        DataArea.Type.PRIVATE_DATA,
+        LocalPath.build("/data_mirror", "data_de", "null", "0"),
+        primary = true,
+        userHandle = UserHandle2(0),
+    )
+    val privateData2 = dataArea(
+        DataArea.Type.PRIVATE_DATA,
+        LocalPath.build("/data_mirror", "data_ce", "null", "0"),
+        userHandle = UserHandle2(0),
+    )
+
+    val sdcard1 by lazy { dataArea(DataArea.Type.SDCARD, sdcardRoot, primary = true, userHandle = UserHandle2(0)) }
+    val sdcard2 by lazy {
+        dataArea(DataArea.Type.SDCARD, LocalPath.build("/storage", "ABCD-EFGH"), userHandle = UserHandle2(0))
+    }
+
+    val publicData1 by lazy { childArea(sdcard1, DataArea.Type.PUBLIC_DATA, "Android", "data") }
+    val publicData2 by lazy { childArea(sdcard2, DataArea.Type.PUBLIC_DATA, "Android", "data") }
+
+    val publicObb1 by lazy { childArea(sdcard1, DataArea.Type.PUBLIC_OBB, "Android", "obb") }
+    val publicObb2 by lazy { childArea(sdcard2, DataArea.Type.PUBLIC_OBB, "Android", "obb") }
+
+    val publicMedia1 by lazy { childArea(sdcard1, DataArea.Type.PUBLIC_MEDIA, "Android", "media") }
+    val publicMedia2 by lazy { childArea(sdcard2, DataArea.Type.PUBLIC_MEDIA, "Android", "media") }
+
+    val dataAreas: Set<DataArea> by lazy {
+        setOf(
+            appSource1, appSource2,
+            appSourcePrivate1, appSourcePrivate2,
+            appLib1, appLib2,
+            appAsec1, appAsec2,
+            artProfile1, artProfile2,
+            dalvikProfile1, dalvikProfile2,
+            dalvikDex1, dalvikDex2,
+            privateData1, privateData2,
+            sdcard1, sdcard2,
+            publicData1, publicData2,
+            publicObb1, publicObb2,
+            publicMedia1, publicMedia2,
+        )
+    }
+
+    private fun dataArea(
+        type: DataArea.Type,
+        path: LocalPath,
+        primary: Boolean = false,
+        userHandle: UserHandle2 = UserHandle2(-1),
+    ) = DataArea(
+        path = path,
+        type = type,
+        flags = if (primary) setOf(DataArea.Flag.PRIMARY) else emptySet(),
+        userHandle = userHandle,
+    )
+
+    private fun childArea(parent: DataArea, type: DataArea.Type, vararg segments: String) = parent.copy(
+        type = type,
+        path = parent.path.child(*segments),
+    )
+
+    /** The two roots we register for [type], in a stable order. */
+    fun areasOf(type: DataArea.Type): List<DataArea> = dataAreas.filter { it.type == type }
+
+    private val areaContents = mutableMapOf<APath, MutableList<APath>>()
+    private val installedExclusions = mutableListOf<Exclusion>()
+    private var fakeSdkLevel: Int = 0
+
+    @BeforeEach
+    open fun setup() {
+        MockKAnnotations.init(this)
+        areaContents.clear()
+        installedExclusions.clear()
+
+        localGateway = mockk()
+        coEvery { gatewaySwitch.getGateway(APath.PathType.LOCAL) } returns localGateway
+        coEvery { localGateway.hasRoot() } returns true
+        coEvery { localGateway.hasAdb() } returns false
+
+        every { areaManager.state } returns flowOf(DataAreaManager.State(areas = dataAreas))
+
+        coEvery { gatewaySwitch.listFiles(any()) } answers {
+            areaContents[arg<APath>(0)]?.asFlow() ?: emptyFlow()
+        }
+        coEvery { gatewaySwitch.exists(any()) } returns false
+        coEvery { gatewaySwitch.canRead(any()) } returns false
+        coEvery { gatewaySwitch.canWrite(any()) } returns false
+
+        riskFlags(keeper = false, common = false)
+        refreshExclusions()
+
+        // hasApiLevel(n) means "device SDK >= n", so a single monotonic answer keeps every call
+        // consistent - stubbing individual levels would allow impossible SDK combinations.
+        mockkStatic("eu.darken.sdmse.common.BuildWrapKt")
+        every { hasApiLevel(any()) } answers { fakeSdkLevel >= firstArg<Int>() }
+        fakeSdk(defaultSdk)
+    }
+
+    @AfterEach
+    open fun teardown() {
+        areaContents.clear()
+        installedExclusions.clear()
+        unmockkAll()
+    }
+
+    fun fakeSdk(level: Int) {
+        fakeSdkLevel = level
+    }
+
+    fun hasRoot(hasRoot: Boolean) {
+        coEvery { localGateway.hasRoot() } returns hasRoot
+    }
+
+    fun hasAdb(hasAdb: Boolean) {
+        coEvery { localGateway.hasAdb() } returns hasAdb
+    }
+
+    fun riskFlags(keeper: Boolean = false, common: Boolean = false) {
+        every { corpseFinderSettings.includeRiskKeeper } returns mockDataStoreValue(keeper)
+        every { corpseFinderSettings.includeRiskCommon } returns mockDataStoreValue(common)
+    }
+
+    fun excludePath(path: APath) {
+        installedExclusions.add(PathExclusion(path = path, tags = setOf(Exclusion.Tag.CORPSEFINDER)))
+        refreshExclusions()
+    }
+
+    private fun refreshExclusions() {
+        val holders: Collection<ExclusionHolder> = installedExclusions.map { UserExclusion(it) }
+        every { exclusionManager.exclusions } returns flowOf(holders)
+    }
+
+    /** Ownership fixtures. The resulting [OwnerInfo] predicates are computed, never stubbed. */
+    sealed interface Preset {
+        /** Blacklist area, nobody claims it -> corpse. */
+        data object BlacklistOrphan : Preset
+
+        /** Whitelist area with a known but uninstalled owner -> corpse. */
+        data class WhitelistStale(val pkg: String = "com.stale.owner") : Preset
+
+        /** Blacklist area, CSI couldn't attribute it -> not a corpse. */
+        data object UnknownOwner : Preset
+
+        /** Owner is currently installed -> not a corpse. */
+        data class InstalledOwner(val pkg: String = "com.installed.owner") : Preset
+
+        /** Corpse, but flagged as a keeper by the clutter DB. */
+        data class Keeper(val pkg: String = "com.keeper.owner") : Preset
+
+        /** Corpse, but flagged as commonly shared by the clutter DB. */
+        data class Common(val pkg: String = "com.common.owner") : Preset
+    }
+
+    data class Candidate(
+        val path: LocalPath,
+        val lookup: LocalPathLookup,
+        val children: List<LocalPathLookup>,
+    )
+
+    /**
+     * Registers [name] as top level content of [area] and wires forensics for it.
+     *
+     * @param forensicArea the area the mocked [FileForensics] reports - set it to a different area
+     * to simulate a CSI/filter area mismatch.
+     */
+    fun candidate(
+        area: DataArea,
+        name: String,
+        preset: Preset = Preset.BlacklistOrphan,
+        fileType: FileType = FileType.DIRECTORY,
+        children: List<String> = emptyList(),
+        forensicArea: DataArea = area,
+    ): Candidate {
+        val path = area.path.child(name) as LocalPath
+        registerContent(area, path)
+
+        val lookup = pathLookup(path, fileType)
+        coEvery { gatewaySwitch.lookup(path) } returns lookup
+
+        val childLookups = children.map { pathLookup(path.child(it) as LocalPath, FileType.FILE) }
+        if (fileType == FileType.DIRECTORY) {
+            coEvery { gatewaySwitch.walk(path, any()) } returns childLookups.asFlow()
+        }
+
+        coEvery { fileForensics.findOwners(path) } returns ownerInfo(path, preset, forensicArea)
+
+        return Candidate(path = path, lookup = lookup, children = childLookups)
+    }
+
+    /** Registers content whose forensics come back `null` (CSI couldn't identify the area). */
+    fun unidentifiedCandidate(area: DataArea, name: String): LocalPath {
+        val path = area.path.child(name) as LocalPath
+        registerContent(area, path)
+        coEvery { fileForensics.findOwners(path) } returns null
+        return path
+    }
+
+    private fun registerContent(area: DataArea, path: APath) {
+        areaContents.getOrPut(area.path) { mutableListOf() }.add(path)
+    }
+
+    fun pathLookup(path: LocalPath, fileType: FileType) = LocalPathLookup(
+        lookedUp = path,
+        fileType = fileType,
+        size = if (fileType == FileType.DIRECTORY) 512L else 1024L,
+        modifiedAt = Instant.EPOCH,
+        target = null,
+    )
+
+    fun ownerInfo(path: LocalPath, preset: Preset, area: DataArea): OwnerInfo {
+        val areaInfo = AreaInfo(
+            file = path,
+            prefix = area.path,
+            dataArea = area,
+            isBlackListLocation = preset !is Preset.WhitelistStale,
+        )
+        fun owner(pkg: String, vararg flags: Marker.Flag) = Owner(
+            pkgId = Pkg.Id(name = pkg),
+            userHandle = area.userHandle,
+            flags = flags.toSet(),
+        )
+        return when (preset) {
+            is Preset.BlacklistOrphan -> OwnerInfo(
+                areaInfo = areaInfo,
+                owners = emptySet(),
+                installedOwners = emptySet(),
+                hasUnknownOwner = false,
+            )
+
+            is Preset.WhitelistStale -> OwnerInfo(
+                areaInfo = areaInfo,
+                owners = setOf(owner(preset.pkg)),
+                installedOwners = emptySet(),
+                hasUnknownOwner = false,
+            )
+
+            is Preset.UnknownOwner -> OwnerInfo(
+                areaInfo = areaInfo,
+                owners = emptySet(),
+                installedOwners = emptySet(),
+                hasUnknownOwner = true,
+            )
+
+            is Preset.InstalledOwner -> OwnerInfo(
+                areaInfo = areaInfo,
+                owners = setOf(owner(preset.pkg)),
+                installedOwners = setOf(owner(preset.pkg)),
+                hasUnknownOwner = false,
+            )
+
+            is Preset.Keeper -> OwnerInfo(
+                areaInfo = areaInfo,
+                owners = setOf(owner(preset.pkg, Marker.Flag.KEEPER)),
+                installedOwners = emptySet(),
+                hasUnknownOwner = false,
+            )
+
+            is Preset.Common -> OwnerInfo(
+                areaInfo = areaInfo,
+                owners = setOf(owner(preset.pkg, Marker.Flag.COMMON)),
+                installedOwners = emptySet(),
+                hasUnknownOwner = false,
+            )
+        }
+    }
+
+    fun Collection<Corpse>.paths(): Set<APath> = map { it.identifier }.toSet()
+
+    fun Corpse.shouldMatch(
+        candidate: Candidate,
+        filterType: KClass<out CorpseFilter>,
+        riskLevel: RiskLevel = RiskLevel.NORMAL,
+    ) {
+        this.identifier shouldBe candidate.path
+        this.filterType shouldBe filterType
+        this.riskLevel shouldBe riskLevel
+        this.lookup shouldBe candidate.lookup
+        this.content.map { it.lookedUp }.toSet() shouldBe candidate.children.map { it.lookedUp }.toSet()
+    }
+}

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/CorpseFilterTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/CorpseFilterTest.kt
@@ -263,6 +263,7 @@ abstract class CorpseFilterTest : BaseTest() {
         fileType: FileType = FileType.DIRECTORY,
         children: List<String> = emptyList(),
         forensicArea: DataArea = area,
+        blacklistArea: Boolean = preset !is Preset.WhitelistStale,
     ): Candidate {
         val path = area.path.child(name) as LocalPath
         registerContent(area, path)
@@ -275,7 +276,7 @@ abstract class CorpseFilterTest : BaseTest() {
             coEvery { gatewaySwitch.walk(path, any()) } returns childLookups.asFlow()
         }
 
-        coEvery { fileForensics.findOwners(path) } returns ownerInfo(path, preset, forensicArea)
+        coEvery { fileForensics.findOwners(path) } returns ownerInfo(path, preset, forensicArea, blacklistArea)
 
         return Candidate(path = path, lookup = lookup, children = childLookups)
     }
@@ -300,12 +301,17 @@ abstract class CorpseFilterTest : BaseTest() {
         target = null,
     )
 
-    fun ownerInfo(path: LocalPath, preset: Preset, area: DataArea): OwnerInfo {
+    fun ownerInfo(
+        path: LocalPath,
+        preset: Preset,
+        area: DataArea,
+        blacklistArea: Boolean = preset !is Preset.WhitelistStale,
+    ): OwnerInfo {
         val areaInfo = AreaInfo(
             file = path,
             prefix = area.path,
             dataArea = area,
-            isBlackListLocation = preset !is Preset.WhitelistStale,
+            isBlackListLocation = blacklistArea,
         )
         fun owner(pkg: String, vararg flags: Marker.Flag) = Owner(
             pkgId = Pkg.Id(name = pkg),

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/DalvikCorpseFilterTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/DalvikCorpseFilterTest.kt
@@ -188,13 +188,13 @@ class DalvikCorpseFilterTest : CorpseFilterTest() {
         val libOwned = candidate(
             dalvikDex1,
             "com.example.sharedlib",
-            preset = Preset.WhitelistStale("com.example.sharedlib"),
+            preset = Preset.StaleOwner("com.example.sharedlib"),
             fileType = FileType.FILE,
         )
         val unrelated = candidate(
             dalvikDex1,
             "com.example.app",
-            preset = Preset.WhitelistStale("com.example.app"),
+            preset = Preset.StaleOwner("com.example.app"),
             fileType = FileType.FILE,
         )
         every { packageManager.getSharedLibraries(0) } returns mutableListOf(sharedLibrary("com.example.sharedlib"))
@@ -209,7 +209,7 @@ class DalvikCorpseFilterTest : CorpseFilterTest() {
         val profileCorpse = candidate(
             dalvikProfile1,
             "com.example.app",
-            preset = Preset.WhitelistStale("com.example.app"),
+            preset = Preset.StaleOwner("com.example.app"),
             fileType = FileType.FILE,
         )
         every { packageManager.getSharedLibraries(0) } returns mutableListOf(sharedLibrary("com.other.library"))

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/DalvikCorpseFilterTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/DalvikCorpseFilterTest.kt
@@ -1,0 +1,219 @@
+package eu.darken.sdmse.corpsefinder.core.filter
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.content.pm.SharedLibraryInfo
+import eu.darken.sdmse.common.files.FileType
+import eu.darken.sdmse.corpsefinder.core.RiskLevel
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.coroutine.runTest2
+
+class DalvikCorpseFilterTest : CorpseFilterTest() {
+
+    @MockK lateinit var context: Context
+    @MockK lateinit var packageManager: PackageManager
+
+    @BeforeEach
+    override fun setup() {
+        super.setup()
+        every { context.packageManager } returns packageManager
+        // Default: the device knows no shared libraries, so checkForLibs() removes nothing.
+        every { packageManager.getSharedLibraries(0) } returns mutableListOf()
+    }
+
+    private fun create() = DalvikCorpseFilter(
+        context = context,
+        areaManager = areaManager,
+        gatewaySwitch = gatewaySwitch,
+        fileForensics = fileForensics,
+        corpseFinderSettings = corpseFinderSettings,
+        exclusionManager = exclusionManager,
+    )
+
+    private fun sharedLibrary(name: String) = mockk<SharedLibraryInfo>().apply {
+        every { this@apply.name } returns name
+    }
+
+    // ─────────────────────────── corpse identification ───────────────────────────
+
+    @Test fun `profile and dex corpses are combined into one result`() = runTest2 {
+        val profileCorpse = candidate(dalvikProfile1, "com.orphan.profile", fileType = FileType.FILE)
+        val dexCorpse = candidate(dalvikDex1, "com.orphan.dex", fileType = FileType.FILE)
+
+        val corpses = create().scan()
+
+        corpses.paths() shouldContainExactlyInAnyOrder listOf(profileCorpse.path, dexCorpse.path)
+        corpses.forEach { it.filterType shouldBe DalvikCorpseFilter::class }
+    }
+
+    @Test fun `profile corpses from both roots are aggregated`() = runTest2 {
+        val first = candidate(dalvikProfile1, "com.orphan.one", fileType = FileType.FILE)
+        val second = candidate(dalvikProfile2, "com.orphan.two", fileType = FileType.FILE)
+
+        create().scan().paths() shouldContainExactlyInAnyOrder listOf(first.path, second.path)
+    }
+
+    @Test fun `dex corpses from both roots are aggregated`() = runTest2 {
+        val first = candidate(dalvikDex1, "com.orphan.one", fileType = FileType.FILE)
+        val second = candidate(dalvikDex2, "com.orphan.two", fileType = FileType.FILE)
+
+        create().scan().paths() shouldContainExactlyInAnyOrder listOf(first.path, second.path)
+    }
+
+    @Test fun `a dalvik directory corpse carries its walked content`() = runTest2 {
+        val target = candidate(dalvikDex1, "com.orphan.dir", children = listOf("classes.dex"))
+
+        create().scan().single().shouldMatch(target, DalvikCorpseFilter::class)
+    }
+
+    @Test fun `items with an installed owner are not corpses`() = runTest2 {
+        candidate(dalvikProfile1, "com.alive.profile", preset = Preset.InstalledOwner(), fileType = FileType.FILE)
+        candidate(dalvikDex1, "com.alive.dex", preset = Preset.InstalledOwner(), fileType = FileType.FILE)
+
+        create().scan() shouldBe emptyList()
+    }
+
+    @Test fun `items reported for a different area are dropped`() = runTest2 {
+        // The dex pass only accepts DALVIK_DEX and the profile pass only DALVIK_PROFILE, so
+        // swapping the areas must drop both.
+        candidate(dalvikProfile1, "com.wrongarea.profile", fileType = FileType.FILE, forensicArea = dalvikDex1)
+        candidate(dalvikDex1, "com.wrongarea.dex", fileType = FileType.FILE, forensicArea = dalvikProfile1)
+
+        create().scan() shouldBe emptyList()
+    }
+
+    @Test fun `unidentified items are skipped and the scan continues`() = runTest2 {
+        unidentifiedCandidate(dalvikProfile1, "com.unidentified.profile")
+        unidentifiedCandidate(dalvikDex1, "com.unidentified.dex")
+        val profileCorpse = candidate(dalvikProfile1, "com.orphan.profile", fileType = FileType.FILE)
+        val dexCorpse = candidate(dalvikDex1, "com.orphan.dex", fileType = FileType.FILE)
+
+        create().scan().paths() shouldContainExactlyInAnyOrder listOf(profileCorpse.path, dexCorpse.path)
+    }
+
+    // ─────────────────────────── risk gating ───────────────────────────
+
+    @Test fun `keepers are dropped unless included`() = runTest2 {
+        riskFlags(keeper = false)
+        candidate(dalvikProfile1, "com.keeper.profile", preset = Preset.Keeper(), fileType = FileType.FILE)
+        candidate(dalvikDex1, "com.keeper.dex", preset = Preset.Keeper(), fileType = FileType.FILE)
+
+        create().scan() shouldBe emptyList()
+    }
+
+    @Test fun `keepers are KEEPER corpses when included`() = runTest2 {
+        riskFlags(keeper = true)
+        val profileCorpse = candidate(dalvikProfile1, "com.keeper.profile", preset = Preset.Keeper(), fileType = FileType.FILE)
+        val dexCorpse = candidate(dalvikDex1, "com.keeper.dex", preset = Preset.Keeper(), fileType = FileType.FILE)
+
+        val corpses = create().scan()
+
+        corpses.paths() shouldContainExactlyInAnyOrder listOf(profileCorpse.path, dexCorpse.path)
+        corpses.forEach { it.riskLevel shouldBe RiskLevel.KEEPER }
+    }
+
+    @Test fun `common items are dropped unless included`() = runTest2 {
+        riskFlags(common = false)
+        candidate(dalvikProfile1, "com.common.profile", preset = Preset.Common(), fileType = FileType.FILE)
+        candidate(dalvikDex1, "com.common.dex", preset = Preset.Common(), fileType = FileType.FILE)
+
+        create().scan() shouldBe emptyList()
+    }
+
+    @Test fun `common items are COMMON corpses when included`() = runTest2 {
+        riskFlags(common = true)
+        val profileCorpse = candidate(dalvikProfile1, "com.common.profile", preset = Preset.Common(), fileType = FileType.FILE)
+        val dexCorpse = candidate(dalvikDex1, "com.common.dex", preset = Preset.Common(), fileType = FileType.FILE)
+
+        val corpses = create().scan()
+
+        corpses.paths() shouldContainExactlyInAnyOrder listOf(profileCorpse.path, dexCorpse.path)
+        corpses.forEach { it.riskLevel shouldBe RiskLevel.COMMON }
+    }
+
+    // ─────────────────────────── exclusions ───────────────────────────
+
+    @Test fun `path exclusions drop candidates before forensics run`() = runTest2 {
+        val excludedProfile = candidate(dalvikProfile1, "com.excluded.profile", fileType = FileType.FILE)
+        val excludedDex = candidate(dalvikDex1, "com.excluded.dex", fileType = FileType.FILE)
+        val target = candidate(dalvikDex1, "com.orphan.dex", fileType = FileType.FILE)
+        excludePath(excludedProfile.path)
+        excludePath(excludedDex.path)
+
+        create().scan().single().shouldMatch(target, DalvikCorpseFilter::class)
+
+        coVerify(exactly = 0) { fileForensics.findOwners(excludedProfile.path) }
+        coVerify(exactly = 0) { fileForensics.findOwners(excludedDex.path) }
+    }
+
+    // ─────────────────────────── capability and API gates ───────────────────────────
+
+    @Test fun `without root nothing is scanned`() = runTest2 {
+        hasRoot(false)
+        hasAdb(true)
+        candidate(dalvikDex1, "com.orphan.dex", fileType = FileType.FILE)
+
+        create().scan() shouldBe emptySet()
+
+        coVerify(exactly = 0) { gatewaySwitch.listFiles(any()) }
+    }
+
+    @Test fun `scans on API 36`() = runTest2 {
+        fakeSdk(36)
+        val target = candidate(dalvikDex1, "com.orphan.dex", fileType = FileType.FILE)
+
+        create().scan().single().shouldMatch(target, DalvikCorpseFilter::class)
+    }
+
+    @Test fun `bails on API 37`() = runTest2 {
+        fakeSdk(37)
+        candidate(dalvikDex1, "com.orphan.dex", fileType = FileType.FILE)
+
+        create().scan() shouldBe emptySet()
+
+        coVerify(exactly = 0) { gatewaySwitch.listFiles(any()) }
+    }
+
+    // ─────────────────────────── shared library filtering ───────────────────────────
+
+    @Test fun `corpses owned by a shared library are ignored`() = runTest2 {
+        // Owners are needed for the library match, so these use the stale-owner shape.
+        val libOwned = candidate(
+            dalvikDex1,
+            "com.example.sharedlib",
+            preset = Preset.WhitelistStale("com.example.sharedlib"),
+            fileType = FileType.FILE,
+        )
+        val unrelated = candidate(
+            dalvikDex1,
+            "com.example.app",
+            preset = Preset.WhitelistStale("com.example.app"),
+            fileType = FileType.FILE,
+        )
+        every { packageManager.getSharedLibraries(0) } returns mutableListOf(sharedLibrary("com.example.sharedlib"))
+
+        val corpses = create().scan()
+
+        corpses.paths() shouldContainExactlyInAnyOrder listOf(unrelated.path)
+        corpses.paths().contains(libOwned.path) shouldBe false
+    }
+
+    @Test fun `corpses are kept when no shared library matches`() = runTest2 {
+        val profileCorpse = candidate(
+            dalvikProfile1,
+            "com.example.app",
+            preset = Preset.WhitelistStale("com.example.app"),
+            fileType = FileType.FILE,
+        )
+        every { packageManager.getSharedLibraries(0) } returns mutableListOf(sharedLibrary("com.other.library"))
+
+        create().scan().single().shouldMatch(profileCorpse, DalvikCorpseFilter::class)
+    }
+}

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/PrivateDataCorpseFilterTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/PrivateDataCorpseFilterTest.kt
@@ -9,6 +9,10 @@ class PrivateDataCorpseFilterTest : StandardCorpseFilterTest() {
     override val areaType = DataArea.Type.PRIVATE_DATA
     override val filterClass = PrivateDataCorpseFilter::class
 
+    // PrivateDataCSI only leaves the owner set empty when it also flags an unknown owner, otherwise
+    // it falls back to dirname=pkgname. An ownerless corpse without that flag cannot happen.
+    override val defaultPreset = Preset.StaleOwner()
+
     override fun create() = PrivateDataCorpseFilter(
         areaManager = areaManager,
         gatewaySwitch = gatewaySwitch,
@@ -16,6 +20,19 @@ class PrivateDataCorpseFilterTest : StandardCorpseFilterTest() {
         corpseFinderSettings = corpseFinderSettings,
         exclusionManager = exclusionManager,
     )
+
+    @Test fun `an item with an unknown owner is not a corpse`() = runTest2 {
+        // PrivateDataCSI reports an unknown owner when the uid maps to a shared or unresolvable owner.
+        assertUnknownOwnerIsNotCorpse()
+    }
+
+    @Test fun `keeper risk gating`() = runTest2 {
+        assertKeeperGating()
+    }
+
+    @Test fun `common risk gating`() = runTest2 {
+        assertCommonGating()
+    }
 
     @Test fun `without root nothing is scanned`() = runTest2 {
         hasRoot(false)

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/PrivateDataCorpseFilterTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/PrivateDataCorpseFilterTest.kt
@@ -1,0 +1,46 @@
+package eu.darken.sdmse.corpsefinder.core.filter
+
+import eu.darken.sdmse.common.areas.DataArea
+import org.junit.jupiter.api.Test
+import testhelpers.coroutine.runTest2
+
+class PrivateDataCorpseFilterTest : StandardCorpseFilterTest() {
+
+    override val areaType = DataArea.Type.PRIVATE_DATA
+    override val filterClass = PrivateDataCorpseFilter::class
+
+    override fun create() = PrivateDataCorpseFilter(
+        areaManager = areaManager,
+        gatewaySwitch = gatewaySwitch,
+        fileForensics = fileForensics,
+        corpseFinderSettings = corpseFinderSettings,
+        exclusionManager = exclusionManager,
+    )
+
+    @Test fun `without root nothing is scanned`() = runTest2 {
+        hasRoot(false)
+        hasAdb(true)
+
+        assertSkipsScan()
+    }
+
+    @Test fun `scans on API 36`() = runTest2 {
+        fakeSdk(36)
+
+        assertScans()
+    }
+
+    @Test fun `bails on API 37`() = runTest2 {
+        fakeSdk(37)
+
+        assertSkipsScan()
+    }
+
+    @Test fun `hosts is excluded by name`() = runTest2 {
+        assertNameExcluded("hosts")
+    }
+
+    @Test fun `lost+found is excluded by name`() = runTest2 {
+        assertNameExcluded("lost+found")
+    }
+}

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/PublicDataCorpseFilterTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/PublicDataCorpseFilterTest.kt
@@ -9,6 +9,10 @@ class PublicDataCorpseFilterTest : StandardCorpseFilterTest() {
     override val areaType = DataArea.Type.PUBLIC_DATA
     override val filterClass = PublicDataCorpseFilter::class
 
+    // PublicDataCSI falls back to dirname=pkgname, so it always names an owner and never reports an
+    // unknown one. Ownerless public data cannot happen.
+    override val defaultPreset = Preset.StaleOwner()
+
     override fun create() = PublicDataCorpseFilter(
         areaManager = areaManager,
         gatewaySwitch = gatewaySwitch,
@@ -16,6 +20,14 @@ class PublicDataCorpseFilterTest : StandardCorpseFilterTest() {
         corpseFinderSettings = corpseFinderSettings,
         exclusionManager = exclusionManager,
     )
+
+    @Test fun `keeper risk gating`() = runTest2 {
+        assertKeeperGating()
+    }
+
+    @Test fun `common risk gating`() = runTest2 {
+        assertCommonGating()
+    }
 
     @Test fun `scans without root or adb below API 33`() = runTest2 {
         fakeSdk(32)

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/PublicDataCorpseFilterTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/PublicDataCorpseFilterTest.kt
@@ -1,0 +1,69 @@
+package eu.darken.sdmse.corpsefinder.core.filter
+
+import eu.darken.sdmse.common.areas.DataArea
+import org.junit.jupiter.api.Test
+import testhelpers.coroutine.runTest2
+
+class PublicDataCorpseFilterTest : StandardCorpseFilterTest() {
+
+    override val areaType = DataArea.Type.PUBLIC_DATA
+    override val filterClass = PublicDataCorpseFilter::class
+
+    override fun create() = PublicDataCorpseFilter(
+        areaManager = areaManager,
+        gatewaySwitch = gatewaySwitch,
+        fileForensics = fileForensics,
+        corpseFinderSettings = corpseFinderSettings,
+        exclusionManager = exclusionManager,
+    )
+
+    @Test fun `scans without root or adb below API 33`() = runTest2 {
+        fakeSdk(32)
+        hasRoot(false)
+        hasAdb(false)
+
+        assertScans()
+    }
+
+    @Test fun `scans with root only on API 33`() = runTest2 {
+        fakeSdk(33)
+        hasRoot(true)
+        hasAdb(false)
+
+        assertScans()
+    }
+
+    @Test fun `scans with adb only on API 33`() = runTest2 {
+        fakeSdk(33)
+        hasRoot(false)
+        hasAdb(true)
+
+        assertScans()
+    }
+
+    @Test fun `skips without root and adb on API 33`() = runTest2 {
+        fakeSdk(33)
+        hasRoot(false)
+        hasAdb(false)
+
+        assertSkipsScan()
+    }
+
+    @Test fun `still scans on untested API levels`() = runTest2 {
+        fakeSdk(37)
+
+        assertScans()
+    }
+
+    @Test fun `nomedia is excluded by name`() = runTest2 {
+        assertNameExcluded(".nomedia")
+    }
+
+    @Test fun `hosts is excluded by name`() = runTest2 {
+        assertNameExcluded("hosts")
+    }
+
+    @Test fun `lost+found is excluded by name`() = runTest2 {
+        assertNameExcluded("lost+found")
+    }
+}

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/PublicMediaCorpseFilterTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/PublicMediaCorpseFilterTest.kt
@@ -1,0 +1,38 @@
+package eu.darken.sdmse.corpsefinder.core.filter
+
+import eu.darken.sdmse.common.areas.DataArea
+import org.junit.jupiter.api.Test
+import testhelpers.coroutine.runTest2
+
+class PublicMediaCorpseFilterTest : StandardCorpseFilterTest() {
+
+    override val areaType = DataArea.Type.PUBLIC_MEDIA
+    override val filterClass = PublicMediaCorpseFilter::class
+
+    override fun create() = PublicMediaCorpseFilter(
+        areaManager = areaManager,
+        gatewaySwitch = gatewaySwitch,
+        fileForensics = fileForensics,
+        corpseFinderSettings = corpseFinderSettings,
+        exclusionManager = exclusionManager,
+    )
+
+    @Test fun `scans without root or adb`() = runTest2 {
+        hasRoot(false)
+        hasAdb(false)
+
+        assertScans()
+    }
+
+    @Test fun `still scans on untested API levels`() = runTest2 {
+        fakeSdk(37)
+        hasRoot(false)
+        hasAdb(false)
+
+        assertScans()
+    }
+
+    @Test fun `nomedia is excluded by name`() = runTest2 {
+        assertNameExcluded(".nomedia")
+    }
+}

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/PublicMediaCorpseFilterTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/PublicMediaCorpseFilterTest.kt
@@ -9,6 +9,10 @@ class PublicMediaCorpseFilterTest : StandardCorpseFilterTest() {
     override val areaType = DataArea.Type.PUBLIC_MEDIA
     override val filterClass = PublicMediaCorpseFilter::class
 
+    // PublicMediaCSI falls back to dirname=pkgname, so it always names an owner and never reports an
+    // unknown one. Ownerless public media cannot happen.
+    override val defaultPreset = Preset.StaleOwner()
+
     override fun create() = PublicMediaCorpseFilter(
         areaManager = areaManager,
         gatewaySwitch = gatewaySwitch,
@@ -16,6 +20,14 @@ class PublicMediaCorpseFilterTest : StandardCorpseFilterTest() {
         corpseFinderSettings = corpseFinderSettings,
         exclusionManager = exclusionManager,
     )
+
+    @Test fun `keeper risk gating`() = runTest2 {
+        assertKeeperGating()
+    }
+
+    @Test fun `common risk gating`() = runTest2 {
+        assertCommonGating()
+    }
 
     @Test fun `scans without root or adb`() = runTest2 {
         hasRoot(false)

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/PublicObbCorpseFilterTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/PublicObbCorpseFilterTest.kt
@@ -9,6 +9,9 @@ class PublicObbCorpseFilterTest : StandardCorpseFilterTest() {
     override val areaType = DataArea.Type.PUBLIC_OBB
     override val filterClass = PublicObbCorpseFilter::class
 
+    // PublicObbCSI has no dirname fallback: an obb dir nobody claims stays ownerless.
+    override val defaultPreset = Preset.BlacklistOrphan
+
     override fun create() = PublicObbCorpseFilter(
         areaManager = areaManager,
         gatewaySwitch = gatewaySwitch,
@@ -16,6 +19,24 @@ class PublicObbCorpseFilterTest : StandardCorpseFilterTest() {
         corpseFinderSettings = corpseFinderSettings,
         exclusionManager = exclusionManager,
     )
+
+    @Test fun `an item with a stale clutter owner is a corpse`() = runTest2 {
+        // PublicObbCSI resolves owners from the clutter DB without verifying they are installed.
+        assertStaleOwnerIsCorpse()
+    }
+
+    @Test fun `an item with an unknown owner is not a corpse`() = runTest2 {
+        // PublicObbCSI reports an unknown owner when the obb is currently mounted.
+        assertUnknownOwnerIsNotCorpse()
+    }
+
+    @Test fun `keeper risk gating`() = runTest2 {
+        assertKeeperGating()
+    }
+
+    @Test fun `common risk gating`() = runTest2 {
+        assertCommonGating()
+    }
 
     @Test fun `scans without root below API 33`() = runTest2 {
         fakeSdk(32)

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/PublicObbCorpseFilterTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/PublicObbCorpseFilterTest.kt
@@ -1,0 +1,53 @@
+package eu.darken.sdmse.corpsefinder.core.filter
+
+import eu.darken.sdmse.common.areas.DataArea
+import org.junit.jupiter.api.Test
+import testhelpers.coroutine.runTest2
+
+class PublicObbCorpseFilterTest : StandardCorpseFilterTest() {
+
+    override val areaType = DataArea.Type.PUBLIC_OBB
+    override val filterClass = PublicObbCorpseFilter::class
+
+    override fun create() = PublicObbCorpseFilter(
+        areaManager = areaManager,
+        gatewaySwitch = gatewaySwitch,
+        fileForensics = fileForensics,
+        corpseFinderSettings = corpseFinderSettings,
+        exclusionManager = exclusionManager,
+    )
+
+    @Test fun `scans without root below API 33`() = runTest2 {
+        fakeSdk(32)
+        hasRoot(false)
+        hasAdb(false)
+
+        assertScans()
+    }
+
+    @Test fun `scans with root on API 33`() = runTest2 {
+        fakeSdk(33)
+        hasRoot(true)
+        hasAdb(false)
+
+        assertScans()
+    }
+
+    @Test fun `skips without root on API 33 even with adb`() = runTest2 {
+        fakeSdk(33)
+        hasRoot(false)
+        hasAdb(true)
+
+        assertSkipsScan()
+    }
+
+    @Test fun `still scans on untested API levels`() = runTest2 {
+        fakeSdk(37)
+
+        assertScans()
+    }
+
+    @Test fun `nomedia is excluded by name`() = runTest2 {
+        assertNameExcluded(".nomedia")
+    }
+}

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/SdcardCorpseFilterTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/SdcardCorpseFilterTest.kt
@@ -134,7 +134,7 @@ class SdcardCorpseFilterTest : CorpseFilterTest() {
         val target = candidate(
             sdcard1,
             "OrphanApp",
-            preset = Preset.WhitelistStale("com.orphan.app"),
+            preset = Preset.StaleOwner("com.orphan.app"),
             children = listOf("data.db"),
         )
 
@@ -142,14 +142,14 @@ class SdcardCorpseFilterTest : CorpseFilterTest() {
     }
 
     @Test fun `top level item with an installed owner is not a corpse`() = runTest2 {
-        candidate(sdcard1, "AliveApp", preset = Preset.InstalledOwner(), blacklistArea = false)
+        candidate(sdcard1, "AliveApp", preset = Preset.InstalledOwner())
 
         create().scan() shouldBe emptyList()
     }
 
     @Test fun `top level items from both sdcard roots are aggregated`() = runTest2 {
-        val first = candidate(sdcard1, "OrphanOne", preset = Preset.WhitelistStale("com.orphan.one"))
-        val second = candidate(sdcard2, "OrphanTwo", preset = Preset.WhitelistStale("com.orphan.two"))
+        val first = candidate(sdcard1, "OrphanOne", preset = Preset.StaleOwner("com.orphan.one"))
+        val second = candidate(sdcard2, "OrphanTwo", preset = Preset.StaleOwner("com.orphan.two"))
 
         create().scan().paths() shouldContainExactlyInAnyOrder listOf(first.path, second.path)
     }
@@ -158,7 +158,7 @@ class SdcardCorpseFilterTest : CorpseFilterTest() {
         val target = candidate(
             sdcard1,
             "orphan.txt",
-            preset = Preset.WhitelistStale("com.orphan.app"),
+            preset = Preset.StaleOwner("com.orphan.app"),
             fileType = FileType.FILE,
         )
 
@@ -172,7 +172,7 @@ class SdcardCorpseFilterTest : CorpseFilterTest() {
     // ─────────────────────────── clutter marker resolution ───────────────────────────
 
     @Test fun `a nested clutter marker with an uninstalled owner is a corpse`() = runTest2 {
-        candidate(sdcard1, "Android", preset = Preset.InstalledOwner(), blacklistArea = false)
+        candidate(sdcard1, "Android", preset = Preset.InstalledOwner())
         clutterMarker(pkg = "com.orphan.app", segments = listOf("Android", "orphandata"))
         val target = markerTarget(sdcard1, listOf("Android", "orphandata"), children = listOf("blob"))
 
@@ -183,7 +183,7 @@ class SdcardCorpseFilterTest : CorpseFilterTest() {
     }
 
     @Test fun `a nested clutter marker with an installed owner is not a corpse`() = runTest2 {
-        candidate(sdcard1, "Android", preset = Preset.InstalledOwner(), blacklistArea = false)
+        candidate(sdcard1, "Android", preset = Preset.InstalledOwner())
         clutterMarker(pkg = "com.alive.app", segments = listOf("Android", "alivedata"))
         markerTarget(sdcard1, listOf("Android", "alivedata"))
         installed("com.alive.app")
@@ -192,7 +192,7 @@ class SdcardCorpseFilterTest : CorpseFilterTest() {
     }
 
     @Test fun `top level markers are not resolved again`() = runTest2 {
-        candidate(sdcard1, "Android", preset = Preset.InstalledOwner(), blacklistArea = false)
+        candidate(sdcard1, "Android", preset = Preset.InstalledOwner())
         clutterMarker(pkg = "com.orphan.app", segments = listOf("Android"))
         val target = markerTarget(sdcard1, listOf("Android"))
 
@@ -203,7 +203,7 @@ class SdcardCorpseFilterTest : CorpseFilterTest() {
     }
 
     @Test fun `regex markers are not resolved`() = runTest2 {
-        candidate(sdcard1, "Android", preset = Preset.InstalledOwner(), blacklistArea = false)
+        candidate(sdcard1, "Android", preset = Preset.InstalledOwner())
         clutterMarker(pkg = "com.orphan.app", segments = listOf("Android", "orphandata"), isDirectMatch = false)
         val target = markerTarget(sdcard1, listOf("Android", "orphandata"))
 
@@ -214,7 +214,7 @@ class SdcardCorpseFilterTest : CorpseFilterTest() {
     }
 
     @Test fun `markers whose top level parent is missing are not resolved`() = runTest2 {
-        candidate(sdcard1, "Android", preset = Preset.InstalledOwner(), blacklistArea = false)
+        candidate(sdcard1, "Android", preset = Preset.InstalledOwner())
         clutterMarker(pkg = "com.orphan.app", segments = listOf("Missing", "orphandata"))
         val target = markerTarget(sdcard1, listOf("Missing", "orphandata"))
 
@@ -224,7 +224,7 @@ class SdcardCorpseFilterTest : CorpseFilterTest() {
     }
 
     @Test fun `markers pointing at a non existing path yield no corpse`() = runTest2 {
-        candidate(sdcard1, "Android", preset = Preset.InstalledOwner(), blacklistArea = false)
+        candidate(sdcard1, "Android", preset = Preset.InstalledOwner())
         clutterMarker(pkg = "com.orphan.app", segments = listOf("Android", "orphandata"))
         markerTarget(sdcard1, listOf("Android", "orphandata"), exists = false)
 
@@ -232,7 +232,7 @@ class SdcardCorpseFilterTest : CorpseFilterTest() {
     }
 
     @Test fun `markers pointing at an unreadable path yield no corpse`() = runTest2 {
-        candidate(sdcard1, "Android", preset = Preset.InstalledOwner(), blacklistArea = false)
+        candidate(sdcard1, "Android", preset = Preset.InstalledOwner())
         clutterMarker(pkg = "com.orphan.app", segments = listOf("Android", "orphandata"))
         markerTarget(sdcard1, listOf("Android", "orphandata"), canRead = false)
 
@@ -243,7 +243,7 @@ class SdcardCorpseFilterTest : CorpseFilterTest() {
         // Real directory tree: the marker says "MiBand", the sdcard holds "miband".
         File(tempDir, "Games/miband").mkdirs()
 
-        candidate(sdcard1, "Games", preset = Preset.InstalledOwner(), blacklistArea = false)
+        candidate(sdcard1, "Games", preset = Preset.InstalledOwner())
         clutterMarker(pkg = "com.mi.band", segments = listOf("Games", "MiBand"))
         // The marker spelling exists as far as the (case-insensitive) gateway is concerned...
         coEvery { gatewaySwitch.exists(sdcard1.path.child("Games", "MiBand")) } returns true
@@ -256,7 +256,7 @@ class SdcardCorpseFilterTest : CorpseFilterTest() {
     // ─────────────────────────── ancestor / coverage passes ───────────────────────────
 
     @Test fun `a dead parent is dropped when it contains a living item`() = runTest2 {
-        candidate(sdcard1, "Shared", preset = Preset.WhitelistStale("com.orphan.app"), blacklistArea = false)
+        candidate(sdcard1, "Shared", preset = Preset.StaleOwner("com.orphan.app"))
         clutterMarker(pkg = "com.alive.app", segments = listOf("Shared", "alivedata"))
         markerTarget(sdcard1, listOf("Shared", "alivedata"))
         installed("com.alive.app")
@@ -265,7 +265,7 @@ class SdcardCorpseFilterTest : CorpseFilterTest() {
     }
 
     @Test fun `a dead nested item survives a living parent`() = runTest2 {
-        candidate(sdcard1, "Shared", preset = Preset.InstalledOwner(), blacklistArea = false)
+        candidate(sdcard1, "Shared", preset = Preset.InstalledOwner())
         clutterMarker(pkg = "com.orphan.app", segments = listOf("Shared", "orphandata"))
         val target = markerTarget(sdcard1, listOf("Shared", "orphandata"))
 
@@ -273,7 +273,7 @@ class SdcardCorpseFilterTest : CorpseFilterTest() {
     }
 
     @Test fun `a dead nested item covered by a dead parent is dropped`() = runTest2 {
-        val parent = candidate(sdcard1, "Shared", preset = Preset.WhitelistStale("com.orphan.app"), blacklistArea = false)
+        val parent = candidate(sdcard1, "Shared", preset = Preset.StaleOwner("com.orphan.app"))
         clutterMarker(pkg = "com.orphan.nested", segments = listOf("Shared", "orphandata"))
         markerTarget(sdcard1, listOf("Shared", "orphandata"))
 
@@ -284,35 +284,35 @@ class SdcardCorpseFilterTest : CorpseFilterTest() {
 
     @Test fun `keepers are treated as alive when keepers are excluded`() = runTest2 {
         riskFlags(keeper = false)
-        candidate(sdcard1, "KeeperDir", preset = Preset.Keeper(), blacklistArea = false)
+        candidate(sdcard1, "KeeperDir", preset = Preset.Keeper())
 
         create().scan() shouldBe emptyList()
     }
 
     @Test fun `keepers are KEEPER corpses when keepers are included`() = runTest2 {
         riskFlags(keeper = true)
-        val target = candidate(sdcard1, "KeeperDir", preset = Preset.Keeper(), blacklistArea = false)
+        val target = candidate(sdcard1, "KeeperDir", preset = Preset.Keeper())
 
         create().scan().single().shouldMatch(target, SdcardCorpseFilter::class, RiskLevel.KEEPER)
     }
 
     @Test fun `common items are treated as alive when common items are excluded`() = runTest2 {
         riskFlags(common = false)
-        candidate(sdcard1, "CommonDir", preset = Preset.Common(), blacklistArea = false)
+        candidate(sdcard1, "CommonDir", preset = Preset.Common())
 
         create().scan() shouldBe emptyList()
     }
 
     @Test fun `common items are COMMON corpses when common items are included`() = runTest2 {
         riskFlags(common = true)
-        val target = candidate(sdcard1, "CommonDir", preset = Preset.Common(), blacklistArea = false)
+        val target = candidate(sdcard1, "CommonDir", preset = Preset.Common())
 
         create().scan().single().shouldMatch(target, SdcardCorpseFilter::class, RiskLevel.COMMON)
     }
 
     @Test fun `an excluded keeper does not block corpses below it`() = runTest2 {
         riskFlags(keeper = false)
-        candidate(sdcard1, "KeeperDir", preset = Preset.Keeper(), blacklistArea = false)
+        candidate(sdcard1, "KeeperDir", preset = Preset.Keeper())
         clutterMarker(pkg = "com.orphan.app", segments = listOf("KeeperDir", "orphandata"))
         markerTarget(sdcard1, listOf("KeeperDir", "orphandata"))
 
@@ -323,7 +323,7 @@ class SdcardCorpseFilterTest : CorpseFilterTest() {
     // ─────────────────────────── characterization probes ───────────────────────────
 
     @Test fun `isWriteProtected is true when the path is writable`() = runTest2 {
-        val target = candidate(sdcard1, "OrphanApp", preset = Preset.WhitelistStale("com.orphan.app"))
+        val target = candidate(sdcard1, "OrphanApp", preset = Preset.StaleOwner("com.orphan.app"))
         coEvery { gatewaySwitch.canWrite(target.path) } returns true
 
         // documents suspect behavior: SdcardCorpseFilter assigns `isWriteProtected = canWrite(...)`.
@@ -332,7 +332,7 @@ class SdcardCorpseFilterTest : CorpseFilterTest() {
     }
 
     @Test fun `isWriteProtected is false when the path is not writable`() = runTest2 {
-        val target = candidate(sdcard1, "OrphanApp", preset = Preset.WhitelistStale("com.orphan.app"))
+        val target = candidate(sdcard1, "OrphanApp", preset = Preset.StaleOwner("com.orphan.app"))
         coEvery { gatewaySwitch.canWrite(target.path) } returns false
 
         // documents suspect behavior: see above, correct behavior would report `true` here because
@@ -342,7 +342,7 @@ class SdcardCorpseFilterTest : CorpseFilterTest() {
 
     @Test fun `an unidentified top level item aborts the whole scan`() = runTest2 {
         unidentifiedCandidate(sdcard1, "Unidentified")
-        candidate(sdcard1, "OrphanApp", preset = Preset.WhitelistStale("com.orphan.app"))
+        candidate(sdcard1, "OrphanApp", preset = Preset.StaleOwner("com.orphan.app"))
 
         // documents suspect behavior: the top level pass uses `findOwners(it)!!`, so one
         // unidentifiable entry kills the entire sdcard scan. The template filters use mapNotNull
@@ -353,7 +353,7 @@ class SdcardCorpseFilterTest : CorpseFilterTest() {
     // ─────────────────────────── marker cache lifecycle ───────────────────────────
 
     @Test fun `a second scan reflects a marker target that disappeared`() = runTest2 {
-        candidate(sdcard1, "Android", preset = Preset.InstalledOwner(), blacklistArea = false)
+        candidate(sdcard1, "Android", preset = Preset.InstalledOwner())
         clutterMarker(pkg = "com.orphan.app", segments = listOf("Android", "orphandata"))
         val target = markerTarget(sdcard1, listOf("Android", "orphandata"))
 
@@ -366,7 +366,7 @@ class SdcardCorpseFilterTest : CorpseFilterTest() {
     }
 
     @Test fun `a filter instance recovers from a failed scan`() = runTest2 {
-        candidate(sdcard1, "Android", preset = Preset.InstalledOwner(), blacklistArea = false)
+        candidate(sdcard1, "Android", preset = Preset.InstalledOwner())
         clutterMarker(pkg = "com.orphan.app", segments = listOf("Android", "orphandata"))
         val target = markerTarget(sdcard1, listOf("Android", "orphandata"))
         // Blows up AFTER the marker cache was populated.

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/SdcardCorpseFilterTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/SdcardCorpseFilterTest.kt
@@ -1,0 +1,384 @@
+package eu.darken.sdmse.corpsefinder.core.filter
+
+import eu.darken.sdmse.common.areas.DataArea
+import eu.darken.sdmse.common.clutter.ClutterRepo
+import eu.darken.sdmse.common.clutter.Marker
+import eu.darken.sdmse.common.files.FileType
+import eu.darken.sdmse.common.files.ReadException
+import eu.darken.sdmse.common.files.Segments
+import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.files.matches
+import eu.darken.sdmse.common.forensics.AreaInfo
+import eu.darken.sdmse.common.pkgs.Pkg
+import eu.darken.sdmse.common.pkgs.PkgRepo
+import eu.darken.sdmse.common.pkgs.features.Installed
+import eu.darken.sdmse.corpsefinder.core.RiskLevel
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import kotlinx.coroutines.flow.asFlow
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import testhelpers.coroutine.runTest2
+import java.io.File
+
+class SdcardCorpseFilterTest : CorpseFilterTest() {
+
+    @MockK lateinit var clutterRepo: ClutterRepo
+    @MockK lateinit var pkgRepo: PkgRepo
+
+    /**
+     * SdcardCorpseFilter re-resolves case-insensitive spellings through the REAL filesystem
+     * (`parentFile.listFiles()`), so the SDCARD area root has to be a directory we control.
+     */
+    @TempDir lateinit var tempDir: File
+
+    override val sdcardRoot: LocalPath get() = LocalPath.build(tempDir)
+
+    private val markers = mutableSetOf<Marker>()
+
+    @BeforeEach
+    override fun setup() {
+        super.setup()
+        markers.clear()
+        coEvery { clutterRepo.getMarkerForLocation(any()) } returns emptySet()
+        coEvery { pkgRepo.query(any(), any()) } returns emptySet()
+        coEvery { fileForensics.identifyArea(any()) } returns null
+    }
+
+    private fun create() = SdcardCorpseFilter(
+        areaManager = areaManager,
+        gatewaySwitch = gatewaySwitch,
+        fileForensics = fileForensics,
+        corpseFinderSettings = corpseFinderSettings,
+        clutterRepo = clutterRepo,
+        pkgRepo = pkgRepo,
+    )
+
+    /**
+     * Mirrors [eu.darken.sdmse.common.clutter.manual.ManualMarker] for SDCARD: direct path match,
+     * case-insensitive because public locations have a restricted charset.
+     */
+    private fun clutterMarker(
+        pkg: String,
+        segments: List<String>,
+        isDirectMatch: Boolean = true,
+        flags: Set<Marker.Flag> = emptySet(),
+    ): Marker {
+        val marker = mockk<Marker>().apply {
+            every { areaType } returns DataArea.Type.SDCARD
+            every { this@apply.segments } returns segments
+            every { this@apply.flags } returns flags
+            every { this@apply.isDirectMatch } returns isDirectMatch
+            every { match(any<DataArea.Type>(), any<Segments>()) } answers {
+                val otherType = firstArg<DataArea.Type>()
+                val otherSegments = secondArg<Segments>()
+                val hit = otherType == DataArea.Type.SDCARD && otherSegments.matches(segments, ignoreCase = true)
+                if (hit) Marker.Match(setOf(Pkg.Id(name = pkg)), flags) else null
+            }
+        }
+        markers.add(marker)
+        coEvery { clutterRepo.getMarkerForLocation(DataArea.Type.SDCARD) } returns markers.toSet()
+        return marker
+    }
+
+    private fun installed(pkg: String) {
+        val installedPkg = mockk<Installed>().apply {
+            every { id } returns Pkg.Id(name = pkg)
+        }
+        coEvery { pkgRepo.query(Pkg.Id(name = pkg), any()) } returns setOf(installedPkg)
+    }
+
+    /**
+     * A path that only exists because a clutter marker points at it - it is NOT part of the area's
+     * top level listing, the filter has to resolve it from the marker.
+     */
+    private fun markerTarget(
+        area: DataArea,
+        segments: List<String>,
+        exists: Boolean = true,
+        canRead: Boolean = true,
+        fileType: FileType = FileType.DIRECTORY,
+        children: List<String> = emptyList(),
+        identifiedArea: DataArea = area,
+    ): Candidate {
+        val path = area.path.child(*segments.toTypedArray()) as LocalPath
+        coEvery { gatewaySwitch.exists(path) } returns exists
+        coEvery { gatewaySwitch.canRead(path) } returns canRead
+        coEvery { fileForensics.identifyArea(path) } returns AreaInfo(
+            file = path,
+            prefix = identifiedArea.path,
+            dataArea = identifiedArea,
+            isBlackListLocation = false,
+        )
+
+        val lookup = pathLookup(path, fileType)
+        coEvery { gatewaySwitch.lookup(path) } returns lookup
+        val childLookups = children.map { pathLookup(path.child(it) as LocalPath, FileType.FILE) }
+        if (fileType == FileType.DIRECTORY) {
+            coEvery { gatewaySwitch.walk(path, any()) } returns childLookups.asFlow()
+        }
+
+        return Candidate(path = path, lookup = lookup, children = childLookups)
+    }
+
+    // ─────────────────────────── top level content ───────────────────────────
+
+    @Test fun `top level item with an uninstalled owner is a corpse`() = runTest2 {
+        val target = candidate(
+            sdcard1,
+            "OrphanApp",
+            preset = Preset.WhitelistStale("com.orphan.app"),
+            children = listOf("data.db"),
+        )
+
+        create().scan().single().shouldMatch(target, SdcardCorpseFilter::class, RiskLevel.NORMAL)
+    }
+
+    @Test fun `top level item with an installed owner is not a corpse`() = runTest2 {
+        candidate(sdcard1, "AliveApp", preset = Preset.InstalledOwner(), blacklistArea = false)
+
+        create().scan() shouldBe emptyList()
+    }
+
+    @Test fun `top level items from both sdcard roots are aggregated`() = runTest2 {
+        val first = candidate(sdcard1, "OrphanOne", preset = Preset.WhitelistStale("com.orphan.one"))
+        val second = candidate(sdcard2, "OrphanTwo", preset = Preset.WhitelistStale("com.orphan.two"))
+
+        create().scan().paths() shouldContainExactlyInAnyOrder listOf(first.path, second.path)
+    }
+
+    @Test fun `a top level file corpse has no content and is never walked`() = runTest2 {
+        val target = candidate(
+            sdcard1,
+            "orphan.txt",
+            preset = Preset.WhitelistStale("com.orphan.app"),
+            fileType = FileType.FILE,
+        )
+
+        val corpse = create().scan().single()
+
+        corpse.shouldMatch(target, SdcardCorpseFilter::class)
+        corpse.content shouldBe emptyList()
+        coVerify(exactly = 0) { gatewaySwitch.walk(target.path, any()) }
+    }
+
+    // ─────────────────────────── clutter marker resolution ───────────────────────────
+
+    @Test fun `a nested clutter marker with an uninstalled owner is a corpse`() = runTest2 {
+        candidate(sdcard1, "Android", preset = Preset.InstalledOwner(), blacklistArea = false)
+        clutterMarker(pkg = "com.orphan.app", segments = listOf("Android", "orphandata"))
+        val target = markerTarget(sdcard1, listOf("Android", "orphandata"), children = listOf("blob"))
+
+        val corpse = create().scan().single()
+
+        corpse.shouldMatch(target, SdcardCorpseFilter::class, RiskLevel.NORMAL)
+        corpse.ownerInfo.owners.map { it.pkgId.name } shouldBe listOf("com.orphan.app")
+    }
+
+    @Test fun `a nested clutter marker with an installed owner is not a corpse`() = runTest2 {
+        candidate(sdcard1, "Android", preset = Preset.InstalledOwner(), blacklistArea = false)
+        clutterMarker(pkg = "com.alive.app", segments = listOf("Android", "alivedata"))
+        markerTarget(sdcard1, listOf("Android", "alivedata"))
+        installed("com.alive.app")
+
+        create().scan() shouldBe emptyList()
+    }
+
+    @Test fun `top level markers are not resolved again`() = runTest2 {
+        candidate(sdcard1, "Android", preset = Preset.InstalledOwner(), blacklistArea = false)
+        clutterMarker(pkg = "com.orphan.app", segments = listOf("Android"))
+        val target = markerTarget(sdcard1, listOf("Android"))
+
+        create().scan() shouldBe emptyList()
+
+        // Single segment markers are dropped before any IO, the top level pass already covered them.
+        coVerify(exactly = 0) { gatewaySwitch.exists(target.path) }
+    }
+
+    @Test fun `regex markers are not resolved`() = runTest2 {
+        candidate(sdcard1, "Android", preset = Preset.InstalledOwner(), blacklistArea = false)
+        clutterMarker(pkg = "com.orphan.app", segments = listOf("Android", "orphandata"), isDirectMatch = false)
+        val target = markerTarget(sdcard1, listOf("Android", "orphandata"))
+
+        create().scan() shouldBe emptyList()
+
+        // Reverse matching a regex is impossible, so those markers never reach the filesystem.
+        coVerify(exactly = 0) { gatewaySwitch.exists(target.path) }
+    }
+
+    @Test fun `markers whose top level parent is missing are not resolved`() = runTest2 {
+        candidate(sdcard1, "Android", preset = Preset.InstalledOwner(), blacklistArea = false)
+        clutterMarker(pkg = "com.orphan.app", segments = listOf("Missing", "orphandata"))
+        val target = markerTarget(sdcard1, listOf("Missing", "orphandata"))
+
+        create().scan() shouldBe emptyList()
+
+        coVerify(exactly = 0) { gatewaySwitch.exists(target.path) }
+    }
+
+    @Test fun `markers pointing at a non existing path yield no corpse`() = runTest2 {
+        candidate(sdcard1, "Android", preset = Preset.InstalledOwner(), blacklistArea = false)
+        clutterMarker(pkg = "com.orphan.app", segments = listOf("Android", "orphandata"))
+        markerTarget(sdcard1, listOf("Android", "orphandata"), exists = false)
+
+        create().scan() shouldBe emptyList()
+    }
+
+    @Test fun `markers pointing at an unreadable path yield no corpse`() = runTest2 {
+        candidate(sdcard1, "Android", preset = Preset.InstalledOwner(), blacklistArea = false)
+        clutterMarker(pkg = "com.orphan.app", segments = listOf("Android", "orphandata"))
+        markerTarget(sdcard1, listOf("Android", "orphandata"), canRead = false)
+
+        create().scan() shouldBe emptyList()
+    }
+
+    @Test fun `marker casing is corrected to the on-disk spelling`() = runTest2 {
+        // Real directory tree: the marker says "MiBand", the sdcard holds "miband".
+        File(tempDir, "Games/miband").mkdirs()
+
+        candidate(sdcard1, "Games", preset = Preset.InstalledOwner(), blacklistArea = false)
+        clutterMarker(pkg = "com.mi.band", segments = listOf("Games", "MiBand"))
+        // The marker spelling exists as far as the (case-insensitive) gateway is concerned...
+        coEvery { gatewaySwitch.exists(sdcard1.path.child("Games", "MiBand")) } returns true
+        // ...but the corpse is reported with the real on-disk spelling.
+        val onDisk = markerTarget(sdcard1, listOf("Games", "miband"))
+
+        create().scan().single().shouldMatch(onDisk, SdcardCorpseFilter::class)
+    }
+
+    // ─────────────────────────── ancestor / coverage passes ───────────────────────────
+
+    @Test fun `a dead parent is dropped when it contains a living item`() = runTest2 {
+        candidate(sdcard1, "Shared", preset = Preset.WhitelistStale("com.orphan.app"), blacklistArea = false)
+        clutterMarker(pkg = "com.alive.app", segments = listOf("Shared", "alivedata"))
+        markerTarget(sdcard1, listOf("Shared", "alivedata"))
+        installed("com.alive.app")
+
+        create().scan() shouldBe emptyList()
+    }
+
+    @Test fun `a dead nested item survives a living parent`() = runTest2 {
+        candidate(sdcard1, "Shared", preset = Preset.InstalledOwner(), blacklistArea = false)
+        clutterMarker(pkg = "com.orphan.app", segments = listOf("Shared", "orphandata"))
+        val target = markerTarget(sdcard1, listOf("Shared", "orphandata"))
+
+        create().scan().single().shouldMatch(target, SdcardCorpseFilter::class)
+    }
+
+    @Test fun `a dead nested item covered by a dead parent is dropped`() = runTest2 {
+        val parent = candidate(sdcard1, "Shared", preset = Preset.WhitelistStale("com.orphan.app"), blacklistArea = false)
+        clutterMarker(pkg = "com.orphan.nested", segments = listOf("Shared", "orphandata"))
+        markerTarget(sdcard1, listOf("Shared", "orphandata"))
+
+        create().scan().paths() shouldBe setOf(parent.path)
+    }
+
+    // ─────────────────────────── risk gating ───────────────────────────
+
+    @Test fun `keepers are treated as alive when keepers are excluded`() = runTest2 {
+        riskFlags(keeper = false)
+        candidate(sdcard1, "KeeperDir", preset = Preset.Keeper(), blacklistArea = false)
+
+        create().scan() shouldBe emptyList()
+    }
+
+    @Test fun `keepers are KEEPER corpses when keepers are included`() = runTest2 {
+        riskFlags(keeper = true)
+        val target = candidate(sdcard1, "KeeperDir", preset = Preset.Keeper(), blacklistArea = false)
+
+        create().scan().single().shouldMatch(target, SdcardCorpseFilter::class, RiskLevel.KEEPER)
+    }
+
+    @Test fun `common items are treated as alive when common items are excluded`() = runTest2 {
+        riskFlags(common = false)
+        candidate(sdcard1, "CommonDir", preset = Preset.Common(), blacklistArea = false)
+
+        create().scan() shouldBe emptyList()
+    }
+
+    @Test fun `common items are COMMON corpses when common items are included`() = runTest2 {
+        riskFlags(common = true)
+        val target = candidate(sdcard1, "CommonDir", preset = Preset.Common(), blacklistArea = false)
+
+        create().scan().single().shouldMatch(target, SdcardCorpseFilter::class, RiskLevel.COMMON)
+    }
+
+    @Test fun `an excluded keeper does not block corpses below it`() = runTest2 {
+        riskFlags(keeper = false)
+        candidate(sdcard1, "KeeperDir", preset = Preset.Keeper(), blacklistArea = false)
+        clutterMarker(pkg = "com.orphan.app", segments = listOf("KeeperDir", "orphandata"))
+        markerTarget(sdcard1, listOf("KeeperDir", "orphandata"))
+
+        // The keeper counts as alive, but it only blocks corpses ABOVE it, not below.
+        create().scan().paths() shouldBe setOf(sdcard1.path.child("KeeperDir", "orphandata"))
+    }
+
+    // ─────────────────────────── characterization probes ───────────────────────────
+
+    @Test fun `isWriteProtected is true when the path is writable`() = runTest2 {
+        val target = candidate(sdcard1, "OrphanApp", preset = Preset.WhitelistStale("com.orphan.app"))
+        coEvery { gatewaySwitch.canWrite(target.path) } returns true
+
+        // documents suspect behavior: SdcardCorpseFilter assigns `isWriteProtected = canWrite(...)`.
+        // Correct behavior would be the negation - a writable corpse is NOT write protected.
+        create().scan().single().isWriteProtected shouldBe true
+    }
+
+    @Test fun `isWriteProtected is false when the path is not writable`() = runTest2 {
+        val target = candidate(sdcard1, "OrphanApp", preset = Preset.WhitelistStale("com.orphan.app"))
+        coEvery { gatewaySwitch.canWrite(target.path) } returns false
+
+        // documents suspect behavior: see above, correct behavior would report `true` here because
+        // an unwritable corpse is exactly the write protected case.
+        create().scan().single().isWriteProtected shouldBe false
+    }
+
+    @Test fun `an unidentified top level item aborts the whole scan`() = runTest2 {
+        unidentifiedCandidate(sdcard1, "Unidentified")
+        candidate(sdcard1, "OrphanApp", preset = Preset.WhitelistStale("com.orphan.app"))
+
+        // documents suspect behavior: the top level pass uses `findOwners(it)!!`, so one
+        // unidentifiable entry kills the entire sdcard scan. The template filters use mapNotNull
+        // and would just skip it, still reporting "OrphanApp".
+        shouldThrow<NullPointerException> { create().scan() }
+    }
+
+    // ─────────────────────────── marker cache lifecycle ───────────────────────────
+
+    @Test fun `a second scan reflects a marker target that disappeared`() = runTest2 {
+        candidate(sdcard1, "Android", preset = Preset.InstalledOwner(), blacklistArea = false)
+        clutterMarker(pkg = "com.orphan.app", segments = listOf("Android", "orphandata"))
+        val target = markerTarget(sdcard1, listOf("Android", "orphandata"))
+
+        val filter = create()
+        filter.scan().single().shouldMatch(target, SdcardCorpseFilter::class)
+
+        coEvery { gatewaySwitch.exists(target.path) } returns false
+
+        filter.scan() shouldBe emptyList()
+    }
+
+    @Test fun `a filter instance recovers from a failed scan`() = runTest2 {
+        candidate(sdcard1, "Android", preset = Preset.InstalledOwner(), blacklistArea = false)
+        clutterMarker(pkg = "com.orphan.app", segments = listOf("Android", "orphandata"))
+        val target = markerTarget(sdcard1, listOf("Android", "orphandata"))
+        // Blows up AFTER the marker cache was populated.
+        coEvery { gatewaySwitch.lookup(target.path) } throws ReadException(path = target.path)
+
+        val filter = create()
+        shouldThrow<ReadException> { filter.scan() }
+
+        // The cache is cleared in a `finally`, so the second scan re-checks existence instead of
+        // reusing the entry from the failed run (which would trip the throwing lookup again).
+        coEvery { gatewaySwitch.exists(target.path) } returns false
+
+        filter.scan() shouldBe emptyList()
+    }
+}

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/SdcardCorpseFilterTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/SdcardCorpseFilterTest.kt
@@ -320,34 +320,29 @@ class SdcardCorpseFilterTest : CorpseFilterTest() {
         create().scan().paths() shouldBe setOf(sdcard1.path.child("KeeperDir", "orphandata"))
     }
 
-    // ─────────────────────────── characterization probes ───────────────────────────
+    // ─────────────────────────── write protection ───────────────────────────
 
-    @Test fun `isWriteProtected is true when the path is writable`() = runTest2 {
+    @Test fun `isWriteProtected is false when the path is writable`() = runTest2 {
         val target = candidate(sdcard1, "OrphanApp", preset = Preset.StaleOwner("com.orphan.app"))
         coEvery { gatewaySwitch.canWrite(target.path) } returns true
 
-        // documents suspect behavior: SdcardCorpseFilter assigns `isWriteProtected = canWrite(...)`.
-        // Correct behavior would be the negation - a writable corpse is NOT write protected.
-        create().scan().single().isWriteProtected shouldBe true
-    }
-
-    @Test fun `isWriteProtected is false when the path is not writable`() = runTest2 {
-        val target = candidate(sdcard1, "OrphanApp", preset = Preset.StaleOwner("com.orphan.app"))
-        coEvery { gatewaySwitch.canWrite(target.path) } returns false
-
-        // documents suspect behavior: see above, correct behavior would report `true` here because
-        // an unwritable corpse is exactly the write protected case.
         create().scan().single().isWriteProtected shouldBe false
     }
 
-    @Test fun `an unidentified top level item aborts the whole scan`() = runTest2 {
-        unidentifiedCandidate(sdcard1, "Unidentified")
-        candidate(sdcard1, "OrphanApp", preset = Preset.StaleOwner("com.orphan.app"))
+    @Test fun `isWriteProtected is true when the path is not writable`() = runTest2 {
+        val target = candidate(sdcard1, "OrphanApp", preset = Preset.StaleOwner("com.orphan.app"))
+        coEvery { gatewaySwitch.canWrite(target.path) } returns false
 
-        // documents suspect behavior: the top level pass uses `findOwners(it)!!`, so one
-        // unidentifiable entry kills the entire sdcard scan. The template filters use mapNotNull
-        // and would just skip it, still reporting "OrphanApp".
-        shouldThrow<NullPointerException> { create().scan() }
+        create().scan().single().isWriteProtected shouldBe true
+    }
+
+    @Test fun `an unidentified top level item is skipped and the scan continues`() = runTest2 {
+        unidentifiedCandidate(sdcard1, "Unidentified")
+        val target = candidate(sdcard1, "OrphanApp", preset = Preset.StaleOwner("com.orphan.app"))
+
+        // Same contract as the template filters: an entry the CSI can't identify is logged and
+        // skipped, it does not take the rest of the scan down with it.
+        create().scan().single().shouldMatch(target, SdcardCorpseFilter::class)
     }
 
     // ─────────────────────────── marker cache lifecycle ───────────────────────────

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/StandardCorpseFilterTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/StandardCorpseFilterTest.kt
@@ -1,0 +1,168 @@
+package eu.darken.sdmse.corpsefinder.core.filter
+
+import eu.darken.sdmse.common.areas.DataArea
+import eu.darken.sdmse.common.files.FileType
+import eu.darken.sdmse.corpsefinder.core.RiskLevel
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import io.mockk.coVerify
+import org.junit.jupiter.api.Test
+import testhelpers.coroutine.runTest2
+import kotlin.reflect.KClass
+
+/**
+ * The nine filters that share the "list area top level, run forensics, keep corpses" template.
+ *
+ * Everything that is identical between them lives here. Capability gates (root/adb), API cutoffs
+ * and name exclusions differ per filter, so they get helpers here and explicit tests there.
+ */
+abstract class StandardCorpseFilterTest : CorpseFilterTest() {
+
+    abstract val areaType: DataArea.Type
+    abstract val filterClass: KClass<out CorpseFilter>
+
+    abstract fun create(): CorpseFilter
+
+    val area1: DataArea get() = areasOf(areaType)[0]
+    val area2: DataArea get() = areasOf(areaType)[1]
+
+    // ─────────────────────────── corpse identification ───────────────────────────
+
+    @Test fun `blacklist orphan becomes a NORMAL corpse with walked content`() = runTest2 {
+        val target = candidate(area1, "com.orphan.pkg", children = listOf("cache/file1", "file2"))
+
+        val corpses = create().scan()
+
+        corpses.single().shouldMatch(target, filterClass, RiskLevel.NORMAL)
+    }
+
+    @Test fun `whitelisted item with a stale owner becomes a corpse`() = runTest2 {
+        val target = candidate(area1, "com.stale.pkg", preset = Preset.WhitelistStale())
+
+        val corpses = create().scan()
+
+        corpses.single().shouldMatch(target, filterClass, RiskLevel.NORMAL)
+    }
+
+    @Test fun `item with an installed owner is not a corpse`() = runTest2 {
+        candidate(area1, "com.alive.pkg", preset = Preset.InstalledOwner())
+
+        create().scan() shouldBe emptyList()
+    }
+
+    @Test fun `item with an unknown owner is not a corpse`() = runTest2 {
+        candidate(area1, "com.mystery.pkg", preset = Preset.UnknownOwner)
+
+        create().scan() shouldBe emptyList()
+    }
+
+    @Test fun `item reported for a different area is dropped`() = runTest2 {
+        // CSI says this belongs to SDCARD while we are scanning `areaType`.
+        candidate(area1, "com.wrongarea.pkg", forensicArea = sdcard1)
+
+        create().scan() shouldBe emptyList()
+    }
+
+    @Test fun `unidentified item is skipped and the scan continues`() = runTest2 {
+        unidentifiedCandidate(area1, "com.unidentified.pkg")
+        val target = candidate(area1, "com.orphan.pkg")
+
+        val corpses = create().scan()
+
+        corpses.single().shouldMatch(target, filterClass)
+    }
+
+    // ─────────────────────────── risk gating ───────────────────────────
+
+    @Test fun `keeper is dropped when keepers are excluded`() = runTest2 {
+        riskFlags(keeper = false)
+        candidate(area1, "com.keeper.pkg", preset = Preset.Keeper())
+
+        create().scan() shouldBe emptyList()
+    }
+
+    @Test fun `keeper is a KEEPER corpse when keepers are included`() = runTest2 {
+        riskFlags(keeper = true)
+        val target = candidate(area1, "com.keeper.pkg", preset = Preset.Keeper())
+
+        create().scan().single().shouldMatch(target, filterClass, RiskLevel.KEEPER)
+    }
+
+    @Test fun `common item is dropped when common items are excluded`() = runTest2 {
+        riskFlags(common = false)
+        candidate(area1, "com.common.pkg", preset = Preset.Common())
+
+        create().scan() shouldBe emptyList()
+    }
+
+    @Test fun `common item is a COMMON corpse when common items are included`() = runTest2 {
+        riskFlags(common = true)
+        val target = candidate(area1, "com.common.pkg", preset = Preset.Common())
+
+        create().scan().single().shouldMatch(target, filterClass, RiskLevel.COMMON)
+    }
+
+    // ─────────────────────────── exclusions ───────────────────────────
+
+    @Test fun `path exclusion drops the candidate before forensics run`() = runTest2 {
+        val excluded = candidate(area1, "com.excluded.pkg")
+        val target = candidate(area1, "com.orphan.pkg")
+        excludePath(excluded.path)
+
+        val corpses = create().scan()
+
+        corpses.single().shouldMatch(target, filterClass)
+        // Exclusions are applied to the raw listing, forensics are the expensive part.
+        coVerify(exactly = 0) { fileForensics.findOwners(excluded.path) }
+    }
+
+    // ─────────────────────────── shape of the result ───────────────────────────
+
+    @Test fun `corpses from both roots of the area are aggregated`() = runTest2 {
+        val first = candidate(area1, "com.orphan.one")
+        val second = candidate(area2, "com.orphan.two")
+
+        val corpses = create().scan()
+
+        corpses.paths() shouldContainExactlyInAnyOrder listOf(first.path, second.path)
+    }
+
+    @Test fun `a file corpse has no content and is never walked`() = runTest2 {
+        val target = candidate(area1, "com.orphan.pkg.file", fileType = FileType.FILE)
+
+        val corpses = create().scan()
+
+        corpses.single().shouldMatch(target, filterClass)
+        corpses.single().content shouldBe emptyList()
+        coVerify(exactly = 0) { gatewaySwitch.walk(target.path, any()) }
+    }
+
+    // ─────────────────────────── helpers for per-filter gates ───────────────────────────
+
+    /** Asserts the filter skips the area entirely, without even listing it. */
+    suspend fun assertSkipsScan() {
+        candidate(area1, "com.orphan.pkg")
+
+        create().scan() shouldBe emptySet()
+
+        coVerify(exactly = 0) { gatewaySwitch.listFiles(any()) }
+    }
+
+    /** Asserts the filter does scan and finds the orphan we planted. */
+    suspend fun assertScans() {
+        val target = candidate(area1, "com.orphan.pkg")
+
+        create().scan().single().shouldMatch(target, filterClass)
+    }
+
+    /** Asserts [name] is filtered out by name, before forensics are consulted. */
+    suspend fun assertNameExcluded(name: String) {
+        val excluded = candidate(area1, name)
+        val target = candidate(area1, "com.orphan.pkg")
+
+        val corpses = create().scan()
+
+        corpses.single().shouldMatch(target, filterClass)
+        coVerify(exactly = 0) { fileForensics.findOwners(excluded.path) }
+    }
+}

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/StandardCorpseFilterTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/StandardCorpseFilterTest.kt
@@ -21,23 +21,28 @@ abstract class StandardCorpseFilterTest : CorpseFilterTest() {
     abstract val areaType: DataArea.Type
     abstract val filterClass: KClass<out CorpseFilter>
 
+    /**
+     * The corpse shape the area's CSI actually produces for an abandoned item.
+     *
+     * [Preset.BlacklistOrphan] only fits CSIs that can return no owners at all. CSIs that always
+     * fall back to a dirname owner (asec, public data/media, private data) can never emit that
+     * state, so they declare [Preset.StaleOwner] instead.
+     */
+    abstract val defaultPreset: Preset
+
     abstract fun create(): CorpseFilter
 
     val area1: DataArea get() = areasOf(areaType)[0]
     val area2: DataArea get() = areasOf(areaType)[1]
 
+    /** A blacklist area that is never the one under test, for the area mismatch scenario. */
+    private val wrongArea: DataArea
+        get() = if (areaType == DataArea.Type.PUBLIC_DATA) publicMedia1 else publicData1
+
     // ─────────────────────────── corpse identification ───────────────────────────
 
-    @Test fun `blacklist orphan becomes a NORMAL corpse with walked content`() = runTest2 {
-        val target = candidate(area1, "com.orphan.pkg", children = listOf("cache/file1", "file2"))
-
-        val corpses = create().scan()
-
-        corpses.single().shouldMatch(target, filterClass, RiskLevel.NORMAL)
-    }
-
-    @Test fun `whitelisted item with a stale owner becomes a corpse`() = runTest2 {
-        val target = candidate(area1, "com.stale.pkg", preset = Preset.WhitelistStale())
+    @Test fun `an abandoned item becomes a NORMAL corpse with walked content`() = runTest2 {
+        val target = candidate(area1, "com.orphan.pkg", preset = defaultPreset, children = listOf("file1", "file2"))
 
         val corpses = create().scan()
 
@@ -50,63 +55,27 @@ abstract class StandardCorpseFilterTest : CorpseFilterTest() {
         create().scan() shouldBe emptyList()
     }
 
-    @Test fun `item with an unknown owner is not a corpse`() = runTest2 {
-        candidate(area1, "com.mystery.pkg", preset = Preset.UnknownOwner)
-
-        create().scan() shouldBe emptyList()
-    }
-
     @Test fun `item reported for a different area is dropped`() = runTest2 {
-        // CSI says this belongs to SDCARD while we are scanning `areaType`.
-        candidate(area1, "com.wrongarea.pkg", forensicArea = sdcard1)
+        // A perfectly good corpse, but the CSI attributed it to another area than the one we scan.
+        candidate(area1, "com.wrongarea.pkg", preset = defaultPreset, forensicArea = wrongArea)
 
         create().scan() shouldBe emptyList()
     }
 
     @Test fun `unidentified item is skipped and the scan continues`() = runTest2 {
         unidentifiedCandidate(area1, "com.unidentified.pkg")
-        val target = candidate(area1, "com.orphan.pkg")
+        val target = candidate(area1, "com.orphan.pkg", preset = defaultPreset)
 
         val corpses = create().scan()
 
         corpses.single().shouldMatch(target, filterClass)
     }
 
-    // ─────────────────────────── risk gating ───────────────────────────
-
-    @Test fun `keeper is dropped when keepers are excluded`() = runTest2 {
-        riskFlags(keeper = false)
-        candidate(area1, "com.keeper.pkg", preset = Preset.Keeper())
-
-        create().scan() shouldBe emptyList()
-    }
-
-    @Test fun `keeper is a KEEPER corpse when keepers are included`() = runTest2 {
-        riskFlags(keeper = true)
-        val target = candidate(area1, "com.keeper.pkg", preset = Preset.Keeper())
-
-        create().scan().single().shouldMatch(target, filterClass, RiskLevel.KEEPER)
-    }
-
-    @Test fun `common item is dropped when common items are excluded`() = runTest2 {
-        riskFlags(common = false)
-        candidate(area1, "com.common.pkg", preset = Preset.Common())
-
-        create().scan() shouldBe emptyList()
-    }
-
-    @Test fun `common item is a COMMON corpse when common items are included`() = runTest2 {
-        riskFlags(common = true)
-        val target = candidate(area1, "com.common.pkg", preset = Preset.Common())
-
-        create().scan().single().shouldMatch(target, filterClass, RiskLevel.COMMON)
-    }
-
     // ─────────────────────────── exclusions ───────────────────────────
 
     @Test fun `path exclusion drops the candidate before forensics run`() = runTest2 {
-        val excluded = candidate(area1, "com.excluded.pkg")
-        val target = candidate(area1, "com.orphan.pkg")
+        val excluded = candidate(area1, "com.excluded.pkg", preset = defaultPreset)
+        val target = candidate(area1, "com.orphan.pkg", preset = defaultPreset)
         excludePath(excluded.path)
 
         val corpses = create().scan()
@@ -119,8 +88,8 @@ abstract class StandardCorpseFilterTest : CorpseFilterTest() {
     // ─────────────────────────── shape of the result ───────────────────────────
 
     @Test fun `corpses from both roots of the area are aggregated`() = runTest2 {
-        val first = candidate(area1, "com.orphan.one")
-        val second = candidate(area2, "com.orphan.two")
+        val first = candidate(area1, "com.orphan.one", preset = defaultPreset)
+        val second = candidate(area2, "com.orphan.two", preset = defaultPreset)
 
         val corpses = create().scan()
 
@@ -128,7 +97,7 @@ abstract class StandardCorpseFilterTest : CorpseFilterTest() {
     }
 
     @Test fun `a file corpse has no content and is never walked`() = runTest2 {
-        val target = candidate(area1, "com.orphan.pkg.file", fileType = FileType.FILE)
+        val target = candidate(area1, "com.orphan.pkg.file", preset = defaultPreset, fileType = FileType.FILE)
 
         val corpses = create().scan()
 
@@ -141,28 +110,73 @@ abstract class StandardCorpseFilterTest : CorpseFilterTest() {
 
     /** Asserts the filter skips the area entirely, without even listing it. */
     suspend fun assertSkipsScan() {
-        candidate(area1, "com.orphan.pkg")
+        candidate(area1, "com.orphan.pkg", preset = defaultPreset)
 
         create().scan() shouldBe emptySet()
 
         coVerify(exactly = 0) { gatewaySwitch.listFiles(any()) }
     }
 
-    /** Asserts the filter does scan and finds the orphan we planted. */
+    /** Asserts the filter does scan and finds the corpse we planted. */
     suspend fun assertScans() {
-        val target = candidate(area1, "com.orphan.pkg")
+        val target = candidate(area1, "com.orphan.pkg", preset = defaultPreset)
 
         create().scan().single().shouldMatch(target, filterClass)
     }
 
     /** Asserts [name] is filtered out by name, before forensics are consulted. */
     suspend fun assertNameExcluded(name: String) {
-        val excluded = candidate(area1, name)
-        val target = candidate(area1, "com.orphan.pkg")
+        val excluded = candidate(area1, name, preset = defaultPreset)
+        val target = candidate(area1, "com.orphan.pkg", preset = defaultPreset)
 
         val corpses = create().scan()
 
         corpses.single().shouldMatch(target, filterClass)
         coVerify(exactly = 0) { fileForensics.findOwners(excluded.path) }
+    }
+
+    /**
+     * For CSIs that can name an owner without it being installed. Only call this where the CSI can
+     * emit owners it did not verify as installed (clutter matches, dirname fallbacks).
+     */
+    suspend fun assertStaleOwnerIsCorpse() {
+        val target = candidate(area1, "com.stale.pkg", preset = Preset.StaleOwner())
+
+        create().scan().single().shouldMatch(target, filterClass, RiskLevel.NORMAL)
+    }
+
+    /**
+     * For CSIs that can report `hasKnownUnknownOwner`. Only call this where the CSI actually sets
+     * that flag, otherwise the state is unreachable in production.
+     */
+    suspend fun assertUnknownOwnerIsNotCorpse() {
+        candidate(area1, "com.mystery.pkg", preset = Preset.UnknownOwner)
+
+        create().scan() shouldBe emptyList()
+    }
+
+    /**
+     * For CSIs that pass clutter flags through to their owners. Asserts both directions of the
+     * keeper risk setting.
+     */
+    suspend fun assertKeeperGating() {
+        val target = candidate(area1, "com.keeper.pkg", preset = Preset.Keeper())
+
+        riskFlags(keeper = false)
+        create().scan() shouldBe emptyList()
+
+        riskFlags(keeper = true)
+        create().scan().single().shouldMatch(target, filterClass, RiskLevel.KEEPER)
+    }
+
+    /** See [assertKeeperGating], for the common flag. */
+    suspend fun assertCommonGating() {
+        val target = candidate(area1, "com.common.pkg", preset = Preset.Common())
+
+        riskFlags(common = false)
+        create().scan() shouldBe emptyList()
+
+        riskFlags(common = true)
+        create().scan().single().shouldMatch(target, filterClass, RiskLevel.COMMON)
     }
 }


### PR DESCRIPTION
## What changed

CorpseFinder's scan filters get their first dedicated test coverage (165 tests across all eleven filters), and the tests immediately caught two bugs in the sdcard filter, both fixed here. The impactful one: a single file that ownership analysis could not identify would crash the entire sdcard scan, so users got nothing instead of everything else; the scan now skips such entries with a warning, like every other filter. The second: sdcard results stored their write-protection flag inverted; nothing in the app currently reads that flag, so this was invisible to users, but it is now stored correctly.

## Technical Context

- The harness constructs real forensics objects (OwnerInfo/AreaInfo/Owner) rather than mocking their derived predicates, and after review the fixture presets are constrained to states each filter's CSI implementation can actually produce; that discipline exists so a planned dedup of the near-identical filter scan skeletons has a trustworthy safety net.
- Coverage includes per-filter capability and API-level truth tables with both-sides boundary cases, proofs that exclusions run before forensics (verified by absence of forensics calls, not just absent results), and the sdcard filter's marker resolution, ancestor/coverage elimination passes, and marker cache lifecycle against a real temp-directory root.
- The two production fixes are isolated in the final commit for review focus and blame: the null-forensics skip (mapNotNull with a warning, progress still advancing) and the write-protection negation, each with tests that were first written as characterization probes of the broken behavior and then flipped.
- The sdcard filter differs structurally from the other ten (clutter markers, nested candidate resolution, host-filesystem access when checking case variants); its tests pin that behavior including the case-insensitive re-resolution, which turned out to be intended behavior, not a defect.
