### PR TITLE
Fix: Stop Shizuku setup hanging when the connection can't be made

### DIFF
--- a/app-common-adb/src/main/java/eu/darken/sdmse/common/adb/AdbConnectTimeoutException.kt
+++ b/app-common-adb/src/main/java/eu/darken/sdmse/common/adb/AdbConnectTimeoutException.kt
@@ -1,0 +1,13 @@
+package eu.darken.sdmse.common.adb
+
+/**
+ * A step of the Shizuku connect sequence used up its whole time budget without answering.
+ *
+ * Distinct from a plain [AdbException] because it says something a generic failure doesn't: we waited
+ * the full budget and nothing happened. Repeating that attempt right away cannot fail differently, it
+ * just spends the budget again, so callers may treat it as terminal instead of retryable.
+ */
+class AdbConnectTimeoutException @JvmOverloads constructor(
+    message: String? = null,
+    cause: Throwable? = null,
+) : AdbException(message = message, cause = cause)

--- a/app-common-adb/src/main/java/eu/darken/sdmse/common/adb/service/internal/AdbHostLauncher.kt
+++ b/app-common-adb/src/main/java/eu/darken/sdmse/common/adb/service/internal/AdbHostLauncher.kt
@@ -3,6 +3,7 @@ package eu.darken.sdmse.common.adb.service.internal
 import android.os.IBinder
 import android.os.IInterface
 import dagger.Reusable
+import eu.darken.sdmse.common.adb.AdbConnectTimeoutException
 import eu.darken.sdmse.common.adb.AdbException
 import eu.darken.sdmse.common.adb.service.AdbHostOptions
 import eu.darken.sdmse.common.coroutine.AppScope
@@ -46,6 +47,7 @@ class AdbHostLauncher @Inject constructor(
         options: AdbHostOptions,
         connectTimeoutMs: Long = CONNECT_TIMEOUT_MS,
         apiVersionTimeoutMs: Long = API_VERSION_TIMEOUT_MS,
+        unbindTimeoutMs: Long = UNBIND_TIMEOUT_MS,
     ): Flow<ConnectionWrapper<Service, Host>> = callbackFlow {
         // Shizuku.getVersion() only returns a cached field once the server has pushed its version via
         // bindApplication(); until then it is a synchronous binder transaction that wedges against an
@@ -53,7 +55,7 @@ class AdbHostLauncher @Inject constructor(
         // own bound. Detached: a wedged binder thread leaks rather than pinning every collector.
         val apiVersion = appScope.runDetachedWithTimeout(dispatcherProvider.IO, apiVersionTimeoutMs) {
             serviceFactory.apiVersion()
-        } ?: throw AdbException("Shizuku getVersion() did not respond within ${apiVersionTimeoutMs}ms")
+        } ?: throw AdbConnectTimeoutException("Shizuku getVersion() did not respond within ${apiVersionTimeoutMs}ms")
         if (apiVersion < 10) throw IllegalStateException("Shizuku API10+ required")
 
         // Completed only once a connection was actually handed downstream, this is what the
@@ -108,7 +110,7 @@ class AdbHostLauncher @Inject constructor(
                 // Residual epsilon race: a send() completing concurrently with the deadline can tear
                 // down a connection that just came up. CompletableDeferred + withTimeoutOrNull narrows
                 // that window but can't close it; the next acquire re-binds.
-                close(AdbException("Shizuku user service did not connect within ${connectTimeoutMs}ms"))
+                close(AdbConnectTimeoutException("Shizuku user service did not connect within ${connectTimeoutMs}ms"))
             }
         }
 
