### PR TITLE
Fix: Explain why the Shizuku link failed instead of waiting forever

### DIFF
--- a/app-common-adb/src/main/java/eu/darken/sdmse/common/adb/AdbConnectTimeoutException.kt
+++ b/app-common-adb/src/main/java/eu/darken/sdmse/common/adb/AdbConnectTimeoutException.kt
@@ -1,5 +1,7 @@
 package eu.darken.sdmse.common.adb
 
+import eu.darken.sdmse.common.error.causes
+
 /**
  * A step of the Shizuku connect sequence used up its whole time budget without answering.
  *
@@ -11,3 +13,17 @@ class AdbConnectTimeoutException @JvmOverloads constructor(
     message: String? = null,
     cause: Throwable? = null,
 ) : AdbException(message = message, cause = cause)
+
+/**
+ * Did this failure come from a spent connect budget?
+ *
+ * Walks the cause chain because the failure is wrapped on its way out (AdbServiceClient turns it
+ * into an AdbUnavailableException). Depth-bounded on purpose: [causes] follows `cause` until null
+ * without tracking identity, so a cyclic chain would spin forever - and both callers sit on paths
+ * whose whole job is to stop things from hanging.
+ */
+fun Throwable.isAdbConnectTimeout(): Boolean = this is AdbConnectTimeoutException ||
+        causes.take(MAX_CAUSE_DEPTH).any { it is AdbConnectTimeoutException }
+
+/** Our own chains are 2 deep; this only has to stop a pathological one. */
+private const val MAX_CAUSE_DEPTH = 16

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/adb/service/AdbServiceClient.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/adb/service/AdbServiceClient.kt
@@ -1,6 +1,6 @@
 package eu.darken.sdmse.common.adb.service
 
-import eu.darken.sdmse.common.adb.AdbConnectTimeoutException
+import eu.darken.sdmse.common.adb.isAdbConnectTimeout
 import eu.darken.sdmse.common.adb.AdbServiceConnection
 import eu.darken.sdmse.common.adb.AdbSettings
 import eu.darken.sdmse.common.adb.AdbUnavailableException
@@ -14,7 +14,6 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
-import eu.darken.sdmse.common.error.causes
 import eu.darken.sdmse.common.files.local.ipc.FileOpsClient
 import eu.darken.sdmse.common.flow.setupCommonEventHandlers
 import eu.darken.sdmse.common.ipc.IpcClientModule
