### PR TITLE
General: Show more of the file path in dashboard progress

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/common/DashboardProgress.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/common/DashboardProgress.kt
@@ -79,7 +79,8 @@ internal fun DashboardProgress(progress: Progress.Data) {
                     text = secondary,
                     style = MaterialTheme.typography.bodySmall,
                     maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
+                    // Secondary is usually a path, where the tail (file name) matters more than the middle
+                    overflow = TextOverflow.MiddleEllipsis,
                 )
             }
         }


### PR DESCRIPTION
## What changed

While a cleaning tool is running, the dashboard card shows a second line with the file or folder currently being processed. That line was cut off at the end, which hid the file name, the part that actually tells you where the tool is. It now shortens in the middle instead, so both the storage location and the file name stay readable.

## Technical Context

- Only the secondary progress line changed. The primary line keeps end-ellipsis because it's a description ("Looking for orphaned data…"), not a path.
- The result lines shown when no scan is running ("Found 12 corpses (2.4 GB)", "Last scan completed 5 minutes ago") also keep end-ellipsis, for the same reason.