@@ -155,12 +157,44 @@ class AdbHostLauncher @Inject constructor(
                     // above owns the eventual cleanup.
                 } else if (bindState.get() == BindState.BOUND) {
                     log(TAG) { "Unbinding Shizuku user service…" }
-                    runCatching { service.unbind() }
-                        .onFailure { log(TAG, WARN) { "unbindUserService() failed: ${it.asLog()}" } }
+                    // unbindUserService() is a synchronous binder transaction against the same server
+                    // that may already be wedged, and runCatching bounds nothing - it only catches a
+                    // throw. Collection of a callbackFlow awaits its producer, so an unbounded wedge
+                    // in this finally pins every collector even though the watchdog above already
+                    // close()d the channel: the eternal setup spinner, moved into teardown. Detached
+                    // + bounded, the same trade bind() makes above.
+                    //
+                    // That trade is not free, and not merely "the unbind finishes later": once we stop
+                    // waiting, an outstanding unbind can outlive this generation, and Shizuku keys its
+                    // remove=true unbind on the service args rather than on our callback - so a late
+                    // one can remove a service a NEWER generation just bound. The late-unbind path
+                    // above already carries that race; a teardown that never returns is worse. The
+                    // detached call may also never run at all, if it was still queued when we gave up.
+                    runCatching {
+                        val unbound = appScope.runDetachedWithTimeout(dispatcherProvider.IO, unbindTimeoutMs) {
+                            runCatching { service.unbind() }
+                                .onFailure { log(TAG, WARN) { "unbindUserService() failed: ${it.asLog()}" } }
+                            Unit
+                        }
+                        if (unbound == null) {
+                            log(TAG, WARN) { "unbindUserService() did not return within ${unbindTimeoutMs}ms" }
+                        }
+                    }.onFailure {
+                        // Mainly @AppScope already cancelled (shutdown): await() then throws a
+                        // CancellationException that withTimeoutOrNull does not convert. It would not
+                        // corrupt what collectors see (the watchdog's close() already latched the
+                        // cause), but it would abandon the rest of this teardown - the disconnect wait
+                        // below - and surface as an unhandled producer failure. Teardown is
+                        // best-effort, and not being able to start the unbind is no reason to skip
+                        // the rest of it.
+                        log(TAG, WARN) { "Detached unbind could not run: ${it.asLog()}" }
+                    }
                     // Bounded wait for the actual disconnect; without it, quick flow restarts can
-                    // cause DeadObjectExceptions from our Shizuku service binder.
+                    // cause DeadObjectExceptions from our Shizuku service binder. Still worth doing
+                    // after a timed-out unbind: the server may have processed the removal while the
+                    // synchronous transaction was still waiting on its reply.
                     withTimeoutOrNull(DISCONNECT_TIMEOUT_MS) { service.awaitDisconnect() }
-                    log(TAG) { "Shizuku user service unbound." }
+                    log(TAG) { "Shizuku user service unbind teardown finished." }
                 }
             }
         }
