### PR TITLE
CorpseFinder: Record what a scan would find on newer Android versions

### DIFF
--- a/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/AppSourceCorpseFilter.kt
+++ b/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/AppSourceCorpseFilter.kt
@@ -33,7 +33,7 @@ class AppSourceCorpseFilter @Inject constructor(
     scanProgressLabel = R.string.corpsefinder_filter_appsource_label,
     capabilityPolicy = CapabilityPolicy.AlwaysRoot,
     // TODO needs to be checked on more rooted ROMs
-    apiBailAt = 37,
+    untestedFromApi = 37,
     areaManager = areaManager,
     gatewaySwitch = gatewaySwitch,
     fileForensics = fileForensics,

--- a/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/ArtProfilesCorpseFilter.kt
+++ b/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/ArtProfilesCorpseFilter.kt
@@ -33,7 +33,7 @@ class ArtProfilesCorpseFilter @Inject constructor(
     defaultProgressLabel = R.string.corpsefinder_filter_dalvik_label,
     scanProgressLabel = R.string.corpsefinder_filter_artprofiles_label,
     capabilityPolicy = CapabilityPolicy.AlwaysRoot,
-    apiBailAt = 37,
+    untestedFromApi = 37,
     indeterminateWhileListing = true,
     onOwnerFound = { log(TAG) { "$it" } },
     areaManager = areaManager,

--- a/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/CorpseFilter.kt
+++ b/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/CorpseFilter.kt
@@ -1,9 +1,16 @@
 package eu.darken.sdmse.corpsefinder.core.filter
 
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.flow.throttleLatest
+import eu.darken.sdmse.common.hasApiLevel
 import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.corpsefinder.core.Corpse
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 
@@ -15,15 +22,54 @@ abstract class CorpseFilter(
     private val progressPub = MutableStateFlow<Progress.Data?>(defaultProgress)
     override val progress: Flow<Progress.Data?> = progressPub.throttleLatest(500)
 
+    /**
+     * API level from which on this filter's findings are no longer validated.
+     *
+     * From it on the filter still scans, but its corpses are logged and then dropped instead of
+     * returned, so a debug log from an affected device shows what the filter would have found
+     * without any of it reaching the UI or the uninstall watcher's automatic deletion.
+     *
+     * Different from a filter that bails before scanning: that marks a location which no longer
+     * exists, where scanning could only ever come up empty.
+     */
+    internal open val untestedApiCeiling: Int? = null
+
     override fun updateProgress(update: (Progress.Data?) -> Progress.Data?) {
         progressPub.value = update(progressPub.value)
     }
 
     suspend fun scan(): Collection<Corpse> = try {
-        doScan()
+        val ceiling = untestedApiCeiling
+        if (ceiling != null && hasApiLevel(ceiling)) scanForLogOnly(ceiling) else doScan()
     } finally {
         progressPub.value = defaultProgress
         log(tag) { "Scan finished" }
+    }
+
+    /**
+     * Runs the scan for the debug log alone: whatever it finds is recorded and dropped, and a
+     * failure is recorded and swallowed.
+     *
+     * Swallowing matters as much as withholding. The scan reaches code this Android version has
+     * never been validated against, and letting it fail the task would turn a scan that used to
+     * end quietly on such a device into a visibly broken one.
+     */
+    private suspend fun scanForLogOnly(ceiling: Int): Collection<Corpse> {
+        val found = try {
+            doScan()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            // Cancellation doesn't always arrive as a CancellationException: LocalGateway wraps
+            // everything its operations throw, cancellation included, into a ReadException.
+            currentCoroutineContext().ensureActive()
+            log(tag, ERROR) { "Untested API level ($ceiling): scan failed: ${e.asLog()}" }
+            return emptySet()
+        }
+
+        log(tag, WARN) { "Untested API level ($ceiling): withholding ${found.size} corpses." }
+        found.forEach { log(tag, WARN) { "Withheld corpse: $it" } }
+        return emptySet()
     }
 
     override fun toString(): String = "${this::class.simpleName}(${hashCode()})"

--- a/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/DalvikCorpseFilter.kt
+++ b/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/DalvikCorpseFilter.kt
@@ -15,7 +15,6 @@ import eu.darken.sdmse.common.areas.currentAreas
 import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
-import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APath
@@ -23,7 +22,6 @@ import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.listFiles
 import eu.darken.sdmse.common.files.local.LocalGateway
 import eu.darken.sdmse.common.forensics.FileForensics
-import eu.darken.sdmse.common.hasApiLevel
 import eu.darken.sdmse.common.pkgs.getSharedLibraries2
 import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.common.progress.updateProgressCount
@@ -47,6 +45,10 @@ class DalvikCorpseFilter @Inject constructor(
     private val exclusionManager: ExclusionManager,
 ) : CorpseFilter(TAG, Progress.Data(primary = R.string.corpsefinder_filter_dalvik_label.toCaString())) {
 
+    // https://github.com/d4rken-org/sdmaid-se/issues/1612
+    // https://github.com/d4rken-org/sdmaid-se/issues/1896
+    override val untestedApiCeiling: Int = 37
+
     override suspend fun doScan(): Collection<Corpse> {
         log(TAG) { "Scanning..." }
 
@@ -54,13 +56,6 @@ class DalvikCorpseFilter @Inject constructor(
 
         if (!gateway.hasRoot()) {
             log(TAG) { "LocalGateway has no root, skipping." }
-            return emptySet()
-        }
-
-        // https://github.com/d4rken-org/sdmaid-se/issues/1612
-        // https://github.com/d4rken-org/sdmaid-se/issues/1896
-        if (hasApiLevel(37)) {
-            log(TAG, WARN) { "Untested API level (37) skipping for safety." }
             return emptySet()
         }
 

--- a/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/PrivateDataCorpseFilter.kt
+++ b/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/PrivateDataCorpseFilter.kt
@@ -33,7 +33,7 @@ class PrivateDataCorpseFilter @Inject constructor(
     scanProgressLabel = R.string.corpsefinder_filter_privatedata_label,
     capabilityPolicy = CapabilityPolicy.AlwaysRoot,
     // TODO needs to be checked on more rooted ROMs
-    apiBailAt = 37,
+    untestedFromApi = 37,
     indeterminateWhileListing = true,
     excludedNames = setOf("hosts", "lost+found"),
     areaManager = areaManager,

--- a/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/StandardCorpseFilter.kt
+++ b/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/StandardCorpseFilter.kt
@@ -39,7 +39,10 @@ abstract class StandardCorpseFilter(
     @param:StringRes private val defaultProgressLabel: Int,
     @param:StringRes private val scanProgressLabel: Int,
     private val capabilityPolicy: CapabilityPolicy,
+    /** Skip the scan entirely from this API level on, for areas that no longer exist. */
     private val apiBailAt: Int? = null,
+    /** Scan but withhold the findings from this API level on, see [CorpseFilter.untestedApiCeiling]. */
+    untestedFromApi: Int? = null,
     private val indeterminateWhileListing: Boolean = false,
     private val excludedNames: Set<String> = emptySet(),
     private val onOwnerFound: ((OwnerInfo) -> Unit)? = null,
@@ -49,6 +52,8 @@ abstract class StandardCorpseFilter(
     private val corpseFinderSettings: CorpseFinderSettings,
     private val exclusionManager: ExclusionManager,
 ) : CorpseFilter(filterTag, Progress.Data(primary = defaultProgressLabel.toCaString())) {
+
+    final override val untestedApiCeiling: Int? = untestedFromApi
 
     /** What the [LocalGateway] has to offer before a scan makes sense. */
     sealed interface CapabilityPolicy {
@@ -68,7 +73,7 @@ abstract class StandardCorpseFilter(
         if (!hasRequiredCapabilities()) return emptySet()
 
         if (apiBailAt != null && hasApiLevel(apiBailAt)) {
-            log(filterTag, WARN) { "Untested API level ($apiBailAt) skipping for safety." }
+            log(filterTag, WARN) { "Area is no longer used from API $apiBailAt on, skipping." }
             return emptySet()
         }
 

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/AppSourceCorpseFilterTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/AppSourceCorpseFilterTest.kt
@@ -51,9 +51,9 @@ class AppSourceCorpseFilterTest : StandardCorpseFilterTest() {
         assertScans()
     }
 
-    @Test fun `bails on API 37`() = runTest2 {
+    @Test fun `scans but withholds on API 37`() = runTest2 {
         fakeSdk(37)
 
-        assertSkipsScan()
+        assertWithholdsScan()
     }
 }

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/ArtProfilesCorpseFilterTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/ArtProfilesCorpseFilterTest.kt
@@ -35,9 +35,9 @@ class ArtProfilesCorpseFilterTest : StandardCorpseFilterTest() {
         assertScans()
     }
 
-    @Test fun `bails on API 37`() = runTest2 {
+    @Test fun `scans but withholds on API 37`() = runTest2 {
         fakeSdk(37)
 
-        assertSkipsScan()
+        assertWithholdsScan()
     }
 }

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/CorpseFilterWithholdingTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/CorpseFilterWithholdingTest.kt
@@ -1,0 +1,145 @@
+package eu.darken.sdmse.corpsefinder.core.filter
+
+import eu.darken.sdmse.common.hasApiLevel
+import eu.darken.sdmse.common.progress.Progress
+import eu.darken.sdmse.corpsefinder.core.Corpse
+import eu.darken.sdmse.corpsefinder.ui.preview.previewCorpse
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.currentCoroutineContext
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+import java.io.IOException
+
+/**
+ * The withholding contract of [CorpseFilter.untestedApiCeiling], independent of any concrete filter:
+ * past the ceiling a filter still scans, but its findings never leave [CorpseFilter.scan].
+ */
+class CorpseFilterWithholdingTest : BaseTest() {
+
+    private val corpses = listOf(previewCorpse(), previewCorpse())
+    private var fakeSdkLevel: Int = 0
+
+    @BeforeEach fun setup() {
+        mockkStatic("eu.darken.sdmse.common.BuildWrapKt")
+        every { hasApiLevel(any()) } answers { fakeSdkLevel >= firstArg<Int>() }
+    }
+
+    @AfterEach fun cleanup() {
+        unmockkAll()
+    }
+
+    private class TestFilter(
+        override val untestedApiCeiling: Int?,
+        private val produces: Collection<Corpse>,
+        private val fails: (() -> Throwable)? = null,
+    ) : CorpseFilter("TestFilter", Progress.Data()) {
+        var scans: Int = 0
+            private set
+
+        override suspend fun doScan(): Collection<Corpse> {
+            scans++
+            fails?.let { throw it() }
+            return produces
+        }
+    }
+
+    private fun filter(ceiling: Int?, produces: Collection<Corpse> = corpses) = TestFilter(ceiling, produces)
+
+    private fun failingFilter(ceiling: Int?, error: () -> Throwable) = TestFilter(ceiling, emptySet(), error)
+
+    @Test fun `corpses are withheld at the ceiling`() = runTest2 {
+        fakeSdkLevel = 37
+        val filter = filter(ceiling = 37)
+
+        filter.scan() shouldBe emptySet()
+        // Withholding is about the findings, the scan itself still ran
+        filter.scans shouldBe 1
+    }
+
+    @Test fun `corpses are withheld above the ceiling`() = runTest2 {
+        fakeSdkLevel = 42
+        val filter = filter(ceiling = 37)
+
+        filter.scan() shouldBe emptySet()
+        filter.scans shouldBe 1
+    }
+
+    @Test fun `corpses are reported below the ceiling`() = runTest2 {
+        fakeSdkLevel = 36
+        val filter = filter(ceiling = 37)
+
+        filter.scan() shouldContainExactlyInAnyOrder corpses
+    }
+
+    @Test fun `a filter without a ceiling always reports`() = runTest2 {
+        fakeSdkLevel = 999
+        val filter = filter(ceiling = null)
+
+        filter.scan() shouldContainExactlyInAnyOrder corpses
+    }
+
+    @Test fun `withholding an empty scan stays empty`() = runTest2 {
+        fakeSdkLevel = 37
+        val filter = filter(ceiling = 37, produces = emptySet())
+
+        filter.scan() shouldBe emptySet()
+        filter.scans shouldBe 1
+    }
+
+    /**
+     * Past the ceiling the scan runs against an Android version nobody validated it on, so a
+     * failure there must not turn a scan that used to end quietly into a failed task.
+     */
+    @Test fun `a failure past the ceiling is swallowed`() = runTest2 {
+        fakeSdkLevel = 37
+        val filter = failingFilter(ceiling = 37) { IOException("nope") }
+
+        filter.scan() shouldBe emptySet()
+        filter.scans shouldBe 1
+    }
+
+    @Test fun `a failure below the ceiling still propagates`() = runTest2 {
+        fakeSdkLevel = 36
+        val filter = failingFilter(ceiling = 37) { IOException("nope") }
+
+        shouldThrow<IOException> { filter.scan() }
+    }
+
+    @Test fun `cancellation past the ceiling is never swallowed`() = runTest2 {
+        fakeSdkLevel = 37
+        val filter = failingFilter(ceiling = 37) { CancellationException("stop") }
+
+        shouldThrow<CancellationException> { filter.scan() }
+    }
+
+    /**
+     * Cancellation doesn't always arrive as a CancellationException. LocalGateway catches every
+     * Exception its operations throw, cancellation included, and rethrows it as a ReadException, so
+     * swallowing on the exception type alone would drop a cancellation on the floor.
+     */
+    @Test fun `a failure delivered after cancellation is not swallowed`() = runTest2 {
+        fakeSdkLevel = 37
+        val filter = object : CorpseFilter("TestFilter", Progress.Data()) {
+            override val untestedApiCeiling: Int = 37
+            override suspend fun doScan(): Collection<Corpse> {
+                currentCoroutineContext().cancel(CancellationException("cancelled mid-scan"))
+                throw IOException("cancellation, wrapped by the gateway")
+            }
+        }
+
+        shouldThrow<CancellationException> {
+            coroutineScope { filter.scan() }
+        }
+    }
+}

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/DalvikCorpseFilterTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/DalvikCorpseFilterTest.kt
@@ -172,13 +172,14 @@ class DalvikCorpseFilterTest : CorpseFilterTest() {
         create().scan().single().shouldMatch(target, DalvikCorpseFilter::class)
     }
 
-    @Test fun `bails on API 37`() = runTest2 {
+    @Test fun `scans but withholds on API 37`() = runTest2 {
         fakeSdk(37)
         candidate(dalvikDex1, "com.orphan.dex", fileType = FileType.FILE)
 
         create().scan() shouldBe emptySet()
 
-        coVerify(exactly = 0) { gatewaySwitch.listFiles(any()) }
+        // Unlike the no-root case above, the area is listed: only the findings are held back
+        coVerify(atLeast = 1) { gatewaySwitch.listFiles(dalvikDex1.path) }
     }
 
     // ─────────────────────────── shared library filtering ───────────────────────────

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/PrivateDataCorpseFilterTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/PrivateDataCorpseFilterTest.kt
@@ -47,10 +47,10 @@ class PrivateDataCorpseFilterTest : StandardCorpseFilterTest() {
         assertScans()
     }
 
-    @Test fun `bails on API 37`() = runTest2 {
+    @Test fun `scans but withholds on API 37`() = runTest2 {
         fakeSdk(37)
 
-        assertSkipsScan()
+        assertWithholdsScan()
     }
 
     @Test fun `hosts is excluded by name`() = runTest2 {

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/StandardCorpseFilterTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/filter/StandardCorpseFilterTest.kt
@@ -124,6 +124,18 @@ abstract class StandardCorpseFilterTest : CorpseFilterTest() {
         create().scan().single().shouldMatch(target, filterClass)
     }
 
+    /**
+     * Asserts the filter scans the area but keeps its findings to itself, which is what an untested
+     * API level does. Distinct from [assertSkipsScan], where the area is never even listed.
+     */
+    suspend fun assertWithholdsScan() {
+        candidate(area1, "com.orphan.pkg", preset = defaultPreset)
+
+        create().scan() shouldBe emptySet()
+
+        coVerify(atLeast = 1) { gatewaySwitch.listFiles(area1.path) }
+    }
+
     /** Asserts [name] is filtered out by name, before forensics are consulted. */
     suspend fun assertNameExcluded(name: String) {
         val excluded = candidate(area1, name, preset = defaultPreset)


### PR DESCRIPTION
## What changed

On Android versions SD Maid has not been verified against yet, CorpseFinder's root-based checks used to give up before looking at anything. They now run, write what they found into the debug log, and still report nothing.

Nothing extra is shown and nothing extra can be deleted, so what you see on such a device is unchanged. The practical difference is that a debug log from an affected device is now enough to tell whether those checks are safe to switch on, which previously meant sending that user a one-off test build. A scan on such a device also takes about as long as it does on a supported version now, instead of finishing almost instantly.

The ceiling itself is unchanged, so Android 17 still reports no findings.

## Technical Context

- The ceiling used to be an early return inside each filter, before any listing happened, so there was never anything to record. It now lives in the shared `CorpseFilter.scan()` wrapper, which runs the scan and drops the result.
- `scan()` is the only route corpses take to any consumer: every task path (scan, one-click, scheduler, uninstall watcher) goes through `CorpseFinder.runScan()`. Withholding there is what also keeps them out of the watcher's automatic deletion, and that is the part worth reviewing closely.
- Past the ceiling a scan swallows its own failure, otherwise an unvalidated Android version could turn a quiet empty scan into a failed task. Cancellation has to survive that and does not always arrive as a `CancellationException`, since `LocalGateway` catches every `Exception` it sees, cancellation included, and rethrows it as a `ReadException`. That is why the generic catch checks the job before swallowing.
- `apiBailAt` and the new `untestedFromApi` look alike but differ: the first skips areas that stopped existing (the API 35 filters), the second scans and withholds. `apiBailAt`'s log line also read "Untested API level", which would now be indistinguishable from the withholding lines, so it was corrected.
- Logging is free when nothing is listening: `log()` is inlined behind `Logging.hasReceivers`, and release builds only install a logger while debug mode or the recorder is active.
