### PR TITLE
Fix: SAF file creation, scan exclusions, and cleanup errors

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/saf/SAFDocFile.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/saf/SAFDocFile.kt
@@ -255,9 +255,10 @@ data class SAFDocFile(
                 if (crumbs.isNotEmpty() && !this.endsWith(Uri.encode(File.separator))) {
                     append(Uri.encode(File.separator))
                 }
-                crumbs.forEach {
-                    if (it != crumbs.first()) append(Uri.encode(File.separator))
-                    append(Uri.encode(it))
+                crumbs.forEachIndexed { index, crumb ->
+                    // By position, not by value: a later crumb may repeat the first one
+                    if (index != 0) append(Uri.encode(File.separator))
+                    append(Uri.encode(crumb))
                 }
             }
             return uriBuilder.toString().toUri()

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/saf/SAFGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/saf/SAFGateway.kt
@@ -107,20 +107,32 @@ class SAFGateway @Inject constructor(
         }
         val targetName = targetSafPath.segments.last()
 
-        val targetParentDocFile: SAFDocFile = targetSafPath.segments
-            .mapIndexed { index, segment ->
-                val segmentSafPath = targetSafPath.copy(
-                    segments = targetSafPath.segments.drop(targetSafPath.segments.size - index)
-                )
-                val segmentDocFile = findDocFile(segmentSafPath)
-                if (!segmentDocFile.exists) {
-                    log(TAG) { "Create parent folder $segmentSafPath" }
-                    segmentDocFile.createDirectory(segment)
+        val match = targetSafPath.findPermission(contentResolver.persistedUriPermissions)
+        if (match == null) {
+            log(TAG, VERBOSE) { "No UriPermission match for $targetSafPath" }
+            throw MissingUriPermissionException(path = targetSafPath)
+        }
+        if (match.missingSegments.isEmpty()) {
+            throw WriteException("Can't create the granted tree root itself", targetSafPath)
+        }
+
+        // The granted document is the deepest ancestor we can address directly, anything below it
+        // may still be missing. Walking down from the volume root instead would fail for any grant
+        // that is narrower than the volume, e.g. one on Android/data.
+        var targetParentDocFile = SAFDocFile.fromTreeUri(context, contentResolver, match.permission.uri)
+
+        match.missingSegments.dropLast(1).forEach { segment ->
+            val existing = targetParentDocFile.findFile(segment)
+            targetParentDocFile = when {
+                existing == null -> {
+                    log(TAG) { "Creating missing parent folder $segment for $targetSafPath" }
+                    targetParentDocFile.createDirectory(segment)
                 }
 
-                segmentDocFile
+                existing.isDirectory -> existing
+                else -> throw WriteException("Parent folder $segment is not a directory", targetSafPath)
             }
-            .last()
+        }
 
         val existing = targetParentDocFile.findFile(targetName)
 
@@ -164,38 +176,33 @@ class SAFGateway @Inject constructor(
 
         log(TAG, VERBOSE) { "delete(recursive=$recursive): $path" }
 
-        val queue = LinkedList(listOf(lookup(path)))
+        // Every failure is a failed delete, including the lookups and enumerations it needs.
+        // Callers like CorpseFinder only handle WriteException, a ReadException escaping from here
+        // would abort their whole run instead of just this target.
+        try {
+            val queue = LinkedList(listOf(lookup(path)))
 
-        while (!queue.isEmpty()) {
-            val lookUp = queue.removeFirst()
+            while (!queue.isEmpty()) {
+                val lookUp = queue.removeFirst()
 
-            if (lookUp.isDirectory) {
-                val newBatch = try {
-                    lookupFiles(lookUp.lookedUp).toList()
-                } catch (e: IOException) {
-                    log(TAG, ERROR) { "Failed to read directory to delete $lookUp: $e" }
-                    throw ReadException(path = path, cause = e)
-                }
-                queue.addAll(newBatch)
-            } else {
-                var success = try {
-                    lookUp.docFile.delete()
-                } catch (e: Exception) {
-                    throw WriteException(path = path, cause = e)
-                }
+                if (lookUp.isDirectory) {
+                    queue.addAll(lookupFiles(lookUp.lookedUp).toList())
+                } else {
+                    var success = lookUp.docFile.delete()
 
-                if (!success) {
-                    success = try {
-                        !lookUp.docFile.exists
-                    } catch (e: IOException) {
-                        log(TAG, ERROR) { "Failed to perform exists() check $lookUp: $e" }
-                        throw ReadException(path = path, cause = e)
+                    if (!success) {
+                        success = !lookUp.docFile.exists
+                        if (success) log(TAG, WARN) { "Tried to delete file, but it's already gone: $path" }
                     }
-                    if (success) log(TAG, WARN) { "Tried to delete file, but it's already gone: $path" }
-                }
 
-                if (!success) throw IOException("Document delete() call returned false")
+                    if (!success) throw IOException("Document delete() call returned false")
+                }
             }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, ERROR) { "delete($path) failed: ${e.asLog()}" }
+            throw WriteException(path = path, cause = e)
         }
     }
 
@@ -342,6 +349,14 @@ class SAFGateway @Inject constructor(
             }
 
             newBatch
+                .filter { child ->
+                    // Same semantic as the local gateway's DirectLocalWalker filter
+                    val excluded = options.pathDoesNotContain?.any { child.path.contains(it) } == true
+                    if (Bugs.isTrace) {
+                        if (excluded) log(TAG, VERBOSE) { "Skipping (pathDoesNotContain): $child" }
+                    }
+                    !excluded
+                }
                 .filter {
                     val allowed = options.onFilter?.invoke(it) ?: true
                     if (Bugs.isTrace) {
@@ -385,6 +400,7 @@ class SAFGateway @Inject constructor(
                     lookupFiles(lookUp.lookedUp).toList()
                 } catch (e: IOException) {
                     log(TAG, ERROR) { "Failed to read $lookUp: $e" }
+                    if (options.abortOnError) throw e
                     emptyList()
                 }
 

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/saf/SAFGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/saf/SAFGateway.kt
@@ -126,7 +126,23 @@ class SAFGateway @Inject constructor(
             targetParentDocFile = when {
                 existing == null -> {
                     log(TAG) { "Creating missing parent folder $segment for $targetSafPath" }
-                    targetParentDocFile.createDirectory(segment)
+                    val created = targetParentDocFile.createDirectory(segment)
+                    val createdName = created.name
+                    if (createdName != segment) {
+                        // Providers may sanitize or uniquify a name (ExternalStorageProvider does both),
+                        // which would put the target below a folder we didn't ask for.
+                        log(TAG, WARN) { "Parent folder $segment was created as $createdName, removing it again" }
+                        try {
+                            created.delete()
+                        } catch (e: Exception) {
+                            log(TAG, WARN) { "Failed to remove renamed parent folder $created: ${e.asLog()}" }
+                        }
+                        throw WriteException(
+                            "Unexpected name change: Wanted parent folder $segment, but got $createdName",
+                            targetSafPath,
+                        )
+                    }
+                    created
                 }
 
                 existing.isDirectory -> existing

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/saf/SAFPath.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/saf/SAFPath.kt
@@ -63,11 +63,12 @@ data class SAFPath(
 
             val uriString = StringBuilder(treeRoot).apply {
                 append("%3A") // Uri.encode(":")
-                segments.forEach {
-                    append(Uri.encode(it))
-                    if (it != segments.last()) {
+                segments.forEachIndexed { index, segment ->
+                    // By position, not by value: an earlier segment may repeat the last one
+                    if (index != 0) {
                         append("%2F") // Uri.encode(File.separator)
                     }
+                    append(Uri.encode(segment))
                 }
             }
             return uriString.toString().toUri()

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/saf/FakeDocumentsProvider.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/saf/FakeDocumentsProvider.kt
@@ -1,0 +1,364 @@
+package eu.darken.sdmse.common.files.saf
+
+import android.database.Cursor
+import android.database.MatrixCursor
+import android.os.CancellationSignal
+import android.os.ParcelFileDescriptor
+import android.provider.DocumentsContract.Document
+import android.provider.DocumentsContract.Root
+import android.provider.DocumentsProvider
+import java.io.File
+import java.io.FileNotFoundException
+
+/**
+ * An in-memory [DocumentsProvider] that behaves like a real SAF provider for the operations
+ * [SAFGateway] and [SAFDocFile] use.
+ *
+ * Document ids are path based, mirroring `ExternalStorageProvider`: [ROOT_ID] is `root:` and a
+ * document below it is `root:<segment>/<segment>`. Ids are normalized on the way in, so a caller
+ * that builds `root:/a/b` (which [SAFDocFile.buildTreeUri] does for a grant on the volume root)
+ * resolves to the same node as `root:a/b`.
+ *
+ * Register it through [SafTestHarness], which wires it behind [LegacyQueryShimProvider].
+ */
+class FakeDocumentsProvider : DocumentsProvider() {
+
+    /**
+     * What deleting a directory does. Real providers differ, so every test states which one it runs
+     * under instead of relying on an incidental default.
+     */
+    enum class DirDeleteMode {
+        /** Deleting a directory removes its whole subtree, like `ExternalStorageProvider` does. */
+        CASCADE,
+
+        /** Deleting a non-empty directory fails, modelling a stricter provider. */
+        REJECT_NONEMPTY,
+    }
+
+    data class Node(
+        val documentId: String,
+        val displayName: String?,
+        val mimeType: String,
+        val size: Long = 0L,
+        val lastModified: Long = 0L,
+        val flags: Int = 0,
+        val file: File? = null,
+    ) {
+        val isDirectory: Boolean
+            get() = mimeType == Document.MIME_TYPE_DIR
+    }
+
+    /** Insertion ordered, so child enumeration order is deterministic. */
+    private val nodes = LinkedHashMap<String, Node>()
+
+    var dirDeleteMode: DirDeleteMode = DirDeleteMode.CASCADE
+
+    /** Fails the next query of any kind, then clears itself. */
+    var failNextQueryWith: Exception? = null
+
+    /** Fails every document query for these (normalized) document ids. */
+    val failDocQueryFor = mutableMapOf<String, Exception>()
+
+    /** Fails every child listing for these (normalized) document ids. */
+    val failChildQueryFor = mutableMapOf<String, Exception>()
+
+    /** Fails the next [deleteDocument], then clears itself. */
+    var failNextDeleteWith: Exception? = null
+
+    /**
+     * Invoked with the parent document id *after* a child listing cursor has been built, so a test
+     * can mutate the tree behind a consumer that already holds the listing.
+     */
+    var onChildQuery: ((String) -> Unit)? = null
+
+    val queriedDocuments = mutableListOf<String>()
+    val queriedChildren = mutableListOf<String>()
+    val createdDocuments = mutableListOf<Pair<String, String>>()
+    val deletedDocuments = mutableListOf<String>()
+    val openedDocuments = mutableListOf<Pair<String, String>>()
+
+    init {
+        nodes[ROOT_ID] = Node(
+            documentId = ROOT_ID,
+            displayName = "root",
+            mimeType = Document.MIME_TYPE_DIR,
+            flags = DEFAULT_DIR_FLAGS,
+        )
+    }
+
+    override fun onCreate(): Boolean = true
+
+    // ---------------------------------------------------------------- tree access for assertions
+
+    fun node(vararg segments: String): Node? = nodes[docIdOf(segments.toList())]
+
+    fun hasNode(vararg segments: String): Boolean = node(*segments) != null
+
+    /** All document ids currently in the tree, root first. */
+    fun documentIds(): List<String> = nodes.keys.toList()
+
+    fun addNode(node: Node) {
+        nodes[normalize(node.documentId)] = node
+    }
+
+    fun removeNode(vararg segments: String) {
+        nodes.remove(docIdOf(segments.toList()))
+    }
+
+    fun resetInstrumentation() {
+        queriedDocuments.clear()
+        queriedChildren.clear()
+        createdDocuments.clear()
+        deletedDocuments.clear()
+        openedDocuments.clear()
+    }
+
+    // ---------------------------------------------------------------------------- DocumentsProvider
+
+    override fun queryRoots(projection: Array<out String>?): Cursor {
+        val cursor = MatrixCursor(arrayOf(Root.COLUMN_ROOT_ID, Root.COLUMN_DOCUMENT_ID, Root.COLUMN_TITLE))
+        cursor.newRow().apply {
+            add(Root.COLUMN_ROOT_ID, "root")
+            add(Root.COLUMN_DOCUMENT_ID, ROOT_ID)
+            add(Root.COLUMN_TITLE, "FakeDocumentsProvider")
+        }
+        return cursor
+    }
+
+    override fun queryDocument(documentId: String, projection: Array<out String>?): Cursor {
+        consumeQueryFailure()
+        val id = normalize(documentId)
+        queriedDocuments.add(id)
+        failDocQueryFor[id]?.let { throw it }
+        val node = nodes[id] ?: throw FileNotFoundException("No such document: $id")
+        return cursorFor(projection, listOf(node))
+    }
+
+    override fun queryChildDocuments(
+        parentDocumentId: String,
+        projection: Array<out String>?,
+        sortOrder: String?,
+    ): Cursor {
+        consumeQueryFailure()
+        val id = normalize(parentDocumentId)
+        queriedChildren.add(id)
+        failChildQueryFor[id]?.let { throw it }
+        val parent = nodes[id] ?: throw FileNotFoundException("No such document: $id")
+        if (!parent.isDirectory) throw FileNotFoundException("Not a directory: $id")
+        val cursor = cursorFor(projection, childrenOf(id))
+        onChildQuery?.invoke(id)
+        return cursor
+    }
+
+    override fun createDocument(parentDocumentId: String, mimeType: String, displayName: String): String {
+        val parentId = normalize(parentDocumentId)
+        createdDocuments.add(parentId to displayName)
+        val parent = nodes[parentId] ?: throw FileNotFoundException("No such document: $parentId")
+        if (!parent.isDirectory) throw FileNotFoundException("Not a directory: $parentId")
+
+        val childId = childIdOf(parentId, displayName)
+        if (nodes.containsKey(childId)) throw FileNotFoundException("Already exists: $childId")
+
+        val isDir = mimeType == Document.MIME_TYPE_DIR
+        nodes[childId] = Node(
+            documentId = childId,
+            displayName = displayName,
+            mimeType = mimeType,
+            flags = if (isDir) DEFAULT_DIR_FLAGS else DEFAULT_FILE_FLAGS,
+            file = if (isDir) null else newBackingFile(""),
+        )
+        return childId
+    }
+
+    override fun deleteDocument(documentId: String) {
+        failNextDeleteWith?.let {
+            failNextDeleteWith = null
+            throw it
+        }
+        val id = normalize(documentId)
+        val node = nodes[id] ?: throw FileNotFoundException("No such document: $id")
+
+        if (node.isDirectory) {
+            val descendants = nodes.keys.filter { isDescendant(id, it) }
+            when (dirDeleteMode) {
+                DirDeleteMode.CASCADE -> descendants.forEach { drop(it) }
+                DirDeleteMode.REJECT_NONEMPTY -> if (descendants.isNotEmpty()) {
+                    throw IllegalStateException("Directory not empty: $id")
+                }
+            }
+        }
+
+        drop(id)
+        deletedDocuments.add(id)
+    }
+
+    override fun openDocument(documentId: String, mode: String, signal: CancellationSignal?): ParcelFileDescriptor {
+        val id = normalize(documentId)
+        openedDocuments.add(id to mode)
+        val node = nodes[id] ?: throw FileNotFoundException("No such document: $id")
+        val file = node.file ?: throw FileNotFoundException("Document has no content: $id")
+        return ParcelFileDescriptor.open(file, ParcelFileDescriptor.parseMode(mode))
+    }
+
+    override fun isChildDocument(parentDocumentId: String, documentId: String): Boolean {
+        // Path based like ExternalStorageProvider, so it also answers for documents that don't exist.
+        return isDescendant(normalize(parentDocumentId), normalize(documentId))
+    }
+
+    // -------------------------------------------------------------------------------- internals
+
+    private fun consumeQueryFailure() {
+        failNextQueryWith?.let {
+            failNextQueryWith = null
+            throw it
+        }
+    }
+
+    private fun drop(documentId: String) {
+        nodes.remove(documentId)?.file?.delete()
+    }
+
+    private fun childrenOf(parentId: String): List<Node> {
+        val parentSegments = segmentsOf(parentId)
+        return nodes.values.filter {
+            val segments = segmentsOf(it.documentId)
+            segments.size == parentSegments.size + 1 && segments.dropLast(1) == parentSegments
+        }
+    }
+
+    private fun cursorFor(projection: Array<out String>?, rows: List<Node>): MatrixCursor {
+        val columns = projection ?: DOCUMENT_PROJECTION
+        val cursor = MatrixCursor(Array(columns.size) { columns[it] })
+        rows.forEach { node ->
+            val row = cursor.newRow()
+            columns.forEach { column -> row.add(column, valueFor(node, column)) }
+        }
+        return cursor
+    }
+
+    private fun valueFor(node: Node, column: String): Any? = when (column) {
+        Document.COLUMN_DOCUMENT_ID -> node.documentId
+        Document.COLUMN_DISPLAY_NAME -> node.displayName
+        Document.COLUMN_MIME_TYPE -> node.mimeType
+        Document.COLUMN_SIZE -> node.file?.length() ?: node.size
+        Document.COLUMN_LAST_MODIFIED -> node.lastModified
+        Document.COLUMN_FLAGS -> node.flags
+        else -> null
+    }
+
+    /** Declares the tree shape a test needs, creating missing ancestors as directories. */
+    inner class Builder internal constructor() {
+
+        fun dir(
+            path: String,
+            flags: Int = DEFAULT_DIR_FLAGS,
+            lastModified: Long = 0L,
+        ): Node = put(
+            segments = pathSegments(path),
+            mimeType = Document.MIME_TYPE_DIR,
+            flags = flags,
+            lastModified = lastModified,
+            size = 0L,
+            content = null,
+            nullDisplayName = false,
+        )
+
+        fun file(
+            path: String,
+            content: String? = null,
+            size: Long = 0L,
+            mimeType: String = "application/octet-stream",
+            flags: Int = DEFAULT_FILE_FLAGS,
+            lastModified: Long = 0L,
+            nullDisplayName: Boolean = false,
+        ): Node = put(
+            segments = pathSegments(path),
+            mimeType = mimeType,
+            flags = flags,
+            lastModified = lastModified,
+            size = size,
+            content = content,
+            nullDisplayName = nullDisplayName,
+        )
+
+        private fun put(
+            segments: List<String>,
+            mimeType: String,
+            flags: Int,
+            lastModified: Long,
+            size: Long,
+            content: String?,
+            nullDisplayName: Boolean,
+        ): Node {
+            require(segments.isNotEmpty()) { "Can't replace the root node" }
+            segments.dropLast(1).indices.forEach { index ->
+                val ancestor = segments.take(index + 1)
+                val ancestorId = docIdOf(ancestor)
+                if (!nodes.containsKey(ancestorId)) {
+                    nodes[ancestorId] = Node(
+                        documentId = ancestorId,
+                        displayName = ancestor.last(),
+                        mimeType = Document.MIME_TYPE_DIR,
+                        flags = DEFAULT_DIR_FLAGS,
+                    )
+                }
+            }
+            val documentId = docIdOf(segments)
+            val node = Node(
+                documentId = documentId,
+                displayName = if (nullDisplayName) null else segments.last(),
+                mimeType = mimeType,
+                size = size,
+                lastModified = lastModified,
+                flags = flags,
+                file = content?.let { newBackingFile(it) },
+            )
+            nodes[documentId] = node
+            return node
+        }
+    }
+
+    companion object {
+        const val ROOT_ID = "root:"
+
+        const val DEFAULT_DIR_FLAGS = Document.FLAG_DIR_SUPPORTS_CREATE or Document.FLAG_SUPPORTS_DELETE
+        const val DEFAULT_FILE_FLAGS = Document.FLAG_SUPPORTS_WRITE or Document.FLAG_SUPPORTS_DELETE
+
+        private val DOCUMENT_PROJECTION = arrayOf(
+            Document.COLUMN_DOCUMENT_ID,
+            Document.COLUMN_DISPLAY_NAME,
+            Document.COLUMN_MIME_TYPE,
+            Document.COLUMN_SIZE,
+            Document.COLUMN_LAST_MODIFIED,
+            Document.COLUMN_FLAGS,
+        )
+
+        fun tree(block: FakeDocumentsProvider.Builder.() -> Unit = {}): FakeDocumentsProvider =
+            FakeDocumentsProvider().also { it.Builder().block() }
+
+        fun pathSegments(path: String): List<String> = path.split('/').filter { it.isNotEmpty() }
+
+        fun segmentsOf(documentId: String): List<String> =
+            documentId.substringAfter(':').split('/').filter { it.isNotEmpty() }
+
+        fun docIdOf(segments: List<String>): String = ROOT_ID + segments.joinToString("/")
+
+        fun normalize(documentId: String): String = docIdOf(segmentsOf(documentId))
+
+        private fun childIdOf(parentId: String, name: String): String = docIdOf(segmentsOf(parentId) + name)
+
+        private fun isDescendant(parentId: String, documentId: String): Boolean {
+            val parent = segmentsOf(parentId)
+            val child = segmentsOf(documentId)
+            return child.size > parent.size && child.take(parent.size) == parent
+        }
+
+        private fun newBackingFile(content: String): File {
+            val dir = File("build/tmp/unit_tests/saf-harness").apply { mkdirs() }
+            return File.createTempFile("fakedoc", ".bin", dir).apply {
+                deleteOnExit()
+                writeText(content)
+            }
+        }
+    }
+}

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/saf/FakeDocumentsProvider.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/saf/FakeDocumentsProvider.kt
@@ -14,14 +14,33 @@ import java.io.FileNotFoundException
  * An in-memory [DocumentsProvider] that behaves like a real SAF provider for the operations
  * [SAFGateway] and [SAFDocFile] use.
  *
- * Document ids are path based, mirroring `ExternalStorageProvider`: [ROOT_ID] is `root:` and a
- * document below it is `root:<segment>/<segment>`. Ids are normalized on the way in, so a caller
- * that builds `root:/a/b` (which [SAFDocFile.buildTreeUri] does for a grant on the volume root)
- * resolves to the same node as `root:a/b`.
+ * The tree is held as nodes with an explicit parent link, so child enumeration never depends on the
+ * shape of a document id. Which ids are handed out is [IdMode]'s job.
  *
  * Register it through [SafTestHarness], which wires it behind [LegacyQueryShimProvider].
  */
-class FakeDocumentsProvider : DocumentsProvider() {
+class FakeDocumentsProvider(val idMode: IdMode = IdMode.PATH_DERIVED) : DocumentsProvider() {
+
+    /**
+     * How ids for newly created documents are minted. Real providers differ, and a caller must not
+     * be able to reconstruct an id instead of using the one the provider handed back.
+     */
+    enum class IdMode {
+        /**
+         * Path based like `ExternalStorageProvider`: [ROOT_ID] is `root:` and a document below it is
+         * `root:<segment>/<segment>`. Ids are normalized on the way in, so a caller that builds
+         * `root:/a/b` (which [SAFDocFile.buildTreeUri] does for a grant on the volume root) resolves
+         * to the same node as `root:a/b`.
+         */
+        PATH_DERIVED,
+
+        /**
+         * Created documents get ids like `doc-1` that carry no path information at all. Fixture nodes
+         * declared through [Builder] keep their path based ids, because that is what the granted tree
+         * uri addresses.
+         */
+        OPAQUE,
+    }
 
     /**
      * What deleting a directory does. Real providers differ, so every test states which one it runs
@@ -37,9 +56,12 @@ class FakeDocumentsProvider : DocumentsProvider() {
 
     data class Node(
         val documentId: String,
+        /** The document this node hangs beneath, null only for the tree root. */
+        val parentId: String?,
         val displayName: String?,
         val mimeType: String,
-        val size: Long = 0L,
+        /** Explicit `COLUMN_SIZE` override, otherwise the backing file's length is reported. */
+        val size: Long? = null,
         val lastModified: Long = 0L,
         val flags: Int = 0,
         val file: File? = null,
@@ -50,6 +72,8 @@ class FakeDocumentsProvider : DocumentsProvider() {
 
     /** Insertion ordered, so child enumeration order is deterministic. */
     private val nodes = LinkedHashMap<String, Node>()
+
+    private var opaqueIdCounter = 0
 
     var dirDeleteMode: DirDeleteMode = DirDeleteMode.CASCADE
 
@@ -66,6 +90,12 @@ class FakeDocumentsProvider : DocumentsProvider() {
     var failNextDeleteWith: Exception? = null
 
     /**
+     * Creates the next document under this display name instead of the requested one, then clears
+     * itself. Models a provider that sanitizes or uniquifies names, like `ExternalStorageProvider`.
+     */
+    var renameNextCreatedTo: String? = null
+
+    /**
      * Invoked with the parent document id *after* a child listing cursor has been built, so a test
      * can mutate the tree behind a consumer that already holds the listing.
      */
@@ -73,13 +103,19 @@ class FakeDocumentsProvider : DocumentsProvider() {
 
     val queriedDocuments = mutableListOf<String>()
     val queriedChildren = mutableListOf<String>()
+
+    /** Parent document id and *requested* display name, per [createDocument] call. */
     val createdDocuments = mutableListOf<Pair<String, String>>()
+
+    /** The ids handed back by [createDocument], in the same order as [createdDocuments]. */
+    val createdDocumentIds = mutableListOf<String>()
     val deletedDocuments = mutableListOf<String>()
     val openedDocuments = mutableListOf<Pair<String, String>>()
 
     init {
         nodes[ROOT_ID] = Node(
             documentId = ROOT_ID,
+            parentId = null,
             displayName = "root",
             mimeType = Document.MIME_TYPE_DIR,
             flags = DEFAULT_DIR_FLAGS,
@@ -90,9 +126,19 @@ class FakeDocumentsProvider : DocumentsProvider() {
 
     // ---------------------------------------------------------------- tree access for assertions
 
+    /** Path based lookup, i.e. only meaningful for [IdMode.PATH_DERIVED] and for fixture nodes. */
     fun node(vararg segments: String): Node? = nodes[docIdOf(segments.toList())]
 
     fun hasNode(vararg segments: String): Boolean = node(*segments) != null
+
+    fun nodeById(documentId: String): Node? = nodes[normalize(documentId)]
+
+    /** Follows the explicit parent links by display name, so it works in either [IdMode]. */
+    fun resolve(vararg segments: String): Node? = segments.fold(nodes[ROOT_ID]) { parent, name ->
+        parent?.let { p -> childrenOf(p.documentId).firstOrNull { it.displayName == name } }
+    }
+
+    fun children(documentId: String): List<Node> = childrenOf(normalize(documentId))
 
     /** All document ids currently in the tree, root first. */
     fun documentIds(): List<String> = nodes.keys.toList()
@@ -109,6 +155,7 @@ class FakeDocumentsProvider : DocumentsProvider() {
         queriedDocuments.clear()
         queriedChildren.clear()
         createdDocuments.clear()
+        createdDocumentIds.clear()
         deletedDocuments.clear()
         openedDocuments.clear()
     }
@@ -156,17 +203,27 @@ class FakeDocumentsProvider : DocumentsProvider() {
         val parent = nodes[parentId] ?: throw FileNotFoundException("No such document: $parentId")
         if (!parent.isDirectory) throw FileNotFoundException("Not a directory: $parentId")
 
-        val childId = childIdOf(parentId, displayName)
+        val effectiveName = renameNextCreatedTo?.also { renameNextCreatedTo = null } ?: displayName
+        if (childrenOf(parentId).any { it.displayName == effectiveName }) {
+            throw FileNotFoundException("Already exists: $effectiveName below $parentId")
+        }
+
+        val childId = when (idMode) {
+            IdMode.PATH_DERIVED -> childIdOf(parentId, effectiveName)
+            IdMode.OPAQUE -> "$OPAQUE_ID_PREFIX${++opaqueIdCounter}"
+        }
         if (nodes.containsKey(childId)) throw FileNotFoundException("Already exists: $childId")
 
         val isDir = mimeType == Document.MIME_TYPE_DIR
         nodes[childId] = Node(
             documentId = childId,
-            displayName = displayName,
+            parentId = parentId,
+            displayName = effectiveName,
             mimeType = mimeType,
             flags = if (isDir) DEFAULT_DIR_FLAGS else DEFAULT_FILE_FLAGS,
             file = if (isDir) null else newBackingFile(""),
         )
+        createdDocumentIds.add(childId)
         return childId
     }
 
@@ -179,7 +236,7 @@ class FakeDocumentsProvider : DocumentsProvider() {
         val node = nodes[id] ?: throw FileNotFoundException("No such document: $id")
 
         if (node.isDirectory) {
-            val descendants = nodes.keys.filter { isDescendant(id, it) }
+            val descendants = descendantsOf(id)
             when (dirDeleteMode) {
                 DirDeleteMode.CASCADE -> descendants.forEach { drop(it) }
                 DirDeleteMode.REJECT_NONEMPTY -> if (descendants.isNotEmpty()) {
@@ -201,8 +258,14 @@ class FakeDocumentsProvider : DocumentsProvider() {
     }
 
     override fun isChildDocument(parentDocumentId: String, documentId: String): Boolean {
-        // Path based like ExternalStorageProvider, so it also answers for documents that don't exist.
-        return isDescendant(normalize(parentDocumentId), normalize(documentId))
+        val parentId = normalize(parentDocumentId)
+        val childId = normalize(documentId)
+        return when (idMode) {
+            // Path based like ExternalStorageProvider, so it also answers for documents that don't exist.
+            IdMode.PATH_DERIVED -> isDescendant(parentId, childId)
+            // Opaque ids say nothing about ancestry, only the links of existing nodes can answer.
+            IdMode.OPAQUE -> ancestorsOf(childId).any { it == parentId }
+        }
     }
 
     // -------------------------------------------------------------------------------- internals
@@ -218,13 +281,14 @@ class FakeDocumentsProvider : DocumentsProvider() {
         nodes.remove(documentId)?.file?.delete()
     }
 
-    private fun childrenOf(parentId: String): List<Node> {
-        val parentSegments = segmentsOf(parentId)
-        return nodes.values.filter {
-            val segments = segmentsOf(it.documentId)
-            segments.size == parentSegments.size + 1 && segments.dropLast(1) == parentSegments
-        }
-    }
+    private fun childrenOf(parentId: String): List<Node> = nodes.values.filter { it.parentId == parentId }
+
+    private fun ancestorsOf(documentId: String): Sequence<String> =
+        generateSequence(nodes[documentId]?.parentId) { nodes[it]?.parentId }
+
+    private fun descendantsOf(parentId: String): List<String> = nodes.values
+        .filter { it.documentId != parentId && ancestorsOf(it.documentId).any { id -> id == parentId } }
+        .map { it.documentId }
 
     private fun cursorFor(projection: Array<out String>?, rows: List<Node>): MatrixCursor {
         val columns = projection ?: DOCUMENT_PROJECTION
@@ -240,7 +304,7 @@ class FakeDocumentsProvider : DocumentsProvider() {
         Document.COLUMN_DOCUMENT_ID -> node.documentId
         Document.COLUMN_DISPLAY_NAME -> node.displayName
         Document.COLUMN_MIME_TYPE -> node.mimeType
-        Document.COLUMN_SIZE -> node.file?.length() ?: node.size
+        Document.COLUMN_SIZE -> node.size ?: node.file?.length() ?: 0L
         Document.COLUMN_LAST_MODIFIED -> node.lastModified
         Document.COLUMN_FLAGS -> node.flags
         else -> null
@@ -258,37 +322,49 @@ class FakeDocumentsProvider : DocumentsProvider() {
             mimeType = Document.MIME_TYPE_DIR,
             flags = flags,
             lastModified = lastModified,
-            size = 0L,
+            size = null,
             content = null,
             nullDisplayName = false,
+            openable = false,
         )
 
+        /**
+         * A file document. It gets a backing temp file unless [openable] says otherwise, so it can be
+         * opened like any real non-virtual document. [size] overrides what `COLUMN_SIZE` reports,
+         * which is the backing file's length by default.
+         */
         fun file(
             path: String,
             content: String? = null,
-            size: Long = 0L,
+            size: Long? = null,
             mimeType: String = "application/octet-stream",
             flags: Int = DEFAULT_FILE_FLAGS,
             lastModified: Long = 0L,
             nullDisplayName: Boolean = false,
-        ): Node = put(
-            segments = pathSegments(path),
-            mimeType = mimeType,
-            flags = flags,
-            lastModified = lastModified,
-            size = size,
-            content = content,
-            nullDisplayName = nullDisplayName,
-        )
+            openable: Boolean = true,
+        ): Node {
+            require(openable || content == null) { "An unopenable document can't hold content" }
+            return put(
+                segments = pathSegments(path),
+                mimeType = mimeType,
+                flags = flags,
+                lastModified = lastModified,
+                size = size,
+                content = content,
+                nullDisplayName = nullDisplayName,
+                openable = openable,
+            )
+        }
 
         private fun put(
             segments: List<String>,
             mimeType: String,
             flags: Int,
             lastModified: Long,
-            size: Long,
+            size: Long?,
             content: String?,
             nullDisplayName: Boolean,
+            openable: Boolean,
         ): Node {
             require(segments.isNotEmpty()) { "Can't replace the root node" }
             segments.dropLast(1).indices.forEach { index ->
@@ -297,6 +373,7 @@ class FakeDocumentsProvider : DocumentsProvider() {
                 if (!nodes.containsKey(ancestorId)) {
                     nodes[ancestorId] = Node(
                         documentId = ancestorId,
+                        parentId = docIdOf(ancestor.dropLast(1)),
                         displayName = ancestor.last(),
                         mimeType = Document.MIME_TYPE_DIR,
                         flags = DEFAULT_DIR_FLAGS,
@@ -306,12 +383,13 @@ class FakeDocumentsProvider : DocumentsProvider() {
             val documentId = docIdOf(segments)
             val node = Node(
                 documentId = documentId,
+                parentId = docIdOf(segments.dropLast(1)),
                 displayName = if (nullDisplayName) null else segments.last(),
                 mimeType = mimeType,
                 size = size,
                 lastModified = lastModified,
                 flags = flags,
-                file = content?.let { newBackingFile(it) },
+                file = if (openable) newBackingFile(content.orEmpty()) else null,
             )
             nodes[documentId] = node
             return node
@@ -320,6 +398,8 @@ class FakeDocumentsProvider : DocumentsProvider() {
 
     companion object {
         const val ROOT_ID = "root:"
+
+        private const val OPAQUE_ID_PREFIX = "doc-"
 
         const val DEFAULT_DIR_FLAGS = Document.FLAG_DIR_SUPPORTS_CREATE or Document.FLAG_SUPPORTS_DELETE
         const val DEFAULT_FILE_FLAGS = Document.FLAG_SUPPORTS_WRITE or Document.FLAG_SUPPORTS_DELETE
@@ -333,8 +413,10 @@ class FakeDocumentsProvider : DocumentsProvider() {
             Document.COLUMN_FLAGS,
         )
 
-        fun tree(block: FakeDocumentsProvider.Builder.() -> Unit = {}): FakeDocumentsProvider =
-            FakeDocumentsProvider().also { it.Builder().block() }
+        fun tree(
+            idMode: IdMode = IdMode.PATH_DERIVED,
+            block: FakeDocumentsProvider.Builder.() -> Unit = {},
+        ): FakeDocumentsProvider = FakeDocumentsProvider(idMode).also { it.Builder().block() }
 
         fun pathSegments(path: String): List<String> = path.split('/').filter { it.isNotEmpty() }
 
@@ -343,7 +425,9 @@ class FakeDocumentsProvider : DocumentsProvider() {
 
         fun docIdOf(segments: List<String>): String = ROOT_ID + segments.joinToString("/")
 
-        fun normalize(documentId: String): String = docIdOf(segmentsOf(documentId))
+        /** Opaque ids are handed out verbatim, only path based ids have a canonical form. */
+        fun normalize(documentId: String): String =
+            if (documentId.startsWith(OPAQUE_ID_PREFIX)) documentId else docIdOf(segmentsOf(documentId))
 
         private fun childIdOf(parentId: String, name: String): String = docIdOf(segmentsOf(parentId) + name)
 

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/saf/LegacyQueryShimProvider.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/saf/LegacyQueryShimProvider.kt
@@ -1,0 +1,109 @@
+package eu.darken.sdmse.common.files.saf
+
+import android.content.ContentProvider
+import android.content.ContentResolver
+import android.content.ContentValues
+import android.database.Cursor
+import android.net.Uri
+import android.os.Bundle
+import android.os.CancellationSignal
+import android.os.ParcelFileDescriptor
+import android.provider.DocumentsContract
+
+/**
+ * Restores production-equivalent query dispatch for a [FakeDocumentsProvider] running under Robolectric.
+ *
+ * This patches a **Robolectric fidelity gap, not a production defect** - do not "fix" [SAFDocFile] to
+ * match this shim.
+ *
+ * On a device, `ContentResolver.query(uri, projection, selection, selectionArgs, sortOrder)` packs the
+ * SQL arguments into a [Bundle] and dispatches over Binder to the provider's
+ * `query(Uri, String[], Bundle, CancellationSignal)` overload, which is the one `DocumentsProvider`
+ * implements. Robolectric's `ShadowContentResolver` skips that packing and calls the provider's 5-arg
+ * overload directly. In `DocumentsProvider` that overload is `final` and throws
+ * `UnsupportedOperationException: Pre-Android-O query format not supported.`, so every
+ * [SAFDocFile.queryForString] / [SAFDocFile.queryForLong] call would fail for a reason that cannot
+ * happen in production. `androidx.documentfile.DocumentFile` uses the very same call shape.
+ *
+ * So this provider is what gets registered with the resolver: it repacks the SQL arguments the way the
+ * platform does and forwards to the [FakeDocumentsProvider] delegate. Everything else is passed straight
+ * through, including the calls that are expected to fail (e.g. `update`, which `DocumentsProvider`
+ * implements as final + throwing).
+ */
+class LegacyQueryShimProvider : ContentProvider() {
+
+    override fun onCreate(): Boolean = true
+
+    @Suppress("DEPRECATION")
+    override fun query(
+        uri: Uri,
+        projection: Array<out String>?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+        sortOrder: String?,
+    ): Cursor? {
+        // ContentResolver.createSqlQueryBundle() is not public API, so the bundle is built from the
+        // three public QUERY_ARG_SQL_* constants the platform uses for exactly this.
+        val queryArgs = Bundle().apply {
+            selection?.let { putString(ContentResolver.QUERY_ARG_SQL_SELECTION, it) }
+            selectionArgs?.let { args -> putStringArray(ContentResolver.QUERY_ARG_SQL_SELECTION_ARGS, args.toList().toTypedArray()) }
+            sortOrder?.let { putString(ContentResolver.QUERY_ARG_SQL_SORT_ORDER, it) }
+        }
+        return delegate(uri.authority).query(uri, projection, queryArgs, null)
+    }
+
+    override fun query(
+        uri: Uri,
+        projection: Array<out String>?,
+        queryArgs: Bundle?,
+        cancellationSignal: CancellationSignal?,
+    ): Cursor? = delegate(uri.authority).query(uri, projection, queryArgs, cancellationSignal)
+
+    override fun getType(uri: Uri): String? = delegate(uri.authority).getType(uri)
+
+    override fun insert(uri: Uri, values: ContentValues?): Uri? = delegate(uri.authority).insert(uri, values)
+
+    override fun update(
+        uri: Uri,
+        values: ContentValues?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+    ): Int = delegate(uri.authority).update(uri, values, selection, selectionArgs)
+
+    override fun delete(uri: Uri, selection: String?, selectionArgs: Array<out String>?): Int =
+        delegate(uri.authority).delete(uri, selection, selectionArgs)
+
+    override fun openFile(uri: Uri, mode: String): ParcelFileDescriptor? =
+        delegate(uri.authority).openFile(uri, mode)
+
+    override fun openFile(uri: Uri, mode: String, signal: CancellationSignal?): ParcelFileDescriptor? =
+        delegate(uri.authority).openFile(uri, mode, signal)
+
+    @Suppress("DEPRECATION")
+    override fun call(method: String, arg: String?, extras: Bundle?): Bundle? {
+        val target = extras?.getParcelable<Uri>(EXTRA_URI)
+        return delegate(target?.authority).call(method, arg, extras)
+    }
+
+    override fun call(authority: String, method: String, arg: String?, extras: Bundle?): Bundle? =
+        delegate(authority).call(method, arg, extras)
+
+    private fun delegate(authority: String?): FakeDocumentsProvider = requireNotNull(
+        delegates[authority] ?: delegates.values.singleOrNull()
+    ) { "No FakeDocumentsProvider registered for authority=$authority" }
+
+    companion object {
+        /** `DocumentsContract.EXTRA_URI`, which is hidden API. */
+        private const val EXTRA_URI = "uri"
+
+        private val delegates = mutableMapOf<String, FakeDocumentsProvider>()
+
+        fun register(authority: String, delegate: FakeDocumentsProvider) {
+            delegates[authority] = delegate
+        }
+
+        fun unregisterAll() {
+            delegates.clear()
+        }
+    }
+}

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/saf/SAFDocFileTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/saf/SAFDocFileTest.kt
@@ -19,6 +19,7 @@ import io.mockk.just
 import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.unmockkAll
+import io.mockk.verify
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import org.junit.After
@@ -354,60 +355,96 @@ class SAFDocFileTest : BaseTest() {
     @Test
     fun `setPermissions propagates a failure to open the descriptor`() {
         // openPFD sits outside the try in SAFDocFile.setPermissions, so this does not return false.
-        val harness = harness(FakeDocumentsProvider.tree { dir("dir") })
+        val harness = harness(
+            FakeDocumentsProvider.tree {
+                dir("dir")
+                file("unopenable.txt", openable = false)
+            }
+        )
 
         shouldThrow<FileNotFoundException> { harness.docFile("dir").setPermissions(Permissions(0b111000000)) }
+        shouldThrow<FileNotFoundException> {
+            harness.docFile("unopenable.txt").setPermissions(Permissions(0b111000000))
+        }
     }
 
     @Test
     fun `setPermissions returns false when fchmod fails`() {
         val harness = harness(FakeDocumentsProvider.tree { file("file.txt", content = "12345") })
+        val permissions = Permissions(0b111000000)
         mockkStatic(Os::class)
-        every { Os.fchmod(any(), any()) } throws ErrnoException("fchmod", OsConstants.EPERM)
+        every { Os.fchmod(any(), permissions.mode) } throws ErrnoException("fchmod", OsConstants.EPERM)
 
-        harness.docFile("file.txt").setPermissions(Permissions(0b111000000)) shouldBe false
+        harness.docFile("file.txt").setPermissions(permissions) shouldBe false
+
+        verify { Os.fchmod(any(), permissions.mode) }
     }
 
     @Test
     fun `setPermissions returns true when fchmod succeeds`() {
         val harness = harness(FakeDocumentsProvider.tree { file("file.txt", content = "12345") })
+        val permissions = Permissions(0b111000000)
         mockkStatic(Os::class)
-        every { Os.fchmod(any(), any()) } just runs
+        every { Os.fchmod(any(), permissions.mode) } just runs
 
-        harness.docFile("file.txt").setPermissions(Permissions(0b111000000)) shouldBe true
+        harness.docFile("file.txt").setPermissions(permissions) shouldBe true
+
+        verify { Os.fchmod(any(), permissions.mode) }
     }
 
     @Test
     fun `setOwnership propagates a failure to open the descriptor`() {
         // openPFD sits outside the try in SAFDocFile.setOwnership too.
-        val harness = harness(FakeDocumentsProvider.tree { dir("dir") })
+        val harness = harness(
+            FakeDocumentsProvider.tree {
+                dir("dir")
+                file("unopenable.txt", openable = false)
+            }
+        )
 
         shouldThrow<FileNotFoundException> { harness.docFile("dir").setOwnership(Ownership(1000L, 1000L)) }
+        shouldThrow<FileNotFoundException> {
+            harness.docFile("unopenable.txt").setOwnership(Ownership(1000L, 1000L))
+        }
     }
 
     @Test
     fun `setOwnership returns false when fchown fails`() {
         val harness = harness(FakeDocumentsProvider.tree { file("file.txt", content = "12345") })
+        val ownership = Ownership(1000L, 1000L)
         mockkStatic(Os::class)
-        every { Os.fchown(any(), any(), any()) } throws ErrnoException("fchown", OsConstants.EPERM)
+        every {
+            Os.fchown(any(), ownership.userId.toInt(), ownership.groupId.toInt())
+        } throws ErrnoException("fchown", OsConstants.EPERM)
 
-        harness.docFile("file.txt").setOwnership(Ownership(1000L, 1000L)) shouldBe false
+        harness.docFile("file.txt").setOwnership(ownership) shouldBe false
+
+        verify { Os.fchown(any(), ownership.userId.toInt(), ownership.groupId.toInt()) }
     }
 
     @Test
     fun `setOwnership returns true when fchown succeeds`() {
         val harness = harness(FakeDocumentsProvider.tree { file("file.txt", content = "12345") })
+        val ownership = Ownership(1000L, 1000L)
         mockkStatic(Os::class)
-        every { Os.fchown(any(), any(), any()) } just runs
+        every { Os.fchown(any(), ownership.userId.toInt(), ownership.groupId.toInt()) } just runs
 
-        harness.docFile("file.txt").setOwnership(Ownership(1000L, 1000L)) shouldBe true
+        harness.docFile("file.txt").setOwnership(ownership) shouldBe true
+
+        verify { Os.fchown(any(), ownership.userId.toInt(), ownership.groupId.toInt()) }
     }
 
     @Test
     fun `fstat returns null when the descriptor can not be opened`() {
-        val harness = harness(FakeDocumentsProvider.tree { dir("dir") })
+        val harness = harness(
+            FakeDocumentsProvider.tree {
+                dir("dir")
+                file("unopenable.txt", openable = false)
+            }
+        )
 
         harness.docFile("dir").fstat().shouldBeNull()
+        harness.docFile("unopenable.txt").fstat().shouldBeNull()
     }
 
     @Test

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/saf/SAFDocFileTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/saf/SAFDocFileTest.kt
@@ -99,18 +99,16 @@ class SAFDocFileTest : BaseTest() {
 
     @Test
     fun `test tree uri with repeated first crumb`() {
-        // documents suspect behavior (D4): the separator is placed by comparing each crumb to
-        // crumbs.first() instead of by position, so a later crumb equal to the first is glued to
-        // its predecessor.
+        // Separators are placed by position: a later crumb repeating the first one used to lose its
+        // separator and get glued to its predecessor.
         SAFDocFile.buildTreeUri(
             Uri.parse("content://auth.ority/tree/primary%3A"),
             listOf("files", "cache", "files")
-        ).toString() shouldBe "content://auth.ority/tree/primary%3A/document/primary%3A%2Ffiles%2Fcachefiles"
+        ).toString() shouldBe "content://auth.ority/tree/primary%3A/document/primary%3A%2Ffiles%2Fcache%2Ffiles"
     }
 
     @Test
     fun `test tree uri with repeated non-first crumb`() {
-        // Bounds D4: only crumbs equal to the *first* one lose their separator.
         SAFDocFile.buildTreeUri(
             Uri.parse("content://auth.ority/tree/primary%3A"),
             listOf("files", "cache", "cache")

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/saf/SAFDocFileTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/saf/SAFDocFileTest.kt
@@ -1,22 +1,55 @@
 package eu.darken.sdmse.common.files.saf
 
-import android.content.ContentResolver
-import android.content.Context
 import android.net.Uri
+import android.provider.DocumentsContract
+import android.provider.DocumentsContract.Document
+import android.system.ErrnoException
+import android.system.Os
+import android.system.OsConstants
+import androidx.core.net.toUri
+import eu.darken.sdmse.common.files.Ownership
+import eu.darken.sdmse.common.files.Permissions
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
-import io.mockk.mockk
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.unmockkAll
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import testhelpers.BaseTest
 import testhelpers.TestApplication
+import java.io.FileNotFoundException
+import java.time.Instant
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [33], application = TestApplication::class)
 class SAFDocFileTest : BaseTest() {
-    private val context: Context = mockk()
-    private val contentResolver: ContentResolver = mockk()
+
+    @After
+    fun tearDown() {
+        // BaseTest's cleanup is a JUnit5 @AfterAll and doesn't run here.
+        unmockkAll()
+        LegacyQueryShimProvider.unregisterAll()
+    }
+
+    private fun harness(
+        provider: FakeDocumentsProvider = FakeDocumentsProvider.tree(),
+        granted: List<String> = emptyList(),
+    ) = SafTestHarness(
+        appScope = CoroutineScope(Dispatchers.Unconfined),
+        provider = provider,
+        grantedSegments = granted,
+    )
 
     @Test
     fun `test tree uri no segments`() {
@@ -64,13 +97,327 @@ class SAFDocFileTest : BaseTest() {
             .toString() shouldBe "content://com.android.externalstorage.documents/tree/primary%3AAndroid%2Fdata/document/primary%3AAndroid%2Fdata%2Fcom.samsung.android.smartmirroring"
     }
 
-//    @Test
-//    fun `docfile instantiation`() {
-//        val fileUri = Uri.parse("content://auth.ority/tree/primary%3A/document/primary%3Asegment1")
-//        SAFDocFile.fromTreeUri(
-//            context,
-//            contentResolver,
-//            fileUri
-//        ).toString() shouldBe "SAFDocFile(uri=$fileUri)"
-//    }
+    @Test
+    fun `test tree uri with repeated first crumb`() {
+        // documents suspect behavior (D4): the separator is placed by comparing each crumb to
+        // crumbs.first() instead of by position, so a later crumb equal to the first is glued to
+        // its predecessor.
+        SAFDocFile.buildTreeUri(
+            Uri.parse("content://auth.ority/tree/primary%3A"),
+            listOf("files", "cache", "files")
+        ).toString() shouldBe "content://auth.ority/tree/primary%3A/document/primary%3A%2Ffiles%2Fcachefiles"
+    }
+
+    @Test
+    fun `test tree uri with repeated non-first crumb`() {
+        // Bounds D4: only crumbs equal to the *first* one lose their separator.
+        SAFDocFile.buildTreeUri(
+            Uri.parse("content://auth.ority/tree/primary%3A"),
+            listOf("files", "cache", "cache")
+        ).toString() shouldBe "content://auth.ority/tree/primary%3A/document/primary%3A%2Ffiles%2Fcache%2Fcache"
+    }
+
+    @Test
+    fun `fromTreeUri without PackageManager registration`() {
+        val harness = harness()
+        val strangerUri = "content://not.registered.authority/tree/root%3A".toUri()
+
+        DocumentsContract.isDocumentUri(harness.context, strangerUri) shouldBe false
+
+        SAFDocFile.fromTreeUri(harness.context, harness.contentResolver, strangerUri).uri shouldBe
+                DocumentsContract.buildDocumentUriUsingTree(strangerUri, FakeDocumentsProvider.ROOT_ID)
+    }
+
+    @Test
+    fun `fromTreeUri with PackageManager registration`() {
+        val harness = harness()
+
+        // A plain tree uri is not a document uri, registered or not, so both take the same branch.
+        DocumentsContract.isDocumentUri(harness.context, harness.treeUri) shouldBe false
+        SAFDocFile.fromTreeUri(harness.context, harness.contentResolver, harness.treeUri).uri shouldBe
+                DocumentsContract.buildDocumentUriUsingTree(harness.treeUri, FakeDocumentsProvider.ROOT_ID)
+
+        // A tree-scoped *document* uri only resolves as one because of the PackageManager registration.
+        val docUri = harness.docUri("dir")
+        DocumentsContract.isDocumentUri(harness.context, docUri) shouldBe true
+        SAFDocFile.fromTreeUri(harness.context, harness.contentResolver, docUri).uri shouldBe docUri
+    }
+
+    @Test
+    fun `name, exists, type, length and lastModified`() {
+        val harness = harness(
+            FakeDocumentsProvider.tree {
+                dir("dir", lastModified = 1000L)
+                file("dir/file.txt", content = "12345", lastModified = 2000L)
+            }
+        )
+
+        harness.docFile("dir", "file.txt").apply {
+            name shouldBe "file.txt"
+            exists shouldBe true
+            isFile shouldBe true
+            isDirectory shouldBe false
+            length shouldBe 5L
+            lastModified shouldBe Instant.ofEpochMilli(2000L)
+        }
+
+        harness.docFile("dir").apply {
+            name shouldBe "dir"
+            exists shouldBe true
+            isFile shouldBe false
+            isDirectory shouldBe true
+            lastModified shouldBe Instant.ofEpochMilli(1000L)
+        }
+
+        harness.docFile("dir", "nope.txt").apply {
+            exists shouldBe false
+            name.shouldBeNull()
+            isFile shouldBe false
+            isDirectory shouldBe false
+            length shouldBe 0L
+            lastModified shouldBe Instant.ofEpochMilli(0L)
+        }
+    }
+
+    @Test
+    fun `listFiles returns the children`() {
+        val harness = harness(
+            FakeDocumentsProvider.tree {
+                file("dir/one.txt")
+                file("dir/two.txt")
+                dir("dir/sub")
+                file("other.txt")
+            }
+        )
+
+        harness.docFile("dir").listFiles().map { it.uri } shouldContainExactly listOf(
+            harness.docUri("dir", "one.txt"),
+            harness.docUri("dir", "two.txt"),
+            harness.docUri("dir", "sub"),
+        )
+    }
+
+    @Test
+    fun `findFile matches by display name`() {
+        val harness = harness(
+            FakeDocumentsProvider.tree {
+                file("dir/wanted.txt")
+                file("dir/other.txt")
+            }
+        )
+
+        harness.docFile("dir").findFile("wanted.txt")!!.uri shouldBe harness.docUri("dir", "wanted.txt")
+    }
+
+    @Test
+    fun `findFile returns null for an empty directory`() {
+        val harness = harness(FakeDocumentsProvider.tree { dir("dir") })
+
+        harness.docFile("dir").findFile("wanted.txt").shouldBeNull()
+    }
+
+    @Test
+    fun `findFile returns null when no row carries the wanted display name`() {
+        // Provider side filtering is not guaranteed - DocumentsProvider ignores the SQL selection and
+        // returns every child, so the name match happens in SAFDocFile.
+        val harness = harness(FakeDocumentsProvider.tree { file("dir/actually-different.txt") })
+
+        harness.docFile("dir").findFile("wanted.txt").shouldBeNull()
+    }
+
+    @Test
+    fun `createFile and createDirectory`() {
+        val harness = harness(FakeDocumentsProvider.tree { dir("dir") })
+
+        val newFile = harness.docFile("dir").createFile("application/octet-stream", "new.bin")
+        newFile.uri shouldBe harness.docUri("dir", "new.bin")
+        harness.provider.hasNode("dir", "new.bin") shouldBe true
+
+        val newDir = harness.docFile("dir").createDirectory("newdir")
+        newDir.uri shouldBe harness.docUri("dir", "newdir")
+        harness.provider.node("dir", "newdir")!!.mimeType shouldBe Document.MIME_TYPE_DIR
+
+        harness.provider.createdDocuments shouldContainExactly listOf(
+            "root:dir" to "new.bin",
+            "root:dir" to "newdir",
+        )
+    }
+
+    @Test
+    fun `delete removes the document`() {
+        val harness = harness(FakeDocumentsProvider.tree { file("dir/file.txt") })
+
+        harness.docFile("dir", "file.txt").delete() shouldBe true
+
+        // Asserting the provider tree, not !exists: a failing query also reports exists == false.
+        harness.provider.hasNode("dir", "file.txt") shouldBe false
+        harness.provider.deletedDocuments shouldContainExactly listOf("root:dir/file.txt")
+    }
+
+    @Test
+    fun `delete swallows an IllegalArgumentException that mentions FileNotFoundException`() {
+        val harness = harness(FakeDocumentsProvider.tree { file("dir/file.txt") })
+        harness.provider.failNextDeleteWith = IllegalArgumentException("java.io.FileNotFoundException: gone")
+
+        harness.docFile("dir", "file.txt").delete() shouldBe false
+
+        harness.provider.hasNode("dir", "file.txt") shouldBe true
+    }
+
+    @Test
+    fun `delete rethrows an IllegalArgumentException that does not mention FileNotFoundException`() {
+        val harness = harness(FakeDocumentsProvider.tree { file("dir/file.txt") })
+        harness.provider.failNextDeleteWith = IllegalArgumentException("something else")
+
+        shouldThrow<IllegalArgumentException> { harness.docFile("dir", "file.txt").delete() }
+    }
+
+    @Test
+    fun `delete lets a real FileNotFoundException escape`() {
+        // documents suspect behavior: SAFDocFile.delete only catches IllegalArgumentException, but
+        // DocumentsContract.deleteDocument rethrows the provider's FileNotFoundException on API 26+.
+        // Containing this is SAFGateway.delete's job (see D9).
+        val harness = harness(FakeDocumentsProvider.tree { dir("dir") })
+
+        shouldThrow<FileNotFoundException> { harness.docFile("dir", "ghost.txt").delete() }
+    }
+
+    @Test
+    fun `setLastModified can not succeed against a conforming provider`() {
+        // documents suspect behavior (D5): DocumentsProvider.update is final and throws, and there is
+        // no DocumentsContract API to set a modification time, so this always reports failure.
+        val harness = harness(FakeDocumentsProvider.tree { file("dir/file.txt", lastModified = 1000L) })
+
+        harness.docFile("dir", "file.txt").setLastModified(Instant.ofEpochMilli(9999L)) shouldBe false
+
+        harness.provider.node("dir", "file.txt")!!.lastModified shouldBe 1000L
+    }
+
+    @Test
+    fun `readable truth table`() {
+        val harness = harness(
+            FakeDocumentsProvider.tree {
+                file("dir/file.txt")
+            }
+        )
+
+        // Grant allows read + document has a mime type
+        harness.docFile("dir", "file.txt").readable shouldBe true
+
+        // Document has no mime type (it doesn't exist)
+        harness.docFile("dir", "ghost.txt").readable shouldBe false
+
+        // Grant denies read
+        harness.docFile("dir", "file.txt", context = harness.deniedUriPermissionContext()).readable shouldBe false
+    }
+
+    @Test
+    fun `writable truth table`() {
+        val harness = harness(
+            FakeDocumentsProvider.tree {
+                file("deletable", flags = Document.FLAG_SUPPORTS_DELETE)
+                file("writable", flags = Document.FLAG_SUPPORTS_WRITE)
+                file("inert", flags = 0)
+                dir("createable", flags = Document.FLAG_DIR_SUPPORTS_CREATE)
+                dir("inertdir", flags = 0)
+            }
+        )
+
+        harness.docFile("deletable").writable shouldBe true
+        harness.docFile("writable").writable shouldBe true
+        harness.docFile("createable").writable shouldBe true
+        harness.docFile("inert").writable shouldBe false
+        harness.docFile("inertdir").writable shouldBe false
+
+        // Document has no mime type (it doesn't exist)
+        harness.docFile("ghost").writable shouldBe false
+
+        // Grant denies write
+        harness.docFile("deletable", context = harness.deniedUriPermissionContext()).writable shouldBe false
+    }
+
+    @Test
+    fun `query errors are swallowed into null`() {
+        val harness = harness(FakeDocumentsProvider.tree { file("dir/file.txt", content = "12345") })
+        val docFile = harness.docFile("dir", "file.txt")
+
+        harness.provider.failNextQueryWith = RuntimeException("provider is having a bad day")
+        docFile.name.shouldBeNull()
+
+        harness.provider.failNextQueryWith = RuntimeException("provider is having a bad day")
+        docFile.length shouldBe 0L
+
+        // This is why deletion must never be proven via exists: a broken provider looks like an empty one.
+        harness.provider.failNextQueryWith = RuntimeException("provider is having a bad day")
+        docFile.exists shouldBe false
+        harness.provider.hasNode("dir", "file.txt") shouldBe true
+    }
+
+    @Test
+    fun `setPermissions propagates a failure to open the descriptor`() {
+        // openPFD sits outside the try in SAFDocFile.setPermissions, so this does not return false.
+        val harness = harness(FakeDocumentsProvider.tree { dir("dir") })
+
+        shouldThrow<FileNotFoundException> { harness.docFile("dir").setPermissions(Permissions(0b111000000)) }
+    }
+
+    @Test
+    fun `setPermissions returns false when fchmod fails`() {
+        val harness = harness(FakeDocumentsProvider.tree { file("file.txt", content = "12345") })
+        mockkStatic(Os::class)
+        every { Os.fchmod(any(), any()) } throws ErrnoException("fchmod", OsConstants.EPERM)
+
+        harness.docFile("file.txt").setPermissions(Permissions(0b111000000)) shouldBe false
+    }
+
+    @Test
+    fun `setPermissions returns true when fchmod succeeds`() {
+        val harness = harness(FakeDocumentsProvider.tree { file("file.txt", content = "12345") })
+        mockkStatic(Os::class)
+        every { Os.fchmod(any(), any()) } just runs
+
+        harness.docFile("file.txt").setPermissions(Permissions(0b111000000)) shouldBe true
+    }
+
+    @Test
+    fun `setOwnership propagates a failure to open the descriptor`() {
+        // openPFD sits outside the try in SAFDocFile.setOwnership too.
+        val harness = harness(FakeDocumentsProvider.tree { dir("dir") })
+
+        shouldThrow<FileNotFoundException> { harness.docFile("dir").setOwnership(Ownership(1000L, 1000L)) }
+    }
+
+    @Test
+    fun `setOwnership returns false when fchown fails`() {
+        val harness = harness(FakeDocumentsProvider.tree { file("file.txt", content = "12345") })
+        mockkStatic(Os::class)
+        every { Os.fchown(any(), any(), any()) } throws ErrnoException("fchown", OsConstants.EPERM)
+
+        harness.docFile("file.txt").setOwnership(Ownership(1000L, 1000L)) shouldBe false
+    }
+
+    @Test
+    fun `setOwnership returns true when fchown succeeds`() {
+        val harness = harness(FakeDocumentsProvider.tree { file("file.txt", content = "12345") })
+        mockkStatic(Os::class)
+        every { Os.fchown(any(), any(), any()) } just runs
+
+        harness.docFile("file.txt").setOwnership(Ownership(1000L, 1000L)) shouldBe true
+    }
+
+    @Test
+    fun `fstat returns null when the descriptor can not be opened`() {
+        val harness = harness(FakeDocumentsProvider.tree { dir("dir") })
+
+        harness.docFile("dir").fstat().shouldBeNull()
+    }
+
+    @Test
+    fun `fstat returns a struct for an openable document`() {
+        // The struct's contents are deliberately not asserted: Robolectric does not back the Os.*
+        // syscalls, Os.fstat().st_size returns 0 no matter how large the backing file is.
+        val harness = harness(FakeDocumentsProvider.tree { file("file.txt", content = "12345") })
+
+        harness.docFile("file.txt").fstat().shouldNotBeNull()
+    }
 }

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/saf/SAFGatewayTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/saf/SAFGatewayTest.kt
@@ -296,10 +296,9 @@ class SAFGatewayTest : BaseTest() {
     }
 
     @Test
-    fun `walk ignores pathDoesNotContain`() = runTest2(autoCancel = true) {
-        // documents suspect behavior (D7): SAFGateway.walk reads only onFilter/onError, so the
-        // exclusions AppScanner passes silently do not apply on SAF routed walks. The local gateway
-        // honors them (FileOpsHost.walkStream).
+    fun `walk applies pathDoesNotContain`() = runTest2(autoCancel = true) {
+        // Same semantic as the local gateway (FileOpsHost.walkStream): a child whose path contains
+        // any of the strings is skipped, and a skipped directory is not descended into.
         val harness = harness(
             FakeDocumentsProvider.tree {
                 file("keepme/kept.txt")
@@ -313,8 +312,6 @@ class SAFGatewayTest : BaseTest() {
         harness.gateway.walk(harness.safPath(), options).toList()
             .map { it.lookedUp } shouldContainExactly listOf(
             harness.safPath("keepme"),
-            harness.safPath("skipme"),
-            harness.safPath("skipme", "skipped.txt"),
             harness.safPath("keepme", "kept.txt"),
         )
     }
@@ -372,9 +369,8 @@ class SAFGatewayTest : BaseTest() {
     }
 
     @Test
-    fun `du ignores abortOnError`() = runTest2(autoCancel = true) {
-        // documents suspect behavior (D8): DuOptions.abortOnError is never read, the enumeration
-        // failure is swallowed either way and du reports a partial total as if it were complete.
+    fun `du propagates enumeration errors when abortOnError is true`() = runTest2(autoCancel = true) {
+        // Without this, du reports a partial total as if it were complete.
         val harness = harness(
             FakeDocumentsProvider.tree {
                 file("a.txt", size = 100L)
@@ -383,10 +379,12 @@ class SAFGatewayTest : BaseTest() {
         )
         harness.provider.failChildQueryFor["root:dir"] = RuntimeException("provider is having a bad day")
 
-        harness.gateway.du(
-            harness.safPath(),
-            APathGateway.DuOptions(abortOnError = true),
-        ) shouldBe 100L
+        shouldThrow<ReadException> {
+            harness.gateway.du(
+                harness.safPath(),
+                APathGateway.DuOptions(abortOnError = true),
+            )
+        }
     }
 
     // ------------------------------------------------------------------------------------- file
@@ -454,33 +452,46 @@ class SAFGatewayTest : BaseTest() {
 
     @Test
     fun `createFile below an existing directory`() = runTest2(autoCancel = true) {
-        // documents suspect behavior (D3): createDocumentFile walks segment *suffixes* instead of
-        // ancestors, so it looks for a top level "new.bin" as the parent of "dir/new.bin" and fails.
         val harness = harness(FakeDocumentsProvider.tree { dir("dir") })
 
-        shouldThrow<WriteException> { harness.gateway.createFile(harness.safPath("dir", "new.bin")) }
+        harness.gateway.createFile(harness.safPath("dir", "new.bin"))
 
-        harness.provider.hasNode("dir", "new.bin") shouldBe false
+        harness.provider.node("dir", "new.bin")!!.mimeType shouldBe "application/octet-stream"
     }
 
     @Test
     fun `createFile with all ancestors present`() = runTest2(autoCancel = true) {
-        // documents suspect behavior (D3): even with every ancestor in place the suffix walk misses.
         val harness = harness(FakeDocumentsProvider.tree { dir("a/b") })
 
-        shouldThrow<WriteException> { harness.gateway.createFile(harness.safPath("a", "b", "new.bin")) }
+        harness.gateway.createFile(harness.safPath("a", "b", "new.bin"))
 
-        harness.provider.hasNode("a", "b", "new.bin") shouldBe false
+        harness.provider.hasNode("a", "b", "new.bin") shouldBe true
+        harness.provider.createdDocuments shouldContainExactly listOf("root:a/b" to "new.bin")
     }
 
     @Test
-    fun `createFile with missing ancestors`() = runTest2(autoCancel = true) {
-        // documents suspect behavior (D3): the missing ancestors are not created either.
+    fun `createFile creates the missing ancestors`() = runTest2(autoCancel = true) {
         val harness = harness()
 
-        shouldThrow<WriteException> { harness.gateway.createFile(harness.safPath("a", "b", "new.bin")) }
+        harness.gateway.createFile(harness.safPath("a", "b", "new.bin"))
 
-        harness.provider.hasNode("a") shouldBe false
+        harness.provider.node("a")!!.mimeType shouldBe Document.MIME_TYPE_DIR
+        harness.provider.node("a", "b")!!.mimeType shouldBe Document.MIME_TYPE_DIR
+        harness.provider.hasNode("a", "b", "new.bin") shouldBe true
+        harness.provider.createdDocuments shouldContainExactly listOf(
+            "root:" to "a",
+            "root:a" to "b",
+            "root:a/b" to "new.bin",
+        )
+    }
+
+    @Test
+    fun `createDir creates the missing ancestors`() = runTest2(autoCancel = true) {
+        val harness = harness()
+
+        harness.gateway.createDir(harness.safPath("a", "b", "newdir"))
+
+        harness.provider.node("a", "b", "newdir")!!.mimeType shouldBe Document.MIME_TYPE_DIR
     }
 
     @Test
@@ -494,19 +505,30 @@ class SAFGatewayTest : BaseTest() {
 
     @Test
     fun `createFile under a grant that is narrower than the volume`() = runTest2(autoCancel = true) {
-        // documents suspect behavior (D3): with a grant on Android/data the suffix walk resolves
-        // segments the grant doesn't cover, which raises MissingUriPermissionException.
+        // Ancestors are resolved from the granted document, not from the volume root: looking up the
+        // volume root raises MissingUriPermissionException whenever the grant is narrower than it.
         val harness = harness(
             provider = FakeDocumentsProvider.tree { dir("Android/data") },
             granted = listOf("Android", "data"),
         )
 
-        val error = shouldThrow<WriteException> {
-            harness.gateway.createFile(harness.safPath("Android", "data", "pkg", "cache.bin"))
-        }
+        harness.gateway.createFile(harness.safPath("Android", "data", "pkg", "cache.bin"))
 
-        error.cause.shouldBeInstanceOf<MissingUriPermissionException>()
-        harness.provider.hasNode("Android", "data", "pkg") shouldBe false
+        harness.provider.node("Android", "data", "pkg")!!.mimeType shouldBe Document.MIME_TYPE_DIR
+        harness.provider.hasNode("Android", "data", "pkg", "cache.bin") shouldBe true
+    }
+
+    @Test
+    fun `createDir on the granted tree root itself`() = runTest2(autoCancel = true) {
+        // The grant's own document has no addressable parent, so there is nothing to create it in.
+        val harness = harness(
+            provider = FakeDocumentsProvider.tree { dir("Android") },
+            granted = listOf("Android", "data"),
+        )
+
+        shouldThrow<WriteException> { harness.gateway.createDir(harness.safPath("Android", "data")) }
+
+        harness.provider.hasNode("Android", "data") shouldBe false
     }
 
     // ----------------------------------------------------------------------------------- delete
@@ -567,34 +589,32 @@ class SAFGatewayTest : BaseTest() {
     }
 
     @Test
-    fun `delete without a permission surfaces as ReadException`() = runTest2(autoCancel = true) {
-        // documents suspect behavior (D9): CorpseFinder catches WriteException around its delete calls,
-        // so a ReadException escapes the per corpse handler and aborts the whole run.
+    fun `delete without a permission surfaces as WriteException`() = runTest2(autoCancel = true) {
+        // CorpseFinder only catches WriteException around its delete calls, a ReadException escaping
+        // from here would abort the whole run instead of just this corpse.
         val harness = harness()
 
-        shouldThrow<ReadException> { harness.gateway.delete(ungrantedPath("file.txt"), recursive = true) }
+        shouldThrow<WriteException> { harness.gateway.delete(ungrantedPath("file.txt"), recursive = true) }
     }
 
     @Test
-    fun `delete of a missing target surfaces as ReadException`() = runTest2(autoCancel = true) {
-        // documents suspect behavior (D9): the initial lookup runs outside any write error handling.
+    fun `delete of a missing target surfaces as WriteException`() = runTest2(autoCancel = true) {
+        // The initial lookup is part of the delete, not a separate read.
         val harness = harness(FakeDocumentsProvider.tree { dir("dir") })
 
-        shouldThrow<ReadException> { harness.gateway.delete(harness.safPath("dir", "ghost.txt"), recursive = true) }
+        shouldThrow<WriteException> { harness.gateway.delete(harness.safPath("dir", "ghost.txt"), recursive = true) }
     }
 
     @Test
-    fun `delete with a failing child enumeration surfaces as ReadException`() = runTest2(autoCancel = true) {
-        // documents suspect behavior (D9).
+    fun `delete with a failing child enumeration surfaces as WriteException`() = runTest2(autoCancel = true) {
         val harness = harness(FakeDocumentsProvider.tree { file("dir/file.txt") })
         harness.provider.failChildQueryFor["root:dir"] = RuntimeException("provider is having a bad day")
 
-        shouldThrow<ReadException> { harness.gateway.delete(harness.safPath("dir"), recursive = true) }
+        shouldThrow<WriteException> { harness.gateway.delete(harness.safPath("dir"), recursive = true) }
     }
 
     @Test
-    fun `delete with a child vanishing mid traversal surfaces as ReadException`() = runTest2(autoCancel = true) {
-        // documents suspect behavior (D9).
+    fun `delete with a child vanishing mid traversal surfaces as WriteException`() = runTest2(autoCancel = true) {
         val harness = harness(
             FakeDocumentsProvider.tree {
                 file("dir/file1.txt")
@@ -603,7 +623,7 @@ class SAFGatewayTest : BaseTest() {
         )
         harness.provider.onChildQuery = { harness.provider.removeNode("dir", "file2.txt") }
 
-        shouldThrow<ReadException> { harness.gateway.delete(harness.safPath("dir"), recursive = true) }
+        shouldThrow<WriteException> { harness.gateway.delete(harness.safPath("dir"), recursive = true) }
     }
 
     @Test

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/saf/SAFGatewayTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/saf/SAFGatewayTest.kt
@@ -1,26 +1,692 @@
 package eu.darken.sdmse.common.files.saf
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.mockk.mockk
+import android.provider.DocumentsContract.Document
+import android.system.Os
+import eu.darken.sdmse.common.files.APathGateway
+import eu.darken.sdmse.common.files.FileType
+import eu.darken.sdmse.common.files.Ownership
+import eu.darken.sdmse.common.files.Permissions
+import eu.darken.sdmse.common.files.ReadException
+import eu.darken.sdmse.common.files.WriteException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.unmockkAll
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import okio.buffer
+import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
-import testhelper.EmptyApp
-import testhelpers.coroutine.TestDispatcherProvider
+import testhelpers.BaseTest
+import testhelpers.TestApplication
 import testhelpers.coroutine.runTest2
+import java.time.Instant
 
-@RunWith(AndroidJUnit4::class)
-@Config(sdk = [29], application = EmptyApp::class)
-class SAFGatewayTest {
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class SAFGatewayTest : BaseTest() {
+
+    @After
+    fun tearDown() {
+        // BaseTest's cleanup is a JUnit5 @AfterAll and doesn't run here.
+        unmockkAll()
+        LegacyQueryShimProvider.unregisterAll()
+    }
+
+    private fun TestScope.harness(
+        provider: FakeDocumentsProvider = FakeDocumentsProvider.tree(),
+        granted: List<String> = emptyList(),
+    ) = SafTestHarness(appScope = this, provider = provider, grantedSegments = granted)
+
+    /** A path on a volume we hold no Uri permission for. */
+    private fun ungrantedPath(vararg segments: String) =
+        SAFPath.build("content://${SafTestHarness.DEFAULT_AUTHORITY}/tree/ungranted%3A", *segments)
+
+    // ------------------------------------------------------------------------------- exists/can*
 
     @Test
-    fun `init`() = runTest2(autoCancel = true) {
-        val dispatcherProvider = TestDispatcherProvider()
-        val safGateway = SAFGateway(
-            mockk(),
-            mockk(),
-            this,
-            dispatcherProvider
+    fun `exists reports presence`() = runTest2(autoCancel = true) {
+        val harness = harness(FakeDocumentsProvider.tree { file("dir/file.txt") })
+
+        harness.gateway.exists(harness.safPath("dir", "file.txt")) shouldBe true
+        harness.gateway.exists(harness.safPath("dir")) shouldBe true
+        harness.gateway.exists(harness.safPath("dir", "ghost.txt")) shouldBe false
+    }
+
+    @Test
+    fun `exists throws when we hold no permission`() = runTest2(autoCancel = true) {
+        val harness = harness()
+
+        // Asymmetry worth knowing: canRead/canWrite map a missing grant to false, exists raises.
+        val error = shouldThrow<ReadException> { harness.gateway.exists(ungrantedPath("file.txt")) }
+        error.cause.shouldBeInstanceOf<MissingUriPermissionException>()
+    }
+
+    @Test
+    fun `canRead and canWrite`() = runTest2(autoCancel = true) {
+        val harness = harness(
+            FakeDocumentsProvider.tree {
+                file("readable.txt", flags = 0)
+                file("writable.txt", flags = Document.FLAG_SUPPORTS_WRITE)
+            }
         )
+
+        harness.gateway.canRead(harness.safPath("readable.txt")) shouldBe true
+        harness.gateway.canRead(harness.safPath("ghost.txt")) shouldBe false
+
+        harness.gateway.canWrite(harness.safPath("writable.txt")) shouldBe true
+        harness.gateway.canWrite(harness.safPath("readable.txt")) shouldBe false
+    }
+
+    @Test
+    fun `canRead and canWrite map a missing permission to false`() = runTest2(autoCancel = true) {
+        val harness = harness()
+
+        harness.gateway.canRead(ungrantedPath("file.txt")) shouldBe false
+        harness.gateway.canWrite(ungrantedPath("file.txt")) shouldBe false
+    }
+
+    // ---------------------------------------------------------------------------------- lookups
+
+    @Test
+    fun `lookup a file and a directory`() = runTest2(autoCancel = true) {
+        val harness = harness(
+            FakeDocumentsProvider.tree {
+                dir("dir", lastModified = 1000L)
+                file("dir/file.txt", size = 512L, lastModified = 2000L)
+            }
+        )
+
+        harness.gateway.lookup(harness.safPath("dir", "file.txt")).apply {
+            lookedUp shouldBe harness.safPath("dir", "file.txt")
+            fileType shouldBe FileType.FILE
+            size shouldBe 512L
+            modifiedAt shouldBe Instant.ofEpochMilli(2000L)
+        }
+
+        harness.gateway.lookup(harness.safPath("dir")).apply {
+            fileType shouldBe FileType.DIRECTORY
+            modifiedAt shouldBe Instant.ofEpochMilli(1000L)
+        }
+    }
+
+    @Test
+    fun `lookup an unreadable document`() = runTest2(autoCancel = true) {
+        val harness = harness(FakeDocumentsProvider.tree { dir("dir") })
+
+        shouldThrow<ReadException> { harness.gateway.lookup(harness.safPath("dir", "ghost.txt")) }
+    }
+
+    @Test
+    fun `lookupExtended wraps the lookup`() = runTest2(autoCancel = true) {
+        val harness = harness(FakeDocumentsProvider.tree { file("dir/file.txt", size = 512L) })
+
+        harness.gateway.lookupExtended(harness.safPath("dir", "file.txt")).apply {
+            lookedUp shouldBe harness.safPath("dir", "file.txt")
+            fileType shouldBe FileType.FILE
+            size shouldBe 512L
+        }
+    }
+
+    @Test
+    fun `listFiles emits the children`() = runTest2(autoCancel = true) {
+        val harness = harness(
+            FakeDocumentsProvider.tree {
+                file("dir/one.txt")
+                dir("dir/sub")
+                file("other.txt")
+            }
+        )
+
+        harness.gateway.listFiles(harness.safPath("dir")).toList() shouldContainExactly listOf(
+            harness.safPath("dir", "one.txt"),
+            harness.safPath("dir", "sub"),
+        )
+    }
+
+    @Test
+    fun `lookupFiles and lookupFilesExtended emit the children`() = runTest2(autoCancel = true) {
+        val harness = harness(
+            FakeDocumentsProvider.tree {
+                file("dir/one.txt", size = 1L)
+                dir("dir/sub")
+            }
+        )
+
+        harness.gateway.lookupFiles(harness.safPath("dir")).toList().map { it.lookedUp } shouldContainExactly listOf(
+            harness.safPath("dir", "one.txt"),
+            harness.safPath("dir", "sub"),
+        )
+
+        harness.gateway.lookupFilesExtended(harness.safPath("dir")).toList()
+            .map { it.lookedUp } shouldContainExactly listOf(
+            harness.safPath("dir", "one.txt"),
+            harness.safPath("dir", "sub"),
+        )
+    }
+
+    @Test
+    fun `lookupFiles falls back to the uri when the provider reports no display name`() =
+        runTest2(autoCancel = true) {
+            val harness = harness(FakeDocumentsProvider.tree { file("dir/nameless.txt", nullDisplayName = true) })
+
+            harness.gateway.lookupFiles(harness.safPath("dir")).toList()
+                .map { it.lookedUp } shouldContainExactly listOf(harness.safPath("dir", "nameless.txt"))
+        }
+
+    @Test
+    fun `listing errors are refined to ReadException`() = runTest2(autoCancel = true) {
+        val harness = harness(FakeDocumentsProvider.tree { file("dir/one.txt") })
+        harness.provider.failChildQueryFor["root:dir"] = RuntimeException("provider is having a bad day")
+
+        shouldThrow<ReadException> { harness.gateway.listFiles(harness.safPath("dir")) }
+        shouldThrow<ReadException> { harness.gateway.lookupFiles(harness.safPath("dir")) }
+        shouldThrow<ReadException> { harness.gateway.lookupFilesExtended(harness.safPath("dir")) }
+    }
+
+    @Test
+    fun `lookupFiles enumerates eagerly`() = runTest2(autoCancel = true) {
+        val harness = harness(
+            FakeDocumentsProvider.tree {
+                file("dir/one.txt")
+                file("dir/two.txt")
+            }
+        )
+
+        val flow = harness.gateway.lookupFiles(harness.safPath("dir"))
+
+        // The child listing is a snapshot taken at call time, before anything collects.
+        harness.provider.queriedChildren shouldContainExactly listOf("root:dir")
+        flow.toList().size shouldBe 2
+    }
+
+    // ------------------------------------------------------------------------------------- walk
+
+    private fun walkTree() = FakeDocumentsProvider.tree {
+        dir("dirA")
+        file("dirA/fileA1")
+        file("dirA/sub/fileS1")
+        dir("dirB")
+        file("dirB/fileB1")
+        file("fileRoot")
+    }
+
+    @Test
+    fun `walk emits the whole tree`() = runTest2(autoCancel = true) {
+        val harness = harness(walkTree())
+
+        harness.gateway.walk(harness.safPath()).toList().map { it.lookedUp } shouldContainExactly listOf(
+            harness.safPath("dirA"),
+            harness.safPath("dirB"),
+            harness.safPath("fileRoot"),
+            harness.safPath("dirB", "fileB1"),
+            harness.safPath("dirA", "fileA1"),
+            harness.safPath("dirA", "sub"),
+            harness.safPath("dirA", "sub", "fileS1"),
+        )
+    }
+
+    @Test
+    fun `walk on a file emits just that file`() = runTest2(autoCancel = true) {
+        val harness = harness(walkTree())
+
+        harness.gateway.walk(harness.safPath("fileRoot")).toList()
+            .map { it.lookedUp } shouldContainExactly listOf(harness.safPath("fileRoot"))
+    }
+
+    @Test
+    fun `walk skips what onFilter rejects, including its subtree`() = runTest2(autoCancel = true) {
+        val harness = harness(walkTree())
+        val options = APathGateway.WalkOptions<SAFPath, SAFPathLookup>(
+            onFilter = { it.name != "dirA" },
+        )
+
+        harness.gateway.walk(harness.safPath(), options).toList()
+            .map { it.lookedUp } shouldContainExactly listOf(
+            harness.safPath("dirB"),
+            harness.safPath("fileRoot"),
+            harness.safPath("dirB", "fileB1"),
+        )
+    }
+
+    @Test
+    fun `walk continues when onError allows it`() = runTest2(autoCancel = true) {
+        val harness = harness(walkTree())
+        harness.provider.failChildQueryFor["root:dirA"] = RuntimeException("provider is having a bad day")
+        val seenErrors = mutableListOf<SAFPathLookup>()
+        val options = APathGateway.WalkOptions<SAFPath, SAFPathLookup>(
+            onError = { lookup, _ ->
+                seenErrors.add(lookup)
+                true
+            },
+        )
+
+        harness.gateway.walk(harness.safPath(), options).toList()
+            .map { it.lookedUp } shouldContainExactly listOf(
+            harness.safPath("dirA"),
+            harness.safPath("dirB"),
+            harness.safPath("fileRoot"),
+            harness.safPath("dirB", "fileB1"),
+        )
+        seenErrors.map { it.lookedUp } shouldContainExactly listOf(harness.safPath("dirA"))
+    }
+
+    @Test
+    fun `walk aborts when onError rejects`() = runTest2(autoCancel = true) {
+        val harness = harness(walkTree())
+        harness.provider.failChildQueryFor["root:dirA"] = RuntimeException("provider is having a bad day")
+        val options = APathGateway.WalkOptions<SAFPath, SAFPathLookup>(
+            onError = { _, _ -> false },
+        )
+
+        shouldThrow<ReadException> { harness.gateway.walk(harness.safPath(), options).toList() }
+    }
+
+    @Test
+    fun `walk ignores pathDoesNotContain`() = runTest2(autoCancel = true) {
+        // documents suspect behavior (D7): SAFGateway.walk reads only onFilter/onError, so the
+        // exclusions AppScanner passes silently do not apply on SAF routed walks. The local gateway
+        // honors them (FileOpsHost.walkStream).
+        val harness = harness(
+            FakeDocumentsProvider.tree {
+                file("keepme/kept.txt")
+                file("skipme/skipped.txt")
+            }
+        )
+        val options = APathGateway.WalkOptions<SAFPath, SAFPathLookup>(
+            pathDoesNotContain = setOf("skipme"),
+        )
+
+        harness.gateway.walk(harness.safPath(), options).toList()
+            .map { it.lookedUp } shouldContainExactly listOf(
+            harness.safPath("keepme"),
+            harness.safPath("skipme"),
+            harness.safPath("skipme", "skipped.txt"),
+            harness.safPath("keepme", "kept.txt"),
+        )
+    }
+
+    @Test
+    fun `walk cancellation is not converted into a ReadException`() = runTest2(autoCancel = true) {
+        val harness = harness(walkTree())
+        val scope = CoroutineScope(Dispatchers.Unconfined)
+        harness.provider.onChildQuery = { scope.cancel() }
+        var caught: Throwable? = null
+
+        val job = scope.launch {
+            try {
+                harness.gateway.walk(harness.safPath()).toList()
+            } catch (e: Throwable) {
+                caught = e
+            }
+        }
+        job.join()
+
+        caught.shouldBeInstanceOf<CancellationException>()
+    }
+
+    // --------------------------------------------------------------------------------------- du
+
+    @Test
+    fun `du sums the tree`() = runTest2(autoCancel = true) {
+        val harness = harness(
+            FakeDocumentsProvider.tree {
+                file("a.txt", size = 100L)
+                file("dir/b.txt", size = 200L)
+                file("dir/sub/c.txt", size = 300L)
+            }
+        )
+
+        harness.gateway.du(harness.safPath()) shouldBe 600L
+        harness.gateway.du(harness.safPath("dir")) shouldBe 500L
+        harness.gateway.du(harness.safPath("a.txt")) shouldBe 100L
+    }
+
+    @Test
+    fun `du swallows enumeration errors when abortOnError is false`() = runTest2(autoCancel = true) {
+        val harness = harness(
+            FakeDocumentsProvider.tree {
+                file("a.txt", size = 100L)
+                file("dir/b.txt", size = 200L)
+            }
+        )
+        harness.provider.failChildQueryFor["root:dir"] = RuntimeException("provider is having a bad day")
+
+        harness.gateway.du(
+            harness.safPath(),
+            APathGateway.DuOptions(abortOnError = false),
+        ) shouldBe 100L
+    }
+
+    @Test
+    fun `du ignores abortOnError`() = runTest2(autoCancel = true) {
+        // documents suspect behavior (D8): DuOptions.abortOnError is never read, the enumeration
+        // failure is swallowed either way and du reports a partial total as if it were complete.
+        val harness = harness(
+            FakeDocumentsProvider.tree {
+                file("a.txt", size = 100L)
+                file("dir/b.txt", size = 200L)
+            }
+        )
+        harness.provider.failChildQueryFor["root:dir"] = RuntimeException("provider is having a bad day")
+
+        harness.gateway.du(
+            harness.safPath(),
+            APathGateway.DuOptions(abortOnError = true),
+        ) shouldBe 100L
+    }
+
+    // ------------------------------------------------------------------------------------- file
+
+    @Test
+    fun `file opens a read handle`() = runTest2(autoCancel = true) {
+        val harness = harness(FakeDocumentsProvider.tree { file("file.txt", content = "hello-saf") })
+
+        val handle = harness.gateway.file(harness.safPath("file.txt"), readWrite = false)
+        val content = handle.use { it.source().buffer().readUtf8() }
+
+        content shouldBe "hello-saf"
+        harness.provider.openedDocuments shouldContainExactly listOf("root:file.txt" to "r")
+    }
+
+    @Test
+    fun `file refuses readWrite on a non-writable document`() = runTest2(autoCancel = true) {
+        val harness = harness(FakeDocumentsProvider.tree { file("file.txt", content = "hello-saf", flags = 0) })
+
+        shouldThrow<ReadException> { harness.gateway.file(harness.safPath("file.txt"), readWrite = true) }
+    }
+
+    // -------------------------------------------------------------------------------- create*
+
+    @Test
+    fun `createFile and createDir with a single segment`() = runTest2(autoCancel = true) {
+        val harness = harness()
+
+        harness.gateway.createFile(harness.safPath("new.bin"))
+        harness.provider.node("new.bin")!!.mimeType shouldBe "application/octet-stream"
+
+        harness.gateway.createDir(harness.safPath("newdir"))
+        harness.provider.node("newdir")!!.mimeType shouldBe Document.MIME_TYPE_DIR
+    }
+
+    @Test
+    fun `createFile and createDir refuse an existing target`() = runTest2(autoCancel = true) {
+        val harness = harness(
+            FakeDocumentsProvider.tree {
+                file("file.txt")
+                dir("dir")
+            }
+        )
+
+        shouldThrow<WriteException> { harness.gateway.createFile(harness.safPath("file.txt")) }
+        shouldThrow<WriteException> { harness.gateway.createDir(harness.safPath("dir")) }
+    }
+
+    @Test
+    fun `createFile on the tree root itself`() = runTest2(autoCancel = true) {
+        val harness = harness()
+
+        // The tree root exists, so the "no segments" guard inside createDocumentFile is unreachable here.
+        shouldThrow<WriteException> { harness.gateway.createFile(harness.safPath()) }
+    }
+
+    @Test
+    fun `createFile on a tree root the provider does not know`() = runTest2(autoCancel = true) {
+        val harness = harness()
+        harness.provider.removeNode()
+
+        val error = shouldThrow<WriteException> { harness.gateway.createFile(harness.safPath()) }
+        error.cause.shouldBeInstanceOf<IllegalArgumentException>()
+    }
+
+    @Test
+    fun `createFile below an existing directory`() = runTest2(autoCancel = true) {
+        // documents suspect behavior (D3): createDocumentFile walks segment *suffixes* instead of
+        // ancestors, so it looks for a top level "new.bin" as the parent of "dir/new.bin" and fails.
+        val harness = harness(FakeDocumentsProvider.tree { dir("dir") })
+
+        shouldThrow<WriteException> { harness.gateway.createFile(harness.safPath("dir", "new.bin")) }
+
+        harness.provider.hasNode("dir", "new.bin") shouldBe false
+    }
+
+    @Test
+    fun `createFile with all ancestors present`() = runTest2(autoCancel = true) {
+        // documents suspect behavior (D3): even with every ancestor in place the suffix walk misses.
+        val harness = harness(FakeDocumentsProvider.tree { dir("a/b") })
+
+        shouldThrow<WriteException> { harness.gateway.createFile(harness.safPath("a", "b", "new.bin")) }
+
+        harness.provider.hasNode("a", "b", "new.bin") shouldBe false
+    }
+
+    @Test
+    fun `createFile with missing ancestors`() = runTest2(autoCancel = true) {
+        // documents suspect behavior (D3): the missing ancestors are not created either.
+        val harness = harness()
+
+        shouldThrow<WriteException> { harness.gateway.createFile(harness.safPath("a", "b", "new.bin")) }
+
+        harness.provider.hasNode("a") shouldBe false
+    }
+
+    @Test
+    fun `createFile with a file blocking an ancestor`() = runTest2(autoCancel = true) {
+        val harness = harness(FakeDocumentsProvider.tree { file("a") })
+
+        shouldThrow<WriteException> { harness.gateway.createFile(harness.safPath("a", "b", "new.bin")) }
+
+        harness.provider.hasNode("a", "b") shouldBe false
+    }
+
+    @Test
+    fun `createFile under a grant that is narrower than the volume`() = runTest2(autoCancel = true) {
+        // documents suspect behavior (D3): with a grant on Android/data the suffix walk resolves
+        // segments the grant doesn't cover, which raises MissingUriPermissionException.
+        val harness = harness(
+            provider = FakeDocumentsProvider.tree { dir("Android/data") },
+            granted = listOf("Android", "data"),
+        )
+
+        val error = shouldThrow<WriteException> {
+            harness.gateway.createFile(harness.safPath("Android", "data", "pkg", "cache.bin"))
+        }
+
+        error.cause.shouldBeInstanceOf<MissingUriPermissionException>()
+        harness.provider.hasNode("Android", "data", "pkg") shouldBe false
+    }
+
+    // ----------------------------------------------------------------------------------- delete
+
+    @Test
+    fun `delete a single file`() = runTest2(autoCancel = true) {
+        val harness = harness(FakeDocumentsProvider.tree { file("dir/file.txt") })
+
+        harness.gateway.delete(harness.safPath("dir", "file.txt"), recursive = false)
+
+        harness.provider.hasNode("dir", "file.txt") shouldBe false
+        harness.provider.hasNode("dir") shouldBe true
+    }
+
+    @Test
+    fun `delete leaves the directory skeleton behind`() = runTest2(autoCancel = true) {
+        // documents a KNOWN DEFECT (D1) that is deliberately NOT fixed in this change: SAFGateway.delete
+        // only ever calls delete() on non-directories, so deleting a folder empties it and leaves every
+        // directory in place, including the target. The fix is destructive enough that it is being held
+        // back until it can be verified on a device against a real ExternalStorageProvider. Do not read
+        // these assertions as intended behavior.
+        val harness = harness(
+            FakeDocumentsProvider.tree {
+                file("dir/file1.txt")
+                file("dir/sub/file2.txt")
+            }
+        )
+        harness.provider.dirDeleteMode = FakeDocumentsProvider.DirDeleteMode.CASCADE
+
+        harness.gateway.delete(harness.safPath("dir"), recursive = true)
+
+        harness.provider.hasNode("dir") shouldBe true
+        harness.provider.hasNode("dir", "sub") shouldBe true
+        harness.provider.hasNode("dir", "file1.txt") shouldBe false
+        harness.provider.hasNode("dir", "sub", "file2.txt") shouldBe false
+        harness.provider.deletedDocuments shouldContainExactly listOf(
+            "root:dir/file1.txt",
+            "root:dir/sub/file2.txt",
+        )
+    }
+
+    @Test
+    fun `delete recurses even when recursive is false`() = runTest2(autoCancel = true) {
+        // documents a KNOWN DEFECT (D2) that is deliberately NOT fixed in this change: the recursive
+        // parameter is only logged, never read. It is held back together with D1 (see above), because
+        // the guard it would need only makes sense once directories are actually deleted.
+        val harness = harness(
+            FakeDocumentsProvider.tree {
+                file("dir/file1.txt")
+                file("dir/sub/file2.txt")
+            }
+        )
+
+        harness.gateway.delete(harness.safPath("dir"), recursive = false)
+
+        harness.provider.hasNode("dir", "file1.txt") shouldBe false
+        harness.provider.hasNode("dir", "sub", "file2.txt") shouldBe false
+    }
+
+    @Test
+    fun `delete without a permission surfaces as ReadException`() = runTest2(autoCancel = true) {
+        // documents suspect behavior (D9): CorpseFinder catches WriteException around its delete calls,
+        // so a ReadException escapes the per corpse handler and aborts the whole run.
+        val harness = harness()
+
+        shouldThrow<ReadException> { harness.gateway.delete(ungrantedPath("file.txt"), recursive = true) }
+    }
+
+    @Test
+    fun `delete of a missing target surfaces as ReadException`() = runTest2(autoCancel = true) {
+        // documents suspect behavior (D9): the initial lookup runs outside any write error handling.
+        val harness = harness(FakeDocumentsProvider.tree { dir("dir") })
+
+        shouldThrow<ReadException> { harness.gateway.delete(harness.safPath("dir", "ghost.txt"), recursive = true) }
+    }
+
+    @Test
+    fun `delete with a failing child enumeration surfaces as ReadException`() = runTest2(autoCancel = true) {
+        // documents suspect behavior (D9).
+        val harness = harness(FakeDocumentsProvider.tree { file("dir/file.txt") })
+        harness.provider.failChildQueryFor["root:dir"] = RuntimeException("provider is having a bad day")
+
+        shouldThrow<ReadException> { harness.gateway.delete(harness.safPath("dir"), recursive = true) }
+    }
+
+    @Test
+    fun `delete with a child vanishing mid traversal surfaces as ReadException`() = runTest2(autoCancel = true) {
+        // documents suspect behavior (D9).
+        val harness = harness(
+            FakeDocumentsProvider.tree {
+                file("dir/file1.txt")
+                file("dir/file2.txt")
+            }
+        )
+        harness.provider.onChildQuery = { harness.provider.removeNode("dir", "file2.txt") }
+
+        shouldThrow<ReadException> { harness.gateway.delete(harness.safPath("dir"), recursive = true) }
+    }
+
+    @Test
+    fun `delete failures surface as WriteException`() = runTest2(autoCancel = true) {
+        val harness = harness(FakeDocumentsProvider.tree { file("dir/file.txt") })
+        harness.provider.failNextDeleteWith = IllegalStateException("provider is having a bad day")
+
+        shouldThrow<WriteException> { harness.gateway.delete(harness.safPath("dir", "file.txt"), recursive = true) }
+    }
+
+    @Test
+    fun `delete stays cancellable`() = runTest2(autoCancel = true) {
+        val harness = harness(
+            FakeDocumentsProvider.tree {
+                file("dir/file1.txt")
+                file("dir/file2.txt")
+            }
+        )
+        val scope = CoroutineScope(Dispatchers.Unconfined)
+        harness.provider.onChildQuery = { scope.cancel() }
+        var caught: Throwable? = null
+
+        val job = scope.launch {
+            try {
+                harness.gateway.delete(harness.safPath("dir"), recursive = true)
+            } catch (e: Throwable) {
+                caught = e
+            }
+        }
+        job.join()
+
+        caught.shouldBeInstanceOf<CancellationException>()
+    }
+
+    // ------------------------------------------------------------------------------ misc writes
+
+    @Test
+    fun `createSymlink is unsupported`() = runTest2(autoCancel = true) {
+        val harness = harness()
+
+        shouldThrow<UnsupportedOperationException> {
+            harness.gateway.createSymlink(harness.safPath("link"), harness.safPath("target"))
+        }
+    }
+
+    @Test
+    fun `setModifiedAt can not succeed over SAF`() = runTest2(autoCancel = true) {
+        // documents D5: DocumentsProvider.update is final and throws, there is no DocumentsContract
+        // API to set a modification time, so there is nothing to fix here.
+        val harness = harness(FakeDocumentsProvider.tree { file("file.txt", lastModified = 1000L) })
+
+        harness.gateway.setModifiedAt(harness.safPath("file.txt"), Instant.ofEpochMilli(9999L)) shouldBe false
+    }
+
+    @Test
+    fun `setPermissions and setOwnership delegate to the document`() = runTest2(autoCancel = true) {
+        val harness = harness(FakeDocumentsProvider.tree { file("file.txt", content = "12345") })
+        mockkStatic(Os::class)
+        every { Os.fchmod(any(), any()) } just runs
+        every { Os.fchown(any(), any(), any()) } just runs
+
+        harness.gateway.setPermissions(harness.safPath("file.txt"), Permissions(0b111000000)) shouldBe true
+        harness.gateway.setOwnership(harness.safPath("file.txt"), Ownership(1000L, 1000L)) shouldBe true
+
+        harness.provider.openedDocuments shouldContainExactly listOf(
+            "root:file.txt" to "w",
+            "root:file.txt" to "w",
+        )
+    }
+
+    @Test
+    fun `write failures are wrapped into WriteException`() = runTest2(autoCancel = true) {
+        val harness = harness(FakeDocumentsProvider.tree { dir("dir") })
+
+        // openPFD sits outside the try in SAFDocFile, so the open failure propagates to the gateway.
+        shouldThrow<WriteException> {
+            harness.gateway.setPermissions(harness.safPath("dir"), Permissions(0b111000000))
+        }
+        shouldThrow<WriteException> {
+            harness.gateway.setOwnership(harness.safPath("dir"), Ownership(1000L, 1000L))
+        }
+        shouldThrow<WriteException> {
+            harness.gateway.setModifiedAt(ungrantedPath("file.txt"), Instant.ofEpochMilli(9999L))
+        }
     }
 }

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/saf/SAFGatewayTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/saf/SAFGatewayTest.kt
@@ -17,6 +17,7 @@ import io.mockk.just
 import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.unmockkAll
+import io.mockk.verify
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -495,6 +496,21 @@ class SAFGatewayTest : BaseTest() {
     }
 
     @Test
+    fun `createDir aborts when the provider renames a missing ancestor`() = runTest2(autoCancel = true) {
+        // ExternalStorageProvider sanitizes and uniquifies display names. Continuing below the folder
+        // it actually created would write the target somewhere nobody asked for.
+        val harness = harness()
+        harness.provider.renameNextCreatedTo = "a (1)"
+
+        shouldThrow<WriteException> { harness.gateway.createDir(harness.safPath("a", "b", "newdir")) }
+
+        harness.provider.createdDocuments shouldContainExactly listOf("root:" to "a")
+        // The renamed directory is removed again, and neither "b" nor the target exist anywhere.
+        harness.provider.deletedDocuments shouldContainExactly listOf("root:a (1)")
+        harness.provider.documentIds() shouldContainExactly listOf(FakeDocumentsProvider.ROOT_ID)
+    }
+
+    @Test
     fun `createFile with a file blocking an ancestor`() = runTest2(autoCancel = true) {
         val harness = harness(FakeDocumentsProvider.tree { file("a") })
 
@@ -529,6 +545,95 @@ class SAFGatewayTest : BaseTest() {
         shouldThrow<WriteException> { harness.gateway.createDir(harness.safPath("Android", "data")) }
 
         harness.provider.hasNode("Android", "data") shouldBe false
+    }
+
+    // The same create paths against a provider that hands out ids carrying no path information (like
+    // most non-ExternalStorageProvider providers do). They only pass if every step addresses the
+    // document the provider handed back, instead of rebuilding an id from the wanted path.
+
+    @Test
+    fun `createFile creates the missing ancestors with opaque document ids`() = runTest2(autoCancel = true) {
+        val harness = harness(FakeDocumentsProvider.tree(FakeDocumentsProvider.IdMode.OPAQUE))
+
+        harness.gateway.createFile(harness.safPath("a", "b", "new.bin"))
+
+        val (idA, idB, idTarget) = harness.provider.createdDocumentIds
+        harness.provider.createdDocuments shouldContainExactly listOf(
+            FakeDocumentsProvider.ROOT_ID to "a",
+            idA to "b",
+            idB to "new.bin",
+        )
+        harness.provider.nodeById(idTarget)!!.apply {
+            displayName shouldBe "new.bin"
+            mimeType shouldBe "application/octet-stream"
+            parentId shouldBe idB
+        }
+        harness.provider.resolve("a", "b", "new.bin")!!.documentId shouldBe idTarget
+    }
+
+    @Test
+    fun `createDir creates the missing ancestors with opaque document ids`() = runTest2(autoCancel = true) {
+        val harness = harness(FakeDocumentsProvider.tree(FakeDocumentsProvider.IdMode.OPAQUE))
+
+        harness.gateway.createDir(harness.safPath("a", "b", "newdir"))
+
+        val (idA, idB, idTarget) = harness.provider.createdDocumentIds
+        harness.provider.createdDocuments shouldContainExactly listOf(
+            FakeDocumentsProvider.ROOT_ID to "a",
+            idA to "b",
+            idB to "newdir",
+        )
+        harness.provider.nodeById(idTarget)!!.apply {
+            displayName shouldBe "newdir"
+            mimeType shouldBe Document.MIME_TYPE_DIR
+            parentId shouldBe idB
+        }
+        harness.provider.resolve("a", "b", "newdir")!!.documentId shouldBe idTarget
+    }
+
+    @Test
+    fun `createFile under a narrow grant with opaque document ids`() = runTest2(autoCancel = true) {
+        val harness = harness(
+            provider = FakeDocumentsProvider.tree(FakeDocumentsProvider.IdMode.OPAQUE) { dir("Android/data") },
+            granted = listOf("Android", "data"),
+        )
+
+        harness.gateway.createFile(harness.safPath("Android", "data", "pkg", "cache.bin"))
+
+        val (idPkg, idTarget) = harness.provider.createdDocumentIds
+        harness.provider.createdDocuments shouldContainExactly listOf(
+            "root:Android/data" to "pkg",
+            idPkg to "cache.bin",
+        )
+        harness.provider.nodeById(idPkg)!!.parentId shouldBe "root:Android/data"
+        harness.provider.nodeById(idTarget)!!.apply {
+            displayName shouldBe "cache.bin"
+            parentId shouldBe idPkg
+        }
+        harness.provider.resolve("Android", "data", "pkg", "cache.bin")!!.documentId shouldBe idTarget
+    }
+
+    @Test
+    fun `createDir under a narrow grant with opaque document ids`() = runTest2(autoCancel = true) {
+        val harness = harness(
+            provider = FakeDocumentsProvider.tree(FakeDocumentsProvider.IdMode.OPAQUE) { dir("Android/data") },
+            granted = listOf("Android", "data"),
+        )
+
+        harness.gateway.createDir(harness.safPath("Android", "data", "pkg", "cache"))
+
+        val (idPkg, idTarget) = harness.provider.createdDocumentIds
+        harness.provider.createdDocuments shouldContainExactly listOf(
+            "root:Android/data" to "pkg",
+            idPkg to "cache",
+        )
+        harness.provider.nodeById(idPkg)!!.parentId shouldBe "root:Android/data"
+        harness.provider.nodeById(idTarget)!!.apply {
+            displayName shouldBe "cache"
+            mimeType shouldBe Document.MIME_TYPE_DIR
+            parentId shouldBe idPkg
+        }
+        harness.provider.resolve("Android", "data", "pkg", "cache")!!.documentId shouldBe idTarget
     }
 
     // ----------------------------------------------------------------------------------- delete
@@ -681,13 +786,17 @@ class SAFGatewayTest : BaseTest() {
     @Test
     fun `setPermissions and setOwnership delegate to the document`() = runTest2(autoCancel = true) {
         val harness = harness(FakeDocumentsProvider.tree { file("file.txt", content = "12345") })
+        val permissions = Permissions(0b111000000)
+        val ownership = Ownership(1000L, 1000L)
         mockkStatic(Os::class)
-        every { Os.fchmod(any(), any()) } just runs
-        every { Os.fchown(any(), any(), any()) } just runs
+        every { Os.fchmod(any(), permissions.mode) } just runs
+        every { Os.fchown(any(), ownership.userId.toInt(), ownership.groupId.toInt()) } just runs
 
-        harness.gateway.setPermissions(harness.safPath("file.txt"), Permissions(0b111000000)) shouldBe true
-        harness.gateway.setOwnership(harness.safPath("file.txt"), Ownership(1000L, 1000L)) shouldBe true
+        harness.gateway.setPermissions(harness.safPath("file.txt"), permissions) shouldBe true
+        harness.gateway.setOwnership(harness.safPath("file.txt"), ownership) shouldBe true
 
+        verify { Os.fchmod(any(), permissions.mode) }
+        verify { Os.fchown(any(), ownership.userId.toInt(), ownership.groupId.toInt()) }
         harness.provider.openedDocuments shouldContainExactly listOf(
             "root:file.txt" to "w",
             "root:file.txt" to "w",

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/saf/SAFPathTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/saf/SAFPathTest.kt
@@ -117,11 +117,10 @@ class SAFPathTest : BaseTest() {
 
     @Test
     fun `path uri with a segment repeating the last one`() {
-        // documents suspect behavior (D6): the separator is placed by comparing each segment to
-        // segments.last() instead of by position, so an earlier segment equal to the last one is
-        // glued to its successor. pathUri feeds findPermission, so this misroutes permission matching.
+        // Separators are placed by position: an earlier segment repeating the last one used to lose
+        // its separator and get glued to its successor, which misroutes findPermission.
         SAFPath.build(testUri, "files", "cache", "files").pathUri
-            .toString() shouldBe "$testUri%3Afilescache%2Ffiles"
+            .toString() shouldBe "$testUri%3Afiles%2Fcache%2Ffiles"
     }
 
     @Test

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/saf/SAFPathTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/saf/SAFPathTest.kt
@@ -109,6 +109,22 @@ class SAFPathTest : BaseTest() {
     }
 
     @Test
+    fun `path uri`() {
+        SAFPath.build(testUri).pathUri.toString() shouldBe testUri
+        SAFPath.build(testUri, "files").pathUri.toString() shouldBe "$testUri%3Afiles"
+        SAFPath.build(testUri, "files", "cache").pathUri.toString() shouldBe "$testUri%3Afiles%2Fcache"
+    }
+
+    @Test
+    fun `path uri with a segment repeating the last one`() {
+        // documents suspect behavior (D6): the separator is placed by comparing each segment to
+        // segments.last() instead of by position, so an earlier segment equal to the last one is
+        // glued to its successor. pathUri feeds findPermission, so this misroutes permission matching.
+        SAFPath.build(testUri, "files", "cache", "files").pathUri
+            .toString() shouldBe "$testUri%3Afilescache%2Ffiles"
+    }
+
+    @Test
     fun `force typing`() {
         val original = RawPath.build("test", "file")
 

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/saf/SafTestHarness.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/saf/SafTestHarness.kt
@@ -1,0 +1,114 @@
+package eu.darken.sdmse.common.files.saf
+
+import android.Manifest
+import android.content.ComponentName
+import android.content.ContentResolver
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.IntentFilter
+import android.content.pm.PackageManager
+import android.content.pm.ProviderInfo
+import android.net.Uri
+import android.provider.DocumentsContract
+import androidx.core.net.toUri
+import kotlinx.coroutines.CoroutineScope
+import org.robolectric.Robolectric
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import testhelpers.coroutine.TestDispatcherProvider
+
+/**
+ * Wires a [FakeDocumentsProvider] into the Robolectric environment and hands out a real [SAFGateway]
+ * that talks to it.
+ *
+ * Registration has three parts, all of them required:
+ * - the delegate gets [ProviderInfo] attached so `DocumentsProvider`'s own `UriMatcher` and tree
+ *   enforcement work (which is also why the info must declare `MANAGE_DOCUMENTS`),
+ * - [LegacyQueryShimProvider] is the provider actually registered with the resolver (see its KDoc),
+ * - the `PackageManager` gets the provider plus a [DocumentsContract.PROVIDER_INTERFACE] intent filter,
+ *   without which `DocumentsContract.isDocumentUri` returns false.
+ *
+ * A persistable Uri permission is taken for [grantedSegments], because that is what
+ * [SAFPath.findPermission] resolves against. Pass a non-empty list to model a grant that is narrower
+ * than the volume (e.g. `Android/data`).
+ */
+class SafTestHarness(
+    appScope: CoroutineScope,
+    val provider: FakeDocumentsProvider = FakeDocumentsProvider.tree(),
+    val authority: String = DEFAULT_AUTHORITY,
+    grantedSegments: List<String> = emptyList(),
+) {
+
+    val context: Context = RuntimeEnvironment.getApplication()
+    val contentResolver: ContentResolver = context.contentResolver
+
+    /** The normalized volume root, i.e. what [SAFPath.treeRoot] holds. */
+    val treeUri: Uri = treeUriFor(emptyList())
+
+    val gateway: SAFGateway by lazy {
+        SAFGateway(
+            context = context,
+            contentResolver = contentResolver,
+            appScope = appScope,
+            dispatcherProvider = TestDispatcherProvider(),
+        )
+    }
+
+    init {
+        val providerInfo = ProviderInfo().apply {
+            this.authority = this@SafTestHarness.authority
+            packageName = context.packageName
+            name = LegacyQueryShimProvider::class.java.name
+            applicationInfo = context.applicationInfo
+            exported = true
+            grantUriPermissions = true
+            readPermission = Manifest.permission.MANAGE_DOCUMENTS
+            writePermission = Manifest.permission.MANAGE_DOCUMENTS
+        }
+
+        provider.attachInfo(context, providerInfo)
+        LegacyQueryShimProvider.register(authority, provider)
+        Robolectric.buildContentProvider(LegacyQueryShimProvider::class.java).create(providerInfo).get()
+
+        shadowOf(context.packageManager).apply {
+            addOrUpdateProvider(providerInfo)
+            addIntentFilterForProvider(
+                ComponentName(context.packageName, LegacyQueryShimProvider::class.java.name),
+                IntentFilter(DocumentsContract.PROVIDER_INTERFACE),
+            )
+        }
+
+        grant(grantedSegments)
+    }
+
+    fun grant(segments: List<String>) {
+        contentResolver.takePersistableUriPermission(treeUriFor(segments), SAFGateway.RW_FLAGSINT)
+    }
+
+    fun treeUriFor(segments: List<String>): Uri =
+        "content://$authority/tree/${Uri.encode(FakeDocumentsProvider.docIdOf(segments))}".toUri()
+
+    fun safPath(vararg segments: String): SAFPath = SAFPath.build(treeUri, *segments)
+
+    fun docUri(vararg segments: String): Uri = DocumentsContract.buildDocumentUriUsingTree(
+        treeUri,
+        FakeDocumentsProvider.docIdOf(segments.toList()),
+    )
+
+    fun docFile(vararg segments: String, context: Context = this.context): SAFDocFile =
+        SAFDocFile(context, contentResolver, docUri(*segments))
+
+    /**
+     * Robolectric's `Context.checkCallingOrSelfUriPermission` returns GRANTED unconditionally (it models
+     * a single process), so the denied branches of [SAFDocFile.readable] / [SAFDocFile.writable] need
+     * a context that says otherwise.
+     */
+    fun deniedUriPermissionContext(): Context = object : ContextWrapper(context) {
+        override fun checkCallingOrSelfUriPermission(uri: Uri?, modeFlags: Int): Int =
+            PackageManager.PERMISSION_DENIED
+    }
+
+    companion object {
+        const val DEFAULT_AUTHORITY = "eu.darken.sdmse.test.documents"
+    }
+}


### PR DESCRIPTION
## What changed

Fixes several bugs in how SD Maid accesses storage through Android's document picker permissions (SAF), the access path used for Android/data on Android 11+ without root:

- Creating a file or folder inside a subfolder of SAF-managed storage now works. Previously the folder chain was assembled wrongly, so anything deeper than one level failed, and it could not work at all when the granted access was narrower than the whole storage volume.
- AppCleaner's scan exclusions now apply when scanning through SAF. Previously the exclusion list was silently ignored on this path, so excluded folders were scanned and processed anyway.
- A single failed deletion over SAF no longer aborts CorpseFinder's entire deletion run; only the affected item is reported as failed.
- Paths with repeated folder names (like `files/cache/files`) no longer produce malformed internal addresses.

The rest of the change is test infrastructure: the SAF layer now has 84 tests driving the real code against a fake documents provider, where it previously had a single test that asserted nothing. Two further known defects found by these tests are documented with tests but deliberately not fixed here: deleting a folder over SAF empties it but leaves the folder structure behind, and the non-recursive delete flag is ignored. Both are held back so the destructive fix can first be verified on a real device.

## Technical Context

- The harness registers a real `DocumentsProvider` subclass under Robolectric behind a small shim that re-packs SQL query args into a Bundle. Real `ContentResolver` does this packing before Binder dispatch; Robolectric's shadow skips it and would hit the final, throwing 5-arg overload. The shim's KDoc documents this as a test-shim fidelity gap so nobody "fixes" the production query calls to match.
- `createDocumentFile` previously computed ancestor paths as suffixes (`segments.drop(size - index)`) and discarded the URIs returned by `createDirectory`. It now walks the missing segments from the matched permission grant, uses each returned document as the next parent, and aborts with cleanup if a provider renames a created folder (ExternalStorageProvider sanitizes and uniquifies names).
- Delete failures are now normalized to `WriteException` including the initial lookup: CorpseFinder catches only `WriteException` around its delete calls, so the previous `ReadException` escapes aborted the whole run.
- The two deferred delete defects are pinned by characterization tests whose comments name them as known defects and state why the fix is held back; the fake provider models both cascade and reject-non-empty directory deletion so the eventual fix can be tested against both behaviors.
- The production surface of the diff is `SAFGateway.kt`, `SAFDocFile.kt`, and `SAFPath.kt` (~100 changed lines); everything else is test-only.