@@ -198,6 +232,20 @@ class AdbHostLauncher @Inject constructor(
         // the same probe against the same upstream Shizuku defect where bindUserService() returns but
         // the connection callback never fires (MediaTek/HyperOS, Shizuku 13.6.0).
         internal const val CONNECT_TIMEOUT_MS = 15 * 1000L
+
+        // How long teardown waits for unbindUserService() before moving on without it. Short, unlike
+        // the probe timeouts around it, because it answers a different question: a probe that gives up
+        // too early reports a working Shizuku as broken, while this one only decides how long a
+        // failing teardown may hold the flow open.
+        //
+        // Measured against a healthy Shizuku, idle, 4 cold teardowns each: Pixel 7a (2023) 4.1-6.1ms,
+        // Pixel 2 (2017) 6.5-10.8ms. So this leaves ~185x headroom over the slowest sample across a
+        // six-year hardware gap. Deliberately not tightened towards those numbers: the measurements
+        // are from idle devices, while the wedge this guards against shows up on low-end hardware
+        // under memory pressure, where a dispatcher hop plus binder round-trip is far slower. Giving
+        // up early is not free either - it is what exposes the cross-generation race described at the
+        // call site - so the headroom is the point.
+        internal const val UNBIND_TIMEOUT_MS = 2 * 1000L
 
         // Budget for the getVersion() round-trip. Same size as CONNECT_TIMEOUT_MS on purpose: this only
         // has to turn "never returns" into "eventually fails", and timing out a slow-but-working

--- a/app-common-adb/src/test/java/eu/darken/sdmse/common/adb/service/internal/AdbHostLauncherTest.kt
+++ b/app-common-adb/src/test/java/eu/darken/sdmse/common/adb/service/internal/AdbHostLauncherTest.kt
@@ -2,9 +2,11 @@ package eu.darken.sdmse.common.adb.service.internal
 
 import android.os.IBinder
 import android.os.IInterface
+import eu.darken.sdmse.common.adb.AdbConnectTimeoutException
 import eu.darken.sdmse.common.adb.AdbException
 import eu.darken.sdmse.common.adb.service.AdbHostOptions
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.withClue
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainInOrder
 import io.kotest.matchers.collections.shouldHaveSize
@@ -22,6 +24,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
@@ -30,7 +33,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
-import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.jupiter.api.Test
 import testhelpers.coroutine.TestDispatcherProvider
 import java.util.concurrent.CountDownLatch
@@ -126,8 +129,10 @@ class AdbHostLauncherTest {
     private fun AdbHostLauncher.connect(
         connectTimeoutMs: Long = AdbHostLauncher.CONNECT_TIMEOUT_MS,
         apiVersionTimeoutMs: Long = AdbHostLauncher.API_VERSION_TIMEOUT_MS,
+        unbindTimeoutMs: Long = AdbHostLauncher.UNBIND_TIMEOUT_MS,
     ) = createConnection(
         apiVersionTimeoutMs = apiVersionTimeoutMs,
+        unbindTimeoutMs = unbindTimeoutMs,
         serviceClass = AdbConnection::class,
         hostClass = AdbConnection::class,
         // Explicit values: AdbHostOptions()'s default isDebug=BuildConfigWrap.DEBUG triggers
@@ -135,6 +140,19 @@ class AdbHostLauncherTest {
         options = AdbHostOptions(isDebug = false, isTrace = false, isDryRun = false, recorderPath = null),
         connectTimeoutMs = connectTimeoutMs,
     )
+
+    /**
+     * Bounded await that fails loudly on timeout.
+     *
+     * withTimeout throws a TimeoutCancellationException, and a CancellationException escaping a
+     * test body unwinds it as a *cancellation* rather than a failure — so a wedge regression these
+     * tests exist to catch can silently pass. withTimeoutOrNull + an explicit null check turns
+     * "never settled" into a real assertion failure.
+     */
+    private suspend fun <T : Any> awaitOrFail(what: String, block: suspend () -> T): T {
+        val settled = withTimeoutOrNull(5_000L) { block() }
+        return withClue("$what did not settle within 5s") { settled.shouldNotBeNull() }
+    }
 
     @Test fun `unsupported shizuku version fails before binding`() = runTest {
         val l = launcher(FakeFactory(version = 9))
@@ -293,9 +311,9 @@ class AdbHostLauncherTest {
 
             withContext(Dispatchers.Default) {
                 // Only measure once the wedge is real: bind() has been entered and is blocked.
-                withTimeout(5_000L) { bindEntered.await() }
+                awaitOrFail("bind()") { bindEntered.await() }
 
-                val error = withTimeout(5_000L) { collectResult.await() }.exceptionOrNull()
+                val error = awaitOrFail("collector") { collectResult.await() }.exceptionOrNull()
                 error.shouldBeInstanceOf<AdbException>()
                 error.message!! shouldContain "did not connect"
 
@@ -305,7 +323,7 @@ class AdbHostLauncherTest {
                 // When the wedged transaction finally returns, the binding must not leak:
                 // teardown already gave up, so the late unbind is the only cleanup left.
                 bindWedge.countDown()
-                withTimeout(5_000L) { unboundLate.await() }
+                awaitOrFail("late unbind") { unboundLate.await() }
             }
         } finally {
             bindWedge.countDown()
@@ -338,10 +356,10 @@ class AdbHostLauncherTest {
 
             withContext(Dispatchers.Default) {
                 // Only measure once the wedge is real: apiVersion() has been entered and is blocked.
-                withTimeout(5_000L) { versionEntered.await() }
+                awaitOrFail("apiVersion()") { versionEntered.await() }
 
-                val error = withTimeout(5_000L) { collectResult.await() }.exceptionOrNull()
-                error.shouldBeInstanceOf<AdbException>()
+                val error = awaitOrFail("collector") { collectResult.await() }.exceptionOrNull()
+                error.shouldBeInstanceOf<AdbConnectTimeoutException>()
                 error.message!! shouldContain "getVersion"
 
                 // Bailed out before binding, so there is nothing to unbind.
@@ -379,4 +397,118 @@ class AdbHostLauncherTest {
         emitted shouldHaveSize 1
         job.cancelAndJoin()
     }
+
+    @Test fun `an unbind wedged in its binder transaction still releases collectors`() = runTest(
+        timeout = 10.seconds,
+    ) {
+        // Third variant of the same upstream wedge, on the teardown side: bind() returns, the service
+        // never calls back, the watchdog close()s - and then unbindUserService() wedges against the
+        // same unresponsive server. Collection of a callbackFlow awaits its producer, so before this
+        // was bounded the close() never reached anyone: collectors waited on a flow whose producer sat
+        // in an uninterruptible binder call inside NonCancellable, forever.
+        val unbindEntered = CompletableDeferred<Unit>()
+        val unbindWedge = CountDownLatch(1)
+        val service = object : ShizukuUserService {
+            override fun bind() {} // returns cleanly, so teardown owns the unbind (BindState.BOUND)
+
+            override fun unbind() {
+                unbindEntered.complete(Unit)
+                unbindWedge.await() // blocks the calling thread, unaffected by coroutine cancellation
+            }
+
+            override suspend fun awaitDisconnect() {}
+        }
+        // Real scope + real IO dispatcher: the wedge blocks an actual thread, virtual time and
+        // Unconfined execution can't model it (Unconfined would block the producer's own thread).
+        val realScope = CoroutineScope(SupervisorJob())
+        val l = AdbHostLauncher(
+            serviceFactory = FakeFactory(service),
+            appScope = realScope,
+            dispatcherProvider = TestDispatcherProvider(Dispatchers.IO),
+        )
+
+        try {
+            // Collection runs in its own scope: on a regression the collector blocks forever, and it
+            // must do so in a coroutine the test only awaits WITH a timeout - a blocked child of the
+            // test coroutine itself would defeat runTest's timeout and hang the JVM.
+            val collectResult = realScope.async(Dispatchers.Default) {
+                runCatching { l.connect(connectTimeoutMs = 250L, unbindTimeoutMs = 250L).collect { } }
+            }
+
+            withContext(Dispatchers.Default) {
+                // Only measure once the wedge is real: unbind() has been entered and is blocked.
+                awaitOrFail("unbind()") { unbindEntered.await() }
+
+                val error = awaitOrFail("collector") { collectResult.await() }.exceptionOrNull()
+                error.shouldBeInstanceOf<AdbConnectTimeoutException>()
+                error.message!! shouldContain "did not connect"
+            }
+        } finally {
+            unbindWedge.countDown()
+            realScope.cancel()
+        }
+    }
+
+
+    @Test fun `a dead app scope during teardown does not abandon the rest of it`() = runTest(
+        timeout = 10.seconds,
+    ) {
+        // The detached unbind runs on @AppScope. If that scope is already cancelled, async() yields a
+        // cancelled Deferred and await() throws a CancellationException that withTimeoutOrNull does
+        // NOT convert (it only converts its own timeout). What the collector sees is safe either way
+        // - the watchdog's close() latched the cause before teardown ran - so this asserts the part
+        // that is NOT safe: an escaping throw abandons the rest of teardown. The disconnect wait
+        // after the unbind is the observable half of that.
+        val bindReturned = CompletableDeferred<Unit>()
+        val disconnectAwaited = CompletableDeferred<Unit>()
+        val service = object : ShizukuUserService {
+            override fun bind() {
+                bindReturned.complete(Unit)
+            }
+
+            // Never reached: the dead scope means the detached block never runs.
+            override fun unbind() = error("must not be reached: the app scope is dead")
+
+            override suspend fun awaitDisconnect() {
+                disconnectAwaited.complete(Unit)
+            }
+        }
+        val appScope = CoroutineScope(SupervisorJob())
+        val collectScope = CoroutineScope(SupervisorJob())
+        val l = AdbHostLauncher(
+            serviceFactory = FakeFactory(service),
+            appScope = appScope,
+            dispatcherProvider = TestDispatcherProvider(Dispatchers.IO),
+        )
+
+        try {
+            // Watchdog long enough that appScope is reliably dead before teardown starts.
+            val collectResult = collectScope.async(Dispatchers.Default) {
+                runCatching { l.connect(connectTimeoutMs = 1_500L).collect { } }
+            }
+
+            withContext(Dispatchers.Default) {
+                awaitOrFail("bind()") { bindReturned.await() }
+                // bind() has returned, so the bind job's CAS to BOUND (which runs immediately after)
+                // has effectively landed - that is the branch that reaches the unbind at teardown.
+                // Settle before killing the scope so this doesn't test the TEARDOWN branch instead.
+                delay(200)
+                appScope.cancel()
+
+                val error = awaitOrFail("collector") { collectResult.await() }.exceptionOrNull()
+                error.shouldBeInstanceOf<AdbConnectTimeoutException>()
+                error.message!! shouldContain "did not connect"
+
+                // The load-bearing assertion: teardown continued past the unbind it could not start.
+                // This also rules out a vacuous pass via the TEARDOWN branch, which never gets here.
+                withClue("teardown was abandoned when the detached unbind could not run") {
+                    disconnectAwaited.isCompleted shouldBe true
+                }
+            }
+        } finally {
+            appScope.cancel()
+            collectScope.cancel()
+        }
+    }
+
 }

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/adb/service/AdbServiceClient.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/adb/service/AdbServiceClient.kt
@@ -1,5 +1,6 @@
 package eu.darken.sdmse.common.adb.service
 
+import eu.darken.sdmse.common.adb.AdbConnectTimeoutException
 import eu.darken.sdmse.common.adb.AdbServiceConnection
 import eu.darken.sdmse.common.adb.AdbSettings
 import eu.darken.sdmse.common.adb.AdbUnavailableException
@@ -13,6 +14,7 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.error.causes
 import eu.darken.sdmse.common.files.local.ipc.FileOpsClient
 import eu.darken.sdmse.common.flow.setupCommonEventHandlers
 import eu.darken.sdmse.common.ipc.IpcClientModule
@@ -54,6 +56,17 @@ class AdbServiceClient @Inject constructor(
     parentScope = coroutineScope + dispatcherProvider.IO,
     stopTimeout = ADB_HOST_KEEPALIVE,
     verboseLifecycle = true,
+    // A connect timeout means the Shizuku handshake burned its entire budget without an answer, so
+    // the default "the starter owns this failure, retry fresh" is a bad trade here: each retry is
+    // another full budget. On a device where Shizuku's user service never comes up (the MediaTek/
+    // HyperOS defect) that turned one 15s stall into up to five for every concurrent probe. The
+    // caller that started the generation always got the real error; this gives it to the others too.
+    // take(): `causes` walks until cause == null without tracking identity, so a cyclic chain would
+    // spin forever - and this predicate runs on the path whose whole job is to stop hangs.
+    isRetryableStartupFailure = { error ->
+        error !is AdbConnectTimeoutException &&
+                error.causes.take(MAX_CAUSE_DEPTH).none { it is AdbConnectTimeoutException }
+    },
     source = callbackFlow {
         log(TAG) { "Instantiating ADB launcher..." }
 
@@ -128,6 +141,9 @@ class AdbServiceClient @Inject constructor(
         // purpose: a uid-2000 host should not linger in the background for long. Teardown still happens
         // (and is prompt/safe); this only delays its start.
         private val ADB_HOST_KEEPALIVE: Duration = Duration.ofSeconds(30)
+
+        /** Depth bound for the cause walk in [isRetryableStartupFailure]; our chains are 2 deep. */
+        private const val MAX_CAUSE_DEPTH = 16
 
         fun AdbHostLauncher.createServiceHostConnection(
             options: AdbHostOptions,

--- a/app-common/src/main/java/eu/darken/sdmse/common/sharedresource/SharedResource.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/sharedresource/SharedResource.kt
@@ -56,6 +56,16 @@ open class SharedResource<T : Any>(
      * yet, so a reuse would otherwise be handed a dead resource. Null (default) disables validation.
      */
     private val isReusable: (suspend (T) -> Boolean)? = null,
+    /**
+     * Decides whether a caller that latched onto an already-running generation should silently retry
+     * when that generation dies before producing its first value. Default: retry, because such a
+     * failure belongs to the caller that STARTED the generation (see [StaleReuseAcquireException]).
+     *
+     * Return false for failures an immediate second attempt cannot fix. The retry is only worth its
+     * cost when a fresh attempt might fail differently; for a source whose failure is a spent timeout
+     * budget it just makes every waiter pay that budget again, once per [reuseValidationAttempts].
+     */
+    private val isRetryableStartupFailure: (Throwable) -> Boolean = { true },
 ) : KeepAlive {
     private val iTag = "$tag:SR"
     override val resourceId: String = iTag
@@ -298,7 +308,7 @@ open class SharedResource<T : Any>(
             generation.ready.await()
         } catch (e: Throwable) {
             if (Bugs.isTrace) log(iTag, DEBUG) { "[${generation.id}|$lId]-get() await failed (${e.javaClass.simpleName}), releasing provisional lease" }
-            if (reused && e !is CancellationException) {
+            if (reused && e !is CancellationException && isRetryableStartupFailure(e)) {
                 // We latched onto an already-running generation that then died before producing a value.
                 // Its startup error belongs to the caller that STARTED it, not to us — force-detach the
                 // corpse (async onCompletion teardown may not have run yet) and signal get() to retry fresh.

--- a/app-common/src/test/java/eu/darken/sdmse/common/sharedresource/SharedResourceTest.kt
+++ b/app-common/src/test/java/eu/darken/sdmse/common/sharedresource/SharedResourceTest.kt
@@ -1112,4 +1112,63 @@ class SharedResourceTest : BaseTest() {
             Logging.remove(capture)
         }
     }
+
+    @Test
+    fun `a non-retryable startup failure is shared with the reusing caller instead of retried`(): Unit = runBlocking {
+        val attempts = AtomicInteger(0)
+        val firstStarted = CompletableDeferred<Unit>()
+        val failFirst = CompletableDeferred<Unit>()
+
+        // Same shape as the retry test above, but the source declares its startup failure hopeless.
+        // Retrying would make the reuser pay the whole doomed attempt a second time, which is what
+        // a spent timeout budget (e.g. the Shizuku connect watchdog) costs in practice.
+        val reuserLatched = CompletableDeferred<Unit>()
+        val capture = object : Logging.Logger {
+            override fun log(
+                priority: Logging.Priority,
+                tag: String,
+                message: String,
+                metaData: Map<String, Any>?
+            ) {
+                if (tag == "no-retry:SR" && message.contains("Source job already exists")) {
+                    reuserLatched.complete(Unit)
+                }
+            }
+        }
+        Logging.install(capture)
+        try {
+            val sr = SharedResource<Int>(
+                tag = "no-retry",
+                parentScope = this + Dispatchers.IO,
+                stopTimeout = Duration.ZERO,
+                isRetryableStartupFailure = { false },
+                source = flow {
+                    if (attempts.incrementAndGet() == 1) {
+                        firstStarted.complete(Unit)
+                        failFirst.await()
+                        throw IOException("source died before producing a value")
+                    }
+                    emit(attempts.get())
+                    awaitCancellation()
+                },
+            )
+
+            val creator = async(Dispatchers.IO) { runCatching { sr.get() } }
+            firstStarted.await()
+            val reuser = async(Dispatchers.IO) { runCatching { sr.get() } }
+            reuserLatched.await()
+            failFirst.complete(Unit)
+
+            // Both callers waited on the same doomed attempt, so both get its real error...
+            (creator.await().exceptionOrNull() is IOException) shouldBe true
+            (reuser.await().exceptionOrNull() is IOException) shouldBe true
+            // ...and nobody silently started a second one.
+            attempts.get() shouldBe 1
+
+            sr.close()
+        } finally {
+            Logging.remove(capture)
+        }
+    }
+
 }


### PR DESCRIPTION
## What changed

When SD Maid cannot establish a Shizuku connection, it now gives up within a predictable amount of time instead of potentially waiting forever. Previously, if Shizuku stopped responding at the wrong moment, the Shizuku setup card could sit unresolved indefinitely, and each repeated check could wait out another full timeout before reporting anything.

This does not make Shizuku work on devices affected by the upstream Shizuku defect (see #2691) — the helper process dying there is not something the app can fix. It makes the resulting failure end promptly and report its real cause.

Refs #2691

## Technical Context

- `AdbHostLauncher`'s teardown called `unbindUserService()` as an unbounded synchronous binder transaction inside the `callbackFlow` producer's `finally`. Collection awaits its producer, so a wedged unbind pinned every collector even though the connect watchdog had already `close()`d the channel — the same eternal-spinner failure the watchdog exists to prevent, one step later. It is now detached and bounded like `bind()` and `getVersion()` already were.
- Worth a close look: bounding the unbind means a late one can outlive its generation, and Shizuku keys its `remove=true` unbind on the service args rather than on our callback, so it can remove a service a newer generation just bound. The pre-existing late-unbind path already carries that race, and a teardown that never returns is worse. Documented at the call site.
- `UNBIND_TIMEOUT_MS` is 2s, chosen against measurements rather than intuition: 4.1-6.1ms on a Pixel 7a and 6.5-10.8ms on a Pixel 2, four cold teardowns each against a healthy Shizuku. The large headroom is deliberate, since those samples come from idle devices while the wedge appears under memory pressure.
- `SharedResource` gained an opt-in `isRetryableStartupFailure` predicate, defaulting to current behavior so the existing retry policy and its test are untouched. `AdbServiceClient` opts out for connect timeouts: retrying a failure that already spent its whole budget just makes every waiter spend it again, up to five times.
- The three binder-wedge tests used `withTimeout`, whose `TimeoutCancellationException` unwinds a test body as a cancellation rather than a failure, so a wedge regression could pass silently — the new unbind test did exactly that before this was found. They now share a helper that fails explicitly on timeout.