@@ -61,12 +60,7 @@ class AdbServiceClient @Inject constructor(
     // another full budget. On a device where Shizuku's user service never comes up (the MediaTek/
     // HyperOS defect) that turned one 15s stall into up to five for every concurrent probe. The
     // caller that started the generation always got the real error; this gives it to the others too.
-    // take(): `causes` walks until cause == null without tracking identity, so a cyclic chain would
-    // spin forever - and this predicate runs on the path whose whole job is to stop hangs.
-    isRetryableStartupFailure = { error ->
-        error !is AdbConnectTimeoutException &&
-                error.causes.take(MAX_CAUSE_DEPTH).none { it is AdbConnectTimeoutException }
-    },
+    isRetryableStartupFailure = { error -> !error.isAdbConnectTimeout() },
     source = callbackFlow {
         log(TAG) { "Instantiating ADB launcher..." }
 
@@ -142,8 +136,6 @@ class AdbServiceClient @Inject constructor(
         // (and is prompt/safe); this only delays its start.
         private val ADB_HOST_KEEPALIVE: Duration = Duration.ofSeconds(30)
 
-        /** Depth bound for the cause walk in [isRetryableStartupFailure]; our chains are 2 deep. */
-        private const val MAX_CAUSE_DEPTH = 16
 
         fun AdbHostLauncher.createServiceHostConnection(
             options: AdbHostOptions,

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/adb/shizuku/ShizukuManager.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/adb/shizuku/ShizukuManager.kt
@@ -2,6 +2,7 @@ package eu.darken.sdmse.common.adb.shizuku
 
 import eu.darken.sdmse.common.access.AccessState
 import eu.darken.sdmse.common.adb.AdbSettings
+import eu.darken.sdmse.common.adb.isAdbConnectTimeout
 import eu.darken.sdmse.common.adb.service.AdbServiceClient
 import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
@@ -132,19 +133,46 @@ class ShizukuManager @Inject constructor(
     suspend fun requestPermission() = shizukuWrapper.requestPermission()
 
 
-    suspend fun isOurServiceAvailable(): Boolean = withContext(dispatcherProvider.IO) {
-        if (isGranted() != true) {
-            log(TAG, VERBOSE) { "isOurServiceAvailable(): Shizuku permission not granted" }
-            return@withContext false
+    suspend fun isOurServiceAvailable(): Boolean = getServiceState() is ShizukuServiceState.Available
+
+    /**
+     * Same probe as [isOurServiceAvailable], but says WHY when the answer is no.
+     *
+     * The distinction that matters for the UI is "we have not finished looking" versus "we looked
+     * and it will not work": only the latter is worth telling the user about, and only the latter
+     * should offer a retry.
+     */
+    suspend fun getServiceState(): ShizukuServiceState = withContext(dispatcherProvider.IO) {
+        when (isGranted()) {
+            false -> {
+                log(TAG, VERBOSE) { "getServiceState(): Shizuku permission not granted" }
+                return@withContext ShizukuServiceState.PermissionDenied
+            }
+            // Not a denial: no live binder means the grant state cannot be read at all.
+            null -> {
+                log(TAG, VERBOSE) { "getServiceState(): No live binder, grant state unknown" }
+                return@withContext ShizukuServiceState.Unknown
+            }
+
+            true -> {}
         }
         try {
-            log(TAG, VERBOSE) { "isOurServiceAvailable(): Requesting service client" }
-            serviceClient.get().use { it.item.ipc.checkBase() != null }
+            log(TAG, VERBOSE) { "getServiceState(): Requesting service client" }
+            val alive = serviceClient.get().use { it.item.ipc.checkBase() != null }
+            if (alive) {
+                ShizukuServiceState.Available
+            } else {
+                // Connected, but the host handed back nothing usable.
+                log(TAG, WARN) { "getServiceState(): checkBase() returned null" }
+                ShizukuServiceState.Failed
+            }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            log(TAG, WARN) { "isOurServiceAvailable(): Error during checkBase(): $e" }
-            false
+            log(TAG, WARN) { "getServiceState(): Error during checkBase(): ${e.asLog()}" }
+            // A spent connect budget is the signature of Shizuku's user service never calling back,
+            // but the same defect also surfaces as a handshake failure, so both are terminal.
+            if (e.isAdbConnectTimeout()) ShizukuServiceState.TimedOut else ShizukuServiceState.Failed
         }
     }
 

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/adb/shizuku/ShizukuServiceState.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/adb/shizuku/ShizukuServiceState.kt
@@ -1,0 +1,51 @@
+package eu.darken.sdmse.common.adb.shizuku
+
+/**
+ * Why our privileged Shizuku service is (not) usable.
+ *
+ * Exists because a bare Boolean cannot tell "still nothing yet" apart from "we tried and it failed",
+ * which is what left the setup card showing the same waiting message forever on devices where
+ * Shizuku's user service never comes up.
+ */
+sealed interface ShizukuServiceState {
+
+    /** Nothing has probed yet. */
+    data object NotChecked : ShizukuServiceState
+
+    /** Our service is up and answering. */
+    data object Available : ShizukuServiceState
+
+    /** Shizuku says we do not have permission. */
+    data object PermissionDenied : ShizukuServiceState
+
+    /**
+     * The grant state could not be read. NOT the same as [PermissionDenied]: it means "cannot know".
+     *
+     * Deliberately NOT a terminal failure even though ShizukuWrapper.isGranted() also returns null
+     * when its own watchdog expires, so a wedged Shizuku server lands here too. The overwhelmingly
+     * common cause is simply that Shizuku has not been started yet, and telling that user their
+     * setup failed would be wrong. The helper-process defect this all exists for does not come
+     * through here: it surfaces as [TimedOut] or [Failed] from the connect attempt itself.
+     */
+    data object Unknown : ShizukuServiceState
+
+    /**
+     * A step of the connect sequence used its whole time budget. Terminal for this attempt: the
+     * upstream defect where Shizuku's user service never calls back lands here.
+     */
+    data object TimedOut : ShizukuServiceState
+
+    /**
+     * Any other terminal failure, e.g. the user-service handshake threw. The same upstream defect
+     * can surface here rather than as [TimedOut] when the service dies mid-handshake, so this is a
+     * real failure to report, not an "unknown yet".
+     *
+     * Deliberately carries no Throwable: this state is cached in long-lived UI state, the manager
+     * already logs the exception, and nothing downstream reads it.
+     */
+    data object Failed : ShizukuServiceState
+
+    /** Did we probe and get a definitive "no"? Drives whether the UI offers a retry. */
+    val isTerminalFailure: Boolean
+        get() = this is TimedOut || this is Failed
+}

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/adb/shizuku/ShizukuManagerTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/adb/shizuku/ShizukuManagerTest.kt
@@ -1,15 +1,19 @@
 package eu.darken.sdmse.common.adb.shizuku
 
+import eu.darken.sdmse.common.adb.AdbConnectTimeoutException
 import eu.darken.sdmse.common.adb.AdbSettings
 import eu.darken.sdmse.common.adb.AdbUnavailableException
 import eu.darken.sdmse.common.adb.service.AdbServiceClient
 import eu.darken.sdmse.common.datastore.DataStoreValue
 import eu.darken.sdmse.common.pkgs.toPkgId
+import eu.darken.sdmse.common.sharedresource.Resource
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -171,4 +175,87 @@ class ShizukuManagerTest : BaseTest() {
         setShizukuPackage(forkPkg)
         runBlocking { mgr.managerIds() } shouldBe setOf(ShizukuManager.PKG_ID, forkPkg.toPkgId())
     }
+
+    // --- getServiceState -----------------------------------------------------------------------
+
+    @Test fun `getServiceState reports Unknown, not PermissionDenied, when isGranted is null`() {
+        // null means "cannot know" (no live binder), which resolves itself once Shizuku runs.
+        // Reporting it as a denial would tell the user to fix a permission that is not the problem.
+        coEvery { shizukuWrapper.isGranted() } returns null
+        val mgr = manager()
+
+        runBlocking { mgr.getServiceState() } shouldBe ShizukuServiceState.Unknown
+
+        coVerify(exactly = 0) { serviceClient.get() }
+    }
+
+    @Test fun `getServiceState reports PermissionDenied when isGranted is false`() {
+        coEvery { shizukuWrapper.isGranted() } returns false
+        val mgr = manager()
+
+        runBlocking { mgr.getServiceState() } shouldBe ShizukuServiceState.PermissionDenied
+
+        coVerify(exactly = 0) { serviceClient.get() }
+    }
+
+    @Test fun `getServiceState reports TimedOut for a direct connect timeout`() {
+        coEvery { shizukuWrapper.isGranted() } returns true
+        coEvery { serviceClient.get() } throws AdbConnectTimeoutException("test")
+        val mgr = manager()
+
+        runBlocking { mgr.getServiceState() } shouldBe ShizukuServiceState.TimedOut
+    }
+
+    @Test fun `getServiceState reports TimedOut for a wrapped connect timeout`() {
+        // How it actually arrives: AdbServiceClient wraps the launcher's failure on its way out.
+        coEvery { shizukuWrapper.isGranted() } returns true
+        coEvery { serviceClient.get() } throws AdbUnavailableException(
+            "wrapped",
+            cause = AdbConnectTimeoutException("did not connect"),
+        )
+        val mgr = manager()
+
+        runBlocking { mgr.getServiceState() } shouldBe ShizukuServiceState.TimedOut
+    }
+
+    @Test fun `getServiceState reports Failed for a generic failure`() {
+        // The same upstream defect can surface as a handshake failure rather than a timeout, so this
+        // has to be a reportable terminal state too, not an "unknown yet".
+        coEvery { shizukuWrapper.isGranted() } returns true
+        coEvery { serviceClient.get() } throws AdbUnavailableException("test")
+        val mgr = manager()
+
+        runBlocking { mgr.getServiceState() } shouldBe ShizukuServiceState.Failed
+    }
+
+    @Test fun `getServiceState propagates cancellation instead of reporting a failure`() {
+        coEvery { shizukuWrapper.isGranted() } returns true
+        coEvery { serviceClient.get() } throws CancellationException("cancelled")
+        val mgr = manager()
+
+        shouldThrow<CancellationException> { runBlocking { mgr.getServiceState() } }
+    }
+
+    @Test fun `terminal failures are the ones that offer a retry`() {
+        ShizukuServiceState.TimedOut.isTerminalFailure shouldBe true
+        ShizukuServiceState.Failed.isTerminalFailure shouldBe true
+        ShizukuServiceState.NotChecked.isTerminalFailure shouldBe false
+        ShizukuServiceState.Available.isTerminalFailure shouldBe false
+        ShizukuServiceState.PermissionDenied.isTerminalFailure shouldBe false
+        ShizukuServiceState.Unknown.isTerminalFailure shouldBe false
+    }
+
+
+    @Test fun `getServiceState reports Failed when the host hands back nothing usable`() {
+        // Connected, but checkBase() returned null: a connection we cannot use is a failure, not an
+        // "unknown yet" that would leave the card waiting forever.
+        coEvery { shizukuWrapper.isGranted() } returns true
+        val connection: AdbServiceClient.Connection = mockk()
+        every { connection.ipc.checkBase() } returns null
+        coEvery { serviceClient.get() } returns Resource(connection, mockk(relaxed = true))
+        val mgr = manager()
+
+        runBlocking { mgr.getServiceState() } shouldBe ShizukuServiceState.Failed
+    }
+
 }

--- a/app-common/src/main/java/eu/darken/sdmse/common/BuildWrap.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/BuildWrap.kt
@@ -21,6 +21,23 @@ object BuildWrap {
     val PRODUCT: String?
         get() = Build.PRODUCT
 
+    val HARDWARE: String?
+        get() = Build.HARDWARE.normalizeBuildValue()
+
+    /**
+     * SoC vendor, e.g. "Google", "Qualcomm", "QTI", "Mediatek". Null below API31, where the
+     * property does not exist.
+     *
+     * Free-form vendor-written text, NOT an enum: Qualcomm ships as both "Qualcomm" and "QTI",
+     * and MediaTek as both "MediaTek" and "Mediatek". Compare case-insensitively, never by equality.
+     */
+    val SOC_MANUFACTURER: String?
+        get() = ifApiLevel(31) { Build.SOC_MANUFACTURER }.normalizeBuildValue()
+
+    /** SoC model, e.g. "Tensor G3", "SM6375", "MT8781V/NA". Null below API31. */
+    val SOC_MODEL: String?
+        get() = ifApiLevel(31) { Build.SOC_MODEL }.normalizeBuildValue()
+
     val VERSION = VersionWrap
 
     object VersionWrap {
@@ -35,6 +52,14 @@ object BuildWrap {
     }
 }
 
+/**
+ * [Build.UNKNOWN] is the documented sentinel for "the vendor did not set this", and some vendors
+ * leave the property blank instead. Neither is a usable value, so both read as absent.
+ */
+internal fun String?.normalizeBuildValue(): String? = this
+    ?.trim()
+    ?.takeUnless { it.isEmpty() || it.equals(Build.UNKNOWN, ignoreCase = true) }
+
 @ChecksSdkIntAtLeast(parameter = 0)
 fun hasApiLevel(level: Int): Boolean = when {
     BuildWrap.VERSION.SDK_INT >= level -> true
@@ -47,5 +72,8 @@ fun hasApiLevel(level: Int): Boolean = when {
 
 const val UNTESTED_API = 37
 
+// lambda = 1: without it lint only knows hasApiLevel() gates something, not that THIS lambda is the
+// gated code, and flags API-restricted calls inside it as NewApi.
+@ChecksSdkIntAtLeast(parameter = 0, lambda = 1)
 inline fun <reified R> ifApiLevel(level: Int, block: () -> R): R? = if (hasApiLevel(level)) block() else null
 

--- a/app-common/src/main/java/eu/darken/sdmse/common/device/DeviceDetective.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/device/DeviceDetective.kt
@@ -39,6 +39,30 @@ class DeviceDetective @Inject constructor(
         return pm.hasSystemFeature(PackageManager.FEATURE_LEANBACK)
     }
 
+    /**
+     * Does this device run a MediaTek SoC?
+     *
+     * The signals are a hierarchy, not an OR. [BuildWrap.SOC_MANUFACTURER] is authoritative when
+     * present, because the weaker signals below would otherwise let an odd board name override a
+     * device that has already told us it is Qualcomm. Matching is case-insensitive and never by
+     * equality: affected devices ship "Mediatek" as well as "MediaTek", so an exact-match check
+     * would miss exactly the hardware this exists for.
+     */
+    fun isMediatekSoc(): Boolean {
+        BuildWrap.SOC_MANUFACTURER?.lowercase()?.let { socVendor ->
+            return socVendor.contains("mediatek") || socVendor == "mtk"
+        }
+        // No vendor, but a model: MediaTek parts are "MT<number>", e.g. "MT8781V/NA".
+        BuildWrap.SOC_MODEL?.lowercase()?.let { socModel ->
+            return socModel.startsWith("mt")
+        }
+        // API<31 only, where neither SoC property exists. On MediaTek this is the chipset
+        // ("mt6789"), but other vendors put a device codename here, so a codename that happens to
+        // start with "mt" is a false positive. Acceptable: this only ever refines the wording of a
+        // hint that is already gated on an observed connection failure.
+        return BuildWrap.HARDWARE?.lowercase()?.startsWith("mt") == true
+    }
+
     private fun manufactor(name: String): Boolean {
         return BuildWrap.MANUFACTOR.equals(name, ignoreCase = true)
     }

--- a/app-common/src/test/java/eu/darken/sdmse/common/BuildWrapTest.kt
+++ b/app-common/src/test/java/eu/darken/sdmse/common/BuildWrapTest.kt
@@ -1,0 +1,28 @@
+package eu.darken.sdmse.common
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class BuildWrapTest : BaseTest() {
+
+    @Test fun `absent build values normalize to null`() {
+        // Build.UNKNOWN is the documented sentinel for "the vendor did not set this", and some
+        // vendors leave the property blank instead. Neither is usable, so both must read as absent,
+        // otherwise a SoC check would treat the literal string "unknown" as a vendor name.
+        null.normalizeBuildValue() shouldBe null
+        "".normalizeBuildValue() shouldBe null
+        "   ".normalizeBuildValue() shouldBe null
+        "unknown".normalizeBuildValue() shouldBe null
+        "UNKNOWN".normalizeBuildValue() shouldBe null
+        "Unknown".normalizeBuildValue() shouldBe null
+    }
+
+    @Test fun `real build values survive, trimmed`() {
+        "Mediatek".normalizeBuildValue() shouldBe "Mediatek"
+        "  Qualcomm  ".normalizeBuildValue() shouldBe "Qualcomm"
+        "MT8781V/NA".normalizeBuildValue() shouldBe "MT8781V/NA"
+        // Only the exact sentinel is dropped, not anything containing it.
+        "unknown-soc".normalizeBuildValue() shouldBe "unknown-soc"
+    }
+}

--- a/app-common/src/test/java/eu/darken/sdmse/common/device/DeviceDetectiveTest.kt
+++ b/app-common/src/test/java/eu/darken/sdmse/common/device/DeviceDetectiveTest.kt
@@ -710,4 +710,71 @@ class DeviceDetectiveTest : BaseTest() {
 
         detective.getROMType() shouldBe RomType.HYPEROS
     }
+
+    // --- isMediatekSoc -------------------------------------------------------------------------
+    // Every value below is observed, not invented: the negatives were read off five attached
+    // devices, the positives off real device trees for the chipsets in RikkaApps/Shizuku#1198.
+
+    private fun detectiveFor(
+        soc: String? = null,
+        model: String? = null,
+        hw: String? = null,
+    ): DeviceDetective = DeviceDetective(
+        mockDevice {
+            manufacturer = "Generic"
+            socManufacturer = soc
+            socModel = model
+            hardware = hw
+        }
+    )
+
+    @Test
+    fun `isMediatekSoc matches the vendor string case-insensitively`() {
+        // "Mediatek" (lowercase t) is what an affected Xiaomi MT6789 tree actually ships, so an
+        // exact-match check would miss the exact hardware this exists for.
+        detectiveFor(soc = "Mediatek").isMediatekSoc() shouldBe true
+        detectiveFor(soc = "MediaTek").isMediatekSoc() shouldBe true
+        detectiveFor(soc = "MEDIATEK").isMediatekSoc() shouldBe true
+        detectiveFor(soc = "MTK").isMediatekSoc() shouldBe true
+    }
+
+    @Test
+    fun `isMediatekSoc rejects other vendors`() {
+        // Qualcomm ships under two different strings on two devices; both must read as not-MediaTek.
+        detectiveFor(soc = "Qualcomm").isMediatekSoc() shouldBe false
+        detectiveFor(soc = "QTI").isMediatekSoc() shouldBe false
+        detectiveFor(soc = "Google").isMediatekSoc() shouldBe false
+    }
+
+    @Test
+    fun `isMediatekSoc trusts a known vendor over the weaker signals`() {
+        // The whole point of the hierarchy: an odd board name must not override a device that has
+        // already told us who made its SoC.
+        detectiveFor(soc = "Qualcomm", model = "MT8781V/NA", hw = "mt6789").isMediatekSoc() shouldBe false
+        detectiveFor(soc = "Mediatek", model = "SM6375", hw = "sargo").isMediatekSoc() shouldBe true
+    }
+
+    @Test
+    fun `isMediatekSoc falls back to the model when no vendor is set`() {
+        detectiveFor(model = "MT8781V/NA").isMediatekSoc() shouldBe true
+        detectiveFor(model = "SM6375").isMediatekSoc() shouldBe false
+        detectiveFor(model = "GS201").isMediatekSoc() shouldBe false
+        detectiveFor(model = "Tensor G3").isMediatekSoc() shouldBe false
+    }
+
+    @Test
+    fun `isMediatekSoc falls back to hardware below API31`() {
+        // Pre-API31 both SoC properties are absent, confirmed on a Pixel 2 (API28).
+        detectiveFor(hw = "mt6789").isMediatekSoc() shouldBe true
+        detectiveFor(hw = "walleye").isMediatekSoc() shouldBe false
+        detectiveFor(hw = "lynx").isMediatekSoc() shouldBe false
+        detectiveFor(hw = "sargo").isMediatekSoc() shouldBe false
+        detectiveFor(hw = "qcom").isMediatekSoc() shouldBe false
+    }
+
+    @Test
+    fun `isMediatekSoc is false when nothing is known`() {
+        detectiveFor().isMediatekSoc() shouldBe false
+    }
+
 }

--- a/app-common/src/test/java/eu/darken/sdmse/common/device/DeviceTestHelper.kt
+++ b/app-common/src/test/java/eu/darken/sdmse/common/device/DeviceTestHelper.kt
@@ -19,6 +19,11 @@ class DeviceConfigBuilder {
     var product: String? = null
     var versionIncremental: String = ""
     var sdkInt: Int = 33
+
+    /** Null models a device below API31, where the SoC properties do not exist. */
+    var socManufacturer: String? = null
+    var socModel: String? = null
+    var hardware: String? = null
     var installedPackages: Set<String> = emptySet()
     var isAndroidTV: Boolean = false
     var uiModeType: Int = Configuration.UI_MODE_TYPE_NORMAL
@@ -48,6 +53,9 @@ fun mockDevice(context: Context = mockk(relaxed = true), block: DeviceConfigBuil
     every { BuildWrap.BRAND } returns config.brand
     every { BuildWrap.DISPLAY } returns config.display
     every { BuildWrap.PRODUCT } returns config.product
+    every { BuildWrap.SOC_MANUFACTURER } returns config.socManufacturer
+    every { BuildWrap.SOC_MODEL } returns config.socModel
+    every { BuildWrap.HARDWARE } returns config.hardware
 
     every { BuildWrap.VERSION.SDK_INT } returns config.sdkInt
     every { BuildWrap.VERSION.INCREMENTAL } returns config.versionIncremental

--- a/app/src/main/java/eu/darken/sdmse/setup/SetupViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/SetupViewModel.kt
@@ -13,6 +13,7 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.device.DeviceDetective
+import eu.darken.sdmse.common.device.RomType
 import eu.darken.sdmse.common.flow.SingleEventFlow
 import eu.darken.sdmse.common.flow.setupCommonEventHandlers
 import eu.darken.sdmse.common.navigation.routes.DashboardRoute
@@ -79,6 +80,22 @@ class SetupViewModel @Inject constructor(
     init {
         log(TAG) { "Setup init: options=${screenOptionsFlow.value}" }
         setupManager.setDismissed(false)
+    }
+
+    /**
+     * Does this device match the hardware/ROM pattern behind the known upstream Shizuku problem
+     * (RikkaApps/Shizuku#1198), where Shizuku's helper process dies before it can call back?
+     *
+     * Resolved here rather than in the card because [DeviceDetective.getROMType] hits the package
+     * manager, which must not run during recomposition. Lazy + cached: the answer cannot change
+     * while the process lives, and the flow that reads it does not run on the main thread.
+     *
+     * The card only RENDERS the hint after a connection has actually failed (this value is read on
+     * every emission, it is the display that is gated), so a false positive costs one imprecise
+     * sentence rather than a wrong diagnosis.
+     */
+    private val hasKnownShizukuIssueRisk: Boolean by lazy {
+        deviceDetective.isMediatekSoc() || deviceDetective.getROMType() in KNOWN_SHIZUKU_ISSUE_ROMS
     }
 
     val events = SingleEventFlow<SetupEvents>()
@@ -243,7 +260,9 @@ class SetupViewModel @Inject constructor(
                                             errorEvents.tryEmit(e)
                                         }
                                     }
-                                }
+                                },
+                                onRetry = { launch { shizukuSetupModule.refresh() } },
+                                showKnownIssueHint = hasKnownShizukuIssueRisk,
                             )
 
                             is SetupModule.State.Loading -> SetupLoadingCardItem(state)
@@ -365,6 +384,9 @@ class SetupViewModel @Inject constructor(
     }
 
     companion object {
+        /** ROMs with the framework modification behind RikkaApps/Shizuku#1198. */
+        private val KNOWN_SHIZUKU_ISSUE_ROMS = setOf(RomType.HYPEROS, RomType.MIUI)
+
         private val TAG = logTag("Setup", "ViewModel")
     }
 }

--- a/app/src/main/java/eu/darken/sdmse/setup/shizuku/ShizukuSetupCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/shizuku/ShizukuSetupCard.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -18,6 +19,7 @@ import eu.darken.sdmse.common.compose.icons.SdmIcons
 import eu.darken.sdmse.common.compose.icons.Shizuku
 import eu.darken.sdmse.common.compose.preview.Preview2
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.common.adb.shizuku.ShizukuServiceState
 import eu.darken.sdmse.common.pkgs.toPkgId
 import eu.darken.sdmse.setup.SetupCardContainer
 import eu.darken.sdmse.setup.SetupCardItem
@@ -28,6 +30,14 @@ data class ShizukuSetupCardItem(
     val onToggleUseShizuku: (Boolean?) -> Unit,
     val onOpen: () -> Unit,
     val onHelp: () -> Unit,
+    val onRetry: () -> Unit = {},
+    /**
+     * Does this device match the hardware/ROM combination with the known upstream Shizuku problem?
+     *
+     * Resolved by the ViewModel, not here: the checks behind it hit the package manager, which must
+     * not happen during recomposition.
+     */
+    val showKnownIssueHint: Boolean = false,
 ) : SetupCardItem
 
 @Composable
@@ -58,11 +68,15 @@ internal fun ShizukuSetupCard(
 
         if (item.state.useShizuku == true) {
             val ready = item.state.isInstalled && item.state.ourService
+            // A settled "no", as opposed to "we haven't finished looking". Only this offers a retry:
+            // showing one while a probe is still running is what made the card feel dead.
+            val failed = item.state.isInstalled && item.state.serviceState.isTerminalFailure
             Text(
                 text = stringResource(
                     when {
                         !item.state.isInstalled -> R.string.setup_shizuku_state_not_installed_label
                         ready -> R.string.setup_shizuku_state_ready_label
+                        failed -> R.string.setup_shizuku_state_failed_label
                         else -> R.string.setup_shizuku_state_waiting_label
                     },
                 ),
@@ -77,6 +91,36 @@ internal fun ShizukuSetupCard(
                     .padding(horizontal = 16.dp),
                 textAlign = TextAlign.Center,
             )
+
+            if (failed && item.showKnownIssueHint) {
+                Text(
+                    text = stringResource(R.string.setup_shizuku_state_known_issue_hint),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp),
+                    textAlign = TextAlign.Center,
+                )
+                TextButton(
+                    onClick = item.onHelp,
+                    modifier = Modifier.align(Alignment.CenterHorizontally),
+                ) {
+                    Text(stringResource(eu.darken.sdmse.common.R.string.general_help_action))
+                }
+            }
+
+            if (failed) {
+                OutlinedButton(
+                    onClick = item.onRetry,
+                    enabled = !item.state.isChecking,
+                    modifier = Modifier
+                        .align(Alignment.CenterHorizontally)
+                        .padding(horizontal = 16.dp),
+                ) {
+                    Text(stringResource(eu.darken.sdmse.common.R.string.general_retry_action))
+                }
+            }
         }
 
         if (item.state.isInstalled && item.state.useShizuku == true && !item.state.isComplete) {
@@ -132,7 +176,7 @@ private fun ShizukuSetupCardPreview() {
                     isCompatible = true,
                     isInstalled = true,
                     basicService = true,
-                    ourService = false,
+                    serviceState = ShizukuServiceState.NotChecked,
                     alsoHasRoot = false,
                 ),
                 onToggleUseShizuku = {},
@@ -155,12 +199,86 @@ private fun ShizukuSetupCardNotInstalledPreview() {
                     isCompatible = true,
                     isInstalled = false,
                     basicService = false,
-                    ourService = false,
+                    serviceState = ShizukuServiceState.NotChecked,
                     alsoHasRoot = false,
                 ),
                 onToggleUseShizuku = {},
                 onOpen = {},
                 onHelp = {},
+            ),
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun ShizukuSetupCardFailedPreview() {
+    PreviewWrapper {
+        ShizukuSetupCard(
+            item = ShizukuSetupCardItem(
+                state = ShizukuSetupModule.Result(
+                    pkg = "moe.shizuku.privileged.api".toPkgId(),
+                    useShizuku = true,
+                    isCompatible = true,
+                    isInstalled = true,
+                    basicService = true,
+                    serviceState = ShizukuServiceState.TimedOut,
+                    alsoHasRoot = false,
+                ),
+                onToggleUseShizuku = {},
+                onOpen = {},
+                onHelp = {},
+                onRetry = {},
+            ),
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun ShizukuSetupCardKnownIssuePreview() {
+    PreviewWrapper {
+        ShizukuSetupCard(
+            item = ShizukuSetupCardItem(
+                state = ShizukuSetupModule.Result(
+                    pkg = "moe.shizuku.privileged.api".toPkgId(),
+                    useShizuku = true,
+                    isCompatible = true,
+                    isInstalled = true,
+                    basicService = true,
+                    serviceState = ShizukuServiceState.Failed,
+                    alsoHasRoot = false,
+                ),
+                onToggleUseShizuku = {},
+                onOpen = {},
+                onHelp = {},
+                onRetry = {},
+                showKnownIssueHint = true,
+            ),
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun ShizukuSetupCardRetryingPreview() {
+    PreviewWrapper {
+        ShizukuSetupCard(
+            item = ShizukuSetupCardItem(
+                state = ShizukuSetupModule.Result(
+                    pkg = "moe.shizuku.privileged.api".toPkgId(),
+                    useShizuku = true,
+                    isCompatible = true,
+                    isInstalled = true,
+                    basicService = true,
+                    serviceState = ShizukuServiceState.TimedOut,
+                    isChecking = true,
+                    alsoHasRoot = false,
+                ),
+                onToggleUseShizuku = {},
+                onOpen = {},
+                onHelp = {},
+                onRetry = {},
             ),
         )
     }

--- a/app/src/main/java/eu/darken/sdmse/setup/shizuku/ShizukuSetupCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/shizuku/ShizukuSetupCard.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
@@ -23,6 +24,7 @@ import eu.darken.sdmse.common.compose.preview.Preview2
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import eu.darken.sdmse.common.pkgs.toPkgId
 import eu.darken.sdmse.setup.SetupCardContainer
+import eu.darken.sdmse.setup.SetupLimitationBox
 import eu.darken.sdmse.setup.SetupCardItem
 import eu.darken.sdmse.setup.root.RadioOption
 
@@ -72,34 +74,24 @@ internal fun ShizukuSetupCard(
             // A settled "no", as opposed to "we haven't finished looking". Only this offers a retry:
             // showing one while a probe is still running is what made the card feel dead.
             val failed = item.state.isInstalled && item.state.serviceState.isTerminalFailure
-            Text(
-                text = stringResource(
-                    when {
-                        !item.state.isInstalled -> R.string.setup_shizuku_state_not_installed_label
-                        ready -> R.string.setup_shizuku_state_ready_label
-                        failed -> R.string.setup_shizuku_state_failed_label
-                        else -> R.string.setup_shizuku_state_waiting_label
-                    },
-                ),
-                style = MaterialTheme.typography.labelMedium,
-                color = if (ready) {
-                    MaterialTheme.colorScheme.onSurfaceVariant
-                } else {
-                    MaterialTheme.colorScheme.error
-                },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
-                textAlign = TextAlign.Center,
-            )
+            val canOpen = item.state.isInstalled && !item.state.isComplete
 
-            if (failed && item.showKnownIssueHint) {
-                // No help button of its own: the card header already carries a help icon pointing at
-                // the same wiki page, and a second affordance for it just crowds the actions below.
+            if (!failed) {
+                // Single short line, so centring reads fine here and matches the other setup cards.
                 Text(
-                    text = stringResource(R.string.setup_shizuku_state_known_issue_hint),
+                    text = stringResource(
+                        when {
+                            !item.state.isInstalled -> R.string.setup_shizuku_state_not_installed_label
+                            ready -> R.string.setup_shizuku_state_ready_label
+                            else -> R.string.setup_shizuku_state_waiting_label
+                        },
+                    ),
                     style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    color = if (ready) {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    } else {
+                        MaterialTheme.colorScheme.error
+                    },
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 16.dp),
@@ -107,28 +99,52 @@ internal fun ShizukuSetupCard(
                 )
             }
 
-            // Retry and "open Shizuku" sit side by side rather than stacked: they are alternatives at
-            // the same level, and stacking read as a queue of steps to work through.
-            val canOpen = item.state.isInstalled && !item.state.isComplete
-            if (failed || canOpen) {
+            if (failed) {
+                // SetupLimitationBox, same as the Automation and Inventory cards use for their own
+                // "this won't work, here is what you can do" states. The explanation and its actions
+                // read as one unit, and the text is start aligned: unlike the one-line states above,
+                // this wraps to several lines, and centring those leaves both edges ragged.
+                SetupLimitationBox(
+                    title = stringResource(R.string.setup_shizuku_state_failed_title),
+                    body = stringResource(R.string.setup_shizuku_state_failed_label),
+                    // No help button of its own: the card header already carries a help icon
+                    // pointing at the same wiki page.
+                    body2 = if (item.showKnownIssueHint) {
+                        stringResource(R.string.setup_shizuku_state_known_issue_hint)
+                    } else {
+                        null
+                    },
+                ) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        OutlinedButton(
+                            onClick = item.onOpen,
+                            modifier = Modifier.weight(1f),
+                        ) {
+                            Text(stringResource(R.string.setup_shizuku_card_title))
+                        }
+                        Button(
+                            onClick = item.onRetry,
+                            enabled = !item.state.isChecking,
+                            modifier = Modifier.weight(1f),
+                        ) {
+                            Text(stringResource(eu.darken.sdmse.common.R.string.general_retry_action))
+                        }
+                    }
+                }
+            } else if (canOpen) {
+                // Not a failure, so there is nothing to explain and nothing to retry: just the way
+                // over to Shizuku, centred as it has always been.
                 Row(
                     horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 16.dp),
                 ) {
-                    if (failed) {
-                        OutlinedButton(
-                            onClick = item.onRetry,
-                            enabled = !item.state.isChecking,
-                        ) {
-                            Text(stringResource(eu.darken.sdmse.common.R.string.general_retry_action))
-                        }
-                    }
-                    if (canOpen) {
-                        OutlinedButton(onClick = item.onOpen) {
-                            Text(stringResource(R.string.setup_shizuku_card_title))
-                        }
+                    OutlinedButton(onClick = item.onOpen) {
+                        Text(stringResource(R.string.setup_shizuku_card_title))
                     }
                 }
             }

--- a/app/src/main/java/eu/darken/sdmse/setup/shizuku/ShizukuSetupCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/shizuku/ShizukuSetupCard.kt
@@ -1,12 +1,13 @@
 package eu.darken.sdmse.setup.shizuku
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -15,11 +16,11 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import eu.darken.sdmse.R
+import eu.darken.sdmse.common.adb.shizuku.ShizukuServiceState
 import eu.darken.sdmse.common.compose.icons.SdmIcons
 import eu.darken.sdmse.common.compose.icons.Shizuku
 import eu.darken.sdmse.common.compose.preview.Preview2
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
-import eu.darken.sdmse.common.adb.shizuku.ShizukuServiceState
 import eu.darken.sdmse.common.pkgs.toPkgId
 import eu.darken.sdmse.setup.SetupCardContainer
 import eu.darken.sdmse.setup.SetupCardItem
@@ -93,6 +94,8 @@ internal fun ShizukuSetupCard(
             )
 
             if (failed && item.showKnownIssueHint) {
+                // No help button of its own: the card header already carries a help icon pointing at
+                // the same wiki page, and a second affordance for it just crowds the actions below.
                 Text(
                     text = stringResource(R.string.setup_shizuku_state_known_issue_hint),
                     style = MaterialTheme.typography.labelMedium,
@@ -102,35 +105,32 @@ internal fun ShizukuSetupCard(
                         .padding(horizontal = 16.dp),
                     textAlign = TextAlign.Center,
                 )
-                TextButton(
-                    onClick = item.onHelp,
-                    modifier = Modifier.align(Alignment.CenterHorizontally),
-                ) {
-                    Text(stringResource(eu.darken.sdmse.common.R.string.general_help_action))
-                }
             }
 
-            if (failed) {
-                OutlinedButton(
-                    onClick = item.onRetry,
-                    enabled = !item.state.isChecking,
+            // Retry and "open Shizuku" sit side by side rather than stacked: they are alternatives at
+            // the same level, and stacking read as a queue of steps to work through.
+            val canOpen = item.state.isInstalled && !item.state.isComplete
+            if (failed || canOpen) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
                     modifier = Modifier
-                        .align(Alignment.CenterHorizontally)
+                        .fillMaxWidth()
                         .padding(horizontal = 16.dp),
                 ) {
-                    Text(stringResource(eu.darken.sdmse.common.R.string.general_retry_action))
+                    if (failed) {
+                        OutlinedButton(
+                            onClick = item.onRetry,
+                            enabled = !item.state.isChecking,
+                        ) {
+                            Text(stringResource(eu.darken.sdmse.common.R.string.general_retry_action))
+                        }
+                    }
+                    if (canOpen) {
+                        OutlinedButton(onClick = item.onOpen) {
+                            Text(stringResource(R.string.setup_shizuku_card_title))
+                        }
+                    }
                 }
-            }
-        }
-
-        if (item.state.isInstalled && item.state.useShizuku == true && !item.state.isComplete) {
-            OutlinedButton(
-                onClick = item.onOpen,
-                modifier = Modifier
-                    .align(Alignment.CenterHorizontally)
-                    .padding(horizontal = 16.dp),
-            ) {
-                Text(stringResource(R.string.setup_shizuku_card_title))
             }
         }
 

--- a/app/src/main/java/eu/darken/sdmse/setup/shizuku/ShizukuSetupModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/shizuku/ShizukuSetupModule.kt
@@ -6,12 +6,16 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.common.adb.AdbSettings
+import eu.darken.sdmse.common.adb.shizuku.ShizukuBaseServiceBinder
 import eu.darken.sdmse.common.adb.shizuku.ShizukuManager
+import eu.darken.sdmse.common.adb.shizuku.ShizukuServiceState
 import eu.darken.sdmse.common.areas.DataAreaManager
 import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.coroutine.runDetachedWithTimeout
 import eu.darken.sdmse.common.datastore.value
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.flow.replayingShare
@@ -19,6 +23,7 @@ import eu.darken.sdmse.common.pkgs.Pkg
 import eu.darken.sdmse.common.rngString
 import eu.darken.sdmse.common.root.RootManager
 import eu.darken.sdmse.setup.SetupModule
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -33,6 +38,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.transformLatest
 import kotlinx.coroutines.withTimeoutOrNull
 import java.time.Instant
 import javax.inject.Inject
@@ -53,9 +59,9 @@ class ShizukuSetupModule @Inject constructor(
     /** Overridden in tests to keep the wedge case fast, never in production. */
     internal var pingTimeoutMs: Long = PING_TIMEOUT_MS
 
-    // Last known concrete Result, kept so re-subscription (e.g. returning to the dashboard) can emit it
+    // Last SETTLED Result, kept so re-subscription (e.g. returning to the dashboard) can emit it
     // immediately instead of regressing to Loading and flickering the setup card while the availability
-    // probe re-runs (a cold AdbHost bind can take ~10s). Only ever holds a real Result, never Loading.
+    // probe re-runs (a cold AdbHost bind can take ~10s). Never holds Loading or a mid-probe state.
     @Volatile
     private var lastResult: Result? = null
 
@@ -83,32 +89,61 @@ class ShizukuSetupModule @Inject constructor(
             alsoHasRoot = useRoot,
         )
 
-        if (useShizuku != true) return@combine flowOf(baseState)
+        if (useShizuku != true) return@combine flowOf<SetupModule.State>(baseState)
 
         combine(
             // Just tie the lifecycle of the requester to the state's subscribers
             permissionRequester,
             shizukuManager.permissionGrantEvents.map { }.onStart { emit(Unit) },
             shizukuManager.shizukuBinder.onStart { emit(null) },
-        ) { _, _, binder ->
-            // pingBinder() is a synchronous PING_TRANSACTION: against a Shizuku server that is alive
-            // but not servicing requests it never returns, and an unbounded wedge here stalls this
-            // combine so the card stays on Loading forever - the exact symptom the ADB-side timeouts
-            // guard against. Detached + bounded, same trade as ShizukuWrapper.isGranted().
-            val basicService = binder?.let { b ->
-                appScope.runDetachedWithTimeout(dispatcherProvider.IO, pingTimeoutMs) { b.pingBinder() }
-                    ?: false.also { log(TAG) { "pingBinder() did not respond within ${pingTimeoutMs}ms" } }
-            } ?: false
+        ) { _, _, binder -> binder }
+            // transformLatest, not map: the probe below has to announce itself BEFORE it runs. A cold
+            // bind can take the full ADB connect budget, and without a state saying so the card kept
+            // offering a retry button that silently did nothing for those seconds.
+            .transformLatest<ShizukuBaseServiceBinder?, SetupModule.State> { binder ->
+                emit(
+                    baseState.copy(
+                        // Keep showing what we last knew rather than regressing to NotChecked, so a
+                        // retry doesn't blank out the failure message it was triggered from.
+                        serviceState = lastResult?.serviceState ?: ShizukuServiceState.NotChecked,
+                        isChecking = true,
+                    )
+                )
 
-            @Suppress("USELESS_CAST")
-            baseState.copy(
-                basicService = basicService,
-                ourService = shizukuManager.isOurServiceAvailable(),
-            ) as SetupModule.State
-        }
+                val settled = try {
+                    // pingBinder() is a synchronous PING_TRANSACTION: against a Shizuku server that is
+                    // alive but not servicing requests it never returns, and an unbounded wedge here
+                    // stalls this flow so the card stays on Loading forever - the exact symptom the
+                    // ADB-side timeouts guard against. Detached + bounded, same trade as isGranted().
+                    val basicService = binder?.let { b ->
+                        appScope.runDetachedWithTimeout(dispatcherProvider.IO, pingTimeoutMs) { b.pingBinder() }
+                            ?: false.also { log(TAG) { "pingBinder() did not respond within ${pingTimeoutMs}ms" } }
+                    } ?: false
+
+                    baseState.copy(
+                        basicService = basicService,
+                        serviceState = shizukuManager.getServiceState(),
+                    )
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    // Must settle rather than propagate. Anything thrown after the checking state
+                    // above kills the sharing coroutine with that state left in replayingShare's
+                    // replay slot, and since the coroutine is dead no refresh can ever replace it:
+                    // every later subscriber would see a permanently disabled retry button.
+                    // runDetachedWithTimeout propagates whatever its block throws, and pingBinder()
+                    // is a binder call, so this is reachable (e.g. DeadObjectException).
+                    log(TAG, WARN) { "Shizuku probe failed: ${e.asLog()}" }
+                    baseState.copy(serviceState = ShizukuServiceState.Failed)
+                }
+
+                emit(settled)
+            }
     }
         .flatMapLatest { it }
-        .onEach { if (it is Result) lastResult = it }
+        // Only settled results: caching a mid-probe state would let onStart replay isChecking=true
+        // with no probe behind it, leaving the retry button disabled forever.
+        .onEach { if (it is Result && !it.isChecking) lastResult = it }
         .onStart {
             // Don't regress to Loading if we already know the result: emit the last known state so the
             // dashboard setup card doesn't flicker while the probe re-runs in the background. Guard
@@ -174,9 +209,15 @@ class ShizukuSetupModule @Inject constructor(
         val isCompatible: Boolean = false,
         val isInstalled: Boolean = false,
         val basicService: Boolean = false,
-        val ourService: Boolean = false,
+        val serviceState: ShizukuServiceState = ShizukuServiceState.NotChecked,
+        /** A probe is running right now. Only gates the retry affordance, never the message. */
+        val isChecking: Boolean = false,
         val alsoHasRoot: Boolean = false,
     ) : SetupModule.State.Current {
+
+        /** Derived, not stored: one source of truth, so it can't disagree with [serviceState]. */
+        val ourService: Boolean
+            get() = serviceState is ShizukuServiceState.Available
 
         override val type: SetupModule.Type = SetupModule.Type.SHIZUKU
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -276,6 +276,7 @@
     <string name="setup_shizuku_state_ready_label">Shizuku link is ready.</string>
     <string name="setup_shizuku_state_waiting_label">Waiting for link with Shizuku.</string>
     <string name="setup_shizuku_state_not_installed_label">The Shizuku app is not installed.</string>
+    <string name="setup_shizuku_state_failed_title">Shizuku link failed</string>
     <string name="setup_shizuku_state_failed_label">Shizuku is running, but it never connected SD Maid to its helper service.</string>
     <string name="setup_shizuku_state_known_issue_hint">Some devices are affected by a known Shizuku problem that stops the helper service from starting. This may be one of them.</string>
     <string name="setup_shizuku_enable_shizuku_use_label">Try to use Shizuku</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -276,6 +276,8 @@
     <string name="setup_shizuku_state_ready_label">Shizuku link is ready.</string>
     <string name="setup_shizuku_state_waiting_label">Waiting for link with Shizuku.</string>
     <string name="setup_shizuku_state_not_installed_label">The Shizuku app is not installed.</string>
+    <string name="setup_shizuku_state_failed_label">Shizuku is running, but it never connected SD Maid to its helper service.</string>
+    <string name="setup_shizuku_state_known_issue_hint">Some devices are affected by a known Shizuku problem that stops the helper service from starting. This may be one of them.</string>
     <string name="setup_shizuku_enable_shizuku_use_label">Try to use Shizuku</string>
     <string name="setup_shizuku_disable_shizuku_use_label">Don\'t use Shizuku</string>
 

--- a/app/src/test/java/eu/darken/sdmse/setup/SetupScreenTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/setup/SetupScreenTest.kt
@@ -18,6 +18,7 @@ import eu.darken.sdmse.common.files.local.LocalPath
 import eu.darken.sdmse.common.permissions.Permission
 import eu.darken.sdmse.common.files.saf.SAFPath
 import eu.darken.sdmse.common.pkgs.toPkgId
+import eu.darken.sdmse.common.adb.shizuku.ShizukuServiceState
 import eu.darken.sdmse.setup.automation.AutomationSetupCardItem
 import eu.darken.sdmse.setup.automation.AutomationSetupModule
 import eu.darken.sdmse.setup.inventory.InventorySetupCardItem
@@ -409,7 +410,7 @@ class SetupScreenTest : BaseComposeRobolectricTest() {
                                 isCompatible = true,
                                 isInstalled = true,
                                 basicService = true,
-                                ourService = false,
+                                serviceState = ShizukuServiceState.NotChecked,
                                 alsoHasRoot = true,
                             ),
                             onToggleUseShizuku = {},
@@ -444,7 +445,7 @@ class SetupScreenTest : BaseComposeRobolectricTest() {
                                 isCompatible = true,
                                 isInstalled = true,
                                 basicService = true,
-                                ourService = true,
+                                serviceState = ShizukuServiceState.Available,
                                 alsoHasRoot = false,
                             ),
                             onToggleUseShizuku = {},

--- a/app/src/test/java/eu/darken/sdmse/setup/shizuku/ShizukuSetupModuleTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/setup/shizuku/ShizukuSetupModuleTest.kt
@@ -2,6 +2,7 @@ package eu.darken.sdmse.setup.shizuku
 
 import eu.darken.sdmse.common.adb.AdbSettings
 import eu.darken.sdmse.common.adb.shizuku.ShizukuManager
+import eu.darken.sdmse.common.adb.shizuku.ShizukuServiceState
 import eu.darken.sdmse.common.areas.DataAreaManager
 import eu.darken.sdmse.common.adb.shizuku.ShizukuBaseServiceBinder
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
@@ -59,7 +60,7 @@ class ShizukuSetupModuleTest : BaseTest() {
         coEvery { shizukuManager.getManagerId() } returns "moe.shizuku.privileged.api".toPkgId()
         coEvery { shizukuManager.isCompatible() } returns true
         coEvery { shizukuManager.isGranted() } returns true
-        coEvery { shizukuManager.isOurServiceAvailable() } coAnswers { probeCount++; true }
+        coEvery { shizukuManager.getServiceState() } coAnswers { probeCount++; ShizukuServiceState.Available }
 
         every { rootManager.useRoot } returns flowOf(false)
     }
@@ -184,4 +185,91 @@ class ShizukuSetupModuleTest : BaseTest() {
             realScope.cancel()
         }
     }
+
+    // --- service state -------------------------------------------------------------------------
+
+    @Test fun `the probe announces itself before it settles`() {
+        // A cold bind can take the whole ADB connect budget. Without an in-flight state the card
+        // keeps offering a retry button that silently does nothing for those seconds.
+        val mod = module()
+
+        val collector = mod.state.test(tag = "checking", scope = scope)
+        collector.await { values, _ -> values.any { it is ShizukuSetupModule.Result && !it.isChecking } }
+
+        val results = collector.latestValues.filterIsInstance<ShizukuSetupModule.Result>()
+        results.first().isChecking shouldBe true
+        results.last().isChecking shouldBe false
+
+        runBlocking { collector.cancelAndJoin() }
+    }
+
+    @Test fun `only Available counts as our service being up`() {
+        fun resultWith(state: ShizukuServiceState) = ShizukuSetupModule.Result(
+            pkg = "moe.shizuku.privileged.api".toPkgId(),
+            useShizuku = true,
+            serviceState = state,
+        )
+
+        resultWith(ShizukuServiceState.Available).ourService shouldBe true
+        resultWith(ShizukuServiceState.NotChecked).ourService shouldBe false
+        resultWith(ShizukuServiceState.PermissionDenied).ourService shouldBe false
+        resultWith(ShizukuServiceState.Unknown).ourService shouldBe false
+        resultWith(ShizukuServiceState.TimedOut).ourService shouldBe false
+        resultWith(ShizukuServiceState.Failed).ourService shouldBe false
+    }
+
+    @Test fun `isComplete truth table across every service outcome`() {
+        fun complete(
+            useShizuku: Boolean?,
+            isCompatible: Boolean = true,
+            isInstalled: Boolean = true,
+            state: ShizukuServiceState = ShizukuServiceState.NotChecked,
+        ) = ShizukuSetupModule.Result(
+            pkg = "moe.shizuku.privileged.api".toPkgId(),
+            useShizuku = useShizuku,
+            isCompatible = isCompatible,
+            isInstalled = isInstalled,
+            serviceState = state,
+        ).isComplete
+
+        // Opted in and working is the only complete "on" state.
+        complete(true, state = ShizukuServiceState.Available) shouldBe true
+        complete(true, state = ShizukuServiceState.TimedOut) shouldBe false
+        complete(true, state = ShizukuServiceState.Failed) shouldBe false
+        complete(true, state = ShizukuServiceState.PermissionDenied) shouldBe false
+        complete(true, state = ShizukuServiceState.Unknown) shouldBe false
+        complete(true, state = ShizukuServiceState.NotChecked) shouldBe false
+
+        // Wants Shizuku but it isn't installed stays incomplete, even when nothing failed.
+        complete(true, isInstalled = false, state = ShizukuServiceState.Available) shouldBe false
+
+        // Opted out, or Shizuku too old to use, are both settled states.
+        complete(false, state = ShizukuServiceState.TimedOut) shouldBe true
+        complete(true, isCompatible = false, state = ShizukuServiceState.TimedOut) shouldBe true
+        complete(null, isCompatible = false) shouldBe true
+    }
+
+
+    @Test fun `a probe that throws settles as Failed instead of stranding the checking state`() {
+        // Regression guard: emitting isChecking=true and THEN throwing kills the sharing coroutine
+        // with that state stuck in replayingShare's replay slot. No refresh can replace it, so every
+        // later subscriber inherits a permanently disabled retry button. pingBinder() is a binder
+        // call and runDetachedWithTimeout propagates whatever its block throws, so this is reachable.
+        val binder: ShizukuBaseServiceBinder = mockk()
+        every { binder.pingBinder() } throws RuntimeException("binder died")
+        every { shizukuManager.shizukuBinder } returns flowOf(binder)
+        val mod = module()
+
+        val collector = mod.state.test(tag = "throwing", scope = scope)
+        collector.await { values, _ -> values.any { it is ShizukuSetupModule.Result && !it.isChecking } }
+
+        val settled = collector.latestValues
+            .filterIsInstance<ShizukuSetupModule.Result>()
+            .last { !it.isChecking }
+        settled.serviceState shouldBe ShizukuServiceState.Failed
+        settled.isChecking shouldBe false
+
+        runBlocking { collector.cancelAndJoin() }
+    }
+
 }


### PR DESCRIPTION
## What changed

When SD Maid cannot establish a Shizuku connection, the setup card now says so and offers a Retry button, instead of showing the same red "Waiting for link with Shizuku." forever with no next step.

On devices that match the hardware and ROM pattern behind a known Shizuku problem, the card adds a line saying this device may be affected, with a link to the wiki for what to do about it. That wording is intentionally cautious: a failed connection on such a device is a strong hint, not proof.

None of this makes Shizuku work on affected devices. The helper process dying is an upstream Shizuku problem (RikkaApps/Shizuku#1198) and not something the app can fix. What changes is that the failure now explains itself.

Refs #2691

## Technical Context

- Both a spent connect budget and a generic failure are treated as settled failures. Gating only on the timeout would have missed the other form of the same upstream defect, where the service dies mid-handshake and surfaces as a plain `AdbException` rather than a timeout.
- The probe announces itself before running, and Retry is disabled while it does. A cold bind can take the whole ADB connect budget, so without that state the card offered a button that silently did nothing for up to fifteen seconds, and repeated taps restarted the probe.
- Worth a close look, both regression-tested: `lastResult` caches only settled results, because caching a mid-probe state would let the anti-flicker replay restore it with no probe behind it; and the probe settles to `Failed` rather than propagating, because throwing after the in-progress emit kills the sharing coroutine with that state stuck in `replayingShare`'s replay slot, leaving every later subscriber with a permanently disabled Retry button.
- MediaTek detection uses `Build.SOC_MANUFACTURER` with no device list. The match is case-insensitive by necessity, not caution: a real Xiaomi MT6789 device tree ships `ro.soc.manufacturer=Mediatek` with a lowercase "t", so an exact-match check would miss the affected hardware. Qualcomm ships as both `Qualcomm` and `QTI`. The signals are a hierarchy, so an odd board name cannot override a known SoC vendor.
- `isGranted() == null` maps to "cannot know", not "permission denied", and stays non-terminal. A wedged Shizuku server lands there too, but the overwhelmingly common cause is Shizuku simply not being started yet, and telling that user their setup failed would be worse than saying nothing.
- `ifApiLevel()` gained `@ChecksSdkIntAtLeast(parameter = 0, lambda = 1)`. This is the codebase's first use of that helper, so lint had never been exercised against it and would otherwise report the API 31 SoC reads as `NewApi`.
