### PR TITLE
General: Measure test coverage for the cleaning tools

### DIFF
--- a/app-tool-analyzer/build.gradle.kts
+++ b/app-tool-analyzer/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
 
 apply(plugin = "dagger.hilt.android.plugin")
 apply(plugin = "org.jetbrains.kotlin.plugin.serialization")
+apply(plugin = "org.jetbrains.kotlinx.kover")
 
 android {
     namespace = "${projectConfig.packageName}.analyzer"

--- a/app-tool-appcleaner/build.gradle.kts
+++ b/app-tool-appcleaner/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
 
 apply(plugin = "dagger.hilt.android.plugin")
 apply(plugin = "org.jetbrains.kotlin.plugin.serialization")
+apply(plugin = "org.jetbrains.kotlinx.kover")
 
 android {
     namespace = "${projectConfig.packageName}.appcleaner"

--- a/app-tool-appcontrol/build.gradle.kts
+++ b/app-tool-appcontrol/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
 
 apply(plugin = "dagger.hilt.android.plugin")
 apply(plugin = "org.jetbrains.kotlin.plugin.serialization")
+apply(plugin = "org.jetbrains.kotlinx.kover")
 
 android {
     namespace = "${projectConfig.packageName}.appcontrol"

--- a/app-tool-corpsefinder/build.gradle.kts
+++ b/app-tool-corpsefinder/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
 
 apply(plugin = "dagger.hilt.android.plugin")
 apply(plugin = "org.jetbrains.kotlin.plugin.serialization")
+apply(plugin = "org.jetbrains.kotlinx.kover")
 
 android {
     namespace = "${projectConfig.packageName}.corpsefinder"

--- a/app-tool-deduplicator/build.gradle.kts
+++ b/app-tool-deduplicator/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
 
 apply(plugin = "dagger.hilt.android.plugin")
 apply(plugin = "org.jetbrains.kotlin.plugin.serialization")
+apply(plugin = "org.jetbrains.kotlinx.kover")
 
 android {
     namespace = "${projectConfig.packageName}.deduplicator"

--- a/app-tool-scheduler/build.gradle.kts
+++ b/app-tool-scheduler/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
 
 apply(plugin = "dagger.hilt.android.plugin")
 apply(plugin = "org.jetbrains.kotlin.plugin.serialization")
+apply(plugin = "org.jetbrains.kotlinx.kover")
 
 android {
     namespace = "${projectConfig.packageName}.scheduler"

--- a/app-tool-squeezer/build.gradle.kts
+++ b/app-tool-squeezer/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
 
 apply(plugin = "dagger.hilt.android.plugin")
 apply(plugin = "org.jetbrains.kotlin.plugin.serialization")
+apply(plugin = "org.jetbrains.kotlinx.kover")
 
 android {
     namespace = "${projectConfig.packageName}.squeezer"

--- a/app-tool-swiper/build.gradle.kts
+++ b/app-tool-swiper/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
 
 apply(plugin = "dagger.hilt.android.plugin")
 apply(plugin = "org.jetbrains.kotlin.plugin.serialization")
+apply(plugin = "org.jetbrains.kotlinx.kover")
 
 android {
     namespace = "${projectConfig.packageName}.swiper"

--- a/app-tool-systemcleaner/build.gradle.kts
+++ b/app-tool-systemcleaner/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
 
 apply(plugin = "dagger.hilt.android.plugin")
 apply(plugin = "org.jetbrains.kotlin.plugin.serialization")
+apply(plugin = "org.jetbrains.kotlinx.kover")
 
 android {
     namespace = "${projectConfig.packageName}.systemcleaner"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,6 +45,15 @@ dependencies {
     "kover"(project(":app-common-io"))
     "kover"(project(":app-common-root"))
     "kover"(project(":app-common-adb"))
+    "kover"(project(":app-tool-corpsefinder"))
+    "kover"(project(":app-tool-systemcleaner"))
+    "kover"(project(":app-tool-appcleaner"))
+    "kover"(project(":app-tool-deduplicator"))
+    "kover"(project(":app-tool-squeezer"))
+    "kover"(project(":app-tool-analyzer"))
+    "kover"(project(":app-tool-swiper"))
+    "kover"(project(":app-tool-appcontrol"))
+    "kover"(project(":app-tool-scheduler"))
 }
 
 configure<KoverProjectExtension> {


### PR DESCRIPTION
## What changed

No user-facing behavior change. The merged test-coverage report now includes all nine cleaning tool modules (CorpseFinder, AppCleaner, SystemCleaner, Deduplicator, Squeezer, Analyzer, Swiper, AppControl, Scheduler), which were previously invisible to coverage reporting entirely.

## Technical Context

- The root kover aggregation covered only five app-common modules; per-tool coverage numbers did not exist, so any "overall coverage" figure silently excluded the largest feature modules.
- Each tool module gets the same one-line plugin apply the instrumented common modules already use, plus its aggregation entry at the root. Adding modules to the aggregation without applying the plugin in them fails with a variant-resolution error, which is why both halves are needed.
- Report filters (generated code, Hilt/Dagger, AIDL stubs) are configured once at the root and apply to the new modules unchanged.
- First merged figure with the tools included: 42.4% line coverage across 14 modules. Not comparable to previously reported numbers, which measured a different module set.
