### PR TITLE
Media Squeeze: Show live progress and results while compressing

### DIFF
--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/progress/ProgressOverlay.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/progress/ProgressOverlay.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
@@ -27,6 +28,8 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -37,6 +40,7 @@ import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.compose.preview.Preview2
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import eu.darken.sdmse.common.progress.Progress
+import eu.darken.sdmse.common.progress.determinateFraction
 
 private const val ENTRANCE_DURATION_MS = 180
 
@@ -45,6 +49,20 @@ private val RING_MIN = 240.dp
 private val RING_MAX = 300.dp
 private const val RING_STROKE_FACTOR = 0.032f // stroke width as a fraction of the ring diameter (~9.6dp @ 300dp)
 private const val RING_INNER_WIDTH_FACTOR = 0.64f // text column max width as a fraction of the ring diameter
+
+// Nested sub-progress ring: the current item's own progress, drawn inside the item ring.
+// At the 300dp maximum that's a 258dp diameter with a ~6.2dp stroke, so its inside edge (~245dp)
+// clears the 192dp text column.
+private const val RING_SUB_SIZE_FACTOR = 0.86f
+private const val RING_SUB_STROKE_FACTOR = 0.024f
+
+// Used when the theme's hero line height isn't expressed in sp (Density.toDp() throws for
+// TextUnit.Unspecified and for em values).
+private val HERO_HEIGHT_FALLBACK = 52.dp
+
+/** Which count supplies the hero number: sub-progress when it is determinate, else the overall count. */
+internal fun heroCount(count: Progress.Count, subCount: Progress.Count?): Progress.Count =
+    if (subCount.determinateFraction() != null) subCount!! else count
 
 /**
  * When [data] is non-null:
@@ -101,17 +119,13 @@ private fun ProgressOverlayPanel(
     val secondary = data.secondary.get(context)
 
     val count = data.count
+    val subCount = data.subCount
     val showRing = count !is Progress.Count.None
     // Only Counter/Percent with a known total drive a determinate arc + an inner number.
     // Indeterminate / Size / unknown-total fall back to a spinning ring with no number (legacy behavior).
-    val fraction: Float? = when (count) {
-        is Progress.Count.Counter,
-        is Progress.Count.Percent,
-        -> if (count.max > 0L) (count.current.toFloat() / count.max.toFloat()).coerceIn(0f, 1f) else null
-
-        else -> null
-    }
-    val countText = if (fraction != null) count.displayValue(context) else null
+    val fraction: Float? = count.determinateFraction()
+    val hero = heroCount(count, subCount)
+    val countText = if (hero.determinateFraction() != null) hero.displayValue(context) else null
 
     Box(
         modifier = modifier
@@ -128,6 +142,17 @@ private fun ProgressOverlayPanel(
             if (showRing) {
                 ProgressRing(size = ringSize, progress = fraction)
             }
+            if (subCount != null && subCount !is Progress.Count.None) {
+                // A second CircularProgressIndicator publishes a second progress semantics node,
+                // so TalkBack would announce two indistinguishable progress bars. The outer ring
+                // stays the announced one.
+                ProgressRing(
+                    size = ringSize * RING_SUB_SIZE_FACTOR,
+                    progress = subCount.determinateFraction(),
+                    strokeFactor = RING_SUB_STROKE_FACTOR,
+                    modifier = Modifier.clearAndSetSemantics {},
+                )
+            }
 
             Column(
                 modifier = Modifier.widthIn(max = ringSize * RING_INNER_WIDTH_FACTOR),
@@ -135,19 +160,32 @@ private fun ProgressOverlayPanel(
                 verticalArrangement = Arrangement.Center,
             ) {
                 if (!countText.isNullOrEmpty()) {
-                    Text(
-                        text = countText,
-                        // Percent is short → make it the dramatic focal point. Counters ("147/2000") can be
-                        // long, so they get a smaller hero style that still fits within the inner circle.
-                        style = if (count is Progress.Count.Percent) {
-                            MaterialTheme.typography.displayMedium
-                        } else {
-                            MaterialTheme.typography.headlineMedium
-                        },
-                        fontWeight = FontWeight.Bold,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
+                    // Reserve the taller of the two hero styles. The style keys off the hero count,
+                    // which flips (e.g. Indeterminate → Percent) mid-run the moment per-item progress
+                    // becomes available — and because this column is vertically centered, a height
+                    // change re-centers it and visibly jumps.
+                    val heroLineHeight = MaterialTheme.typography.displayMedium.lineHeight
+                    val heroHeight = with(LocalDensity.current) {
+                        if (heroLineHeight.isSp) heroLineHeight.toDp() else HERO_HEIGHT_FALLBACK
+                    }
+                    Box(
+                        modifier = Modifier.height(heroHeight),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Text(
+                            text = countText,
+                            // Percent is short → make it the dramatic focal point. Counters ("147/2000") can be
+                            // long, so they get a smaller hero style that still fits within the inner circle.
+                            style = if (hero is Progress.Count.Percent) {
+                                MaterialTheme.typography.displayMedium
+                            } else {
+                                MaterialTheme.typography.headlineMedium
+                            },
+                            fontWeight = FontWeight.Bold,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
                 }
                 // Reserve fixed line counts (minLines == maxLines) and render both slots unconditionally so
                 // the inner block stays a constant height. Otherwise a secondary path going 1↔2 lines — or a
@@ -183,8 +221,9 @@ private fun ProgressRing(
     size: Dp,
     progress: Float?,
     modifier: Modifier = Modifier,
+    strokeFactor: Float = RING_STROKE_FACTOR,
 ) {
-    val stroke = (size.value * RING_STROKE_FACTOR).dp
+    val stroke = (size.value * strokeFactor).dp
     if (progress != null) {
         // Sweep the arc smoothly instead of snapping when the fraction jumps.
         val animated by animateFloatAsState(

--- a/app-common-ui/src/test/java/eu/darken/sdmse/common/compose/progress/ProgressOverlayLogicTest.kt
+++ b/app-common-ui/src/test/java/eu/darken/sdmse/common/compose/progress/ProgressOverlayLogicTest.kt
@@ -1,0 +1,46 @@
+package eu.darken.sdmse.common.compose.progress
+
+import eu.darken.sdmse.common.progress.Progress
+import eu.darken.sdmse.common.progress.determinateFraction
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class ProgressOverlayLogicTest : BaseTest() {
+
+    @Test
+    fun `a determinate sub count owns the hero number`() {
+        // Video transcode: the item counter barely moves, the per-file percentage is what the
+        // user watches.
+        heroCount(
+            count = Progress.Count.Counter(1, 2),
+            subCount = Progress.Count.Percent(42, 100),
+        ) shouldBe Progress.Count.Percent(42, 100)
+    }
+
+    @Test
+    fun `no sub count leaves the hero number on the overall count`() {
+        val count = Progress.Count.Counter(1, 2)
+        heroCount(count = count, subCount = null) shouldBe count
+    }
+
+    @Test
+    fun `an indeterminate sub count leaves the hero number on the overall count`() {
+        // Images, and videos before Media3's first available progress poll.
+        val count = Progress.Count.Counter(1, 2)
+        heroCount(count = count, subCount = Progress.Count.Indeterminate()) shouldBe count
+    }
+
+    @Test
+    fun `a sub count without a total leaves the hero number on the overall count`() {
+        val count = Progress.Count.Counter(1, 2)
+        heroCount(count = count, subCount = Progress.Count.Percent(0, 0)) shouldBe count
+    }
+
+    @Test
+    fun `an indeterminate sub count spins the inner ring`() {
+        // What makes the inner ring spin instead of showing a frozen arc.
+        Progress.Count.Indeterminate().determinateFraction() shouldBe null
+        Progress.Count.Percent(42, 100).determinateFraction() shouldBe 0.42f
+    }
+}

--- a/app-common/src/main/java/eu/darken/sdmse/common/progress/Progress.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/progress/Progress.kt
@@ -14,6 +14,8 @@ interface Progress {
         val primary: CaString = eu.darken.sdmse.common.R.string.general_progress_loading.toCaString(),
         val secondary: CaString = easterEggProgressMsg.toCaString(),
         val count: Count = Count.Indeterminate(),
+        /** Progress *within* the item [count] is currently on. Null when the producer has no per-item concept. */
+        val subCount: Count? = null,
         val extra: Any? = null
     )
 

--- a/app-common/src/main/java/eu/darken/sdmse/common/progress/ProgressExtensions.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/progress/ProgressExtensions.kt
@@ -53,6 +53,19 @@ fun <T : Progress.Client> T.updateProgressCount(count: Progress.Count) {
     updateProgress { (it ?: Progress.Data()).copy(count = count) }
 }
 
