### PR TITLE
Fix: Remove folders, not just their contents, when cleaning via SAF

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathGateway.kt
@@ -76,6 +76,14 @@ interface APathGateway<
 
     suspend fun file(path: P, readWrite: Boolean): FileHandle
 
+    /**
+     * Deletes [path]. With [recursive] the whole subtree goes, without it a directory that still has
+     * children should be refused with a [WriteException], deleting nothing.
+     *
+     * That refusal is best-effort, not a guarantee. No backend can check emptiness and delete as one
+     * atomic step, so a child that appears in between can still be taken along (a SAF provider
+     * cascades a directory delete). [recursive] = false states intent, it is not a safety interlock.
+     */
     suspend fun delete(path: P, recursive: Boolean)
 
     suspend fun createSymlink(linkPath: P, targetPath: P): Boolean

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/saf/SAFDocFile.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/saf/SAFDocFile.kt
@@ -40,6 +40,17 @@ data class SAFDocFile(
     val exists: Boolean
         get() = queryForString(DocumentsContract.Document.COLUMN_DOCUMENT_ID) != null
 
+    /**
+     * Like [exists], but a failing query raises instead of reading as "does not exist".
+     *
+     * Only for verifying a mutation: a delete that returned false must not be reported as success
+     * just because the query that was supposed to prove it never got an answer.
+     */
+    @SuppressLint("Recycle")
+    fun existsStrict(): Boolean = resolver
+        .query(uri, arrayOf(DocumentsContract.Document.COLUMN_DOCUMENT_ID), null, null, null)
+        .useQuietly { c -> c != null && c.moveToFirst() && !c.isNull(0) }
+
     private val mimeType: String? by lazy { queryForString(DocumentsContract.Document.COLUMN_MIME_TYPE) }
 
     val isFile: Boolean
@@ -144,6 +155,30 @@ data class SAFDocFile(
         requireNotNull(foundUris) { "Unable to list files for $uri" }
 
         return foundUris.map { SAFDocFile(context, resolver, it) }
+    }
+
+    /**
+     * Whether this document has at least one child, answered by the child cursor alone.
+     *
+     * No per-child metadata is queried, so a child that vanishes while we ask can't turn the answer
+     * into an unrelated lookup failure. Query failures propagate: "we couldn't ask" must not read as
+     * "the directory is empty".
+     */
+    @SuppressLint("Recycle")
+    fun hasChildren(): Boolean {
+        val childrenUri = DocumentsContract.buildChildDocumentsUriUsingTree(uri, DocumentsContract.getDocumentId(uri))
+
+        val cursor = resolver.query(
+            childrenUri,
+            arrayOf(DocumentsContract.Document.COLUMN_DOCUMENT_ID),
+            null,
+            null,
+            null
+        )
+
+        requireNotNull(cursor) { "Unable to list files for $uri" }
+
+        return cursor.useQuietly { it.moveToFirst() }
     }
 
     fun delete(): Boolean = try {

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/saf/SAFDocFile.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/saf/SAFDocFile.kt
@@ -8,6 +8,7 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.ParcelFileDescriptor
+import android.os.RemoteException
 import android.provider.DocumentsContract
 import android.system.Os
 import android.system.StructStat
@@ -45,11 +46,28 @@ data class SAFDocFile(
      *
      * Only for verifying a mutation: a delete that returned false must not be reported as success
      * just because the query that was supposed to prove it never got an answer.
+     *
+     * [ContentResolver.query] can't carry that distinction: it hands back a null cursor both for a
+     * document the provider says is gone and for a provider it never reached. So the provider is
+     * addressed through a client instead - no client means nobody to ask, and only a null cursor
+     * from a live one counts as "missing" (`DocumentsProvider.query` returns null after catching
+     * the [FileNotFoundException] from `queryDocument`).
      */
     @SuppressLint("Recycle")
-    fun existsStrict(): Boolean = resolver
-        .query(uri, arrayOf(DocumentsContract.Document.COLUMN_DOCUMENT_ID), null, null, null)
-        .useQuietly { c -> c != null && c.moveToFirst() && !c.isNull(0) }
+    fun existsStrict(): Boolean {
+        val client = resolver.acquireUnstableContentProviderClient(uri)
+            ?: throw IOException("provider unavailable for $uri")
+
+        return try {
+            client
+                .query(uri, arrayOf(DocumentsContract.Document.COLUMN_DOCUMENT_ID), null, null, null)
+                .useQuietly { c -> c != null && c.moveToFirst() && !c.isNull(0) }
+        } catch (e: RemoteException) {
+            throw IOException("existsStrict() failed for $uri", e)
+        } finally {
+            client.close()
+        }
+    }
 
     private val mimeType: String? by lazy { queryForString(DocumentsContract.Document.COLUMN_MIME_TYPE) }
 

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/saf/SAFGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/saf/SAFGateway.kt
@@ -196,30 +196,76 @@ class SAFGateway @Inject constructor(
         // Callers like CorpseFinder only handle WriteException, a ReadException escaping from here
         // would abort their whole run instead of just this target.
         try {
-            val queue = LinkedList(listOf(lookup(path)))
+            val target = lookup(path)
 
-            while (!queue.isEmpty()) {
-                val lookUp = queue.removeFirst()
+            when {
+                !target.isDirectory -> deleteDocument(target.docFile, path)
 
-                if (lookUp.isDirectory) {
-                    queue.addAll(lookupFiles(lookUp.lookedUp).toList())
-                } else {
-                    var success = lookUp.docFile.delete()
+                recursive -> deleteTreeCascading(target)
 
-                    if (!success) {
-                        success = !lookUp.docFile.exists
-                        if (success) log(TAG, WARN) { "Tried to delete file, but it's already gone: $path" }
-                    }
+                // Best-effort refusal, see the APathGateway.delete contract: a child that appears
+                // after this check can still be taken by a provider that cascades.
+                target.docFile.hasChildren() -> throw WriteException("Directory not empty", path)
 
-                    if (!success) throw IOException("Document delete() call returned false")
-                }
+                else -> deleteDocument(target.docFile, path)
             }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
             log(TAG, ERROR) { "delete($path) failed: ${e.asLog()}" }
-            throw WriteException(path = path, cause = e)
+            throw if (e is WriteException) e else WriteException(path = path, cause = e)
         }
+    }
+
+    /**
+     * Deletes a directory and everything below it.
+     *
+     * The fast path is a single delete on the directory itself: AOSP's `FileSystemProvider` removes
+     * the whole subtree, and the platform allows (but does not promise) that. A provider that
+     * refuses, fails or only gets part way through falls back to a post-order walk, where every
+     * directory is already empty by the time it is deleted.
+     */
+    private suspend fun deleteTreeCascading(target: SAFPathLookup) {
+        val cascaded = try {
+            target.docFile.delete()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, WARN) { "Cascading delete of ${target.lookedUp} failed: ${e.asLog()}" }
+            false
+        }
+
+        // Under a dry-run SAFDocFile.delete deletes nothing and reports the document as still there,
+        // which counts as a cascade here, so the fallback and its real deletions never run.
+        if (cascaded) return
+
+        if (!target.docFile.existsStrict()) {
+            log(TAG, WARN) { "Tried to delete directory, but it's already gone: ${target.lookedUp}" }
+            return
+        }
+
+        log(TAG, WARN) { "Provider didn't cascade ${target.lookedUp}, deleting children individually" }
+        deleteTreePostOrder(target)
+    }
+
+    private suspend fun deleteTreePostOrder(target: SAFPathLookup) {
+        if (target.isDirectory) {
+            lookupFiles(target.lookedUp).toList().forEach { deleteTreePostOrder(it) }
+        }
+        deleteDocument(target.docFile, target.lookedUp)
+    }
+
+    private fun deleteDocument(docFile: SAFDocFile, path: SAFPath) {
+        if (docFile.delete()) return
+
+        // Providers report a failure for a document that is already gone, but only a query that
+        // actually answers may turn that into a success.
+        if (!docFile.existsStrict()) {
+            log(TAG, WARN) { "Tried to delete, but it's already gone: $path" }
+            return
+        }
+
+        throw IOException("Document delete() call returned false")
     }
 
     override suspend fun canWrite(path: SAFPath): Boolean = runIO {
@@ -259,6 +305,8 @@ class SAFGateway @Inject constructor(
             ).also {
                 if (Bugs.isTrace) log(TAG, VERBOSE) { "Looked up: $it" }
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             log(TAG, WARN) { "lookup($path) failed." }
             throw ReadException(path = path, cause = e)
@@ -305,6 +353,8 @@ class SAFGateway @Inject constructor(
             val name = it.name ?: it.uri.pathSegments.last().split('/').last()
             path.child(name)
         }
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: Exception) {
         log(TAG, WARN) { "$label($path) failed." }
         throw ReadException(path = path, cause = e)

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/saf/SAFGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/saf/SAFGateway.kt
@@ -24,6 +24,8 @@ import eu.darken.sdmse.common.files.isFile
 import eu.darken.sdmse.common.sharedresource.SharedResource
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.emitAll
@@ -203,11 +205,16 @@ class SAFGateway @Inject constructor(
 
                 recursive -> deleteTreeCascading(target)
 
-                // Best-effort refusal, see the APathGateway.delete contract: a child that appears
-                // after this check can still be taken by a provider that cascades.
-                target.docFile.hasChildren() -> throw WriteException("Directory not empty", path)
+                else -> {
+                    // Best-effort refusal, see the APathGateway.delete contract: a child that appears
+                    // after this check can still be taken by a provider that cascades.
+                    val hasChildren = target.docFile.hasChildren()
+                    currentCoroutineContext().ensureActive()
 
-                else -> deleteDocument(target.docFile, path)
+                    if (hasChildren) throw WriteException("Directory not empty", path)
+
+                    deleteDocument(target.docFile, path)
+                }
             }
         } catch (e: CancellationException) {
             throw e
@@ -226,6 +233,8 @@ class SAFGateway @Inject constructor(
      * directory is already empty by the time it is deleted.
      */
     private suspend fun deleteTreeCascading(target: SAFPathLookup) {
+        currentCoroutineContext().ensureActive()
+
         val cascaded = try {
             target.docFile.delete()
         } catch (e: CancellationException) {
@@ -234,6 +243,8 @@ class SAFGateway @Inject constructor(
             log(TAG, WARN) { "Cascading delete of ${target.lookedUp} failed: ${e.asLog()}" }
             false
         }
+
+        currentCoroutineContext().ensureActive()
 
         // Under a dry-run SAFDocFile.delete deletes nothing and reports the document as still there,
         // which counts as a cascade here, so the fallback and its real deletions never run.
@@ -245,17 +256,27 @@ class SAFGateway @Inject constructor(
         }
 
         log(TAG, WARN) { "Provider didn't cascade ${target.lookedUp}, deleting children individually" }
-        deleteTreePostOrder(target)
+        deleteTreePostOrder(target.docFile, target.lookedUp)
     }
 
-    private suspend fun deleteTreePostOrder(target: SAFPathLookup) {
-        if (target.isDirectory) {
-            lookupFiles(target.lookedUp).toList().forEach { deleteTreePostOrder(it) }
+    /**
+     * Deletes [docFile] and everything below it, children before their parents.
+     *
+     * The walk runs on the [SAFDocFile]s the provider itself handed out. Document ids are opaque in
+     * general, they can't be rebuilt from display names, and a provider whose ids aren't path derived
+     * is exactly the kind that doesn't cascade, i.e. the only reason this fallback exists. [root] is
+     * carried along for log and exception context only.
+     */
+    private suspend fun deleteTreePostOrder(docFile: SAFDocFile, root: SAFPath) {
+        if (docFile.isDirectory) {
+            docFile.listFiles().forEach { deleteTreePostOrder(it, root) }
         }
-        deleteDocument(target.docFile, target.lookedUp)
+        deleteDocument(docFile, root)
     }
 
-    private fun deleteDocument(docFile: SAFDocFile, path: SAFPath) {
+    private suspend fun deleteDocument(docFile: SAFDocFile, path: SAFPath) {
+        currentCoroutineContext().ensureActive()
+
         if (docFile.delete()) return
 
         // Providers report a failure for a document that is already gone, but only a query that

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/saf/FakeDocumentsProvider.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/saf/FakeDocumentsProvider.kt
@@ -52,6 +52,13 @@ class FakeDocumentsProvider(val idMode: IdMode = IdMode.PATH_DERIVED) : Document
 
         /** Deleting a non-empty directory fails, modelling a stricter provider. */
         REJECT_NONEMPTY,
+
+        /**
+         * The first directory delete removes the childless documents below the target and then fails,
+         * modelling a cascade that gives up part way through. Afterwards the provider behaves like
+         * [REJECT_NONEMPTY], so whatever cleans up the remains has to work bottom up.
+         */
+        CASCADE_PARTIAL_FAILURE,
     }
 
     data class Node(
@@ -86,8 +93,14 @@ class FakeDocumentsProvider(val idMode: IdMode = IdMode.PATH_DERIVED) : Document
     /** Fails every child listing for these (normalized) document ids. */
     val failChildQueryFor = mutableMapOf<String, Exception>()
 
-    /** Fails the next [deleteDocument], then clears itself. */
+    /** Fails the next [deleteDocument] before it deletes anything, then clears itself. */
     var failNextDeleteWith: Exception? = null
+
+    /**
+     * Fails the next [deleteDocument] *after* it deleted, then clears itself. Models a provider that
+     * reports a failure for a deletion that actually went through.
+     */
+    var failNextDeleteAfterwardsWith: Exception? = null
 
     /**
      * Creates the next document under this display name instead of the requested one, then clears
@@ -101,8 +114,17 @@ class FakeDocumentsProvider(val idMode: IdMode = IdMode.PATH_DERIVED) : Document
      */
     var onChildQuery: ((String) -> Unit)? = null
 
+    /** Invoked with the document id *after* a document cursor has been built, see [onChildQuery]. */
+    var onDocumentQuery: ((String) -> Unit)? = null
+
+    /** Invoked with the document id at the start of [deleteDocument], before any failure hook fires. */
+    var onDelete: ((String) -> Unit)? = null
+
     val queriedDocuments = mutableListOf<String>()
     val queriedChildren = mutableListOf<String>()
+
+    /** Every [deleteDocument] call, including the ones that end up failing. */
+    val deleteCalls = mutableListOf<String>()
 
     /** Parent document id and *requested* display name, per [createDocument] call. */
     val createdDocuments = mutableListOf<Pair<String, String>>()
@@ -156,6 +178,7 @@ class FakeDocumentsProvider(val idMode: IdMode = IdMode.PATH_DERIVED) : Document
         queriedChildren.clear()
         createdDocuments.clear()
         createdDocumentIds.clear()
+        deleteCalls.clear()
         deletedDocuments.clear()
         openedDocuments.clear()
     }
@@ -178,7 +201,9 @@ class FakeDocumentsProvider(val idMode: IdMode = IdMode.PATH_DERIVED) : Document
         queriedDocuments.add(id)
         failDocQueryFor[id]?.let { throw it }
         val node = nodes[id] ?: throw FileNotFoundException("No such document: $id")
-        return cursorFor(projection, listOf(node))
+        val cursor = cursorFor(projection, listOf(node))
+        onDocumentQuery?.invoke(id)
+        return cursor
     }
 
     override fun queryChildDocuments(
@@ -228,25 +253,41 @@ class FakeDocumentsProvider(val idMode: IdMode = IdMode.PATH_DERIVED) : Document
     }
 
     override fun deleteDocument(documentId: String) {
+        val id = normalize(documentId)
+        deleteCalls.add(id)
+        onDelete?.invoke(id)
+
         failNextDeleteWith?.let {
             failNextDeleteWith = null
             throw it
         }
-        val id = normalize(documentId)
+
         val node = nodes[id] ?: throw FileNotFoundException("No such document: $id")
 
         if (node.isDirectory) {
             val descendants = descendantsOf(id)
             when (dirDeleteMode) {
                 DirDeleteMode.CASCADE -> descendants.forEach { drop(it) }
+
                 DirDeleteMode.REJECT_NONEMPTY -> if (descendants.isNotEmpty()) {
                     throw IllegalStateException("Directory not empty: $id")
+                }
+
+                DirDeleteMode.CASCADE_PARTIAL_FAILURE -> {
+                    dirDeleteMode = DirDeleteMode.REJECT_NONEMPTY
+                    descendants.filter { childrenOf(it).isEmpty() }.forEach { drop(it) }
+                    throw IllegalStateException("Gave up while deleting $id")
                 }
             }
         }
 
         drop(id)
         deletedDocuments.add(id)
+
+        failNextDeleteAfterwardsWith?.let {
+            failNextDeleteAfterwardsWith = null
+            throw it
+        }
     }
 
     override fun openDocument(documentId: String, mode: String, signal: CancellationSignal?): ParcelFileDescriptor {

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/saf/FakeDocumentsProvider.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/saf/FakeDocumentsProvider.kt
@@ -19,7 +19,15 @@ import java.io.FileNotFoundException
  *
  * Register it through [SafTestHarness], which wires it behind [LegacyQueryShimProvider].
  */
-class FakeDocumentsProvider(val idMode: IdMode = IdMode.PATH_DERIVED) : DocumentsProvider() {
+class FakeDocumentsProvider(
+    val idMode: IdMode = IdMode.PATH_DERIVED,
+    /**
+     * Mints opaque ids for [Builder] fixture nodes too, so that nothing below the tree root can be
+     * addressed by a rebuilt id. Only the root document keeps [ROOT_ID], which is what the granted
+     * tree uri points at. Requires [IdMode.OPAQUE].
+     */
+    val opaqueFixtureIds: Boolean = false,
+) : DocumentsProvider() {
 
     /**
      * How ids for newly created documents are minted. Real providers differ, and a caller must not
@@ -37,7 +45,7 @@ class FakeDocumentsProvider(val idMode: IdMode = IdMode.PATH_DERIVED) : Document
         /**
          * Created documents get ids like `doc-1` that carry no path information at all. Fixture nodes
          * declared through [Builder] keep their path based ids, because that is what the granted tree
-         * uri addresses.
+         * uri addresses, unless [opaqueFixtureIds] says otherwise.
          */
         OPAQUE,
     }
@@ -79,6 +87,9 @@ class FakeDocumentsProvider(val idMode: IdMode = IdMode.PATH_DERIVED) : Document
 
     /** Insertion ordered, so child enumeration order is deterministic. */
     private val nodes = LinkedHashMap<String, Node>()
+
+    /** Path based id -> the id the fixture node actually got, only used under [opaqueFixtureIds]. */
+    private val fixtureIds = mutableMapOf<String, String>()
 
     private var opaqueIdCounter = 0
 
@@ -135,6 +146,9 @@ class FakeDocumentsProvider(val idMode: IdMode = IdMode.PATH_DERIVED) : Document
     val openedDocuments = mutableListOf<Pair<String, String>>()
 
     init {
+        require(!opaqueFixtureIds || idMode == IdMode.OPAQUE) {
+            "opaqueFixtureIds only makes sense together with IdMode.OPAQUE"
+        }
         nodes[ROOT_ID] = Node(
             documentId = ROOT_ID,
             parentId = null,
@@ -148,7 +162,10 @@ class FakeDocumentsProvider(val idMode: IdMode = IdMode.PATH_DERIVED) : Document
 
     // ---------------------------------------------------------------- tree access for assertions
 
-    /** Path based lookup, i.e. only meaningful for [IdMode.PATH_DERIVED] and for fixture nodes. */
+    /**
+     * Path based lookup, i.e. only meaningful for [IdMode.PATH_DERIVED] and for fixture nodes that
+     * kept a path based id. Use [resolve] under [opaqueFixtureIds].
+     */
     fun node(vararg segments: String): Node? = nodes[docIdOf(segments.toList())]
 
     fun hasNode(vararg segments: String): Boolean = node(*segments) != null
@@ -311,6 +328,13 @@ class FakeDocumentsProvider(val idMode: IdMode = IdMode.PATH_DERIVED) : Document
 
     // -------------------------------------------------------------------------------- internals
 
+    /** The id a fixture node gets, minted once per path so parent links stay consistent. */
+    private fun fixtureId(segments: List<String>): String {
+        val pathId = docIdOf(segments)
+        if (!opaqueFixtureIds || segments.isEmpty()) return pathId
+        return fixtureIds.getOrPut(pathId) { "$OPAQUE_ID_PREFIX${++opaqueIdCounter}" }
+    }
+
     private fun consumeQueryFailure() {
         failNextQueryWith?.let {
             failNextQueryWith = null
@@ -410,21 +434,21 @@ class FakeDocumentsProvider(val idMode: IdMode = IdMode.PATH_DERIVED) : Document
             require(segments.isNotEmpty()) { "Can't replace the root node" }
             segments.dropLast(1).indices.forEach { index ->
                 val ancestor = segments.take(index + 1)
-                val ancestorId = docIdOf(ancestor)
+                val ancestorId = fixtureId(ancestor)
                 if (!nodes.containsKey(ancestorId)) {
                     nodes[ancestorId] = Node(
                         documentId = ancestorId,
-                        parentId = docIdOf(ancestor.dropLast(1)),
+                        parentId = fixtureId(ancestor.dropLast(1)),
                         displayName = ancestor.last(),
                         mimeType = Document.MIME_TYPE_DIR,
                         flags = DEFAULT_DIR_FLAGS,
                     )
                 }
             }
-            val documentId = docIdOf(segments)
+            val documentId = fixtureId(segments)
             val node = Node(
                 documentId = documentId,
-                parentId = docIdOf(segments.dropLast(1)),
+                parentId = fixtureId(segments.dropLast(1)),
                 displayName = if (nullDisplayName) null else segments.last(),
                 mimeType = mimeType,
                 size = size,
@@ -456,8 +480,9 @@ class FakeDocumentsProvider(val idMode: IdMode = IdMode.PATH_DERIVED) : Document
 
         fun tree(
             idMode: IdMode = IdMode.PATH_DERIVED,
+            opaqueFixtureIds: Boolean = false,
             block: FakeDocumentsProvider.Builder.() -> Unit = {},
-        ): FakeDocumentsProvider = FakeDocumentsProvider(idMode).also { it.Builder().block() }
+        ): FakeDocumentsProvider = FakeDocumentsProvider(idMode, opaqueFixtureIds).also { it.Builder().block() }
 
         fun pathSegments(path: String): List<String> = path.split('/').filter { it.isNotEmpty() }
 

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/saf/SAFDocFileTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/saf/SAFDocFileTest.kt
@@ -197,6 +197,50 @@ class SAFDocFileTest : BaseTest() {
     }
 
     @Test
+    fun `hasChildren answers from the child cursor alone`() {
+        val harness = harness(
+            FakeDocumentsProvider.tree {
+                file("populated/file.txt")
+                dir("empty")
+            }
+        )
+
+        harness.docFile("populated").hasChildren() shouldBe true
+        harness.docFile("empty").hasChildren() shouldBe false
+    }
+
+    @Test
+    fun `hasChildren does not query the children themselves`() {
+        // A directory whose children can't be looked up individually is still non-empty. Answering
+        // this with lookupFiles() would turn a vanishing or broken child into an unrelated failure.
+        val harness = harness(FakeDocumentsProvider.tree { file("dir/file.txt") })
+        harness.provider.failDocQueryFor["root:dir/file.txt"] = RuntimeException("provider is having a bad day")
+
+        harness.docFile("dir").hasChildren() shouldBe true
+    }
+
+    @Test
+    fun `hasChildren propagates a failing query`() {
+        // "We couldn't ask" must not read as "the directory is empty".
+        val harness = harness(FakeDocumentsProvider.tree { file("dir/file.txt") })
+        harness.provider.failChildQueryFor["root:dir"] = RuntimeException("provider is having a bad day")
+
+        shouldThrow<RuntimeException> { harness.docFile("dir").hasChildren() }
+    }
+
+    @Test
+    fun `existsStrict propagates what exists swallows`() {
+        val harness = harness(FakeDocumentsProvider.tree { file("dir/file.txt") })
+        val docFile = harness.docFile("dir", "file.txt")
+
+        docFile.existsStrict() shouldBe true
+        harness.docFile("dir", "ghost.txt").existsStrict() shouldBe false
+
+        harness.provider.failNextQueryWith = RuntimeException("provider is having a bad day")
+        shouldThrow<RuntimeException> { docFile.existsStrict() }
+    }
+
+    @Test
     fun `findFile matches by display name`() {
         val harness = harness(
             FakeDocumentsProvider.tree {

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/saf/SAFGatewayTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/saf/SAFGatewayTest.kt
@@ -13,6 +13,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotStartWith
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.every
 import io.mockk.just
@@ -812,6 +813,54 @@ class SAFGatewayTest : BaseTest() {
     }
 
     @Test
+    fun `delete surfaces an unreachable provider as WriteException`() = runTest2(autoCancel = true) {
+        // "The document is gone" and "nobody answered" arrive as the same null cursor, so the
+        // verification asks the provider directly. Without a provider to ask there is no proof, and a
+        // delete that reported a failure must not be turned into a success.
+        val harness = harness(FakeDocumentsProvider.tree { file("dir/file.txt") })
+        harness.provider.failNextDeleteWith = IllegalArgumentException("java.io.FileNotFoundException: gone")
+        harness.provider.onDelete = { harness.killProviderProcess() }
+
+        shouldThrow<WriteException> {
+            harness.gateway.delete(harness.safPath("dir", "file.txt"), recursive = false)
+        }
+
+        harness.provider.hasNode("dir", "file.txt") shouldBe true
+    }
+
+    @Test
+    fun `recursive delete walks the ids the provider handed out`() = runTest2(autoCancel = true) {
+        // Document ids are opaque in general and can't be rebuilt from a display name, and a provider
+        // whose ids aren't path derived is exactly the kind that doesn't cascade. So here nothing below
+        // the granted tree root is addressable by a rebuilt id: the fallback walk only works if it uses
+        // the ids the child cursor handed it.
+        val harness = harness(
+            FakeDocumentsProvider.tree(FakeDocumentsProvider.IdMode.OPAQUE, opaqueFixtureIds = true) {
+                file("dir/sub/file1.txt")
+                file("dir/file2.txt")
+            }
+        )
+        harness.provider.dirDeleteMode = FakeDocumentsProvider.DirDeleteMode.REJECT_NONEMPTY
+        val idDir = harness.provider.resolve("dir")!!.documentId
+        val idSub = harness.provider.resolve("dir", "sub")!!.documentId
+        val idFile1 = harness.provider.resolve("dir", "sub", "file1.txt")!!.documentId
+        val idFile2 = harness.provider.resolve("dir", "file2.txt")!!.documentId
+        listOf(idDir, idSub, idFile1, idFile2).forEach { it shouldNotStartWith FakeDocumentsProvider.ROOT_ID }
+
+        harness.gateway.delete(harness.safPath(), recursive = true)
+
+        harness.provider.documentIds().shouldBeEmpty()
+        // Children before their parents, every one of them by its opaque id.
+        harness.provider.deletedDocuments shouldContainExactly listOf(
+            idFile1,
+            idSub,
+            idFile2,
+            idDir,
+            FakeDocumentsProvider.ROOT_ID,
+        )
+    }
+
+    @Test
     fun `delete deletes nothing during a dry run`() = runTest2(autoCancel = true) {
         val harness = harness(
             FakeDocumentsProvider.tree {
@@ -907,6 +956,35 @@ class SAFGatewayTest : BaseTest() {
         cancellableDelete(scope) {
             harness.gateway.delete(harness.safPath("dir"), recursive = false)
         }.shouldBeInstanceOf<CancellationException>()
+
+        // A cancelled delete deletes nothing: the checkpoint sits between the check and the call.
+        harness.provider.deleteCalls.shouldBeEmpty()
+        harness.provider.hasNode("dir") shouldBe true
+    }
+
+    @Test
+    fun `a cancelled fallback walk stops at the current child`() = runTest2(autoCancel = true) {
+        val harness = harness(
+            FakeDocumentsProvider.tree {
+                file("dir/sub/file1.txt")
+                file("dir/sub/file2.txt")
+                file("dir/file3.txt")
+            }
+        )
+        harness.provider.dirDeleteMode = FakeDocumentsProvider.DirDeleteMode.REJECT_NONEMPTY
+        val scope = CoroutineScope(Dispatchers.Unconfined)
+        harness.provider.onDelete = { if (it == "root:dir/sub/file1.txt") scope.cancel() }
+
+        cancellableDelete(scope) {
+            harness.gateway.delete(harness.safPath("dir"), recursive = true)
+        }.shouldBeInstanceOf<CancellationException>()
+
+        // The failed cascade attempt and the child that was already in flight, nothing after it.
+        harness.provider.deleteCalls shouldContainExactly listOf("root:dir", "root:dir/sub/file1.txt")
+        harness.provider.hasNode("dir") shouldBe true
+        harness.provider.hasNode("dir", "sub") shouldBe true
+        harness.provider.hasNode("dir", "sub", "file2.txt") shouldBe true
+        harness.provider.hasNode("dir", "file3.txt") shouldBe true
     }
 
     @Test

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/saf/SAFGatewayTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/saf/SAFGatewayTest.kt
@@ -2,6 +2,7 @@ package eu.darken.sdmse.common.files.saf
 
 import android.provider.DocumentsContract.Document
 import android.system.Os
+import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.files.APathGateway
 import eu.darken.sdmse.common.files.FileType
 import eu.darken.sdmse.common.files.Ownership
@@ -9,6 +10,7 @@ import eu.darken.sdmse.common.files.Permissions
 import eu.darken.sdmse.common.files.ReadException
 import eu.darken.sdmse.common.files.WriteException
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -45,6 +47,8 @@ class SAFGatewayTest : BaseTest() {
         // BaseTest's cleanup is a JUnit5 @AfterAll and doesn't run here.
         unmockkAll()
         LegacyQueryShimProvider.unregisterAll()
+        // A global flag, a leak from a failing dry-run test would silently disarm every other one.
+        Bugs.isDryRun = false
     }
 
     private fun TestScope.harness(
@@ -649,12 +653,8 @@ class SAFGatewayTest : BaseTest() {
     }
 
     @Test
-    fun `delete leaves the directory skeleton behind`() = runTest2(autoCancel = true) {
-        // documents a KNOWN DEFECT (D1) that is deliberately NOT fixed in this change: SAFGateway.delete
-        // only ever calls delete() on non-directories, so deleting a folder empties it and leaves every
-        // directory in place, including the target. The fix is destructive enough that it is being held
-        // back until it can be verified on a device against a real ExternalStorageProvider. Do not read
-        // these assertions as intended behavior.
+    fun `recursive delete removes the directory itself`() = runTest2(autoCancel = true) {
+        // A cascading provider takes the whole subtree from a single call on the target.
         val harness = harness(
             FakeDocumentsProvider.tree {
                 file("dir/file1.txt")
@@ -665,21 +665,60 @@ class SAFGatewayTest : BaseTest() {
 
         harness.gateway.delete(harness.safPath("dir"), recursive = true)
 
-        harness.provider.hasNode("dir") shouldBe true
-        harness.provider.hasNode("dir", "sub") shouldBe true
+        harness.provider.hasNode("dir") shouldBe false
+        harness.provider.hasNode("dir", "sub") shouldBe false
         harness.provider.hasNode("dir", "file1.txt") shouldBe false
         harness.provider.hasNode("dir", "sub", "file2.txt") shouldBe false
+        harness.provider.deleteCalls shouldContainExactly listOf("root:dir")
+    }
+
+    @Test
+    fun `recursive delete falls back to a post order walk when the provider does not cascade`() =
+        runTest2(autoCancel = true) {
+            val harness = harness(
+                FakeDocumentsProvider.tree {
+                    file("dir/file1.txt")
+                    file("dir/sub/file2.txt")
+                }
+            )
+            harness.provider.dirDeleteMode = FakeDocumentsProvider.DirDeleteMode.REJECT_NONEMPTY
+
+            harness.gateway.delete(harness.safPath("dir"), recursive = true)
+
+            harness.provider.hasNode("dir") shouldBe false
+            harness.provider.hasNode("dir", "sub") shouldBe false
+            // Children before their parents, otherwise a provider that refuses a non-empty directory
+            // could never be satisfied.
+            harness.provider.deletedDocuments shouldContainExactly listOf(
+                "root:dir/file1.txt",
+                "root:dir/sub/file2.txt",
+                "root:dir/sub",
+                "root:dir",
+            )
+        }
+
+    @Test
+    fun `recursive delete resumes when the provider cascade fails part way`() = runTest2(autoCancel = true) {
+        val harness = harness(
+            FakeDocumentsProvider.tree {
+                file("dir/file1.txt")
+                file("dir/sub/file2.txt")
+            }
+        )
+        harness.provider.dirDeleteMode = FakeDocumentsProvider.DirDeleteMode.CASCADE_PARTIAL_FAILURE
+
+        harness.gateway.delete(harness.safPath("dir"), recursive = true)
+
+        harness.provider.hasNode("dir") shouldBe false
+        // The cascade took the files before it gave up, the walk finished what was left.
         harness.provider.deletedDocuments shouldContainExactly listOf(
-            "root:dir/file1.txt",
-            "root:dir/sub/file2.txt",
+            "root:dir/sub",
+            "root:dir",
         )
     }
 
     @Test
-    fun `delete recurses even when recursive is false`() = runTest2(autoCancel = true) {
-        // documents a KNOWN DEFECT (D2) that is deliberately NOT fixed in this change: the recursive
-        // parameter is only logged, never read. It is held back together with D1 (see above), because
-        // the guard it would need only makes sense once directories are actually deleted.
+    fun `delete refuses a populated directory when recursive is false`() = runTest2(autoCancel = true) {
         val harness = harness(
             FakeDocumentsProvider.tree {
                 file("dir/file1.txt")
@@ -687,10 +726,112 @@ class SAFGatewayTest : BaseTest() {
             }
         )
 
+        shouldThrow<WriteException> { harness.gateway.delete(harness.safPath("dir"), recursive = false) }
+
+        harness.provider.hasNode("dir") shouldBe true
+        harness.provider.hasNode("dir", "sub") shouldBe true
+        harness.provider.hasNode("dir", "file1.txt") shouldBe true
+        harness.provider.hasNode("dir", "sub", "file2.txt") shouldBe true
+        harness.provider.deleteCalls.shouldBeEmpty()
+    }
+
+    @Test
+    fun `delete removes an empty directory when recursive is false`() = runTest2(autoCancel = true) {
+        val harness = harness(FakeDocumentsProvider.tree { dir("dir") })
+
         harness.gateway.delete(harness.safPath("dir"), recursive = false)
 
-        harness.provider.hasNode("dir", "file1.txt") shouldBe false
-        harness.provider.hasNode("dir", "sub", "file2.txt") shouldBe false
+        harness.provider.hasNode("dir") shouldBe false
+        harness.provider.deletedDocuments shouldContainExactly listOf("root:dir")
+    }
+
+    @Test
+    fun `a child appearing after the emptiness check is taken along`() = runTest2(autoCancel = true) {
+        // The refusal in the recursive=false path is best-effort, exactly as the APathGateway.delete
+        // contract states: emptiness check and delete can't be one atomic step, so a child that shows
+        // up in between is cascaded away by the provider.
+        val harness = harness(FakeDocumentsProvider.tree { dir("dir") })
+        harness.provider.onChildQuery = {
+            harness.provider.onChildQuery = null
+            harness.provider.addNode(
+                FakeDocumentsProvider.Node(
+                    documentId = "root:dir/sneaky.txt",
+                    parentId = "root:dir",
+                    displayName = "sneaky.txt",
+                    mimeType = "application/octet-stream",
+                    flags = FakeDocumentsProvider.DEFAULT_FILE_FLAGS,
+                )
+            )
+        }
+
+        harness.gateway.delete(harness.safPath("dir"), recursive = false)
+
+        harness.provider.hasNode("dir") shouldBe false
+        harness.provider.hasNode("dir", "sneaky.txt") shouldBe false
+    }
+
+    @Test
+    fun `delete counts a false return as success when the document is really gone`() = runTest2(autoCancel = true) {
+        val harness = harness(FakeDocumentsProvider.tree { file("dir/file.txt") })
+        // Deleted, but reported as failed.
+        harness.provider.failNextDeleteAfterwardsWith = IllegalArgumentException("java.io.FileNotFoundException: gone")
+
+        harness.gateway.delete(harness.safPath("dir", "file.txt"), recursive = false)
+
+        harness.provider.hasNode("dir", "file.txt") shouldBe false
+    }
+
+    @Test
+    fun `delete surfaces a false return as WriteException when the document survives`() =
+        runTest2(autoCancel = true) {
+            val harness = harness(FakeDocumentsProvider.tree { file("dir/file.txt") })
+            harness.provider.failNextDeleteWith = IllegalArgumentException("java.io.FileNotFoundException: gone")
+
+            shouldThrow<WriteException> {
+                harness.gateway.delete(harness.safPath("dir", "file.txt"), recursive = false)
+            }
+
+            harness.provider.hasNode("dir", "file.txt") shouldBe true
+        }
+
+    @Test
+    fun `delete surfaces a failing verification query as WriteException`() = runTest2(autoCancel = true) {
+        // The lenient SAFDocFile.exists reads a failing query as "gone" and would report success for a
+        // document that is still there, which is why the verification uses existsStrict.
+        val harness = harness(FakeDocumentsProvider.tree { file("dir/file.txt") })
+        harness.provider.failNextDeleteWith = IllegalArgumentException("java.io.FileNotFoundException: gone")
+        harness.provider.onDelete = { id ->
+            harness.provider.failDocQueryFor[id] = RuntimeException("provider is having a bad day")
+        }
+
+        shouldThrow<WriteException> {
+            harness.gateway.delete(harness.safPath("dir", "file.txt"), recursive = false)
+        }
+
+        harness.provider.hasNode("dir", "file.txt") shouldBe true
+    }
+
+    @Test
+    fun `delete deletes nothing during a dry run`() = runTest2(autoCancel = true) {
+        val harness = harness(
+            FakeDocumentsProvider.tree {
+                file("dir/file1.txt")
+                file("dir/sub/file2.txt")
+            }
+        )
+
+        Bugs.isDryRun = true
+        try {
+            harness.gateway.delete(harness.safPath("dir"), recursive = true)
+        } finally {
+            Bugs.isDryRun = false
+        }
+
+        harness.provider.hasNode("dir") shouldBe true
+        harness.provider.hasNode("dir", "sub") shouldBe true
+        harness.provider.hasNode("dir", "file1.txt") shouldBe true
+        harness.provider.hasNode("dir", "sub", "file2.txt") shouldBe true
+        harness.provider.deleteCalls.shouldBeEmpty()
     }
 
     @Test
@@ -711,24 +852,31 @@ class SAFGatewayTest : BaseTest() {
     }
 
     @Test
-    fun `delete with a failing child enumeration surfaces as WriteException`() = runTest2(autoCancel = true) {
+    fun `delete with a failing emptiness check surfaces as WriteException`() = runTest2(autoCancel = true) {
+        // The emptiness check is the only enumeration left in delete, and an unanswerable one must not
+        // read as "empty" and take the directory with it.
         val harness = harness(FakeDocumentsProvider.tree { file("dir/file.txt") })
         harness.provider.failChildQueryFor["root:dir"] = RuntimeException("provider is having a bad day")
 
-        shouldThrow<WriteException> { harness.gateway.delete(harness.safPath("dir"), recursive = true) }
+        shouldThrow<WriteException> { harness.gateway.delete(harness.safPath("dir"), recursive = false) }
+
+        harness.provider.hasNode("dir") shouldBe true
     }
 
     @Test
-    fun `delete with a child vanishing mid traversal surfaces as WriteException`() = runTest2(autoCancel = true) {
+    fun `a failing fallback walk surfaces as WriteException`() = runTest2(autoCancel = true) {
         val harness = harness(
             FakeDocumentsProvider.tree {
                 file("dir/file1.txt")
-                file("dir/file2.txt")
+                file("dir/sub/file2.txt")
             }
         )
-        harness.provider.onChildQuery = { harness.provider.removeNode("dir", "file2.txt") }
+        harness.provider.dirDeleteMode = FakeDocumentsProvider.DirDeleteMode.REJECT_NONEMPTY
+        harness.provider.failChildQueryFor["root:dir/sub"] = RuntimeException("provider is having a bad day")
 
         shouldThrow<WriteException> { harness.gateway.delete(harness.safPath("dir"), recursive = true) }
+
+        harness.provider.hasNode("dir") shouldBe true
     }
 
     @Test
@@ -740,27 +888,49 @@ class SAFGatewayTest : BaseTest() {
     }
 
     @Test
-    fun `delete stays cancellable`() = runTest2(autoCancel = true) {
-        val harness = harness(
-            FakeDocumentsProvider.tree {
-                file("dir/file1.txt")
-                file("dir/file2.txt")
-            }
-        )
+    fun `delete stays cancellable during the initial lookup`() = runTest2(autoCancel = true) {
+        val harness = harness(FakeDocumentsProvider.tree { file("dir/file.txt") })
+        val scope = CoroutineScope(Dispatchers.Unconfined)
+        harness.provider.onDocumentQuery = { scope.cancel() }
+
+        cancellableDelete(scope) {
+            harness.gateway.delete(harness.safPath("dir", "file.txt"), recursive = false)
+        }.shouldBeInstanceOf<CancellationException>()
+    }
+
+    @Test
+    fun `delete stays cancellable during the emptiness check`() = runTest2(autoCancel = true) {
+        val harness = harness(FakeDocumentsProvider.tree { dir("dir") })
         val scope = CoroutineScope(Dispatchers.Unconfined)
         harness.provider.onChildQuery = { scope.cancel() }
-        var caught: Throwable? = null
 
-        val job = scope.launch {
+        cancellableDelete(scope) {
+            harness.gateway.delete(harness.safPath("dir"), recursive = false)
+        }.shouldBeInstanceOf<CancellationException>()
+    }
+
+    @Test
+    fun `delete stays cancellable during the document deletion`() = runTest2(autoCancel = true) {
+        val harness = harness(FakeDocumentsProvider.tree { file("dir/file.txt") })
+        val scope = CoroutineScope(Dispatchers.Unconfined)
+        harness.provider.onDelete = { scope.cancel() }
+
+        cancellableDelete(scope) {
+            harness.gateway.delete(harness.safPath("dir", "file.txt"), recursive = false)
+        }.shouldBeInstanceOf<CancellationException>()
+    }
+
+    /** Runs [block] on [scope] and returns whatever it threw, so the cancellation shape can be asserted. */
+    private suspend fun cancellableDelete(scope: CoroutineScope, block: suspend () -> Unit): Throwable? {
+        var caught: Throwable? = null
+        scope.launch {
             try {
-                harness.gateway.delete(harness.safPath("dir"), recursive = true)
+                block()
             } catch (e: Throwable) {
                 caught = e
             }
-        }
-        job.join()
-
-        caught.shouldBeInstanceOf<CancellationException>()
+        }.join()
+        return caught
     }
 
     // ------------------------------------------------------------------------------ misc writes

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/saf/SafTestHarness.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/saf/SafTestHarness.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.CoroutineScope
 import org.robolectric.Robolectric
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows.shadowOf
+import org.robolectric.shadows.ShadowContentResolver
 import testhelpers.coroutine.TestDispatcherProvider
 
 /**
@@ -83,6 +84,15 @@ class SafTestHarness(
 
     fun grant(segments: List<String>) {
         contentResolver.takePersistableUriPermission(treeUriFor(segments), SAFGateway.RW_FLAGSINT)
+    }
+
+    /**
+     * Makes the provider unreachable, i.e. every `acquire*ContentProviderClient` for [authority] hands
+     * back null from here on. That models the provider process being gone, which is a different answer
+     * than any cursor could give.
+     */
+    fun killProviderProcess() {
+        ShadowContentResolver.registerProviderInternal(authority, null)
     }
 
     fun treeUriFor(segments: List<String>): Uri =

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/BaseExpendablesFilterTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/BaseExpendablesFilterTest.kt
@@ -1,0 +1,125 @@
+package eu.darken.sdmse.appcleaner.core.forensics
+
+import eu.darken.sdmse.common.areas.DataArea
+import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.common.files.FileType
+import eu.darken.sdmse.common.files.GatewaySwitch
+import eu.darken.sdmse.common.files.Segments
+import eu.darken.sdmse.common.files.WriteException
+import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.files.local.LocalPathLookup
+import eu.darken.sdmse.common.pkgs.Pkg
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.time.Instant
+
+/**
+ * Covers [BaseExpendablesFilter.deleteAll], the shared deletion path of every AppCleaner filter.
+ *
+ * Matched directories are deleted as directories: over SAF that is the only thing that removes them
+ * at all, everything else just empties them.
+ */
+class BaseExpendablesFilterTest : BaseTest() {
+
+    private val gatewaySwitch = mockk<GatewaySwitch>()
+
+    private class TestFilter : BaseExpendablesFilter() {
+        override suspend fun initialize() {}
+
+        override suspend fun match(
+            pkgId: Pkg.Id,
+            target: APathLookup<APath>,
+            areaType: DataArea.Type,
+            pfpSegs: Segments,
+        ): ExpendablesFilter.Match? = null
+
+        override suspend fun process(
+            targets: Collection<ExpendablesFilter.Match>,
+            allMatches: Collection<ExpendablesFilter.Match>,
+        ): ExpendablesFilter.ProcessResult = throw NotImplementedError()
+    }
+
+    private fun match(path: String, fileType: FileType = FileType.DIRECTORY): ExpendablesFilter.Match.Deletion =
+        ExpendablesFilter.Match.Deletion(
+            identifier = TestFilter::class,
+            lookup = LocalPathLookup(
+                lookedUp = LocalPath.build(path),
+                fileType = fileType,
+                size = 16L,
+                modifiedAt = Instant.EPOCH,
+                target = null,
+            ),
+        )
+
+    @Test
+    fun `a matched directory is deleted recursively`() = runTest {
+        val target = match("/storage/emulated/0/Android/data/com.test.pkg/cache/dir")
+        coEvery { gatewaySwitch.delete(any(), any()) } just runs
+
+        val result = TestFilter().deleteAll(setOf(target), gatewaySwitch, setOf(target))
+
+        // Not recursive = false: over SAF that refuses a populated directory, and nothing else
+        // removes the directory itself.
+        coVerify { gatewaySwitch.delete(target.path, recursive = true) }
+        result.success shouldContainExactly listOf(target)
+        result.failed.shouldBeEmpty()
+    }
+
+    @Test
+    fun `matches below a deleted directory count as deleted too`() = runTest {
+        val root = match("/storage/emulated/0/Android/data/com.test.pkg/cache/dir")
+        val child = match("/storage/emulated/0/Android/data/com.test.pkg/cache/dir/file", FileType.FILE)
+        coEvery { gatewaySwitch.delete(any(), any()) } just runs
+
+        val result = TestFilter().deleteAll(setOf(root, child), gatewaySwitch, setOf(root, child))
+
+        // Only the distinct root is deleted, the subtree goes with it.
+        coVerify(exactly = 1) { gatewaySwitch.delete(any(), any()) }
+        coVerify { gatewaySwitch.delete(root.path, recursive = true) }
+        result.success shouldContainExactlyInAnyOrder listOf(root, child)
+    }
+
+    @Test
+    fun `a failing root does not stop the other roots`() = runTest {
+        val failing = match("/storage/emulated/0/Android/data/com.test.pkg/cache/broken")
+        val other = match("/storage/emulated/0/Android/data/com.test.pkg/cache/fine")
+        val failure = WriteException(path = failing.path)
+        coEvery { gatewaySwitch.delete(failing.path, any()) } throws failure
+        coEvery { gatewaySwitch.delete(other.path, any()) } just runs
+        // The post-failure check: the directory is still there, so this really failed.
+        coEvery { gatewaySwitch.exists(failing.path) } returns true
+
+        val result = TestFilter().deleteAll(setOf(failing, other), gatewaySwitch, setOf(failing, other))
+
+        coVerify { gatewaySwitch.delete(other.path, recursive = true) }
+        result.success shouldContainExactly listOf(other)
+        result.failed.single().apply {
+            first shouldBe failing
+            second.shouldBeInstanceOf<WriteException>()
+        }
+    }
+
+    @Test
+    fun `a failed delete counts as success when the target is gone anyway`() = runTest {
+        val target = match("/storage/emulated/0/Android/data/com.test.pkg/cache/dir")
+        coEvery { gatewaySwitch.delete(any(), any()) } throws WriteException(path = target.path)
+        coEvery { gatewaySwitch.exists(target.path) } returns false
+
+        val result = TestFilter().deleteAll(setOf(target), gatewaySwitch, setOf(target))
+
+        result.success shouldContainExactly listOf(target)
+        result.failed.shouldBeEmpty()
+    }
+}


### PR DESCRIPTION
## What changed

When SD Maid cleans through Android's document picker permissions (SAF — how Android/data is accessed on Android 11+ without root), deleting a folder used to remove only the files inside and leave the whole empty folder structure behind, including the folder itself. CorpseFinder would then find the same leftover again on every scan. Folders are now actually removed:

- CorpseFinder deletes corpse folders in Android/data for real, and they stay gone on the next scan.
- AppCleaner no longer leaves empty junk folders behind after cleaning app data reached via SAF.
- SystemCleaner's empty-directory filter starts working on SAF-routed storage at all (an empty folder has no files to delete, so it previously did nothing there).
- The "don't recurse" deletion mode is honored now: deleting a folder that still has contents without asking for recursion is refused instead of silently emptying it.
- Cancelling a running deletion stops it promptly instead of letting a few more files disappear.

Verified on real hardware: a Pixel 3a (Android 12) ran the complete scenario — SAF access granted to Android/data through the system picker, a planted app leftover found by CorpseFinder and deleted from the UI, with the folder's removal confirmed on the filesystem — and both a Pixel 3a and a Pixel 7a (Android 16) confirmed the provider-level deletion behavior directly.

## Technical Context

- Stacked on #2683; merge that one first. This builds on the SAF test harness from that PR.
- Root cause: the delete loop only ever issued document deletes for non-directories; directories were enumerated and skipped. The rewrite deletes a directory with a single provider call (the provider removes the subtree, as AOSP's ExternalStorageProvider does — confirmed on-device on API 32 and 36) and falls back to a post-order walk over the provider's own child handles when a provider doesn't cascade; that fallback deliberately avoids rebuilding document ids from names, which only works for path-shaped ids.
- Deletion verification no longer trusts a query that never got an answer: a "delete returned false" is confirmed gone only through an explicitly acquired provider client, so a crashed provider can't turn a failed delete into a reported success.
- Non-recursive directory deletion is documented on the gateway contract as best-effort refusal — no SAF backend can check emptiness and delete atomically, and a deterministic race test pins the accepted behavior.
- All 21 AppCleaner filters were audited for what they can match before making directory deletion real: no filter can target an app's cache/files root or package folder (structural guards verified per filter), so nothing user-critical becomes deletable that wasn't already targeted.
- On-device verification used temporary instrumentation tooling that is deliberately not part of this PR; the repository gains only JVM tests (the flipped characterization probes from #2683 plus fallback, cancellation, verification and dry-run coverage, and an AppCleaner deleteAll regression test).
