### PR TITLE
Analyzer: Open the folder you are browsing in a file manager

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/ViewIntentTool.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/ViewIntentTool.kt
@@ -59,7 +59,7 @@ class ViewIntentTool @Inject constructor(
             log(TAG, WARN) { "createForFolder(): Can't view $path externally" }
             return null
         }
-        return Intent.createChooser(intent, path.name).apply {
+        return Intent.createChooser(intent, path.userReadablePath.get(context)).apply {
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         }
     }

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/ViewIntentTool.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/ViewIntentTool.kt
@@ -2,21 +2,28 @@ package eu.darken.sdmse.common
 
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
+import android.provider.DocumentsContract
 import androidx.core.content.FileProvider
 import dagger.Reusable
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.files.APathLookup
 import eu.darken.sdmse.common.files.core.local.File
+import eu.darken.sdmse.common.files.local.LocalPath
 import eu.darken.sdmse.common.files.local.LocalPathLookup
+import eu.darken.sdmse.common.storage.PathMapper
 import javax.inject.Inject
 
 @Reusable
 class ViewIntentTool @Inject constructor(
     @ApplicationContext private val context: Context,
     private val mimeTypeTool: MimeTypeTool,
+    private val pathMapper: PathMapper,
 ) {
 
     suspend fun create(lookup: APathLookup<*>): Intent? {
@@ -41,6 +48,50 @@ class ViewIntentTool @Inject constructor(
         return Intent.createChooser(intent, lookup.name).apply {
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         }
+    }
+
+    suspend fun canOpenFolder(path: APath): Boolean = buildFolderViewIntent(path) != null
+
+    suspend fun createForFolder(path: APath): Intent? {
+        log(TAG) { "createForFolder(): Creating intent for $path" }
+        val intent = buildFolderViewIntent(path)
+        if (intent == null) {
+            log(TAG, WARN) { "createForFolder(): Can't view $path externally" }
+            return null
+        }
+        return Intent.createChooser(intent, path.name).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+    }
+
+    private suspend fun buildFolderViewIntent(path: APath): Intent? {
+        if (path !is LocalPath) return null
+        val safPath = pathMapper.toSAFPath(path) ?: return null
+        if (safPath.segments.isProviderRestricted()) return null
+
+        val treeRoot = safPath.treeRootUri
+        val authority = treeRoot.authority ?: return null
+        val rootId = treeRoot.lastPathSegment?.substringBefore(':')?.takeIf { it.isNotEmpty() } ?: return null
+        val documentId = "$rootId:${safPath.segments.joinToString("/")}"
+
+        val intent = Intent(Intent.ACTION_VIEW).apply {
+            setDataAndType(
+                DocumentsContract.buildDocumentUri(authority, documentId),
+                DocumentsContract.Document.MIME_TYPE_DIR,
+            )
+        }
+        val handlers = context.packageManager.queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY)
+        return intent.takeIf { handlers.isNotEmpty() }
+    }
+
+    /**
+     * ExternalStorageProvider hides these subtrees on API 30+, so a document URI pointing into
+     * them resolves to nothing and the handling app shows an empty/error screen.
+     */
+    private fun List<String>.isProviderRestricted(): Boolean {
+        if (!hasApiLevel(30)) return false
+        if (size < 2 || this[0] != "Android") return false
+        return this[1] == "data" || this[1] == "obb" || this[1] == "sandbox"
     }
 
     companion object {

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/ViewIntentToolTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/ViewIntentToolTest.kt
@@ -70,7 +70,10 @@ class ViewIntentToolTest : BaseTest() {
             val expected = "content://$STORAGE_AUTHORITY/document/primary%3ADCIM%2FCamera".toUri()
             context.registerFolderHandler(expected)
 
-            val target = subject.createForFolder(localPath).shouldNotBeNull().targetIntent()
+            val chooser = subject.createForFolder(localPath).shouldNotBeNull()
+            chooser.getStringExtra(Intent.EXTRA_TITLE) shouldBe "/storage/emulated/0/DCIM/Camera"
+
+            val target = chooser.targetIntent()
             target.action shouldBe Intent.ACTION_VIEW
             target.data shouldBe expected
             target.type shouldBe DocumentsContract.Document.MIME_TYPE_DIR
@@ -123,8 +126,10 @@ class ViewIntentToolTest : BaseTest() {
             val expected = "content://$STORAGE_AUTHORITY/document/primary%3A".toUri()
             context.registerFolderHandler(expected)
 
-            val target = subject.createForFolder(localPath).shouldNotBeNull().targetIntent()
-            target.data shouldBe expected
+            val chooser = subject.createForFolder(localPath).shouldNotBeNull()
+            chooser.getStringExtra(Intent.EXTRA_TITLE) shouldBe "/storage/emulated/0"
+
+            chooser.targetIntent().data shouldBe expected
 
             subject.canOpenFolder(localPath) shouldBe true
         }

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/ViewIntentToolTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/ViewIntentToolTest.kt
@@ -1,0 +1,258 @@
+package eu.darken.sdmse.common
+
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ActivityInfo
+import android.content.pm.ApplicationInfo
+import android.content.pm.ResolveInfo
+import android.net.Uri
+import android.provider.DocumentsContract
+import androidx.core.net.toUri
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.files.saf.SAFPath
+import eu.darken.sdmse.common.storage.PathMapper
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+
+private const val STORAGE_AUTHORITY = "com.android.externalstorage.documents"
+
+private fun Context.registerFolderHandler(documentUri: Uri) {
+    val intent = Intent(Intent.ACTION_VIEW).apply {
+        setDataAndType(documentUri, DocumentsContract.Document.MIME_TYPE_DIR)
+    }
+    val resolveInfo = ResolveInfo().apply {
+        activityInfo = ActivityInfo().apply {
+            packageName = "com.example.filemanager"
+            name = "com.example.filemanager.BrowseActivity"
+            applicationInfo = ApplicationInfo().apply {
+                packageName = "com.example.filemanager"
+            }
+        }
+    }
+    shadowOf(packageManager).addResolveInfoForIntent(intent, resolveInfo)
+}
+
+@Suppress("DEPRECATION")
+private fun Intent.targetIntent(): Intent = getParcelableExtra<Intent>(Intent.EXTRA_INTENT).shouldNotBeNull()
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class ViewIntentToolTest : BaseTest() {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val pathMapper = mockk<PathMapper>()
+    private val subject = ViewIntentTool(
+        context = context,
+        mimeTypeTool = MimeTypeTool(),
+        pathMapper = pathMapper,
+    )
+
+    @Test
+    fun `nested folder maps to a document uri`() {
+        runBlocking {
+            val localPath = LocalPath.build("storage", "emulated", "0", "DCIM", "Camera")
+            coEvery { pathMapper.toSAFPath(localPath) } returns SAFPath.build(
+                "content://$STORAGE_AUTHORITY/tree/primary",
+                "DCIM",
+                "Camera",
+            )
+            val expected = "content://$STORAGE_AUTHORITY/document/primary%3ADCIM%2FCamera".toUri()
+            context.registerFolderHandler(expected)
+
+            val target = subject.createForFolder(localPath).shouldNotBeNull().targetIntent()
+            target.action shouldBe Intent.ACTION_VIEW
+            target.data shouldBe expected
+            target.type shouldBe DocumentsContract.Document.MIME_TYPE_DIR
+            (target.flags and Intent.FLAG_GRANT_READ_URI_PERMISSION) shouldBe 0
+
+            subject.canOpenFolder(localPath) shouldBe true
+        }
+    }
+
+    @Test
+    fun `tree root with a trailing colon yields the same document uri`() {
+        runBlocking {
+            val localPath = LocalPath.build("storage", "emulated", "0", "DCIM", "Camera")
+            coEvery { pathMapper.toSAFPath(localPath) } returns SAFPath.build(
+                "content://$STORAGE_AUTHORITY/tree/primary%3A",
+                "DCIM",
+                "Camera",
+            )
+            val expected = "content://$STORAGE_AUTHORITY/document/primary%3ADCIM%2FCamera".toUri()
+            context.registerFolderHandler(expected)
+
+            val target = subject.createForFolder(localPath).shouldNotBeNull().targetIntent()
+            target.data shouldBe expected
+        }
+    }
+
+    @Test
+    fun `secondary volumes use their volume id as document root`() {
+        runBlocking {
+            val localPath = LocalPath.build("storage", "1A2B-3C4D", "DCIM")
+            coEvery { pathMapper.toSAFPath(localPath) } returns SAFPath.build(
+                "content://$STORAGE_AUTHORITY/tree/1A2B-3C4D",
+                "DCIM",
+            )
+            val expected = "content://$STORAGE_AUTHORITY/document/1A2B-3C4D%3ADCIM".toUri()
+            context.registerFolderHandler(expected)
+
+            val target = subject.createForFolder(localPath).shouldNotBeNull().targetIntent()
+            target.data shouldBe expected
+        }
+    }
+
+    @Test
+    fun `the volume root maps to a document uri without segments`() {
+        runBlocking {
+            val localPath = LocalPath.build("storage", "emulated", "0")
+            coEvery { pathMapper.toSAFPath(localPath) } returns SAFPath.build(
+                "content://$STORAGE_AUTHORITY/tree/primary",
+            )
+            val expected = "content://$STORAGE_AUTHORITY/document/primary%3A".toUri()
+            context.registerFolderHandler(expected)
+
+            val target = subject.createForFolder(localPath).shouldNotBeNull().targetIntent()
+            target.data shouldBe expected
+
+            subject.canOpenFolder(localPath) shouldBe true
+        }
+    }
+
+    @Test
+    fun `Android data is provider restricted on API 30 and up`() {
+        runBlocking {
+            val localPath = LocalPath.build("storage", "emulated", "0", "Android", "data", "com.example.app")
+            coEvery { pathMapper.toSAFPath(localPath) } returns SAFPath.build(
+                "content://$STORAGE_AUTHORITY/tree/primary",
+                "Android",
+                "data",
+                "com.example.app",
+            )
+            context.registerFolderHandler(
+                "content://$STORAGE_AUTHORITY/document/primary%3AAndroid%2Fdata%2Fcom.example.app".toUri(),
+            )
+
+            subject.createForFolder(localPath) shouldBe null
+            subject.canOpenFolder(localPath) shouldBe false
+        }
+    }
+
+    @Test
+    fun `Android obb is provider restricted on API 30 and up`() {
+        runBlocking {
+            val localPath = LocalPath.build("storage", "emulated", "0", "Android", "obb", "com.example.app")
+            coEvery { pathMapper.toSAFPath(localPath) } returns SAFPath.build(
+                "content://$STORAGE_AUTHORITY/tree/primary",
+                "Android",
+                "obb",
+                "com.example.app",
+            )
+            context.registerFolderHandler(
+                "content://$STORAGE_AUTHORITY/document/primary%3AAndroid%2Fobb%2Fcom.example.app".toUri(),
+            )
+
+            subject.createForFolder(localPath) shouldBe null
+            subject.canOpenFolder(localPath) shouldBe false
+        }
+    }
+
+    @Test
+    fun `non local paths are not supported`() {
+        runBlocking {
+            val safPath = SAFPath.build("content://$STORAGE_AUTHORITY/tree/primary", "DCIM")
+
+            subject.createForFolder(safPath) shouldBe null
+            subject.canOpenFolder(safPath) shouldBe false
+        }
+    }
+
+    @Test
+    fun `unmappable paths are not supported`() {
+        runBlocking {
+            val localPath = LocalPath.build("data", "data", "com.example.app")
+            coEvery { pathMapper.toSAFPath(localPath) } returns null
+
+            subject.createForFolder(localPath) shouldBe null
+            subject.canOpenFolder(localPath) shouldBe false
+        }
+    }
+
+    @Test
+    fun `without a handling activity there is no intent`() {
+        runBlocking {
+            val localPath = LocalPath.build("storage", "emulated", "0", "Documents")
+            coEvery { pathMapper.toSAFPath(localPath) } returns SAFPath.build(
+                "content://$STORAGE_AUTHORITY/tree/primary",
+                "Documents",
+            )
+
+            subject.createForFolder(localPath) shouldBe null
+            subject.canOpenFolder(localPath) shouldBe false
+        }
+    }
+}
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [29], application = TestApplication::class)
+class ViewIntentToolLegacyApiTest : BaseTest() {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val pathMapper = mockk<PathMapper>()
+    private val subject = ViewIntentTool(
+        context = context,
+        mimeTypeTool = MimeTypeTool(),
+        pathMapper = pathMapper,
+    )
+
+    @Test
+    fun `Android data is not restricted below API 30`() {
+        runBlocking {
+            val localPath = LocalPath.build("storage", "emulated", "0", "Android", "data", "com.example.app")
+            coEvery { pathMapper.toSAFPath(localPath) } returns SAFPath.build(
+                "content://$STORAGE_AUTHORITY/tree/primary",
+                "Android",
+                "data",
+                "com.example.app",
+            )
+            val expected = "content://$STORAGE_AUTHORITY/document/primary%3AAndroid%2Fdata%2Fcom.example.app".toUri()
+            context.registerFolderHandler(expected)
+
+            val target = subject.createForFolder(localPath).shouldNotBeNull().targetIntent()
+            target.data shouldBe expected
+
+            subject.canOpenFolder(localPath) shouldBe true
+        }
+    }
+
+    @Test
+    fun `Android obb is not restricted below API 30`() {
+        runBlocking {
+            val localPath = LocalPath.build("storage", "emulated", "0", "Android", "obb", "com.example.app")
+            coEvery { pathMapper.toSAFPath(localPath) } returns SAFPath.build(
+                "content://$STORAGE_AUTHORITY/tree/primary",
+                "Android",
+                "obb",
+                "com.example.app",
+            )
+            val expected = "content://$STORAGE_AUTHORITY/document/primary%3AAndroid%2Fobb%2Fcom.example.app".toUri()
+            context.registerFolderHandler(expected)
+
+            val target = subject.createForFolder(localPath).shouldNotBeNull().targetIntent()
+            target.data shouldBe expected
+
+            subject.canOpenFolder(localPath) shouldBe true
+        }
+    }
+}

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentScreen.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentScreen.kt
@@ -1,6 +1,5 @@
 package eu.darken.sdmse.analyzer.ui.storage.content
 
-import android.content.ActivityNotFoundException
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -15,6 +14,7 @@ import androidx.compose.foundation.lazy.grid.LazyGridScope
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.ArrowBack
+import androidx.compose.material.icons.automirrored.twotone.OpenInNew
 import androidx.compose.material.icons.automirrored.twotone.ViewList
 import androidx.compose.material.icons.twotone.Close
 import androidx.compose.material.icons.twotone.Delete
@@ -137,15 +137,18 @@ fun ContentScreenHost(
                 }
                 is ContentViewModel.Event.OpenContent -> {
                     runCatching { context.startActivity(event.intent) }
-                        .onFailure { error ->
-                            if (error is ActivityNotFoundException) {
-                                snackScope.launch {
-                                    snackbarHostState.showSnackbar(
-                                        message = context.getString(CommonR.string.general_error_no_compatible_app_found_msg),
-                                    )
-                                }
+                        .onFailure {
+                            snackScope.launch {
+                                snackbarHostState.showSnackbar(
+                                    message = context.getString(CommonR.string.general_error_no_compatible_app_found_msg),
+                                )
                             }
                         }
+                }
+                is ContentViewModel.Event.NoExternalAppFound -> snackScope.launch {
+                    snackbarHostState.showSnackbar(
+                        message = context.getString(CommonR.string.general_error_no_compatible_app_found_msg),
+                    )
                 }
                 is ContentViewModel.Event.SwiperSessionCreated -> snackScope.launch {
                     val msg = context.resources.getQuantityString(
@@ -174,6 +177,7 @@ fun ContentScreenHost(
         onCreateFilter = vm::onCreateFilter,
         onCreateSwiperSession = vm::onCreateSwiperSession,
         onLayoutModeToggle = vm::onLayoutModeToggle,
+        onOpenExternally = vm::onOpenExternally,
         onNavigateBack = vm::onNavigateBack,
     )
 
@@ -200,6 +204,7 @@ internal fun ContentScreen(
     onCreateFilter: (Set<ContentItem>) -> Unit = {},
     onCreateSwiperSession: (Set<ContentItem>) -> Unit = {},
     onLayoutModeToggle: () -> Unit = {},
+    onOpenExternally: (APath) -> Unit = {},
     onNavigateBack: () -> Unit = {},
 ) {
     val state by stateSource.collectAsStateWithLifecycle(initialValue = ContentViewModel.State.Loading)
@@ -371,6 +376,13 @@ internal fun ContentScreen(
                                 )
                             },
                             actions = {
+                                s.externalFolder?.let { target ->
+                                    SdmTooltipIconButton(
+                                        icon = Icons.AutoMirrored.TwoTone.OpenInNew,
+                                        label = stringResource(R.string.analyzer_content_open_externally_action),
+                                        onClick = { onOpenExternally(target) },
+                                    )
+                                }
                                 SdmTooltipIconButton(
                                     icon = when (s.layoutMode) {
                                         LayoutMode.LINEAR -> Icons.TwoTone.GridView

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentViewModel.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentViewModel.kt
@@ -148,6 +148,12 @@ class ContentViewModel @Inject constructor(
                     isReadOnly -> R.string.analyzer_storage_content_type_media_readonly_info.toCaString()
                     else -> null
                 }
+                // Only real directories can be handed to a file manager, onItemClick also navigates
+                // into symlinks and unknown types.
+                val externalFolder = currentLevel
+                    ?.takeIf { it.type == FileType.DIRECTORY }
+                    ?.path
+                    ?.takeIf { viewIntentTool.canOpenFolder(it) }
 
                 // Loading frame: no items yet (progress stamped by the outer combine).
                 emit(
@@ -160,6 +166,7 @@ class ContentViewModel @Inject constructor(
                         progress = null,
                         isReadOnly = isReadOnly,
                         infoBanner = infoBanner,
+                        externalFolder = externalFolder,
                     ),
                 )
 
@@ -185,6 +192,7 @@ class ContentViewModel @Inject constructor(
                         progress = null,
                         isReadOnly = isReadOnly,
                         infoBanner = infoBanner,
+                        externalFolder = externalFolder,
                     ),
                 )
             }
@@ -220,6 +228,17 @@ class ContentViewModel @Inject constructor(
         val intent = viewIntentTool.create(lookup)
         if (intent == null) {
             log(TAG, WARN) { "open(): Unable to create view intent for $lookup" }
+            return@launch
+        }
+        events.emit(Event.OpenContent(intent))
+    }
+
+    fun onOpenExternally(path: APath) = launch {
+        log(TAG) { "onOpenExternally($path)" }
+        val intent = viewIntentTool.createForFolder(path)
+        if (intent == null) {
+            log(TAG, WARN) { "onOpenExternally(): No intent for $path" }
+            events.emit(Event.NoExternalAppFound)
             return@launch
         }
         events.emit(Event.OpenContent(intent))
@@ -333,6 +352,7 @@ class ContentViewModel @Inject constructor(
             val progress: Progress.Data?,
             val isReadOnly: Boolean,
             val infoBanner: CaString?,
+            val externalFolder: APath?,
         ) : State
         data object NotFound : State
     }
@@ -342,6 +362,7 @@ class ContentViewModel @Inject constructor(
         data class ExclusionsCreated(val items: List<ContentItem>) : Event
         data class ContentDeleted(val count: Int, val freedSpace: Long) : Event
         data class OpenContent(val intent: Intent) : Event
+        data object NoExternalAppFound : Event
         data class SwiperSessionCreated(val sessionId: String, val itemCount: Int) : Event
     }
 

--- a/app-tool-analyzer/src/main/res/values/strings.xml
+++ b/app-tool-analyzer/src/main/res/values/strings.xml
@@ -17,6 +17,7 @@
     </plurals>
     <string name="analyzer_content_access_opaque">No direct access available</string>
     <string name="analyzer_content_create_swiper_session_action">Create Swiper session</string>
+    <string name="analyzer_content_open_externally_action">Open in file manager</string>
     <plurals name="analyzer_content_swiper_session_created_x_items">
         <item quantity="one">Swiper session created with %d item</item>
         <item quantity="other">Swiper session created with %d items</item>

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentScreenTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentScreenTest.kt
@@ -1,0 +1,95 @@
+package eu.darken.sdmse.analyzer.ui.storage.content
+
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import eu.darken.sdmse.analyzer.ui.storage.preview.previewContentItem
+import eu.darken.sdmse.analyzer.ui.storage.preview.previewDeviceStorage
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.files.FileType
+import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.ui.LayoutMode
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+
+class ContentScreenTest : BaseComposeRobolectricTest() {
+
+    private val itemPath = LocalPath.build("storage", "emulated", "0", "DCIM")
+
+    private val item = ContentViewModel.Item(
+        parent = null,
+        content = previewContentItem(
+            segments = arrayOf("storage", "emulated", "0", "DCIM"),
+            type = FileType.DIRECTORY,
+        ),
+        sizeRatio = 1f,
+    )
+
+    private fun readyState(externalFolder: APath?) = ContentViewModel.State.Ready(
+        title = "Media".toCaString(),
+        subtitle = "DCIM".toCaString(),
+        storage = previewDeviceStorage(),
+        items = listOf(item),
+        layoutMode = LayoutMode.LINEAR,
+        progress = null,
+        isReadOnly = false,
+        infoBanner = null,
+        externalFolder = externalFolder,
+    )
+
+    private fun ComposeContentTestRule.setContentScreen(
+        externalFolder: APath?,
+        onOpenExternally: (APath) -> Unit = {},
+    ) {
+        setContent {
+            PreviewWrapper {
+                ContentScreen(
+                    stateSource = MutableStateFlow(readyState(externalFolder)),
+                    onOpenExternally = onOpenExternally,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `without an external folder the action is hidden`() {
+        composeRule.setContentScreen(externalFolder = null)
+
+        composeRule.onNodeWithContentDescription("Open in file manager").assertDoesNotExist()
+    }
+
+    @Test
+    fun `with an external folder the action is shown`() {
+        composeRule.setContentScreen(externalFolder = itemPath)
+
+        composeRule.onNodeWithContentDescription("Open in file manager").assertExists()
+    }
+
+    @Test
+    fun `tapping the action reports the external folder`() {
+        val opened = mutableListOf<APath>()
+        composeRule.setContentScreen(externalFolder = itemPath, onOpenExternally = { opened.add(it) })
+
+        composeRule.onNodeWithContentDescription("Open in file manager").performClick()
+
+        opened shouldBe listOf(itemPath)
+    }
+
+    @Test
+    fun `the action is hidden while the selection top bar is showing`() {
+        composeRule.setContentScreen(externalFolder = itemPath)
+
+        // Without a parent level the row renders the item's default label: its full path.
+        composeRule.onNodeWithText("/storage/emulated/0/DCIM").performTouchInput { longClick() }
+
+        composeRule.onNodeWithText("1 item").assertExists()
+        composeRule.onNodeWithContentDescription("Open in file manager").assertDoesNotExist()
+    }
+}

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentViewModelTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentViewModelTest.kt
@@ -1,6 +1,7 @@
 package eu.darken.sdmse.analyzer.ui.storage.content
 
 import android.content.Context
+import android.content.Intent
 import eu.darken.sdmse.analyzer.R
 import eu.darken.sdmse.analyzer.core.Analyzer
 import eu.darken.sdmse.analyzer.core.AnalyzerSettings
@@ -12,6 +13,7 @@ import eu.darken.sdmse.analyzer.core.storage.categories.ContentCategory
 import eu.darken.sdmse.analyzer.core.storage.categories.MediaCategory
 import eu.darken.sdmse.analyzer.core.storage.categories.SystemCategory
 import eu.darken.sdmse.analyzer.ui.ContentRoute
+import eu.darken.sdmse.common.ViewIntentTool
 import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.files.FileType
@@ -26,11 +28,13 @@ import eu.darken.sdmse.common.ui.LayoutMode
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
@@ -63,11 +67,11 @@ class ContentViewModelTest : BaseTest() {
         setupIncomplete = false,
     )
 
-    private fun dirItem(name: String) = ContentItem(
+    private fun dirItem(name: String, type: FileType = FileType.DIRECTORY) = ContentItem(
         path = LocalPath.build("storage", "emulated", "0", name),
         lookup = null,
         itemSize = 0L,
-        type = FileType.DIRECTORY,
+        type = type,
         children = emptySet(),
         inaccessible = false,
     )
@@ -77,6 +81,7 @@ class ContentViewModelTest : BaseTest() {
         val analyzer: Analyzer,
         val swiperSessionCreator: eu.darken.sdmse.common.files.SwiperSessionCreator,
         val filterEditorOptionsCreator: eu.darken.sdmse.common.files.FilterEditorOptionsCreator,
+        val viewIntentTool: ViewIntentTool,
     )
 
     private fun TestScope.harness(
@@ -100,12 +105,13 @@ class ContentViewModelTest : BaseTest() {
         val swiperSessionCreator = mockk<eu.darken.sdmse.common.files.SwiperSessionCreator>(relaxed = true)
         val filterEditorOptionsCreator =
             mockk<eu.darken.sdmse.common.files.FilterEditorOptionsCreator>(relaxed = true)
+        val viewIntentTool = mockk<ViewIntentTool>(relaxed = true)
 
         val vm = ContentViewModel(
             dispatcherProvider = TestDispatcherProvider(),
             analyzer = analyzer,
             analyzerSettings = settings,
-            viewIntentTool = mockk(relaxed = true),
+            viewIntentTool = viewIntentTool,
             exclusionManager = mockk(relaxed = true),
             filterEditorOptionsCreator = filterEditorOptionsCreator,
             upgradeRepo = mockk(relaxed = true),
@@ -116,7 +122,7 @@ class ContentViewModelTest : BaseTest() {
         // safeStateIn uses WhileSubscribed(5000) — keep a subscriber alive for the test scope's lifetime.
         backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { vm.state.collect { } }
 
-        return Harness(vm, analyzer, swiperSessionCreator, filterEditorOptionsCreator)
+        return Harness(vm, analyzer, swiperSessionCreator, filterEditorOptionsCreator, viewIntentTool)
     }
 
     private fun ContentViewModel.readyState(): ContentViewModel.State.Ready {
@@ -241,5 +247,103 @@ class ContentViewModelTest : BaseTest() {
         advanceUntilIdle()
 
         coVerify(exactly = 0) { h.swiperSessionCreator.createSession(any()) }
+    }
+
+    @Test
+    fun `there is no external folder at the group root`() = runTest2 {
+        val child = dirItem("DCIM")
+        val group = ContentGroup(label = "Media".toCaString(), contents = setOf(child))
+        val h = harness(MediaCategory(storageId, setOf(group), isReadOnly = false), group)
+        coEvery { h.viewIntentTool.canOpenFolder(any()) } returns true
+        advanceUntilIdle()
+
+        h.vm.readyState().externalFolder.shouldBeNull()
+    }
+
+    @Test
+    fun `the browsed folder is offered when it can be opened externally`() = runTest2 {
+        val child = dirItem("DCIM")
+        val group = ContentGroup(label = "Media".toCaString(), contents = setOf(child))
+        val h = harness(MediaCategory(storageId, setOf(group), isReadOnly = false), group)
+        coEvery { h.viewIntentTool.canOpenFolder(child.path) } returns true
+        advanceUntilIdle()
+
+        h.vm.onItemClick(ContentViewModel.Item(parent = null, content = child, sizeRatio = null))
+        advanceUntilIdle()
+
+        h.vm.readyState().externalFolder shouldBe child.path
+    }
+
+    @Test
+    fun `the browsed folder is not offered when it can not be opened externally`() = runTest2 {
+        val child = dirItem("DCIM")
+        val group = ContentGroup(label = "Media".toCaString(), contents = setOf(child))
+        val h = harness(MediaCategory(storageId, setOf(group), isReadOnly = false), group)
+        coEvery { h.viewIntentTool.canOpenFolder(child.path) } returns false
+        advanceUntilIdle()
+
+        h.vm.onItemClick(ContentViewModel.Item(parent = null, content = child, sizeRatio = null))
+        advanceUntilIdle()
+
+        h.vm.readyState().externalFolder.shouldBeNull()
+    }
+
+    @Test
+    fun `symbolic links are never offered as external folders`() = runTest2 {
+        val child = dirItem("link", type = FileType.SYMBOLIC_LINK)
+        val group = ContentGroup(label = "Media".toCaString(), contents = setOf(child))
+        val h = harness(MediaCategory(storageId, setOf(group), isReadOnly = false), group)
+        coEvery { h.viewIntentTool.canOpenFolder(any()) } returns true
+        advanceUntilIdle()
+
+        h.vm.onItemClick(ContentViewModel.Item(parent = null, content = child, sizeRatio = null))
+        advanceUntilIdle()
+
+        h.vm.readyState().externalFolder.shouldBeNull()
+    }
+
+    @Test
+    fun `unknown item types are never offered as external folders`() = runTest2 {
+        val child = dirItem("mystery", type = FileType.UNKNOWN)
+        val group = ContentGroup(label = "Media".toCaString(), contents = setOf(child))
+        val h = harness(MediaCategory(storageId, setOf(group), isReadOnly = false), group)
+        coEvery { h.viewIntentTool.canOpenFolder(any()) } returns true
+        advanceUntilIdle()
+
+        h.vm.onItemClick(ContentViewModel.Item(parent = null, content = child, sizeRatio = null))
+        advanceUntilIdle()
+
+        h.vm.readyState().externalFolder.shouldBeNull()
+    }
+
+    @Test
+    fun `opening externally emits the intent from the view intent tool`() = runTest2 {
+        val child = dirItem("DCIM")
+        val group = ContentGroup(label = "Media".toCaString(), contents = setOf(child))
+        val h = harness(MediaCategory(storageId, setOf(group), isReadOnly = false), group)
+        val intent = mockk<Intent>()
+        coEvery { h.viewIntentTool.createForFolder(child.path) } returns intent
+        advanceUntilIdle()
+
+        h.vm.onOpenExternally(child.path)
+        advanceUntilIdle()
+
+        val event = h.vm.events.first()
+        event.shouldBeInstanceOf<ContentViewModel.Event.OpenContent>()
+        event.intent shouldBe intent
+    }
+
+    @Test
+    fun `opening externally reports when no app can handle the folder`() = runTest2 {
+        val child = dirItem("DCIM")
+        val group = ContentGroup(label = "Media".toCaString(), contents = setOf(child))
+        val h = harness(MediaCategory(storageId, setOf(group), isReadOnly = false), group)
+        coEvery { h.viewIntentTool.createForFolder(child.path) } returns null
+        advanceUntilIdle()
+
+        h.vm.onOpenExternally(child.path)
+        advanceUntilIdle()
+
+        h.vm.events.first() shouldBe ContentViewModel.Event.NoExternalAppFound
     }
 }


### PR DESCRIPTION
## What changed

The Analyzer's folder browser now has an "Open in file manager" button in the top bar. It opens whatever folder you are currently looking at in a file manager, so you can act on what the storage breakdown just showed you instead of navigating back to it by hand.

The button only appears where it can actually work: inside a real folder, on a storage volume a file manager can reach, on a device that has an app able to handle the request. It stays hidden for the folders Android hides from every normal app.

Refs #1815

## Technical Context

- The intent is `ACTION_VIEW` on an ExternalStorageProvider document URI, built with `DocumentsContract.buildDocumentUri` from `PathMapper`'s existing volume mapping and typed `vnd.android.document/directory`. Paths under `Android/data`, `Android/obb` and `Android/sandbox` are excluded on API 30+, where that provider hides them and such a URI would just open an empty screen.
- No `FLAG_GRANT_READ_URI_PERMISSION`, deliberately. The app holds `MANAGE_EXTERNAL_STORAGE`, not `MANAGE_DOCUMENTS`, and no volume-root SAF grant on API 30+, so there is nothing to delegate. Passing a grant flag for a URI the caller does not hold can make `startActivity` throw `SecurityException`.
- `canOpenFolder()` and `createForFolder()` share one private builder, so the button's visibility and the launch path cannot disagree about whether a folder is openable. `State.Ready.externalFolder` is the single value driving both the button's visibility and the action's target.
- The existing `OpenContent` handler no longer swallows non-`ActivityNotFoundException` launch failures silently. Worth a close look, since that path is also used by the pre-existing file-open action.
- Tested on emulators at API 30, 34 and 36: the intent resolves and the file manager lands on the exact folder that was open in the Analyzer. API 29 could not be verified, as the Analyzer cannot render folder content on that system image for reasons unrelated to this change.
