### PR TITLE
CorpseFinder: Share one scan implementation across the cleanup filters

### DIFF
--- a/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/AppAsecFileCorpseFilter.kt
+++ b/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/AppAsecFileCorpseFilter.kt
@@ -6,125 +6,41 @@ import dagger.Reusable
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
-import eu.darken.sdmse.corpsefinder.R
 import eu.darken.sdmse.common.areas.DataArea
 import eu.darken.sdmse.common.areas.DataAreaManager
-import eu.darken.sdmse.common.areas.currentAreas
-import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.datastore.value
-import eu.darken.sdmse.common.debug.logging.Logging.Priority.*
-import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
-import eu.darken.sdmse.common.files.*
-import eu.darken.sdmse.common.files.local.LocalGateway
+import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.forensics.FileForensics
-import eu.darken.sdmse.common.hasApiLevel
-import eu.darken.sdmse.common.progress.*
-import eu.darken.sdmse.corpsefinder.core.Corpse
+import eu.darken.sdmse.corpsefinder.R
 import eu.darken.sdmse.corpsefinder.core.CorpseFinderSettings
-import eu.darken.sdmse.corpsefinder.core.RiskLevel
 import eu.darken.sdmse.exclusion.core.ExclusionManager
-import eu.darken.sdmse.exclusion.core.pathExclusions
-import eu.darken.sdmse.main.core.SDMTool
-import kotlinx.coroutines.flow.*
-import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Provider
 
 
 @Reusable
 class AppAsecFileCorpseFilter @Inject constructor(
-    private val areaManager: DataAreaManager,
-    private val gatewaySwitch: GatewaySwitch,
-    private val fileForensics: FileForensics,
-    private val corpseFinderSettings: CorpseFinderSettings,
-    private val exclusionManager: ExclusionManager,
-) : CorpseFilter(TAG, Progress.Data(primary = R.string.corpsefinder_filter_appasec_label.toCaString())) {
-
-    override suspend fun doScan(): Collection<Corpse> {
-        log(TAG) { "Scanning..." }
-        val gateway = gatewaySwitch.getGateway(APath.PathType.LOCAL) as LocalGateway
-
-        if (!gateway.hasRoot()) {
-            log(TAG) { "LocalGateway has no root, skipping." }
-            return emptySet()
-        }
-
-        // Unseen (exists, but empty) on Android 15+
-        // https://github.com/d4rken-org/sdmaid-se/issues/1612
-        if (hasApiLevel(35)) {
-            log(TAG, WARN) { "Untested API level (35) skipping for safety." }
-            return emptySet()
-        }
-
-        updateProgressPrimary(R.string.corpsefinder_filter_appasec_label)
-
-        val pathExclusions = exclusionManager.pathExclusions(SDMTool.Type.CORPSEFINDER)
-
-        return areaManager.currentAreas()
-            .filter { it.type == DataArea.Type.APP_ASEC }
-            .map { area ->
-                updateProgressSecondary {
-                    it.getString(eu.darken.sdmse.common.R.string.general_progress_processing_x, area.label.get(it))
-                }
-
-                log(TAG) { "Reading $area" }
-
-                val topLevelContents = area.path
-                    .listFiles(gatewaySwitch)
-                    .filter { path ->
-                        pathExclusions.none { excl ->
-                            excl.match(path).also {
-                                if (it) log(TAG, INFO) { "Excluded due to $excl: $path" }
-                            }
-                        }
-                    }
-
-                log(TAG) { "Filtering $area" }
-                doFilter(topLevelContents)
-            }
-            .flatten()
-    }
-
-    @Throws(IOException::class) private suspend fun doFilter(candidates: Collection<APath>): Collection<Corpse> {
-        updateProgressCount(Progress.Count.Percent(candidates.size))
-
-        val includeRiskKeeper: Boolean = corpseFinderSettings.includeRiskKeeper.value()
-        val includeRiskCommon: Boolean = corpseFinderSettings.includeRiskCommon.value()
-
-        return candidates
-            .asFlow()
-            .mapNotNull {
-                log(TAG) { "Checking $it" }
-                increaseProgress()
-                fileForensics.findOwners(it)
-            }
-            .filter { ownerInfo ->
-                (ownerInfo.areaInfo.type == DataArea.Type.APP_ASEC).also {
-                    if (!it) log(TAG, WARN) { "Wrong area: $ownerInfo" }
-                }
-            }
-            .filter { it.isCorpse }
-            .filter { !it.isKeeper || includeRiskKeeper }
-            .filter { !it.isCommon || includeRiskCommon }
-            .map { ownerInfo ->
-                val lookup = ownerInfo.item.lookup(gatewaySwitch)
-                val content = if (lookup.isDirectory) ownerInfo.item.walk(gatewaySwitch).toSet() else emptyList()
-                Corpse(
-                    filterType = this@AppAsecFileCorpseFilter::class,
-                    ownerInfo = ownerInfo,
-                    lookup = lookup,
-                    content = content,
-                    isWriteProtected = false,
-                    riskLevel = when {
-                        ownerInfo.isKeeper -> RiskLevel.KEEPER
-                        ownerInfo.isCommon -> RiskLevel.COMMON
-                        else -> RiskLevel.NORMAL
-                    }
-                ).also { log(TAG, INFO) { "Found Corpse: $it" } }
-            }
-            .toList()
-    }
+    areaManager: DataAreaManager,
+    gatewaySwitch: GatewaySwitch,
+    fileForensics: FileForensics,
+    corpseFinderSettings: CorpseFinderSettings,
+    exclusionManager: ExclusionManager,
+) : StandardCorpseFilter(
+    filterTag = TAG,
+    areaType = DataArea.Type.APP_ASEC,
+    defaultProgressLabel = R.string.corpsefinder_filter_appasec_label,
+    scanProgressLabel = R.string.corpsefinder_filter_appasec_label,
+    capabilityPolicy = CapabilityPolicy.AlwaysRoot,
+    // Unseen (exists, but empty) on Android 15+
+    // https://github.com/d4rken-org/sdmaid-se/issues/1612
+    apiBailAt = 35,
+    areaManager = areaManager,
+    gatewaySwitch = gatewaySwitch,
+    fileForensics = fileForensics,
+    corpseFinderSettings = corpseFinderSettings,
+    exclusionManager = exclusionManager,
+) {
 
     @Reusable
     class Factory @Inject constructor(

--- a/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/AppLibCorpseFilter.kt
+++ b/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/AppLibCorpseFilter.kt
@@ -6,140 +6,41 @@ import dagger.Reusable
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
-import eu.darken.sdmse.corpsefinder.R
 import eu.darken.sdmse.common.areas.DataArea
 import eu.darken.sdmse.common.areas.DataAreaManager
-import eu.darken.sdmse.common.areas.currentAreas
-import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.datastore.value
-import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
-import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
-import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
-import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.files.GatewaySwitch
-import eu.darken.sdmse.common.files.isDirectory
-import eu.darken.sdmse.common.files.listFiles
-import eu.darken.sdmse.common.files.local.LocalGateway
-import eu.darken.sdmse.common.files.lookup
-import eu.darken.sdmse.common.files.walk
 import eu.darken.sdmse.common.forensics.FileForensics
-import eu.darken.sdmse.common.hasApiLevel
-import eu.darken.sdmse.common.progress.Progress
-import eu.darken.sdmse.common.progress.increaseProgress
-import eu.darken.sdmse.common.progress.updateProgressCount
-import eu.darken.sdmse.common.progress.updateProgressPrimary
-import eu.darken.sdmse.common.progress.updateProgressSecondary
-import eu.darken.sdmse.corpsefinder.core.Corpse
+import eu.darken.sdmse.corpsefinder.R
 import eu.darken.sdmse.corpsefinder.core.CorpseFinderSettings
-import eu.darken.sdmse.corpsefinder.core.RiskLevel
 import eu.darken.sdmse.exclusion.core.ExclusionManager
-import eu.darken.sdmse.exclusion.core.pathExclusions
-import eu.darken.sdmse.main.core.SDMTool
-import kotlinx.coroutines.flow.asFlow
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.mapNotNull
-import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.flow.toSet
-import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Provider
 
 
 @Reusable
 class AppLibCorpseFilter @Inject constructor(
-    private val areaManager: DataAreaManager,
-    private val gatewaySwitch: GatewaySwitch,
-    private val fileForensics: FileForensics,
-    private val corpseFinderSettings: CorpseFinderSettings,
-    private val exclusionManager: ExclusionManager,
-) : CorpseFilter(TAG, Progress.Data(primary = R.string.corpsefinder_filter_applib_label.toCaString())) {
-
-    override suspend fun doScan(): Collection<Corpse> {
-        log(TAG) { "Scanning..." }
-
-        val gateway = gatewaySwitch.getGateway(APath.PathType.LOCAL) as LocalGateway
-
-        if (!gateway.hasRoot()) {
-            log(TAG) { "LocalGateway has no root, skipping." }
-            return emptySet()
-        }
-
-        // Based on https://github.com/d4rken-org/sdmaid-se/issues/1612
-        // No longer used on newer APIs, system uses `/data/app/<package>/lib/<arch>`
-        if (hasApiLevel(35)) {
-            log(TAG, WARN) { "Untested API level (35) skipping for safety." }
-            return emptySet()
-        }
-
-        updateProgressPrimary(R.string.corpsefinder_filter_applib_label)
-
-        val pathExclusions = exclusionManager.pathExclusions(SDMTool.Type.CORPSEFINDER)
-
-        return areaManager.currentAreas()
-            .filter { it.type == DataArea.Type.APP_LIB }
-            .map { area ->
-                updateProgressSecondary {
-                    it.getString(eu.darken.sdmse.common.R.string.general_progress_processing_x, area.label.get(it))
-                }
-
-                log(TAG) { "Reading $area" }
-                val topLevelContents = area.path
-                    .listFiles(gatewaySwitch)
-                    .filter { path ->
-                        pathExclusions.none { excl ->
-                            excl.match(path).also {
-                                if (it) log(TAG, INFO) { "Excluded due to $excl: $path" }
-                            }
-                        }
-                    }
-
-                log(TAG) { "Filtering $area" }
-                doFilter(topLevelContents)
-            }
-            .flatten()
-    }
-
-    @Throws(IOException::class) private suspend fun doFilter(candidates: Collection<APath>): Collection<Corpse> {
-        updateProgressCount(Progress.Count.Percent(candidates.size))
-
-        val includeRiskKeeper: Boolean = corpseFinderSettings.includeRiskKeeper.value()
-        val includeRiskCommon: Boolean = corpseFinderSettings.includeRiskCommon.value()
-
-        return candidates
-            .asFlow()
-            .mapNotNull {
-                log(TAG) { "Checking $it" }
-                increaseProgress()
-                fileForensics.findOwners(it)
-            }
-            .filter { ownerInfo ->
-                (ownerInfo.areaInfo.type == DataArea.Type.APP_LIB).also {
-                    if (!it) log(TAG, WARN) { "Wrong area: $ownerInfo" }
-                }
-            }
-            .filter { it.isCorpse }
-            .filter { !it.isKeeper || includeRiskKeeper }
-            .filter { !it.isCommon || includeRiskCommon }
-            .map { ownerInfo ->
-                val lookup = ownerInfo.item.lookup(gatewaySwitch)
-                val content = if (lookup.isDirectory) ownerInfo.item.walk(gatewaySwitch).toSet() else emptyList()
-                Corpse(
-                    filterType = this@AppLibCorpseFilter::class,
-                    ownerInfo = ownerInfo,
-                    lookup = lookup,
-                    content = content,
-                    isWriteProtected = false,
-                    riskLevel = when {
-                        ownerInfo.isKeeper -> RiskLevel.KEEPER
-                        ownerInfo.isCommon -> RiskLevel.COMMON
-                        else -> RiskLevel.NORMAL
-                    }
-                ).also { log(TAG, INFO) { "Found Corpse: $it" } }
-            }
-            .toList()
-    }
+    areaManager: DataAreaManager,
+    gatewaySwitch: GatewaySwitch,
+    fileForensics: FileForensics,
+    corpseFinderSettings: CorpseFinderSettings,
+    exclusionManager: ExclusionManager,
+) : StandardCorpseFilter(
+    filterTag = TAG,
+    areaType = DataArea.Type.APP_LIB,
+    defaultProgressLabel = R.string.corpsefinder_filter_applib_label,
+    scanProgressLabel = R.string.corpsefinder_filter_applib_label,
+    capabilityPolicy = CapabilityPolicy.AlwaysRoot,
+    // Based on https://github.com/d4rken-org/sdmaid-se/issues/1612
+    // No longer used on newer APIs, system uses `/data/app/<package>/lib/<arch>`
+    apiBailAt = 35,
+    areaManager = areaManager,
+    gatewaySwitch = gatewaySwitch,
+    fileForensics = fileForensics,
+    corpseFinderSettings = corpseFinderSettings,
+    exclusionManager = exclusionManager,
+) {
 
     @Reusable
     class Factory @Inject constructor(

--- a/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/AppSourceCorpseFilter.kt
+++ b/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/AppSourceCorpseFilter.kt
@@ -6,138 +6,40 @@ import dagger.Reusable
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
-import eu.darken.sdmse.corpsefinder.R
 import eu.darken.sdmse.common.areas.DataArea
 import eu.darken.sdmse.common.areas.DataAreaManager
-import eu.darken.sdmse.common.areas.currentAreas
-import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.datastore.value
-import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
-import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
-import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
-import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.files.GatewaySwitch
-import eu.darken.sdmse.common.files.isDirectory
-import eu.darken.sdmse.common.files.listFiles
-import eu.darken.sdmse.common.files.local.LocalGateway
-import eu.darken.sdmse.common.files.lookup
-import eu.darken.sdmse.common.files.walk
 import eu.darken.sdmse.common.forensics.FileForensics
-import eu.darken.sdmse.common.hasApiLevel
-import eu.darken.sdmse.common.progress.Progress
-import eu.darken.sdmse.common.progress.increaseProgress
-import eu.darken.sdmse.common.progress.updateProgressCount
-import eu.darken.sdmse.common.progress.updateProgressPrimary
-import eu.darken.sdmse.common.progress.updateProgressSecondary
-import eu.darken.sdmse.corpsefinder.core.Corpse
+import eu.darken.sdmse.corpsefinder.R
 import eu.darken.sdmse.corpsefinder.core.CorpseFinderSettings
-import eu.darken.sdmse.corpsefinder.core.RiskLevel
 import eu.darken.sdmse.exclusion.core.ExclusionManager
-import eu.darken.sdmse.exclusion.core.pathExclusions
-import eu.darken.sdmse.main.core.SDMTool
-import kotlinx.coroutines.flow.asFlow
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.mapNotNull
-import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.flow.toSet
 import javax.inject.Inject
 import javax.inject.Provider
 
 
 @Reusable
 class AppSourceCorpseFilter @Inject constructor(
-    private val areaManager: DataAreaManager,
-    private val gatewaySwitch: GatewaySwitch,
-    private val fileForensics: FileForensics,
-    private val corpseFinderSettings: CorpseFinderSettings,
-    private val exclusionManager: ExclusionManager,
-) : CorpseFilter(TAG, Progress.Data(primary = R.string.corpsefinder_filter_appsource_label.toCaString())) {
-
-    override suspend fun doScan(): Collection<Corpse> {
-        log(TAG) { "Scanning..." }
-
-        val gateway = gatewaySwitch.getGateway(APath.PathType.LOCAL) as LocalGateway
-
-        if (!gateway.hasRoot()) {
-            log(TAG) { "LocalGateway has no root, skipping." }
-            return emptySet()
-        }
-
-        // TODO needs to be checked on more rooted ROMs
-        if (hasApiLevel(37)) {
-            log(TAG, WARN) { "Untested API level (37) skipping for safety." }
-            return emptySet()
-        }
-
-        updateProgressPrimary(R.string.corpsefinder_filter_appsource_label)
-
-        val pathExclusions = exclusionManager.pathExclusions(SDMTool.Type.CORPSEFINDER)
-
-        return areaManager.currentAreas()
-            .filter { it.type == DataArea.Type.APP_APP }
-            .map { area ->
-                updateProgressSecondary {
-                    it.getString(eu.darken.sdmse.common.R.string.general_progress_processing_x, area.label.get(it))
-                }
-
-                log(TAG) { "Reading $area" }
-                val topLevelContents = area.path
-                    .listFiles(gatewaySwitch)
-                    .filter { path ->
-                        pathExclusions.none { excl ->
-                            excl.match(path).also {
-                                if (it) log(TAG, INFO) { "Excluded due to $excl: $path" }
-                            }
-                        }
-                    }
-
-                log(TAG) { "Filtering $area" }
-                doFilter(topLevelContents)
-            }
-            .flatten()
-    }
-
-    private suspend fun doFilter(candidates: Collection<APath>): Collection<Corpse> {
-        updateProgressCount(Progress.Count.Percent(candidates.size))
-
-        val includeRiskKeeper: Boolean = corpseFinderSettings.includeRiskKeeper.value()
-        val includeRiskCommon: Boolean = corpseFinderSettings.includeRiskCommon.value()
-
-        return candidates
-            .asFlow()
-            .mapNotNull {
-                log(TAG) { "Checking $it" }
-                increaseProgress()
-                fileForensics.findOwners(it)
-            }
-            .filter { ownerInfo ->
-                (ownerInfo.areaInfo.type == DataArea.Type.APP_APP).also {
-                    if (!it) log(TAG, WARN) { "Wrong area: $ownerInfo" }
-                }
-            }
-            .filter { it.isCorpse }
-            .filter { !it.isKeeper || includeRiskKeeper }
-            .filter { !it.isCommon || includeRiskCommon }
-            .map { ownerInfo ->
-                val lookup = ownerInfo.item.lookup(gatewaySwitch)
-                val content = if (lookup.isDirectory) ownerInfo.item.walk(gatewaySwitch).toSet() else emptyList()
-                Corpse(
-                    filterType = this::class,
-                    ownerInfo = ownerInfo,
-                    lookup = lookup,
-                    content = content,
-                    isWriteProtected = false,
-                    riskLevel = when {
-                        ownerInfo.isKeeper -> RiskLevel.KEEPER
-                        ownerInfo.isCommon -> RiskLevel.COMMON
-                        else -> RiskLevel.NORMAL
-                    }
-                ).also { log(TAG, INFO) { "Found Corpse: $it" } }
-            }
-            .toList()
-    }
+    areaManager: DataAreaManager,
+    gatewaySwitch: GatewaySwitch,
+    fileForensics: FileForensics,
+    corpseFinderSettings: CorpseFinderSettings,
+    exclusionManager: ExclusionManager,
+) : StandardCorpseFilter(
+    filterTag = TAG,
+    areaType = DataArea.Type.APP_APP,
+    defaultProgressLabel = R.string.corpsefinder_filter_appsource_label,
+    scanProgressLabel = R.string.corpsefinder_filter_appsource_label,
+    capabilityPolicy = CapabilityPolicy.AlwaysRoot,
+    // TODO needs to be checked on more rooted ROMs
+    apiBailAt = 37,
+    areaManager = areaManager,
+    gatewaySwitch = gatewaySwitch,
+    fileForensics = fileForensics,
+    corpseFinderSettings = corpseFinderSettings,
+    exclusionManager = exclusionManager,
+) {
 
     @Reusable
     class Factory @Inject constructor(

--- a/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/AppSourcePrivateCorpseFilter.kt
+++ b/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/AppSourcePrivateCorpseFilter.kt
@@ -6,126 +6,42 @@ import dagger.Reusable
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
-import eu.darken.sdmse.corpsefinder.R
 import eu.darken.sdmse.common.areas.DataArea
 import eu.darken.sdmse.common.areas.DataAreaManager
-import eu.darken.sdmse.common.areas.currentAreas
-import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.datastore.value
-import eu.darken.sdmse.common.debug.logging.Logging.Priority.*
-import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
-import eu.darken.sdmse.common.files.*
-import eu.darken.sdmse.common.files.local.LocalGateway
+import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.forensics.FileForensics
-import eu.darken.sdmse.common.hasApiLevel
-import eu.darken.sdmse.common.progress.*
-import eu.darken.sdmse.corpsefinder.core.Corpse
+import eu.darken.sdmse.corpsefinder.R
 import eu.darken.sdmse.corpsefinder.core.CorpseFinderSettings
-import eu.darken.sdmse.corpsefinder.core.RiskLevel
 import eu.darken.sdmse.exclusion.core.ExclusionManager
-import eu.darken.sdmse.exclusion.core.pathExclusions
-import eu.darken.sdmse.main.core.SDMTool
-import kotlinx.coroutines.flow.*
-import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Provider
 
 
 @Reusable
 class AppSourcePrivateCorpseFilter @Inject constructor(
-    private val areaManager: DataAreaManager,
-    private val gatewaySwitch: GatewaySwitch,
-    private val fileForensics: FileForensics,
-    private val corpseFinderSettings: CorpseFinderSettings,
-    private val exclusionManager: ExclusionManager,
-) : CorpseFilter(TAG, Progress.Data(primary = R.string.corpsefinder_filter_appsource_private_label.toCaString())) {
-
-    override suspend fun doScan(): Collection<Corpse> {
-        log(TAG) { "Scanning..." }
-
-        val gateway = gatewaySwitch.getGateway(APath.PathType.LOCAL) as LocalGateway
-
-        if (!gateway.hasRoot()) {
-            log(TAG) { "LocalGateway has no root, skipping." }
-            return emptySet()
-        }
-
-        // TODO needs to be checked on more rooted ROMs
-        // https://github.com/d4rken-org/sdmaid-se/issues/1612
-        // Have not seen this on API35+ yet
-        if (hasApiLevel(35)) {
-            log(TAG, WARN) { "Untested API level (35) skipping for safety." }
-            return emptySet()
-        }
-
-        updateProgressPrimary(R.string.corpsefinder_filter_appsource_private_label)
-
-        val pathExclusions = exclusionManager.pathExclusions(SDMTool.Type.CORPSEFINDER)
-
-        return areaManager.currentAreas()
-            .filter { it.type == DataArea.Type.APP_APP_PRIVATE }
-            .map { area ->
-                updateProgressSecondary {
-                    it.getString(eu.darken.sdmse.common.R.string.general_progress_processing_x, area.label.get(it))
-                }
-
-                log(TAG) { "Reading $area" }
-                val topLevelContents = area.path
-                    .listFiles(gatewaySwitch)
-                    .filter { path ->
-                        pathExclusions.none { excl ->
-                            excl.match(path).also {
-                                if (it) log(TAG, INFO) { "Excluded due to $excl: $path" }
-                            }
-                        }
-                    }
-
-                log(TAG) { "Filtering $area" }
-                doFilter(topLevelContents)
-            }
-            .flatten()
-    }
-
-    @Throws(IOException::class) private suspend fun doFilter(candidates: Collection<APath>): Collection<Corpse> {
-        updateProgressCount(Progress.Count.Percent(candidates.size))
-
-        val includeRiskKeeper: Boolean = corpseFinderSettings.includeRiskKeeper.value()
-        val includeRiskCommon: Boolean = corpseFinderSettings.includeRiskCommon.value()
-
-        return candidates
-            .asFlow()
-            .mapNotNull {
-                log(TAG) { "Checking $it" }
-                increaseProgress()
-                fileForensics.findOwners(it)
-            }
-            .filter { ownerInfo ->
-                (ownerInfo.areaInfo.type == DataArea.Type.APP_APP_PRIVATE).also {
-                    if (!it) log(TAG, WARN) { "Wrong area: $ownerInfo" }
-                }
-            }
-            .filter { it.isCorpse }
-            .filter { !it.isKeeper || includeRiskKeeper }
-            .filter { !it.isCommon || includeRiskCommon }
-            .map { ownerInfo ->
-                val lookup = ownerInfo.item.lookup(gatewaySwitch)
-                val content = if (lookup.isDirectory) ownerInfo.item.walk(gatewaySwitch).toSet() else emptyList()
-                Corpse(
-                    filterType = this::class,
-                    ownerInfo = ownerInfo,
-                    lookup = lookup,
-                    content = content,
-                    isWriteProtected = false,
-                    riskLevel = when {
-                        ownerInfo.isKeeper -> RiskLevel.KEEPER
-                        ownerInfo.isCommon -> RiskLevel.COMMON
-                        else -> RiskLevel.NORMAL
-                    }
-                ).also { log(TAG, INFO) { "Found Corpse: $it" } }
-            }
-            .toList()
-    }
+    areaManager: DataAreaManager,
+    gatewaySwitch: GatewaySwitch,
+    fileForensics: FileForensics,
+    corpseFinderSettings: CorpseFinderSettings,
+    exclusionManager: ExclusionManager,
+) : StandardCorpseFilter(
+    filterTag = TAG,
+    areaType = DataArea.Type.APP_APP_PRIVATE,
+    defaultProgressLabel = R.string.corpsefinder_filter_appsource_private_label,
+    scanProgressLabel = R.string.corpsefinder_filter_appsource_private_label,
+    capabilityPolicy = CapabilityPolicy.AlwaysRoot,
+    // TODO needs to be checked on more rooted ROMs
+    // https://github.com/d4rken-org/sdmaid-se/issues/1612
+    // Have not seen this on API35+ yet
+    apiBailAt = 35,
+    areaManager = areaManager,
+    gatewaySwitch = gatewaySwitch,
+    fileForensics = fileForensics,
+    corpseFinderSettings = corpseFinderSettings,
+    exclusionManager = exclusionManager,
+) {
 
     @Reusable
     class Factory @Inject constructor(

--- a/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/ArtProfilesCorpseFilter.kt
+++ b/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/ArtProfilesCorpseFilter.kt
@@ -6,137 +6,42 @@ import dagger.Reusable
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
-import eu.darken.sdmse.corpsefinder.R
 import eu.darken.sdmse.common.areas.DataArea
 import eu.darken.sdmse.common.areas.DataAreaManager
-import eu.darken.sdmse.common.areas.currentAreas
-import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.datastore.value
-import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
-import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
-import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.files.GatewaySwitch
-import eu.darken.sdmse.common.files.isDirectory
-import eu.darken.sdmse.common.files.listFiles
-import eu.darken.sdmse.common.files.local.LocalGateway
-import eu.darken.sdmse.common.files.lookup
-import eu.darken.sdmse.common.files.walk
 import eu.darken.sdmse.common.forensics.FileForensics
-import eu.darken.sdmse.common.hasApiLevel
-import eu.darken.sdmse.common.progress.Progress
-import eu.darken.sdmse.common.progress.increaseProgress
-import eu.darken.sdmse.common.progress.updateProgressCount
-import eu.darken.sdmse.common.progress.updateProgressPrimary
-import eu.darken.sdmse.common.progress.updateProgressSecondary
-import eu.darken.sdmse.corpsefinder.core.Corpse
+import eu.darken.sdmse.corpsefinder.R
 import eu.darken.sdmse.corpsefinder.core.CorpseFinderSettings
-import eu.darken.sdmse.corpsefinder.core.RiskLevel
 import eu.darken.sdmse.exclusion.core.ExclusionManager
-import eu.darken.sdmse.exclusion.core.pathExclusions
-import eu.darken.sdmse.main.core.SDMTool
-import kotlinx.coroutines.flow.asFlow
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.mapNotNull
-import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.flow.toSet
 import javax.inject.Inject
 import javax.inject.Provider
 
 @Reusable
 class ArtProfilesCorpseFilter @Inject constructor(
-    private val areaManager: DataAreaManager,
-    private val gatewaySwitch: GatewaySwitch,
-    private val fileForensics: FileForensics,
-    private val corpseFinderSettings: CorpseFinderSettings,
-    private val exclusionManager: ExclusionManager,
-) : CorpseFilter(TAG, Progress.Data(primary = R.string.corpsefinder_filter_dalvik_label.toCaString())) {
-
-    override suspend fun doScan(): Collection<Corpse> {
-        log(TAG) { "Scanning..." }
-
-        val gateway = gatewaySwitch.getGateway(APath.PathType.LOCAL) as LocalGateway
-
-        if (!gateway.hasRoot()) {
-            log(TAG) { "LocalGateway has no root, skipping." }
-            return emptySet()
-        }
-
-        if (hasApiLevel(37)) {
-            log(TAG, WARN) { "Untested API level (37) skipping for safety." }
-            return emptySet()
-        }
-
-        updateProgressPrimary(R.string.corpsefinder_filter_artprofiles_label)
-
-        val pathExclusions = exclusionManager.pathExclusions(SDMTool.Type.CORPSEFINDER)
-
-        return areaManager.currentAreas()
-            .filter { it.type == DataArea.Type.ART_PROFILE }
-            .map { area ->
-                updateProgressSecondary {
-                    it.getString(eu.darken.sdmse.common.R.string.general_progress_processing_x, area.label.get(it))
-                }
-                updateProgressCount(Progress.Count.Indeterminate())
-
-                log(TAG) { "Reading $area" }
-                val topLevelContents = area.path
-                    .listFiles(gatewaySwitch)
-                    .filter { path ->
-                        pathExclusions.none { excl ->
-                            excl.match(path).also { if (it) log(TAG, INFO) { "Excluded due to $excl: $path" } }
-                        }
-                    }
-                log(TAG) { "Filtering $area" }
-                doFilter(topLevelContents)
-            }
-            .flatten()
-    }
-
-    private suspend fun doFilter(candidates: Collection<APath>): Collection<Corpse> {
-        updateProgressCount(Progress.Count.Percent(candidates.size))
-
-        val includeRiskKeeper: Boolean = corpseFinderSettings.includeRiskKeeper.value()
-        val includeRiskCommon: Boolean = corpseFinderSettings.includeRiskCommon.value()
-
-        return candidates.asFlow()
-            .mapNotNull {
-                log(TAG) { "Checking $it" }
-                increaseProgress()
-                fileForensics.findOwners(it)
-            }
-            .filter { ownerInfo ->
-                (ownerInfo.areaInfo.type == DataArea.Type.ART_PROFILE).also {
-                    if (!it) log(TAG, WARN) { "Wrong area: $ownerInfo" }
-                }
-            }
-            .onEach {
-                log(TAG) { "$it" }
-            }
-            .filter { it.isCorpse }
-            .filter { !it.isKeeper || includeRiskKeeper }
-            .filter { !it.isCommon || includeRiskCommon }
-            .map { ownerInfo ->
-                val lookup = ownerInfo.item.lookup(gatewaySwitch)
-                val content = if (lookup.isDirectory) ownerInfo.item.walk(gatewaySwitch).toSet() else emptyList()
-                Corpse(
-                    filterType = this::class,
-                    ownerInfo = ownerInfo,
-                    lookup = lookup,
-                    content = content,
-                    isWriteProtected = false,
-                    riskLevel = when {
-                        ownerInfo.isKeeper -> RiskLevel.KEEPER
-                        ownerInfo.isCommon -> RiskLevel.COMMON
-                        else -> RiskLevel.NORMAL
-                    }
-                ).also { log(TAG, INFO) { "Found Corpse: $it" } }
-            }
-            .toList()
-    }
+    areaManager: DataAreaManager,
+    gatewaySwitch: GatewaySwitch,
+    fileForensics: FileForensics,
+    corpseFinderSettings: CorpseFinderSettings,
+    exclusionManager: ExclusionManager,
+) : StandardCorpseFilter(
+    filterTag = TAG,
+    areaType = DataArea.Type.ART_PROFILE,
+    // Idle progress shows the Dalvik label, the scan itself is labeled as ART profiles.
+    defaultProgressLabel = R.string.corpsefinder_filter_dalvik_label,
+    scanProgressLabel = R.string.corpsefinder_filter_artprofiles_label,
+    capabilityPolicy = CapabilityPolicy.AlwaysRoot,
+    apiBailAt = 37,
+    indeterminateWhileListing = true,
+    onOwnerFound = { log(TAG) { "$it" } },
+    areaManager = areaManager,
+    gatewaySwitch = gatewaySwitch,
+    fileForensics = fileForensics,
+    corpseFinderSettings = corpseFinderSettings,
+    exclusionManager = exclusionManager,
+) {
 
     @Reusable
     class Factory @Inject constructor(

--- a/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/DalvikCorpseFilter.kt
+++ b/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/DalvikCorpseFilter.kt
@@ -20,31 +20,20 @@ import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.files.GatewaySwitch
-import eu.darken.sdmse.common.files.isDirectory
 import eu.darken.sdmse.common.files.listFiles
 import eu.darken.sdmse.common.files.local.LocalGateway
-import eu.darken.sdmse.common.files.lookup
-import eu.darken.sdmse.common.files.walk
 import eu.darken.sdmse.common.forensics.FileForensics
 import eu.darken.sdmse.common.hasApiLevel
 import eu.darken.sdmse.common.pkgs.getSharedLibraries2
 import eu.darken.sdmse.common.progress.Progress
-import eu.darken.sdmse.common.progress.increaseProgress
 import eu.darken.sdmse.common.progress.updateProgressCount
 import eu.darken.sdmse.common.progress.updateProgressPrimary
 import eu.darken.sdmse.common.progress.updateProgressSecondary
 import eu.darken.sdmse.corpsefinder.core.Corpse
 import eu.darken.sdmse.corpsefinder.core.CorpseFinderSettings
-import eu.darken.sdmse.corpsefinder.core.RiskLevel
 import eu.darken.sdmse.exclusion.core.ExclusionManager
 import eu.darken.sdmse.exclusion.core.pathExclusions
 import eu.darken.sdmse.main.core.SDMTool
-import kotlinx.coroutines.flow.asFlow
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.mapNotNull
-import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.flow.toSet
 import javax.inject.Inject
 import javax.inject.Provider
 
@@ -155,40 +144,17 @@ class DalvikCorpseFilter @Inject constructor(
         includeRiskCommon: Boolean,
     ): Collection<Corpse> {
         log(TAG) { "doFilterDalvikProfiles(${profileItems.size}, keeper=$includeRiskKeeper, common=$includeRiskCommon)" }
-        updateProgressCount(Progress.Count.Percent(profileItems.size))
-
-        return profileItems
-            .asFlow()
-            .mapNotNull {
-                log(TAG) { "Checking $it" }
-                increaseProgress()
-                fileForensics.findOwners(it)
-            }
-            .filter { ownerInfo ->
-                (ownerInfo.areaInfo.type == DataArea.Type.DALVIK_PROFILE).also {
-                    if (!it) log(TAG, WARN) { "Wrong area: $ownerInfo" }
-                }
-            }
-            .filter { it.isCorpse }
-            .filter { !it.isKeeper || includeRiskKeeper }
-            .filter { !it.isCommon || includeRiskCommon }
-            .map { ownerInfo ->
-                val lookup = ownerInfo.item.lookup(gatewaySwitch)
-                val content = if (lookup.isDirectory) ownerInfo.item.walk(gatewaySwitch).toSet() else emptyList()
-                Corpse(
-                    filterType = this::class,
-                    ownerInfo = ownerInfo,
-                    lookup = lookup,
-                    content = content,
-                    isWriteProtected = false,
-                    riskLevel = when {
-                        ownerInfo.isKeeper -> RiskLevel.KEEPER
-                        ownerInfo.isCommon -> RiskLevel.COMMON
-                        else -> RiskLevel.NORMAL
-                    }
-                ).also { log(TAG, INFO) { "Found Corpse: $it" } }
-            }
-            .toList()
+        return filterCandidates(
+            candidates = profileItems,
+            areaType = DataArea.Type.DALVIK_PROFILE,
+            filterType = this::class,
+            includeRiskKeeper = includeRiskKeeper,
+            includeRiskCommon = includeRiskCommon,
+            tag = TAG,
+            progress = this,
+            gatewaySwitch = gatewaySwitch,
+            fileForensics = fileForensics,
+        )
     }
 
     private suspend fun doFilterOdex(
@@ -197,40 +163,17 @@ class DalvikCorpseFilter @Inject constructor(
         includeRiskCommon: Boolean,
     ): Collection<Corpse> {
         log(TAG) { "doFilterOdex(${dalvikItems.size}, keeper=$includeRiskKeeper, common=$includeRiskCommon)" }
-        updateProgressCount(Progress.Count.Percent(dalvikItems.size))
-
-        return dalvikItems
-            .asFlow()
-            .mapNotNull {
-                log(TAG) { "Checking $it" }
-                increaseProgress()
-                fileForensics.findOwners(it)
-            }
-            .filter { ownerInfo ->
-                (ownerInfo.areaInfo.type == DataArea.Type.DALVIK_DEX).also {
-                    if (!it) log(TAG, WARN) { "Wrong area: $ownerInfo" }
-                }
-            }
-            .filter { it.isCorpse }
-            .filter { !it.isKeeper || includeRiskKeeper }
-            .filter { !it.isCommon || includeRiskCommon }
-            .map { ownerInfo ->
-                val lookup = ownerInfo.item.lookup(gatewaySwitch)
-                val content = if (lookup.isDirectory) ownerInfo.item.walk(gatewaySwitch).toSet() else emptyList()
-                Corpse(
-                    filterType = this::class,
-                    ownerInfo = ownerInfo,
-                    lookup = lookup,
-                    content = content,
-                    isWriteProtected = false,
-                    riskLevel = when {
-                        ownerInfo.isKeeper -> RiskLevel.KEEPER
-                        ownerInfo.isCommon -> RiskLevel.COMMON
-                        else -> RiskLevel.NORMAL
-                    }
-                ).also { log(TAG, INFO) { "Found Corpse: $it" } }
-            }
-            .toList()
+        return filterCandidates(
+            candidates = dalvikItems,
+            areaType = DataArea.Type.DALVIK_DEX,
+            filterType = this::class,
+            includeRiskKeeper = includeRiskKeeper,
+            includeRiskCommon = includeRiskCommon,
+            tag = TAG,
+            progress = this,
+            gatewaySwitch = gatewaySwitch,
+            fileForensics = fileForensics,
+        )
     }
 
     @Reusable

--- a/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/FilterCandidates.kt
+++ b/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/FilterCandidates.kt
@@ -1,0 +1,84 @@
+package eu.darken.sdmse.corpsefinder.core.filter
+
+import eu.darken.sdmse.common.areas.DataArea
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.files.GatewaySwitch
+import eu.darken.sdmse.common.files.isDirectory
+import eu.darken.sdmse.common.files.lookup
+import eu.darken.sdmse.common.files.walk
+import eu.darken.sdmse.common.forensics.FileForensics
+import eu.darken.sdmse.common.forensics.OwnerInfo
+import eu.darken.sdmse.common.progress.Progress
+import eu.darken.sdmse.common.progress.increaseProgress
+import eu.darken.sdmse.common.progress.updateProgressCount
+import eu.darken.sdmse.corpsefinder.core.Corpse
+import eu.darken.sdmse.corpsefinder.core.RiskLevel
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.flow.toSet
+import kotlin.reflect.KClass
+
+/**
+ * Turns the top level content of a single data area into corpses.
+ *
+ * Shared by [StandardCorpseFilter] and [DalvikCorpseFilter]. [filterType] is the filter that owns
+ * the result, the risk settings are resolved by the caller because Dalvik reads them once for two
+ * areas while the standard skeleton reads them per area.
+ */
+internal suspend fun filterCandidates(
+    candidates: Collection<APath>,
+    areaType: DataArea.Type,
+    filterType: KClass<out CorpseFilter>,
+    includeRiskKeeper: Boolean,
+    includeRiskCommon: Boolean,
+    tag: String,
+    progress: Progress.Client,
+    gatewaySwitch: GatewaySwitch,
+    fileForensics: FileForensics,
+    shouldExcludeCandidate: (APath) -> Boolean = { false },
+    onOwnerFound: ((OwnerInfo) -> Unit)? = null,
+): Collection<Corpse> {
+    progress.updateProgressCount(Progress.Count.Percent(candidates.size))
+
+    return candidates
+        .asFlow()
+        .filter { !shouldExcludeCandidate(it) }
+        .mapNotNull {
+            log(tag) { "Checking $it" }
+            progress.increaseProgress()
+            fileForensics.findOwners(it)
+        }
+        .filter { ownerInfo ->
+            (ownerInfo.areaInfo.type == areaType).also {
+                if (!it) log(tag, WARN) { "Wrong area: $ownerInfo" }
+            }
+        }
+        .onEach { onOwnerFound?.invoke(it) }
+        .filter { it.isCorpse }
+        .filter { !it.isKeeper || includeRiskKeeper }
+        .filter { !it.isCommon || includeRiskCommon }
+        .map { ownerInfo ->
+            val lookup = ownerInfo.item.lookup(gatewaySwitch)
+            val content = if (lookup.isDirectory) ownerInfo.item.walk(gatewaySwitch).toSet() else emptyList()
+            Corpse(
+                filterType = filterType,
+                ownerInfo = ownerInfo,
+                lookup = lookup,
+                content = content,
+                isWriteProtected = false,
+                riskLevel = when {
+                    ownerInfo.isKeeper -> RiskLevel.KEEPER
+                    ownerInfo.isCommon -> RiskLevel.COMMON
+                    else -> RiskLevel.NORMAL
+                }
+            ).also { log(tag, INFO) { "Found Corpse: $it" } }
+        }
+        .toList()
+}

--- a/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/PrivateDataCorpseFilter.kt
+++ b/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/PrivateDataCorpseFilter.kt
@@ -6,146 +6,42 @@ import dagger.Reusable
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
-import eu.darken.sdmse.corpsefinder.R
 import eu.darken.sdmse.common.areas.DataArea
 import eu.darken.sdmse.common.areas.DataAreaManager
-import eu.darken.sdmse.common.areas.currentAreas
-import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.datastore.value
-import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
-import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
-import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
-import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.files.GatewaySwitch
-import eu.darken.sdmse.common.files.isDirectory
-import eu.darken.sdmse.common.files.listFiles
-import eu.darken.sdmse.common.files.local.LocalGateway
-import eu.darken.sdmse.common.files.lookup
-import eu.darken.sdmse.common.files.walk
 import eu.darken.sdmse.common.forensics.FileForensics
-import eu.darken.sdmse.common.hasApiLevel
-import eu.darken.sdmse.common.progress.Progress
-import eu.darken.sdmse.common.progress.increaseProgress
-import eu.darken.sdmse.common.progress.updateProgressCount
-import eu.darken.sdmse.common.progress.updateProgressPrimary
-import eu.darken.sdmse.common.progress.updateProgressSecondary
-import eu.darken.sdmse.corpsefinder.core.Corpse
+import eu.darken.sdmse.corpsefinder.R
 import eu.darken.sdmse.corpsefinder.core.CorpseFinderSettings
-import eu.darken.sdmse.corpsefinder.core.RiskLevel
 import eu.darken.sdmse.exclusion.core.ExclusionManager
-import eu.darken.sdmse.exclusion.core.pathExclusions
-import eu.darken.sdmse.main.core.SDMTool
-import kotlinx.coroutines.flow.asFlow
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.mapNotNull
-import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.flow.toSet
-import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Provider
 
 
 @Reusable
 class PrivateDataCorpseFilter @Inject constructor(
-    private val areaManager: DataAreaManager,
-    private val gatewaySwitch: GatewaySwitch,
-    private val fileForensics: FileForensics,
-    private val corpseFinderSettings: CorpseFinderSettings,
-    private val exclusionManager: ExclusionManager,
-) : CorpseFilter(TAG, Progress.Data(primary = R.string.corpsefinder_filter_privatedata_label.toCaString())) {
-
-    override suspend fun doScan(): Collection<Corpse> {
-        log(TAG) { "Scanning..." }
-
-        val gateway = gatewaySwitch.getGateway(APath.PathType.LOCAL) as LocalGateway
-
-        if (!gateway.hasRoot()) {
-            log(TAG) { "LocalGateway has no root, skipping." }
-            return emptySet()
-        }
-
-        // TODO needs to be checked on more rooted ROMs
-        if (hasApiLevel(37)) {
-            log(TAG, WARN) { "Untested API level (37) skipping for safety." }
-            return emptySet()
-        }
-
-        updateProgressPrimary(R.string.corpsefinder_filter_privatedata_label)
-
-        val pathExclusions = exclusionManager.pathExclusions(SDMTool.Type.CORPSEFINDER)
-
-        return areaManager.currentAreas()
-            .filter { it.type == DataArea.Type.PRIVATE_DATA }
-            .map { area ->
-                updateProgressSecondary {
-                    it.getString(eu.darken.sdmse.common.R.string.general_progress_processing_x, area.label.get(it))
-                }
-                updateProgressCount(Progress.Count.Indeterminate())
-
-                log(TAG) { "Reading $area" }
-                val topLevelContents = area.path
-                    .listFiles(gatewaySwitch)
-                    .filter { path ->
-                        pathExclusions.none { excl ->
-                            excl.match(path).also {
-                                if (it) log(TAG, INFO) { "Excluded due to $excl: $path" }
-                            }
-                        }
-                    }
-                log(TAG) { "Filtering $area" }
-                doFilter(topLevelContents)
-            }
-            .flatten()
-    }
-
-    @Throws(IOException::class) private suspend fun doFilter(candidates: Collection<APath>): Collection<Corpse> {
-        updateProgressCount(Progress.Count.Percent(candidates.size))
-
-        val includeRiskKeeper: Boolean = corpseFinderSettings.includeRiskKeeper.value()
-        val includeRiskCommon: Boolean = corpseFinderSettings.includeRiskCommon.value()
-
-        return candidates
-            .asFlow()
-            .filter { !shouldBeExcluded(it) }
-            .mapNotNull {
-                log(TAG) { "Checking $it" }
-                increaseProgress()
-                fileForensics.findOwners(it)
-            }
-            .filter { ownerInfo ->
-                (ownerInfo.areaInfo.type == DataArea.Type.PRIVATE_DATA).also {
-                    if (!it) log(TAG, WARN) { "Wrong area: $ownerInfo" }
-                }
-            }
-            .filter { it.isCorpse }
-            .filter { !it.isKeeper || includeRiskKeeper }
-            .filter { !it.isCommon || includeRiskCommon }
-            .map { ownerInfo ->
-                val lookup = ownerInfo.item.lookup(gatewaySwitch)
-                val content = if (lookup.isDirectory) ownerInfo.item.walk(gatewaySwitch).toSet() else emptyList()
-                Corpse(
-                    filterType = this::class,
-                    ownerInfo = ownerInfo,
-                    lookup = lookup,
-                    content = content,
-                    isWriteProtected = false,
-                    riskLevel = when {
-                        ownerInfo.isKeeper -> RiskLevel.KEEPER
-                        ownerInfo.isCommon -> RiskLevel.COMMON
-                        else -> RiskLevel.NORMAL
-                    }
-                ).also { log(TAG, INFO) { "Found Corpse: $it" } }
-            }
-            .toList()
-    }
-
-    private fun shouldBeExcluded(inspectedDir: APath): Boolean = when (inspectedDir.name) {
-        "hosts" -> true
-        "lost+found" -> true
-        else -> false
-    }
+    areaManager: DataAreaManager,
+    gatewaySwitch: GatewaySwitch,
+    fileForensics: FileForensics,
+    corpseFinderSettings: CorpseFinderSettings,
+    exclusionManager: ExclusionManager,
+) : StandardCorpseFilter(
+    filterTag = TAG,
+    areaType = DataArea.Type.PRIVATE_DATA,
+    defaultProgressLabel = R.string.corpsefinder_filter_privatedata_label,
+    scanProgressLabel = R.string.corpsefinder_filter_privatedata_label,
+    capabilityPolicy = CapabilityPolicy.AlwaysRoot,
+    // TODO needs to be checked on more rooted ROMs
+    apiBailAt = 37,
+    indeterminateWhileListing = true,
+    excludedNames = setOf("hosts", "lost+found"),
+    areaManager = areaManager,
+    gatewaySwitch = gatewaySwitch,
+    fileForensics = fileForensics,
+    corpseFinderSettings = corpseFinderSettings,
+    exclusionManager = exclusionManager,
+) {
 
     @Reusable
     class Factory @Inject constructor(

--- a/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/PublicDataCorpseFilter.kt
+++ b/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/PublicDataCorpseFilter.kt
@@ -6,125 +6,38 @@ import dagger.Reusable
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
-import eu.darken.sdmse.corpsefinder.R
 import eu.darken.sdmse.common.areas.DataArea
 import eu.darken.sdmse.common.areas.DataAreaManager
-import eu.darken.sdmse.common.areas.currentAreas
-import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.datastore.value
-import eu.darken.sdmse.common.debug.logging.Logging.Priority.*
-import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
-import eu.darken.sdmse.common.files.*
-import eu.darken.sdmse.common.files.local.LocalGateway
+import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.forensics.FileForensics
-import eu.darken.sdmse.common.hasApiLevel
-import eu.darken.sdmse.common.progress.*
-import eu.darken.sdmse.corpsefinder.core.Corpse
+import eu.darken.sdmse.corpsefinder.R
 import eu.darken.sdmse.corpsefinder.core.CorpseFinderSettings
-import eu.darken.sdmse.corpsefinder.core.RiskLevel
 import eu.darken.sdmse.exclusion.core.ExclusionManager
-import eu.darken.sdmse.exclusion.core.pathExclusions
-import eu.darken.sdmse.main.core.SDMTool
-import kotlinx.coroutines.flow.*
-import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Provider
 
 @Reusable
 class PublicDataCorpseFilter @Inject constructor(
-    private val areaManager: DataAreaManager,
-    private val gatewaySwitch: GatewaySwitch,
-    private val fileForensics: FileForensics,
-    private val corpseFinderSettings: CorpseFinderSettings,
-    private val exclusionManager: ExclusionManager,
-) : CorpseFilter(TAG, Progress.Data(primary = R.string.corpsefinder_filter_publicdata_label.toCaString())) {
-
-    override suspend fun doScan(): Collection<Corpse> {
-        log(TAG) { "Scanning..." }
-
-        val gateway = gatewaySwitch.getGateway(APath.PathType.LOCAL) as LocalGateway
-
-        if (hasApiLevel(33) && !gateway.hasRoot() && !gateway.hasAdb()) {
-            log(TAG) { "LocalGateway has no root/adb, skipping public data on Android 13+" }
-            return emptySet()
-        }
-
-        updateProgressPrimary(R.string.corpsefinder_filter_publicdata_label)
-
-        val pathExclusions = exclusionManager.pathExclusions(SDMTool.Type.CORPSEFINDER)
-
-        return areaManager.currentAreas()
-            .filter { it.type == DataArea.Type.PUBLIC_DATA }
-            .map { area ->
-                updateProgressSecondary {
-                    it.getString(eu.darken.sdmse.common.R.string.general_progress_processing_x, area.label.get(it))
-                }
-
-                log(TAG) { "Reading $area" }
-                val topLevelContents = area.path
-                    .listFiles(gatewaySwitch)
-                    .filter { path ->
-                        pathExclusions.none { excl ->
-                            excl.match(path).also {
-                                if (it) log(TAG, INFO) { "Excluded due to $excl: $path" }
-                            }
-                        }
-                    }
-
-                log(TAG) { "Filtering $area" }
-                doFilter(topLevelContents)
-            }
-            .flatten()
-    }
-
-    @Throws(IOException::class) private suspend fun doFilter(candidates: Collection<APath>): Collection<Corpse> {
-        updateProgressCount(Progress.Count.Percent(candidates.size))
-
-        val includeRiskKeeper: Boolean = corpseFinderSettings.includeRiskKeeper.value()
-        val includeRiskCommon: Boolean = corpseFinderSettings.includeRiskCommon.value()
-
-        return candidates
-            .asFlow()
-            .filter { !shouldBeExcluded(it) }
-            .mapNotNull {
-                log(TAG) { "Checking $it" }
-                increaseProgress()
-                fileForensics.findOwners(it)
-            }
-            .filter { ownerInfo ->
-                (ownerInfo.areaInfo.type == DataArea.Type.PUBLIC_DATA).also {
-                    if (!it) log(TAG, WARN) { "Wrong area: $ownerInfo" }
-                }
-            }
-            .filter { it.isCorpse }
-            .filter { !it.isKeeper || includeRiskKeeper }
-            .filter { !it.isCommon || includeRiskCommon }
-            .map { ownerInfo ->
-                val lookup = ownerInfo.item.lookup(gatewaySwitch)
-                val content = if (lookup.isDirectory) ownerInfo.item.walk(gatewaySwitch).toSet() else emptyList()
-                Corpse(
-                    filterType = this::class,
-                    ownerInfo = ownerInfo,
-                    lookup = lookup,
-                    content = content,
-                    isWriteProtected = false,
-                    riskLevel = when {
-                        ownerInfo.isKeeper -> RiskLevel.KEEPER
-                        ownerInfo.isCommon -> RiskLevel.COMMON
-                        else -> RiskLevel.NORMAL
-                    }
-                ).also { log(TAG, INFO) { "Found Corpse: $it" } }
-            }
-            .toList()
-    }
-
-    private fun shouldBeExcluded(inspectedDir: APath): Boolean = when (inspectedDir.name) {
-        ".nomedia" -> true
-        "hosts" -> true
-        "lost+found" -> true
-        else -> false
-    }
+    areaManager: DataAreaManager,
+    gatewaySwitch: GatewaySwitch,
+    fileForensics: FileForensics,
+    corpseFinderSettings: CorpseFinderSettings,
+    exclusionManager: ExclusionManager,
+) : StandardCorpseFilter(
+    filterTag = TAG,
+    areaType = DataArea.Type.PUBLIC_DATA,
+    defaultProgressLabel = R.string.corpsefinder_filter_publicdata_label,
+    scanProgressLabel = R.string.corpsefinder_filter_publicdata_label,
+    capabilityPolicy = CapabilityPolicy.RootOrAdbFromApi(33),
+    excludedNames = setOf(".nomedia", "hosts", "lost+found"),
+    areaManager = areaManager,
+    gatewaySwitch = gatewaySwitch,
+    fileForensics = fileForensics,
+    corpseFinderSettings = corpseFinderSettings,
+    exclusionManager = exclusionManager,
+) {
 
     @Reusable
     class Factory @Inject constructor(

--- a/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/PublicMediaCorpseFilter.kt
+++ b/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/PublicMediaCorpseFilter.kt
@@ -6,114 +6,38 @@ import dagger.Reusable
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
-import eu.darken.sdmse.corpsefinder.R
 import eu.darken.sdmse.common.areas.DataArea
 import eu.darken.sdmse.common.areas.DataAreaManager
-import eu.darken.sdmse.common.areas.currentAreas
-import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.datastore.value
-import eu.darken.sdmse.common.debug.logging.Logging.Priority.*
-import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
-import eu.darken.sdmse.common.files.*
+import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.forensics.FileForensics
-import eu.darken.sdmse.common.progress.*
-import eu.darken.sdmse.corpsefinder.core.Corpse
+import eu.darken.sdmse.corpsefinder.R
 import eu.darken.sdmse.corpsefinder.core.CorpseFinderSettings
-import eu.darken.sdmse.corpsefinder.core.RiskLevel
 import eu.darken.sdmse.exclusion.core.ExclusionManager
-import eu.darken.sdmse.exclusion.core.pathExclusions
-import eu.darken.sdmse.main.core.SDMTool
-import kotlinx.coroutines.flow.*
-import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Provider
 
 @Reusable
 class PublicMediaCorpseFilter @Inject constructor(
-    private val areaManager: DataAreaManager,
-    private val gatewaySwitch: GatewaySwitch,
-    private val fileForensics: FileForensics,
-    private val corpseFinderSettings: CorpseFinderSettings,
-    private val exclusionManager: ExclusionManager,
-) : CorpseFilter(TAG, Progress.Data(primary = R.string.corpsefinder_filter_publicmedia_label.toCaString())) {
-
-    override suspend fun doScan(): Collection<Corpse> {
-        log(TAG) { "Scanning..." }
-
-        updateProgressPrimary(R.string.corpsefinder_filter_publicmedia_label)
-
-        val pathExclusions = exclusionManager.pathExclusions(SDMTool.Type.CORPSEFINDER)
-
-        return areaManager.currentAreas()
-            .filter { it.type == DataArea.Type.PUBLIC_MEDIA }
-            .map { area ->
-                updateProgressSecondary {
-                    it.getString(eu.darken.sdmse.common.R.string.general_progress_processing_x, area.label.get(it))
-                }
-
-                log(TAG) { "Reading $area" }
-                val topLevelContents = area.path
-                    .listFiles(gatewaySwitch)
-                    .filter { path ->
-                        pathExclusions.none { excl ->
-                            excl.match(path).also {
-                                if (it) log(TAG, INFO) { "Excluded due to $excl: $path" }
-                            }
-                        }
-                    }
-
-                log(TAG) { "Filtering $area" }
-                doFilter(topLevelContents)
-            }
-            .flatten()
-    }
-
-    @Throws(IOException::class) private suspend fun doFilter(candidates: Collection<APath>): Collection<Corpse> {
-        updateProgressCount(Progress.Count.Percent(candidates.size))
-
-        val includeRiskKeeper: Boolean = corpseFinderSettings.includeRiskKeeper.value()
-        val includeRiskCommon: Boolean = corpseFinderSettings.includeRiskCommon.value()
-
-        return candidates
-            .asFlow()
-            .filter { !shouldBeExcluded(it) }
-            .mapNotNull {
-                log(TAG) { "Checking $it" }
-                increaseProgress()
-                fileForensics.findOwners(it)
-            }
-            .filter { ownerInfo ->
-                (ownerInfo.areaInfo.type == DataArea.Type.PUBLIC_MEDIA).also {
-                    if (!it) log(TAG, WARN) { "Wrong area: $ownerInfo" }
-                }
-            }
-            .filter { it.isCorpse }
-            .filter { !it.isKeeper || includeRiskKeeper }
-            .filter { !it.isCommon || includeRiskCommon }
-            .map { ownerInfo ->
-                val lookup = ownerInfo.item.lookup(gatewaySwitch)
-                val content = if (lookup.isDirectory) ownerInfo.item.walk(gatewaySwitch).toSet() else emptyList()
-                Corpse(
-                    filterType = this::class,
-                    ownerInfo = ownerInfo,
-                    lookup = lookup,
-                    content = content,
-                    isWriteProtected = false,
-                    riskLevel = when {
-                        ownerInfo.isKeeper -> RiskLevel.KEEPER
-                        ownerInfo.isCommon -> RiskLevel.COMMON
-                        else -> RiskLevel.NORMAL
-                    }
-                ).also { log(TAG, INFO) { "Found Corpse: $it" } }
-            }
-            .toList()
-    }
-
-    private fun shouldBeExcluded(inspectedDir: APath): Boolean = when (inspectedDir.name) {
-        ".nomedia" -> true
-        else -> false
-    }
+    areaManager: DataAreaManager,
+    gatewaySwitch: GatewaySwitch,
+    fileForensics: FileForensics,
+    corpseFinderSettings: CorpseFinderSettings,
+    exclusionManager: ExclusionManager,
+) : StandardCorpseFilter(
+    filterTag = TAG,
+    areaType = DataArea.Type.PUBLIC_MEDIA,
+    defaultProgressLabel = R.string.corpsefinder_filter_publicmedia_label,
+    scanProgressLabel = R.string.corpsefinder_filter_publicmedia_label,
+    capabilityPolicy = CapabilityPolicy.None,
+    excludedNames = setOf(".nomedia"),
+    areaManager = areaManager,
+    gatewaySwitch = gatewaySwitch,
+    fileForensics = fileForensics,
+    corpseFinderSettings = corpseFinderSettings,
+    exclusionManager = exclusionManager,
+) {
 
     @Reusable
     class Factory @Inject constructor(

--- a/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/PublicObbCorpseFilter.kt
+++ b/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/PublicObbCorpseFilter.kt
@@ -6,123 +6,38 @@ import dagger.Reusable
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
-import eu.darken.sdmse.corpsefinder.R
 import eu.darken.sdmse.common.areas.DataArea
 import eu.darken.sdmse.common.areas.DataAreaManager
-import eu.darken.sdmse.common.areas.currentAreas
-import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.datastore.value
-import eu.darken.sdmse.common.debug.logging.Logging.Priority.*
-import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
-import eu.darken.sdmse.common.files.*
-import eu.darken.sdmse.common.files.local.LocalGateway
+import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.forensics.FileForensics
-import eu.darken.sdmse.common.hasApiLevel
-import eu.darken.sdmse.common.progress.*
-import eu.darken.sdmse.corpsefinder.core.Corpse
+import eu.darken.sdmse.corpsefinder.R
 import eu.darken.sdmse.corpsefinder.core.CorpseFinderSettings
-import eu.darken.sdmse.corpsefinder.core.RiskLevel
 import eu.darken.sdmse.exclusion.core.ExclusionManager
-import eu.darken.sdmse.exclusion.core.pathExclusions
-import eu.darken.sdmse.main.core.SDMTool
-import kotlinx.coroutines.flow.*
-import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Provider
 
 @Reusable
 class PublicObbCorpseFilter @Inject constructor(
-    private val areaManager: DataAreaManager,
-    private val gatewaySwitch: GatewaySwitch,
-    private val fileForensics: FileForensics,
-    private val corpseFinderSettings: CorpseFinderSettings,
-    private val exclusionManager: ExclusionManager,
-) : CorpseFilter(TAG, Progress.Data(primary = R.string.corpsefinder_filter_publicobb_label.toCaString())) {
-
-    override suspend fun doScan(): Collection<Corpse> {
-        log(TAG) { "Scanning..." }
-
-        val gateway = gatewaySwitch.getGateway(APath.PathType.LOCAL) as LocalGateway
-
-        if (hasApiLevel(33) && !gateway.hasRoot()) {
-            log(TAG) { "LocalGateway has no root, skipping public data on Android 13" }
-            return emptySet()
-        }
-
-        updateProgressPrimary(R.string.corpsefinder_filter_publicobb_label)
-
-        val pathExclusions = exclusionManager.pathExclusions(SDMTool.Type.CORPSEFINDER)
-
-        return areaManager.currentAreas()
-            .filter { it.type == DataArea.Type.PUBLIC_OBB }
-            .map { area ->
-                updateProgressSecondary {
-                    it.getString(eu.darken.sdmse.common.R.string.general_progress_processing_x, area.label.get(it))
-                }
-
-                log(TAG) { "Reading $area" }
-                val topLevelContents = area.path
-                    .listFiles(gatewaySwitch)
-                    .filter { path ->
-                        pathExclusions.none { excl ->
-                            excl.match(path).also {
-                                if (it) log(TAG, INFO) { "Excluded due to $excl: $path" }
-                            }
-                        }
-                    }
-
-                log(TAG) { "Filtering $area" }
-                doFilter(topLevelContents)
-            }
-            .flatten()
-    }
-
-    @Throws(IOException::class) private suspend fun doFilter(candidates: Collection<APath>): Collection<Corpse> {
-        updateProgressCount(Progress.Count.Percent(candidates.size))
-
-        val includeRiskKeeper: Boolean = corpseFinderSettings.includeRiskKeeper.value()
-        val includeRiskCommon: Boolean = corpseFinderSettings.includeRiskCommon.value()
-
-        return candidates
-            .asFlow()
-            .filter { !shouldBeExcluded(it) }
-            .mapNotNull {
-                log(TAG) { "Checking $it" }
-                increaseProgress()
-                fileForensics.findOwners(it)
-            }
-            .filter { ownerInfo ->
-                (ownerInfo.areaInfo.type == DataArea.Type.PUBLIC_OBB).also {
-                    if (!it) log(TAG, WARN) { "Wrong area: $ownerInfo" }
-                }
-            }
-            .filter { it.isCorpse }
-            .filter { !it.isKeeper || includeRiskKeeper }
-            .filter { !it.isCommon || includeRiskCommon }
-            .map { ownerInfo ->
-                val lookup = ownerInfo.item.lookup(gatewaySwitch)
-                val content = if (lookup.isDirectory) ownerInfo.item.walk(gatewaySwitch).toSet() else emptyList()
-                Corpse(
-                    filterType = this::class,
-                    ownerInfo = ownerInfo,
-                    lookup = lookup,
-                    content = content,
-                    isWriteProtected = false,
-                    riskLevel = when {
-                        ownerInfo.isKeeper -> RiskLevel.KEEPER
-                        ownerInfo.isCommon -> RiskLevel.COMMON
-                        else -> RiskLevel.NORMAL
-                    }
-                ).also { log(TAG, INFO) { "Found Corpse: $it" } }
-            }
-            .toList()
-    }
-
-    private fun shouldBeExcluded(inspectedDir: APath): Boolean = when (inspectedDir.name) {
-        ".nomedia" -> true
-        else -> false
-    }
+    areaManager: DataAreaManager,
+    gatewaySwitch: GatewaySwitch,
+    fileForensics: FileForensics,
+    corpseFinderSettings: CorpseFinderSettings,
+    exclusionManager: ExclusionManager,
+) : StandardCorpseFilter(
+    filterTag = TAG,
+    areaType = DataArea.Type.PUBLIC_OBB,
+    defaultProgressLabel = R.string.corpsefinder_filter_publicobb_label,
+    scanProgressLabel = R.string.corpsefinder_filter_publicobb_label,
+    capabilityPolicy = CapabilityPolicy.RootFromApi(33),
+    excludedNames = setOf(".nomedia"),
+    areaManager = areaManager,
+    gatewaySwitch = gatewaySwitch,
+    fileForensics = fileForensics,
+    corpseFinderSettings = corpseFinderSettings,
+    exclusionManager = exclusionManager,
+) {
 
     @Reusable
     class Factory @Inject constructor(

--- a/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/StandardCorpseFilter.kt
+++ b/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/StandardCorpseFilter.kt
@@ -1,0 +1,153 @@
+package eu.darken.sdmse.corpsefinder.core.filter
+
+import androidx.annotation.StringRes
+import eu.darken.sdmse.common.areas.DataArea
+import eu.darken.sdmse.common.areas.DataAreaManager
+import eu.darken.sdmse.common.areas.currentAreas
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.datastore.value
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.files.GatewaySwitch
+import eu.darken.sdmse.common.files.listFiles
+import eu.darken.sdmse.common.files.local.LocalGateway
+import eu.darken.sdmse.common.forensics.FileForensics
+import eu.darken.sdmse.common.forensics.OwnerInfo
+import eu.darken.sdmse.common.hasApiLevel
+import eu.darken.sdmse.common.progress.Progress
+import eu.darken.sdmse.common.progress.updateProgressCount
+import eu.darken.sdmse.common.progress.updateProgressPrimary
+import eu.darken.sdmse.common.progress.updateProgressSecondary
+import eu.darken.sdmse.corpsefinder.core.Corpse
+import eu.darken.sdmse.corpsefinder.core.CorpseFinderSettings
+import eu.darken.sdmse.exclusion.core.ExclusionManager
+import eu.darken.sdmse.exclusion.core.pathExclusions
+import eu.darken.sdmse.main.core.SDMTool
+
+/**
+ * The scan skeleton shared by the filters that check the top level content of a single data area:
+ * gate on the gateway's capabilities, list each area, drop excluded paths, hand the rest to
+ * [filterCandidates].
+ *
+ * [DalvikCorpseFilter] is not one of these, it walks two areas in one scan.
+ */
+abstract class StandardCorpseFilter(
+    private val filterTag: String,
+    private val areaType: DataArea.Type,
+    @param:StringRes private val defaultProgressLabel: Int,
+    @param:StringRes private val scanProgressLabel: Int,
+    private val capabilityPolicy: CapabilityPolicy,
+    private val apiBailAt: Int? = null,
+    private val indeterminateWhileListing: Boolean = false,
+    private val excludedNames: Set<String> = emptySet(),
+    private val onOwnerFound: ((OwnerInfo) -> Unit)? = null,
+    private val areaManager: DataAreaManager,
+    private val gatewaySwitch: GatewaySwitch,
+    private val fileForensics: FileForensics,
+    private val corpseFinderSettings: CorpseFinderSettings,
+    private val exclusionManager: ExclusionManager,
+) : CorpseFilter(filterTag, Progress.Data(primary = defaultProgressLabel.toCaString())) {
+
+    /** What the [LocalGateway] has to offer before a scan makes sense. */
+    sealed interface CapabilityPolicy {
+        /** No gateway is needed at all. */
+        data object None : CapabilityPolicy
+
+        data object AlwaysRoot : CapabilityPolicy
+
+        data class RootFromApi(val api: Int) : CapabilityPolicy
+
+        data class RootOrAdbFromApi(val api: Int) : CapabilityPolicy
+    }
+
+    final override suspend fun doScan(): Collection<Corpse> {
+        log(filterTag) { "Scanning..." }
+
+        if (!hasRequiredCapabilities()) return emptySet()
+
+        if (apiBailAt != null && hasApiLevel(apiBailAt)) {
+            log(filterTag, WARN) { "Untested API level ($apiBailAt) skipping for safety." }
+            return emptySet()
+        }
+
+        updateProgressPrimary(scanProgressLabel)
+
+        val pathExclusions = exclusionManager.pathExclusions(SDMTool.Type.CORPSEFINDER)
+
+        return areaManager.currentAreas()
+            .filter { it.type == areaType }
+            .map { area ->
+                updateProgressSecondary {
+                    it.getString(eu.darken.sdmse.common.R.string.general_progress_processing_x, area.label.get(it))
+                }
+                if (indeterminateWhileListing) updateProgressCount(Progress.Count.Indeterminate())
+
+                log(filterTag) { "Reading $area" }
+                val topLevelContents = area.path
+                    .listFiles(gatewaySwitch)
+                    .filter { path ->
+                        pathExclusions.none { excl ->
+                            excl.match(path).also {
+                                if (it) log(filterTag, INFO) { "Excluded due to $excl: $path" }
+                            }
+                        }
+                    }
+
+                log(filterTag) { "Filtering $area" }
+                doFilter(topLevelContents)
+            }
+            .flatten()
+    }
+
+    private suspend fun hasRequiredCapabilities(): Boolean = when (val policy = capabilityPolicy) {
+        is CapabilityPolicy.None -> true
+
+        is CapabilityPolicy.AlwaysRoot -> {
+            val gateway = gatewaySwitch.getGateway(APath.PathType.LOCAL) as LocalGateway
+            if (gateway.hasRoot()) {
+                true
+            } else {
+                log(filterTag) { "LocalGateway has no root, skipping." }
+                false
+            }
+        }
+
+        is CapabilityPolicy.RootFromApi -> {
+            val gateway = gatewaySwitch.getGateway(APath.PathType.LOCAL) as LocalGateway
+            if (hasApiLevel(policy.api) && !gateway.hasRoot()) {
+                log(filterTag) { "LocalGateway has no root, skipping public data on Android 13" }
+                false
+            } else {
+                true
+            }
+        }
+
+        is CapabilityPolicy.RootOrAdbFromApi -> {
+            val gateway = gatewaySwitch.getGateway(APath.PathType.LOCAL) as LocalGateway
+            if (hasApiLevel(policy.api) && !gateway.hasRoot() && !gateway.hasAdb()) {
+                log(filterTag) { "LocalGateway has no root/adb, skipping public data on Android 13+" }
+                false
+            } else {
+                true
+            }
+        }
+    }
+
+    private suspend fun doFilter(candidates: Collection<APath>): Collection<Corpse> = filterCandidates(
+        candidates = candidates,
+        areaType = areaType,
+        filterType = this::class,
+        includeRiskKeeper = corpseFinderSettings.includeRiskKeeper.value(),
+        includeRiskCommon = corpseFinderSettings.includeRiskCommon.value(),
+        tag = filterTag,
+        progress = this,
+        gatewaySwitch = gatewaySwitch,
+        fileForensics = fileForensics,
+        shouldExcludeCandidate = { shouldExcludeCandidate(it) },
+        onOwnerFound = onOwnerFound,
+    )
+
+    private fun shouldExcludeCandidate(path: APath): Boolean = excludedNames.contains(path.name)
+}

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/CorpseFilterContractTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/CorpseFilterContractTest.kt
@@ -1,0 +1,431 @@
+package eu.darken.sdmse.corpsefinder.core.filter
+
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.annotation.StringRes
+import eu.darken.sdmse.common.ca.CaString
+import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.progress.Progress
+import eu.darken.sdmse.corpsefinder.R
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.coroutine.runTest2
+import java.io.IOException
+
+/**
+ * Pins the behaviour the per-filter tests don't look at: progress labels and counts, which
+ * capability methods a filter calls, how often it reads the risk settings and what a failure
+ * mid-scan leaves behind.
+ *
+ * These are all things that are invisible in the corpse results, so they need explicit coverage.
+ */
+class CorpseFilterContractTest : CorpseFilterTest() {
+
+    @MockK lateinit var context: Context
+    @MockK lateinit var packageManager: PackageManager
+
+    /** Resolves [CaString]s to a marker for the resource id they carry. */
+    private lateinit var resContext: Context
+
+    @BeforeEach
+    override fun setup() {
+        super.setup()
+        every { context.packageManager } returns packageManager
+        every { packageManager.getSharedLibraries(0) } returns mutableListOf()
+
+        resContext = mockk<Context>().apply {
+            every { getString(any<Int>()) } answers { stringRes(firstArg<Int>()) }
+            every { getString(any<Int>(), *anyVararg()) } answers { stringRes(firstArg<Int>()) }
+        }
+    }
+
+    private fun stringRes(@StringRes id: Int): String = "res#$id"
+
+    private fun CaString.resolved(): String = get(resContext)
+
+    /**
+     * The current progress state.
+     *
+     * [CorpseFilter.progress] is conflated and throttled, so collecting it drops exactly the
+     * intermediate states these tests are about. [Progress.Client.updateProgress] reads the same
+     * state synchronously and without side effects.
+     */
+    private fun CorpseFilter.currentProgress(): Progress.Data? {
+        var snapshot: Progress.Data? = null
+        updateProgress { snapshot = it; it }
+        return snapshot
+    }
+
+    private fun appSourceFilter() = AppSourceCorpseFilter(
+        areaManager = areaManager,
+        gatewaySwitch = gatewaySwitch,
+        fileForensics = fileForensics,
+        corpseFinderSettings = corpseFinderSettings,
+        exclusionManager = exclusionManager,
+    )
+
+    private fun appSourcePrivateFilter() = AppSourcePrivateCorpseFilter(
+        areaManager = areaManager,
+        gatewaySwitch = gatewaySwitch,
+        fileForensics = fileForensics,
+        corpseFinderSettings = corpseFinderSettings,
+        exclusionManager = exclusionManager,
+    )
+
+    private fun appLibFilter() = AppLibCorpseFilter(
+        areaManager = areaManager,
+        gatewaySwitch = gatewaySwitch,
+        fileForensics = fileForensics,
+        corpseFinderSettings = corpseFinderSettings,
+        exclusionManager = exclusionManager,
+    )
+
+    private fun appAsecFilter() = AppAsecFileCorpseFilter(
+        areaManager = areaManager,
+        gatewaySwitch = gatewaySwitch,
+        fileForensics = fileForensics,
+        corpseFinderSettings = corpseFinderSettings,
+        exclusionManager = exclusionManager,
+    )
+
+    private fun artProfilesFilter() = ArtProfilesCorpseFilter(
+        areaManager = areaManager,
+        gatewaySwitch = gatewaySwitch,
+        fileForensics = fileForensics,
+        corpseFinderSettings = corpseFinderSettings,
+        exclusionManager = exclusionManager,
+    )
+
+    private fun privateDataFilter() = PrivateDataCorpseFilter(
+        areaManager = areaManager,
+        gatewaySwitch = gatewaySwitch,
+        fileForensics = fileForensics,
+        corpseFinderSettings = corpseFinderSettings,
+        exclusionManager = exclusionManager,
+    )
+
+    private fun publicDataFilter() = PublicDataCorpseFilter(
+        areaManager = areaManager,
+        gatewaySwitch = gatewaySwitch,
+        fileForensics = fileForensics,
+        corpseFinderSettings = corpseFinderSettings,
+        exclusionManager = exclusionManager,
+    )
+
+    private fun publicObbFilter() = PublicObbCorpseFilter(
+        areaManager = areaManager,
+        gatewaySwitch = gatewaySwitch,
+        fileForensics = fileForensics,
+        corpseFinderSettings = corpseFinderSettings,
+        exclusionManager = exclusionManager,
+    )
+
+    private fun publicMediaFilter() = PublicMediaCorpseFilter(
+        areaManager = areaManager,
+        gatewaySwitch = gatewaySwitch,
+        fileForensics = fileForensics,
+        corpseFinderSettings = corpseFinderSettings,
+        exclusionManager = exclusionManager,
+    )
+
+    private fun dalvikFilter() = DalvikCorpseFilter(
+        context = context,
+        areaManager = areaManager,
+        gatewaySwitch = gatewaySwitch,
+        fileForensics = fileForensics,
+        corpseFinderSettings = corpseFinderSettings,
+        exclusionManager = exclusionManager,
+    )
+
+    // ─────────────────────────── progress labels ───────────────────────────
+
+    @Test fun `art profiles shows the dalvik label when idle and the art label while scanning`() = runTest2 {
+        val filter = artProfilesFilter()
+        candidate(artProfile1, "com.orphan.pkg")
+
+        filter.currentProgress()!!.primary.resolved() shouldBe stringRes(R.string.corpsefinder_filter_dalvik_label)
+
+        val whileScanning = mutableListOf<String>()
+        onListFiles = { whileScanning += filter.currentProgress()!!.primary.resolved() }
+
+        filter.scan()
+
+        whileScanning.distinct() shouldBe listOf(stringRes(R.string.corpsefinder_filter_artprofiles_label))
+        filter.currentProgress()!!.primary.resolved() shouldBe stringRes(R.string.corpsefinder_filter_dalvik_label)
+    }
+
+    @Test fun `public data uses the same label when idle and while scanning`() = runTest2 {
+        val filter = publicDataFilter()
+        candidate(publicData1, "com.orphan.pkg", preset = Preset.StaleOwner())
+        val expected = stringRes(R.string.corpsefinder_filter_publicdata_label)
+
+        filter.currentProgress()!!.primary.resolved() shouldBe expected
+
+        val whileScanning = mutableListOf<String>()
+        onListFiles = { whileScanning += filter.currentProgress()!!.primary.resolved() }
+
+        filter.scan()
+
+        whileScanning.distinct() shouldBe listOf(expected)
+        filter.currentProgress()!!.primary.resolved() shouldBe expected
+    }
+
+    @Test fun `app source uses the same label when idle and while scanning`() = runTest2 {
+        val filter = appSourceFilter()
+        candidate(appSource1, "com.orphan.pkg")
+        val expected = stringRes(R.string.corpsefinder_filter_appsource_label)
+
+        filter.currentProgress()!!.primary.resolved() shouldBe expected
+
+        val whileScanning = mutableListOf<String>()
+        onListFiles = { whileScanning += filter.currentProgress()!!.primary.resolved() }
+
+        filter.scan()
+
+        whileScanning.distinct() shouldBe listOf(expected)
+        filter.currentProgress()!!.primary.resolved() shouldBe expected
+    }
+
+    // ─────────────────────────── indeterminate while listing ───────────────────────────
+
+    /** Progress count at the moment each area of [areaType] gets listed. */
+    private suspend fun countsWhileListing(filter: CorpseFilter): List<Progress.Count> {
+        val counts = mutableListOf<Progress.Count>()
+        onListFiles = { counts += filter.currentProgress()!!.count }
+        filter.scan()
+        return counts
+    }
+
+    @Test fun `art profiles goes indeterminate before listing each area`() = runTest2 {
+        candidate(artProfile1, "com.orphan.one")
+        candidate(artProfile2, "com.orphan.two")
+
+        countsWhileListing(artProfilesFilter()) shouldBe listOf(
+            Progress.Count.Indeterminate(),
+            Progress.Count.Indeterminate(),
+        )
+    }
+
+    @Test fun `private data goes indeterminate before listing each area`() = runTest2 {
+        candidate(privateData1, "com.orphan.one", preset = Preset.StaleOwner())
+        candidate(privateData2, "com.orphan.two", preset = Preset.StaleOwner())
+
+        countsWhileListing(privateDataFilter()) shouldBe listOf(
+            Progress.Count.Indeterminate(),
+            Progress.Count.Indeterminate(),
+        )
+    }
+
+    @Test fun `public data keeps the previous area count while listing the next one`() = runTest2 {
+        candidate(publicData1, "com.orphan.one", preset = Preset.StaleOwner())
+        candidate(publicData2, "com.orphan.two", preset = Preset.StaleOwner())
+
+        // No indeterminate reset here: the second area is listed while the first area's percentage
+        // is still on display.
+        countsWhileListing(publicDataFilter()) shouldBe listOf(
+            Progress.Count.Indeterminate(),
+            Progress.Count.Percent(1, 1),
+        )
+    }
+
+    // ─────────────────────────── progress denominator ───────────────────────────
+
+    @Test fun `name excluded candidates count towards the total but never advance progress`() = runTest2 {
+        val excluded = candidate(publicData1, ".nomedia", preset = Preset.StaleOwner())
+        candidate(publicData1, "com.orphan.pkg", preset = Preset.StaleOwner())
+        val filter = publicDataFilter()
+
+        val counts = mutableListOf<Progress.Count>()
+        onFindOwners = { counts += filter.currentProgress()!!.count }
+
+        filter.scan()
+
+        // Two candidates were counted, but only the one that survived the name check advanced.
+        counts shouldBe listOf(Progress.Count.Percent(1, 2))
+        coVerify(exactly = 0) { fileForensics.findOwners(excluded.path) }
+    }
+
+    // ─────────────────────────── gateway and capability usage ───────────────────────────
+
+    @Test fun `public media never asks for the local gateway`() = runTest2 {
+        candidate(publicMedia1, "com.orphan.pkg", preset = Preset.StaleOwner())
+
+        publicMediaFilter().scan()
+
+        coVerify(exactly = 0) { gatewaySwitch.getGateway(any()) }
+    }
+
+    @Test fun `public data takes the gateway but no capability below API 33`() = runTest2 {
+        fakeSdk(32)
+        candidate(publicData1, "com.orphan.pkg", preset = Preset.StaleOwner())
+
+        publicDataFilter().scan()
+
+        coVerify(exactly = 1) { gatewaySwitch.getGateway(APath.PathType.LOCAL) }
+        coVerify(exactly = 0) { localGateway.hasRoot() }
+        coVerify(exactly = 0) { localGateway.hasAdb() }
+    }
+
+    @Test fun `public obb takes the gateway but no capability below API 33`() = runTest2 {
+        fakeSdk(32)
+        candidate(publicObb1, "com.orphan.pkg")
+
+        publicObbFilter().scan()
+
+        coVerify(exactly = 1) { gatewaySwitch.getGateway(APath.PathType.LOCAL) }
+        coVerify(exactly = 0) { localGateway.hasRoot() }
+        coVerify(exactly = 0) { localGateway.hasAdb() }
+    }
+
+    @Test fun `public data skips the adb check when it has root on API 33`() = runTest2 {
+        fakeSdk(33)
+        hasRoot(true)
+        candidate(publicData1, "com.orphan.pkg", preset = Preset.StaleOwner())
+
+        publicDataFilter().scan()
+
+        coVerify(exactly = 1) { localGateway.hasRoot() }
+        coVerify(exactly = 0) { localGateway.hasAdb() }
+    }
+
+    @Test fun `public data falls back to the adb check without root on API 33`() = runTest2 {
+        fakeSdk(33)
+        hasRoot(false)
+        hasAdb(true)
+        candidate(publicData1, "com.orphan.pkg", preset = Preset.StaleOwner())
+
+        publicDataFilter().scan()
+
+        coVerify(exactly = 1) { localGateway.hasRoot() }
+        coVerify(exactly = 1) { localGateway.hasAdb() }
+    }
+
+    @Test fun `public obb never asks for adb with root on API 33`() = runTest2 {
+        fakeSdk(33)
+        hasRoot(true)
+        candidate(publicObb1, "com.orphan.pkg")
+
+        publicObbFilter().scan()
+
+        coVerify(exactly = 1) { localGateway.hasRoot() }
+        coVerify(exactly = 0) { localGateway.hasAdb() }
+    }
+
+    @Test fun `public obb never asks for adb without root on API 33`() = runTest2 {
+        fakeSdk(33)
+        hasRoot(false)
+        hasAdb(true)
+        candidate(publicObb1, "com.orphan.pkg")
+
+        publicObbFilter().scan()
+
+        coVerify(exactly = 1) { localGateway.hasRoot() }
+        coVerify(exactly = 0) { localGateway.hasAdb() }
+    }
+
+    /**
+     * The root check comes first, so a rootless device never even reaches the API cutoff, and adb
+     * is not an option for these filters.
+     */
+    private suspend fun assertRootIsCheckedBeforeTheApiBail(bailApi: Int, filter: CorpseFilter) {
+        fakeSdk(bailApi)
+        hasRoot(false)
+        hasAdb(true)
+
+        filter.scan() shouldBe emptySet()
+
+        coVerify(exactly = 1) { gatewaySwitch.getGateway(APath.PathType.LOCAL) }
+        coVerify(exactly = 1) { localGateway.hasRoot() }
+        coVerify(exactly = 0) { localGateway.hasAdb() }
+        coVerify(exactly = 0) { gatewaySwitch.listFiles(any()) }
+    }
+
+    @Test fun `app source checks root before its API bail`() = runTest2 {
+        assertRootIsCheckedBeforeTheApiBail(37, appSourceFilter())
+    }
+
+    @Test fun `app source private checks root before its API bail`() = runTest2 {
+        assertRootIsCheckedBeforeTheApiBail(35, appSourcePrivateFilter())
+    }
+
+    @Test fun `app lib checks root before its API bail`() = runTest2 {
+        assertRootIsCheckedBeforeTheApiBail(35, appLibFilter())
+    }
+
+    @Test fun `app asec checks root before its API bail`() = runTest2 {
+        assertRootIsCheckedBeforeTheApiBail(35, appAsecFilter())
+    }
+
+    @Test fun `art profiles checks root before its API bail`() = runTest2 {
+        assertRootIsCheckedBeforeTheApiBail(37, artProfilesFilter())
+    }
+
+    @Test fun `private data checks root before its API bail`() = runTest2 {
+        assertRootIsCheckedBeforeTheApiBail(37, privateDataFilter())
+    }
+
+    // ─────────────────────────── risk setting reads ───────────────────────────
+
+    @Test fun `the standard skeleton reads the risk settings once per area`() = runTest2 {
+        candidate(publicData1, "com.orphan.one", preset = Preset.StaleOwner())
+        candidate(publicData2, "com.orphan.two", preset = Preset.StaleOwner())
+
+        publicDataFilter().scan()
+
+        verify(exactly = 2) { keeperSetting.flow }
+        verify(exactly = 2) { commonSetting.flow }
+    }
+
+    @Test fun `dalvik reads the risk settings once for both of its areas`() = runTest2 {
+        candidate(dalvikProfile1, "com.orphan.profile")
+        candidate(dalvikDex1, "com.orphan.dex")
+
+        dalvikFilter().scan()
+
+        verify(exactly = 1) { keeperSetting.flow }
+        verify(exactly = 1) { commonSetting.flow }
+    }
+
+    // ─────────────────────────── failures mid-scan ───────────────────────────
+
+    @Test fun `a failing listing propagates and still resets progress`() = runTest2 {
+        candidate(publicData1, "com.orphan.pkg", preset = Preset.StaleOwner())
+        val filter = publicDataFilter()
+        val idle = filter.currentProgress()
+        coEvery { gatewaySwitch.listFiles(any()) } throws IOException("Listing failed")
+
+        shouldThrow<IOException> { filter.scan() }
+
+        filter.currentProgress() shouldBe idle
+    }
+
+    @Test fun `failing forensics propagate and still reset progress`() = runTest2 {
+        val target = candidate(publicData1, "com.orphan.pkg", preset = Preset.StaleOwner())
+        val filter = publicDataFilter()
+        val idle = filter.currentProgress()
+        coEvery { fileForensics.findOwners(target.path) } throws IOException("Forensics failed")
+
+        shouldThrow<IOException> { filter.scan() }
+
+        filter.currentProgress() shouldBe idle
+    }
+
+    @Test fun `a failing lookup propagates and still resets progress`() = runTest2 {
+        val target = candidate(publicData1, "com.orphan.pkg", preset = Preset.StaleOwner())
+        val filter = publicDataFilter()
+        val idle = filter.currentProgress()
+        coEvery { gatewaySwitch.lookup(target.path) } throws IOException("Lookup failed")
+
+        shouldThrow<IOException> { filter.scan() }
+
+        filter.currentProgress() shouldBe idle
+    }
+}

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/CorpseFilterTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/CorpseFilterTest.kt
@@ -3,6 +3,7 @@ package eu.darken.sdmse.corpsefinder.core.filter
 import eu.darken.sdmse.common.areas.DataArea
 import eu.darken.sdmse.common.areas.DataAreaManager
 import eu.darken.sdmse.common.clutter.Marker
+import eu.darken.sdmse.common.datastore.DataStoreValue
 import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.files.FileType
 import eu.darken.sdmse.common.files.GatewaySwitch
@@ -166,11 +167,23 @@ abstract class CorpseFilterTest : BaseTest() {
     private val installedExclusions = mutableListOf<Exclusion>()
     private var fakeSdkLevel: Int = 0
 
+    /** The setting mocks [riskFlags] installed, so tests can verify how often a filter reads them. */
+    lateinit var keeperSetting: DataStoreValue<Boolean>
+    lateinit var commonSetting: DataStoreValue<Boolean>
+
+    /** Called when a filter lists an area, for observing filter state mid-scan. */
+    var onListFiles: ((APath) -> Unit)? = null
+
+    /** Called when a filter consults forensics for a candidate, for observing filter state mid-scan. */
+    var onFindOwners: ((APath) -> Unit)? = null
+
     @BeforeEach
     open fun setup() {
         MockKAnnotations.init(this)
         areaContents.clear()
         installedExclusions.clear()
+        onListFiles = null
+        onFindOwners = null
 
         localGateway = mockk()
         coEvery { gatewaySwitch.getGateway(APath.PathType.LOCAL) } returns localGateway
@@ -180,7 +193,9 @@ abstract class CorpseFilterTest : BaseTest() {
         every { areaManager.state } returns flowOf(DataAreaManager.State(areas = dataAreas))
 
         coEvery { gatewaySwitch.listFiles(any()) } answers {
-            areaContents[arg<APath>(0)]?.asFlow() ?: emptyFlow()
+            val path = arg<APath>(0)
+            onListFiles?.invoke(path)
+            areaContents[path]?.asFlow() ?: emptyFlow()
         }
         coEvery { gatewaySwitch.exists(any()) } returns false
         coEvery { gatewaySwitch.canRead(any()) } returns false
@@ -216,8 +231,10 @@ abstract class CorpseFilterTest : BaseTest() {
     }
 
     fun riskFlags(keeper: Boolean = false, common: Boolean = false) {
-        every { corpseFinderSettings.includeRiskKeeper } returns mockDataStoreValue(keeper)
-        every { corpseFinderSettings.includeRiskCommon } returns mockDataStoreValue(common)
+        keeperSetting = mockDataStoreValue(keeper)
+        commonSetting = mockDataStoreValue(common)
+        every { corpseFinderSettings.includeRiskKeeper } returns keeperSetting
+        every { corpseFinderSettings.includeRiskCommon } returns commonSetting
     }
 
     fun excludePath(path: APath) {
@@ -289,7 +306,11 @@ abstract class CorpseFilterTest : BaseTest() {
             coEvery { gatewaySwitch.walk(path, any()) } returns childLookups.asFlow()
         }
 
-        coEvery { fileForensics.findOwners(path) } returns ownerInfo(path, preset, forensicArea, blacklistArea)
+        val owners = ownerInfo(path, preset, forensicArea, blacklistArea)
+        coEvery { fileForensics.findOwners(path) } answers {
+            onFindOwners?.invoke(path)
+            owners
+        }
 
         return Candidate(path = path, lookup = lookup, children = childLookups)
     }
@@ -298,7 +319,10 @@ abstract class CorpseFilterTest : BaseTest() {
     fun unidentifiedCandidate(area: DataArea, name: String): LocalPath {
         val path = area.path.child(name) as LocalPath
         registerContent(area, path)
-        coEvery { fileForensics.findOwners(path) } returns null
+        coEvery { fileForensics.findOwners(path) } answers {
+            onFindOwners?.invoke(path)
+            null
+        }
         return path
     }
 


### PR DESCRIPTION
## What changed

No user-facing behavior change. CorpseFinder's nine single-area scan filters had nearly identical scan logic copy-pasted across them; they now share one implementation and keep only their own configuration. The Dalvik filter reuses the shared candidate-filtering step while keeping its two-area scan.

## Technical Context

- Stacked on #2677; merge that one first (CI runs here after retargeting).
- The nine filters were not actually identical: ART Profiles uses a different progress label while scanning than at rest, ART Profiles and Private Data set indeterminate progress before listing while the others don't, ART Profiles logs each attributed owner, each capability gate has its own skip message, Public Media never obtains the local gateway, and Dalvik reads the risk settings once per scan where the others read them per area. Every one of those is now explicit configuration rather than a casualty of the merge.
- The first commit adds 25 tests that pin exactly those behaviors, because the existing filter suite observes results and gate outcomes only, and would have stayed green if the refactor had erased them. Those tests were mutation-checked: two deliberate production changes each failed exactly the expected test before being reverted.
- The extraction splits into a shared candidate-filter helper (taking the owning filter's type and pre-resolved risk flags, so identity and read scope can't drift) and a base class owning the single-area scan skeleton. Dalvik stays outside the base and calls the helper twice, once per area.
- Constructor signatures of all nine filters are unchanged so the existing test classes compile untouched; the sdcard filter is deliberately not part of this refactor.
- One deliberate deviation: the risk settings are now read immediately before the progress denominator is set rather than immediately after. Read counts, ordering, and all observable progress values are unchanged.
