### PR TITLE
Analyzer: Show storage used by other users and work profiles

### DIFF
--- a/app-common-data/src/main/java/eu/darken/sdmse/common/storage/StorageStatsManager2.kt
+++ b/app-common-data/src/main/java/eu/darken/sdmse/common/storage/StorageStatsManager2.kt
@@ -6,6 +6,7 @@ import dagger.Reusable
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.funnel.IPCFunnel
 import eu.darken.sdmse.common.pkgs.features.Installed
+import eu.darken.sdmse.common.user.UserHandle2
 import javax.inject.Inject
 
 @Reusable
@@ -22,6 +23,16 @@ class StorageStatsManager2 @Inject constructor(
 
     suspend fun queryStatsForPkg(storageId: StorageId, pkg: Installed): StorageStats = ipcFunnel.use {
         osStatManager.queryStatsForPackage(storageId.externalId, pkg.packageName, pkg.userHandle.asUserHandle())
+    }
+
+    /**
+     * Storage stats for a whole user/profile.
+     *
+     * Beyond usage-stats access this needs [eu.darken.sdmse.common.permissions.Permission.INTERACT_ACROSS_USERS]
+     * for any user other than the current one.
+     */
+    suspend fun queryStatsForUser(storageId: StorageId, userHandle: UserHandle2): StorageStats = ipcFunnel.use {
+        osStatManager.queryStatsForUser(storageId.externalId, userHandle.asUserHandle())
     }
 
     @Throws(IllegalStateException::class)

--- a/app-common-setup/src/main/java/eu/darken/sdmse/setup/SetupHelper.kt
+++ b/app-common-setup/src/main/java/eu/darken/sdmse/setup/SetupHelper.kt
@@ -1,6 +1,8 @@
 package eu.darken.sdmse.setup
 
+import android.content.Context
 import dagger.Reusable
+import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.sdmse.common.SystemSettingsProvider
 import eu.darken.sdmse.common.adb.AdbManager
 import eu.darken.sdmse.common.adb.canUseAdbNow
@@ -19,6 +21,7 @@ import javax.inject.Inject
 
 @Reusable
 class SetupHelper @Inject constructor(
+    @ApplicationContext private val context: Context,
     private val adbManager: AdbManager,
     private val rootManager: RootManager,
     private val settingsProvider: SystemSettingsProvider,
@@ -68,6 +71,38 @@ class SetupHelper @Inject constructor(
             log(TAG, INFO) { "setSecureSettings(granted=$granted): We achieved desired access state :)" }
         } else {
             log(TAG, ERROR) { "setSecureSettings(granted=$granted): Failed to achieve desired access state :(" }
+        }
+
+        return true
+    }
+
+    suspend fun hasCrossUserAccess(): Boolean = Permission.INTERACT_ACROSS_USERS.isGranted(context).also {
+        log(TAG, VERBOSE) { "hasCrossUserAccess(): $it" }
+    }
+
+    suspend fun setCrossUserAccess(granted: Boolean): Boolean {
+        log(TAG) { "setCrossUserAccess(granted=$granted)" }
+
+        if (granted == hasCrossUserAccess()) {
+            log(TAG, VERBOSE) { "setCrossUserAccess(granted=$granted): We already have desired access state" }
+            return true
+        }
+
+        if (!checkGrantPermissions()) {
+            log(TAG) { "setCrossUserAccess(granted=$granted): Can't gain grant permissions" }
+            return false
+        }
+
+        if (granted) {
+            pkgOps.grantPermission(userManager2.ourInstall(), Permission.INTERACT_ACROSS_USERS)
+        } else {
+            pkgOps.revokePermission(userManager2.ourInstall(), Permission.INTERACT_ACROSS_USERS)
+        }
+
+        if (granted == hasCrossUserAccess()) {
+            log(TAG, INFO) { "setCrossUserAccess(granted=$granted): We achieved desired access state :)" }
+        } else {
+            log(TAG, ERROR) { "setCrossUserAccess(granted=$granted): Failed to achieve desired access state :(" }
         }
 
         return true

--- a/app-common/src/main/java/eu/darken/sdmse/common/permissions/Permission.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/permissions/Permission.kt
@@ -110,6 +110,11 @@ sealed class Permission(
     data object QUERY_ALL_PACKAGES
         : Permission("android.permission.QUERY_ALL_PACKAGES")
 
+    // Signature|privileged permission, only obtainable via ADB/root grant.
+    // Required to query storage stats and walk data of users other than the current one.
+    data object INTERACT_ACROSS_USERS
+        : Permission("android.permission.INTERACT_ACROSS_USERS")
+
     // Non-AOSP permission from Chinese TAF standard (TTAF 108-2022).
     // Required by Chinese ROMs (HyperOS, ColorOS, OriginOS, HarmonyOS) to access the full app list.
     // Does not exist on AOSP/Pixel/Samsung — isGranted() returns true when absent.
@@ -147,6 +152,7 @@ sealed class Permission(
                 PACKAGE_USAGE_STATS,
                 WRITE_SECURE_SETTINGS,
                 QUERY_ALL_PACKAGES,
+                INTERACT_ACROSS_USERS,
                 GET_INSTALLED_APPS,
             )
         }

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/Analyzer.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/Analyzer.kt
@@ -17,6 +17,7 @@ import eu.darken.sdmse.analyzer.core.storage.StorageScanner
 import eu.darken.sdmse.analyzer.core.storage.categories.AppCategory
 import eu.darken.sdmse.analyzer.core.storage.categories.ContentCategory
 import eu.darken.sdmse.analyzer.core.storage.categories.MediaCategory
+import eu.darken.sdmse.analyzer.core.storage.categories.OtherUsersCategory
 import eu.darken.sdmse.analyzer.core.storage.categories.SystemCategory
 import eu.darken.sdmse.analyzer.core.storage.categories.isContentReadOnly
 import eu.darken.sdmse.analyzer.core.storage.categories.ownsGroup
@@ -239,7 +240,11 @@ class Analyzer @Inject constructor(
         val oldGroup = oldCategory.groups.single { it.id == task.groupId }
 
         if (oldCategory.isContentReadOnly) {
-            val what = if (oldCategory is SystemCategory) "system content" else "read-only media content"
+            val what = when (oldCategory) {
+                is SystemCategory -> "system content"
+                is OtherUsersCategory -> "another user's content"
+                else -> "read-only media content"
+            }
             log(TAG, WARN) { "deleteContent(): Blocked — $what is read-only" }
             throw UnsupportedOperationException("Deletion is not supported for $what")
         }
@@ -305,6 +310,10 @@ class Analyzer @Inject constructor(
 
             is SystemCategory -> {
                 throw UnsupportedOperationException("Deletion is not supported for system content")
+            }
+
+            is OtherUsersCategory -> {
+                throw UnsupportedOperationException("Deletion is not supported for other users' content")
             }
         }
 

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/OtherUserStorageScanner.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/OtherUserStorageScanner.kt
@@ -1,0 +1,227 @@
+package eu.darken.sdmse.analyzer.core.storage
+
+import dagger.Reusable
+import eu.darken.sdmse.analyzer.core.content.ContentGroup
+import eu.darken.sdmse.analyzer.core.content.ContentItem
+import eu.darken.sdmse.analyzer.core.device.DeviceStorage
+import eu.darken.sdmse.analyzer.core.storage.categories.OtherUsersCategory
+import eu.darken.sdmse.common.areas.DataArea
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.asLog
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.files.APathGateway
+import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.common.files.FileType
+import eu.darken.sdmse.common.files.GatewaySwitch
+import eu.darken.sdmse.common.files.du
+import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.files.walk
+import eu.darken.sdmse.common.storage.StorageStatsManager2
+import eu.darken.sdmse.common.user.UserProfile2
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import javax.inject.Inject
+
+/**
+ * Sizes the storage of users/profiles other than the current one.
+ *
+ * Deliberately does not reuse [AppStorageScanner], which is current-user-only: its root app-code
+ * path would count shared APKs a second time for every user.
+ *
+ * Tiers, in order:
+ * - ROOT: walk `/data/media/<id>` plus the user's private data areas. `/storage/emulated/<id>` is
+ *   NOT usable here, FUSE filters it per calling user.
+ * - STATS: `queryStatsForUser().dataBytes` as one opaque item. Exact app data, no shared files.
+ * - NEITHER: the user is listed by name only, its bytes stay in the system residual.
+ */
+@Reusable
+class OtherUserStorageScanner @Inject constructor(
+    private val gatewaySwitch: GatewaySwitch,
+    private val statsManager: StorageStatsManager2,
+) {
+
+    suspend fun scan(
+        storage: DeviceStorage,
+        users: Collection<UserProfile2>,
+        dataAreas: Set<DataArea>,
+        useRoot: Boolean,
+        onUser: (suspend (UserProfile2) -> Unit)? = null,
+    ): OtherUsersCategory? {
+        log(TAG) { "scan(): storage=${storage.id}, users=$users, useRoot=$useRoot" }
+        if (users.isEmpty()) return null
+
+        val groups = mutableListOf<ContentGroup>()
+        val entries = mutableListOf<OtherUsersCategory.UserEntry>()
+
+        users.sortedBy { it.handle.handleId }.forEach { user ->
+            onUser?.invoke(user)
+            val result = scanUser(storage, user, dataAreas, useRoot)
+            groups.add(result.group)
+            entries.add(result.entry)
+        }
+
+        return OtherUsersCategory(
+            storageId = storage.id,
+            groups = groups,
+            users = entries,
+        )
+    }
+
+    private data class UserResult(
+        val group: ContentGroup,
+        val entry: OtherUsersCategory.UserEntry,
+    )
+
+    private suspend fun scanUser(
+        storage: DeviceStorage,
+        user: UserProfile2,
+        dataAreas: Set<DataArea>,
+        useRoot: Boolean,
+    ): UserResult {
+        val label = user.getHumanLabel()
+        val rootContents = if (useRoot) walkUser(user, dataAreas) else null
+
+        val contents: Collection<ContentItem>
+        val appDataKnown: Boolean
+        val sharedMediaKnown: Boolean
+
+        if (rootContents != null) {
+            contents = rootContents
+            appDataKnown = true
+            sharedMediaKnown = true
+        } else {
+            // dataBytes already includes cacheBytes (see PkgOps.Stats), adding cache on top would
+            // over-report every user by its entire cache.
+            val dataBytes = try {
+                statsManager.queryStatsForUser(storage.id, user.handle).dataBytes
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                log(TAG, WARN) { "Storage stats unavailable for ${user.handle}: ${e.asLog()}" }
+                null
+            }
+
+            if (dataBytes != null) {
+                log(TAG, INFO) { "Stats-only sizing for ${user.handle}: dataBytes=$dataBytes" }
+                contents = setOf(
+                    ContentItem.fromInaccessible(
+                        LocalPath.build("data", "user", "${user.handle.handleId}"),
+                        dataBytes,
+                    )
+                )
+                appDataKnown = true
+            } else {
+                log(TAG, WARN) { "No size available for ${user.handle}, listing name only" }
+                contents = emptySet()
+                appDataKnown = false
+            }
+            // Never size another user's public storage below root: as shell `du` on
+            // /storage/emulated/<id> reports a few KB for a real tree, without any error.
+            sharedMediaKnown = false
+        }
+
+        val group = ContentGroup(label = label, contents = contents)
+
+        return UserResult(
+            group = group,
+            entry = OtherUsersCategory.UserEntry(
+                handle = user.handle,
+                label = label,
+                groupId = group.id,
+                appDataKnown = appDataKnown,
+                sharedMediaKnown = sharedMediaKnown,
+                // Opaque stats items have nothing to browse into.
+                isBrowsable = contents.any { !it.inaccessible },
+            ),
+        )
+    }
+
+    /**
+     * Root sizing for one user, all-or-nothing.
+     *
+     * Returns null on any partial failure: [StorageStatsManager2.queryStatsForUser]'s dataBytes
+     * already covers app-owned external data under `/data/media/<id>/Android`, so mixing a
+     * successful media walk with stats for a failed private-data walk would double-count.
+     */
+    private suspend fun walkUser(user: UserProfile2, dataAreas: Set<DataArea>): Collection<ContentItem>? {
+        val privateAreas = dataAreas
+            .filter { it.type == DataArea.Type.PRIVATE_DATA }
+            .filter { it.userHandle == user.handle }
+
+        // PrivateDataModule silently omits locked credential-encrypted areas, so a missing half
+        // means "we can't see this user's app data", not "this user has none".
+        val hasCredentialEncrypted = privateAreas.any { it.isCredentialEncrypted }
+        val hasDeviceEncrypted = privateAreas.any { it.isDeviceEncrypted }
+        if (!hasCredentialEncrypted || !hasDeviceEncrypted) {
+            log(TAG, WARN) {
+                "Private data areas incomplete for ${user.handle} (ce=$hasCredentialEncrypted, de=$hasDeviceEncrypted)"
+            }
+            return null
+        }
+
+        val items = mutableListOf<ContentItem>()
+
+        for (area in privateAreas) {
+            val item = walkOrNull(area.path) ?: return null
+            items.add(item)
+        }
+
+        // /data/media/<id>, not /storage/emulated/<id>: the latter is FUSE-filtered per calling user.
+        val mediaPath = LocalPath.build("data", "media", "${user.handle.handleId}")
+        val mediaItem = walkOrNull(mediaPath) ?: return null
+        items.add(mediaItem)
+
+        return items
+    }
+
+    /**
+     * Walk that reports failure instead of degrading into an apparently-successful, tiny directory.
+     */
+    private suspend fun walkOrNull(path: APath): ContentItem? = try {
+        val lookup = gatewaySwitch.lookup(path, type = GatewaySwitch.Type.AUTO)
+        when {
+            lookup.fileType != FileType.DIRECTORY -> ContentItem.fromLookup(lookup)
+            else -> {
+                val options = APathGateway.WalkOptions<APath, APathLookup<APath>>(followSymlinks = false)
+                val children = lookup.walk(gatewaySwitch, options)
+                    .map { ContentItem.fromLookup(it) }
+                    .take(WALK_MAX_ITEMS + 1)
+                    .toList()
+
+                if (children.size > WALK_MAX_ITEMS) {
+                    log(TAG, WARN) { "Walk item limit exceeded for $path, sizing it instead" }
+                    ContentItem.fromInaccessible(path, lookup.size + lookup.du(gatewaySwitch))
+                } else {
+                    children.plus(ContentItem.fromLookup(lookup)).toNestedContent().single()
+                }
+            }
+        }
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        log(TAG, WARN) { "Failed to size $path: ${e.asLog()}" }
+        null
+    }
+
+    companion object {
+        private const val WALK_MAX_ITEMS = 100_000
+        private val TAG = logTag("Analyzer", "Storage", "Scanner", "OtherUsers")
+    }
+}
+
+/**
+ * `/data_mirror/data_ce/null/<id>` (API 30+) or `/data/user/<id>` (legacy).
+ */
+private val DataArea.isCredentialEncrypted: Boolean
+    get() = path.segments.contains("data_ce") || path.segments.contains("user")
+
+/**
+ * `/data_mirror/data_de/null/<id>` (API 30+) or `/data/user_de/<id>` (legacy).
+ */
+private val DataArea.isDeviceEncrypted: Boolean
+    get() = path.segments.contains("data_de") || path.segments.contains("user_de")

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/OtherUserStorageScanner.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/OtherUserStorageScanner.kt
@@ -16,7 +16,6 @@ import eu.darken.sdmse.common.files.APathGateway
 import eu.darken.sdmse.common.files.APathLookup
 import eu.darken.sdmse.common.files.FileType
 import eu.darken.sdmse.common.files.GatewaySwitch
-import eu.darken.sdmse.common.files.du
 import eu.darken.sdmse.common.files.local.LocalPath
 import eu.darken.sdmse.common.files.walk
 import eu.darken.sdmse.common.storage.StorageStatsManager2
@@ -181,21 +180,30 @@ class OtherUserStorageScanner @Inject constructor(
 
     /**
      * Walk that reports failure instead of degrading into an apparently-successful, tiny directory.
+     *
+     * `onError` returns false so a failure anywhere below the root aborts the walk instead of
+     * finishing with a partial tree: the default (`true`, keep going) lets a listing error deep in
+     * the tree pass as a complete result, which marks an under-counted user as fully known.
      */
     private suspend fun walkOrNull(path: APath): ContentItem? = try {
         val lookup = gatewaySwitch.lookup(path, type = GatewaySwitch.Type.AUTO)
         when {
             lookup.fileType != FileType.DIRECTORY -> ContentItem.fromLookup(lookup)
             else -> {
-                val options = APathGateway.WalkOptions<APath, APathLookup<APath>>(followSymlinks = false)
+                val options = APathGateway.WalkOptions<APath, APathLookup<APath>>(
+                    followSymlinks = false,
+                    onError = { _, _ -> false },
+                )
                 val children = lookup.walk(gatewaySwitch, options)
                     .map { ContentItem.fromLookup(it) }
                     .take(WALK_MAX_ITEMS + 1)
                     .toList()
 
                 if (children.size > WALK_MAX_ITEMS) {
-                    log(TAG, WARN) { "Walk item limit exceeded for $path, sizing it instead" }
-                    ContentItem.fromInaccessible(path, lookup.size + lookup.du(gatewaySwitch))
+                    // `du` is not atomic either, so a truncated walk counts as a failed walk: let
+                    // the stats-only tier size this user instead of passing off a partial tree.
+                    log(TAG, WARN) { "Walk item limit exceeded for $path" }
+                    null
                 } else {
                     children.plus(ContentItem.fromLookup(lookup)).toNestedContent().single()
                 }

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/StorageScanner.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/StorageScanner.kt
@@ -152,20 +152,14 @@ class StorageScanner @Inject constructor(
         log(TAG) { "Other users on $storage: $otherUsers" }
     }
 
-    /**
-     * Neither source alone is enough: [UserManager2.allUsers] falls back to `UserManager.userProfiles`
-     * without root/ADB and misses full secondary users, while the hidden `getVolumes()` lists every
-     * user's emulated volume even without any permission but carries no names.
-     */
     private suspend fun resolveOtherUsers(storage: DeviceStorage): Set<UserProfile2> {
-        val handles = otherUserHandles(storage.type, storageManager2.volumes, currentUser)
-        if (handles.isEmpty()) return emptySet()
-
-        val named = userManager2.otherUsers()
-            .filter { it.handle != currentUser }
-            .associateBy { it.handle }
-
-        return handles.map { named[it] ?: UserProfile2(handle = it) }.toSet()
+        if (storage.type != DeviceStorage.Type.PRIMARY) return emptySet()
+        return mergeOtherUsers(
+            storageType = storage.type,
+            volumes = storageManager2.volumes,
+            named = userManager2.otherUsers(),
+            currentUser = currentUser,
+        )
     }
 
     suspend fun scan(storage: DeviceStorage): Collection<ContentCategory> {
@@ -526,11 +520,40 @@ class StorageScanner @Inject constructor(
             .filter { it.userHandle == currentUser }
 
         /**
+         * Other users on this storage, from both sources combined.
+         *
+         * Neither source alone is enough: [UserManager2.allUsers] falls back to
+         * `UserManager.userProfiles` without root/ADB and misses full secondary users, while the
+         * hidden `getVolumes()` lists every user's emulated volume even without any permission but
+         * carries no names. Older devices (e.g. API 27/28) expose a single `emulated` volume with
+         * `mountUserId=-1`, so there the named list is the only source that finds anything.
+         *
+         * Negative handle ids are dropped from either source, they are sentinels
+         * (`-1` unknown, `-10000` private volume), not users.
+         */
+        fun mergeOtherUsers(
+            storageType: DeviceStorage.Type,
+            volumes: List<VolumeInfoX>?,
+            named: Collection<UserProfile2>,
+            currentUser: UserHandle2,
+        ): Set<UserProfile2> {
+            if (storageType != DeviceStorage.Type.PRIMARY) return emptySet()
+            val namedByHandle = named.associateBy { it.handle }
+            return namedByHandle.keys
+                .plus(otherUserHandles(storageType, volumes, currentUser))
+                .filter { it != currentUser }
+                .filter { it.handleId >= 0 }
+                .map { namedByHandle[it] ?: UserProfile2(handle = it) }
+                .toSet()
+        }
+
+        /**
          * Emulated storage roots of other users, from the hidden volume list.
          *
-         * Only mounted, emulated, primary volumes count. The private volume reports
-         * `mountUserId=-10000`, so an unfiltered scan would invent a user. Secondary/portable
-         * storage has no `/data/media/<id>` model, so the whole category doesn't apply there.
+         * Only emulated, primary volumes count. The private volume reports `mountUserId=-10000`, so
+         * an unfiltered scan would invent a user. Secondary/portable storage has no
+         * `/data/media/<id>` model, so the whole category doesn't apply there. Mount state is not a
+         * filter: a stopped user still occupies storage.
          */
         fun otherUserHandles(
             storageType: DeviceStorage.Type,
@@ -539,7 +562,6 @@ class StorageScanner @Inject constructor(
         ): Set<UserHandle2> {
             if (storageType != DeviceStorage.Type.PRIMARY) return emptySet()
             return volumes
-                ?.filter { it.isMounted }
                 ?.filter { it.isEmulated }
                 ?.filter { it.isPrimary == true }
                 ?.mapNotNull { it.mountUserId }

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/StorageScanner.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/StorageScanner.kt
@@ -6,6 +6,7 @@ import eu.darken.sdmse.analyzer.core.device.DeviceStorage
 import eu.darken.sdmse.analyzer.core.storage.categories.AppCategory
 import eu.darken.sdmse.analyzer.core.storage.categories.ContentCategory
 import eu.darken.sdmse.analyzer.core.storage.categories.MediaCategory
+import eu.darken.sdmse.analyzer.core.storage.categories.OtherUsersCategory
 import eu.darken.sdmse.analyzer.core.storage.categories.SystemCategory
 import eu.darken.sdmse.common.adb.AdbManager
 import eu.darken.sdmse.common.adb.canUseAdbNow
@@ -32,6 +33,7 @@ import eu.darken.sdmse.common.forensics.FileForensics
 import eu.darken.sdmse.common.forensics.OwnerInfo
 import eu.darken.sdmse.common.pkgs.PkgRepo
 import eu.darken.sdmse.common.pkgs.current
+import eu.darken.sdmse.common.pkgs.features.Installed
 import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.common.progress.increaseProgress
 import eu.darken.sdmse.common.progress.updateProgressCount
@@ -41,8 +43,11 @@ import eu.darken.sdmse.common.root.RootManager
 import eu.darken.sdmse.common.root.canUseRootNow
 import eu.darken.sdmse.common.storage.StorageManager2
 import eu.darken.sdmse.common.storage.StorageVolumeX
+import eu.darken.sdmse.common.storage.VolumeInfoX
 import eu.darken.sdmse.common.user.UserHandle2
 import eu.darken.sdmse.common.user.UserManager2
+import eu.darken.sdmse.common.user.UserProfile2
+import eu.darken.sdmse.setup.SetupHelper
 import eu.darken.sdmse.setup.SetupModule
 import eu.darken.sdmse.setup.isComplete
 import eu.darken.sdmse.setup.SetupBinding
@@ -63,6 +68,8 @@ class StorageScanner @Inject constructor(
     private val dataAreaManager: DataAreaManager,
     private val appScannerFactory: AppStorageScanner.Factory,
     private val systemStorageScanner: SystemStorageScanner,
+    private val otherUserStorageScanner: OtherUserStorageScanner,
+    private val setupHelper: SetupHelper,
     @SetupBinding(SetupModule.Type.INVENTORY) private val inventorySetupModule: SetupModule,
     @SetupBinding(SetupModule.Type.USAGE_STATS) private val usageStatsSetupModule: SetupModule,
 ) : Progress.Host, Progress.Client {
@@ -83,6 +90,7 @@ class StorageScanner @Inject constructor(
     private var useAdb = false
     private var dataAreas = mutableSetOf<DataArea>()
     private var volume: StorageVolumeX? = null
+    private var otherUsers = emptySet<UserProfile2>()
     private lateinit var currentUser: UserHandle2
 
     suspend fun init(storage: DeviceStorage) {
@@ -90,6 +98,21 @@ class StorageScanner @Inject constructor(
         useRoot = rootManager.canUseRootNow()
         useAdb = adbManager.canUseAdbNow()
         currentUser = userManager2.currentUser().handle
+
+        // Cross-user access is only grantable via root/ADB. Without it we stay on the no-stats tier
+        // for other users, which is a degraded result, not a failure.
+        if (useRoot || useAdb) {
+            try {
+                if (!setupHelper.hasCrossUserAccess()) {
+                    val granted = setupHelper.setCrossUserAccess(true)
+                    log(TAG, INFO) { "init(): setCrossUserAccess(true)=$granted" }
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                log(TAG, WARN) { "init(): Failed to gain cross-user access: ${e.asLog()}" }
+            }
+        }
 
         val availableVolumes = storageManager2.storageVolumes
         log(TAG) { "Available volumes:\n${availableVolumes.joinToString("\n")}" }
@@ -124,6 +147,25 @@ class StorageScanner @Inject constructor(
                 dataAreas.clear()
                 dataAreas.addAll(it)
             }
+
+        otherUsers = resolveOtherUsers(storage)
+        log(TAG) { "Other users on $storage: $otherUsers" }
+    }
+
+    /**
+     * Neither source alone is enough: [UserManager2.allUsers] falls back to `UserManager.userProfiles`
+     * without root/ADB and misses full secondary users, while the hidden `getVolumes()` lists every
+     * user's emulated volume even without any permission but carries no names.
+     */
+    private suspend fun resolveOtherUsers(storage: DeviceStorage): Set<UserProfile2> {
+        val handles = otherUserHandles(storage.type, storageManager2.volumes, currentUser)
+        if (handles.isEmpty()) return emptySet()
+
+        val named = userManager2.otherUsers()
+            .filter { it.handle != currentUser }
+            .associateBy { it.handle }
+
+        return handles.map { named[it] ?: UserProfile2(handle = it) }.toSet()
     }
 
     suspend fun scan(storage: DeviceStorage): Collection<ContentCategory> {
@@ -183,14 +225,17 @@ class StorageScanner @Inject constructor(
                     ?.let { scanForMedia(storage, it, storageChildren, ownersResolved) }
                     ?: MediaCategory(storage.id, emptySet())
 
+                val otherUsersCategory = scanForOtherUsers(storage)
+
                 updateProgressSecondary("Scanning system data")
-                val system = scanForSystem(storage, apps, media)
+                val system = scanForSystem(storage, apps, media, otherUsersCategory)
 
                 log(TAG) { "Apps: ${apps?.spaceUsed}" }
                 log(TAG) { "Media: ${media.spaceUsed}" }
+                log(TAG) { "Other users: ${otherUsersCategory?.spaceUsed}" }
                 log(TAG) { "System: ${system?.spaceUsed}" }
 
-                setOfNotNull(apps, media, system)
+                setOfNotNull(apps, media, otherUsersCategory, system)
             }
         }
     }
@@ -231,9 +276,7 @@ class StorageScanner @Inject constructor(
         // Same failure mode as the top-level owner forensics: setup can report complete while the pkg repo holds a
         // stale error. Degrade to "setup incomplete" instead of aborting the whole storage scan.
         val targetPkgs = try {
-            pkgRepo.current()
-                .filter { it.packageName != "android" }
-                .filter { it.applicationInfo != null }
+            scanTargets(pkgRepo.current(), currentUser)
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -363,10 +406,29 @@ class StorageScanner @Inject constructor(
         )
     }
 
+    private suspend fun scanForOtherUsers(storage: DeviceStorage): OtherUsersCategory? {
+        log(TAG) { "scanForOtherUsers($storage)" }
+        if (otherUsers.isEmpty()) return null
+
+        updateProgressPrimary(eu.darken.sdmse.analyzer.R.string.analyzer_storage_content_type_otherusers_label)
+        updateProgressSecondary(Progress.Data().secondary)
+        updateProgressCount(Progress.Count.Indeterminate())
+
+        return otherUserStorageScanner.scan(
+            storage = storage,
+            users = otherUsers,
+            dataAreas = dataAreas,
+            useRoot = useRoot,
+        ) { user ->
+            updateProgressSecondary(user.getHumanLabel())
+        }
+    }
+
     private suspend fun scanForSystem(
         storage: DeviceStorage,
         appCategory: AppCategory?,
-        mediaCategory: MediaCategory
+        mediaCategory: MediaCategory,
+        otherUsersCategory: OtherUsersCategory?,
     ): SystemCategory? {
         log(TAG) { "scanForSystem($storage)" }
         updateProgressPrimary(eu.darken.sdmse.analyzer.R.string.analyzer_progress_scanning_system)
@@ -378,10 +440,12 @@ class StorageScanner @Inject constructor(
             return null
         }
 
-        // In the degraded scan media folders are du-sized (no owner forensics), which can overcount and push this
-        // below zero. Clamp so the system category never reports a negative size.
-        val unaccountedFor = (storage.spaceUsed - (appCategory?.spaceUsed ?: 0L) - mediaCategory.spaceUsed)
-            .coerceAtLeast(0L)
+        val unaccountedFor = computeResidual(
+            spaceUsed = storage.spaceUsed,
+            apps = appCategory?.spaceUsed ?: 0L,
+            media = mediaCategory.spaceUsed,
+            otherUsers = otherUsersCategory?.spaceUsed ?: 0L,
+        )
 
         val contentItems = setOf(
             ContentItem.fromInaccessible(LocalPath.build("system")),
@@ -449,5 +513,59 @@ class StorageScanner @Inject constructor(
 
     companion object {
         private val TAG = logTag("Analyzer", "Storage", "Scanner")
+
+        /**
+         * Packages this scan may attribute: real installs of the current user.
+         *
+         * Other users' packages belong to [OtherUsersCategory]; listing them here would duplicate
+         * every app row and count their bytes twice.
+         */
+        fun scanTargets(pkgs: Collection<Installed>, currentUser: UserHandle2): Collection<Installed> = pkgs
+            .filter { it.packageName != "android" }
+            .filter { it.applicationInfo != null }
+            .filter { it.userHandle == currentUser }
+
+        /**
+         * Emulated storage roots of other users, from the hidden volume list.
+         *
+         * Only mounted, emulated, primary volumes count. The private volume reports
+         * `mountUserId=-10000`, so an unfiltered scan would invent a user. Secondary/portable
+         * storage has no `/data/media/<id>` model, so the whole category doesn't apply there.
+         */
+        fun otherUserHandles(
+            storageType: DeviceStorage.Type,
+            volumes: List<VolumeInfoX>?,
+            currentUser: UserHandle2,
+        ): Set<UserHandle2> {
+            if (storageType != DeviceStorage.Type.PRIMARY) return emptySet()
+            return volumes
+                ?.filter { it.isMounted }
+                ?.filter { it.isEmulated }
+                ?.filter { it.isPrimary == true }
+                ?.mapNotNull { it.mountUserId }
+                ?.filter { it >= 0 }
+                ?.map { UserHandle2(handleId = it) }
+                ?.filter { it != currentUser }
+                ?.toSet()
+                ?: emptySet()
+        }
+
+        /**
+         * Storage not attributed to apps, media or other users.
+         *
+         * In the degraded scan media folders are du-sized (no owner forensics), which can overcount
+         * and push this below zero. Clamp so the system category never reports a negative size, and
+         * name the components when the inputs don't add up.
+         */
+        fun computeResidual(spaceUsed: Long, apps: Long, media: Long, otherUsers: Long): Long {
+            val accounted = apps + media + otherUsers
+            if (accounted > spaceUsed) {
+                log(TAG, WARN) {
+                    "Over-accounted storage: apps=$apps + media=$media + otherUsers=$otherUsers " +
+                        "= $accounted > spaceUsed=$spaceUsed"
+                }
+            }
+            return (spaceUsed - accounted).coerceAtLeast(0L)
+        }
     }
 }

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/categories/ContentCategory.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/categories/ContentCategory.kt
@@ -14,13 +14,14 @@ fun ContentCategory.ownsGroup(groupId: ContentGroup.Id): Boolean = groups.any { 
 /**
  * Whether content actions (delete, filter, Swiper) must be blocked for this category.
  *
- * System content is always read-only. Media content is read-only only in the degraded scan, i.e. when the app
- * inventory is unavailable and files can't be matched to their owners. Shared by the UI and the core delete guard so
- * the two definitions can't drift.
+ * System content and other users' content are always read-only. Media content is read-only only in the degraded scan,
+ * i.e. when the app inventory is unavailable and files can't be matched to their owners. Shared by the UI and the core
+ * delete guard so the two definitions can't drift.
  */
 val ContentCategory.isContentReadOnly: Boolean
     get() = when (this) {
         is SystemCategory -> true
+        is OtherUsersCategory -> true
         is MediaCategory -> isReadOnly
         is AppCategory -> false
     }

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/categories/OtherUsersCategory.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/categories/OtherUsersCategory.kt
@@ -1,0 +1,37 @@
+package eu.darken.sdmse.analyzer.core.storage.categories
+
+import eu.darken.sdmse.analyzer.core.content.ContentGroup
+import eu.darken.sdmse.common.ca.CaString
+import eu.darken.sdmse.common.storage.StorageId
+import eu.darken.sdmse.common.user.UserHandle2
+
+/**
+ * Storage occupied by users/profiles other than the current one.
+ *
+ * Without this category their bytes are silently absorbed by the system residual, which makes
+ * "System data" look inexplicably large on devices with a second user or a work profile.
+ */
+data class OtherUsersCategory(
+    override val storageId: StorageId,
+    override val groups: Collection<ContentGroup>,
+    val users: Collection<UserEntry>,
+    val spaceUsedOverride: Long? = null,
+) : ContentCategory {
+
+    override val spaceUsed: Long
+        get() = spaceUsedOverride ?: groups.sumOf { it.groupSize }
+
+    /**
+     * One entry per other user. Completeness is tracked per user, not per category: a single
+     * category-wide "exact" flag can't express "user A was measured, user B is locked", and a
+     * stats-only number is exact APP data, not exact user storage.
+     */
+    data class UserEntry(
+        val handle: UserHandle2,
+        val label: CaString,
+        val groupId: ContentGroup.Id,
+        val appDataKnown: Boolean,
+        val sharedMediaKnown: Boolean,
+        val isBrowsable: Boolean,
+    )
+}

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentScreen.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentScreen.kt
@@ -47,8 +47,11 @@ import eu.darken.sdmse.analyzer.R
 import eu.darken.sdmse.analyzer.core.content.ContentItem
 import eu.darken.sdmse.analyzer.core.storage.SystemStorageScanner
 import eu.darken.sdmse.analyzer.ui.ContentRoute
+import eu.darken.sdmse.analyzer.ui.storage.preview.previewContentItem
+import eu.darken.sdmse.analyzer.ui.storage.preview.previewDeviceStorage
 import eu.darken.sdmse.common.ByteFormatter
 import eu.darken.sdmse.common.R as CommonR
+import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.compose.dialog.SdmConfirmDialog
 import eu.darken.sdmse.common.compose.dialog.SdmDialogAction
 import eu.darken.sdmse.common.compose.icons.SdmIcons
@@ -415,7 +418,7 @@ internal fun ContentScreen(
                                 s.infoBanner?.let { banner ->
                                     item(key = "info-banner") {
                                         ContentInfoBanner(
-                                            modifier = Modifier.padding(horizontal = 16.dp),
+                                            modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 8.dp),
                                             text = banner,
                                         )
                                     }
@@ -524,5 +527,30 @@ private fun LazyGridScope.contentTiles(
 private fun ContentScreenLoadingPreview() {
     PreviewWrapper {
         ContentScreen()
+    }
+}
+
+@Preview2
+@Composable
+private fun ContentScreenInfoBannerListPreview() {
+    val items = listOf(
+        previewContentItem(segments = arrayOf("data", "media", "10", "DCIM", "vacation.mp4"), size = 3L * 1024 * 1024 * 1024),
+        previewContentItem(segments = arrayOf("data", "media", "10", "Music", "playlist.mp3"), size = 8L * 1024 * 1024),
+    )
+    PreviewWrapper {
+        ContentScreen(
+            stateSource = MutableStateFlow(
+                ContentViewModel.State.Ready(
+                    title = "Second user".toCaString(),
+                    subtitle = "/data/media/10".toCaString(),
+                    storage = previewDeviceStorage(),
+                    items = items.map { ContentViewModel.Item(parent = null, content = it, sizeRatio = null) },
+                    layoutMode = LayoutMode.LINEAR,
+                    progress = null,
+                    isReadOnly = true,
+                    infoBanner = R.string.analyzer_storage_content_type_otherusers_info.toCaString(),
+                ),
+            ),
+        )
     }
 }

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentScreen.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentScreen.kt
@@ -325,14 +325,16 @@ internal fun ContentScreen(
                                         onClick = { pendingDelete = selectedItems },
                                     )
                                 }
-                                SdmTooltipIconButton(
-                                    icon = SdmIcons.ShieldAdd,
-                                    label = stringResource(CommonR.string.general_exclude_action),
-                                    onClick = {
-                                        onExcludeSelected(selectedItems)
-                                        selection.clear()
-                                    },
-                                )
+                                if (!s.isReadOnly) {
+                                    SdmTooltipIconButton(
+                                        icon = SdmIcons.ShieldAdd,
+                                        label = stringResource(CommonR.string.general_exclude_action),
+                                        onClick = {
+                                            onExcludeSelected(selectedItems)
+                                            selection.clear()
+                                        },
+                                    )
+                                }
                                 if (!s.isReadOnly && noneInaccessible) {
                                     SdmTooltipIconButton(
                                         icon = Icons.TwoTone.Filter,

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentScreen.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentScreen.kt
@@ -549,6 +549,7 @@ private fun ContentScreenInfoBannerListPreview() {
                     progress = null,
                     isReadOnly = true,
                     infoBanner = R.string.analyzer_storage_content_type_otherusers_info.toCaString(),
+                    externalFolder = null,
                 ),
             ),
         )

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentViewModel.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentViewModel.kt
@@ -10,6 +10,7 @@ import eu.darken.sdmse.analyzer.core.content.ContentGroup
 import eu.darken.sdmse.analyzer.core.content.ContentItem
 import eu.darken.sdmse.analyzer.core.device.DeviceStorage
 import eu.darken.sdmse.analyzer.core.storage.categories.AppCategory
+import eu.darken.sdmse.analyzer.core.storage.categories.OtherUsersCategory
 import eu.darken.sdmse.analyzer.core.storage.categories.SystemCategory
 import eu.darken.sdmse.analyzer.core.storage.categories.isContentReadOnly
 import eu.darken.sdmse.analyzer.core.storage.categories.ownsGroup
@@ -102,6 +103,12 @@ class ContentViewModel @Inject constructor(
             ?: false
     }
 
+    private fun Analyzer.Data.isOtherUserGroup(route: ContentRoute): Boolean {
+        return categories[route.storageId]
+            ?.any { it is OtherUsersCategory && it.ownsGroup(route.groupId) }
+            ?: false
+    }
+
     private fun Analyzer.Data.isReadOnlyGroup(route: ContentRoute): Boolean {
         return categories[route.storageId]
             ?.any { it.ownsGroup(route.groupId) && it.isContentReadOnly }
@@ -127,6 +134,7 @@ class ContentViewModel @Inject constructor(
                 }
                 val isReadOnly = data.isReadOnlyGroup(route)
                 val isSystemGroup = data.isSystemGroup(route)
+                val isOtherUserGroup = data.isOtherUserGroup(route)
                 val pkgStat = route.installId?.let { installId ->
                     data.categories[route.storageId]
                         ?.filterIsInstance<AppCategory>()?.singleOrNull()
@@ -143,6 +151,9 @@ class ContentViewModel @Inject constructor(
                     // System content: top-level banner only, mirroring the system category presentation.
                     isSystemGroup -> R.string.analyzer_storage_content_type_system_info.toCaString()
                         .takeIf { currentLevel == null }
+                    // Another user's storage: read-only for a different reason than degraded media,
+                    // so it must not inherit the media wording below.
+                    isOtherUserGroup -> R.string.analyzer_storage_content_type_otherusers_info.toCaString()
                     // Degraded read-only media: keep the banner visible while browsing too, since the group is a
                     // single storage-root item the user must open before seeing any folders.
                     isReadOnly -> R.string.analyzer_storage_content_type_media_readonly_info.toCaString()

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentViewModel.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentViewModel.kt
@@ -272,7 +272,12 @@ class ContentViewModel @Inject constructor(
     }
 
     fun onExcludeSelected(items: Set<ContentItem>) = launch {
+        val route = routeFlow.value ?: return@launch
         log(TAG) { "onExcludeSelected(): ${items.size}" }
+        if (analyzer.data.first().isReadOnlyGroup(route)) {
+            log(TAG, WARN) { "exclude(): Blocked — content is read-only" }
+            return@launch
+        }
         val newExclusions = items.map { PathExclusion(path = it.path) }.toSet()
         if (newExclusions.isEmpty()) return@launch
         exclusionManager.save(newExclusions)

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/preview/AnalyzerPreviewData.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/preview/AnalyzerPreviewData.kt
@@ -7,6 +7,7 @@ import eu.darken.sdmse.analyzer.core.content.ContentGroup
 import eu.darken.sdmse.analyzer.core.content.ContentItem
 import eu.darken.sdmse.analyzer.core.device.DeviceStorage
 import eu.darken.sdmse.analyzer.core.storage.categories.AppCategory
+import eu.darken.sdmse.analyzer.core.storage.categories.OtherUsersCategory
 import eu.darken.sdmse.common.ca.CaString
 import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.files.FileType
@@ -113,3 +114,64 @@ internal fun previewPkgStat(
     appMedia = appMedia,
     extraData = extraData,
 )
+
+/**
+ * Covers all three per-user completeness states at once: fully measured and browsable, app data
+ * known but shared files missing, and name only.
+ */
+internal fun previewOtherUsersCategory(
+    storageId: StorageId = previewStorageId(),
+): OtherUsersCategory {
+    val measured = previewContentGroup(
+        label = "Second user",
+        contents = listOf(
+            previewContentItem(
+                segments = arrayOf("data", "media", "10", "DCIM", "vacation.mp4"),
+                size = 3L * 1024 * 1024 * 1024,
+            ),
+        ),
+    )
+    val statsOnly = previewContentGroup(
+        label = "Work profile",
+        contents = listOf(
+            previewContentItem(
+                segments = arrayOf("data", "user", "11"),
+                type = FileType.DIRECTORY,
+                size = 800L * 1024 * 1024,
+                inaccessible = true,
+                withLookup = false,
+            ),
+        ),
+    )
+    val unknown = previewContentGroup(label = "Guest", contents = emptyList())
+    return OtherUsersCategory(
+        storageId = storageId,
+        groups = listOf(measured, statsOnly, unknown),
+        users = listOf(
+            OtherUsersCategory.UserEntry(
+                handle = UserHandle2(handleId = 10),
+                label = "Second user".toCaString(),
+                groupId = measured.id,
+                appDataKnown = true,
+                sharedMediaKnown = true,
+                isBrowsable = true,
+            ),
+            OtherUsersCategory.UserEntry(
+                handle = UserHandle2(handleId = 11),
+                label = "Work profile".toCaString(),
+                groupId = statsOnly.id,
+                appDataKnown = true,
+                sharedMediaKnown = false,
+                isBrowsable = false,
+            ),
+            OtherUsersCategory.UserEntry(
+                handle = UserHandle2(handleId = 12),
+                label = "Guest".toCaString(),
+                groupId = unknown.id,
+                appDataKnown = false,
+                sharedMediaKnown = false,
+                isBrowsable = false,
+            ),
+        ),
+    )
+}

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/storage/StorageContentScreen.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/storage/StorageContentScreen.kt
@@ -29,9 +29,11 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import eu.darken.sdmse.analyzer.R
+import eu.darken.sdmse.analyzer.core.storage.categories.OtherUsersCategory
 import eu.darken.sdmse.analyzer.ui.StorageContentRoute
 import eu.darken.sdmse.analyzer.ui.storage.storage.categories.AppCategoryCard
 import eu.darken.sdmse.analyzer.ui.storage.storage.categories.MediaCategoryCard
+import eu.darken.sdmse.analyzer.ui.storage.storage.categories.OtherUsersCategoryCard
 import eu.darken.sdmse.analyzer.ui.storage.storage.categories.SystemCategoryCard
 import eu.darken.sdmse.common.compose.layout.ScrollAwareFab
 import eu.darken.sdmse.common.compose.layout.SdmListDefaults
@@ -59,6 +61,7 @@ fun StorageContentScreenHost(
     StorageContentScreen(
         stateSource = vm.state,
         onCategoryClick = vm::onCategoryClick,
+        onUserClick = vm::onUserClick,
         onNavigateBack = vm::onNavigateBack,
         onExitNotFound = vm::exitOnNotFound,
         onRefresh = vm::refresh,
@@ -69,6 +72,7 @@ fun StorageContentScreenHost(
 internal fun StorageContentScreen(
     stateSource: Flow<StorageContentViewModel.State> = MutableStateFlow(StorageContentViewModel.State.Loading),
     onCategoryClick: (StorageContentViewModel.Row) -> Unit = {},
+    onUserClick: (OtherUsersCategory.UserEntry) -> Unit = {},
     onNavigateBack: () -> Unit = {},
     onExitNotFound: () -> Unit = {},
     onRefresh: () -> Unit = {},
@@ -183,6 +187,10 @@ internal fun StorageContentScreen(
                                 is StorageContentViewModel.Row.System -> SystemCategoryCard(
                                     row = row,
                                     onClick = { onCategoryClick(row) },
+                                )
+                                is StorageContentViewModel.Row.OtherUsers -> OtherUsersCategoryCard(
+                                    row = row,
+                                    onUserClick = onUserClick,
                                 )
                             }
                         }

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/storage/StorageContentViewModel.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/storage/StorageContentViewModel.kt
@@ -83,7 +83,16 @@ class StorageContentViewModel @Inject constructor(
                 if (storage == null) {
                     State.NotFound
                 } else {
-                    val rows: List<Row>? = data.categories[targetStorageId]
+                    val categories = data.categories[targetStorageId]
+                    // Other users are only fully measured with root. Whatever we couldn't measure
+                    // stays inside the system residual, so the system card has to say so.
+                    val hidesOtherUsers = categories
+                        ?.filterIsInstance<OtherUsersCategory>()
+                        ?.any { category ->
+                            category.users.any { !it.appDataKnown || !it.sharedMediaKnown }
+                        }
+                        ?: false
+                    val rows: List<Row>? = categories
                         ?.sortedBy {
                             when (it) {
                                 is AppCategory -> 1
@@ -96,7 +105,11 @@ class StorageContentViewModel @Inject constructor(
                             when (content) {
                                 is AppCategory -> Row.Apps(storage = storage, category = content)
                                 is MediaCategory -> Row.Media(storage = storage, category = content)
-                                is SystemCategory -> Row.System(storage = storage, category = content)
+                                is SystemCategory -> Row.System(
+                                    storage = storage,
+                                    category = content,
+                                    hidesOtherUsers = hidesOtherUsers,
+                                )
                                 is OtherUsersCategory -> Row.OtherUsers(storage = storage, category = content)
                             }
                         }
@@ -191,7 +204,15 @@ class StorageContentViewModel @Inject constructor(
         val storage: DeviceStorage
         data class Apps(override val storage: DeviceStorage, val category: AppCategory) : Row
         data class Media(override val storage: DeviceStorage, val category: MediaCategory) : Row
-        data class System(override val storage: DeviceStorage, val category: SystemCategory) : Row
+        /**
+         * [hidesOtherUsers] is true when another user's storage on this device could not be fully
+         * measured. Their unmeasured bytes end up in the system residual, so the card says so.
+         */
+        data class System(
+            override val storage: DeviceStorage,
+            val category: SystemCategory,
+            val hidesOtherUsers: Boolean = false,
+        ) : Row
         data class OtherUsers(override val storage: DeviceStorage, val category: OtherUsersCategory) : Row
     }
 

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/storage/StorageContentViewModel.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/storage/StorageContentViewModel.kt
@@ -7,6 +7,7 @@ import eu.darken.sdmse.analyzer.core.storage.StorageScanTask
 import eu.darken.sdmse.analyzer.core.storage.SystemDeepScanTask
 import eu.darken.sdmse.analyzer.core.storage.categories.AppCategory
 import eu.darken.sdmse.analyzer.core.storage.categories.MediaCategory
+import eu.darken.sdmse.analyzer.core.storage.categories.OtherUsersCategory
 import eu.darken.sdmse.analyzer.core.storage.categories.SystemCategory
 import eu.darken.sdmse.analyzer.ui.AppsRoute
 import eu.darken.sdmse.analyzer.ui.ContentRoute
@@ -88,6 +89,7 @@ class StorageContentViewModel @Inject constructor(
                                 is AppCategory -> 1
                                 is MediaCategory -> 2
                                 is SystemCategory -> 3
+                                is OtherUsersCategory -> 4
                             }
                         }
                         ?.map { content ->
@@ -95,6 +97,7 @@ class StorageContentViewModel @Inject constructor(
                                 is AppCategory -> Row.Apps(storage = storage, category = content)
                                 is MediaCategory -> Row.Media(storage = storage, category = content)
                                 is SystemCategory -> Row.System(storage = storage, category = content)
+                                is OtherUsersCategory -> Row.OtherUsers(storage = storage, category = content)
                             }
                         }
                     State.Ready(
@@ -168,7 +171,20 @@ class StorageContentViewModel @Inject constructor(
                     launch { taskSubmitter.submit(SystemDeepScanTask(storageId)) }
                 }
             }
+            // The card holds one group per user, so a whole-card click can't pick one.
+            // Navigation happens per user row, see onUserClick.
+            is Row.OtherUsers -> Unit
         }
+    }
+
+    fun onUserClick(user: OtherUsersCategory.UserEntry) = launch {
+        log(TAG) { "onUserClick(${user.handle})" }
+        val storageId = routeFlow.value?.storageId ?: return@launch
+        if (!user.isBrowsable) {
+            log(TAG) { "User ${user.handle} is not browsable, ignoring click" }
+            return@launch
+        }
+        navTo(ContentRoute(storageId = storageId, groupId = user.groupId, installId = null))
     }
 
     sealed interface Row {
@@ -176,6 +192,7 @@ class StorageContentViewModel @Inject constructor(
         data class Apps(override val storage: DeviceStorage, val category: AppCategory) : Row
         data class Media(override val storage: DeviceStorage, val category: MediaCategory) : Row
         data class System(override val storage: DeviceStorage, val category: SystemCategory) : Row
+        data class OtherUsers(override val storage: DeviceStorage, val category: OtherUsersCategory) : Row
     }
 
     sealed interface State {

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/storage/categories/OtherUsersCategoryCard.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/storage/categories/OtherUsersCategoryCard.kt
@@ -1,0 +1,173 @@
+package eu.darken.sdmse.analyzer.ui.storage.storage.categories
+
+import android.text.format.Formatter
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.twotone.KeyboardArrowRight
+import androidx.compose.material.icons.twotone.Groups
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import eu.darken.sdmse.analyzer.R
+import eu.darken.sdmse.analyzer.core.storage.categories.OtherUsersCategory
+import eu.darken.sdmse.analyzer.ui.storage.preview.previewDeviceStorage
+import eu.darken.sdmse.analyzer.ui.storage.preview.previewOtherUsersCategory
+import eu.darken.sdmse.analyzer.ui.storage.storage.StorageContentViewModel
+import eu.darken.sdmse.common.ByteFormatter
+import eu.darken.sdmse.common.compose.preview.Preview2
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import kotlin.math.roundToInt
+
+@Composable
+internal fun OtherUsersCategoryCard(
+    modifier: Modifier = Modifier,
+    row: StorageContentViewModel.Row.OtherUsers,
+    onUserClick: (OtherUsersCategory.UserEntry) -> Unit = {},
+) {
+    val context = LocalContext.current
+    val storage = row.storage
+    val content = row.category
+    val percentUsed: Int = if (storage.spaceUsed > 0L) {
+        ((content.spaceUsed.toDouble() / storage.spaceUsed.toDouble()) * 100).toInt()
+    } else 0
+    val usedText = Formatter.formatShortFileSize(context, content.spaceUsed)
+    val groupSizes = content.groups.associate { it.id to it.groupSize }
+
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+    ) {
+        Column(modifier = Modifier.padding(vertical = 16.dp)) {
+            Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = Icons.TwoTone.Groups,
+                        contentDescription = null,
+                        modifier = Modifier.size(20.dp),
+                    )
+                    Spacer(Modifier.size(8.dp))
+                    Text(
+                        text = stringResource(R.string.analyzer_storage_content_type_otherusers_label),
+                        style = MaterialTheme.typography.titleMedium,
+                    )
+                }
+                Text(
+                    text = stringResource(R.string.analyzer_storage_content_type_otherusers_description),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 4.dp),
+                )
+            }
+
+            content.users.forEach { user ->
+                OtherUserRow(
+                    user = user,
+                    size = groupSizes[user.groupId],
+                    onClick = { onUserClick(user) },
+                )
+            }
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+                    .padding(top = 12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                LinearProgressIndicator(
+                    progress = { (percentUsed / 100f).coerceIn(0f, 1f) },
+                    modifier = Modifier.weight(1f),
+                )
+                val quantity = ByteFormatter.stripSizeUnit(usedText)?.roundToInt() ?: 1
+                Text(
+                    text = pluralStringResource(R.plurals.analyzer_space_used, quantity, usedText),
+                    style = MaterialTheme.typography.labelMedium,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun OtherUserRow(
+    modifier: Modifier = Modifier,
+    user: OtherUsersCategory.UserEntry,
+    size: Long?,
+    onClick: () -> Unit = {},
+) {
+    val context = LocalContext.current
+    // Only app data is exact on the stats tier, and nothing is exact while the user's areas are
+    // locked. Say so instead of presenting a partial number as this user's total storage.
+    val hint = when {
+        !user.appDataKnown -> stringResource(R.string.analyzer_storage_content_type_otherusers_user_unknown)
+        !user.sharedMediaKnown -> stringResource(R.string.analyzer_storage_content_type_otherusers_user_partial)
+        else -> null
+    }
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .then(if (user.isBrowsable) Modifier.clickable(onClick = onClick) else Modifier)
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = user.label.get(context),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            hint?.let {
+                Text(
+                    text = it,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+        if (user.appDataKnown && size != null) {
+            Text(
+                text = Formatter.formatShortFileSize(context, size),
+                style = MaterialTheme.typography.labelMedium,
+            )
+        }
+        if (user.isBrowsable) {
+            Icon(
+                imageVector = Icons.AutoMirrored.TwoTone.KeyboardArrowRight,
+                contentDescription = null,
+                modifier = Modifier.size(20.dp),
+            )
+        }
+    }
+}
+
+@Preview2
+@Composable
+private fun OtherUsersCategoryCardPreview() {
+    val storage = previewDeviceStorage()
+    PreviewWrapper {
+        OtherUsersCategoryCard(
+            row = StorageContentViewModel.Row.OtherUsers(
+                storage = storage,
+                category = previewOtherUsersCategory(storageId = storage.id),
+            ),
+        )
+    }
+}

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/storage/categories/SystemCategoryCard.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/storage/categories/SystemCategoryCard.kt
@@ -68,6 +68,14 @@ internal fun SystemCategoryCard(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(top = 4.dp),
             )
+            if (row.hidesOtherUsers) {
+                Text(
+                    text = stringResource(R.string.analyzer_storage_content_type_system_otherusers_hint),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 4.dp),
+                )
+            }
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -120,6 +128,26 @@ private fun SystemCategoryCardPreview() {
                     groups = listOf(previewContentGroup(label = "System")),
                     isBrowsable = true,
                 ),
+            ),
+            onClick = {},
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun SystemCategoryCardHidesOtherUsersPreview() {
+    val storage = previewDeviceStorage()
+    PreviewWrapper {
+        SystemCategoryCard(
+            row = StorageContentViewModel.Row.System(
+                storage = storage,
+                category = SystemCategory(
+                    storageId = storage.id,
+                    groups = listOf(previewContentGroup(label = "System")),
+                    isBrowsable = true,
+                ),
+                hidesOtherUsers = true,
             ),
             onClick = {},
         )

--- a/app-tool-analyzer/src/main/res/values/strings.xml
+++ b/app-tool-analyzer/src/main/res/values/strings.xml
@@ -41,6 +41,11 @@
     <string name="analyzer_storage_content_type_system_info">Files that don\'t fit the Apps or User files categories. Browse only — deletion is not supported. Some areas may be incomplete due to access restrictions.</string>
     <string name="analyzer_storage_content_type_media_readonly_info">Files can\'t be matched to the apps that own them right now. Sizes are shown for reference only — deletion, filters and Swiper are disabled.</string>
     <string name="analyzer_storage_content_type_system_other_desc">System files and other data that SD Maid could not access or categorize. The operating system restricts listing the contents of some areas.</string>
+    <string name="analyzer_storage_content_type_otherusers_label">Other users</string>
+    <string name="analyzer_storage_content_type_otherusers_description">Apps and files that belong to other users or work profiles on this device.</string>
+    <string name="analyzer_storage_content_type_otherusers_user_partial">App data only, shared files of this user are not included.</string>
+    <string name="analyzer_storage_content_type_otherusers_user_unknown">Size unavailable, this user\'s storage can\'t be read.</string>
+    <string name="analyzer_storage_content_type_otherusers_info">Storage of another user on this device. Browse only, deletion is not supported.</string>
     <string name="analyzer_storage_content_app_code_label">App code</string>
     <string name="analyzer_storage_content_app_code_description">Application files, libraries and resources. This space can be freed by uninstalling the app or archiving it (available on newer Android version).</string>
     <string name="analyzer_storage_content_app_data_label">App data</string>

--- a/app-tool-analyzer/src/main/res/values/strings.xml
+++ b/app-tool-analyzer/src/main/res/values/strings.xml
@@ -37,7 +37,7 @@
     <string name="analyzer_storage_content_type_media_description">Captured pictures, recorded videos or downloaded data. Any data that doesn\'t belong to a specific app.</string>
     <string name="analyzer_storage_content_type_system_label">System data</string>
     <string name="analyzer_storage_content_type_system_description">System apps and system data. Apps and data from other users, if several user accounts are set on this device.</string>
-    <string name="analyzer_storage_content_type_system_otherusers_hint">Storage of other users that can\'t be measured is included here.</string>
+    <string name="analyzer_storage_content_type_system_otherusers_hint">Other users couldn\'t be fully measured, so this total may include some of their storage.</string>
     <string name="analyzer_storage_content_type_system_other_label">Other</string>
     <string name="analyzer_storage_content_type_system_info">Files that don\'t fit the Apps or User files categories. Browse only — deletion is not supported. Some areas may be incomplete due to access restrictions.</string>
     <string name="analyzer_storage_content_type_media_readonly_info">Files can\'t be matched to the apps that own them right now. Sizes are shown for reference only — deletion, filters and Swiper are disabled.</string>

--- a/app-tool-analyzer/src/main/res/values/strings.xml
+++ b/app-tool-analyzer/src/main/res/values/strings.xml
@@ -37,6 +37,7 @@
     <string name="analyzer_storage_content_type_media_description">Captured pictures, recorded videos or downloaded data. Any data that doesn\'t belong to a specific app.</string>
     <string name="analyzer_storage_content_type_system_label">System data</string>
     <string name="analyzer_storage_content_type_system_description">System apps and system data. Apps and data from other users, if several user accounts are set on this device.</string>
+    <string name="analyzer_storage_content_type_system_otherusers_hint">Storage of other users that can\'t be measured is included here.</string>
     <string name="analyzer_storage_content_type_system_other_label">Other</string>
     <string name="analyzer_storage_content_type_system_info">Files that don\'t fit the Apps or User files categories. Browse only — deletion is not supported. Some areas may be incomplete due to access restrictions.</string>
     <string name="analyzer_storage_content_type_media_readonly_info">Files can\'t be matched to the apps that own them right now. Sizes are shown for reference only — deletion, filters and Swiper are disabled.</string>

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/AnalyzerDeleteGuardTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/AnalyzerDeleteGuardTest.kt
@@ -5,6 +5,7 @@ import eu.darken.sdmse.analyzer.core.content.ContentGroup
 import eu.darken.sdmse.analyzer.core.storage.categories.AppCategory
 import eu.darken.sdmse.analyzer.core.storage.categories.ContentCategory
 import eu.darken.sdmse.analyzer.core.storage.categories.MediaCategory
+import eu.darken.sdmse.analyzer.core.storage.categories.OtherUsersCategory
 import eu.darken.sdmse.analyzer.core.storage.categories.SystemCategory
 import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.files.APath
@@ -113,6 +114,33 @@ class AnalyzerDeleteGuardTest : BaseTest() {
     @Test
     fun `system content deletion is blocked before any filesystem access`() = runTest2 {
         val analyzer = buildAnalyzer(setOf(SystemCategory(storageId, setOf(group))))
+
+        shouldThrow<UnsupportedOperationException> { analyzer.submit(deleteTask()) }
+
+        coVerify(exactly = 0) { gatewaySwitch.delete(any(), any()) }
+        coVerify(exactly = 0) { mediaStoreTool.notifyDeleted(any()) }
+    }
+
+    @Test
+    fun `other users content deletion is blocked before any filesystem access`() = runTest2 {
+        val analyzer = buildAnalyzer(
+            setOf(
+                OtherUsersCategory(
+                    storageId = storageId,
+                    groups = setOf(group),
+                    users = listOf(
+                        OtherUsersCategory.UserEntry(
+                            handle = UserHandle2(10),
+                            label = "Second user".toCaString(),
+                            groupId = group.id,
+                            appDataKnown = true,
+                            sharedMediaKnown = true,
+                            isBrowsable = true,
+                        ),
+                    ),
+                ),
+            ),
+        )
 
         shouldThrow<UnsupportedOperationException> { analyzer.submit(deleteTask()) }
 

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/storage/OtherUserStorageScannerTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/storage/OtherUserStorageScannerTest.kt
@@ -4,6 +4,9 @@ import android.app.usage.StorageStats
 import eu.darken.sdmse.analyzer.core.device.DeviceStorage
 import eu.darken.sdmse.common.areas.DataArea
 import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.files.APathGateway
+import eu.darken.sdmse.common.files.APathLookup
 import eu.darken.sdmse.common.files.FileType
 import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.ReadException
@@ -87,6 +90,33 @@ class OtherUserStorageScannerTest : BaseTest() {
     private fun stubWalkFailure(path: LocalPath) {
         coEvery { gatewaySwitch.lookup(path, type = any()) } returns dirLookup(path)
         coEvery { gatewaySwitch.walk(path, any()) } returns flow { throw ReadException(path = path) }
+    }
+
+    /**
+     * A walk that emits part of the tree and then fails on a descendant, like the real walkers do:
+     * the error goes to [APathGateway.WalkOptions.onError] and is only rethrown when the handler
+     * declines to continue. With the default handler (keep going) the walk completes on a partial
+     * tree.
+     */
+    private fun stubWalkDescendantFailure(path: LocalPath, childSize: Long) {
+        coEvery { gatewaySwitch.lookup(path, type = any()) } returns dirLookup(path)
+        coEvery { gatewaySwitch.walk(path, any()) } answers {
+            val options = secondArg<APathGateway.WalkOptions<APath, APathLookup<APath>>>()
+            flow {
+                emit(fileLookup(path.child("payload.bin"), childSize))
+                val subDir = dirLookup(path.child("subdir"))
+                val error = ReadException(path = subDir.lookedUp)
+                if (options.onError?.invoke(subDir, error) == false) throw error
+            }
+        }
+    }
+
+    private fun stubWalkOverItemLimit(path: LocalPath) {
+        coEvery { gatewaySwitch.lookup(path, type = any()) } returns dirLookup(path)
+        coEvery { gatewaySwitch.walk(path, any()) } returns flow {
+            // One past the scanner's 100_000 item ceiling.
+            repeat(100_001) { emit(fileLookup(path.child("payload-$it.bin"), 1L)) }
+        }
     }
 
     private fun stubStats(dataBytes: Long, cacheBytes: Long) {
@@ -191,6 +221,41 @@ class OtherUserStorageScannerTest : BaseTest() {
         entry.appDataKnown shouldBe true
         entry.sharedMediaKnown shouldBe false
         entry.isBrowsable shouldBe false
+    }
+
+    @Test
+    fun `a descendant failure mid-walk falls back to stats, not a partial tree`() = runTest {
+        // An app writing or deleting inside a directory while it is being walked. Continuing past
+        // the error would finish with a partial tree and report the user as fully known.
+        stubWalk(ceArea.path as LocalPath, childSize = 1_000L)
+        stubWalk(deArea.path as LocalPath, childSize = 2_000L)
+        stubWalkDescendantFailure(mediaPath, childSize = 3_000L)
+        stubStats(dataBytes = 500_000L, cacheBytes = 10_000L)
+
+        val category = scan(useRoot = true, dataAreas = setOf(ceArea, deArea)).shouldNotBeNull()
+
+        category.spaceUsed shouldBe 500_000L
+        category.groups.single().contents.single().path shouldBe LocalPath.build("data", "user", "10")
+        val entry = category.users.single()
+        entry.appDataKnown shouldBe true
+        entry.sharedMediaKnown shouldBe false
+        entry.isBrowsable shouldBe false
+    }
+
+    @Test
+    fun `exceeding the walk item limit falls back to stats instead of sizing`() = runTest {
+        stubWalk(ceArea.path as LocalPath, childSize = 1_000L)
+        stubWalk(deArea.path as LocalPath, childSize = 2_000L)
+        stubWalkOverItemLimit(mediaPath)
+        stubStats(dataBytes = 500_000L, cacheBytes = 10_000L)
+
+        val category = scan(useRoot = true, dataAreas = setOf(ceArea, deArea)).shouldNotBeNull()
+
+        category.spaceUsed shouldBe 500_000L
+        category.groups.single().contents.single().path shouldBe LocalPath.build("data", "user", "10")
+        category.users.single().sharedMediaKnown shouldBe false
+        // `du` isn't atomic either, a truncated walk must not be papered over with a size.
+        coVerify(exactly = 0) { gatewaySwitch.du(any(), any()) }
     }
 
     @Test

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/storage/OtherUserStorageScannerTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/storage/OtherUserStorageScannerTest.kt
@@ -1,0 +1,225 @@
+package eu.darken.sdmse.analyzer.core.storage
+
+import android.app.usage.StorageStats
+import eu.darken.sdmse.analyzer.core.device.DeviceStorage
+import eu.darken.sdmse.common.areas.DataArea
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.files.FileType
+import eu.darken.sdmse.common.files.GatewaySwitch
+import eu.darken.sdmse.common.files.ReadException
+import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.files.local.LocalPathLookup
+import eu.darken.sdmse.common.storage.StorageId
+import eu.darken.sdmse.common.storage.StorageStatsManager2
+import eu.darken.sdmse.common.user.UserHandle2
+import eu.darken.sdmse.common.user.UserProfile2
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.time.Instant
+import java.util.UUID
+
+class OtherUserStorageScannerTest : BaseTest() {
+
+    private val gatewaySwitch = mockk<GatewaySwitch>()
+    private val statsManager = mockk<StorageStatsManager2>()
+
+    private val storageId = StorageId(internalId = null, externalId = UUID.randomUUID())
+    private val storage = DeviceStorage(
+        id = storageId,
+        label = "Primary storage".toCaString(),
+        type = DeviceStorage.Type.PRIMARY,
+        hardware = DeviceStorage.Hardware.BUILT_IN,
+        spaceCapacity = 256_000_000_000L,
+        spaceFree = 100_000_000_000L,
+        setupIncomplete = false,
+    )
+
+    private val user = UserProfile2(handle = UserHandle2(handleId = 10), label = "Second user")
+
+    private val ceArea = DataArea(
+        path = LocalPath.build("data_mirror", "data_ce", "null", "10"),
+        type = DataArea.Type.PRIVATE_DATA,
+        userHandle = user.handle,
+    )
+    private val deArea = DataArea(
+        path = LocalPath.build("data_mirror", "data_de", "null", "10"),
+        type = DataArea.Type.PRIVATE_DATA,
+        userHandle = user.handle,
+    )
+    private val mediaPath = LocalPath.build("data", "media", "10")
+
+    private fun dirLookup(path: LocalPath) = LocalPathLookup(
+        lookedUp = path,
+        fileType = FileType.DIRECTORY,
+        size = 4096L,
+        modifiedAt = Instant.EPOCH,
+        target = null,
+    )
+
+    private fun fileLookup(path: LocalPath, size: Long) = LocalPathLookup(
+        lookedUp = path,
+        fileType = FileType.FILE,
+        size = size,
+        modifiedAt = Instant.EPOCH,
+        target = null,
+    )
+
+    /** A walked directory contributes its own 4096 plus the sizes of its children. */
+    private fun stubWalk(path: LocalPath, childSize: Long) {
+        coEvery { gatewaySwitch.lookup(path, type = any()) } returns dirLookup(path)
+        coEvery { gatewaySwitch.walk(path, any()) } returns flowOf(
+            fileLookup(path.child("payload.bin"), childSize),
+        )
+    }
+
+    private fun stubWalkFailure(path: LocalPath) {
+        coEvery { gatewaySwitch.lookup(path, type = any()) } returns dirLookup(path)
+        coEvery { gatewaySwitch.walk(path, any()) } returns flow { throw ReadException(path = path) }
+    }
+
+    private fun stubStats(dataBytes: Long, cacheBytes: Long) {
+        val stats = mockk<StorageStats>().apply {
+            every { this@apply.dataBytes } returns dataBytes
+            every { this@apply.cacheBytes } returns cacheBytes
+            every { appBytes } returns 999_999L
+        }
+        coEvery { statsManager.queryStatsForUser(storageId, user.handle) } returns stats
+    }
+
+    @BeforeEach
+    fun setup() {
+        coEvery { statsManager.queryStatsForUser(any(), any()) } throws SecurityException("Test")
+        coEvery { gatewaySwitch.du(any(), any()) } throws ReadException("Test")
+    }
+
+    private val scanner: OtherUserStorageScanner
+        get() = OtherUserStorageScanner(gatewaySwitch = gatewaySwitch, statsManager = statsManager)
+
+    private suspend fun scan(
+        useRoot: Boolean,
+        dataAreas: Set<DataArea> = emptySet(),
+        users: Collection<UserProfile2> = setOf(user),
+    ) = scanner.scan(
+        storage = storage,
+        users = users,
+        dataAreas = dataAreas,
+        useRoot = useRoot,
+    )
+
+    @Test
+    fun `no other users means no category`() = runTest {
+        scan(useRoot = true, users = emptySet()).shouldBeNull()
+    }
+
+    @Test
+    fun `stats tier counts dataBytes only, never dataBytes plus cacheBytes`() = runTest {
+        // dataBytes already includes cacheBytes, adding them would over-report by the whole cache.
+        stubStats(dataBytes = 5_000_000L, cacheBytes = 1_500_000L)
+
+        val category = scan(useRoot = false).shouldNotBeNull()
+
+        category.spaceUsed shouldBe 5_000_000L
+        category.groups.single().groupSize shouldBe 5_000_000L
+    }
+
+    @Test
+    fun `stats tier does not claim shared media and is not browsable`() = runTest {
+        stubStats(dataBytes = 5_000_000L, cacheBytes = 1_500_000L)
+
+        val entry = scan(useRoot = false).shouldNotBeNull().users.single()
+
+        entry.handle shouldBe user.handle
+        entry.appDataKnown shouldBe true
+        entry.sharedMediaKnown shouldBe false
+        entry.isBrowsable shouldBe false
+    }
+
+    @Test
+    fun `stats tier never walks or sizes another user's public storage`() = runTest {
+        // Below root, `du` on /storage/emulated/<id> silently reports a few KB for a real tree.
+        stubStats(dataBytes = 5_000_000L, cacheBytes = 0L)
+
+        scan(useRoot = false).shouldNotBeNull()
+
+        coVerify(exactly = 0) { gatewaySwitch.walk(any(), any()) }
+        coVerify(exactly = 0) { gatewaySwitch.du(any(), any()) }
+        coVerify(exactly = 0) { gatewaySwitch.lookup(any(), type = any()) }
+    }
+
+    @Test
+    fun `a complete root walk covers app data and shared media`() = runTest {
+        stubWalk(ceArea.path as LocalPath, childSize = 1_000L)
+        stubWalk(deArea.path as LocalPath, childSize = 2_000L)
+        stubWalk(mediaPath, childSize = 3_000L)
+
+        val category = scan(useRoot = true, dataAreas = setOf(ceArea, deArea)).shouldNotBeNull()
+
+        // Each of the three walked dirs contributes its own 4096 plus its child.
+        category.spaceUsed shouldBe (3 * 4096L + 1_000L + 2_000L + 3_000L)
+        val entry = category.users.single()
+        entry.appDataKnown shouldBe true
+        entry.sharedMediaKnown shouldBe true
+        entry.isBrowsable shouldBe true
+    }
+
+    @Test
+    fun `a partial root failure falls back to stats and discards the partial sizes`() = runTest {
+        // The private-data walks succeed, the media walk doesn't. Keeping the partial root sizes and
+        // adding stats on top would double-count: dataBytes covers /data/media/<id>/Android too.
+        stubWalk(ceArea.path as LocalPath, childSize = 1_000L)
+        stubWalk(deArea.path as LocalPath, childSize = 2_000L)
+        stubWalkFailure(mediaPath)
+        stubStats(dataBytes = 500_000L, cacheBytes = 10_000L)
+
+        val category = scan(useRoot = true, dataAreas = setOf(ceArea, deArea)).shouldNotBeNull()
+
+        category.spaceUsed shouldBe 500_000L
+        category.groups.single().contents.single().path shouldBe LocalPath.build("data", "user", "10")
+        val entry = category.users.single()
+        entry.appDataKnown shouldBe true
+        entry.sharedMediaKnown shouldBe false
+        entry.isBrowsable shouldBe false
+    }
+
+    @Test
+    fun `a locked credential encrypted area leaves app data unknown`() = runTest {
+        // PrivateDataModule silently omits locked CE areas, so only the DE half shows up.
+        stubWalk(deArea.path as LocalPath, childSize = 2_000L)
+        stubWalk(mediaPath, childSize = 3_000L)
+
+        val category = scan(useRoot = true, dataAreas = setOf(deArea)).shouldNotBeNull()
+
+        category.spaceUsed shouldBe 0L
+        category.groups.single().contents.shouldBeEmpty()
+        val entry = category.users.single()
+        entry.appDataKnown shouldBe false
+        entry.sharedMediaKnown shouldBe false
+        entry.isBrowsable shouldBe false
+    }
+
+    @Test
+    fun `a failed root walk does not present as a small success`() = runTest {
+        // walkContentItem swallows ReadException and returns the bare directory, which would show
+        // this user as a 4 KB user. Without stats there must be no size at all.
+        stubWalkFailure(ceArea.path as LocalPath)
+        stubWalk(deArea.path as LocalPath, childSize = 2_000L)
+        stubWalk(mediaPath, childSize = 3_000L)
+
+        val category = scan(useRoot = true, dataAreas = setOf(ceArea, deArea)).shouldNotBeNull()
+
+        category.spaceUsed shouldBe 0L
+        category.users.single().appDataKnown shouldBe false
+    }
+}

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/storage/StorageScannerTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/storage/StorageScannerTest.kt
@@ -5,6 +5,7 @@ import eu.darken.sdmse.analyzer.core.device.DeviceStorage
 import eu.darken.sdmse.common.pkgs.features.Installed
 import eu.darken.sdmse.common.storage.VolumeInfoX
 import eu.darken.sdmse.common.user.UserHandle2
+import eu.darken.sdmse.common.user.UserProfile2
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -58,17 +59,25 @@ class StorageScannerTest : BaseTest() {
     }
 
     @Test
-    fun `unmounted, non-emulated and non-primary volumes are ignored`() {
+    fun `non-emulated and non-primary volumes are ignored`() {
         StorageScanner.otherUserHandles(
             storageType = DeviceStorage.Type.PRIMARY,
             volumes = listOf(
-                volume(mountUserId = 10, isMounted = false),
                 volume(mountUserId = 11, isEmulated = false),
                 volume(mountUserId = 12, isPrimary = false),
                 volume(mountUserId = 13, isPrimary = null),
             ),
             currentUser = currentUser,
         ).shouldBeEmpty()
+    }
+
+    @Test
+    fun `an unmounted volume still counts, a stopped user still occupies storage`() {
+        StorageScanner.otherUserHandles(
+            storageType = DeviceStorage.Type.PRIMARY,
+            volumes = listOf(volume(mountUserId = 10, isMounted = false)),
+            currentUser = currentUser,
+        ) shouldBe setOf(UserHandle2(10))
     }
 
     @Test
@@ -86,6 +95,70 @@ class StorageScannerTest : BaseTest() {
         val volumes = listOf(volume(mountUserId = 10))
         StorageScanner.otherUserHandles(DeviceStorage.Type.SECONDARY, volumes, currentUser).shouldBeEmpty()
         StorageScanner.otherUserHandles(DeviceStorage.Type.PORTABLE, volumes, currentUser).shouldBeEmpty()
+    }
+
+    @Test
+    fun `a user known only to the volume list is included`() {
+        StorageScanner.mergeOtherUsers(
+            storageType = DeviceStorage.Type.PRIMARY,
+            volumes = listOf(volume(mountUserId = 10)),
+            named = emptySet(),
+            currentUser = currentUser,
+        ) shouldBe setOf(UserProfile2(handle = UserHandle2(10)))
+    }
+
+    @Test
+    fun `a user known only to the user list is included`() {
+        // API 27/28 expose a single `emulated` volume with mountUserId=-1, gating on the volume
+        // list alone hides every secondary user there.
+        StorageScanner.mergeOtherUsers(
+            storageType = DeviceStorage.Type.PRIMARY,
+            volumes = listOf(volume(mountUserId = -1)),
+            named = setOf(UserProfile2(handle = UserHandle2(10), label = "Second user")),
+            currentUser = currentUser,
+        ) shouldBe setOf(UserProfile2(handle = UserHandle2(10), label = "Second user"))
+    }
+
+    @Test
+    fun `both sources are unioned and names win over bare handles`() {
+        StorageScanner.mergeOtherUsers(
+            storageType = DeviceStorage.Type.PRIMARY,
+            volumes = listOf(volume(mountUserId = 10), volume(mountUserId = 11)),
+            named = setOf(UserProfile2(handle = UserHandle2(10), label = "Second user")),
+            currentUser = currentUser,
+        ) shouldBe setOf(
+            UserProfile2(handle = UserHandle2(10), label = "Second user"),
+            UserProfile2(handle = UserHandle2(11)),
+        )
+    }
+
+    @Test
+    fun `the current user is not an other user, from either source`() {
+        StorageScanner.mergeOtherUsers(
+            storageType = DeviceStorage.Type.PRIMARY,
+            volumes = listOf(volume(mountUserId = 0)),
+            named = setOf(UserProfile2(handle = currentUser, label = "Owner")),
+            currentUser = currentUser,
+        ).shouldBeEmpty()
+    }
+
+    @Test
+    fun `negative handles from either source are not users`() {
+        // -1 is the "unknown" sentinel of the pre-API29 emulated volume, -10000 the private volume.
+        StorageScanner.mergeOtherUsers(
+            storageType = DeviceStorage.Type.PRIMARY,
+            volumes = listOf(volume(mountUserId = -10000)),
+            named = setOf(UserProfile2(handle = UserHandle2(-1), label = "System")),
+            currentUser = currentUser,
+        ).shouldBeEmpty()
+    }
+
+    @Test
+    fun `secondary and portable storage have no other users at all`() {
+        val volumes = listOf(volume(mountUserId = 10))
+        val named = setOf(UserProfile2(handle = UserHandle2(11)))
+        StorageScanner.mergeOtherUsers(DeviceStorage.Type.SECONDARY, volumes, named, currentUser).shouldBeEmpty()
+        StorageScanner.mergeOtherUsers(DeviceStorage.Type.PORTABLE, volumes, named, currentUser).shouldBeEmpty()
     }
 
     @Test

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/storage/StorageScannerTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/storage/StorageScannerTest.kt
@@ -1,0 +1,136 @@
+package eu.darken.sdmse.analyzer.core.storage
+
+import android.content.pm.ApplicationInfo
+import eu.darken.sdmse.analyzer.core.device.DeviceStorage
+import eu.darken.sdmse.common.pkgs.features.Installed
+import eu.darken.sdmse.common.storage.VolumeInfoX
+import eu.darken.sdmse.common.user.UserHandle2
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class StorageScannerTest : BaseTest() {
+
+    private val currentUser = UserHandle2(handleId = 0)
+
+    private fun volume(
+        mountUserId: Int?,
+        isMounted: Boolean = true,
+        isEmulated: Boolean = true,
+        isPrimary: Boolean? = true,
+    ) = mockk<VolumeInfoX>().apply {
+        every { this@apply.mountUserId } returns mountUserId
+        every { this@apply.isMounted } returns isMounted
+        every { this@apply.isEmulated } returns isEmulated
+        every { this@apply.isPrimary } returns isPrimary
+    }
+
+    private fun pkg(
+        name: String,
+        userHandle: UserHandle2 = currentUser,
+        appInfo: ApplicationInfo? = ApplicationInfo(),
+    ) = mockk<Installed>(relaxed = true).apply {
+        every { packageName } returns name
+        every { this@apply.userHandle } returns userHandle
+        every { applicationInfo } returns appInfo
+    }
+
+    @Test
+    fun `other user handles come from the emulated volumes`() {
+        StorageScanner.otherUserHandles(
+            storageType = DeviceStorage.Type.PRIMARY,
+            volumes = listOf(volume(mountUserId = 0), volume(mountUserId = 10), volume(mountUserId = 11)),
+            currentUser = currentUser,
+        ) shouldBe setOf(UserHandle2(10), UserHandle2(11))
+    }
+
+    @Test
+    fun `the private volume's negative sentinel is not a user`() {
+        // The private volume reports mountUserId=-10000, taking it at face value invents a user.
+        StorageScanner.otherUserHandles(
+            storageType = DeviceStorage.Type.PRIMARY,
+            volumes = listOf(volume(mountUserId = -10000), volume(mountUserId = -1)),
+            currentUser = currentUser,
+        ).shouldBeEmpty()
+    }
+
+    @Test
+    fun `unmounted, non-emulated and non-primary volumes are ignored`() {
+        StorageScanner.otherUserHandles(
+            storageType = DeviceStorage.Type.PRIMARY,
+            volumes = listOf(
+                volume(mountUserId = 10, isMounted = false),
+                volume(mountUserId = 11, isEmulated = false),
+                volume(mountUserId = 12, isPrimary = false),
+                volume(mountUserId = 13, isPrimary = null),
+            ),
+            currentUser = currentUser,
+        ).shouldBeEmpty()
+    }
+
+    @Test
+    fun `an unavailable volume list yields no users`() {
+        StorageScanner.otherUserHandles(
+            storageType = DeviceStorage.Type.PRIMARY,
+            volumes = null,
+            currentUser = currentUser,
+        ).shouldBeEmpty()
+    }
+
+    @Test
+    fun `secondary and portable storage have no other-user model`() {
+        // /data/media/<id> only exists for primary storage.
+        val volumes = listOf(volume(mountUserId = 10))
+        StorageScanner.otherUserHandles(DeviceStorage.Type.SECONDARY, volumes, currentUser).shouldBeEmpty()
+        StorageScanner.otherUserHandles(DeviceStorage.Type.PORTABLE, volumes, currentUser).shouldBeEmpty()
+    }
+
+    @Test
+    fun `app scan targets are limited to the current user`() {
+        val targets = StorageScanner.scanTargets(
+            pkgs = listOf(
+                pkg("com.example.mine"),
+                pkg("com.example.theirs", userHandle = UserHandle2(10)),
+                pkg("android"),
+                pkg("com.example.noinfo", appInfo = null),
+            ),
+            currentUser = currentUser,
+        )
+
+        targets.map { it.packageName } shouldBe listOf("com.example.mine")
+    }
+
+    @Test
+    fun `the residual is what apps, media and other users don't account for`() {
+        StorageScanner.computeResidual(
+            spaceUsed = 1_000L,
+            apps = 300L,
+            media = 200L,
+            otherUsers = 100L,
+        ) shouldBe 400L
+    }
+
+    @Test
+    fun `over-accounted input clamps the residual to zero`() {
+        // The degraded scan du-sizes media folders, which can overcount past the used space.
+        StorageScanner.computeResidual(
+            spaceUsed = 1_000L,
+            apps = 800L,
+            media = 400L,
+            otherUsers = 100L,
+        ) shouldBe 0L
+    }
+
+    @Test
+    fun `without other users the residual is unchanged`() {
+        StorageScanner.computeResidual(
+            spaceUsed = 1_000L,
+            apps = 300L,
+            media = 200L,
+            otherUsers = 0L,
+        ) shouldBe 500L
+    }
+}

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/storage/categories/ContentCategoryTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/storage/categories/ContentCategoryTest.kt
@@ -3,6 +3,7 @@ package eu.darken.sdmse.analyzer.core.storage.categories
 import eu.darken.sdmse.analyzer.core.content.ContentGroup
 import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.storage.StorageId
+import eu.darken.sdmse.common.user.UserHandle2
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
@@ -36,6 +37,31 @@ class ContentCategoryTest : BaseTest() {
         val category = MediaCategory(storageId = storageId, groups = setOf(group))
         category.isReadOnly shouldBe false
         category.isContentReadOnly shouldBe false
+    }
+
+    @Test
+    fun `other users content is always read-only`() {
+        OtherUsersCategory(
+            storageId = storageId,
+            groups = setOf(group),
+            users = listOf(
+                OtherUsersCategory.UserEntry(
+                    handle = UserHandle2(10),
+                    label = "Second user".toCaString(),
+                    groupId = group.id,
+                    appDataKnown = true,
+                    sharedMediaKnown = true,
+                    isBrowsable = true,
+                ),
+            ),
+        ).isContentReadOnly shouldBe true
+    }
+
+    @Test
+    fun `other users space falls back to the group sizes without an override`() {
+        val category = OtherUsersCategory(storageId = storageId, groups = setOf(group), users = emptyList())
+        category.spaceUsed shouldBe group.groupSize
+        category.copy(spaceUsedOverride = 1234L).spaceUsed shouldBe 1234L
     }
 
     @Test

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentViewModelTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentViewModelTest.kt
@@ -24,6 +24,8 @@ import eu.darken.sdmse.common.pkgs.features.Installed
 import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.common.storage.StorageId
 import eu.darken.sdmse.common.user.UserHandle2
+import eu.darken.sdmse.exclusion.core.ExclusionManager
+import eu.darken.sdmse.exclusion.core.types.Exclusion
 import eu.darken.sdmse.common.ui.LayoutMode
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
@@ -82,6 +84,7 @@ class ContentViewModelTest : BaseTest() {
         val swiperSessionCreator: eu.darken.sdmse.common.files.SwiperSessionCreator,
         val filterEditorOptionsCreator: eu.darken.sdmse.common.files.FilterEditorOptionsCreator,
         val viewIntentTool: ViewIntentTool,
+        val exclusionManager: ExclusionManager,
     )
 
     private fun TestScope.harness(
@@ -106,13 +109,14 @@ class ContentViewModelTest : BaseTest() {
         val filterEditorOptionsCreator =
             mockk<eu.darken.sdmse.common.files.FilterEditorOptionsCreator>(relaxed = true)
         val viewIntentTool = mockk<ViewIntentTool>(relaxed = true)
+        val exclusionManager = mockk<ExclusionManager>(relaxed = true)
 
         val vm = ContentViewModel(
             dispatcherProvider = TestDispatcherProvider(),
             analyzer = analyzer,
             analyzerSettings = settings,
             viewIntentTool = viewIntentTool,
-            exclusionManager = mockk(relaxed = true),
+            exclusionManager = exclusionManager,
             filterEditorOptionsCreator = filterEditorOptionsCreator,
             upgradeRepo = mockk(relaxed = true),
             swiperSessionCreator = swiperSessionCreator,
@@ -122,7 +126,14 @@ class ContentViewModelTest : BaseTest() {
         // safeStateIn uses WhileSubscribed(5000) — keep a subscriber alive for the test scope's lifetime.
         backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { vm.state.collect { } }
 
-        return Harness(vm, analyzer, swiperSessionCreator, filterEditorOptionsCreator, viewIntentTool)
+        return Harness(
+            vm,
+            analyzer,
+            swiperSessionCreator,
+            filterEditorOptionsCreator,
+            viewIntentTool,
+            exclusionManager,
+        )
     }
 
     private fun ContentViewModel.readyState(): ContentViewModel.State.Ready {
@@ -345,5 +356,31 @@ class ContentViewModelTest : BaseTest() {
         advanceUntilIdle()
 
         h.vm.events.first() shouldBe ContentViewModel.Event.NoExternalAppFound
+    }
+
+    @Test
+    fun `exclusion is blocked on read-only content`() = runTest2 {
+        // The UI hides the exclude action for read-only content, but the handler must refuse too:
+        // excluding paths the user can neither delete nor filter only creates dead exclusions.
+        val group = ContentGroup(label = "System".toCaString())
+        val h = harness(SystemCategory(storageId, setOf(group)), group)
+        advanceUntilIdle()
+
+        h.vm.onExcludeSelected(setOf(dirItem("data")))
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { h.exclusionManager.save(any<Set<Exclusion>>()) }
+    }
+
+    @Test
+    fun `exclusion is allowed on writable content`() = runTest2 {
+        val group = ContentGroup(label = "Media".toCaString())
+        val h = harness(MediaCategory(storageId, setOf(group), isReadOnly = false), group)
+        advanceUntilIdle()
+
+        h.vm.onExcludeSelected(setOf(dirItem("DCIM")))
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { h.exclusionManager.save(any<Set<Exclusion>>()) }
     }
 }

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/storage/storage/StorageContentViewModelTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/storage/storage/StorageContentViewModelTest.kt
@@ -1,0 +1,145 @@
+package eu.darken.sdmse.analyzer.ui.storage.storage
+
+import eu.darken.sdmse.analyzer.core.Analyzer
+import eu.darken.sdmse.analyzer.core.content.ContentGroup
+import eu.darken.sdmse.analyzer.core.device.DeviceStorage
+import eu.darken.sdmse.analyzer.core.storage.categories.OtherUsersCategory
+import eu.darken.sdmse.analyzer.ui.ContentRoute
+import eu.darken.sdmse.analyzer.ui.StorageContentRoute
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.navigation.NavEvent
+import eu.darken.sdmse.common.progress.Progress
+import eu.darken.sdmse.common.storage.StorageId
+import eu.darken.sdmse.common.user.UserHandle2
+import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import testhelpers.coroutine.runTest2
+import java.util.UUID
+
+class StorageContentViewModelTest : BaseTest() {
+
+    private val storageId = StorageId(
+        internalId = null,
+        externalId = UUID.fromString("00000000-0000-0000-0000-000000000001"),
+    )
+
+    private fun storage() = DeviceStorage(
+        id = storageId,
+        label = "Internal".toCaString(),
+        type = DeviceStorage.Type.PRIMARY,
+        hardware = DeviceStorage.Hardware.BUILT_IN,
+        spaceCapacity = 100L,
+        spaceFree = 50L,
+        setupIncomplete = false,
+    )
+
+    private fun userEntry(
+        handleId: Int,
+        groupId: ContentGroup.Id,
+        isBrowsable: Boolean,
+    ) = OtherUsersCategory.UserEntry(
+        handle = UserHandle2(handleId),
+        label = "User-$handleId".toCaString(),
+        groupId = groupId,
+        appDataKnown = true,
+        sharedMediaKnown = isBrowsable,
+        isBrowsable = isBrowsable,
+    )
+
+    private fun TestScope.harness(category: OtherUsersCategory): StorageContentViewModel {
+        val dataFlow = MutableStateFlow(
+            Analyzer.Data(
+                storages = setOf(storage()),
+                categories = mapOf(storageId to listOf(category)),
+                groups = category.groups.associateBy { it.id },
+            ),
+        )
+        val analyzer = mockk<Analyzer>(relaxed = true).apply {
+            every { data } returns dataFlow
+            every { progress } returns MutableStateFlow<Progress.Data?>(null)
+        }
+        val vm = StorageContentViewModel(
+            dispatcherProvider = TestDispatcherProvider(),
+            analyzer = analyzer,
+            taskSubmitter = mockk<TaskSubmitter>(relaxed = true),
+        )
+        vm.bindRoute(StorageContentRoute(storageId = storageId))
+
+        // safeStateIn uses WhileSubscribed(5000) — keep a subscriber alive for the test scope's lifetime.
+        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { vm.state.collect { } }
+
+        return vm
+    }
+
+    private fun CoroutineScope.collectNavEvents(vm: StorageContentViewModel): MutableList<NavEvent> {
+        val list = mutableListOf<NavEvent>()
+        launch(start = CoroutineStart.UNDISPATCHED) { vm.navEvents.collect { list.add(it) } }
+        return list
+    }
+
+    private fun category(vararg users: Pair<Int, Boolean>): OtherUsersCategory {
+        val groups = users.map { (handleId, _) -> handleId to ContentGroup(label = "User-$handleId".toCaString()) }
+        return OtherUsersCategory(
+            storageId = storageId,
+            groups = groups.map { it.second },
+            users = users.mapIndexed { index, (handleId, browsable) ->
+                userEntry(handleId, groups[index].second.id, browsable)
+            },
+        )
+    }
+
+    @Test
+    fun `a browsable user navigates to its own content group`() = runTest2 {
+        // One group per user, so the route must carry that user's group, not the first one.
+        val category = category(10 to true, 11 to true)
+        val vm = harness(category)
+        val events = backgroundScope.collectNavEvents(vm)
+        advanceUntilIdle()
+
+        val second = category.users.last()
+        vm.onUserClick(second)
+        advanceUntilIdle()
+
+        events.single() shouldBe NavEvent.GoTo(
+            destination = ContentRoute(storageId = storageId, groupId = second.groupId, installId = null),
+        )
+    }
+
+    @Test
+    fun `a non-browsable user does not navigate`() = runTest2 {
+        val category = category(10 to false)
+        val vm = harness(category)
+        val events = backgroundScope.collectNavEvents(vm)
+        advanceUntilIdle()
+
+        vm.onUserClick(category.users.single())
+        advanceUntilIdle()
+
+        events.shouldBeEmpty()
+    }
+
+    @Test
+    fun `clicking the card itself does not navigate`() = runTest2 {
+        val category = category(10 to true)
+        val vm = harness(category)
+        val events = backgroundScope.collectNavEvents(vm)
+        advanceUntilIdle()
+
+        vm.onCategoryClick(StorageContentViewModel.Row.OtherUsers(storage = storage(), category = category))
+        advanceUntilIdle()
+
+        events.shouldBeEmpty()
+    }
+}

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/storage/storage/StorageContentViewModelTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/storage/storage/StorageContentViewModelTest.kt
@@ -18,6 +18,7 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
@@ -83,10 +84,20 @@ class StorageContentViewModelTest : BaseTest() {
         return vm
     }
 
-    private fun CoroutineScope.collectNavEvents(vm: StorageContentViewModel): MutableList<NavEvent> {
+    private class CollectedNavEvents(val list: MutableList<NavEvent>, private val job: Job) {
+        fun cancel() = job.cancel()
+    }
+
+    /**
+     * Must be called on the test scope itself, NOT on [TestScope.backgroundScope]: advanceUntilIdle()
+     * stops as soon as only background work is left, so a collector living in backgroundScope never
+     * gets resumed and every assertion would read an empty list — including the "no navigation"
+     * ones, which would then pass vacuously.
+     */
+    private fun CoroutineScope.collectNavEvents(vm: StorageContentViewModel): CollectedNavEvents {
         val list = mutableListOf<NavEvent>()
-        launch(start = CoroutineStart.UNDISPATCHED) { vm.navEvents.collect { list.add(it) } }
-        return list
+        val job = launch(start = CoroutineStart.UNDISPATCHED) { vm.navEvents.collect { list.add(it) } }
+        return CollectedNavEvents(list, job)
     }
 
     private fun category(vararg users: Pair<Int, Boolean>): OtherUsersCategory {
@@ -105,41 +116,44 @@ class StorageContentViewModelTest : BaseTest() {
         // One group per user, so the route must carry that user's group, not the first one.
         val category = category(10 to true, 11 to true)
         val vm = harness(category)
-        val events = backgroundScope.collectNavEvents(vm)
+        val events = collectNavEvents(vm)
         advanceUntilIdle()
 
         val second = category.users.last()
         vm.onUserClick(second)
         advanceUntilIdle()
 
-        events.single() shouldBe NavEvent.GoTo(
+        events.list.single() shouldBe NavEvent.GoTo(
             destination = ContentRoute(storageId = storageId, groupId = second.groupId, installId = null),
         )
+        events.cancel()
     }
 
     @Test
     fun `a non-browsable user does not navigate`() = runTest2 {
         val category = category(10 to false)
         val vm = harness(category)
-        val events = backgroundScope.collectNavEvents(vm)
+        val events = collectNavEvents(vm)
         advanceUntilIdle()
 
         vm.onUserClick(category.users.single())
         advanceUntilIdle()
 
-        events.shouldBeEmpty()
+        events.list.shouldBeEmpty()
+        events.cancel()
     }
 
     @Test
     fun `clicking the card itself does not navigate`() = runTest2 {
         val category = category(10 to true)
         val vm = harness(category)
-        val events = backgroundScope.collectNavEvents(vm)
+        val events = collectNavEvents(vm)
         advanceUntilIdle()
 
         vm.onCategoryClick(StorageContentViewModel.Row.OtherUsers(storage = storage(), category = category))
         advanceUntilIdle()
 
-        events.shouldBeEmpty()
+        events.list.shouldBeEmpty()
+        events.cancel()
     }
 }

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/storage/storage/StorageContentViewModelTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/storage/storage/StorageContentViewModelTest.kt
@@ -3,7 +3,9 @@ package eu.darken.sdmse.analyzer.ui.storage.storage
 import eu.darken.sdmse.analyzer.core.Analyzer
 import eu.darken.sdmse.analyzer.core.content.ContentGroup
 import eu.darken.sdmse.analyzer.core.device.DeviceStorage
+import eu.darken.sdmse.analyzer.core.storage.categories.ContentCategory
 import eu.darken.sdmse.analyzer.core.storage.categories.OtherUsersCategory
+import eu.darken.sdmse.analyzer.core.storage.categories.SystemCategory
 import eu.darken.sdmse.analyzer.ui.ContentRoute
 import eu.darken.sdmse.analyzer.ui.StorageContentRoute
 import eu.darken.sdmse.common.ca.toCaString
@@ -46,25 +48,31 @@ class StorageContentViewModelTest : BaseTest() {
         setupIncomplete = false,
     )
 
-    private fun userEntry(
-        handleId: Int,
-        groupId: ContentGroup.Id,
-        isBrowsable: Boolean,
-    ) = OtherUsersCategory.UserEntry(
-        handle = UserHandle2(handleId),
-        label = "User-$handleId".toCaString(),
-        groupId = groupId,
-        appDataKnown = true,
-        sharedMediaKnown = isBrowsable,
-        isBrowsable = isBrowsable,
+    private data class UserSpec(
+        val handleId: Int,
+        val isBrowsable: Boolean = true,
+        val appDataKnown: Boolean = true,
+        val sharedMediaKnown: Boolean = true,
     )
 
-    private fun TestScope.harness(category: OtherUsersCategory): StorageContentViewModel {
+    private fun userEntry(
+        spec: UserSpec,
+        groupId: ContentGroup.Id,
+    ) = OtherUsersCategory.UserEntry(
+        handle = UserHandle2(spec.handleId),
+        label = "User-${spec.handleId}".toCaString(),
+        groupId = groupId,
+        appDataKnown = spec.appDataKnown,
+        sharedMediaKnown = spec.sharedMediaKnown,
+        isBrowsable = spec.isBrowsable,
+    )
+
+    private fun TestScope.harness(vararg categories: ContentCategory): StorageContentViewModel {
         val dataFlow = MutableStateFlow(
             Analyzer.Data(
                 storages = setOf(storage()),
-                categories = mapOf(storageId to listOf(category)),
-                groups = category.groups.associateBy { it.id },
+                categories = mapOf(storageId to categories.toList()),
+                groups = categories.flatMap { it.groups }.associateBy { it.id },
             ),
         )
         val analyzer = mockk<Analyzer>(relaxed = true).apply {
@@ -100,15 +108,31 @@ class StorageContentViewModelTest : BaseTest() {
         return CollectedNavEvents(list, job)
     }
 
-    private fun category(vararg users: Pair<Int, Boolean>): OtherUsersCategory {
-        val groups = users.map { (handleId, _) -> handleId to ContentGroup(label = "User-$handleId".toCaString()) }
+    private fun category(vararg users: Pair<Int, Boolean>): OtherUsersCategory = categoryOf(
+        *users
+            .map { (handleId, browsable) ->
+                UserSpec(handleId = handleId, isBrowsable = browsable, sharedMediaKnown = browsable)
+            }
+            .toTypedArray(),
+    )
+
+    private fun categoryOf(vararg specs: UserSpec): OtherUsersCategory {
+        val groups = specs.map { ContentGroup(label = "User-${it.handleId}".toCaString()) }
         return OtherUsersCategory(
             storageId = storageId,
-            groups = groups.map { it.second },
-            users = users.mapIndexed { index, (handleId, browsable) ->
-                userEntry(handleId, groups[index].second.id, browsable)
-            },
+            groups = groups,
+            users = specs.mapIndexed { index, spec -> userEntry(spec, groups[index].id) },
         )
+    }
+
+    private fun systemCategory() = SystemCategory(
+        storageId = storageId,
+        groups = listOf(ContentGroup(label = "System".toCaString())),
+    )
+
+    private fun StorageContentViewModel.systemRow(): StorageContentViewModel.Row.System {
+        val ready = state.value as StorageContentViewModel.State.Ready
+        return ready.rows!!.filterIsInstance<StorageContentViewModel.Row.System>().single()
     }
 
     @Test
@@ -155,5 +179,45 @@ class StorageContentViewModelTest : BaseTest() {
 
         events.list.shouldBeEmpty()
         events.cancel()
+    }
+
+    @Test
+    fun `system row admits other users when shared media is unmeasured`() = runTest2 {
+        // Stats tier: app data is exact, shared media isn't measured at all.
+        val others = categoryOf(UserSpec(handleId = 10, sharedMediaKnown = false))
+        val vm = harness(systemCategory(), others)
+        advanceUntilIdle()
+
+        vm.systemRow().hidesOtherUsers shouldBe true
+    }
+
+    @Test
+    fun `system row admits other users when app data is unmeasured`() = runTest2 {
+        val others = categoryOf(
+            UserSpec(handleId = 10),
+            UserSpec(handleId = 11, isBrowsable = false, appDataKnown = false, sharedMediaKnown = false),
+        )
+        val vm = harness(systemCategory(), others)
+        advanceUntilIdle()
+
+        vm.systemRow().hidesOtherUsers shouldBe true
+    }
+
+    @Test
+    fun `system row stays quiet when every other user is fully measured`() = runTest2 {
+        // Root tier: both flags are true for every user, so there is nothing hidden to admit.
+        val others = categoryOf(UserSpec(handleId = 10), UserSpec(handleId = 11))
+        val vm = harness(systemCategory(), others)
+        advanceUntilIdle()
+
+        vm.systemRow().hidesOtherUsers shouldBe false
+    }
+
+    @Test
+    fun `system row stays quiet without other users`() = runTest2 {
+        val vm = harness(systemCategory())
+        advanceUntilIdle()
+
+        vm.systemRow().hidesOtherUsers shouldBe false
     }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,6 +37,11 @@
         android:name="android.permission.WRITE_SECURE_SETTINGS"
         tools:ignore="ProtectedPermissions" />
 
+    <!--    Storage of other users/profiles, granted via ADB/root-->
+    <uses-permission
+        android:name="android.permission.INTERACT_ACROSS_USERS"
+        tools:ignore="ProtectedPermissions" />
+
     <!--    Android 17+: detect "Advanced Protection" so we can explain why the accessibility service is blocked-->
     <uses-permission android:name="android.permission.QUERY_ADVANCED_PROTECTION_MODE" />
 

--- a/app/src/main/java/eu/darken/sdmse/setup/SetupViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/SetupViewModel.kt
@@ -320,6 +320,7 @@ class SetupViewModel @Inject constructor(
                 Permission.POST_NOTIFICATIONS -> {}
                 Permission.WRITE_SECURE_SETTINGS -> {}
                 Permission.QUERY_ALL_PACKAGES -> {}
+                Permission.INTERACT_ACROSS_USERS -> {}
                 Permission.GET_INSTALLED_APPS -> {}
                 null -> {}
             }


### PR DESCRIPTION
## What changed

The storage analyzer now shows how much space other users and profiles take up on the device.

That space was always counted in the device total, but nothing accounted for it, so it silently inflated "System data" and the categories never added up to the total. On a test device with three extra profiles, "System data" read 1.25 GB when 667 MB of that actually belonged to other users.

What you get depends on the access SD Maid has:

* With root, each other user is listed with its real size and you can browse its files. That content is read-only, deleting and excluding are both refused.
* With ADB/Shizuku, each other user is listed with the exact size of its app data. Shared files like photos and downloads of other users can't be read at this level, and the card says so instead of implying the number is complete.
* With neither, other users and profiles are listed by name with no size. Nothing is guessed.

A few smaller things are fixed along the way: apps belonging to other users could show up as unlabeled duplicate rows in the app list on rooted multi-user devices, the "exclude" action was offered on read-only content where it shouldn't have been, and the grey info banner on storage screens sat flush against the first row with no gap.

Refs #1905

## Technical Context

* Per-user app sizes come from `StorageStatsManager.queryStatsForUser`, gated on `INTERACT_ACROSS_USERS`. That permission carries the `development` protection flag, so the existing ADB/root grant path can grant it, and it's granted automatically only when root or ADB is already available. The flag was confirmed present on API 27, 28, 32 and 36, so the ADB tier is viable across the whole supported range rather than on modern Android only.
* Only `dataBytes` from that API is used. It already includes cache, and the same call's `appBytes` is shared APK code reported once per user, so adding either would over-report every extra user by its entire cache plus roughly 460 MB of code.
* Other users are discovered from the union of the user list and the per-user emulated volumes, because neither source alone is sufficient: without root the user list only sees profiles of the current user, and before roughly Android 11 there are no per-user volume entries at all, just one `emulated` volume with a negative sentinel id. Treating either as authoritative silently disables the feature on one whole class of device.
* Root sizing is all-or-nothing per user. `queryStatsForUser` already covers app-owned external data, so combining a successful media walk with stats for a failed private-data walk would double count; any partial failure discards the partial sizes and falls back to stats. The walk passes an error handler so a mid-walk failure aborts rather than returning a partial tree that looks complete, which is what the default behaviour would do.
* Another user's public storage is never sized by walking it below root. On current Android that path is FUSE-filtered per calling user and returns an empty listing with no error at all, so a walk there would report a believable zero instead of failing.

Worth a close read: the residual arithmetic in `StorageScanner.computeResidual`, and the tier selection in `OtherUserStorageScanner`.

Not covered: Samsung's "dual apps" predates AOSP clone profiles and uses its own mechanism, so that specific case is unverified. Shared media of other users stays unreadable without root.