+fun <T : Progress.Client> T.updateProgressSubCount(subCount: Progress.Count?) {
+    updateProgress { (it ?: Progress.Data()).copy(subCount = subCount) }
+}
+
+/** Fraction for a determinate ring, or null when the ring should spin. */
+fun Progress.Count?.determinateFraction(): Float? = when (this) {
+    is Progress.Count.Counter,
+    is Progress.Count.Percent,
+    -> if (max > 0L) (current.toFloat() / max.toFloat()).coerceIn(0f, 1f) else null
+
+    else -> null
+}
+
 fun <T : Progress.Client> T.increaseProgress(value: Int = 1) {
     updateProgress {
         when (it?.count) {

--- a/app-common/src/test/java/eu/darken/sdmse/common/progress/ProgressCountTest.kt
+++ b/app-common/src/test/java/eu/darken/sdmse/common/progress/ProgressCountTest.kt
@@ -35,4 +35,32 @@ class ProgressCountTest : BaseTest() {
         Progress.Count.Indeterminate().displayValue(context) shouldBe ""
         Progress.Count.None().displayValue(context) shouldBe null
     }
+
+    @Test
+    fun `counter and percent drive a determinate ring`() {
+        Progress.Count.Counter(1, 4).determinateFraction() shouldBe 0.25f
+        Progress.Count.Percent(50, 100).determinateFraction() shouldBe 0.5f
+    }
+
+    @Test
+    fun `determinate fraction clamps to the ring range`() {
+        Progress.Count.Counter(9, 4).determinateFraction() shouldBe 1f
+        Progress.Count.Counter(-1, 4).determinateFraction() shouldBe 0f
+    }
+
+    @Test
+    fun `an unknown total makes the ring spin`() {
+        // Percent(0) / Counter(0) is what a producer publishes before it knows the item count.
+        Progress.Count.Counter(0, 0).determinateFraction() shouldBe null
+        Progress.Count.Percent(0, 0).determinateFraction() shouldBe null
+    }
+
+    @Test
+    fun `size, indeterminate, none and null make the ring spin`() {
+        // Size is deliberately excluded: the overlay has never rendered a determinate arc for it.
+        Progress.Count.Size(1, 2).determinateFraction() shouldBe null
+        Progress.Count.Indeterminate().determinateFraction() shouldBe null
+        Progress.Count.None().determinateFraction() shouldBe null
+        (null as Progress.Count?).determinateFraction() shouldBe null
+    }
 }

--- a/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/Squeezer.kt
+++ b/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/Squeezer.kt
@@ -176,6 +176,18 @@ class Squeezer @Inject constructor(
         val imageResult = if (imageTargets.isNotEmpty()) {
             imageProcessor.get().withProgress(
                 client = this,
+                // A processor's replayed initial state still carries Progress.Data's default
+                // Indeterminate count, which would make the outer ring spin until the pre-loop
+                // Counter gets past throttleLatest(). Neither processor publishes an indeterminate
+                // count intentionally (they publish Counter pre-loop and per item, Indeterminate
+                // only ever as a subCount), so this only ever rewrites that initial state.
+                onUpdate = { _, new ->
+                    if (new != null && new.count is Progress.Count.Indeterminate && new.subCount == null) {
+                        new.copy(count = Progress.Count.Counter(0, totalItems))
+                    } else {
+                        new
+                    }
+                },
                 // withProgress' default onCompletion is Progress.Data(), whose primary is
                 // "Loading" - that's what flashes at every phase boundary. Publishing the phase's
                 // completed count instead also makes the terminal count deterministic, which
@@ -191,6 +203,14 @@ class Squeezer @Inject constructor(
         val videoResult = if (videoTargets.isNotEmpty()) {
             videoProcessor.get().withProgress(
                 client = this,
+                // Same replayed-initial-state rewrite as the image phase above.
+                onUpdate = { _, new ->
+                    if (new != null && new.count is Progress.Count.Indeterminate && new.subCount == null) {
+                        new.copy(count = Progress.Count.Counter(imageTargets.size, totalItems))
+                    } else {
+                        new
+                    }
+                },
                 onCompletion = { itemsCompleted(it, totalItems, totalItems) },
             ) {
                 process(videoTargets, quality, itemOffset = imageTargets.size, itemTotal = totalItems)

--- a/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/Squeezer.kt
+++ b/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/Squeezer.kt
@@ -5,6 +5,7 @@ import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
+import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.*
@@ -78,7 +79,9 @@ class Squeezer @Inject constructor(
     override suspend fun submit(task: SDMTool.Task): SDMTool.Task.Result = toolLock.withLock {
         task as SqueezerTask
         log(TAG, INFO) { "submit($task) starting..." }
-        updateProgress { Progress.Data() }
+        updateProgress {
+            Progress.Data(primary = eu.darken.sdmse.common.R.string.general_progress_preparing.toCaString())
+        }
 
         try {
             val result = keepResourceHoldersAlive(gatewaySwitch) {
@@ -166,14 +169,32 @@ class Squeezer @Inject constructor(
         val imageTargets = targets.filterIsInstance<CompressibleImage>().toSet()
         val videoTargets = targets.filterIsInstance<CompressibleVideo>().toSet()
 
+        // Both processors count their own batch, so without a shared offset/total a 1 image + 1
+        // video run reads "0/1 -> 1/1" twice and never "2 of 2".
+        val totalItems = imageTargets.size + videoTargets.size
+
         val imageResult = if (imageTargets.isNotEmpty()) {
-            imageProcessor.get().withProgress(this) { process(imageTargets, quality) }
+            imageProcessor.get().withProgress(
+                client = this,
+                // withProgress' default onCompletion is Progress.Data(), whose primary is
+                // "Loading" - that's what flashes at every phase boundary. Publishing the phase's
+                // completed count instead also makes the terminal count deterministic, which
+                // throttleLatest() alone can't guarantee.
+                onCompletion = { itemsCompleted(it, imageTargets.size, totalItems) },
+            ) {
+                process(imageTargets, quality, itemOffset = 0, itemTotal = totalItems)
+            }
         } else {
             ImageProcessor.Result(success = emptySet(), failed = emptyMap(), savedSpace = 0L)
         }
 
         val videoResult = if (videoTargets.isNotEmpty()) {
-            videoProcessor.get().withProgress(this) { process(videoTargets, quality) }
+            videoProcessor.get().withProgress(
+                client = this,
+                onCompletion = { itemsCompleted(it, totalItems, totalItems) },
+            ) {
+                process(videoTargets, quality, itemOffset = imageTargets.size, itemTotal = totalItems)
+            }
         } else {
             VideoProcessor.Result(success = emptySet(), failed = emptyMap(), savedSpace = 0L)
         }
@@ -187,7 +208,7 @@ class Squeezer @Inject constructor(
             .groupingBy { it }
             .eachCount()
 
-        updateProgress { Progress.Data() }
+        updateProgress { itemsCompleted(it, totalItems, totalItems) }
 
         // Consume both compressed items and HDR/depth-preserved (guard-skipped) ones from the list,
         // but only compressed items count toward processedCount / affectedPaths below.
@@ -203,6 +224,16 @@ class Squeezer @Inject constructor(
             guardSkippedCount = imageResult.skippedGuarded.size,
         )
     }
+
+    /**
+     * Keeps the current message but reports [completed] of [total] items done, with no per-item
+     * progress. Returning null here would blank the overlay mid-run.
+     */
+    private fun itemsCompleted(current: Progress.Data?, completed: Int, total: Int): Progress.Data =
+        (current ?: Progress.Data()).copy(
+            count = Progress.Count.Counter(completed, total),
+            subCount = null,
+        )
 
     suspend fun exclude(
         identifiers: Collection<CompressibleMedia.Id>

--- a/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/processor/ImageProcessor.kt
+++ b/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/processor/ImageProcessor.kt
@@ -41,7 +41,12 @@ class ImageProcessor @Inject constructor(
     private val settings: SqueezerSettings,
 ) : Progress.Host, Progress.Client {
 
-    private val progressPub = MutableStateFlow<Progress.Data?>(Progress.Data())
+    // Progress.Data()'s default primary is "Loading". withProgress() starts forwarding before it
+    // calls action() and a StateFlow replays its current value to a new collector, so a bare
+    // default would flash "Loading" before the pre-loop publish below lands.
+    private val progressPub = MutableStateFlow<Progress.Data?>(
+        Progress.Data(primary = eu.darken.sdmse.common.R.string.general_progress_preparing.toCaString())
+    )
     override val progress: Flow<Progress.Data?> = progressPub.throttleLatest(250)
 
     override fun updateProgress(update: (Progress.Data?) -> Progress.Data?) {
@@ -75,7 +80,9 @@ class ImageProcessor @Inject constructor(
             (it ?: Progress.Data()).copy(
                 primary = eu.darken.sdmse.common.R.string.general_progress_preparing.toCaString(),
                 secondary = CaString.EMPTY,
-                count = Progress.Count.Indeterminate(),
+                // Keeps the item counter the caller already published for the previous phase,
+                // otherwise the outer ring drops from "1 of 2" to spinning and then jumps back.
+                count = Progress.Count.Counter(itemOffset, itemTotal),
                 subCount = null,
             )
         }

--- a/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/processor/ImageProcessor.kt
+++ b/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/processor/ImageProcessor.kt
@@ -3,6 +3,8 @@ package eu.darken.sdmse.squeezer.core.processor
 import android.content.Context
 import android.media.MediaScannerConnection
 import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.sdmse.common.ca.CaString
+import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.Bugs
@@ -13,9 +15,6 @@ import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.local.LocalPath
 import eu.darken.sdmse.common.flow.throttleLatest
 import eu.darken.sdmse.common.progress.Progress
-import eu.darken.sdmse.common.progress.updateProgressCount
-import eu.darken.sdmse.common.progress.updateProgressPrimary
-import eu.darken.sdmse.common.progress.updateProgressSecondary
 import eu.darken.sdmse.squeezer.core.CompressibleImage
 import eu.darken.sdmse.squeezer.core.SqueezerEligibility
 import eu.darken.sdmse.squeezer.core.SqueezerSettings
@@ -60,15 +59,26 @@ class ImageProcessor @Inject constructor(
         val skippedGuarded: Set<CompressibleImage> = emptySet(),
     )
 
+    /**
+     * [itemOffset] / [itemTotal] carry the position of this batch inside a run that also processes
+     * videos, so the published counter is "file 2 of 10" across both passes instead of restarting.
+     */
     suspend fun process(
         targets: Set<CompressibleImage>,
         quality: Int,
+        itemOffset: Int = 0,
+        itemTotal: Int = targets.size,
     ): Result = withContext(dispatcherProvider.IO) {
-        log(TAG) { "process(${targets.size} images, quality=$quality)" }
+        log(TAG) { "process(${targets.size} images, quality=$quality, offset=$itemOffset, total=$itemTotal)" }
 
-        updateProgressPrimary(eu.darken.sdmse.common.R.string.general_progress_loading)
-        updateProgressSecondary()
-        updateProgressCount(Progress.Count.Indeterminate())
+        updateProgress {
+            (it ?: Progress.Data()).copy(
+                primary = eu.darken.sdmse.common.R.string.general_progress_preparing.toCaString(),
+                secondary = CaString.EMPTY,
+                count = Progress.Count.Indeterminate(),
+                subCount = null,
+            )
+        }
 
         log(TAG, INFO) { "Processing ${targets.size} images" }
 
@@ -78,8 +88,19 @@ class ImageProcessor @Inject constructor(
         var totalSaved = 0L
 
         targets.forEachIndexed { index, image ->
-            updateProgressCount(Progress.Count.Percent(index, targets.size))
-            updateProgressSecondary(image.lookup.userReadablePath)
+            // One publish, not four: progress is exposed through throttleLatest(250), which
+            // conflates. Separate mutations let a fast item show up with the new file name next to
+            // the previous path and counter for up to a throttle window. There is no per-image
+            // progress to report, so the sub-count just spins for the duration of the item.
+            updateProgress {
+                (it ?: Progress.Data()).copy(
+                    primary = eu.darken.sdmse.common.R.string.general_progress_processing_x
+                        .toCaString(image.path.name),
+                    secondary = image.lookup.userReadablePath,
+                    count = Progress.Count.Counter(itemOffset + index, itemTotal),
+                    subCount = Progress.Count.Indeterminate(),
+                )
+            }
 
             // Authoritative HDR/depth guard. The scan already excludes these when the opt-in is off,
             // but re-check against the CURRENT setting here so a photo can't be flattened if the user
@@ -92,6 +113,13 @@ class ImageProcessor @Inject constructor(
             ) {
                 log(TAG, INFO) { "Skipped ${image.path} (HDR/depth preserved)" }
                 skippedGuarded.add(image)
+                // Skipped photos advance the counter too, otherwise the ring stalls across them.
+                updateProgress {
+                    (it ?: Progress.Data()).copy(
+                        count = Progress.Count.Counter(itemOffset + index + 1, itemTotal),
+                        subCount = Progress.Count.Indeterminate(),
+                    )
+                }
                 return@forEachIndexed
             }
 
@@ -128,6 +156,15 @@ class ImageProcessor @Inject constructor(
             } catch (e: Exception) {
                 log(TAG, ERROR) { "Failed to compress ${image.path}: ${e.asLog()}" }
                 failed[image] = e
+            }
+
+            // Every exit path (compressed, skipped, failed) advances the item counter here, so the
+            // ring doesn't stall through FileTransaction's rename/verify and the history write.
+            updateProgress {
+                (it ?: Progress.Data()).copy(
+                    count = Progress.Count.Counter(itemOffset + index + 1, itemTotal),
+                    subCount = Progress.Count.Indeterminate(),
+                )
             }
         }
 

--- a/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/processor/VideoProcessor.kt
+++ b/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/processor/VideoProcessor.kt
@@ -3,7 +3,8 @@ package eu.darken.sdmse.squeezer.core.processor
 import android.content.Context
 import android.media.MediaScannerConnection
 import dagger.hilt.android.qualifiers.ApplicationContext
-import eu.darken.sdmse.common.ca.caString
+import eu.darken.sdmse.common.ca.CaString
+import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.*
@@ -13,9 +14,7 @@ import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.local.LocalPath
 import eu.darken.sdmse.common.flow.throttleLatest
 import eu.darken.sdmse.common.progress.Progress
-import eu.darken.sdmse.common.progress.updateProgressCount
-import eu.darken.sdmse.common.progress.updateProgressPrimary
-import eu.darken.sdmse.common.progress.updateProgressSecondary
+import eu.darken.sdmse.common.progress.updateProgressSubCount
 import eu.darken.sdmse.squeezer.core.CompressibleVideo
 import eu.darken.sdmse.squeezer.core.InsufficientStorageException
 import eu.darken.sdmse.squeezer.core.SqueezerEligibility
@@ -51,26 +50,49 @@ class VideoProcessor @Inject constructor(
         val savedSpace: Long,
     )
 
+    /**
+     * [itemOffset] / [itemTotal] carry the position of this batch inside a run that also processes
+     * images, so the published counter is "file 2 of 10" across both passes instead of restarting.
+     */
     suspend fun process(
         targets: Set<CompressibleVideo>,
         quality: Int,
+        itemOffset: Int = 0,
+        itemTotal: Int = targets.size,
     ): Result = withContext(dispatcherProvider.IO) {
-        log(TAG) { "process(${targets.size} videos, quality=$quality)" }
+        log(TAG) { "process(${targets.size} videos, quality=$quality, offset=$itemOffset, total=$itemTotal)" }
 
-        updateProgressPrimary(eu.darken.sdmse.common.R.string.general_progress_loading)
-        updateProgressSecondary()
-        updateProgressCount(Progress.Count.Indeterminate())
+        updateProgress {
+            (it ?: Progress.Data()).copy(
+                primary = eu.darken.sdmse.common.R.string.general_progress_preparing.toCaString(),
+                secondary = CaString.EMPTY,
+                count = Progress.Count.Indeterminate(),
+                subCount = null,
+            )
+        }
 
         val successful = mutableSetOf<CompressibleVideo>()
         val failed = mutableMapOf<CompressibleVideo, Throwable>()
         var totalSaved = 0L
 
         targets.forEachIndexed { index, video ->
-            updateProgressCount(Progress.Count.Percent(index, targets.size))
-            updateProgressSecondary(video.lookup.userReadablePath)
+            // One publish, not four: progress is exposed through throttleLatest(250), which
+            // conflates. Separate mutations let a fast item show up with the new file name next to
+            // the previous path and counter for up to a throttle window.
+            updateProgress {
+                (it ?: Progress.Data()).copy(
+                    primary = eu.darken.sdmse.common.R.string.general_progress_processing_x
+                        .toCaString(video.path.name),
+                    secondary = video.lookup.userReadablePath,
+                    count = Progress.Count.Counter(itemOffset + index, itemTotal),
+                    subCount = Progress.Count.Indeterminate(),
+                )
+            }
 
             try {
-                val outcome = processVideo(video, quality)
+                val outcome = processVideo(video, quality) { pct ->
+                    updateProgressSubCount(Progress.Count.Percent(pct, 100))
+                }
                 successful.add(video)
 
                 if (outcome.replaced) {
@@ -103,6 +125,15 @@ class VideoProcessor @Inject constructor(
                 log(TAG, ERROR) { "Failed to compress ${video.path}: ${e.asLog()}" }
                 failed[video] = e
             }
+
+            // Every exit path (compressed, skipped, failed) advances the item counter here, so the
+            // ring doesn't stall through FileTransaction's rename/verify and the history write.
+            updateProgress {
+                (it ?: Progress.Data()).copy(
+                    count = Progress.Count.Counter(itemOffset + index + 1, itemTotal),
+                    subCount = Progress.Count.Indeterminate(),
+                )
+            }
         }
 
         log(TAG, INFO) {
@@ -119,6 +150,7 @@ class VideoProcessor @Inject constructor(
     private suspend fun processVideo(
         video: CompressibleVideo,
         quality: Int,
+        onTranscodeProgress: (Int) -> Unit,
     ): FileTransaction.Outcome {
         val originalSize = video.size
 
@@ -163,11 +195,8 @@ class VideoProcessor @Inject constructor(
                 inputFile = originalFile,
                 outputFile = tempFile,
                 targetBitrateBps = targetBitrate,
-                progressListener = { pct ->
-                    updateProgressSecondary(
-                        caString { "${video.lookup.userReadablePath.get(this)} ($pct%)" }
-                    )
-                },
+                // The transcoder reports -1 while Media3 has no progress to give yet.
+                progressListener = { pct -> if (pct >= 0) onTranscodeProgress(pct) },
             )
         }
 

--- a/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/processor/VideoProcessor.kt
+++ b/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/processor/VideoProcessor.kt
@@ -37,7 +37,12 @@ class VideoProcessor @Inject constructor(
     private val fileTransaction: FileTransaction,
 ) : Progress.Host, Progress.Client {
 
-    private val progressPub = MutableStateFlow<Progress.Data?>(Progress.Data())
+    // Progress.Data()'s default primary is "Loading". withProgress() starts forwarding before it
+    // calls action() and a StateFlow replays its current value to a new collector, so a bare
+    // default would flash "Loading" before the pre-loop publish below lands.
+    private val progressPub = MutableStateFlow<Progress.Data?>(
+        Progress.Data(primary = eu.darken.sdmse.common.R.string.general_progress_preparing.toCaString())
+    )
     override val progress: Flow<Progress.Data?> = progressPub.throttleLatest(250)
 
     override fun updateProgress(update: (Progress.Data?) -> Progress.Data?) {
@@ -66,7 +71,9 @@ class VideoProcessor @Inject constructor(
             (it ?: Progress.Data()).copy(
                 primary = eu.darken.sdmse.common.R.string.general_progress_preparing.toCaString(),
                 secondary = CaString.EMPTY,
-                count = Progress.Count.Indeterminate(),
+                // Keeps the item counter the caller already published for the previous phase,
+                // otherwise the outer ring drops from "1 of 2" to spinning and then jumps back.
+                count = Progress.Count.Counter(itemOffset, itemTotal),
                 subCount = null,
             )
         }

--- a/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/ui/setup/SqueezerSetupScreen.kt
+++ b/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/ui/setup/SqueezerSetupScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.ArrowBack
 import androidx.compose.material.icons.automirrored.twotone.InsertDriveFile
+import androidx.compose.material.icons.twotone.Compress
 import androidx.compose.material.icons.twotone.Edit
 import androidx.compose.material.icons.twotone.Info
 import androidx.compose.material.icons.twotone.FolderOpen
@@ -56,6 +57,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import eu.darken.sdmse.common.BuildConfigWrap
 import eu.darken.sdmse.common.R as CommonR
+import eu.darken.sdmse.common.compose.asComposable
 import eu.darken.sdmse.common.compose.layout.SdmTooltipIconButton
 import eu.darken.sdmse.common.compose.preview.Preview2
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
@@ -67,6 +69,7 @@ import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.navigation.NavigationEventHandler
 import eu.darken.sdmse.squeezer.R
 import eu.darken.sdmse.squeezer.core.SqueezerSettings
+import eu.darken.sdmse.squeezer.core.tasks.SqueezerProcessTask
 import eu.darken.sdmse.squeezer.ui.comparison.SqueezerComparisonDialog
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -167,6 +170,14 @@ internal fun SqueezerSetupScreen(
 ) {
     val state by stateSource.collectAsStateWithLifecycle()
     var showAgeDialog by remember { mutableStateOf(false) }
+    // Hoisted (and not just inlined below) so a fresh process result can scroll itself into view:
+    // rememberScrollState is rememberSaveable, and a popped-and-restored entry comes back at its
+    // old offset, which can be far below the result card.
+    val scrollState = rememberScrollState()
+
+    LaunchedEffect(state.processResult) {
+        if (state.processResult != null) scrollState.animateScrollTo(0)
+    }
 
     SdmScaffold(
         topBar = {
@@ -195,9 +206,13 @@ internal fun SqueezerSetupScreen(
                 Column(
                     modifier = Modifier
                         .fillMaxSize()
-                        .verticalScroll(rememberScrollState())
+                        .verticalScroll(scrollState)
                         .padding(16.dp),
                 ) {
+                    state.processResult?.let { result ->
+                        ProcessResultCard(result = result)
+                        Spacer(Modifier.height(16.dp))
+                    }
                     ExplanationCard()
                     Spacer(Modifier.height(16.dp))
                     PathsCard(
@@ -251,6 +266,42 @@ internal fun SqueezerSetupScreen(
             },
             onDismiss = { showAgeDialog = false },
         )
+    }
+}
+
+@Composable
+private fun ProcessResultCard(result: SqueezerProcessTask.Result) {
+    val secondary = result.secondaryInfo.asComposable()
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer),
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = Icons.TwoTone.Compress,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+            Spacer(Modifier.width(16.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = result.primaryInfo.asComposable(),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                )
+                if (secondary.isNotBlank()) {
+                    Spacer(Modifier.height(4.dp))
+                    Text(
+                        text = secondary,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSecondaryContainer,
+                    )
+                }
+            }
+        }
     }
 }
 
@@ -486,6 +537,24 @@ private fun SqueezerSetupScreenEmptyPreview() {
     PreviewWrapper {
         SqueezerSetupScreen(
             stateSource = MutableStateFlow(SqueezerSetupViewModel.State()),
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun SqueezerSetupScreenResultPreview() {
+    PreviewWrapper {
+        SqueezerSetupScreen(
+            stateSource = MutableStateFlow(
+                SqueezerSetupViewModel.State(
+                    processResult = SqueezerProcessTask.Success(
+                        affectedSpace = 34 * 1024 * 1024L,
+                        affectedPaths = emptySet(),
+                        processedCount = 2,
+                    ),
+                ),
+            ),
         )
     }
 }

--- a/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/ui/setup/SqueezerSetupScreen.kt
+++ b/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/ui/setup/SqueezerSetupScreen.kt
@@ -271,7 +271,7 @@ internal fun SqueezerSetupScreen(
 
 @Composable
 private fun ProcessResultCard(result: SqueezerProcessTask.Result) {
-    val secondary = result.secondaryInfo.asComposable()
+    val secondary = result.secondaryInfo?.asComposable()
     Card(
         modifier = Modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer),
@@ -292,7 +292,7 @@ private fun ProcessResultCard(result: SqueezerProcessTask.Result) {
                     style = MaterialTheme.typography.titleMedium,
                     color = MaterialTheme.colorScheme.onSecondaryContainer,
                 )
-                if (secondary.isNotBlank()) {
+                if (!secondary.isNullOrBlank()) {
                     Spacer(Modifier.height(4.dp))
                     Text(
                         text = secondary,

--- a/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/ui/setup/SqueezerSetupViewModel.kt
+++ b/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/ui/setup/SqueezerSetupViewModel.kt
@@ -36,6 +36,7 @@ import eu.darken.sdmse.squeezer.core.tasks.SqueezerProcessTask
 import eu.darken.sdmse.squeezer.core.tasks.SqueezerScanTask
 import eu.darken.sdmse.squeezer.ui.SqueezerListRoute
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
@@ -96,6 +97,11 @@ class SqueezerSetupViewModel @Inject constructor(
             canStartScan = scanPaths.paths.isNotEmpty(),
         )
     }.safeStateIn(
+        // The setup entry stays in the back stack while the list screen runs a compression on top
+        // of it. With the default `WhileSubscribed(5000)` this ViewModel would stop collecting
+        // while it is covered and, on back navigation, resume from its stale pre-navigation value
+        // (progress == null) — flashing the configuration before the progress overlay returns.
+        started = SharingStarted.Eagerly,
         initialValue = State(),
         onError = { State() },
     )

--- a/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/ui/setup/SqueezerSetupViewModel.kt
+++ b/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/ui/setup/SqueezerSetupViewModel.kt
@@ -32,6 +32,7 @@ import eu.darken.sdmse.squeezer.core.SqueezerEligibility
 import eu.darken.sdmse.squeezer.core.SqueezerPathNormalizer
 import eu.darken.sdmse.squeezer.core.SqueezerSettings
 import eu.darken.sdmse.squeezer.core.hasData
+import eu.darken.sdmse.squeezer.core.tasks.SqueezerProcessTask
 import eu.darken.sdmse.squeezer.core.tasks.SqueezerScanTask
 import eu.darken.sdmse.squeezer.ui.SqueezerListRoute
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -74,9 +75,9 @@ class SqueezerSetupViewModel @Inject constructor(
         settings.scanPaths.flow,
         settings.compressionQuality.flow,
         settings.minAge.flow,
-        squeezer.progress,
+        squeezer.state,
         isLoadingExample,
-    ) { scanPaths, quality, minAge, progress, loadingExample ->
+    ) { scanPaths, quality, minAge, squeezerState, loadingExample ->
         val jpegRatio = compressionEstimator.estimateOutputRatio(CompressibleImage.MIME_TYPE_JPEG, quality)
         val estimatedSavings = jpegRatio?.let { ((1.0 - it) * 100).toInt() }
 
@@ -85,7 +86,12 @@ class SqueezerSetupViewModel @Inject constructor(
             quality = quality,
             minAge = minAge,
             estimatedSavingsPercent = estimatedSavings,
-            progress = progress,
+            progress = squeezerState.progress,
+            // Process results only: `performProcess` prunes the data before `submit()` stores its
+            // result, so there is a window where `lastResult` is still the preceding scan success.
+            // Unfiltered, the card would flash "x items found" before "x items compressed" and
+            // would keep showing scan summaries where a compression receipt belongs.
+            processResult = squeezerState.lastResult as? SqueezerProcessTask.Result,
             isLoadingExample = loadingExample,
             canStartScan = scanPaths.paths.isNotEmpty(),
         )
@@ -100,6 +106,7 @@ class SqueezerSetupViewModel @Inject constructor(
         val minAge: Duration = SqueezerSettings.MIN_AGE_DEFAULT,
         val estimatedSavingsPercent: Int? = null,
         val progress: Progress.Data? = null,
+        val processResult: SqueezerProcessTask.Result? = null,
         val isLoadingExample: Boolean = false,
         val canStartScan: Boolean = false,
     )

--- a/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/core/SqueezerTest.kt
+++ b/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/core/SqueezerTest.kt
@@ -5,6 +5,7 @@ import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.core.local.File
 import eu.darken.sdmse.common.files.local.LocalPath
 import eu.darken.sdmse.common.files.local.LocalPathLookup
+import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.common.sharedresource.SharedResource
 import eu.darken.sdmse.exclusion.core.ExclusionManager
 import eu.darken.sdmse.exclusion.core.types.Exclusion
@@ -26,9 +27,12 @@ import io.mockk.slot
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
@@ -296,6 +300,16 @@ class SqueezerTest : BaseTest() {
         return Setup(squeezer, scanner, imageProcessor, videoProcessor, exclusionManager, settings)
     }
 
+    /**
+     * The published progress, read synchronously - [Squeezer.progress] is conflated, so collecting
+     * it drops exactly the intermediate states these tests are about.
+     */
+    private fun Squeezer.currentProgress(): Progress.Data? {
+        var snapshot: Progress.Data? = null
+        updateProgress { snapshot = it; it }
+        return snapshot
+    }
+
     private suspend fun Squeezer.dataFromState(): Squeezer.Data? = state.map { it.data }.first()
     private suspend fun Squeezer.lastResultFromState(): eu.darken.sdmse.squeezer.core.tasks.SqueezerTask.Result? =
         state.map { it.lastResult }.first()
@@ -477,7 +491,7 @@ class SqueezerTest : BaseTest() {
         s.squeezer.submit(SqueezerScanTask())
 
         val capturedTargets = slot<Set<CompressibleImage>>()
-        coEvery { s.imageProcessor.process(capture(capturedTargets), any()) } returns
+        coEvery { s.imageProcessor.process(capture(capturedTargets), any(), any(), any()) } returns
             ImageProcessor.Result(success = setOf(a, b), failed = emptyMap(), savedSpace = 400L)
 
         s.squeezer.submit(SqueezerProcessTask(mode = SqueezerProcessTask.TargetMode.All()))
@@ -494,7 +508,7 @@ class SqueezerTest : BaseTest() {
         s.squeezer.submit(SqueezerScanTask())
 
         val capturedTargets = slot<Set<CompressibleImage>>()
-        coEvery { s.imageProcessor.process(capture(capturedTargets), any()) } returns
+        coEvery { s.imageProcessor.process(capture(capturedTargets), any(), any(), any()) } returns
             ImageProcessor.Result(success = setOf(keep), failed = emptyMap(), savedSpace = 100L)
 
         s.squeezer.submit(
@@ -516,7 +530,7 @@ class SqueezerTest : BaseTest() {
         s.squeezer.submit(SqueezerScanTask())
 
         val capturedTargets = slot<Set<CompressibleImage>>()
-        coEvery { s.imageProcessor.process(capture(capturedTargets), any()) } returns
+        coEvery { s.imageProcessor.process(capture(capturedTargets), any(), any(), any()) } returns
             ImageProcessor.Result(success = setOf(real), failed = emptyMap(), savedSpace = 0L)
 
         s.squeezer.submit(
@@ -536,15 +550,66 @@ class SqueezerTest : BaseTest() {
         coEvery { s.scanner.scan(any()) } returns scanResult(items = setOf(img, vid))
         s.squeezer.submit(SqueezerScanTask())
 
-        coEvery { s.imageProcessor.process(any(), any()) } returns
+        coEvery { s.imageProcessor.process(any(), any(), any(), any()) } returns
             ImageProcessor.Result(success = setOf(img), failed = emptyMap(), savedSpace = 100L)
-        coEvery { s.videoProcessor.process(any(), any()) } returns
+        coEvery { s.videoProcessor.process(any(), any(), any(), any()) } returns
             VideoProcessor.Result(success = setOf(vid), failed = emptyMap(), savedSpace = 200L)
 
         s.squeezer.submit(SqueezerProcessTask())
 
-        coVerify(exactly = 1) { s.imageProcessor.process(setOf(img), any()) }
-        coVerify(exactly = 1) { s.videoProcessor.process(setOf(vid), any()) }
+        coVerify(exactly = 1) { s.imageProcessor.process(setOf(img), any(), any(), any()) }
+        coVerify(exactly = 1) { s.videoProcessor.process(setOf(vid), any(), any(), any()) }
+    }
+
+    @Test
+    fun `submit ProcessTask numbers items globally across both phases`() = runTest2 {
+        val img = createImage("a.jpg")
+        val vid = createVideo("b.mp4")
+        val s = setup()
+        coEvery { s.scanner.scan(any()) } returns scanResult(items = setOf(img, vid))
+        s.squeezer.submit(SqueezerScanTask())
+
+        // A progress flow that never completes. With emptyFlow() the forwarding job's onCompletion
+        // fires right away on a background dispatcher, racing the phase it is meant to close.
+        every { s.imageProcessor.progress } returns MutableSharedFlow<Progress.Data?>()
+        every { s.videoProcessor.progress } returns MutableSharedFlow<Progress.Data?>()
+
+        val published = mutableListOf<Progress.Data?>()
+        backgroundScope.launch(Dispatchers.Unconfined) { s.squeezer.progress.toList(published) }
+
+        val imageOffset = slot<Int>()
+        val imageTotal = slot<Int>()
+        coEvery {
+            s.imageProcessor.process(any(), any(), capture(imageOffset), capture(imageTotal))
+        } returns ImageProcessor.Result(success = setOf(img), failed = emptyMap(), savedSpace = 100L)
+
+        val videoOffset = slot<Int>()
+        val videoTotal = slot<Int>()
+        var videoPhaseStart: Progress.Count? = null
+        coEvery {
+            s.videoProcessor.process(any(), any(), capture(videoOffset), capture(videoTotal))
+        } coAnswers {
+            videoPhaseStart = s.squeezer.currentProgress()?.count
+            VideoProcessor.Result(success = setOf(vid), failed = emptyMap(), savedSpace = 200L)
+        }
+
+        s.squeezer.submit(SqueezerProcessTask())
+
+        // Each processor is told where its batch sits in the run, instead of counting its own.
+        imageOffset.captured shouldBe 0
+        imageTotal.captured shouldBe 2
+        videoOffset.captured shouldBe 1
+        videoTotal.captured shouldBe 2
+
+        // The image phase closes at "1 of 2", so the video phase starts there, not at "0 of 1".
+        videoPhaseStart!!.current shouldBe 1L
+        videoPhaseStart!!.max shouldBe 2L
+
+        // ... and the run finishes at "2 of 2" instead of a second "1 of 1".
+        val terminal = published.last { it != null }!!
+        terminal.count.current shouldBe 2L
+        terminal.count.max shouldBe 2L
+        terminal.subCount shouldBe null
     }
 
     @Test
@@ -554,7 +619,7 @@ class SqueezerTest : BaseTest() {
         coEvery { s.scanner.scan(any()) } returns scanResult(items = setOf(vid))
         s.squeezer.submit(SqueezerScanTask())
 
-        coEvery { s.videoProcessor.process(any(), any()) } returns
+        coEvery { s.videoProcessor.process(any(), any(), any(), any()) } returns
             VideoProcessor.Result(success = setOf(vid), failed = emptyMap(), savedSpace = 200L)
 
         s.squeezer.submit(SqueezerProcessTask())
@@ -562,7 +627,7 @@ class SqueezerTest : BaseTest() {
         // No image targets → image processor must not be invoked. Pin the short-circuit (line
         // 162 in Squeezer.kt) — a regression that always called process(emptySet()) would still
         // be technically correct but burns the withProgress() scaffolding for nothing.
-        coVerify(exactly = 0) { s.imageProcessor.process(any(), any()) }
+        coVerify(exactly = 0) { s.imageProcessor.process(any(), any(), any(), any()) }
     }
 
     @Test
@@ -572,12 +637,12 @@ class SqueezerTest : BaseTest() {
         coEvery { s.scanner.scan(any()) } returns scanResult(items = setOf(img))
         s.squeezer.submit(SqueezerScanTask())
 
-        coEvery { s.imageProcessor.process(any(), any()) } returns
+        coEvery { s.imageProcessor.process(any(), any(), any(), any()) } returns
             ImageProcessor.Result(success = setOf(img), failed = emptyMap(), savedSpace = 100L)
 
         s.squeezer.submit(SqueezerProcessTask())
 
-        coVerify(exactly = 0) { s.videoProcessor.process(any(), any()) }
+        coVerify(exactly = 0) { s.videoProcessor.process(any(), any(), any(), any()) }
     }
 
     @Test
@@ -588,7 +653,7 @@ class SqueezerTest : BaseTest() {
         coEvery { s.scanner.scan(any()) } returns scanResult(items = setOf(processed, keep))
         s.squeezer.submit(SqueezerScanTask())
 
-        coEvery { s.imageProcessor.process(any(), any()) } returns
+        coEvery { s.imageProcessor.process(any(), any(), any(), any()) } returns
             ImageProcessor.Result(success = setOf(processed), failed = emptyMap(), savedSpace = 100L)
 
         s.squeezer.submit(
@@ -608,7 +673,7 @@ class SqueezerTest : BaseTest() {
         coEvery { s.scanner.scan(any()) } returns scanResult(items = setOf(failed))
         s.squeezer.submit(SqueezerScanTask())
 
-        coEvery { s.imageProcessor.process(any(), any()) } returns ImageProcessor.Result(
+        coEvery { s.imageProcessor.process(any(), any(), any(), any()) } returns ImageProcessor.Result(
             success = emptySet(),
             failed = mapOf(failed to IllegalStateException("nope")),
             savedSpace = 0L,
@@ -629,9 +694,9 @@ class SqueezerTest : BaseTest() {
         coEvery { s.scanner.scan(any()) } returns scanResult(items = setOf(img, vid))
         s.squeezer.submit(SqueezerScanTask())
 
-        coEvery { s.imageProcessor.process(any(), any()) } returns
+        coEvery { s.imageProcessor.process(any(), any(), any(), any()) } returns
             ImageProcessor.Result(success = setOf(img), failed = emptyMap(), savedSpace = 100L)
-        coEvery { s.videoProcessor.process(any(), any()) } returns
+        coEvery { s.videoProcessor.process(any(), any(), any(), any()) } returns
             VideoProcessor.Result(success = setOf(vid), failed = emptyMap(), savedSpace = 200L)
 
         val result = s.squeezer.submit(SqueezerProcessTask()) as SqueezerProcessTask.Success
@@ -654,7 +719,7 @@ class SqueezerTest : BaseTest() {
 
         // Two IOExceptions → one FailureReason bucket; one UnsupportedFormatException → another.
         // Catches a regression that grouped by Throwable identity instead of via toFailureReason().
-        coEvery { s.imageProcessor.process(any(), any()) } returns ImageProcessor.Result(
+        coEvery { s.imageProcessor.process(any(), any(), any(), any()) } returns ImageProcessor.Result(
             success = emptySet(),
             failed = mapOf(
                 a to java.io.IOException("io a"),
@@ -679,7 +744,7 @@ class SqueezerTest : BaseTest() {
         s.squeezer.submit(SqueezerScanTask())
 
         val capturedQuality = slot<Int>()
-        coEvery { s.imageProcessor.process(any(), capture(capturedQuality)) } returns
+        coEvery { s.imageProcessor.process(any(), capture(capturedQuality), any(), any()) } returns
             ImageProcessor.Result(success = setOf(img), failed = emptyMap(), savedSpace = 100L)
 
         s.squeezer.submit(SqueezerProcessTask(qualityOverride = 50))
@@ -695,7 +760,7 @@ class SqueezerTest : BaseTest() {
         s.squeezer.submit(SqueezerScanTask())
 
         val capturedQuality = slot<Int>()
-        coEvery { s.imageProcessor.process(any(), capture(capturedQuality)) } returns
+        coEvery { s.imageProcessor.process(any(), capture(capturedQuality), any(), any()) } returns
             ImageProcessor.Result(success = setOf(img), failed = emptyMap(), savedSpace = 100L)
 
         s.squeezer.submit(SqueezerProcessTask(qualityOverride = null))

--- a/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/core/SqueezerTest.kt
+++ b/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/core/SqueezerTest.kt
@@ -1,5 +1,6 @@
 package eu.darken.sdmse.squeezer.core
 
+import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.files.FileType
 import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.core.local.File
@@ -18,6 +19,7 @@ import eu.darken.sdmse.squeezer.core.tasks.SqueezerScanTask
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -27,7 +29,7 @@ import io.mockk.slot
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -571,8 +573,14 @@ class SqueezerTest : BaseTest() {
 
         // A progress flow that never completes. With emptyFlow() the forwarding job's onCompletion
         // fires right away on a background dispatcher, racing the phase it is meant to close.
-        every { s.imageProcessor.progress } returns MutableSharedFlow<Progress.Data?>()
-        every { s.videoProcessor.progress } returns MutableSharedFlow<Progress.Data?>()
+        // Like the real processors, each replays an initial state that still carries Progress.Data's
+        // default Indeterminate count - that replay is what used to reset the tool's ring.
+        val imagePhasePrimary = eu.darken.sdmse.common.R.string.general_progress_preparing.toCaString()
+        val videoPhasePrimary = eu.darken.sdmse.common.R.string.general_progress_preparing.toCaString()
+        every { s.imageProcessor.progress } returns
+            MutableStateFlow<Progress.Data?>(Progress.Data(primary = imagePhasePrimary))
+        every { s.videoProcessor.progress } returns
+            MutableStateFlow<Progress.Data?>(Progress.Data(primary = videoPhasePrimary))
 
         val published = mutableListOf<Progress.Data?>()
         backgroundScope.launch(Dispatchers.Unconfined) { s.squeezer.progress.toList(published) }
@@ -589,6 +597,10 @@ class SqueezerTest : BaseTest() {
         coEvery {
             s.videoProcessor.process(any(), any(), capture(videoOffset), capture(videoTotal))
         } coAnswers {
+            // The forwarding collector runs on its own dispatcher, so wait until the video phase's
+            // replayed initial state has actually reached the tool - otherwise the mock could
+            // return before it ever ran and the phase-start assertions below would prove nothing.
+            s.squeezer.progress.first { it?.primary === videoPhasePrimary }
             videoPhaseStart = s.squeezer.currentProgress()?.count
             VideoProcessor.Result(success = setOf(vid), failed = emptyMap(), savedSpace = 200L)
         }
@@ -610,6 +622,17 @@ class SqueezerTest : BaseTest() {
         terminal.count.current shouldBe 2L
         terminal.count.max shouldBe 2L
         terminal.subCount shouldBe null
+
+        // The video phase's replayed initial state must not knock the ring back to spinning:
+        // from the image phase's close onwards, every published count stays determinate.
+        val imagePhaseEnd = published.indexOfFirst {
+            val count = it?.count
+            count is Progress.Count.Counter && count.current == 1L && count.max == 2L
+        }
+        imagePhaseEnd shouldNotBe -1
+        published.drop(imagePhaseEnd)
+            .mapNotNull { it?.count }
+            .filterIsInstance<Progress.Count.Indeterminate>() shouldBe emptyList()
     }
 
     @Test

--- a/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/core/processor/ImageProcessorTest.kt
+++ b/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/core/processor/ImageProcessorTest.kt
@@ -205,6 +205,20 @@ class ImageProcessorTest : BaseTest() {
     }
 
     @Test
+    fun `process - the state published before the first item keeps the batch counter`() = runTest {
+        // No targets, so the pre-loop publish is the only state: the run's starting position inside
+        // the batch. An Indeterminate here would drop the card's ring from "1 of 3" to spinning.
+        subject.process(emptySet(), quality = 80, itemOffset = 1, itemTotal = 3)
+
+        subject.currentProgress()!!.let {
+            it.count.current shouldBe 1L
+            it.count.max shouldBe 3L
+            it.subCount shouldBe null
+            it.primary.get(RuntimeEnvironment.getApplication()) shouldBe "Preparing"
+        }
+    }
+
+    @Test
     fun `process - the item counter reaches the last item`() = runTest {
         val first = createImage()
         val secondPath = java.io.File(tempFolder.root, "second.jpg").apply {

--- a/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/core/processor/ImageProcessorTest.kt
+++ b/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/core/processor/ImageProcessorTest.kt
@@ -4,6 +4,7 @@ import eu.darken.sdmse.common.files.FileType
 import eu.darken.sdmse.common.files.core.local.File
 import eu.darken.sdmse.common.files.local.LocalPath
 import eu.darken.sdmse.common.files.local.LocalPathLookup
+import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.squeezer.core.CompressibleImage
 import eu.darken.sdmse.squeezer.core.ContentId
 import eu.darken.sdmse.squeezer.core.ContentIdentifier
@@ -190,5 +191,62 @@ class ImageProcessorTest : BaseTest() {
         result.success shouldBe emptySet()
         result.failed shouldBe emptyMap()
         result.savedSpace shouldBe 0L
+    }
+
+    /**
+     * The published progress. [ImageProcessor.progress] is throttled, so collecting it drops exactly
+     * the intermediate states these tests are about; [Progress.Client.updateProgress] reads the same
+     * state synchronously and without side effects.
+     */
+    private fun ImageProcessor.currentProgress(): Progress.Data? {
+        var snapshot: Progress.Data? = null
+        updateProgress { snapshot = it; it }
+        return snapshot
+    }
+
+    @Test
+    fun `process - the item counter reaches the last item`() = runTest {
+        val first = createImage()
+        val secondPath = java.io.File(tempFolder.root, "second.jpg").apply {
+            writeBytes(ByteArray(5_000_000))
+        }.absolutePath
+        val second = createImage(path = secondPath)
+
+        // Sampled while an item is in flight.
+        var inFlight: Progress.Data? = null
+        coEvery { fileTransaction.replace(any(), any(), any()) } coAnswers {
+            inFlight = subject.currentProgress()
+            FileTransaction.Outcome(
+                originalSize = 5_000_000L,
+                replacementSize = 2_000_000L,
+                savedBytes = 3_000_000L,
+                replaced = true,
+            )
+        }
+        coEvery { imageContentHasher.computeHash(any()) } returns ContentIdentifier.ImageHash(ContentId("img"))
+
+        subject.process(setOf(first, second), quality = 80)
+
+        // There is no per-image progress, so the inner ring spins for the duration of each item.
+        inFlight!!.subCount shouldBe Progress.Count.Indeterminate()
+
+        subject.currentProgress()!!.let {
+            it.count.current shouldBe 2L
+            it.count.max shouldBe 2L
+        }
+    }
+
+    @Test
+    fun `process - a preserved HDR-depth photo still advances the counter`() = runTest {
+        val image = createImage()
+        every { settings.includeLossyAuxImages } returns mockDataStoreValue(false)
+        every { lossyAuxDetector.hasLossyAux(any(), any()) } returns true
+
+        subject.process(setOf(image), quality = 80)
+
+        subject.currentProgress()!!.let {
+            it.count.current shouldBe 1L
+            it.count.max shouldBe 1L
+        }
     }
 }

--- a/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/core/processor/VideoProcessorTest.kt
+++ b/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/core/processor/VideoProcessorTest.kt
@@ -4,6 +4,7 @@ import eu.darken.sdmse.common.files.FileType
 import eu.darken.sdmse.common.files.core.local.File
 import eu.darken.sdmse.common.files.local.LocalPath
 import eu.darken.sdmse.common.files.local.LocalPathLookup
+import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.squeezer.core.CompressibleVideo
 import eu.darken.sdmse.squeezer.core.ContentId
 import eu.darken.sdmse.squeezer.core.ContentIdentifier
@@ -201,5 +202,86 @@ class VideoProcessorTest : BaseTest() {
         result.success shouldBe emptySet()
         result.failed shouldBe emptyMap()
         result.savedSpace shouldBe 0L
+    }
+
+    /**
+     * The published progress. [VideoProcessor.progress] is throttled, so collecting it drops exactly
+     * the intermediate states these tests are about; [Progress.Client.updateProgress] reads the same
+     * state synchronously and without side effects.
+     */
+    private fun VideoProcessor.currentProgress(): Progress.Data? {
+        var snapshot: Progress.Data? = null
+        updateProgress { snapshot = it; it }
+        return snapshot
+    }
+
+    /** Makes the mocked transaction actually run its produce lambda, i.e. reach the transcoder. */
+    private fun stubTransactionRunningProduce(savedBytes: Long = 5_000_000L) {
+        coEvery { fileTransaction.replace(any(), any(), any()) } coAnswers {
+            thirdArg<suspend (java.io.File) -> Unit>().invoke(java.io.File(tempFolder.root, "temp.mp4"))
+            FileTransaction.Outcome(
+                originalSize = 10_000_000L,
+                replacementSize = 10_000_000L - savedBytes,
+                savedBytes = savedBytes,
+                replaced = true,
+            )
+        }
+    }
+
+    @Test
+    fun `process - transcode progress becomes the sub count`() = runTest {
+        val video = createVideo()
+        stubTransactionRunningProduce()
+        coEvery { videoContentHasher.computeHash(any()) } returns ContentIdentifier.VideoHash(ContentId("h"))
+
+        // Sampled from inside the transcode, i.e. while the item is still in flight. MockK runs
+        // coAnswers blocks with runBlocking, so the item can't be parked on a deferred instead.
+        var onFortyPercent: Progress.Data? = null
+        var onUnavailable: Progress.Data? = null
+        coEvery { videoTranscoder.transcode(any(), any(), any(), any()) } coAnswers {
+            val listener = arg<VideoTranscoder.ProgressListener>(3)
+            listener.onProgress(40)
+            onFortyPercent = subject.currentProgress()
+            // -1 is the transcoder's "no progress available yet", it must not move the ring.
+            listener.onProgress(-1)
+            onUnavailable = subject.currentProgress()
+        }
+
+        subject.process(setOf(video), quality = 80)
+
+        onFortyPercent!!.let {
+            it.subCount shouldBe Progress.Count.Percent(40, 100)
+            it.count.current shouldBe 0L
+            it.count.max shouldBe 1L
+        }
+        onUnavailable!!.subCount shouldBe Progress.Count.Percent(40, 100)
+    }
+
+    @Test
+    fun `process - the item counter reaches the last item`() = runTest {
+        val first = createVideo()
+        val secondPath = java.io.File(tempFolder.root, "second.mp4").apply {
+            writeBytes(ByteArray(5_000_000))
+        }.absolutePath
+        val second = createVideo(path = secondPath, size = 5_000_000L)
+
+        coEvery { fileTransaction.replace(any(), any(), any()) } coAnswers {
+            FileTransaction.Outcome(
+                originalSize = 10_000_000L,
+                replacementSize = 5_000_000L,
+                savedBytes = 5_000_000L,
+                replaced = true,
+            )
+        }
+        coEvery { videoContentHasher.computeHash(any()) } returns ContentIdentifier.VideoHash(ContentId("h"))
+
+        subject.process(setOf(first, second), quality = 80)
+
+        val context = RuntimeEnvironment.getApplication()
+        subject.currentProgress()!!.let {
+            it.count.current shouldBe 2L
+            it.count.max shouldBe 2L
+            it.primary.get(context) shouldBe "Processing second.mp4"
+        }
     }
 }

--- a/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/core/processor/VideoProcessorTest.kt
+++ b/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/core/processor/VideoProcessorTest.kt
@@ -258,6 +258,20 @@ class VideoProcessorTest : BaseTest() {
     }
 
     @Test
+    fun `process - the state published before the first item keeps the batch counter`() = runTest {
+        // No targets, so the pre-loop publish is the only state: the run's starting position inside
+        // the batch. An Indeterminate here would drop the card's ring from "1 of 3" to spinning.
+        subject.process(emptySet(), quality = 80, itemOffset = 1, itemTotal = 3)
+
+        subject.currentProgress()!!.let {
+            it.count.current shouldBe 1L
+            it.count.max shouldBe 3L
+            it.subCount shouldBe null
+            it.primary.get(RuntimeEnvironment.getApplication()) shouldBe "Preparing"
+        }
+    }
+
+    @Test
     fun `process - the item counter reaches the last item`() = runTest {
         val first = createVideo()
         val secondPath = java.io.File(tempFolder.root, "second.mp4").apply {

--- a/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/ui/list/SqueezerListViewModelTest.kt
+++ b/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/ui/list/SqueezerListViewModelTest.kt
@@ -471,6 +471,62 @@ class SqueezerListViewModelTest : BaseTest() {
     }
 
     @Test
+    fun `compressing a subset keeps the screen so the result snackbar can render`() = runTest2 {
+        // A partial compression prunes only the handled items, so the list keeps data and the
+        // drain observer stays quiet. That's what lets ToolListEventHandler show the result
+        // snackbar — a full compression drains the list and pops the screen instead.
+        val a = image("a.jpg")
+        val b = image("b.jpg")
+        val h = harness(data = Squeezer.Data(media = setOf(a, b)), isPro = true)
+        h.vm.state.first()  // prime state.value so compress() can read current media
+        val collected = collectEvents(h.vm)
+        val collectedNav = collectNavEvents(h.vm)
+
+        val processSuccess = SqueezerProcessTask.Success(
+            affectedSpace = 512L,
+            affectedPaths = setOf(a.path),
+            processedCount = 1,
+        )
+        coEvery { h.taskSubmitter.submit(any()) } answers {
+            h.stateFlow.value = squeezerState(data = Squeezer.Data(media = setOf(b)))
+            processSuccess
+        }
+
+        h.vm.compress(setOf(a.identifier), confirmed = true)
+        advanceUntilIdle()
+
+        val event = collected.list.single()
+        event.shouldBeInstanceOf<SqueezerListViewModel.Event.TaskResult>()
+        event.result shouldBe processSuccess
+        collectedNav.list shouldBe emptyList()
+        collected.cancel()
+        collectedNav.cancel()
+    }
+
+    @Test
+    fun `compressing everything drains the data and navigates up`() = runTest2 {
+        val a = image("a.jpg")
+        val h = harness(data = Squeezer.Data(media = setOf(a)), isPro = true)
+        h.vm.state.first()  // prime
+        val collectedNav = collectNavEvents(h.vm)
+
+        coEvery { h.taskSubmitter.submit(any()) } answers {
+            h.stateFlow.value = squeezerState(data = Squeezer.Data(media = emptySet()))
+            SqueezerProcessTask.Success(
+                affectedSpace = 512L,
+                affectedPaths = setOf(a.path),
+                processedCount = 1,
+            )
+        }
+
+        h.vm.compress(setOf(a.identifier), confirmed = true)
+        advanceUntilIdle()
+
+        collectedNav.list shouldBe listOf(NavEvent.Up)
+        collectedNav.cancel()
+    }
+
+    @Test
     fun `init does not navigate up when Data transitions from non-empty to null - loading state`() = runTest2 {
         // Regression: data going to `null` indicates a fresh scan started (Squeezer sets
         // internalData = null at the top of performScan). That's a loading state, not an

--- a/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/ui/setup/SqueezerSetupViewModelTest.kt
+++ b/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/ui/setup/SqueezerSetupViewModelTest.kt
@@ -16,7 +16,9 @@ import eu.darken.sdmse.squeezer.core.CompressibleImage
 import eu.darken.sdmse.squeezer.core.CompressionEstimator
 import eu.darken.sdmse.squeezer.core.Squeezer
 import eu.darken.sdmse.squeezer.core.SqueezerSettings
+import eu.darken.sdmse.squeezer.core.tasks.SqueezerProcessTask
 import eu.darken.sdmse.squeezer.core.tasks.SqueezerScanTask
+import eu.darken.sdmse.squeezer.core.tasks.SqueezerTask
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.coEvery
@@ -97,6 +99,7 @@ class SqueezerSetupViewModelTest : BaseTest() {
         minSizeBytes: Long = SqueezerSettings.MIN_FILE_SIZE,
         squeezerData: Squeezer.Data? = null,
         squeezerProgress: Progress.Data? = null,
+        squeezerLastResult: SqueezerTask.Result? = null,
     ): Harness {
         val scanPathsValue = rwDataStoreValue(SqueezerSettings.ScanPaths(paths = scanPaths))
         val qualityValue = rwDataStoreValue(compressionQuality)
@@ -110,7 +113,13 @@ class SqueezerSetupViewModelTest : BaseTest() {
             every { this@apply.minSizeBytes } returns minSizeValue
         }
 
-        val squeezerStateFlow = MutableStateFlow(Squeezer.State(data = squeezerData, progress = squeezerProgress))
+        val squeezerStateFlow = MutableStateFlow(
+            Squeezer.State(
+                data = squeezerData,
+                progress = squeezerProgress,
+                lastResult = squeezerLastResult,
+            ),
+        )
         val squeezerProgressFlow = MutableStateFlow(squeezerProgress)
         val squeezer = mockk<Squeezer>(relaxed = true).apply {
             every { state } returns squeezerStateFlow
@@ -217,6 +226,47 @@ class SqueezerSetupViewModelTest : BaseTest() {
         val h = harness(scanPaths = setOf(LocalPath.build("/dcim")), compressionQuality = 100)
 
         h.vm.state.first().estimatedSavingsPercent shouldBe 0
+    }
+
+    // ─────────────────────────── processResult ───────────────────────────
+
+    @Test
+    fun `state processResult is null when the last result was a scan`() = runTest2 {
+        // performProcess prunes the media data before submit() stores the process result, so
+        // there's a window where the list has drained while lastResult is still the preceding
+        // scan success. Showing it would flash "x items found" where a compression receipt
+        // belongs.
+        val h = harness(
+            squeezerLastResult = SqueezerScanTask.Success(
+                itemCount = 2,
+                totalSize = 2048L,
+                estimatedSavings = 1024L,
+            ),
+        )
+
+        h.vm.state.first().processResult shouldBe null
+    }
+
+    @Test
+    fun `state processResult carries the last process result`() = runTest2 {
+        val processResult = SqueezerProcessTask.Success(
+            affectedSpace = 1024L,
+            affectedPaths = setOf(LocalPath.build("/dcim/a.jpg")),
+            processedCount = 2,
+        )
+        val h = harness(squeezerLastResult = processResult)
+
+        h.vm.state.first().processResult shouldBe processResult
+    }
+
+    @Test
+    fun `state progress comes from the squeezer state`() = runTest2 {
+        // The VM reads progress off Squeezer.state (not squeezer.progress) so progress and the
+        // process result can't disagree within a frame.
+        val progress = Progress.Data()
+        val h = harness(squeezerProgress = progress)
+
+        h.vm.state.first().progress shouldBe progress
     }
 
     // ─────────────────────────── updateQuality / updateMinAge ───────────────────────────

--- a/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/ui/setup/SqueezerSetupViewModelTest.kt
+++ b/app-tool-squeezer/src/test/java/eu/darken/sdmse/squeezer/ui/setup/SqueezerSetupViewModelTest.kt
@@ -269,6 +269,24 @@ class SqueezerSetupViewModelTest : BaseTest() {
         h.vm.state.first().progress shouldBe progress
     }
 
+    @Test
+    fun `state tracks the squeezer while nothing is collecting it`() = runTest2 {
+        // The setup entry stays in the back stack while the list screen runs a compression on top
+        // of it, so nothing collects this state meanwhile. With the default WhileSubscribed(5000)
+        // the VM would serve its stale pre-navigation value on back navigation and the screen
+        // would flash the configuration before the progress overlay returned. Eager sharing means
+        // a progress change made without a live collector is already in state.value afterwards.
+        val h = harness(squeezerProgress = null)
+        advanceUntilIdle()
+        h.vm.state.value.progress shouldBe null
+
+        val progress = Progress.Data(count = Progress.Count.Percent(current = 3, max = 10))
+        h.squeezerState.value = Squeezer.State(data = null, progress = progress)
+        advanceUntilIdle()
+
+        h.vm.state.value.progress shouldBe progress
+    }
+
     // ─────────────────────────── updateQuality / updateMinAge ───────────────────────────
 
     @Test

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardCardFlows.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardCardFlows.kt
@@ -308,6 +308,9 @@ internal fun DashboardViewModel.buildSqueezerItem(): Flow<SqueezerDashboardCardI
                 onViewDetails = {
                     navTo(SqueezerSetupRoute)
                 },
+                onCancel = {
+                    launch { taskManager.cancel(SDMTool.Type.SQUEEZER) }
+                },
             )
         }
 

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardCardFlows.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardCardFlows.kt
@@ -41,6 +41,7 @@ import eu.darken.sdmse.main.ui.dashboard.cards.ToolDashboardCardItem
 import eu.darken.sdmse.main.ui.dashboard.cards.UpdateDashboardCardItem
 import eu.darken.sdmse.setup.SetupRoute
 import eu.darken.sdmse.squeezer.core.Squeezer
+import eu.darken.sdmse.squeezer.core.tasks.SqueezerProcessTask
 import eu.darken.sdmse.squeezer.ui.SqueezerSetupRoute
 import eu.darken.sdmse.stats.core.db.SpaceSnapshotEntity
 import eu.darken.sdmse.stats.ui.ReportsRoute
@@ -300,6 +301,10 @@ internal fun DashboardViewModel.buildSqueezerItem(): Flow<SqueezerDashboardCardI
                 isInitializing = state == null,
                 data = state?.data,
                 progress = state?.progress,
+                // Process results only: performProcess prunes the data before submit() stores its
+                // result, so an unfiltered lastResult would show the preceding scan summary where
+                // a compression receipt belongs.
+                result = state?.lastResult as? SqueezerProcessTask.Result,
                 onViewDetails = {
                     navTo(SqueezerSetupRoute)
                 },

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/SqueezerDashboardCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/SqueezerDashboardCard.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.Cancel
 import androidx.compose.material.icons.twotone.Compress
 import androidx.compose.material.icons.twotone.Tune
 import androidx.compose.material3.CircularProgressIndicator
@@ -19,6 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import eu.darken.sdmse.common.R as CommonR
+import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.compose.asComposable
 import eu.darken.sdmse.common.compose.preview.Preview2
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
@@ -27,6 +29,7 @@ import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.main.ui.dashboard.cards.common.DashboardActionIconSpacing
 import eu.darken.sdmse.main.ui.dashboard.cards.common.DashboardCard
 import eu.darken.sdmse.main.ui.dashboard.cards.common.DashboardFlatActionButton
+import eu.darken.sdmse.main.ui.dashboard.cards.common.DashboardOutlinedActionButton
 import eu.darken.sdmse.main.ui.dashboard.cards.common.ProgressContainer
 import eu.darken.sdmse.squeezer.core.Squeezer
 import eu.darken.sdmse.squeezer.core.tasks.SqueezerProcessTask
@@ -38,13 +41,17 @@ data class SqueezerDashboardCardItem(
     val progress: Progress.Data?,
     val result: SqueezerProcessTask.Result?,
     val onViewDetails: () -> Unit,
+    val onCancel: () -> Unit,
 ) : DashboardItem {
     override val stableId: Long = this.javaClass.hashCode().toLong()
 }
 
 @Composable
 internal fun SqueezerDashboardCard(item: SqueezerDashboardCardItem) {
-    DashboardCard(onClick = item.onViewDetails.takeIf { !item.isInitializing }) {
+    // The card opens the squeezer setup screen, which renders its configuration before its
+    // progress overlay arrives. Tapping mid-operation would show that configuration for a moment
+    // before the overlay covers it, so the click is disabled while an operation runs.
+    DashboardCard(onClick = item.onViewDetails.takeIf { !item.isInitializing && item.progress == null }) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Icon(
                 imageVector = Icons.TwoTone.Compress,
@@ -85,17 +92,31 @@ internal fun SqueezerDashboardCard(item: SqueezerDashboardCardItem) {
 
         Spacer(modifier = Modifier.height(8.dp))
 
-        DashboardFlatActionButton(
-            onClick = item.onViewDetails,
-            enabled = !item.isInitializing,
-            modifier = Modifier.align(Alignment.End),
-        ) {
-            Icon(
-                imageVector = Icons.TwoTone.Tune,
-                contentDescription = null,
-            )
-            Spacer(modifier = Modifier.width(DashboardActionIconSpacing))
-            Text(text = stringResource(CommonR.string.general_configure_action))
+        if (item.progress != null) {
+            DashboardOutlinedActionButton(
+                onClick = item.onCancel,
+                modifier = Modifier.align(Alignment.End),
+            ) {
+                Icon(
+                    imageVector = Icons.TwoTone.Cancel,
+                    contentDescription = null,
+                )
+                Spacer(modifier = Modifier.width(DashboardActionIconSpacing))
+                Text(text = stringResource(CommonR.string.general_cancel_action))
+            }
+        } else {
+            DashboardFlatActionButton(
+                onClick = item.onViewDetails,
+                enabled = !item.isInitializing,
+                modifier = Modifier.align(Alignment.End),
+            ) {
+                Icon(
+                    imageVector = Icons.TwoTone.Tune,
+                    contentDescription = null,
+                )
+                Spacer(modifier = Modifier.width(DashboardActionIconSpacing))
+                Text(text = stringResource(CommonR.string.general_configure_action))
+            }
         }
     }
 }
@@ -111,6 +132,7 @@ private fun SqueezerDashboardCardPreview() {
                 progress = null,
                 result = null,
                 onViewDetails = {},
+                onCancel = {},
             ),
         )
     }
@@ -131,6 +153,27 @@ private fun SqueezerDashboardCardResultPreview() {
                     processedCount = 2,
                 ),
                 onViewDetails = {},
+                onCancel = {},
+            ),
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun SqueezerDashboardCardProgressPreview() {
+    PreviewWrapper {
+        SqueezerDashboardCard(
+            item = SqueezerDashboardCardItem(
+                data = null,
+                isInitializing = false,
+                progress = Progress.Data(
+                    primary = "Compressing images".toCaString(),
+                    count = Progress.Count.Counter(current = 1, max = 2),
+                ),
+                result = null,
+                onViewDetails = {},
+                onCancel = {},
             ),
         )
     }

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/SqueezerDashboardCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/SqueezerDashboardCard.kt
@@ -2,6 +2,7 @@ package eu.darken.sdmse.main.ui.dashboard.cards
 
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -18,6 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import eu.darken.sdmse.common.R as CommonR
+import eu.darken.sdmse.common.compose.asComposable
 import eu.darken.sdmse.common.compose.preview.Preview2
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import eu.darken.sdmse.common.progress.Progress
@@ -25,13 +27,16 @@ import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.main.ui.dashboard.cards.common.DashboardActionIconSpacing
 import eu.darken.sdmse.main.ui.dashboard.cards.common.DashboardCard
 import eu.darken.sdmse.main.ui.dashboard.cards.common.DashboardFlatActionButton
+import eu.darken.sdmse.main.ui.dashboard.cards.common.ProgressContainer
 import eu.darken.sdmse.squeezer.core.Squeezer
+import eu.darken.sdmse.squeezer.core.tasks.SqueezerProcessTask
 import eu.darken.sdmse.squeezer.R as SqueezerR
 
 data class SqueezerDashboardCardItem(
     val data: Squeezer.Data?,
     val isInitializing: Boolean,
     val progress: Progress.Data?,
+    val result: SqueezerProcessTask.Result?,
     val onViewDetails: () -> Unit,
 ) : DashboardItem {
     override val stableId: Long = this.javaClass.hashCode().toLong()
@@ -60,12 +65,23 @@ internal fun SqueezerDashboardCard(item: SqueezerDashboardCardItem) {
             }
         }
 
-        Spacer(modifier = Modifier.height(4.dp))
+        if (item.progress == null && item.result == null) {
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = stringResource(SqueezerR.string.squeezer_explanation_short),
+                style = MaterialTheme.typography.bodySmall,
+            )
+        }
 
-        Text(
-            text = stringResource(SqueezerR.string.squeezer_explanation_short),
-            style = MaterialTheme.typography.bodySmall,
-        )
+        if (item.progress != null || item.result != null) {
+            Spacer(modifier = Modifier.height(16.dp))
+            ProgressContainer(
+                modifier = Modifier.fillMaxWidth(),
+                progress = item.progress,
+                resultPrimary = item.result?.primaryInfo?.asComposable(),
+                resultSecondary = item.result?.secondaryInfo?.asComposable()?.takeUnless { it.isBlank() },
+            )
+        }
 
         Spacer(modifier = Modifier.height(8.dp))
 
@@ -93,6 +109,27 @@ private fun SqueezerDashboardCardPreview() {
                 data = null,
                 isInitializing = false,
                 progress = null,
+                result = null,
+                onViewDetails = {},
+            ),
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun SqueezerDashboardCardResultPreview() {
+    PreviewWrapper {
+        SqueezerDashboardCard(
+            item = SqueezerDashboardCardItem(
+                data = null,
+                isInitializing = false,
+                progress = null,
+                result = SqueezerProcessTask.Success(
+                    affectedSpace = 34 * 1024 * 1024L,
+                    affectedPaths = emptySet(),
+                    processedCount = 2,
+                ),
                 onViewDetails = {},
             ),
         )

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/common/DashboardProgress.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/common/DashboardProgress.kt
@@ -24,6 +24,8 @@ import eu.darken.sdmse.common.compose.asComposable
 import eu.darken.sdmse.common.compose.preview.Preview2
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import eu.darken.sdmse.common.progress.Progress
+import eu.darken.sdmse.common.progress.determinateFraction
+import kotlin.math.ceil
 
 @Composable
 internal fun ProgressContainer(
@@ -61,6 +63,28 @@ internal fun ProgressContainer(
             }
         }
     }
+}
+
+/**
+ * The card's 32dp ring is too small to nest a second ring, so per-item progress is blended into the
+ * single arc instead.
+ *
+ * Unlike the tool overlay's shared helper this keeps [Progress.Count.Size] determinate: the card has
+ * always rendered a real arc for it (Analyzer, CorpseFinder deletion), and dropping it would make
+ * those cards spin forever.
+ */
+internal fun dashboardFraction(count: Progress.Count, subCount: Progress.Count?): Float? {
+    val base: Float? = when (count) {
+        is Progress.Count.Counter,
+        is Progress.Count.Percent,
+        is Progress.Count.Size,
+        -> if (count.max > 0L) (count.current.toFloat() / count.max.toFloat()).coerceIn(0f, 1f) else null
+
+        else -> null
+    }
+    val subFraction = subCount.determinateFraction() ?: return base
+    if (count.max <= 0L) return base
+    return ((count.current + subFraction) / count.max).coerceIn(0f, 1f)
 }
 
 @Composable
@@ -101,23 +125,29 @@ internal fun DashboardProgress(progress: Progress.Data) {
             is Progress.Count.Counter,
             is Progress.Count.Size -> {
                 Spacer(modifier = Modifier.width(12.dp))
-                val isDeterminate = count.current > 0L && count.max > 0L
+                val subCount = progress.subCount
+                val fraction = dashboardFraction(count, subCount)
+                // With no sub-count this is exactly the old `count.current > 0 && count.max > 0`.
+                val isDeterminate = count.max > 0L && (fraction ?: 0f) > 0f
                 val context = LocalContext.current
                 Box(modifier = Modifier.size(32.dp)) {
                     if (isDeterminate) {
-                        val fraction = (count.current.toFloat() / count.max.toFloat()).coerceIn(0f, 1f)
+                        val ringFraction = fraction ?: 0f
                         CircularProgressIndicator(
-                            progress = { fraction },
+                            progress = { ringFraction },
                             modifier = Modifier.matchParentSize(),
                             strokeWidth = 2.5.dp,
                         )
                         // Percent renders itself, so the card agrees with the tool screen and the
                         // automation overlay instead of flooring where they round up. Counter and
                         // Size display as "3/10" and "1.2 MB/5 MB", which doesn't fit inside the
-                        // ring, so they keep showing a percentage of their own.
+                        // ring, so they keep showing a percentage of their own. Only a blended
+                        // fraction (sub-count present) is derived from the float, rounded up to
+                        // match Percent.
                         Text(
-                            text = when (count) {
-                                is Progress.Count.Percent -> count.displayValue(context)
+                            text = when {
+                                subCount != null -> "${ceil(ringFraction * 100f).toInt()}%"
+                                count is Progress.Count.Percent -> count.displayValue(context)
                                 else -> "${(count.current * 100 / count.max).toInt()}%"
                             },
                             style = MaterialTheme.typography.labelSmall.copy(fontSize = 9.sp),

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/common/DashboardProgress.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/common/DashboardProgress.kt
@@ -25,7 +25,6 @@ import eu.darken.sdmse.common.compose.preview.Preview2
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.common.progress.determinateFraction
-import kotlin.math.ceil
 
 @Composable
 internal fun ProgressContainer(
@@ -87,6 +86,35 @@ internal fun dashboardFraction(count: Progress.Count, subCount: Progress.Count?)
     return ((count.current + subFraction) / count.max).coerceIn(0f, 1f)
 }
 
+/**
+ * The percentage shown inside the ring, rounded up like [Progress.Count.Percent.displayValue].
+ *
+ * Computed from the raw counts rather than from [dashboardFraction], because the float round trip
+ * overshoots: `30f / 100f` is 0.30000001192092896, `* 100f` is 30.0000019, and ceil turns a real
+ * 30% into 31%.
+ *
+ * Long is wide enough for the worst realistic magnitude: a [Progress.Count.Size] byte total (~1e13)
+ * times a sub-count max of 100 times 100 is ~1e17, an order of magnitude below Long.MAX_VALUE
+ * (9.2e18).
+ */
+internal fun dashboardPercent(count: Progress.Count, subCount: Progress.Count?): Int {
+    val max = count.max
+    if (max <= 0L) return 0
+    val current = count.current.coerceIn(0L, max)
+    // A determinate sub-count implies subCount.max > 0, so the divisor below can't be zero.
+    val determinateSub = subCount?.takeIf { it.determinateFraction() != null }
+    val percent = if (determinateSub != null) {
+        val subMax = determinateSub.max
+        val subCurrent = determinateSub.current.coerceIn(0L, subMax)
+        ceilDiv(100L * (current * subMax + subCurrent), max * subMax)
+    } else {
+        ceilDiv(100L * current, max)
+    }
+    return percent.coerceIn(0L, 100L).toInt()
+}
+
+private fun ceilDiv(a: Long, b: Long): Long = (a + b - 1) / b
+
 @Composable
 internal fun DashboardProgress(progress: Progress.Data) {
     Row(verticalAlignment = Alignment.CenterVertically) {
@@ -127,8 +155,12 @@ internal fun DashboardProgress(progress: Progress.Data) {
                 Spacer(modifier = Modifier.width(12.dp))
                 val subCount = progress.subCount
                 val fraction = dashboardFraction(count, subCount)
+                val subFraction = subCount.determinateFraction()
                 // With no sub-count this is exactly the old `count.current > 0 && count.max > 0`.
-                val isDeterminate = count.max > 0L && (fraction ?: 0f) > 0f
+                // A determinate sub-count is admitted even at a blended 0f, otherwise a known 0%
+                // on the first item (Counter(0,1) + Percent(0,100)) would be indistinguishable
+                // from "no information" and keep spinning without a label.
+                val isDeterminate = count.max > 0L && ((fraction ?: 0f) > 0f || subFraction != null)
                 val context = LocalContext.current
                 Box(modifier = Modifier.size(32.dp)) {
                     if (isDeterminate) {
@@ -141,12 +173,12 @@ internal fun DashboardProgress(progress: Progress.Data) {
                         // Percent renders itself, so the card agrees with the tool screen and the
                         // automation overlay instead of flooring where they round up. Counter and
                         // Size display as "3/10" and "1.2 MB/5 MB", which doesn't fit inside the
-                        // ring, so they keep showing a percentage of their own. Only a blended
-                        // fraction (sub-count present) is derived from the float, rounded up to
-                        // match Percent.
+                        // ring, so they keep showing a percentage of their own. A blended value
+                        // (sub-count present) is computed from the raw counts, rounded up to match
+                        // Percent; the float fraction only drives the arc.
                         Text(
                             text = when {
-                                subCount != null -> "${ceil(ringFraction * 100f).toInt()}%"
+                                subCount != null -> "${dashboardPercent(count, subCount)}%"
                                 count is Progress.Count.Percent -> count.displayValue(context)
                                 else -> "${(count.current * 100 / count.max).toInt()}%"
                             },

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/cards/SqueezerDashboardCardTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/cards/SqueezerDashboardCardTest.kt
@@ -1,0 +1,112 @@
+package eu.darken.sdmse.main.ui.dashboard.cards
+
+import android.content.Context
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.common.progress.Progress
+import eu.darken.sdmse.squeezer.core.tasks.SqueezerProcessTask
+import eu.darken.sdmse.squeezer.R as SqueezerR
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+
+/**
+ * The Squeezer card used to render neither progress nor a result: a full compression drains the
+ * media list, which pops the tool screen before its snackbar shows, so the dashboard is where the
+ * user actually sees what happened.
+ */
+class SqueezerDashboardCardTest : BaseComposeRobolectricTest() {
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    private val result = SqueezerProcessTask.Success(
+        affectedSpace = 34 * 1024 * 1024L,
+        affectedPaths = emptySet(),
+        processedCount = 2,
+    )
+
+    private val progress = Progress.Data(
+        primary = "Compressing images".toCaString(),
+        secondary = "".toCaString(),
+        count = Progress.Count.Counter(current = 1, max = 2),
+    )
+
+    private fun setContent(
+        progress: Progress.Data? = null,
+        result: SqueezerProcessTask.Result? = null,
+    ) {
+        composeRule.setContent {
+            PreviewWrapper {
+                SqueezerDashboardCard(
+                    item = SqueezerDashboardCardItem(
+                        data = null,
+                        isInitializing = false,
+                        progress = progress,
+                        result = result,
+                        onViewDetails = {},
+                    ),
+                )
+            }
+        }
+    }
+
+    private val description get() = context.getString(SqueezerR.string.squeezer_explanation_short)
+
+    private val resultPrimary get() = result.primaryInfo.get(context)
+
+    private val resultSecondary get() = result.secondaryInfo.get(context)
+
+    @Test
+    fun `without progress or result the card shows its description`() {
+        setContent()
+
+        composeRule.onNodeWithText(description).assertIsDisplayed()
+    }
+
+    @Test
+    fun `a process result replaces the description`() {
+        setContent(result = result)
+
+        composeRule.onNodeWithText(resultPrimary).assertIsDisplayed()
+        composeRule.onNodeWithText(resultSecondary).assertIsDisplayed()
+        composeRule.onNodeWithText(description).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the result appears once progress clears`() {
+        val liveProgress = mutableStateOf<Progress.Data?>(progress)
+        composeRule.setContent {
+            PreviewWrapper {
+                SqueezerDashboardCard(
+                    item = SqueezerDashboardCardItem(
+                        data = null,
+                        isInitializing = false,
+                        progress = liveProgress.value,
+                        result = result,
+                        onViewDetails = {},
+                    ),
+                )
+            }
+        }
+
+        composeRule.onNodeWithText(resultPrimary).assertDoesNotExist()
+
+        liveProgress.value = null
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText(resultPrimary).assertIsDisplayed()
+        composeRule.onNodeWithText(resultSecondary).assertIsDisplayed()
+    }
+
+    @Test
+    fun `progress takes precedence over a result`() {
+        setContent(progress = progress, result = result)
+
+        composeRule.onNodeWithText("Compressing images").assertIsDisplayed()
+        composeRule.onNodeWithText(resultPrimary).assertDoesNotExist()
+        composeRule.onNodeWithText(description).assertDoesNotExist()
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/cards/SqueezerDashboardCardTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/cards/SqueezerDashboardCardTest.kt
@@ -4,12 +4,15 @@ import android.content.Context
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ApplicationProvider
+import eu.darken.sdmse.common.R as CommonR
 import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.squeezer.core.tasks.SqueezerProcessTask
 import eu.darken.sdmse.squeezer.R as SqueezerR
+import io.kotest.matchers.shouldBe
 import org.junit.Test
 import testhelpers.compose.BaseComposeRobolectricTest
 
@@ -21,6 +24,8 @@ import testhelpers.compose.BaseComposeRobolectricTest
 class SqueezerDashboardCardTest : BaseComposeRobolectricTest() {
 
     private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    private var cancels = 0
 
     private val result = SqueezerProcessTask.Success(
         affectedSpace = 34 * 1024 * 1024L,
@@ -47,6 +52,7 @@ class SqueezerDashboardCardTest : BaseComposeRobolectricTest() {
                         progress = progress,
                         result = result,
                         onViewDetails = {},
+                        onCancel = { cancels++ },
                     ),
                 )
             }
@@ -58,6 +64,11 @@ class SqueezerDashboardCardTest : BaseComposeRobolectricTest() {
     private val resultPrimary get() = result.primaryInfo.get(context)
 
     private val resultSecondary get() = result.secondaryInfo.get(context)
+
+    private fun cancelButton() = composeRule.onNodeWithText(context.getString(CommonR.string.general_cancel_action))
+
+    private fun configureButton() =
+        composeRule.onNodeWithText(context.getString(CommonR.string.general_configure_action))
 
     @Test
     fun `without progress or result the card shows its description`() {
@@ -87,6 +98,7 @@ class SqueezerDashboardCardTest : BaseComposeRobolectricTest() {
                         progress = liveProgress.value,
                         result = result,
                         onViewDetails = {},
+                        onCancel = { cancels++ },
                     ),
                 )
             }
@@ -108,5 +120,30 @@ class SqueezerDashboardCardTest : BaseComposeRobolectricTest() {
         composeRule.onNodeWithText("Compressing images").assertIsDisplayed()
         composeRule.onNodeWithText(resultPrimary).assertDoesNotExist()
         composeRule.onNodeWithText(description).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a running operation swaps configure for cancel`() {
+        setContent(progress = progress)
+
+        cancelButton().assertIsDisplayed()
+        configureButton().assertDoesNotExist()
+    }
+
+    @Test
+    fun `without progress the card offers configure`() {
+        setContent()
+
+        configureButton().assertIsDisplayed()
+        cancelButton().assertDoesNotExist()
+    }
+
+    @Test
+    fun `tapping cancel while in progress cancels the operation`() {
+        setContent(progress = progress)
+
+        cancelButton().performClick()
+
+        composeRule.runOnIdle { cancels shouldBe 1 }
     }
 }

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/cards/common/DashboardProgressFractionTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/cards/common/DashboardProgressFractionTest.kt
@@ -1,6 +1,7 @@
 package eu.darken.sdmse.main.ui.dashboard.cards.common
 
 import eu.darken.sdmse.common.progress.Progress
+import eu.darken.sdmse.common.progress.determinateFraction
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
@@ -43,5 +44,48 @@ class DashboardProgressFractionTest : BaseTest() {
     fun `the blended fraction stays inside the ring range`() {
         dashboardFraction(Progress.Count.Counter(4, 4), Progress.Count.Percent(100, 100)) shouldBe 1f
         dashboardFraction(Progress.Count.Counter(-1, 4), Progress.Count.Percent(0, 100)) shouldBe 0f
+    }
+
+    @Test
+    fun `a known zero percent sub count is determinate`() {
+        // Media3's first available poll reports 0%. The blended fraction is exactly 0f, but it is a
+        // real measurement, so the card must not fall back to the "no information" spinner.
+        val fraction = dashboardFraction(Progress.Count.Counter(0, 1), Progress.Count.Percent(0, 100))
+        fraction shouldBe 0f
+        Progress.Count.Percent(0, 100).determinateFraction() shouldBe 0f
+    }
+
+    @Test
+    fun `an indeterminate sub count keeps the legacy spinner`() {
+        dashboardFraction(Progress.Count.Counter(0, 1), Progress.Count.Indeterminate()) shouldBe 0f
+        Progress.Count.Indeterminate().determinateFraction() shouldBe null
+    }
+
+    @Test
+    fun `the percentage does not overshoot the real value`() {
+        // Via the float fraction these two came out as 31% and 61%.
+        dashboardPercent(Progress.Count.Counter(0, 1), Progress.Count.Percent(30, 100)) shouldBe 30
+        dashboardPercent(Progress.Count.Counter(0, 1), Progress.Count.Percent(60, 100)) shouldBe 60
+    }
+
+    @Test
+    fun `the percentage rounds a blended value up`() {
+        // Item 2 of 4 is half done => 37.5%.
+        dashboardPercent(Progress.Count.Counter(1, 4), Progress.Count.Percent(50, 100)) shouldBe 38
+    }
+
+    @Test
+    fun `the percentage ignores an indeterminate sub count`() {
+        // Rounded up, matching Percent.displayValue.
+        dashboardPercent(Progress.Count.Counter(1, 3), Progress.Count.Indeterminate()) shouldBe 34
+        dashboardPercent(Progress.Count.Counter(1, 3), null) shouldBe 34
+    }
+
+    @Test
+    fun `the percentage stays inside 0 and 100`() {
+        dashboardPercent(Progress.Count.Counter(0, 0), null) shouldBe 0
+        dashboardPercent(Progress.Count.Counter(0, 0), Progress.Count.Percent(50, 100)) shouldBe 0
+        dashboardPercent(Progress.Count.Counter(-1, 4), Progress.Count.Percent(0, 100)) shouldBe 0
+        dashboardPercent(Progress.Count.Counter(9, 4), Progress.Count.Percent(200, 100)) shouldBe 100
     }
 }

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/cards/common/DashboardProgressFractionTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/cards/common/DashboardProgressFractionTest.kt
@@ -1,0 +1,47 @@
+package eu.darken.sdmse.main.ui.dashboard.cards.common
+
+import eu.darken.sdmse.common.progress.Progress
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class DashboardProgressFractionTest : BaseTest() {
+
+    @Test
+    fun `size stays determinate`() {
+        // Regression guard: the shared overlay helper excludes Size, the card must not — every
+        // Analyzer / CorpseFinder deletion card would spin forever.
+        dashboardFraction(Progress.Count.Size(1, 2), null) shouldBe 0.5f
+    }
+
+    @Test
+    fun `without a sub count the fraction is unchanged`() {
+        dashboardFraction(Progress.Count.Counter(1, 3), null) shouldBe (1f / 3f)
+        dashboardFraction(Progress.Count.Percent(42, 100), null) shouldBe 0.42f
+    }
+
+    @Test
+    fun `an unknown total has no fraction`() {
+        dashboardFraction(Progress.Count.Counter(0, 0), null) shouldBe null
+        dashboardFraction(Progress.Count.Counter(0, 0), Progress.Count.Percent(50, 100)) shouldBe null
+        dashboardFraction(Progress.Count.Indeterminate(), null) shouldBe null
+        dashboardFraction(Progress.Count.None(), null) shouldBe null
+    }
+
+    @Test
+    fun `a determinate sub count blends into the item fraction`() {
+        // Item 2 of 4 is half done => 1.5 of 4.
+        dashboardFraction(Progress.Count.Counter(1, 4), Progress.Count.Percent(50, 100)) shouldBe 0.375f
+    }
+
+    @Test
+    fun `an indeterminate sub count does not blend`() {
+        dashboardFraction(Progress.Count.Counter(1, 4), Progress.Count.Indeterminate()) shouldBe 0.25f
+    }
+
+    @Test
+    fun `the blended fraction stays inside the ring range`() {
+        dashboardFraction(Progress.Count.Counter(4, 4), Progress.Count.Percent(100, 100)) shouldBe 1f
+        dashboardFraction(Progress.Count.Counter(-1, 4), Progress.Count.Percent(0, 100)) shouldBe 0f
+    }
+}


### PR DESCRIPTION
## What changed

Compressing media used to show "Loading" and 0% for the entire run. Nothing moved until the operation
suddenly finished, which on a single large video meant minutes of a completely static screen.

Progress is now a nested ring. The outer ring tracks how many files are done, the inner ring tracks the
file being worked on right now: a live percentage while a video is being compressed, and a spinner for
images, where no per-file percentage is available. The message line names the file currently being
processed instead of just saying "Loading".

Files are also counted across the whole run. A batch of photos and videos now counts "2 of 5" straight
through, rather than restarting the count when it moves from photos to videos.

After compressing, you finally see what happened. "2 items compressed, freed 36 MB space" now appears on
the Media Squeeze screen you land back on, and on the Media Squeeze dashboard card. Previously a full
compression run showed no summary at all, anywhere. The dashboard card also shows live progress while a
run is going, which it never did before.

## Technical Context

* `Progress.Data` gains a nullable `subCount`, and `ProgressOverlay` draws a second inner ring from it,
  with its accessibility semantics cleared so TalkBack does not announce two indistinguishable progress
  bars. Every existing producer passes null, so no other tool's progress display changes.
* Per-file video progress already existed (the Media3 `Transformer` poller), but was being written into
  the secondary text line as a `"path (42%)"` suffix, where the ring and the large number stayed at 0%.
  It now drives the inner ring and the hero number instead.
* Item numbering is passed into both processors as an offset plus a total, because `performProcess` runs
  the image and video passes under separate `withProgress` scopes, and each previously counted only its
  own batch.
* `withProgress`'s default `onCompletion` republishes a default `Progress.Data`, whose primary string is
  "Loading". That was a second, independent source of the reported symptom, and it is why the Squeezer
  call sites now pass explicit `onCompletion` and `onUpdate` lambdas.
* Worth close review: `dashboardPercent` in `DashboardProgress`. The card blends per-item progress into
  its single 32dp ring instead of nesting, and its percentage is computed from the raw counts rather than
  from the float fraction, because `ceil()` on the fraction turns a real 30% into 31%. The `Count.Size`
  carve-out next to it is deliberate, and preserves the existing determinate ring on the Analyzer and
  CorpseFinder cards.
